### PR TITLE
fix(datastore): detect SQLite corruption at startup with auto-recovery

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -148,7 +148,7 @@ func (c *Controller) registerHealthChecks() {
 				return "", false
 			}
 			sqliteStore, ok := ds.(*datastore.SQLiteStore)
-			if !ok {
+			if !ok || sqliteStore == nil {
 				return "", false
 			}
 			return sqliteStore.IntegrityResult()

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/health/checks"
@@ -140,6 +141,17 @@ func (c *Controller) registerHealthChecks() {
 				return 0, errors.NewStd("datastore unavailable")
 			}
 			return ds.PingWithLatency(ctx)
+		}),
+		checks.NewDatabaseIntegrityCheck(func() (string, bool) {
+			ds := c.DS
+			if ds == nil {
+				return "", false
+			}
+			sqliteStore, ok := ds.(*datastore.SQLiteStore)
+			if !ok {
+				return "", false
+			}
+			return sqliteStore.IntegrityResult()
 		}),
 
 		// Network checks

--- a/internal/datastore/errors_helper.go
+++ b/internal/datastore/errors_helper.go
@@ -261,7 +261,7 @@ func getUserFriendlyMessage(operation string, err error) string {
 	case isNotFoundError(err):
 		return "The requested item could not be found."
 	case corruptionPattern.MatchString(err.Error()):
-		return "Database integrity issue detected. Please contact support immediately."
+		return "Database integrity issue detected. Please back up your database file, then go to Settings > Support to upload a support dump for analysis. If you have a recent backup, restoring from it is the safest recovery option."
 	default:
 		return fmt.Sprintf("Failed to %s. Please try again or contact support if the issue persists.", operation)
 	}

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -302,15 +302,6 @@ func (s *SQLiteStore) Open() error {
 		return err
 	}
 
-	// Initialize monitoring context before the integrity check so that any
-	// deferred goroutine (e.g. notifyCorruptionDeferred) gets a cancellable
-	// context instead of falling back to context.Background().
-	s.monitoringMu.Lock()
-	if s.monitoringCtx == nil {
-		s.monitoringCtx, s.monitoringCancel = context.WithCancel(context.Background())
-	}
-	s.monitoringMu.Unlock()
-
 	// Run synchronous integrity check after migration succeeds.
 	// If corruption is found, attempts REINDEX auto-recovery.
 	// On failure, latches corruption flag and notifies user but does NOT

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -302,6 +302,15 @@ func (s *SQLiteStore) Open() error {
 		return err
 	}
 
+	// Initialize monitoring context before the integrity check so that any
+	// deferred goroutine (e.g. notifyCorruptionDeferred) gets a cancellable
+	// context instead of falling back to context.Background().
+	s.monitoringMu.Lock()
+	if s.monitoringCtx == nil {
+		s.monitoringCtx, s.monitoringCancel = context.WithCancel(context.Background())
+	}
+	s.monitoringMu.Unlock()
+
 	// Run synchronous integrity check after migration succeeds.
 	// If corruption is found, attempts REINDEX auto-recovery.
 	// On failure, latches corruption flag and notifies user but does NOT

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -302,6 +302,13 @@ func (s *SQLiteStore) Open() error {
 		return err
 	}
 
