### PR TITLE
fix(analysis): detect model assignment changes during hot-reload

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/alerting"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/schedule"
@@ -1006,6 +1007,41 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 		running.Channels != desired.Channels
 }
 
+// sourceModelsChanged reports whether the set of models currently active for a
+// source (as reflected by allocated analysis buffers) differs from the desired
+// config model set. Only models that are both resolvable and loaded are
+// considered; unknown or unloaded config IDs are ignored so that a model
+// appearing in the config but not yet installed does not trigger a spurious
+// rebuild on every hot-reload cycle.
+func sourceModelsChanged(bufMgr *buffer.Manager, sourceID string, desiredConfigIDs []string, loadedModels map[string]classifier.ModelInfo, primaryModelID string) bool {
+	currentBuffers := bufMgr.AnalysisBuffers(sourceID)
+
+	desiredSet := make(map[string]bool, len(desiredConfigIDs))
+	for _, configID := range desiredConfigIDs {
+		registryID, known := classifier.ResolveConfigModelID(configID)
+		if !known {
+			continue
+		}
+		if _, loaded := loadedModels[registryID]; loaded {
+			desiredSet[registryID] = true
+		}
+	}
+	// Empty desired list means the source falls back to the primary model.
+	if len(desiredSet) == 0 {
+		desiredSet[primaryModelID] = true
+	}
+
+	if len(currentBuffers) != len(desiredSet) {
+		return true
+	}
+	for modelID := range currentBuffers {
+		if !desiredSet[modelID] {
+			return true
+		}
+	}
+	return false
+}
+
 // reconfigureChangedSources diffs the currently running sources against the
 // desired config from settings. Only sources that were added, removed, or
 // changed are touched - unchanged streams keep their capture buffers and
@@ -1023,6 +1059,21 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		desired[scm.config.ConnectionString] = scm
 	}
 
+	// Build a lookup of loaded models for model-change detection.
+	// The bnAnalyzer may be nil in minimal test setups that only exercise
+	// the add/remove paths; model-change detection is skipped in that case.
+	var loadedModels map[string]classifier.ModelInfo
+	var primaryModelID string
+	if p.bnAnalyzer != nil {
+		modelInfoSlice := p.bnAnalyzer.BirdNET().ModelInfos()
+		loadedModels = make(map[string]classifier.ModelInfo, len(modelInfoSlice))
+		for i := range modelInfoSlice {
+			loadedModels[modelInfoSlice[i].ID] = modelInfoSlice[i]
+		}
+		primaryModelID = p.bnAnalyzer.BirdNET().ModelInfo.ID
+	}
+	bufMgr := p.engine.BufferManager()
+
 	// Determine which desired configs already have a running source.
 	// Registry.List() returns copies with cleared connectionStrings for
 	// security, so we look up sources via GetByConnection on the desired
@@ -1033,6 +1084,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	var newSourceIDs []string
 	var gainChangedIDs []string
 	var reconfiguredIDs []string
+	var modelChangedIDs []string
 	var keptCount int
 
 	for connStr, scm := range desired {
@@ -1049,11 +1101,13 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				logger.Int("model_count", len(scm.modelIDs)),
 				logger.String("operation", "reconfigure_diff"))
 
