### PR TITLE
fix(frontend): fix detection list layout shift when select mode is enabled

### DIFF
--- a/frontend/src/lib/desktop/components/ui/SelectionToolbar.svelte
+++ b/frontend/src/lib/desktop/components/ui/SelectionToolbar.svelte
@@ -66,16 +66,18 @@
         {t('detections.selection.nSelected', { count: selectedCount })}
       {/if}
     </span>
-    <button
-      type="button"
-      class="inline-flex items-center justify-center w-6 h-6 rounded-full
-             text-[var(--color-base-content)]/60 hover:text-[var(--color-base-content)]
-             hover:bg-[var(--color-base-300)] transition-colors"
-      onclick={onClear}
-      aria-label={t('detections.selection.clear')}
-    >
-      <X class="size-3.5" />
-    </button>
+    {#if selectedCount > 0}
+      <button
+        type="button"
+        class="inline-flex items-center justify-center w-6 h-6 rounded-full
+               text-[var(--color-base-content)]/60 hover:text-[var(--color-base-content)]
+               hover:bg-[var(--color-base-300)] transition-colors"
+        onclick={onClear}
+        aria-label={t('detections.selection.clear')}
+      >
+        <X class="size-3.5" />
+      </button>
+    {/if}
   </div>
 
   {#if showSelectAllBanner}
@@ -92,7 +94,7 @@
   {/if}
 
   {#if actions}
-    <div class="ml-auto flex items-center gap-1">
+    <div class="ml-auto flex flex-wrap items-center justify-end gap-1">
       {@render actions()}
     </div>
   {/if}

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
@@ -483,7 +483,8 @@
     </div>
   </div>
 
-  {#if selection.selectionActive && selection.selectedCount > 0}
+  {#if selection.selectionActive}
+    {@const hasSelection = selection.selectedCount > 0}
     <SelectionToolbar
       selectedCount={selection.selectedCount}
       totalCount={data?.totalResults ?? 0}
@@ -494,25 +495,35 @@
       onClear={() => selection.clear()}
     >
       {#snippet actions()}
-        <Button variant="default" size="sm" onclick={handleBulkMarkCorrect}>
-          <CircleCheck class="size-4 text-[var(--color-success)]" />
+        <Button
+          variant="default"
+          size="sm"
+          disabled={!hasSelection}
+          onclick={handleBulkMarkCorrect}
+        >
+          <CircleCheck class="size-4 {hasSelection ? 'text-[var(--color-success)]' : ''}" />
           {t('dashboard.recentDetections.actions.markCorrect')}
         </Button>
-        <Button variant="default" size="sm" onclick={handleBulkMarkFalsePositive}>
-          <CircleX class="size-4 text-[var(--color-error)]" />
+        <Button
+          variant="default"
+          size="sm"
+          disabled={!hasSelection}
+          onclick={handleBulkMarkFalsePositive}
+        >
+          <CircleX class="size-4 {hasSelection ? 'text-[var(--color-error)]' : ''}" />
           {t('dashboard.recentDetections.actions.markFalsePositive')}
         </Button>
-        <Button variant="default" size="sm" onclick={handleBulkLock}>
+        <Button variant="default" size="sm" disabled={!hasSelection} onclick={handleBulkLock}>
           <Lock class="size-4" />
           {t('dashboard.recentDetections.modals.lockDetection')}
         </Button>
-        <Button variant="default" size="sm" onclick={handleBulkUnlock}>
+        <Button variant="default" size="sm" disabled={!hasSelection} onclick={handleBulkUnlock}>
           <LockOpen class="size-4" />
           {t('dashboard.recentDetections.modals.unlockDetection')}
         </Button>
         <div class="w-px h-6 bg-[var(--color-base-300)] mx-1" role="separator"></div>
-        <Button variant="default" size="sm" onclick={handleBulkDelete}>
-          <Trash2 class="size-4 text-[var(--color-error)]" />
+        <Button variant="default" size="sm" disabled={!hasSelection} onclick={handleBulkDelete}>
+          <Trash2 class="size-4 {hasSelection ? 'text-[var(--color-error)]' : ''}" />
           {t('dashboard.recentDetections.actions.deleteDetection')}
         </Button>
       {/snippet}

--- a/frontend/src/lib/styles/species-display.css
+++ b/frontend/src/lib/styles/species-display.css
@@ -336,8 +336,7 @@ tbody td:last-child,
   text-align: right;
 }
 
-tbody td:last-child > *,
-.detection-header-list th:last-child {
+tbody td:last-child > * {
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
## Summary
- Fix Actions column header misalignment in select mode by removing `display: flex` from `.detection-header-list th:last-child` CSS rule that broke table cell vertical alignment
- Show bulk action toolbar immediately when select mode is activated, with buttons disabled/grayed out until at least one detection is selected, eliminating the layout shift on first selection
- Add `flex-wrap` to toolbar action button container to prevent horizontal overflow on narrower screens

## Test Plan
- [ ] Open detection listing with species filter (e.g. Turdus pilaris)
- [ ] Toggle select mode and verify Actions column header aligns with other headers
- [ ] Verify bulk action toolbar appears immediately with grayed-out buttons
- [ ] Select a detection and verify buttons become active with colored icons
- [ ] Clear selection and verify buttons return to disabled state
- [ ] Test on narrower browser widths to verify toolbar buttons wrap properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clear selection button now only displays when items are selected.
  * Action buttons are disabled when no items are selected for clearer feedback.
  * Action buttons now wrap responsively in constrained spaces instead of staying in a single row.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->