### PR TITLE
refactor(classifier): consolidate ORT pre-check, fix settings access

### DIFF
--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -15,39 +15,29 @@ import (
 func (bn *BirdNET) initializeONNXModel() error {
 	start := time.Now()
 	log := GetLogger()
+	settings := bn.currentSettings()
 
-	// Pre-check ORT availability before attempting model load.
-	ortStatus := inference.CheckORTAvailability(bn.Settings.BirdNET.ONNXRuntimePath)
-	if !ortStatus.Available {
-		log.Warn("ONNX classifier requires ONNX Runtime which is not available",
-			logger.String("error", ortStatus.Error))
-		emitORTUnavailableNotification("BirdNET ONNX Classifier", ortStatus.Error)
-		return errors.Newf("ONNX classifier requires ONNX Runtime %s: %s",
-			inference.ORTRequiredVersion(), ortStatus.Error).
-			Category(errors.CategoryModelInit).
-			Context("model", "onnx_classifier").
-			Context("ort_error", ortStatus.Error).
-			Timing("ort-check", time.Since(start)).
-			Build()
+	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "ONNX classifier", "onnx_classifier", ""); err != nil {
+		return err
 	}
 
 	// Initialize ONNX Runtime if not already done
-	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
+	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			Context("onnx_runtime_path", bn.Settings.BirdNET.ONNXRuntimePath).
+			Context("onnx_runtime_path", settings.BirdNET.ONNXRuntimePath).
 			Timing("onnx-init", time.Since(start)).
 			Build()
 	}
 
-	classifier, err := inference.NewONNXClassifier(bn.Settings.BirdNET.ModelPath, inference.ONNXClassifierOptions{
-		Labels:  bn.Settings.BirdNET.Labels,
-		Threads: bn.Settings.BirdNET.Threads,
+	classifier, err := inference.NewONNXClassifier(settings.BirdNET.ModelPath, inference.ONNXClassifierOptions{
+		Labels:  settings.BirdNET.Labels,
+		Threads: settings.BirdNET.Threads,
 	})
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Timing("onnx-model-init", time.Since(start)).
 			Build()
 	}
@@ -55,7 +45,7 @@ func (bn *BirdNET) initializeONNXModel() error {
 	bn.classifier = classifier
 
 	log.Info("ONNX model initialized",
-		logger.String("model", bn.Settings.BirdNET.ModelPath),
+		logger.String("model", settings.BirdNET.ModelPath),
 		logger.Int("species", classifier.NumSpecies()))
 
 	return nil
@@ -66,29 +56,16 @@ func (bn *BirdNET) initializeONNXModel() error {
 // with its own 12K labels and wraps it in a mappedRangeFilter.
 func (bn *BirdNET) initializeONNXMetaModel() error {
 	settings := bn.currentSettings()
-	log := GetLogger()
 	start := time.Now()
 
-	ortStatus := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
-	if !ortStatus.Available {
-		modelCtx := "range_filter"
-		modelName := "ONNX range filter"
-		notifName := "BirdNET Range Filter"
-		if settings.BirdNET.RangeFilter.Model == "v3" {
-			modelCtx = "v3_geomodel"
-			modelName = "v3 geomodel"
-			notifName = "BirdNET Geomodel"
-		}
-		log.Warn(modelName+" requires ONNX Runtime which is not available",
-			logger.String("error", ortStatus.Error))
-		emitORTUnavailableNotification(notifName, ortStatus.Error)
-		return errors.Newf("%s requires ONNX Runtime %s: %s",
-			modelName, inference.ORTRequiredVersion(), ortStatus.Error).
-			Category(errors.CategoryModelInit).
-			Context("model", modelCtx).
-			Context("ort_error", ortStatus.Error).
-			Timing("ort-check", time.Since(start)).
-			Build()
+	modelName := "ONNX range filter"
+	modelCtx := "range_filter"
+	if settings.BirdNET.RangeFilter.Model == "v3" {
+		modelName = "v3 geomodel"
+		modelCtx = "v3_geomodel"
+	}
+	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, modelName, modelCtx, ""); err != nil {
+		return err
 	}
 
 	if settings.BirdNET.RangeFilter.Model == "v3" {

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -26,6 +26,14 @@ func (o *Orchestrator) loadBat(threads int) error {
 		}
 	}
 
+	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
+		return errors.Newf("bat model files not installed or configured").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("model", "Bat").
+			Build()
+	}
+
 	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", "Bat", "classifier.orchestrator"); err != nil {
 		return err
 	}

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -2,7 +2,6 @@ package classifier
 
 import (
 	"github.com/tphakala/birdnet-go/internal/errors"
-	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -27,19 +26,8 @@ func (o *Orchestrator) loadBat(threads int) error {
 		}
 	}
 
-	// Pre-check ORT availability before attempting bat model load.
-	ortStatus := inference.CheckORTAvailability(o.Settings.BirdNET.ONNXRuntimePath)
-	if !ortStatus.Available {
-		log.Warn("Bat model requires ONNX Runtime which is not available",
-			logger.String("error", ortStatus.Error))
-		emitORTUnavailableNotification("Bat Model", ortStatus.Error)
-		return errors.Newf("Bat model requires ONNX Runtime %s: %s",
-			inference.ORTRequiredVersion(), ortStatus.Error).
-			Component("classifier.orchestrator").
-			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
-			Context("ort_error", ortStatus.Error).
-			Build()
+	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", "Bat", "classifier.orchestrator"); err != nil {
+		return err
 	}
 
 	cfg := BatModelConfig{

--- a/internal/classifier/orchestrator_notifications.go
+++ b/internal/classifier/orchestrator_notifications.go
@@ -3,9 +3,36 @@ package classifier
 import (
 	"fmt"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+// checkORTOrFail checks ONNX Runtime availability and returns a descriptive
+// error with a log warning and bell notification if ORT is not available.
+// Returns nil when ORT is ready. Pass empty component to omit it from the error.
+func checkORTOrFail(configuredPath, modelName, modelContext, component string) error {
+	ortStatus := inference.CheckORTAvailability(configuredPath)
+	if ortStatus.Available {
+		return nil
+	}
+
+	log := GetLogger()
+	log.Warn(modelName+" requires ONNX Runtime which is not available",
+		logger.String("error", ortStatus.Error))
+	emitORTUnavailableNotification(modelName, ortStatus.Error)
+
+	b := errors.Newf("%s requires ONNX Runtime %s: %s",
+		modelName, inference.ORTRequiredVersion(), ortStatus.Error).
+		Category(errors.CategoryModelInit).
+		Context("model", modelContext).
+		Context("ort_error", ortStatus.Error)
+	if component != "" {
+		b = b.Component(component)
+	}
+	return b.Build()
+}
 
 // emitORTUnavailableNotification sends a bell notification when a model
 // cannot load because ONNX Runtime is missing or incompatible.

--- a/internal/classifier/orchestrator_notifications.go
+++ b/internal/classifier/orchestrator_notifications.go
@@ -42,18 +42,19 @@ func emitORTUnavailableNotification(modelName, ortError string) {
 		return
 	}
 
+	requiredVersion := inference.ORTRequiredVersion()
 	notif := notification.NewNotification(
 		notification.TypeWarning,
 		notification.PriorityHigh,
 		fmt.Sprintf("ONNX Runtime required for %s", modelName),
 		fmt.Sprintf("ONNX Runtime %s is required for %s but is not available. %s",
-			inference.ORTRequiredVersion(), modelName, ortError),
+			requiredVersion, modelName, ortError),
 	).
 		WithComponent("classifier").
 		WithTitleKey(notification.MsgORTUnavailableTitle, nil).
 		WithMessageKey(notification.MsgORTUnavailableMessage, map[string]any{
 			"modelName":       modelName,
-			"requiredVersion": inference.ORTRequiredVersion(),
+			"requiredVersion": requiredVersion,
 			"installGuideURL": inference.ORTInstallGuideURL,
 		}).
 		WithDeliveryTarget("bell")

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -2,7 +2,6 @@ package classifier
 
 import (
 	"github.com/tphakala/birdnet-go/internal/errors"
-	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -23,19 +22,8 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		}
 	}
 
-	// Pre-check ORT availability before attempting Perch load.
-	ortStatus := inference.CheckORTAvailability(o.Settings.BirdNET.ONNXRuntimePath)
-	if !ortStatus.Available {
-		log.Warn("Perch v2 requires ONNX Runtime which is not available",
-			logger.String("error", ortStatus.Error))
-		emitORTUnavailableNotification("Perch v2", ortStatus.Error)
-		return errors.Newf("Perch v2 requires ONNX Runtime %s: %s",
-			inference.ORTRequiredVersion(), ortStatus.Error).
-			Component("classifier.orchestrator").
-			Category(errors.CategoryModelInit).
-			Context("model", "Perch_V2").
-			Context("ort_error", ortStatus.Error).
-			Build()
+	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", "Perch_V2", "classifier.orchestrator"); err != nil {
+		return err
 	}
 
 	cfg := PerchConfig{

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -22,6 +22,14 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		}
 	}
 
+	if modelPath == "" || labelPath == "" {
+		return errors.Newf("Perch v2 model files not installed or configured").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("model", "Perch_V2").
+			Build()
+	}
+
 	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", "Perch_V2", "classifier.orchestrator"); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Extract repeated ORT availability check + log + notification + error pattern into `checkORTOrFail()` helper, reducing ~12 lines per call site to 1. Four call sites consolidated: `initializeONNXModel`, `initializeONNXMetaModel`, `loadPerch`, `loadBat`.
- Fix `initializeONNXModel` to use `bn.currentSettings()` instead of direct `bn.Settings` access, matching the pattern used by sibling functions for hot-reload safety.
- Add early path validation in `loadBat`/`loadPerch` to fail fast with a descriptive error when model files are not installed, instead of falling through to deeper stack failures.
- Cache `ORTRequiredVersion()` in `emitORTUnavailableNotification` to avoid redundant string allocation.

## Test Plan
- [x] `go build ./internal/classifier/` passes
- [x] `golangci-lint run ./internal/classifier/` clean (zero issues)
- [x] `go test -race -count=1 ./internal/classifier/` passes (574 tests)
- [x] Gate review (6 parallel agents + Gemini) found no blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated ONNX Runtime availability checks across model initialization paths for improved consistency and maintainability.
  * Enhanced error handling and validation for model file configuration, providing clearer feedback when models are not properly installed or configured.
  * Streamlined notification logic for ONNX Runtime compatibility issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->