### PR TITLE
fix(ux): add ONNX Runtime install guide URL to error messages

### DIFF
--- a/doc/ONNX-Runtime-Installation.md
+++ b/doc/ONNX-Runtime-Installation.md
@@ -142,7 +142,8 @@ curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSIO
 # Extract (BSD tar needs special handling)
 mkdir -p onnxruntime-tmp
 tar xzf onnxruntime.tgz -C onnxruntime-tmp
-sudo cp onnxruntime-tmp/onnxruntime-*/lib/libonnxruntime*.dylib /usr/local/lib/
+sudo cp -P onnxruntime-tmp/onnxruntime-*/lib/libonnxruntime*.dylib /usr/local/lib/
+sudo xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime*.dylib 2>/dev/null || true
 rm -rf onnxruntime.tgz onnxruntime-tmp
 ```
 

--- a/doc/ONNX-Runtime-Installation.md
+++ b/doc/ONNX-Runtime-Installation.md
@@ -36,7 +36,7 @@ ldconfig -p | grep onnxruntime
 
 Expected output:
 
-```
+```text
 libonnxruntime.so (libc6,x86-64) => /usr/lib/libonnxruntime.so
 ```
 
@@ -81,7 +81,7 @@ Note: macOS System Integrity Protection strips `DYLD_LIBRARY_PATH` when launchin
 
 After extracting the archive, keep `onnxruntime.dll` in the **same directory** as `birdnet-go.exe`. Windows loads DLLs from the application directory automatically, so no additional installation is needed.
 
-```
+```text
 C:\BirdNET-Go\
   birdnet-go.exe
   onnxruntime.dll
@@ -107,10 +107,11 @@ VERSION=1.25.1
 curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-x64-${VERSION}.tgz" \
   -o onnxruntime.tgz
 
-tar xzf onnxruntime.tgz --strip-components=1
-sudo cp lib/libonnxruntime*.so* /usr/lib/
+mkdir -p onnxruntime-tmp
+tar xzf onnxruntime.tgz -C onnxruntime-tmp --strip-components=1
+sudo cp onnxruntime-tmp/lib/libonnxruntime*.so* /usr/lib/
 sudo ldconfig
-rm -rf onnxruntime.tgz include lib
+rm -rf onnxruntime.tgz onnxruntime-tmp
 ```
 
 ### Linux (aarch64 / arm64)
@@ -121,10 +122,11 @@ VERSION=1.25.1
 curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-aarch64-${VERSION}.tgz" \
   -o onnxruntime.tgz
 
-tar xzf onnxruntime.tgz --strip-components=1
-sudo cp lib/libonnxruntime*.so* /usr/lib/
+mkdir -p onnxruntime-tmp
+tar xzf onnxruntime.tgz -C onnxruntime-tmp --strip-components=1
+sudo cp onnxruntime-tmp/lib/libonnxruntime*.so* /usr/lib/
 sudo ldconfig
-rm -rf onnxruntime.tgz include lib
+rm -rf onnxruntime.tgz onnxruntime-tmp
 ```
 
 This covers Raspberry Pi 4/5 (64-bit OS), NVIDIA Jetson, and other ARM64 single-board computers.
@@ -140,7 +142,7 @@ curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSIO
 # Extract (BSD tar needs special handling)
 mkdir -p onnxruntime-tmp
 tar xzf onnxruntime.tgz -C onnxruntime-tmp
-cp onnxruntime-tmp/onnxruntime-*/lib/libonnxruntime*.dylib /usr/local/lib/
+sudo cp onnxruntime-tmp/onnxruntime-*/lib/libonnxruntime*.dylib /usr/local/lib/
 rm -rf onnxruntime.tgz onnxruntime-tmp
 ```
 
@@ -231,13 +233,13 @@ where.exe onnxruntime.dll
 
 When BirdNET-Go starts, it logs the ONNX Runtime version it loaded. Look for a line like:
 
-```
+```text
 ONNX Runtime initialized (version 1.25.1)
 ```
 
 If the library is missing, you will see an error like:
 
