### PR TITLE
feat(startup): add database startup visibility and deployment context to support dumps

### DIFF
--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -133,15 +133,16 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 
 	// Set collection options
 	opts := support.CollectorOptions{
-		IncludeLogs:         req.IncludeLogs,
-		IncludeConfig:       req.IncludeConfig,
-		IncludeSystemInfo:   req.IncludeSystemInfo,
-		IncludeDatabaseInfo: req.IncludeDatabaseInfo,
-		IncludeAppEvents:    req.IncludeAppEvents,
-		LogDuration:         supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
-		MaxLogSize:          supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
-		ScrubSensitive:      true,
-		AnonymizePII:        true,
+		IncludeLogs:           req.IncludeLogs,
+		IncludeConfig:         req.IncludeConfig,
+		IncludeSystemInfo:     req.IncludeSystemInfo,
+		IncludeDatabaseInfo:   req.IncludeDatabaseInfo,
+		IncludeDeploymentInfo: true,
+		IncludeAppEvents:      req.IncludeAppEvents,
+		LogDuration:           supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
+		MaxLogSize:            supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
+		ScrubSensitive:        true,
+		AnonymizePII:          true,
 	}
 
 	// Collect data

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -138,20 +138,23 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 
 	// Fresh install: neither database exists
 	if !configuredExists && !v2MigrationExists {
-		// Safety check: warn if .db files exist in the data directory
-		dir := filepath.Dir(absConfigured)
-		if entries, err := os.ReadDir(dir); err == nil {
-			for _, e := range entries {
-				if e.IsDir() || !strings.HasSuffix(e.Name(), ".db") {
-					continue
-				}
-				if info, infoErr := e.Info(); infoErr == nil {
-					logger.Global().Module("datastore").Warn(
-						"fresh install detected but database files found in data directory",
-						logger.String("file", e.Name()),
-						logger.Int64("size", info.Size()),
-						logger.String("modified", info.ModTime().Format(time.RFC3339)),
-					)
+		// Safety check: warn if .db files exist in the data directory.
+		// Skip if path resolution failed (absConfigured empty) to avoid scanning ".".
+		if absConfigured != "" {
+			dir := filepath.Dir(absConfigured)
+			if entries, err := os.ReadDir(dir); err == nil {
+				for _, e := range entries {
+					if e.IsDir() || !strings.HasSuffix(e.Name(), ".db") {
+						continue
+					}
+					if info, infoErr := e.Info(); infoErr == nil {
+						logger.Global().Module("datastore").Warn(
+							"fresh install detected but database files found in data directory",
+							logger.String("file", e.Name()),
+							logger.Int64("size", info.Size()),
+							logger.String("modified", info.ModTime().Format(time.RFC3339)),
+						)
+					}
 				}
 			}
 		}

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -40,6 +41,14 @@ func reportStartupError(dbType, operation string, err error, paths ...string) {
 			"datastore-startup",
 		)
 	})
+}
+
+// logStartupDecision logs the outcome of the startup migration state check.
+func logStartupDecision(decision string, fields ...logger.Field) {
+	logger.Global().Module("datastore").Info(
+		"database startup: state determined",
+		append([]logger.Field{logger.String("decision", decision)}, fields...)...,
+	)
 }
 
 // dbStartupTimeout is the timeout for database startup operations.
@@ -101,6 +110,31 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 		v2MigrationExists = false
 	}
 
