### PR TITLE
fix(datastore): add schema evolution validation to MySQL and fix DSN separator

### DIFF
--- a/internal/analysis/database_migration.go
+++ b/internal/analysis/database_migration.go
@@ -357,6 +357,7 @@ func initializeMySQLMigrationInfrastructure(settings *conf.Settings, ds datastor
 		Database:    settings.Output.MySQL.Database,
 		UseV2Prefix: true, // v2_ prefix avoids collisions with legacy auxiliary tables
 		Debug:       settings.Debug,
+		Logger:      log,
 	})
 	if err != nil {
 		return nil, errors.New(err).
@@ -461,6 +462,7 @@ func initializeV2OnlyMode(settings *conf.Settings) (*v2only.Datastore, error) {
 			Database:    settings.Output.MySQL.Database,
 			UseV2Prefix: useV2Prefix,
 			Debug:       settings.Debug,
+			Logger:      log,
 		})
 
 	default:

--- a/internal/analysis/database_service.go
+++ b/internal/analysis/database_service.go
@@ -411,7 +411,12 @@ func initializeV2WithSelfHealing(manager datastoreV2.Manager, v2Path string, log
 // empty and no migration is in progress.
 func isV2DatabaseSafeToDelete(dbPath string, log logger.Logger) bool {
 	// Open database in read-only mode.
-	dsn := dbPath + "?mode=ro&_journal_mode=WAL&_busy_timeout=5000"
+	// Use safe separator in case dbPath already contains query parameters.
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		sep = "&"
+	}
+	dsn := dbPath + sep + "mode=ro&_journal_mode=WAL&_busy_timeout=5000"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gorm_logger.Default.LogMode(gorm_logger.Silent),
 	})

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -128,10 +128,10 @@ func reportInitFailure(dbType, operation string, err error, paths ...string) {
 
 // reportSchemaEvolution reports extra columns from schema evolution to Sentry telemetry.
 // These are harmless leftovers from earlier entity versions that GORM never drops.
-func reportSchemaEvolution(tableName string, unexpected []string, rowCount int64) {
+func reportSchemaEvolution(dbType, tableName string, unexpected []string, rowCount int64) {
 	sentry.WithScope(func(scope *sentry.Scope) {
 		scope.SetTag("component", "datastore-init")
-		scope.SetTag("db_type", "sqlite")
+		scope.SetTag("db_type", dbType)
 		scope.SetTag("operation", "schema_evolution_detected")
 		scope.SetTag("table", tableName)
 		scope.SetFingerprint([]string{"schema-evolution", tableName})
@@ -431,18 +431,61 @@ func (m *SQLiteManager) cleanupLegacySchemaContamination() error {
 //     but continue. Extra columns are harmless: GORM ignores them when querying.
 //     This prevents the cascade failure from Discussion #3210 where users upgrading
 //     from older builds were blocked by columns that existed in earlier entity versions.
-func (m *SQLiteManager) validateV2SchemaIntegrity() error {
-	migrator := m.db.Migrator()
+//
+// columnLister returns the actual column names for a given table.
+type columnLister func(db *gorm.DB, tableName string) ([]string, error)
+
+// sqliteColumnLister queries SQLite pragma_table_info for column names.
+func sqliteColumnLister(db *gorm.DB, tableName string) ([]string, error) {
+	type pragmaCol struct {
+		Name string
+	}
+	var cols []pragmaCol
+	if err := db.Raw("SELECT name FROM pragma_table_info(?)", tableName).Scan(&cols).Error; err != nil {
+		return nil, err
+	}
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = c.Name
+	}
+	return names, nil
+}
+
+// mysqlColumnLister queries information_schema for column names.
+func mysqlColumnLister(db *gorm.DB, tableName string) ([]string, error) {
+	type colInfo struct {
+		ColumnName string `gorm:"column:COLUMN_NAME"`
+	}
+	var cols []colInfo
+	if err := db.Raw(
+		"SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ?",
+		tableName,
+	).Scan(&cols).Error; err != nil {
+		return nil, err
+	}
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = c.ColumnName
+	}
+	return names, nil
+}
+
+// validateSchemaIntegrity checks all v2 tables for unexpected columns that may
+// indicate legacy schema contamination or schema evolution leftovers. For each table:
+//   - If the table doesn't exist yet, skip (AutoMigrate will create it).
+//   - If unexpected columns are found and the table is empty, drop it so
+//     AutoMigrate can recreate it with the correct schema.
+//   - If unexpected columns are found and the table has data, log a warning
+//     but continue. Extra columns are harmless: GORM ignores them when querying.
+func validateSchemaIntegrity(db *gorm.DB, log logger.Logger, dbType string, listColumns columnLister) error {
+	migrator := db.Migrator()
 
 	for _, entity := range v2Entities() {
 		if !migrator.HasTable(entity) {
 			continue
 		}
 
-		// Parse the Go struct to get expected column names from GORM tags.
-		// This uses GORM's schema parser (not the database), so it reflects
-		// the Go entity definition — the source of truth.
-		stmt := &gorm.Statement{DB: m.db}
+		stmt := &gorm.Statement{DB: db}
 		if parseErr := stmt.Parse(entity); parseErr != nil {
 			continue
 		}
@@ -453,20 +496,15 @@ func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 			expectedNames[dbName] = true
 		}
 
-		// Get actual columns from SQLite pragma
-		type pragmaCol struct {
-			Name string
-		}
-		var actualCols []pragmaCol
-		if err := m.db.Raw("SELECT name FROM pragma_table_info(?)", tableName).Scan(&actualCols).Error; err != nil {
+		actualCols, err := listColumns(db, tableName)
+		if err != nil {
 			continue
 		}
 
-		// Find unexpected columns
 		var unexpected []string
-		for _, col := range actualCols {
-			if !expectedNames[col.Name] {
-				unexpected = append(unexpected, col.Name)
+		for _, colName := range actualCols {
+			if !expectedNames[colName] {
+				unexpected = append(unexpected, colName)
 			}
 		}
 
@@ -474,12 +512,11 @@ func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 			continue
 		}
 
-		// Check if table is empty — must verify count before dropping to avoid data loss
+		// Check if table is empty before dropping to avoid data loss
 		var rowCount int64
-		if countErr := m.db.Raw("SELECT COUNT(*) FROM `" + tableName + "`").Scan(&rowCount).Error; countErr != nil {
-			// Cannot determine row count — skip this table rather than risk data loss
-			if m.log != nil {
-				m.log.Warn("skipping schema validation for table due to query error",
+		if countErr := db.Raw("SELECT COUNT(*) FROM `" + tableName + "`").Scan(&rowCount).Error; countErr != nil {
+			if log != nil {
+				log.Warn("skipping schema validation for table due to query error",
 					logger.String("table", tableName),
 					logger.Error(countErr),
 					logger.String("operation", "validate_schema_integrity"))
@@ -488,12 +525,12 @@ func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 		}
 
 		if rowCount == 0 {
-			if dropErr := m.db.Exec("DROP TABLE IF EXISTS `" + tableName + "`").Error; dropErr != nil {
+			if dropErr := db.Exec("DROP TABLE IF EXISTS `" + tableName + "`").Error; dropErr != nil {
 				return fmt.Errorf("%w: failed to drop contaminated table %s: %w",
 					ErrV2SchemaCorrupted, tableName, dropErr)
 			}
-			if m.log != nil {
-				m.log.Info("dropped empty contaminated table for recreation",
+			if log != nil {
+				log.Info("dropped empty contaminated table for recreation",
 					logger.String("table", tableName),
 					logger.Any("unexpected_columns", unexpected),
 					logger.String("operation", "validate_schema_integrity"))
@@ -503,19 +540,22 @@ func (m *SQLiteManager) validateV2SchemaIntegrity() error {
 
 		// Populated table with extra columns: warn but continue.
 		// Extra columns from schema evolution are harmless; GORM ignores them.
-		// Blocking initialization here causes the cascade failure described in
-		// Discussion #3210 (v2 init fails -> legacy fallback -> NOT NULL crash).
-		if m.log != nil {
-			m.log.Warn("table has extra columns from schema evolution, continuing",
+		if log != nil {
+			log.Warn("table has extra columns from schema evolution, continuing",
 				logger.String("table", tableName),
 				logger.Any("unexpected_columns", unexpected),
 				logger.Int64("row_count", rowCount),
 				logger.String("operation", "validate_schema_integrity"))
 		}
 
-		reportSchemaEvolution(tableName, unexpected, rowCount)
+		reportSchemaEvolution(dbType, tableName, unexpected, rowCount)
 	}
 	return nil
+}
+
+// validateV2SchemaIntegrity delegates to the shared validation with SQLite column listing.
+func (m *SQLiteManager) validateV2SchemaIntegrity() error {
+	return validateSchemaIntegrity(m.db, m.log, "sqlite", sqliteColumnLister)
 }
 
 // fixSQLiteForeignKeys ensures ON DELETE SET NULL behavior for SQLite.

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -117,41 +117,9 @@ func (m *MySQLManager) Initialize() error {
 		return fmt.Errorf("v2 schema integrity check failed: %w", err)
 	}
 
-	// Run GORM auto-migrations for all entities
-	// Tables will be created with v2_ prefix due to NamingStrategy
-	err := m.db.AutoMigrate(
-		// Lookup tables (must be created first due to FK constraints)
-		&entities.LabelType{},
-		&entities.TaxonomicClass{},
-		// Core detection entities
-		&entities.AIModel{},
-		&entities.Label{},
-		&entities.AudioSource{},
-		&entities.Detection{},
-		&entities.DetectionPrediction{},
-		&entities.DetectionModelContribution{},
-		&entities.DetectionReview{},
-		&entities.DetectionComment{},
-		&entities.DetectionLock{},
-		&entities.MigrationState{},
-		&entities.MigrationDirtyID{},
-		// Auxiliary tables
-		&entities.DailyEvents{},
-		&entities.HourlyWeather{},
-		&entities.ImageCache{},
-		&entities.DynamicThreshold{},
-		&entities.ThresholdEvent{},
-		&entities.NotificationHistory{},
-		// Alert rules engine
-		&entities.AlertRule{},
-		&entities.AlertCondition{},
-		&entities.AlertAction{},
-		&entities.AlertHistory{},
-		// Application metadata
-		&entities.AppMetadata{},
-		// Application event log
-		&entities.AppEvent{},
-	)
+	// Run GORM auto-migrations for all entities using the shared canonical list.
+	// Tables will be created with v2_ prefix due to NamingStrategy.
+	err := m.db.AutoMigrate(v2Entities()...)
 	if err != nil {
 		reportInitFailure("mysql", "AutoMigrate", err, m.config.Host, m.config.Database, m.config.Username)
 		return fmt.Errorf("failed to migrate v2 schema: %w", err)

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
+	gorm_logger "gorm.io/gorm/logger"
 	"gorm.io/gorm/schema"
 )
 
@@ -24,6 +25,7 @@ type MySQLConfig struct {
 	// Set to false for fresh installs (clean table names).
 	// Default (false) means no prefix for fresh installs.
 	UseV2Prefix bool
+	Logger      logger.Logger
 }
 
 // MySQLManager handles the v2 normalized database for MySQL.
@@ -34,6 +36,7 @@ type MySQLManager struct {
 	config      MySQLConfig
 	location    string // host:port/database for display
 	tablePrefix string // "" for fresh installs, "v2_" for migration
+	log         logger.Logger
 }
 
 // v2TablePrefix is the prefix used for all v2 tables in MySQL.
@@ -46,9 +49,16 @@ func NewMySQLManager(cfg *MySQLConfig) (*MySQLManager, error) {
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 		cfg.Username, cfg.Password, cfg.Host, cfg.Port, cfg.Database)
 
-	logLevel := logger.Silent
-	if cfg.Debug {
-		logLevel = logger.Info
+	// Create GORM logger using the adapter if a logger is provided
+	var gormLog gorm_logger.Interface
+	if cfg.Logger != nil {
+		gormLog = logger.NewGormLoggerAdapter(cfg.Logger, defaultGormSlowThreshold)
+	} else {
+		logLevel := gorm_logger.Silent
+		if cfg.Debug {
+			logLevel = gorm_logger.Info
+		}
+		gormLog = gorm_logger.Default.LogMode(logLevel)
 	}
 
 	// Determine table prefix based on configuration
@@ -58,7 +68,7 @@ func NewMySQLManager(cfg *MySQLConfig) (*MySQLManager, error) {
 	}
 
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logLevel),
+		Logger: gormLog,
 		NamingStrategy: schema.NamingStrategy{
 			TablePrefix: tablePrefix, // "" for fresh install, "v2_" for migration
 		},
@@ -84,6 +94,7 @@ func NewMySQLManager(cfg *MySQLConfig) (*MySQLManager, error) {
 		config:      *cfg,
 		location:    fmt.Sprintf("%s:%s/%s", cfg.Host, cfg.Port, cfg.Database),
 		tablePrefix: tablePrefix,
+		log:         cfg.Logger,
 	}, nil
 }
 
@@ -98,6 +109,13 @@ func (m *MySQLManager) Initialize() error {
 	// Remove orphaned columns added by legacy AutoMigrate when the app incorrectly
 	// fell back to legacy mode due to the PR #2165 table name mismatch.
 	m.cleanupLegacySchemaContamination()
+
+	// Validate schema integrity: detect unexpected columns from schema evolution.
+	// Empty contaminated tables are dropped so AutoMigrate can recreate them cleanly.
+	// Populated tables with extra columns are tolerated (logged, reported to Sentry).
+	if err := m.validateV2SchemaIntegrity(); err != nil {
+		return fmt.Errorf("v2 schema integrity check failed: %w", err)
+	}
 
 	// Run GORM auto-migrations for all entities
 	// Tables will be created with v2_ prefix due to NamingStrategy
@@ -211,6 +229,11 @@ func (m *MySQLManager) cleanupLegacySchemaContamination() {
 			reportInitFailure("mysql", "dropOrphanedColumn_"+tableName+"_"+c.column, err, m.config.Host, m.config.Database, m.config.Username)
 		}
 	}
+}
+
+// validateV2SchemaIntegrity delegates to the shared validation with MySQL column listing.
+func (m *MySQLManager) validateV2SchemaIntegrity() error {
+	return validateSchemaIntegrity(m.db, m.log, "mysql", mysqlColumnLister)
 }
 
 // seedLookupTables seeds the label_types and taxonomic_classes tables with default values.

--- a/internal/datastore/v2only/fresh_install.go
+++ b/internal/datastore/v2only/fresh_install.go
@@ -72,6 +72,7 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesC
 			Database:    settings.Output.MySQL.Database,
 			UseV2Prefix: false, // NO prefix for fresh installs
 			Debug:       settings.Debug,
+			Logger:      log,
 		})
 
 	default:


### PR DESCRIPTION
## Summary

- Extract shared `validateSchemaIntegrity()` with a `columnLister` strategy pattern, eliminating code duplication between SQLite and MySQL managers
- Add schema evolution validation to MySQL manager (`validateV2SchemaIntegrity()`), closing an observability gap where MySQL deployments silently carried extra columns with no telemetry
- Add structured logger to `MySQLManager` (matching `SQLiteManager` pattern), wired through all three `NewMySQLManager` call sites
- Parameterize `reportSchemaEvolution()` to accept `dbType` instead of hardcoding "sqlite"
- Fix `isV2DatabaseSafeToDelete()` DSN construction to check for existing query parameters before choosing separator, matching the safe pattern already used in `NewSQLiteManager()`
- Replace inline entity list in `MySQLManager.Initialize()` with `v2Entities()...`, eliminating drift risk when new entities are added

## Test Plan

- [x] All 129 v2 package tests pass with `-race`
- [x] All 191 tests across v2 and v2only packages pass
- [x] Zero golangci-lint issues across all changed packages
- [x] Existing schema evolution tests continue to pass (validates refactoring correctness)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database path parameter handling to prevent malformed connections.
  * Enhanced database schema integrity validation with better error detection and recovery for corrupted tables.

* **Improvements**
  * Added configurable logging for MySQL database operations.
  * Optimized schema validation to work consistently across supported database types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->