### PR TITLE
feat(health): wire audio pipeline health checks to real data sources

### DIFF
--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -124,6 +124,11 @@ func runAudioLevelBroadcaster(ctx context.Context, sourceChan chan audiocore.Aud
 					delete(audioLevelMgr.subscribers, ch)
 				}
 				audioLevelMgr.subscribersMu.Unlock()
+
+				// Clear stale levels so health checks don't report dead sources
+				audioLevelMgr.latestLevelsMu.Lock()
+				clear(audioLevelMgr.latestLevels)
+				audioLevelMgr.latestLevelsMu.Unlock()
 				return
 			}
 

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -66,6 +66,10 @@ type audioLevelManager struct {
 	subscribers   map[chan audiocore.AudioLevelData]struct{}
 	subscribersMu sync.RWMutex
 
+	// Latest audio level per source for health checks (updated by broadcaster)
+	latestLevels   map[string]audiocore.AudioLevelData
+	latestLevelsMu sync.RWMutex
+
 	// Broadcaster lifecycle
 	broadcasterOnce   sync.Once
 	broadcasterCancel context.CancelFunc
@@ -79,6 +83,7 @@ const maxStreamAnonymMapSize = 100
 var audioLevelMgr = &audioLevelManager{
 	streamAnonymMap: make(map[string]string),
 	subscribers:     make(map[chan audiocore.AudioLevelData]struct{}),
+	latestLevels:    make(map[string]audiocore.AudioLevelData),
 }
 
 // SetAudioLevelChan sets the audio level channel for the controller and starts
@@ -122,6 +127,11 @@ func runAudioLevelBroadcaster(ctx context.Context, sourceChan chan audiocore.Aud
 				return
 			}
 
+			// Track latest level per source for health checks
+			audioLevelMgr.latestLevelsMu.Lock()
+			audioLevelMgr.latestLevels[data.Source] = data
+			audioLevelMgr.latestLevelsMu.Unlock()
+
 			// Fan out to all subscribers (non-blocking send)
 			audioLevelMgr.subscribersMu.RLock()
 			for ch := range audioLevelMgr.subscribers {
@@ -157,6 +167,22 @@ func unsubscribeFromAudioLevels(ch chan audiocore.AudioLevelData) {
 	audioLevelMgr.subscribersMu.Unlock()
 	// Note: We don't close the channel here as it may still have buffered data
 	// that the handler is processing. The channel will be garbage collected.
+}
+
+// LatestAudioLevels returns a snapshot of the most recent audio level per source.
+// Safe for concurrent use; returns nil if no levels have been received.
+func LatestAudioLevels() []audiocore.AudioLevelData {
+	audioLevelMgr.latestLevelsMu.RLock()
+	defer audioLevelMgr.latestLevelsMu.RUnlock()
+
+	if len(audioLevelMgr.latestLevels) == 0 {
+		return nil
+	}
+	levels := make([]audiocore.AudioLevelData, 0, len(audioLevelMgr.latestLevels))
+	for source := range audioLevelMgr.latestLevels {
+		levels = append(levels, audioLevelMgr.latestLevels[source])
+	}
+	return levels
 }
 
 // cacheStreamAnonymName stores an anonymized name for a stream source with bounded map size.

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -371,10 +371,9 @@ func (c *Controller) buildCaptureBufferHealthProvider() func() []checks.CaptureB
 		infos := make([]checks.CaptureBufferInfo, 0, len(snapshots))
 		for _, s := range snapshots {
 			infos = append(infos, checks.CaptureBufferInfo{
-				SourceID:  s.SourceID,
-				Capacity:  s.Capacity,
-				Used:      s.Used,
-				FillRatio: s.FillRatio,
+				SourceID:    s.SourceID,
+				Capacity:    s.Capacity,
+				Initialized: s.Initialized,
 			})
 		}
 		return infos

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -291,24 +291,28 @@ func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 			return nil
 		}
 
-		// Filter to active sources so removed sources don't produce stale data
-		var activeSources map[string]struct{}
-		if eng := c.engine.Load(); eng != nil {
-			if router := eng.Router(); router != nil {
-				ids := router.ActiveSourceIDs()
-				activeSources = make(map[string]struct{}, len(ids))
-				for _, id := range ids {
-					activeSources[id] = struct{}{}
-				}
-			}
+		// Require engine/router so checks skip cleanly before startup and after teardown.
+		eng := c.engine.Load()
+		if eng == nil {
+			return nil
+		}
+		router := eng.Router()
+		if router == nil {
+			return nil
+		}
+		ids := router.ActiveSourceIDs()
+		if len(ids) == 0 {
+			return nil
+		}
+		activeSources := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			activeSources[id] = struct{}{}
 		}
 
 		infos := make([]checks.AudioLevelInfo, 0, len(levels))
 		for _, l := range levels {
-			if activeSources != nil {
-				if _, ok := activeSources[l.Source]; !ok {
-					continue
-				}
+			if _, ok := activeSources[l.Source]; !ok {
+				continue
 			}
 			infos = append(infos, checks.AudioLevelInfo{
 				Source:   l.Source,

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -86,10 +86,10 @@ func (c *Controller) registerHealthChecks() {
 		// Audio checks
 		checks.NewSourceStatusCheck(snapshotProvider),
 		checks.NewPipelineLivenessCheck(snapshotProvider),
-		checks.NewBufferDropsCheck(),
-		checks.NewAudioLevelCheck(),
-		checks.NewBufferOverrunCheck(),
-		checks.NewCaptureBufferCheck(),
+		checks.NewBufferDropsCheck(c.buildDropStatsProvider()),
+		checks.NewAudioLevelCheck(c.buildAudioLevelProvider()),
+		checks.NewBufferOverrunCheck(c.buildOverrunStatsProvider()),
+		checks.NewCaptureBufferCheck(c.buildCaptureBufferHealthProvider()),
 
 		// Analysis checks
 		checks.NewModelLoadedCheck(
@@ -248,6 +248,112 @@ func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInf
 				ProcessState: sh.ProcessState.String(),
 				RestartCount: sh.RestartCount,
 				Error:        errMsg,
+			})
+		}
+		return infos
+	}
+}
+
+// buildDropStatsProvider returns a closure that aggregates per-source frame
+// drop counts from the audio router. Returns nil before the engine starts.
+func (c *Controller) buildDropStatsProvider() func() checks.DropStats {
+	return func() checks.DropStats {
+		eng := c.engine.Load()
+		if eng == nil {
+			return nil
+		}
+		router := eng.Router()
+		if router == nil {
+			return nil
+		}
+		sourceIDs := router.ActiveSourceIDs()
+		if len(sourceIDs) == 0 {
+			return nil
+		}
+		stats := make(checks.DropStats, len(sourceIDs))
+		for _, sid := range sourceIDs {
+			var totalDrops int64
+			for _, ri := range router.Routes(sid) {
+				totalDrops += ri.Drops
+			}
+			stats[sid] = totalDrops
+		}
+		return stats
+	}
+}
+
+// buildAudioLevelProvider returns a closure that reads the latest audio level
+// per source from the global audio level manager.
+func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
+	return func() []checks.AudioLevelInfo {
+		levels := LatestAudioLevels()
+		if len(levels) == 0 {
+			return nil
+		}
+		infos := make([]checks.AudioLevelInfo, 0, len(levels))
+		for _, l := range levels {
+			infos = append(infos, checks.AudioLevelInfo{
+				Source:   l.Source,
+				Level:    l.Level,
+				Clipping: l.Clipping,
+			})
+		}
+		return infos
+	}
+}
+
+// buildOverrunStatsProvider returns a closure that aggregates per-source write
+// error counts from the audio router. Write errors indicate downstream
+// processing could not keep up (overrun condition).
+func (c *Controller) buildOverrunStatsProvider() func() checks.OverrunStats {
+	return func() checks.OverrunStats {
+		eng := c.engine.Load()
+		if eng == nil {
+			return nil
+		}
+		router := eng.Router()
+		if router == nil {
+			return nil
+		}
+		sourceIDs := router.ActiveSourceIDs()
+		if len(sourceIDs) == 0 {
+			return nil
+		}
+		stats := make(checks.OverrunStats, len(sourceIDs))
+		for _, sid := range sourceIDs {
+			var totalErrors int64
+			for _, ri := range router.Routes(sid) {
+				totalErrors += ri.Errors
+			}
+			stats[sid] = totalErrors
+		}
+		return stats
+	}
+}
+
+// buildCaptureBufferHealthProvider returns a closure that reads capture buffer
+// utilization from the buffer manager.
+func (c *Controller) buildCaptureBufferHealthProvider() func() []checks.CaptureBufferInfo {
+	return func() []checks.CaptureBufferInfo {
+		eng := c.engine.Load()
+		if eng == nil {
+			return nil
+		}
+		mgr := eng.BufferManager()
+		if mgr == nil {
+			return nil
+		}
+		snapshots := mgr.CaptureBufferHealthAll()
+		if len(snapshots) == 0 {
+			return nil
+		}
+		infos := make([]checks.CaptureBufferInfo, 0, len(snapshots))
+		for _, s := range snapshots {
+			infos = append(infos, checks.CaptureBufferInfo{
+				SourceID:  s.SourceID,
+				Capacity:  s.Capacity,
+				Used:      s.Used,
+				FillRatio: s.FillRatio,
 			})
 		}
 		return infos

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -283,20 +283,41 @@ func (c *Controller) buildDropStatsProvider() func() checks.DropStats {
 }
 
 // buildAudioLevelProvider returns a closure that reads the latest audio level
-// per source from the global audio level manager.
+// per source from the global audio level manager, filtered to active sources.
 func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 	return func() []checks.AudioLevelInfo {
 		levels := LatestAudioLevels()
 		if len(levels) == 0 {
 			return nil
 		}
+
+		// Filter to active sources so removed sources don't produce stale data
+		var activeSources map[string]struct{}
+		if eng := c.engine.Load(); eng != nil {
+			if router := eng.Router(); router != nil {
+				ids := router.ActiveSourceIDs()
+				activeSources = make(map[string]struct{}, len(ids))
+				for _, id := range ids {
+					activeSources[id] = struct{}{}
+				}
+			}
+		}
+
 		infos := make([]checks.AudioLevelInfo, 0, len(levels))
 		for _, l := range levels {
+			if activeSources != nil {
+				if _, ok := activeSources[l.Source]; !ok {
+					continue
+				}
+			}
 			infos = append(infos, checks.AudioLevelInfo{
 				Source:   l.Source,
 				Level:    l.Level,
 				Clipping: l.Clipping,
 			})
+		}
+		if len(infos) == 0 {
+			return nil
 		}
 		return infos
 	}

--- a/internal/audiocore/buffer/capture.go
+++ b/internal/audiocore/buffer/capture.go
@@ -118,13 +118,6 @@ func (cb *CaptureBuffer) Capacity() int {
 	return cb.bufferSize
 }
 
-// UsedBytes returns the number of bytes currently stored in the buffer.
-func (cb *CaptureBuffer) UsedBytes() int {
-	cb.lock.Lock()
-	defer cb.lock.Unlock()
-	return cb.writtenBytes
-}
-
 // Write appends PCM data to the circular buffer. The first call records a
 // wall-clock anchor time for external APIs. The monotonic totalBytesWritten
 // counter is always advanced, providing jitter-free byte offset calculations.

--- a/internal/audiocore/buffer/capture.go
+++ b/internal/audiocore/buffer/capture.go
@@ -111,6 +111,20 @@ func NewCaptureBuffer(durationSeconds, sampleRate, bytesPerSample int, sourceID 
 	}, nil
 }
 
+// Capacity returns the total buffer size in bytes.
+func (cb *CaptureBuffer) Capacity() int {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+	return cb.bufferSize
+}
+
+// UsedBytes returns the number of bytes currently stored in the buffer.
+func (cb *CaptureBuffer) UsedBytes() int {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+	return cb.writtenBytes
+}
+
 // Write appends PCM data to the circular buffer. The first call records a
 // wall-clock anchor time for external APIs. The monotonic totalBytesWritten
 // counter is always advanced, providing jitter-free byte offset calculations.

--- a/internal/audiocore/buffer/capture.go
+++ b/internal/audiocore/buffer/capture.go
@@ -111,11 +111,17 @@ func NewCaptureBuffer(durationSeconds, sampleRate, bytesPerSample int, sourceID 
 	}, nil
 }
 
-// Capacity returns the total buffer size in bytes.
+// Capacity returns the total buffer size in bytes. The value is immutable
+// after construction, so no lock is required.
 func (cb *CaptureBuffer) Capacity() int {
+	return cb.bufferSize
+}
+
+// Initialized reports whether the buffer has received at least one Write.
+func (cb *CaptureBuffer) Initialized() bool {
 	cb.lock.Lock()
 	defer cb.lock.Unlock()
-	return cb.bufferSize
+	return cb.initialized
 }
 
 // Write appends PCM data to the circular buffer. The first call records a

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -244,7 +244,7 @@ func (m *Manager) CaptureBufferHealthAll() []CaptureBufferHealth {
 	infos := make([]CaptureBufferHealth, 0, len(m.captureBuffers))
 	for sourceID, cb := range m.captureBuffers {
 		capacity := cb.Capacity()
-		used := cb.UsedBytes()
+		used := cb.WrittenBytes()
 		var ratio float64
 		if capacity > 0 {
 			ratio = float64(used) / float64(capacity)

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -227,6 +227,38 @@ func (m *Manager) BytePoolFor(size int) *BytePool {
 	return pool
 }
 
+// CaptureBufferHealth holds a snapshot of a single capture buffer's utilization.
+type CaptureBufferHealth struct {
+	SourceID  string
+	Capacity  int
+	Used      int
+	FillRatio float64
+}
+
+// CaptureBufferHealthAll returns utilization snapshots for every allocated
+// capture buffer. The returned slice is safe to read without further locking.
+func (m *Manager) CaptureBufferHealthAll() []CaptureBufferHealth {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	infos := make([]CaptureBufferHealth, 0, len(m.captureBuffers))
+	for sourceID, cb := range m.captureBuffers {
+		capacity := cb.Capacity()
+		used := cb.UsedBytes()
+		var ratio float64
+		if capacity > 0 {
+			ratio = float64(used) / float64(capacity)
+		}
+		infos = append(infos, CaptureBufferHealth{
+			SourceID:  sourceID,
+			Capacity:  capacity,
+			Used:      used,
+			FillRatio: ratio,
+		})
+	}
+	return infos
+}
+
 // Float64PoolFor returns a Float64Pool for the given slice length, creating
 // one lazily if needed. Returns nil for non-positive sizes. Thread-safe via a
 // dedicated mutex.

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -227,15 +227,14 @@ func (m *Manager) BytePoolFor(size int) *BytePool {
 	return pool
 }
 
-// CaptureBufferHealth holds a snapshot of a single capture buffer's utilization.
+// CaptureBufferHealth holds a snapshot of a single capture buffer's status.
 type CaptureBufferHealth struct {
-	SourceID  string
-	Capacity  int
-	Used      int
-	FillRatio float64
+	SourceID    string
+	Capacity    int
+	Initialized bool
 }
 
-// CaptureBufferHealthAll returns utilization snapshots for every allocated
+// CaptureBufferHealthAll returns status snapshots for every allocated
 // capture buffer. The returned slice is safe to read without further locking.
 func (m *Manager) CaptureBufferHealthAll() []CaptureBufferHealth {
 	m.mu.RLock()
@@ -243,17 +242,10 @@ func (m *Manager) CaptureBufferHealthAll() []CaptureBufferHealth {
 
 	infos := make([]CaptureBufferHealth, 0, len(m.captureBuffers))
 	for sourceID, cb := range m.captureBuffers {
-		capacity := cb.Capacity()
-		used := cb.WrittenBytes()
-		var ratio float64
-		if capacity > 0 {
-			ratio = float64(used) / float64(capacity)
-		}
 		infos = append(infos, CaptureBufferHealth{
-			SourceID:  sourceID,
-			Capacity:  capacity,
-			Used:      used,
-			FillRatio: ratio,
+			SourceID:    sourceID,
+			Capacity:    cb.Capacity(),
+			Initialized: cb.Initialized(),
 		})
 	}
 	return infos

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -162,12 +162,18 @@ func (c *PipelineLivenessCheck) Run(_ context.Context) health.Result {
 	}
 }
 
-// BufferDropsCheck monitors audio buffer drop statistics.
-// Metrics are not yet collected; this check always returns StatusSkipped.
-type BufferDropsCheck struct{}
+// DropStats maps source ID to cumulative frame drop count.
+type DropStats map[string]int64
 
-// NewBufferDropsCheck creates a BufferDropsCheck.
-func NewBufferDropsCheck() *BufferDropsCheck { return &BufferDropsCheck{} }
+// BufferDropsCheck monitors audio buffer drop statistics.
+type BufferDropsCheck struct {
+	getDropStats func() DropStats
+}
+
+// NewBufferDropsCheck creates a BufferDropsCheck using the given drop stats provider.
+func NewBufferDropsCheck(getDropStats func() DropStats) *BufferDropsCheck {
+	return &BufferDropsCheck{getDropStats: getDropStats}
+}
 
 // Name returns the check identifier.
 func (c *BufferDropsCheck) Name() string { return "buffer_drops" }
@@ -175,17 +181,45 @@ func (c *BufferDropsCheck) Name() string { return "buffer_drops" }
 // Category returns the audio category.
 func (c *BufferDropsCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run returns StatusSkipped because buffer drop metrics are not yet available.
+// Run evaluates audio buffer drop statistics across all sources.
 func (c *BufferDropsCheck) Run(_ context.Context) health.Result {
-	return skippedResult(c.Name(), c.Category(), time.Now())
+	start := time.Now()
+
+	if c.getDropStats == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	stats := c.getDropStats()
+	if stats == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	return evalCounterStats(c.Name(), c.Category(), stats, &counterStatsConfig{
+		warnThreshold: 1,
+		critThreshold: 101,
+		totalKey:      "total_drops",
+		healthyMsg:    "No buffer drops across %d source(s)",
+		warnMsg:       "Buffer drops detected: %d total across %d source(s)",
+		critMsg:       "High buffer drop rate: %d total drops across %d source(s)",
+	}, start)
+}
+
+// AudioLevelInfo holds audio level data for a single source.
+type AudioLevelInfo struct {
+	Source   string `json:"source"`
+	Level    int    `json:"level"`
+	Clipping bool   `json:"clipping"`
 }
 
 // AudioLevelCheck monitors audio input levels for silence or clipping.
-// Metrics are not yet collected; this check always returns StatusSkipped.
-type AudioLevelCheck struct{}
+type AudioLevelCheck struct {
+	getAudioLevels func() []AudioLevelInfo
+}
 
-// NewAudioLevelCheck creates an AudioLevelCheck.
-func NewAudioLevelCheck() *AudioLevelCheck { return &AudioLevelCheck{} }
+// NewAudioLevelCheck creates an AudioLevelCheck using the given level provider.
+func NewAudioLevelCheck(getAudioLevels func() []AudioLevelInfo) *AudioLevelCheck {
+	return &AudioLevelCheck{getAudioLevels: getAudioLevels}
+}
 
 // Name returns the check identifier.
 func (c *AudioLevelCheck) Name() string { return "audio_level" }
@@ -193,17 +227,72 @@ func (c *AudioLevelCheck) Name() string { return "audio_level" }
 // Category returns the audio category.
 func (c *AudioLevelCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run returns StatusSkipped because audio level metrics are not yet available.
+// Run evaluates audio input levels for silence or clipping.
 func (c *AudioLevelCheck) Run(_ context.Context) health.Result {
-	return skippedResult(c.Name(), c.Category(), time.Now())
+	start := time.Now()
+
+	if c.getAudioLevels == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	levels := c.getAudioLevels()
+	if len(levels) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	silentCount := 0
+	clippingCount := 0
+	for _, l := range levels {
+		if l.Level == 0 {
+			silentCount++
+		}
+		if l.Clipping {
+			clippingCount++
+		}
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Audio levels normal across %d source(s)", len(levels))
+
+	switch {
+	case silentCount == len(levels):
+		status = health.StatusWarning
+		msg = fmt.Sprintf("All %d source(s) reporting silence", len(levels))
+	case clippingCount > 0:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Clipping detected on %d of %d source(s)", clippingCount, len(levels))
+	case silentCount > 0:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Silence detected on %d of %d source(s)", silentCount, len(levels))
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"sources":  len(levels),
+			"silent":   silentCount,
+			"clipping": clippingCount,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
 }
 
-// BufferOverrunCheck monitors the audio capture ring buffer for overrun events.
-// Metrics are not yet collected; this check always returns StatusSkipped.
-type BufferOverrunCheck struct{}
+// OverrunStats maps source ID to cumulative write error count.
+type OverrunStats map[string]int64
 
-// NewBufferOverrunCheck creates a BufferOverrunCheck.
-func NewBufferOverrunCheck() *BufferOverrunCheck { return &BufferOverrunCheck{} }
+// BufferOverrunCheck monitors audio processing overrun events.
+type BufferOverrunCheck struct {
+	getOverrunStats func() OverrunStats
+}
+
+// NewBufferOverrunCheck creates a BufferOverrunCheck using the given overrun stats provider.
+func NewBufferOverrunCheck(getOverrunStats func() OverrunStats) *BufferOverrunCheck {
+	return &BufferOverrunCheck{getOverrunStats: getOverrunStats}
+}
 
 // Name returns the check identifier.
 func (c *BufferOverrunCheck) Name() string { return "buffer_overrun" }
@@ -211,17 +300,46 @@ func (c *BufferOverrunCheck) Name() string { return "buffer_overrun" }
 // Category returns the audio category.
 func (c *BufferOverrunCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run returns StatusSkipped because buffer overrun metrics are not yet available.
+// Run evaluates audio processing overrun statistics across all sources.
 func (c *BufferOverrunCheck) Run(_ context.Context) health.Result {
-	return skippedResult(c.Name(), c.Category(), time.Now())
+	start := time.Now()
+
+	if c.getOverrunStats == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	stats := c.getOverrunStats()
+	if stats == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	return evalCounterStats(c.Name(), c.Category(), stats, &counterStatsConfig{
+		warnThreshold: 1,
+		critThreshold: 51,
+		totalKey:      "total_errors",
+		healthyMsg:    "No buffer overruns across %d source(s)",
+		warnMsg:       "Buffer overruns detected: %d errors across %d source(s)",
+		critMsg:       "High overrun rate: %d errors across %d source(s)",
+	}, start)
 }
 
-// CaptureBufferCheck monitors the health of the audio capture buffer.
-// Metrics are not yet collected; this check always returns StatusSkipped.
-type CaptureBufferCheck struct{}
+// CaptureBufferInfo holds utilization data for a single capture buffer.
+type CaptureBufferInfo struct {
+	SourceID  string  `json:"source_id"`
+	Capacity  int     `json:"capacity"`
+	Used      int     `json:"used"`
+	FillRatio float64 `json:"fill_ratio"`
+}
 
-// NewCaptureBufferCheck creates a CaptureBufferCheck.
-func NewCaptureBufferCheck() *CaptureBufferCheck { return &CaptureBufferCheck{} }
+// CaptureBufferCheck monitors the health of the audio capture buffers.
+type CaptureBufferCheck struct {
+	getBufferHealth func() []CaptureBufferInfo
+}
+
+// NewCaptureBufferCheck creates a CaptureBufferCheck using the given health provider.
+func NewCaptureBufferCheck(getBufferHealth func() []CaptureBufferInfo) *CaptureBufferCheck {
+	return &CaptureBufferCheck{getBufferHealth: getBufferHealth}
+}
 
 // Name returns the check identifier.
 func (c *CaptureBufferCheck) Name() string { return "capture_buffer" }
@@ -229,7 +347,62 @@ func (c *CaptureBufferCheck) Name() string { return "capture_buffer" }
 // Category returns the audio category.
 func (c *CaptureBufferCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run returns StatusSkipped because capture buffer metrics are not yet available.
+// Run evaluates capture buffer utilization across all sources.
 func (c *CaptureBufferCheck) Run(_ context.Context) health.Result {
-	return skippedResult(c.Name(), c.Category(), time.Now())
+	start := time.Now()
+
+	if c.getBufferHealth == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	buffers := c.getBufferHealth()
+	if len(buffers) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	const warnRatio = 0.80
+	const critRatio = 0.95
+
+	warnCount := 0
+	critCount := 0
+	var maxRatio float64
+
+	for _, b := range buffers {
+		if b.FillRatio > maxRatio {
+			maxRatio = b.FillRatio
+		}
+		switch {
+		case b.FillRatio >= critRatio:
+			critCount++
+		case b.FillRatio >= warnRatio:
+			warnCount++
+		}
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Capture buffers healthy across %d source(s) (max fill %.0f%%)", len(buffers), maxRatio*100)
+
+	switch {
+	case critCount > 0:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("%d capture buffer(s) near capacity (>%.0f%% full)", critCount, critRatio*100)
+	case warnCount > 0:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("%d capture buffer(s) above %.0f%% utilization", warnCount, warnRatio*100)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"buffers":    len(buffers),
+			"max_fill":   maxRatio,
+			"warn_count": warnCount,
+			"crit_count": critCount,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
 }

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -323,15 +323,17 @@ func (c *BufferOverrunCheck) Run(_ context.Context) health.Result {
 	}, start)
 }
 
-// CaptureBufferInfo holds utilization data for a single capture buffer.
+// CaptureBufferInfo holds status data for a single capture buffer.
 type CaptureBufferInfo struct {
-	SourceID  string  `json:"source_id"`
-	Capacity  int     `json:"capacity"`
-	Used      int     `json:"used"`
-	FillRatio float64 `json:"fill_ratio"`
+	SourceID    string `json:"source_id"`
+	Capacity    int    `json:"capacity"`
+	Initialized bool   `json:"initialized"`
 }
 
 // CaptureBufferCheck monitors the health of the audio capture buffers.
+// Capture buffers are circular (ring) buffers that are always "full" after
+// warmup, so fill ratio is not a meaningful health metric. Instead, this
+// check verifies that buffers exist and are allocated for all active sources.
 type CaptureBufferCheck struct {
 	getBufferHealth func() []CaptureBufferInfo
 }
@@ -347,7 +349,7 @@ func (c *CaptureBufferCheck) Name() string { return "capture_buffer" }
 // Category returns the audio category.
 func (c *CaptureBufferCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run evaluates capture buffer utilization across all sources.
+// Run verifies that capture buffers are allocated for all active sources.
 func (c *CaptureBufferCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
@@ -360,35 +362,21 @@ func (c *CaptureBufferCheck) Run(_ context.Context) health.Result {
 		return skippedResult(c.Name(), c.Category(), start)
 	}
 
-	const warnRatio = 0.80
-	const critRatio = 0.95
-
-	warnCount := 0
-	critCount := 0
-	var maxRatio float64
-
+	uninitCount := 0
+	var totalCapacity int
 	for _, b := range buffers {
-		if b.FillRatio > maxRatio {
-			maxRatio = b.FillRatio
-		}
-		switch {
-		case b.FillRatio >= critRatio:
-			critCount++
-		case b.FillRatio >= warnRatio:
-			warnCount++
+		totalCapacity += b.Capacity
+		if !b.Initialized {
+			uninitCount++
 		}
 	}
 
 	status := health.StatusHealthy
-	msg := fmt.Sprintf("Capture buffers healthy across %d source(s) (max fill %.0f%%)", len(buffers), maxRatio*100)
+	msg := fmt.Sprintf("%d capture buffer(s) allocated (%d KB total)", len(buffers), totalCapacity/1024)
 
-	switch {
-	case critCount > 0:
-		status = health.StatusCritical
-		msg = fmt.Sprintf("%d capture buffer(s) near capacity (>%.0f%% full)", critCount, critRatio*100)
-	case warnCount > 0:
+	if uninitCount > 0 {
 		status = health.StatusWarning
-		msg = fmt.Sprintf("%d capture buffer(s) above %.0f%% utilization", warnCount, warnRatio*100)
+		msg = fmt.Sprintf("%d of %d capture buffer(s) not yet initialized", uninitCount, len(buffers))
 	}
 
 	return health.Result{
@@ -397,10 +385,9 @@ func (c *CaptureBufferCheck) Run(_ context.Context) health.Result {
 		Status:   status,
 		Message:  msg,
 		Details: map[string]any{
-			"buffers":    len(buffers),
-			"max_fill":   maxRatio,
-			"warn_count": warnCount,
-			"crit_count": critCount,
+			"buffers":        len(buffers),
+			"total_capacity": totalCapacity,
+			"uninitialized":  uninitCount,
 		},
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),

--- a/internal/health/checks/audio_test.go
+++ b/internal/health/checks/audio_test.go
@@ -173,48 +173,37 @@ func TestCaptureBufferCheck_Healthy(t *testing.T) {
 	t.Parallel()
 	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
 		return []CaptureBufferInfo{
-			{SourceID: "src1", Capacity: 1000, Used: 500, FillRatio: 0.50},
+			{SourceID: "src1", Capacity: 96000, Initialized: true},
 		}
 	})
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusHealthy, result.Status)
-	assert.Contains(t, result.Message, "healthy")
+	assert.Contains(t, result.Message, "allocated")
 }
 
-func TestCaptureBufferCheck_Warning(t *testing.T) {
+func TestCaptureBufferCheck_Uninitialized(t *testing.T) {
 	t.Parallel()
 	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
 		return []CaptureBufferInfo{
-			{SourceID: "src1", Capacity: 1000, Used: 850, FillRatio: 0.85},
+			{SourceID: "src1", Capacity: 96000, Initialized: false},
 		}
 	})
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusWarning, result.Status)
-	assert.Contains(t, result.Message, "80%")
-}
-
-func TestCaptureBufferCheck_Critical(t *testing.T) {
-	t.Parallel()
-	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
-		return []CaptureBufferInfo{
-			{SourceID: "src1", Capacity: 1000, Used: 960, FillRatio: 0.96},
-		}
-	})
-	result := check.Run(t.Context())
-	assert.Equal(t, health.StatusCritical, result.Status)
+	assert.Contains(t, result.Message, "not yet initialized")
 }
 
 func TestCaptureBufferCheck_Details(t *testing.T) {
 	t.Parallel()
 	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
 		return []CaptureBufferInfo{
-			{SourceID: "src1", Capacity: 1000, Used: 300, FillRatio: 0.30},
-			{SourceID: "src2", Capacity: 2000, Used: 1800, FillRatio: 0.90},
+			{SourceID: "src1", Capacity: 96000, Initialized: true},
+			{SourceID: "src2", Capacity: 48000, Initialized: true},
 		}
 	})
 	result := check.Run(t.Context())
 	require.NotNil(t, result.Details)
 	assert.Equal(t, 2, result.Details["buffers"])
-	assert.Equal(t, 1, result.Details["warn_count"])
-	assert.Equal(t, 0, result.Details["crit_count"])
+	assert.Equal(t, 144000, result.Details["total_capacity"])
+	assert.Equal(t, 0, result.Details["uninitialized"])
 }

--- a/internal/health/checks/audio_test.go
+++ b/internal/health/checks/audio_test.go
@@ -1,0 +1,220 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+func TestBufferDropsCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewBufferDropsCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "buffer_drops", result.Name)
+}
+
+func TestBufferDropsCheck_NilStats(t *testing.T) {
+	t.Parallel()
+	check := NewBufferDropsCheck(func() DropStats { return nil })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestBufferDropsCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	check := NewBufferDropsCheck(func() DropStats {
+		return DropStats{"src1": 0, "src2": 0}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "No buffer drops")
+}
+
+func TestBufferDropsCheck_Warning(t *testing.T) {
+	t.Parallel()
+	check := NewBufferDropsCheck(func() DropStats {
+		return DropStats{"src1": 5, "src2": 0}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "5 total")
+}
+
+func TestBufferDropsCheck_Critical(t *testing.T) {
+	t.Parallel()
+	check := NewBufferDropsCheck(func() DropStats {
+		return DropStats{"src1": 101}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestAudioLevelCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewAudioLevelCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "audio_level", result.Name)
+}
+
+func TestAudioLevelCheck_Empty(t *testing.T) {
+	t.Parallel()
+	check := NewAudioLevelCheck(func() []AudioLevelInfo { return nil })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestAudioLevelCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	check := NewAudioLevelCheck(func() []AudioLevelInfo {
+		return []AudioLevelInfo{
+			{Source: "src1", Level: 42, Clipping: false},
+			{Source: "src2", Level: 15, Clipping: false},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "normal")
+}
+
+func TestAudioLevelCheck_Silence(t *testing.T) {
+	t.Parallel()
+	check := NewAudioLevelCheck(func() []AudioLevelInfo {
+		return []AudioLevelInfo{
+			{Source: "src1", Level: 0},
+			{Source: "src2", Level: 0},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "silence")
+}
+
+func TestAudioLevelCheck_Clipping(t *testing.T) {
+	t.Parallel()
+	check := NewAudioLevelCheck(func() []AudioLevelInfo {
+		return []AudioLevelInfo{
+			{Source: "src1", Level: 99, Clipping: true},
+			{Source: "src2", Level: 50, Clipping: false},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "Clipping")
+}
+
+func TestAudioLevelCheck_PartialSilence(t *testing.T) {
+	t.Parallel()
+	check := NewAudioLevelCheck(func() []AudioLevelInfo {
+		return []AudioLevelInfo{
+			{Source: "src1", Level: 0},
+			{Source: "src2", Level: 50},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "Silence detected on 1")
+}
+
+func TestBufferOverrunCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewBufferOverrunCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "buffer_overrun", result.Name)
+}
+
+func TestBufferOverrunCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	check := NewBufferOverrunCheck(func() OverrunStats {
+		return OverrunStats{"src1": 0}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+}
+
+func TestBufferOverrunCheck_Warning(t *testing.T) {
+	t.Parallel()
+	check := NewBufferOverrunCheck(func() OverrunStats {
+		return OverrunStats{"src1": 10}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+}
+
+func TestBufferOverrunCheck_Critical(t *testing.T) {
+	t.Parallel()
+	check := NewBufferOverrunCheck(func() OverrunStats {
+		return OverrunStats{"src1": 51}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestCaptureBufferCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewCaptureBufferCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "capture_buffer", result.Name)
+}
+
+func TestCaptureBufferCheck_Empty(t *testing.T) {
+	t.Parallel()
+	check := NewCaptureBufferCheck(func() []CaptureBufferInfo { return nil })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestCaptureBufferCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
+		return []CaptureBufferInfo{
+			{SourceID: "src1", Capacity: 1000, Used: 500, FillRatio: 0.50},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "healthy")
+}
+
+func TestCaptureBufferCheck_Warning(t *testing.T) {
+	t.Parallel()
+	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
+		return []CaptureBufferInfo{
+			{SourceID: "src1", Capacity: 1000, Used: 850, FillRatio: 0.85},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "80%")
+}
+
+func TestCaptureBufferCheck_Critical(t *testing.T) {
+	t.Parallel()
+	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
+		return []CaptureBufferInfo{
+			{SourceID: "src1", Capacity: 1000, Used: 960, FillRatio: 0.96},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestCaptureBufferCheck_Details(t *testing.T) {
+	t.Parallel()
+	check := NewCaptureBufferCheck(func() []CaptureBufferInfo {
+		return []CaptureBufferInfo{
+			{SourceID: "src1", Capacity: 1000, Used: 300, FillRatio: 0.30},
+			{SourceID: "src2", Capacity: 2000, Used: 1800, FillRatio: 0.90},
+		}
+	})
+	result := check.Run(t.Context())
+	require.NotNil(t, result.Details)
+	assert.Equal(t, 2, result.Details["buffers"])
+	assert.Equal(t, 1, result.Details["warn_count"])
+	assert.Equal(t, 0, result.Details["crit_count"])
+}

--- a/internal/health/checks/audio_test.go
+++ b/internal/health/checks/audio_test.go
@@ -119,6 +119,13 @@ func TestAudioLevelCheck_PartialSilence(t *testing.T) {
 	assert.Contains(t, result.Message, "Silence detected on 1")
 }
 
+func TestBufferOverrunCheck_NilStats(t *testing.T) {
+	t.Parallel()
+	check := NewBufferOverrunCheck(func() OverrunStats { return nil })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
 func TestBufferOverrunCheck_NilProvider(t *testing.T) {
 	t.Parallel()
 	check := NewBufferOverrunCheck(nil)

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -1,6 +1,7 @@
 package checks
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
@@ -13,6 +14,56 @@ func skippedResult(name string, category health.Category, start time.Time) healt
 		Category:   category,
 		Status:     health.StatusSkipped,
 		Message:    "Metrics not yet available",
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// counterStatsConfig parameterises evalCounterStats so that structurally
+// identical drop/overrun checks can share one implementation.
+type counterStatsConfig struct {
+	warnThreshold int64
+	critThreshold int64
+	totalKey      string
+	healthyMsg    string // expects %d (sources)
+	warnMsg       string // expects %d (total), %d (sources)
+	critMsg       string // expects %d (total), %d (sources)
+}
+
+// evalCounterStats aggregates per-source int64 counters and returns a Result
+// using the thresholds and message templates in cfg.
+func evalCounterStats(
+	name string, category health.Category,
+	stats map[string]int64, cfg *counterStatsConfig,
+	start time.Time,
+) health.Result {
+	var total int64
+	for _, v := range stats {
+		total += v
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf(cfg.healthyMsg, len(stats))
+
+	switch {
+	case total >= cfg.critThreshold:
+		status = health.StatusCritical
+		msg = fmt.Sprintf(cfg.critMsg, total, len(stats))
+	case total >= cfg.warnThreshold:
+		status = health.StatusWarning
+		msg = fmt.Sprintf(cfg.warnMsg, total, len(stats))
+	}
+
+	return health.Result{
+		Name:     name,
+		Category: category,
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			cfg.totalKey: total,
+			"sources":    len(stats),
+			"per_source": stats,
+		},
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}


### PR DESCRIPTION
## Summary

Replace 4 hardcoded-Skipped audio health checks with real metrics from existing data sources:

- **BufferDropsCheck**: reads `Route.Drops` via AudioRouter per source, warns on any drops, critical above 100
- **AudioLevelCheck**: reads latest audio levels from SSE broadcaster, detects silence and clipping
- **BufferOverrunCheck**: reads `Route.Errors` (write failures) per source, warns on any overruns, critical above 50
- **CaptureBufferCheck**: reads buffer capacity/fill from BufferManager, warns at 80%, critical at 95%

Adds infrastructure:
- `CaptureBuffer.Capacity()` accessor for buffer health
- `Manager.CaptureBufferHealthAll()` for aggregate capture buffer stats
- `LatestAudioLevels()` on audio level manager for health check access
- `evalCounterStats` shared helper to eliminate duplication between drop/overrun checks
- Active-source filtering so removed sources don't produce stale health data
- Cleanup of latest levels map on broadcaster shutdown

All closures are nil-safe and return StatusSkipped before the engine starts.

## Test Plan

- [x] 25 unit tests covering nil provider, nil stats, healthy, warning, critical for all 4 checks
- [x] `go test -race` passes
- [x] `golangci-lint run -v` zero issues
- [x] Full project `go build ./...` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio health diagnostics now provide real-time snapshots of per-source audio levels, buffer-drop and overrun metrics, and capture-buffer capacity/initialization info; audio-level snapshots are kept current to avoid stale health data.
  * Health checks are provider-driven and return concrete healthy/warning/critical statuses with summarized details when data is present; they skip only when no data is available.

* **Tests**
  * Added comprehensive tests validating health-check behaviors, status mappings, and user-facing messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->