### PR TITLE
feat(ui): replace Probe Stream with generic Test Stream button

### DIFF
--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -26,16 +26,10 @@
     Check,
     X,
     AlertCircle,
-    AlertTriangle,
     Radio,
     ChevronDown,
     Moon,
-    Search,
-    CircleCheck,
-    CircleX,
-    Loader2,
   } from '@lucide/svelte';
-  import { api } from '$lib/utils/api';
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
@@ -55,6 +49,7 @@
   } from '$lib/stores/settings';
   import { defaultQuietHoursConfig } from '$lib/stores/settings';
   import type { StreamHealthResponse } from './StreamManager.svelte';
+  import StreamTestButton from './StreamTestButton.svelte';
   import StreamTimeline from './StreamTimeline.svelte';
 
   interface LocalEqualizerSettings {
@@ -173,19 +168,7 @@
     return 'Unknown';
   });
 
-  interface ProbeResult {
-    sampleRate: number;
-    channels: number;
-    codec: string;
-    batCompatible: boolean;
-    warnings: string[];
-  }
-
-  // Probe state
-  let isProbing = $state(false);
-  let probeResult = $state<ProbeResult | null>(null);
-  let probeError = $state<string | null>(null);
-  let probeController: AbortController | null = null;
+  let probeResult = $state<{ sampleRate: number } | null>(null);
 
   // Local editing state - initialized with defaults, synced from props in startEdit()
   let isEditing = $state(false);
@@ -338,15 +321,11 @@
       : { enabled: false, filters: [] };
     editQuietHours = { ...defaultQuietHoursConfig, ...stream.quietHours };
     showEqualizer = false;
-    probeController?.abort();
     probeResult = null;
-    probeError = null;
-    prevEditUrl = stream.url;
     isEditing = true;
   }
 
   function cancelEdit() {
-    probeController?.abort();
     isEditing = false;
     showDeleteConfirm = false;
   }
@@ -410,41 +389,9 @@
 
   let sourceSampleRate = $derived(probeResult?.sampleRate ?? 48000);
 