+	// Log all path check results for diagnostic visibility
+	absConfigured, _ := filepath.Abs(configuredPath)
+	absV2Migration, _ := filepath.Abs(v2MigrationPath)
+	cwd, _ := os.Getwd()
+
+	var configuredSize, v2MigrationSize int64
+	if fi, err := os.Stat(configuredPath); err == nil {
+		configuredSize = fi.Size()
+	}
+	if fi, err := os.Stat(v2MigrationPath); err == nil {
+		v2MigrationSize = fi.Size()
+	}
+
+	logger.Global().Module("datastore").Info("database startup: path check",
+		logger.String("cwd", cwd),
+		logger.String("configured_path", configuredPath),
+		logger.String("configured_abs", absConfigured),
+		logger.Bool("configured_exists", configuredExists),
+		logger.Int64("configured_size", configuredSize),
+		logger.String("v2_migration_path", v2MigrationPath),
+		logger.String("v2_migration_abs", absV2Migration),
+		logger.Bool("v2_migration_exists", v2MigrationExists),
+		logger.Int64("v2_migration_size", v2MigrationSize),
+	)
+
 	// Fresh install: neither database exists
 	if !configuredExists && !v2MigrationExists {
 		return StartupState{
@@ -116,9 +150,11 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	if !v2MigrationExists {
 		if configuredExists && CheckSQLiteHasV2Schema(configuredPath) {
 			// Fresh v2 install (restart after initial fresh install)
+			logStartupDecision("v2_restart")
 			return completedV2StartupState()
 		}
 		// Configured path exists but is not v2 = legacy mode
+		logStartupDecision("legacy_mode")
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
 			V2Available:     false,
@@ -136,8 +172,10 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	if err != nil {
 		reportStartupError("sqlite", "openV2Database", err, v2MigrationPath)
 		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			logStartupDecision("stale_sidecar_fallback", logger.String("trigger", "openV2Database"))
 			return fallback
 		}
+		logStartupDecision("v2_corrupted", logger.String("trigger", "openV2Database"))
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
 			V2Available:     false,
@@ -151,8 +189,10 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	if err != nil {
 		reportStartupError("sqlite", "getUnderlyingDB", err, v2MigrationPath)
 		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			logStartupDecision("stale_sidecar_fallback", logger.String("trigger", "getUnderlyingDB"))
 			return fallback
 		}
+		logStartupDecision("v2_corrupted", logger.String("trigger", "getUnderlyingDB"))
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
 			V2Available:     false,
@@ -169,8 +209,10 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 		// sql.DB.Close is idempotent, so the deferred close remains safe.
 		_ = sqlDB.Close()
 		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			logStartupDecision("stale_sidecar_fallback", logger.String("trigger", "migrationTableNotFound"))
 			return fallback
 		}
+		logStartupDecision("v2_corrupted", logger.String("trigger", "migrationTableNotFound"))
 		reportStartupError("sqlite", "readMigrationState", fmt.Errorf("migration state table not found"), v2MigrationPath)
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
@@ -183,8 +225,10 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	if err := db.Table(migrationTable).First(&state).Error; err != nil {
 		_ = sqlDB.Close()
 		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			logStartupDecision("stale_sidecar_fallback", logger.String("trigger", "readMigrationState"))
 			return fallback
 		}
+		logStartupDecision("v2_corrupted", logger.String("trigger", "readMigrationState"))
 		reportStartupError("sqlite", "readMigrationState", err, v2MigrationPath)
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
@@ -196,6 +240,10 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 
 	// Determine if legacy is required based on migration status
 	legacyRequired := state.State != entities.MigrationStatusCompleted
+
+	logStartupDecision("migration_"+string(state.State),
+		logger.Bool("legacy_required", legacyRequired),
+	)
 
 	return StartupState{
 		MigrationStatus: state.State,

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -137,6 +138,24 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 
 	// Fresh install: neither database exists
 	if !configuredExists && !v2MigrationExists {
+		// Safety check: warn if .db files exist in the data directory
+		dir := filepath.Dir(absConfigured)
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".db") {
+					continue
+				}
+				if info, infoErr := e.Info(); infoErr == nil {
+					logger.Global().Module("datastore").Warn(
+						"fresh install detected but database files found in data directory",
+						logger.String("file", e.Name()),
+						logger.Int64("size", info.Size()),
+						logger.String("modified", info.ModTime().Format(time.RFC3339)),
+					)
+				}
+			}
+		}
+		logStartupDecision("fresh_install")
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
 			V2Available:     false,

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -46,6 +46,25 @@ func TestCheckMigrationState_FreshInstall_CustomPath(t *testing.T) {
 	assert.False(t, state.LegacyRequired, "should not require legacy")
 }
 
+func TestCheckMigrationState_FreshInstall_WarnsAboutNearbyDBFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a .db file that is NOT the configured path
+	existingDB := filepath.Join(tmpDir, "old-birdnet.db")
+	require.NoError(t, os.WriteFile(existingDB, make([]byte, 1024), 0o644))
+
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = filepath.Join(tmpDir, "birdnet.db")
+
+	state := CheckMigrationStateBeforeStartup(settings)
+
+	// Behavior is unchanged: still fresh install
+	assert.True(t, state.FreshInstall, "should still detect fresh install")
+	assert.False(t, state.LegacyRequired)
+	assert.NoError(t, state.Error)
+}
+
 func TestCheckMigrationState_ExistingLegacy_SQLite(t *testing.T) {
 	tmpDir := t.TempDir()
 	legacyPath := filepath.Join(tmpDir, "birdnet.db")

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -416,6 +416,13 @@ func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*Suppor
 		}
 	}
 
