### PR TITLE
fix(api): add isGlobalOwner guard and rollback to TLS/MQTT settings save

### DIFF
--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1594,18 +1594,8 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 		isExcluded = true
 	}
 
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
-	}
-	c.Settings = updated
-
-	if c.isGlobalOwner && !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			// Rollback so in-memory state matches disk.
-			conf.StoreSettings(current)
-			c.Settings = current
-			return "", wasExcluded, fmt.Errorf("failed to save settings: %w", err)
-		}
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		return "", wasExcluded, err
 	}
 
 	// Trigger side-effects (range filter rebuild, etc.) so the include list
@@ -1638,17 +1628,8 @@ func (c *Controller) addSpeciesToIgnoredList(species string) error {
 	updated := conf.CloneSettings(current)
 	updated.Realtime.Species.Exclude = append(updated.Realtime.Species.Exclude, species)
 
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
-	}
-	c.Settings = updated
-
-	if c.isGlobalOwner && !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			conf.StoreSettings(current)
-			c.Settings = current
-			return fmt.Errorf("failed to save settings: %w", err)
-		}
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		return err
 	}
 
 	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 const mqttTLSServiceName = "mqtt"
@@ -207,18 +206,12 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		updated.Realtime.MQTT.TLS.ClientCert = ""
 		updated.Realtime.MQTT.TLS.ClientKey = ""
 	}
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		c.settingsMutex.Unlock()
+		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
+			http.StatusInternalServerError)
 	}
-	c.Settings = updated
 	c.settingsMutex.Unlock()
-
-	if !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			c.logErrorIfEnabled("Failed to save settings after MQTT TLS certificate upload",
-				logger.Error(err))
-		}
-	}
 
 	return c.GetMQTTTLSCertificate(ctx)
 }
@@ -242,18 +235,12 @@ func (c *Controller) DeleteMQTTTLSCertificate(ctx echo.Context) error {
 	updated.Realtime.MQTT.TLS.CACert = ""
 	updated.Realtime.MQTT.TLS.ClientCert = ""
 	updated.Realtime.MQTT.TLS.ClientKey = ""
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		c.settingsMutex.Unlock()
+		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate deletion",
+			http.StatusInternalServerError)
 	}
-	c.Settings = updated
 	c.settingsMutex.Unlock()
-
-	if !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			c.logErrorIfEnabled("Failed to save settings after MQTT TLS certificate deletion",
-				logger.Error(err))
-		}
-	}
 
 	return ctx.NoContent(http.StatusNoContent)
 }

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -211,6 +211,7 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
 			http.StatusInternalServerError)
 	}
+	_ = c.handleSettingsChanges(current, updated)
 	c.settingsMutex.Unlock()
 
 	return c.GetMQTTTLSCertificate(ctx)
@@ -240,6 +241,7 @@ func (c *Controller) DeleteMQTTTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate deletion",
 			http.StatusInternalServerError)
 	}
+	_ = c.handleSettingsChanges(current, updated)
 	c.settingsMutex.Unlock()
 
 	return ctx.NoContent(http.StatusNoContent)

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 const mqttTLSServiceName = "mqtt"
@@ -211,7 +212,10 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
 			http.StatusInternalServerError)
 	}
-	_ = c.handleSettingsChanges(current, updated)
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after MQTT TLS certificate change",
+			logger.Error(handleErr))
+	}
 	c.settingsMutex.Unlock()
 
 	return c.GetMQTTTLSCertificate(ctx)
@@ -241,7 +245,10 @@ func (c *Controller) DeleteMQTTTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate deletion",
 			http.StatusInternalServerError)
 	}
-	_ = c.handleSettingsChanges(current, updated)
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after MQTT TLS certificate change",
+			logger.Error(handleErr))
+	}
 	c.settingsMutex.Unlock()
 
 	return ctx.NoContent(http.StatusNoContent)

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -555,6 +555,25 @@ func handlePrimitiveField(
 	return nil
 }
 
+// publishAndSaveSettings publishes updated settings and persists to disk.
+// Must be called while c.settingsMutex is held. On save failure, both the
+// atomic pointer and c.Settings are rolled back to current.
+func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) error {
+	if c.isGlobalOwner {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
+
+	if c.isGlobalOwner && !c.DisableSaveSettings {
+		if err := conf.SaveSettings(); err != nil {
+			conf.StoreSettings(current)
+			c.Settings = current
+			return fmt.Errorf("failed to save settings: %w", err)
+		}
+	}
+	return nil
+}
+
 // getSettingsOrFallback returns the current settings snapshot for write handlers.
 // When this controller owns the global singleton (production), it reads from
 // conf.GetSettings() so that out-of-band publishers (range filter rebuild,

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -140,6 +140,7 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate upload",
 			http.StatusInternalServerError)
 	}
