### PR TITLE
fix: notification 404, MQTT HA discovery timing, diskmanager empty path, species API guard, buffer reallocation

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -58,7 +58,7 @@
 
   // Fetch image attribution when popup opens
   async function fetchImageAttribution() {
-    if (!scientificName || lastFetchedScientificName === scientificName) return;
+    if (!scientificName?.trim() || lastFetchedScientificName === scientificName) return;
     lastFetchedScientificName = scientificName;
 
     try {

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -242,7 +242,7 @@
 
   // Fetch image attribution metadata
   async function fetchImageAttribution() {
-    if (!detection?.scientificName) return;
+    if (!detection?.scientificName?.trim()) return;
 
     attributionController?.abort();
     attributionController = new AbortController();
@@ -268,7 +268,7 @@
 
   // Fetch species information (public data - no auth required)
   async function fetchSpeciesInfo() {
-    if (!detection?.scientificName) return;
+    if (!detection?.scientificName?.trim()) return;
 
     speciesController?.abort();
     speciesController = new AbortController();
@@ -298,7 +298,7 @@
 
   // Fetch taxonomy information (public data - no auth required)
   async function fetchTaxonomy() {
-    if (!detection?.scientificName) return;
+    if (!detection?.scientificName?.trim()) return;
 
     taxonomyController?.abort();
     taxonomyController = new AbortController();

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1462,7 +1462,16 @@ func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 			return
 
 		case t := <-timer.C:
-			currentPolicy := conf.Setting().Realtime.Audio.Export.Retention.Policy
+			currentSettings := conf.Setting()
+			exportCfg := currentSettings.Realtime.Audio.Export
+			currentPolicy := exportCfg.Retention.Policy
+
+			if strings.TrimSpace(exportCfg.Path) == "" {
+				log.Debug("skipping clip cleanup: export path not configured",
+					logger.String("operation", "clip_cleanup_skip"))
+				continue
+			}
+
 			log.Info("starting clip cleanup task",
 				logger.String("timestamp", t.Format(time.RFC3339)),
 				logger.String("policy", currentPolicy),
@@ -1483,8 +1492,8 @@ func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 			}
 
 			if currentPolicy == "usage" {
-				currentRetention := conf.Setting().Realtime.Audio.Export.Retention
-				baseDir := conf.Setting().Realtime.Audio.Export.Path
+				currentRetention := exportCfg.Retention
+				baseDir := exportCfg.Path
 
 				skip, utilization, err := diskmanager.ShouldSkipUsageBasedCleanup(&currentRetention, baseDir)
 				if err != nil {

--- a/internal/analysis/processor/mqtt.go
+++ b/internal/analysis/processor/mqtt.go
@@ -168,15 +168,20 @@ func (p *Processor) registerHomeAssistantDiscovery(client mqtt.Client, settings 
 	log := GetLogger()
 	haSettings := settings.Realtime.MQTT.HomeAssistant
 
-	// Register the OnConnect handler
+	// Register the OnConnect handler. The handler runs in a goroutine
+	// (client.go onConnect), so the client may disconnect between the
+	// callback firing and the goroutine executing.
 	client.RegisterOnConnectHandler(func() {
+		if !client.IsConnected() {
+			log.Debug("MQTT client disconnected before HA discovery handler executed, skipping")
+			return
+		}
+
 		log.Info("MQTT connected, publishing Home Assistant discovery messages")
 
-		// Create a context for publishing
 		ctx, cancel := context.WithTimeout(context.Background(), discoveryPublishTimeout)
 		defer cancel()
 
-		// Publish discovery messages using the helper
 		if err := p.publishHomeAssistantDiscovery(ctx, client, settings); err != nil {
 			log.Error("Failed to publish Home Assistant discovery",
 				logger.Error(err))

--- a/internal/api/v2/notifications_mark_read_test.go
+++ b/internal/api/v2/notifications_mark_read_test.go
@@ -54,14 +54,14 @@ func TestMarkNotificationRead_NotFound(t *testing.T) {
 	}
 
 	err := controller.MarkNotificationRead(ctx)
-	require.NoError(t, err, "handler should return nil and write error to response")
+	require.NoError(t, err, "handler should return nil")
 
-	assert.Equal(t, http.StatusNotFound, rec.Code, "expected 404 for missing notification")
+	assert.Equal(t, http.StatusOK, rec.Code, "mark-as-read is idempotent: missing notification returns 200")
 
 	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	require.NoError(t, err)
-	assert.Contains(t, body["message"], "Notification not found")
+	assert.Contains(t, body["message"], "Notification marked as read")
 }
 
 func TestMarkNotificationRead_EmptyID(t *testing.T) {
@@ -127,12 +127,12 @@ func TestMarkNotificationAcknowledged_NotFound(t *testing.T) {
 	}
 
 	err := controller.MarkNotificationAcknowledged(ctx)
-	require.NoError(t, err, "handler should return nil and write error to response")
+	require.NoError(t, err, "handler should return nil")
 
-	assert.Equal(t, http.StatusNotFound, rec.Code, "expected 404 for missing notification")
+	assert.Equal(t, http.StatusOK, rec.Code, "mark-as-acknowledged is idempotent: missing notification returns 200")
 
 	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	require.NoError(t, err)
-	assert.Contains(t, body["message"], "Notification not found")
+	assert.Contains(t, body["message"], "Notification marked as acknowledged")
 }

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -363,6 +363,10 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 	// 2. Allocate analysis buffer using the primary model's native dimensions.
 	// BufferConsumer resamples audio to the model's target rate before writing,
 	// so buffer size must match the model spec, not the source sample rate.
+	// Clear any stale buffers for this source ID (e.g., watchdog restart
+	// reuses the same source ID without going through ReconfigureSource).
+	e.bufferMgr.DeallocateSource(sourceID)
+
 	if err := e.bufferMgr.AllocateAnalysis(
 		sourceID,
 		e.primaryModelID,

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -219,6 +219,9 @@ func (s *Service) MarkAsRead(id string) error {
 
 	notification, err := s.store.Get(id)
 	if err != nil {
+		if errors.Is(err, ErrNotificationNotFound) {
+			return nil
+		}
 		return err
 	}
 
@@ -243,6 +246,9 @@ func (s *Service) MarkAsAcknowledged(id string) error {
 
 	notification, err := s.store.Get(id)
 	if err != nil {
+		if errors.Is(err, ErrNotificationNotFound) {
+			return nil
+		}
 		return err
 	}
 
@@ -259,7 +265,11 @@ func (s *Service) Delete(id string) error {
 			Build()
 	}
 
-	return s.store.Delete(id)
+	err := s.store.Delete(id)
+	if err != nil && errors.Is(err, ErrNotificationNotFound) {
+		return nil
+	}
+	return err
 }
 
 // Subscribe creates a channel to receive real-time notifications.

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -226,7 +226,13 @@ func (s *Service) MarkAsRead(id string) error {
 	}
 
 	notification.MarkAsRead()
-	return s.store.Update(notification)
+	if err := s.store.Update(notification); err != nil {
+		if errors.Is(err, ErrNotificationNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // MarkAllAsRead marks every unread notification as read in a single
@@ -253,7 +259,13 @@ func (s *Service) MarkAsAcknowledged(id string) error {
 	}
 
 	notification.MarkAsAcknowledged()
-	return s.store.Update(notification)
+	if err := s.store.Update(notification); err != nil {
+		if errors.Is(err, ErrNotificationNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // Delete removes a notification


### PR DESCRIPTION
## Summary

Batch fix for 5 Sentry-reported bugs totaling ~437 error events:

- **Notification mark-as-read 404** (44 events): Make `MarkAsRead`, `MarkAsAcknowledged`, and `Delete` idempotent by returning nil when the notification was already removed by the cleanup loop. Prevents Sentry noise from the TOCTOU race between cleanup and user interaction.

- **MQTT HA discovery timing** (19 events): Add `IsConnected()` guard in the OnConnect handler to skip HA discovery publish when the client disconnects between callback dispatch and goroutine execution. Mirrors the existing guard in the manual trigger endpoint.

- **Diskmanager empty path** (340 events): Skip clip cleanup when export path is empty, preventing repeated `Statfs` and `filepath.Walk` failures on unconfigured containers. Guard lives inside the timer loop so hot-reload of the path still works.

- **Species API empty parameter** (29 events): Strengthen `scientificName` guards in `DetectionDetail` and `BirdThumbnailPopup` with `.trim()` to prevent API calls with whitespace-only species names.

- **Analysis buffer reallocation** (5 events): Call `DeallocateSource` before `AllocateAnalysis` in `AddSource` to handle watchdog restarts that reuse the same source ID without going through `ReconfigureSource`.

Gate review also caught and fixed: incomplete multi-site fix on `Delete` idempotency, missing `.trim()` in `BirdThumbnailPopup`, and redundant `conf.Setting()` reads in the cleanup timer loop.

## Test Plan
- [x] `go test -race ./internal/notification/...` (721 tests pass)
- [x] `go test -race ./internal/analysis/processor/...` (693 tests pass)
- [x] `go test -race ./internal/audiocore/engine/...` (21 tests pass)
- [x] `golangci-lint run -v` (0 new issues)
- [x] `npx prettier --check` (frontend files formatted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of scientific names to properly handle whitespace-only values in bird identification
  * Enhanced MQTT connection verification before publishing Home Assistant discovery messages
  * Fixed resource deallocation for audio sources in watchdog/restart scenarios
  * Improved error handling for operations on missing notifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->