### PR TITLE
fix(SettingSave): fix exclude list settings save failure

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -58,8 +58,7 @@ type Controller struct {
 	TaxonomyDB          *classifier.TaxonomyDatabase
 	controlChan         chan string
 	shutdownRequester   ShutdownRequester // programmatic shutdown trigger (e.g., for restart)
-	shutdownMu          sync.RWMutex      // protects shutdownRequester
-	speciesExcludeMutex sync.RWMutex      // Mutex for species exclude list operations
+	shutdownMu sync.RWMutex // protects shutdownRequester
 	// DisableSaveSettings prevents persisting settings changes to disk.
 	// When set to true, all settings modifications remain in memory only.
 	// This is primarily used in testing but can be used in production for read-only mode.

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1543,13 +1543,9 @@ func (c *Controller) IgnoreSpecies(ctx echo.Context) error {
 
 // GetExcludedSpecies returns the list of excluded species
 func (c *Controller) GetExcludedSpecies(ctx echo.Context) error {
-	settings := c.Settings
-
-	// Create a copy of the slice to avoid race conditions
-	c.speciesExcludeMutex.Lock()
-	species := make([]string, len(settings.Realtime.Species.Exclude))
-	copy(species, settings.Realtime.Species.Exclude)
-	c.speciesExcludeMutex.Unlock()
+	c.settingsMutex.RLock()
+	species := slices.Clone(c.getSettingsOrFallback().Realtime.Species.Exclude)
+	c.settingsMutex.RUnlock()
 
 	return ctx.JSON(http.StatusOK, ExcludedSpeciesResponse{
 		Species: species,
@@ -1573,40 +1569,59 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 		return "", false, nil
 	}
 
-	// Use the controller's mutex to protect this operation
-	c.speciesExcludeMutex.Lock()
-	defer c.speciesExcludeMutex.Unlock()
+	// Serialise against concurrent settings saves so that out-of-band
+	// StoreSettings calls (range filter rebuild, etc.) cannot desynchronise
+	// c.Settings from the live atomic pointer between read and publish.
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
 
-	// Access settings via dependency injection (not the global singleton)
-	settings := c.Settings
+	// Always read the live atomic snapshot; c.Settings may be stale after
+	// UpdateIncludedSpecies or other out-of-band StoreSettings calls.
+	current := c.getSettingsOrFallback()
 
-	// Check if species is already in the excluded list
-	wasExcluded := slices.Contains(settings.Realtime.Species.Exclude, species)
+	wasExcluded := slices.Contains(current.Realtime.Species.Exclude, species)
 
+	updated := conf.CloneSettings(current)
 	if wasExcluded {
-		// Remove from excluded list
-		newExcludeList := make([]string, 0, len(settings.Realtime.Species.Exclude)-1)
-		for _, s := range settings.Realtime.Species.Exclude {
+		newExcludeList := make([]string, 0, len(updated.Realtime.Species.Exclude)-1)
+		for _, s := range updated.Realtime.Species.Exclude {
 			if s != species {
 				newExcludeList = append(newExcludeList, s)
 			}
 		}
-		settings.Realtime.Species.Exclude = newExcludeList
+		updated.Realtime.Species.Exclude = newExcludeList
 		action = "removed"
 		isExcluded = false
 	} else {
-		// Add to excluded list
-		newExcludeList := make([]string, len(settings.Realtime.Species.Exclude), len(settings.Realtime.Species.Exclude)+1)
-		copy(newExcludeList, settings.Realtime.Species.Exclude)
+		newExcludeList := make([]string, len(updated.Realtime.Species.Exclude), len(updated.Realtime.Species.Exclude)+1)
+		copy(newExcludeList, updated.Realtime.Species.Exclude)
 		newExcludeList = append(newExcludeList, species)
-		settings.Realtime.Species.Exclude = newExcludeList
+		updated.Realtime.Species.Exclude = newExcludeList
 		action = "added"
 		isExcluded = true
 	}
 
-	// Save settings using the package function that handles concurrency
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
+
 	if err := conf.SaveSettings(); err != nil {
+		// Rollback so in-memory state matches disk.
+		if c.isGlobalOwner {
+			conf.StoreSettings(current)
+		}
+		c.Settings = current
 		return "", wasExcluded, fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	// Trigger side-effects (range filter rebuild, etc.) so the include list
+	// reflects the updated exclude list without waiting for the daily rebuild.
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after species exclusion change",
+			logger.Error(handleErr),
+			logger.String("species", species),
+			logger.String("action", action))
 	}
 
 	return action, isExcluded, nil
@@ -1619,32 +1634,37 @@ func (c *Controller) addSpeciesToIgnoredList(species string) error {
 		return nil
 	}
 
-	// Use the controller's mutex to protect this operation
-	c.speciesExcludeMutex.Lock()
-	defer c.speciesExcludeMutex.Unlock()
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
 
-	// Access settings via dependency injection (not the global singleton)
-	settings := c.Settings
+	current := c.getSettingsOrFallback()
+	if slices.Contains(current.Realtime.Species.Exclude, species) {
+		return nil
+	}
 
-	// Check if species is already in the excluded list
-	isExcluded := slices.Contains(settings.Realtime.Species.Exclude, species)
+	updated := conf.CloneSettings(current)
+	newExcludeList := make([]string, len(updated.Realtime.Species.Exclude), len(updated.Realtime.Species.Exclude)+1)
+	copy(newExcludeList, updated.Realtime.Species.Exclude)
+	newExcludeList = append(newExcludeList, species)
+	updated.Realtime.Species.Exclude = newExcludeList
 
-	// If not already excluded, add it
-	if !isExcluded {
-		// Create a copy of the current exclude list to avoid race conditions
-		newExcludeList := make([]string, len(settings.Realtime.Species.Exclude), len(settings.Realtime.Species.Exclude)+1)
-		copy(newExcludeList, settings.Realtime.Species.Exclude)
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 
-		// Add the new species to the list
-		newExcludeList = append(newExcludeList, species)
-
-		// Update the settings with the new list
-		settings.Realtime.Species.Exclude = newExcludeList
-
-		// Save settings using the package function that handles concurrency
-		if err := conf.SaveSettings(); err != nil {
-			return fmt.Errorf("failed to save settings: %w", err)
+	if err := conf.SaveSettings(); err != nil {
+		if c.isGlobalOwner {
+			conf.StoreSettings(current)
 		}
+		c.Settings = current
+		return fmt.Errorf("failed to save settings: %w", err)
+	}
+
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after species exclusion change",
+			logger.Error(handleErr),
+			logger.String("species", species))
 	}
 
 	return nil

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1593,10 +1593,7 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 		action = "removed"
 		isExcluded = false
 	} else {
-		newExcludeList := make([]string, len(updated.Realtime.Species.Exclude), len(updated.Realtime.Species.Exclude)+1)
-		copy(newExcludeList, updated.Realtime.Species.Exclude)
-		newExcludeList = append(newExcludeList, species)
-		updated.Realtime.Species.Exclude = newExcludeList
+		updated.Realtime.Species.Exclude = append(updated.Realtime.Species.Exclude, species)
 		action = "added"
 		isExcluded = true
 	}
@@ -1606,13 +1603,13 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 	}
 	c.Settings = updated
 
-	if err := conf.SaveSettings(); err != nil {
-		// Rollback so in-memory state matches disk.
-		if c.isGlobalOwner {
+	if c.isGlobalOwner && !c.DisableSaveSettings {
+		if err := conf.SaveSettings(); err != nil {
+			// Rollback so in-memory state matches disk.
 			conf.StoreSettings(current)
+			c.Settings = current
+			return "", wasExcluded, fmt.Errorf("failed to save settings: %w", err)
 		}
-		c.Settings = current
-		return "", wasExcluded, fmt.Errorf("failed to save settings: %w", err)
 	}
 
 	// Trigger side-effects (range filter rebuild, etc.) so the include list
@@ -1643,22 +1640,19 @@ func (c *Controller) addSpeciesToIgnoredList(species string) error {
 	}
 
 	updated := conf.CloneSettings(current)
-	newExcludeList := make([]string, len(updated.Realtime.Species.Exclude), len(updated.Realtime.Species.Exclude)+1)
-	copy(newExcludeList, updated.Realtime.Species.Exclude)
-	newExcludeList = append(newExcludeList, species)
-	updated.Realtime.Species.Exclude = newExcludeList
+	updated.Realtime.Species.Exclude = append(updated.Realtime.Species.Exclude, species)
 
 	if c.isGlobalOwner {
 		conf.StoreSettings(updated)
 	}
 	c.Settings = updated
 
-	if err := conf.SaveSettings(); err != nil {
-		if c.isGlobalOwner {
+	if c.isGlobalOwner && !c.DisableSaveSettings {
+		if err := conf.SaveSettings(); err != nil {
 			conf.StoreSettings(current)
+			c.Settings = current
+			return fmt.Errorf("failed to save settings: %w", err)
 		}
-		c.Settings = current
-		return fmt.Errorf("failed to save settings: %w", err)
 	}
 
 	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1583,13 +1583,9 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 
 	updated := conf.CloneSettings(current)
 	if wasExcluded {
-		newExcludeList := make([]string, 0, len(updated.Realtime.Species.Exclude)-1)
-		for _, s := range updated.Realtime.Species.Exclude {
-			if s != species {
-				newExcludeList = append(newExcludeList, s)
-			}
-		}
-		updated.Realtime.Species.Exclude = newExcludeList
+		updated.Realtime.Species.Exclude = slices.DeleteFunc(updated.Realtime.Species.Exclude, func(s string) bool {
+			return s == species
+		})
 		action = "removed"
 		isExcluded = false
 	} else {

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -193,18 +193,24 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 
 	// Stage 2: Apply all settings atomically after all I/O succeeded.
 	c.settingsMutex.Lock()
+	current := c.getSettingsOrFallback()
+	updated := conf.CloneSettings(current)
 	if update.caCert != "" {
-		c.Settings.Realtime.MQTT.TLS.CACert = update.caCert
+		updated.Realtime.MQTT.TLS.CACert = update.caCert
 	} else if update.clearCA {
-		c.Settings.Realtime.MQTT.TLS.CACert = ""
+		updated.Realtime.MQTT.TLS.CACert = ""
 	}
 	if update.clientCert != "" {
-		c.Settings.Realtime.MQTT.TLS.ClientCert = update.clientCert
-		c.Settings.Realtime.MQTT.TLS.ClientKey = update.clientKey
+		updated.Realtime.MQTT.TLS.ClientCert = update.clientCert
+		updated.Realtime.MQTT.TLS.ClientKey = update.clientKey
 	} else if update.clearClient {
-		c.Settings.Realtime.MQTT.TLS.ClientCert = ""
-		c.Settings.Realtime.MQTT.TLS.ClientKey = ""
+		updated.Realtime.MQTT.TLS.ClientCert = ""
+		updated.Realtime.MQTT.TLS.ClientKey = ""
 	}
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 	c.settingsMutex.Unlock()
 
 	if !c.DisableSaveSettings {
@@ -231,9 +237,15 @@ func (c *Controller) DeleteMQTTTLSCertificate(ctx echo.Context) error {
 
 	// Clear all certificate paths in settings
 	c.settingsMutex.Lock()
-	c.Settings.Realtime.MQTT.TLS.CACert = ""
-	c.Settings.Realtime.MQTT.TLS.ClientCert = ""
-	c.Settings.Realtime.MQTT.TLS.ClientKey = ""
+	current := c.getSettingsOrFallback()
+	updated := conf.CloneSettings(current)
+	updated.Realtime.MQTT.TLS.CACert = ""
+	updated.Realtime.MQTT.TLS.ClientCert = ""
+	updated.Realtime.MQTT.TLS.ClientKey = ""
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 	c.settingsMutex.Unlock()
 
 	if !c.DisableSaveSettings {

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -133,7 +133,13 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 
 	// Update TLS mode to manual
 	c.settingsMutex.Lock()
-	c.Settings.Security.TLSMode = conf.TLSModeManual
+	current := c.getSettingsOrFallback()
+	updated := conf.CloneSettings(current)
+	updated.Security.TLSMode = conf.TLSModeManual
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 	c.settingsMutex.Unlock()
 
 	if !c.DisableSaveSettings {
@@ -165,7 +171,13 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 
 	// Reset TLS mode to none
 	c.settingsMutex.Lock()
-	c.Settings.Security.TLSMode = conf.TLSModeNone
+	current := c.getSettingsOrFallback()
+	updated := conf.CloneSettings(current)
+	updated.Security.TLSMode = conf.TLSModeNone
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 	c.settingsMutex.Unlock()
 
 	if !c.DisableSaveSettings {
@@ -207,8 +219,9 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 
 	// Collect SANs from settings
 	c.settingsMutex.RLock()
-	host := c.Settings.Security.Host
-	baseURL := c.Settings.Security.BaseURL
+	snap := c.getSettingsOrFallback()
+	host := snap.Security.Host
+	baseURL := snap.Security.BaseURL
 	c.settingsMutex.RUnlock()
 
 	sans := tlspkg.CollectSANs(host, baseURL)
@@ -236,7 +249,13 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 
 	// Update TLS mode to self-signed
 	c.settingsMutex.Lock()
-	c.Settings.Security.TLSMode = conf.TLSModeSelfSigned
+	current := c.getSettingsOrFallback()
+	updated := conf.CloneSettings(current)
+	updated.Security.TLSMode = conf.TLSModeSelfSigned
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 	c.settingsMutex.Unlock()
 
 	if !c.DisableSaveSettings {


### PR DESCRIPTION
## Summary

- Fix ignored species silently re-appearing in detections after the ONNX geomodel and Perch model were introduced
- Fix `GetExcludedSpecies` reading from a stale settings pointer under an incorrect write lock
- Remove now-unused `speciesExcludeMutex` field from the API controller

## Root Cause

Every time the range filter rebuilds its species list (on startup and daily), `UpdateIncludedSpecies` publishes a brand-new settings snapshot via `conf.StoreSettings(newSnapshot)`. After that call, the API controller's `c.Settings` field is **stale** — it still points to the old settings object, not the live one.

`toggleSpeciesInIgnoredList` and `addSpeciesToIgnoredList` were reading `settings := c.Settings` (the stale pointer), mutating the exclude list **in-place** on that stale object, then calling `conf.SaveSettings()`. Because `conf.SaveSettings()` reads from the **live** atomic pointer (not the mutated stale one), it wrote the old exclude list to disk. The processor also reads from the live atomic pointer, so it never saw the in-place change either. The ignore was silently discarded both in-memory and on disk — every single time.

This regression was introduced alongside the ONNX geomodel because that was the first time `UpdateIncludedSpecies` ran regularly (on startup + daily), causing `c.Settings` to diverge from `conf.GetSettings()` shortly after boot. Before the geomodel, the atomic pointer was rarely replaced, so `c.Settings` happened to stay in sync and the bug was latent.

The main settings save path (`UpdateSettings`) already handled this correctly — its `getSettingsOrFallback()` helper explicitly reads from `conf.GetSettings()` to avoid "a stale `c.Settings` pointer being overwritten by out-of-band `StoreSettings` calls (range filter, etc.)". The ignore-species functions were never updated to follow the same pattern.

## Fix

Replaced the in-place mutation pattern in `toggleSpeciesInIgnoredList` and `addSpeciesToIgnoredList` with the same **clone-mutate-publish** approach used by the main settings save path:

1. Acquire `c.settingsMutex.Lock()` (same mutex as `UpdateSettings`) to serialise against concurrent saves
2. Read the live snapshot via `c.getSettingsOrFallback()` instead of `c.Settings`
3. Deep-clone via `conf.CloneSettings(current)`
4. Modify the exclude list on the clone
5. Publish via `conf.StoreSettings(updated)` so the atomic pointer is updated immediately
6. Keep `c.Settings = updated` in sync
7. Persist to disk via `conf.SaveSettings()` (which now reads the correctly updated snapshot)
8. Call `c.handleSettingsChanges(current, updated)` to trigger an immediate range filter rebuild, so the species include list also reflects the change without waiting for the next daily cycle

Also fixed `GetExcludedSpecies` to read from `c.getSettingsOrFallback()` under `c.settingsMutex.RLock()` instead of the stale `c.Settings` under a write lock, and removed the now-unused `speciesExcludeMutex` field from the controller struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified settings update flow to use consistent snapshots and cloned updates for safer applies.
  * Consolidated concurrency handling for excluded-species management under a single settings lock.

* **Bug Fixes**
  * Settings changes now reliably trigger dependent operations; persistence failures roll back in-memory state.
  * TLS and MQTT certificate operations (upload/delete/generate) are handled more safely and consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->