### PR TITLE
fix(tls): transactional cert writes, backup/restore, and TLSMode detection

### DIFF
--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -132,15 +132,13 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 
 	tlsMgr := conf.GetTLSManager()
 
-	// Serialise the entire cert-save-settings sequence.
+	// Serialise the entire cert-save-settings sequence. Cannot use defer
+	// because GetMQTTTLSCertificate on the success path acquires a read lock.
 	c.settingsMutex.Lock()
-	defer c.settingsMutex.Unlock()
 
-	if err := tlsMgr.BackupAllCertificates(mqttTLSServiceName); err != nil {
-		return c.HandleError(ctx, err, "Failed to backup MQTT TLS certificates", http.StatusInternalServerError)
-	}
-
-	// Stage 1: Save new cert files. On failure, restore backups.
+	// Stage 1: Save new cert files. On failure, clean up newly written files.
+	// Cannot use BackupAllCertificates here because this handler selectively
+	// modifies some certs while leaving others untouched.
 	type pathUpdate struct {
 		caCert, clientCert, clientKey string
 		clearCA, clearClient          bool
@@ -154,7 +152,7 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		} else {
 			path, err := tlsMgr.SaveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA, ca)
 			if err != nil {
-				tlsMgr.RestoreBackups(mqttTLSServiceName)
+				c.settingsMutex.Unlock()
 				return c.HandleError(ctx, err, "Failed to save CA certificate", http.StatusBadRequest)
 			}
 			update.caCert = path
@@ -169,12 +167,19 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		} else {
 			certPath, err := tlsMgr.SaveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient, cert)
 			if err != nil {
-				tlsMgr.RestoreBackups(mqttTLSServiceName)
+				if update.caCert != "" {
+					_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
+				}
+				c.settingsMutex.Unlock()
 				return c.HandleError(ctx, err, "Failed to save client certificate", http.StatusBadRequest)
 			}
 			keyPath, err := tlsMgr.SaveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey, key)
 			if err != nil {
-				tlsMgr.RestoreBackups(mqttTLSServiceName)
+				_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
+				if update.caCert != "" {
+					_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
+				}
+				c.settingsMutex.Unlock()
 				return c.HandleError(ctx, err, "Failed to save client key", http.StatusBadRequest)
 			}
 			update.clientCert = certPath
@@ -198,7 +203,14 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		updated.Realtime.MQTT.TLS.ClientKey = ""
 	}
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		tlsMgr.RestoreBackups(mqttTLSServiceName)
+		if update.caCert != "" {
+			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
+		}
+		if update.clientCert != "" {
+			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
+			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
+		}
+		c.settingsMutex.Unlock()
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
 			http.StatusInternalServerError)
 	}
@@ -206,7 +218,6 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		GetLogger().Warn("Failed to trigger settings side-effects after MQTT TLS certificate change",
 			logger.Error(handleErr))
 	}
-	tlsMgr.CleanupBackups(mqttTLSServiceName)
 
 	// Stage 3: Settings saved. Now perform clears (best-effort).
 	if update.clearCA {
@@ -216,6 +227,10 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
 		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
 	}
+
+	// Release the write lock before calling GetMQTTTLSCertificate which
+	// acquires a read lock (sync.RWMutex is not reentrant).
+	c.settingsMutex.Unlock()
 
 	return c.GetMQTTTLSCertificate(ctx)
 }

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -182,16 +182,8 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		}
 	}
 
-	// Stage 2: All saves succeeded — now perform clears (best-effort, cannot fail meaningfully).
-	if update.clearCA {
-		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
-	}
-	if update.clearClient {
-		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
-		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
-	}
-
-	// Stage 2: Apply all settings atomically after all I/O succeeded.
+	// Stage 2: Apply settings atomically. Clears are deferred to stage 3
+	// so that a settings save failure does not leave orphaned deletions.
 	c.settingsMutex.Lock()
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
@@ -209,6 +201,14 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 	}
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
 		c.settingsMutex.Unlock()
