### PR TITLE
feat(health): wire network health checks to real data sources

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1422,8 +1422,11 @@ func (p *AudioPipelineService) startWeatherPolling(metrics *observability.Metric
 		return
 	}
 
+	weather.RegisterService(weatherService)
+
 	p.wg.Go(func() {
 		weatherService.StartPolling(p.done)
+		weather.UnregisterService()
 	})
 }
 

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -226,7 +226,7 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewWeatherCheck(
 			func() bool {
 				p := c.currentSettings().Realtime.Weather.Provider
-				return p != "" && p != string(conf.WeatherNone)
+				return p != string(conf.WeatherNone)
 			},
 			weather.GetStatus,
 		),

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -18,7 +19,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/health/checks"
 	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/privacy"
+	"github.com/tphakala/birdnet-go/internal/weather"
 )
 
 // diagnosticsStatusResponse is the quick health summary returned by GET /status.
@@ -184,13 +187,49 @@ func (c *Controller) registerHealthChecks() {
 		),
 		checks.NewBirdWeatherCheck(
 			func() bool { return c.currentSettings().Realtime.Birdweather.Enabled },
-			nil, // TODO: wire actual BirdWeather status
+			func() (bool, string) {
+				proc := c.Processor
+				if proc == nil {
+					return false, "Processor unavailable"
+				}
+				bw := proc.GetBwClient()
+				if bw == nil {
+					return false, "BirdWeather client not initialized"
+				}
+				return bw.Status()
+			},
 		),
