### PR TITLE
fix(health): address follow-up issues from health check system reviews

### DIFF
--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -102,8 +102,10 @@
     switch (level) {
       case 'fatal':
       case 'panic':
-        return 'var(--color-error)';
       case 'error':
+        return 'var(--color-error)';
+      case 'warn':
+      case 'warning':
         return 'var(--color-warning)';
       default:
         return 'var(--color-base-content)';

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -71,6 +71,43 @@
   let error = $state<string | null>(null);
   let copied = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  let expandedChecks = $state(new Set<string>());
+
+  function toggleExpand(checkName: string) {
+    const next = new Set(expandedChecks);
+    if (next.has(checkName)) {
+      next.delete(checkName);
+    } else {
+      next.add(checkName);
+    }
+    expandedChecks = next;
+  }
+
+  interface ErrorGroup {
+    component?: string;
+    message: string;
+    count: number;
+    level: string;
+    sample_fields?: Record<string, unknown>;
+  }
+
+  function getTopErrors(result: DiagnosticsResult): ErrorGroup[] | null {
+    const topErrors = result.details?.top_errors;
+    if (!Array.isArray(topErrors) || topErrors.length === 0) return null;
+    return topErrors as ErrorGroup[];
+  }
+
+  function levelColor(level: string): string {
+    switch (level) {
+      case 'fatal':
+      case 'panic':
+        return 'var(--color-error)';
+      case 'error':
+        return 'var(--color-warning)';
+      default:
+        return 'var(--color-base-content)';
+    }
+  }
 
   onMount(() => {
     return () => {
@@ -338,27 +375,101 @@
       >
         <div class="space-y-2">
           {#each results as result (result.name)}
-            <div
-              class="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-[var(--color-base-200)]/50"
-            >
-              <StatusPill
-                variant={statusToVariant(result.status)}
-                label={t(`health.status.${result.status}`)}
-                size="sm"
+            {@const topErrors = getTopErrors(result)}
+            {@const isExpandable =
+              topErrors !== null && (result.status === 'warning' || result.status === 'critical')}
+            {@const isExpanded = expandedChecks.has(result.name)}
+            <div>
+              <button
+                type="button"
+                class="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg bg-[var(--color-base-200)]/50 text-left {isExpandable
+                  ? 'cursor-pointer hover:bg-[var(--color-base-200)]'
+                  : 'cursor-default'}"
+                onclick={() => isExpandable && toggleExpand(result.name)}
+                disabled={!isExpandable}
               >
-                {#snippet leadingIcon()}
-                  {@render statusIcon(result.status, 'size-3.5')}
-                {/snippet}
-              </StatusPill>
-              <div class="flex-1 min-w-0">
-                <span class="text-sm font-medium">{formatCheckName(result.name)}</span>
-                <p class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
-                  {result.message}
-                </p>
-              </div>
-              <span class="text-xs text-[var(--color-base-content)] opacity-40 shrink-0">
-                {result.duration_ms.toFixed(1)}ms
-              </span>
+                <StatusPill
+                  variant={statusToVariant(result.status)}
+                  label={t(`health.status.${result.status}`)}
+                  size="sm"
+                >
+                  {#snippet leadingIcon()}
+                    {@render statusIcon(result.status, 'size-3.5')}
+                  {/snippet}
+                </StatusPill>
+                <div class="flex-1 min-w-0">
+                  <span class="text-sm font-medium">{formatCheckName(result.name)}</span>
+                  <p class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
+                    {result.message}
+                  </p>
+                </div>
+                <span class="text-xs text-[var(--color-base-content)] opacity-40 shrink-0">
+                  {result.duration_ms.toFixed(1)}ms
+                </span>
+                {#if isExpandable}
+                  <svg
+                    class="size-4 shrink-0 opacity-40 transition-transform"
+                    class:rotate-180={isExpanded}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                  </svg>
+                {/if}
+              </button>
+
+              {#if isExpanded && topErrors}
+                <div
+                  class="mt-1 ml-3 mr-3 mb-2 rounded-lg bg-[var(--color-base-200)]/30 overflow-hidden"
+                >
+                  <table class="w-full text-xs">
+                    <thead>
+                      <tr
+                        class="text-left text-[var(--color-base-content)] opacity-50 border-b border-[var(--color-base-200)]"
+                      >
+                        <th class="px-3 py-1.5 font-medium">{t('health.logs.errorComponent')}</th>
+                        <th class="px-3 py-1.5 font-medium">{t('health.logs.errorMessage')}</th>
+                        <th class="px-3 py-1.5 font-medium text-right"
+                          >{t('health.logs.errorCount')}</th
+                        >
+                        <th class="px-3 py-1.5 font-medium">{t('health.logs.errorLevel')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {#each topErrors as group (group.component + ':' + group.message)}
+                        <tr class="border-b border-[var(--color-base-200)]/50 last:border-0">
+                          <td class="px-3 py-1.5">
+                            {#if group.component}
+                              <span
+                                class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-base-300)] text-[var(--color-base-content)]"
+                              >
+                                {group.component}
+                              </span>
+                            {:else}
+                              <span class="opacity-30">-</span>
+                            {/if}
+                          </td>
+                          <td class="px-3 py-1.5 max-w-[300px] truncate" title={group.message}>
+                            {group.message}
+                          </td>
+                          <td class="px-3 py-1.5 text-right font-mono">{group.count}</td>
+                          <td class="px-3 py-1.5">
+                            <span
+                              class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                              style:color={levelColor(group.level)}
+                              style:background="color-mix(in srgb, {levelColor(group.level)} 10%, transparent)"
+                            >
+                              {group.level}
+                            </span>
+                          </td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                </div>
+              {/if}
             </div>
           {/each}
         </div>

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -14,6 +14,7 @@
     Clock,
     Loader2,
     Info,
+    ChevronDown,
   } from '@lucide/svelte';
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
@@ -387,6 +388,7 @@
                   : 'cursor-default'}"
                 onclick={() => isExpandable && toggleExpand(result.name)}
                 disabled={!isExpandable}
+                aria-expanded={isExpandable ? isExpanded : undefined}
               >
                 <StatusPill
                   variant={statusToVariant(result.status)}
@@ -407,16 +409,11 @@
                   {result.duration_ms.toFixed(1)}ms
                 </span>
                 {#if isExpandable}
-                  <svg
-                    class="size-4 shrink-0 opacity-40 transition-transform"
-                    class:rotate-180={isExpanded}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-                  </svg>
+                  <ChevronDown
+                    class="size-4 shrink-0 opacity-40 transition-transform {isExpanded
+                      ? 'rotate-180'
+                      : ''}"
+                  />
                 {/if}
               </button>
 
@@ -424,6 +421,11 @@
                 <div
                   class="mt-1 ml-3 mr-3 mb-2 rounded-lg bg-[var(--color-base-200)]/30 overflow-hidden"
                 >
+                  <p
+                    class="px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] opacity-60"
+                  >
+                    {t('health.logs.topErrors')}
+                  </p>
                   <table class="w-full text-xs">
                     <thead>
                       <tr

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Nejčastější chyby",
+      "errorCount": "Počet",
+      "errorComponent": "Komponenta",
+      "errorLevel": "Úroveň",
+      "errorMessage": "Zpráva"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Hyppigste fejl",
+      "errorCount": "Antal",
+      "errorComponent": "Komponent",
+      "errorLevel": "Niveau",
+      "errorMessage": "Besked"
     }
   }
 }

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Häufigste Fehler",
+      "errorCount": "Anzahl",
+      "errorComponent": "Komponente",
+      "errorLevel": "Stufe",
+      "errorMessage": "Nachricht"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Top error patterns",
+      "errorCount": "Count",
+      "errorComponent": "Component",
+      "errorLevel": "Level",
+      "errorMessage": "Message"
     }
   }
 }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Errores frecuentes",
+      "errorCount": "Cantidad",
+      "errorComponent": "Componente",
+      "errorLevel": "Nivel",
+      "errorMessage": "Mensaje"
     }
   }
 }

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Yleisimmät virheet",
+      "errorCount": "Lukumäärä",
+      "errorComponent": "Komponentti",
+      "errorLevel": "Taso",
+      "errorMessage": "Viesti"
     }
   }
 }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Erreurs fréquentes",