+	// Collect deployment context
+	if opts.IncludeDeploymentInfo {
+		getLogger().Debug("support: collecting deployment information")
+		dump.DeploymentInfo = c.collectDeploymentInfo(ctx, opts.AnonymizePII)
+		getLogger().Debug("support: deployment information collected")
+	}
+
 	// Collect app events
 	if opts.IncludeAppEvents && c.appEventsProvider != nil {
 		getLogger().Debug("support: collecting app events")

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -56,13 +56,14 @@ const (
 	logTimeFormat      = "2006-01-02 15:04:05"
 
 	// Archive file names
-	diagnosticsFileName  = "collection_diagnostics.json"
-	metadataFileName     = "metadata.json"
-	configYAMLFileName   = "config.yaml"
-	systemInfoFileName   = "system_info.json"
-	databaseInfoFileName = "database_info.json"
-	appEventsFileName    = "app_events.json"
-	logReadmeFileName    = "logs/README.txt"
+	diagnosticsFileName    = "collection_diagnostics.json"
+	metadataFileName       = "metadata.json"
+	configYAMLFileName     = "config.yaml"
+	systemInfoFileName     = "system_info.json"
+	databaseInfoFileName   = "database_info.json"
+	deploymentInfoFileName = "deployment_info.json"
+	appEventsFileName      = "app_events.json"
+	logReadmeFileName      = "logs/README.txt"
 
 	// Redaction and privacy
 	redactedPlaceholder      = "[redacted]"
@@ -580,6 +581,29 @@ func (c *Collector) CreateArchive(ctx context.Context, dump *SupportDump, opts C
 				Build()
 		}
 		getLogger().Debug("support: database info added successfully")
+	}
+
+	// Add deployment info if collected
+	if dump.DeploymentInfo != nil {
+		getLogger().Debug("support: adding deployment info to archive")
+		deployFile, err := w.Create(deploymentInfoFileName)
+		if err != nil {
+			getLogger().Error("support: failed to create deployment info file in archive", logger.Error(err))
+			return nil, errors.New(err).
+				Component("support").
+				Category(errors.CategoryFileIO).
+				Context("operation", "create_deployment_info_file").
+				Build()
+		}
+		if err := json.NewEncoder(deployFile).Encode(dump.DeploymentInfo); err != nil {
+			getLogger().Error("support: failed to write deployment info to archive", logger.Error(err))
+			return nil, errors.New(err).
+				Component("support").
+				Category(errors.CategoryFileIO).
+				Context("operation", "write_deployment_info").
+				Build()
+		}
+		getLogger().Debug("support: deployment info added successfully")
 	}
 
 	// Add app events if collected

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -333,7 +333,7 @@ func (c *Collector) SetAppEventsProvider(provider AppEventsProvider) {
 // Collect gathers support data based on the provided options
 func (c *Collector) Collect(ctx context.Context, opts CollectorOptions) (*SupportDump, error) {
 	// Validate options
-	if !opts.IncludeLogs && !opts.IncludeConfig && !opts.IncludeSystemInfo && !opts.IncludeDatabaseInfo && !opts.IncludeAppEvents {
+	if !opts.IncludeLogs && !opts.IncludeConfig && !opts.IncludeSystemInfo && !opts.IncludeDatabaseInfo && !opts.IncludeDeploymentInfo && !opts.IncludeAppEvents {
 		getLogger().Error("support: collection validation failed: at least one data type must be included")
 		return nil, errors.Newf("at least one data type must be included in support dump").
 			Component("support").

--- a/internal/support/deployment_collector.go
+++ b/internal/support/deployment_collector.go
@@ -1,0 +1,234 @@
+package support
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
+)
+
+const (
+	systemdServicePath     = "/etc/systemd/system/birdnet-go.service"
+	maxServiceFileSize     = 64 * 1024 // 64KB limit for service files
+	maxDataDirEntries      = 500
+	mountInfoPath          = "/proc/1/mountinfo"
+	dockerEnvPath          = "/.dockerenv"
+	mountInfoMinFields     = 10
+	mountInfoDestIdx       = 4
+	mountInfoSeparatorSkip = 3
+)
+
+// systemMountPrefixes are mount destinations to skip (not useful for diagnostics).
+var systemMountPrefixes = []string{"/proc", "/sys", "/dev", "/run", "/tmp", "/etc/resolv", "/etc/hostname", "/etc/hosts"}
+
+// collectDeploymentInfo gathers deployment context for the support dump.
+func (c *Collector) collectDeploymentInfo(ctx context.Context, anonymizePII bool) *DeploymentInfo {
+	info := &DeploymentInfo{}
+
+	cwd, err := os.Getwd()
+	switch {
+	case err != nil:
+		info.CollectionErrors = append(info.CollectionErrors, "working directory: "+err.Error())
+	case anonymizePII:
+		info.WorkingDirectory = privacy.AnonymizePath(cwd)
+	default:
+		info.WorkingDirectory = cwd
+	}
+
+	if content, err := c.collectSystemdServiceFile(systemdServicePath); err != nil {
+		info.CollectionErrors = append(info.CollectionErrors, "systemd service: "+err.Error())
+	} else {
+		info.SystemdServiceFile = content
+	}
+
+	if files, err := c.collectDataDirectoryListing(anonymizePII); err != nil {
+		info.CollectionErrors = append(info.CollectionErrors, "data directory: "+err.Error())
+	} else {
+		info.DataDirectoryFiles = files
+	}
+
+	if mounts, err := c.collectDockerMounts(ctx, anonymizePII); err != nil {
+		info.CollectionErrors = append(info.CollectionErrors, "docker mounts: "+err.Error())
+	} else {
+		info.DockerMounts = mounts
+	}
+
+	return info
+}
+
+// collectSystemdServiceFile reads and scrubs the systemd service file.
+func (c *Collector) collectSystemdServiceFile(path string) (string, error) {
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if fi.Size() > maxServiceFileSize {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // Path is a constant or test-injected
+	if err != nil {
+		return "", err
+	}
+
+	return c.scrubServiceFileContent(string(data)), nil
+}
+
+// scrubServiceFileContent redacts sensitive Environment= values.
+func (c *Collector) scrubServiceFileContent(content string) string {
+	var result strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Environment=") {
+			line = c.scrubEnvironmentLine(line)
+		}
+		result.WriteString(line)
+		result.WriteByte('\n')
+	}
+	return result.String()
+}
+
+// scrubEnvironmentLine redacts the value of a systemd Environment= line if the key is sensitive.
+func (c *Collector) scrubEnvironmentLine(line string) string {
+	prefix := "Environment="
+	idx := strings.Index(line, prefix)
+	if idx == -1 {
+		return line
+	}
+	kvPart := line[idx+len(prefix):]
+
+	eqIdx := strings.IndexByte(kvPart, '=')
+	if eqIdx == -1 {
+		return line
+	}
+
+	key := kvPart[:eqIdx]
+	lowerKey := strings.ToLower(key)
+	for _, sensitive := range c.sensitiveKeys {
+		if isSensitiveKey(lowerKey, sensitive) {
+			return line[:idx+len(prefix)] + key + "=[REDACTED]"
+		}
+	}
+	return line
+}
+
+// collectDataDirectoryListing lists files in the data directory with metadata.
+func (c *Collector) collectDataDirectoryListing(anonymizePII bool) ([]DataDirectoryFile, error) {
+	entries, err := os.ReadDir(c.dataPath)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]DataDirectoryFile, 0, len(entries))
+	for i, e := range entries {
+		if i >= maxDataDirEntries {
+			getLogger().Warn("data directory listing truncated",
+				logger.Int("limit", maxDataDirEntries),
+				logger.Int("total", len(entries)),
+			)
+			break
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		name := e.Name()
+		if anonymizePII && e.IsDir() {
+			name = privacy.AnonymizePath(name)
+		}
+		files = append(files, DataDirectoryFile{
+			Name:     name,
+			Size:     info.Size(),
+			Modified: info.ModTime(),
+			IsDir:    e.IsDir(),
+		})
+	}
+	return files, nil
+}
+
+// collectDockerMounts reads container mount info from /proc/1/mountinfo.
+func (c *Collector) collectDockerMounts(_ context.Context, anonymizePII bool) ([]DockerMount, error) {
+	if _, err := os.Stat(dockerEnvPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(mountInfoPath) //nolint:gosec // Constant path
+	if err != nil {
+		return nil, err
+	}
+
+	return parseMountInfo(string(data), anonymizePII), nil
+}
+
+// parseMountInfo parses /proc/1/mountinfo format and extracts bind mounts.
+// Format: id parent major:minor root mount-point mount-options ... - fs-type mount-source super-options
+func parseMountInfo(content string, anonymizePII bool) []DockerMount {
+	if content == "" {
+		return nil
+	}
+
+	var mounts []DockerMount
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < mountInfoMinFields {
+			continue
+		}
+
+		source := fields[3]
+		destination := fields[mountInfoDestIdx]
+		options := fields[5]
+
+		// Find the separator "-" to get fs type
+		sepIdx := -1
+		for i, f := range fields {
+			if f == "-" {
+				sepIdx = i
+				break
+			}
+		}
+		if sepIdx == -1 || sepIdx+mountInfoSeparatorSkip > len(fields) {
+			continue
+		}
+		fsType := fields[sepIdx+1]
+
+		// Skip system mounts and root
+		if destination == "/" {
+			continue
+		}
+		skip := false
+		for _, prefix := range systemMountPrefixes {
+			if strings.HasPrefix(destination, prefix) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+
+		if anonymizePII {
+			source = privacy.AnonymizePath(source)
+		}
+
+		mounts = append(mounts, DockerMount{
+			Source:      source,
+			Destination: destination,
+			Type:        fsType,
+			Options:     options,
+		})
+	}
+	return mounts
+}

--- a/internal/support/deployment_collector.go
+++ b/internal/support/deployment_collector.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
 const (
@@ -15,7 +16,6 @@ const (
 	maxServiceFileSize     = 64 * 1024 // 64KB limit for service files
 	maxDataDirEntries      = 500
 	mountInfoPath          = "/proc/1/mountinfo"
-	dockerEnvPath          = "/.dockerenv"
 	mountInfoMinFields     = 10
 	mountInfoDestIdx       = 4
 	mountInfoSeparatorSkip = 3
@@ -69,6 +69,10 @@ func (c *Collector) collectSystemdServiceFile(path string) (string, error) {
 		return "", err
 	}
 	if fi.Size() > maxServiceFileSize {
+		getLogger().Warn("systemd service file too large, skipping",
+			logger.Int64("size", fi.Size()),
+			logger.Int("limit", maxServiceFileSize),
+		)
 		return "", nil
 	}
 
@@ -104,6 +108,8 @@ func (c *Collector) scrubEnvironmentLine(line string) string {
 		return line
 	}
 	kvPart := line[idx+len(prefix):]
+	// Strip surrounding quotes (systemd supports Environment="KEY=value")
+	kvPart = strings.Trim(kvPart, `"'`)
 
 	eqIdx := strings.IndexByte(kvPart, '=')
 	if eqIdx == -1 {
@@ -156,7 +162,7 @@ func (c *Collector) collectDataDirectoryListing(anonymizePII bool) ([]DataDirect
 
 // collectDockerMounts reads container mount info from /proc/1/mountinfo.
 func (c *Collector) collectDockerMounts(_ context.Context, anonymizePII bool) ([]DockerMount, error) {
-	if _, err := os.Stat(dockerEnvPath); os.IsNotExist(err) {
+	if !sysinfo.IsContainer() {
 		return nil, nil
 	}
 

--- a/internal/support/deployment_collector.go
+++ b/internal/support/deployment_collector.go
@@ -111,7 +111,7 @@ func (c *Collector) scrubEnvironmentLine(line string) string {
 
 	// Detect and strip surrounding quotes, preserving them for output
 	var quoteChar string
-	if len(kvPart) >= 2 && (kvPart[0] == '"' || kvPart[0] == '\'') {
+	if len(kvPart) >= 2 && (kvPart[0] == '"' || kvPart[0] == '\'') && kvPart[len(kvPart)-1] == kvPart[0] {
 		quoteChar = string(kvPart[0])
 		kvPart = kvPart[1 : len(kvPart)-1]
 	}

--- a/internal/support/deployment_collector.go
+++ b/internal/support/deployment_collector.go
@@ -108,8 +108,13 @@ func (c *Collector) scrubEnvironmentLine(line string) string {
 		return line
 	}
 	kvPart := line[idx+len(prefix):]
-	// Strip surrounding quotes (systemd supports Environment="KEY=value")
-	kvPart = strings.Trim(kvPart, `"'`)
+
+	// Detect and strip surrounding quotes, preserving them for output
+	var quoteChar string
+	if len(kvPart) >= 2 && (kvPart[0] == '"' || kvPart[0] == '\'') {
+		quoteChar = string(kvPart[0])
+		kvPart = kvPart[1 : len(kvPart)-1]
+	}
 
 	eqIdx := strings.IndexByte(kvPart, '=')
 	if eqIdx == -1 {
@@ -120,7 +125,7 @@ func (c *Collector) scrubEnvironmentLine(line string) string {
 	lowerKey := strings.ToLower(key)
 	for _, sensitive := range c.sensitiveKeys {
 		if isSensitiveKey(lowerKey, sensitive) {
-			return line[:idx+len(prefix)] + key + "=[REDACTED]"
+			return line[:idx+len(prefix)] + quoteChar + key + "=[REDACTED]" + quoteChar
 		}
 	}
 	return line
@@ -133,7 +138,11 @@ func (c *Collector) collectDataDirectoryListing(anonymizePII bool) ([]DataDirect
 		return nil, err
 	}
 
-	files := make([]DataDirectoryFile, 0, len(entries))
+	allocSize := len(entries)
+	if allocSize > maxDataDirEntries {
+		allocSize = maxDataDirEntries
+	}
+	files := make([]DataDirectoryFile, 0, allocSize)
 	for i, e := range entries {
 		if i >= maxDataDirEntries {
 			getLogger().Warn("data directory listing truncated",

--- a/internal/support/deployment_collector_test.go
+++ b/internal/support/deployment_collector_test.go
@@ -12,7 +12,7 @@ import (
 // --- Systemd service file tests ---
 
 func TestCollectSystemdServiceFile_MissingFile(t *testing.T) {
-	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	c := &Collector{sensitiveKeys: DefaultSensitiveKeys()}
 	content, err := c.collectSystemdServiceFile("/nonexistent/path/birdnet-go.service")
 	require.NoError(t, err)
 	assert.Empty(t, content)
@@ -24,7 +24,7 @@ func TestCollectSystemdServiceFile_BasicContent(t *testing.T) {
 	serviceContent := "[Unit]\nDescription=BirdNET-Go\nAfter=network.target\n\n[Service]\nType=simple\nWorkingDirectory=/home/user/birdnet-go-app/data\nExecStart=/usr/local/bin/birdnet-go\nRestart=always\n\n[Install]\nWantedBy=multi-user.target\n"
 	require.NoError(t, os.WriteFile(servicePath, []byte(serviceContent), 0o644))
 
-	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	c := &Collector{sensitiveKeys: DefaultSensitiveKeys()}
 	content, err := c.collectSystemdServiceFile(servicePath)
 	require.NoError(t, err)
 	assert.Contains(t, content, "WorkingDirectory=/home/user/birdnet-go-app/data")
@@ -37,7 +37,7 @@ func TestCollectSystemdServiceFile_ScrubsSensitiveEnvVars(t *testing.T) {
 	serviceContent := "[Service]\nEnvironment=DATA_DIR=/data\nEnvironment=BIRDWEATHER_ID=abc123secret\nEnvironment=MQTT_PASSWORD=supersecret\nExecStart=/usr/local/bin/birdnet-go\n"
 	require.NoError(t, os.WriteFile(servicePath, []byte(serviceContent), 0o644))
 
-	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	c := &Collector{sensitiveKeys: DefaultSensitiveKeys()}
 	content, err := c.collectSystemdServiceFile(servicePath)
 	require.NoError(t, err)
 	assert.Contains(t, content, "DATA_DIR=/data")
@@ -52,7 +52,7 @@ func TestCollectSystemdServiceFile_ScrubsQuotedEnvVars(t *testing.T) {
 	serviceContent := "[Service]\nEnvironment=\"MQTT_PASSWORD=supersecret\"\nEnvironment='BIRDWEATHER_ID=abc123'\n"
 	require.NoError(t, os.WriteFile(servicePath, []byte(serviceContent), 0o644))
 
-	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	c := &Collector{sensitiveKeys: DefaultSensitiveKeys()}
 	content, err := c.collectSystemdServiceFile(servicePath)
 	require.NoError(t, err)
 	// Quotes must be preserved in redacted output
@@ -144,7 +144,7 @@ func TestCollectDeploymentInfo_Orchestration(t *testing.T) {
 
 	c := &Collector{
 		dataPath:      tmpDir,
-		sensitiveKeys: defaultSensitiveKeys(),
+		sensitiveKeys: DefaultSensitiveKeys(),
 	}
 	info := c.collectDeploymentInfo(t.Context(), false)
 

--- a/internal/support/deployment_collector_test.go
+++ b/internal/support/deployment_collector_test.go
@@ -46,6 +46,19 @@ func TestCollectSystemdServiceFile_ScrubsSensitiveEnvVars(t *testing.T) {
 	assert.Contains(t, content, "ExecStart=/usr/local/bin/birdnet-go")
 }
 
+func TestCollectSystemdServiceFile_ScrubsQuotedEnvVars(t *testing.T) {
+	tmpDir := t.TempDir()
+	servicePath := filepath.Join(tmpDir, "birdnet-go.service")
+	serviceContent := "[Service]\nEnvironment=\"MQTT_PASSWORD=supersecret\"\nEnvironment='BIRDWEATHER_ID=abc123'\n"
+	require.NoError(t, os.WriteFile(servicePath, []byte(serviceContent), 0o644))
+
+	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	content, err := c.collectSystemdServiceFile(servicePath)
+	require.NoError(t, err)
+	assert.Contains(t, content, "MQTT_PASSWORD=[REDACTED]")
+	assert.Contains(t, content, "BIRDWEATHER_ID=[REDACTED]")
+}
+
 // --- Data directory listing tests ---
 
 func TestCollectDataDirectoryListing_EmptyDir(t *testing.T) {

--- a/internal/support/deployment_collector_test.go
+++ b/internal/support/deployment_collector_test.go
@@ -55,8 +55,9 @@ func TestCollectSystemdServiceFile_ScrubsQuotedEnvVars(t *testing.T) {
 	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
 	content, err := c.collectSystemdServiceFile(servicePath)
 	require.NoError(t, err)
-	assert.Contains(t, content, "MQTT_PASSWORD=[REDACTED]")
-	assert.Contains(t, content, "BIRDWEATHER_ID=[REDACTED]")
+	// Quotes must be preserved in redacted output
+	assert.Contains(t, content, `Environment="MQTT_PASSWORD=[REDACTED]"`)
+	assert.Contains(t, content, `Environment='BIRDWEATHER_ID=[REDACTED]'`)
 }
 
 // --- Data directory listing tests ---

--- a/internal/support/deployment_collector_test.go
+++ b/internal/support/deployment_collector_test.go
@@ -1,0 +1,142 @@
+package support
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Systemd service file tests ---
+
+func TestCollectSystemdServiceFile_MissingFile(t *testing.T) {
+	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	content, err := c.collectSystemdServiceFile("/nonexistent/path/birdnet-go.service")
+	require.NoError(t, err)
+	assert.Empty(t, content)
+}
+
+func TestCollectSystemdServiceFile_BasicContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	servicePath := filepath.Join(tmpDir, "birdnet-go.service")
+	serviceContent := "[Unit]\nDescription=BirdNET-Go\nAfter=network.target\n\n[Service]\nType=simple\nWorkingDirectory=/home/user/birdnet-go-app/data\nExecStart=/usr/local/bin/birdnet-go\nRestart=always\n\n[Install]\nWantedBy=multi-user.target\n"
+	require.NoError(t, os.WriteFile(servicePath, []byte(serviceContent), 0o644))
+
+	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	content, err := c.collectSystemdServiceFile(servicePath)
+	require.NoError(t, err)
+	assert.Contains(t, content, "WorkingDirectory=/home/user/birdnet-go-app/data")
+	assert.Contains(t, content, "ExecStart=/usr/local/bin/birdnet-go")
+}
+
+func TestCollectSystemdServiceFile_ScrubsSensitiveEnvVars(t *testing.T) {
+	tmpDir := t.TempDir()
+	servicePath := filepath.Join(tmpDir, "birdnet-go.service")
+	serviceContent := "[Service]\nEnvironment=DATA_DIR=/data\nEnvironment=BIRDWEATHER_ID=abc123secret\nEnvironment=MQTT_PASSWORD=supersecret\nExecStart=/usr/local/bin/birdnet-go\n"
+	require.NoError(t, os.WriteFile(servicePath, []byte(serviceContent), 0o644))
+
+	c := &Collector{sensitiveKeys: defaultSensitiveKeys()}
+	content, err := c.collectSystemdServiceFile(servicePath)
+	require.NoError(t, err)
+	assert.Contains(t, content, "DATA_DIR=/data")
+	assert.Contains(t, content, "BIRDWEATHER_ID=[REDACTED]")
+	assert.Contains(t, content, "MQTT_PASSWORD=[REDACTED]")
+	assert.Contains(t, content, "ExecStart=/usr/local/bin/birdnet-go")
+}
+
+// --- Data directory listing tests ---
+
+func TestCollectDataDirectoryListing_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	c := &Collector{dataPath: tmpDir}
+
+	files, err := c.collectDataDirectoryListing(false)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestCollectDataDirectoryListing_WithFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "birdnet.db"), make([]byte, 1024), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "birdnet.db-wal"), make([]byte, 512), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(tmpDir, "logs"), 0o755))
+
+	c := &Collector{dataPath: tmpDir}
+	files, err := c.collectDataDirectoryListing(false)
+	require.NoError(t, err)
+	assert.Len(t, files, 3)
+
+	var dbFile *DataDirectoryFile
+	for i := range files {
+		if files[i].Name == "birdnet.db" {
+			dbFile = &files[i]
+			break
+		}
+	}
+	require.NotNil(t, dbFile)
+	assert.Equal(t, int64(1024), dbFile.Size)
+	assert.False(t, dbFile.IsDir)
+}
+
+func TestCollectDataDirectoryListing_NonexistentDir(t *testing.T) {
+	c := &Collector{dataPath: "/nonexistent/path"}
+	files, err := c.collectDataDirectoryListing(false)
+	require.Error(t, err)
+	assert.Nil(t, files)
+}
+
+// --- Docker mount tests ---
+
+func TestParseMountInfo_BasicMounts(t *testing.T) {
+	mountInfo := "22 1 8:1 / / rw,relatime - ext4 /dev/sda1 rw\n29 22 0:26 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw\n35 22 0:27 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw\n45 22 8:1 /home/user/data /data rw,relatime - ext4 /dev/sda1 rw\n50 22 8:1 /home/user/config /config rw,relatime - ext4 /dev/sda1 rw\n"
+
+	mounts := parseMountInfo(mountInfo, false)
+
+	assert.Len(t, mounts, 2)
+	assert.Equal(t, "/home/user/data", mounts[0].Source)
+	assert.Equal(t, "/data", mounts[0].Destination)
+	assert.Equal(t, "ext4", mounts[0].Type)
+}
+
+func TestParseMountInfo_AnonymizesPII(t *testing.T) {
+	mountInfo := "45 22 8:1 /home/user/data /data rw,relatime - ext4 /dev/sda1 rw\n"
+	mounts := parseMountInfo(mountInfo, true)
+
+	require.Len(t, mounts, 1)
+	assert.NotEqual(t, "/home/user/data", mounts[0].Source)
+	assert.Equal(t, "/data", mounts[0].Destination)
+}
+
+func TestParseMountInfo_EmptyInput(t *testing.T) {
+	mounts := parseMountInfo("", false)
+	assert.Empty(t, mounts)
+}
+
+func TestCollectDockerMounts_NotInContainer(t *testing.T) {
+	c := &Collector{}
+	mounts, err := c.collectDockerMounts(t.Context(), false)
+	require.NoError(t, err)
+	assert.Nil(t, mounts)
+}
+
+// --- Orchestration test ---
+
+func TestCollectDeploymentInfo_Orchestration(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "birdnet.db"), make([]byte, 2048), 0o644))
+
+	c := &Collector{
+		dataPath:      tmpDir,
+		sensitiveKeys: defaultSensitiveKeys(),
+	}
+	info := c.collectDeploymentInfo(t.Context(), false)
+
+	assert.NotEmpty(t, info.WorkingDirectory)
+	assert.Len(t, info.DataDirectoryFiles, 1)
+	assert.Equal(t, "birdnet.db", info.DataDirectoryFiles[0].Name)
+	assert.Empty(t, info.SystemdServiceFile)
+	assert.Nil(t, info.DockerMounts)
+}

--- a/internal/support/types.go
+++ b/internal/support/types.go
@@ -10,17 +10,18 @@ import (
 // and system information used for troubleshooting and debugging BirdNET-Go issues.
 // The data is privacy-scrubbed before collection to remove sensitive information.
 type SupportDump struct {
-	ID           string                `json:"id"`
-	Timestamp    time.Time             `json:"timestamp"`
-	SystemID     string                `json:"system_id"`
-	Version      string                `json:"version"`
-	Logs         []LogEntry            `json:"logs"`
-	Config       map[string]any        `json:"config"`
-	SystemInfo   SystemInfo            `json:"system_info"`
-	Attachments  []AttachmentInfo      `json:"attachments"`
-	Diagnostics  CollectionDiagnostics `json:"diagnostics"`             // Diagnostic information about collection process
-	DatabaseInfo *DatabaseInfo         `json:"database_info,omitempty"` // Database schema and health diagnostics
-	AppEvents    []AppEventEntry       `json:"app_events,omitempty"`    // Recent application events
+	ID             string                `json:"id"`
+	Timestamp      time.Time             `json:"timestamp"`
+	SystemID       string                `json:"system_id"`
+	Version        string                `json:"version"`
+	Logs           []LogEntry            `json:"logs"`
+	Config         map[string]any        `json:"config"`
+	SystemInfo     SystemInfo            `json:"system_info"`
+	Attachments    []AttachmentInfo      `json:"attachments"`
+	Diagnostics    CollectionDiagnostics `json:"diagnostics"`               // Diagnostic information about collection process
+	DatabaseInfo   *DatabaseInfo         `json:"database_info,omitempty"`   // Database schema and health diagnostics
+	DeploymentInfo *DeploymentInfo       `json:"deployment_info,omitempty"` // Deployment context for troubleshooting
+	AppEvents      []AppEventEntry       `json:"app_events,omitempty"`      // Recent application events
 }
 
 // LogEntry represents a single log entry from application logs or system journals.
@@ -76,15 +77,16 @@ type AttachmentInfo struct {
 // It allows users to control which types of information are included based on
 // their privacy preferences and the specific issue being debugged.
 type CollectorOptions struct {
-	IncludeLogs         bool          `json:"include_logs"`
-	IncludeConfig       bool          `json:"include_config"`
-	IncludeSystemInfo   bool          `json:"include_system_info"`
-	IncludeDatabaseInfo bool          `json:"include_database_info"`
-	IncludeAppEvents    bool          `json:"include_app_events"`
-	LogDuration         time.Duration `json:"log_duration"`
-	MaxLogSize          int64         `json:"max_log_size"`
-	ScrubSensitive      bool          `json:"scrub_sensitive"`
-	AnonymizePII        bool          `json:"anonymize_pii"`
+	IncludeLogs           bool          `json:"include_logs"`
+	IncludeConfig         bool          `json:"include_config"`
+	IncludeSystemInfo     bool          `json:"include_system_info"`
+	IncludeDatabaseInfo   bool          `json:"include_database_info"`
+	IncludeDeploymentInfo bool          `json:"include_deployment_info"`
+	IncludeAppEvents      bool          `json:"include_app_events"`
+	LogDuration           time.Duration `json:"log_duration"`
+	MaxLogSize            int64         `json:"max_log_size"`
+	ScrubSensitive        bool          `json:"scrub_sensitive"`
+	AnonymizePII          bool          `json:"anonymize_pii"`
 }
 
 // CollectionDiagnostics contains diagnostic information about the support data collection process.
@@ -151,15 +153,16 @@ type TimeRange struct {
 // includes all data types, 4-week log window, 50MB max log size, sensitive data scrubbing and PII anonymization enabled.
 func DefaultCollectorOptions() CollectorOptions {
 	return CollectorOptions{
-		IncludeLogs:         true,
-		IncludeConfig:       true,
-		IncludeSystemInfo:   true,
-		IncludeDatabaseInfo: true,
-		IncludeAppEvents:    true,
-		LogDuration:         defaultLogDurationWeeks * 7 * 24 * time.Hour, // 4 weeks
-		MaxLogSize:          defaultMaxLogSizeMB * bytesPerMB,             // 50MB to accommodate more logs
-		ScrubSensitive:      true,
-		AnonymizePII:        true,
+		IncludeLogs:           true,
+		IncludeConfig:         true,
+		IncludeSystemInfo:     true,
+		IncludeDatabaseInfo:   true,
+		IncludeDeploymentInfo: true,
+		IncludeAppEvents:      true,
+		LogDuration:           defaultLogDurationWeeks * 7 * 24 * time.Hour, // 4 weeks
+		MaxLogSize:            defaultMaxLogSizeMB * bytesPerMB,             // 50MB to accommodate more logs
+		ScrubSensitive:        true,
+		AnonymizePII:          true,
 	}
 }
 
@@ -234,6 +237,32 @@ type MigrationStateInfo struct {
 	ErrorMessage     string  `json:"error_message,omitempty"`
 	RelatedDataError string  `json:"related_data_error,omitempty"`
 	DirtyRecordCount int64   `json:"dirty_record_count,omitempty"`
+}
+
+// DeploymentInfo contains deployment context for troubleshooting path mismatches
+// and configuration issues. Collected as part of support dumps.
+type DeploymentInfo struct {
+	WorkingDirectory   string              `json:"working_directory"`
+	SystemdServiceFile string              `json:"systemd_service_file,omitempty"`
+	DataDirectoryFiles []DataDirectoryFile `json:"data_directory_files,omitempty"`
+	DockerMounts       []DockerMount       `json:"docker_mounts,omitempty"`
+	CollectionErrors   []string            `json:"collection_errors,omitempty"`
+}
+
+// DataDirectoryFile describes a file in the data directory.
+type DataDirectoryFile struct {
+	Name     string    `json:"name"`
+	Size     int64     `json:"size"`
+	Modified time.Time `json:"modified"`
+	IsDir    bool      `json:"is_dir"`
+}
+
+// DockerMount describes a mount point visible inside a container.
+type DockerMount struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	Type        string `json:"type"`
+	Options     string `json:"options,omitempty"`
 }
 
 // AppEventEntry is a support-package-local representation of an application event.


### PR DESCRIPTION
## Summary

Improves diagnostic visibility for database startup decisions and adds deployment context to support dumps. Motivated by GitHub #3211 where an upgrade incorrectly detected a fresh install despite an existing 110MB database, and the logs provided no way to understand why.

**Startup logging:**
- Add structured path check log in `checkSQLiteMigrationState` capturing working directory, configured path (relative + absolute), file existence, and sizes for both the configured database and v2 migration sidecar
- Add decision outcome log (`logStartupDecision`) at every return point: `fresh_install`, `v2_restart`, `legacy_mode`, `stale_sidecar_fallback`, `v2_corrupted`, `migration_<state>`
- Add safety check: when fresh install is detected, scan the data directory for existing `.db` files and warn about each one (diagnostic only, no behavior change)

**Support dump deployment context:**
- New `DeploymentInfo` type with working directory, systemd service file, data directory listing, and Docker mount info
- New `deployment_collector.go`: reads systemd service file with sensitive env var scrubbing (handles both unquoted and quoted `Environment=` values), lists data directory files with sizes and modification times, parses `/proc/1/mountinfo` for container bind mounts
- Uses `sysinfo.IsContainer()` for container detection (covers Docker, Podman, LXC, systemd-nspawn)
- Writes `deployment_info.json` to the support dump archive
- All collection is best-effort: errors recorded in `CollectionErrors`, never propagated
- Privacy: working directory and mount source paths anonymized when PII mode is on

## Test Plan

- [x] `go test -race ./internal/datastore/v2/ -run TestCheckMigrationState` (10 tests pass, including new `WarnsAboutNearbyDBFiles`)
- [x] `go test -race ./internal/support/` (153 tests pass, including 12 new deployment collector tests)
- [x] `golangci-lint run` clean on all changed packages
- [x] `go build ./...` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support dumps now include deployment context by default (working dir, service config, data-directory listing, and container mount diagnostics), with sensitive values redacted.
  * Deployment context is added to support archives as a deployment_info JSON entry.

* **Bug Fixes / Reliability**
  * Database startup emits richer decision logs and warnings (including detection of nearby DB files) to improve troubleshooting.

* **Tests**
  * Added tests for deployment info collection and fresh-install/migration-state detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->