### PR TITLE
fix: spectrogram 404, note ID parsing, HLS cleanup, FFmpeg RTSPS args

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1603,14 +1603,22 @@ func cleanupHLSStreamingFiles() error {
 				logger.String("path", path),
 				logger.String("operation", "cleanup_hls_files"))
 
-			// Remove the directory and all its contents
+			// Remove the directory and all its contents.
+			// Retry once on "directory not empty" to handle the race where
+			// a concurrent HLS writer creates a file between RemoveAll's
+			// internal traversal and the final parent unlink.
 			if err := os.RemoveAll(path); err != nil {
-				log.Warn("failed to remove HLS stream directory",
-					logger.String("path", path),
-					logger.Error(err),
-					logger.String("operation", "cleanup_hls_files"))
-				cleanupErrors = append(cleanupErrors, fmt.Sprintf("%s: %v", path, err))
-				// Continue with other directories
+				if strings.Contains(err.Error(), "directory not empty") {
+					time.Sleep(100 * time.Millisecond)
+					err = os.RemoveAll(path)
+				}
+				if err != nil {
+					log.Warn("failed to remove HLS stream directory",
+						logger.String("path", path),
+						logger.Error(err),
+						logger.String("operation", "cleanup_hls_files"))
+					cleanupErrors = append(cleanupErrors, fmt.Sprintf("%s: %v", path, err))
+				}
 			}
 		}
 	}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -796,11 +796,16 @@ func (s *Stream) startProcess() error {
 		"-loglevel", logLevel,
 		"-vn",
 		"-f", format,
-		"-ar", sampleRate,
-		"-ac", numChannels,
-		"-hide_banner",
-		"pipe:1",
 	)
+
+	// Protocol-based streams (RTSP, HTTP, HLS, RTMP, UDP) negotiate audio
+	// parameters via SDP/headers. Only local sources need explicit values.
+	srcType := s.config.sourceType()
+	if srcType == audiocore.SourceTypeAudioCard || srcType == audiocore.SourceTypeFile || srcType == audiocore.SourceTypeUnknown {
+		args = append(args, "-ar", sampleRate, "-ac", numChannels)
+	}
+
+	args = append(args, "-hide_banner", "pipe:1")
 
 	s.cmd = exec.CommandContext(s.ctx, s.config.FFmpegPath, args...) //nolint:gosec // G204: FFmpegPath from validated settings, args built internally
 

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -232,6 +232,10 @@ func (c *StreamConfig) sourceType() audiocore.SourceType {
 		return audiocore.SourceTypeRTMP
 	case "udp":
 		return audiocore.SourceTypeUDP
+	case "audio_card":
+		return audiocore.SourceTypeAudioCard
+	case "file":
+		return audiocore.SourceTypeFile
 	default:
 		return audiocore.SourceTypeUnknown
 	}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -442,35 +442,23 @@ func (ds *DataStore) Save(note *Note, results []Results) error {
 	return nil
 }
 
