### PR TITLE
feat(events): add app event instrumentation and support dump integration

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -107,34 +107,30 @@ func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
 }
 
 // emitStartupEvents records the startup event and checks for version changes.
+// Version change detection is done BEFORE emitting the new startup event to
+// avoid a race condition where the async persist of the new startup event
+// could appear in the query results, requiring fragile skip logic.
 func emitStartupEvents(ctx context.Context, settings *conf.Settings, ds datastore.Interface) {
+	// Check for version change BEFORE emitting new startup (avoids race with async persist)
+	recent, err := ds.GetRecentAppEvents(ctx, 50)
+	if err == nil {
+		for _, ev := range recent {
+			if ev.Category == "system" && ev.EventType == "startup" {
+				if prev, ok := ev.Metadata["version"].(string); ok && prev != "" && prev != settings.Version {
+					events.Emit(ctx, "system", "version_change", "Application version changed", map[string]any{
+						"previous_version": prev,
+						"current_version":  settings.Version,
+					})
+				}
+				break
+			}
+		}
+	}
+
 	events.Emit(ctx, "system", "startup", "Application started", map[string]any{
 		"version":    settings.Version,
 		"go_version": runtime.Version(),
 		"os":         runtime.GOOS,
 		"arch":       runtime.GOARCH,
 	})
-
-	// Detect version change by finding the previous startup event (skip the one
-	// we just emitted, which will be the most recent).
-	recent, err := ds.GetRecentAppEvents(ctx, 50)
-	if err != nil {
-		return
-	}
-	found := 0
-	for _, ev := range recent {
-		if ev.Category == "system" && ev.EventType == "startup" {
-			found++
-			if found < 2 {
-				continue // skip the one we just emitted
-			}
-			if prev, ok := ev.Metadata["version"].(string); ok && prev != "" && prev != settings.Version {
-				events.Emit(ctx, "system", "version_change", "Application version changed", map[string]any{
-					"previous_version": prev,
-					"current_version":  settings.Version,
-				})
-			}
-			break
-		}
-	}
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,8 +1,10 @@
 package serve
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -10,6 +12,8 @@ import (
 	"github.com/tphakala/birdnet-go/internal/app"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/events"
 )
 
 // Command creates the serve command which starts the BirdNET-Go server.
@@ -62,6 +66,14 @@ The "realtime" command is an alias for backward compatibility.`,
 			if err := application.Start(cmd.Context()); err != nil {
 				return err
 			}
+
+			// Wire the global event emitter after all services have started
+			// (DatabaseService must be running so its datastore is available).
+			if ds := dbService.DataStore(); ds != nil {
+				events.SetDefault(events.NewEmitter(ds))
+				emitStartupEvents(cmd.Context(), settings, ds)
+			}
+
 			return application.Wait()
 		},
 	}
@@ -92,4 +104,37 @@ func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
 	}
 
 	return nil
+}
+
+// emitStartupEvents records the startup event and checks for version changes.
+func emitStartupEvents(ctx context.Context, settings *conf.Settings, ds datastore.Interface) {
+	events.Emit(ctx, "system", "startup", "Application started", map[string]any{
+		"version":    settings.Version,
+		"go_version": runtime.Version(),
+		"os":         runtime.GOOS,
+		"arch":       runtime.GOARCH,
+	})
+
+	// Detect version change by finding the previous startup event (skip the one
+	// we just emitted, which will be the most recent).
+	recent, err := ds.GetRecentAppEvents(ctx, 50)
+	if err != nil {
+		return
+	}
+	found := 0
+	for _, ev := range recent {
+		if ev.Category == "system" && ev.EventType == "startup" {
+			found++
+			if found < 2 {
+				continue // skip the one we just emitted
+			}
+			if prev, ok := ev.Metadata["version"].(string); ok && prev != "" && prev != settings.Version {
+				events.Emit(ctx, "system", "version_change", "Application version changed", map[string]any{
+					"previous_version": prev,
+					"current_version":  settings.Version,
+				})
+			}
+			break
+		}
+	}
 }

--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -56,6 +57,10 @@ func (a *BirdNETAnalyzer) Start(_ context.Context) error {
 	}
 
 	a.bn = bn
+
+	events.Emit(context.Background(), "detection", "model_loaded", "BirdNET model loaded", map[string]any{
+		"species_count": len(bn.Settings.BirdNET.Labels),
+	})
 
 	// Initialize ModelManager for the model gallery. Failure is non-fatal
 	// because the gallery is an optional feature; core detection still works.

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
 	"github.com/tphakala/birdnet-go/internal/notification"
@@ -267,6 +268,7 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 func (cm *ControlMonitor) handleReconfigureBatFilter() {
 	if cm.bn != nil {
 		cm.bn.ReloadBatFilter()
+		emitHotReload("bat_filter")
 	}
 }
 
@@ -278,6 +280,7 @@ func (cm *ControlMonitor) handleRebuildRangeFilter() {
 	} else {
 		GetLogger().Info("Range filter rebuilt successfully")
 		cm.notifySuccess("Range filter rebuilt successfully")
+		emitHotReload("range_filter")
 	}
 
 	// Perform log deduplicator cleanup when range filter is rebuilt
@@ -322,6 +325,8 @@ func (cm *ControlMonitor) handleReloadBirdnet() {
 		cm.apiController.UpdateCommonNameMap(labels)
 		GetLogger().Info("API controller common name map updated with new labels")
 	}
+
+	emitHotReload("birdnet_model")
 }
 
 // handleReconfigureMQTT reconfigures the MQTT connection
@@ -374,6 +379,8 @@ func (cm *ControlMonitor) handleReconfigureMQTT() {
 		GetLogger().Info("MQTT connection disabled")
 		cm.notifySuccess("MQTT connection disabled")
 	}
+
+	emitHotReload("mqtt")
 }
 
 // handleReconfigureStreams reconfigures audio streams using the AudioEngine.
@@ -392,6 +399,7 @@ func (cm *ControlMonitor) handleReconfigureStreams() {
 	}
 
 	audiocore.GetLogger().Info("Audio streams reconfigured successfully")
+	emitHotReload("rtsp_sources")
 }
 
 // handleReconfigureBirdWeather reconfigures the BirdWeather integration
@@ -430,6 +438,8 @@ func (cm *ControlMonitor) handleReconfigureBirdWeather() {
 		GetLogger().Info("BirdWeather integration disabled")
 		cm.notifySuccess("BirdWeather integration disabled")
 	}
+
+	emitHotReload("birdweather")
 }
 
 // handleUpdateDetectionIntervals updates event tracking intervals for species
@@ -474,6 +484,14 @@ func (cm *ControlMonitor) handleUpdateDetectionIntervals() {
 
 	GetLogger().Info("Detection rate limits updated successfully")
 	cm.notifySuccess("Detection rate limits updated successfully")
+	emitHotReload("detection_intervals")
+}
+
+// emitHotReload records a hot-reload event for the given component.
+func emitHotReload(component string) {
+	events.Emit(context.Background(), "settings", "hot_reload", "Component reconfigured", map[string]any{
+		"component": component,
+	})
 }
 
 // notifySuccess logs a success message
@@ -523,6 +541,8 @@ func (cm *ControlMonitor) handleReconfigureSoundLevel() {
 		GetLogger().Info("Sound level monitoring disabled")
 		cm.notifySuccess("Sound level monitoring disabled")
 	}
+
+	emitHotReload("sound_level")
 }
 
 // handleReconfigureTelemetry reconfigures the telemetry/metrics endpoint
@@ -588,6 +608,8 @@ func (cm *ControlMonitor) handleReconfigureTelemetry() {
 		GetLogger().Info("Telemetry endpoint disabled")
 		cm.notifySuccess("Telemetry endpoint disabled")
 	}
+
+	emitHotReload("telemetry")
 }
 
 // validateListenAddress checks if the listen address is in a valid format
@@ -712,6 +734,7 @@ func (cm *ControlMonitor) handleReconfigureSpeciesTracking() {
 		logger.Int("sync_minutes", settings.Realtime.SpeciesTracking.SyncIntervalMinutes),
 		logger.String("hemisphere", hemisphere))
 	cm.notifySuccess("Species tracking reconfigured successfully")
+	emitHotReload("species_tracking")
 }
 
 // handleReconfigurePushNotifications reconfigures the push notification dispatcher.
@@ -727,6 +750,7 @@ func (cm *ControlMonitor) handleReconfigurePushNotifications() {
 
 	GetLogger().Info("Push notification providers reconfigured successfully")
 	cm.notifySuccess("Push notification providers configured successfully")
+	emitHotReload("push_notifications")
 }
 
 // handleRebuildExtendedCapture rebuilds the extended capture species filter
@@ -748,6 +772,7 @@ func (cm *ControlMonitor) handleRebuildExtendedCapture() {
 
 	GetLogger().Info("Extended capture species filter rebuilt successfully")
 	cm.notifySuccess("Extended capture species filter rebuilt successfully")
+	emitHotReload("extended_capture")
 }
 
 // handleReconfigureAudioSources reconfigures audio capture sources (sound cards)
@@ -780,6 +805,7 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 	}
 
 	audiocore.GetLogger().Info("Audio sources reconfigured successfully")
+	emitHotReload("audio_sources")
 }
 
 // handleRecalculateDynamicThresholds recalculates all dynamic threshold CurrentValue entries
@@ -788,6 +814,7 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 func (cm *ControlMonitor) handleRecalculateDynamicThresholds() {
 	if cm.proc != nil {
 		cm.proc.RecalculateDynamicThresholds()
+		emitHotReload("dynamic_thresholds")
 	}
 }
 
@@ -816,6 +843,8 @@ func (cm *ControlMonitor) handleReconfigureDynamicThresholds() {
 		GetLogger().Info("Dynamic thresholds disabled")
 		cm.notifySuccess("Dynamic thresholds disabled")
 	}
+
+	emitHotReload("dynamic_thresholds_config")
 }
 
 // handleReconfigureQuietHours triggers a re-evaluation of quiet hours after settings change.
@@ -826,6 +855,7 @@ func (cm *ControlMonitor) handleReconfigureQuietHours() {
 		cm.quietHoursScheduler.Evaluate()
 		GetLogger().Info("Quiet hours re-evaluated successfully")
 		cm.notifySuccess("Quiet hours reconfigured successfully")
+		emitHotReload("quiet_hours")
 	} else {
 		GetLogger().Warn("Quiet hours scheduler not available")
 	}

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -697,6 +697,7 @@ func (cm *ControlMonitor) handleReconfigureSpeciesTracking() {
 		cm.proc.SetNewSpeciesTracker(nil)
 		GetLogger().Info("Species tracking disabled")
 		cm.notifySuccess("Species tracking disabled")
+		emitHotReload("species_tracking")
 		return
 	}
 

--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -359,7 +359,7 @@ func (a *MqttAction) Execute(_ context.Context, data any) error {
 // Execute updates the range filter species list, this is run every day
 // Note: The ShouldUpdateRangeFilterToday() check in processor.go ensures this action
 // is only created once per day, preventing duplicate concurrent updates (GitHub issue #1357)
-func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
+func (a *UpdateRangeFilterAction) Execute(ctx context.Context, data any) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -389,7 +389,7 @@ func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
 	// Update the species list (this also updates LastUpdated timestamp atomically)
 	conf.UpdateIncludedSpecies(includedSpecies)
 
-	events.Emit(context.Background(), "detection", "filter_reconfigured", "Range filter updated", map[string]any{
+	events.Emit(ctx, "detection", "filter_reconfigured", "Range filter updated", map[string]any{
 		"species_count": len(includedSpecies),
 		"date":          today.Format(time.DateOnly),
 	})

--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
@@ -387,6 +388,11 @@ func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
 
 	// Update the species list (this also updates LastUpdated timestamp atomically)
 	conf.UpdateIncludedSpecies(includedSpecies)
+
+	events.Emit(context.Background(), "detection", "filter_reconfigured", "Range filter updated", map[string]any{
+		"species_count": len(includedSpecies),
+		"date":          today.Format(time.DateOnly),
+	})
 
 	if a.Settings.Debug {
 		GetLogger().Info("Range filter updated successfully",

--- a/internal/api/v2/api_goroutine_test.go
+++ b/internal/api/v2/api_goroutine_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -36,6 +37,7 @@ func TestControllerShutdownCleansUpGoroutines(t *testing.T) {
 
 	// Create mock datastore
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	// Create settings with required paths
 	settings := &conf.Settings{

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -41,6 +41,7 @@ func setupAppConfigTest(t *testing.T, securityConfig *conf.Security) (*echo.Echo
 
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	// Use empty security config if nil
 	secCfg := conf.Security{}
@@ -90,6 +91,7 @@ func setupAppConfigTestWithAuth(t *testing.T, securityConfig *conf.Security) (*e
 
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	// Use empty security config if nil
 	secCfg := conf.Security{}
@@ -522,6 +524,7 @@ func TestGetAppConfig_Concurrent(t *testing.T) {
 func TestGetAppConfig_EmptyVersion(t *testing.T) {
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	settings := &conf.Settings{
 		Version: "", // Empty version
@@ -581,6 +584,7 @@ func TestGetAppConfig_VersionWithSpecialChars(t *testing.T) {
 		t.Run(version, func(t *testing.T) {
 			e := echo.New()
 			mockDS := mocks.NewMockInterface(t)
+			mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 			settings := &conf.Settings{
 				Version: version,
@@ -935,6 +939,7 @@ func FuzzGetAppConfig_Headers(f *testing.F) {
 	f.Fuzz(func(t *testing.T, accept, customHeader, csrfToken string) {
 		e := echo.New()
 		mockDS := mocks.NewMockInterface(t)
+		mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 		settings := &conf.Settings{
 			Version: "1.0.0-fuzz",
 		}
@@ -996,6 +1001,7 @@ func FuzzGetAppConfig_QueryParams(f *testing.F) {
 	f.Fuzz(func(t *testing.T, queryString string) {
 		e := echo.New()
 		mockDS := mocks.NewMockInterface(t)
+		mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 		settings := &conf.Settings{
 			Version: "1.0.0-fuzz",
 		}
@@ -1060,6 +1066,7 @@ func FuzzGetAppConfig_CSRFToken(f *testing.F) {
 	f.Fuzz(func(t *testing.T, csrfToken string) {
 		e := echo.New()
 		mockDS := mocks.NewMockInterface(t)
+		mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 		settings := &conf.Settings{
 			Version: "1.0.0-fuzz",
 		}
@@ -1124,6 +1131,7 @@ func FuzzGetAppConfig_Version(f *testing.F) {
 	f.Fuzz(func(t *testing.T, version string) {
 		e := echo.New()
 		mockDS := mocks.NewMockInterface(t)
+		mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 		settings := &conf.Settings{
 			Version: version,
 		}
@@ -1270,6 +1278,7 @@ func FuzzGetAppConfig_SecurityConfig(f *testing.F) {
 
 		e := echo.New()
 		mockDS := mocks.NewMockInterface(t)
+		mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 		settings := &conf.Settings{
 			Version: "1.0.0-fuzz",

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -34,6 +34,7 @@ func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Controller, *conf.Sett
 
 	// Create mock datastore
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	// Create settings with BasicAuth enabled
 	settings := &conf.Settings{
@@ -205,6 +206,7 @@ func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 	// Create custom test environment with empty ClientID
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	settings := &conf.Settings{
 		WebServer: conf.WebServerSettings{Debug: true},

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2688,9 +2688,19 @@ func flattenInto(result map[string]any, prefix string, m map[string]any) {
 		if prefix != "" {
 			key = prefix + "." + k
 		}
-		if child, ok := v.(map[string]any); ok {
-			flattenInto(result, key, child)
-		} else {
+		switch val := v.(type) {
+		case map[string]any:
+			flattenInto(result, key, val)
+		case []any:
+			for i, item := range val {
+				sliceKey := fmt.Sprintf("%s.%d", key, i)
+				if child, ok := item.(map[string]any); ok {
+					flattenInto(result, sliceKey, child)
+				} else {
+					result[sliceKey] = item
+				}
+			}
+		default:
 			result[key] = v
 		}
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -323,6 +323,15 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		}
 	}
 
+	// Emit settings_saved event with key-level diff (fire-and-forget).
+	if changes := diffSettings(current, updated); len(changes) > 0 {
+		events.Emit(context.Background(), "settings", "settings_saved", "Settings saved via UI", map[string]any{
+			"source":       "ui",
+			"change_count": len(changes),
+			"changes":      changes,
+		})
+	}
+
 	telemetry.UpdateTelemetryEnabled()
 	imageprovider.SetCustomSynonyms(updated.TaxonomySynonyms, updated.BirdNET.Labels)
 
@@ -724,6 +733,15 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 			logger.String("section", section),
 			logger.Bool("publishGlobal", publishGlobal),
 			logger.Bool("disableSaveSettings", c.DisableSaveSettings))
+	}
+
+	// Emit settings_saved event with key-level diff (fire-and-forget).
+	if changes := diffSettings(current, updated); len(changes) > 0 {
+		events.Emit(context.Background(), "settings", "settings_saved", "Settings saved via UI", map[string]any{
+			"source":       "ui",
+			"change_count": len(changes),
+			"changes":      changes,
+		})
 	}
 
 	telemetry.UpdateTelemetryEnabled()
@@ -2658,19 +2676,22 @@ func settingsToFlatMap(s *conf.Settings) map[string]any {
 // flattenMap recursively flattens a nested map into dot-separated keys.
 func flattenMap(prefix string, m map[string]any) map[string]any {
 	result := make(map[string]any)
+	flattenInto(result, prefix, m)
+	return result
+}
+
+// flattenInto recursively populates result with dot-separated keys from a nested map,
+// avoiding intermediate map allocations that the previous recursive-merge approach created.
+func flattenInto(result map[string]any, prefix string, m map[string]any) {
 	for k, v := range m {
 		key := k
 		if prefix != "" {
 			key = prefix + "." + k
 		}
-		switch child := v.(type) {
-		case map[string]any:
-			for ck, cv := range flattenMap(key, child) {
-				result[ck] = cv
-			}
-		default:
+		if child, ok := v.(map[string]any); ok {
+			flattenInto(result, key, child)
+		} else {
 			result[key] = v
 		}
 	}
-	return result
 }

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -18,10 +19,13 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/audiocore/schedule"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/support"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
+	"gopkg.in/yaml.v3"
 )
 
 // Settings validation and UI constants (file-local)
@@ -571,6 +575,16 @@ func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) err
 			return fmt.Errorf("failed to save settings: %w", err)
 		}
 	}
+
+	// Emit settings_saved event with key-level diff (fire-and-forget).
+	if changes := diffSettings(current, updated); len(changes) > 0 {
+		events.Emit(context.Background(), "settings", "settings_saved", "Settings saved via UI", map[string]any{
+			"source":       "ui",
+			"change_count": len(changes),
+			"changes":      changes,
+		})
+	}
+
 	return nil
 }
 
@@ -2586,4 +2600,77 @@ func (c *Controller) GetSystemID(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, response)
+}
+
+// diffSettings computes a key-level diff between two settings snapshots.
+// Both snapshots are YAML-marshalled, flattened to dot-separated paths, and
+// compared. Sensitive values are scrubbed. Returns nil if nothing changed.
+func diffSettings(current, updated *conf.Settings) map[string]map[string]any {
+	currentMap := settingsToFlatMap(current)
+	updatedMap := settingsToFlatMap(updated)
+
+	sensitiveKeys := support.DefaultSensitiveKeys()
+	changes := make(map[string]map[string]any)
+
+	allKeys := make(map[string]struct{}, len(currentMap)+len(updatedMap))
+	for k := range currentMap {
+		allKeys[k] = struct{}{}
+	}
+	for k := range updatedMap {
+		allKeys[k] = struct{}{}
+	}
+
+	for key := range allKeys {
+		oldVal := currentMap[key]
+		newVal := updatedMap[key]
+		if reflect.DeepEqual(oldVal, newVal) {
+			continue
+		}
+		if support.MatchesSensitiveKey(key, sensitiveKeys) {
+			changes[key] = map[string]any{"old": "[redacted]", "new": "[redacted]"}
+		} else {
+			changes[key] = map[string]any{"old": oldVal, "new": newVal}
+		}
+	}
+
+	if len(changes) == 0 {
+		return nil
+	}
+	return changes
+}
+
+// settingsToFlatMap marshals settings to YAML, unmarshals to a generic map,
+// and flattens to dot-separated keys.
+func settingsToFlatMap(s *conf.Settings) map[string]any {
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		GetLogger().Warn("failed to marshal settings for diff", logger.Error(err))
+		return nil
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		GetLogger().Warn("failed to unmarshal settings for diff", logger.Error(err))
+		return nil
+	}
+	return flattenMap("", m)
+}
+
+// flattenMap recursively flattens a nested map into dot-separated keys.
+func flattenMap(prefix string, m map[string]any) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch child := v.(type) {
+		case map[string]any:
+			for ck, cv := range flattenMap(key, child) {
+				result[ck] = cv
+			}
+		default:
+			result[key] = v
+		}
+	}
+	return result
 }

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -64,6 +64,7 @@ func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
 	})
 
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	settings := &conf.Settings{
 		Version: "1.0.0-test",

--- a/internal/api/v2/sse_connection_test.go
+++ b/internal/api/v2/sse_connection_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -394,6 +395,7 @@ func setupSSETestServer(t *testing.T) (*httptest.Server, *Controller) {
 
 	// Create mock datastore
 	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	// Create settings with required paths
 	settings := &conf.Settings{
@@ -480,6 +482,7 @@ func setupSSETestServerForBench(b *testing.B) (*httptest.Server, *Controller) {
 	b.Helper()
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(b)
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 	settings := &conf.Settings{
 		WebServer: conf.WebServerSettings{Debug: false}, // Disable debug for benchmarking
 		Realtime: conf.RealtimeSettings{

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -32,6 +32,7 @@ type GenerateSupportDumpRequest struct {
 	IncludeConfig       bool   `json:"include_config"`
 	IncludeSystemInfo   bool   `json:"include_system_info"`
 	IncludeDatabaseInfo bool   `json:"include_database_info"`
+	IncludeAppEvents    bool   `json:"include_app_events"`
 	UserMessage         string `json:"user_message"`
 	UploadToSentry      bool   `json:"upload_to_sentry"`
 	GitHubIssueNumber   string `json:"github_issue_number"`
@@ -74,16 +75,18 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		logger.Bool("include_config", req.IncludeConfig),
 		logger.Bool("include_system_info", req.IncludeSystemInfo),
 		logger.Bool("include_database_info", req.IncludeDatabaseInfo),
+		logger.Bool("include_app_events", req.IncludeAppEvents),
 		logger.Bool("upload_to_sentry", req.UploadToSentry),
 		logger.String("github_issue", req.GitHubIssueNumber),
 		logger.Bool("has_user_message", req.UserMessage != ""))
 
 	// Set defaults if nothing is selected
-	if !req.IncludeLogs && !req.IncludeConfig && !req.IncludeSystemInfo && !req.IncludeDatabaseInfo {
+	if !req.IncludeLogs && !req.IncludeConfig && !req.IncludeSystemInfo && !req.IncludeDatabaseInfo && !req.IncludeAppEvents {
 		req.IncludeLogs = true
 		req.IncludeConfig = true
 		req.IncludeSystemInfo = true
 		req.IncludeDatabaseInfo = true
+		req.IncludeAppEvents = true
 		c.logDebugIfEnabled("Set default options for support dump")
 	}
 
@@ -123,12 +126,18 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		collector.SetDatabaseInfoProvider(dbCollector)
 	}
 
+	// Wire app events provider
+	if req.IncludeAppEvents && c.DS != nil {
+		collector.SetAppEventsProvider(support.NewDatastoreAppEventsProvider(c.DS, nil))
+	}
+
 	// Set collection options
 	opts := support.CollectorOptions{
 		IncludeLogs:         req.IncludeLogs,
 		IncludeConfig:       req.IncludeConfig,
 		IncludeSystemInfo:   req.IncludeSystemInfo,
 		IncludeDatabaseInfo: req.IncludeDatabaseInfo,
+		IncludeAppEvents:    req.IncludeAppEvents,
 		LogDuration:         supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
 		MaxLogSize:          supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
 		ScrubSensitive:      true,
@@ -295,6 +304,9 @@ func (c *Controller) initSupportRoutes() {
 		c.wg.Go(func() {
 			c.startSupportDumpCleanup(c.ctx)
 		})
+		c.wg.Go(func() {
+			c.startAppEventPruning(c.ctx)
+		})
 	}
 }
 
@@ -372,4 +384,45 @@ func (c *Controller) tryRemoveOldFile(file string, cutoff time.Time) bool {
 		return false
 	}
 	return true
+}
+
+// appEventRetentionDays is the default retention period for application events.
+const appEventRetentionDays = 90
+
+// startAppEventPruning runs periodic pruning of old application events.
+func (c *Controller) startAppEventPruning(ctx context.Context) {
+	if ctx == nil || c.DS == nil {
+		return
+	}
+
+	// Prune once at startup
+	c.pruneAppEvents(ctx)
+
+	// Then prune daily
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.pruneAppEvents(ctx)
+		}
+	}
+}
+
+// pruneAppEvents removes application events older than the retention period.
+func (c *Controller) pruneAppEvents(ctx context.Context) {
+	if c.DS == nil {
+		return
+	}
+	pruned, err := c.DS.PruneAppEvents(ctx, appEventRetentionDays)
+	if err != nil {
+		c.logWarnIfEnabled("Failed to prune app events", logger.Error(err))
+		return
+	}
+	if pruned > 0 {
+		c.logInfoIfEnabled("Pruned old app events", logger.Int64("count", pruned))
+	}
 }

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -395,8 +395,13 @@ func (c *Controller) startAppEventPruning(ctx context.Context) {
 		return
 	}
 
-	// Prune once at startup
-	c.pruneAppEvents(ctx)
+	// Prune once at startup, but check for early cancellation first
+	select {
+	case <-ctx.Done():
+		return
+	default:
+		c.pruneAppEvents(ctx)
+	}
 
 	// Then prune daily
 	ticker := time.NewTicker(24 * time.Hour)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -98,6 +99,8 @@ func (a *App) Start(ctx context.Context) error {
 // Shutdown stops all services using tiered shutdown.
 // TierNetwork services stop first, then TierCore services get a guaranteed fresh budget.
 func (a *App) Shutdown(ctx context.Context) error {
+	events.Emit(ctx, "system", "shutdown", "Application shutting down", nil)
+
 	network, core := a.groupByTier()
 
 	var allErrs []error

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
@@ -388,6 +389,12 @@ func (m *SQLiteManager) cleanupLegacySchemaContamination() error {
 					ErrV2SchemaCorrupted, c.table, c.column, rowCount)
 			}
 		}
+
+		events.Emit(context.Background(), "database", "schema_repair", "Legacy schema contamination cleaned", map[string]any{
+			"action": "drop_legacy_columns",
+			"table":  c.table,
+			"column": c.column,
+		})
 	}
 
 	return nil

--- a/internal/datastore/v2/state_manager.go
+++ b/internal/datastore/v2/state_manager.go
@@ -1,12 +1,14 @@
 package v2
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 	"gorm.io/gorm"
@@ -93,12 +95,27 @@ func (m *StateManager) StartMigration(totalRecords int64) error {
 		return startErr
 	}
 
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state":    "idle",
+		"to_state":      "initializing",
+		"total_records": totalRecords,
+	})
+
 	return nil
 }
 
 // TransitionToDualWrite transitions from INITIALIZING to DUAL_WRITE.
 func (m *StateManager) TransitionToDualWrite() error {
-	return m.transitionState(entities.MigrationStatusInitializing, entities.MigrationStatusDualWrite)
+	if err := m.transitionState(entities.MigrationStatusInitializing, entities.MigrationStatusDualWrite); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "initializing",
+		"to_state":   "dual_write",
+	})
+
+	return nil
 }
 
 // Pause transitions from DUAL_WRITE or MIGRATING to PAUSED.
@@ -129,6 +146,11 @@ func (m *StateManager) Pause() error {
 		return fmt.Errorf("cannot pause migration: current state is %s", current.State)
 	}
 
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "pausable",
+		"to_state":   "paused",
+	})
+
 	return nil
 }
 
@@ -144,7 +166,16 @@ func (m *StateManager) Pause() error {
 // DUAL_WRITE simply restarts the state machine loop. The worker will see LastMigratedID=50000
 // and continue from ID 50001, eventually transitioning back through MIGRATING → VALIDATING.
 func (m *StateManager) Resume() error {
-	return m.transitionState(entities.MigrationStatusPaused, entities.MigrationStatusDualWrite)
+	if err := m.transitionState(entities.MigrationStatusPaused, entities.MigrationStatusDualWrite); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "paused",
+		"to_state":   "dual_write",
+	})
+
+	return nil
 }
 
 // Fail transitions from VALIDATING to FAILED.
@@ -152,32 +183,77 @@ func (m *StateManager) Resume() error {
 // Unlike Pause, this indicates a validation failure that requires explicit
 // retry rather than a simple resume.
 func (m *StateManager) Fail() error {
-	return m.transitionState(entities.MigrationStatusValidating, entities.MigrationStatusFailed)
+	if err := m.transitionState(entities.MigrationStatusValidating, entities.MigrationStatusFailed); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "validating",
+		"to_state":   "failed",
+	})
+
+	return nil
 }
 
 // RetryValidation transitions from FAILED back to VALIDATING.
 // This allows re-running validation after a failure, without restarting the
 // entire migration from DUAL_WRITE (which Resume would do from PAUSED).
 func (m *StateManager) RetryValidation() error {
-	return m.transitionState(entities.MigrationStatusFailed, entities.MigrationStatusValidating)
+	if err := m.transitionState(entities.MigrationStatusFailed, entities.MigrationStatusValidating); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "failed",
+		"to_state":   "validating",
+	})
+
+	return nil
 }
 
 // TransitionToMigrating transitions from DUAL_WRITE to MIGRATING.
 // This is called when the migration worker starts processing records.
 func (m *StateManager) TransitionToMigrating() error {
-	return m.transitionState(entities.MigrationStatusDualWrite, entities.MigrationStatusMigrating)
+	if err := m.transitionState(entities.MigrationStatusDualWrite, entities.MigrationStatusMigrating); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "dual_write",
+		"to_state":   "migrating",
+	})
+
+	return nil
 }
 
 // TransitionToValidating transitions from MIGRATING to VALIDATING.
 // This is called when all records have been migrated.
 func (m *StateManager) TransitionToValidating() error {
-	return m.transitionState(entities.MigrationStatusMigrating, entities.MigrationStatusValidating)
+	if err := m.transitionState(entities.MigrationStatusMigrating, entities.MigrationStatusValidating); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "migrating",
+		"to_state":   "validating",
+	})
+
+	return nil
 }
 
 // TransitionToCutover transitions from VALIDATING to CUTOVER.
 // This is called when validation passes.
 func (m *StateManager) TransitionToCutover() error {
-	return m.transitionState(entities.MigrationStatusValidating, entities.MigrationStatusCutover)
+	if err := m.transitionState(entities.MigrationStatusValidating, entities.MigrationStatusCutover); err != nil {
+		return err
+	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "validating",
+		"to_state":   "cutover",
+	})
+
+	return nil
 }
 
 // Complete transitions from CUTOVER to COMPLETED.
@@ -210,6 +286,11 @@ func (m *StateManager) Complete() error {
 		reportStateTransitionError(string(entities.MigrationStatusCutover), string(entities.MigrationStatusCompleted), completeErr)
 		return completeErr
 	}
+
+	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
+		"from_state": "cutover",
+		"to_state":   "completed",
+	})
 
 	return nil
 }

--- a/internal/datastore/v2/state_manager.go
+++ b/internal/datastore/v2/state_manager.go
@@ -132,7 +132,9 @@ func (m *StateManager) Pause() error {
 
 	// Read the current state before the update so we can emit the actual from_state.
 	var currentState entities.MigrationState
-	_ = m.db.First(&currentState)
+	if err := m.db.First(&currentState).Error; err != nil {
+		currentState.State = "unknown"
+	}
 
 	result := m.db.Model(&entities.MigrationState{}).
 		Where("id = ? AND state IN ?", migrationStateID, pausableStates).

--- a/internal/datastore/v2/state_manager.go
+++ b/internal/datastore/v2/state_manager.go
@@ -130,6 +130,10 @@ func (m *StateManager) Pause() error {
 		entities.MigrationStatusMigrating,
 	}
 
+	// Read the current state before the update so we can emit the actual from_state.
+	var currentState entities.MigrationState
+	_ = m.db.First(&currentState)
+
 	result := m.db.Model(&entities.MigrationState{}).
 		Where("id = ? AND state IN ?", migrationStateID, pausableStates).
 		Update("state", entities.MigrationStatusPaused)
@@ -147,7 +151,7 @@ func (m *StateManager) Pause() error {
 	}
 
 	events.Emit(context.Background(), "migration", "state_transition", "Migration state changed", map[string]any{
-		"from_state": "pausable",
+		"from_state": string(currentState.State),
 		"to_state":   "paused",
 	})
 

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -659,6 +659,7 @@ func (d *pushDispatcher) shouldRetry(err error, attempts int, providerName strin
 			"provider": providerName,
 			"success":  false,
 			"attempts": attempts,
+			"error":    categorizeError(err),
 		})
 		return false
 	}

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 	"golang.org/x/sync/semaphore"
@@ -581,6 +582,12 @@ func (d *pushDispatcher) logSuccess(providerName string, notif *Notification, no
 		logger.Int("attempt", attempts),
 		logger.Duration("elapsed", duration))
 
+	events.Emit(context.Background(), "notification", "delivery_attempt", "Notification delivered", map[string]any{
+		"provider": providerName,
+		"success":  true,
+		"attempts": attempts,
+	})
+
 	// Reset error suppression state on success. This logs a recovery message
 	// if the provider was in a failure state and resets the consecutive failure count.
 	if d.errorSuppressor != nil {
@@ -641,6 +648,12 @@ func (d *pushDispatcher) shouldRetry(err error, attempts int, providerName strin
 					logger.Bool("retryable", retryable))
 			}
 		}
+
+		events.Emit(context.Background(), "notification", "delivery_attempt", "Notification delivery failed", map[string]any{
+			"provider": providerName,
+			"success":  false,
+			"attempts": attempts,
+		})
 		return false
 	}
 

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -508,6 +508,11 @@ func (d *pushDispatcher) retryLoop(ctx context.Context, notif *Notification, ep 
 		// Handle circuit breaker open
 		if errors.Is(err, ErrCircuitBreakerOpen) {
 			d.logCircuitBreakerOpen(ep.name, notif.ID)
+			events.Emit(context.Background(), "notification", "delivery_attempt", "Notification blocked by circuit breaker", map[string]any{
+				"provider": ep.name,
+				"success":  false,
+				"error":    "circuit_breaker_open",
+			})
 			return
 		}
 

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -512,6 +512,7 @@ func (d *pushDispatcher) retryLoop(ctx context.Context, notif *Notification, ep 
 				"provider": ep.name,
 				"success":  false,
 				"error":    "circuit_breaker_open",
+				"attempts": attempts,
 			})
 			return
 		}

--- a/internal/support/app_events_provider.go
+++ b/internal/support/app_events_provider.go
@@ -39,7 +39,7 @@ func (p *DatastoreAppEventsProvider) GetRecentAppEvents(ctx context.Context, lim
 		limit = supportDumpEventLimit
 	}
 
-	since := time.Now().Add(-supportDumpEventDays * 24 * time.Hour)
+	since := time.Now().AddDate(0, 0, -supportDumpEventDays)
 	events, err := p.ds.GetAppEventsSince(ctx, since, limit)
 	if err != nil {
 		return nil, err

--- a/internal/support/app_events_provider.go
+++ b/internal/support/app_events_provider.go
@@ -1,0 +1,98 @@
+package support
+
+import (
+	"context"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// supportDumpEventLimit is the maximum number of events included in a support dump.
+const supportDumpEventLimit = 1000
+
+// supportDumpEventDays is the number of days of events to include in a support dump.
+const supportDumpEventDays = 30
+
+// DatastoreAppEventsProvider adapts a datastore.Interface to the AppEventsProvider
+// interface, converting datastore.AppEvent values to support-local AppEventEntry
+// and scrubbing sensitive metadata keys at export time.
+type DatastoreAppEventsProvider struct {
+	ds            datastore.Interface
+	sensitiveKeys []string
+}
+
+// NewDatastoreAppEventsProvider creates a provider backed by the given datastore.
+func NewDatastoreAppEventsProvider(ds datastore.Interface, sensitiveKeys []string) *DatastoreAppEventsProvider {
+	if len(sensitiveKeys) == 0 {
+		sensitiveKeys = DefaultSensitiveKeys()
+	}
+	return &DatastoreAppEventsProvider{
+		ds:            ds,
+		sensitiveKeys: sensitiveKeys,
+	}
+}
+
+// GetRecentAppEvents returns events from the last 30 days, capped at 1000 entries,
+// with sensitive metadata values scrubbed.
+func (p *DatastoreAppEventsProvider) GetRecentAppEvents(ctx context.Context, limit int) ([]AppEventEntry, error) {
+	if limit <= 0 {
+		limit = supportDumpEventLimit
+	}
+
+	since := time.Now().Add(-supportDumpEventDays * 24 * time.Hour)
+	events, err := p.ds.GetAppEventsSince(ctx, since, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]AppEventEntry, 0, len(events))
+	for _, ev := range events {
+		entries = append(entries, AppEventEntry{
+			Timestamp: ev.Timestamp,
+			Category:  ev.Category,
+			EventType: ev.EventType,
+			Message:   ev.Message,
+			Metadata:  p.scrubMetadata(ev.Metadata),
+		})
+	}
+
+	return entries, nil
+}
+
+// scrubMetadata redacts values for sensitive keys in the metadata map.
+func (p *DatastoreAppEventsProvider) scrubMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return metadata
+	}
+
+	scrubbed := make(map[string]any, len(metadata))
+	for k, v := range metadata {
+		if p.isKeySensitive(k) {
+			scrubbed[k] = redactedPlaceholder
+		} else {
+			scrubbed[k] = p.scrubNestedValue(v)
+		}
+	}
+	return scrubbed
+}
+
+// scrubNestedValue recursively scrubs sensitive keys in nested maps and slices.
+func (p *DatastoreAppEventsProvider) scrubNestedValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return p.scrubMetadata(v)
+	case []any:
+		scrubbed := make([]any, len(v))
+		for i, item := range v {
+			scrubbed[i] = p.scrubNestedValue(item)
+		}
+		return scrubbed
+	default:
+		return value
+	}
+}
+
+// isKeySensitive checks if a metadata key matches any sensitive key pattern.
+func (p *DatastoreAppEventsProvider) isKeySensitive(key string) bool {
+	return MatchesSensitiveKey(key, p.sensitiveKeys)
+}

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -61,6 +61,7 @@ const (
 	configYAMLFileName   = "config.yaml"
 	systemInfoFileName   = "system_info.json"
 	databaseInfoFileName = "database_info.json"
+	appEventsFileName    = "app_events.json"
 	logReadmeFileName    = "logs/README.txt"
 
 	// Redaction and privacy
@@ -105,16 +106,17 @@ func getLogger() logger.Logger {
 
 // Collector collects support data for troubleshooting
 type Collector struct {
-	configPath     string
-	dataPath       string
-	systemID       string
-	version        string
-	sensitiveKeys  []string
-	dbInfoProvider DatabaseInfoProvider
+	configPath        string
+	dataPath          string
+	systemID          string
+	version           string
+	sensitiveKeys     []string
+	dbInfoProvider    DatabaseInfoProvider
+	appEventsProvider AppEventsProvider
 }
 
-// defaultSensitiveKeys returns the default list of sensitive configuration keys to redact
-func defaultSensitiveKeys() []string {
+// DefaultSensitiveKeys returns the default list of sensitive configuration keys to redact.
+func DefaultSensitiveKeys() []string {
 	return []string{
 		// Authentication credentials (snake_case and camelCase variants)
 		"password", "pass", "token", "secret", "key", "api_key", "api_token",
@@ -147,6 +149,17 @@ func defaultSensitiveKeys() []string {
 // isURLValue checks if a string value appears to be a URL
 func isURLValue(s string) bool {
 	return strings.Contains(s, urlSchemeDelimiter)
+}
+
+// MatchesSensitiveKey checks if a dot-separated key path contains any sensitive key pattern.
+func MatchesSensitiveKey(key string, sensitiveKeys []string) bool {
+	lowerKey := strings.ToLower(key)
+	for _, sensitive := range sensitiveKeys {
+		if isSensitiveKey(lowerKey, sensitive) {
+			return true
+		}
+	}
+	return false
 }
 
 // isSensitiveKey checks if a key matches a sensitive key pattern using word boundaries.
@@ -278,7 +291,7 @@ func NewCollector(configPath, dataPath, systemID, version string) *Collector {
 		dataPath:      dataPath,
 		systemID:      systemID,
 		version:       version,
-		sensitiveKeys: defaultSensitiveKeys(),
+		sensitiveKeys: DefaultSensitiveKeys(),
 	}
 }
 
@@ -294,7 +307,7 @@ func NewCollectorWithOptions(configPath, dataPath, systemID, version string, sen
 
 	// Use default sensitive keys if none provided
 	if len(sensitiveKeys) == 0 {
-		sensitiveKeys = defaultSensitiveKeys()
+		sensitiveKeys = DefaultSensitiveKeys()
 	}
 
 	return &Collector{
@@ -311,10 +324,15 @@ func (c *Collector) SetDatabaseInfoProvider(provider DatabaseInfoProvider) {
 	c.dbInfoProvider = provider
 }
 
+// SetAppEventsProvider configures the application events provider.
+func (c *Collector) SetAppEventsProvider(provider AppEventsProvider) {
+	c.appEventsProvider = provider
+}
+
 // Collect gathers support data based on the provided options
 func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*SupportDump, error) {
 	// Validate options
-	if !opts.IncludeLogs && !opts.IncludeConfig && !opts.IncludeSystemInfo && !opts.IncludeDatabaseInfo {
+	if !opts.IncludeLogs && !opts.IncludeConfig && !opts.IncludeSystemInfo && !opts.IncludeDatabaseInfo && !opts.IncludeAppEvents {
 		getLogger().Error("support: collection validation failed: at least one data type must be included")
 		return nil, errors.Newf("at least one data type must be included in support dump").
 			Component("support").
@@ -343,6 +361,7 @@ func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*Suppor
 		logger.Bool("include_config", opts.IncludeConfig),
 		logger.Bool("include_system_info", opts.IncludeSystemInfo),
 		logger.Bool("include_database_info", opts.IncludeDatabaseInfo),
+		logger.Bool("include_app_events", opts.IncludeAppEvents),
 		logger.Duration("log_duration", opts.LogDuration),
 		logger.Int64("max_log_size", opts.MaxLogSize))
 
@@ -394,6 +413,19 @@ func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*Suppor
 			getLogger().Debug("support: database information collected",
 				logger.String("dialect", dbInfo.Dialect),
 				logger.Int("table_count", len(dbInfo.Tables)))
+		}
+	}
+
+	// Collect app events
+	if opts.IncludeAppEvents && c.appEventsProvider != nil {
+		getLogger().Debug("support: collecting app events")
+		appEvents, err := c.appEventsProvider.GetRecentAppEvents(ctx, supportDumpEventLimit)
+		if err != nil {
+			getLogger().Error("support: failed to collect app events", logger.Error(err))
+		} else {
+			dump.AppEvents = appEvents
+			getLogger().Debug("support: app events collected",
+				logger.Int("event_count", len(appEvents)))
 		}
 	}
 
@@ -541,6 +573,29 @@ func (c *Collector) CreateArchive(ctx context.Context, dump *SupportDump, opts C
 				Build()
 		}
 		getLogger().Debug("support: database info added successfully")
+	}
+
+	// Add app events if collected
+	if len(dump.AppEvents) > 0 {
+		getLogger().Debug("support: adding app events to archive")
+		eventsFile, err := w.Create(appEventsFileName)
+		if err != nil {
+			getLogger().Error("support: failed to create app events file in archive", logger.Error(err))
+			return nil, errors.New(err).
+				Component("support").
+				Category(errors.CategoryFileIO).
+				Context("operation", "create_app_events_file").
+				Build()
+		}
+		if err := json.NewEncoder(eventsFile).Encode(dump.AppEvents); err != nil {
+			getLogger().Error("support: failed to write app events to archive", logger.Error(err))
+			return nil, errors.New(err).
+				Component("support").
+				Category(errors.CategoryFileIO).
+				Context("operation", "write_app_events").
+				Build()
+		}
+		getLogger().Debug("support: app events added successfully")
 	}
 
 	// Always add diagnostics - this is crucial for troubleshooting collection issues

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -153,7 +153,7 @@ func isURLValue(s string) bool {
 
 // MatchesSensitiveKey checks if a dot-separated key path contains any sensitive key pattern.
 func MatchesSensitiveKey(key string, sensitiveKeys []string) bool {
-	lowerKey := strings.ToLower(key)
+	lowerKey := strings.ReplaceAll(strings.ToLower(key), ".", "_")
 	for _, sensitive := range sensitiveKeys {
 		if isSensitiveKey(lowerKey, sensitive) {
 			return true

--- a/internal/support/collector_test.go
+++ b/internal/support/collector_test.go
@@ -242,7 +242,7 @@ func TestLogFileCollector_addNoLogsNote(t *testing.T) {
 // TestCollector_scrubConfig tests sensitive data scrubbing
 func TestCollector_scrubConfig(t *testing.T) {
 	c := &Collector{
-		sensitiveKeys: defaultSensitiveKeys(),
+		sensitiveKeys: DefaultSensitiveKeys(),
 	}
 
 	tests := []struct {
@@ -1041,7 +1041,7 @@ func TestCollector_Collect_AlwaysIncludesDiagnostics(t *testing.T) {
 	c := &Collector{
 		configPath:    tempDir,
 		dataPath:      tempDir,
-		sensitiveKeys: defaultSensitiveKeys(),
+		sensitiveKeys: DefaultSensitiveKeys(),
 	}
 
 	// Create a bundle with minimal options - at least one type must be enabled
@@ -1958,7 +1958,7 @@ func TestComprehensivePrivacyScrubbing_Integration(t *testing.T) {
 
 	// Create collector with default sensitive keys
 	c := &Collector{
-		sensitiveKeys: defaultSensitiveKeys(),
+		sensitiveKeys: DefaultSensitiveKeys(),
 	}
 
 	// Build comprehensive mock config

--- a/internal/support/types.go
+++ b/internal/support/types.go
@@ -20,6 +20,7 @@ type SupportDump struct {
 	Attachments  []AttachmentInfo      `json:"attachments"`
 	Diagnostics  CollectionDiagnostics `json:"diagnostics"`             // Diagnostic information about collection process
 	DatabaseInfo *DatabaseInfo         `json:"database_info,omitempty"` // Database schema and health diagnostics
+	AppEvents    []AppEventEntry       `json:"app_events,omitempty"`    // Recent application events
 }
 
 // LogEntry represents a single log entry from application logs or system journals.
@@ -79,6 +80,7 @@ type CollectorOptions struct {
 	IncludeConfig       bool          `json:"include_config"`
 	IncludeSystemInfo   bool          `json:"include_system_info"`
 	IncludeDatabaseInfo bool          `json:"include_database_info"`
+	IncludeAppEvents    bool          `json:"include_app_events"`
 	LogDuration         time.Duration `json:"log_duration"`
 	MaxLogSize          int64         `json:"max_log_size"`
 	ScrubSensitive      bool          `json:"scrub_sensitive"`
@@ -153,6 +155,7 @@ func DefaultCollectorOptions() CollectorOptions {
 		IncludeConfig:       true,
 		IncludeSystemInfo:   true,
 		IncludeDatabaseInfo: true,
+		IncludeAppEvents:    true,
 		LogDuration:         defaultLogDurationWeeks * 7 * 24 * time.Hour, // 4 weeks
 		MaxLogSize:          defaultMaxLogSizeMB * bytesPerMB,             // 50MB to accommodate more logs
 		ScrubSensitive:      true,
@@ -231,4 +234,20 @@ type MigrationStateInfo struct {
 	ErrorMessage     string  `json:"error_message,omitempty"`
 	RelatedDataError string  `json:"related_data_error,omitempty"`
 	DirtyRecordCount int64   `json:"dirty_record_count,omitempty"`
+}
+
+// AppEventEntry is a support-package-local representation of an application event.
+// It uses plain types (no gorm dependency) for clean serialization into the support dump.
+type AppEventEntry struct {
+	Timestamp time.Time      `json:"timestamp"`
+	Category  string         `json:"category"`
+	EventType string         `json:"event_type"`
+	Message   string         `json:"message"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// AppEventsProvider retrieves recent application events for inclusion in support dumps.
+// Implemented by the datastore layer, consumed by the support collector.
+type AppEventsProvider interface {
+	GetRecentAppEvents(ctx context.Context, limit int) ([]AppEventEntry, error)
 }


### PR DESCRIPTION
## Summary

- Wire global event emitter at startup, emit system/startup/shutdown/version_change events
- Add settings_saved events with key-level diff and sensitive value scrubbing
- Instrument 16 hot-reload components, 10 migration state transitions, model loading, range filter updates, notification delivery attempts, and schema repair
- Add `app_events.json` to support dump ZIPs (last 30 days, max 1000 events, metadata scrubbed)
- Add daily retention pruning (90-day cutoff, 10k row cap)

PR 3 of 3 for the enhanced support dump feature (PRs #3213 and #3215 merged).

## Test plan

- [x] All 4,227 tests pass with `-race` across 13 affected packages
- [x] `golangci-lint run -v` reports zero issues
- [x] Full `go build ./...` succeeds
- [x] Gate review (4 parallel agents) passed: correctness, safety, quality, reuse
- [x] Gate findings fixed: metadata slice scrubbing, `MatchesSensitiveKey` rename, `reflect.DeepEqual` for diff, `emitHotReload` helper, error logging in `settingsToFlatMap`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App event tracking for startup, shutdown, version changes, hot-reloads, model loads, config updates, migration/state transitions, and notification delivery attempts.
  * Settings saves now produce per-key diffs with sensitive values redacted.
  * Support dumps include recent app events by default and write them into the archive.
  * Automatic 90-day retention with periodic pruning of old app events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->