### PR TITLE
feat(health): make model and inference checks multi-model aware

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -94,38 +94,9 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewBufferOverrunCheck(c.buildOverrunStatsProvider()),
 		checks.NewCaptureBufferCheck(c.buildCaptureBufferHealthProvider()),
 
-		// Analysis checks
-		checks.NewModelLoadedCheck(
-			func() bool { return true },
-			func() string { return c.currentSettings().BirdNET.ModelPath },
-		),
-		checks.NewInferenceLatencyCheck(func() (avgMS, p99MS, windowMS float64) {
-			counters := classifier.GetInferenceCounters()
-			snapshots := counters.PeekAll()
-			if len(snapshots) == 0 {
-				return 0, 0, 0
-			}
-			var totalUs, maxUs, count int64
-			for _, s := range snapshots {
-				totalUs += s.InvokeTotalUs
-				count += s.InvokeCount
-				if s.InvokeMaxUs > maxUs {
-					maxUs = s.InvokeMaxUs
-				}
-			}
-			if count == 0 {
-				return 0, 0, 0
-			}
-			avgMS = float64(totalUs) / float64(count) / 1000.0
-			// max used as p99 approximation; true p99 requires histogram data
-			p99MS = float64(maxUs) / 1000.0
-			stride := 3.0 - c.currentSettings().BirdNET.Overlap
-			if stride <= 0 {
-				stride = 3.0
-			}
-			windowMS = stride * 1000.0
-			return avgMS, p99MS, windowMS
-		}),
+		// Analysis checks (multi-model aware)
+		checks.NewModelsLoadedCheck(c.buildModelLoadInfoProvider()),
+		checks.NewPerModelInferenceLatencyCheck(c.buildPerModelInferenceProvider()),
 		checks.NewDetectionRateCheck(func(ctx context.Context, hours int) (int, error) {
 			ds := c.DS
 			if ds == nil {
@@ -246,6 +217,84 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewErrorTrendCheck(c.healthErrors),
 		checks.NewCriticalEventsCheck(c.healthErrors),
 	)
+}
+
+// buildModelLoadInfoProvider returns a closure that queries the orchestrator for
+// all loaded models and converts them to the health check's ModelLoadInfo format.
+func (c *Controller) buildModelLoadInfoProvider() func() []checks.ModelLoadInfo {
+	return func() []checks.ModelLoadInfo {
+		p := c.Processor
+		if p == nil {
+			return nil
+		}
+		bn := p.GetBirdNET()
+		if bn == nil {
+			return nil
+		}
+		infos := bn.ModelInfos()
+		result := make([]checks.ModelLoadInfo, 0, len(infos))
+		for i := range infos {
+			m := &infos[i]
+			result = append(result, checks.ModelLoadInfo{
+				ID:      m.ID,
+				Name:    m.DisplayName(),
+				Loaded:  true,
+				Backend: m.Backend,
+				SpecInfo: fmt.Sprintf("%dkHz, %ss clips",
+					m.Spec.SampleRate/1000,
+					strconv.FormatFloat(m.Spec.ClipLength.Seconds(), 'f', -1, 64)),
+			})
+		}
+		return result
+	}
+}
+
+// buildPerModelInferenceProvider returns a closure that queries per-model
+// inference counters and model specs to produce per-model latency stats.
+// Each model's analysis window is derived from its own BufferInterval
+// (ClipLength / 2), not from a global setting.
+func (c *Controller) buildPerModelInferenceProvider() func() []checks.ModelInferenceInfo {
+	return func() []checks.ModelInferenceInfo {
+		p := c.Processor
+		if p == nil {
+			return nil
+		}
+		bn := p.GetBirdNET()
+		if bn == nil {
+			return nil
+		}
+		counters := classifier.GetInferenceCounters()
+		snapshots := counters.PeekAll()
+		if len(snapshots) == 0 {
+			return nil
+		}
+		infos := bn.ModelInfos()
+		infoMap := make(map[string]*classifier.ModelInfo, len(infos))
+		for i := range infos {
+			infoMap[infos[i].ID] = &infos[i]
+		}
+		result := make([]checks.ModelInferenceInfo, 0, len(snapshots))
+		for modelID, s := range snapshots {
+			mi, ok := infoMap[modelID]
+			if !ok {
+				continue
+			}
+			var avgMS, p99MS float64
+			if s.InvokeCount > 0 {
+				avgMS = float64(s.InvokeTotalUs) / float64(s.InvokeCount) / 1000.0
+			}
+			p99MS = float64(s.InvokeMaxUs) / 1000.0
+			windowMS := float64(mi.Spec.BufferInterval().Milliseconds())
+			result = append(result, checks.ModelInferenceInfo{
+				ModelID:   modelID,
+				ModelName: mi.DisplayName(),
+				AvgMS:     avgMS,
+				P99MS:     p99MS,
+				WindowMS:  windowMS,
+			})
+		}
+		return result
+	}
 }
 
 // errNoTempSensors is returned when no temperature sensors are found on the system.

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -57,18 +57,28 @@ type Check interface {
 	Run(ctx context.Context) Result
 }
 
+// MultiResultCheck is implemented by checks that produce multiple results
+// at run time, such as per-model health checks. The registry detects this
+// interface and calls RunMulti instead of Run when present.
+type MultiResultCheck interface {
+	Check
+	RunMulti(ctx context.Context) []Result
+}
+
 // WorstStatus returns the most severe status from a slice of results.
 func WorstStatus(results []Result) Status {
 	worst := StatusHealthy
 	for _, r := range results {
-		if severity(r.Status) > severity(worst) {
+		if Severity(r.Status) > Severity(worst) {
 			worst = r.Status
 		}
 	}
 	return worst
 }
 
-func severity(s Status) int {
+// Severity returns the numeric severity of a status for comparison.
+// Higher values indicate more severe conditions.
+func Severity(s Status) int {
 	switch s {
 	case StatusHealthy:
 		return 0

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -79,16 +79,16 @@ func TestWorstStatus_MixedStatuses(t *testing.T) {
 func TestSeverityOrdering(t *testing.T) {
 	t.Parallel()
 	// Verify the ordering: healthy < skipped == unknown < warning < critical
-	assert.Less(t, severity(StatusHealthy), severity(StatusSkipped))
-	assert.Less(t, severity(StatusHealthy), severity(StatusUnknown))
-	assert.Equal(t, severity(StatusSkipped), severity(StatusUnknown))
-	assert.Less(t, severity(StatusSkipped), severity(StatusWarning))
-	assert.Less(t, severity(StatusUnknown), severity(StatusWarning))
-	assert.Less(t, severity(StatusWarning), severity(StatusCritical))
+	assert.Less(t, Severity(StatusHealthy), Severity(StatusSkipped))
+	assert.Less(t, Severity(StatusHealthy), Severity(StatusUnknown))
+	assert.Equal(t, Severity(StatusSkipped), Severity(StatusUnknown))
+	assert.Less(t, Severity(StatusSkipped), Severity(StatusWarning))
+	assert.Less(t, Severity(StatusUnknown), Severity(StatusWarning))
+	assert.Less(t, Severity(StatusWarning), Severity(StatusCritical))
 }
 
 func TestSeverityUnknownStatus(t *testing.T) {
 	t.Parallel()
 	// An unrecognised status string should map to severity 0 (same as healthy)
-	assert.Equal(t, severity(StatusHealthy), severity(Status("bogus")))
+	assert.Equal(t, Severity(StatusHealthy), Severity(Status("bogus")))
 }

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -9,127 +9,188 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health"
 )
 
-// ModelLoadedCheck verifies that the BirdNET analysis model is loaded and ready.
-type ModelLoadedCheck struct {
-	isLoaded  func() bool
-	modelName func() string
+// ModelLoadInfo describes a loaded model for health reporting.
+type ModelLoadInfo struct {
+	ID       string
+	Name     string
+	Loaded   bool
+	Backend  string
+	SpecInfo string // e.g. "48kHz, 3s clips"
 }
 
-// NewModelLoadedCheck creates a ModelLoadedCheck using the given predicate and name provider.
-func NewModelLoadedCheck(isLoaded func() bool, modelName func() string) *ModelLoadedCheck {
-	return &ModelLoadedCheck{isLoaded: isLoaded, modelName: modelName}
+// ModelsLoadedCheck verifies that all analysis models are loaded and ready.
+// Implements MultiResultCheck to produce one result per model.
+type ModelsLoadedCheck struct {
+	getModels func() []ModelLoadInfo
+}
+
+// NewModelsLoadedCheck creates a ModelsLoadedCheck using the given model provider.
+func NewModelsLoadedCheck(getModels func() []ModelLoadInfo) *ModelsLoadedCheck {
+	return &ModelsLoadedCheck{getModels: getModels}
 }
 
 // Name returns the check identifier.
-func (c *ModelLoadedCheck) Name() string { return "model_loaded" }
+func (c *ModelsLoadedCheck) Name() string { return "models_loaded" }
 
 // Category returns the analysis category.
-func (c *ModelLoadedCheck) Category() health.Category { return health.CategoryAnalysis }
+func (c *ModelsLoadedCheck) Category() health.Category { return health.CategoryAnalysis }
 
-// Run verifies that the analysis model is loaded.
-func (c *ModelLoadedCheck) Run(_ context.Context) health.Result {
+// Run returns a single aggregate result (worst status across all models).
+func (c *ModelsLoadedCheck) Run(ctx context.Context) health.Result {
+	return worstResult(c.Name(), c.Category(), c.RunMulti(ctx))
+}
+
+// RunMulti returns one result per loaded model.
+func (c *ModelsLoadedCheck) RunMulti(_ context.Context) []health.Result {
 	start := time.Now()
 
-	if c.isLoaded == nil {
-		return skippedResult(c.Name(), c.Category(), start)
+	if c.getModels == nil {
+		return []health.Result{skippedResult(c.Name(), c.Category(), start)}
 	}
 
-	name := ""
-	if c.modelName != nil {
-		name = c.modelName()
+	models := c.getModels()
+	if len(models) == 0 {
+		return []health.Result{{
+			Name:       "model_loaded",
+			Category:   c.Category(),
+			Status:     health.StatusCritical,
+			Message:    "No analysis models loaded",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}}
 	}
 
-	status := health.StatusHealthy
-	msg := fmt.Sprintf("Model loaded: %s", name)
-	if name == "" {
-		msg = "Model loaded"
-	}
+	results := make([]health.Result, 0, len(models))
+	for _, m := range models {
+		checkName := "model_loaded_" + sanitizeID(m.ID)
+		status := health.StatusHealthy
+		msg := fmt.Sprintf("%s loaded (%s)", m.Name, m.SpecInfo)
 
-	if !c.isLoaded() {
-		status = health.StatusCritical
-		msg = "Analysis model is not loaded"
-		if name != "" {
-			msg = fmt.Sprintf("Analysis model not loaded: %s", name)
+		if !m.Loaded {
+			status = health.StatusCritical
+			msg = fmt.Sprintf("%s not loaded", m.Name)
 		}
-	}
 
-	return health.Result{
-		Name:     c.Name(),
-		Category: c.Category(),
-		Status:   status,
-		Message:  msg,
-		Details: map[string]any{
-			"model_name": name,
-		},
-		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
-		Timestamp:  time.Now(),
+		results = append(results, health.Result{
+			Name:     checkName,
+			Category: c.Category(),
+			Status:   status,
+			Message:  msg,
+			Details: map[string]any{
+				"model_id":   m.ID,
+				"model_name": m.Name,
+				"backend":    m.Backend,
+				"spec":       m.SpecInfo,
+			},
+			Timestamp: time.Now(),
+		})
 	}
+	return results
 }
 
-// InferenceLatencyCheck verifies that inference latency is within acceptable bounds
-// relative to the analysis window size.
-type InferenceLatencyCheck struct {
-	getStats func() (avgMS, p99MS, windowMS float64)
+// ModelInferenceInfo describes per-model inference statistics for health reporting.
+type ModelInferenceInfo struct {
+	ModelID   string
+	ModelName string
+	AvgMS     float64
+	P99MS     float64
+	WindowMS  float64 // model-specific analysis window (BufferInterval in ms)
 }
 
-// NewInferenceLatencyCheck creates an InferenceLatencyCheck using the given stats provider.
-func NewInferenceLatencyCheck(getStats func() (avgMS, p99MS, windowMS float64)) *InferenceLatencyCheck {
-	return &InferenceLatencyCheck{getStats: getStats}
+// PerModelInferenceLatencyCheck verifies that inference latency for each model
+// is within acceptable bounds relative to that model's analysis window.
+// Implements MultiResultCheck to produce one result per model.
+type PerModelInferenceLatencyCheck struct {
+	getStats func() []ModelInferenceInfo
+}
+
+// NewPerModelInferenceLatencyCheck creates a check that evaluates each model's
+// inference latency against its own analysis window.
+func NewPerModelInferenceLatencyCheck(getStats func() []ModelInferenceInfo) *PerModelInferenceLatencyCheck {
+	return &PerModelInferenceLatencyCheck{getStats: getStats}
 }
 
 // Name returns the check identifier.
-func (c *InferenceLatencyCheck) Name() string { return "inference_latency" }
+func (c *PerModelInferenceLatencyCheck) Name() string { return "inference_latency" }
 
 // Category returns the analysis category.
-func (c *InferenceLatencyCheck) Category() health.Category { return health.CategoryAnalysis }
+func (c *PerModelInferenceLatencyCheck) Category() health.Category { return health.CategoryAnalysis }
 
-// Run evaluates inference latency against the analysis window duration.
-func (c *InferenceLatencyCheck) Run(_ context.Context) health.Result {
+// Run returns a single aggregate result (worst status across all models).
+func (c *PerModelInferenceLatencyCheck) Run(ctx context.Context) health.Result {
+	return worstResult(c.Name(), c.Category(), c.RunMulti(ctx))
+}
+
+// RunMulti evaluates each model's inference latency independently.
+func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Result {
 	start := time.Now()
 
 	if c.getStats == nil {
-		return skippedResult(c.Name(), c.Category(), start)
+		return []health.Result{skippedResult(c.Name(), c.Category(), start)}
 	}
 
-	avgMS, p99MS, windowMS := c.getStats()
-
-	if windowMS <= 0 {
-		return health.Result{
-			Name:       c.Name(),
+	stats := c.getStats()
+	if len(stats) == 0 {
+		return []health.Result{{
+			Name:       "inference_latency",
 			Category:   c.Category(),
 			Status:     health.StatusUnknown,
 			Message:    "Inference stats not available",
 			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 			Timestamp:  time.Now(),
+		}}
+	}
+
+	results := make([]health.Result, 0, len(stats))
+	for _, s := range stats {
+		checkName := "inference_latency_" + sanitizeID(s.ModelID)
+
+		if s.WindowMS <= 0 {
+			results = append(results, health.Result{
+				Name:     checkName,
+				Category: c.Category(),
+				Status:   health.StatusUnknown,
+				Message:  fmt.Sprintf("%s: inference stats not available", s.ModelName),
+				Details: map[string]any{
+					"model_id":   s.ModelID,
+					"model_name": s.ModelName,
+				},
+				Timestamp: time.Now(),
+			})
+			continue
 		}
-	}
 
-	ratio := p99MS / windowMS
-	status := health.StatusHealthy
-	msg := fmt.Sprintf("Inference latency OK (p99=%.1fms, window=%.1fms)", p99MS, windowMS)
+		ratio := s.P99MS / s.WindowMS
+		status := health.StatusHealthy
+		msg := fmt.Sprintf("%s latency OK (p99=%.1fms, window=%.1fms)", s.ModelName, s.P99MS, s.WindowMS)
 
-	switch {
-	case ratio >= 0.90:
-		status = health.StatusCritical
-		msg = fmt.Sprintf("Inference p99 (%.1fms) exceeds 90%% of analysis window (%.1fms)", p99MS, windowMS)
-	case ratio >= 0.50:
-		status = health.StatusWarning
-		msg = fmt.Sprintf("Inference p99 (%.1fms) exceeds 50%% of analysis window (%.1fms)", p99MS, windowMS)
-	}
+		switch {
+		case ratio >= 0.90:
+			status = health.StatusCritical
+			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds 90%% of analysis window (%.1fms)",
+				s.ModelName, s.P99MS, s.WindowMS)
+		case ratio >= 0.50:
+			status = health.StatusWarning
+			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds 50%% of analysis window (%.1fms)",
+				s.ModelName, s.P99MS, s.WindowMS)
+		}
 
-	return health.Result{
-		Name:     c.Name(),
-		Category: c.Category(),
-		Status:   status,
-		Message:  msg,
-		Details: map[string]any{
-			"avg_ms":    avgMS,
-			"p99_ms":    p99MS,
-			"window_ms": windowMS,
-		},
-		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
-		Timestamp:  time.Now(),
+		results = append(results, health.Result{
+			Name:     checkName,
+			Category: c.Category(),
+			Status:   status,
+			Message:  msg,
+			Details: map[string]any{
+				"model_id":   s.ModelID,
+				"model_name": s.ModelName,
+				"avg_ms":     s.AvgMS,
+				"p99_ms":     s.P99MS,
+				"window_ms":  s.WindowMS,
+			},
+			Timestamp: time.Now(),
+		})
 	}
+	return results
 }
 
 // DetectionRateCheck monitors whether detections are occurring at expected intervals.

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -9,6 +9,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health"
 )
 
+const (
+	latencyCriticalRatio = 0.90
+	latencyWarningRatio  = 0.50
+)
+
 // ModelLoadInfo describes a loaded model for health reporting.
 type ModelLoadInfo struct {
 	ID       string
@@ -37,7 +42,13 @@ func (c *ModelsLoadedCheck) Category() health.Category { return health.CategoryA
 
 // Run returns a single aggregate result (worst status across all models).
 func (c *ModelsLoadedCheck) Run(ctx context.Context) health.Result {
-	return worstResult(c.Name(), c.Category(), c.RunMulti(ctx))
+	start := time.Now()
+	r := worstResult(c.Name(), c.Category(), c.RunMulti(ctx))
+	r.DurationMS = float64(time.Since(start).Microseconds()) / 1000
+	if r.Timestamp.IsZero() {
+		r.Timestamp = time.Now()
+	}
+	return r
 }
 
 // RunMulti returns one result per loaded model.
@@ -118,7 +129,13 @@ func (c *PerModelInferenceLatencyCheck) Category() health.Category { return heal
 
 // Run returns a single aggregate result (worst status across all models).
 func (c *PerModelInferenceLatencyCheck) Run(ctx context.Context) health.Result {
-	return worstResult(c.Name(), c.Category(), c.RunMulti(ctx))
+	start := time.Now()
+	r := worstResult(c.Name(), c.Category(), c.RunMulti(ctx))
+	r.DurationMS = float64(time.Since(start).Microseconds()) / 1000
+	if r.Timestamp.IsZero() {
+		r.Timestamp = time.Now()
+	}
+	return r
 }
 
 // RunMulti evaluates each model's inference latency independently.
@@ -165,14 +182,14 @@ func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Res
 		msg := fmt.Sprintf("%s latency OK (p99=%.1fms, window=%.1fms)", s.ModelName, s.P99MS, s.WindowMS)
 
 		switch {
-		case ratio >= 0.90:
+		case ratio >= latencyCriticalRatio:
 			status = health.StatusCritical
-			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds 90%% of analysis window (%.1fms)",
-				s.ModelName, s.P99MS, s.WindowMS)
-		case ratio >= 0.50:
+			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
+				s.ModelName, s.P99MS, latencyCriticalRatio*100, s.WindowMS)
+		case ratio >= latencyWarningRatio:
 			status = health.StatusWarning
-			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds 50%% of analysis window (%.1fms)",
-				s.ModelName, s.P99MS, s.WindowMS)
+			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
+				s.ModelName, s.P99MS, latencyWarningRatio*100, s.WindowMS)
 		}
 
 		results = append(results, health.Result{

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -62,7 +62,7 @@ func (c *ModelsLoadedCheck) RunMulti(_ context.Context) []health.Result {
 	models := c.getModels()
 	if len(models) == 0 {
 		return []health.Result{{
-			Name:       "model_loaded",
+			Name:       c.Name(),
 			Category:   c.Category(),
 			Status:     health.StatusCritical,
 			Message:    "No analysis models loaded",
@@ -149,7 +149,7 @@ func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Res
 	stats := c.getStats()
 	if len(stats) == 0 {
 		return []health.Result{{
-			Name:       "inference_latency",
+			Name:       c.Name(),
 			Category:   c.Category(),
 			Status:     health.StatusUnknown,
 			Message:    "Inference stats not available",

--- a/internal/health/checks/analysis_test.go
+++ b/internal/health/checks/analysis_test.go
@@ -4,8 +4,210 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/health"
 )
+
+// --- ModelsLoadedCheck tests ---
+
+func TestModelsLoadedCheck_SingleModel(t *testing.T) {
+	t.Parallel()
+	check := NewModelsLoadedCheck(func() []ModelLoadInfo {
+		return []ModelLoadInfo{
+			{ID: "BirdNET_V2.4", Name: "BirdNET v2.4", Loaded: true, Backend: "TFLite", SpecInfo: "48kHz, 3s clips"},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusHealthy, results[0].Status)
+	assert.Contains(t, results[0].Name, "birdnet_v2_4")
+	assert.Contains(t, results[0].Message, "BirdNET v2.4")
+}
+
+func TestModelsLoadedCheck_MultipleModels(t *testing.T) {
+	t.Parallel()
+	check := NewModelsLoadedCheck(func() []ModelLoadInfo {
+		return []ModelLoadInfo{
+			{ID: "BirdNET_V2.4", Name: "BirdNET v2.4", Loaded: true, Backend: "TFLite", SpecInfo: "48kHz, 3s clips"},
+			{ID: "Perch_V2", Name: "Perch V2", Loaded: true, Backend: "ONNX", SpecInfo: "32kHz, 5s clips"},
+			{ID: "Bat", Name: "Bat Classifier", Loaded: true, Backend: "ONNX", SpecInfo: "48kHz, 3s clips"},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 3)
+	for _, r := range results {
+		assert.Equal(t, health.StatusHealthy, r.Status)
+		assert.Equal(t, health.CategoryAnalysis, r.Category)
+	}
+}
+
+func TestModelsLoadedCheck_UnloadedModel(t *testing.T) {
+	t.Parallel()
+	check := NewModelsLoadedCheck(func() []ModelLoadInfo {
+		return []ModelLoadInfo{
+			{ID: "BirdNET_V2.4", Name: "BirdNET v2.4", Loaded: true},
+			{ID: "Perch_V2", Name: "Perch V2", Loaded: false},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 2)
+	assert.Equal(t, health.StatusHealthy, results[0].Status)
+	assert.Equal(t, health.StatusCritical, results[1].Status)
+	assert.Contains(t, results[1].Message, "not loaded")
+}
+
+func TestModelsLoadedCheck_NoModels(t *testing.T) {
+	t.Parallel()
+	check := NewModelsLoadedCheck(func() []ModelLoadInfo {
+		return nil
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusCritical, results[0].Status)
+	assert.Contains(t, results[0].Message, "No analysis models loaded")
+}
+
+func TestModelsLoadedCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewModelsLoadedCheck(nil)
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusSkipped, results[0].Status)
+}
+
+func TestModelsLoadedCheck_Run_ReturnsWorst(t *testing.T) {
+	t.Parallel()
+	check := NewModelsLoadedCheck(func() []ModelLoadInfo {
+		return []ModelLoadInfo{
+			{ID: "A", Name: "Model A", Loaded: true},
+			{ID: "B", Name: "Model B", Loaded: false},
+		}
+	})
+
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+// --- PerModelInferenceLatencyCheck tests ---
+
+func TestPerModelInferenceLatencyCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return []ModelInferenceInfo{
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, P99MS: 200, WindowMS: 1500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 300, P99MS: 600, WindowMS: 2500},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 2)
+	for _, r := range results {
+		assert.Equal(t, health.StatusHealthy, r.Status, "model %s should be healthy", r.Name)
+	}
+}
+
+func TestPerModelInferenceLatencyCheck_Warning(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return []ModelInferenceInfo{
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, P99MS: 800, WindowMS: 1500},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusWarning, results[0].Status)
+	assert.Contains(t, results[0].Message, "50%")
+}
+
+func TestPerModelInferenceLatencyCheck_Critical(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return []ModelInferenceInfo{
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, P99MS: 2300, WindowMS: 2500},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusCritical, results[0].Status)
+	assert.Contains(t, results[0].Message, "90%")
+}
+
+func TestPerModelInferenceLatencyCheck_MixedStatus(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return []ModelInferenceInfo{
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 50, P99MS: 100, WindowMS: 1500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, P99MS: 2300, WindowMS: 2500},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 2)
+	assert.Equal(t, health.StatusHealthy, results[0].Status)
+	assert.Equal(t, health.StatusCritical, results[1].Status)
+
+	aggregate := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, aggregate.Status)
+}
+
+func TestPerModelInferenceLatencyCheck_NoStats(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return nil
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusUnknown, results[0].Status)
+}
+
+func TestPerModelInferenceLatencyCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(nil)
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusSkipped, results[0].Status)
+}
+
+func TestPerModelInferenceLatencyCheck_ZeroWindow(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return []ModelInferenceInfo{
+			{ModelID: "Test", ModelName: "Test Model", AvgMS: 100, P99MS: 200, WindowMS: 0},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 1)
+	assert.Equal(t, health.StatusUnknown, results[0].Status)
+}
+
+func TestPerModelInferenceLatencyCheck_CorrectWindowPerModel(t *testing.T) {
+	t.Parallel()
+	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
+		return []ModelInferenceInfo{
+			// BirdNET v2.4: 3s clips, 50% overlap -> 1500ms window
+			// 800ms p99 / 1500ms = 53% -> Warning
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 400, P99MS: 800, WindowMS: 1500},
+			// Perch V2: 5s clips, 50% overlap -> 2500ms window
+			// 800ms p99 / 2500ms = 32% -> Healthy
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 400, P99MS: 800, WindowMS: 2500},
+		}
+	})
+
+	results := check.RunMulti(t.Context())
+	require.Len(t, results, 2)
+	assert.Equal(t, health.StatusWarning, results[0].Status, "BirdNET should be warning at 53% of window")
+	assert.Equal(t, health.StatusHealthy, results[1].Status, "Perch should be healthy at 32% of window")
+}
+
+// --- ORTAvailabilityCheck tests ---
 
 func TestORTAvailabilityCheck_Available(t *testing.T) {
 	t.Parallel()
@@ -45,4 +247,22 @@ func TestORTAvailabilityCheck_FoundNotInitialized(t *testing.T) {
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusHealthy, result.Status)
 	assert.Contains(t, result.Message, "not yet initialized")
+}
+
+// --- Helper tests ---
+
+func TestSanitizeID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"BirdNET_V2.4", "birdnet_v2_4"},
+		{"Perch_V2", "perch_v2"},
+		{"Bat", "bat"},
+		{"My-Model.v3.0", "my_model_v3_0"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, sanitizeID(tt.input), "sanitizeID(%q)", tt.input)
+	}
 }

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -2,10 +2,40 @@ package checks
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
 )
+
+// sanitizeID converts a model ID into a safe check-name suffix by
+// lowercasing and replacing non-alphanumeric characters with underscores.
+func sanitizeID(id string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		if r >= 'A' && r <= 'Z' {
+			return r - 'A' + 'a'
+		}
+		return '_'
+	}, id)
+}
+
+// worstResult returns the result with the most severe status, or a skipped
+// result if the slice is empty. Used by MultiResultCheck.Run() implementations.
+func worstResult(name string, cat health.Category, results []health.Result) health.Result {
+	if len(results) == 0 {
+		return skippedResult(name, cat, time.Now())
+	}
+	worst := results[0]
+	for _, r := range results[1:] {
+		if health.Severity(r.Status) > health.Severity(worst.Status) {
+			worst = r
+		}
+	}
+	return worst
+}
 
 // skippedResult builds a StatusSkipped Result for checks without available data.
 func skippedResult(name string, category health.Category, start time.Time) health.Result {

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -34,6 +34,8 @@ func worstResult(name string, cat health.Category, results []health.Result) heal
 			worst = r
 		}
 	}
+	worst.Name = name
+	worst.Category = cat
 	return worst
 }
 

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -94,7 +94,9 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 			dur := float64(time.Since(start).Microseconds()) / 1000.0
 			now := time.Now()
 			for j := range rs {
-				rs[j].DurationMS = dur
+				if rs[j].DurationMS == 0 {
+					rs[j].DurationMS = dur
+				}
 				if rs[j].Timestamp.IsZero() {
 					rs[j].Timestamp = now
 				}
@@ -105,7 +107,7 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 
 	wg.Wait()
 
-	var results []Result
+	results := make([]Result, 0, len(checks))
 	for _, o := range outputs {
 		results = append(results, o.results...)
 	}

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -67,8 +67,13 @@ func (r *Registry) RunCategory(ctx context.Context, cat Category) []Result {
 }
 
 // runChecks executes the given checks in parallel with per-check timeout.
+// Checks that implement MultiResultCheck produce multiple results per check;
+// all results are flattened into the returned slice in registration order.
 func runChecks(ctx context.Context, checks []Check) []Result {
-	results := make([]Result, len(checks))
+	type checkOutput struct {
+		results []Result
+	}
+	outputs := make([]checkOutput, len(checks))
 	var wg sync.WaitGroup
 
 	for i, c := range checks {
@@ -78,16 +83,32 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 			defer cancel()
 			start := time.Now()
-			result := check.Run(checkCtx)
-			result.DurationMS = float64(time.Since(start).Microseconds()) / 1000.0
-			if result.Timestamp.IsZero() {
-				result.Timestamp = time.Now()
+
+			var rs []Result
+			if mc, ok := check.(MultiResultCheck); ok {
+				rs = mc.RunMulti(checkCtx)
+			} else {
+				rs = []Result{check.Run(checkCtx)}
 			}
-			results[idx] = result
+
+			dur := float64(time.Since(start).Microseconds()) / 1000.0
+			now := time.Now()
+			for j := range rs {
+				rs[j].DurationMS = dur
+				if rs[j].Timestamp.IsZero() {
+					rs[j].Timestamp = now
+				}
+			}
+			outputs[idx] = checkOutput{results: rs}
 		}(i, c)
 	}
 
 	wg.Wait()
+
+	var results []Result
+	for _, o := range outputs {
+		results = append(results, o.results...)
+	}
 	return results
 }
 

--- a/internal/health/registry_test.go
+++ b/internal/health/registry_test.go
@@ -190,3 +190,64 @@ func TestRegistry_Categories_Empty(t *testing.T) {
 	r := NewRegistry()
 	assert.Empty(t, r.Categories())
 }
+
+// mockMultiCheck implements both Check and MultiResultCheck.
+type mockMultiCheck struct {
+	name     string
+	category Category
+	results  []Result
+}
+
+func (m *mockMultiCheck) Name() string       { return m.name }
+func (m *mockMultiCheck) Category() Category { return m.category }
+func (m *mockMultiCheck) Run(_ context.Context) Result {
+	if len(m.results) == 0 {
+		return Result{Name: m.name, Category: m.category, Status: StatusUnknown}
+	}
+	return m.results[0]
+}
+func (m *mockMultiCheck) RunMulti(_ context.Context) []Result { return m.results }
+
+func TestRegistry_RunAll_MultiResultCheck(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.RegisterAll(
+		&mockCheck{
+			name:     "single",
+			category: CategorySystem,
+			result:   Result{Name: "single", Category: CategorySystem, Status: StatusHealthy},
+		},
+		&mockMultiCheck{
+			name:     "multi",
+			category: CategoryAnalysis,
+			results: []Result{
+				{Name: "model_a", Category: CategoryAnalysis, Status: StatusHealthy},
+				{Name: "model_b", Category: CategoryAnalysis, Status: StatusWarning},
+			},
+		},
+	)
+
+	results := r.RunAll(t.Context())
+
+	require.Len(t, results, 3)
+	byName := make(map[string]Result, len(results))
+	for _, res := range results {
+		byName[res.Name] = res
+	}
+	assert.Equal(t, StatusHealthy, byName["single"].Status)
+	assert.Equal(t, StatusHealthy, byName["model_a"].Status)
+	assert.Equal(t, StatusWarning, byName["model_b"].Status)
+}
+
+func TestRegistry_RunAll_MultiResultCheck_Empty(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(&mockMultiCheck{
+		name:     "empty_multi",
+		category: CategoryAnalysis,
+		results:  nil,
+	})
+
+	results := r.RunAll(t.Context())
+	assert.Empty(t, results)
+}


### PR DESCRIPTION
## Summary
- Replace single-model `ModelLoadedCheck` and `InferenceLatencyCheck` with multi-model versions (`ModelsLoadedCheck`, `PerModelInferenceLatencyCheck`) that report per-model health status
- Each model's inference latency is compared against its own analysis window (`BufferInterval = ClipLength / 2`) instead of the hardcoded BirdNET v2.4 3-second segment size
- Add `MultiResultCheck` interface to the health framework so a single registered check can produce multiple results (one per model)
- Export `Severity()` from the health package and extract a `worstResult()` helper to eliminate duplication

## Why
The health check system only reported BirdNET v2.4 model status and compared all inference times against its 3s segment size. With multi-model support (Perch V2 at 5s clips, Bat at 3s clips), the inference latency thresholds were wrong: Perch's 2500ms window was compared against BirdNET's 600ms window, triggering false warnings.

## What changes
- **`internal/health/check.go`**: Add `MultiResultCheck` interface, export `Severity()`
- **`internal/health/registry.go`**: Detect `MultiResultCheck` in `runChecks`, flatten results
- **`internal/health/checks/analysis.go`**: New `ModelsLoadedCheck` and `PerModelInferenceLatencyCheck` implementing `MultiResultCheck`
- **`internal/health/checks/helpers.go`**: Add `sanitizeID()` and `worstResult()` helpers
- **`internal/api/v2/diagnostics.go`**: Wire new checks via `buildModelLoadInfoProvider()` and `buildPerModelInferenceProvider()` using `Orchestrator.ModelInfos()` and per-model `BufferInterval()`

## Test plan
- [x] Unit tests for all new check types (single model, multiple models, unloaded model, nil provider, zero window)
- [x] Registry tests for MultiResultCheck flattening (mixed single + multi, empty multi)
- [x] `sanitizeID()` helper tests
- [x] `go test -race ./internal/health/...` passes (108 tests)
- [x] `golangci-lint run` passes with zero issues
- [ ] Manual verification on running instance with multiple models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics now report per-model availability and per-model inference latency as individual entries (instead of only aggregate metrics).

* **Refactor**
  * Health-check system now supports checks that emit multiple results, enabling granular per-model diagnostics and accurate aggregated statuses.

* **Tests**
  * Expanded test coverage for multi-result and per-model reporting, ID sanitization, and edge-case behaviors (nil/empty providers, window-edge cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->