-```
+```text
 error while loading shared libraries: libonnxruntime.so: cannot open shared object file
 ```
 

--- a/doc/ONNX-Runtime-Installation.md
+++ b/doc/ONNX-Runtime-Installation.md
@@ -1,0 +1,315 @@
+# ONNX Runtime Installation Guide
+
+ONNX Runtime is a shared library required by BirdNET-Go for neural network inference. It powers the BirdNET v2.4 classifier, Perch v2 embeddings, BattyBirdNET bat detection, range filtering, and BirdNET Geomodel features.
+
+> **Note:** ONNX Runtime will become the sole inference backend in a future release. TensorFlow Lite support is being phased out. If you are setting up a new installation, only ONNX Runtime is needed going forward.
+
+## Do You Need This Guide?
+
+**Docker / container installs (`install.sh`):** ONNX Runtime is baked into the container image. No action needed.
+
+**Release tarballs (`.tar.gz` from GitHub Releases):** The ONNX Runtime library is bundled in every tarball. You just need to install it to the right location on your system. See the [Installing from Release Tarballs](#installing-from-release-tarballs) section.
+
+**Building from source:** You need to download ONNX Runtime yourself. See [Manual Download](#manual-download).
+
+## Required Version
+
+BirdNET-Go requires **ONNX Runtime 1.25.x**. The Go bindings (`onnxruntime_go`) are compiled against `ORT_API_VERSION 25`, which only exists in the 1.25.x series. Older versions (1.24.x and below) and newer major versions will fail to load.
+
+## Installing from Release Tarballs
+
+Every release tarball includes the ONNX Runtime library for the target platform. After extracting the archive, install the library to a system path so the dynamic linker can find it.
+
+### Linux
+
+```bash
+# Extract the tarball
+tar xzf birdnet-go-linux-amd64-*.tar.gz
+
+# Install the library system-wide
+sudo cp libonnxruntime.so /usr/lib/
+sudo ldconfig
+
+# Verify
+ldconfig -p | grep onnxruntime
+```
+
+Expected output:
+
+```
+libonnxruntime.so (libc6,x86-64) => /usr/lib/libonnxruntime.so
+```
+
+If you don't have root access, use `LD_LIBRARY_PATH` instead:
+
+```bash
+export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH"
+./birdnet-go
+```
+
+Add the export to your `~/.bashrc` or `~/.profile` to make it persistent.
+
+### macOS
+
+```bash
+# Extract the tarball
+tar xzf birdnet-go-darwin-arm64-*.tar.gz
+
+# Install the library
+sudo mkdir -p /usr/local/lib
+sudo cp libonnxruntime.dylib /usr/local/lib/
+
+# Remove quarantine attribute (macOS Gatekeeper)
+xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime.dylib
+
+# Verify
+ls -la /usr/local/lib/libonnxruntime.dylib
+```
+
+macOS does not use `ldconfig`. The dynamic linker searches `/usr/local/lib/` by default.
+
+If you prefer not to copy system-wide:
+
+```bash
+export DYLD_LIBRARY_PATH="$(pwd):$DYLD_LIBRARY_PATH"
+./birdnet-go
+```
+
+Note: macOS System Integrity Protection strips `DYLD_LIBRARY_PATH` when launching through `sudo` or `launchd`. Use the `/usr/local/lib/` method for service installations.
+
+### Windows
+
+After extracting the archive, keep `onnxruntime.dll` in the **same directory** as `birdnet-go.exe`. Windows loads DLLs from the application directory automatically, so no additional installation is needed.
+
+```
+C:\BirdNET-Go\
+  birdnet-go.exe
+  onnxruntime.dll
+```
+
+If you want to run `birdnet-go.exe` from any directory, copy the DLL to a location in your system PATH:
+
+```powershell
+copy onnxruntime.dll C:\Windows\System32\
+```
+
+This requires Administrator privileges.
+
+## Manual Download
+
+If you are building from source or need to install ONNX Runtime separately, download it from the official Microsoft releases.
+
+### Linux (x86_64 / amd64)
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-x64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+
+tar xzf onnxruntime.tgz --strip-components=1
+sudo cp lib/libonnxruntime*.so* /usr/lib/
+sudo ldconfig
+rm -rf onnxruntime.tgz include lib
+```
+
+### Linux (aarch64 / arm64)
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-aarch64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+
+tar xzf onnxruntime.tgz --strip-components=1
+sudo cp lib/libonnxruntime*.so* /usr/lib/
+sudo ldconfig
+rm -rf onnxruntime.tgz include lib
+```
+
+This covers Raspberry Pi 4/5 (64-bit OS), NVIDIA Jetson, and other ARM64 single-board computers.
+
+### macOS (Apple Silicon / arm64)
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-osx-arm64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+
+# Extract (BSD tar needs special handling)
+mkdir -p onnxruntime-tmp
+tar xzf onnxruntime.tgz -C onnxruntime-tmp
+cp onnxruntime-tmp/onnxruntime-*/lib/libonnxruntime*.dylib /usr/local/lib/
+rm -rf onnxruntime.tgz onnxruntime-tmp
+```
+
+For Intel Macs (x86_64), replace `arm64` with `x86_64` in the download URL:
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-osx-x86_64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+```
+
+Note: BirdNET-Go does not currently publish pre-built binaries for Intel Macs. You would need to build from source.
+
+### Windows (x86_64 / amd64)
+
+Download from a browser or PowerShell:
+
+```powershell
+$VERSION = "1.25.1"
+
+Invoke-WebRequest `
+  -Uri "https://github.com/microsoft/onnxruntime/releases/download/v$VERSION/onnxruntime-win-x64-$VERSION.zip" `
+  -OutFile onnxruntime.zip
+
+Expand-Archive onnxruntime.zip -DestinationPath onnxruntime-tmp
+Copy-Item onnxruntime-tmp\onnxruntime-*\lib\onnxruntime.dll -Destination .
+Remove-Item -Recurse onnxruntime.zip, onnxruntime-tmp
+```
+
+Place `onnxruntime.dll` in the same directory as `birdnet-go.exe`.
+
+### Using the Taskfile (Build from Source)
+
+If you have the BirdNET-Go source tree and [Task](https://taskfile.dev) installed:
+
+```bash
+task download-onnxruntime
+```
+
+This automatically detects your platform, downloads the correct archive, and installs the library to the appropriate system path. It requires `sudo` on Linux.
+
+## Platform Support Matrix
+
+| Platform | Architecture | Release Tarball | Manual Download | Docker |
+|----------|-------------|:-:|:-:|:-:|
+| Linux | x86_64 (amd64) | Yes | Yes | Yes |
+| Linux | aarch64 (arm64) | Yes | Yes | Yes |
+| macOS | Apple Silicon (arm64) | Yes | Yes | - |
+| macOS | Intel (x86_64) | - | Yes | - |
+| Windows | x86_64 (amd64) | Yes | Yes | - |
+
+Platforms marked with "-" are not officially supported but may work with manual setup.
+
+## Verification
+
+### Linux
+
+```bash
+# Check the library is in the linker cache
+ldconfig -p | grep onnxruntime
+
+# Check the library version
+readelf -d /usr/lib/libonnxruntime.so | grep SONAME
+```
+
+### macOS
+
+```bash
+# Check the library exists
+ls -la /usr/local/lib/libonnxruntime*.dylib
+
+# Check the library can be loaded
+otool -L /usr/local/lib/libonnxruntime.dylib
+```
+
+### Windows
+
+```powershell
+# Check the DLL exists alongside the binary
+dir C:\BirdNET-Go\onnxruntime.dll
+
+# Or check system-wide
+where.exe onnxruntime.dll
+```
+
+### BirdNET-Go Startup Check
+
+When BirdNET-Go starts, it logs the ONNX Runtime version it loaded. Look for a line like:
+
+```
+ONNX Runtime initialized (version 1.25.1)
+```
+
+If the library is missing, you will see an error like:
+
+```
+error while loading shared libraries: libonnxruntime.so: cannot open shared object file
+```
+
+## Troubleshooting
+
+### "error while loading shared libraries: libonnxruntime.so"
+
+**Linux:** The library is not in the dynamic linker search path.
+
+```bash
+# Option 1: Install system-wide
+sudo cp libonnxruntime.so /usr/lib/
+sudo ldconfig
+
+# Option 2: Set library path for current session
+export LD_LIBRARY_PATH="/path/to/library:$LD_LIBRARY_PATH"
+```
+
+### "dyld: Library not loaded: libonnxruntime.dylib"
+
+**macOS:** The library is not in `/usr/local/lib/` or not in `DYLD_LIBRARY_PATH`.
+
+```bash
+sudo cp libonnxruntime.dylib /usr/local/lib/
+```
+
+If you get a Gatekeeper block, remove the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime.dylib
+```
+
+### "onnxruntime.dll was not found"
+
+**Windows:** The DLL is not in the same directory as `birdnet-go.exe` and not in the system PATH.
+
+Move `onnxruntime.dll` to the same folder as the executable.
+
+### Wrong ONNX Runtime version
+
+If BirdNET-Go reports version incompatibility errors, download the exact version listed at the top of this guide (currently 1.25.1). Newer major versions may introduce breaking API changes.
+
+### Permission denied errors
+
+**Linux:** Ensure the library file is readable:
+
+```bash
+sudo chmod 644 /usr/lib/libonnxruntime.so
+sudo ldconfig
+```
+
+**macOS:** Same approach:
+
+```bash
+sudo chmod 644 /usr/local/lib/libonnxruntime.dylib
+```
+
+### Raspberry Pi / ARM SBC
+
+Use the Linux aarch64 package. Make sure you are running a **64-bit OS**. The 32-bit (armhf) architecture is not supported by ONNX Runtime.
+
+Check your architecture with:
+
+```bash
+uname -m
+# Should show: aarch64
+```
+
+If it shows `armv7l`, you are running a 32-bit OS and need to switch to a 64-bit image (e.g., Raspberry Pi OS 64-bit).
+
+## Further Reading
+
+- [ONNX Runtime GitHub](https://github.com/microsoft/onnxruntime) - official releases and documentation
+- [BirdNET-Go documentation](https://birdnet-go.dev)
+- [BirdNET-Go GitHub](https://github.com/tphakala/birdnet-go) - issues and discussions

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime není k dispozici",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} je vyžadován pro {modelName}, ale nebyl nalezen. Ověřte, že libonnxruntime.so je nainstalován na očekávané cestě."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} je vyžadován pro {modelName}, ale nebyl nalezen. Viz průvodce instalací: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime ikke tilgængelig",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} er påkrævet til {modelName}, men blev ikke fundet. Kontrollér, at libonnxruntime.so er installeret på den forventede sti."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} er påkrævet til {modelName}, men blev ikke fundet. Se installationsguiden: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime nicht verfügbar",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} wird für {modelName} benötigt, wurde aber nicht gefunden. Prüfen Sie, ob libonnxruntime.so im erwarteten Pfad installiert ist."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} wird für {modelName} benötigt, wurde aber nicht gefunden. Siehe Installationsanleitung: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime Not Available",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} is required for {modelName} but was not found. Check that libonnxruntime.so is installed at the expected path."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} is required for {modelName} but was not found. See the install guide: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime no disponible",
-        "unavailableMessage": "Se requiere ONNX Runtime {requiredVersion} para {modelName}, pero no se encontró. Compruebe que libonnxruntime.so esté instalado en la ruta esperada."
+        "unavailableMessage": "Se requiere ONNX Runtime {requiredVersion} para {modelName}, pero no se encontró. Consulte la guía de instalación: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime ei ole käytettävissä",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} vaaditaan mallille {modelName}, mutta sitä ei löytynyt. Varmista, että libonnxruntime.so on asennettu odotettuun sijaintiin."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} vaaditaan mallille {modelName}, mutta sitä ei löytynyt. Katso asennusohje: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime non disponible",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} est requis pour {modelName} mais n'a pas été trouvé. Vérifiez que libonnxruntime.so est installé à l'emplacement attendu."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} est requis pour {modelName} mais n'a pas été trouvé. Voir le guide d'installation : {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "Az ONNX Runtime nem elérhető",
-        "unavailableMessage": "Az ONNX Runtime {requiredVersion} szükséges a(z) {modelName} modellhez, de nem található. Ellenőrizze, hogy a libonnxruntime.so telepítve van-e a várt elérési úton."
+        "unavailableMessage": "Az ONNX Runtime {requiredVersion} szükséges a(z) {modelName} modellhez, de nem található. Lásd a telepítési útmutatót: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime non disponibile",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} è richiesto per {modelName} ma non è stato trovato. Verificare che libonnxruntime.so sia installato nel percorso previsto."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} è richiesto per {modelName} ma non è stato trovato. Consulta la guida all'installazione: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime nav pieejams",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} ir nepieciešams modelim {modelName}, bet netika atrasts. Pārliecinieties, ka libonnxruntime.so ir instalēts paredzētajā ceļā."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} ir nepieciešams modelim {modelName}, bet netika atrasts. Skatiet instalēšanas rokasgrāmatu: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime niet beschikbaar",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} is vereist voor {modelName}, maar werd niet gevonden. Controleer of libonnxruntime.so is geïnstalleerd op het verwachte pad."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} is vereist voor {modelName}, maar werd niet gevonden. Zie de installatiegids: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime niedostępny",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} jest wymagany dla {modelName}, ale nie został znaleziony. Sprawdź, czy libonnxruntime.so jest zainstalowany we właściwej ścieżce."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} jest wymagany dla {modelName}, ale nie został znaleziony. Zobacz przewodnik instalacji: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime não disponível",
-        "unavailableMessage": "O ONNX Runtime {requiredVersion} é necessário para {modelName}, mas não foi encontrado. Verifique se o libonnxruntime.so está instalado no caminho esperado."
+        "unavailableMessage": "O ONNX Runtime {requiredVersion} é necessário para {modelName}, mas não foi encontrado. Consulte o guia de instalação: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime nie je k dispozícii",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} je vyžadovaný pre {modelName}, ale nebol nájdený. Skontrolujte, či je libonnxruntime.so nainštalovaný na očakávanej ceste."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} je vyžadovaný pre {modelName}, ale nebol nájdený. Pozrite si príručku inštalácie: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -437,7 +437,7 @@
       },
       "ort": {
         "unavailableTitle": "ONNX Runtime inte tillgänglig",
-        "unavailableMessage": "ONNX Runtime {requiredVersion} krävs för {modelName} men hittades inte. Kontrollera att libonnxruntime.so är installerat på den förväntade sökvägen."
+        "unavailableMessage": "ONNX Runtime {requiredVersion} krävs för {modelName} men hittades inte. Se installationsguiden: {installGuideURL}"
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/internal/classifier/orchestrator_notifications.go
+++ b/internal/classifier/orchestrator_notifications.go
@@ -27,6 +27,7 @@ func emitORTUnavailableNotification(modelName, ortError string) {
 		WithMessageKey(notification.MsgORTUnavailableMessage, map[string]any{
 			"modelName":       modelName,
 			"requiredVersion": inference.ORTRequiredVersion(),
+			"installGuideURL": inference.ORTInstallGuideURL,
 		}).
 		WithDeliveryTarget("bell")
 

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -280,7 +280,7 @@ func InitONNXRuntime(libraryPath string) (err error) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("failed to initialize ONNX Runtime: %v", r)
+			err = fmt.Errorf("failed to initialize ONNX Runtime: %v; install guide: %s", r, ORTInstallGuideURL)
 		}
 	}()
 