+		// Clean up cert files written in stage 1.
+		if update.caCert != "" {
+			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
+		}
+		if update.clientCert != "" {
+			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
+			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
+		}
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
 			http.StatusInternalServerError)
 	}
@@ -217,6 +217,15 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 			logger.Error(handleErr))
 	}
 	c.settingsMutex.Unlock()
+
+	// Stage 3: Settings saved successfully. Now perform clears (best-effort).
+	if update.clearCA {
+		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
+	}
+	if update.clearClient {
+		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
+		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
+	}
 
 	return c.GetMQTTTLSCertificate(ctx)
 }
@@ -227,21 +236,28 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 func (c *Controller) DeleteMQTTTLSCertificate(ctx echo.Context) error {
 	tlsMgr := conf.GetTLSManager()
 
-	// Only remove files in the managed directory
+	// Serialise the entire backup-remove-save sequence so concurrent
+	// requests cannot interleave between backup and remove.
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
+
+	if err := tlsMgr.BackupAllCertificates(mqttTLSServiceName); err != nil {
+		return c.HandleError(ctx, err, "Failed to backup MQTT TLS certificates before deletion",
+			http.StatusInternalServerError)
+	}
 	if err := tlsMgr.RemoveAllCertificates(mqttTLSServiceName); err != nil {
+		tlsMgr.RestoreBackups(mqttTLSServiceName)
 		return c.HandleError(ctx, err, "Failed to remove MQTT TLS certificates",
 			http.StatusInternalServerError)
 	}
 
-	// Clear all certificate paths in settings
-	c.settingsMutex.Lock()
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Realtime.MQTT.TLS.CACert = ""
 	updated.Realtime.MQTT.TLS.ClientCert = ""
 	updated.Realtime.MQTT.TLS.ClientKey = ""
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		c.settingsMutex.Unlock()
+		tlsMgr.RestoreBackups(mqttTLSServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate deletion",
 			http.StatusInternalServerError)
 	}
@@ -249,7 +265,7 @@ func (c *Controller) DeleteMQTTTLSCertificate(ctx echo.Context) error {
 		GetLogger().Warn("Failed to trigger settings side-effects after MQTT TLS certificate change",
 			logger.Error(handleErr))
 	}
-	c.settingsMutex.Unlock()
+	tlsMgr.CleanupBackups(mqttTLSServiceName)
 
 	return ctx.NoContent(http.StatusNoContent)
 }

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -200,8 +200,7 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		updated.Realtime.MQTT.TLS.ClientKey = ""
 	}
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		c.settingsMutex.Unlock()
-		// Clean up cert files written in stage 1.
+		// Clean up cert files written in stage 1 while still holding the lock.
 		if update.caCert != "" {
 			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
 		}
@@ -209,6 +208,7 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
 			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
 		}
+		c.settingsMutex.Unlock()
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
 			http.StatusInternalServerError)
 	}

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -132,16 +132,21 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 
 	tlsMgr := conf.GetTLSManager()
 
-	// Stage 1: Perform all save operations first (these can fail and need rollback).
-	// Clear operations are deferred to after all saves succeed, since a deleted file
-	// cannot be restored on rollback.
+	// Serialise the entire cert-save-settings sequence.
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
+
+	if err := tlsMgr.BackupAllCertificates(mqttTLSServiceName); err != nil {
+		return c.HandleError(ctx, err, "Failed to backup MQTT TLS certificates", http.StatusInternalServerError)
+	}
+
+	// Stage 1: Save new cert files. On failure, restore backups.
 	type pathUpdate struct {
 		caCert, clientCert, clientKey string
 		clearCA, clearClient          bool
 	}
 	var update pathUpdate
 
-	// Save new CA certificate (if provided and non-empty)
 	if req.CACertificate != nil {
 		ca := strings.TrimSpace(*req.CACertificate)
 		if ca == "" {
@@ -149,13 +154,13 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		} else {
 			path, err := tlsMgr.SaveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA, ca)
 			if err != nil {
+				tlsMgr.RestoreBackups(mqttTLSServiceName)
 				return c.HandleError(ctx, err, "Failed to save CA certificate", http.StatusBadRequest)
 			}
 			update.caCert = path
 		}
 	}
 
