### PR TITLE
fix: preserve timezone across upgrades in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1832,10 +1832,19 @@ migrate_installation() {
     fi
 
     # Step 5: Preserve timezone and clean up old systemd service
-    if [ -f "/etc/systemd/system/birdnet-go.service" ] && [ -z "$CONFIGURED_TZ" ]; then
-        CONFIGURED_TZ=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' /etc/systemd/system/birdnet-go.service 2>/dev/null | head -1)
-        if [ -n "$CONFIGURED_TZ" ]; then
-            log_message "INFO" "Preserved timezone from old service: $CONFIGURED_TZ"
+    if [ -z "$CONFIGURED_TZ" ]; then
+        local tz_service_file=""
+        if [ -f "/etc/systemd/system/birdnet-go.service" ]; then
+            tz_service_file="/etc/systemd/system/birdnet-go.service"
+        elif [ -f "/lib/systemd/system/birdnet-go.service" ]; then
+            tz_service_file="/lib/systemd/system/birdnet-go.service"
+        fi
+        if [ -n "$tz_service_file" ]; then
+            CONFIGURED_TZ=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' "$tz_service_file" 2>/dev/null | head -1)
+            if [ -n "$CONFIGURED_TZ" ]; then
+                log_message "INFO" "Preserved timezone from old service: $CONFIGURED_TZ"
+                print_message "📍 Preserved existing timezone configuration: $CONFIGURED_TZ" "$GREEN"
+            fi
         fi
     fi
     sudo systemctl disable --now birdnet-go.service 2>/dev/null || true
@@ -4521,12 +4530,20 @@ handle_container_update() {
     print_message "🔄 Checking for updates..." "$YELLOW"
     
     # Extract existing timezone from systemd service file if updating
-    if [ -f "/etc/systemd/system/birdnet-go.service" ] && [ -z "$CONFIGURED_TZ" ]; then
-        local existing_tz=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' /etc/systemd/system/birdnet-go.service 2>/dev/null | head -1)
-        if [ -n "$existing_tz" ]; then
-            CONFIGURED_TZ="$existing_tz"
-            log_message "INFO" "Extracted existing timezone from service: $CONFIGURED_TZ"
-            print_message "📍 Using existing timezone configuration: $CONFIGURED_TZ" "$GREEN"
+    if [ -z "$CONFIGURED_TZ" ]; then
+        local tz_service_file=""
+        if [ -f "/etc/systemd/system/birdnet-go.service" ]; then
+            tz_service_file="/etc/systemd/system/birdnet-go.service"
+        elif [ -f "/lib/systemd/system/birdnet-go.service" ]; then
+            tz_service_file="/lib/systemd/system/birdnet-go.service"
+        fi
+        if [ -n "$tz_service_file" ]; then
+            local existing_tz=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' "$tz_service_file" 2>/dev/null | head -1)
+            if [ -n "$existing_tz" ]; then
+                CONFIGURED_TZ="$existing_tz"
+                log_message "INFO" "Extracted existing timezone from service: $CONFIGURED_TZ"
+                print_message "📍 Using existing timezone configuration: $CONFIGURED_TZ" "$GREEN"
+            fi
         fi
     fi
     

--- a/install.sh
+++ b/install.sh
@@ -1831,7 +1831,13 @@ migrate_installation() {
         return 1
     fi
 
-    # Step 5: Clean up old systemd service and related files (new one will be created during install)
+    # Step 5: Preserve timezone and clean up old systemd service
+    if [ -f "/etc/systemd/system/birdnet-go.service" ] && [ -z "$CONFIGURED_TZ" ]; then
+        CONFIGURED_TZ=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' /etc/systemd/system/birdnet-go.service 2>/dev/null | head -1)
+        if [ -n "$CONFIGURED_TZ" ]; then
+            log_message "INFO" "Preserved timezone from old service: $CONFIGURED_TZ"
+        fi
+    fi
     sudo systemctl disable --now birdnet-go.service 2>/dev/null || true
     sudo rm -f /etc/systemd/system/birdnet-go.service
     sudo rm -f /etc/systemd/system/multi-user.target.wants/birdnet-go.service
@@ -4516,7 +4522,7 @@ handle_container_update() {
     
     # Extract existing timezone from systemd service file if updating
     if [ -f "/etc/systemd/system/birdnet-go.service" ] && [ -z "$CONFIGURED_TZ" ]; then
-        local existing_tz=$(grep -oP '(?<=--env TZ=")[^"]+' /etc/systemd/system/birdnet-go.service 2>/dev/null)
+        local existing_tz=$(sed -n 's/.*--env TZ="\([^"]*\)".*/\1/p' /etc/systemd/system/birdnet-go.service 2>/dev/null | head -1)
         if [ -n "$existing_tz" ]; then
             CONFIGURED_TZ="$existing_tz"
             log_message "INFO" "Extracted existing timezone from service: $CONFIGURED_TZ"


### PR DESCRIPTION
## Summary

Fixes #3238.

The timezone extraction in `handle_container_update()` uses `grep -oP` with a PCRE lookbehind pattern, which fails silently on systems where grep lacks PCRE support. This causes `CONFIGURED_TZ` to remain empty, and the generated systemd service file falls back to the system timezone (UTC on Proxmox VMs), resetting the user's timezone on every upgrade.

## Changes

- Replace `grep -oP` (PCRE) with POSIX-compatible `sed` for timezone extraction in `handle_container_update()`
- Add timezone extraction in `migrate_installation()` before the old service file is deleted, preventing TZ loss during root-to-user migration

## Testing

- The fix is in install.sh (bash script), not covered by Go unit tests
- Verified the sed pattern correctly extracts timezone values in all standard formats (America/New_York, US/Eastern, UTC, Etc/GMT+5)
- Verified graceful degradation: empty TZ, missing file, and malformed service file all produce no output rather than errors

_This PR was generated by an automated fix agent based on the technical analysis in #3238. Please review carefully._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing system timezone during installation migration so prior timezone settings are retained.
  * Improved detection of existing timezone during container updates by checking alternate service locations and logging the preserved timezone before replacing the old service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->