### PR TITLE
feat(support): add database schema snapshot to support dumps

### DIFF
--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -27,12 +27,13 @@ const (
 
 // GenerateSupportDumpRequest represents the request for generating a support dump
 type GenerateSupportDumpRequest struct {
-	IncludeLogs       bool   `json:"include_logs"`
-	IncludeConfig     bool   `json:"include_config"`
-	IncludeSystemInfo bool   `json:"include_system_info"`
-	UserMessage       string `json:"user_message"`
-	UploadToSentry    bool   `json:"upload_to_sentry"`
-	GitHubIssueNumber string `json:"github_issue_number"`
+	IncludeLogs         bool   `json:"include_logs"`
+	IncludeConfig       bool   `json:"include_config"`
+	IncludeSystemInfo   bool   `json:"include_system_info"`
+	IncludeDatabaseInfo bool   `json:"include_database_info"`
+	UserMessage         string `json:"user_message"`
+	UploadToSentry      bool   `json:"upload_to_sentry"`
+	GitHubIssueNumber   string `json:"github_issue_number"`
 }
 
 // GenerateSupportDumpResponse represents the response for support dump generation
@@ -76,10 +77,11 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		logger.Bool("has_user_message", req.UserMessage != ""))
 
 	// Set defaults if nothing is selected
-	if !req.IncludeLogs && !req.IncludeConfig && !req.IncludeSystemInfo {
+	if !req.IncludeLogs && !req.IncludeConfig && !req.IncludeSystemInfo && !req.IncludeDatabaseInfo {
 		req.IncludeLogs = true
 		req.IncludeConfig = true
 		req.IncludeSystemInfo = true
+		req.IncludeDatabaseInfo = true
 		c.logDebugIfEnabled("Set default options for support dump")
 	}
 
@@ -103,14 +105,31 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		settings.Version,
 	)
 
+	// Wire database info provider if V2Manager is available
+	if req.IncludeDatabaseInfo && c.V2Manager != nil {
+		dialect := "sqlite"
+		if c.V2Manager.IsMySQL() {
+			dialect = "mysql"
+		}
+		dbCollector := support.NewGormDatabaseInfoCollector(
+			c.V2Manager.DB(),
+			dialect,
+			c.V2Manager.Path(),
+			c.DS.SchemaVersion(),
+			c.V2Manager.TablePrefix(),
+		)
+		collector.SetDatabaseInfoProvider(dbCollector)
+	}
+
 	// Set collection options
 	opts := support.CollectorOptions{
-		IncludeLogs:       req.IncludeLogs,
-		IncludeConfig:     req.IncludeConfig,
-		IncludeSystemInfo: req.IncludeSystemInfo,
-		LogDuration:       supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
-		MaxLogSize:        supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
-		ScrubSensitive:    true,
+		IncludeLogs:         req.IncludeLogs,
+		IncludeConfig:       req.IncludeConfig,
+		IncludeSystemInfo:   req.IncludeSystemInfo,
+		IncludeDatabaseInfo: req.IncludeDatabaseInfo,
+		LogDuration:         supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
+		MaxLogSize:          supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
+		ScrubSensitive:      true,
 	}
 
 	// Collect data

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -132,6 +132,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		LogDuration:         supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
 		MaxLogSize:          supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
 		ScrubSensitive:      true,
+		AnonymizePII:        true,
 	}
 
 	// Collect data

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/support"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
@@ -72,6 +73,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		logger.Bool("include_logs", req.IncludeLogs),
 		logger.Bool("include_config", req.IncludeConfig),
 		logger.Bool("include_system_info", req.IncludeSystemInfo),
+		logger.Bool("include_database_info", req.IncludeDatabaseInfo),
 		logger.Bool("upload_to_sentry", req.UploadToSentry),
 		logger.String("github_issue", req.GitHubIssueNumber),
 		logger.Bool("has_user_message", req.UserMessage != ""))
