### PR TITLE
fix(datastore): harden file operations and connection cleanup

### DIFF
--- a/internal/api/v2/prerequisites.go
+++ b/internal/api/v2/prerequisites.go
@@ -393,16 +393,15 @@ func (c *Controller) checkWritePermission() PrerequisiteCheck {
 		return check
 	}
 
-	testFile := filepath.Join(dir, ".migration_permission_test")
-
-	f, err := os.Create(testFile) //#nosec G304 -- testFile is constructed from trusted path
+	f, err := os.CreateTemp(dir, ".birdnet_write_test_*")
 	if err != nil {
 		check.Status = CheckStatusFailed
 		check.Message = fmt.Sprintf("Cannot write to %s: %v", dir, err)
 		return check
 	}
+	name := f.Name()
 	_ = f.Close()
-	_ = os.Remove(testFile)
+	_ = os.Remove(name)
 
 	check.Status = CheckStatusPassed
 	check.Message = fmt.Sprintf("Write access verified for %s", dir)

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -719,7 +719,7 @@ func (m *Manager) createArchive(ctx context.Context, archivePath string, reader 
 	start := time.Now()
 
 	// Create the archive file (internal temp path from backup manager)
-	archiveFile, err := os.Create(archivePath) //nolint:gosec // G304 - archivePath is an internal temp path from backup manager
+	archiveFile, err := os.OpenFile(archivePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // G304 - archivePath is an internal temp path from backup manager
 	if err != nil {
 		return errors.New(err).
 			Component("backup").

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -44,7 +44,7 @@ func validateMySQLConfig() error {
 }
 
 // InitializeDatabase sets up the MySQL database connection
-func (store *MySQLStore) Open() error {
+func (store *MySQLStore) Open() (retErr error) {
 	if err := validateMySQLConfig(); err != nil {
 		return err // validateMySQLConfig returns a properly formatted error
 	}
@@ -100,6 +100,16 @@ func (store *MySQLStore) Open() error {
 	sqlDB.SetMaxIdleConns(MySQLMaxIdleConns)
 	sqlDB.SetConnMaxLifetime(MySQLConnMaxLifetime)
 	sqlDB.SetConnMaxIdleTime(MySQLConnMaxIdleTime)
+
+	// Clean up connection pool if any subsequent initialization step fails.
+	defer func() {
+		if retErr != nil {
+			if closeErr := sqlDB.Close(); closeErr != nil {
+				GetLogger().Warn("Failed to close DB pool after init error", logger.Error(closeErr))
+			}
+			store.DB = nil
+		}
+	}()
 
 	store.DB = db
 

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -72,24 +72,24 @@ func getDiskSpace(path string) (uint64, error) {
 
 // checkWritePermission checks if we have write permission to the directory
 func checkWritePermission(path string) error {
-	// Create a temporary file to test write permissions
-	tempFile := filepath.Join(filepath.Dir(path), ".tmp_write_test")
-	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // G304: tempFile derived from database path
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".birdnet_write_test_*")
 	if err != nil {
 		return errors.New(err).
 			Component("datastore").
 			Category(errors.CategorySystem).
 			Context("operation", "check_write_permission").
-			Context("directory", filepath.Dir(path)).
+			Context("directory", dir).
 			Build()
 	}
+	name := f.Name()
+	defer func() {
+		if err := os.Remove(name); err != nil {
+			GetLogger().Warn("Failed to remove temp file", logger.Error(err))
+		}
+	}()
 	if err := f.Close(); err != nil {
-		// Log but don't fail permission check
 		GetLogger().Warn("Failed to close temp file", logger.Error(err))
-	}
-	if err := os.Remove(tempFile); err != nil {
-		// Log but don't fail permission check
-		GetLogger().Warn("Failed to remove temp file", logger.Error(err))
 	}
 	return nil
 }
@@ -155,8 +155,8 @@ func (s *SQLiteStore) createBackup(dbPath string) error {
 		}
 	}()
 
-	// Create backup file
-	destination, err := os.Create(backupPath) //nolint:gosec // G304: backupPath derived from dbPath (application settings)
+	// Create backup file with restricted permissions (owner-only)
+	destination, err := os.OpenFile(backupPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // G304: backupPath derived from dbPath (application settings)
 	if err != nil {
 		return errors.New(err).
 			Component("datastore").
@@ -187,7 +187,7 @@ func (s *SQLiteStore) createBackup(dbPath string) error {
 }
 
 // Open initializes the SQLite database connection
-func (s *SQLiteStore) Open() error {
+func (s *SQLiteStore) Open() (retErr error) {
 	// Get database path from settings
 	dbPath := s.Settings.Output.SQLite.Path
 
@@ -271,6 +271,16 @@ func (s *SQLiteStore) Open() error {
 			Build()
 	}
 	sqlDB.SetMaxOpenConns(1)
+
+	// Clean up connection pool if any subsequent initialization step fails.
+	defer func() {
+		if retErr != nil {
+			if closeErr := sqlDB.Close(); closeErr != nil {
+				GetLogger().Warn("Failed to close DB pool after init error", logger.Error(closeErr))
+			}
+			s.DB = nil
+		}
+	}()
 
 	// Store the database connection
 	s.DB = db

--- a/internal/datastore/sqlite_security_test.go
+++ b/internal/datastore/sqlite_security_test.go
@@ -1,0 +1,135 @@
+package datastore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func TestCreateBackup_FilePermissions(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	require.NoError(t, os.WriteFile(dbPath, []byte("fake db content"), 0o600))
+
+	store := &SQLiteStore{
+		Settings: &conf.Settings{},
+	}
+
+	err := store.createBackup(dbPath)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+
+	var backupPath string
+	for _, e := range entries {
+		if e.Name() != "test.db" {
+			backupPath = filepath.Join(tmpDir, e.Name())
+			break
+		}
+	}
+	require.NotEmpty(t, backupPath, "backup file should exist")
+
+	info, err := os.Stat(backupPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"backup file should have 0600 permissions")
+}
+
+func TestCheckWritePermission_NoSymlinkFollow(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Pre-create a symlink at the old predictable path
+	oldPredictablePath := filepath.Join(tmpDir, ".tmp_write_test")
+	targetPath := filepath.Join(tmpDir, "symlink_target")
+	require.NoError(t, os.Symlink(targetPath, oldPredictablePath))
+
+	err := checkWritePermission(dbPath)
+	require.NoError(t, err)
+
+	// The symlink target should NOT have been created
+	_, statErr := os.Stat(targetPath)
+	assert.True(t, os.IsNotExist(statErr),
+		"symlink target should not be created; function should use random temp name")
+}
+
+func TestCheckWritePermission_CleansUpTempFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	err := checkWritePermission(dbPath)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "temp file should be cleaned up after permission check")
+}
+
+func TestCheckWritePermission_FailsOnReadOnlyDir(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Make directory read-only
+	require.NoError(t, os.Chmod(tmpDir, 0o555))
+	t.Cleanup(func() {
+		_ = os.Chmod(tmpDir, 0o755)
+	})
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	err := checkWritePermission(dbPath)
+	assert.Error(t, err)
+}
+
+func TestOpen_ClosesPoolOnPostConnectionFailure(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Create a WAL-mode database, checkpoint, and remove WAL/SHM files.
+	// This leaves a valid DB file that gorm.Open can reopen successfully.
+	dsn := buildSQLiteDSN(dbPath, "_journal_mode=WAL&_busy_timeout=5000")
+	setupDB, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	setupSQL, err := setupDB.DB()
+	require.NoError(t, err)
+	_, err = setupSQL.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	require.NoError(t, err)
+	require.NoError(t, setupSQL.Close())
+	_ = os.Remove(dbPath + "-wal")
+	_ = os.Remove(dbPath + "-shm")
+
+	// Make the DB file read-only. gorm.Open will succeed (SQLite can open
+	// a read-only WAL DB if the directory is writable for the new WAL file),
+	// but performAutoMigration will fail with "attempt to write a readonly
+	// database". This exercises the defer cleanup path that closes sqlDB
+	// and nils s.DB.
+	require.NoError(t, os.Chmod(dbPath, 0o444))
+	t.Cleanup(func() {
+		_ = os.Chmod(dbPath, 0o644)
+	})
+
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Path = dbPath
+
+	store := &SQLiteStore{
+		Settings: settings,
+	}
+
+	openErr := store.Open()
+	require.Error(t, openErr, "Open should fail when DB file is read-only")
+	assert.Nil(t, store.DB, "store.DB should be nil after Open() failure (pool closed by defer)")
+}

--- a/internal/logger/rotation.go
+++ b/internal/logger/rotation.go
@@ -312,7 +312,7 @@ func (rm *RotationManager) compressFile(srcPath string) {
 	}()
 
 	// Create destination .gz file
-	dst, err := os.Create(dstPath) //nolint:gosec // path derived from rotation
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, LogFilePermissions) //nolint:gosec // path derived from rotation
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "rotation: failed to create compressed file: %v\n", err)
 		return
@@ -422,13 +422,14 @@ func (rm *RotationManager) recoverDiskSpace() bool {
 
 // testDiskSpace checks if we can create a file (disk has space).
 func (rm *RotationManager) testDiskSpace() bool {
-	testPath := rm.basePath + ".test"
-	f, err := os.Create(testPath) //nolint:gosec // path derived from config
+	dir := filepath.Dir(rm.basePath)
+	f, err := os.CreateTemp(dir, ".birdnet_disk_test_*")
 	if err != nil {
 		return false
 	}
+	name := f.Name()
 	_ = f.Close()
-	_ = os.Remove(testPath)
+	_ = os.Remove(name)
 	return true
 }
 


### PR DESCRIPTION
## Summary

- Replace predictable temp file paths with `os.CreateTemp` (random name + `O_EXCL`) across datastore, API prerequisites, and log rotation to prevent symlink attacks
- Use `0600` permissions for backup files and archives instead of `os.Create` default (`0666` before umask)
- Close `sql.DB` connection pool when post-`Open()` initialization steps fail (SQLite + MySQL) using named-return + defer pattern
- Use `LogFilePermissions` (0600) for compressed log files, matching live log file permissions

## Test Plan

- [x] `TestCreateBackup_FilePermissions` - verifies backup file gets 0600 permissions
- [x] `TestCheckWritePermission_NoSymlinkFollow` - verifies old predictable path is not used
- [x] `TestCheckWritePermission_CleansUpTempFile` - verifies temp file cleanup
- [x] `TestCheckWritePermission_FailsOnReadOnlyDir` - verifies error on unwritable dir
- [x] `TestOpen_ClosesPoolOnPostConnectionFailure` - verifies defer cleanup fires on migration error (validated: fails without fix)
- [x] Full test suite: 2976 tests pass with `-race`
- [x] `golangci-lint` clean across all modified packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization reliability by ensuring proper resource cleanup when initialization steps fail
  * Enhanced security checks to properly validate write permissions in target directories

* **Chores**
  * Strengthened backup and archive file creation with improved security permission handling
  * Improved error handling and resource management across datastore initialization operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->