### PR TITLE
fix: resolve Windows onnxruntime.dll to absolute path

### DIFF
--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -297,10 +297,14 @@ func findONNXRuntimeLibrary() string {
 	var candidates []string
 	switch runtime.GOOS {
 	case "windows":
+		candidates = []string{"onnxruntime.dll"}
 		if exePath, err := os.Executable(); err == nil {
-			candidates = []string{filepath.Join(filepath.Dir(exePath), "onnxruntime.dll")}
-		} else {
-			candidates = []string{"onnxruntime.dll"}
+			candidates = append([]string{filepath.Join(filepath.Dir(exePath), "onnxruntime.dll")}, candidates...)
+		}
+		for i, c := range candidates {
+			if abs, err := filepath.Abs(c); err == nil {
+				candidates[i] = abs
+			}
 		}
 	case "darwin":
 		candidates = []string{

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -296,7 +297,11 @@ func findONNXRuntimeLibrary() string {
 	var candidates []string
 	switch runtime.GOOS {
 	case "windows":
-		candidates = []string{"onnxruntime.dll"}
+		if exePath, err := os.Executable(); err == nil {
+			candidates = []string{filepath.Join(filepath.Dir(exePath), "onnxruntime.dll")}
+		} else {
+			candidates = []string{"onnxruntime.dll"}
+		}
 	case "darwin":
 		candidates = []string{
 			"/opt/homebrew/lib/libonnxruntime.dylib",

--- a/internal/inference/ort_status_test.go
+++ b/internal/inference/ort_status_test.go
@@ -138,6 +138,14 @@ func TestVersionError(t *testing.T) {
 func TestLibraryFileExists(t *testing.T) {
 	t.Parallel()
 
+	t.Run("real file with directory component", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		fakeLib := filepath.Join(dir, "onnxruntime.dll")
+		require.NoError(t, os.WriteFile(fakeLib, nil, 0o644))
+		assert.True(t, libraryFileExists(fakeLib), "libraryFileExists(%q) should be true for existing file", fakeLib)
+	})
+
 	tests := []struct {
 		name string
 		path string
@@ -146,6 +154,7 @@ func TestLibraryFileExists(t *testing.T) {
 		{name: "empty string", path: "", want: false},
 		{name: "bare dlopen name", path: "onnxruntime", want: false},
 		{name: "bare so name", path: "libonnxruntime.so", want: false},
+		{name: "bare dll name", path: "onnxruntime.dll", want: false},
 		{name: "nonexistent absolute path", path: "/nonexistent/path/libonnxruntime.so", want: false},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #3240.

On Windows, `findONNXRuntimeLibrary()` returned the bare filename `onnxruntime.dll` without any directory separator. The `libraryFileExists()` function rejects bare filenames (treating them as dlopen hints), so `CheckORTAvailability()` always reported ONNX Runtime as missing, even when the DLL was co-located with the executable. This caused all ONNX-dependent models to show "no onnxruntime available" errors.

The fix resolves the Windows candidate to an absolute path using `os.Executable()` + `filepath.Dir()`, which is the standard pattern for locating co-located DLLs.

## Changes

- `internal/inference/onnx.go`: Resolve Windows DLL candidate to absolute path using the executable's directory, with fallback to bare filename if `os.Executable()` fails.
- `internal/inference/ort_status_test.go`: Add positive test case for `libraryFileExists` with a real file containing a directory component, and a negative test for bare DLL name.

## Testing

- Added `TestLibraryFileExists/"real file with directory component"` verifying that a file with a directory path returns true.
- Added `TestLibraryFileExists/"bare dll name"` confirming bare `onnxruntime.dll` returns false.
- All existing tests pass (`go test ./internal/inference/ -count=1`).
- Linter clean (`golangci-lint run --build-tags=noembed,skipfrontend ./internal/inference/`).

_This PR was generated by an automated fix agent based on the technical analysis in #3240. Please review carefully._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ONNX Runtime library discovery on Windows to check the application's executable directory first, increasing startup reliability across deployments.

* **Tests**
  * Added unit coverage for library-file detection to ensure paths with directory components are recognized and bare library names are handled as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->