@@ -107,9 +109,9 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 
 	// Wire database info provider if V2Manager is available
 	if req.IncludeDatabaseInfo && c.V2Manager != nil {
-		dialect := "sqlite"
+		dialect := datastore.DialectSQLite
 		if c.V2Manager.IsMySQL() {
-			dialect = "mysql"
+			dialect = datastore.DialectMySQL
 		}
 		dbCollector := support.NewGormDatabaseInfoCollector(
 			c.V2Manager.DB(),

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -342,6 +342,7 @@ func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*Suppor
 		logger.Bool("include_logs", opts.IncludeLogs),
 		logger.Bool("include_config", opts.IncludeConfig),
 		logger.Bool("include_system_info", opts.IncludeSystemInfo),
+		logger.Bool("include_database_info", opts.IncludeDatabaseInfo),
 		logger.Duration("log_duration", opts.LogDuration),
 		logger.Int64("max_log_size", opts.MaxLogSize))
 

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -56,11 +56,12 @@ const (
 	logTimeFormat      = "2006-01-02 15:04:05"
 
 	// Archive file names
-	diagnosticsFileName = "collection_diagnostics.json"
-	metadataFileName    = "metadata.json"
-	configYAMLFileName  = "config.yaml"
-	systemInfoFileName  = "system_info.json"
-	logReadmeFileName   = "logs/README.txt"
+	diagnosticsFileName  = "collection_diagnostics.json"
+	metadataFileName     = "metadata.json"
+	configYAMLFileName   = "config.yaml"
+	systemInfoFileName   = "system_info.json"
+	databaseInfoFileName = "database_info.json"
+	logReadmeFileName    = "logs/README.txt"
 
 	// Redaction and privacy
 	redactedPlaceholder      = "[redacted]"
@@ -104,11 +105,12 @@ func getLogger() logger.Logger {
 
 // Collector collects support data for troubleshooting
 type Collector struct {
-	configPath    string
-	dataPath      string
-	systemID      string
-	version       string
-	sensitiveKeys []string
+	configPath     string
+	dataPath       string
+	systemID       string
+	version        string
+	sensitiveKeys  []string
+	dbInfoProvider DatabaseInfoProvider
 }
 
 // defaultSensitiveKeys returns the default list of sensitive configuration keys to redact
@@ -304,10 +306,15 @@ func NewCollectorWithOptions(configPath, dataPath, systemID, version string, sen
 	}
 }
 
+// SetDatabaseInfoProvider configures the database diagnostics provider.
+func (c *Collector) SetDatabaseInfoProvider(provider DatabaseInfoProvider) {
+	c.dbInfoProvider = provider
+}
+
 // Collect gathers support data based on the provided options
 func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*SupportDump, error) {
 	// Validate options
-	if !opts.IncludeLogs && !opts.IncludeConfig && !opts.IncludeSystemInfo {
+	if !opts.IncludeLogs && !opts.IncludeConfig && !opts.IncludeSystemInfo && !opts.IncludeDatabaseInfo {
 		getLogger().Error("support: collection validation failed: at least one data type must be included")
 		return nil, errors.Newf("at least one data type must be included in support dump").
 			Component("support").
@@ -373,6 +380,20 @@ func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*Suppor
 		logs := c.collectLogs(ctx, opts.LogDuration, opts.MaxLogSize, opts.AnonymizePII, &dump.Diagnostics.LogCollection)
 		dump.Logs = logs
 		getLogger().Debug("support: logs collected", logger.Int("log_count", len(logs)))
+	}
+
+	// Collect database information
+	if opts.IncludeDatabaseInfo && c.dbInfoProvider != nil {
+		getLogger().Debug("support: collecting database information")
+		dbInfo, err := c.dbInfoProvider.CollectDatabaseInfo(ctx)
+		if err != nil {
+			getLogger().Error("support: failed to collect database information", logger.Error(err))
+		} else {
+			dump.DatabaseInfo = dbInfo
+			getLogger().Debug("support: database information collected",
+				logger.String("dialect", dbInfo.Dialect),
+				logger.Int("table_count", len(dbInfo.Tables)))
+		}
 	}
 
 	getLogger().Info("support: collection completed successfully",
@@ -496,6 +517,29 @@ func (c *Collector) CreateArchive(ctx context.Context, dump *SupportDump, opts C
 				Build()
 		}
 		getLogger().Debug("support: system info added successfully")
+	}
+
+	// Add database info if collected
+	if dump.DatabaseInfo != nil {
+		getLogger().Debug("support: adding database info to archive")
+		dbInfoFile, err := w.Create(databaseInfoFileName)
+		if err != nil {
+			getLogger().Error("support: failed to create database info file in archive", logger.Error(err))
+			return nil, errors.New(err).
+				Component("support").
+				Category(errors.CategoryFileIO).
+				Context("operation", "create_database_info_file").
+				Build()
+		}
+		if err := json.NewEncoder(dbInfoFile).Encode(dump.DatabaseInfo); err != nil {
+			getLogger().Error("support: failed to write database info to archive", logger.Error(err))
+			return nil, errors.New(err).
+				Component("support").
+				Category(errors.CategoryFileIO).
+				Context("operation", "write_database_info").
+				Build()
+		}
+		getLogger().Debug("support: database info added successfully")
 	}
 
 	// Always add diagnostics - this is crucial for troubleshooting collection issues

--- a/internal/support/database_collector.go
+++ b/internal/support/database_collector.go
@@ -296,6 +296,7 @@ func (c *GormDatabaseInfoCollector) collectTableRowCount(ctx context.Context, ts
 	var count int64
 	if err := c.db.WithContext(countCtx).Raw("SELECT COUNT(*) FROM " + quoteIdentifier(ts.Name)).Row().Scan(&count); err != nil { //nolint:gosec // table names from sqlite_master/INFORMATION_SCHEMA
 		log.Warn("support: row count timed out or failed", logger.String("table", ts.Name), logger.Error(err))
+		*errs = append(*errs, fmt.Sprintf("count(%s): %v", ts.Name, err))
 		ts.RowCount = -1
 	} else {
 		ts.RowCount = count
@@ -535,9 +536,9 @@ func (c *GormDatabaseInfoCollector) collectMigrationState(ctx context.Context, i
 		msi.CompletedAt = &s
 	}
 
-	// Count dirty records if the table exists
+	// Count dirty records if the table exists (apply prefix for MySQL migration mode)
 	var dirtyCount int64
-	if err := db.Table("migration_dirty_ids").Count(&dirtyCount).Error; err == nil {
+	if err := db.Table(c.tablePrefix + "migration_dirty_ids").Count(&dirtyCount).Error; err == nil {
 		msi.DirtyRecordCount = dirtyCount
 	}
 

--- a/internal/support/database_collector.go
+++ b/internal/support/database_collector.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
@@ -31,7 +32,11 @@ type GormDatabaseInfoCollector struct {
 }
 
 // NewGormDatabaseInfoCollector creates a collector for database diagnostics.
+// Returns nil if db is nil (caller must nil-check before use).
 func NewGormDatabaseInfoCollector(db *gorm.DB, dialect, dbPath, schemaVersion, tablePrefix string) *GormDatabaseInfoCollector {
+	if db == nil {
+		return nil
+	}
 	return &GormDatabaseInfoCollector{
 		db:            db,
 		dialect:       dialect,
@@ -39,6 +44,12 @@ func NewGormDatabaseInfoCollector(db *gorm.DB, dialect, dbPath, schemaVersion, t
 		schemaVersion: schemaVersion,
 		tablePrefix:   tablePrefix,
 	}
+}
+
+// quoteIdentifier wraps a SQL identifier in double quotes, escaping internal quotes per SQL standard.
+func quoteIdentifier(name string) string {
+	escaped := strings.ReplaceAll(name, `"`, `""`)
+	return `"` + escaped + `"`
 }
 
 // CollectDatabaseInfo gathers database schema, health, and metadata.
@@ -60,9 +71,9 @@ func (c *GormDatabaseInfoCollector) CollectDatabaseInfo(ctx context.Context) (*D
 	var collectionErrors []string
 
 	switch c.dialect {
-	case "sqlite":
+	case datastore.DialectSQLite:
 		c.collectSQLiteInfo(ctx, info, &collectionErrors, log)
-	case "mysql":
+	case datastore.DialectMySQL:
 		c.collectMySQLInfo(ctx, info, &collectionErrors, log)
 	default:
 		collectionErrors = append(collectionErrors, fmt.Sprintf("unsupported dialect: %s", c.dialect))
@@ -181,7 +192,7 @@ func (c *GormDatabaseInfoCollector) collectSQLiteTables(ctx context.Context, inf
 func (c *GormDatabaseInfoCollector) collectSQLiteTableColumns(ctx context.Context, ts *TableSchema, errs *[]string) {
 	db := c.db.WithContext(ctx)
 
-	rows, err := db.Raw(fmt.Sprintf("PRAGMA table_info('%s')", ts.Name)).Rows()
+	rows, err := db.Raw(fmt.Sprintf("PRAGMA table_info(%s)", quoteIdentifier(ts.Name))).Rows()
 	if err != nil {
 		*errs = append(*errs, fmt.Sprintf("table_info(%s): %v", ts.Name, err))
 		return
@@ -206,6 +217,9 @@ func (c *GormDatabaseInfoCollector) collectSQLiteTableColumns(ctx context.Contex
 			DefaultValue: dfltValue,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		*errs = append(*errs, fmt.Sprintf("iterate table_info(%s): %v", ts.Name, err))
+	}
 	ts.Columns = columns
 }
 
@@ -221,7 +235,7 @@ func (c *GormDatabaseInfoCollector) collectSQLiteTableIndexes(ctx context.Contex
 		Partial int
 	}
 
-	rows, err := db.Raw(fmt.Sprintf("PRAGMA index_list('%s')", ts.Name)).Rows()
+	rows, err := db.Raw(fmt.Sprintf("PRAGMA index_list(%s)", quoteIdentifier(ts.Name))).Rows()
 	if err != nil {
 		*errs = append(*errs, fmt.Sprintf("index_list(%s): %v", ts.Name, err))
 		return
@@ -236,30 +250,42 @@ func (c *GormDatabaseInfoCollector) collectSQLiteTableIndexes(ctx context.Contex
 			continue
 		}
 
-		// Get columns for this index
-		var indexColumns []string
-		infoRows, err := db.Raw(fmt.Sprintf("PRAGMA index_info('%s')", ilr.Name)).Rows()
-		if err != nil {
-			*errs = append(*errs, fmt.Sprintf("index_info(%s): %v", ilr.Name, err))
-			continue
-		}
-		for infoRows.Next() {
-			var seqno, cid int
-			var colName string
-			if err := infoRows.Scan(&seqno, &cid, &colName); err != nil {
-				continue
-			}
-			indexColumns = append(indexColumns, colName)
-		}
-		_ = infoRows.Close()
-
+		indexColumns := c.collectIndexColumns(db, ilr.Name, errs)
 		indexes = append(indexes, IndexInfo{
 			Name:    ilr.Name,
 			Columns: indexColumns,
 			Unique:  ilr.Unique != 0,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		*errs = append(*errs, fmt.Sprintf("iterate index_list(%s): %v", ts.Name, err))
+	}
 	ts.Indexes = indexes
+}
+
+// collectIndexColumns reads columns for a single index via PRAGMA index_info.
+func (c *GormDatabaseInfoCollector) collectIndexColumns(db *gorm.DB, indexName string, errs *[]string) []string {
+	infoRows, err := db.Raw(fmt.Sprintf("PRAGMA index_info(%s)", quoteIdentifier(indexName))).Rows()
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("index_info(%s): %v", indexName, err))
+		return nil
+	}
+	defer func() { _ = infoRows.Close() }()
+
+	var columns []string
+	for infoRows.Next() {
+		var seqno, cid int
+		var colName string
+		if err := infoRows.Scan(&seqno, &cid, &colName); err != nil {
+			*errs = append(*errs, fmt.Sprintf("scan index_info(%s): %v", indexName, err))
+			continue
+		}
+		columns = append(columns, colName)
+	}
+	if err := infoRows.Err(); err != nil {
+		*errs = append(*errs, fmt.Sprintf("iterate index_info(%s): %v", indexName, err))
+	}
+	return columns
 }
 
 // collectTableRowCount counts rows with a per-table timeout.
@@ -268,7 +294,7 @@ func (c *GormDatabaseInfoCollector) collectTableRowCount(ctx context.Context, ts
 	defer cancel()
 
 	var count int64
-	if err := c.db.WithContext(countCtx).Raw(fmt.Sprintf("SELECT COUNT(*) FROM %q", ts.Name)).Row().Scan(&count); err != nil {
+	if err := c.db.WithContext(countCtx).Raw("SELECT COUNT(*) FROM " + quoteIdentifier(ts.Name)).Row().Scan(&count); err != nil { //nolint:gosec // table names from sqlite_master/INFORMATION_SCHEMA
 		log.Warn("support: row count timed out or failed", logger.String("table", ts.Name), logger.Error(err))
 		ts.RowCount = -1
 	} else {
@@ -277,12 +303,13 @@ func (c *GormDatabaseInfoCollector) collectTableRowCount(ctx context.Context, ts
 }
 
 // collectSQLiteIntegrityCheck runs PRAGMA quick_check with a timeout.
+// Reads all result rows (quick_check returns multiple rows when issues are found).
 func (c *GormDatabaseInfoCollector) collectSQLiteIntegrityCheck(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
 	integrityCtx, cancel := context.WithTimeout(ctx, integrityTimeout)
 	defer cancel()
 
-	var result string
-	if err := c.db.WithContext(integrityCtx).Raw("PRAGMA quick_check").Row().Scan(&result); err != nil {
+	var results []string
+	if err := c.db.WithContext(integrityCtx).Raw("PRAGMA quick_check").Scan(&results).Error; err != nil {
 		if integrityCtx.Err() != nil {
 			info.IntegrityCheck = "timeout_exceeded"
 			*errs = append(*errs, "integrity check timed out")
@@ -290,9 +317,13 @@ func (c *GormDatabaseInfoCollector) collectSQLiteIntegrityCheck(ctx context.Cont
 			info.IntegrityCheck = fmt.Sprintf("error: %v", err)
 			*errs = append(*errs, fmt.Sprintf("quick_check: %v", err))
 		}
-	} else {
-		info.IntegrityCheck = result
+		return
 	}
+	result := strings.Join(results, "; ")
+	if result == "" {
+		result = "ok"
+	}
+	info.IntegrityCheck = result
 }
 
 // collectSQLiteFKViolations runs PRAGMA foreign_key_check with a timeout.
@@ -327,6 +358,9 @@ func (c *GormDatabaseInfoCollector) collectSQLiteFKViolations(ctx context.Contex
 			FKIndex:  fkIdx,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		*errs = append(*errs, fmt.Sprintf("iterate fk_check: %v", err))
+	}
 	if violations != nil {
 		info.FKViolations = violations
 	}
@@ -360,27 +394,24 @@ func (c *GormDatabaseInfoCollector) collectMySQLInfo(ctx context.Context, info *
 }
 
 // collectMySQLTables enumerates MySQL tables, columns, and indexes.
-func (c *GormDatabaseInfoCollector) collectMySQLTables(ctx context.Context, info *DatabaseInfo, errs *[]string, log logger.Logger) {
+// Row counts are InnoDB estimates from TABLE_ROWS (not exact COUNT(*)) to avoid full table scans.
+func (c *GormDatabaseInfoCollector) collectMySQLTables(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
 	db := c.db.WithContext(ctx)
 
 	type tableRow struct {
-		TableName string
-		TableRows int64
+		TableName string `gorm:"column:table_name"`
+		TableRows int64  `gorm:"column:table_rows"`
 	}
 
 	var tableRows []tableRow
-	query := "SELECT TABLE_NAME, IFNULL(TABLE_ROWS, 0) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+	query := "SELECT TABLE_NAME AS table_name, IFNULL(TABLE_ROWS, 0) AS table_rows FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+	rawQuery := db.Raw(query)
 	if c.tablePrefix != "" {
-		query += " AND TABLE_NAME LIKE ?"
-		if err := db.Raw(query, c.tablePrefix+"%").Scan(&tableRows).Error; err != nil {
-			*errs = append(*errs, fmt.Sprintf("list mysql tables: %v", err))
-			return
-		}
-	} else {
-		if err := db.Raw(query).Scan(&tableRows).Error; err != nil {
-			*errs = append(*errs, fmt.Sprintf("list mysql tables: %v", err))
-			return
-		}
+		rawQuery = db.Raw(query+" AND TABLE_NAME LIKE ?", c.tablePrefix+"%")
+	}
+	if err := rawQuery.Scan(&tableRows).Error; err != nil {
+		*errs = append(*errs, fmt.Sprintf("list mysql tables: %v", err))
+		return
 	}
 
 	tables := make([]TableSchema, 0, len(tableRows))
@@ -390,7 +421,6 @@ func (c *GormDatabaseInfoCollector) collectMySQLTables(ctx context.Context, info
 		c.collectMySQLTableIndexes(ctx, &ts, errs)
 		tables = append(tables, ts)
 	}
-	_ = log // used by other collectors; consistent parameter signature
 	info.Tables = tables
 }
 
@@ -424,6 +454,9 @@ func (c *GormDatabaseInfoCollector) collectMySQLTableColumns(ctx context.Context
 			PrimaryKey:   columnKey == "PRI",
 			DefaultValue: dfltValue,
 		})
+	}
+	if err := rows.Err(); err != nil {
+		*errs = append(*errs, fmt.Sprintf("iterate mysql columns(%s): %v", ts.Name, err))
 	}
 	ts.Columns = columns
 }
@@ -462,6 +495,10 @@ func (c *GormDatabaseInfoCollector) collectMySQLTableIndexes(ctx context.Context
 			}
 			indexOrder = append(indexOrder, indexName)
 		}
+	}
+
+	if err := rows.Err(); err != nil {
+		*errs = append(*errs, fmt.Sprintf("iterate mysql indexes(%s): %v", ts.Name, err))
 	}
 
 	indexes := make([]IndexInfo, 0, len(indexOrder))

--- a/internal/support/database_collector.go
+++ b/internal/support/database_collector.go
@@ -1,0 +1,527 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
+	"gorm.io/gorm"
+)
+
+// Database collection timeouts
+const (
+	countTimeout     = 2 * time.Second
+	integrityTimeout = 5 * time.Second
+	fkCheckTimeout   = 10 * time.Second
+	totalDBTimeout   = 30 * time.Second
+)
+
+// GormDatabaseInfoCollector implements DatabaseInfoProvider using a GORM connection.
+type GormDatabaseInfoCollector struct {
+	db            *gorm.DB
+	dialect       string
+	dbPath        string
+	schemaVersion string
+	tablePrefix   string
+}
+
+// NewGormDatabaseInfoCollector creates a collector for database diagnostics.
+func NewGormDatabaseInfoCollector(db *gorm.DB, dialect, dbPath, schemaVersion, tablePrefix string) *GormDatabaseInfoCollector {
+	return &GormDatabaseInfoCollector{
+		db:            db,
+		dialect:       dialect,
+		dbPath:        dbPath,
+		schemaVersion: schemaVersion,
+		tablePrefix:   tablePrefix,
+	}
+}
+
+// CollectDatabaseInfo gathers database schema, health, and metadata.
+// Each sub-collection is independent; failures are recorded in error fields, not propagated.
+func (c *GormDatabaseInfoCollector) CollectDatabaseInfo(ctx context.Context) (*DatabaseInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, totalDBTimeout)
+	defer cancel()
+
+	log := logger.Global().Module("support")
+
+	info := &DatabaseInfo{
+		Dialect:       c.dialect,
+		SchemaVersion: c.schemaVersion,
+		DatabasePath:  privacy.AnonymizePath(c.dbPath),
+		Tables:        []TableSchema{},
+		FKViolations:  []ForeignKeyViolation{},
+	}
+
+	var collectionErrors []string
+
+	switch c.dialect {
+	case "sqlite":
+		c.collectSQLiteInfo(ctx, info, &collectionErrors, log)
+	case "mysql":
+		c.collectMySQLInfo(ctx, info, &collectionErrors, log)
+	default:
+		collectionErrors = append(collectionErrors, fmt.Sprintf("unsupported dialect: %s", c.dialect))
+	}
+
+	c.collectMigrationState(ctx, info, &collectionErrors, log)
+	c.collectAppMetadata(ctx, info, &collectionErrors, log)
+
+	if len(collectionErrors) > 0 {
+		info.CollectionError = strings.Join(collectionErrors, "; ")
+	}
+
+	return info, nil
+}
+
+// collectSQLiteInfo gathers SQLite-specific diagnostics.
+func (c *GormDatabaseInfoCollector) collectSQLiteInfo(ctx context.Context, info *DatabaseInfo, errs *[]string, log logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	// Engine version
+	var version string
+	if err := db.Raw("SELECT sqlite_version()").Row().Scan(&version); err != nil {
+		*errs = append(*errs, fmt.Sprintf("sqlite_version: %v", err))
+	} else {
+		info.EngineVersion = version
+	}
+
+	// File sizes
+	c.collectSQLiteFileSizes(info)
+
+	// SQLite PRAGMAs for diagnostics
+	c.collectSQLitePragmas(ctx, info, errs, log)
+
+	// Table schemas
+	c.collectSQLiteTables(ctx, info, errs, log)
+
+	// Integrity check
+	c.collectSQLiteIntegrityCheck(ctx, info, errs, log)
+
+	// Foreign key violations
+	c.collectSQLiteFKViolations(ctx, info, errs, log)
+}
+
+// collectSQLiteFileSizes reads the database, WAL, and SHM file sizes.
+func (c *GormDatabaseInfoCollector) collectSQLiteFileSizes(info *DatabaseInfo) {
+	if stat, err := os.Stat(c.dbPath); err == nil {
+		info.DatabaseSizeBytes = stat.Size()
+	}
+	if stat, err := os.Stat(c.dbPath + "-wal"); err == nil {
+		info.WALSizeBytes = stat.Size()
+	}
+	if stat, err := os.Stat(c.dbPath + "-shm"); err == nil {
+		info.SHMSizeBytes = stat.Size()
+	}
+}
+
+// collectSQLitePragmas reads diagnostic PRAGMAs (journal_mode, auto_vacuum, page_size, etc.).
+func (c *GormDatabaseInfoCollector) collectSQLitePragmas(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	pragmas := []struct {
+		name   string
+		target any
+	}{
+		{"journal_mode", &info.JournalMode},
+		{"page_size", &info.PageSize},
+		{"page_count", &info.PageCount},
+		{"freelist_count", &info.FreelistCount},
+	}
+	for _, p := range pragmas {
+		if err := db.Raw(fmt.Sprintf("PRAGMA %s", p.name)).Row().Scan(p.target); err != nil {
+			*errs = append(*errs, fmt.Sprintf("PRAGMA %s: %v", p.name, err))
+		}
+	}
+
+	// auto_vacuum returns an integer; map to human-readable string
+	var autoVacuumVal int
+	if err := db.Raw("PRAGMA auto_vacuum").Row().Scan(&autoVacuumVal); err != nil {
+		*errs = append(*errs, fmt.Sprintf("PRAGMA auto_vacuum: %v", err))
+	} else {
+		switch autoVacuumVal {
+		case 0:
+			info.AutoVacuum = "none"
+		case 1:
+			info.AutoVacuum = "full"
+		case 2:
+			info.AutoVacuum = "incremental"
+		default:
+			info.AutoVacuum = fmt.Sprintf("unknown(%d)", autoVacuumVal)
+		}
+	}
+}
+
+// collectSQLiteTables enumerates tables and their schemas.
+func (c *GormDatabaseInfoCollector) collectSQLiteTables(ctx context.Context, info *DatabaseInfo, errs *[]string, log logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	var tableNames []string
+	if err := db.Raw("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'").Scan(&tableNames).Error; err != nil {
+		*errs = append(*errs, fmt.Sprintf("list tables: %v", err))
+		return
+	}
+
+	tables := make([]TableSchema, 0, len(tableNames))
+	for _, name := range tableNames {
+		ts := TableSchema{Name: name}
+		c.collectSQLiteTableColumns(ctx, &ts, errs)
+		c.collectSQLiteTableIndexes(ctx, &ts, errs)
+		c.collectTableRowCount(ctx, &ts, errs, log)
+		tables = append(tables, ts)
+	}
+	info.Tables = tables
+}
+
+// collectSQLiteTableColumns reads column definitions via PRAGMA table_info.
+func (c *GormDatabaseInfoCollector) collectSQLiteTableColumns(ctx context.Context, ts *TableSchema, errs *[]string) {
+	db := c.db.WithContext(ctx)
+
+	rows, err := db.Raw(fmt.Sprintf("PRAGMA table_info('%s')", ts.Name)).Rows()
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("table_info(%s): %v", ts.Name, err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []ColumnInfo
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var dfltValue *string
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			*errs = append(*errs, fmt.Sprintf("scan table_info(%s): %v", ts.Name, err))
+			continue
+		}
+		columns = append(columns, ColumnInfo{
+			Name:         name,
+			Type:         colType,
+			Nullable:     notNull == 0,
+			PrimaryKey:   pk > 0,
+			DefaultValue: dfltValue,
+		})
+	}
+	ts.Columns = columns
+}
+
+// collectSQLiteTableIndexes reads indexes via PRAGMA index_list and index_info.
+func (c *GormDatabaseInfoCollector) collectSQLiteTableIndexes(ctx context.Context, ts *TableSchema, errs *[]string) {
+	db := c.db.WithContext(ctx)
+
+	type indexListRow struct {
+		Seq     int
+		Name    string
+		Unique  int
+		Origin  string
+		Partial int
+	}
+
+	rows, err := db.Raw(fmt.Sprintf("PRAGMA index_list('%s')", ts.Name)).Rows()
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("index_list(%s): %v", ts.Name, err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var indexes []IndexInfo
+	for rows.Next() {
+		var ilr indexListRow
+		if err := rows.Scan(&ilr.Seq, &ilr.Name, &ilr.Unique, &ilr.Origin, &ilr.Partial); err != nil {
+			*errs = append(*errs, fmt.Sprintf("scan index_list(%s): %v", ts.Name, err))
+			continue
+		}
+
+		// Get columns for this index
+		var indexColumns []string
+		infoRows, err := db.Raw(fmt.Sprintf("PRAGMA index_info('%s')", ilr.Name)).Rows()
+		if err != nil {
+			*errs = append(*errs, fmt.Sprintf("index_info(%s): %v", ilr.Name, err))
+			continue
+		}
+		for infoRows.Next() {
+			var seqno, cid int
+			var colName string
+			if err := infoRows.Scan(&seqno, &cid, &colName); err != nil {
+				continue
+			}
+			indexColumns = append(indexColumns, colName)
+		}
+		_ = infoRows.Close()
+
+		indexes = append(indexes, IndexInfo{
+			Name:    ilr.Name,
+			Columns: indexColumns,
+			Unique:  ilr.Unique != 0,
+		})
+	}
+	ts.Indexes = indexes
+}
+
+// collectTableRowCount counts rows with a per-table timeout.
+func (c *GormDatabaseInfoCollector) collectTableRowCount(ctx context.Context, ts *TableSchema, errs *[]string, log logger.Logger) {
+	countCtx, cancel := context.WithTimeout(ctx, countTimeout)
+	defer cancel()
+
+	var count int64
+	if err := c.db.WithContext(countCtx).Raw(fmt.Sprintf("SELECT COUNT(*) FROM %q", ts.Name)).Row().Scan(&count); err != nil {
+		log.Warn("support: row count timed out or failed", logger.String("table", ts.Name), logger.Error(err))
+		ts.RowCount = -1
+	} else {
+		ts.RowCount = count
+	}
+}
+
+// collectSQLiteIntegrityCheck runs PRAGMA quick_check with a timeout.
+func (c *GormDatabaseInfoCollector) collectSQLiteIntegrityCheck(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
+	integrityCtx, cancel := context.WithTimeout(ctx, integrityTimeout)
+	defer cancel()
+
+	var result string
+	if err := c.db.WithContext(integrityCtx).Raw("PRAGMA quick_check").Row().Scan(&result); err != nil {
+		if integrityCtx.Err() != nil {
+			info.IntegrityCheck = "timeout_exceeded"
+			*errs = append(*errs, "integrity check timed out")
+		} else {
+			info.IntegrityCheck = fmt.Sprintf("error: %v", err)
+			*errs = append(*errs, fmt.Sprintf("quick_check: %v", err))
+		}
+	} else {
+		info.IntegrityCheck = result
+	}
+}
+
+// collectSQLiteFKViolations runs PRAGMA foreign_key_check with a timeout.
+func (c *GormDatabaseInfoCollector) collectSQLiteFKViolations(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
+	fkCtx, cancel := context.WithTimeout(ctx, fkCheckTimeout)
+	defer cancel()
+
+	rows, err := c.db.WithContext(fkCtx).Raw("PRAGMA foreign_key_check").Rows()
+	if err != nil {
+		if fkCtx.Err() != nil {
+			*errs = append(*errs, "foreign key check timed out")
+		} else {
+			*errs = append(*errs, fmt.Sprintf("foreign_key_check: %v", err))
+		}
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var violations []ForeignKeyViolation
+	for rows.Next() {
+		var table, refTable string
+		var rowID int64
+		var fkIdx int
+		if err := rows.Scan(&table, &rowID, &refTable, &fkIdx); err != nil {
+			*errs = append(*errs, fmt.Sprintf("scan fk_check: %v", err))
+			continue
+		}
+		violations = append(violations, ForeignKeyViolation{
+			Table:    table,
+			RowID:    rowID,
+			RefTable: refTable,
+			FKIndex:  fkIdx,
+		})
+	}
+	if violations != nil {
+		info.FKViolations = violations
+	}
+}
+
+// collectMySQLInfo gathers MySQL-specific diagnostics.
+func (c *GormDatabaseInfoCollector) collectMySQLInfo(ctx context.Context, info *DatabaseInfo, errs *[]string, log logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	// Engine version
+	var version string
+	if err := db.Raw("SELECT VERSION()").Row().Scan(&version); err != nil {
+		*errs = append(*errs, fmt.Sprintf("mysql version: %v", err))
+	} else {
+		info.EngineVersion = version
+	}
+
+	// Integrity check not available for MySQL
+	info.IntegrityCheck = "not_available"
+
+	// Database size
+	var dbSize *int64
+	if err := db.Raw("SELECT SUM(data_length + index_length) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()").Row().Scan(&dbSize); err != nil {
+		*errs = append(*errs, fmt.Sprintf("mysql db size: %v", err))
+	} else if dbSize != nil {
+		info.DatabaseSizeBytes = *dbSize
+	}
+
+	// Tables
+	c.collectMySQLTables(ctx, info, errs, log)
+}
+
+// collectMySQLTables enumerates MySQL tables, columns, and indexes.
+func (c *GormDatabaseInfoCollector) collectMySQLTables(ctx context.Context, info *DatabaseInfo, errs *[]string, log logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	type tableRow struct {
+		TableName string
+		TableRows int64
+	}
+
+	var tableRows []tableRow
+	query := "SELECT TABLE_NAME, IFNULL(TABLE_ROWS, 0) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()"
+	if c.tablePrefix != "" {
+		query += " AND TABLE_NAME LIKE ?"
+		if err := db.Raw(query, c.tablePrefix+"%").Scan(&tableRows).Error; err != nil {
+			*errs = append(*errs, fmt.Sprintf("list mysql tables: %v", err))
+			return
+		}
+	} else {
+		if err := db.Raw(query).Scan(&tableRows).Error; err != nil {
+			*errs = append(*errs, fmt.Sprintf("list mysql tables: %v", err))
+			return
+		}
+	}
+
+	tables := make([]TableSchema, 0, len(tableRows))
+	for _, tr := range tableRows {
+		ts := TableSchema{Name: tr.TableName, RowCount: tr.TableRows}
+		c.collectMySQLTableColumns(ctx, &ts, errs)
+		c.collectMySQLTableIndexes(ctx, &ts, errs)
+		tables = append(tables, ts)
+	}
+	_ = log // used by other collectors; consistent parameter signature
+	info.Tables = tables
+}
+
+// collectMySQLTableColumns reads columns from INFORMATION_SCHEMA.
+func (c *GormDatabaseInfoCollector) collectMySQLTableColumns(ctx context.Context, ts *TableSchema, errs *[]string) {
+	db := c.db.WithContext(ctx)
+
+	rows, err := db.Raw(
+		"SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_KEY, COLUMN_DEFAULT "+
+			"FROM INFORMATION_SCHEMA.COLUMNS "+
+			"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? "+
+			"ORDER BY ORDINAL_POSITION", ts.Name).Rows()
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("mysql columns(%s): %v", ts.Name, err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []ColumnInfo
+	for rows.Next() {
+		var name, colType, nullable, columnKey string
+		var dfltValue *string
+		if err := rows.Scan(&name, &colType, &nullable, &columnKey, &dfltValue); err != nil {
+			*errs = append(*errs, fmt.Sprintf("scan mysql columns(%s): %v", ts.Name, err))
+			continue
+		}
+		columns = append(columns, ColumnInfo{
+			Name:         name,
+			Type:         colType,
+			Nullable:     nullable == "YES",
+			PrimaryKey:   columnKey == "PRI",
+			DefaultValue: dfltValue,
+		})
+	}
+	ts.Columns = columns
+}
+
+// collectMySQLTableIndexes reads indexes from INFORMATION_SCHEMA.STATISTICS.
+func (c *GormDatabaseInfoCollector) collectMySQLTableIndexes(ctx context.Context, ts *TableSchema, errs *[]string) {
+	db := c.db.WithContext(ctx)
+
+	rows, err := db.Raw(
+		"SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE "+
+			"FROM INFORMATION_SCHEMA.STATISTICS "+
+			"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? "+
+			"ORDER BY INDEX_NAME, SEQ_IN_INDEX", ts.Name).Rows()
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("mysql indexes(%s): %v", ts.Name, err))
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	indexMap := make(map[string]*IndexInfo)
+	var indexOrder []string
+	for rows.Next() {
+		var indexName, colName string
+		var nonUnique int
+		if err := rows.Scan(&indexName, &colName, &nonUnique); err != nil {
+			*errs = append(*errs, fmt.Sprintf("scan mysql indexes(%s): %v", ts.Name, err))
+			continue
+		}
+		if existing, ok := indexMap[indexName]; ok {
+			existing.Columns = append(existing.Columns, colName)
+		} else {
+			indexMap[indexName] = &IndexInfo{
+				Name:    indexName,
+				Columns: []string{colName},
+				Unique:  nonUnique == 0,
+			}
+			indexOrder = append(indexOrder, indexName)
+		}
+	}
+
+	indexes := make([]IndexInfo, 0, len(indexOrder))
+	for _, name := range indexOrder {
+		indexes = append(indexes, *indexMap[name])
+	}
+	ts.Indexes = indexes
+}
+
+// collectMigrationState reads the migration_states singleton row.
+func (c *GormDatabaseInfoCollector) collectMigrationState(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	var state entities.MigrationState
+	if err := db.First(&state, 1).Error; err != nil {
+		// Table may not exist in legacy mode; this is expected
+		return
+	}
+
+	msi := &MigrationStateInfo{
+		State:            string(state.State),
+		CurrentPhase:     string(state.CurrentPhase),
+		TotalRecords:     state.TotalRecords,
+		MigratedRecords:  state.MigratedRecords,
+		ErrorMessage:     state.ErrorMessage,
+		RelatedDataError: state.RelatedDataError,
+	}
+	if state.StartedAt != nil {
+		s := state.StartedAt.UTC().Format(time.RFC3339)
+		msi.StartedAt = &s
+	}
+	if state.CompletedAt != nil {
+		s := state.CompletedAt.UTC().Format(time.RFC3339)
+		msi.CompletedAt = &s
+	}
+
+	// Count dirty records if the table exists
+	var dirtyCount int64
+	if err := db.Table("migration_dirty_ids").Count(&dirtyCount).Error; err == nil {
+		msi.DirtyRecordCount = dirtyCount
+	}
+
+	info.MigrationState = msi
+}
+
+// collectAppMetadata reads the app_metadata key-value store.
+func (c *GormDatabaseInfoCollector) collectAppMetadata(ctx context.Context, info *DatabaseInfo, errs *[]string, _ logger.Logger) {
+	db := c.db.WithContext(ctx)
+
+	var entries []entities.AppMetadata
+	if err := db.Find(&entries).Error; err != nil {
+		// Table may not exist in legacy mode
+		return
+	}
+
+	if len(entries) > 0 {
+		metadata := make(map[string]string, len(entries))
+		for _, e := range entries {
+			metadata[e.Key] = e.Value
+		}
+		info.AppMetadata = metadata
+	}
+}

--- a/internal/support/database_collector_test.go
+++ b/internal/support/database_collector_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -68,13 +69,13 @@ func TestCollectDatabaseInfo_SQLite(t *testing.T) {
 	db, dbPath := openTestDB(t)
 	seedTestSchema(t, db)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
 	require.NotNil(t, info)
 
-	assert.Equal(t, "sqlite", info.Dialect)
+	assert.Equal(t, datastore.DialectSQLite, info.Dialect)
 	assert.NotEmpty(t, info.EngineVersion)
 	assert.Equal(t, "v2", info.SchemaVersion)
 	assert.Positive(t, info.DatabaseSizeBytes)
@@ -142,7 +143,7 @@ func TestCollectDatabaseInfo_FKViolations(t *testing.T) {
 	require.NoError(t, db.Exec("INSERT INTO detections (id, label_id, confidence) VALUES (100, 99999, 0.5)").Error)
 	require.NoError(t, db.Exec("PRAGMA foreign_keys = ON").Error)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
@@ -169,7 +170,7 @@ func TestCollectDatabaseInfo_SchemaContamination(t *testing.T) {
 	// Add an extra column that shouldn't exist (schema contamination)
 	require.NoError(t, db.Exec("ALTER TABLE detections ADD COLUMN spurious_col TEXT").Error)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
@@ -198,13 +199,13 @@ func TestCollectDatabaseInfo_EmptyDB(t *testing.T) {
 	t.Parallel()
 	db, dbPath := openTestDB(t)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
 	require.NotNil(t, info)
 
-	assert.Equal(t, "sqlite", info.Dialect)
+	assert.Equal(t, datastore.DialectSQLite, info.Dialect)
 	assert.NotEmpty(t, info.EngineVersion)
 	assert.Equal(t, "ok", info.IntegrityCheck)
 	assert.Empty(t, info.FKViolations)
@@ -230,7 +231,7 @@ func TestCollectDatabaseInfo_MigrationState(t *testing.T) {
 	}
 	require.NoError(t, db.Save(&state).Error)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
@@ -251,7 +252,7 @@ func TestCollectDatabaseInfo_AppMetadata(t *testing.T) {
 	require.NoError(t, db.Create(&entities.AppMetadata{Key: "wizard_completed", Value: "true"}).Error)
 	require.NoError(t, db.Create(&entities.AppMetadata{Key: "last_version", Value: "0.8.0"}).Error)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
@@ -264,7 +265,7 @@ func TestCollectDatabaseInfo_PathScrubbing(t *testing.T) {
 	t.Parallel()
 	db, dbPath := openTestDB(t)
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
@@ -279,7 +280,7 @@ func TestArchiveIncludesDatabaseInfo(t *testing.T) {
 
 	// Create a collector with database info provider
 	collector := NewCollector(t.TempDir(), t.TempDir(), "test-system", "0.1.0")
-	dbCollector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	dbCollector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	collector.SetDatabaseInfoProvider(dbCollector)
 
 	opts := CollectorOptions{
@@ -312,7 +313,7 @@ func TestArchiveIncludesDatabaseInfo(t *testing.T) {
 		var dbInfo DatabaseInfo
 		require.NoError(t, json.NewDecoder(rc).Decode(&dbInfo))
 
-		assert.Equal(t, "sqlite", dbInfo.Dialect)
+		assert.Equal(t, datastore.DialectSQLite, dbInfo.Dialect)
 		assert.NotEmpty(t, dbInfo.Tables)
 		break
 	}
@@ -327,11 +328,11 @@ func TestCollectDatabaseInfo_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
-	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector := NewGormDatabaseInfoCollector(db, datastore.DialectSQLite, dbPath, "v2", "")
 	info, err := collector.CollectDatabaseInfo(ctx)
 
 	// Should still return a result (with errors noted), not fail outright
 	require.NoError(t, err)
 	require.NotNil(t, info)
-	assert.Equal(t, "sqlite", info.Dialect)
+	assert.Equal(t, datastore.DialectSQLite, info.Dialect)
 }

--- a/internal/support/database_collector_test.go
+++ b/internal/support/database_collector_test.go
@@ -1,0 +1,337 @@
+package support
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gorm_logger "gorm.io/gorm/logger"
+)
+
+const testTableDetections = "detections"
+
+// openTestDB creates a file-based SQLite database in a temp directory.
+// File-based is required for PRAGMA tests and file-size collection.
+func openTestDB(t *testing.T) (db *gorm.DB, dbPath string) {
+	t.Helper()
+	dbPath = filepath.Join(t.TempDir(), "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath+"?_foreign_keys=ON"), &gorm.Config{
+		Logger: gorm_logger.Discard,
+	})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	return db, dbPath
+}
+
+// seedTestSchema creates tables that mirror a subset of the v2 schema.
+func seedTestSchema(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.AutoMigrate(
+		&entities.MigrationState{},
+		&entities.AppMetadata{},
+	))
+
+	// Create a labels table with a detection referencing it (for FK testing)
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS labels (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE IF NOT EXISTS detections (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		label_id INTEGER NOT NULL REFERENCES labels(id),
+		confidence REAL NOT NULL DEFAULT 0.0
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE INDEX IF NOT EXISTS idx_detections_label_id ON detections(label_id)`).Error)
+
+	// Insert some test data
+	require.NoError(t, db.Exec("INSERT INTO labels (id, name) VALUES (1, 'Turdus merula')").Error)
+	require.NoError(t, db.Exec("INSERT INTO labels (id, name) VALUES (2, 'Parus major')").Error)
+	require.NoError(t, db.Exec("INSERT INTO detections (label_id, confidence) VALUES (1, 0.95)").Error)
+	require.NoError(t, db.Exec("INSERT INTO detections (label_id, confidence) VALUES (2, 0.87)").Error)
+}
+
+func TestCollectDatabaseInfo_SQLite(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "sqlite", info.Dialect)
+	assert.NotEmpty(t, info.EngineVersion)
+	assert.Equal(t, "v2", info.SchemaVersion)
+	assert.Positive(t, info.DatabaseSizeBytes)
+
+	// PRAGMAs
+	assert.NotEmpty(t, info.JournalMode)
+	assert.NotEmpty(t, info.AutoVacuum)
+	assert.Positive(t, info.PageSize)
+	assert.Positive(t, info.PageCount)
+
+	// Tables should include at least labels, detections, migration_states, app_metadata
+	assert.GreaterOrEqual(t, len(info.Tables), 4)
+
+	// Find the detections table and verify its schema
+	var detectionsTable *TableSchema
+	for i := range info.Tables {
+		if info.Tables[i].Name == testTableDetections {
+			detectionsTable = &info.Tables[i]
+			break
+		}
+	}
+	require.NotNil(t, detectionsTable, "detections table should be present")
+	assert.Equal(t, int64(2), detectionsTable.RowCount)
+	assert.GreaterOrEqual(t, len(detectionsTable.Columns), 3) // id, label_id, confidence
+
+	// Verify column details
+	var labelIDCol *ColumnInfo
+	for i := range detectionsTable.Columns {
+		if detectionsTable.Columns[i].Name == "label_id" {
+			labelIDCol = &detectionsTable.Columns[i]
+			break
+		}
+	}
+	require.NotNil(t, labelIDCol)
+	assert.False(t, labelIDCol.Nullable)
+	assert.False(t, labelIDCol.PrimaryKey)
+
+	// Verify index
+	assert.NotEmpty(t, detectionsTable.Indexes)
+	var labelIdx *IndexInfo
+	for i := range detectionsTable.Indexes {
+		if detectionsTable.Indexes[i].Name == "idx_detections_label_id" {
+			labelIdx = &detectionsTable.Indexes[i]
+			break
+		}
+	}
+	require.NotNil(t, labelIdx)
+	assert.Equal(t, []string{"label_id"}, labelIdx.Columns)
+	assert.False(t, labelIdx.Unique)
+
+	// Integrity check
+	assert.Equal(t, "ok", info.IntegrityCheck)
+
+	// No FK violations with valid data
+	assert.Empty(t, info.FKViolations)
+}
+
+func TestCollectDatabaseInfo_FKViolations(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	// Disable FK enforcement, insert orphan, re-enable
+	require.NoError(t, db.Exec("PRAGMA foreign_keys = OFF").Error)
+	require.NoError(t, db.Exec("INSERT INTO detections (id, label_id, confidence) VALUES (100, 99999, 0.5)").Error)
+	require.NoError(t, db.Exec("PRAGMA foreign_keys = ON").Error)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.NotEmpty(t, info.FKViolations)
+
+	// Should find a violation in the detections table
+	found := false
+	for _, v := range info.FKViolations {
+		if v.Table == "detections" && v.RowID == 100 {
+			found = true
+			assert.Equal(t, "labels", v.RefTable)
+			break
+		}
+	}
+	assert.True(t, found, "expected FK violation for orphaned detection row 100")
+}
+
+func TestCollectDatabaseInfo_SchemaContamination(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	// Add an extra column that shouldn't exist (schema contamination)
+	require.NoError(t, db.Exec("ALTER TABLE detections ADD COLUMN spurious_col TEXT").Error)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+
+	var detectionsTable *TableSchema
+	for i := range info.Tables {
+		if info.Tables[i].Name == testTableDetections {
+			detectionsTable = &info.Tables[i]
+			break
+		}
+	}
+	require.NotNil(t, detectionsTable)
+
+	// The spurious column should appear in the schema snapshot
+	var foundSpurious bool
+	for _, col := range detectionsTable.Columns {
+		if col.Name == "spurious_col" {
+			foundSpurious = true
+			break
+		}
+	}
+	assert.True(t, foundSpurious, "schema contamination (spurious_col) should be visible")
+}
+
+func TestCollectDatabaseInfo_EmptyDB(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	assert.Equal(t, "sqlite", info.Dialect)
+	assert.NotEmpty(t, info.EngineVersion)
+	assert.Equal(t, "ok", info.IntegrityCheck)
+	assert.Empty(t, info.FKViolations)
+	assert.Nil(t, info.MigrationState)
+	assert.Nil(t, info.AppMetadata)
+}
+
+func TestCollectDatabaseInfo_MigrationState(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	// Populate migration state
+	now := time.Now().UTC()
+	state := entities.MigrationState{
+		ID:              1,
+		State:           entities.MigrationStatusCompleted,
+		CurrentPhase:    entities.MigrationPhaseNone,
+		StartedAt:       &now,
+		CompletedAt:     &now,
+		TotalRecords:    1000,
+		MigratedRecords: 1000,
+	}
+	require.NoError(t, db.Save(&state).Error)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, info.MigrationState)
+
+	assert.Equal(t, "completed", info.MigrationState.State)
+	assert.Equal(t, int64(1000), info.MigrationState.TotalRecords)
+	assert.Equal(t, int64(1000), info.MigrationState.MigratedRecords)
+	assert.NotNil(t, info.MigrationState.StartedAt)
+	assert.NotNil(t, info.MigrationState.CompletedAt)
+}
+
+func TestCollectDatabaseInfo_AppMetadata(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	require.NoError(t, db.Create(&entities.AppMetadata{Key: "wizard_completed", Value: "true"}).Error)
+	require.NoError(t, db.Create(&entities.AppMetadata{Key: "last_version", Value: "0.8.0"}).Error)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, info.AppMetadata)
+	assert.Equal(t, "true", info.AppMetadata["wizard_completed"])
+	assert.Equal(t, "0.8.0", info.AppMetadata["last_version"])
+}
+
+func TestCollectDatabaseInfo_PathScrubbing(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(t.Context())
+
+	require.NoError(t, err)
+	// The raw dbPath should not appear verbatim in the output
+	assert.NotEqual(t, dbPath, info.DatabasePath)
+}
+
+func TestArchiveIncludesDatabaseInfo(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	// Create a collector with database info provider
+	collector := NewCollector(t.TempDir(), t.TempDir(), "test-system", "0.1.0")
+	dbCollector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	collector.SetDatabaseInfoProvider(dbCollector)
+
+	opts := CollectorOptions{
+		IncludeDatabaseInfo: true,
+		IncludeSystemInfo:   true,
+	}
+
+	dump, err := collector.Collect(t.Context(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, dump.DatabaseInfo)
+
+	archive, err := collector.CreateArchive(t.Context(), dump, opts)
+	require.NoError(t, err)
+
+	// Read the ZIP and verify database_info.json is present
+	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	require.NoError(t, err)
+
+	var foundDBInfo bool
+	for _, f := range reader.File {
+		if f.Name != "database_info.json" {
+			continue
+		}
+		foundDBInfo = true
+
+		rc, err := f.Open()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = rc.Close() })
+
+		var dbInfo DatabaseInfo
+		require.NoError(t, json.NewDecoder(rc).Decode(&dbInfo))
+
+		assert.Equal(t, "sqlite", dbInfo.Dialect)
+		assert.NotEmpty(t, dbInfo.Tables)
+		break
+	}
+	assert.True(t, foundDBInfo, "database_info.json should be in the archive")
+}
+
+func TestCollectDatabaseInfo_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	db, dbPath := openTestDB(t)
+	seedTestSchema(t, db)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	collector := NewGormDatabaseInfoCollector(db, "sqlite", dbPath, "v2", "")
+	info, err := collector.CollectDatabaseInfo(ctx)
+
+	// Should still return a result (with errors noted), not fail outright
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "sqlite", info.Dialect)
+}

--- a/internal/support/database_collector_test.go
+++ b/internal/support/database_collector_test.go
@@ -269,8 +269,9 @@ func TestCollectDatabaseInfo_PathScrubbing(t *testing.T) {
 	info, err := collector.CollectDatabaseInfo(t.Context())
 
 	require.NoError(t, err)
-	// The raw dbPath should not appear verbatim in the output
+	// The raw dbPath should not appear verbatim or as a substring in the output
 	assert.NotEqual(t, dbPath, info.DatabasePath)
+	assert.NotContains(t, info.DatabasePath, dbPath)
 }
 
 func TestArchiveIncludesDatabaseInfo(t *testing.T) {

--- a/internal/support/types.go
+++ b/internal/support/types.go
@@ -2,6 +2,7 @@
 package support
 
 import (
+	"context"
 	"time"
 )
 
@@ -9,15 +10,16 @@ import (
 // and system information used for troubleshooting and debugging BirdNET-Go issues.
 // The data is privacy-scrubbed before collection to remove sensitive information.
 type SupportDump struct {
-	ID          string                `json:"id"`
-	Timestamp   time.Time             `json:"timestamp"`
-	SystemID    string                `json:"system_id"`
-	Version     string                `json:"version"`
-	Logs        []LogEntry            `json:"logs"`
-	Config      map[string]any        `json:"config"`
-	SystemInfo  SystemInfo            `json:"system_info"`
-	Attachments []AttachmentInfo      `json:"attachments"`
-	Diagnostics CollectionDiagnostics `json:"diagnostics"` // Diagnostic information about collection process
+	ID           string                `json:"id"`
+	Timestamp    time.Time             `json:"timestamp"`
+	SystemID     string                `json:"system_id"`
+	Version      string                `json:"version"`
+	Logs         []LogEntry            `json:"logs"`
+	Config       map[string]any        `json:"config"`
+	SystemInfo   SystemInfo            `json:"system_info"`
+	Attachments  []AttachmentInfo      `json:"attachments"`
+	Diagnostics  CollectionDiagnostics `json:"diagnostics"`             // Diagnostic information about collection process
+	DatabaseInfo *DatabaseInfo         `json:"database_info,omitempty"` // Database schema and health diagnostics
 }
 
 // LogEntry represents a single log entry from application logs or system journals.
@@ -73,13 +75,14 @@ type AttachmentInfo struct {
 // It allows users to control which types of information are included based on
 // their privacy preferences and the specific issue being debugged.
 type CollectorOptions struct {
-	IncludeLogs       bool          `json:"include_logs"`
-	IncludeConfig     bool          `json:"include_config"`
-	IncludeSystemInfo bool          `json:"include_system_info"`
-	LogDuration       time.Duration `json:"log_duration"`
-	MaxLogSize        int64         `json:"max_log_size"`
-	ScrubSensitive    bool          `json:"scrub_sensitive"`
-	AnonymizePII      bool          `json:"anonymize_pii"`
+	IncludeLogs         bool          `json:"include_logs"`
+	IncludeConfig       bool          `json:"include_config"`
+	IncludeSystemInfo   bool          `json:"include_system_info"`
+	IncludeDatabaseInfo bool          `json:"include_database_info"`
+	LogDuration         time.Duration `json:"log_duration"`
+	MaxLogSize          int64         `json:"max_log_size"`
+	ScrubSensitive      bool          `json:"scrub_sensitive"`
+	AnonymizePII        bool          `json:"anonymize_pii"`
 }
 
 // CollectionDiagnostics contains diagnostic information about the support data collection process.
@@ -146,12 +149,86 @@ type TimeRange struct {
 // includes all data types, 4-week log window, 50MB max log size, sensitive data scrubbing and PII anonymization enabled.
 func DefaultCollectorOptions() CollectorOptions {
 	return CollectorOptions{
-		IncludeLogs:       true,
-		IncludeConfig:     true,
-		IncludeSystemInfo: true,
-		LogDuration:       defaultLogDurationWeeks * 7 * 24 * time.Hour, // 4 weeks
-		MaxLogSize:        defaultMaxLogSizeMB * bytesPerMB,             // 50MB to accommodate more logs
-		ScrubSensitive:    true,
-		AnonymizePII:      true,
+		IncludeLogs:         true,
+		IncludeConfig:       true,
+		IncludeSystemInfo:   true,
+		IncludeDatabaseInfo: true,
+		LogDuration:         defaultLogDurationWeeks * 7 * 24 * time.Hour, // 4 weeks
+		MaxLogSize:          defaultMaxLogSizeMB * bytesPerMB,             // 50MB to accommodate more logs
+		ScrubSensitive:      true,
+		AnonymizePII:        true,
 	}
+}
+
+// DatabaseInfoProvider collects database diagnostic information.
+// Implemented by the datastore layer, consumed by the support collector.
+type DatabaseInfoProvider interface {
+	CollectDatabaseInfo(ctx context.Context) (*DatabaseInfo, error)
+}
+
+// DatabaseInfo contains database schema and health information for troubleshooting.
+type DatabaseInfo struct {
+	Dialect           string                `json:"dialect"`
+	EngineVersion     string                `json:"engine_version"`
+	DatabasePath      string                `json:"database_path"`
+	DatabaseSizeBytes int64                 `json:"database_size_bytes"`
+	WALSizeBytes      int64                 `json:"wal_size_bytes,omitempty"`
+	SHMSizeBytes      int64                 `json:"shm_size_bytes,omitempty"`
+	SchemaVersion     string                `json:"schema_version"`
+	Tables            []TableSchema         `json:"tables"`
+	MigrationState    *MigrationStateInfo   `json:"migration_state,omitempty"`
+	IntegrityCheck    string                `json:"integrity_check"`
+	FKViolations      []ForeignKeyViolation `json:"foreign_key_violations"`
+	AppMetadata       map[string]string     `json:"app_metadata,omitempty"`
+	JournalMode       string                `json:"journal_mode,omitempty"`
+	AutoVacuum        string                `json:"auto_vacuum,omitempty"`
+	PageSize          int                   `json:"page_size,omitempty"`
+	PageCount         int64                 `json:"page_count,omitempty"`
+	FreelistCount     int64                 `json:"freelist_count,omitempty"`
+	CollectionError   string                `json:"collection_error,omitempty"`
+}
+
+// TableSchema describes a single database table's structure.
+type TableSchema struct {
+	Name     string       `json:"name"`
+	RowCount int64        `json:"row_count"`
+	Columns  []ColumnInfo `json:"columns"`
+	Indexes  []IndexInfo  `json:"indexes"`
+}
+
+// ColumnInfo describes a single column in a database table.
+type ColumnInfo struct {
+	Name         string  `json:"name"`
+	Type         string  `json:"type"`
+	Nullable     bool    `json:"nullable"`
+	PrimaryKey   bool    `json:"primary_key"`
+	DefaultValue *string `json:"default_value"`
+}
+
+// IndexInfo describes a database index.
+type IndexInfo struct {
+	Name    string   `json:"name"`
+	Columns []string `json:"columns"`
+	Unique  bool     `json:"unique"`
+}
+
+// ForeignKeyViolation describes a foreign key constraint violation found during integrity checking.
+type ForeignKeyViolation struct {
+	Table    string `json:"table"`
+	RowID    int64  `json:"row_id"`
+	RefTable string `json:"referenced_table"`
+	FKIndex  int    `json:"fk_index"`
+}
+
+// MigrationStateInfo captures the state of a v1-to-v2 database migration.
+type MigrationStateInfo struct {
+	State            string  `json:"state"`
+	CurrentPhase     string  `json:"current_phase"`
+	StartedAt        *string `json:"started_at,omitempty"`
+	CompletedAt      *string `json:"completed_at,omitempty"`
+	TotalRecords     int64   `json:"total_records"`
+	MigratedRecords  int64   `json:"migrated_records"`
+	ErrorMessage     string  `json:"error_message,omitempty"`
+	RelatedDataError string  `json:"related_data_error,omitempty"`
+	DirtyRecordCount int64   `json:"dirty_record_count,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add `database_info.json` to the support dump ZIP containing complete database schema snapshots for troubleshooting
- SQLite: table schemas, column definitions, indexes, row counts, integrity check (PRAGMA quick_check), FK violations (PRAGMA foreign_key_check), migration state, app metadata, WAL/SHM sizes, and diagnostic PRAGMAs (journal_mode, auto_vacuum, page_size, page/freelist counts)
- MySQL: table schemas via INFORMATION_SCHEMA, column definitions, indexes, estimated row counts, database size
- Each sub-collection is independent with individual timeouts (2s per-table count, 5s integrity check, 10s FK check, 30s total); failures recorded in error fields, never kill the dump
- Database paths scrubbed via `privacy.AnonymizePath` before inclusion
- API handler wires `GormDatabaseInfoCollector` via `V2Manager` with nil-check for legacy mode

**New files:** `internal/support/database_collector.go`, `internal/support/database_collector_test.go`
**Modified:** `internal/support/types.go`, `internal/support/collector.go`, `internal/api/v2/support.go`

Zero schema changes. Zero interface changes. Zero mock regeneration. PR 1 of 3 for Forgejo #757.

## Test plan
- [x] `TestCollectDatabaseInfo_SQLite` - verifies all fields populated with known schema
- [x] `TestCollectDatabaseInfo_FKViolations` - orphaned FK reference detected
- [x] `TestCollectDatabaseInfo_SchemaContamination` - extra columns captured
- [x] `TestCollectDatabaseInfo_EmptyDB` - fresh database handled gracefully
- [x] `TestCollectDatabaseInfo_MigrationState` - migration state captured correctly
- [x] `TestCollectDatabaseInfo_AppMetadata` - key-value pairs collected
- [x] `TestCollectDatabaseInfo_PathScrubbing` - raw path not in output
- [x] `TestArchiveIncludesDatabaseInfo` - database_info.json present in ZIP
- [x] `TestCollectDatabaseInfo_ContextCancellation` - cancelled context handled
- [x] All 141 existing support package tests pass
- [x] `golangci-lint run -v` clean
- [x] `go test -race` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support dumps can include optional database diagnostics (schema, sizes, integrity, indexes, FK violations, migration/app metadata) for MySQL and SQLite.
  * Database diagnostics are added to support archives when present; collection is resilient to partial failures and scrubs raw DB paths.
  * Collector defaults now enable database info when no include flags are selected.

* **Tests**
  * Added integration-style tests for database diagnostics, integrity checks, FK violations, metadata persistence, archive inclusion, and cancellation resiliency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->