-			// Detect audio parameter changes (sample rate, bit depth, channels)
-			// that require a full source reconfigure (stop + route removal +
-			// buffer realloc + restart). ReconfigureSource handles everything,
-			// so skip the gain-only route rebuild for this source.
-			if sourceNeedsReconfigure(src, scm.config) {
+			// Classify the kind of change needed, from most to least
+			// disruptive. Model changes are checked before gain-only
+			// changes so that a simultaneous gain + model update takes
+			// the model-change path (which also handles gain).
+			switch {
+			case sourceNeedsReconfigure(src, scm.config):
+				// Audio parameter change: full stop + restart.
 				log.Info("audio parameters changed, reconfiguring source",
 					logger.String("source_id", src.ID),
 					logger.Int("old_sample_rate", src.SampleRate),
@@ -1064,9 +1118,6 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				if src.Gain != scm.config.Gain {
 					registry.UpdateGain(src.ID, scm.config.Gain)
 				}
-				// ReconfigureSource removes all routes; clear the sound level
-				// tracking entry so re-registration is not blocked by the
-				// idempotency check.
 				p.untrackSoundLevelConsumer(src.ID)
 				if err := p.engine.ReconfigureSource(src.ID, scm.config); err != nil {
 					log.Error("failed to reconfigure source",
@@ -1076,8 +1127,9 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				} else {
 					reconfiguredIDs = append(reconfiguredIDs, src.ID)
 				}
-			} else if src.Gain != scm.config.Gain {
-				// Gain-only change: update registry and rebuild routes (no restart needed).
+
+			case src.Gain != scm.config.Gain:
+				// Gain-only change: rebuild routes, keep capture running.
 				log.Info("gain changed for kept source, rebuilding routes",
 					logger.String("source_id", src.ID),
 					logger.Float64("old_gain_db", src.Gain),
@@ -1085,6 +1137,14 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.String("operation", "reconfigure_diff"))
 				registry.UpdateGain(src.ID, scm.config.Gain)
 				gainChangedIDs = append(gainChangedIDs, src.ID)
+
+			case loadedModels != nil && sourceModelsChanged(bufMgr, src.ID, scm.modelIDs, loadedModels, primaryModelID):
+				// Model assignment changed (e.g., Perch added/removed):
+				// rebuild the consumer/buffer/monitor layer, keep capture running.
+				log.Info("model assignment changed for kept source, rebuilding consumers",
+					logger.String("source_id", src.ID),
+					logger.String("operation", "reconfigure_diff"))
+				modelChangedIDs = append(modelChangedIDs, src.ID)
 			}
 
 			// Sync display name if the config name changed (e.g., stream renamed in UI).
@@ -1170,6 +1230,20 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		p.registerSoundLevelConsumers(gainChangedIDs, "gain_change")
 	}
 
+	// Rebuild routes for sources whose model assignment changed (e.g.,
+	// Perch added or removed). The capture device stays running; routes
+	// are torn down, stale analysis buffers are deallocated, and
+	// consumers are re-created with the new model targets.
+	if len(modelChangedIDs) > 0 {
+		for _, sid := range modelChangedIDs {
+			p.engine.Router().RemoveAllRoutes(sid)
+			p.untrackSoundLevelConsumer(sid)
+			deallocateStaleAnalysisBuffers(bufMgr, sid, sourceModelMap[sid], primaryModelID)
+		}
+		p.registerConsumersForSources(modelChangedIDs, sourceModelMap, audioLevelChan, "model_change")
+		p.registerSoundLevelConsumers(modelChangedIDs, "model_change")
+	}
+
 	// Sync monitors for ALL active sources (kept + new) so UpdateMonitors
 	// receives the full desired state and removes stale monitors correctly.
 	allActiveIDs := slices.Collect(maps.Values(alreadyRunning))
@@ -1188,6 +1262,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		logger.Int("added", len(newSourceIDs)),
 		logger.Int("removed", removedCount),
 		logger.Int("gain_changed", len(gainChangedIDs)),
+		logger.Int("model_changed", len(modelChangedIDs)),
 		logger.String("operation", "reconfigure_diff"))
 }
 
@@ -1285,6 +1360,26 @@ func (p *AudioPipelineService) buildMonitorConfigs(sourceModelMap map[string][]s
 	}
 
 	return result
+}
+
+// deallocateStaleAnalysisBuffers removes analysis buffers for models that are
+// no longer assigned to a source. This prevents memory leaks when models are
+// removed from a source's config via hot-reload.
+func deallocateStaleAnalysisBuffers(bufMgr *buffer.Manager, sourceID string, desiredConfigIDs []string, primaryModelID string) {
+	desiredSet := make(map[string]bool, len(desiredConfigIDs))
+	for _, configID := range desiredConfigIDs {
+		if regID, known := classifier.ResolveConfigModelID(configID); known {
+			desiredSet[regID] = true
+		}
+	}
+	if len(desiredSet) == 0 {
+		desiredSet[primaryModelID] = true
+	}
+	for modelID := range bufMgr.AnalysisBuffers(sourceID) {
+		if !desiredSet[modelID] {
+			bufMgr.DeallocateAnalysis(sourceID, modelID)
+		}
+	}
 }
 
 // resolveModelTargets converts config-level model IDs to ModelTarget entries

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1007,6 +1007,27 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 		running.Channels != desired.Channels
 }
 