-  async function probeStream() {
-    if (!editUrl.trim()) return;
-    probeController?.abort();
-    probeController = new AbortController();
-    isProbing = true;
-    probeResult = null;
-    probeError = null;
-    try {
-      const result = await api.post<ProbeResult>(
-        '/api/v2/streams/probe',
-        { url: editUrl.trim() },
-        { signal: probeController.signal }
-      );
-      probeResult = result;
-    } catch (err: unknown) {
-      if (err instanceof Error && err.name === 'AbortError') return;
-      probeError = err instanceof Error ? err.message : '';
-    } finally {
-      isProbing = false;
-    }
+  function handleProbeResult(result: { sampleRate: number } | null) {
+    probeResult = result;
   }
-
-  let prevEditUrl = '';
-  $effect(() => {
-    if (isEditing && editUrl !== prevEditUrl) {
-      if (prevEditUrl !== '') {
-        probeResult = null;
-        probeError = null;
-      }
-      prevEditUrl = editUrl;
-    }
-    return () => {
-      probeController?.abort();
-    };
-  });
 
   function updateEnabled(enabled: boolean) {
     onUpdate({ ...stream, enabled });
@@ -532,64 +479,14 @@
           />
         </div>
 
-        <!-- Probe Stream -->
-        <div class="flex items-center gap-2">
-          <button
-            type="button"
-            class="inline-flex items-center gap-1.5 h-8 px-3 text-sm font-medium rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            onclick={probeStream}
-            disabled={isProbing || !editUrl.trim()}
-          >
-            {#if isProbing}
-              <Loader2 class="size-4 animate-spin" />
-              {t('settings.audio.streams.probe.probing')}
-            {:else}
-              <Search class="size-4" />
-              {t('settings.audio.streams.probe.button')}
-            {/if}
-          </button>
-
-          {#if probeResult}
-            <div class="flex items-center gap-2 text-xs">
-              <span class="font-mono text-[var(--color-base-content)]">
-                {probeResult.sampleRate / 1000} kHz, {probeResult.codec}
-              </span>
-              {#if probeResult.batCompatible}
-                <span
-                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-medium bg-[var(--color-success)]/15 text-[var(--color-success)]"
-                >
-                  <CircleCheck class="size-3" />
-                  {t('settings.audio.streams.probe.batCompatible')}
-                </span>
-              {:else}
-                <span
-                  class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-medium bg-[var(--color-error)]/15 text-[var(--color-error)]"
-                >
-                  <CircleX class="size-3" />
-                  {t('settings.audio.streams.probe.batIncompatible')}
-                </span>
-              {/if}
-            </div>
-          {/if}
-        </div>
-
-        {#if probeResult && !probeResult.batCompatible && probeResult.sampleRate >= 96000}
-          <div
-            class="flex items-start gap-2 p-2.5 rounded-lg text-xs leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
-            role="status"
-          >
-            <AlertTriangle class="size-3.5 shrink-0 mt-0.5 text-[var(--color-warning)]" />
-            <span class="text-[var(--color-base-content)]">
-              {t('settings.audio.streams.codecWarning.lossy')}
-            </span>
-          </div>
-        {/if}
-
-        {#if probeError !== null}
-          <p class="text-xs text-[var(--color-error)]">
-            {t('settings.audio.streams.probe.error')}{probeError ? `: ${probeError}` : ''}
-          </p>
-        {/if}
+        <!-- Test Stream -->
+        <StreamTestButton
+          url={editUrl}
+          models={availableModels}
+          selectedModels={editModels}
+          {disabled}
+          onResult={handleProbeResult}
+        />
 
         <!-- Type and Transport Row -->
         <div class="grid grid-cols-2 gap-4">

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -127,6 +127,8 @@
   let newQuietHours = $state<QuietHoursConfig>({ ...defaultQuietHoursConfig });
   let nameError = $state<string | null>(null);
   let urlError = $state<string | null>(null);
+  let newProbeResult = $state<{ sampleRate: number } | null>(null);
+  let newSourceSampleRate = $derived(newProbeResult?.sampleRate ?? 48000);
 
   // SSE connection for real-time health updates
   let eventSource: ReconnectingEventSource | null = null;
@@ -415,6 +417,7 @@
     newStreamType = 'rtsp';
     newModels = [DEFAULT_MODEL_ID];
     newQuietHours = { ...defaultQuietHoursConfig };
+    newProbeResult = null;
     clearErrors();
     showAddForm = false;
 
@@ -656,6 +659,7 @@
               models={availableModels}
               selectedModels={newModels}
               {disabled}
+              onResult={result => (newProbeResult = result)}
             />
 
             <!-- Stream Type and Protocol -->
@@ -687,6 +691,7 @@
             <ModelCheckboxList
               models={availableModels}
               selectedModels={newModels}
+              sourceSampleRate={newSourceSampleRate}
               isStream={true}
               {disabled}
               onToggle={models => (newModels = models)}
@@ -713,6 +718,7 @@
                   newTransport = 'tcp';
                   newModels = [DEFAULT_MODEL_ID];
                   newQuietHours = { ...defaultQuietHoursConfig };
+                  newProbeResult = null;
                   clearErrors();
                 }}
               >

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -36,6 +36,7 @@
   import QuietHoursEditor from './QuietHoursEditor.svelte';
   import type { StreamConfig, StreamType, QuietHoursConfig } from '$lib/stores/settings';
   import { defaultQuietHoursConfig } from '$lib/stores/settings';
+  import StreamTestButton from './StreamTestButton.svelte';
 
   const logger = loggers.audio;
 
@@ -648,6 +649,14 @@
                 </p>
               {/if}
             </div>
+
+            <!-- Test Stream -->
+            <StreamTestButton
+              url={newUrl}
+              models={availableModels}
+              selectedModels={newModels}
+              {disabled}
+            />
 
             <!-- Stream Type and Protocol -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/frontend/src/lib/desktop/components/forms/StreamTestButton.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamTestButton.svelte
@@ -1,0 +1,153 @@
+<!--
+  Stream Test Button Component
+
+  Purpose: Test stream connectivity and audio properties via the probe API.
+  Shows stream info (sample rate, codec, channels) and model-specific
+  compatibility badges when relevant.
+
+  @component
+-->
+<script lang="ts">
+  import { Search, CircleCheck, CircleX, Loader2, AlertTriangle } from '@lucide/svelte';
+  import { api } from '$lib/utils/api';
+  import { t } from '$lib/i18n';
+
+  interface ModelOption {
+    id: string;
+    name: string;
+    category: string;
+    minSampleRate?: number;
+    recommendedSampleRate?: number;
+  }
+
+  interface ProbeResult {
+    sampleRate: number;
+    channels: number;
+    codec: string;
+    batCompatible: boolean;
+    warnings: string[];
+  }
+
+  interface Props {
+    url: string;
+    models: ModelOption[];
+    selectedModels: string[];
+    disabled?: boolean;
+    onResult?: (_result: ProbeResult | null) => void;
+  }
+
+  let { url, models, selectedModels, disabled = false, onResult }: Props = $props();
+
+  let isTesting = $state(false);
+  let testResult = $state<ProbeResult | null>(null);
+  let testError = $state<string | null>(null);
+  let testController: AbortController | null = null;
+
+  let hasBatModel = $derived(
+    selectedModels.some(id => {
+      const model = models.find(m => m.id === id);
+      return model?.category === 'bat';
+    })
+  );
+
+  async function testStream() {
+    if (!url.trim()) return;
+    testController?.abort();
+    testController = new AbortController();
+    isTesting = true;
+    testResult = null;
+    testError = null;
+    onResult?.(null);
+    try {
+      const result = await api.post<ProbeResult>(
+        '/api/v2/streams/probe',
+        { url: url.trim() },
+        { signal: testController.signal }
+      );
+      testResult = result;
+      onResult?.(result);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      testError = err instanceof Error ? err.message : '';
+    } finally {
+      isTesting = false;
+    }
+  }
+
+  let prevUrl = '';
+  $effect(() => {
+    if (url !== prevUrl) {
+      if (prevUrl !== '') {
+        testResult = null;
+        testError = null;
+        onResult?.(null);
+      }
+      prevUrl = url;
+    }
+    return () => {
+      testController?.abort();
+    };
+  });
+</script>
+
+<div class="space-y-2">
+  <div class="flex items-center gap-2">
+    <button
+      type="button"
+      class="inline-flex items-center gap-1.5 h-8 px-3 text-sm font-medium rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      onclick={testStream}
+      disabled={isTesting || !url.trim() || disabled}
+    >
+      {#if isTesting}
+        <Loader2 class="size-4 animate-spin" />
+        {t('settings.audio.streams.probe.probing')}
+      {:else}
+        <Search class="size-4" />
+        {t('settings.audio.streams.probe.button')}
+      {/if}
+    </button>
+
+    {#if testResult}
+      <div class="flex items-center gap-2 text-xs">
+        <span class="font-mono text-[var(--color-base-content)]">
+          {testResult.sampleRate / 1000} kHz, {testResult.codec}, {testResult.channels}ch
+        </span>
+        {#if hasBatModel}
+          {#if testResult.batCompatible}
+            <span
+              class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-medium bg-[var(--color-success)]/15 text-[var(--color-success)]"
+            >
+              <CircleCheck class="size-3" />
+              {t('settings.audio.streams.probe.batCompatible')}
+            </span>
+          {:else}
+            <span
+              class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-medium bg-[var(--color-error)]/15 text-[var(--color-error)]"
+            >
+              <CircleX class="size-3" />
+              {t('settings.audio.streams.probe.batIncompatible')}
+            </span>
+          {/if}
+        {/if}
+      </div>
+    {/if}
+  </div>
+
+  {#if testResult && hasBatModel && !testResult.batCompatible && testResult.sampleRate >= 96000}
+    <div
+      class="flex items-start gap-2 p-2.5 rounded-lg text-xs leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
+      role="status"
+    >
+      <AlertTriangle class="size-3.5 shrink-0 mt-0.5 text-[var(--color-warning)]" />
+      <span class="text-[var(--color-base-content)]">
+        {t('settings.audio.streams.codecWarning.lossy')}
+      </span>
+    </div>
+  {/if}
+
+  {#if testError !== null}
+    <p class="text-xs text-[var(--color-error)]">
+      {t('settings.audio.streams.probe.error')}{testError ? `: ${testError}` : ''}
+    </p>
+  {/if}
+</div>

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3046,14 +3046,14 @@
           "unknown": "Neznámé"
         },
         "probe": {
-          "button": "Prozkoumat stream",
-          "probing": "Zkoumaní...",
+          "button": "Testovat stream",
+          "probing": "Testování...",
           "result": "Výsledek průzkumu",
-          "error": "Průzkum selhal",
+          "error": "Test selhal",
           "batCompatible": "Kompatibilní s netopýry",
           "batIncompatible": "Nekompatibilní s netopýry"
         },
-        "batWarning": "Modely pro netopýry vyžadují streamy s bezeztrátovým kodekem (PCM) a vzorkovací frekvencí alespoň 96 kHz. Pomocí tlačítka Prozkoumat stream ověřte, zda váš stream splňuje tyto požadavky.",
+        "batWarning": "Modely netopýrů vyžadují streamy s bezeztrátovým kodekem (PCM) a vzorkovací frekvencí alespoň 96 kHz. Pomocí tlačítka Testovat stream výše ověřte kompatibilitu.",
         "codecWarning": {
           "lossy": "Ztrátové kodeky (AAC, Opus, MP3) ničí ultrazvukové frekvence nad ~20 kHz, čímž se stream stává nevhodným pro detekci netopýrů."
         }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3046,14 +3046,14 @@
           "unknown": "Ukendt"
         },
         "probe": {
-          "button": "Undersøg stream",
-          "probing": "Undersøger...",
+          "button": "Test stream",
+          "probing": "Tester...",
           "result": "Undersøgelsesresultat",
-          "error": "Undersøgelse mislykkedes",
+          "error": "Test mislykkedes",
           "batCompatible": "Kompatibel med flagermus",
           "batIncompatible": "Ikke kompatibel med flagermus"
         },
-        "batWarning": "Flagermusmodeller kræver streams med et tabsfrit codec (PCM) og en samplerate på mindst 96 kHz. Brug knappen Undersøg stream for at bekræfte, at din stream opfylder disse krav.",
+        "batWarning": "Flagermusmodeller kræver streams med en tabsfri codec (PCM) og en samplerate på mindst 96 kHz. Brug knappen Test stream ovenfor for at verificere kompatibilitet.",
         "codecWarning": {
           "lossy": "Tabsgivende codecs (AAC, Opus, MP3) ødelægger ultralydsfrekvenser over ~20 kHz, hvilket gør streamen uegnet til detektering af flagermus."
         }

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3046,14 +3046,14 @@
           "unknown": "Unbekannt"
         },
         "probe": {
-          "button": "Stream prüfen",
-          "probing": "Wird geprüft...",
+          "button": "Stream testen",
+          "probing": "Teste...",
           "result": "Prüfergebnis",
-          "error": "Prüfung fehlgeschlagen",
+          "error": "Test fehlgeschlagen",
           "batCompatible": "Fledermaus-kompatibel",
           "batIncompatible": "Nicht fledermaus-kompatibel"
         },
-        "batWarning": "Fledermausmodelle erfordern Streams mit einem verlustfreien Codec (PCM) und einer Abtastrate von mindestens 96 kHz. Verwenden Sie die Schaltfläche Stream prüfen, um zu überprüfen, ob Ihr Stream diese Anforderungen erfüllt.",
+        "batWarning": "Fledermausmodelle erfordern Streams mit einem verlustfreien Codec (PCM) und einer Abtastrate von mindestens 96 kHz. Verwenden Sie die Schaltfläche Stream testen oben, um die Kompatibilität zu überprüfen.",
         "codecWarning": {
           "lossy": "Verlustbehaftete Codecs (AAC, Opus, MP3) zerstören Ultraschallfrequenzen über ~20 kHz und machen den Stream für die Fledermauserkennung ungeeignet."
         }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3046,14 +3046,14 @@
           "unknown": "Unknown"
         },
         "probe": {
-          "button": "Probe Stream",
-          "probing": "Probing...",
+          "button": "Test Stream",
+          "probing": "Testing...",
           "result": "Probe Result",
-          "error": "Probe failed",
+          "error": "Test failed",
           "batCompatible": "Bat compatible",
           "batIncompatible": "Not bat compatible"
         },
-        "batWarning": "Bat models require streams with a lossless codec (PCM) and a sample rate of at least 96 kHz. Use the Probe Stream button to verify your stream meets these requirements.",
+        "batWarning": "Bat models require streams with a lossless codec (PCM) and a sample rate of at least 96 kHz. Use the Test Stream button above to verify compatibility.",
         "codecWarning": {
           "lossy": "Lossy codecs (AAC, Opus, MP3) destroy ultrasonic frequencies above ~20 kHz, making the stream unsuitable for bat detection."
         }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3046,14 +3046,14 @@
           "unknown": "Desconocido"
         },
         "probe": {
-          "button": "Sondear stream",
-          "probing": "Sondeando...",
+          "button": "Probar stream",
+          "probing": "Probando...",
           "result": "Resultado del sondeo",
-          "error": "El sondeo falló",
+          "error": "Prueba fallida",
           "batCompatible": "Compatible con murciélagos",
           "batIncompatible": "No compatible con murciélagos"
         },
-        "batWarning": "Los modelos de murciélagos requieren streams con un códec sin pérdida (PCM) y una tasa de muestreo de al menos 96 kHz. Use el botón Sondear stream para verificar que su stream cumple estos requisitos.",
+        "batWarning": "Los modelos de murciélagos requieren streams con un códec sin pérdida (PCM) y una tasa de muestreo de al menos 96 kHz. Use el botón Probar stream de arriba para verificar la compatibilidad.",
         "codecWarning": {
           "lossy": "Los códecs con pérdida (AAC, Opus, MP3) destruyen las frecuencias ultrasónicas por encima de ~20 kHz, haciendo el stream inadecuado para la detección de murciélagos."
         }

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3046,14 +3046,14 @@
           "unknown": "Tuntematon"
         },
         "probe": {
-          "button": "Tutki striimi",
-          "probing": "Tutkitaan...",
+          "button": "Testaa striimi",
+          "probing": "Testataan...",
           "result": "Tutkimuksen tulos",
-          "error": "Tutkinta epäonnistui",
+          "error": "Testi epäonnistui",
           "batCompatible": "Yhteensopiva lepakoiden kanssa",
           "batIncompatible": "Ei yhteensopiva lepakoiden kanssa"
         },
-        "batWarning": "Lepakkomallit vaativat striimejä, joissa on häviötön koodekki (PCM) ja näytteenottotaajuus vähintään 96 kHz. Käytä Tutki striimi -painiketta varmistaaksesi, että striimisi täyttää nämä vaatimukset.",
+        "batWarning": "Lepakkomallit vaativat häviöttömän koodekin (PCM) ja vähintään 96 kHz näytteenottotaajuuden. Tarkista yhteensopivuus yllä olevalla Testaa striimi -painikkeella.",
         "codecWarning": {
           "lossy": "Häviölliset koodekit (AAC, Opus, MP3) tuhoavat ultraäänitaajuudet yli ~20 kHz, mikä tekee striimistä soveltumattoman lepakoiden havaitsemiseen."
         }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3046,14 +3046,14 @@
           "unknown": "Inconnue"
         },
         "probe": {
-          "button": "Sonder le flux",
-          "probing": "Sondage en cours...",
+          "button": "Tester le flux",
+          "probing": "Test en cours...",
           "result": "Résultat du sondage",
-          "error": "Le sondage a échoué",
+          "error": "Test échoué",
           "batCompatible": "Compatible chauves-souris",
           "batIncompatible": "Non compatible chauves-souris"
         },
-        "batWarning": "Les modèles pour chauves-souris nécessitent des flux avec un codec sans perte (PCM) et un taux d'échantillonnage d'au moins 96 kHz. Utilisez le bouton Sonder le flux pour vérifier que votre flux répond à ces exigences.",
+        "batWarning": "Les modèles de chauves-souris nécessitent des flux avec un codec sans perte (PCM) et un taux d'échantillonnage d'au moins 96 kHz. Utilisez le bouton Tester le flux ci-dessus pour vérifier la compatibilité.",
         "codecWarning": {
           "lossy": "Les codecs avec perte (AAC, Opus, MP3) détruisent les fréquences ultrasoniques au-dessus de ~20 kHz, rendant le flux inadapté à la détection des chauves-souris."
         }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3046,14 +3046,14 @@
           "unknown": "Ismeretlen"
         },
         "probe": {
-          "button": "Stream vizsgálat",
-          "probing": "Vizsgálat...",
+          "button": "Stream tesztelése",
+          "probing": "Tesztelés...",
           "result": "Vizsgálat eredménye",
-          "error": "A vizsgálat sikertelen",
+          "error": "Teszt sikertelen",
           "batCompatible": "Denevér-kompatibilis",
           "batIncompatible": "Nem denevér-kompatibilis"
         },
-        "batWarning": "A denevérmodellek veszteségmentes kodeket (PCM) és legalább 96 kHz-es mintavételezési frekvenciájú streameket igényelnek. A Stream vizsgálat gombbal ellenőrizheti, hogy a streamje megfelel-e ezeknek a követelményeknek.",
+        "batWarning": "A denevérmodellek veszteségmentes kodeket (PCM) és legalább 96 kHz-es mintavételezési frekvenciát igényelnek. Használja a fenti Stream tesztelése gombot a kompatibilitás ellenőrzéséhez.",
         "codecWarning": {
           "lossy": "A veszteséges kodekek (AAC, Opus, MP3) megsemmisítik az ~20 kHz feletti ultrahang-frekvenciákat, így a stream alkalmatlanná válik a denevérek észlelésére."
         }

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3046,14 +3046,14 @@
           "unknown": "Sconosciuto"
         },
         "probe": {
-          "button": "Analizza stream",
-          "probing": "Analisi in corso...",
+          "button": "Testa stream",
+          "probing": "Test in corso...",
           "result": "Risultato dell'analisi",
-          "error": "Analisi non riuscita",
+          "error": "Test fallito",
           "batCompatible": "Compatibile con pipistrelli",
           "batIncompatible": "Non compatibile con pipistrelli"
         },
-        "batWarning": "I modelli per pipistrelli richiedono stream con un codec senza perdita (PCM) e una frequenza di campionamento di almeno 96 kHz. Usa il pulsante Analizza stream per verificare che il tuo stream soddisfi questi requisiti.",
+        "batWarning": "I modelli per pipistrelli richiedono flussi con un codec lossless (PCM) e una frequenza di campionamento di almeno 96 kHz. Usa il pulsante Testa stream sopra per verificare la compatibilità.",
         "codecWarning": {
           "lossy": "I codec con perdita (AAC, Opus, MP3) distruggono le frequenze ultrasoniche sopra i ~20 kHz, rendendo lo stream inadatto al rilevamento dei pipistrelli."
         }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3046,14 +3046,14 @@
           "unknown": "Nezināms"
         },
         "probe": {
-          "button": "Pārbaudīt straumi",
-          "probing": "Pārbauda...",
+          "button": "Testēt straumi",
+          "probing": "Testē...",
           "result": "Pārbaudes rezultāts",
-          "error": "Pārbaude neizdevās",
+          "error": "Tests neizdevās",
           "batCompatible": "Saderīgs ar sikspārņiem",
           "batIncompatible": "Nav saderīgs ar sikspārņiem"
         },
-        "batWarning": "Sikspārņu modeļiem ir nepieciešamas straumes ar bezzudumu kodeku (PCM) un iztveršanas frekvenci vismaz 96 kHz. Izmantojiet pogu Pārbaudīt straumi, lai pārliecinātos, ka jūsu straume atbilst šīm prasībām.",
+        "batWarning": "Sikspārņu modeļiem nepieciešamas straumes ar bezzudumu kodeku (PCM) un iztveršanas frekvenci vismaz 96 kHz. Izmantojiet pogu Testēt straumi augstāk, lai pārbaudītu saderību.",
         "codecWarning": {
           "lossy": "Zudumu kodeki (AAC, Opus, MP3) iznīcina ultraskaņas frekvences virs ~20 kHz, padarot straumi nepiemērotu sikspārņu noteikšanai."
         }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3053,7 +3053,7 @@
           "batCompatible": "Vleermuis-compatibel",
           "batIncompatible": "Niet vleermuis-compatibel"
         },