-// parseNoteID validates and converts a string note ID to uint.
-func parseNoteID(id string) (uint, error) {
+// parseEntityID validates and converts a string entity ID to uint.
+// entityName is used in error messages (e.g., "note", "comment").
+func parseEntityID(id, entityName string) (uint, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return 0, validationError("note ID cannot be empty", "id", "")
+		return 0, validationError(entityName+" ID cannot be empty", "id", "")
 	}
 	val, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		return 0, validationError("invalid note ID format", "id", id)
-	}
-	return uint(val), nil
-}
-
-// parseCommentID validates and converts a string comment ID to uint.
-func parseCommentID(id string) (uint, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return 0, validationError("comment ID cannot be empty", "id", "")
-	}
-	val, err := strconv.ParseUint(id, 10, 64)
-	if err != nil {
-		return 0, validationError("invalid comment ID format", "id", id)
+		return 0, validationError("invalid "+entityName+" ID format", "id", id)
 	}
 	return uint(val), nil
 }
 
 // Get retrieves a note by its ID from the database.
 func (ds *DataStore) Get(id string) (Note, error) {
-	noteID, err := parseNoteID(id)
+	noteID, err := parseEntityID(id, "note")
 	if err != nil {
 		return Note{}, err
 	}
@@ -501,7 +489,7 @@ func (ds *DataStore) Get(id string) (Note, error) {
 
 // Delete removes a note and its associated results from the database.
 func (ds *DataStore) Delete(id string) error {
-	noteID, err := parseNoteID(id)
+	noteID, err := parseEntityID(id, "note")
 	if err != nil {
 		return err
 	}
@@ -1276,12 +1264,9 @@ func (ds *DataStore) CountSpeciesDetections(species, date, hour string, duration
 // UpdateNote updates specific fields of a note. It validates the input parameters
 // and returns appropriate errors if the note doesn't exist or if the update fails.
 func (ds *DataStore) UpdateNote(id string, updates map[string]any) error {
-	if id == "" {
-		return errors.Newf("invalid id: must not be empty").
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "update_note").
-			Build()
+	noteID, err := parseEntityID(id, "note")
+	if err != nil {
+		return err
 	}
 	if len(updates) == 0 {
 		return errors.Newf("no updates provided").
@@ -1292,8 +1277,8 @@ func (ds *DataStore) UpdateNote(id string, updates map[string]any) error {
 	}
 
 	var rowsAffected int64
-	err := RetryOnLock(context.Background(), "update_note", func() error {
-		result := ds.DB.Model(&Note{}).Where("id = ?", id).Updates(updates)
+	err = RetryOnLock(context.Background(), "update_note", func() error {
+		result := ds.DB.Model(&Note{}).Where("id = ?", noteID).Updates(updates)
 		if result.Error != nil {
 			return result.Error
 		}
@@ -1324,7 +1309,7 @@ func (ds *DataStore) UpdateNote(id string, updates map[string]any) error {
 // GetNoteReview retrieves the review status for a note
 func (ds *DataStore) GetNoteReview(noteID string) (*NoteReview, error) {
 	var review NoteReview
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return nil, err
 	}
@@ -1378,7 +1363,7 @@ func (ds *DataStore) SaveNoteReview(review *NoteReview) error {
 // GetNoteComments retrieves all comments for a note
 func (ds *DataStore) GetNoteComments(noteID string) ([]NoteComment, error) {
 	var comments []NoteComment
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return nil, err
 	}
@@ -1398,7 +1383,7 @@ func (ds *DataStore) GetNoteComments(noteID string) ([]NoteComment, error) {
 
 // GetNoteResults returns the additional predictions for a note.
 func (ds *DataStore) GetNoteResults(noteID string) ([]Results, error) {
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return nil, err
 	}
@@ -1584,7 +1569,7 @@ func (ds *DataStore) SaveNoteComment(comment *NoteComment) error {
 
 // DeleteNoteComment deletes a comment
 func (ds *DataStore) DeleteNoteComment(commentID string) error {
-	id, err := parseCommentID(commentID)
+	id, err := parseEntityID(commentID, "comment")
 	if err != nil {
 		return err
 	}
@@ -1604,7 +1589,7 @@ func (ds *DataStore) DeleteNoteComment(commentID string) error {
 
 // UpdateNoteComment updates an existing comment's entry
 func (ds *DataStore) UpdateNoteComment(commentID, entry string) error {
-	id, err := parseCommentID(commentID)
+	id, err := parseEntityID(commentID, "comment")
 	if err != nil {
 		return err
 	}
@@ -1685,7 +1670,7 @@ func (ds *DataStore) Transaction(fc func(tx *gorm.DB) error) error {
 
 // GetNoteLock retrieves the lock status for a note
 func (ds *DataStore) GetNoteLock(noteID string) (*NoteLock, error) {
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return nil, err
 	}
@@ -1710,7 +1695,7 @@ func (ds *DataStore) GetNoteLock(noteID string) (*NoteLock, error) {
 
 // IsNoteLocked checks if a note is locked
 func (ds *DataStore) IsNoteLocked(noteID string) (bool, error) {
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return false, err
 	}
@@ -1735,7 +1720,7 @@ func (ds *DataStore) IsNoteLocked(noteID string) (bool, error) {
 
 // LockNote creates or updates a lock for a note
 func (ds *DataStore) LockNote(noteID string) error {
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return err
 	}
@@ -1766,7 +1751,7 @@ func (ds *DataStore) LockNote(noteID string) error {
 
 // UnlockNote removes a lock from a note
 func (ds *DataStore) UnlockNote(noteID string) error {
-	id, err := parseNoteID(noteID)
+	id, err := parseEntityID(noteID, "note")
 	if err != nil {
 		return err
 	}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -442,12 +442,37 @@ func (ds *DataStore) Save(note *Note, results []Results) error {
 	return nil
 }
 
+// parseNoteID validates and converts a string note ID to uint.
+func parseNoteID(id string) (uint, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return 0, validationError("note ID cannot be empty", "id", "")
+	}
+	val, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return 0, validationError("invalid note ID format", "id", id)
+	}
+	return uint(val), nil
+}
+
+// parseCommentID validates and converts a string comment ID to uint.
+func parseCommentID(id string) (uint, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return 0, validationError("comment ID cannot be empty", "id", "")
+	}
+	val, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return 0, validationError("invalid comment ID format", "id", id)
+	}
+	return uint(val), nil
+}
+
 // Get retrieves a note by its ID from the database.
 func (ds *DataStore) Get(id string) (Note, error) {
-	// Convert the id from string to integer
-	noteID, err := strconv.Atoi(id)
+	noteID, err := parseNoteID(id)
 	if err != nil {
-		return Note{}, validationError("invalid note ID format", "id", id)
+		return Note{}, err
 	}
 
 	var note Note
@@ -476,10 +501,9 @@ func (ds *DataStore) Get(id string) (Note, error) {
 
 // Delete removes a note and its associated results from the database.
 func (ds *DataStore) Delete(id string) error {
-	// Convert the id from string to unsigned integer
-	noteID, err := strconv.ParseUint(id, 10, 32)
+	noteID, err := parseNoteID(id)
 	if err != nil {
-		return validationError("invalid note ID format for deletion", "id", id)
+		return err
 	}
 
 	// Check if the note is locked
@@ -1300,14 +1324,9 @@ func (ds *DataStore) UpdateNote(id string, updates map[string]any) error {
 // GetNoteReview retrieves the review status for a note
 func (ds *DataStore) GetNoteReview(noteID string) (*NoteReview, error) {
 	var review NoteReview
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return nil, errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "get_note_review").
-			Context("note_id", noteID).
-			Build()
+		return nil, err
 	}
 
 	// Use Session to temporarily modify logger config for this query
@@ -1359,14 +1378,9 @@ func (ds *DataStore) SaveNoteReview(review *NoteReview) error {
 // GetNoteComments retrieves all comments for a note
 func (ds *DataStore) GetNoteComments(noteID string) ([]NoteComment, error) {
 	var comments []NoteComment
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return nil, errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "get_note_comments").
-			Context("note_id", noteID).
-			Build()
+		return nil, err
 	}
 
 	err = ds.DB.Where("note_id = ?", id).Order("created_at DESC").Find(&comments).Error
@@ -1384,15 +1398,9 @@ func (ds *DataStore) GetNoteComments(noteID string) ([]NoteComment, error) {
 
 // GetNoteResults returns the additional predictions for a note.
 func (ds *DataStore) GetNoteResults(noteID string) ([]Results, error) {
-	// Parse ID for consistency and MySQL compatibility
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return nil, errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "get_note_results").
-			Context("note_id", noteID).
-			Build()
+		return nil, err
 	}
 
 	var results []Results
@@ -1576,14 +1584,9 @@ func (ds *DataStore) SaveNoteComment(comment *NoteComment) error {
 
 // DeleteNoteComment deletes a comment
 func (ds *DataStore) DeleteNoteComment(commentID string) error {
-	id, err := strconv.ParseUint(commentID, 10, 32)
+	id, err := parseCommentID(commentID)
 	if err != nil {
-		return errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "delete_note_comment").
-			Context("comment_id", commentID).
-			Build()
+		return err
 	}
 
 	return RetryOnLock(context.Background(), "delete_note_comment", func() error {
@@ -1601,14 +1604,9 @@ func (ds *DataStore) DeleteNoteComment(commentID string) error {
 
 // UpdateNoteComment updates an existing comment's entry
 func (ds *DataStore) UpdateNoteComment(commentID, entry string) error {
-	id, err := strconv.ParseUint(commentID, 10, 32)
+	id, err := parseCommentID(commentID)
 	if err != nil {
-		return errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "update_note_comment").
-			Context("comment_id", commentID).
-			Build()
+		return err
 	}
 
 	var rowsAffected int64
@@ -1687,14 +1685,9 @@ func (ds *DataStore) Transaction(fc func(tx *gorm.DB) error) error {
 
 // GetNoteLock retrieves the lock status for a note
 func (ds *DataStore) GetNoteLock(noteID string) (*NoteLock, error) {
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return nil, errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "get_note_lock").
-			Context("note_id", noteID).
-			Build()
+		return nil, err
 	}
 
 	var lock NoteLock
@@ -1717,14 +1710,9 @@ func (ds *DataStore) GetNoteLock(noteID string) (*NoteLock, error) {
 
 // IsNoteLocked checks if a note is locked
 func (ds *DataStore) IsNoteLocked(noteID string) (bool, error) {
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return false, errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "is_note_locked").
-			Context("note_id", noteID).
-			Build()
+		return false, err
 	}
 
 	var count int64
@@ -1747,19 +1735,14 @@ func (ds *DataStore) IsNoteLocked(noteID string) (bool, error) {
 
 // LockNote creates or updates a lock for a note
 func (ds *DataStore) LockNote(noteID string) error {
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "lock_note").
-			Context("note_id", noteID).
-			Build()
+		return err
 	}
 
 	err = RetryOnLock(context.Background(), "lock_note", func() error {
 		lock := &NoteLock{
-			NoteID:   uint(id),
+			NoteID:   id,
 			LockedAt: time.Now(),
 		}
 
@@ -1783,9 +1766,9 @@ func (ds *DataStore) LockNote(noteID string) error {
 
 // UnlockNote removes a lock from a note
 func (ds *DataStore) UnlockNote(noteID string) error {
-	id, err := strconv.ParseUint(noteID, 10, 32)
+	id, err := parseNoteID(noteID)
 	if err != nil {
-		return validationError("invalid note ID format for unlock", "note_id", noteID)
+		return err
 	}
 
 	err = RetryOnLock(context.Background(), "unlock_note", func() error {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -78,7 +78,7 @@ func parseHour(hour string) (int, error) {
 
 // parseID converts a string ID to uint.
 func parseID(id string) (uint, error) {
-	parsed, err := strconv.ParseUint(id, 10, 32)
+	parsed, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid ID %q: %w", id, err)
 	}

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -300,6 +300,13 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 			Build()
 	}
 
+	// Verify the audio file is accessible before starting generation.
+	// Checked here (not in each generator method) to produce a clear error
+	// and skip the Sox->FFmpeg fallback when the file simply does not exist.
+	if _, statErr := os.Stat(audioPath); statErr != nil {
+		return fmt.Errorf("audio file inaccessible: %w", statErr)
+	}
+
 	// Ensure output directory exists using SecureFS (validates path automatically)
 	if err := g.ensureOutputDirectory(outputPath); err != nil {
 		return err
@@ -470,10 +477,6 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 			Build()
 	}
 
-	if _, statErr := os.Stat(audioPath); statErr != nil {
-		return fmt.Errorf("audio file not found: %w", os.ErrNotExist)
-	}
-
 	// Build Sox arguments for file input
 	soxArgs := g.getSoxArgs(ctx, settings, audioPath, outputPath, width, raw, SoxInputFile, preValidatedDuration)
 
@@ -563,10 +566,6 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Category(errors.CategoryConfiguration).
 			Context("operation", "generate_with_ffmpeg_sox_pipeline").
 			Build()
-	}
-
-	if _, statErr := os.Stat(audioPath); statErr != nil {
-		return fmt.Errorf("audio file not found: %w", os.ErrNotExist)
 	}
 
 	// FFmpeg converts audio to Sox format and pipes to Sox
@@ -796,10 +795,6 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 			Context("operation", "generate_with_ffmpeg").
 			Context("ffmpeg_path", ffmpegBinary).
 			Build()
-	}
-
-	if _, statErr := os.Stat(audioPath); statErr != nil {
-		return fmt.Errorf("audio file not found: %w", os.ErrNotExist)
 	}
 
 	height := fftFriendlyHeight(width)

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -470,6 +470,10 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 			Build()
 	}
 
+	if _, statErr := os.Stat(audioPath); statErr != nil {
+		return fmt.Errorf("audio file not found: %w", os.ErrNotExist)
+	}
+
 	// Build Sox arguments for file input
 	soxArgs := g.getSoxArgs(ctx, settings, audioPath, outputPath, width, raw, SoxInputFile, preValidatedDuration)
 
@@ -559,6 +563,10 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Category(errors.CategoryConfiguration).
 			Context("operation", "generate_with_ffmpeg_sox_pipeline").
 			Build()
+	}
+
+	if _, statErr := os.Stat(audioPath); statErr != nil {
+		return fmt.Errorf("audio file not found: %w", os.ErrNotExist)
 	}
 
 	// FFmpeg converts audio to Sox format and pipes to Sox
@@ -788,6 +796,10 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 			Context("operation", "generate_with_ffmpeg").
 			Context("ffmpeg_path", ffmpegBinary).
 			Build()
+	}
+
+	if _, statErr := os.Stat(audioPath); statErr != nil {
+		return fmt.Errorf("audio file not found: %w", os.ErrNotExist)
 	}
 
 	height := fftFriendlyHeight(width)


### PR DESCRIPTION
## Summary

Batch of four backend bug fixes from the Forgejo tracker, plus pre-existing improvements found during gate review.

**Bug fixes:**
- **Spectrogram 404** (Forgejo #745): add file existence check in `GenerateFromFile` before calling FFmpeg/Sox. Returns the actual stat error (wrapping `os.ErrNotExist` for missing files) so `spectrogramHTTPError` maps it to HTTP 404 instead of 500. Skips the Sox->FFmpeg fallback when the file simply does not exist.
- **Note ID parsing** (Forgejo #568): add shared `parseEntityID(id, entityName)` helper using consistent `strconv.ParseUint(id, 10, 64)`. Replaces `strconv.Atoi` in `Get()` and inline `ParseUint(id, 10, 32)` across 12 note/comment operations. Consolidates two near-identical helpers into one.
- **HLS cleanup** (Forgejo #561): retry `os.RemoveAll` once after 100ms on "directory not empty" to handle the race where a concurrent HLS writer creates a file between `RemoveAll`'s internal traversal and the final parent unlink.
- **FFmpeg RTSPS** (Forgejo #730): make `-ar`/`-ac` flags conditional on source type. Protocol-based streams (RTSP, HTTP, HLS, RTMP, UDP) negotiate audio parameters via SDP/headers; only local sources (audio card, file) need explicit sample rate and channel count.

**Pre-existing fixes** (found during gate review):
- `sourceType()` now maps "audio_card" and "file" explicitly instead of falling through to Unknown
- `v2only/datastore.go` `parseID` upgraded from `ParseUint(32)` to `ParseUint(64)` for consistency
- `UpdateNote` now validates ID via `parseEntityID` instead of raw string comparison

## Test plan
- [ ] `golangci-lint run -v` passes with zero issues
- [ ] `go test -race ./internal/datastore/... ./internal/audiocore/ffmpeg/... ./internal/spectrogram/...` passes (1201 tests)
- [ ] Verify spectrogram requests for deleted audio files return 404 (not 500)
- [ ] Verify RTSPS stream sources connect without "Option sample_rate not found" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS stream cleanup reliability with automatic retry on failures
  * Added file accessibility validation for spectrogram generation
  * Enhanced error handling and validation for note/comment operations

* **New Features**
  * Extended audio source type support for better processing
  * Support for larger numeric IDs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->