-	// Save new client certificate and key (if provided and non-empty)
 	if req.ClientCertificate != nil {
 		cert := strings.TrimSpace(*req.ClientCertificate)
 		key := strings.TrimSpace(*req.ClientKey)
@@ -164,17 +169,12 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		} else {
 			certPath, err := tlsMgr.SaveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient, cert)
 			if err != nil {
-				if update.caCert != "" {
-					_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
-				}
+				tlsMgr.RestoreBackups(mqttTLSServiceName)
 				return c.HandleError(ctx, err, "Failed to save client certificate", http.StatusBadRequest)
 			}
 			keyPath, err := tlsMgr.SaveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey, key)
 			if err != nil {
-				_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
-				if update.caCert != "" {
-					_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
-				}
+				tlsMgr.RestoreBackups(mqttTLSServiceName)
 				return c.HandleError(ctx, err, "Failed to save client key", http.StatusBadRequest)
 			}
 			update.clientCert = certPath
@@ -182,9 +182,7 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		}
 	}
 
-	// Stage 2: Apply settings atomically. Clears are deferred to stage 3
-	// so that a settings save failure does not leave orphaned deletions.
-	c.settingsMutex.Lock()
+	// Stage 2: Apply settings atomically.
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	if update.caCert != "" {
@@ -200,15 +198,7 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		updated.Realtime.MQTT.TLS.ClientKey = ""
 	}
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		// Clean up cert files written in stage 1 while still holding the lock.
-		if update.caCert != "" {
-			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
-		}
-		if update.clientCert != "" {
-			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeClient)
-			_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
-		}
-		c.settingsMutex.Unlock()
+		tlsMgr.RestoreBackups(mqttTLSServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after MQTT TLS certificate upload",
 			http.StatusInternalServerError)
 	}
@@ -216,9 +206,9 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		GetLogger().Warn("Failed to trigger settings side-effects after MQTT TLS certificate change",
 			logger.Error(handleErr))
 	}
-	c.settingsMutex.Unlock()
+	tlsMgr.CleanupBackups(mqttTLSServiceName)
 
-	// Stage 3: Settings saved successfully. Now perform clears (best-effort).
+	// Stage 3: Settings saved. Now perform clears (best-effort).
 	if update.clearCA {
 		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeCA)
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2467,6 +2467,7 @@ func webserverSettingsChanged(oldSettings, currentSettings *conf.Settings) bool 
 	newSec := currentSettings.Security
 
 	if oldSec.Host != newSec.Host ||
+		oldSec.TLSMode != newSec.TLSMode ||
 		oldSec.AutoTLS != newSec.AutoTLS || //nolint:staticcheck // Intentional: backward-compatible migration
 		oldSec.RedirectToHTTPS != newSec.RedirectToHTTPS {
 		return true

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -138,6 +138,7 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 	updated.Security.TLSMode = conf.TLSModeManual
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
 		c.settingsMutex.Unlock()
+		_ = tlsMgr.RemoveAllCertificates(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate upload",
 			http.StatusInternalServerError)
 	}
@@ -163,17 +164,25 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 	tlsMgr := conf.GetTLSManager()
 
+	// Serialise the entire backup-remove-save sequence so concurrent
+	// requests cannot interleave between backup and remove.
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
+
+	if err := tlsMgr.BackupAllCertificates(tlsServiceName); err != nil {
+		return c.HandleError(ctx, err, "Failed to backup TLS certificates before deletion",
+			http.StatusInternalServerError)
+	}
 	if err := tlsMgr.RemoveAllCertificates(tlsServiceName); err != nil {
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to remove TLS certificates", http.StatusInternalServerError)
 	}
 
-	// Reset TLS mode to none
-	c.settingsMutex.Lock()
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Security.TLSMode = conf.TLSModeNone
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		c.settingsMutex.Unlock()
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate deletion",
 			http.StatusInternalServerError)
 	}