-        "batWarning": "Vleermuismodellen vereisen streams met een verliesvrije codec (PCM) en een samplefrequentie van minimaal 96 kHz. Gebruik de knop Stream testen om te controleren of uw stream aan deze vereisten voldoet.",
+        "batWarning": "Vleermuismodellen vereisen streams met een verliesvrije codec (PCM) en een samplerate van minimaal 96 kHz. Gebruik de knop Stream testen hierboven om de compatibiliteit te controleren.",
         "codecWarning": {
           "lossy": "Codecs met verlies (AAC, Opus, MP3) vernietigen ultrasone frequenties boven ~20 kHz, waardoor de stream ongeschikt wordt voor vleermuisdetectie."
         }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3046,14 +3046,14 @@
           "unknown": "Nieznany"
         },
         "probe": {
-          "button": "Zbadaj strumień",
-          "probing": "Badanie...",
+          "button": "Testuj strumień",
+          "probing": "Testowanie...",
           "result": "Wynik badania",
-          "error": "Badanie nie powiodło się",
+          "error": "Test nieudany",
           "batCompatible": "Kompatybilny z nietoperzami",
           "batIncompatible": "Niekompatybilny z nietoperzami"
         },
-        "batWarning": "Modele nietoperzy wymagają strumieni z bezstratnym kodekiem (PCM) i częstotliwością próbkowania co najmniej 96 kHz. Użyj przycisku Zbadaj strumień, aby sprawdzić, czy strumień spełnia te wymagania.",
+        "batWarning": "Modele nietoperzy wymagają strumieni z bezstratnym kodekiem (PCM) i częstotliwością próbkowania co najmniej 96 kHz. Użyj przycisku Testuj strumień powyżej, aby sprawdzić kompatybilność.",
         "codecWarning": {
           "lossy": "Stratne kodeki (AAC, Opus, MP3) niszczą częstotliwości ultradźwiękowe powyżej ~20 kHz, przez co strumień jest nieodpowiedni do wykrywania nietoperzy."
         }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3046,14 +3046,14 @@
           "unknown": "Desconhecido"
         },
         "probe": {
-          "button": "Sondar stream",
-          "probing": "Sondando...",
+          "button": "Testar stream",
+          "probing": "Testando...",
           "result": "Resultado da sondagem",
-          "error": "A sondagem falhou",
+          "error": "Teste falhou",
           "batCompatible": "Compatível com morcegos",
           "batIncompatible": "Não compatível com morcegos"
         },