+	// Run synchronous integrity check after migration succeeds.
+	// If corruption is found, attempts REINDEX auto-recovery.
+	// On failure, latches corruption flag and notifies user but does NOT
+	// return an error: the app continues in degraded mode so the web UI
+	// remains accessible for diagnostics and recovery guidance.
+	s.performStartupIntegrityCheck()
+
 	// Ensure _metadata table exists for tracking operational timestamps (e.g. last vacuum)
 	if err := s.EnsureMetadataTable(); err != nil {
 		GetLogger().Warn("Failed to create _metadata table", logger.Error(err))
@@ -348,9 +355,9 @@ func (s *SQLiteStore) startIntegrityCheckLoop() {
 		ctx := s.monitoringCtx
 		s.monitoringMu.Unlock()
 
-		// Run initial check immediately, then on interval
 		s.monitoringWg.Go(func() {
-			s.RunIntegrityCheck()
+			// Skip immediate check: performStartupIntegrityCheck() already
+			// ran synchronously and cached the result in Open().
 
 			ticker := time.NewTicker(integrityCheckInterval)
 			defer ticker.Stop()

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -29,6 +30,11 @@ type SQLiteStore struct {
 	// Cached integrity check result (updated by monitoring goroutine)
 	integrityMu     sync.RWMutex
 	integrityResult string // "ok" or error string; empty until first check
+
+	// dbCorrupted is latched on first detection of SQLite corruption
+	// ("database disk image is malformed"). Once set, duplicate Sentry
+	// reports are suppressed. The app continues in degraded mode.
+	dbCorrupted atomic.Bool
 
 	// dbstatAvailable caches whether the dbstat virtual table exists.
 	// 0 = unchecked, 1 = available, -1 = not available.
@@ -682,4 +688,19 @@ func (s *SQLiteStore) GetDatabaseStats(ctx context.Context) (*DatabaseStats, err
 	}
 
 	return stats, nil
+}
+
+// IsCorrupted reports whether the database has been flagged as corrupted.
+// Safe to call concurrently. Used by health checks and diagnostics.
+func (s *SQLiteStore) IsCorrupted() bool {
+	return s.dbCorrupted.Load()
+}
+
+// IntegrityResult returns the cached integrity check result and corruption status.
+// Returns ("", false) if no check has run yet.
+func (s *SQLiteStore) IntegrityResult() (string, bool) {
+	s.integrityMu.RLock()
+	result := s.integrityResult
+	s.integrityMu.RUnlock()
+	return result, s.dbCorrupted.Load()
 }

--- a/internal/datastore/sqlite_inspector.go
+++ b/internal/datastore/sqlite_inspector.go
@@ -239,14 +239,7 @@ func quoteIdentifier(name string) string {
 // RunIntegrityCheck executes PRAGMA quick_check and caches the result.
 // Called by the monitoring goroutine on a daily schedule.
 func (s *SQLiteStore) RunIntegrityCheck() {
-	var results []string
-	if err := s.DB.Raw("PRAGMA quick_check").Scan(&results).Error; err != nil {
-		results = []string{err.Error()}
-	}
-	result := strings.Join(results, "; ")
-	if result == "" {
-		result = "ok"
-	}
+	result := s.runQuickCheck()
 	s.integrityMu.Lock()
 	s.integrityResult = result
 	s.integrityMu.Unlock()

--- a/internal/datastore/sqlite_integrity.go
+++ b/internal/datastore/sqlite_integrity.go
@@ -1,0 +1,191 @@
+package datastore
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// performStartupIntegrityCheck runs PRAGMA quick_check synchronously during
+// Open(). If corruption is found, it attempts REINDEX auto-recovery. On
+// failure the corruption flag is latched and a deferred notification is
+// queued, but no error is returned: the application continues in degraded
+// mode so the web UI remains accessible for diagnostics.
+func (s *SQLiteStore) performStartupIntegrityCheck() {
+	log := GetLogger()
+	log.Info("running startup database integrity check")
+
+	result := s.runQuickCheck()
+
+	// Cache the result for the health endpoint.
+	s.integrityMu.Lock()
+	s.integrityResult = result
+	s.integrityMu.Unlock()
+
+	if result == "ok" {
+		log.Info("startup integrity check passed")
+		return
+	}
+
+	log.Warn("startup integrity check detected corruption",
+		logger.String("result", truncateResult(result, 200)))
+
+	// Attempt automatic recovery via REINDEX.
+	if s.attemptAutoRecovery() {
+		log.Info("REINDEX auto-recovery succeeded, database integrity restored")
+		return
+	}
+
+	// Recovery failed: latch corruption flag.
+	s.dbCorrupted.Store(true)
+
+	log.Error("REINDEX auto-recovery failed, database flagged as corrupted",
+		logger.String("integrity_result", truncateResult(result, 200)))
+
+	// Report to Sentry once.
+	if s.telemetry != nil {
+		s.telemetry.CaptureEnhancedError(
+			fmt.Errorf("startup integrity check failed: %s", truncateResult(result, 500)),
+			"startup_integrity_check",
+			s,
+		)
+	}
+
+	// Queue a deferred user notification (notification service may not be
+	// ready yet during Open()).
+	s.notifyCorruptionDeferred(result)
+}
+
+// runQuickCheck executes PRAGMA quick_check and returns "ok" or an error
+// description string.
+func (s *SQLiteStore) runQuickCheck() string {
+	var results []string
+	if err := s.DB.Raw("PRAGMA quick_check").Scan(&results).Error; err != nil {
+		return err.Error()
+	}
+	result := strings.Join(results, "; ")
+	if result == "" {
+		return "ok"
+	}
+	return result
+}
+
+// attemptAutoRecovery runs REINDEX and re-checks integrity. Returns true if
+// the database passes quick_check after reindexing.
+func (s *SQLiteStore) attemptAutoRecovery() bool {
+	log := GetLogger()
+	log.Info("attempting REINDEX auto-recovery")
+
+	if err := s.DB.Exec("REINDEX").Error; err != nil {
+		log.Error("REINDEX command failed", logger.Error(err))
+		return false
+	}
+
+	result := s.runQuickCheck()
+
+	// Update the cached result.
+	s.integrityMu.Lock()
+	s.integrityResult = result
+	s.integrityMu.Unlock()
+
+	return result == "ok"
+}
+
+// notifyCorruptionDeferred spawns a goroutine that polls for the notification
+// service (up to 30 seconds) and sends a persistent warning notification.
+// The notification service may not be initialized when Open() runs, so this
+// must be deferred.
+func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
+	s.monitoringWg.Go(func() {
+		const (
+			pollInterval = 500 * time.Millisecond
+			maxWait      = 30 * time.Second
+		)
+
+		deadline := time.Now().Add(maxWait)
+		var svc *notification.Service
+		for time.Now().Before(deadline) {
+			svc = notification.GetService()
+			if svc != nil {
+				break
+			}
+			time.Sleep(pollInterval)
+		}
+		if svc == nil {
+			GetLogger().Warn("notification service unavailable, corruption notification not sent")
+			return
+		}
+
+		notif := notification.NewNotification(
+			notification.TypeWarning,
+			notification.PriorityCritical,
+			"Database Integrity Issue",
+			fmt.Sprintf(
+				"Database corruption detected during startup. REINDEX recovery failed. Details: %s. "+
+					"Please back up your database and consider restoring from a known good backup.",
+				truncateResult(integrityResult, 200),
+			),
+		).WithComponent("database")
+
+		if err := svc.CreateWithMetadata(notif); err != nil {
+			GetLogger().Warn("failed to send corruption notification", logger.Error(err))
+		}
+	})
+}
+
+// checkAndLatchCorruption inspects a runtime database error for signs of
+// corruption. On first detection it latches the corruption flag, sends a
+// single Sentry event, and queues a user notification. Returns true if the
+// error is a corruption error.
+func (s *SQLiteStore) checkAndLatchCorruption(err error, operation string) bool {
+	if err == nil {
+		return false
+	}
+	if !IsDatabaseCorruption(err) {
+		return false
+	}
+
+	// Only act on the first detection (CompareAndSwap returns true on first flip).
+	if !s.dbCorrupted.CompareAndSwap(false, true) {
+		// Already latched; suppress duplicate processing.
+		return true
+	}
+
+	log := GetLogger()
+	log.Error("database corruption detected at runtime",
+		logger.String("operation", operation),
+		logger.Error(err))
+
+	// Cache the result for the health endpoint.
+	s.integrityMu.Lock()
+	s.integrityResult = err.Error()
+	s.integrityMu.Unlock()
+
+	// Send one Sentry event.
+	if s.telemetry != nil {
+		s.telemetry.CaptureEnhancedError(err, operation, s)
+	}
+
+	// Queue user notification.
+	s.notifyCorruptionDeferred(err.Error())
+
+	return true
+}
+
+// truncateResult shortens a string to maxLen characters, appending an
+// ellipsis if truncation occurred.
+func truncateResult(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// corruptionSentryThrottled reports whether the corruption latch is set,
+// indicating that further Sentry reports should be suppressed.
+func (s *SQLiteStore) corruptionSentryThrottled() bool {
+	return s.dbCorrupted.Load()
+}

--- a/internal/datastore/sqlite_integrity.go
+++ b/internal/datastore/sqlite_integrity.go
@@ -93,8 +93,9 @@ func (s *SQLiteStore) attemptAutoRecovery() bool {
 // notifyCorruptionDeferred spawns a goroutine that polls for the notification
 // service (up to 30 seconds) and sends a persistent warning notification.
 // The notification service may not be initialized when Open() runs, so this
-// must be deferred. The goroutine respects the monitoring context for clean
-// shutdown.
+// must be deferred. Uses a dedicated 30-second timeout context independent of
+// monitoringCtx, which StartMonitoring cancels and replaces shortly after
+// Open() returns.
 func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
 	// Use a dedicated context with timeout instead of monitoringCtx.
 	// StartMonitoring cancels and replaces monitoringCtx shortly after

--- a/internal/datastore/sqlite_integrity.go
+++ b/internal/datastore/sqlite_integrity.go
@@ -1,61 +1,59 @@
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
 // performStartupIntegrityCheck runs PRAGMA quick_check synchronously during
 // Open(). If corruption is found, it attempts REINDEX auto-recovery. On
-// failure the corruption flag is latched and a deferred notification is
-// queued, but no error is returned: the application continues in degraded
-// mode so the web UI remains accessible for diagnostics.
+// failure a Sentry event is sent, the corruption flag is latched, and a
+// deferred notification is queued. No error is returned: the application
+// continues in degraded mode so the web UI remains accessible.
 func (s *SQLiteStore) performStartupIntegrityCheck() {
-	log := GetLogger()
-	log.Info("running startup database integrity check")
-
 	result := s.runQuickCheck()
 
-	// Cache the result for the health endpoint.
 	s.integrityMu.Lock()
 	s.integrityResult = result
 	s.integrityMu.Unlock()
 
 	if result == "ok" {
-		log.Info("startup integrity check passed")
+		GetLogger().Debug("startup integrity check passed")
 		return
 	}
 
-	log.Warn("startup integrity check detected corruption",
+	GetLogger().Warn("startup integrity check detected corruption",
 		logger.String("result", truncateResult(result, 200)))
 
-	// Attempt automatic recovery via REINDEX.
 	if s.attemptAutoRecovery() {
-		log.Info("REINDEX auto-recovery succeeded, database integrity restored")
+		GetLogger().Info("REINDEX auto-recovery succeeded, database integrity restored")
 		return
 	}
 
-	// Recovery failed: latch corruption flag.
-	s.dbCorrupted.Store(true)
-
-	log.Error("REINDEX auto-recovery failed, database flagged as corrupted",
+	GetLogger().Error("REINDEX auto-recovery failed, database flagged as corrupted",
 		logger.String("integrity_result", truncateResult(result, 200)))
 
-	// Report to Sentry once.
+	// Send Sentry event BEFORE latching so the suppression guard in
+	// CaptureEnhancedError does not block this first report.
 	if s.telemetry != nil {
-		s.telemetry.CaptureEnhancedError(
-			fmt.Errorf("startup integrity check failed: %s", truncateResult(result, 500)),
-			"startup_integrity_check",
-			s,
-		)
+		enhancedErr := errors.Newf("startup integrity check failed: %s", truncateResult(result, 500)).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Priority(errors.PriorityCritical).
+			Context("operation", "startup_integrity_check").
+			Context("integrity_result", truncateResult(result, 200)).
+			Build()
+		s.telemetry.CaptureEnhancedError(enhancedErr, "startup_integrity_check", s)
 	}
 
-	// Queue a deferred user notification (notification service may not be
-	// ready yet during Open()).
+	s.dbCorrupted.Store(true)
+
 	s.notifyCorruptionDeferred(result)
 }
 
@@ -76,17 +74,15 @@ func (s *SQLiteStore) runQuickCheck() string {
 // attemptAutoRecovery runs REINDEX and re-checks integrity. Returns true if
 // the database passes quick_check after reindexing.
 func (s *SQLiteStore) attemptAutoRecovery() bool {
-	log := GetLogger()
-	log.Info("attempting REINDEX auto-recovery")
+	GetLogger().Info("attempting REINDEX auto-recovery")
 
 	if err := s.DB.Exec("REINDEX").Error; err != nil {
-		log.Error("REINDEX command failed", logger.Error(err))
+		GetLogger().Error("REINDEX command failed", logger.Error(err))
 		return false
 	}
 
 	result := s.runQuickCheck()
 
-	// Update the cached result.
 	s.integrityMu.Lock()
 	s.integrityResult = result
 	s.integrityMu.Unlock()
@@ -97,8 +93,17 @@ func (s *SQLiteStore) attemptAutoRecovery() bool {
 // notifyCorruptionDeferred spawns a goroutine that polls for the notification
 // service (up to 30 seconds) and sends a persistent warning notification.
 // The notification service may not be initialized when Open() runs, so this
-// must be deferred.
+// must be deferred. The goroutine respects the monitoring context for clean
+// shutdown.
 func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
+	s.monitoringMu.Lock()
+	ctx := s.monitoringCtx
+	s.monitoringMu.Unlock()
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	s.monitoringWg.Go(func() {
 		const (
 			pollInterval = 500 * time.Millisecond
@@ -112,7 +117,11 @@ func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
 			if svc != nil {
 				break
 			}
-			time.Sleep(pollInterval)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(pollInterval):
+			}
 		}
 		if svc == nil {
 			GetLogger().Warn("notification service unavailable, corruption notification not sent")
@@ -137,39 +146,34 @@ func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
 }
 
 // checkAndLatchCorruption inspects a runtime database error for signs of
-// corruption. On first detection it latches the corruption flag, sends a
-// single Sentry event, and queues a user notification. Returns true if the
-// error is a corruption error.
+// corruption. On first detection it sends a single Sentry event, latches the
+// corruption flag, and queues a user notification. Returns true if the error
+// is a corruption error (regardless of whether the latch was already set).
 func (s *SQLiteStore) checkAndLatchCorruption(err error, operation string) bool {
-	if err == nil {
-		return false
-	}
-	if !IsDatabaseCorruption(err) {
+	if err == nil || !IsDatabaseCorruption(err) {
 		return false
 	}
 
-	// Only act on the first detection (CompareAndSwap returns true on first flip).
-	if !s.dbCorrupted.CompareAndSwap(false, true) {
-		// Already latched; suppress duplicate processing.
+	if s.dbCorrupted.Load() {
 		return true
 	}
 
-	log := GetLogger()
-	log.Error("database corruption detected at runtime",
+	GetLogger().Error("database corruption detected at runtime",
 		logger.String("operation", operation),
 		logger.Error(err))
 
-	// Cache the result for the health endpoint.
 	s.integrityMu.Lock()
 	s.integrityResult = err.Error()
 	s.integrityMu.Unlock()
 
-	// Send one Sentry event.
+	// Send Sentry event BEFORE latching so the suppression guard in
+	// CaptureEnhancedError does not block this first report.
 	if s.telemetry != nil {
 		s.telemetry.CaptureEnhancedError(err, operation, s)
 	}
 
-	// Queue user notification.
+	s.dbCorrupted.Store(true)
+
 	s.notifyCorruptionDeferred(err.Error())
 
 	return true
@@ -181,11 +185,8 @@ func truncateResult(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
+	if maxLen < 4 {
+		return s[:maxLen]
+	}
 	return s[:maxLen-3] + "..."
-}
-
-// corruptionSentryThrottled reports whether the corruption latch is set,
-// indicating that further Sentry reports should be suppressed.
-func (s *SQLiteStore) corruptionSentryThrottled() bool {
-	return s.dbCorrupted.Load()
 }

--- a/internal/datastore/sqlite_integrity.go
+++ b/internal/datastore/sqlite_integrity.go
@@ -191,11 +191,12 @@ func (s *SQLiteStore) checkAndLatchCorruption(err error, operation string) bool 
 // truncateResult shortens a string to maxLen characters, appending an
 // ellipsis if truncation occurred.
 func truncateResult(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
 	if maxLen < 4 {
-		return s[:maxLen]
+		return string(runes[:maxLen])
 	}
-	return s[:maxLen-3] + "..."
+	return string(runes[:maxLen-3]) + "..."
 }

--- a/internal/datastore/sqlite_integrity.go
+++ b/internal/datastore/sqlite_integrity.go
@@ -110,6 +110,15 @@ func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
 			maxWait      = 30 * time.Second
 		)
 
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+
 		deadline := time.Now().Add(maxWait)
 		var svc *notification.Service
 		for time.Now().Before(deadline) {
@@ -120,7 +129,7 @@ func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(pollInterval):
+			case <-ticker.C:
 			}
 		}
 		if svc == nil {

--- a/internal/datastore/sqlite_integrity.go
+++ b/internal/datastore/sqlite_integrity.go
@@ -96,45 +96,30 @@ func (s *SQLiteStore) attemptAutoRecovery() bool {
 // must be deferred. The goroutine respects the monitoring context for clean
 // shutdown.
 func (s *SQLiteStore) notifyCorruptionDeferred(integrityResult string) {
-	s.monitoringMu.Lock()
-	ctx := s.monitoringCtx
-	s.monitoringMu.Unlock()
-
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	// Use a dedicated context with timeout instead of monitoringCtx.
+	// StartMonitoring cancels and replaces monitoringCtx shortly after
+	// Open() returns, which would kill this goroutine before it can send
+	// the notification.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	s.monitoringWg.Go(func() {
-		const (
-			pollInterval = 500 * time.Millisecond
-			maxWait      = 30 * time.Second
-		)
+		defer cancel()
 
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		ticker := time.NewTicker(pollInterval)
+		ticker := time.NewTicker(500 * time.Millisecond)
 		defer ticker.Stop()
 
-		deadline := time.Now().Add(maxWait)
 		var svc *notification.Service
-		for time.Now().Before(deadline) {
+		for {
 			svc = notification.GetService()
 			if svc != nil {
 				break
 			}
 			select {
 			case <-ctx.Done():
+				GetLogger().Warn("notification service unavailable, corruption notification not sent")
 				return
 			case <-ticker.C:
 			}
-		}
-		if svc == nil {
-			GetLogger().Warn("notification service unavailable, corruption notification not sent")
-			return
 		}
 
 		notif := notification.NewNotification(

--- a/internal/datastore/sqlite_integrity_test.go
+++ b/internal/datastore/sqlite_integrity_test.go
@@ -134,14 +134,6 @@ func TestIntegrityResult_AfterHealthyCheck(t *testing.T) {
 	assert.False(t, corrupted)
 }
 
-func TestCorruptionSentryThrottled(t *testing.T) {
-	store := newIntegrityTestStore(t)
-	assert.False(t, store.corruptionSentryThrottled())
-
-	store.dbCorrupted.Store(true)
-	assert.True(t, store.corruptionSentryThrottled())
-}
-
 // TestPerformStartupIntegrityCheck_CorruptedDatabase verifies the full
 // corruption detection flow using a file-based database that is deliberately
 // corrupted by overwriting bytes in the middle of the file.

--- a/internal/datastore/sqlite_integrity_test.go
+++ b/internal/datastore/sqlite_integrity_test.go
@@ -1,0 +1,197 @@
+package datastore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// newIntegrityTestStore creates a minimal SQLiteStore with an in-memory database
+// for testing integrity check logic.
+func newIntegrityTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	return &SQLiteStore{
+		DataStore: DataStore{DB: db},
+	}
+}
+
+func TestRunQuickCheck_HealthyDatabase(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	result := store.runQuickCheck()
+	assert.Equal(t, "ok", result)
+}
+
+func TestPerformStartupIntegrityCheck_HealthyDatabase(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	store.performStartupIntegrityCheck()
+
+	assert.False(t, store.IsCorrupted(), "healthy database should not be flagged as corrupted")
+
+	store.integrityMu.RLock()
+	assert.Equal(t, "ok", store.integrityResult)
+	store.integrityMu.RUnlock()
+}
+
+func TestAttemptAutoRecovery_HealthyDatabase(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	assert.True(t, store.attemptAutoRecovery())
+	assert.False(t, store.IsCorrupted())
+}
+
+func TestTruncateResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "short string unchanged",
+			input:    "ok",
+			maxLen:   10,
+			expected: "ok",
+		},
+		{
+			name:     "exact length unchanged",
+			input:    "hello",
+			maxLen:   5,
+			expected: "hello",
+		},
+		{
+			name:     "long string truncated",
+			input:    "this is a very long integrity check result that exceeds the limit",
+			maxLen:   30,
+			expected: "this is a very long integri...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, truncateResult(tt.input, tt.maxLen))
+		})
+	}
+}
+
+func TestCheckAndLatchCorruption_NonCorruptionError(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	err := fmt.Errorf("some other error")
+	assert.False(t, store.checkAndLatchCorruption(err, "test_op"))
+	assert.False(t, store.IsCorrupted())
+}
+
+func TestCheckAndLatchCorruption_CorruptionError(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	err := fmt.Errorf("database disk image is malformed")
+	assert.True(t, store.checkAndLatchCorruption(err, "test_op"))
+	assert.True(t, store.IsCorrupted())
+}
+
+func TestCheckAndLatchCorruption_OnlyLatchesOnce(t *testing.T) {
+	store := newIntegrityTestStore(t)
+
+	err := fmt.Errorf("database disk image is malformed")
+
+	// First call latches
+	assert.True(t, store.checkAndLatchCorruption(err, "op1"))
+	assert.True(t, store.IsCorrupted())
+
+	// Second call returns true (still corruption) but doesn't panic or re-latch
+	assert.True(t, store.checkAndLatchCorruption(err, "op2"))
+	assert.True(t, store.IsCorrupted())
+}
+
+func TestIntegrityResult_BeforeCheck(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	result, corrupted := store.IntegrityResult()
+	assert.Empty(t, result, "should be empty before any check runs")
+	assert.False(t, corrupted)
+}
+
+func TestIntegrityResult_AfterHealthyCheck(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	store.performStartupIntegrityCheck()
+
+	result, corrupted := store.IntegrityResult()
+	assert.Equal(t, "ok", result)
+	assert.False(t, corrupted)
+}
+
+func TestCorruptionSentryThrottled(t *testing.T) {
+	store := newIntegrityTestStore(t)
+	assert.False(t, store.corruptionSentryThrottled())
+
+	store.dbCorrupted.Store(true)
+	assert.True(t, store.corruptionSentryThrottled())
+}
+
+// TestPerformStartupIntegrityCheck_CorruptedDatabase verifies the full
+// corruption detection flow using a file-based database that is deliberately
+// corrupted by overwriting bytes in the middle of the file.
+func TestPerformStartupIntegrityCheck_CorruptedDatabase(t *testing.T) {
+	// Create a file-based database with real data
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+
+	// Create a table and insert rows to generate multiple pages
+	require.NoError(t, db.Exec("CREATE TABLE data (id INTEGER PRIMARY KEY, value TEXT)").Error)
+	for i := range 100 {
+		require.NoError(t, db.Exec("INSERT INTO data (value) VALUES (?)", fmt.Sprintf("row-%d-padding-to-fill-pages", i)).Error)
+	}
+
+	// Close the database before corrupting
+	sqlDB, _ := db.DB()
+	require.NoError(t, sqlDB.Close())
+
+	// Corrupt the file by overwriting bytes in the data region (after the header)
+	f, err := os.OpenFile(dbPath, os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteAt([]byte("CORRUPT_DATA_HERE_DEADBEEF"), 4096)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Reopen with a fresh store
+	db2, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sqlDB2, _ := db2.DB()
+		if sqlDB2 != nil {
+			_ = sqlDB2.Close()
+		}
+	})
+
+	store := &SQLiteStore{
+		DataStore: DataStore{DB: db2},
+	}
+
+	store.performStartupIntegrityCheck()
+
+	// The database should be flagged as corrupted (REINDEX can't fix page corruption)
+	assert.True(t, store.IsCorrupted(), "page-level corruption should be detected")
+
+	result, corrupted := store.IntegrityResult()
+	assert.True(t, corrupted)
+	assert.NotEqual(t, "ok", result)
+}

--- a/internal/datastore/telemetry_integration.go
+++ b/internal/datastore/telemetry_integration.go
@@ -74,6 +74,18 @@ func (dt *DatastoreTelemetry) CaptureEnhancedError(err error, operation string, 
 		return
 	}
 
+	// Suppress duplicate Sentry events for corruption errors once the
+	// corruption latch is set. The first corruption event is always sent
+	// (the latch is set after the first CaptureEnhancedError call).
+	// Subsequent corruption errors are logged locally but not sent to Sentry.
+	if IsDatabaseCorruption(err) {
+		if corruptible, ok := store.(interface{ IsCorrupted() bool }); ok && corruptible.IsCorrupted() {
+			GetLogger().Debug("Suppressing duplicate Sentry event for database corruption",
+				logger.String("operation", operation))
+			return
+		}
+	}
+
 	// Gather comprehensive error context
 	context := dt.gatherErrorContext(err, operation, store)
 

--- a/internal/health/checks/database.go
+++ b/internal/health/checks/database.go
@@ -218,3 +218,73 @@ func (c *DatabasePerformanceCheck) Run(ctx context.Context) health.Result {
 		Timestamp:  time.Now(),
 	}
 }
+
+// DatabaseIntegrityCheck reports the cached result of PRAGMA quick_check.
+// Returns critical if corruption was detected, healthy if the last check passed.
+type DatabaseIntegrityCheck struct {
+	getIntegrityResult func() (string, bool)
+}
+
+// NewDatabaseIntegrityCheck creates a DatabaseIntegrityCheck.
+// The function must return (integrityResult, isCorrupted).
+// integrityResult is "ok" or the error string from PRAGMA quick_check.
+// isCorrupted is true if the global corruption latch is set.
+func NewDatabaseIntegrityCheck(getIntegrityResult func() (string, bool)) *DatabaseIntegrityCheck {
+	return &DatabaseIntegrityCheck{getIntegrityResult: getIntegrityResult}
+}
+
+// Name returns the check identifier.
+func (c *DatabaseIntegrityCheck) Name() string { return "database_integrity" }
+
+// Category returns the database category.
+func (c *DatabaseIntegrityCheck) Category() health.Category { return health.CategoryDatabase }
+
+// Run checks the cached integrity result and reports corruption status.
+func (c *DatabaseIntegrityCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getIntegrityResult == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	result, isCorrupted := c.getIntegrityResult()
+
+	if result == "" {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "Integrity check has not run yet",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	if isCorrupted || result != "ok" {
+		return health.Result{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   health.StatusCritical,
+			Message:  "Database corruption detected",
+			Details: map[string]any{
+				"integrity_result": result,
+				"auto_recovery":    "failed",
+				"recovery_hint":    "Back up the database file and use Settings > Support to upload a support dump",
+			},
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   health.StatusHealthy,
+		Message:  "Database integrity check passed",
+		Details: map[string]any{
+			"integrity_result": result,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/database_test.go
+++ b/internal/health/checks/database_test.go
@@ -1,0 +1,58 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+func TestDatabaseIntegrityCheck_Healthy(t *testing.T) {
+	check := NewDatabaseIntegrityCheck(func() (string, bool) {
+		return "ok", false
+	})
+
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Equal(t, "database_integrity", result.Name)
+	assert.Equal(t, health.CategoryDatabase, result.Category)
+	assert.Contains(t, result.Message, "passed")
+}
+
+func TestDatabaseIntegrityCheck_Corrupted(t *testing.T) {
+	check := NewDatabaseIntegrityCheck(func() (string, bool) {
+		return "database disk image is malformed", true
+	})
+
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+	assert.Contains(t, result.Message, "corruption")
+	assert.Contains(t, result.Details["recovery_hint"].(string), "Support")
+}
+
+func TestDatabaseIntegrityCheck_NotYetRun(t *testing.T) {
+	check := NewDatabaseIntegrityCheck(func() (string, bool) {
+		return "", false
+	})
+
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusUnknown, result.Status)
+	assert.Contains(t, result.Message, "not run yet")
+}
+
+func TestDatabaseIntegrityCheck_NilProvider(t *testing.T) {
+	check := NewDatabaseIntegrityCheck(nil)
+
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestDatabaseIntegrityCheck_ResultNotOkButNotLatched(t *testing.T) {
+	check := NewDatabaseIntegrityCheck(func() (string, bool) {
+		return "*** in database main ***\nPage 42: btreeInitPage() error", false
+	})
+
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status,
+		"non-ok integrity result should be critical even without latch")
+}

--- a/internal/health/checks/database_test.go
+++ b/internal/health/checks/database_test.go
@@ -27,7 +27,9 @@ func TestDatabaseIntegrityCheck_Corrupted(t *testing.T) {
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusCritical, result.Status)
 	assert.Contains(t, result.Message, "corruption")
-	assert.Contains(t, result.Details["recovery_hint"].(string), "Support")
+	recoveryHint, ok := result.Details["recovery_hint"].(string)
+	assert.True(t, ok, "recovery_hint should be a string")
+	assert.Contains(t, recoveryHint, "Support")
 }
 
 func TestDatabaseIntegrityCheck_NotYetRun(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add synchronous `PRAGMA quick_check` at startup in `SQLiteStore.Open()` after migration
- Attempt automatic recovery via `REINDEX` for index-level corruption (common from power loss on SD cards)
- Continue in degraded mode if recovery fails, so headless users keep web UI access
- Latch corruption flag (`atomic.Bool`) to suppress Sentry event floods (prevents the 244+ duplicate events seen in production)
- Send deferred persistent notification with actionable recovery guidance (back up database, use Settings > Support)
- Add `DatabaseIntegrityCheck` to the health/diagnostics system
- Improve user-facing corruption error message with specific recovery steps
- Refactor `RunIntegrityCheck` to delegate to shared `runQuickCheck()`, eliminating duplicate PRAGMA logic

## Test Plan

- [x] `go test -race ./internal/datastore/...` - 849 tests pass
- [x] `go test -race ./internal/health/checks/...` - all tests pass
- [x] `golangci-lint run -v` - zero issues
- [x] Simulated file corruption test (`TestPerformStartupIntegrityCheck_CorruptedDatabase`) verifies end-to-end detection
- [ ] Manual verification on a deliberately corrupted database file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a database integrity health check to Diagnostics reporting PRAGMA quick_check results.

* **Bug Fixes**
  * Startup now runs an integrity check, attempts automatic repair, latches corruption state to continue in degraded mode, and notifies users with clearer recovery guidance (backup + support dump).
  * Suppresses duplicate error reporting for already-latched corruption.

* **Tests**
  * Added tests covering integrity checks, recovery, corruption latching, and result reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->