### PR TITLE
fix: SoxPath validation, species count aggregation, PlayOverlay cleanup, macOS dylib paths

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -448,7 +448,7 @@
 
         // Stop audio playback to prevent resource leaks
         audioElement.pause();
-        audioElement.src = '';
+        audioElement.removeAttribute('src');
       }
 
       // Clean up Web Audio API using shared utilities

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -449,6 +449,7 @@
         // Stop audio playback to prevent resource leaks
         audioElement.pause();
         audioElement.removeAttribute('src');
+        audioElement.load();
       }
 
       // Clean up Web Audio API using shared utilities

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -510,7 +510,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 	}
 
 	// Get probable species for the test parameters
-	speciesScores, err := birdnetInstance.GetProbableSpeciesWithSettings(testDate, week, testSettings)
+	speciesScores, err := birdnetInstance.GetAllProbableSpeciesWithSettings(testDate, week, testSettings)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -59,6 +59,43 @@ func ValidateFFmpegPath(ffmpegPath string) error {
 	return nil
 }
 
+// ValidateSoxPath checks if the Sox path is valid for execution.
+// It rejects empty paths, relative paths, and paths that appear to be
+// HTTP/proxy URL prefixes rather than filesystem paths (e.g., ingress path contamination).
+func ValidateSoxPath(soxPath string) error {
+	if soxPath == "" {
+		return errors.Newf("Sox is not available").
+			Component("audiocore").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate_sox_path").
+			Build()
+	}
+
+	if !filepath.IsAbs(soxPath) {
+		return errors.Newf("Sox path must be absolute, got: %s", soxPath).
+			Component("audiocore").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate_sox_path").
+			Context("path", soxPath).
+			Build()
+	}
+
+	// Reject paths contaminated by HTTP proxy/ingress prefixes.
+	// A valid Sox binary path should be a clean filesystem path,
+	// not contain URL-like segments such as "/api/", "/ingress/", "/proxy/",
+	// or "/hassio/". Uses a case-insensitive regex for broader detection.
+	if rePathContamination.MatchString(soxPath) {
+		return errors.Newf("Sox path appears contaminated by proxy/ingress prefix: %s", soxPath).
+			Component("audiocore").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate_sox_path").
+			Context("path", soxPath).
+			Build()
+	}
+
+	return nil
+}
+
 // GetFFmpegFormat converts audio configuration values to FFmpeg-compatible format strings.
 // Returns sampleRateStr (e.g. "48000"), channelsStr (e.g. "1"), and formatStr (e.g. "s16le").
 // Supported bit depths: 16 → "s16le", 24 → "s24le", 32 → "s32le". Defaults to "s16le".

--- a/internal/audiocore/ffmpeg/common_test.go
+++ b/internal/audiocore/ffmpeg/common_test.go
@@ -83,6 +83,79 @@ func TestValidateFFmpegPath_Invalid(t *testing.T) {
 	})
 }
 
