### PR TITLE
feat(health): add tool availability check for FFmpeg and Sox

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -204,6 +204,20 @@ func (c *Controller) registerHealthChecks() {
 		),
 
 		// Config checks
+		checks.NewToolAvailabilityCheck(func() []checks.ToolInfo {
+			s := c.currentSettings()
+			return []checks.ToolInfo{
+				{
+					Name:    "FFmpeg",
+					Path:    s.Realtime.Audio.FfmpegPath,
+					Version: s.Realtime.Audio.FfmpegVersion,
+				},
+				{
+					Name: "Sox",
+					Path: s.Realtime.Audio.SoxPath,
+				},
+			}
+		}),
 		checks.NewPathAccessCheck(map[string]string{
 			"data": filepath.Dir(c.currentSettings().Output.SQLite.Path),
 		}),

--- a/internal/health/checks/config.go
+++ b/internal/health/checks/config.go
@@ -10,6 +10,87 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health"
 )
 
+// ToolInfo holds the runtime availability status of an external tool (FFmpeg, Sox, etc.).
+type ToolInfo struct {
+	Name    string // e.g. "FFmpeg", "Sox"
+	Path    string // resolved absolute path, empty if unavailable
+	Version string // version string, empty if unknown
+}
+
+// ToolAvailabilityCheck verifies that required external tools (FFmpeg, Sox) are present.
+type ToolAvailabilityCheck struct {
+	getTools func() []ToolInfo
+}
+
+// NewToolAvailabilityCheck creates a check using the given provider closure.
+// getTools must return the current availability status of each tool.
+func NewToolAvailabilityCheck(getTools func() []ToolInfo) *ToolAvailabilityCheck {
+	return &ToolAvailabilityCheck{getTools: getTools}
+}
+
+// Name returns the check identifier.
+func (c *ToolAvailabilityCheck) Name() string { return "tool_availability" }
+
+// Category returns the config category.
+func (c *ToolAvailabilityCheck) Category() health.Category { return health.CategoryConfig }
+
+// Run checks whether each required tool is available.
+func (c *ToolAvailabilityCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getTools == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	tools := c.getTools()
+	if len(tools) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	type toolResult struct {
+		Name    string `json:"name"`
+		Path    string `json:"path,omitempty"`
+		Version string `json:"version,omitempty"`
+		Status  string `json:"status"`
+	}
+
+	results := make([]toolResult, 0, len(tools))
+	var missing []string
+
+	for _, t := range tools {
+		tr := toolResult{Name: t.Name}
+		if t.Path == "" {
+			tr.Status = "missing"
+			missing = append(missing, t.Name)
+		} else {
+			tr.Path = t.Path
+			tr.Version = t.Version
+			tr.Status = "available"
+		}
+		results = append(results, tr)
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("All %d tools available", len(tools))
+
+	if len(missing) > 0 {
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Missing tools: %s", strings.Join(missing, ", "))
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"tools": results,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
 // PathAccessCheck verifies write access to configured filesystem paths.
 type PathAccessCheck struct {
 	paths map[string]string // label -> path

--- a/internal/health/checks/config_test.go
+++ b/internal/health/checks/config_test.go
@@ -1,0 +1,95 @@
+package checks
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+func TestToolAvailabilityCheck_NilClosure(t *testing.T) {
+	t.Parallel()
+	check := NewToolAvailabilityCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestToolAvailabilityCheck_EmptyTools(t *testing.T) {
+	t.Parallel()
+	check := NewToolAvailabilityCheck(func() []ToolInfo { return nil })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestToolAvailabilityCheck_AllAvailable(t *testing.T) {
+	t.Parallel()
+	check := NewToolAvailabilityCheck(func() []ToolInfo {
+		return []ToolInfo{
+			{Name: "FFmpeg", Path: "/usr/bin/ffmpeg", Version: "7.1"},
+			{Name: "Sox", Path: "/usr/bin/sox"},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "2 tools available")
+	assert.Equal(t, "tool_availability", result.Name)
+	assert.Equal(t, health.CategoryConfig, result.Category)
+}
+
+func TestToolAvailabilityCheck_OneMissing(t *testing.T) {
+	t.Parallel()
+	check := NewToolAvailabilityCheck(func() []ToolInfo {
+		return []ToolInfo{
+			{Name: "FFmpeg", Path: "/usr/bin/ffmpeg", Version: "7.1"},
+			{Name: "Sox", Path: ""},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "Sox")
+}
+
+func TestToolAvailabilityCheck_AllMissing(t *testing.T) {
+	t.Parallel()
+	check := NewToolAvailabilityCheck(func() []ToolInfo {
+		return []ToolInfo{
+			{Name: "FFmpeg", Path: ""},
+			{Name: "Sox", Path: ""},
+		}
+	})
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "FFmpeg")
+	assert.Contains(t, result.Message, "Sox")
+}
+
+func TestToolAvailabilityCheck_DetailsContent(t *testing.T) {
+	t.Parallel()
+	check := NewToolAvailabilityCheck(func() []ToolInfo {
+		return []ToolInfo{
+			{Name: "FFmpeg", Path: "/usr/bin/ffmpeg", Version: "7.1"},
+			{Name: "Sox", Path: ""},
+		}
+	})
+	result := check.Run(t.Context())
+	require.Contains(t, result.Details, "tools")
+
+	// Round-trip through JSON to inspect the anonymous struct slice.
+	raw, err := json.Marshal(result.Details["tools"])
+	require.NoError(t, err)
+
+	var tools []map[string]string
+	require.NoError(t, json.Unmarshal(raw, &tools))
+	require.Len(t, tools, 2)
+
+	assert.Equal(t, "FFmpeg", tools[0]["name"])
+	assert.Equal(t, "/usr/bin/ffmpeg", tools[0]["path"])
+	assert.Equal(t, "7.1", tools[0]["version"])
+	assert.Equal(t, "available", tools[0]["status"])
+
+	assert.Equal(t, "Sox", tools[1]["name"])
+	assert.Empty(t, tools[1]["path"])
+	assert.Equal(t, "missing", tools[1]["status"])
+}


### PR DESCRIPTION
## Summary
- Add `ToolAvailabilityCheck` to the health diagnostics system (Config category)
- Reports whether FFmpeg and Sox binaries are available at runtime, including version info for FFmpeg
- Wired via closure injection reading paths from current audio settings (hot-reload safe)
- Includes 6 unit tests covering nil closure, empty tools, all available, one missing, all missing, and detailed content assertions

## Test Plan
- [x] `go test -race ./internal/health/...` passes (121 tests)
- [x] `golangci-lint run` clean
- [x] Gate review passed (4 agents, no blocking issues)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now includes health checks to monitor external tool availability (FFmpeg and Sox), reporting configured paths, versions, and status to help diagnose system dependencies and configuration issues.

* **Tests**
  * Comprehensive unit tests added for tool availability health checks, covering scenarios such as missing tools, available tools, and various configuration states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->