-        "batWarning": "Os modelos de morcegos requerem streams com um codec sem perdas (PCM) e uma taxa de amostragem de pelo menos 96 kHz. Use o botão Sondar stream para verificar se o seu stream atende a estes requisitos.",
+        "batWarning": "Os modelos de morcegos requerem streams com um codec sem perda (PCM) e uma taxa de amostragem de pelo menos 96 kHz. Use o botão Testar stream acima para verificar a compatibilidade.",
         "codecWarning": {
           "lossy": "Codecs com perdas (AAC, Opus, MP3) destroem frequências ultrassónicas acima de ~20 kHz, tornando o stream inadequado para a deteção de morcegos."
         }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3046,14 +3046,14 @@
           "unknown": "Neznáme"
         },
         "probe": {
-          "button": "Preskúmať stream",
-          "probing": "Skúmanie...",
+          "button": "Testovať stream",
+          "probing": "Testovanie...",
           "result": "Výsledok prieskumu",
-          "error": "Prieskum zlyhal",
+          "error": "Test zlyhal",
           "batCompatible": "Kompatibilný s netopiermi",
           "batIncompatible": "Nekompatibilný s netopiermi"
         },
-        "batWarning": "Modely pre netopiere vyžadujú streamy s bezstratovým kodekom (PCM) a vzorkovacou frekvenciou aspoň 96 kHz. Pomocou tlačidla Preskúmať stream overte, či váš stream spĺňa tieto požiadavky.",
+        "batWarning": "Modely netopierov vyžadujú streamy s bezstratovým kodekom (PCM) a vzorkovacou frekvenciou aspoň 96 kHz. Pomocou tlačidla Testovať stream vyššie overte kompatibilitu.",
         "codecWarning": {
           "lossy": "Stratové kodeky (AAC, Opus, MP3) ničia ultrazvukové frekvencie nad ~20 kHz, čím sa stream stáva nevhodným na detekciu netopierov."
         }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3046,14 +3046,14 @@
           "unknown": "Okänd"
         },
         "probe": {
-          "button": "Undersök ström",
-          "probing": "Undersöker...",
+          "button": "Testa ström",
+          "probing": "Testar...",
           "result": "Undersökningsresultat",
-          "error": "Undersökningen misslyckades",
+          "error": "Test misslyckades",
           "batCompatible": "Fladdermus-kompatibel",
           "batIncompatible": "Inte fladdermus-kompatibel"
         },