+// TestValidateSoxPath_Valid verifies that a real, absolute sox path passes validation.
+func TestValidateSoxPath_Valid(t *testing.T) {
+	t.Parallel()
+
+	soxPath, err := exec.LookPath("sox")
+	if err != nil {
+		t.Skip("sox not found in PATH, skipping valid-path test")
+	}
+
+	// LookPath may return a relative path on some systems; resolve it.
+	if !filepath.IsAbs(soxPath) {
+		abs, absErr := filepath.Abs(soxPath)
+		require.NoError(t, absErr)
+		soxPath = abs
+	}
+
+	err = ffmpeg.ValidateSoxPath(soxPath)
+	assert.NoError(t, err, "absolute path to real sox binary should pass validation")
+}
+
+// TestValidateSoxPath_Invalid verifies that malformed or suspicious paths are rejected.
+func TestValidateSoxPath_Invalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "empty path",
+			path: "",
+		},
+		{
+			name: "relative path",
+			path: "usr/bin/sox",
+		},
+		{
+			name: "path with api prefix contamination",
+			path: "/api/v1/sox",
+		},
+		{
+			name: "path with ingress prefix contamination",
+			path: "/ingress/sox",
+		},
+		{
+			name: "path with proxy prefix contamination",
+			path: "/proxy/sox",
+		},
+		{
+			name: "path with hassio prefix contamination",
+			path: "/hassio/sox",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ffmpeg.ValidateSoxPath(tt.path)
+			assert.Error(t, err, "path %q should fail validation", tt.path)
+		})
+	}
+
+	// ValidateSoxPath does NOT check whether the file exists; a non-existent
+	// absolute path with no proxy contamination should pass.
+	t.Run("non-existent absolute path passes (existence not checked)", func(t *testing.T) {
+		t.Parallel()
+
+		err := ffmpeg.ValidateSoxPath("/nonexistent/path/to/sox")
+		assert.NoError(t, err, "non-existent absolute path should pass path-format validation")
+	})
+}
+
 // TestGetFFmpegFormat verifies format string output for various sample rate/channel/bit-depth combinations.
 func TestGetFFmpegFormat(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -372,7 +372,15 @@ func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float
 // supplied settings. Additional models (except bat) contribute their full label
 // set since they have no range filter. Results are deduplicated by label.
 func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
-	scores, err := o.primary.GetProbableSpeciesWithSettings(date, week, settings)
+	// Snapshot primary under read lock to avoid racing with Delete().
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil, nil
+	}
+
+	scores, err := primary.GetProbableSpeciesWithSettings(date, week, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +397,7 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 
 	var refs []entryRef
 	o.mu.RLock()
-	primaryID := o.primary.ModelInfo.ID
+	primaryID := primary.ModelInfo.ID
 	for id, entry := range o.models {
 		if id == primaryID || id == RegistryIDBat {
 			continue

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -367,6 +367,57 @@ func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float
 	return o.primary.GetProbableSpeciesWithSettings(date, week, settings)
 }
 
+// GetAllProbableSpeciesWithSettings returns species from all active classifiers.
+// The primary BirdNET model's species are filtered by the range filter using the
+// supplied settings. Additional models (except bat) contribute their full label
+// set since they have no range filter. Results are deduplicated by label.
+func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
+	scores, err := o.primary.GetProbableSpeciesWithSettings(date, week, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool, len(scores))
+	for _, s := range scores {
+		seen[s.Label] = true
+	}
+
+	type entryRef struct {
+		id    string
+		entry *modelEntry
+	}
+
+	var refs []entryRef
+	o.mu.RLock()
+	primaryID := o.primary.ModelInfo.ID
+	for id, entry := range o.models {
+		if id == primaryID || id == RegistryIDBat {
+			continue
+		}
+		refs = append(refs, entryRef{id: id, entry: entry})
+	}
+	o.mu.RUnlock()
+
+	for _, ref := range refs {
+		ref.entry.mu.Lock()
+		if ref.entry.instance == nil {
+			ref.entry.mu.Unlock()
+			continue
+		}
+		labels := ref.entry.instance.Labels()
+		ref.entry.mu.Unlock()
+
+		for _, label := range labels {
+			if !seen[label] {
+				scores = append(scores, SpeciesScore{Label: label, Score: 1.0})
+				seen[label] = true
+			}
+		}
+	}
+
+	return scores, nil
+}
+
 // GetSpeciesOccurrence returns the occurrence probability for a species at the current time.
 func (o *Orchestrator) GetSpeciesOccurrence(species string) float64 {
 	return o.primary.GetSpeciesOccurrence(species)

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -294,9 +294,16 @@ func InitONNXRuntime(libraryPath string) (err error) {
 // fallback for dlopen's default search.
 func findONNXRuntimeLibrary() string {
 	var candidates []string
-	if runtime.GOOS == "windows" {
+	switch runtime.GOOS {
+	case "windows":
 		candidates = []string{"onnxruntime.dll"}
-	} else {
+	case "darwin":
+		candidates = []string{
+			"/opt/homebrew/lib/libonnxruntime.dylib",
+			"/usr/local/lib/libonnxruntime.dylib",
+			"libonnxruntime.dylib",
+		}
+	default:
 		candidates = []string{
 			"/usr/lib/libonnxruntime.so",
 			"/usr/local/lib/libonnxruntime.so",

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -317,6 +317,9 @@ func findONNXRuntimeLibrary() string {
 			return path
 		}
 	}
+	if runtime.GOOS == "darwin" {
+		return "libonnxruntime.dylib"
+	}
 	return "onnxruntime"
 }
 

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -469,11 +469,13 @@ func (g *Generator) generateWithSoxFile(ctx context.Context, settings *conf.Sett
 // Used when the audio file format is natively supported by Sox.
 func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
-	if soxBinary == "" {
-		return errors.Newf("sox binary not configured").
+	// Validate Sox path before exec (defense-in-depth against ingress path contamination)
+	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
+		return errors.Newf("invalid Sox path: %s", err).
 			Component("spectrogram").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "generate_with_sox_direct").
+			Context("sox_path", soxBinary).
 			Build()
 	}
 
@@ -560,11 +562,12 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Context("ffmpeg_path", ffmpegBinary).
 			Build()
 	}
-	if soxBinary == "" {
-		return errors.Newf("sox binary not configured").
+	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
+		return errors.Newf("invalid Sox path: %s", err).
 			Component("spectrogram").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "generate_with_ffmpeg_sox_pipeline").
+			Context("sox_path", soxBinary).
 			Build()
 	}
 
@@ -698,11 +701,12 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 // pass 0 to fall back to conf.SampleRate (48000 Hz).
 func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Settings, pcmData []byte, outputPath string, width int, raw bool, sampleRate int) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
-	if soxBinary == "" {
-		return errors.Newf("sox binary not configured").
+	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
+		return errors.Newf("invalid Sox path: %s", err).
 			Component("spectrogram").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "generate_with_sox_pcm").
+			Context("sox_path", soxBinary).
 			Build()
 	}
 
@@ -1142,11 +1146,11 @@ func evictOldCacheEntriesLocked() {
 // getAudioDurationViaSox calls sox --info -D to get audio duration.
 // This is ~30x faster than ffprobe for duration queries.
 func getAudioDurationViaSox(ctx context.Context, soxPath, audioPath string) (float64, error) {
-	if soxPath == "" {
-		return 0, fmt.Errorf("sox path not configured")
+	if err := ffmpeg.ValidateSoxPath(soxPath); err != nil {
+		return 0, fmt.Errorf("invalid sox path: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, soxPath, "--info", "-D", audioPath) //nolint:gosec // G204: soxPath from validated settings, args are fixed
+	cmd := exec.CommandContext(ctx, soxPath, "--info", "-D", audioPath) //nolint:gosec // G204: soxPath validated by ValidateSoxPath above, args are fixed
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -436,11 +436,12 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 // Otherwise, it uses FFmpeg to convert to Sox format and pipes to Sox.
 func (g *Generator) generateWithSoxFile(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
-	if soxBinary == "" {
-		return errors.Newf("sox binary not configured").
+	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
+		return errors.Newf("invalid Sox path: %s", err).
 			Component("spectrogram").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "generate_with_sox_file").
+			Context("sox_path", soxBinary).
 			Build()
 	}
 

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -589,7 +589,7 @@ func TestGenerateWithSoxDirect_MissingBinary(t *testing.T) {
 
 	err = gen.generateWithSoxDirect(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
 	require.Error(t, err, "should error when Sox binary not configured")
-	assert.Contains(t, err.Error(), "sox binary not configured", "error should mention sox binary")
+	assert.Contains(t, err.Error(), "invalid Sox path", "error should mention invalid sox path")
 }
 
 // TestGenerateWithFFmpegSoxPipeline_MissingBinaries tests error handling for missing binaries.
@@ -612,7 +612,7 @@ func TestGenerateWithFFmpegSoxPipeline_MissingBinaries(t *testing.T) {
 			name:       "missing sox",
 			ffmpegPath: "/usr/bin/ffmpeg",
 			soxPath:    "",
-			errContain: "sox binary not configured",
+			errContain: "invalid Sox path",
 		},
 	}
 
@@ -660,7 +660,7 @@ func TestGenerateWithSoxPCM_MissingBinary(t *testing.T) {
 
 	err := gen.generateWithSoxPCM(t.Context(), gen.currentSettings(), pcmData, outputPath, 400, false, 0)
 	require.Error(t, err, "should error when Sox binary not configured")
-	assert.Contains(t, err.Error(), "sox binary not configured", "error should mention sox binary")
+	assert.Contains(t, err.Error(), "invalid Sox path", "error should mention invalid sox path")
 }
 
 // TestGetSoxArgs_FileInput tests getSoxArgs for file input type.


### PR DESCRIPTION
## Summary

- **SoxPath validation before exec**: Add `ValidateSoxPath` mirroring `ValidateFFmpegPath` to reject empty, relative, and proxy-contaminated paths before all 5 Sox `exec.CommandContext` call sites in the spectrogram generator. Defense-in-depth against command injection via settings.
- **Species count aggregation**: The species settings page test endpoint only returned species from the primary BirdNET classifier. Add `GetAllProbableSpeciesWithSettings` that combines range-filtered primary species with full label sets from additional models (Perch v2, etc.), following the existing `RangeFilterStatus` locking pattern.
- **PlayOverlay audio cleanup**: Replace `audioElement.src = ''` with `removeAttribute('src')` + `.load()` to prevent spurious network requests and properly abort active downloads during cleanup.
- **macOS .dylib search paths**: Add a darwin-specific branch to `findONNXRuntimeLibrary` with Homebrew paths (`/opt/homebrew/lib` for Apple Silicon, `/usr/local/lib` for Intel) and correct fallback string (`libonnxruntime.dylib`).

## Test plan

- [x] `golangci-lint run -v` passes with zero issues
- [x] `go test -race ./internal/audiocore/ffmpeg/... ./internal/spectrogram/... ./internal/classifier/... ./internal/api/v2/... ./internal/inference/...` (3074 tests pass)
- [x] `npm run check:all` passes (0 errors, 0 warnings from svelte-check)
- [x] New `TestValidateSoxPath_Valid` and `TestValidateSoxPath_Invalid` tests cover empty, relative, and all contamination patterns
- [ ] Verify species count on settings page reflects all active classifiers (requires multi-model setup)
- [ ] Verify PlayOverlay cleanup does not trigger spurious network request in browser devtools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio element cleanup to prevent retaining previous audio source state
  * Validated configured audio-processing binary path and standardized related error messages
  * Improved runtime library detection across Windows, Linux, and macOS systems

* **New Features**
  * Broadened species aggregation to include labels from all loaded models for richer classification results

* **Tests**
  * Expanded tests for audio-processing path validation and updated expected error wording

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->