@@ -181,7 +190,7 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
 			logger.Error(handleErr))
 	}
-	c.settingsMutex.Unlock()
+	tlsMgr.CleanupBackups(tlsServiceName)
 
 	return ctx.NoContent(http.StatusNoContent)
 }
@@ -250,6 +259,7 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 	updated.Security.TLSMode = conf.TLSModeSelfSigned
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
 		c.settingsMutex.Unlock()
+		_ = tlsMgr.RemoveAllCertificates(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after self-signed certificate generation",
 			http.StatusInternalServerError)
 	}

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -109,24 +109,25 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 
 	tlsMgr := conf.GetTLSManager()
 
+	// Backup existing certs so we can restore if settings save fails.
+	_ = tlsMgr.BackupAllCertificates(tlsServiceName)
+
 	// Save certificate
 	if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeServerCert, req.Certificate); err != nil {
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save TLS certificate", http.StatusInternalServerError)
 	}
 
 	// Save private key
 	if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeServerKey, req.PrivateKey); err != nil {
-		// Clean up the cert that was saved
-		_ = tlsMgr.RemoveCertificate(tlsServiceName, conf.TLSCertTypeServerCert)
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save TLS private key", http.StatusInternalServerError)
 	}
 
 	// Save CA certificate if provided
 	if strings.TrimSpace(req.CACertificate) != "" {
 		if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeCA, req.CACertificate); err != nil {
-			// Clean up cert and key that were saved
-			_ = tlsMgr.RemoveCertificate(tlsServiceName, conf.TLSCertTypeServerCert)
-			_ = tlsMgr.RemoveCertificate(tlsServiceName, conf.TLSCertTypeServerKey)
+			tlsMgr.RestoreBackups(tlsServiceName)
 			return c.HandleError(ctx, err, "Failed to save CA certificate", http.StatusInternalServerError)
 		}
 	}
@@ -138,7 +139,7 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 	updated.Security.TLSMode = conf.TLSModeManual
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
 		c.settingsMutex.Unlock()
-		_ = tlsMgr.RemoveAllCertificates(tlsServiceName)
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate upload",
 			http.StatusInternalServerError)
 	}
@@ -147,6 +148,7 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 			logger.Error(handleErr))
 	}
 	c.settingsMutex.Unlock()
+	tlsMgr.CleanupBackups(tlsServiceName)
 
 	// Return certificate info
 	certPath := tlsMgr.GetCertificatePath(tlsServiceName, conf.TLSCertTypeServerCert)
@@ -243,12 +245,14 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 	// Save certificate and key
 	tlsMgr := conf.GetTLSManager()
 
+	_ = tlsMgr.BackupAllCertificates(tlsServiceName)
+
 	if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeServerCert, certPEM); err != nil {
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save generated certificate", http.StatusInternalServerError)
 	}
 	if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeServerKey, keyPEM); err != nil {
-		// Clean up the cert that was saved
-		_ = tlsMgr.RemoveCertificate(tlsServiceName, conf.TLSCertTypeServerCert)
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save generated private key", http.StatusInternalServerError)
 	}
 
@@ -259,7 +263,7 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 	updated.Security.TLSMode = conf.TLSModeSelfSigned
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
 		c.settingsMutex.Unlock()
-		_ = tlsMgr.RemoveAllCertificates(tlsServiceName)
+		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after self-signed certificate generation",
 			http.StatusInternalServerError)
 	}
@@ -268,6 +272,7 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 			logger.Error(handleErr))
 	}
 	c.settingsMutex.Unlock()
+	tlsMgr.CleanupBackups(tlsServiceName)
 
 	// Return certificate info
 	certPath := tlsMgr.GetCertificatePath(tlsServiceName, conf.TLSCertTypeServerCert)

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -109,8 +109,13 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 
 	tlsMgr := conf.GetTLSManager()
 
