### PR TITLE
feat(ui): add stream probe button and bat model warnings

### DIFF
--- a/frontend/src/lib/desktop/components/forms/ModelCheckboxList.svelte
+++ b/frontend/src/lib/desktop/components/forms/ModelCheckboxList.svelte
@@ -141,7 +141,7 @@
   {#if showBatStreamWarning}
     <div
       class="flex items-start gap-2 mt-2 p-2.5 rounded-lg text-xs leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
-      role="alert"
+      role="status"
     >
       <AlertTriangle class="size-3.5 shrink-0 mt-0.5 text-[var(--color-warning)]" />
       <span class="text-[var(--color-base-content)]">

--- a/frontend/src/lib/desktop/components/forms/ModelCheckboxList.svelte
+++ b/frontend/src/lib/desktop/components/forms/ModelCheckboxList.svelte
@@ -24,6 +24,7 @@
     models: ModelOption[];
     selectedModels: string[];
     sourceSampleRate?: number;
+    isStream?: boolean;
     disabled?: boolean;
     onToggle: (_models: string[]) => void;
   }
@@ -32,6 +33,7 @@
     models,
     selectedModels,
     sourceSampleRate = 48000,
+    isStream = false,
     disabled = false,
     onToggle,
   }: Props = $props();
@@ -51,6 +53,14 @@
 
   let showPerchOnlyWarning = $derived(hasBothFamilies && selectedHasPerch && !selectedHasBirdnet);
   let showRecommendBoth = $derived(hasBothFamilies && selectedHasBirdnet && !selectedHasPerch);