+      "errorCount": "Nombre",
+      "errorComponent": "Composant",
+      "errorLevel": "Niveau",
+      "errorMessage": "Message"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Leggyakoribb hibák",
+      "errorCount": "Darab",
+      "errorComponent": "Komponens",
+      "errorLevel": "Szint",
+      "errorMessage": "Üzenet"
     }
   }
 }

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Errori frequenti",
+      "errorCount": "Conteggio",
+      "errorComponent": "Componente",
+      "errorLevel": "Livello",
+      "errorMessage": "Messaggio"
     }
   }
 }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Biežākās kļūdas",
+      "errorCount": "Skaits",
+      "errorComponent": "Komponents",
+      "errorLevel": "Līmenis",
+      "errorMessage": "Ziņojums"
     }
   }
 }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Meest voorkomende fouten",
+      "errorCount": "Aantal",
+      "errorComponent": "Component",
+      "errorLevel": "Niveau",
+      "errorMessage": "Bericht"
     }
   }
 }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Najczęstsze błędy",
+      "errorCount": "Liczba",
+      "errorComponent": "Komponent",
+      "errorLevel": "Poziom",
+      "errorMessage": "Wiadomość"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Erros frequentes",
+      "errorCount": "Contagem",
+      "errorComponent": "Componente",
+      "errorLevel": "Nível",
+      "errorMessage": "Mensagem"
     }
   }
 }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Najčastejšie chyby",