+	_ = c.handleSettingsChanges(current, updated)
 	c.settingsMutex.Unlock()
 
 	// Return certificate info
@@ -172,6 +173,7 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate deletion",
 			http.StatusInternalServerError)
 	}
+	_ = c.handleSettingsChanges(current, updated)
 	c.settingsMutex.Unlock()
 
 	return ctx.NoContent(http.StatusNoContent)
@@ -244,6 +246,7 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after self-signed certificate generation",
 			http.StatusInternalServerError)
 	}
+	_ = c.handleSettingsChanges(current, updated)
 	c.settingsMutex.Unlock()
 
 	// Return certificate info

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	tlspkg "github.com/tphakala/birdnet-go/internal/tls"
 )
 
@@ -140,7 +141,10 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate upload",
 			http.StatusInternalServerError)
 	}
-	_ = c.handleSettingsChanges(current, updated)
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
+			logger.Error(handleErr))
+	}
 	c.settingsMutex.Unlock()
 
 	// Return certificate info
@@ -173,7 +177,10 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate deletion",
 			http.StatusInternalServerError)
 	}
-	_ = c.handleSettingsChanges(current, updated)
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
+			logger.Error(handleErr))
+	}
 	c.settingsMutex.Unlock()
 
 	return ctx.NoContent(http.StatusNoContent)
@@ -246,7 +253,10 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save settings after self-signed certificate generation",
 			http.StatusInternalServerError)
 	}
-	_ = c.handleSettingsChanges(current, updated)
+	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
+			logger.Error(handleErr))
+	}
 	c.settingsMutex.Unlock()
 
 	// Return certificate info

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/logger"
 	tlspkg "github.com/tphakala/birdnet-go/internal/tls"
 )
 
@@ -136,18 +135,12 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Security.TLSMode = conf.TLSModeManual
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		c.settingsMutex.Unlock()
+		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate upload",
+			http.StatusInternalServerError)
 	}
-	c.Settings = updated
 	c.settingsMutex.Unlock()
-
-	if !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			c.logErrorIfEnabled("Failed to save settings after TLS certificate upload",
-				logger.Error(err))
-		}
-	}
 
 	// Return certificate info
 	certPath := tlsMgr.GetCertificatePath(tlsServiceName, conf.TLSCertTypeServerCert)
@@ -174,18 +167,12 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Security.TLSMode = conf.TLSModeNone
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		c.settingsMutex.Unlock()
+		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate deletion",
+			http.StatusInternalServerError)
 	}
-	c.Settings = updated
 	c.settingsMutex.Unlock()
-
-	if !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			c.logErrorIfEnabled("Failed to save settings after TLS certificate deletion",
-				logger.Error(err))
-		}
-	}
 
 	return ctx.NoContent(http.StatusNoContent)
 }
@@ -252,18 +239,12 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Security.TLSMode = conf.TLSModeSelfSigned
-	if c.isGlobalOwner {
-		conf.StoreSettings(updated)
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		c.settingsMutex.Unlock()
+		return c.HandleError(ctx, err, "Failed to save settings after self-signed certificate generation",
+			http.StatusInternalServerError)
 	}
-	c.Settings = updated
 	c.settingsMutex.Unlock()
-
-	if !c.DisableSaveSettings {
-		if err := conf.SaveSettings(); err != nil {
-			c.logErrorIfEnabled("Failed to save settings after self-signed certificate generation",
-				logger.Error(err))
-		}
-	}
 
 	// Return certificate info
 	certPath := tlsMgr.GetCertificatePath(tlsServiceName, conf.TLSCertTypeServerCert)


### PR DESCRIPTION
## Summary
- Extract `publishAndSaveSettings` helper to eliminate duplicated clone-mutate-publish-save-rollback boilerplate across 7 call sites in detections.go, mqtt_tls.go, and tls.go
- Fix three issues in TLS/MQTT handlers introduced by PR #3196:
  - Missing `isGlobalOwner` guard on `SaveSettings()` (could persist wrong snapshot in tests)
  - No rollback on `SaveSettings()` failure (in-memory/disk state divergence)
  - `SaveSettings()` called outside mutex (race window with concurrent writers)
- Net reduction of 30 lines while adding proper guards and rollback

## Test Plan
- [x] `go build ./internal/api/v2/...` passes
- [x] `golangci-lint run -v ./internal/api/v2/...` passes with zero issues
- [x] `go test -race ./internal/api/v2/... -count=1` passes (2008 tests)
- [x] Gate review (5 parallel agents) found no blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized how updated settings are persisted and published across detection, MQTT TLS, and TLS certificate flows for consistent behavior.
* **Behavior Change**
  * On persistence failure, requests now return an error (HTTP 500) instead of only logging; after successful persistence, post-update side effects are applied consistently and any failures are logged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->