+
+  let selectedHasBatModel = $derived(
+    selectedModels.some(id => {
+      const model = models.find(m => m.id === id);
+      return model?.category === 'bat';
+    })
+  );
+  let showBatStreamWarning = $derived(isStream && selectedHasBatModel);
 
   function handleToggle(modelId: string, checked: boolean) {
     if (checked) {
@@ -124,6 +134,18 @@
       <Info class="size-3.5 shrink-0 mt-0.5 text-[var(--color-info)]" />
       <span class="text-[var(--color-base-content)]">
         {t('settings.audio.models.recommendBoth')}
+      </span>
+    </div>
+  {/if}
+
+  {#if showBatStreamWarning}
+    <div
+      class="flex items-start gap-2 mt-2 p-2.5 rounded-lg text-xs leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
+      role="alert"
+    >
+      <AlertTriangle class="size-3.5 shrink-0 mt-0.5 text-[var(--color-warning)]" />
+      <span class="text-[var(--color-base-content)]">
+        {t('settings.audio.streams.batWarning')}
       </span>
     </div>
   {/if}

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -388,6 +388,7 @@
           models={availableModels}
           selectedModels={editModels}
           sourceSampleRate={editSampleRate}
+          isStream={false}
           {disabled}
           onToggle={models => (editModels = models)}
         />

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -184,7 +184,7 @@
   // Probe state
   let isProbing = $state(false);
   let probeResult = $state<ProbeResult | null>(null);
-  let probeError = $state('');
+  let probeError = $state<string | null>(null);
   let probeController: AbortController | null = $state(null);
 
   // Local editing state - initialized with defaults, synced from props in startEdit()
@@ -340,7 +340,7 @@
     showEqualizer = false;
     probeController?.abort();
     probeResult = null;
-    probeError = '';
+    probeError = null;
     prevEditUrl = stream.url;
     isEditing = true;
   }
@@ -416,7 +416,7 @@
     probeController = new AbortController();
     isProbing = true;
     probeResult = null;
-    probeError = '';
+    probeError = null;
     try {
       const result = await api.post<ProbeResult>(
         '/api/v2/streams/probe',
@@ -426,7 +426,7 @@
       probeResult = result;
     } catch (err: unknown) {
       if (err instanceof Error && err.name === 'AbortError') return;
-      probeError = err instanceof Error ? err.message : t('settings.audio.streams.probe.error');
+      probeError = err instanceof Error ? err.message : '';
     } finally {
       isProbing = false;
     }
@@ -437,7 +437,7 @@
     if (isEditing && editUrl !== prevEditUrl) {
       if (prevEditUrl !== '') {
         probeResult = null;
-        probeError = '';
+        probeError = null;
       }
       prevEditUrl = editUrl;
     }
@@ -585,9 +585,9 @@
           </div>
         {/if}
 
-        {#if probeError}
+        {#if probeError !== null}
           <p class="text-xs text-[var(--color-error)]">
-            {t('settings.audio.streams.probe.error')}: {probeError}
+            {t('settings.audio.streams.probe.error')}{probeError ? `: ${probeError}` : ''}
           </p>
         {/if}
 

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -185,7 +185,7 @@
   let isProbing = $state(false);
   let probeResult = $state<ProbeResult | null>(null);
   let probeError = $state<string | null>(null);
-  let probeController: AbortController | null = $state(null);
+  let probeController: AbortController | null = null;
 
   // Local editing state - initialized with defaults, synced from props in startEdit()
   let isEditing = $state(false);
@@ -576,7 +576,7 @@
         {#if probeResult && !probeResult.batCompatible && probeResult.sampleRate >= 96000}
           <div
             class="flex items-start gap-2 p-2.5 rounded-lg text-xs leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
-            role="alert"
+            role="status"
           >
             <AlertTriangle class="size-3.5 shrink-0 mt-0.5 text-[var(--color-warning)]" />
             <span class="text-[var(--color-base-content)]">

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -26,10 +26,16 @@
     Check,
     X,
     AlertCircle,
+    AlertTriangle,
     Radio,
     ChevronDown,
     Moon,
+    Search,
+    CircleCheck,
+    CircleX,
+    Loader2,
   } from '@lucide/svelte';
+  import { api } from '$lib/utils/api';
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
@@ -166,6 +172,20 @@
     if (health.is_healthy && health.is_receiving_data) return 'Stable';
     return 'Unknown';
   });
+
+  interface ProbeResult {
+    sampleRate: number;
+    channels: number;
+    codec: string;
+    batCompatible: boolean;
+    warnings: string[];
+  }
+
+  // Probe state
+  let isProbing = $state(false);
+  let probeResult = $state<ProbeResult | null>(null);
+  let probeError = $state('');
+  let probeController: AbortController | null = $state(null);
 
   // Local editing state - initialized with defaults, synced from props in startEdit()
   let isEditing = $state(false);
@@ -318,10 +338,15 @@
       : { enabled: false, filters: [] };
     editQuietHours = { ...defaultQuietHoursConfig, ...stream.quietHours };
     showEqualizer = false;
+    probeController?.abort();
+    probeResult = null;
+    probeError = '';
+    prevEditUrl = stream.url;
     isEditing = true;
   }
 
   function cancelEdit() {
+    probeController?.abort();
     isEditing = false;
     showDeleteConfirm = false;
   }
@@ -382,6 +407,44 @@
       cancelEdit();
     }
   }
