### PR TITLE
fix(conf): silence spurious cgroup error on non-Linux platforms

### DIFF
--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -311,7 +311,6 @@ func RunningInContainer() bool {
 	// Check cgroup for hints of container runtime.
 	file, err := os.Open("/proc/self/cgroup")
 	if err != nil {
-		fmt.Println("Error opening /proc/self/cgroup:", err)
 		return false
 	}
 	defer func() {


### PR DESCRIPTION
## Summary

The `IsRunningInContainer()` check in `internal/conf/utils.go` prints `Error opening /proc/self/cgroup: ...` to stdout on macOS and other non-Linux systems where `/proc` doesn't exist. This is expected behavior (the system is not in a container) and shouldn't produce user-visible output.

The other two callers of the same pattern (`internal/sysinfo/environment.go`, `internal/support/collector.go`) already handle the error silently. This aligns the behavior.

## Test plan

- [x] Run `birdnet-go realtime` on macOS — no more spurious error line in output
- [ ] Run in Docker on Linux — container detection still works correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved an issue where unnecessary console output was being displayed during error handling, resulting in cleaner application behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->