### PR TITLE
fix(datastore): MySQL startup check rejects mysql_native_password auth

### DIFF
--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -250,13 +250,18 @@ func fallbackConsolidatedV2State(configuredPath, v2MigrationPath string) (Startu
 
 // checkMySQLMigrationState checks migration state for MySQL deployments.
 func checkMySQLMigrationState(settings *conf.Settings) StartupState {
-	// Build MySQL DSN using mysql.Config for proper credential escaping and timeouts
+	// Build MySQL DSN using mysql.Config for proper credential escaping and timeouts.
+	// AllowNativePasswords must be explicitly true because mysql.Config{} struct
+	// literals default to false (Go zero value), while mysql.NewConfig() defaults
+	// to true. MariaDB and MySQL configured with mysql_native_password require this.
 	cfg := mysql.Config{
-		User:   settings.Output.MySQL.Username,
-		Passwd: settings.Output.MySQL.Password,
-		Net:    "tcp",
-		Addr:   fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
-		DBName: settings.Output.MySQL.Database,
+		User:                 settings.Output.MySQL.Username,
+		Passwd:               settings.Output.MySQL.Password,
+		Net:                  "tcp",
+		Addr:                 fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
+		DBName:               settings.Output.MySQL.Database,
+		AllowNativePasswords: true,
+		CheckConnLiveness:    true,
 		Params: map[string]string{
 			"charset":      "utf8mb4",
 			"parseTime":    "True",
@@ -542,11 +547,13 @@ func hasUnmigratedLegacySQLite(settings *conf.Settings, log logger.Logger) bool 
 // hasUnmigratedLegacyMySQL checks for unmigrated records in a MySQL legacy database.
 func hasUnmigratedLegacyMySQL(settings *conf.Settings, log logger.Logger) bool {
 	cfg := mysql.Config{
-		User:   settings.Output.MySQL.Username,
-		Passwd: settings.Output.MySQL.Password,
-		Net:    "tcp",
-		Addr:   fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
-		DBName: settings.Output.MySQL.Database,
+		User:                 settings.Output.MySQL.Username,
+		Passwd:               settings.Output.MySQL.Password,
+		Net:                  "tcp",
+		Addr:                 fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
+		DBName:               settings.Output.MySQL.Database,
+		AllowNativePasswords: true,
+		CheckConnLiveness:    true,
 		Params: map[string]string{
 			"charset":      "utf8mb4",
 			"parseTime":    "True",
@@ -679,11 +686,13 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
 	// Build MySQL DSN
 	cfg := mysql.Config{
-		User:   settings.Output.MySQL.Username,
-		Passwd: settings.Output.MySQL.Password,
-		Net:    "tcp",
-		Addr:   fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
-		DBName: settings.Output.MySQL.Database,
+		User:                 settings.Output.MySQL.Username,
+		Passwd:               settings.Output.MySQL.Password,
+		Net:                  "tcp",
+		Addr:                 fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
+		DBName:               settings.Output.MySQL.Database,
+		AllowNativePasswords: true,
+		CheckConnLiveness:    true,
 		Params: map[string]string{
 			"charset":      "utf8mb4",
 			"parseTime":    "True",

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -248,12 +248,12 @@ func fallbackConsolidatedV2State(configuredPath, v2MigrationPath string) (Startu
 	return completedV2StartupState(), true
 }
 
-// checkMySQLMigrationState checks migration state for MySQL deployments.
-func checkMySQLMigrationState(settings *conf.Settings) StartupState {
-	// Build MySQL DSN using mysql.Config for proper credential escaping and timeouts.
-	// AllowNativePasswords must be explicitly true because mysql.Config{} struct
-	// literals default to false (Go zero value), while mysql.NewConfig() defaults
-	// to true. MariaDB and MySQL configured with mysql_native_password require this.
+// buildMySQLStartupDSN builds a MySQL DSN for startup-time checks.
+// Uses mysql.Config for proper credential escaping and timeouts.
+// AllowNativePasswords must be explicitly true because mysql.Config{} struct
+// literals default to false (Go zero value), while mysql.NewConfig() defaults
+// to true. MariaDB and MySQL configured with mysql_native_password require this.
+func buildMySQLStartupDSN(settings *conf.Settings) string {
 	cfg := mysql.Config{
 		User:                 settings.Output.MySQL.Username,
 		Passwd:               settings.Output.MySQL.Password,
@@ -271,7 +271,12 @@ func checkMySQLMigrationState(settings *conf.Settings) StartupState {
 			"writeTimeout": dbStartupTimeout,
 		},
 	}
-	dsn := cfg.FormatDSN()
+	return cfg.FormatDSN()
+}
+
+// checkMySQLMigrationState checks migration state for MySQL deployments.
+func checkMySQLMigrationState(settings *conf.Settings) StartupState {
+	dsn := buildMySQLStartupDSN(settings)
 
 	// Collect MySQL endpoint info for redaction from error messages
 	mysqlHost := settings.Output.MySQL.Host
@@ -546,24 +551,7 @@ func hasUnmigratedLegacySQLite(settings *conf.Settings, log logger.Logger) bool 
 
 // hasUnmigratedLegacyMySQL checks for unmigrated records in a MySQL legacy database.
 func hasUnmigratedLegacyMySQL(settings *conf.Settings, log logger.Logger) bool {
-	cfg := mysql.Config{
-		User:                 settings.Output.MySQL.Username,
-		Passwd:               settings.Output.MySQL.Password,
-		Net:                  "tcp",
-		Addr:                 fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
-		DBName:               settings.Output.MySQL.Database,
-		AllowNativePasswords: true,
-		CheckConnLiveness:    true,
-		Params: map[string]string{
-			"charset":      "utf8mb4",
-			"parseTime":    "True",
-			"loc":          "Local",
-			"timeout":      dbStartupTimeout,
-			"readTimeout":  dbStartupTimeout,
-			"writeTimeout": dbStartupTimeout,
-		},
-	}
-	dsn := cfg.FormatDSN()
+	dsn := buildMySQLStartupDSN(settings)
 
 	db, err := gorm.Open(gormmysql.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
@@ -684,25 +672,7 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 // This is used to determine whether to use v2_ prefix for migration mode or no prefix for fresh installs.
 // Returns true if the fresh v2 schema exists (migration_states table without prefix).
 func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
-	// Build MySQL DSN
-	cfg := mysql.Config{
-		User:                 settings.Output.MySQL.Username,
-		Passwd:               settings.Output.MySQL.Password,
-		Net:                  "tcp",
-		Addr:                 fmt.Sprintf("%s:%s", settings.Output.MySQL.Host, settings.Output.MySQL.Port),
-		DBName:               settings.Output.MySQL.Database,
-		AllowNativePasswords: true,
-		CheckConnLiveness:    true,
-		Params: map[string]string{
-			"charset":      "utf8mb4",
-			"parseTime":    "True",
-			"loc":          "Local",
-			"timeout":      dbStartupTimeout,
-			"readTimeout":  dbStartupTimeout,
-			"writeTimeout": dbStartupTimeout,
-		},
-	}
-	dsn := cfg.FormatDSN()
+	dsn := buildMySQLStartupDSN(settings)
 
 	db, err := gorm.Open(gormmysql.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -456,13 +456,8 @@ func TestReportStartupError_NilSafe(t *testing.T) {
 	})
 }
 
-// TestCheckMySQLMigrationState_NativePasswordAuth verifies that the MySQL
-// startup check works with mysql_native_password authentication, which is the
-// default for MariaDB and some MySQL configurations.
-// This test requires MYSQL_TEST_* environment variables to be set.
-func TestCheckMySQLMigrationState_NativePasswordAuth(t *testing.T) {
-	cfg := skipIfNoMySQL(t)
-
+// mysqlTestSettings builds conf.Settings from a MySQLConfig for startup tests.
+func mysqlTestSettings(cfg *MySQLConfig) *conf.Settings {
 	settings := &conf.Settings{}
 	settings.Output.MySQL.Enabled = true
 	settings.Output.MySQL.Host = cfg.Host
@@ -470,10 +465,17 @@ func TestCheckMySQLMigrationState_NativePasswordAuth(t *testing.T) {
 	settings.Output.MySQL.Username = cfg.Username
 	settings.Output.MySQL.Password = cfg.Password
 	settings.Output.MySQL.Database = cfg.Database
+	return settings
+}
+
+// TestCheckMySQLMigrationState_NativePasswordAuth verifies that the MySQL
+// startup check works with mysql_native_password authentication, which is the
+// default for MariaDB and some MySQL configurations.
+func TestCheckMySQLMigrationState_NativePasswordAuth(t *testing.T) {
+	settings := mysqlTestSettings(skipIfNoMySQL(t))
 
 	state := checkMySQLMigrationState(settings)
 
-	// The key assertion: the function must NOT return an error.
 	// Before the fix, mysql_native_password servers would get
 	// ErrV2DatabaseCorrupted because AllowNativePasswords defaulted to false.
 	require.NoError(t, state.Error, "startup check must not fail due to auth plugin rejection")
@@ -483,39 +485,19 @@ func TestCheckMySQLMigrationState_NativePasswordAuth(t *testing.T) {
 // TestHasUnmigratedLegacyMySQL_NativePasswordAuth verifies that the unmigrated
 // records check connects successfully with mysql_native_password.
 func TestHasUnmigratedLegacyMySQL_NativePasswordAuth(t *testing.T) {
-	cfg := skipIfNoMySQL(t)
-
-	settings := &conf.Settings{}
-	settings.Output.MySQL.Enabled = true
-	settings.Output.MySQL.Host = cfg.Host
-	settings.Output.MySQL.Port = cfg.Port
-	settings.Output.MySQL.Username = cfg.Username
-	settings.Output.MySQL.Password = cfg.Password
-	settings.Output.MySQL.Database = cfg.Database
-
-	log := testStartupLogger()
+	settings := mysqlTestSettings(skipIfNoMySQL(t))
 
 	// Should not panic or fail due to auth plugin rejection.
-	// The return value depends on whether legacy tables exist, which is fine.
 	assert.NotPanics(t, func() {
-		_ = hasUnmigratedLegacyMySQL(settings, log)
+		_ = hasUnmigratedLegacyMySQL(settings, testStartupLogger())
 	})
 }
 
 // TestCheckMySQLHasFreshV2Schema_NativePasswordAuth verifies that the fresh v2
 // schema check connects successfully with mysql_native_password.
 func TestCheckMySQLHasFreshV2Schema_NativePasswordAuth(t *testing.T) {
-	cfg := skipIfNoMySQL(t)
+	settings := mysqlTestSettings(skipIfNoMySQL(t))
 
-	settings := &conf.Settings{}
-	settings.Output.MySQL.Enabled = true
-	settings.Output.MySQL.Host = cfg.Host
-	settings.Output.MySQL.Port = cfg.Port
-	settings.Output.MySQL.Username = cfg.Username
-	settings.Output.MySQL.Password = cfg.Password
-	settings.Output.MySQL.Database = cfg.Database
-
-	// Should not panic or fail due to auth plugin rejection
 	assert.NotPanics(t, func() {
 		_ = CheckMySQLHasFreshV2Schema(settings)
 	})

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -455,3 +455,68 @@ func TestReportStartupError_NilSafe(t *testing.T) {
 		reportStartupError("sqlite", "openV2Database", fmt.Errorf("open /home/user/birdnet_v2.db: denied"), "/home/user/birdnet_v2.db")
 	})
 }
+
+// TestCheckMySQLMigrationState_NativePasswordAuth verifies that the MySQL
+// startup check works with mysql_native_password authentication, which is the
+// default for MariaDB and some MySQL configurations.
+// This test requires MYSQL_TEST_* environment variables to be set.
+func TestCheckMySQLMigrationState_NativePasswordAuth(t *testing.T) {
+	cfg := skipIfNoMySQL(t)
+
+	settings := &conf.Settings{}
+	settings.Output.MySQL.Enabled = true
+	settings.Output.MySQL.Host = cfg.Host
+	settings.Output.MySQL.Port = cfg.Port
+	settings.Output.MySQL.Username = cfg.Username
+	settings.Output.MySQL.Password = cfg.Password
+	settings.Output.MySQL.Database = cfg.Database
+
+	state := checkMySQLMigrationState(settings)
+
+	// The key assertion: the function must NOT return an error.
+	// Before the fix, mysql_native_password servers would get
+	// ErrV2DatabaseCorrupted because AllowNativePasswords defaulted to false.
+	require.NoError(t, state.Error, "startup check must not fail due to auth plugin rejection")
+	assert.NotEmpty(t, string(state.MigrationStatus), "migration status should be set")
+}
+
+// TestHasUnmigratedLegacyMySQL_NativePasswordAuth verifies that the unmigrated
+// records check connects successfully with mysql_native_password.
+func TestHasUnmigratedLegacyMySQL_NativePasswordAuth(t *testing.T) {
+	cfg := skipIfNoMySQL(t)
+
+	settings := &conf.Settings{}
+	settings.Output.MySQL.Enabled = true
+	settings.Output.MySQL.Host = cfg.Host
+	settings.Output.MySQL.Port = cfg.Port
+	settings.Output.MySQL.Username = cfg.Username
+	settings.Output.MySQL.Password = cfg.Password
+	settings.Output.MySQL.Database = cfg.Database
+
+	log := testStartupLogger()
+
+	// Should not panic or fail due to auth plugin rejection.
+	// The return value depends on whether legacy tables exist, which is fine.
+	assert.NotPanics(t, func() {
+		_ = hasUnmigratedLegacyMySQL(settings, log)
+	})
+}
+
+// TestCheckMySQLHasFreshV2Schema_NativePasswordAuth verifies that the fresh v2
+// schema check connects successfully with mysql_native_password.
+func TestCheckMySQLHasFreshV2Schema_NativePasswordAuth(t *testing.T) {
+	cfg := skipIfNoMySQL(t)
+
+	settings := &conf.Settings{}
+	settings.Output.MySQL.Enabled = true
+	settings.Output.MySQL.Host = cfg.Host
+	settings.Output.MySQL.Port = cfg.Port
+	settings.Output.MySQL.Username = cfg.Username
+	settings.Output.MySQL.Password = cfg.Password
+	settings.Output.MySQL.Database = cfg.Database
+
+	// Should not panic or fail due to auth plugin rejection
+	assert.NotPanics(t, func() {
+		_ = CheckMySQLHasFreshV2Schema(settings)
+	})
+}


### PR DESCRIPTION
## Summary

- Fix MySQL startup-check functions rejecting `mysql_native_password` authentication, which prevented MariaDB users from switching to V2-only database mode after migration
- Extract `buildMySQLStartupDSN()` helper to eliminate triple `mysql.Config{}` duplication and prevent future drift

## Root Cause

Three MySQL startup-check functions in `internal/datastore/v2/startup.go` used `mysql.Config{}` struct literals where `AllowNativePasswords` defaults to `false` (Go zero value). The `go-sql-driver/mysql` v1.10.0 `NewConfig()` sets it to `true`, but struct literals bypass `NewConfig()`. `FormatDSN()` then emitted `allowNativePasswords=false`, and the driver rejected `mysql_native_password` at auth time.

This silently broke MariaDB users (and MySQL with native password auth) post-migration: the startup check fell back to legacy mode despite migration being complete, showing "Restart Required" on every restart.

## Related Issues

Fixes #3165

## Test Plan

- [x] Reproduced exact error from #3165 against local MySQL with `mysql_native_password`
- [x] Verified fix resolves it (struct literal with `AllowNativePasswords: false` fails, `true` succeeds)
- [x] 3 new integration tests pass with `-race` against real MySQL
- [x] Zero lint issues (`golangci-lint run`)
- [x] All 27 startup tests pass