### PR TITLE
fix(imageprovider): harden image cache against corruption and empty names

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1304,8 +1304,9 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 	var result []sourceConfigWithModels
 
 	// Collect enabled streams so we can iterate twice: once for probing,
-	// once for building configs. EnabledStreams() returns an iterator.
-	var enabledStreams []*conf.StreamConfig
+	// once for building configs. EnabledStreams() returns an iterator;
+	// preallocate using the parent slice length as an upper bound.
+	enabledStreams := make([]*conf.StreamConfig, 0, len(settings.Realtime.RTSP.Streams))
 	for _, stream := range settings.Realtime.RTSP.EnabledStreams() {
 		enabledStreams = append(enabledStreams, stream)
 	}

--- a/internal/datastore/errors_helper.go
+++ b/internal/datastore/errors_helper.go
@@ -203,9 +203,13 @@ func criticalError(err error, operation, reason string, context ...any) error {
 	return builder.Build()
 }
 
-// isDatabaseLocked checks if an error indicates database lock conditions
-// This is already defined in interfaces.go, so we'll extend it here
-func isDatabaseCorruption(err error) bool {
+// IsDatabaseCorruption reports whether err describes a SQLite corruption
+// condition such as "database disk image is malformed" or "file is not a
+// database". Callers outside the datastore package (notably the image cache
+// in internal/imageprovider) use this to disable further DB operations once
+// the underlying file is unrecoverable, instead of repeatedly failing and
+// reporting the same fatal error to Sentry.
+func IsDatabaseCorruption(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2642,18 +2642,22 @@ func thresholdModelName(t *entities.DynamicThreshold) string {
 // pre-built name maps. Falls back to the scientific name if no mapping exists.
 // Handles legacy concatenated "ScientificName_CommonName" format by extracting
 // only the scientific name portion before lookup.
-// Logs a warning (once per species) when the fallback is used and maps are populated,
-// to help diagnose issues where common names stop appearing.
+// Logs at info (once per species) when the fallback is used and maps are populated,
+// to help diagnose issues where common names stop appearing without surfacing
+// the benign fallback on the diagnostics health check.
 func (ds *Datastore) resolveCommonName(scientificName string) string {
 	sciName := detection.ExtractScientificName(scientificName)
 	nm := ds.loadNameMaps()
 	if cn, ok := nm.common[sciName]; ok {
 		return cn
 	}
-	// Log once per missing species when maps are populated (not during startup with empty maps)
+	// Log once per missing species when maps are populated (not during startup with empty maps).
+	// Logged at info because the fallback to the scientific name is the intended
+	// behavior; surfacing as a warning made it surface on the diagnostics health
+	// check as an "elevated error count" for benign missing translations.
 	if len(nm.common) > 0 {
 		if _, alreadyLogged := ds.loggedMissingNames.LoadOrStore(sciName, struct{}{}); !alreadyLogged {
-			ds.log.Warn("common name not found in name maps, falling back to scientific name",
+			ds.log.Info("common name not found in name maps, falling back to scientific name",
 				logger.String("scientific_name", sciName),
 				logger.Int("name_map_size", len(nm.common)))
 		}

--- a/internal/imageprovider/cache_resilience_test.go
+++ b/internal/imageprovider/cache_resilience_test.go
@@ -1,0 +1,316 @@
+package imageprovider_test
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// emptyNameProvider returns a BirdImage with a populated URL but an empty
+// ScientificName, simulating providers that hand back partial metadata.
+type emptyNameProvider struct {
+	fetchCount atomic.Int32
+}
+
+func (p *emptyNameProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
+	p.fetchCount.Add(1)
+	return imageprovider.BirdImage{
+		URL:         fmt.Sprintf("http://example.com/%s.jpg", scientificName),
+		LicenseName: "CC BY 4.0",
+		AuthorName:  "Test Author",
+		CachedAt:    time.Now(),
+	}, nil
+}
+
+// TestStoreSuccessfulFetchPopulatesScientificName verifies that fetched images
+// are persisted with the requested scientific name even when the provider
+// returns a BirdImage with an empty ScientificName. Regression test for
+// Forgejo #756 (NOT NULL constraint on image_caches.scientific_name during
+// the warmup path).
+func TestStoreSuccessfulFetchPopulatesScientificName(t *testing.T) {
+	t.Parallel()
+
+	provider := &emptyNameProvider{}
+	store := newMockStore()
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	cache, err := imageprovider.CreateDefaultCache(metrics, store)
+	require.NoError(t, err)
+	cache.SetImageProvider(provider)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close())
+	})
+
+	const speciesName = "Pipistrellus pygmaeus"
+	got, err := cache.Get(speciesName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.URL, "Get should return the fetched image")
+
+	cached, err := store.GetImageCache(datastore.ImageCacheQuery{
+		ScientificName: speciesName,
+		ProviderName:   "wikimedia",
+	})
+	require.NoError(t, err, "image must be persisted with the requested scientific name")
+	require.NotNil(t, cached)
+	assert.Equal(t, speciesName, cached.ScientificName,
+		"saveToDB must receive ScientificName from the request even when the provider omits it")
+}
+
+// errCorrupt simulates a SQLite "database disk image is malformed" error
+// that the datastore corruption detector should recognize.
+var errCorrupt = errors.NewStd("database disk image is malformed")
+
+// mockCorruptStore is a mockStore that returns a corruption error from
+// configurable image-cache read/write methods. It counts how many times each
+// method was invoked so tests can verify the cache short-circuits subsequent
+// calls once corruption has been detected (Forgejo #762).
+type mockCorruptStore struct {
+	mockStore
+	corruptGet     atomic.Bool
+	corruptSave    atomic.Bool
+	corruptBatch   atomic.Bool
+	corruptLoadAll atomic.Bool
+	getCalls       atomic.Int32
+	saveCalls      atomic.Int32
+	batchCalls     atomic.Int32
+	loadAllCalls   atomic.Int32
+}
+
+func newMockCorruptStore() *mockCorruptStore {
+	return &mockCorruptStore{
+		mockStore: mockStore{
+			images: make(map[string]*datastore.ImageCache),
+		},
+	}
+}
+
+func (m *mockCorruptStore) GetImageCache(query datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
+	m.getCalls.Add(1)
+	if m.corruptGet.Load() {
+		return nil, errCorrupt
+	}
+	return m.mockStore.GetImageCache(query)
+}
+
+func (m *mockCorruptStore) SaveImageCache(cache *datastore.ImageCache) error {
+	m.saveCalls.Add(1)
+	if m.corruptSave.Load() {
+		return errCorrupt
+	}
+	return m.mockStore.SaveImageCache(cache)
+}
+
+func (m *mockCorruptStore) GetImageCacheBatch(providerName string, scientificNames []string) (map[string]*datastore.ImageCache, error) {
+	m.batchCalls.Add(1)
+	if m.corruptBatch.Load() {
+		return nil, errCorrupt
+	}
+	return m.mockStore.GetImageCacheBatch(providerName, scientificNames)
+}
+
+func (m *mockCorruptStore) GetAllImageCaches(providerName string) ([]datastore.ImageCache, error) {
+	m.loadAllCalls.Add(1)
+	if m.corruptLoadAll.Load() {
+		return nil, errCorrupt
+	}
+	return m.mockStore.GetAllImageCaches(providerName)
+}
+
+// TestImageCacheDisablesReadsOnCorruption verifies that once GetImageCache
+// reports SQLite corruption, the cache stops issuing further reads or writes
+// for the rest of the session. Without this latch the same fatal error gets
+// reported to Sentry on every detection cycle (Forgejo #762 collected 1,763
+// events from a single corrupted file before this fix).
+func TestImageCacheDisablesReadsOnCorruption(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockImageProvider{}
+	store := newMockCorruptStore()
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	cache, err := imageprovider.CreateDefaultCache(metrics, store)
+	require.NoError(t, err)
+	cache.SetImageProvider(provider)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close())
+	})
+
+	// Switch the read path to corruption AFTER startup so the cache's
+	// initialization-time GetAllImageCaches call succeeds normally.
+	store.corruptGet.Store(true)
+
+	// First Get must attempt the corrupted read so the cache can latch the
+	// disabled-DB flag. It then falls through to the provider.
+	_, err = cache.Get("Turdus merula")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, store.getCalls.Load(), int32(1),
+		"first call must reach GetImageCache so corruption can be detected")
+
+	getsAfterFirst := store.getCalls.Load()
+	savesAfterFirst := store.saveCalls.Load()
+
+	// Subsequent reads (different species, to bypass the in-memory cache)
+	// must not exercise the corrupted DB.
+	_, err = cache.Get("Parus major")
+	require.NoError(t, err)
+	_, err = cache.Get("Cyanistes caeruleus")
+	require.NoError(t, err)
+
+	assert.Equal(t, getsAfterFirst, store.getCalls.Load(),
+		"GetImageCache must not be retried after corruption is latched")
+	assert.Equal(t, savesAfterFirst, store.saveCalls.Load(),
+		"SaveImageCache must not run after corruption is latched on the read path")
+}
+
+// TestImageCacheDisablesWritesOnCorruption verifies that a corruption error
+// from SaveImageCache also latches the disabled-DB flag, preventing further
+// save attempts from generating Sentry events (Forgejo #762 save path).
+func TestImageCacheDisablesWritesOnCorruption(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockImageProvider{}
+	store := newMockCorruptStore()
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	cache, err := imageprovider.CreateDefaultCache(metrics, store)
+	require.NoError(t, err)
+	cache.SetImageProvider(provider)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close())
+	})
+
+	store.corruptSave.Store(true)
+
+	// First Get fetches from the provider and triggers a save that will hit
+	// the corrupted write path.
+	_, err = cache.Get("Turdus merula")
+	require.NoError(t, err)
+	savesAfterFirst := store.saveCalls.Load()
+	require.GreaterOrEqual(t, savesAfterFirst, int32(1),
+		"first call must reach SaveImageCache so corruption can be detected")
+
+	// Subsequent calls must not retry the write.
+	_, err = cache.Get("Parus major")
+	require.NoError(t, err)
+	_, err = cache.Get("Cyanistes caeruleus")
+	require.NoError(t, err)
+
+	assert.Equal(t, savesAfterFirst, store.saveCalls.Load(),
+		"SaveImageCache must not be retried after corruption is latched")
+}
+
+// TestImageCacheDisablesBatchOnCorruption verifies that a corruption error
+// from GetImageCacheBatch (the dashboard's batch thumbnail path) latches the
+// flag too. Without this guard, every dashboard render would re-issue a batch
+// query against the corrupted DB (Forgejo #762 batch path).
+func TestImageCacheDisablesBatchOnCorruption(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockImageProvider{}
+	store := newMockCorruptStore()
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	cache, err := imageprovider.CreateDefaultCache(metrics, store)
+	require.NoError(t, err)
+	cache.SetImageProvider(provider)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close())
+	})
+
+	store.corruptBatch.Store(true)
+
+	// First batch fetch triggers the corrupted batch read.
+	_ = cache.GetBatch([]string{"Turdus merula", "Parus major"})
+	batchesAfterFirst := store.batchCalls.Load()
+	require.GreaterOrEqual(t, batchesAfterFirst, int32(1),
+		"first batch call must reach GetImageCacheBatch so corruption can be detected")
+
+	// Subsequent batch fetches must not retry the corrupted call.
+	_ = cache.GetBatch([]string{"Cyanistes caeruleus", "Sitta europaea"})
+	_ = cache.GetBatch([]string{"Erithacus rubecula"})
+
+	assert.Equal(t, batchesAfterFirst, store.batchCalls.Load(),
+		"GetImageCacheBatch must not be retried after corruption is latched")
+}
+
+// TestImageCacheCorruptionAtStartup verifies that a corruption error raised
+// during the warmup load (loadCachedImages) latches the flag, lets init
+// complete cleanly, and prevents any further GetAll calls. Without this the
+// startup error would propagate and abort image cache init entirely
+// (Forgejo #762 startup path).
+func TestImageCacheCorruptionAtStartup(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockImageProvider{}
+	store := newMockCorruptStore()
+	store.corruptLoadAll.Store(true)
+
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	cache, err := imageprovider.CreateDefaultCache(metrics, store)
+	require.NoError(t, err)
+	cache.SetImageProvider(provider)
+	t.Cleanup(func() {
+		require.NoError(t, cache.Close())
+	})
+
+	// loadCachedImages must have run once during init and surfaced corruption.
+	require.GreaterOrEqual(t, store.loadAllCalls.Load(), int32(1),
+		"startup load must reach GetAllImageCaches so corruption can be detected")
+
+	// Provider-backed fetches still work; the corrupted DB is bypassed.
+	_, err = cache.Get("Turdus merula")
+	require.NoError(t, err)
+
+	assert.Zero(t, store.getCalls.Load(),
+		"GetImageCache must not run after startup corruption is latched")
+	assert.Zero(t, store.saveCalls.Load(),
+		"SaveImageCache must not run after startup corruption is latched")
+}
+
+// TestIsDatabaseCorruptionExposesHelper verifies that the datastore package
+// exposes a corruption detector that callers (such as the image cache) can
+// invoke to recognise malformed-database errors. Without this helper, the
+// imageprovider package cannot tell corruption apart from transient errors
+// and ends up reporting the same fatal condition to Sentry over and over.
+func TestIsDatabaseCorruptionExposesHelper(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"malformed", errors.NewStd("database disk image is malformed"), true},
+		{"not_a_database", errors.NewStd("file is not a database"), true},
+		{"generic_corrupt", errors.NewStd("table is corrupt"), true},
+		{"locked", errors.NewStd("database is locked"), false},
+		{"transient", errors.NewStd("connection reset"), false},
+		{"nil", nil, false},
+		{"wrapped",
+			errors.New(errors.NewStd("database disk image is malformed")).
+				Component("imageprovider").
+				Category(errors.CategoryImageCache).
+				Build(),
+			true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, datastore.IsDatabaseCorruption(tc.err))
+		})
+	}
+}

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -138,9 +138,16 @@ type BirdImageCache struct {
 	debug        bool
 	store        datastore.Interface
 	fileCache    *ImageFileCache
-	quit         chan struct{}                         // Channel to signal shutdown
-	closeMu      sync.Mutex                            // Guards closed + wg.Go atomicity in tryGo to prevent Add-after-Wait panic
-	closed       atomic.Bool                           // Set during shutdown to reject new DB operations
+	quit         chan struct{} // Channel to signal shutdown
+	closeMu      sync.Mutex    // Guards closed + wg.Go atomicity in tryGo to prevent Add-after-Wait panic
+	closed       atomic.Bool   // Set during shutdown to reject new DB operations
+	// dbCorrupted is latched the first time the datastore reports a SQLite
+	// corruption error ("database disk image is malformed"). Once latched,
+	// loadFromDBCache, saveToDB, fetchFromDBWithFallback and loadCachedImages
+	// all return ErrCacheMiss without touching the DB, so the cache continues
+	// to serve fresh fetches from the provider instead of generating an
+	// unbounded stream of Sentry events (Forgejo #762, BIRDNET-GO-ZR/ZS).
+	dbCorrupted  atomic.Bool
 	wg           sync.WaitGroup                        // Tracks in-flight DB and background operations
 	Initializing sync.Map                              // Track which species are being initialized
 	registry     atomic.Pointer[ImageProviderRegistry] // Use atomic pointer
@@ -387,6 +394,14 @@ func (c *BirdImageCache) refreshStaleEntries() {
 		return
 	}
 
+	// Skip the hourly refresh once the DB has been latched corrupted; otherwise
+	// the ticker would keep emitting one Sentry event per hour for the lifetime
+	// of the process (Forgejo #762).
+	if c.dbCorrupted.Load() {
+		log.Debug("Skipping cache refresh: image cache database is corrupted")
+		return
+	}
+
 	if c.store == nil {
 		log.Debug("DB store is nil, skipping cache refresh")
 		return
@@ -399,6 +414,11 @@ func (c *BirdImageCache) refreshStaleEntries() {
 
 	entries, err := c.store.GetAllImageCaches(c.providerName)
 	if err != nil {
+		// Latch on corruption so the refresh ticker stops issuing read errors
+		// (Forgejo #762).
+		if c.handleDBCorruption(err, "get_cached_entries_for_refresh") {
+			return
+		}
 		c.logRefreshError(err)
 		return
 	}
@@ -561,6 +581,13 @@ func (c *BirdImageCache) refreshEntry(scientificName string) {
 		return
 	}
 
+	// Ensure ScientificName is populated from the request before persisting,
+	// mirroring storeSuccessfulFetch. Providers can return a BirdImage with an
+	// empty ScientificName, which would otherwise cause a NOT NULL constraint
+	// violation on image_caches.scientific_name during background refresh too
+	// (Forgejo #756 sibling-callsite fix).
+	birdImage.ScientificName = scientificName
+
 	// Update memory cache
 	log.Debug("Updating memory cache with refreshed image")
 	c.dataMap.Store(scientificName, &birdImage)
@@ -602,7 +629,7 @@ func (c *BirdImageCache) tryRefreshFallback(scientificName string) (BirdImage, b
 	}
 
 	// Tier 1: Check fallback providers' DB cache (no network)
-	if c.store != nil && !c.closed.Load() {
+	if c.store != nil && !c.closed.Load() && !c.dbCorrupted.Load() {
 		for _, providerName := range fallbackProviders {
 			if providerName == c.providerName {
 				continue
@@ -612,7 +639,14 @@ func (c *BirdImageCache) tryRefreshFallback(scientificName string) (BirdImage, b
 				ProviderName:   providerName,
 			}
 			cachedImage, err := c.store.GetImageCache(query)
-			if err != nil || cachedImage == nil {
+			if err != nil {
+				// Latch on corruption and stop trying further fallback DBs.
+				if c.handleDBCorruption(err, "tier1_fallback_lookup") {
+					break
+				}
+				continue
+			}
+			if cachedImage == nil {
 				continue
 			}
 			img := dbEntryToBirdImage(cachedImage)
@@ -721,6 +755,42 @@ func InitCache(providerName string, e ImageProvider, t *observability.Metrics, s
 	return cache
 }
 
+// handleDBCorruption inspects err for SQLite corruption ("database disk image
+// is malformed", "file is not a database", etc.) and, the first time it is
+// seen, latches the dbCorrupted flag so subsequent DB operations short-circuit
+// instead of repeatedly failing. Returns true when corruption is detected so
+// callers can treat the read/write as a cache miss without surfacing further
+// errors.
+//
+// Why latch instead of recover: the image cache shares the main SQLite file
+// in v2-only mode, so we cannot safely DROP or recreate the table from here.
+// A latch keeps the service healthy (fresh fetches from the provider) and
+// stops a single bad file from generating thousands of Sentry events
+// (Forgejo #762: 1,763 events from one corrupted system over 2+ months).
+func (c *BirdImageCache) handleDBCorruption(err error, operation string) bool {
+	if !datastore.IsDatabaseCorruption(err) {
+		return false
+	}
+	if c.dbCorrupted.CompareAndSwap(false, true) {
+		log := GetLogger().With(
+			logger.String("provider", c.providerName),
+			logger.String("operation", operation))
+		enhancedErr := errors.New(err).
+			Component("imageprovider").
+			Category(errors.CategoryImageCache).
+			Context("provider", c.providerName).
+			Context("operation", operation).
+			Context("recovery_action", "image_cache_db_disabled_for_session").
+			Build()
+		log.Error("Image cache database is corrupted, disabling further DB operations for this session",
+			logger.Error(enhancedErr))
+		if c.metrics != nil {
+			c.metrics.IncrementDownloadErrorsWithCategory("image-cache", c.providerName, "db_corruption")
+		}
+	}
+	return true
+}
+
 // loadFromDBCache loads a BirdImage from the database cache
 func (c *BirdImageCache) loadFromDBCache(scientificName string) (*BirdImage, error) {
 	log := GetLogger().With(
@@ -730,6 +800,11 @@ func (c *BirdImageCache) loadFromDBCache(scientificName string) (*BirdImage, err
 	// Reject DB reads after shutdown to avoid "database is closed" errors
 	if c.closed.Load() {
 		log.Debug("Skipping DB load: cache is shutting down")
+		return nil, ErrCacheMiss
+	}
+	// Skip DB reads once corruption has been detected to avoid Sentry spam.
+	if c.dbCorrupted.Load() {
+		log.Debug("Skipping DB load: image cache database is corrupted")
 		return nil, ErrCacheMiss
 	}
 	// Check if store is nil to prevent nil pointer dereference
@@ -750,6 +825,11 @@ func (c *BirdImageCache) loadFromDBCache(scientificName string) (*BirdImage, err
 		// Check if it's a record not found error (which is expected for cache misses)
 		if errors.Is(err, datastore.ErrImageCacheNotFound) {
 			log.Debug("Image not found in DB cache (GetImageCache returned ErrImageCacheNotFound)")
+			return nil, ErrCacheMiss
+		}
+		// Treat SQLite corruption as a permanent cache miss and disable future
+		// DB reads/writes for this session (Forgejo #762).
+		if c.handleDBCorruption(err, "query_image_cache") {
 			return nil, ErrCacheMiss
 		}
 		// Log database errors for other errors
@@ -820,6 +900,11 @@ func (c *BirdImageCache) fetchFromDBWithFallback(scientificNames []string) (map[
 		log.Debug("Skipping batch DB load: cache is shutting down")
 		return nil, ErrCacheMiss
 	}
+	// Skip batch reads once corruption has been detected (Forgejo #762).
+	if c.dbCorrupted.Load() {
+		log.Debug("Skipping batch DB load: image cache database is corrupted")
+		return nil, ErrCacheMiss
+	}
 
 	settings := conf.Setting()
 	debug := settings.Realtime.Dashboard.Thumbnails.Debug
@@ -832,6 +917,9 @@ func (c *BirdImageCache) fetchFromDBWithFallback(scientificNames []string) (map[
 
 	dbImages, err := c.store.GetImageCacheBatch(c.providerName, scientificNames)
 	if err != nil {
+		if c.handleDBCorruption(err, "get_image_cache_batch") {
+			return nil, ErrCacheMiss
+		}
 		log.Error("Failed to batch load from DB cache",
 			logger.Error(err))
 		return nil, err
@@ -858,6 +946,10 @@ func (c *BirdImageCache) tryBatchFallbackProviders(scientificNames []string, deb
 	if c.closed.Load() {
 		return nil
 	}
+	// Skip fallback DB lookups once corruption is latched (Forgejo #762).
+	if c.dbCorrupted.Load() {
+		return nil
+	}
 
 	settings := conf.Setting()
 
@@ -877,7 +969,15 @@ func (c *BirdImageCache) tryBatchFallbackProviders(scientificNames []string, deb
 			continue
 		}
 		fallbackImages, err := c.store.GetImageCacheBatch(fallbackProvider, scientificNames)
-		if err == nil && len(fallbackImages) > 0 {
+		if err != nil {
+			// Stop iterating fallbacks if the DB is corrupted; the next batch
+			// query would also fail and inflate the corruption metric.
+			if c.handleDBCorruption(err, "batch_fallback_lookup") {
+				return nil
+			}
+			continue
+		}
+		if len(fallbackImages) > 0 {
 			if debug {
 				log.Debug("Found images using fallback provider",
 					logger.String("fallback_provider", fallbackProvider),
@@ -930,6 +1030,11 @@ func (c *BirdImageCache) saveToDB(image *BirdImage) {
 		log.Debug("Skipping DB save: cache is shutting down")
 		return
 	}
+	// Skip DB writes once corruption has been detected to avoid Sentry spam.
+	if c.dbCorrupted.Load() {
+		log.Debug("Skipping DB save: image cache database is corrupted")
+		return
+	}
 	// Check if store is nil
 	if c.store == nil {
 		log.Warn("Cannot save to DB cache: DB store is nil")
@@ -978,6 +1083,11 @@ func (c *BirdImageCache) saveToDB(image *BirdImage) {
 	}
 
 	if err := c.store.SaveImageCache(dbEntry); err != nil {
+		// SQLite corruption is permanent at this point; latch the flag so
+		// future saves short-circuit rather than re-reporting (Forgejo #762).
+		if c.handleDBCorruption(err, "save_image_cache") {
+			return
+		}
 		enhancedErr := errors.New(err).
 			Component("imageprovider").
 			Category(errors.CategoryImageCache).
@@ -1010,6 +1120,11 @@ func (c *BirdImageCache) loadCachedImages() error {
 
 	entries, err := c.store.GetAllImageCaches(c.providerName) // Get entries specific to this provider
 	if err != nil {
+		// On corruption at startup, latch the flag and skip the warmup load
+		// without surfacing an error so init can still complete (Forgejo #762).
+		if c.handleDBCorruption(err, "get_all_image_caches") {
+			return nil
+		}
 		enhancedErr := errors.New(err).
 			Component("imageprovider").
 			Category(errors.CategoryImageCache).
@@ -1447,6 +1562,12 @@ func (c *BirdImageCache) storeSuccessfulFetch(scientificName string, fetchedImag
 		logger.String("provider", c.providerName),
 		logger.String("scientific_name", scientificName))
 
+	// Ensure ScientificName is populated from the request before persisting,
+	// mirroring storeNegativeCacheEntry. Some providers return a BirdImage with
+	// an empty ScientificName, which would otherwise cause a NOT NULL constraint
+	// violation on image_caches.scientific_name when saved via the fetch path
+	// (Forgejo #756).
+	fetchedImage.ScientificName = scientificName
 	fetchedImage.CachedAt = time.Now()
 	fetchedImage.SourceProvider = c.providerName
 	log.Debug("Image successfully fetched from provider", logger.String("url", fetchedImage.URL))
@@ -1481,7 +1602,12 @@ func (c *BirdImageCache) downloadImageToFileCache(scientificName string, img *Bi
 	}
 
 	if _, _, err := c.fileCache.DownloadAndStore(context.Background(), provider, scientificName, img.URL); err != nil {
-		log.Warn("Failed to download image to file cache", logger.Error(err))
+		// File cache populates lazily; the image is already in the in-memory and
+		// DB caches, so a download failure here just means the proxy will refetch
+		// on the next request. Logged at info to keep the diagnostics health
+		// check from flagging an "elevated error count" on transient upstream
+		// failures (404s, throttling, etc.).
+		log.Info("Failed to download image to file cache", logger.Error(err))
 		return
 	}
 	log.Debug("Image downloaded to file cache")


### PR DESCRIPTION
## Summary

Two image cache resilience bugs both surface repeatedly via Sentry and never self-recover:

- **NOT NULL on `image_caches.scientific_name`**: `storeSuccessfulFetch` did not set `ScientificName` on the fetched `BirdImage` before `saveToDB`, so providers that returned partial metadata triggered a constraint violation. Fix mirrors the existing pattern in `storeNegativeCacheEntry`. `refreshEntry` had the same gap and is fixed alongside.
- **No recovery from SQLite corruption**: when the image cache file becomes malformed (`database disk image is malformed`), every read, save, batch lookup, hourly refresh, and fallback chain keeps retrying the dead DB, generating thousands of Sentry events. The image cache now latches a `dbCorrupted atomic.Bool` on the first corruption error, logs the failure once with the recovery action, and short-circuits all subsequent `loadFromDBCache`, `saveToDB`, `fetchFromDBWithFallback`, `loadCachedImages`, `refreshStaleEntries`, `tryRefreshFallback`, and `tryBatchFallbackProviders` calls. The service continues to serve fresh fetches from the provider until restart.

To support cross-package detection, the previously unused `isDatabaseCorruption` helper in `internal/datastore` is renamed to the exported `IsDatabaseCorruption`.

Also lowers two benign WARN logs to INFO so they stop tripping the diagnostics health check's "elevated error count" signal:
- `imageprovider`: `Failed to download image to file cache` (lazy proxy refetches on next request; in-memory and DB caches are already populated).
- `datastore/v2only`: `common name not found in name maps, falling back to scientific name` (the fallback is the intended behavior).

## Test Plan

- [x] New `cache_resilience_test.go` with 6 tests covering: ScientificName population, read corruption latching, write corruption latching, batch corruption latching, startup corruption tolerance, and the exported `IsDatabaseCorruption` helper.
- [x] All 245 imageprovider tests pass with `-race`.
- [x] All 2737 tests across imageprovider, datastore, analysis, and health packages pass.
- [x] `golangci-lint run` clean.
- [x] Pre-push quality gate run; reviewer-flagged refresh-path gaps fixed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database resilience: when corruption is detected, image fetching falls back to providers and avoids further corrupted DB activity.
  * Ensured cached images consistently preserve scientific names.

* **Behavior Changes**
  * Reduced log severity for missing common-name mappings and standardized some cache download failure messages.

* **Tests**
  * Added comprehensive tests covering cache behavior and corruption detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->