### PR TITLE
fix(datastore): fix SQLite DSN separator, backup DSN bug, and AppEvent wiring

### DIFF
--- a/internal/backup/sources/sqlite.go
+++ b/internal/backup/sources/sqlite.go
@@ -79,11 +79,10 @@ func (s *SQLiteSource) openDatabase(dbPath string, readOnly bool) (*DatabaseConn
 	// Build DSN with additional safety parameters
 	dsn := dbPath
 	if readOnly {
-		dsn += "?mode=ro"
+		dsn += "?mode=ro&_busy_timeout=30000&_journal_mode=WAL&_sync=NORMAL"
+	} else {
+		dsn += "?_busy_timeout=30000&_journal_mode=WAL&_sync=NORMAL"
 	}
-	dsn += "&_busy_timeout=30000" // 30 second timeout
-	dsn += "&_journal_mode=WAL"   // Ensure WAL mode
-	dsn += "&_sync=NORMAL"        // Less aggressive syncing for better performance
 
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {

--- a/internal/backup/sources/sqlite.go
+++ b/internal/backup/sources/sqlite.go
@@ -79,9 +79,9 @@ func (s *SQLiteSource) openDatabase(dbPath string, readOnly bool) (*DatabaseConn
 	// Build DSN with additional safety parameters
 	dsn := dbPath
 	if readOnly {
-		dsn += "?mode=ro&_busy_timeout=30000&_journal_mode=WAL&_sync=NORMAL"
+		dsn += "?mode=ro&_busy_timeout=30000&_journal_mode=WAL&_synchronous=NORMAL"
 	} else {
-		dsn += "?_busy_timeout=30000&_journal_mode=WAL&_sync=NORMAL"
+		dsn += "?_busy_timeout=30000&_journal_mode=WAL&_synchronous=NORMAL"
 	}
 
 	db, err := sql.Open("sqlite3", dsn)
@@ -496,7 +496,7 @@ func (s *SQLiteSource) streamBackupToWriter(ctx context.Context, db *sql.DB, w i
 	}()
 
 	// Open the destination database (using the temp path)
-	destDB, err := sql.Open("sqlite3", tempPath+"?_journal_mode=WAL&_sync=OFF") // Turn off sync for backup target
+	destDB, err := sql.Open("sqlite3", tempPath+"?_journal_mode=WAL&_synchronous=OFF") // Turn off sync for backup target
 	if err != nil {
 		return errors.New(err).
 			Component("backup").

--- a/internal/backup/sources/sqlite.go
+++ b/internal/backup/sources/sqlite.go
@@ -77,11 +77,13 @@ func (dc *DatabaseConnection) Close() error {
 // openDatabase opens a database connection with the given path
 func (s *SQLiteSource) openDatabase(dbPath string, readOnly bool) (*DatabaseConnection, error) {
 	// Build DSN with additional safety parameters
-	dsn := dbPath
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		sep = "&"
+	}
+	dsn := dbPath + sep + "_busy_timeout=30000&_journal_mode=WAL&_synchronous=NORMAL"
 	if readOnly {
-		dsn += "?mode=ro&_busy_timeout=30000&_journal_mode=WAL&_synchronous=NORMAL"
-	} else {
-		dsn += "?_busy_timeout=30000&_journal_mode=WAL&_synchronous=NORMAL"
+		dsn += "&mode=ro"
 	}
 
 	db, err := sql.Open("sqlite3", dsn)

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -20,6 +20,15 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
+// readOnlyDSN appends mode=ro to a SQLite path, using the correct query separator.
+func readOnlyDSN(dbPath string) string {
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		sep = "&"
+	}
+	return dbPath + sep + "mode=ro"
+}
+
 // reportStartupError reports a startup state check failure to Sentry telemetry.
 // The paths parameter lists file paths that should be anonymized in the error message.
 func reportStartupError(dbType, operation string, err error, paths ...string) {
@@ -187,7 +196,7 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	}
 
 	// Open v2 database in read-only mode to check state
-	dsn := v2MigrationPath + "?mode=ro"
+	dsn := readOnlyDSN(v2MigrationPath)
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})
@@ -554,7 +563,7 @@ func hasUnmigratedLegacySQLite(settings *conf.Settings, log logger.Logger) bool 
 	}
 
 	// Open v2 migration database read-only to get LastMigratedID
-	v2DSN := v2MigrationPath + "?mode=ro"
+	v2DSN := readOnlyDSN(v2MigrationPath)
 	v2DB, err := gorm.Open(sqlite.Open(v2DSN), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})
@@ -587,7 +596,7 @@ func hasUnmigratedLegacySQLite(settings *conf.Settings, log logger.Logger) bool 
 	}
 
 	// Open legacy database read-only to count records beyond the watermark
-	legacyDSN := configuredPath + "?mode=ro"
+	legacyDSN := readOnlyDSN(configuredPath)
 	legacyDB, err := gorm.Open(sqlite.Open(legacyDSN), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})
@@ -695,7 +704,7 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 		return false
 	}
 
-	dsn := dbPath + "?mode=ro"
+	dsn := readOnlyDSN(dbPath)
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})

--- a/internal/datastore/v2only/fresh_install.go
+++ b/internal/datastore/v2only/fresh_install.go
@@ -126,6 +126,7 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesC
 	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
 	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
 	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	appEventRepo := repository.NewAppEventRepository(db, nil, useV2Prefix, isMySQL)
 	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, useV2Prefix)
 	taxClassRepo := repository.NewTaxonomicClassRepository(db, nil, useV2Prefix)
 
@@ -176,6 +177,7 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesC
 		ImageCache:         imageCacheRepo,
 		Threshold:          thresholdRepo,
 		Notification:       notificationRepo,
+		AppEvent:           appEventRepo,
 		Logger:             log,
 		Timezone:           time.Local,
 		DefaultModelID:     defaultModel.ID,


### PR DESCRIPTION
## Summary

- Add `readOnlyDSN()` helper in v2/startup.go that uses the correct query parameter separator (`?` vs `&`) when constructing read-only SQLite DSNs; replace 4 bare `+ "?mode=ro"` concatenation sites
- Fix `openDatabase()` in backup/sources/sqlite.go producing an invalid DSN when `readOnly=false` (the first pragma was appended with `&` instead of `?`, making the entire DSN unparseable)
- Wire `AppEvent` repository in `InitializeFreshInstall()` to match the post-migration path, closing an observability gap where fresh installs silently dropped app events
- Align SQLite pragma naming from `_sync` to `_synchronous` across the backup package for consistency with the rest of the codebase

## Test Plan
- [x] All modified packages compile cleanly
- [x] `golangci-lint run -v` passes (zero issues in changed code)
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized SQLite backup reliability with refined connection parameters.
  * Enhanced consistency in read-only database access patterns.

* **Chores**
  * Integrated app event repository infrastructure into the datastore initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->