### PR TITLE
fix(datastore): detect missing columns after AutoMigrate and stop silent legacy fallback

### DIFF
--- a/internal/analysis/database_service.go
+++ b/internal/analysis/database_service.go
@@ -28,6 +28,29 @@ import (
 // databaseServiceName is the service name used for logging and diagnostics.
 const databaseServiceName = "database"
 
+// schemaCorruptionRecoveryHint is the user-facing instruction emitted alongside every
+// v2-schema-corruption log entry. Kept in one place so every call site shows the same
+// recovery steps; the path matches the tool's real location on disk.
+const schemaCorruptionRecoveryHint = "run tools/db-doctor/db-doctor.py --fix or restore from backup"
+
+// abortOnV2SchemaCorruption inspects an error returned by a v2 schema initializer.
+// If the error chains to datastoreV2.ErrV2SchemaCorrupted it logs at Error level with
+// the recovery hint and returns a wrapped error the caller must propagate; this stops
+// silent fallback to legacy mode that would mask the real failure mode (GitHub #3211).
+// Returns nil for non-corruption errors and for nil input so the caller's existing
+// fallback path stays in effect for transient problems.
+func abortOnV2SchemaCorruption(log logger.Logger, err error, operation, modeLabel string) error {
+	if err == nil || !errors.Is(err, datastoreV2.ErrV2SchemaCorrupted) {
+		return nil
+	}
+	log.Error("v2 database schema is corrupted, refusing to fall back to legacy mode",
+		logger.Error(err),
+		logger.String("mode", modeLabel),
+		logger.String("operation", operation),
+		logger.String("recovery_hint", schemaCorruptionRecoveryHint))
+	return fmt.Errorf("v2 schema corrupted in %s mode, refusing silent fallback to legacy mode: %w", modeLabel, err)
+}
+
 // DatabaseService manages the database lifecycle as an app.Service with TierCore shutdown.
 // It owns both the primary datastore (v1) and the optional v2 database manager.
 type DatabaseService struct {
@@ -161,7 +184,12 @@ func (d *DatabaseService) Start(_ context.Context) error {
 		var err error
 		v2OnlyDatastore, err = initializeV2OnlyMode(settings)
 		if err != nil {
-			// Enhanced database mode failed, fall back to legacy startup
+			if corrErr := abortOnV2SchemaCorruption(datastoreLog, err,
+				"initialize_enhanced_database_mode", "v2-only"); corrErr != nil {
+				return corrErr
+			}
+			// Non-corruption errors (disk, permissions, etc.) keep the legacy fallback so
+			// the app remains usable in a degraded mode while the operator investigates.
 			datastoreLog.Warn("enhanced database mode initialization failed, falling back to legacy mode",
 				logger.Error(err),
 				logger.String("operation", "initialize_enhanced_database_mode"))
@@ -184,7 +212,11 @@ func (d *DatabaseService) Start(_ context.Context) error {
 		var err error
 		v2OnlyDatastore, err = v2only.InitializeFreshInstall(settings, GetLogger(), freshSciIndex)
 		if err != nil {
-			// Fresh install failed, fall back to legacy mode
+			if corrErr := abortOnV2SchemaCorruption(GetLogger(), err,
+				"initialize_fresh_install", "fresh-install"); corrErr != nil {
+				return corrErr
+			}
+			// Non-corruption errors fall back to legacy mode for graceful degradation.
 			GetLogger().Warn("fresh install failed, falling back to legacy mode",
 				logger.Error(err),
 				logger.String("operation", "initialize_fresh_install"))
@@ -241,7 +273,17 @@ func (d *DatabaseService) Start(_ context.Context) error {
 		// Store the returned manager so Stop() can close the v2 database connection.
 		migrationManager, err := initializeMigrationInfrastructure(settings, d.dataStore)
 		if err != nil {
-			// Migration infrastructure is optional - log warning but continue
+			// Schema corruption during migration setup is the same silent-fallback class
+			// of failure the v2-only and fresh-install arms now refuse. A migration v2
+			// database with a missing column will lose every detection the worker tries
+			// to tail-sync, exactly the symptom from GitHub #3211; surface it instead of
+			// hiding behind a Warn.
+			if corrErr := abortOnV2SchemaCorruption(GetLogger(), err,
+				"initialize_migration_infrastructure", "migration"); corrErr != nil {
+				return corrErr
+			}
+			// Non-corruption migration setup failures remain optional: the legacy
+			// datastore is already open and the app stays usable in degraded mode.
 			GetLogger().Warn("migration infrastructure initialization failed",
 				logger.Error(err),
 				logger.String("operation", "initialize_migration_infrastructure"))

--- a/internal/analysis/database_service_test.go
+++ b/internal/analysis/database_service_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/app"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
@@ -47,6 +50,32 @@ func TestDatabaseService_Stop_NilSafe(t *testing.T) {
 		err := svc.Stop(t.Context())
 		assert.NoError(t, err)
 	})
+}
+
+// TestErrV2SchemaCorrupted_PropagatesThroughInitializeWrapChain pins the unwrap
+// behavior the silent-fallback prevention in Start() depends on. validateSchemaIntegrity
+// wraps the sentinel with fmt.Errorf, SQLiteManager.Initialize wraps that again, and
+// initializeV2OnlyMode / v2only.InitializeFreshInstall wrap the result with the internal
+// errors package. errors.Is must unwrap through all three layers and still match the
+// sentinel; otherwise Start() would silently fall back to legacy mode for corrupted
+// databases (GitHub #3211).
+func TestErrV2SchemaCorrupted_PropagatesThroughInitializeWrapChain(t *testing.T) {
+	t.Parallel()
+
+	// Layer 1: validator returns the sentinel wrapped with details.
+	validatorErr := fmt.Errorf("%w: detections missing columns [unlikely]", datastoreV2.ErrV2SchemaCorrupted)
+	// Layer 2: Manager.Initialize wraps the validator error.
+	initializeErr := fmt.Errorf("v2 schema integrity check failed: %w", validatorErr)
+	// Layer 3: initializeV2OnlyMode wraps the manager error with the internal errors
+	// package. EnhancedError.Unwrap() must keep the chain intact.
+	wrapped := errors.New(initializeErr).
+		Component("analysis").
+		Category(errors.CategoryDatabase).
+		Context("operation", "initialize_v2_database").
+		Build()
+
+	assert.True(t, errors.Is(wrapped, datastoreV2.ErrV2SchemaCorrupted),
+		"errors.Is must unwrap through fmt.Errorf and EnhancedError to find the sentinel")
 }
 
 func TestDatabaseService_Start_FreshInstall(t *testing.T) {

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -148,6 +148,44 @@ func reportSchemaEvolution(dbType, tableName string, unexpected []string, rowCou
 	})
 }
 
+// reportMissingColumns reports columns AutoMigrate failed to add. Distinct fingerprint
+// from extra-column reports so the two failure modes group separately in Sentry.
+func reportMissingColumns(dbType string, missing []missingColumnsEntry) {
+	if len(missing) == 0 {
+		return
+	}
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("component", "datastore-init")
+		scope.SetTag("db_type", dbType)
+		scope.SetTag("operation", "missing_columns_detected")
+		scope.SetFingerprint([]string{"missing-columns", dbType})
+
+		detail := make([]map[string]any, 0, len(missing))
+		tables := make([]string, 0, len(missing))
+		totalCols := 0
+		for _, m := range missing {
+			tables = append(tables, m.table)
+			totalCols += len(m.columns)
+			detail = append(detail, map[string]any{
+				"table":           m.table,
+				"missing_columns": m.columns,
+			})
+		}
+		scope.SetContext("missing_columns", map[string]any{
+			"tables":        tables,
+			"per_table":     detail,
+			"total_missing": totalCols,
+		})
+
+		telemetry.CaptureMessage(
+			fmt.Sprintf("Schema corruption: AutoMigrate did not add %d column(s) across %d table(s)",
+				totalCols, len(missing)),
+			sentry.LevelError,
+			"datastore-init",
+		)
+	})
+}
+
 // SQLiteManager handles the v2 normalized database for SQLite.
 type SQLiteManager struct {
 	db     *gorm.DB
@@ -283,18 +321,20 @@ func (m *SQLiteManager) Initialize() error {
 		}
 	}
 
-	// Validate schema integrity: detect unexpected columns from schema evolution.
-	// Empty contaminated tables are dropped so AutoMigrate can recreate them cleanly.
-	// Populated tables with extra columns are tolerated (logged, reported to Sentry).
-	if err := m.validateV2SchemaIntegrity(); err != nil {
-		return fmt.Errorf("v2 schema integrity check failed: %w", err)
-	}
-
 	// Run GORM auto-migrations for all entities
 	err := m.db.AutoMigrate(v2Entities()...)
 	if err != nil {
 		reportInitFailure("sqlite", "AutoMigrate", err, m.dbPath)
 		return fmt.Errorf("failed to migrate v2 schema: %w", err)
+	}
+
+	// Validate schema integrity AFTER AutoMigrate so missing columns indicate a real
+	// silent failure (GitHub #3211: GORM AutoMigrate sometimes does not add
+	// newly-introduced columns to an existing table, breaking every subsequent INSERT).
+	// Extra columns from schema evolution remain tolerated; missing columns surface as
+	// ErrV2SchemaCorrupted so callers can stop and not fall back to legacy.
+	if err := m.validateV2SchemaIntegrity(); err != nil {
+		return fmt.Errorf("v2 schema integrity check failed: %w", err)
 	}
 
 	// Fix SQLite foreign key constraints that GORM's AutoMigrate may not handle correctly.
@@ -470,15 +510,34 @@ func mysqlColumnLister(db *gorm.DB, tableName string) ([]string, error) {
 	return names, nil
 }
 
-// validateSchemaIntegrity checks all v2 tables for unexpected columns that may
-// indicate legacy schema contamination or schema evolution leftovers. For each table:
-//   - If the table doesn't exist yet, skip (AutoMigrate will create it).
-//   - If unexpected columns are found and the table is empty, drop it so
-//     AutoMigrate can recreate it with the correct schema.
-//   - If unexpected columns are found and the table has data, log a warning
-//     but continue. Extra columns are harmless: GORM ignores them when querying.
+// missingColumnsEntry records the missing columns for a single table during validation.
+type missingColumnsEntry struct {
+	table   string
+	columns []string
+}
+
+// validateSchemaIntegrity checks all v2 tables for column drift in either direction.
+// It must run AFTER AutoMigrate; calling it before AutoMigrate on a database from an
+// older version would misreport pending schema additions as corruption.
+// For each table:
+//   - If the table doesn't exist, skip. Post-AutoMigrate this should be impossible
+//     on a healthy run, so the skip is defensive only; expected-but-missing tables
+//     surface elsewhere via AutoMigrate's own error reporting.
+//   - MISSING columns (expected by the entity but not present in the database)
+//     indicate AutoMigrate silently failed to apply the new schema. These are real
+//     corruption: GORM-generated INSERTs reference the column by name and will fail
+//     with "table has no column named X". All missing columns are accumulated and
+//     reported as ErrV2SchemaCorrupted so callers can surface the failure instead of
+//     silently falling back.
+//   - EXTRA columns (present in the database but not in the entity) are tolerated:
+//     GORM ignores them on read/write. Per the additive-only rule from PR #3222,
+//     extras are normal schema-evolution residue and must not block startup. Empty
+//     tables with extras are still dropped so a fresh AutoMigrate run can recreate
+//     them cleanly; populated tables are logged + reported to Sentry only.
 func validateSchemaIntegrity(db *gorm.DB, log logger.Logger, dbType string, listColumns columnLister) error {
 	migrator := db.Migrator()
+
+	var missing []missingColumnsEntry
 
 	for _, entity := range v2Entities() {
 		if !migrator.HasTable(entity) {
@@ -487,6 +546,12 @@ func validateSchemaIntegrity(db *gorm.DB, log logger.Logger, dbType string, list
 
 		stmt := &gorm.Statement{DB: db}
 		if parseErr := stmt.Parse(entity); parseErr != nil {
+			if log != nil {
+				log.Warn("entity parse failed; cannot validate columns for this entity",
+					logger.String("entity_type", fmt.Sprintf("%T", entity)),
+					logger.Error(parseErr),
+					logger.String("operation", "validate_schema_integrity"))
+			}
 			continue
 		}
 		tableName := stmt.Schema.Table
@@ -498,14 +563,48 @@ func validateSchemaIntegrity(db *gorm.DB, log logger.Logger, dbType string, list
 
 		actualCols, err := listColumns(db, tableName)
 		if err != nil {
+			// Listing columns is the gatekeeper for missing-column detection. If it
+			// fails we cannot prove the schema is healthy, so log loudly so the
+			// failure shows up in support dumps instead of silently degrading the
+			// post-AutoMigrate guarantee. Continue rather than fail closed: a single
+			// transient SQLite/MySQL hiccup must not block startup.
+			if log != nil {
+				log.Warn("column listing failed; skipping schema validation for this table",
+					logger.String("table", tableName),
+					logger.Error(err),
+					logger.String("operation", "validate_schema_integrity"))
+			}
 			continue
 		}
 
-		var unexpected []string
+		actualNames := make(map[string]bool, len(actualCols))
+		unexpected := make([]string, 0, len(actualCols))
 		for _, colName := range actualCols {
+			actualNames[colName] = true
 			if !expectedNames[colName] {
 				unexpected = append(unexpected, colName)
 			}
+		}
+
+		missingCols := make([]string, 0, len(stmt.Schema.DBNames))
+		for _, dbName := range stmt.Schema.DBNames {
+			if !actualNames[dbName] {
+				missingCols = append(missingCols, dbName)
+			}
+		}
+
+		if len(missingCols) > 0 {
+			missing = append(missing, missingColumnsEntry{table: tableName, columns: missingCols})
+			if log != nil {
+				log.Error("table is missing expected columns; GORM writes will fail",
+					logger.String("table", tableName),
+					logger.Any("missing_columns", missingCols),
+					logger.String("db_type", dbType),
+					logger.String("operation", "validate_schema_integrity"))
+			}
+			// Skip the extras-handling branch below: a table with missing columns
+			// must not be dropped or downgraded to a warning.
+			continue
 		}
 
 		if len(unexpected) == 0 {
@@ -550,7 +649,23 @@ func validateSchemaIntegrity(db *gorm.DB, log logger.Logger, dbType string, list
 
 		reportSchemaEvolution(dbType, tableName, unexpected, rowCount)
 	}
+
+	if len(missing) > 0 {
+		reportMissingColumns(dbType, missing)
+		return fmt.Errorf("%w: %s", ErrV2SchemaCorrupted, formatMissingColumns(missing))
+	}
 	return nil
+}
+
+// formatMissingColumns renders accumulated missing-column entries into a deterministic
+// message suitable for logs and error chains. Tables and columns appear in input order
+// to keep the output stable when there is a single source of truth (v2Entities()).
+func formatMissingColumns(missing []missingColumnsEntry) string {
+	parts := make([]string, 0, len(missing))
+	for _, m := range missing {
+		parts = append(parts, fmt.Sprintf("%s missing columns [%s]", m.table, strings.Join(m.columns, ", ")))
+	}
+	return "AutoMigrate did not apply: " + strings.Join(parts, "; ")
 }
 
 // validateV2SchemaIntegrity delegates to the shared validation with SQLite column listing.

--- a/internal/datastore/v2/manager_test.go
+++ b/internal/datastore/v2/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"gorm.io/gorm"
 )
 
 func TestNewSQLiteManager(t *testing.T) {
@@ -784,6 +785,154 @@ func TestSchemaEvolution_ExtraColumnsDoNotBlockInitialize(t *testing.T) {
 	err = mgr2.DB().Find(&models).Error
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(models), 1, "should be able to query with extra columns present")
+}
+
+// TestValidateV2SchemaIntegrity_DetectsMissingColumn covers GitHub #3211: GORM
+// AutoMigrate sometimes silently fails to add a newly-introduced column to an existing
+// table. The post-AutoMigrate validator must catch this so callers can surface a real
+// error instead of letting INSERTs fail with "table has no column named X".
+func TestValidateV2SchemaIntegrity_DetectsMissingColumn(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	require.NoError(t, mgr.Initialize())
+
+	// Disable FK checks so we can populate detections without lookup setup.
+	require.NoError(t, mgr.DB().Exec("PRAGMA foreign_keys = OFF").Error)
+	require.NoError(t, mgr.DB().Exec(
+		"INSERT INTO labels (scientific_name, model_id, label_type_id) VALUES ('Turdus merula', 1, 1)").Error)
+	require.NoError(t, mgr.DB().Exec(
+		"INSERT INTO detections (model_id, label_id, detected_at, confidence) VALUES (1, 1, 1716184800, 0.85)").Error)
+	require.NoError(t, mgr.DB().Exec("PRAGMA foreign_keys = ON").Error)
+
+	// Simulate AutoMigrate silently failing to add the `unlikely` column that was
+	// introduced in PR #3072 / commit e805e6eb0.
+	require.NoError(t, mgr.DB().Exec("ALTER TABLE detections DROP COLUMN unlikely").Error)
+
+	err = mgr.validateV2SchemaIntegrity()
+	require.Error(t, err, "missing column must be reported as corruption")
+	require.ErrorIs(t, err, ErrV2SchemaCorrupted)
+	assert.Contains(t, err.Error(), "detections", "error should name the table")
+	assert.Contains(t, err.Error(), "unlikely", "error should name the missing column")
+}
+
+// TestValidateV2SchemaIntegrity_DetectsMissingColumnEmptyTable verifies missing column
+// detection also fires on empty tables. Row count must not affect corruption verdict.
+func TestValidateV2SchemaIntegrity_DetectsMissingColumnEmptyTable(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	require.NoError(t, mgr.Initialize())
+
+	require.NoError(t, mgr.DB().Exec("ALTER TABLE detections DROP COLUMN unlikely").Error)
+
+	err = mgr.validateV2SchemaIntegrity()
+	require.Error(t, err, "missing column must be reported even on empty tables")
+	require.ErrorIs(t, err, ErrV2SchemaCorrupted)
+}
+
+// TestValidateV2SchemaIntegrity_MissingColumnWinsOverExtras verifies that when a table
+// has both extra and missing columns, the missing-column corruption is reported.
+// Extra columns alone are harmless (additive-only rule from PR #3222), but a missing
+// column means GORM-generated INSERTs will fail.
+func TestValidateV2SchemaIntegrity_MissingColumnWinsOverExtras(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	require.NoError(t, mgr.Initialize())
+
+	// Add a harmless extra column from older schema evolution.
+	require.NoError(t, mgr.DB().Exec(
+		"ALTER TABLE detections ADD COLUMN legacy_extra TEXT DEFAULT ''").Error)
+	// Also drop a required column.
+	require.NoError(t, mgr.DB().Exec("ALTER TABLE detections DROP COLUMN unlikely").Error)
+
+	err = mgr.validateV2SchemaIntegrity()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrV2SchemaCorrupted)
+	assert.Contains(t, err.Error(), "unlikely")
+}
+
+// TestValidateSchemaIntegrity_MySQLParity_DetectsMissingColumn exercises the shared
+// validator with a stub columnLister that mimics MySQL information_schema returning a
+// table missing a column. SQLite is used as the actual backing store so we can keep
+// the test hermetic, but the validator path covered is the MySQL one.
+func TestValidateSchemaIntegrity_MySQLParity_DetectsMissingColumn(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	require.NoError(t, mgr.Initialize())
+
+	// Stub lister: returns the real SQLite columns for every table EXCEPT
+	// `detections`, where it drops the `unlikely` column to simulate a MySQL
+	// information_schema result on a database that pre-dates PR #3072.
+	stubLister := func(db *gorm.DB, tableName string) ([]string, error) {
+		cols, listErr := sqliteColumnLister(db, tableName)
+		if listErr != nil {
+			return nil, listErr
+		}
+		if tableName != "detections" {
+			return cols, nil
+		}
+		filtered := make([]string, 0, len(cols))
+		for _, c := range cols {
+			if c == "unlikely" {
+				continue
+			}
+			filtered = append(filtered, c)
+		}
+		return filtered, nil
+	}
+
+	err = validateSchemaIntegrity(mgr.DB(), mgr.log, "mysql", stubLister)
+	require.Error(t, err, "MySQL listing path must also report missing columns")
+	require.ErrorIs(t, err, ErrV2SchemaCorrupted)
+	assert.Contains(t, err.Error(), "detections")
+	assert.Contains(t, err.Error(), "unlikely")
+}
+
+// TestInitialize_PostAutoMigrate_HealsDroppedColumn verifies that validation runs
+// AFTER AutoMigrate. If AutoMigrate successfully re-adds a column that was previously
+// missing, Initialize must succeed and not surface a stale "missing column" error.
+// This pins the ordering change so a future refactor that moves the validator back
+// before AutoMigrate fails this test loudly.
+func TestInitialize_PostAutoMigrate_HealsDroppedColumn(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	require.NoError(t, mgr.Initialize())
+
+	// Drop the column that PR #3072 added so the schema looks like a pre-PR #3072
+	// database. AutoMigrate on the next Initialize should re-add it.
+	require.NoError(t, mgr.DB().Exec("ALTER TABLE detections DROP COLUMN unlikely").Error)
+	require.NoError(t, mgr.Close())
+
+	mgr2, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr2.Close() })
+
+	require.NoError(t, mgr2.Initialize(),
+		"Initialize must succeed: AutoMigrate should re-add the missing column "+
+			"and the post-AutoMigrate validator should then see a healthy schema")
+
+	var colCount int64
+	require.NoError(t, mgr2.DB().Raw(
+		"SELECT COUNT(*) FROM pragma_table_info('detections') WHERE name = 'unlikely'",
+	).Scan(&colCount).Error)
+	assert.Equal(t, int64(1), colCount, "AutoMigrate must have re-added the column")
 }
 
 func TestSQLiteManager_Close_NilsOutDB(t *testing.T) {

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -110,19 +110,20 @@ func (m *MySQLManager) Initialize() error {
 	// fell back to legacy mode due to the PR #2165 table name mismatch.
 	m.cleanupLegacySchemaContamination()
 
-	// Validate schema integrity: detect unexpected columns from schema evolution.
-	// Empty contaminated tables are dropped so AutoMigrate can recreate them cleanly.
-	// Populated tables with extra columns are tolerated (logged, reported to Sentry).
-	if err := m.validateV2SchemaIntegrity(); err != nil {
-		return fmt.Errorf("v2 schema integrity check failed: %w", err)
-	}
-
 	// Run GORM auto-migrations for all entities using the shared canonical list.
 	// Tables will be created with v2_ prefix due to NamingStrategy.
 	err := m.db.AutoMigrate(v2Entities()...)
 	if err != nil {
 		reportInitFailure("mysql", "AutoMigrate", err, m.config.Host, m.config.Database, m.config.Username)
 		return fmt.Errorf("failed to migrate v2 schema: %w", err)
+	}
+
+	// Validate schema integrity AFTER AutoMigrate so missing columns indicate a real
+	// silent failure (GitHub #3211). Extra columns from schema evolution remain
+	// tolerated; missing columns surface as ErrV2SchemaCorrupted so callers can stop
+	// and not fall back to legacy mode.
+	if err := m.validateV2SchemaIntegrity(); err != nil {
+		return fmt.Errorf("v2 schema integrity check failed: %w", err)
 	}
 
 	// Initialize migration state singleton using FirstOrCreate to handle race conditions


### PR DESCRIPTION
## Summary

- Adds a missing-column check to `validateSchemaIntegrity()` that runs **after** `AutoMigrate` so GORM's silent failures stop being invisible: missing columns return `ErrV2SchemaCorrupted` with table and column names; extra columns continue to be tolerated per the additive-only rule.
- `DatabaseService.Start()` now refuses to fall back to legacy mode when the v2 schema is corrupted. A single helper (`abortOnV2SchemaCorruption`) covers all three init paths (v2-only, fresh-install, and the migration infrastructure path). Non-corruption errors still get the existing legacy fallback so transient issues stay non-fatal.
- Sentry telemetry emits a distinct `["missing-columns", dbType]` fingerprint so this failure mode groups separately from extras (`["schema-evolution", tableName]`).

Closes #3211. `tools/db-doctor/db-doctor.py --fix` already repairs missing columns via `V2_COLUMN_DEFS`, so users hit by the bug have a recovery path.

## Why

User upgrades from a 6-week-old build sometimes ended up with the new `unlikely` column never added to the `detections` table. Every INSERT errored with "table has no column named unlikely", and the silent legacy fallback then masked the failure. Result: dashboard data appears to vanish even though the binary is "running fine".

## Test plan

- [x] `go test -race ./internal/datastore/v2/... ./internal/analysis/...` (2103 passed)
- [x] New unit tests cover: populated-table missing column, empty-table missing column, missing-wins-over-extras, MySQL listing strategy parity, post-AutoMigrate self-heal of a dropped column, and the `errors.Is` unwrap chain through `fmt.Errorf` + `EnhancedError`.
- [x] `golangci-lint run` clean on both local v2.11.4 and the CI-pinned v2.10.1 (`--build-tags=noembed,skipfrontend`)
- [x] Local `coderabbit review --plain -t uncommitted` reports no findings.
- [x] Manual db-doctor end-to-end: created a SQLite db missing `unlikely`, `db-doctor.py --fix` added it back and preserved the existing detection row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database schema corruption detection with clear recovery guidance during startup instead of silent fallback to degraded mode.
  * Added detection and explicit reporting for missing database columns in schema validation.
  * Improved error propagation through multi-layer error chains to surface schema integrity issues that previously went undetected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->