### PR TITLE
fix(datastore): tolerate extra columns from schema evolution in v2 init

### DIFF
--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -514,13 +514,6 @@ func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 		}
 
 		reportSchemaEvolution(tableName, unexpected, rowCount)
-
-		// Emit app event for support dump visibility
-		events.Emit(context.Background(), "database", "schema_evolution", "Extra columns detected from schema evolution", map[string]any{
-			"table":              tableName,
-			"unexpected_columns": unexpected,
-			"row_count":          rowCount,
-		})
 	}
 	return nil
 }

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -126,6 +126,28 @@ func reportInitFailure(dbType, operation string, err error, paths ...string) {
 	})
 }
 
+// reportSchemaEvolution reports extra columns from schema evolution to Sentry telemetry.
+// These are harmless leftovers from earlier entity versions that GORM never drops.
+func reportSchemaEvolution(tableName string, unexpected []string, rowCount int64) {
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("component", "datastore-init")
+		scope.SetTag("db_type", "sqlite")
+		scope.SetTag("operation", "schema_evolution_detected")
+		scope.SetTag("table", tableName)
+		scope.SetFingerprint([]string{"schema-evolution", tableName})
+		scope.SetContext("schema_evolution", map[string]any{
+			"table":              tableName,
+			"unexpected_columns": unexpected,
+			"row_count":          rowCount,
+		})
+		telemetry.CaptureMessage(
+			fmt.Sprintf("Schema evolution: table %s has %d extra column(s)", tableName, len(unexpected)),
+			sentry.LevelWarning,
+			"datastore-init",
+		)
+	})
+}
+
 // SQLiteManager handles the v2 normalized database for SQLite.
 type SQLiteManager struct {
 	db     *gorm.DB
@@ -261,9 +283,9 @@ func (m *SQLiteManager) Initialize() error {
 		}
 	}
 
-	// Validate schema integrity: detect unexpected columns from legacy contamination.
+	// Validate schema integrity: detect unexpected columns from schema evolution.
 	// Empty contaminated tables are dropped so AutoMigrate can recreate them cleanly.
-	// Populated contaminated tables return ErrV2SchemaCorrupted for manual intervention.
+	// Populated tables with extra columns are tolerated (logged, reported to Sentry).
 	if err := m.validateV2SchemaIntegrity(); err != nil {
 		return fmt.Errorf("v2 schema integrity check failed: %w", err)
 	}
@@ -401,12 +423,14 @@ func (m *SQLiteManager) cleanupLegacySchemaContamination() error {
 }
 
 // validateV2SchemaIntegrity checks all v2 tables for unexpected columns that
-// indicate legacy schema contamination. For each table:
+// indicate legacy schema contamination or schema evolution leftovers. For each table:
 //   - If the table doesn't exist yet, skip (AutoMigrate will create it).
 //   - If unexpected columns are found and the table is empty, drop it so
 //     AutoMigrate can recreate it with the correct schema.
-//   - If unexpected columns are found and the table has data, return
-//     ErrV2SchemaCorrupted so the caller can trigger self-healing or notify the user.
+//   - If unexpected columns are found and the table has data, log a warning
+//     but continue. Extra columns are harmless: GORM ignores them when querying.
+//     This prevents the cascade failure from Discussion #3210 where users upgrading
+//     from older builds were blocked by columns that existed in earlier entity versions.
 func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 	migrator := m.db.Migrator()
 
@@ -477,8 +501,26 @@ func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 			continue
 		}
 
-		return fmt.Errorf("%w: table %s has unexpected columns %v (%d rows): manual cleanup required",
-			ErrV2SchemaCorrupted, tableName, unexpected, rowCount)
+		// Populated table with extra columns: warn but continue.
+		// Extra columns from schema evolution are harmless; GORM ignores them.
+		// Blocking initialization here causes the cascade failure described in
+		// Discussion #3210 (v2 init fails -> legacy fallback -> NOT NULL crash).
+		if m.log != nil {
+			m.log.Warn("table has extra columns from schema evolution, continuing",
+				logger.String("table", tableName),
+				logger.Any("unexpected_columns", unexpected),
+				logger.Int64("row_count", rowCount),
+				logger.String("operation", "validate_schema_integrity"))
+		}
+
+		reportSchemaEvolution(tableName, unexpected, rowCount)
+
+		// Emit app event for support dump visibility
+		events.Emit(context.Background(), "database", "schema_evolution", "Extra columns detected from schema evolution", map[string]any{
+			"table":              tableName,
+			"unexpected_columns": unexpected,
+			"row_count":          rowCount,
+		})
 	}
 	return nil
 }