+// resolveDesiredModelSet resolves config-level model IDs to registry IDs,
+// filtering out models that are unknown or not loaded. When the resolved set
+// is empty the primary model is used as a fallback, matching the behavior of
+// registerConsumersForSources.
+func resolveDesiredModelSet(desiredConfigIDs []string, loadedModels map[string]classifier.ModelInfo, primaryModelID string) map[string]bool {
+	set := make(map[string]bool, len(desiredConfigIDs))
+	for _, configID := range desiredConfigIDs {
+		registryID, known := classifier.ResolveConfigModelID(configID)
+		if !known {
+			continue
+		}
+		if _, loaded := loadedModels[registryID]; loaded {
+			set[registryID] = true
+		}
+	}
+	if len(set) == 0 {
+		set[primaryModelID] = true
+	}
+	return set
+}
+
 // sourceModelsChanged reports whether the set of models currently active for a
 // source (as reflected by allocated analysis buffers) differs from the desired
 // config model set. Only models that are both resolvable and loaded are
@@ -1015,21 +1036,7 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 // rebuild on every hot-reload cycle.
 func sourceModelsChanged(bufMgr *buffer.Manager, sourceID string, desiredConfigIDs []string, loadedModels map[string]classifier.ModelInfo, primaryModelID string) bool {
 	currentBuffers := bufMgr.AnalysisBuffers(sourceID)
-
-	desiredSet := make(map[string]bool, len(desiredConfigIDs))
-	for _, configID := range desiredConfigIDs {
-		registryID, known := classifier.ResolveConfigModelID(configID)
-		if !known {
-			continue
-		}
-		if _, loaded := loadedModels[registryID]; loaded {
-			desiredSet[registryID] = true
-		}
-	}
-	// Empty desired list means the source falls back to the primary model.
-	if len(desiredSet) == 0 {
-		desiredSet[primaryModelID] = true
-	}
+	desiredSet := resolveDesiredModelSet(desiredConfigIDs, loadedModels, primaryModelID)
 
 	if len(currentBuffers) != len(desiredSet) {
 		return true
@@ -1238,7 +1245,8 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		for _, sid := range modelChangedIDs {
 			p.engine.Router().RemoveAllRoutes(sid)
 			p.untrackSoundLevelConsumer(sid)
-			deallocateStaleAnalysisBuffers(bufMgr, sid, sourceModelMap[sid], primaryModelID)
+			desiredSet := resolveDesiredModelSet(sourceModelMap[sid], loadedModels, primaryModelID)
+			deallocateStaleAnalysisBuffers(bufMgr, sid, desiredSet)
 		}
 		p.registerConsumersForSources(modelChangedIDs, sourceModelMap, audioLevelChan, "model_change")
 		p.registerSoundLevelConsumers(modelChangedIDs, "model_change")
@@ -1363,18 +1371,10 @@ func (p *AudioPipelineService) buildMonitorConfigs(sourceModelMap map[string][]s
 }
 
 // deallocateStaleAnalysisBuffers removes analysis buffers for models that are
-// no longer assigned to a source. This prevents memory leaks when models are
-// removed from a source's config via hot-reload.
-func deallocateStaleAnalysisBuffers(bufMgr *buffer.Manager, sourceID string, desiredConfigIDs []string, primaryModelID string) {
-	desiredSet := make(map[string]bool, len(desiredConfigIDs))
-	for _, configID := range desiredConfigIDs {
-		if regID, known := classifier.ResolveConfigModelID(configID); known {
-			desiredSet[regID] = true
-		}
-	}
-	if len(desiredSet) == 0 {
-		desiredSet[primaryModelID] = true
-	}
+// no longer in the desired set. The desiredSet should be pre-built via
+// resolveDesiredModelSet to ensure consistent filtering with the change
+// detection in sourceModelsChanged.
+func deallocateStaleAnalysisBuffers(bufMgr *buffer.Manager, sourceID string, desiredSet map[string]bool) {
 	for modelID := range bufMgr.AnalysisBuffers(sourceID) {
 		if !desiredSet[modelID] {
 			bufMgr.DeallocateAnalysis(sourceID, modelID)

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -895,25 +895,20 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 			modelInfos = primaryTargets
 		}
 
-		// Allocate analysis buffers for secondary models. The engine
-		// already allocates a buffer for the primary model in AddSource(),
-		// so only non-primary models need allocation here. Track which
-		// models have usable buffers so we only create targets for them.
+		// Ensure analysis buffers exist for all target models. The engine
+		// pre-allocates the primary model's buffer in AddSource(), so it
+		// usually exists already. Use HasAnalysis for all models uniformly
+		// to handle the case where a prior model-change reconfigure
+		// deallocated a buffer that is now needed again.
 		allocatedModels := make(map[string]bool, len(modelInfos))
-		allocatedModels[primaryInfo.ID] = true // pre-allocated by engine
 		for i := range modelInfos {
-			if modelInfos[i].ID == primaryInfo.ID {
-				continue
-			}
-			// If the analysis buffer already exists (e.g., gain-only reconfigure),
-			// skip allocation and mark the model as usable.
 			if bufMgr.HasAnalysis(sid, modelInfos[i].ID) {
 				allocatedModels[modelInfos[i].ID] = true
 				continue
 			}
 			clipBytes, overlapBytes, readSize := modelInfos[i].Spec.BufferDimensions()
 			if allocErr := bufMgr.AllocateAnalysis(sid, modelInfos[i].ID, clipBytes, overlapBytes, readSize); allocErr != nil {
-				log.Warn("failed to allocate analysis buffer for secondary model",
+				log.Warn("failed to allocate analysis buffer",
 					logger.String("source_id", sid),
 					logger.String("model_id", modelInfos[i].ID),
 					logger.Error(allocErr),
@@ -921,7 +916,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				continue
 			}
 			allocatedModels[modelInfos[i].ID] = true
-			log.Info("allocated analysis buffer for secondary model",
+			log.Info("allocated analysis buffer",
 				logger.String("source_id", sid),
 				logger.String("model_id", modelInfos[i].ID),
 				logger.Int("clip_bytes", clipBytes),

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1130,6 +1130,18 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					reconfiguredIDs = append(reconfiguredIDs, src.ID)
 				}
 
+			case loadedModels != nil && sourceModelsChanged(bufMgr, src.ID, scm.modelIDs, loadedModels, primaryModelID):
+				// Model assignment changed (e.g., Perch added/removed):
+				// rebuild the consumer/buffer/monitor layer, keep capture running.
+				// Also pick up any simultaneous gain change.
+				if src.Gain != scm.config.Gain {
+					registry.UpdateGain(src.ID, scm.config.Gain)
+				}
+				log.Info("model assignment changed for kept source, rebuilding consumers",
+					logger.String("source_id", src.ID),
+					logger.String("operation", "reconfigure_diff"))
+				modelChangedIDs = append(modelChangedIDs, src.ID)
+
 			case src.Gain != scm.config.Gain:
 				// Gain-only change: rebuild routes, keep capture running.
 				log.Info("gain changed for kept source, rebuilding routes",
@@ -1139,14 +1151,6 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.String("operation", "reconfigure_diff"))
 				registry.UpdateGain(src.ID, scm.config.Gain)
 				gainChangedIDs = append(gainChangedIDs, src.ID)
-
-			case loadedModels != nil && sourceModelsChanged(bufMgr, src.ID, scm.modelIDs, loadedModels, primaryModelID):
-				// Model assignment changed (e.g., Perch added/removed):
-				// rebuild the consumer/buffer/monitor layer, keep capture running.
-				log.Info("model assignment changed for kept source, rebuilding consumers",
-					logger.String("source_id", src.ID),
-					logger.String("operation", "reconfigure_diff"))
-				modelChangedIDs = append(modelChangedIDs, src.ID)
 			}
 
 			// Sync display name if the config name changed (e.g., stream renamed in UI).

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -1,10 +1,15 @@
 package analysis
 
 import (
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 func TestSourceNeedsReconfigure(t *testing.T) {
@@ -81,4 +86,116 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// newModelTestBufferManager creates a buffer.Manager with analysis buffers allocated
+// for the given (sourceID, modelID) pairs. Each buffer is allocated with
+// minimal dimensions suitable for testing.
+func newModelTestBufferManager(t *testing.T, pairs [][2]string) *buffer.Manager {
+	t.Helper()
+	mgr := buffer.NewManager(logger.NewSlogLogger(io.Discard, logger.LogLevelError, time.UTC))
+	for _, p := range pairs {
+		err := mgr.AllocateAnalysis(p[0], p[1], 1024, 0, 512)
+		assert.NoError(t, err)
+	}
+	return mgr
+}
+
+func TestSourceModelsChanged(t *testing.T) {
+	t.Parallel()
+
+	const (
+		src            = "rtsp_abc123"
+		birdnetID      = "BirdNET_V2.4"
+		perchID        = "Perch_V2"
+		primaryModelID = birdnetID
+	)
+
+	loaded := map[string]classifier.ModelInfo{
+		birdnetID: {ID: birdnetID},
+		perchID:   {ID: perchID},
+	}
+
+	tests := []struct {
+		name             string
+		currentModels    [][2]string // (sourceID, modelID) pairs for buffer allocation
+		desiredConfigIDs []string
+		expected         bool
+	}{
+		{
+			name:             "no change, single model",
+			currentModels:    [][2]string{{src, birdnetID}},
+			desiredConfigIDs: []string{"birdnet"},
+			expected:         false,
+		},
+		{
+			name:             "no change, both models",
+			currentModels:    [][2]string{{src, birdnetID}, {src, perchID}},
+			desiredConfigIDs: []string{"birdnet", "perch_v2"},
+			expected:         false,
+		},
+		{
+			name:             "perch added",
+			currentModels:    [][2]string{{src, birdnetID}},
+			desiredConfigIDs: []string{"birdnet", "perch_v2"},
+			expected:         true,
+		},
+		{
+			name:             "perch removed",
+			currentModels:    [][2]string{{src, birdnetID}, {src, perchID}},
+			desiredConfigIDs: []string{"birdnet"},
+			expected:         true,
+		},
+		{
+			name:             "model swapped",
+			currentModels:    [][2]string{{src, birdnetID}},
+			desiredConfigIDs: []string{"perch_v2"},
+			expected:         true,
+		},
+		{
+			name:             "empty desired falls back to primary, no change",
+			currentModels:    [][2]string{{src, birdnetID}},
+			desiredConfigIDs: []string{},
+			expected:         false,
+		},
+		{
+			name:             "empty desired falls back to primary, perch stale",
+			currentModels:    [][2]string{{src, birdnetID}, {src, perchID}},
+			desiredConfigIDs: []string{},
+			expected:         true,
+		},
+		{
+			name:             "unknown config ID ignored, no effective change",
+			currentModels:    [][2]string{{src, birdnetID}},
+			desiredConfigIDs: []string{"birdnet", "unknown_model"},
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mgr := newModelTestBufferManager(t, tt.currentModels)
+			result := sourceModelsChanged(mgr, src, tt.desiredConfigIDs, loaded, primaryModelID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSourceModelsChanged_UnloadedModelIgnored(t *testing.T) {
+	t.Parallel()
+
+	const src = "rtsp_abc123"
+
+	// Only BirdNET is loaded; Perch is not.
+	loadedOnlyBirdnet := map[string]classifier.ModelInfo{
+		"BirdNET_V2.4": {ID: "BirdNET_V2.4"},
+	}
+
+	mgr := newModelTestBufferManager(t, [][2]string{{src, "BirdNET_V2.4"}})
+
+	// Config requests perch_v2 but it's not loaded: should NOT report a
+	// change so we avoid a spurious rebuild on every hot-reload tick.
+	changed := sourceModelsChanged(mgr, src, []string{"birdnet", "perch_v2"}, loadedOnlyBirdnet, "BirdNET_V2.4")
+	assert.False(t, changed, "unloaded model in desired config should be ignored")
 }

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -182,6 +182,47 @@ func TestSourceModelsChanged(t *testing.T) {
 	}
 }
 
+func TestResolveDesiredModelSet(t *testing.T) {
+	t.Parallel()
+
+	loaded := map[string]classifier.ModelInfo{
+		"BirdNET_V2.4": {ID: "BirdNET_V2.4"},
+		"Perch_V2":     {ID: "Perch_V2"},
+	}
+
+	t.Run("resolves known loaded models", func(t *testing.T) {
+		t.Parallel()
+		set := resolveDesiredModelSet([]string{"birdnet", "perch_v2"}, loaded, "BirdNET_V2.4")
+		assert.True(t, set["BirdNET_V2.4"])
+		assert.True(t, set["Perch_V2"])
+		assert.Len(t, set, 2)
+	})
+
+	t.Run("skips unknown config IDs", func(t *testing.T) {
+		t.Parallel()
+		set := resolveDesiredModelSet([]string{"birdnet", "unknown"}, loaded, "BirdNET_V2.4")
+		assert.True(t, set["BirdNET_V2.4"])
+		assert.Len(t, set, 1)
+	})
+
+	t.Run("skips unloaded models", func(t *testing.T) {
+		t.Parallel()
+		onlyBirdnet := map[string]classifier.ModelInfo{
+			"BirdNET_V2.4": {ID: "BirdNET_V2.4"},
+		}
+		set := resolveDesiredModelSet([]string{"birdnet", "perch_v2"}, onlyBirdnet, "BirdNET_V2.4")
+		assert.True(t, set["BirdNET_V2.4"])
+		assert.Len(t, set, 1)
+	})
+
+	t.Run("empty config falls back to primary", func(t *testing.T) {
+		t.Parallel()
+		set := resolveDesiredModelSet(nil, loaded, "BirdNET_V2.4")
+		assert.True(t, set["BirdNET_V2.4"])
+		assert.Len(t, set, 1)
+	})
+}
+
 func TestSourceModelsChanged_UnloadedModelIgnored(t *testing.T) {
 	t.Parallel()
 

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -110,6 +110,14 @@ func (m *Manager) AllocateCapture(sourceID string, durationSeconds, sampleRate, 
 	return nil
 }
 
+// DeallocateAnalysis removes the AnalysisBuffer for a single (sourceID,
+// modelID) pair. It is a no-op if no buffer exists for that key.
+func (m *Manager) DeallocateAnalysis(sourceID, modelID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.analysisBuffers, bufferKey{sourceID: sourceID, modelID: modelID})
+}
+
 // DeallocateSource removes all AnalysisBuffers (across all models) and the
 // CaptureBuffer for the given sourceID in a single atomic operation. It is
 // safe to call for sourceIDs that were never allocated; the method is a no-op

--- a/internal/audiocore/buffer/manager_test.go
+++ b/internal/audiocore/buffer/manager_test.go
@@ -252,6 +252,33 @@ func TestManager_HasAnalysis(t *testing.T) {
 	assert.False(t, m.HasAnalysis("source-2", "birdnet"))
 }
 
+func TestManager_DeallocateAnalysis(t *testing.T) {
+	t.Parallel()
+
+	m := buffer.NewManager(newTestLogger())
+
+	// Allocate two models for the same source.
+	require.NoError(t, m.AllocateAnalysis("src-1", "birdnet", managerTestCapacity, managerTestOverlapSize, managerTestReadSize))
+	require.NoError(t, m.AllocateAnalysis("src-1", "perch_v2", managerTestCapacity, managerTestOverlapSize, managerTestReadSize))
+
+	// Deallocate only the Perch buffer.
+	m.DeallocateAnalysis("src-1", "perch_v2")
+
+	assert.True(t, m.HasAnalysis("src-1", "birdnet"), "birdnet buffer should still exist")
+	assert.False(t, m.HasAnalysis("src-1", "perch_v2"), "perch buffer should be gone")
+}
+
+func TestManager_DeallocateAnalysis_NonExistent(t *testing.T) {
+	t.Parallel()
+
+	m := buffer.NewManager(newTestLogger())
+
+	// Should not panic when deallocating a buffer that was never allocated.
+	assert.NotPanics(t, func() {
+		m.DeallocateAnalysis("nonexistent", "nonexistent")
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Per-size Float32Pool tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Hot-reload now detects model assignment changes (e.g., adding/removing Perch) on existing audio sources and rebuilds the consumer/buffer/monitor layer without restarting the capture process
- Adds `buffer.Manager.DeallocateAnalysis()` for targeted single-model buffer removal
- Stale analysis buffers for removed models are cleaned up to prevent memory leaks
- Fixes `registerConsumersForSources` primary buffer assumption: all models now use `HasAnalysis` uniformly instead of assuming the primary is always pre-allocated

Fixes #3180

## Test plan

- [x] Unit tests for `sourceModelsChanged` covering: add model, remove model, swap model, empty config fallback, unknown/unloaded model filtering
- [x] Unit tests for `resolveDesiredModelSet` covering: known+loaded, unknown, unloaded, empty fallback
- [x] Unit tests for `DeallocateAnalysis` including no-op on non-existent keys
- [x] All 226 existing tests pass with `-race`
- [x] Zero lint issues (`golangci-lint run`)
- [x] Gate review: 5 parallel agents + Gemini cross-validation, all findings addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply model-assignment changes during hot-reload so active sources update analysis targets.
  * Per-source+model analysis buffer deallocation.
  * Completion logs now include a model_changed count.

* **Bug Fixes**
  * Ensure analysis buffers exist for all resolved target models to avoid missed analysis.
  * Ignore requested models that are not loaded to prevent unnecessary rebuilds.

* **Tests**
  * Added tests for model-set diff logic and buffer deallocation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->