+      "errorCount": "Počet",
+      "errorComponent": "Komponent",
+      "errorLevel": "Úroveň",
+      "errorMessage": "Správa"
     }
   }
 }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4818,6 +4818,13 @@
       "timeLabel": "Time",
       "durationLabel": "Duration",
       "checksLabel": "Checks"
+    },
+    "logs": {
+      "topErrors": "Vanligaste felen",
+      "errorCount": "Antal",
+      "errorComponent": "Komponent",
+      "errorLevel": "Nivå",
+      "errorMessage": "Meddelande"
     }
   }
 }

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -108,27 +108,32 @@ func (c *Controller) SetAudioLevelChan(ch chan audiocore.AudioLevelData) {
 	})
 }
 
+// cleanupBroadcaster closes all subscriber channels and clears stale audio levels.
+// Called when the broadcaster exits (context cancel or source channel close).
+func cleanupBroadcaster() {
+	audioLevelMgr.subscribersMu.Lock()
+	for ch := range audioLevelMgr.subscribers {
+		close(ch)
+		delete(audioLevelMgr.subscribers, ch)
+	}
+	audioLevelMgr.subscribersMu.Unlock()
+
+	audioLevelMgr.latestLevelsMu.Lock()
+	clear(audioLevelMgr.latestLevels)
+	audioLevelMgr.latestLevelsMu.Unlock()
+}
+
 // runAudioLevelBroadcaster reads from the source channel and broadcasts to all subscribers.
 // This allows multiple SSE clients to receive the same audio level data.
 func runAudioLevelBroadcaster(ctx context.Context, sourceChan chan audiocore.AudioLevelData) {
 	for {
 		select {
 		case <-ctx.Done():
+			cleanupBroadcaster()
 			return
 		case data, ok := <-sourceChan:
 			if !ok {
-				// Source channel closed, close all subscriber channels
-				audioLevelMgr.subscribersMu.Lock()
-				for ch := range audioLevelMgr.subscribers {
-					close(ch)
-					delete(audioLevelMgr.subscribers, ch)
-				}
-				audioLevelMgr.subscribersMu.Unlock()
-
-				// Clear stale levels so health checks don't report dead sources
-				audioLevelMgr.latestLevelsMu.Lock()
-				clear(audioLevelMgr.latestLevels)
-				audioLevelMgr.latestLevelsMu.Unlock()
+				cleanupBroadcaster()
 				return
 			}
 

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -76,7 +77,7 @@ func (c *Controller) registerHealthChecks() {
 				}
 				return 0, errNoTempSensors
 			}
-			var maxTemp float64
+			maxTemp := math.Inf(-1)
 			for _, t := range temps {
 				if t.Temperature > maxTemp {
 					maxTemp = t.Temperature

--- a/internal/health/checks/logs.go
+++ b/internal/health/checks/logs.go
@@ -1,9 +1,10 @@
 package checks
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
@@ -25,7 +26,6 @@ type errorGroup struct {
 func groupErrors(entries []health.LogEntry) []errorGroup {
 	type key struct{ component, message string }
 	seen := make(map[key]*errorGroup)
-	var order []key
 
 	for i := range entries {
 		k := key{entries[i].Component, entries[i].Message}
@@ -39,16 +39,15 @@ func groupErrors(entries []health.LogEntry) []errorGroup {
 				Level:        entries[i].Level,
 				SampleFields: entries[i].Fields,
 			}
-			order = append(order, k)
 		}
 	}
 
-	groups := make([]errorGroup, 0, len(order))
-	for _, k := range order {
-		groups = append(groups, *seen[k])
+	groups := make([]errorGroup, 0, len(seen))
+	for _, g := range seen {
+		groups = append(groups, *g)
 	}
-	sort.Slice(groups, func(i, j int) bool {
-		return groups[i].Count > groups[j].Count
+	slices.SortFunc(groups, func(a, b errorGroup) int {
+		return cmp.Compare(b.Count, a.Count)
 	})
 	if len(groups) > maxTopErrors {
 		groups = groups[:maxTopErrors]

--- a/internal/health/checks/logs.go
+++ b/internal/health/checks/logs.go
@@ -3,10 +3,58 @@ package checks
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
 )
+
+// maxTopErrors is the maximum number of grouped error patterns returned in details.
+const maxTopErrors = 10
+
+// errorGroup represents a set of identical errors grouped by component and message.
+type errorGroup struct {
+	Component    string         `json:"component,omitempty"`
+	Message      string         `json:"message"`
+	Count        int            `json:"count"`
+	Level        string         `json:"level"`
+	SampleFields map[string]any `json:"sample_fields,omitempty"`
+}
+
+// groupErrors groups log entries by (Component, Message), sorted by count descending, capped at maxTopErrors.
+func groupErrors(entries []health.LogEntry) []errorGroup {
+	type key struct{ component, message string }
+	seen := make(map[key]*errorGroup)
+	var order []key
+
+	for i := range entries {
+		k := key{entries[i].Component, entries[i].Message}
+		if g, ok := seen[k]; ok {
+			g.Count++
+		} else {
+			seen[k] = &errorGroup{
+				Component:    entries[i].Component,
+				Message:      entries[i].Message,
+				Count:        1,
+				Level:        entries[i].Level,
+				SampleFields: entries[i].Fields,
+			}
+			order = append(order, k)
+		}
+	}
+
+	groups := make([]errorGroup, 0, len(order))
+	for _, k := range order {
+		groups = append(groups, *seen[k])
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Count > groups[j].Count
+	})
+	if len(groups) > maxTopErrors {
+		groups = groups[:maxTopErrors]
+	}
+	return groups
+}
 
 // recentErrorWindow is the lookback period used by RecentErrorsCheck.
 const recentErrorWindow = time.Hour
@@ -56,14 +104,19 @@ func (c *RecentErrorsCheck) Run(_ context.Context) health.Result {
 		msg = fmt.Sprintf("Elevated error count (%d errors in last hour)", count)
 	}
 
+	details := map[string]any{
+		"count_last_hour": count,
+	}
+	if status != health.StatusHealthy {
+		entries := c.errorBuffer.EntriesSince(since)
+		details["top_errors"] = groupErrors(entries)
+	}
 	return health.Result{
-		Name:     c.Name(),
-		Category: c.Category(),
-		Status:   status,
-		Message:  msg,
-		Details: map[string]any{
-			"count_last_hour": count,
-		},
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     status,
+		Message:    msg,
+		Details:    details,
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}
@@ -124,15 +177,20 @@ func (c *ErrorTrendCheck) Run(_ context.Context) health.Result {
 		msg = fmt.Sprintf("Error rate increasing (recent=%d, previous=0)", recent)
 	}
 
+	details := map[string]any{
+		"recent_30m":   recent,
+		"previous_30m": previous,
+	}
+	if status != health.StatusHealthy {
+		entries := c.errorBuffer.EntriesSince(midpoint)
+		details["top_errors"] = groupErrors(entries)
+	}
 	return health.Result{
-		Name:     c.Name(),
-		Category: c.Category(),
-		Status:   status,
-		Message:  msg,
-		Details: map[string]any{
-			"recent_30m":   recent,
-			"previous_30m": previous,
-		},
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     status,
+		Message:    msg,
+		Details:    details,
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}

--- a/internal/health/checks/logs_test.go
+++ b/internal/health/checks/logs_test.go
@@ -1,0 +1,114 @@
+package checks
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+func TestRecentErrorsCheck_TopErrorsPresent(t *testing.T) {
+	t.Parallel()
+	buf := health.NewErrorRingBuffer(100)
+	now := time.Now()
+
+	for i := range 15 {
+		buf.Add(&health.LogEntry{
+			Level:     "error",
+			Message:   "connection timeout",
+			Component: "database",
+			Timestamp: now.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+	for range 3 {
+		buf.Add(&health.LogEntry{
+			Level:     "error",
+			Message:   "auth failed",
+			Component: "api",
+			Timestamp: now.Add(-5 * time.Minute),
+		})
+	}
+
+	check := NewRecentErrorsCheck(buf)
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusWarning, result.Status)
+	require.Contains(t, result.Details, "top_errors")
+	topErrors, ok := result.Details["top_errors"].([]errorGroup)
+	require.True(t, ok, "top_errors should be []errorGroup")
+	require.GreaterOrEqual(t, len(topErrors), 2)
+	assert.Equal(t, "database", topErrors[0].Component)
+	assert.Equal(t, "connection timeout", topErrors[0].Message)
+	assert.Equal(t, 15, topErrors[0].Count)
+}
+
+func TestRecentErrorsCheck_NoTopErrorsWhenHealthy(t *testing.T) {
+	t.Parallel()
+	buf := health.NewErrorRingBuffer(100)
+
+	for i := range 3 {
+		buf.Add(&health.LogEntry{
+			Level:     "error",
+			Message:   "minor",
+			Component: "test",
+			Timestamp: time.Now().Add(-time.Duration(i) * time.Minute),
+		})
+	}
+
+	check := NewRecentErrorsCheck(buf)
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.NotContains(t, result.Details, "top_errors")
+}
+
+func TestErrorTrendCheck_TopErrorsPresent(t *testing.T) {
+	t.Parallel()
+	buf := health.NewErrorRingBuffer(200)
+	now := time.Now()
+
+	for i := range 10 {
+		buf.Add(&health.LogEntry{
+			Level:     "error",
+			Message:   "disk full",
+			Component: "storage",
+			Timestamp: now.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+
+	check := NewErrorTrendCheck(buf)
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusWarning, result.Status)
+	require.Contains(t, result.Details, "top_errors")
+	topErrors, ok := result.Details["top_errors"].([]errorGroup)
+	require.True(t, ok)
+	assert.Equal(t, "disk full", topErrors[0].Message)
+}
+
+func TestTopErrorGrouping_Cap(t *testing.T) {
+	t.Parallel()
+	buf := health.NewErrorRingBuffer(500)
+	now := time.Now()
+
+	for i := range 15 {
+		for range 5 {
+			buf.Add(&health.LogEntry{
+				Level:     "error",
+				Message:   fmt.Sprintf("error-type-%d", i),
+				Component: "test",
+				Timestamp: now.Add(-5 * time.Minute),
+			})
+		}
+	}
+
+	check := NewRecentErrorsCheck(buf)
+	result := check.Run(t.Context())
+
+	topErrors, ok := result.Details["top_errors"].([]errorGroup)
+	require.True(t, ok)
+	assert.LessOrEqual(t, len(topErrors), 10)
+}

--- a/internal/health/checks/network.go
+++ b/internal/health/checks/network.go
@@ -166,7 +166,7 @@ func (c *NotificationProvidersCheck) Run(_ context.Context) health.Result {
 			Name:       c.Name(),
 			Category:   c.Category(),
 			Status:     health.StatusSkipped,
-			Message:    "No notification providers configured",
+			Message:    "Notification health checks disabled",
 			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 			Timestamp:  time.Now(),
 		}

--- a/internal/health/checks/network_test.go
+++ b/internal/health/checks/network_test.go
@@ -64,14 +64,14 @@ func TestNotificationProvidersCheck_NilClosure(t *testing.T) {
 	assert.Equal(t, health.StatusSkipped, result.Status)
 }
 
-func TestNotificationProvidersCheck_NoProviders(t *testing.T) {
+func TestNotificationProvidersCheck_HealthCheckDisabled(t *testing.T) {
 	t.Parallel()
 	check := NewNotificationProvidersCheck(func() (int, int, string) {
 		return 0, 0, ""
 	})
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusSkipped, result.Status)
-	assert.Contains(t, result.Message, "No notification providers")
+	assert.Contains(t, result.Message, "health checks disabled")
 }
 
 func TestNotificationProvidersCheck_AllHealthy(t *testing.T) {

--- a/internal/health/error_buffer.go
+++ b/internal/health/error_buffer.go
@@ -163,7 +163,7 @@ func (b *ErrorRingBuffer) CountSince(since time.Time) int {
 func (b *ErrorRingBuffer) EntriesSince(since time.Time) []LogEntry {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	var result []LogEntry
+	result := make([]LogEntry, 0, b.count)
 	for i := range b.count {
 		if !b.entries[i].Timestamp.Before(since) {
 			result = append(result, cloneEntry(&b.entries[i]))

--- a/internal/health/error_buffer.go
+++ b/internal/health/error_buffer.go
@@ -158,6 +158,20 @@ func (b *ErrorRingBuffer) CountSince(since time.Time) int {
 	return count
 }
 
+// EntriesSince returns cloned entries with timestamps at or after the given time.
+// Like CountSince, all valid entries are scanned regardless of insertion order.
+func (b *ErrorRingBuffer) EntriesSince(since time.Time) []LogEntry {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	var result []LogEntry
+	for i := range b.count {
+		if !b.entries[i].Timestamp.Before(since) {
+			result = append(result, cloneEntry(&b.entries[i]))
+		}
+	}
+	return result
+}
+
 // Clear removes all entries from the buffer, zeroing the backing slice to release references.
 func (b *ErrorRingBuffer) Clear() {
 	b.mu.Lock()

--- a/internal/health/error_buffer_test.go
+++ b/internal/health/error_buffer_test.go
@@ -206,3 +206,55 @@ func TestErrorRingBuffer_ConcurrentAdd(t *testing.T) {
 	assert.LessOrEqual(t, count, maxSize)
 	assert.Positive(t, count)
 }
+
+func TestErrorRingBuffer_EntriesSince(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(10)
+	base := time.Now()
+
+	for i := range 5 {
+		buf.Add(&LogEntry{
+			Level:     "error",
+			Message:   fmt.Sprintf("msg-%d", i),
+			Component: "test",
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	// Entries at or after base+2s: messages 2, 3, 4
+	entries := buf.EntriesSince(base.Add(2 * time.Second))
+	assert.Len(t, entries, 3)
+	for _, e := range entries {
+		assert.False(t, e.Timestamp.Before(base.Add(2*time.Second)))
+	}
+
+	// Future cutoff: none
+	assert.Empty(t, buf.EntriesSince(base.Add(10*time.Second)))
+
+	// Past cutoff: all entries
+	assert.Len(t, buf.EntriesSince(base.Add(-time.Second)), 5)
+}
+
+func TestErrorRingBuffer_EntriesSince_Empty(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(10)
+	assert.Empty(t, buf.EntriesSince(time.Now()))
+}
+
+func TestErrorRingBuffer_EntriesSince_ClonesEntries(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(10)
+	buf.Add(&LogEntry{
+		Level:   "error",
+		Message: "original",
+		Fields:  map[string]any{"key": "value"},
+	})
+
+	entries := buf.EntriesSince(time.Time{})
+	require.Len(t, entries, 1)
+
+	// Mutating returned entry should not affect buffer
+	entries[0].Fields["key"] = "mutated"
+	original := buf.Entries()
+	assert.Equal(t, "value", original[0].Fields["key"])
+}


### PR DESCRIPTION
## Summary

Fixes four open Forgejo issues from the health check system review cycle:

- **Temperature check (#739)**: `maxTemp` was initialized to 0, causing environments with only negative sensor readings to incorrectly report 0. Fixed by initializing to `math.Inf(-1)`.
- **Broadcaster cleanup (#740)**: The `ctx.Done()` path in `runAudioLevelBroadcaster` returned without closing subscriber channels or clearing stale audio levels. Extracted a `cleanupBroadcaster()` helper called from both exit paths.
- **Notification providers message (#741)**: When health checking is disabled but providers are configured, the check now reports "Notification health checks disabled" instead of the misleading "No notification providers configured".
- **Error reporting details (#736)**: Log-category health checks (RecentErrors, ErrorTrend) now include grouped error patterns in their Details when reporting warning/critical status. Frontend shows expandable rows with component, message, count, and level. Added `EntriesSince()` to `ErrorRingBuffer` and `groupErrors()` helper.

## Changes

| Area | Files | What |
|------|-------|------|
| Backend | `diagnostics.go` | `math.Inf(-1)` temperature init |
| Backend | `audio_level.go` | Extract `cleanupBroadcaster()`, call from both paths |
| Backend | `network.go` | Updated message string |
| Backend | `error_buffer.go` | New `EntriesSince()` method |
| Backend | `checks/logs.go` | `errorGroup` type, `groupErrors()`, enriched Details |
| Frontend | `SystemHealth.svelte` | Expandable error detail rows with Lucide ChevronDown |
| i18n | 15 locale files | 5 new keys under `health.logs` |
| Tests | `error_buffer_test.go`, `logs_test.go`, `network_test.go` | New and updated tests |

## Test plan

- [x] `golangci-lint run -v` passes with zero issues
- [x] `go test -race ./internal/health/ ./internal/health/checks/` passes (115 tests)
- [x] `npm run check:all` passes (prettier, eslint, stylelint, svelte-check, ast-grep)
- [x] Gate review: 5 agents (4 Claude + Gemini), all findings addressed
- [ ] CI checks pass
- [ ] Automated reviews (CodeRabbit, Gemini) clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System health checks show expandable rows with top error patterns when status is warning or critical
  * Health diagnostics export now includes detailed top-error fields (component, count, level, message)
  * Added localization for health report export labels in 15 languages

* **Bug Fixes**
  * Improved temperature reading handling for negative sensor values
  * Clarified notification provider health check messaging when health checks are disabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->