--- a/internal/inference/ort_status.go
+++ b/internal/inference/ort_status.go
@@ -14,6 +14,8 @@ import (
 // will not work unless the installed library version starts with this.
 const RequiredORTAPIMajor = "1.25"
 
+const ORTInstallGuideURL = "https://github.com/tphakala/birdnet-go/wiki/ONNX-Runtime-Installation"
+
 // ORTStatus describes the availability and version compatibility of the
 // ONNX Runtime shared library on the current system.
 type ORTStatus struct {
@@ -56,7 +58,7 @@ func CheckORTAvailability(configuredPath string) ORTStatus {
 	libPath := resolvedORTPath(configuredPath)
 	if libPath == "" || !libraryFileExists(libPath) {
 		return ORTStatus{
-			Error: "ONNX Runtime shared library not found",
+			Error: fmt.Sprintf("ONNX Runtime shared library not found; install guide: %s", ORTInstallGuideURL),
 		}
 	}
 
@@ -158,10 +160,10 @@ func isVersionCompatible(version string) bool {
 // incompatible. Returns empty string for compatible versions.
 func versionError(version string) string {
 	if version == "" {
-		return fmt.Sprintf("unable to determine ONNX Runtime version; required %s", ORTRequiredVersion())
+		return fmt.Sprintf("unable to determine ONNX Runtime version; required %s; install guide: %s", ORTRequiredVersion(), ORTInstallGuideURL)
 	}
 	if !isVersionCompatible(version) {
-		return fmt.Sprintf("ONNX Runtime version %s is incompatible; required %s", version, ORTRequiredVersion())
+		return fmt.Sprintf("ONNX Runtime version %s is incompatible; required %s; install guide: %s", version, ORTRequiredVersion(), ORTInstallGuideURL)
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

- Add wiki install guide link to all ONNX Runtime error messages (not found, version mismatch, init failure)
- Users now get an actionable URL immediately when ORT is missing or incompatible
- URL is defined once as `ORTInstallGuideURL` constant, passed as `{installGuideURL}` i18n parameter
- All 15 locale files updated with properly translated "install guide" preambles
- Added `doc/ONNX-Runtime-Installation.md` covering Linux, macOS, and Windows installation

## Test Plan

- [ ] Verify notification renders correctly when ORT is missing (URL visible, no duplication)
- [ ] Verify health check includes URL in error message
- [ ] Spot-check non-English locales for correct translated preamble + URL parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive ONNX Runtime installation guide with platform-specific install, verification, troubleshooting and manual-download instructions.

* **Bug Fixes**
  * Improved ONNX Runtime error messages to report required version and model and include a link to installation guidance.

* **Localization**
  * Updated unavailable-runtime messages to use parameterized placeholders (required version, model name, install guide URL) across supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->