### PR TITLE
fix: consolidate ORT availability check in ONNX range filter init

### DIFF
--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -66,27 +66,32 @@ func (bn *BirdNET) initializeONNXModel() error {
 // with its own 12K labels and wraps it in a mappedRangeFilter.
 func (bn *BirdNET) initializeONNXMetaModel() error {
 	settings := bn.currentSettings()
+	log := GetLogger()
+
+	ortStatus := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
+	if !ortStatus.Available {
+		modelCtx := "range_filter"
+		notifName := "BirdNET Range Filter"
+		if settings.BirdNET.RangeFilter.Model == "v3" {
+			modelCtx = "v3_geomodel"
+			notifName = "BirdNET Geomodel"
+		}
+		log.Warn("ONNX range filter requires ONNX Runtime which is not available",
+			logger.String("error", ortStatus.Error))
+		emitORTUnavailableNotification(notifName, ortStatus.Error)
+		return errors.Newf("ONNX range filter requires ONNX Runtime %s: %s",
+			inference.ORTRequiredVersion(), ortStatus.Error).
+			Category(errors.CategoryModelInit).
+			Context("model", modelCtx).
+			Context("ort_error", ortStatus.Error).
+			Build()
+	}
+
 	if settings.BirdNET.RangeFilter.Model == "v3" {
 		return bn.initializeV3GeoModel()
 	}
 
 	start := time.Now()
-	log := GetLogger()
-
-	// Pre-check ORT availability before attempting range filter load.
-	ortStatus := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
-	if !ortStatus.Available {
-		log.Warn("ONNX range filter requires ONNX Runtime which is not available",
-			logger.String("error", ortStatus.Error))
-		emitORTUnavailableNotification("BirdNET Range Filter", ortStatus.Error)
-		return errors.Newf("ONNX range filter requires ONNX Runtime %s: %s",
-			inference.ORTRequiredVersion(), ortStatus.Error).
-			Category(errors.CategoryModelInit).
-			Context("model", "range_filter").
-			Context("ort_error", ortStatus.Error).
-			Timing("ort-check", time.Since(start)).
-			Build()
-	}
 
 	// Ensure ONNX Runtime is initialized (idempotent - may already be init from classifier)
 	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
@@ -163,22 +168,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 			Build()
 	}
 
-	// Pre-check ORT availability before attempting geomodel load.
-	ortStatus := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
-	if !ortStatus.Available {
-		log.Warn("V3 geomodel requires ONNX Runtime which is not available",
-			logger.String("error", ortStatus.Error))
-		emitORTUnavailableNotification("BirdNET Geomodel", ortStatus.Error)
-		return errors.Newf("v3 geomodel requires ONNX Runtime %s: %s",
-			inference.ORTRequiredVersion(), ortStatus.Error).
-			Category(errors.CategoryModelInit).
-			Context("model", "v3_geomodel").
-			Context("ort_error", ortStatus.Error).
-			Timing("ort-check", time.Since(start)).
-			Build()
-	}
-
-	// Ensure ONNX Runtime is initialized
+	// Ensure ONNX Runtime is initialized (ORT availability checked by initializeONNXMetaModel)
 	log.Debug("V3 geomodel: initializing ONNX Runtime")
 	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -67,31 +67,33 @@ func (bn *BirdNET) initializeONNXModel() error {
 func (bn *BirdNET) initializeONNXMetaModel() error {
 	settings := bn.currentSettings()
 	log := GetLogger()
+	start := time.Now()
 
 	ortStatus := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
 	if !ortStatus.Available {
 		modelCtx := "range_filter"
+		modelName := "ONNX range filter"
 		notifName := "BirdNET Range Filter"
 		if settings.BirdNET.RangeFilter.Model == "v3" {
 			modelCtx = "v3_geomodel"
+			modelName = "v3 geomodel"
 			notifName = "BirdNET Geomodel"
 		}
-		log.Warn("ONNX range filter requires ONNX Runtime which is not available",
+		log.Warn(modelName+" requires ONNX Runtime which is not available",
 			logger.String("error", ortStatus.Error))
 		emitORTUnavailableNotification(notifName, ortStatus.Error)
-		return errors.Newf("ONNX range filter requires ONNX Runtime %s: %s",
-			inference.ORTRequiredVersion(), ortStatus.Error).
+		return errors.Newf("%s requires ONNX Runtime %s: %s",
+			modelName, inference.ORTRequiredVersion(), ortStatus.Error).
 			Category(errors.CategoryModelInit).
 			Context("model", modelCtx).
 			Context("ort_error", ortStatus.Error).
+			Timing("ort-check", time.Since(start)).
 			Build()
 	}
 
 	if settings.BirdNET.RangeFilter.Model == "v3" {
 		return bn.initializeV3GeoModel()
 	}
-
-	start := time.Now()
 
 	// Ensure ONNX Runtime is initialized (idempotent - may already be init from classifier)
 	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {


### PR DESCRIPTION
## Summary

Moves the ONNX Runtime availability check to the top of `initializeONNXMetaModel()`, before the v3/non-v3 branch, so both paths are guarded by a single early check.

Previously the v3 geomodel path bypassed the early ORT check (it returned before reaching it), relying on a redundant check buried deep in `initializeV3GeoModel()`. This caused unnecessary work (path expansion, file validation) and generated repeated Sentry events and bell notifications on every range filter reload when ORT was unavailable.

**Changes:**
- Add ORT availability check at the top of `initializeONNXMetaModel()` with model-specific error context (`v3_geomodel` vs `range_filter`) and notification names (`BirdNET Geomodel` vs `BirdNET Range Filter`)
- Remove redundant ORT check from the non-v3 path
- Remove redundant ORT check from `initializeV3GeoModel()`

Net result: -25 lines, +15 lines (10 lines removed).

## Test Plan

- [ ] Lint passes: `golangci-lint run -v ./internal/classifier/`
- [ ] Build succeeds: `go build ./internal/classifier/`
- [ ] On a system without ORT with `rangefilter.model: v3`, confirm range filter reload returns error immediately without path expansion log lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined model initialization flow by centralizing the runtime availability check and timing/logging setup.
  * Removed redundant pre-checks and moved responsibility for availability handling to a single entry point.
  * Added dynamic selection of model context/notifications depending on whether the requested model is v3 or not, and delegated v3-specific setup accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->