+
+  let sourceSampleRate = $derived(probeResult?.sampleRate ?? 48000);
+
+  async function probeStream() {
+    if (!editUrl.trim()) return;
+    probeController?.abort();
+    probeController = new AbortController();
+    isProbing = true;
+    probeResult = null;
+    probeError = '';
+    try {
+      const result = await api.post<ProbeResult>(
+        '/api/v2/streams/probe',
+        { url: editUrl.trim() },
+        { signal: probeController.signal }
+      );
+      probeResult = result;
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      probeError = err instanceof Error ? err.message : t('settings.audio.streams.probe.error');
+    } finally {
+      isProbing = false;
+    }
+  }
+
+  let prevEditUrl = '';
+  $effect(() => {
+    if (isEditing && editUrl !== prevEditUrl) {
+      if (prevEditUrl !== '') {
+        probeResult = null;
+        probeError = '';
+      }
+      prevEditUrl = editUrl;
+    }
+    return () => {
+      probeController?.abort();
+    };
+  });
 
   function updateEnabled(enabled: boolean) {
     onUpdate({ ...stream, enabled });
@@ -469,6 +532,65 @@
           />
         </div>
 
+        <!-- Probe Stream -->
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 h-8 px-3 text-sm font-medium rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            onclick={probeStream}
+            disabled={isProbing || !editUrl.trim()}
+          >
+            {#if isProbing}
+              <Loader2 class="size-4 animate-spin" />
+              {t('settings.audio.streams.probe.probing')}
+            {:else}
+              <Search class="size-4" />
+              {t('settings.audio.streams.probe.button')}
+            {/if}
+          </button>
+
+          {#if probeResult}
+            <div class="flex items-center gap-2 text-xs">
+              <span class="font-mono text-[var(--color-base-content)]">
+                {probeResult.sampleRate / 1000} kHz, {probeResult.codec}
+              </span>
+              {#if probeResult.batCompatible}
+                <span
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-medium bg-[var(--color-success)]/15 text-[var(--color-success)]"
+                >
+                  <CircleCheck class="size-3" />
+                  {t('settings.audio.streams.probe.batCompatible')}
+                </span>
+              {:else}
+                <span
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-medium bg-[var(--color-error)]/15 text-[var(--color-error)]"
+                >
+                  <CircleX class="size-3" />
+                  {t('settings.audio.streams.probe.batIncompatible')}
+                </span>
+              {/if}
+            </div>
+          {/if}
+        </div>
+
+        {#if probeResult && !probeResult.batCompatible && probeResult.sampleRate >= 96000}
+          <div
+            class="flex items-start gap-2 p-2.5 rounded-lg text-xs leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
+            role="alert"
+          >
+            <AlertTriangle class="size-3.5 shrink-0 mt-0.5 text-[var(--color-warning)]" />
+            <span class="text-[var(--color-base-content)]">
+              {t('settings.audio.streams.codecWarning.lossy')}
+            </span>
+          </div>
+        {/if}
+
+        {#if probeError}
+          <p class="text-xs text-[var(--color-error)]">
+            {t('settings.audio.streams.probe.error')}: {probeError}
+          </p>
+        {/if}
+
         <!-- Type and Transport Row -->
         <div class="grid grid-cols-2 gap-4">
           <div>
@@ -508,6 +630,8 @@
         <ModelCheckboxList
           models={availableModels}
           selectedModels={editModels}
+          {sourceSampleRate}
+          isStream={true}
           {disabled}
           onToggle={models => (editModels = models)}
         />

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -678,6 +678,7 @@
             <ModelCheckboxList
               models={availableModels}
               selectedModels={newModels}
+              isStream={true}
               {disabled}
               onToggle={models => (newModels = models)}
             />

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3044,6 +3044,18 @@
           "degraded": "Zhoršené",
           "failed": "Selhalo",
           "unknown": "Neznámé"
+        },
+        "probe": {
+          "button": "Prozkoumat stream",
+          "probing": "Zkoumaní...",
+          "result": "Výsledek průzkumu",
+          "error": "Průzkum selhal",
+          "batCompatible": "Kompatibilní s netopýry",
+          "batIncompatible": "Nekompatibilní s netopýry"
+        },
+        "batWarning": "Modely pro netopýry vyžadují streamy s bezeztrátovým kodekem (PCM) a vzorkovací frekvencí alespoň 96 kHz. Pomocí tlačítka Prozkoumat stream ověřte, zda váš stream splňuje tyto požadavky.",
+        "codecWarning": {
+          "lossy": "Ztrátové kodeky (AAC, Opus, MP3) ničí ultrazvukové frekvence nad ~20 kHz, čímž se stream stává nevhodným pro detekci netopýrů."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3044,6 +3044,18 @@
           "degraded": "Forringet",
           "failed": "Fejlet",
           "unknown": "Ukendt"
+        },
+        "probe": {
+          "button": "Undersøg stream",
+          "probing": "Undersøger...",
+          "result": "Undersøgelsesresultat",
+          "error": "Undersøgelse mislykkedes",
+          "batCompatible": "Kompatibel med flagermus",
+          "batIncompatible": "Ikke kompatibel med flagermus"
+        },
+        "batWarning": "Flagermusmodeller kræver streams med et tabsfrit codec (PCM) og en samplerate på mindst 96 kHz. Brug knappen Undersøg stream for at bekræfte, at din stream opfylder disse krav.",
+        "codecWarning": {
+          "lossy": "Tabsgivende codecs (AAC, Opus, MP3) ødelægger ultralydsfrekvenser over ~20 kHz, hvilket gør streamen uegnet til detektering af flagermus."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3055,7 +3055,7 @@
         },
         "batWarning": "Fledermausmodelle erfordern Streams mit einem verlustfreien Codec (PCM) und einer Abtastrate von mindestens 96 kHz. Verwenden Sie die Schaltfläche Stream prüfen, um zu überprüfen, ob Ihr Stream diese Anforderungen erfüllt.",
         "codecWarning": {
-          "lossy": "Verlustbehaftete Codecs (AAC, Opus, MP3) zerstören Ultraschallfrequenzen über ~20 kHz und machen den Stream für die Fledermauerkennung ungeeignet."
+          "lossy": "Verlustbehaftete Codecs (AAC, Opus, MP3) zerstören Ultraschallfrequenzen über ~20 kHz und machen den Stream für die Fledermauserkennung ungeeignet."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3044,6 +3044,18 @@
           "degraded": "Beeinträchtigt",
           "failed": "Fehlgeschlagen",
           "unknown": "Unbekannt"
+        },
+        "probe": {
+          "button": "Stream prüfen",
+          "probing": "Wird geprüft...",
+          "result": "Prüfergebnis",
+          "error": "Prüfung fehlgeschlagen",
+          "batCompatible": "Fledermaus-kompatibel",
+          "batIncompatible": "Nicht fledermaus-kompatibel"
+        },
+        "batWarning": "Fledermausmodelle erfordern Streams mit einem verlustfreien Codec (PCM) und einer Abtastrate von mindestens 96 kHz. Verwenden Sie die Schaltfläche Stream prüfen, um zu überprüfen, ob Ihr Stream diese Anforderungen erfüllt.",
+        "codecWarning": {
+          "lossy": "Verlustbehaftete Codecs (AAC, Opus, MP3) zerstören Ultraschallfrequenzen über ~20 kHz und machen den Stream für die Fledermauerkennung ungeeignet."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3044,6 +3044,18 @@
           "degraded": "Degraded",
           "failed": "Failed",
           "unknown": "Unknown"
+        },
+        "probe": {
+          "button": "Probe Stream",
+          "probing": "Probing...",
+          "result": "Probe Result",
+          "error": "Probe failed",
+          "batCompatible": "Bat compatible",
+          "batIncompatible": "Not bat compatible"
+        },
+        "batWarning": "Bat models require streams with a lossless codec (PCM) and a sample rate of at least 96 kHz. Use the Probe Stream button to verify your stream meets these requirements.",
+        "codecWarning": {
+          "lossy": "Lossy codecs (AAC, Opus, MP3) destroy ultrasonic frequencies above ~20 kHz, making the stream unsuitable for bat detection."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3044,6 +3044,18 @@
           "degraded": "Degradada",
           "failed": "Fallida",
           "unknown": "Desconocido"
+        },
+        "probe": {
+          "button": "Sondear stream",
+          "probing": "Sondeando...",
+          "result": "Resultado del sondeo",
+          "error": "El sondeo falló",
+          "batCompatible": "Compatible con murciélagos",
+          "batIncompatible": "No compatible con murciélagos"
+        },
+        "batWarning": "Los modelos de murciélagos requieren streams con un códec sin pérdida (PCM) y una tasa de muestreo de al menos 96 kHz. Use el botón Sondear stream para verificar que su stream cumple estos requisitos.",
+        "codecWarning": {
+          "lossy": "Los códecs con pérdida (AAC, Opus, MP3) destruyen las frecuencias ultrasónicas por encima de ~20 kHz, haciendo el stream inadecuado para la detección de murciélagos."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3044,6 +3044,18 @@
           "degraded": "Heikentynyt",
           "failed": "Epäonnistunut",
           "unknown": "Tuntematon"
+        },
+        "probe": {
+          "button": "Tutki striimi",
+          "probing": "Tutkitaan...",
+          "result": "Tutkimuksen tulos",
+          "error": "Tutkinta epäonnistui",
+          "batCompatible": "Yhteensopiva lepakoiden kanssa",
+          "batIncompatible": "Ei yhteensopiva lepakoiden kanssa"
+        },
+        "batWarning": "Lepakkomallit vaativat striimejä, joissa on häviötön koodekki (PCM) ja näytteenottotaajuus vähintään 96 kHz. Käytä Tutki striimi -painiketta varmistaaksesi, että striimisi täyttää nämä vaatimukset.",
+        "codecWarning": {
+          "lossy": "Häviölliset koodekit (AAC, Opus, MP3) tuhoavat ultraäänitaajuudet yli ~20 kHz, mikä tekee striimistä soveltumattoman lepakoiden havaitsemiseen."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3044,6 +3044,18 @@
           "degraded": "Dégradée",
           "failed": "Échouée",
           "unknown": "Inconnue"
+        },
+        "probe": {
+          "button": "Sonder le flux",
+          "probing": "Sondage en cours...",
+          "result": "Résultat du sondage",
+          "error": "Le sondage a échoué",
+          "batCompatible": "Compatible chauves-souris",
+          "batIncompatible": "Non compatible chauves-souris"
+        },
+        "batWarning": "Les modèles pour chauves-souris nécessitent des flux avec un codec sans perte (PCM) et un taux d'échantillonnage d'au moins 96 kHz. Utilisez le bouton Sonder le flux pour vérifier que votre flux répond à ces exigences.",
+        "codecWarning": {
+          "lossy": "Les codecs avec perte (AAC, Opus, MP3) détruisent les fréquences ultrasoniques au-dessus de ~20 kHz, rendant le flux inadapté à la détection des chauves-souris."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3044,6 +3044,18 @@
           "degraded": "Degradált",
           "failed": "Sikertelen",
           "unknown": "Ismeretlen"
+        },
+        "probe": {
+          "button": "Stream vizsgálat",
+          "probing": "Vizsgálat...",
+          "result": "Vizsgálat eredménye",
+          "error": "A vizsgálat sikertelen",
+          "batCompatible": "Denevér-kompatibilis",
+          "batIncompatible": "Nem denevér-kompatibilis"
+        },
+        "batWarning": "A denevérmodellek veszteségmentes kodeket (PCM) és legalább 96 kHz-es mintavételezési frekvenciájú streameket igényelnek. A Stream vizsgálat gombbal ellenőrizheti, hogy a streamje megfelel-e ezeknek a követelményeknek.",
+        "codecWarning": {
+          "lossy": "A veszteséges kodekek (AAC, Opus, MP3) megsemmisítik az ~20 kHz feletti ultrahang-frekvenciákat, így a stream alkalmatlanná válik a denevérek észlelésére."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3044,6 +3044,18 @@
           "degraded": "Degradato",
           "failed": "Fallito",
           "unknown": "Sconosciuto"
+        },
+        "probe": {
+          "button": "Analizza stream",
+          "probing": "Analisi in corso...",
+          "result": "Risultato dell'analisi",
+          "error": "Analisi non riuscita",
+          "batCompatible": "Compatibile con pipistrelli",
+          "batIncompatible": "Non compatibile con pipistrelli"
+        },
+        "batWarning": "I modelli per pipistrelli richiedono stream con un codec senza perdita (PCM) e una frequenza di campionamento di almeno 96 kHz. Usa il pulsante Analizza stream per verificare che il tuo stream soddisfi questi requisiti.",
+        "codecWarning": {
+          "lossy": "I codec con perdita (AAC, Opus, MP3) distruggono le frequenze ultrasoniche sopra i ~20 kHz, rendendo lo stream inadatto al rilevamento dei pipistrelli."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3044,6 +3044,18 @@
           "degraded": "Pasliktināts",
           "failed": "Neizdevies",
           "unknown": "Nezināms"
+        },
+        "probe": {
+          "button": "Pārbaudīt straumi",
+          "probing": "Pārbauda...",
+          "result": "Pārbaudes rezultāts",
+          "error": "Pārbaude neizdevās",
+          "batCompatible": "Saderīgs ar sikspārņiem",
+          "batIncompatible": "Nav saderīgs ar sikspārņiem"
+        },
+        "batWarning": "Sikspārņu modeļiem ir nepieciešamas straumes ar bezzudumu kodeku (PCM) un iztveršanas frekvenci vismaz 96 kHz. Izmantojiet pogu Pārbaudīt straumi, lai pārliecinātos, ka jūsu straume atbilst šīm prasībām.",
+        "codecWarning": {
+          "lossy": "Zudumu kodeki (AAC, Opus, MP3) iznīcina ultraskaņas frekvences virs ~20 kHz, padarot straumi nepiemērotu sikspārņu noteikšanai."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3044,6 +3044,18 @@
           "degraded": "Verslechterd",
           "failed": "Mislukt",
           "unknown": "Onbekend"
+        },
+        "probe": {
+          "button": "Stream testen",
+          "probing": "Testen...",
+          "result": "Testresultaat",
+          "error": "Test mislukt",
+          "batCompatible": "Vleermuis-compatibel",
+          "batIncompatible": "Niet vleermuis-compatibel"
+        },
+        "batWarning": "Vleermuismodellen vereisen streams met een verliesvrije codec (PCM) en een samplefrequentie van minimaal 96 kHz. Gebruik de knop Stream testen om te controleren of uw stream aan deze vereisten voldoet.",
+        "codecWarning": {
+          "lossy": "Codecs met verlies (AAC, Opus, MP3) vernietigen ultrasone frequenties boven ~20 kHz, waardoor de stream ongeschikt wordt voor vleermuisdetectie."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3044,6 +3044,18 @@
           "degraded": "Pogorszone",
           "failed": "Nieudane",
           "unknown": "Nieznany"
+        },
+        "probe": {
+          "button": "Zbadaj strumień",
+          "probing": "Badanie...",
+          "result": "Wynik badania",
+          "error": "Badanie nie powiodło się",
+          "batCompatible": "Kompatybilny z nietoperzami",
+          "batIncompatible": "Niekompatybilny z nietoperzami"
+        },
+        "batWarning": "Modele nietoperzy wymagają strumieni z bezstratnym kodekiem (PCM) i częstotliwością próbkowania co najmniej 96 kHz. Użyj przycisku Zbadaj strumień, aby sprawdzić, czy strumień spełnia te wymagania.",
+        "codecWarning": {
+          "lossy": "Stratne kodeki (AAC, Opus, MP3) niszczą częstotliwości ultradźwiękowe powyżej ~20 kHz, przez co strumień jest nieodpowiedni do wykrywania nietoperzy."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3044,6 +3044,18 @@
           "degraded": "Degradada",
           "failed": "Falhou",
           "unknown": "Desconhecido"
+        },
+        "probe": {
+          "button": "Sondar stream",
+          "probing": "Sondando...",
+          "result": "Resultado da sondagem",
+          "error": "A sondagem falhou",
+          "batCompatible": "Compatível com morcegos",
+          "batIncompatible": "Não compatível com morcegos"
+        },
+        "batWarning": "Os modelos de morcegos requerem streams com um codec sem perdas (PCM) e uma taxa de amostragem de pelo menos 96 kHz. Use o botão Sondar stream para verificar se o seu stream atende a estes requisitos.",
+        "codecWarning": {
+          "lossy": "Codecs com perdas (AAC, Opus, MP3) destroem frequências ultrassónicas acima de ~20 kHz, tornando o stream inadequado para a deteção de morcegos."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3044,6 +3044,18 @@
           "degraded": "Zhoršené",
           "failed": "Zlyhalo",
           "unknown": "Neznáme"
+        },
+        "probe": {
+          "button": "Preskúmať stream",
+          "probing": "Skúmanie...",
+          "result": "Výsledok prieskumu",
+          "error": "Prieskum zlyhal",
+          "batCompatible": "Kompatibilný s netopiermi",
+          "batIncompatible": "Nekompatibilný s netopiermi"
+        },
+        "batWarning": "Modely pre netopiere vyžadujú streamy s bezstratovým kodekom (PCM) a vzorkovacou frekvenciou aspoň 96 kHz. Pomocou tlačidla Preskúmať stream overte, či váš stream spĺňa tieto požiadavky.",
+        "codecWarning": {
+          "lossy": "Stratové kodeky (AAC, Opus, MP3) ničia ultrazvukové frekvencie nad ~20 kHz, čím sa stream stáva nevhodným na detekciu netopierov."
         }
       },
       "audioFilters": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3044,6 +3044,18 @@
           "degraded": "Försämrad",
           "failed": "Misslyckad",
           "unknown": "Okänd"
+        },
+        "probe": {
+          "button": "Undersök ström",
+          "probing": "Undersöker...",
+          "result": "Undersökningsresultat",
+          "error": "Undersökningen misslyckades",
+          "batCompatible": "Fladdermus-kompatibel",
+          "batIncompatible": "Inte fladdermus-kompatibel"
+        },
+        "batWarning": "Fladdermusmodeller kräver strömmar med en förlustfri codec (PCM) och en samplingsfrekvens på minst 96 kHz. Använd knappen Undersök ström för att kontrollera att din ström uppfyller dessa krav.",
+        "codecWarning": {
+          "lossy": "Förlustbringande codecs (AAC, Opus, MP3) förstör ultraljudsfrekvenser över ~20 kHz, vilket gör strömmen olämplig för fladdermusdetektion."
         }
       },
       "audioFilters": {


### PR DESCRIPTION
## Summary

- Add **Probe Stream** button in stream edit mode that calls `POST /api/v2/streams/probe` to discover stream audio properties (sample rate, codec, bat compatibility)
- Show probed sample rate, codec name, and a bat compatible/incompatible badge inline with the probe button
- Display localized lossy codec warning when the stream has sufficient sample rate but uses a lossy codec (AAC, Opus, MP3)
- Add `isStream` prop to `ModelCheckboxList` to show a bat model requirements warning when bat models are selected on stream sources
- Pass `sourceSampleRate` from probe results to `ModelCheckboxList` for dynamic sample rate compatibility badges
- Add `AbortController` for probe requests with cleanup on edit cancel and URL changes
- Clear stale probe results when the stream URL is edited
- Add i18n keys (`probe.*`, `batWarning`, `codecWarning.lossy`) with proper native translations across all 15 locales

This is PR 2 of 2 for bat model streaming support. PR 1 (backend, #3229) added the probe API endpoint.

## Test Plan

- [ ] Open Settings > Audio > Streams, edit a stream, verify "Probe Stream" button appears
- [ ] Click Probe Stream with a valid RTSP URL, verify sample rate and codec display
- [ ] Verify bat compatible/incompatible badge shows correctly
- [ ] Select a bat model on a stream, verify warning banner appears
- [ ] Add a new stream (not just edit), verify bat warning also appears
- [ ] Change stream URL after probing, verify old results clear
- [ ] Cancel edit during probing, verify no errors
- [ ] Check non-English locale, verify all probe-related text is translated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stream probing UI to analyze stream sample rate/codec and surface results
  * Added bat-compatibility checks and warnings (codec/sample-rate) and explicit lossy-codec warning
  * Model selection now shows a bat-specific warning when configuring streams

* **Localization**
  * Added/extended translations in 15 languages for stream probing, results, errors and bat-compatibility messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->