-		checks.NewNotificationProvidersCheck(),
-		checks.NewWeatherCheck(func() bool {
-			p := c.currentSettings().Realtime.Weather.Provider
-			return p != "" && p != string(conf.WeatherNone)
+		checks.NewNotificationProvidersCheck(func() (int, int, string) {
+			providers := notification.GetAllPushProviderHealth()
+			if len(providers) == 0 {
+				return 0, 0, ""
+			}
+			total := len(providers)
+			healthy := 0
+			for i := range providers {
+				if providers[i].Healthy {
+					healthy++
+				}
+			}
+			unhealthy := total - healthy
+			var msg string
+			switch unhealthy {
+			case 0:
+				msg = fmt.Sprintf("All %d providers healthy", total)
+			case total:
+				msg = fmt.Sprintf("All %d providers failing", total)
+			default:
+				msg = fmt.Sprintf("%d of %d providers unhealthy", unhealthy, total)
+			}
+			return total, healthy, msg
 		}),
+		checks.NewWeatherCheck(
+			func() bool {
+				p := c.currentSettings().Realtime.Weather.Provider
+				return p != "" && p != string(conf.WeatherNone)
+			},
+			weather.GetStatus,
+		),
 
 		// Config checks
 		checks.NewPathAccessCheck(map[string]string{

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -160,6 +160,26 @@ func closeResponseBody(resp *http.Response) {
 	}
 }
 
+// Status reports the health of the BirdWeather client by inspecting the
+// circuit breaker state. Returns (connected, statusMessage).
+func (b *BwClient) Status() (connected bool, msg string) {
+	if b.circuitBreaker == nil {
+		return true, "BirdWeather API connected (no circuit breaker)"
+	}
+
+	state := b.circuitBreaker.EffectiveState()
+	failures := b.circuitBreaker.Failures()
+
+	switch state {
+	case notification.StateOpen:
+		return false, fmt.Sprintf("BirdWeather API disconnected (circuit open, %d failures)", failures)
+	case notification.StateHalfOpen:
+		return false, "BirdWeather API recovering (half-open)"
+	default:
+		return true, "BirdWeather API connected"
+	}
+}
+
 // BirdweatherClientInterface defines what methods a BirdweatherClient must have
 type Interface interface {
 	Publish(note *datastore.Note, pcmData []byte) error

--- a/internal/birdweather/circuit_breaker_test.go
+++ b/internal/birdweather/circuit_breaker_test.go
@@ -240,3 +240,83 @@ func TestBwClient_CircuitBreaker_NotFoundDoesNotTrip(t *testing.T) {
 	assert.Equal(t, notification.StateClosed, client.CircuitBreakerState(),
 		"CategoryNotFound (species validation) must not trip the circuit breaker")
 }
+
+// TestBwClient_Status verifies the Status method maps circuit breaker states
+// to the expected (connected, message) pairs used by health checks.
+func TestBwClient_Status(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cbState       notification.CircuitState
+		failures      int
+		wantConnected bool
+		wantContains  string
+	}{
+		{
+			name:          "closed circuit reports connected",
+			cbState:       notification.StateClosed,
+			failures:      0,
+			wantConnected: true,
+			wantContains:  "connected",
+		},
+		{
+			name:          "open circuit reports disconnected",
+			cbState:       notification.StateOpen,
+			failures:      5,
+			wantConnected: false,
+			wantContains:  "circuit open",
+		},
+		{
+			name:          "half-open circuit reports recovering",
+			cbState:       notification.StateHalfOpen,
+			failures:      0,
+			wantConnected: false,
+			wantContains:  "recovering",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+
+			cfg := newCBTestConfig()
+			client := newCBTestClient(t, server, cfg)
+
+			// Drive circuit breaker to desired state via failures.
+			if tt.cbState == notification.StateOpen || tt.cbState == notification.StateHalfOpen {
+				for range cfg.MaxFailures {
+					_ = client.PostDetection("1", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+				}
+				// One more to trigger the open state.
+				_ = client.PostDetection("1", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+				assert.Equal(t, notification.StateOpen, client.CircuitBreakerState())
+
+				if tt.cbState == notification.StateHalfOpen {
+					time.Sleep(cfg.Timeout + 10*time.Millisecond)
+				}
+			}
+
+			connected, msg := client.Status()
+			assert.Equal(t, tt.wantConnected, connected)
+			assert.Contains(t, msg, tt.wantContains)
+		})
+	}
+}
+
+// TestBwClient_Status_NilCircuitBreaker ensures Status() handles a nil
+// circuit breaker (legacy test construction paths) gracefully.
+func TestBwClient_Status_NilCircuitBreaker(t *testing.T) {
+	t.Parallel()
+
+	client := &BwClient{}
+	connected, msg := client.Status()
+
+	assert.True(t, connected)
+	assert.Contains(t, msg, "no circuit breaker")
+}

--- a/internal/health/checks/network.go
+++ b/internal/health/checks/network.go
@@ -131,13 +131,17 @@ func (c *BirdWeatherCheck) Run(_ context.Context) health.Result {
 	}
 }
 
-// NotificationProvidersCheck reports the connectivity state of configured notification providers.
-// Probe infrastructure is not yet available; this check always returns StatusSkipped.
-type NotificationProvidersCheck struct{}
+// NotificationProvidersCheck reports the connectivity state of configured
+// notification providers. The getHealth closure returns (total, healthy, summaryMsg)
+// aggregated from the push dispatcher's health checker.
+type NotificationProvidersCheck struct {
+	getHealth func() (total, healthy int, summaryMsg string)
+}
 
 // NewNotificationProvidersCheck creates a NotificationProvidersCheck.
-func NewNotificationProvidersCheck() *NotificationProvidersCheck {
-	return &NotificationProvidersCheck{}
+// getHealth returns (total, healthy, summaryMsg); nil means health data unavailable.
+func NewNotificationProvidersCheck(getHealth func() (total, healthy int, summaryMsg string)) *NotificationProvidersCheck {
+	return &NotificationProvidersCheck{getHealth: getHealth}
 }
 
 // Name returns the check identifier.
@@ -146,20 +150,62 @@ func (c *NotificationProvidersCheck) Name() string { return "notification_provid
 // Category returns the network category.
 func (c *NotificationProvidersCheck) Category() health.Category { return health.CategoryNetwork }
 
-// Run returns StatusSkipped because notification probe infrastructure is not yet available.
+// Run evaluates notification provider health. Returns Skipped when no providers
+// are configured, Healthy when all providers are OK, Warning when some fail,
+// and Critical when all fail.
 func (c *NotificationProvidersCheck) Run(_ context.Context) health.Result {
-	return skippedResult(c.Name(), c.Category(), time.Now())
+	start := time.Now()
+
+	if c.getHealth == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	total, healthy, summaryMsg := c.getHealth()
+	if total == 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "No notification providers configured",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	unhealthy := total - healthy
+	status := health.StatusHealthy
+	switch {
+	case unhealthy == total:
+		status = health.StatusCritical
+	case unhealthy > 0:
+		status = health.StatusWarning
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  summaryMsg,
+		Details: map[string]any{
+			"total":     total,
+			"healthy":   healthy,
+			"unhealthy": unhealthy,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
 }
 
 // WeatherCheck verifies connectivity to the configured weather provider.
-// Probe infrastructure is not yet available; enabled instances return StatusSkipped.
 type WeatherCheck struct {
 	isEnabled func() bool
+	getStatus func() (bool, string)
 }
 
-// NewWeatherCheck creates a WeatherCheck using the given enable predicate.
-func NewWeatherCheck(isEnabled func() bool) *WeatherCheck {
-	return &WeatherCheck{isEnabled: isEnabled}
+// NewWeatherCheck creates a WeatherCheck using the given enable predicate and
+// status provider. getStatus must return (ok, statusMessage).
+func NewWeatherCheck(isEnabled func() bool, getStatus func() (bool, string)) *WeatherCheck {
+	return &WeatherCheck{isEnabled: isEnabled, getStatus: getStatus}
 }
 
 // Name returns the check identifier.
@@ -168,7 +214,7 @@ func (c *WeatherCheck) Name() string { return "weather" }
 // Category returns the network category.
 func (c *WeatherCheck) Category() health.Category { return health.CategoryNetwork }
 
-// Run returns StatusSkipped when disabled, or StatusSkipped with a not-yet-available message when enabled.
+// Run verifies weather provider connectivity when the integration is enabled.
 func (c *WeatherCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
@@ -187,11 +233,21 @@ func (c *WeatherCheck) Run(_ context.Context) health.Result {
 		}
 	}
 
+	if c.getStatus == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	ok, statusMsg := c.getStatus()
+	status := health.StatusHealthy
+	if !ok {
+		status = health.StatusWarning
+	}
+
 	return health.Result{
 		Name:       c.Name(),
 		Category:   c.Category(),
-		Status:     health.StatusSkipped,
-		Message:    "Probe infrastructure not yet available",
+		Status:     status,
+		Message:    statusMsg,
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}

--- a/internal/health/checks/network_test.go
+++ b/internal/health/checks/network_test.go
@@ -1,0 +1,149 @@
+package checks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+func TestBirdWeatherCheck_NilGetStatus(t *testing.T) {
+	t.Parallel()
+	check := NewBirdWeatherCheck(func() bool { return true }, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestBirdWeatherCheck_Disabled(t *testing.T) {
+	t.Parallel()
+	check := NewBirdWeatherCheck(func() bool { return false }, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Contains(t, result.Message, "disabled")
+}
+
+func TestBirdWeatherCheck_Connected(t *testing.T) {
+	t.Parallel()
+	check := NewBirdWeatherCheck(
+		func() bool { return true },
+		func() (bool, string) { return true, "BirdWeather API connected" },
+	)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+}
+
+func TestBirdWeatherCheck_Disconnected(t *testing.T) {
+	t.Parallel()
+	check := NewBirdWeatherCheck(
+		func() bool { return true },
+		func() (bool, string) { return false, "circuit open" },
+	)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+}
+
+func TestMQTTCheck_NilEnabled(t *testing.T) {
+	t.Parallel()
+	check := NewMQTTCheck(nil, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestMQTTCheck_Connected(t *testing.T) {
+	t.Parallel()
+	check := NewMQTTCheck(func() bool { return true }, func() bool { return true })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+}
+
+func TestNotificationProvidersCheck_NilClosure(t *testing.T) {
+	t.Parallel()
+	check := NewNotificationProvidersCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestNotificationProvidersCheck_NoProviders(t *testing.T) {
+	t.Parallel()
+	check := NewNotificationProvidersCheck(func() (int, int, string) {
+		return 0, 0, ""
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Contains(t, result.Message, "No notification providers")
+}
+
+func TestNotificationProvidersCheck_AllHealthy(t *testing.T) {
+	t.Parallel()
+	check := NewNotificationProvidersCheck(func() (int, int, string) {
+		return 3, 3, "All 3 providers healthy"
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "All 3 providers healthy")
+}
+
+func TestNotificationProvidersCheck_SomeFailing(t *testing.T) {
+	t.Parallel()
+	check := NewNotificationProvidersCheck(func() (int, int, string) {
+		return 3, 1, "2 of 3 providers unhealthy"
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+}
+
+func TestNotificationProvidersCheck_AllFailing(t *testing.T) {
+	t.Parallel()
+	check := NewNotificationProvidersCheck(func() (int, int, string) {
+		return 2, 0, "All 2 providers failing"
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestWeatherCheck_NilEnabled(t *testing.T) {
+	t.Parallel()
+	check := NewWeatherCheck(nil, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestWeatherCheck_Disabled(t *testing.T) {
+	t.Parallel()
+	check := NewWeatherCheck(func() bool { return false }, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Contains(t, result.Message, "disabled")
+}
+
+func TestWeatherCheck_NilGetStatus(t *testing.T) {
+	t.Parallel()
+	check := NewWeatherCheck(func() bool { return true }, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestWeatherCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	check := NewWeatherCheck(
+		func() bool { return true },
+		func() (bool, string) { return true, "Weather provider yrno healthy" },
+	)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "healthy")
+}
+
+func TestWeatherCheck_Degraded(t *testing.T) {
+	t.Parallel()
+	check := NewWeatherCheck(
+		func() bool { return true },
+		func() (bool, string) {
+			return false, fmt.Sprintf("Weather provider yrno backing off (%d failures)", 3)
+		},
+	)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "backing off")
+}

--- a/internal/notification/circuit_breaker.go
+++ b/internal/notification/circuit_breaker.go
@@ -338,6 +338,21 @@ func (cb *PushCircuitBreaker) State() CircuitState {
 	return cb.state
 }
 
+// EffectiveState returns the state that the next call would see. When the
+// breaker is Open and the timeout has elapsed, the next beforeCall() would
+// transition to HalfOpen, so this reports StateHalfOpen proactively. This
+// is useful for health checks that need to report the current readiness
+// without triggering an actual state transition.
+func (cb *PushCircuitBreaker) EffectiveState() CircuitState {
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+
+	if cb.state == StateOpen && time.Since(cb.lastStateChange) >= cb.config.Timeout {
+		return StateHalfOpen
+	}
+	return cb.state
+}
+
 // Failures returns the current number of consecutive failures.
 func (cb *PushCircuitBreaker) Failures() int {
 	cb.mu.RLock()

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -313,6 +313,20 @@ func (d *pushDispatcher) startHealthChecker(ctx context.Context) {
 	}
 }
 
+// GetAllPushProviderHealth returns health status for all registered push
+// notification providers. Returns nil when the push dispatcher or its health
+// checker has not been initialized.
+func GetAllPushProviderHealth() []ProviderHealth {
+	dispatcherMu.Lock()
+	pd := globalPushDispatcher
+	dispatcherMu.Unlock()
+
+	if pd == nil || pd.healthChecker == nil {
+		return nil
+	}
+	return pd.healthChecker.GetAllProviderHealth()
+}
+
 func (d *pushDispatcher) dispatch(ctx context.Context, notif *Notification) {
 	if notif.DeliveryTarget == DeliveryTargetBell {
 		d.log.Debug("skipping bell-only notification in push dispatch",

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -1345,3 +1345,57 @@ func TestPushDispatcher_ForwardsNoTargetNotification(t *testing.T) {
 		require.Fail(t, "no-target notification should reach push provider (backwards compat)")
 	}
 }
+
+func TestGetAllPushProviderHealth_NilDispatcher(t *testing.T) {
+	dispatcherMu.Lock()
+	saved := globalPushDispatcher
+	globalPushDispatcher = nil
+	dispatcherMu.Unlock()
+	t.Cleanup(func() {
+		dispatcherMu.Lock()
+		globalPushDispatcher = saved
+		dispatcherMu.Unlock()
+	})
+
+	result := GetAllPushProviderHealth()
+	assert.Nil(t, result)
+}
+
+func TestGetAllPushProviderHealth_NilHealthChecker(t *testing.T) {
+	pd := &pushDispatcher{healthChecker: nil}
+
+	dispatcherMu.Lock()
+	saved := globalPushDispatcher
+	globalPushDispatcher = pd
+	dispatcherMu.Unlock()
+	t.Cleanup(func() {
+		dispatcherMu.Lock()
+		globalPushDispatcher = saved
+		dispatcherMu.Unlock()
+	})
+
+	result := GetAllPushProviderHealth()
+	assert.Nil(t, result)
+}
+
+func TestGetAllPushProviderHealth_WithProviders(t *testing.T) {
+	hc := NewHealthChecker(DefaultHealthCheckConfig(), nil, nil)
+	fp := newFakeProvider("test-push", true)
+	hc.RegisterProvider(fp, nil)
+
+	pd := &pushDispatcher{healthChecker: hc}
+
+	dispatcherMu.Lock()
+	saved := globalPushDispatcher
+	globalPushDispatcher = pd
+	dispatcherMu.Unlock()
+	t.Cleanup(func() {
+		dispatcherMu.Lock()
+		globalPushDispatcher = saved
+		dispatcherMu.Unlock()
+	})
+
+	result := GetAllPushProviderHealth()
+	require.Len(t, result, 1)
+	assert.Equal(t, "test-push", result[0].ProviderName)
+}

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -13,6 +13,40 @@ import (
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
+var (
+	globalServiceMu sync.RWMutex
+	globalService   *Service
+)
+
+// RegisterService stores the weather service instance for package-level access.
+// Called during audio pipeline startup.
+func RegisterService(s *Service) {
+	globalServiceMu.Lock()
+	globalService = s
+	globalServiceMu.Unlock()
+}
+
+// UnregisterService clears the stored weather service instance.
+func UnregisterService() {
+	globalServiceMu.Lock()
+	globalService = nil
+	globalServiceMu.Unlock()
+}
+
+// GetStatus returns the health status of the weather service. Returns
+// (ok, message) suitable for health check consumption. Returns (true, "not started")
+// when no service has been registered.
+func GetStatus() (ok bool, msg string) {
+	globalServiceMu.RLock()
+	svc := globalService
+	globalServiceMu.RUnlock()
+
+	if svc == nil {
+		return true, "Weather service not started"
+	}
+	return svc.Status()
+}
+
 // getLogger returns the weather service logger.
 // Fetched dynamically to ensure it uses the current centralized logger.
 func getLogger() logger.Logger {
@@ -565,4 +599,28 @@ func (s *Service) fetchAndSave() error {
 
 	// Errors logged within SaveWeatherData
 	return s.SaveWeatherData(data)
+}
+
+// Status reports the health of the weather service by inspecting backoff state.
+// Returns (ok, statusMessage).
+func (s *Service) Status() (ok bool, msg string) {
+	s.backoff.mu.Lock()
+	authDisabled := s.backoff.authDisabled
+	failures := s.backoff.consecutiveFailures
+	inBackoff := !s.backoff.nextAllowedFetchTime.IsZero() && time.Now().Before(s.backoff.nextAllowedFetchTime)
+	s.backoff.mu.Unlock()
+
+	if authDisabled {
+		return false, fmt.Sprintf("Weather provider %s auth disabled", s.providerName)
+	}
+
+	if inBackoff {
+		return false, fmt.Sprintf("Weather provider %s backing off (%d failures)", s.providerName, failures)
+	}
+
+	if failures > 0 {
+		return false, fmt.Sprintf("Weather provider %s degraded (%d failures)", s.providerName, failures)
+	}
+
+	return true, fmt.Sprintf("Weather provider %s healthy", s.providerName)
 }

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -42,7 +42,7 @@ func GetStatus() (ok bool, msg string) {
 	globalServiceMu.RUnlock()
 
 	if svc == nil {
-		return true, "Weather service not started"
+		return false, "Weather service not started"
 	}
 	return svc.Status()
 }

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1415,7 +1415,7 @@ func TestGetStatus_NoService(t *testing.T) {
 	})
 
 	ok, msg := GetStatus()
-	assert.True(t, ok)
+	assert.False(t, ok)
 	assert.Contains(t, msg, "not started")
 }
 
@@ -1439,6 +1439,6 @@ func TestRegisterUnregisterService(t *testing.T) {
 	UnregisterService()
 
 	ok, msg = GetStatus()
-	assert.True(t, ok)
+	assert.False(t, ok)
 	assert.Contains(t, msg, "not started")
 }

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1366,3 +1366,79 @@ func TestWundergroundProvider_HTTP401_AuthFailed(t *testing.T) {
 	assert.ErrorIs(t, err, ErrWeatherAuthFailed,
 		"HTTP 401 should return ErrWeatherAuthFailed sentinel")
 }
+
+func TestService_Status_Healthy(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{providerName: "yrno"}
+	ok, msg := svc.Status()
+	assert.True(t, ok)
+	assert.Contains(t, msg, "healthy")
+	assert.Contains(t, msg, "yrno")
+}
+
+func TestService_Status_Backoff(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{providerName: "openweather"}
+	svc.backoff.recordFailure()
+	svc.backoff.recordFailure()
+
+	ok, msg := svc.Status()
+	assert.False(t, ok)
+	assert.Contains(t, msg, "backing off")
+	assert.Contains(t, msg, "2 failures")
+}
+
+func TestService_Status_AuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{providerName: "openweather"}
+	svc.backoff.mu.Lock()
+	svc.backoff.authDisabled = true
+	svc.backoff.mu.Unlock()
+
+	ok, msg := svc.Status()
+	assert.False(t, ok)
+	assert.Contains(t, msg, "auth disabled")
+}
+
+func TestGetStatus_NoService(t *testing.T) {
+	globalServiceMu.Lock()
+	saved := globalService
+	globalService = nil
+	globalServiceMu.Unlock()
+	t.Cleanup(func() {
+		globalServiceMu.Lock()
+		globalService = saved
+		globalServiceMu.Unlock()
+	})
+
+	ok, msg := GetStatus()
+	assert.True(t, ok)
+	assert.Contains(t, msg, "not started")
+}
+
+func TestRegisterUnregisterService(t *testing.T) {
+	globalServiceMu.Lock()
+	saved := globalService
+	globalServiceMu.Unlock()
+	t.Cleanup(func() {
+		globalServiceMu.Lock()
+		globalService = saved
+		globalServiceMu.Unlock()
+	})
+
+	svc := &Service{providerName: "test-provider"}
+	RegisterService(svc)
+
+	ok, msg := GetStatus()
+	assert.True(t, ok)
+	assert.Contains(t, msg, "test-provider")
+
+	UnregisterService()
+
+	ok, msg = GetStatus()
+	assert.True(t, ok)
+	assert.Contains(t, msg, "not started")
+}


### PR DESCRIPTION
## Summary

Wire 3 network health checks that previously returned "Skipped" to real runtime data sources, completing the second phase of the health check metrics gap closure effort (Forgejo #694).

- **BirdWeather**: reads circuit breaker state via new `EffectiveState()` method that accounts for lazy Open-to-HalfOpen transitions
- **Notification providers**: exposes push dispatcher health checker via new `GetAllPushProviderHealth()` package-level function, aggregates per-provider health into total/healthy/unhealthy counts
- **Weather**: adds `Status()` method reading backoff state (failures, auth disabled) and package-level `RegisterService`/`UnregisterService` for health check access

All checks use the same closure-injection pattern established in #3185 (audio pipeline checks).

### Changes
- `internal/birdweather/birdweather_client.go`: Add `BwClient.Status()` method
- `internal/notification/circuit_breaker.go`: Add `PushCircuitBreaker.EffectiveState()` for timeout-aware reads
- `internal/notification/push_dispatcher.go`: Add `GetAllPushProviderHealth()` accessor
- `internal/weather/weather.go`: Add `Service.Status()`, `RegisterService`/`UnregisterService`
- `internal/health/checks/network.go`: Refactor `NotificationProvidersCheck` and `WeatherCheck` to accept closures
- `internal/api/v2/diagnostics.go`: Wire all 3 closures
- `internal/analysis/audio_pipeline_service.go`: Register weather service during startup

## Test plan
- [x] Unit tests for `BwClient.Status()` covering closed/open/half-open/nil circuit breaker states
- [x] Unit tests for `GetAllPushProviderHealth()` covering nil dispatcher, nil health checker, with providers
- [x] Unit tests for `weather.Service.Status()` covering healthy, backoff, auth disabled states
- [x] Unit tests for `weather.GetStatus()` and `RegisterService`/`UnregisterService`
- [x] Unit tests for refactored `NotificationProvidersCheck` and `WeatherCheck` (all status paths)
- [x] All tests pass with `-race` flag
- [x] `golangci-lint run -v` passes with zero issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved diagnostics: more detailed health/status reporting for BirdWeather, weather, and push notification providers
  * Weather service exposes global status (includes backoff and auth-state visibility)
  * Push provider health enumeration available for diagnostics

* **Tests**
  * Added extensive unit tests covering health checks, client/circuit-breaker status, and weather/push behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->