--- a/internal/datastore/v2/manager_test.go
+++ b/internal/datastore/v2/manager_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
-	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 func TestNewSQLiteManager(t *testing.T) {
@@ -660,7 +659,7 @@ func TestValidateV2SchemaIntegrity_DetectsContamination(t *testing.T) {
 		"image_caches should have been dropped because it was empty and contaminated")
 }
 
-func TestValidateV2SchemaIntegrity_ErrorsOnPopulatedContamination(t *testing.T) {
+func TestValidateV2SchemaIntegrity_ToleratesPopulatedContamination(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
@@ -686,13 +685,11 @@ func TestValidateV2SchemaIntegrity_ErrorsOnPopulatedContamination(t *testing.T) 
 	err = mgr.DB().Exec("ALTER TABLE image_caches ADD COLUMN bogus_column TEXT DEFAULT ''").Error
 	require.NoError(t, err)
 
-	// Run validation — should return an error for the populated contaminated table
+	// Run validation: extra columns in populated tables are tolerated (warn, not error).
+	// This changed from the original behavior (ErrV2SchemaCorrupted) to prevent
+	// the cascade failure from Discussion #3210.
 	err = mgr.validateV2SchemaIntegrity()
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrV2SchemaCorrupted),
-		"error should wrap ErrV2SchemaCorrupted, got: %v", err)
-	assert.Contains(t, err.Error(), "bogus_column",
-		"error should mention the unexpected column name")
+	require.NoError(t, err, "extra columns in populated tables should be tolerated")
 }
 
 func TestValidateV2SchemaIntegrity_PassesCleanSchema(t *testing.T) {
@@ -709,6 +706,83 @@ func TestValidateV2SchemaIntegrity_PassesCleanSchema(t *testing.T) {
 	// Run validation on a clean schema - should pass with no error
 	err = mgr.validateV2SchemaIntegrity()
 	require.NoError(t, err)
+}
+
+// TestSchemaEvolution_ExtraColumnsDoNotBlockInitialize reproduces Discussion #3210:
+// a database created on an earlier nightly has extra columns from schema evolution
+// (e.g. label_count in ai_models, label_type/taxonomic_class in labels).
+// These extra columns are harmless (GORM ignores them) and must not prevent
+// Initialize from running AutoMigrate.
+func TestSchemaEvolution_ExtraColumnsDoNotBlockInitialize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Step 1: Create a clean v2 database
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	err = mgr.Initialize()
+	require.NoError(t, err)
+
+	// Step 2: Add extra columns that simulate schema evolution
+	// (columns that existed in earlier entity versions but were later removed)
+	extraColumns := []struct {
+		table  string
+		column string
+		sql    string
+	}{
+		{"ai_models", "label_count", "ALTER TABLE ai_models ADD COLUMN label_count INTEGER DEFAULT 0"},
+		{"labels", "label_type", "ALTER TABLE labels ADD COLUMN label_type TEXT DEFAULT 'species'"},
+		{"labels", "taxonomic_class", "ALTER TABLE labels ADD COLUMN taxonomic_class TEXT DEFAULT ''"},
+		{"detections", "sensitivity", "ALTER TABLE detections ADD COLUMN sensitivity REAL"},
+		{"detections", "threshold", "ALTER TABLE detections ADD COLUMN threshold REAL"},
+		{"detections", "created_at", "ALTER TABLE detections ADD COLUMN created_at DATETIME"},
+		{"daily_events", "created_at", "ALTER TABLE daily_events ADD COLUMN created_at DATETIME"},
+		{"daily_events", "updated_at", "ALTER TABLE daily_events ADD COLUMN updated_at DATETIME"},
+	}
+	for _, ec := range extraColumns {
+		err = mgr.DB().Exec(ec.sql).Error
+		require.NoError(t, err, "failed to add %s.%s", ec.table, ec.column)
+	}
+
+	// Step 3: Insert data into contaminated tables (mimics a real user's database)
+	// ai_models already has a seeded row from Initialize, so just update it with the extra column
+	err = mgr.DB().Exec("UPDATE ai_models SET label_count = 6522 WHERE name = 'BirdNET'").Error
+	require.NoError(t, err)
+	err = mgr.DB().Exec("INSERT INTO daily_events (date, sunrise, sunset, country, city_name) VALUES ('2026-05-20', 1716184800, 1716228000, 'US', 'Test City')").Error
+	require.NoError(t, err)
+
+	// Insert a label so we can insert a detection with valid FK
+	err = mgr.DB().Exec("INSERT INTO labels (scientific_name, model_id, label_type_id) VALUES ('Turdus merula', 1, 1)").Error
+	require.NoError(t, err)
+	// Insert a detection row so the table is populated (mimics 463K detections in user's DB)
+	err = mgr.DB().Exec("INSERT INTO detections (model_id, label_id, detected_at, confidence) VALUES (1, 1, 1716184800, 0.85)").Error
+	require.NoError(t, err)
+
+	// Close and reopen to simulate app restart after upgrade
+	err = mgr.Close()
+	require.NoError(t, err)
+
+	// Step 4: Re-open and Initialize (simulating upgrade to newer build)
+	mgr2, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr2.Close() })
+
+	// This is the critical assertion: Initialize must succeed despite extra columns.
+	// Before the fix, validateV2SchemaIntegrity() would return ErrV2SchemaCorrupted
+	// and block AutoMigrate from running.
+	err = mgr2.Initialize()
+	require.NoError(t, err, "Initialize must succeed with harmless extra columns from schema evolution")
+
+	// Verify that the extra columns still exist (they're harmless, not dropped)
+	var colCount int64
+	err = mgr2.DB().Raw("SELECT COUNT(*) FROM pragma_table_info('ai_models') WHERE name = 'label_count'").Scan(&colCount).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), colCount, "extra columns should be preserved (harmless)")
+
+	// Verify GORM operations work despite extra columns
+	var models []entities.AIModel
+	err = mgr2.DB().Find(&models).Error
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(models), 1, "should be able to query with extra columns present")
 }
 
 func TestSQLiteManager_Close_NilsOutDB(t *testing.T) {

--- a/internal/datastore/v2/manager_test.go
+++ b/internal/datastore/v2/manager_test.go
@@ -719,6 +719,7 @@ func TestSchemaEvolution_ExtraColumnsDoNotBlockInitialize(t *testing.T) {
 	// Step 1: Create a clean v2 database
 	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
 	err = mgr.Initialize()
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

- `validateV2SchemaIntegrity()` now warns and continues when it finds extra columns in populated v2 tables, instead of returning `ErrV2SchemaCorrupted` which blocked `AutoMigrate` from running
- Adds Sentry telemetry (`reportSchemaEvolution` helper) and app event emission for observability in support dumps
- Fixes the cascade failure from Discussion #3210 where users upgrading from older nightly builds were blocked by harmless leftover columns from schema evolution

## Root Cause

V2 entity structs went through several iterations during development (e.g., `LabelCount` in AIModel, `Sensitivity`/`Threshold` in Detection). When these fields were removed from the structs, GORM AutoMigrate never drops the corresponding database columns (documented behavior). The overly strict `validateV2SchemaIntegrity()` treated these harmless extra columns as fatal schema corruption, causing: v2 init failure -> silent legacy fallback -> legacy AutoMigrate tries to add `species_name NOT NULL` (no DEFAULT) to a populated table -> SQLite refuses -> app crash.

## Test plan

- [x] New test `TestSchemaEvolution_ExtraColumnsDoNotBlockInitialize` reproduces Discussion #3210 scenario end-to-end
- [x] Updated `TestValidateV2SchemaIntegrity_ToleratesPopulatedContamination` verifies the behavioral change
- [x] All 129 v2 package tests pass with `-race`
- [x] All 156 analysis package tests pass with `-race`
- [x] `golangci-lint run -v` clean
- [x] Gate review (5 agents + Gemini) completed, all findings addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initialization no longer fails when existing populated tables contain unexpected extra columns; this prevents startup blocking during schema evolution.

* **Improvements**
  * Added telemetry warnings for detected extra/unexpected columns (including table and row context) to aid monitoring and diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->