### PR TITLE
fix(health): don't let skipped checks override healthy overall status

### DIFF
--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -65,13 +65,31 @@ type MultiResultCheck interface {
 	RunMulti(ctx context.Context) []Result
 }
 
-// WorstStatus returns the most severe status from a slice of results.
+// WorstStatus returns the most severe actionable status from a slice of results.
+// Skipped and unknown results are ignored when actionable results (healthy,
+// warning, critical) exist. If every result is skipped or unknown, the
+// function returns StatusSkipped.
 func WorstStatus(results []Result) Status {
 	worst := StatusHealthy
+	hasActionable := false
+	sawUnknown := false
 	for _, r := range results {
+		if r.Status == StatusSkipped || r.Status == StatusUnknown {
+			if r.Status == StatusUnknown {
+				sawUnknown = true
+			}
+			continue
+		}
+		hasActionable = true
 		if Severity(r.Status) > Severity(worst) {
 			worst = r.Status
 		}
+	}
+	if !hasActionable && len(results) > 0 {
+		if sawUnknown {
+			return StatusUnknown
+		}
+		return StatusSkipped
 	}
 	return worst
 }

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -67,8 +67,8 @@ type MultiResultCheck interface {
 
 // WorstStatus returns the most severe actionable status from a slice of results.
 // Skipped and unknown results are ignored when actionable results (healthy,
-// warning, critical) exist. If every result is skipped or unknown, the
-// function returns StatusSkipped.
+// warning, critical) exist. If every result is non-actionable, it returns
+// StatusUnknown when any unknown result is present, otherwise StatusSkipped.
 func WorstStatus(results []Result) Status {
 	worst := StatusHealthy
 	hasActionable := false

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -42,14 +42,39 @@ func TestWorstStatus_MixedStatuses(t *testing.T) {
 			want:     StatusCritical,
 		},
 		{
-			name:     "skipped beats healthy",
+			name:     "healthy with skipped stays healthy",
 			statuses: []Status{StatusHealthy, StatusSkipped},
+			want:     StatusHealthy,
+		},
+		{
+			name:     "healthy with unknown stays healthy",
+			statuses: []Status{StatusHealthy, StatusUnknown},
+			want:     StatusHealthy,
+		},
+		{
+			name:     "all skipped returns skipped",
+			statuses: []Status{StatusSkipped, StatusSkipped},
 			want:     StatusSkipped,
 		},
 		{
-			name:     "unknown beats healthy",
-			statuses: []Status{StatusHealthy, StatusUnknown},
+			name:     "all unknown returns unknown",
+			statuses: []Status{StatusUnknown, StatusUnknown},
 			want:     StatusUnknown,
+		},
+		{
+			name:     "mixed skipped and unknown returns unknown",
+			statuses: []Status{StatusSkipped, StatusUnknown},
+			want:     StatusUnknown,
+		},
+		{
+			name:     "single skipped returns skipped",
+			statuses: []Status{StatusSkipped},
+			want:     StatusSkipped,
+		},
+		{
+			name:     "warning with skipped stays warning",
+			statuses: []Status{StatusWarning, StatusSkipped},
+			want:     StatusWarning,
 		},
 		{
 			name:     "critical beats all",


### PR DESCRIPTION
## Summary

- Fix `WorstStatus()` treating skipped/unknown checks as worse than healthy, causing the system health page to show "Skipped" overall when all actionable checks are healthy
- Preserve the unknown vs skipped distinction: all-unknown returns unknown, all-skipped returns skipped
- Add comprehensive test cases for the new behavior

## Test plan

- [x] `go test -race ./internal/health/...` passes (126 tests)
- [x] `golangci-lint run -v ./internal/health/...` clean
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-check status determination to prioritize actionable results (healthy/warning/critical) over non-actionable ones (skipped/unknown). If no actionable results exist, the overall status now correctly distinguishes unknown vs. all-skipped outcomes.

* **Tests**
  * Expanded unit test coverage for mixed status scenarios, including combinations of actionable, skipped, and unknown results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->