-        "batWarning": "Fladdermusmodeller kräver strömmar med en förlustfri codec (PCM) och en samplingsfrekvens på minst 96 kHz. Använd knappen Undersök ström för att kontrollera att din ström uppfyller dessa krav.",
+        "batWarning": "Fladdermusmodeller kräver strömmar med en förlustfri kodek (PCM) och en samplingsfrekvens på minst 96 kHz. Använd knappen Testa ström ovan för att verifiera kompatibilitet.",
         "codecWarning": {
           "lossy": "Förlustbringande codecs (AAC, Opus, MP3) förstör ultraljudsfrekvenser över ~20 kHz, vilket gör strömmen olämplig för fladdermusdetektion."
         }


### PR DESCRIPTION
## Summary

- Extract inline probe logic from StreamCard into reusable `StreamTestButton.svelte` component
- Add the test button to the add-stream form (StreamManager) where the bat warning previously referenced a non-existent "Probe Stream" button
- Bat compatibility badges now only appear when a bat model is selected (contextually relevant)
- Wire probe results to ModelCheckboxList in both edit and add forms for accurate model compatibility badges
- Rename "Probe Stream" to "Test Stream" across all 15 locales with proper native translations

Fixes the bug where selecting a bat model in the add-stream form showed a warning saying "Use the Probe Stream button" but no such button existed.

## Test plan

- [ ] Add a new stream with bat model selected: verify "Test Stream" button appears and works
- [ ] Edit an existing stream: verify "Test Stream" button works as before
- [ ] Test with unreachable URL: verify error displays
- [ ] Test with bat-compatible stream (192 kHz PCM): verify green bat badge
- [ ] Test with 48 kHz Opus stream: verify "Not bat compatible" badge when bat model selected, no badge with only bird models
- [ ] Change URL after successful test: verify results clear
- [ ] Verify all 15 locales render updated text without missing translations