-	// Backup existing certs so we can restore if settings save fails.
-	_ = tlsMgr.BackupAllCertificates(tlsServiceName)
+	// Serialise the entire backup-save-settings sequence.
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
+
+	if err := tlsMgr.BackupAllCertificates(tlsServiceName); err != nil {
+		return c.HandleError(ctx, err, "Failed to backup TLS certificates", http.StatusInternalServerError)
+	}
 
 	// Save certificate
 	if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeServerCert, req.Certificate); err != nil {
@@ -133,12 +138,10 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 	}
 
 	// Update TLS mode to manual
-	c.settingsMutex.Lock()
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Security.TLSMode = conf.TLSModeManual
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		c.settingsMutex.Unlock()
 		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after TLS certificate upload",
 			http.StatusInternalServerError)
@@ -147,7 +150,6 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
 			logger.Error(handleErr))
 	}
-	c.settingsMutex.Unlock()
 	tlsMgr.CleanupBackups(tlsServiceName)
 
 	// Return certificate info
@@ -242,10 +244,15 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to generate self-signed certificate", http.StatusInternalServerError)
 	}
 
-	// Save certificate and key
+	// Save certificate and key under settingsMutex for full serialisation.
 	tlsMgr := conf.GetTLSManager()
 
-	_ = tlsMgr.BackupAllCertificates(tlsServiceName)
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
+
+	if err := tlsMgr.BackupAllCertificates(tlsServiceName); err != nil {
+		return c.HandleError(ctx, err, "Failed to backup TLS certificates", http.StatusInternalServerError)
+	}
 
 	if _, err := tlsMgr.SaveCertificate(tlsServiceName, conf.TLSCertTypeServerCert, certPEM); err != nil {
 		tlsMgr.RestoreBackups(tlsServiceName)
@@ -256,13 +263,10 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to save generated private key", http.StatusInternalServerError)
 	}
 
-	// Update TLS mode to self-signed
-	c.settingsMutex.Lock()
 	current := c.getSettingsOrFallback()
 	updated := conf.CloneSettings(current)
 	updated.Security.TLSMode = conf.TLSModeSelfSigned
 	if err := c.publishAndSaveSettings(current, updated); err != nil {
-		c.settingsMutex.Unlock()
 		tlsMgr.RestoreBackups(tlsServiceName)
 		return c.HandleError(ctx, err, "Failed to save settings after self-signed certificate generation",
 			http.StatusInternalServerError)
@@ -271,7 +275,6 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
 			logger.Error(handleErr))
 	}
-	c.settingsMutex.Unlock()
 	tlsMgr.CleanupBackups(tlsServiceName)
 
 	// Return certificate info

--- a/internal/conf/tls.go
+++ b/internal/conf/tls.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // TLSCertificateType represents the type of TLS certificate/key
@@ -22,6 +23,12 @@ const (
 	TLSCertTypeServerCert TLSCertificateType = "server_cert"
 	TLSCertTypeServerKey  TLSCertificateType = "server_key"
 )
+
+// allCertTypes lists every TLS certificate type for bulk operations.
+var allCertTypes = []TLSCertificateType{
+	TLSCertTypeCA, TLSCertTypeClient, TLSCertTypeKey,
+	TLSCertTypeServerCert, TLSCertTypeServerKey,
+}
 
 // TLSManager handles TLS certificate storage and retrieval
 type TLSManager struct {
@@ -159,12 +166,24 @@ func (tm *TLSManager) SaveCertificate(service string, certType TLSCertificateTyp
 		perm = 0o644 // Certificates: read for all, write for owner
 	}
 
-	// Write file with appropriate permissions
-	if err := os.WriteFile(filePath, []byte(content), perm); err != nil {
+	// Write to a temp file in the same directory, then rename atomically.
+	// This prevents partial writes from leaving a corrupted cert on disk.
+	tmpPath := filePath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(content), perm); err != nil {
+		_ = os.Remove(tmpPath)
 		return "", errors.New(err).
 			Component("tls-manager").
 			Category(errors.CategoryFileIO).
-			Context("operation", "write-cert").
+			Context("operation", "write-cert-tmp").
+			Context("file", tmpPath).
+			Build()
+	}
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", errors.New(err).
+			Component("tls-manager").
+			Category(errors.CategoryFileIO).
+			Context("operation", "rename-cert").
 			Context("file", filePath).
 			Build()
 	}
@@ -213,13 +232,69 @@ func (tm *TLSManager) RemoveAllCertificates(service string) error {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
-	certTypes := []TLSCertificateType{TLSCertTypeCA, TLSCertTypeClient, TLSCertTypeKey, TLSCertTypeServerCert, TLSCertTypeServerKey}
+	certTypes := allCertTypes
 	for _, certType := range certTypes {
 		if err := tm.removeCertificateUnlocked(service, certType); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// BackupAllCertificates renames all existing certificate files to .bak
+// so they can be restored if a subsequent operation fails.
+func (tm *TLSManager) BackupAllCertificates(service string) error {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	certTypes := allCertTypes
+	for _, certType := range certTypes {
+		path := tm.GetCertificatePath(service, certType)
+		if err := os.Rename(path, path+".bak"); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			tm.restoreBackupsUnlocked(service)
+			return errors.New(err).
+				Component("tls-manager").
+				Category(errors.CategoryFileIO).
+				Context("operation", "backup-cert").
+				Context("file", path).
+				Build()
+		}
+	}
+	return nil
+}
+
+// RestoreBackups restores all .bak files to their original paths.
+func (tm *TLSManager) RestoreBackups(service string) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.restoreBackupsUnlocked(service)
+}
+
+func (tm *TLSManager) restoreBackupsUnlocked(service string) {
+	certTypes := allCertTypes
+	for _, certType := range certTypes {
+		path := tm.GetCertificatePath(service, certType)
+		bakPath := path + ".bak"
+		if err := os.Rename(bakPath, path); err != nil && !os.IsNotExist(err) {
+			GetLogger().Warn("Failed to restore certificate backup",
+				logger.String("file", path), logger.Error(err))
+		}
+	}
+}
+
+// CleanupBackups removes all .bak files after a successful operation.
+func (tm *TLSManager) CleanupBackups(service string) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	certTypes := allCertTypes
+	for _, certType := range certTypes {
+		path := tm.GetCertificatePath(service, certType)
+		_ = os.Remove(path + ".bak")
+	}
 }
 
 // validateCertificateContent validates that the content is a valid PEM-encoded certificate or key


### PR DESCRIPTION
## Summary
- Atomic writes in `SaveCertificate` using temp file + rename to prevent partial writes from leaving corrupted certs on disk
- Backup/restore mechanism for delete handlers (`BackupAllCertificates`, `RestoreBackups`, `CleanupBackups`) so cert files can be restored if settings save fails
- Cert file cleanup on settings save failure in upload handlers (TLS and MQTT TLS)
- Defer cert clears in MQTT upload handler until after settings save succeeds, preventing orphaned deletions on save failure
- Add `TLSMode` to `webserverSettingsChanged` so TLS mode transitions trigger the "Restart required" toast
- Extract `allCertTypes` package-level variable (was duplicated 4 times across bulk operations)
- Fix TOCTOU in backup: attempt rename directly, handle ENOENT instead of stat-then-rename
- Log warnings in `restoreBackupsUnlocked` instead of silently discarding errors
- Serialise delete handlers with `settingsMutex` to prevent race between backup and remove

## Test Plan
- [x] `go build ./internal/...` passes
- [x] `golangci-lint run -v ./internal/api/v2/... ./internal/conf/...` zero issues
- [x] `go test -race ./internal/api/v2/... ./internal/conf/... -count=1` passes (3187 tests)
- [x] Gate review (5 parallel agents + Gemini) found no blocking issues after fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS and MQTT certificate upload, generation, and deletion flows with safer rollback and cleanup on failure.
  * Serialized certificate operations to prevent race conditions during concurrent requests.
  * Added backup-and-restore handling for certificate changes to avoid partial or inconsistent states.
  * Fixed TLS mode change detection so webserver reconfigure/restart triggers correctly when TLS settings are updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->