### PR TITLE
feat: time-windowed health evaluation with sparkline visualization

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -14,7 +14,7 @@
 - **NEVER create inline SVGs** - use `@lucide/svelte` icons
 - **NEVER use `toISOString()` for dates** - use `getLocalDateString()`
 - **NEVER use Secure Context APIs without fallback** - BirdNET-Go commonly runs on plain HTTP in home networks. `crypto.randomUUID()` and `navigator.clipboard` are undefined on non-HTTPS. Use `Math.random().toString(36).slice(2, 10)` for unique IDs. For clipboard, check `navigator.clipboard?.writeText` and fall back to textarea + `document.execCommand('copy')`
-- **NEVER ship ambiguous UI states** - disabled controls, errors, and loading states must always explain *why* to the user. A disabled Save button with no tooltip is a support ticket waiting to be filed. See [UX Design Principles](#ux-design-principles) below.
+- **NEVER ship ambiguous UI states** - disabled controls, errors, and loading states must always explain _why_ to the user. A disabled Save button with no tooltip is a support ticket waiting to be filed. See [UX Design Principles](#ux-design-principles) below.
 - **Use D3.js for ALL charting/plotting** - unless specific requirement for custom approach
 - **Run `npm run check:all` before EVERY commit**
 
@@ -356,7 +356,7 @@ Every interactive element needs a deliberate UX pass before it ships. Ambiguity 
 
 ### No Ambiguous Disabled States
 
-When a control is disabled (button, input, toggle, link), the user MUST be able to tell *why* without guessing or clicking around. Silent disabled controls are the single biggest source of "this is broken" reports that turn out to be a missing prerequisite the user could have satisfied themselves.
+When a control is disabled (button, input, toggle, link), the user MUST be able to tell _why_ without guessing or clicking around. Silent disabled controls are the single biggest source of "this is broken" reports that turn out to be a missing prerequisite the user could have satisfied themselves.
 
 Required indicators when a control is disabled:
 

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -15,7 +15,7 @@
     RefreshCw,
   } from '@lucide/svelte';
   import { onMount } from 'svelte';
-  import { t } from '$lib/i18n';
+  import { t, getLocale } from '$lib/i18n';
   import { api } from '$lib/utils/api';
   import { copyToClipboard, COPY_FEEDBACK_TIMEOUT_MS } from '$lib/utils/clipboard';
   import { getLocalDateString, getLocalTimeString } from '$lib/utils/date';
@@ -180,13 +180,15 @@
     const diffMs = now - then;
     const diffSec = Math.floor(diffMs / 1000);
 
-    if (diffSec < 60) return `${diffSec}s ago`;
+    const rtf = new Intl.RelativeTimeFormat(getLocale(), { numeric: 'auto' });
+
+    if (diffSec < 60) return rtf.format(-diffSec, 'second');
     const diffMin = Math.floor(diffSec / 60);
-    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffMin < 60) return rtf.format(-diffMin, 'minute');
     const diffHours = Math.floor(diffMin / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffHours < 24) return rtf.format(-diffHours, 'hour');
     const diffDays = Math.floor(diffHours / 24);
-    return `${diffDays}d ago`;
+    return rtf.format(-diffDays, 'day');
   }
 
   onMount(() => {
@@ -232,7 +234,11 @@
 
   function selectWindow(w: string) {
     selectedWindow = w;
-    localStorage.setItem('health-eval-window', w);
+    try {
+      localStorage.setItem('health-eval-window', w);
+    } catch {
+      // Ignore storage failures (private browsing, quota); selection stays in memory.
+    }
     if (report) {
       runDiagnostics();
     }

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -328,9 +328,9 @@
     viewBox="0 0 {totalWidth} {height}"
     class="inline-block align-middle"
     role="img"
-    aria-label="Activity sparkline"
+    aria-label={t('health.detail.sparklineLabel')}
   >
-    {#each buckets as bucket, i (bucket.t)}
+    {#each buckets as bucket, i (i)}
       {@const barHeight = bucket.v > 0 ? Math.max(2, (bucket.v / maxVal) * height) : 1}
       <rect
         x={i * (barWidth + gap)}

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -90,10 +90,14 @@
 
   function safeGetWindow(): string {
     try {
-      return localStorage.getItem('health-eval-window') ?? '1h';
+      const stored = localStorage.getItem('health-eval-window');
+      if (stored && (windowPresets as readonly string[]).includes(stored)) {
+        return stored;
+      }
     } catch {
-      return '1h';
+      // localStorage unavailable in strict privacy modes
     }
+    return '1h';
   }
 
   let selectedWindow = $state<string>(safeGetWindow());

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -34,6 +34,18 @@
     | 'config'
     | 'logs';
 
+  interface SparklineBucket {
+    t: string;
+    v: number;
+  }
+
+  interface RecentEvent {
+    time: string;
+    source: string;
+    delta: number;
+    metric: string;
+  }
+
   interface DiagnosticsResult {
     name: string;
     category: HealthCategory;
@@ -67,12 +79,24 @@
     'logs',
   ];
 
+  const windowPresets = ['15m', '30m', '1h', '6h', '24h', '7d'] as const;
+
   let report = $state<DiagnosticsReport | null>(null);
   let running = $state(false);
   let error = $state<string | null>(null);
   let copied = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   let expandedChecks = $state(new Set<string>());
+
+  function safeGetWindow(): string {
+    try {
+      return localStorage.getItem('health-eval-window') ?? '1h';
+    } catch {
+      return '1h';
+    }
+  }
+
+  let selectedWindow = $state<string>(safeGetWindow());
 
   function toggleExpand(checkName: string) {
     const next = new Set(expandedChecks);
@@ -98,6 +122,29 @@
     return topErrors as ErrorGroup[];
   }
 
+  function getSparkline(result: DiagnosticsResult): SparklineBucket[] | null {
+    const sparkline = result.details?.sparkline;
+    if (!Array.isArray(sparkline) || sparkline.length === 0) return null;
+    return sparkline as SparklineBucket[];
+  }
+
+  function getRecentEvents(result: DiagnosticsResult): RecentEvent[] | null {
+    const events = result.details?.recent_events;
+    if (!Array.isArray(events) || events.length === 0) return null;
+    return events as RecentEvent[];
+  }
+
+  function isCheckExpandable(result: DiagnosticsResult): boolean {
+    const topErrors = getTopErrors(result);
+    if (topErrors !== null && (result.status === 'warning' || result.status === 'critical')) {
+      return true;
+    }
+    if (result.details?.sparkline != null || result.details?.recent_events != null) {
+      return true;
+    }
+    return false;
+  }
+
   function levelColor(level: string): string {
     switch (level) {
       case 'fatal':
@@ -110,6 +157,34 @@
       default:
         return 'var(--color-base-content)';
     }
+  }
+
+  function statusColor(status: HealthStatus): string {
+    switch (status) {
+      case 'healthy':
+        return 'var(--color-success)';
+      case 'warning':
+        return 'var(--color-warning)';
+      case 'critical':
+        return 'var(--color-error)';
+      default:
+        return 'var(--color-base-content)';
+    }
+  }
+
+  function formatTimeAgo(isoTime: string): string {
+    const now = Date.now();
+    const then = new Date(isoTime).getTime();
+    const diffMs = now - then;
+    const diffSec = Math.floor(diffMs / 1000);
+
+    if (diffSec < 60) return `${diffSec}s ago`;
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHours = Math.floor(diffMin / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d ago`;
   }
 
   onMount(() => {
@@ -152,12 +227,22 @@
     }
   }
 
+  function selectWindow(w: string) {
+    selectedWindow = w;
+    localStorage.setItem('health-eval-window', w);
+    if (report) {
+      runDiagnostics();
+    }
+  }
+
   async function runDiagnostics() {
     if (running) return;
     running = true;
     error = null;
     try {
-      report = await api.post<DiagnosticsReport>('/api/v2/system/diagnostics/run');
+      report = await api.post<DiagnosticsReport>(
+        `/api/v2/system/diagnostics/run?window=${selectedWindow}`
+      );
     } catch {
       error = t('health.errors.fetchFailed');
     } finally {
@@ -228,6 +313,35 @@
   {/if}
 {/snippet}
 
+{#snippet sparklineSvg(buckets: SparklineBucket[], color: string)}
+  {@const maxVal = Math.max(...buckets.map(b => b.v), 1)}
+  {@const barWidth = 4}
+  {@const gap = 1}
+  {@const height = 20}
+  {@const totalWidth = buckets.length * (barWidth + gap) - gap}
+  <svg
+    width={totalWidth}
+    {height}
+    viewBox="0 0 {totalWidth} {height}"
+    class="inline-block align-middle"
+    role="img"
+    aria-label="Activity sparkline"
+  >
+    {#each buckets as bucket, i (bucket.t)}
+      {@const barHeight = bucket.v > 0 ? Math.max(2, (bucket.v / maxVal) * height) : 1}
+      <rect
+        x={i * (barWidth + gap)}
+        y={height - barHeight}
+        width={barWidth}
+        height={barHeight}
+        fill={color}
+        opacity={bucket.v > 0 ? 0.85 : 0.15}
+        rx="1"
+      />
+    {/each}
+  </svg>
+{/snippet}
+
 <div class="col-span-12 space-y-4">
   <!-- Page Header -->
   <Card className="bg-[var(--color-base-100)] shadow-sm">
@@ -244,7 +358,7 @@
         </p>
       </div>
 
-      <div class="mt-4">
+      <div class="mt-4 flex flex-col items-center gap-3">
         <button
           onclick={runDiagnostics}
           disabled={running}
@@ -258,6 +372,34 @@
             {t('health.runDiagnostics')}
           {/if}
         </button>
+
+        <!-- Window Selector -->
+        <div class="flex items-center gap-2">
+          <span class="text-xs text-[var(--color-base-content)] opacity-60">
+            {t('health.window.label')}:
+          </span>
+          <div
+            class="inline-flex rounded-md border border-[var(--color-base-300)] overflow-hidden"
+            role="radiogroup"
+            aria-label={t('health.window.label')}
+          >
+            {#each windowPresets as w (w)}
+              <button
+                type="button"
+                role="radio"
+                aria-checked={selectedWindow === w}
+                disabled={running}
+                onclick={() => selectWindow(w)}
+                class="px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-50 {selectedWindow ===
+                w
+                  ? 'bg-[var(--color-primary)] text-[var(--color-primary-content)]'
+                  : 'bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]'}"
+              >
+                {t(`health.window.${w}`)}
+              </button>
+            {/each}
+          </div>
+        </div>
       </div>
     </div>
   </Card>
@@ -379,18 +521,19 @@
         <div class="space-y-2">
           {#each results as result (result.name)}
             {@const topErrors = getTopErrors(result)}
-            {@const isExpandable =
-              topErrors !== null && (result.status === 'warning' || result.status === 'critical')}
+            {@const sparkline = getSparkline(result)}
+            {@const recentEvents = getRecentEvents(result)}
+            {@const expandable = isCheckExpandable(result)}
             {@const isExpanded = expandedChecks.has(result.name)}
             <div>
               <button
                 type="button"
-                class="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg bg-[var(--color-base-200)]/50 text-left {isExpandable
+                class="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg bg-[var(--color-base-200)]/50 text-left {expandable
                   ? 'cursor-pointer hover:bg-[var(--color-base-200)]'
                   : 'cursor-default'}"
-                onclick={() => isExpandable && toggleExpand(result.name)}
-                disabled={!isExpandable}
-                aria-expanded={isExpandable ? isExpanded : undefined}
+                onclick={() => expandable && toggleExpand(result.name)}
+                disabled={!expandable}
+                aria-expanded={expandable ? isExpanded : undefined}
               >
                 <StatusPill
                   variant={statusToVariant(result.status)}
@@ -402,7 +545,12 @@
                   {/snippet}
                 </StatusPill>
                 <div class="flex-1 min-w-0">
-                  <span class="text-sm font-medium">{formatCheckName(result.name)}</span>
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-medium">{formatCheckName(result.name)}</span>
+                    {#if sparkline}
+                      {@render sparklineSvg(sparkline, statusColor(result.status))}
+                    {/if}
+                  </div>
                   <p class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
                     {result.message}
                   </p>
@@ -410,7 +558,7 @@
                 <span class="text-xs text-[var(--color-base-content)] opacity-40 shrink-0">
                   {result.duration_ms.toFixed(1)}ms
                 </span>
-                {#if isExpandable}
+                {#if expandable}
                   <ChevronDown
                     class="size-4 shrink-0 opacity-40 transition-transform {isExpanded
                       ? 'rotate-180'
@@ -419,59 +567,120 @@
                 {/if}
               </button>
 
-              {#if isExpanded && topErrors}
+              <!-- Expanded Detail Panel -->
+              {#if isExpanded}
                 <div
                   class="mt-1 ml-3 mr-3 mb-2 rounded-lg bg-[var(--color-base-200)]/30 overflow-hidden"
                 >
-                  <p
-                    class="px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] opacity-60"
-                  >
-                    {t('health.logs.topErrors')}
-                  </p>
-                  <table class="w-full text-xs">
-                    <thead>
-                      <tr
-                        class="text-left text-[var(--color-base-content)] opacity-50 border-b border-[var(--color-base-200)]"
-                      >
-                        <th class="px-3 py-1.5 font-medium">{t('health.logs.errorComponent')}</th>
-                        <th class="px-3 py-1.5 font-medium">{t('health.logs.errorMessage')}</th>
-                        <th class="px-3 py-1.5 font-medium text-right"
-                          >{t('health.logs.errorCount')}</th
+                  <!-- Top Errors (for log checks) -->
+                  {#if topErrors}
+                    <p
+                      class="px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] opacity-60"
+                    >
+                      {t('health.logs.topErrors')}
+                    </p>
+                    <table class="w-full text-xs">
+                      <thead>
+                        <tr
+                          class="text-left text-[var(--color-base-content)] opacity-50 border-b border-[var(--color-base-200)]"
                         >
-                        <th class="px-3 py-1.5 font-medium">{t('health.logs.errorLevel')}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {#each topErrors as group (group.component + ':' + group.message)}
-                        <tr class="border-b border-[var(--color-base-200)]/50 last:border-0">
-                          <td class="px-3 py-1.5">
-                            {#if group.component}
-                              <span
-                                class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-base-300)] text-[var(--color-base-content)]"
-                              >
-                                {group.component}
-                              </span>
-                            {:else}
-                              <span class="opacity-30">-</span>
-                            {/if}
-                          </td>
-                          <td class="px-3 py-1.5 max-w-[300px] truncate" title={group.message}>
-                            {group.message}
-                          </td>
-                          <td class="px-3 py-1.5 text-right font-mono">{group.count}</td>
-                          <td class="px-3 py-1.5">
-                            <span
-                              class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
-                              style:color={levelColor(group.level)}
-                              style:background="color-mix(in srgb, {levelColor(group.level)} 10%, transparent)"
-                            >
-                              {group.level}
-                            </span>
-                          </td>
+                          <th class="px-3 py-1.5 font-medium">{t('health.logs.errorComponent')}</th>
+                          <th class="px-3 py-1.5 font-medium">{t('health.logs.errorMessage')}</th>
+                          <th class="px-3 py-1.5 font-medium text-right"
+                            >{t('health.logs.errorCount')}</th
+                          >
+                          <th class="px-3 py-1.5 font-medium">{t('health.logs.errorLevel')}</th>
                         </tr>
-                      {/each}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        {#each topErrors as group (group.component + ':' + group.message)}
+                          <tr class="border-b border-[var(--color-base-200)]/50 last:border-0">
+                            <td class="px-3 py-1.5">
+                              {#if group.component}
+                                <span
+                                  class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-base-300)] text-[var(--color-base-content)]"
+                                >
+                                  {group.component}
+                                </span>
+                              {:else}
+                                <span class="opacity-30">-</span>
+                              {/if}
+                            </td>
+                            <td class="px-3 py-1.5 max-w-[300px] truncate" title={group.message}>
+                              {group.message}
+                            </td>
+                            <td class="px-3 py-1.5 text-right font-mono">{group.count}</td>
+                            <td class="px-3 py-1.5">
+                              <span
+                                class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                                style:color={levelColor(group.level)}
+                                style:background="color-mix(in srgb, {levelColor(group.level)} 10%, transparent)"
+                              >
+                                {group.level}
+                              </span>
+                            </td>
+                          </tr>
+                        {/each}
+                      </tbody>
+                    </table>
+                  {/if}
+
+                  <!-- Windowed Health Detail (for counter-based checks) -->
+                  {#if sparkline || recentEvents}
+                    <!-- Last Event Callout -->
+                    {#if result.details?.last_event}
+                      <div class="px-3 py-2 flex items-center gap-2">
+                        <Clock class="size-3.5 opacity-50" />
+                        <span class="text-xs font-medium">
+                          {t('health.detail.lastEvent')}:
+                          <span class="opacity-70" title={String(result.details.last_event)}>
+                            {formatTimeAgo(String(result.details.last_event))}
+                          </span>
+                        </span>
+                        {#if result.details?.lifetime_total != null}
+                          <span class="text-xs opacity-50">
+                            ({result.details.lifetime_total}
+                            {t('health.detail.lifetime')})
+                          </span>
+                        {/if}
+                      </div>
+                    {/if}
+
+                    <!-- Recent Events Table -->
+                    {#if recentEvents && recentEvents.length > 0}
+                      <p
+                        class="px-3 py-1.5 text-xs font-medium text-[var(--color-base-content)] opacity-60 border-t border-[var(--color-base-200)]/50"
+                      >
+                        {t('health.detail.recentEvents')}
+                      </p>
+                      <table class="w-full text-xs">
+                        <thead>
+                          <tr
+                            class="text-left text-[var(--color-base-content)] opacity-50 border-b border-[var(--color-base-200)]"
+                          >
+                            <th class="px-3 py-1.5 font-medium">{t('health.detail.time')}</th>
+                            <th class="px-3 py-1.5 font-medium">{t('health.detail.source')}</th>
+                            <th class="px-3 py-1.5 font-medium text-right"
+                              >{t('health.detail.count')}</th
+                            >
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {#each recentEvents as event, idx (event.time + event.source + idx)}
+                            <tr class="border-b border-[var(--color-base-200)]/50 last:border-0">
+                              <td class="px-3 py-1.5" title={new Date(event.time).toLocaleString()}>
+                                {formatTimeAgo(event.time)}
+                              </td>
+                              <td class="px-3 py-1.5 font-mono text-[10px] truncate max-w-[200px]">
+                                {event.source}
+                              </td>
+                              <td class="px-3 py-1.5 text-right font-mono">{event.delta}</td>
+                            </tr>
+                          {/each}
+                        </tbody>
+                      </table>
+                    {/if}
+                  {/if}
                 </div>
               {/if}
             </div>

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -3,8 +3,6 @@
   import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
   import type { StatusVariant } from '$lib/desktop/components/ui/StatusPill.svelte';
   import {
-    Activity,
-    Play,
     Download,
     ClipboardCopy,
     CheckCircle,
@@ -15,6 +13,7 @@
     Loader2,
     Info,
     ChevronDown,
+    RefreshCw,
   } from '@lucide/svelte';
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
@@ -192,6 +191,7 @@
   }
 
   onMount(() => {
+    runDiagnostics();
     return () => {
       if (copyTimer !== null) clearTimeout(copyTimer);
     };
@@ -347,99 +347,12 @@
 {/snippet}
 
 <div class="col-span-12 space-y-4">
-  <!-- Page Header -->
+  <!-- Status & Controls Toolbar -->
   <Card className="bg-[var(--color-base-100)] shadow-sm">
-    <div class="flex flex-col items-center text-center">
-      <div
-        class="w-20 h-20 rounded-full bg-gradient-to-b from-[var(--surface-200)] to-[var(--color-base-100)] flex items-center justify-center border border-[var(--border-100)]"
-      >
-        <Activity class="size-10 text-[var(--color-primary)]" />
-      </div>
-      <div class="mt-3">
-        <h1 class="text-3xl font-bold">{t('health.title')}</h1>
-        <p class="text-[var(--color-base-content)] opacity-70 text-base mt-2">
-          {t('health.subtitle')}
-        </p>
-      </div>
-
-      <div class="mt-4 flex flex-col items-center gap-3">
-        <button
-          onclick={runDiagnostics}
-          disabled={running}
-          class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary-hover)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {#if running}
-            <Loader2 class="size-4 animate-spin" />
-            {t('health.running')}
-          {:else}
-            <Play class="size-4" />
-            {t('health.runDiagnostics')}
-          {/if}
-        </button>
-
-        <!-- Window Selector -->
-        <div class="flex items-center gap-2">
-          <span class="text-xs text-[var(--color-base-content)] opacity-60">
-            {t('health.window.label')}:
-          </span>
-          <div
-            class="inline-flex rounded-md border border-[var(--color-base-300)] overflow-hidden"
-            role="radiogroup"
-            aria-label={t('health.window.label')}
-          >
-            {#each windowPresets as w (w)}
-              <button
-                type="button"
-                role="radio"
-                aria-checked={selectedWindow === w}
-                disabled={running}
-                onclick={() => selectWindow(w)}
-                class="px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-50 {selectedWindow ===
-                w
-                  ? 'bg-[var(--color-primary)] text-[var(--color-primary-content)]'
-                  : 'bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]'}"
-              >
-                {t(`health.window.${w}`)}
-              </button>
-            {/each}
-          </div>
-        </div>
-      </div>
-    </div>
-  </Card>
-
-  <!-- Error State -->
-  {#if error}
-    <Card className="bg-[var(--color-base-100)] shadow-sm">
-      <div
-        role="alert"
-        aria-live="assertive"
-        class="flex items-center gap-3 p-3 rounded-lg bg-[color-mix(in_srgb,var(--color-error)_10%,transparent)]"
-      >
-        <XCircle class="size-5 shrink-0 text-[var(--color-error)]" />
-        <p class="text-sm text-[var(--color-base-content)]">{error}</p>
-      </div>
-    </Card>
-  {/if}
-
-  <!-- No Results State -->
-  {#if !report && !running && !error}
-    <Card className="bg-[var(--color-base-100)] shadow-sm">
-      <div class="flex flex-col items-center py-6 text-center">
-        <Activity class="size-12 text-[var(--color-base-content)] opacity-20 mb-3" />
-        <p class="text-[var(--color-base-content)] opacity-60 text-sm">
-          {t('health.noResults')}
-        </p>
-      </div>
-    </Card>
-  {/if}
-
-  <!-- Results -->
-  {#if report}
-    <!-- Summary Bar -->
-    <Card className="bg-[var(--color-base-100)] shadow-sm">
-      <div class="flex flex-wrap items-center gap-4">
-        <div class="flex items-center gap-2">
+    <!-- Row 1: Status + last run + refresh -->
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div class="flex flex-wrap items-center gap-3 min-w-0">
+        {#if report}
           <StatusPill
             variant={statusToVariant(report.status)}
             label={t(`health.status.${report.status}`)}
@@ -451,52 +364,120 @@
               {/if}
             {/snippet}
           </StatusPill>
-        </div>
 
-        <div class="flex items-center gap-3 text-sm text-[var(--color-base-content)] opacity-70">
-          {#if report.count_by_status.healthy}
-            <span class="flex items-center gap-1">
-              <CheckCircle class="size-3.5 text-[var(--color-success)]" />
-              {report.count_by_status.healthy}
-              {t('health.summary.healthy')}
-            </span>
-          {/if}
-          {#if report.count_by_status.warning}
-            <span class="flex items-center gap-1">
-              <AlertTriangle class="size-3.5 text-[var(--color-warning)]" />
-              {report.count_by_status.warning}
-              {t('health.summary.warnings')}
-            </span>
-          {/if}
-          {#if report.count_by_status.critical}
-            <span class="flex items-center gap-1">
-              <XCircle class="size-3.5 text-[var(--color-error)]" />
-              {report.count_by_status.critical}
-              {t('health.summary.critical')}
-            </span>
-          {/if}
-          {#if report.count_by_status.skipped}
-            <span class="flex items-center gap-1">
-              <SkipForward class="size-3.5 opacity-40" />
-              {report.count_by_status.skipped}
-              {t('health.summary.skipped')}
-            </span>
-          {/if}
-        </div>
+          <div
+            class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-[var(--color-base-content)] opacity-70"
+          >
+            {#if report.count_by_status.healthy}
+              <span class="flex items-center gap-1">
+                <CheckCircle class="size-3.5 text-[var(--color-success)]" />
+                {report.count_by_status.healthy}
+                {t('health.summary.healthy')}
+              </span>
+            {/if}
+            {#if report.count_by_status.warning}
+              <span class="flex items-center gap-1">
+                <AlertTriangle class="size-3.5 text-[var(--color-warning)]" />
+                {report.count_by_status.warning}
+                {t('health.summary.warnings')}
+              </span>
+            {/if}
+            {#if report.count_by_status.critical}
+              <span class="flex items-center gap-1">
+                <XCircle class="size-3.5 text-[var(--color-error)]" />
+                {report.count_by_status.critical}
+                {t('health.summary.critical')}
+              </span>
+            {/if}
+            {#if report.count_by_status.skipped}
+              <span class="flex items-center gap-1">
+                <SkipForward class="size-3.5 opacity-40" />
+                {report.count_by_status.skipped}
+                {t('health.summary.skipped')}
+              </span>
+            {/if}
+          </div>
+        {:else if running}
+          <div class="flex items-center gap-2 text-sm text-[var(--color-base-content)] opacity-70">
+            <Loader2 class="size-4 animate-spin" />
+            {t('health.running')}
+          </div>
+        {:else if error}
+          <div
+            role="alert"
+            aria-live="assertive"
+            class="flex items-center gap-2 text-sm text-[var(--color-error)]"
+          >
+            <XCircle class="size-4" />
+            {error}
+          </div>
+        {/if}
+      </div>
 
-        <div
-          class="ml-auto flex items-center gap-2 text-xs text-[var(--color-base-content)] opacity-50"
+      <div
+        class="flex items-center gap-3 text-xs text-[var(--color-base-content)] opacity-60 shrink-0"
+      >
+        {#if report}
+          <span
+            class="flex items-center gap-1.5"
+            title={new Date(report.started_at).toLocaleString()}
+          >
+            <Clock class="size-3.5" />
+            {t('health.lastRun')}
+            {getLocalTimeString(new Date(report.started_at))}
+            <span class="opacity-60">· {report.duration_ms.toFixed(0)}ms</span>
+          </span>
+        {/if}
+        <button
+          type="button"
+          onclick={runDiagnostics}
+          disabled={running}
+          aria-label={t('health.refresh')}
+          title={t('health.refresh')}
+          class="inline-flex items-center justify-center size-8 rounded-md transition-colors hover:bg-[var(--color-base-200)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <Clock class="size-3.5" />
-          {report.duration_ms.toFixed(0)}ms
+          <RefreshCw class="size-4 {running ? 'animate-spin' : ''}" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Row 2: Window selector + export -->
+    <div
+      class="flex flex-wrap items-center justify-between gap-3 mt-3 pt-3 border-t border-[var(--color-base-200)]"
+    >
+      <div class="flex items-center gap-2">
+        <span class="text-xs text-[var(--color-base-content)] opacity-60">
+          {t('health.window.label')}:
+        </span>
+        <div
+          class="inline-flex rounded-md border border-[var(--color-base-300)] overflow-hidden"
+          role="radiogroup"
+          aria-label={t('health.window.label')}
+        >
+          {#each windowPresets as w (w)}
+            <button
+              type="button"
+              role="radio"
+              aria-checked={selectedWindow === w}
+              disabled={running}
+              onclick={() => selectWindow(w)}
+              class="px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-50 {selectedWindow ===
+              w
+                ? 'bg-[var(--color-primary)] text-[var(--color-primary-content)]'
+                : 'bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]'}"
+            >
+              {t(`health.window.${w}`)}
+            </button>
+          {/each}
         </div>
       </div>
 
-      <!-- Export Buttons -->
-      <div class="flex items-center gap-2 mt-3 pt-3 border-t border-[var(--color-base-200)]">
+      <div class="flex items-center gap-2">
         <button
+          type="button"
           onclick={copyReport}
-          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]"
+          disabled={!report}
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {#if copied}
             <CheckCircle class="size-3.5 text-[var(--color-success)]" />
@@ -507,15 +488,20 @@
           {/if}
         </button>
         <button
+          type="button"
           onclick={downloadJSON}
-          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]"
+          disabled={!report}
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)] disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Download class="size-3.5" />
           {t('health.exportJSON')}
         </button>
       </div>
-    </Card>
+    </div>
+  </Card>
 
+  <!-- Results -->
+  {#if report}
     <!-- Category Results -->
     {#each [...groupedResults] as [category, results] (category)}
       <Card

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Card from '$lib/desktop/components/ui/Card.svelte';
   import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
   import type { StatusVariant } from '$lib/desktop/components/ui/StatusPill.svelte';
   import {
@@ -347,77 +346,153 @@
 {/snippet}
 
 <div class="col-span-12 space-y-4">
-  <!-- Status & Controls Toolbar -->
-  <Card className="bg-[var(--color-base-100)] shadow-sm">
-    <!-- Row 1: Status + last run + refresh -->
-    <div class="flex flex-wrap items-center justify-between gap-3">
-      <div class="flex flex-wrap items-center gap-3 min-w-0">
+  <!-- Status Metric Strip (matches System Overview pattern) -->
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+    <!-- Healthy -->
+    <div
+      class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col"
+    >
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <div class="p-1.5 rounded-lg bg-green-500/10">
+            <CheckCircle class="w-4 h-4 text-[var(--color-success)]" />
+          </div>
+          <span class="text-xs font-medium text-muted">{t('health.summary.healthy')}</span>
+        </div>
+        <span class="font-mono tabular-nums text-2xl font-semibold text-[var(--color-success)]">
+          {report?.count_by_status?.healthy ?? (running ? '…' : '—')}
+        </span>
+      </div>
+      <div class="mt-auto text-[10px] text-muted">
         {#if report}
-          <StatusPill
-            variant={statusToVariant(report.status)}
-            label={t(`health.status.${report.status}`)}
-            size="md"
-          >
-            {#snippet leadingIcon()}
-              {#if report}
-                {@render statusIcon(report.status, 'size-4')}
-              {/if}
-            {/snippet}
-          </StatusPill>
-
-          <div
-            class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-[var(--color-base-content)] opacity-70"
-          >
-            {#if report.count_by_status.healthy}
-              <span class="flex items-center gap-1">
-                <CheckCircle class="size-3.5 text-[var(--color-success)]" />
-                {report.count_by_status.healthy}
-                {t('health.summary.healthy')}
-              </span>
-            {/if}
-            {#if report.count_by_status.warning}
-              <span class="flex items-center gap-1">
-                <AlertTriangle class="size-3.5 text-[var(--color-warning)]" />
-                {report.count_by_status.warning}
-                {t('health.summary.warnings')}
-              </span>
-            {/if}
-            {#if report.count_by_status.critical}
-              <span class="flex items-center gap-1">
-                <XCircle class="size-3.5 text-[var(--color-error)]" />
-                {report.count_by_status.critical}
-                {t('health.summary.critical')}
-              </span>
-            {/if}
-            {#if report.count_by_status.skipped}
-              <span class="flex items-center gap-1">
-                <SkipForward class="size-3.5 opacity-40" />
-                {report.count_by_status.skipped}
-                {t('health.summary.skipped')}
-              </span>
-            {/if}
-          </div>
+          {@const h = report.count_by_status.healthy ?? 0}
+          {@const total = report.total_checks}
+          {h === total ? t('health.metricFooter.allPassing') : `${h} of ${total}`}
         {:else if running}
-          <div class="flex items-center gap-2 text-sm text-[var(--color-base-content)] opacity-70">
-            <Loader2 class="size-4 animate-spin" />
-            {t('health.running')}
-          </div>
-        {:else if error}
-          <div
-            role="alert"
-            aria-live="assertive"
-            class="flex items-center gap-2 text-sm text-[var(--color-error)]"
-          >
-            <XCircle class="size-4" />
-            {error}
-          </div>
+          {t('health.running')}
+        {:else}
+          —
         {/if}
       </div>
+    </div>
 
+    <!-- Warning -->
+    <div
+      class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col"
+    >
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <div class="p-1.5 rounded-lg bg-amber-500/10">
+            <AlertTriangle class="w-4 h-4 text-[var(--color-warning)]" />
+          </div>
+          <span class="text-xs font-medium text-muted">{t('health.summary.warnings')}</span>
+        </div>
+        <span
+          class="font-mono tabular-nums text-2xl font-semibold {(report?.count_by_status?.warning ??
+            0) > 0
+            ? 'text-[var(--color-warning)]'
+            : 'opacity-40'}"
+        >
+          {report?.count_by_status?.warning ?? (running ? '…' : '—')}
+        </span>
+      </div>
+      <div class="mt-auto text-[10px] text-muted">
+        {#if report}
+          {(report.count_by_status.warning ?? 0) > 0
+            ? t('health.metricFooter.needsAttention')
+            : t('health.metricFooter.none')}
+        {:else if running}
+          {t('health.running')}
+        {:else}
+          —
+        {/if}
+      </div>
+    </div>
+
+    <!-- Critical -->
+    <div
+      class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col"
+    >
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <div class="p-1.5 rounded-lg bg-red-500/10">
+            <XCircle class="w-4 h-4 text-[var(--color-error)]" />
+          </div>
+          <span class="text-xs font-medium text-muted">{t('health.summary.critical')}</span>
+        </div>
+        <span
+          class="font-mono tabular-nums text-2xl font-semibold {(report?.count_by_status
+            ?.critical ?? 0) > 0
+            ? 'text-[var(--color-error)]'
+            : 'opacity-40'}"
+        >
+          {report?.count_by_status?.critical ?? (running ? '…' : '—')}
+        </span>
+      </div>
+      <div class="mt-auto text-[10px] text-muted">
+        {#if report}
+          {(report.count_by_status.critical ?? 0) > 0
+            ? t('health.metricFooter.failing')
+            : t('health.metricFooter.allClear')}
+        {:else if running}
+          {t('health.running')}
+        {:else}
+          —
+        {/if}
+      </div>
+    </div>
+
+    <!-- Skipped -->
+    <div
+      class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm flex flex-col"
+    >
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <div class="p-1.5 rounded-lg bg-slate-500/10">
+            <SkipForward class="w-4 h-4 text-slate-500" />
+          </div>
+          <span class="text-xs font-medium text-muted">{t('health.summary.skipped')}</span>
+        </div>
+        <span
+          class="font-mono tabular-nums text-2xl font-semibold" class:opacity-40={!((report?.count_by_status?.skipped ??
+            0) > 0)}
+        >
+          {report?.count_by_status?.skipped ?? (running ? '…' : '—')}
+        </span>
+      </div>
+      <div class="mt-auto text-[10px] text-muted">
+        {#if report}
+          {(report.count_by_status.skipped ?? 0) > 0
+            ? t('health.metricFooter.noData')
+            : t('health.metricFooter.none')}
+        {:else if running}
+          {t('health.running')}
+        {:else}
+          —
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <!-- Diagnostics Control Card -->
+  <div class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm">
+    <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-muted">
+        {t('health.diagnostics')}
+      </h3>
       <div
         class="flex items-center gap-3 text-xs text-[var(--color-base-content)] opacity-60 shrink-0"
       >
-        {#if report}
+        {#if error}
+          <span
+            role="alert"
+            aria-live="assertive"
+            class="flex items-center gap-1.5 text-[var(--color-error)] opacity-100"
+          >
+            <XCircle class="size-3.5" />
+            {error}
+          </span>
+        {:else if report}
           <span
             class="flex items-center gap-1.5"
             title={new Date(report.started_at).toLocaleString()}
@@ -426,6 +501,11 @@
             {t('health.lastRun')}
             {getLocalTimeString(new Date(report.started_at))}
             <span class="opacity-60">· {report.duration_ms.toFixed(0)}ms</span>
+          </span>
+        {:else if running}
+          <span class="flex items-center gap-1.5">
+            <Loader2 class="size-3.5 animate-spin" />
+            {t('health.running')}
           </span>
         {/if}
         <button
@@ -441,10 +521,7 @@
       </div>
     </div>
 
-    <!-- Row 2: Window selector + export -->
-    <div
-      class="flex flex-wrap items-center justify-between gap-3 mt-3 pt-3 border-t border-[var(--color-base-200)]"
-    >
+    <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-2">
         <span class="text-xs text-[var(--color-base-content)] opacity-60">
           {t('health.window.label')}:
@@ -498,16 +575,18 @@
         </button>
       </div>
     </div>
-  </Card>
+  </div>
 
   <!-- Results -->
   {#if report}
     <!-- Category Results -->
     {#each [...groupedResults] as [category, results] (category)}
-      <Card
-        title={t(`health.categories.${category}`)}
-        className="bg-[var(--color-base-100)] shadow-sm"
+      <div
+        class="bg-[var(--surface-100)] border border-[var(--border-100)] rounded-xl p-4 shadow-sm"
       >
+        <h3 class="text-xs font-semibold uppercase tracking-wider mb-3 text-muted">
+          {t(`health.categories.${category}`)}
+        </h3>
         <div class="space-y-2">
           {#each results as result (result.name)}
             {@const topErrors = getTopErrors(result)}
@@ -676,7 +755,7 @@
             </div>
           {/each}
         </div>
-      </Card>
+      </div>
     {/each}
   {/if}
 </div>

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -363,7 +363,7 @@
           {report?.count_by_status?.healthy ?? (running ? '…' : '—')}
         </span>
       </div>
-      <div class="mt-auto text-[10px] text-muted">
+      <div class="mt-auto text-xs text-muted">
         {#if report}
           {@const h = report.count_by_status.healthy ?? 0}
           {@const total = report.total_checks}
@@ -396,7 +396,7 @@
           {report?.count_by_status?.warning ?? (running ? '…' : '—')}
         </span>
       </div>
-      <div class="mt-auto text-[10px] text-muted">
+      <div class="mt-auto text-xs text-muted">
         {#if report}
           {(report.count_by_status.warning ?? 0) > 0
             ? t('health.metricFooter.needsAttention')
@@ -429,7 +429,7 @@
           {report?.count_by_status?.critical ?? (running ? '…' : '—')}
         </span>
       </div>
-      <div class="mt-auto text-[10px] text-muted">
+      <div class="mt-auto text-xs text-muted">
         {#if report}
           {(report.count_by_status.critical ?? 0) > 0
             ? t('health.metricFooter.failing')
@@ -454,13 +454,13 @@
           <span class="text-xs font-medium text-muted">{t('health.summary.skipped')}</span>
         </div>
         <span
-          class="font-mono tabular-nums text-2xl font-semibold" class:opacity-40={!((report?.count_by_status?.skipped ??
-            0) > 0)}
+          class="font-mono tabular-nums text-2xl font-semibold"
+          class:opacity-40={!((report?.count_by_status?.skipped ?? 0) > 0)}
         >
           {report?.count_by_status?.skipped ?? (running ? '…' : '—')}
         </span>
       </div>
-      <div class="mt-auto text-[10px] text-muted">
+      <div class="mt-auto text-xs text-muted">
         {#if report}
           {(report.count_by_status.skipped ?? 0) > 0
             ? t('health.metricFooter.noData')

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4903,7 +4903,7 @@
       "source": "Zdroj",
       "count": "Počet",
       "lifetime": "celkem",
-      "noEvents": "Žádné zaznamenané události"
+      "sparklineLabel": "Graf aktivity"
     }
   }
 }

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Vše v pořádku",
+      "needsAttention": "Vyžaduje pozornost",
+      "failing": "Selhává",
+      "allClear": "Bez problémů",
+      "noData": "Žádná data",
+      "none": "Žádné"
+    },
+    "diagnostics": "Diagnostika",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Obnovit",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponenta",
       "errorLevel": "Úroveň",
       "errorMessage": "Zpráva"
+    },
+    "window": {
+      "label": "Časové okno vyhodnocení",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Poslední událost",
+      "recentEvents": "Nedávné události",
+      "time": "Čas",
+      "source": "Zdroj",
+      "count": "Počet",
+      "lifetime": "celkem",
+      "noEvents": "Žádné zaznamenané události"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponent",
       "errorLevel": "Niveau",
       "errorMessage": "Besked"
+    },
+    "window": {
+      "label": "Evalueringsvindue",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Seneste hændelse",
+      "recentEvents": "Seneste hændelser",
+      "time": "Tid",
+      "source": "Kilde",
+      "count": "Antal",
+      "lifetime": "i alt",
+      "noEvents": "Ingen hændelser registreret"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Opdater",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4903,7 +4903,7 @@
       "source": "Kilde",
       "count": "Antal",
       "lifetime": "i alt",
-      "noEvents": "Ingen hændelser registreret"
+      "sparklineLabel": "Aktivitetsgraf"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Alt OK",
+      "needsAttention": "Kræver opmærksomhed",
+      "failing": "Fejler",
+      "allClear": "Alt klart",
+      "noData": "Ingen data",
+      "none": "Ingen"
+    },
+    "diagnostics": "Diagnostik",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Alles in Ordnung",
+      "needsAttention": "Erfordert Aufmerksamkeit",
+      "failing": "Fehlerhaft",
+      "allClear": "Keine Probleme",
+      "noData": "Keine Daten",
+      "none": "Keine"
+    },
+    "diagnostics": "Diagnose",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponente",
       "errorLevel": "Stufe",
       "errorMessage": "Nachricht"
+    },
+    "window": {
+      "label": "Auswertungszeitraum",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Letztes Ereignis",
+      "recentEvents": "Letzte Ereignisse",
+      "time": "Zeit",
+      "source": "Quelle",
+      "count": "Anzahl",
+      "lifetime": "gesamt",
+      "noEvents": "Keine Ereignisse aufgezeichnet"
     }
   }
 }

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Aktualisieren",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4903,7 +4903,7 @@
       "source": "Quelle",
       "count": "Anzahl",
       "lifetime": "gesamt",
-      "noEvents": "Keine Ereignisse aufgezeichnet"
+      "sparklineLabel": "Aktivitäts-Sparkline"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4903,7 +4903,7 @@
       "source": "Source",
       "count": "Count",
       "lifetime": "lifetime",
-      "noEvents": "No events recorded"
+      "sparklineLabel": "Activity sparkline"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Refresh",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Component",
       "errorLevel": "Level",
       "errorMessage": "Message"
+    },
+    "window": {
+      "label": "Evaluation window",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Last event",
+      "recentEvents": "Recent events",
+      "time": "Time",
+      "source": "Source",
+      "count": "Count",
+      "lifetime": "lifetime",
+      "noEvents": "No events recorded"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "All passing",
+      "needsAttention": "Needs attention",
+      "failing": "Failing",
+      "allClear": "All clear",
+      "noData": "No recent data",
+      "none": "None"
+    },
+    "diagnostics": "Diagnostics",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4903,7 +4903,7 @@
       "source": "Fuente",
       "count": "Cantidad",
       "lifetime": "total",
-      "noEvents": "No se han registrado eventos"
+      "sparklineLabel": "Gráfico de actividad"
     }
   }
 }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Componente",
       "errorLevel": "Nivel",
       "errorMessage": "Mensaje"
+    },
+    "window": {
+      "label": "Ventana de evaluación",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Último evento",
+      "recentEvents": "Eventos recientes",
+      "time": "Hora",
+      "source": "Fuente",
+      "count": "Cantidad",
+      "lifetime": "total",
+      "noEvents": "No se han registrado eventos"
     }
   }
 }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Actualizar",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Todo correcto",
+      "needsAttention": "Requiere atención",
+      "failing": "Fallando",
+      "allClear": "Sin problemas",
+      "noData": "Sin datos",
+      "none": "Ninguno"
+    },
+    "diagnostics": "Diagnóstico",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Kaikki kunnossa",
+      "needsAttention": "Vaatii huomiota",
+      "failing": "Epäonnistuu",
+      "allClear": "Ei ongelmia",
+      "noData": "Ei dataa",
+      "none": "Ei mitään"
+    },
+    "diagnostics": "Diagnostiikka",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponentti",
       "errorLevel": "Taso",
       "errorMessage": "Viesti"
+    },
+    "window": {
+      "label": "Arviointijakso",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Viimeisin tapahtuma",
+      "recentEvents": "Viimeaikaiset tapahtumat",
+      "time": "Aika",
+      "source": "Lähde",
+      "count": "Määrä",
+      "lifetime": "yhteensä",
+      "noEvents": "Ei tallennettuja tapahtumia"
     }
   }
 }

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Päivitä",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4903,7 +4903,7 @@
       "source": "Lähde",
       "count": "Määrä",
       "lifetime": "yhteensä",
-      "noEvents": "Ei tallennettuja tapahtumia"
+      "sparklineLabel": "Aktiivisuuskaavio"
     }
   }
 }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Actualiser",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Composant",
       "errorLevel": "Niveau",
       "errorMessage": "Message"
+    },
+    "window": {
+      "label": "Fenêtre d'évaluation",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Dernier événement",
+      "recentEvents": "Événements récents",
+      "time": "Heure",
+      "source": "Source",
+      "count": "Nombre",
+      "lifetime": "total",
+      "noEvents": "Aucun événement enregistré"
     }
   }
 }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Tout va bien",
+      "needsAttention": "Attention requise",
+      "failing": "En échec",
+      "allClear": "RAS",
+      "noData": "Aucune donnée",
+      "none": "Aucun"
+    },
+    "diagnostics": "Diagnostic",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4903,7 +4903,7 @@
       "source": "Source",
       "count": "Nombre",
       "lifetime": "total",
-      "noEvents": "Aucun événement enregistré"
+      "sparklineLabel": "Graphique d'activité"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4903,7 +4903,7 @@
       "source": "Forrás",
       "count": "Darab",
       "lifetime": "összesen",
-      "noEvents": "Nincsenek rögzített események"
+      "sparklineLabel": "Aktivitási diagram"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponens",
       "errorLevel": "Szint",
       "errorMessage": "Üzenet"
+    },
+    "window": {
+      "label": "Kiértékelési időablak",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Utolsó esemény",
+      "recentEvents": "Legutóbbi események",
+      "time": "Idő",
+      "source": "Forrás",
+      "count": "Darab",
+      "lifetime": "összesen",
+      "noEvents": "Nincsenek rögzített események"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Frissítés",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Minden rendben",
+      "needsAttention": "Figyelmet igényel",
+      "failing": "Sikertelen",
+      "allClear": "Nincs probléma",
+      "noData": "Nincs adat",
+      "none": "Nincs"
+    },
+    "diagnostics": "Diagnosztika",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Componente",
       "errorLevel": "Livello",
       "errorMessage": "Messaggio"
+    },
+    "window": {
+      "label": "Finestra di valutazione",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Ultimo evento",
+      "recentEvents": "Eventi recenti",
+      "time": "Ora",
+      "source": "Sorgente",
+      "count": "Conteggio",
+      "lifetime": "totale",
+      "noEvents": "Nessun evento registrato"
     }
   }
 }

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Tutto OK",
+      "needsAttention": "Richiede attenzione",
+      "failing": "In errore",
+      "allClear": "Tutto a posto",
+      "noData": "Nessun dato",
+      "none": "Nessuno"
+    },
+    "diagnostics": "Diagnostica",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Aggiorna",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4903,7 +4903,7 @@
       "source": "Sorgente",
       "count": "Conteggio",
       "lifetime": "totale",
-      "noEvents": "Nessun evento registrato"
+      "sparklineLabel": "Grafico di attività"
     }
   }
 }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Atjaunot",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Viss kārtībā",
+      "needsAttention": "Nepieciešama uzmanība",
+      "failing": "Neizdodas",
+      "allClear": "Bez problēmām",
+      "noData": "Nav datu",
+      "none": "Nav"
+    },
+    "diagnostics": "Diagnostika",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponents",
       "errorLevel": "Līmenis",
       "errorMessage": "Ziņojums"
+    },
+    "window": {
+      "label": "Novērtēšanas logs",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Pēdējais notikums",
+      "recentEvents": "Nesenie notikumi",
+      "time": "Laiks",
+      "source": "Avots",
+      "count": "Skaits",
+      "lifetime": "kopā",
+      "noEvents": "Nav reģistrētu notikumu"
     }
   }
 }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4903,7 +4903,7 @@
       "source": "Avots",
       "count": "Skaits",
       "lifetime": "kopā",
-      "noEvents": "Nav reģistrētu notikumu"
+      "sparklineLabel": "Aktivitātes diagramma"
     }
   }
 }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Vernieuwen",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Alles in orde",
+      "needsAttention": "Vereist aandacht",
+      "failing": "Mislukt",
+      "allClear": "Geen problemen",
+      "noData": "Geen gegevens",
+      "none": "Geen"
+    },
+    "diagnostics": "Diagnostiek",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4903,7 +4903,7 @@
       "source": "Bron",
       "count": "Aantal",
       "lifetime": "totaal",
-      "noEvents": "Geen gebeurtenissen geregistreerd"
+      "sparklineLabel": "Activiteitsgrafiek"
     }
   }
 }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Component",
       "errorLevel": "Niveau",
       "errorMessage": "Bericht"
+    },
+    "window": {
+      "label": "Evaluatievenster",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Laatste gebeurtenis",
+      "recentEvents": "Recente gebeurtenissen",
+      "time": "Tijd",
+      "source": "Bron",
+      "count": "Aantal",
+      "lifetime": "totaal",
+      "noEvents": "Geen gebeurtenissen geregistreerd"
     }
   }
 }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Wszystko w porządku",
+      "needsAttention": "Wymaga uwagi",
+      "failing": "Niepowodzenie",
+      "allClear": "Bez problemów",
+      "noData": "Brak danych",
+      "none": "Brak"
+    },
+    "diagnostics": "Diagnostyka",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Odśwież",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4903,7 +4903,7 @@
       "source": "Źródło",
       "count": "Liczba",
       "lifetime": "łącznie",
-      "noEvents": "Brak zarejestrowanych zdarzeń"
+      "sparklineLabel": "Wykres aktywności"
     }
   }
 }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponent",
       "errorLevel": "Poziom",
       "errorMessage": "Wiadomość"
+    },
+    "window": {
+      "label": "Okno oceny",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Ostatnie zdarzenie",
+      "recentEvents": "Ostatnie zdarzenia",
+      "time": "Czas",
+      "source": "Źródło",
+      "count": "Liczba",
+      "lifetime": "łącznie",
+      "noEvents": "Brak zarejestrowanych zdarzeń"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Componente",
       "errorLevel": "Nível",
       "errorMessage": "Mensagem"
+    },
+    "window": {
+      "label": "Janela de avaliação",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Último evento",
+      "recentEvents": "Eventos recentes",
+      "time": "Hora",
+      "source": "Fonte",
+      "count": "Contagem",
+      "lifetime": "total",
+      "noEvents": "Nenhum evento registrado"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Tudo OK",
+      "needsAttention": "Requer atenção",
+      "failing": "A falhar",
+      "allClear": "Sem problemas",
+      "noData": "Sem dados",
+      "none": "Nenhum"
+    },
+    "diagnostics": "Diagnóstico",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4903,7 +4903,7 @@
       "source": "Fonte",
       "count": "Contagem",
       "lifetime": "total",
-      "noEvents": "Nenhum evento registrado"
+      "sparklineLabel": "Gráfico de atividade"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Atualizar",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Obnoviť",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4903,7 +4903,7 @@
       "source": "Zdroj",
       "count": "Počet",
       "lifetime": "celkom",
-      "noEvents": "Žiadne zaznamenané udalosti"
+      "sparklineLabel": "Graf aktivity"
     }
   }
 }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponent",
       "errorLevel": "Úroveň",
       "errorMessage": "Správa"
+    },
+    "window": {
+      "label": "Časové okno vyhodnotenia",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Posledná udalosť",
+      "recentEvents": "Nedávne udalosti",
+      "time": "Čas",
+      "source": "Zdroj",
+      "count": "Počet",
+      "lifetime": "celkom",
+      "noEvents": "Žiadne zaznamenané udalosti"
     }
   }
 }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "Všetko v poriadku",
+      "needsAttention": "Vyžaduje pozornosť",
+      "failing": "Zlyháva",
+      "allClear": "Bez problémov",
+      "noData": "Žiadne dáta",
+      "none": "Žiadne"
+    },
+    "diagnostics": "Diagnostika",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4879,6 +4879,24 @@
       "errorComponent": "Komponent",
       "errorLevel": "Nivå",
       "errorMessage": "Meddelande"
+    },
+    "window": {
+      "label": "Utvärderingsfönster",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1h",
+      "6h": "6h",
+      "24h": "24h",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Senaste händelse",
+      "recentEvents": "Senaste händelser",
+      "time": "Tid",
+      "source": "Källa",
+      "count": "Antal",
+      "lifetime": "totalt",
+      "noEvents": "Inga händelser registrerade"
     }
   }
 }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4843,14 +4843,14 @@
       "total": "Total checks"
     },
     "metricFooter": {
-      "allPassing": "All passing",
-      "needsAttention": "Needs attention",
-      "failing": "Failing",
-      "allClear": "All clear",
-      "noData": "No recent data",
-      "none": "None"
+      "allPassing": "Allt OK",
+      "needsAttention": "Kräver uppmärksamhet",
+      "failing": "Misslyckas",
+      "allClear": "Inga problem",
+      "noData": "Inga data",
+      "none": "Inga"
     },
-    "diagnostics": "Diagnostics",
+    "diagnostics": "Diagnostik",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4903,7 +4903,7 @@
       "source": "Källa",
       "count": "Antal",
       "lifetime": "totalt",
-      "noEvents": "Inga händelser registrerade"
+      "sparklineLabel": "Aktivitetsdiagram"
     }
   }
 }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4842,6 +4842,15 @@
       "skipped": "Skipped",
       "total": "Total checks"
     },
+    "metricFooter": {
+      "allPassing": "All passing",
+      "needsAttention": "Needs attention",
+      "failing": "Failing",
+      "allClear": "All clear",
+      "noData": "No recent data",
+      "none": "None"
+    },
+    "diagnostics": "Diagnostics",
     "categories": {
       "system": "System",
       "audio": "Audio Pipeline",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4828,11 +4828,9 @@
   },
   "health": {
     "title": "System Health",
-    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
-    "runDiagnostics": "Run Diagnostics",
     "running": "Running diagnostics...",
     "lastRun": "Last run",
-    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "refresh": "Uppdatera",
     "exportText": "Copy Report",
     "exportJSON": "Download JSON",
     "copied": "Report copied to clipboard",

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -138,9 +138,11 @@ type Controller struct {
 	audioWatchdog atomic.Pointer[audiocore.LivenessWatchdog]
 
 	// Health check infrastructure for the diagnostics endpoints.
-	healthRegistry *health.Registry
-	healthReports  *health.ReportStore
-	healthErrors   *health.ErrorRingBuffer
+	healthRegistry     *health.Registry
+	healthReports      *health.ReportStore
+	healthErrors       *health.ErrorRingBuffer
+	healthMetricsStore *observability.HealthMetricsStore
+	healthEvents       *observability.HealthEventBuffer
 
 	// sourceRestarter restarts a single audio source by ID. Set during
 	// pipeline Start() and called by the restart-source control endpoint.
@@ -649,6 +651,7 @@ func (c *Controller) initRoutes() {
 		{"range routes", c.initRangeRoutes},
 		{"heatmap routes", c.initHeatmapRoutes},
 		{"sse routes", c.initSSERoutes},
+		{"diagnostics routes", c.initDiagnosticsRoutes},
 		{"metrics history routes", c.initMetricsHistoryRoutes},
 		{"notification routes", c.initNotificationRoutes},
 		{"support routes", c.initSupportRoutes},
@@ -659,7 +662,6 @@ func (c *Controller) initRoutes() {
 		{"model routes", c.initModelRoutes},
 		{"insights routes", c.initInsightsRoutes},
 		{"tls routes", c.initTLSRoutes},
-		{"diagnostics routes", c.initDiagnosticsRoutes},
 	}
 
 	for _, initializer := range routeInitializers {

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -412,7 +412,7 @@ func (c *Controller) buildStreamHealthSnapshotProvider() func() []observability.
 		snaps := make([]observability.StreamHealthSnapshot, 0, len(healthMap))
 		for sourceID, sh := range healthMap {
 			snaps = append(snaps, observability.StreamHealthSnapshot{
-				URL:          sourceID,
+				SourceID:     sourceID,
 				RestartCount: sh.RestartCount,
 			})
 		}

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health/checks"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/weather"
 )
@@ -40,6 +41,8 @@ func (c *Controller) initDiagnosticsRoutes() {
 		c.healthErrors = health.NewErrorRingBuffer(health.DefaultErrorBufferSize)
 	}
 	c.healthRegistry = health.NewRegistry()
+	c.healthMetricsStore = observability.NewHealthMetricsStore()
+	c.healthEvents = observability.NewHealthEventBuffer(observability.DefaultEventBufferCapacity)
 
 	c.registerHealthChecks()
 
@@ -90,9 +93,9 @@ func (c *Controller) registerHealthChecks() {
 		// Audio checks
 		checks.NewSourceStatusCheck(snapshotProvider),
 		checks.NewPipelineLivenessCheck(snapshotProvider),
-		checks.NewBufferDropsCheck(c.buildDropStatsProvider()),
+		checks.NewBufferDropsCheck(c.healthMetricsStore, c.healthEvents.Recent),
 		checks.NewAudioLevelCheck(c.buildAudioLevelProvider()),
-		checks.NewBufferOverrunCheck(c.buildOverrunStatsProvider()),
+		checks.NewBufferOverrunCheck(c.healthMetricsStore, c.healthEvents.Recent),
 		checks.NewCaptureBufferCheck(c.buildCaptureBufferHealthProvider()),
 
 		// Analysis checks (multi-model aware)
@@ -117,7 +120,7 @@ func (c *Controller) registerHealthChecks() {
 
 		// Stream checks
 		checks.NewStreamConnectivityCheck(getStreamHealthInfos),
-		checks.NewStreamErrorRateCheck(getStreamHealthInfos),
+		checks.NewStreamErrorRateCheck(c.healthMetricsStore, c.healthEvents.Recent),
 		checks.NewFFmpegHealthCheck(getStreamHealthInfos),
 
 		// Database checks
@@ -357,10 +360,10 @@ func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInf
 	}
 }
 
-// buildDropStatsProvider returns a closure that aggregates per-source frame
-// drop counts from the audio router. Returns nil before the engine starts.
-func (c *Controller) buildDropStatsProvider() func() checks.DropStats {
-	return func() checks.DropStats {
+// buildAudioRouterSnapshotProvider returns a closure that reads cumulative
+// audio counter values from the audio router for the health metrics collector.
+func (c *Controller) buildAudioRouterSnapshotProvider() func() []observability.AudioRouterSnapshot {
+	return func() []observability.AudioRouterSnapshot {
 		eng := c.engine.Load()
 		if eng == nil {
 			return nil
@@ -373,15 +376,47 @@ func (c *Controller) buildDropStatsProvider() func() checks.DropStats {
 		if len(sourceIDs) == 0 {
 			return nil
 		}
-		stats := make(checks.DropStats, len(sourceIDs))
+		snaps := make([]observability.AudioRouterSnapshot, 0, len(sourceIDs))
 		for _, sid := range sourceIDs {
-			var totalDrops int64
+			var totalDrops, totalErrors int64
 			for _, ri := range router.Routes(sid) {
 				totalDrops += ri.Drops
+				totalErrors += ri.Errors
 			}
-			stats[sid] = totalDrops
+			snaps = append(snaps, observability.AudioRouterSnapshot{
+				SourceID: sid,
+				Drops:    totalDrops,
+				Errors:   totalErrors,
+			})
 		}
-		return stats
+		return snaps
+	}
+}
+
+// buildStreamHealthSnapshotProvider returns a closure that reads cumulative
+// stream restart counts for the health metrics collector.
+func (c *Controller) buildStreamHealthSnapshotProvider() func() []observability.StreamHealthSnapshot {
+	return func() []observability.StreamHealthSnapshot {
+		eng := c.engine.Load()
+		if eng == nil {
+			return nil
+		}
+		mgr := eng.FFmpegManager()
+		if mgr == nil {
+			return nil
+		}
+		healthMap := mgr.AllStreamHealth()
+		if len(healthMap) == 0 {
+			return nil
+		}
+		snaps := make([]observability.StreamHealthSnapshot, 0, len(healthMap))
+		for sourceID, sh := range healthMap {
+			snaps = append(snaps, observability.StreamHealthSnapshot{
+				URL:          sourceID,
+				RestartCount: sh.RestartCount,
+			})
+		}
+		return snaps
 	}
 }
 
@@ -427,35 +462,6 @@ func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 			return nil
 		}
 		return infos
-	}
-}
-
-// buildOverrunStatsProvider returns a closure that aggregates per-source write
-// error counts from the audio router. Write errors indicate downstream
-// processing could not keep up (overrun condition).
-func (c *Controller) buildOverrunStatsProvider() func() checks.OverrunStats {
-	return func() checks.OverrunStats {
-		eng := c.engine.Load()
-		if eng == nil {
-			return nil
-		}
-		router := eng.Router()
-		if router == nil {
-			return nil
-		}
-		sourceIDs := router.ActiveSourceIDs()
-		if len(sourceIDs) == 0 {
-			return nil
-		}
-		stats := make(checks.OverrunStats, len(sourceIDs))
-		for _, sid := range sourceIDs {
-			var totalErrors int64
-			for _, ri := range router.Routes(sid) {
-				totalErrors += ri.Errors
-			}
-			stats[sid] = totalErrors
-		}
-		return stats
 	}
 }
 
@@ -529,12 +535,40 @@ func (c *Controller) GetDiagnosticsStatus(ctx echo.Context) error {
 	})
 }
 
+// validWindows maps accepted window parameter values to durations.
+var validWindows = map[string]time.Duration{
+	"15m": 15 * time.Minute,
+	"30m": 30 * time.Minute,
+	"1h":  time.Hour,
+	"6h":  6 * time.Hour,
+	"24h": 24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+}
+
+// parseWindow converts a window query parameter to a duration.
+// Returns the default (1h) for empty input, or an error for invalid values.
+func parseWindow(s string) (time.Duration, error) {
+	if s == "" {
+		return time.Hour, nil
+	}
+	d, ok := validWindows[s]
+	if !ok {
+		return 0, fmt.Errorf("invalid window %q: valid values are 15m, 30m, 1h, 6h, 24h, 7d", s)
+	}
+	return d, nil
+}
+
 // RunDiagnostics executes all registered health checks and stores the report.
 func (c *Controller) RunDiagnostics(ctx echo.Context) error {
+	window, err := parseWindow(ctx.QueryParam("window"))
+	if err != nil {
+		return c.HandleError(ctx, err, err.Error(), http.StatusBadRequest)
+	}
+
 	id := uuid.New().String()
 	startedAt := time.Now()
 
-	results := c.healthRegistry.RunAll(ctx.Request().Context())
+	results := c.healthRegistry.RunAllWithWindow(ctx.Request().Context(), window)
 	report := health.NewReport(id, startedAt, results)
 	c.healthReports.Save(report)
 

--- a/internal/api/v2/metrics_history.go
+++ b/internal/api/v2/metrics_history.go
@@ -228,6 +228,14 @@ func (c *Controller) initMetricsHistoryRoutes() {
 		// Wire BirdNET inference counters
 		collector.SetInferenceCounters(classifier.GetInferenceCounters())
 
+		// Wire health counter collection (drops, overruns, stream restarts)
+		if c.healthMetricsStore != nil {
+			collector.SetHealthStore(c.healthMetricsStore)
+			collector.SetHealthEvents(c.healthEvents)
+			collector.SetAudioRouter(c.buildAudioRouterSnapshotProvider())
+			collector.SetStreamHealth(c.buildStreamHealthSnapshotProvider())
+		}
+
 		collector.Start(c.ctx)
 	})
 

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -65,6 +65,14 @@ type MultiResultCheck interface {
 	RunMulti(ctx context.Context) []Result
 }
 
+// WindowedCheck is implemented by counter-based checks that support
+// time-windowed evaluation. The registry calls WithWindow before Run
+// to configure the evaluation window for the current diagnostics request.
+type WindowedCheck interface {
+	Check
+	WithWindow(d time.Duration) Check
+}
+
 // WorstStatus returns the most severe actionable status from a slice of results.
 // Skipped and unknown results are ignored when actionable results (healthy,
 // warning, critical) exist. If every result is non-actionable, it returns

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -68,6 +68,11 @@ type MultiResultCheck interface {
 // WindowedCheck is implemented by counter-based checks that support
 // time-windowed evaluation. The registry calls WithWindow before Run
 // to configure the evaluation window for the current diagnostics request.
+//
+// Note: WithWindow returns the narrower Check interface, so an implementation
+// that also satisfies MultiResultCheck will lose that capability after the
+// registry rewraps it. Currently no check is both windowed and multi-result;
+// if that changes, this interface should return the same dynamic type.
 type WindowedCheck interface {
 	Check
 	WithWindow(d time.Duration) Check

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
 // SourceStatusCheck monitors the health state of audio sources via the liveness watchdog.
@@ -162,17 +163,23 @@ func (c *PipelineLivenessCheck) Run(_ context.Context) health.Result {
 	}
 }
 
-// DropStats maps source ID to cumulative frame drop count.
-type DropStats map[string]int64
+// DefaultWindow is the default evaluation window for windowed checks.
+const DefaultWindow = time.Hour
 
-// BufferDropsCheck monitors audio buffer drop statistics.
+// BufferDropsCheck monitors audio buffer drop statistics using time-windowed evaluation.
 type BufferDropsCheck struct {
-	getDropStats func() DropStats
+	store     *observability.HealthMetricsStore
+	getEvents func(metric string, n int) []observability.HealthEvent
+	window    time.Duration
 }
 
-// NewBufferDropsCheck creates a BufferDropsCheck using the given drop stats provider.
-func NewBufferDropsCheck(getDropStats func() DropStats) *BufferDropsCheck {
-	return &BufferDropsCheck{getDropStats: getDropStats}
+// NewBufferDropsCheck creates a BufferDropsCheck using the health metrics store and event getter.
+func NewBufferDropsCheck(store *observability.HealthMetricsStore, getEvents func(metric string, n int) []observability.HealthEvent) *BufferDropsCheck {
+	return &BufferDropsCheck{
+		store:     store,
+		getEvents: getEvents,
+		window:    DefaultWindow,
+	}
 }
 
 // Name returns the check identifier.
@@ -181,26 +188,22 @@ func (c *BufferDropsCheck) Name() string { return "buffer_drops" }
 // Category returns the audio category.
 func (c *BufferDropsCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run evaluates audio buffer drop statistics across all sources.
+// WithWindow returns a copy of this check configured with the given evaluation window.
+func (c *BufferDropsCheck) WithWindow(d time.Duration) health.Check {
+	cp := *c
+	cp.window = d
+	return &cp
+}
+
+// Run evaluates audio buffer drop statistics within the configured time window.
 func (c *BufferDropsCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
-	if c.getDropStats == nil {
-		return skippedResult(c.Name(), c.Category(), start)
-	}
-
-	stats := c.getDropStats()
-	if stats == nil {
-		return skippedResult(c.Name(), c.Category(), start)
-	}
-
-	return evalCounterStats(c.Name(), c.Category(), stats, &counterStatsConfig{
-		warnThreshold: 1,
-		critThreshold: 101,
-		totalKey:      "total_drops",
-		healthyMsg:    "No buffer drops across %d source(s)",
-		warnMsg:       "Buffer drops detected: %d total across %d source(s)",
-		critMsg:       "High buffer drop rate: %d total drops across %d source(s)",
+	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
+		warnThreshold: 10,
+		critThreshold: 100,
+		metricPrefix:  observability.MetricPrefixAudioDrops,
+		window:        c.window,
 	}, start)
 }
 
@@ -281,17 +284,20 @@ func (c *AudioLevelCheck) Run(_ context.Context) health.Result {
 	}
 }
 
-// OverrunStats maps source ID to cumulative write error count.
-type OverrunStats map[string]int64
-
-// BufferOverrunCheck monitors audio processing overrun events.
+// BufferOverrunCheck monitors audio processing overrun events using time-windowed evaluation.
 type BufferOverrunCheck struct {
-	getOverrunStats func() OverrunStats
+	store     *observability.HealthMetricsStore
+	getEvents func(metric string, n int) []observability.HealthEvent
+	window    time.Duration
 }
 
-// NewBufferOverrunCheck creates a BufferOverrunCheck using the given overrun stats provider.
-func NewBufferOverrunCheck(getOverrunStats func() OverrunStats) *BufferOverrunCheck {
-	return &BufferOverrunCheck{getOverrunStats: getOverrunStats}
+// NewBufferOverrunCheck creates a BufferOverrunCheck using the health metrics store and event getter.
+func NewBufferOverrunCheck(store *observability.HealthMetricsStore, getEvents func(metric string, n int) []observability.HealthEvent) *BufferOverrunCheck {
+	return &BufferOverrunCheck{
+		store:     store,
+		getEvents: getEvents,
+		window:    DefaultWindow,
+	}
 }
 
 // Name returns the check identifier.
@@ -300,26 +306,22 @@ func (c *BufferOverrunCheck) Name() string { return "buffer_overrun" }
 // Category returns the audio category.
 func (c *BufferOverrunCheck) Category() health.Category { return health.CategoryAudio }
 
-// Run evaluates audio processing overrun statistics across all sources.
+// WithWindow returns a copy of this check configured with the given evaluation window.
+func (c *BufferOverrunCheck) WithWindow(d time.Duration) health.Check {
+	cp := *c
+	cp.window = d
+	return &cp
+}
+
+// Run evaluates audio processing overrun statistics within the configured time window.
 func (c *BufferOverrunCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
-	if c.getOverrunStats == nil {
-		return skippedResult(c.Name(), c.Category(), start)
-	}
-
-	stats := c.getOverrunStats()
-	if stats == nil {
-		return skippedResult(c.Name(), c.Category(), start)
-	}
-
-	return evalCounterStats(c.Name(), c.Category(), stats, &counterStatsConfig{
-		warnThreshold: 1,
-		critThreshold: 51,
-		totalKey:      "total_errors",
-		healthyMsg:    "No buffer overruns across %d source(s)",
-		warnMsg:       "Buffer overruns detected: %d errors across %d source(s)",
-		critMsg:       "High overrun rate: %d errors across %d source(s)",
+	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
+		warnThreshold: 10,
+		critThreshold: 50,
+		metricPrefix:  observability.MetricPrefixAudioOverruns,
+		window:        c.window,
 	}, start)
 }
 

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -189,7 +189,11 @@ func (c *BufferDropsCheck) Name() string { return "buffer_drops" }
 func (c *BufferDropsCheck) Category() health.Category { return health.CategoryAudio }
 
 // WithWindow returns a copy of this check configured with the given evaluation window.
+// Returns the receiver unchanged when d equals the current window to avoid an allocation.
 func (c *BufferDropsCheck) WithWindow(d time.Duration) health.Check {
+	if d == c.window {
+		return c
+	}
 	cp := *c
 	cp.window = d
 	return &cp
@@ -307,7 +311,11 @@ func (c *BufferOverrunCheck) Name() string { return "buffer_overrun" }
 func (c *BufferOverrunCheck) Category() health.Category { return health.CategoryAudio }
 
 // WithWindow returns a copy of this check configured with the given evaluation window.
+// Returns the receiver unchanged when d equals the current window to avoid an allocation.
 func (c *BufferOverrunCheck) WithWindow(d time.Duration) health.Check {
+	if d == c.window {
+		return c
+	}
 	cp := *c
 	cp.window = d
 	return &cp

--- a/internal/health/checks/audio_test.go
+++ b/internal/health/checks/audio_test.go
@@ -2,54 +2,169 @@ package checks
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
-func TestBufferDropsCheck_NilProvider(t *testing.T) {
+func newTestHealthStore(t *testing.T) *observability.HealthMetricsStore {
+	t.Helper()
+	return observability.NewHealthMetricsStore()
+}
+
+func newTestEventBuffer(t *testing.T) *observability.HealthEventBuffer {
+	t.Helper()
+	return observability.NewHealthEventBuffer(100)
+}
+
+func eventGetter(buf *observability.HealthEventBuffer) func(string, int) []observability.HealthEvent {
+	return buf.Recent
+}
+
+func TestBufferDropsCheck_NilStore(t *testing.T) {
 	t.Parallel()
-	check := NewBufferDropsCheck(nil)
+	check := NewBufferDropsCheck(nil, nil)
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusSkipped, result.Status)
 	assert.Equal(t, "buffer_drops", result.Name)
 }
 
-func TestBufferDropsCheck_NilStats(t *testing.T) {
+func TestBufferDropsCheck_NoData(t *testing.T) {
 	t.Parallel()
-	check := NewBufferDropsCheck(func() DropStats { return nil })
+	store := newTestHealthStore(t)
+	check := NewBufferDropsCheck(store, nil)
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusSkipped, result.Status)
 }
 
-func TestBufferDropsCheck_Healthy(t *testing.T) {
+func TestBufferDropsCheck_HealthyWithHistory(t *testing.T) {
 	t.Parallel()
-	check := NewBufferDropsCheck(func() DropStats {
-		return DropStats{"src1": 0, "src2": 0}
-	})
+	store := newTestHealthStore(t)
+	buf := newTestEventBuffer(t)
+
+	now := time.Now()
+	store.RecordAt("audio.drops.src1", 50, now.Add(-3*time.Hour))
+	buf.Add(observability.HealthEvent{Time: now.Add(-3 * time.Hour), Source: "src1", Delta: 50, Metric: "drops"})
+	store.RecordAt("audio.drops.src1", 0, now)
+
+	check := NewBufferDropsCheck(store, eventGetter(buf))
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusHealthy, result.Status)
-	assert.Contains(t, result.Message, "No buffer drops")
+	assert.Contains(t, result.Message, "No drops in last 1h")
+	assert.Contains(t, result.Message, "50 lifetime")
 }
 
 func TestBufferDropsCheck_Warning(t *testing.T) {
 	t.Parallel()
-	check := NewBufferDropsCheck(func() DropStats {
-		return DropStats{"src1": 5, "src2": 0}
-	})
+	store := newTestHealthStore(t)
+
+	store.RecordAt("audio.drops.src1", 15, time.Now())
+
+	check := NewBufferDropsCheck(store, nil)
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusWarning, result.Status)
-	assert.Contains(t, result.Message, "5 total")
+	assert.Contains(t, result.Message, "15 drops in last 1h")
 }
 
 func TestBufferDropsCheck_Critical(t *testing.T) {
 	t.Parallel()
-	check := NewBufferDropsCheck(func() DropStats {
-		return DropStats{"src1": 101}
-	})
+	store := newTestHealthStore(t)
+
+	store.RecordAt("audio.drops.src1", 150, time.Now())
+
+	check := NewBufferDropsCheck(store, nil)
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestBufferDropsCheck_WithWindow(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	now := time.Now()
+
+	store.RecordAt("audio.drops.src1", 20, now.Add(-3*time.Hour))
+	store.RecordAt("audio.drops.src1", 0, now)
+
+	check := NewBufferDropsCheck(store, nil)
+
+	narrowed := check.WithWindow(1 * time.Hour)
+	result := narrowed.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+
+	wide := check.WithWindow(6 * time.Hour)
+	result = wide.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+}
+
+func TestBufferDropsCheck_SparklineInDetails(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+
+	store.RecordAt("audio.drops.src1", 10, time.Now().Add(-2*time.Hour))
+	store.RecordAt("audio.drops.src1", 5, time.Now())
+
+	check := NewBufferDropsCheck(store, nil)
+	result := check.Run(t.Context())
+
+	require.NotNil(t, result.Details)
+	assert.NotNil(t, result.Details["sparkline"])
+	assert.Equal(t, "1h", result.Details["window"])
+}
+
+func TestBufferOverrunCheck_NilStore(t *testing.T) {
+	t.Parallel()
+	check := NewBufferOverrunCheck(nil, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "buffer_overrun", result.Name)
+}
+
+func TestBufferOverrunCheck_Healthy(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	store.RecordAt("audio.overruns.src1", 0, time.Now())
+	check := NewBufferOverrunCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+}
+
+func TestBufferOverrunCheck_NoData(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	check := NewBufferOverrunCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestBufferOverrunCheck_Warning(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	store.RecordAt("audio.overruns.src1", 15, time.Now())
+
+	check := NewBufferOverrunCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+}
+
+func TestBufferOverrunCheck_Critical(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	store.RecordAt("audio.overruns.src1", 60, time.Now())
+
+	check := NewBufferOverrunCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestBufferOverrunCheck_WithWindow(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	check := NewBufferOverrunCheck(store, nil)
+	narrowed := check.WithWindow(15 * time.Minute)
+	assert.NotNil(t, narrowed)
 }
 
 func TestAudioLevelCheck_NilProvider(t *testing.T) {
@@ -117,48 +232,6 @@ func TestAudioLevelCheck_PartialSilence(t *testing.T) {
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusWarning, result.Status)
 	assert.Contains(t, result.Message, "Silence detected on 1")
-}
-
-func TestBufferOverrunCheck_NilStats(t *testing.T) {
-	t.Parallel()
-	check := NewBufferOverrunCheck(func() OverrunStats { return nil })
-	result := check.Run(t.Context())
-	assert.Equal(t, health.StatusSkipped, result.Status)
-}
-
-func TestBufferOverrunCheck_NilProvider(t *testing.T) {
-	t.Parallel()
-	check := NewBufferOverrunCheck(nil)
-	result := check.Run(t.Context())
-	assert.Equal(t, health.StatusSkipped, result.Status)
-	assert.Equal(t, "buffer_overrun", result.Name)
-}
-
-func TestBufferOverrunCheck_Healthy(t *testing.T) {
-	t.Parallel()
-	check := NewBufferOverrunCheck(func() OverrunStats {
-		return OverrunStats{"src1": 0}
-	})
-	result := check.Run(t.Context())
-	assert.Equal(t, health.StatusHealthy, result.Status)
-}
-
-func TestBufferOverrunCheck_Warning(t *testing.T) {
-	t.Parallel()
-	check := NewBufferOverrunCheck(func() OverrunStats {
-		return OverrunStats{"src1": 10}
-	})
-	result := check.Run(t.Context())
-	assert.Equal(t, health.StatusWarning, result.Status)
-}
-
-func TestBufferOverrunCheck_Critical(t *testing.T) {
-	t.Parallel()
-	check := NewBufferOverrunCheck(func() OverrunStats {
-		return OverrunStats{"src1": 51}
-	})
-	result := check.Run(t.Context())
-	assert.Equal(t, health.StatusCritical, result.Status)
 }
 
 func TestCaptureBufferCheck_NilProvider(t *testing.T) {

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
 // sanitizeID converts a model ID into a safe check-name suffix by
@@ -51,52 +52,221 @@ func skippedResult(name string, category health.Category, start time.Time) healt
 	}
 }
 
-// counterStatsConfig parameterises evalCounterStats so that structurally
-// identical drop/overrun checks can share one implementation.
-type counterStatsConfig struct {
+// windowedStatsConfig parameterises evalWindowedStats for counter-based checks.
+type windowedStatsConfig struct {
 	warnThreshold int64
 	critThreshold int64
-	totalKey      string
-	healthyMsg    string // expects %d (sources)
-	warnMsg       string // expects %d (total), %d (sources)
-	critMsg       string // expects %d (total), %d (sources)
+	metricPrefix  string
+	window        time.Duration
 }
 
-// evalCounterStats aggregates per-source int64 counters and returns a Result
-// using the thresholds and message templates in cfg.
-func evalCounterStats(
-	name string, category health.Category,
-	stats map[string]int64, cfg *counterStatsConfig,
+// sparklineBuckets is the number of hourly buckets included in the sparkline response.
+const sparklineBuckets = 24
+
+// recentEventsLimit is the number of recent events included in the response.
+const recentEventsLimit = 20
+
+// staleBucketAge is the maximum age of the latest bucket before a source is
+// considered stale and excluded from evaluation.
+const staleBucketAge = 30 * time.Second
+
+// evalWindowedStats evaluates counter-based metrics using time-windowed data from
+// the HealthMetricsStore. It sums events within the configured window, builds
+// sparkline data, and formats messages with temporal context.
+func evalWindowedStats(
+	name string,
+	category health.Category,
+	store *observability.HealthMetricsStore,
+	getEvents func(metric string, n int) []observability.HealthEvent,
+	cfg *windowedStatsConfig,
 	start time.Time,
 ) health.Result {
-	var total int64
-	for _, v := range stats {
-		total += v
+	if store == nil {
+		return skippedResult(name, category, start)
+	}
+
+	now := time.Now()
+	keys := store.KeysWithPrefix(cfg.metricPrefix)
+
+	var windowTotal int64
+	var lifetimeTotal int64
+	var lastEvent time.Time
+	perSource := make(map[string]int64, len(keys))
+	activeSources := 0
+
+	for _, key := range keys {
+		sourceID := key[len(cfg.metricPrefix):]
+
+		latestBucket := store.LatestBucketTime(key)
+		if !latestBucket.IsZero() && now.Sub(latestBucket) > time.Hour+staleBucketAge {
+			continue
+		}
+
+		activeSources++
+		wTotal := store.SumAt(key, cfg.window, now)
+		perSource[sourceID] = wTotal
+		windowTotal += wTotal
+		lifetimeTotal += store.LifetimeTotal(key)
+
+		if et := store.LastEventTime(key); !et.IsZero() && et.After(lastEvent) {
+			lastEvent = et
+		}
+	}
+
+	if len(keys) == 0 || activeSources == 0 {
+		return skippedResult(name, category, start)
 	}
 
 	status := health.StatusHealthy
-	msg := fmt.Sprintf(cfg.healthyMsg, len(stats))
-
 	switch {
-	case total >= cfg.critThreshold:
+	case windowTotal >= cfg.critThreshold:
 		status = health.StatusCritical
-		msg = fmt.Sprintf(cfg.critMsg, total, len(stats))
-	case total >= cfg.warnThreshold:
+	case windowTotal >= cfg.warnThreshold:
 		status = health.StatusWarning
-		msg = fmt.Sprintf(cfg.warnMsg, total, len(stats))
+	}
+
+	msg := formatWindowedMessage(name, windowTotal, lifetimeTotal, activeSources, lastEvent, cfg.window, now)
+
+	metricType := extractMetricType(cfg.metricPrefix)
+
+	sparkline := buildMergedSparkline(store, keys, sparklineBuckets, now)
+
+	var recentEvents []observability.HealthEvent
+	if getEvents != nil {
+		recentEvents = getEvents(metricType, recentEventsLimit)
+	}
+
+	details := map[string]any{
+		"window":         formatDuration(cfg.window),
+		"window_total":   windowTotal,
+		"lifetime_total": lifetimeTotal,
+		"sources":        activeSources,
+		"per_source":     perSource,
+	}
+	if !lastEvent.IsZero() {
+		details["last_event"] = lastEvent.Format(time.RFC3339)
+	}
+	if len(sparkline) > 0 {
+		details["sparkline"] = sparkline
+	}
+	if len(recentEvents) > 0 {
+		details["recent_events"] = recentEvents
 	}
 
 	return health.Result{
-		Name:     name,
-		Category: category,
-		Status:   status,
-		Message:  msg,
-		Details: map[string]any{
-			cfg.totalKey: total,
-			"sources":    len(stats),
-			"per_source": stats,
-		},
+		Name:       name,
+		Category:   category,
+		Status:     status,
+		Message:    msg,
+		Details:    details,
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}
+}
+
+// formatWindowedMessage builds a human-readable message with temporal context.
+func formatWindowedMessage(
+	name string,
+	windowTotal, lifetimeTotal int64,
+	sources int,
+	lastEvent time.Time,
+	window time.Duration,
+	now time.Time,
+) string {
+	windowStr := formatDuration(window)
+	label := checkNameLabel(name)
+
+	if lifetimeTotal == 0 {
+		return fmt.Sprintf("No %s across %d source(s)", label, sources)
+	}
+
+	if windowTotal == 0 {
+		timeAgo := formatTimeAgo(lastEvent, now)
+		return fmt.Sprintf("No %s in last %s (%d lifetime, last: %s)", label, windowStr, lifetimeTotal, timeAgo)
+	}
+
+	timeAgo := formatTimeAgo(lastEvent, now)
+	return fmt.Sprintf("%d %s in last %s across %d source(s) (last: %s)", windowTotal, label, windowStr, sources, timeAgo)
+}
+
+// checkNameLabel converts a check name to a human-readable label.
+func checkNameLabel(name string) string {
+	switch name {
+	case "buffer_drops":
+		return "drops"
+	case "buffer_overrun":
+		return "overruns"
+	case "stream_error_rate":
+		return "restarts"
+	default:
+		return "events"
+	}
+}
+
+// formatDuration formats a duration as a compact string (e.g. "1h", "30m", "7d").
+func formatDuration(d time.Duration) string {
+	switch {
+	case d >= 24*time.Hour:
+		days := int(d / (24 * time.Hour))
+		return fmt.Sprintf("%dd", days)
+	case d >= time.Hour:
+		hours := int(d / time.Hour)
+		return fmt.Sprintf("%dh", hours)
+	default:
+		minutes := int(d / time.Minute)
+		return fmt.Sprintf("%dm", minutes)
+	}
+}
+
+// formatTimeAgo formats a time as a relative duration string.
+func formatTimeAgo(t, now time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		days := int(d.Hours() / 24)
+		return fmt.Sprintf("%dd ago", days)
+	}
+}
+
+// extractMetricType extracts the metric type from a prefix like "audio.drops." -> "drops".
+func extractMetricType(prefix string) string {
+	trimmed := strings.TrimSuffix(prefix, ".")
+	if idx := strings.LastIndex(trimmed, "."); idx >= 0 {
+		return trimmed[idx+1:]
+	}
+	return trimmed
+}
+
+// buildMergedSparkline merges multiple metric keys into a single sparkline
+// of n hourly buckets, with zeros for hours without data.
+func buildMergedSparkline(store *observability.HealthMetricsStore, keys []string, n int, now time.Time) []observability.HourlyBucket {
+	startHour := now.Truncate(time.Hour).Add(-time.Duration(n-1) * time.Hour)
+
+	merged := make([]observability.HourlyBucket, n)
+	for i := range n {
+		merged[i] = observability.HourlyBucket{
+			Start: startHour.Add(time.Duration(i) * time.Hour),
+		}
+	}
+
+	for _, key := range keys {
+		buckets := store.Buckets(key, n)
+		for _, b := range buckets {
+			idx := int(b.Start.Sub(startHour) / time.Hour)
+			if idx >= 0 && idx < n {
+				merged[idx].Count += b.Count
+			}
+		}
+	}
+
+	return merged
 }

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -66,10 +66,6 @@ const sparklineBuckets = 24
 // recentEventsLimit is the number of recent events included in the response.
 const recentEventsLimit = 20
 
-// staleBucketAge is the maximum age of the latest bucket before a source is
-// considered stale and excluded from evaluation.
-const staleBucketAge = 30 * time.Second
-
 // evalWindowedStats evaluates counter-based metrics using time-windowed data from
 // the HealthMetricsStore. It sums events within the configured window, builds
 // sparkline data, and formats messages with temporal context.
@@ -97,23 +93,18 @@ func evalWindowedStats(
 	for _, key := range keys {
 		sourceID := key[len(cfg.metricPrefix):]
 
-		latestBucket := store.LatestBucketTime(key)
-		if !latestBucket.IsZero() && now.Sub(latestBucket) > time.Hour+staleBucketAge {
-			continue
-		}
-
 		activeSources++
 		wTotal := store.SumAt(key, cfg.window, now)
 		perSource[sourceID] = wTotal
 		windowTotal += wTotal
 		lifetimeTotal += store.LifetimeTotal(key)
 
-		if et := store.LastEventTime(key); !et.IsZero() && et.After(lastEvent) {
+		if et := store.LastEventTime(key); et.After(lastEvent) {
 			lastEvent = et
 		}
 	}
 
-	if len(keys) == 0 || activeSources == 0 {
+	if len(keys) == 0 {
 		return skippedResult(name, category, start)
 	}
 

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -108,7 +108,11 @@ func (c *StreamErrorRateCheck) Name() string { return "stream_error_rate" }
 func (c *StreamErrorRateCheck) Category() health.Category { return health.CategoryStreams }
 
 // WithWindow returns a copy of this check configured with the given evaluation window.
+// Returns the receiver unchanged when d equals the current window to avoid an allocation.
 func (c *StreamErrorRateCheck) WithWindow(d time.Duration) health.Check {
+	if d == c.window {
+		return c
+	}
 	cp := *c
 	cp.window = d
 	return &cp

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
 // StreamHealthInfo is a snapshot of a single RTSP stream's health.
@@ -84,14 +85,20 @@ func (c *StreamConnectivityCheck) Run(_ context.Context) health.Result {
 	}
 }
 
-// StreamErrorRateCheck monitors RTSP stream restart counts to detect error loops.
+// StreamErrorRateCheck monitors RTSP stream restart counts using time-windowed evaluation.
 type StreamErrorRateCheck struct {
-	getStreams func() []StreamHealthInfo
+	store     *observability.HealthMetricsStore
+	getEvents func(metric string, n int) []observability.HealthEvent
+	window    time.Duration
 }
 
-// NewStreamErrorRateCheck creates a StreamErrorRateCheck using the given stream provider.
-func NewStreamErrorRateCheck(getStreams func() []StreamHealthInfo) *StreamErrorRateCheck {
-	return &StreamErrorRateCheck{getStreams: getStreams}
+// NewStreamErrorRateCheck creates a StreamErrorRateCheck using the health metrics store and event getter.
+func NewStreamErrorRateCheck(store *observability.HealthMetricsStore, getEvents func(metric string, n int) []observability.HealthEvent) *StreamErrorRateCheck {
+	return &StreamErrorRateCheck{
+		store:     store,
+		getEvents: getEvents,
+		window:    DefaultWindow,
+	}
 }
 
 // Name returns the check identifier.
@@ -100,61 +107,23 @@ func (c *StreamErrorRateCheck) Name() string { return "stream_error_rate" }
 // Category returns the streams category.
 func (c *StreamErrorRateCheck) Category() health.Category { return health.CategoryStreams }
 
-// Run evaluates the restart count of each RTSP stream.
+// WithWindow returns a copy of this check configured with the given evaluation window.
+func (c *StreamErrorRateCheck) WithWindow(d time.Duration) health.Check {
+	cp := *c
+	cp.window = d
+	return &cp
+}
+
+// Run evaluates stream restart counts within the configured time window.
 func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
-	if c.getStreams == nil {
-		return skippedResult(c.Name(), c.Category(), start)
-	}
-
-	streams := c.getStreams()
-	if len(streams) == 0 {
-		return skippedResult(c.Name(), c.Category(), start)
-	}
-
-	const warnRestarts = 3
-	const critRestarts = 10
-
-	status := health.StatusHealthy
-	var msg string
-	warnCount := 0
-	critCount := 0
-
-	for _, s := range streams {
-		switch {
-		case s.RestartCount > critRestarts:
-			critCount++
-		case s.RestartCount > warnRestarts:
-			warnCount++
-		}
-	}
-
-	switch {
-	case critCount > 0:
-		status = health.StatusCritical
-		msg = fmt.Sprintf("%d stream(s) have restarted more than %d times", critCount, critRestarts)
-	case warnCount > 0:
-		status = health.StatusWarning
-		msg = fmt.Sprintf("%d stream(s) have restarted more than %d times", warnCount, warnRestarts)
-	default:
-		msg = "Stream restart counts within normal range"
-	}
-
-	return health.Result{
-		Name:     c.Name(),
-		Category: c.Category(),
-		Status:   status,
-		Message:  msg,
-		Details: map[string]any{
-			"streams_above_warn_threshold": warnCount,
-			"streams_above_crit_threshold": critCount,
-			"warn_threshold":               warnRestarts,
-			"crit_threshold":               critRestarts,
-		},
-		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
-		Timestamp:  time.Now(),
-	}
+	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
+		warnThreshold: 3,
+		critThreshold: 10,
+		metricPrefix:  observability.MetricPrefixStreamRestarts,
+		window:        c.window,
+	}, start)
 }
 
 // FFmpegHealthCheck monitors the process state of the FFmpeg processes backing each RTSP stream.

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -44,10 +44,25 @@ func (r *Registry) RegisterAll(checks ...Check) {
 
 // RunAll executes all checks in parallel with per-check timeout.
 func (r *Registry) RunAll(ctx context.Context) []Result {
+	return r.RunAllWithWindow(ctx, 0)
+}
+
+// RunAllWithWindow executes all checks in parallel. For checks implementing
+// WindowedCheck, the given window duration is applied before execution.
+// A zero window leaves checks at their default window.
+func (r *Registry) RunAllWithWindow(ctx context.Context, window time.Duration) []Result {
 	r.mu.RLock()
 	checks := make([]Check, len(r.checks))
 	copy(checks, r.checks)
 	r.mu.RUnlock()
+
+	if window > 0 {
+		for i, c := range checks {
+			if wc, ok := c.(WindowedCheck); ok {
+				checks[i] = wc.WithWindow(window)
+			}
+		}
+	}
 
 	return runChecks(ctx, checks)
 }

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -39,6 +39,14 @@ type Collector struct {
 	inferenceCounters  *inferencestats.CounterMap
 	prevInferenceSnaps map[string]*inferencestats.Snapshot
 
+	// Health counter tracking (optional, set via SetHealthStore/SetHealthEvents)
+	healthStore     *HealthMetricsStore
+	healthEvents    *HealthEventBuffer
+	audioRouterFn   func() []AudioRouterSnapshot
+	streamHealthFn  func() []StreamHealthSnapshot
+	prevAudioSnaps  map[string]AudioRouterSnapshot
+	prevStreamSnaps map[string]StreamHealthSnapshot
+
 	// Track which metrics have had logged errors to avoid log spam
 	loggedErrors map[string]bool
 }
@@ -122,6 +130,8 @@ func (c *Collector) collect() {
 	if len(points) > 0 {
 		c.store.RecordBatch(points)
 	}
+
+	c.collectHealthCounters()
 }
 
 // collectCPU reads CPU usage from the injected function.
@@ -266,6 +276,43 @@ func (c *Collector) SetInferenceCounters(counters *inferencestats.CounterMap) {
 	c.inferenceCounters = counters
 }
 
+// AudioRouterSnapshot holds cumulative counter values for a single audio source.
+type AudioRouterSnapshot struct {
+	SourceID string
+	Drops    int64
+	Errors   int64
+}
+
+// StreamHealthSnapshot holds cumulative counter values for a single RTSP stream.
+type StreamHealthSnapshot struct {
+	URL          string
+	RestartCount int
+}
+
+// SetAudioRouter injects a function that provides cumulative audio counter snapshots.
+// Must be called before Start.
+func (c *Collector) SetAudioRouter(fn func() []AudioRouterSnapshot) {
+	c.audioRouterFn = fn
+}
+
+// SetStreamHealth injects a function that provides cumulative stream counter snapshots.
+// Must be called before Start.
+func (c *Collector) SetStreamHealth(fn func() []StreamHealthSnapshot) {
+	c.streamHealthFn = fn
+}
+
+// SetHealthStore sets the dedicated health metrics store for hourly bucket aggregation.
+// Must be called before Start.
+func (c *Collector) SetHealthStore(store *HealthMetricsStore) {
+	c.healthStore = store
+}
+
+// SetHealthEvents sets the event ring buffer for recording individual health events.
+// Must be called before Start.
+func (c *Collector) SetHealthEvents(buf *HealthEventBuffer) {
+	c.healthEvents = buf
+}
+
 func (c *Collector) collectInference(points map[string]float64) {
 	if c.inferenceCounters == nil {
 		return
@@ -350,6 +397,96 @@ var skipCollectorFSTypes = map[string]bool{
 // skipCollectorFS returns true for virtual/pseudo filesystem types that should not be tracked.
 func skipCollectorFS(fstype string) bool {
 	return skipCollectorFSTypes[fstype]
+}
+
+// collectHealthCounters samples cumulative audio and stream counters,
+// computes deltas from the previous snapshot, and records them into the
+// dedicated HealthMetricsStore. Follows the same delta pattern as collectDiskIO.
+func (c *Collector) collectHealthCounters() {
+	if c.healthStore == nil {
+		return
+	}
+	now := time.Now()
+	c.collectAudioHealthCounters(now)
+	c.collectStreamHealthCounters(now)
+}
+
+// collectAudioHealthCounters computes deltas for audio drops and overruns.
+func (c *Collector) collectAudioHealthCounters(now time.Time) {
+	if c.audioRouterFn == nil {
+		return
+	}
+
+	snaps := c.audioRouterFn()
+	current := make(map[string]AudioRouterSnapshot, len(snaps))
+	for _, s := range snaps {
+		current[s.SourceID] = s
+	}
+
+	if c.prevAudioSnaps != nil {
+		for id, cur := range current {
+			prev, ok := c.prevAudioSnaps[id]
+			if !ok {
+				continue
+			}
+			c.recordHealthDelta(MetricPrefixAudioDrops+id, cur.Drops, prev.Drops, id, "drops", now)
+			c.recordHealthDelta(MetricPrefixAudioOverruns+id, cur.Errors, prev.Errors, id, "overruns", now)
+		}
+	}
+
+	c.prevAudioSnaps = current
+}
+
+// collectStreamHealthCounters computes deltas for stream restart counts.
+func (c *Collector) collectStreamHealthCounters(now time.Time) {
+	if c.streamHealthFn == nil {
+		return
+	}
+
+	snaps := c.streamHealthFn()
+	current := make(map[string]StreamHealthSnapshot, len(snaps))
+	for _, s := range snaps {
+		current[s.URL] = s
+	}
+
+	if c.prevStreamSnaps != nil {
+		for url, cur := range current {
+			prev, ok := c.prevStreamSnaps[url]
+			if !ok {
+				continue
+			}
+			c.recordHealthDelta(MetricPrefixStreamRestarts+url, int64(cur.RestartCount), int64(prev.RestartCount), url, "restarts", now)
+		}
+	}
+
+	c.prevStreamSnaps = current
+}
+
+// recordHealthDelta computes the delta between current and previous counter values
+// and records it into the health store. Handles counter resets: if current < previous,
+// treat current as the delta (fresh start from zero).
+func (c *Collector) recordHealthDelta(key string, current, previous int64, source, metric string, now time.Time) {
+	var delta int64
+	if current >= previous {
+		delta = current - previous
+	} else {
+		delta = current
+	}
+
+	if delta <= 0 {
+		return
+	}
+
+	c.healthStore.RecordAt(key, delta, now)
+
+	if c.healthEvents != nil {
+		c.healthEvents.Add(HealthEvent{
+			Time:   now,
+			Source: source,
+			Delta:  delta,
+			Metric: metric,
+		})
+	}
 }
 
 // --- CPU Temperature reading (Linux-specific) ---

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -283,9 +283,11 @@ type AudioRouterSnapshot struct {
 	Errors   int64
 }
 
-// StreamHealthSnapshot holds cumulative counter values for a single RTSP stream.
+// StreamHealthSnapshot holds cumulative counter values for a single RTSP stream,
+// keyed by the stable internal source ID (not the raw URL) to avoid leaking
+// credentials into metric keys and to remain stable across URL changes.
 type StreamHealthSnapshot struct {
-	URL          string
+	SourceID     string
 	RestartCount int
 }
 
@@ -446,16 +448,16 @@ func (c *Collector) collectStreamHealthCounters(now time.Time) {
 	snaps := c.streamHealthFn()
 	current := make(map[string]StreamHealthSnapshot, len(snaps))
 	for _, s := range snaps {
-		current[s.URL] = s
+		current[s.SourceID] = s
 	}
 
 	if c.prevStreamSnaps != nil {
-		for url, cur := range current {
-			prev, ok := c.prevStreamSnaps[url]
+		for sourceID, cur := range current {
+			prev, ok := c.prevStreamSnaps[sourceID]
 			if !ok {
 				continue
 			}
-			c.recordHealthDelta(MetricPrefixStreamRestarts+url, int64(cur.RestartCount), int64(prev.RestartCount), url, "restarts", now)
+			c.recordHealthDelta(MetricPrefixStreamRestarts+sourceID, int64(cur.RestartCount), int64(prev.RestartCount), sourceID, "restarts", now)
 		}
 	}
 

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -91,14 +91,14 @@ func TestCollector_StreamHealthDelta(t *testing.T) {
 
 	c.SetStreamHealth(func() []StreamHealthSnapshot {
 		return []StreamHealthSnapshot{
-			{URL: "rtsp://cam1", RestartCount: 2},
+			{SourceID: "rtsp://cam1", RestartCount: 2},
 		}
 	})
 	c.collectHealthCounters()
 
 	c.SetStreamHealth(func() []StreamHealthSnapshot {
 		return []StreamHealthSnapshot{
-			{URL: "rtsp://cam1", RestartCount: 5},
+			{SourceID: "rtsp://cam1", RestartCount: 5},
 		}
 	})
 	c.collectHealthCounters()

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -1,0 +1,169 @@
+package observability
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCollectorWithHealth(t *testing.T) (*Collector, *HealthMetricsStore, *HealthEventBuffer) {
+	t.Helper()
+	store := NewMemoryStore(100)
+	healthStore := NewHealthMetricsStore()
+	healthEvents := NewHealthEventBuffer(100)
+
+	c := NewCollector(store, 15*time.Second, func() float64 { return 0 })
+	c.SetHealthStore(healthStore)
+	c.SetHealthEvents(healthEvents)
+	return c, healthStore, healthEvents
+}
+
+func TestCollector_AudioHealthDelta(t *testing.T) {
+	t.Parallel()
+	c, healthStore, healthEvents := newTestCollectorWithHealth(t)
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 10, Errors: 2},
+		}
+	})
+
+	c.collectHealthCounters()
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src1"))
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 15, Errors: 5},
+		}
+	})
+	c.collectHealthCounters()
+	assert.Equal(t, int64(5), healthStore.LifetimeTotal("audio.drops.src1"))
+	assert.Equal(t, int64(3), healthStore.LifetimeTotal("audio.overruns.src1"))
+
+	events := healthEvents.Recent("drops", 10)
+	require.Len(t, events, 1)
+	assert.Equal(t, int64(5), events[0].Delta)
+}
+
+func TestCollector_AudioHealthZeroDeltaSkip(t *testing.T) {
+	t.Parallel()
+	c, healthStore, healthEvents := newTestCollectorWithHealth(t)
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 10, Errors: 0},
+		}
+	})
+
+	c.collectHealthCounters()
+	c.collectHealthCounters()
+
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src1"))
+	assert.Empty(t, healthEvents.RecentAll(10))
+}
+
+func TestCollector_AudioHealthCounterReset(t *testing.T) {
+	t.Parallel()
+	c, healthStore, _ := newTestCollectorWithHealth(t)
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 100, Errors: 0},
+		}
+	})
+	c.collectHealthCounters()
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 5, Errors: 0},
+		}
+	})
+	c.collectHealthCounters()
+
+	assert.Equal(t, int64(5), healthStore.LifetimeTotal("audio.drops.src1"))
+}
+
+func TestCollector_StreamHealthDelta(t *testing.T) {
+	t.Parallel()
+	c, healthStore, healthEvents := newTestCollectorWithHealth(t)
+
+	c.SetStreamHealth(func() []StreamHealthSnapshot {
+		return []StreamHealthSnapshot{
+			{URL: "rtsp://cam1", RestartCount: 2},
+		}
+	})
+	c.collectHealthCounters()
+
+	c.SetStreamHealth(func() []StreamHealthSnapshot {
+		return []StreamHealthSnapshot{
+			{URL: "rtsp://cam1", RestartCount: 5},
+		}
+	})
+	c.collectHealthCounters()
+
+	assert.Equal(t, int64(3), healthStore.LifetimeTotal("stream.restarts.rtsp://cam1"))
+
+	events := healthEvents.Recent("restarts", 10)
+	require.Len(t, events, 1)
+	assert.Equal(t, int64(3), events[0].Delta)
+}
+
+func TestCollector_MultiSourceAudio(t *testing.T) {
+	t.Parallel()
+	c, healthStore, _ := newTestCollectorWithHealth(t)
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 0},
+			{SourceID: "src2", Drops: 0},
+		}
+	})
+	c.collectHealthCounters()
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 10},
+			{SourceID: "src2", Drops: 20},
+		}
+	})
+	c.collectHealthCounters()
+
+	assert.Equal(t, int64(10), healthStore.LifetimeTotal("audio.drops.src1"))
+	assert.Equal(t, int64(20), healthStore.LifetimeTotal("audio.drops.src2"))
+}
+
+func TestCollector_SourceRemoval(t *testing.T) {
+	t.Parallel()
+	c, healthStore, _ := newTestCollectorWithHealth(t)
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 10},
+			{SourceID: "src2", Drops: 5},
+		}
+	})
+	c.collectHealthCounters()
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 15},
+		}
+	})
+	c.collectHealthCounters()
+
+	assert.Equal(t, int64(5), healthStore.LifetimeTotal("audio.drops.src1"))
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src2"))
+}
+
+func TestCollector_NoHealthStoreSkips(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore(100)
+	c := NewCollector(store, 15*time.Second, func() float64 { return 0 })
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{{SourceID: "src1", Drops: 10}}
+	})
+
+	c.collectHealthCounters()
+}

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -91,19 +91,19 @@ func TestCollector_StreamHealthDelta(t *testing.T) {
 
 	c.SetStreamHealth(func() []StreamHealthSnapshot {
 		return []StreamHealthSnapshot{
-			{SourceID: "rtsp://cam1", RestartCount: 2},
+			{SourceID: "stream_abc123", RestartCount: 2},
 		}
 	})
 	c.collectHealthCounters()
 
 	c.SetStreamHealth(func() []StreamHealthSnapshot {
 		return []StreamHealthSnapshot{
-			{SourceID: "rtsp://cam1", RestartCount: 5},
+			{SourceID: "stream_abc123", RestartCount: 5},
 		}
 	})
 	c.collectHealthCounters()
 
-	assert.Equal(t, int64(3), healthStore.LifetimeTotal("stream.restarts.rtsp://cam1"))
+	assert.Equal(t, int64(3), healthStore.LifetimeTotal("stream.restarts.stream_abc123"))
 
 	events := healthEvents.Recent("restarts", 10)
 	require.Len(t, events, 1)

--- a/internal/observability/health_events.go
+++ b/internal/observability/health_events.go
@@ -1,0 +1,79 @@
+package observability
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultEventBufferCapacity is the default number of recent events to retain per buffer.
+const DefaultEventBufferCapacity = 100
+
+// HealthEvent records a single occurrence of a health counter change.
+type HealthEvent struct {
+	Time   time.Time `json:"time"`
+	Source string    `json:"source"`
+	Delta  int64     `json:"delta"`
+	Metric string    `json:"metric"`
+}
+
+// HealthEventBuffer is a thread-safe ring buffer that stores recent health events.
+type HealthEventBuffer struct {
+	mu       sync.RWMutex
+	events   []HealthEvent
+	head     int
+	size     int
+	capacity int
+}
+
+// NewHealthEventBuffer creates a buffer with the given capacity.
+func NewHealthEventBuffer(capacity int) *HealthEventBuffer {
+	if capacity <= 0 {
+		capacity = DefaultEventBufferCapacity
+	}
+	return &HealthEventBuffer{
+		events:   make([]HealthEvent, capacity),
+		head:     -1,
+		capacity: capacity,
+	}
+}
+
+// Add appends an event to the ring buffer, evicting the oldest if full.
+func (b *HealthEventBuffer) Add(event HealthEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.head = (b.head + 1) % b.capacity
+	b.events[b.head] = event
+	if b.size < b.capacity {
+		b.size++
+	}
+}
+
+// Recent returns the last n events matching the given metric, sorted most recent first.
+// If metric is empty, all events are returned.
+func (b *HealthEventBuffer) Recent(metric string, n int) []HealthEvent {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.size == 0 || n <= 0 {
+		return nil
+	}
+
+	result := make([]HealthEvent, 0, min(n, b.size))
+	for i := range b.size {
+		if len(result) >= n {
+			break
+		}
+		idx := (b.head - i + b.capacity) % b.capacity
+		e := b.events[idx]
+		if metric == "" || e.Metric == metric {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// RecentAll returns the last n events regardless of metric type, most recent first.
+func (b *HealthEventBuffer) RecentAll(n int) []HealthEvent {
+	return b.Recent("", n)
+}

--- a/internal/observability/health_events_test.go
+++ b/internal/observability/health_events_test.go
@@ -1,0 +1,152 @@
+package observability
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthEventBuffer_AddAndRecent(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+
+	now := time.Now()
+	buf.Add(HealthEvent{Time: now, Source: "src1", Delta: 5, Metric: "drops"})
+	buf.Add(HealthEvent{Time: now.Add(time.Second), Source: "src2", Delta: 3, Metric: "drops"})
+
+	events := buf.Recent("drops", 10)
+	require.Len(t, events, 2)
+	assert.Equal(t, "src2", events[0].Source)
+	assert.Equal(t, "src1", events[1].Source)
+}
+
+func TestHealthEventBuffer_FilterByMetric(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+
+	now := time.Now()
+	buf.Add(HealthEvent{Time: now, Source: "s1", Delta: 1, Metric: "drops"})
+	buf.Add(HealthEvent{Time: now, Source: "s2", Delta: 2, Metric: "overruns"})
+	buf.Add(HealthEvent{Time: now, Source: "s3", Delta: 3, Metric: "drops"})
+
+	drops := buf.Recent("drops", 10)
+	assert.Len(t, drops, 2)
+
+	overruns := buf.Recent("overruns", 10)
+	assert.Len(t, overruns, 1)
+	assert.Equal(t, int64(2), overruns[0].Delta)
+}
+
+func TestHealthEventBuffer_Overflow(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(3)
+
+	for i := range 5 {
+		buf.Add(HealthEvent{
+			Time:   time.Now(),
+			Source: fmt.Sprintf("src%d", i),
+			Delta:  int64(i),
+			Metric: "drops",
+		})
+	}
+
+	events := buf.Recent("drops", 10)
+	require.Len(t, events, 3)
+	assert.Equal(t, "src4", events[0].Source)
+	assert.Equal(t, "src3", events[1].Source)
+	assert.Equal(t, "src2", events[2].Source)
+}
+
+func TestHealthEventBuffer_LimitN(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+
+	for i := range 5 {
+		buf.Add(HealthEvent{
+			Time:   time.Now(),
+			Source: fmt.Sprintf("src%d", i),
+			Delta:  1,
+			Metric: "drops",
+		})
+	}
+
+	events := buf.Recent("drops", 2)
+	assert.Len(t, events, 2)
+}
+
+func TestHealthEventBuffer_EmptyBuffer(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+
+	events := buf.Recent("drops", 10)
+	assert.Nil(t, events)
+}
+
+func TestHealthEventBuffer_ZeroN(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+	buf.Add(HealthEvent{Time: time.Now(), Source: "s1", Delta: 1, Metric: "drops"})
+
+	events := buf.Recent("drops", 0)
+	assert.Nil(t, events)
+}
+
+func TestHealthEventBuffer_RecentAll(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+
+	buf.Add(HealthEvent{Time: time.Now(), Source: "s1", Delta: 1, Metric: "drops"})
+	buf.Add(HealthEvent{Time: time.Now(), Source: "s2", Delta: 2, Metric: "overruns"})
+
+	events := buf.RecentAll(10)
+	assert.Len(t, events, 2)
+}
+
+func TestHealthEventBuffer_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(50)
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			buf.Add(HealthEvent{
+				Time:   time.Now(),
+				Source: fmt.Sprintf("src%d", n),
+				Delta:  1,
+				Metric: "drops",
+			})
+			_ = buf.Recent("drops", 10)
+		}(i)
+	}
+	wg.Wait()
+
+	events := buf.RecentAll(100)
+	assert.Len(t, events, 50)
+}
+
+func TestHealthEventBuffer_MostRecentFirst(t *testing.T) {
+	t.Parallel()
+	buf := NewHealthEventBuffer(10)
+
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+	for i := range 5 {
+		buf.Add(HealthEvent{
+			Time:   base.Add(time.Duration(i) * time.Minute),
+			Source: fmt.Sprintf("src%d", i),
+			Delta:  1,
+			Metric: "drops",
+		})
+	}
+
+	events := buf.Recent("drops", 5)
+	require.Len(t, events, 5)
+	for i := range len(events) - 1 {
+		assert.True(t, events[i].Time.After(events[i+1].Time) || events[i].Time.Equal(events[i+1].Time))
+	}
+}

--- a/internal/observability/health_metrics_store.go
+++ b/internal/observability/health_metrics_store.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 )
@@ -231,7 +232,7 @@ func (s *HealthMetricsStore) KeysWithPrefix(prefix string) []string {
 
 	var keys []string
 	for k := range s.series {
-		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+		if strings.HasPrefix(k, prefix) {
 			keys = append(keys, k)
 		}
 	}

--- a/internal/observability/health_metrics_store.go
+++ b/internal/observability/health_metrics_store.go
@@ -1,0 +1,257 @@
+package observability
+
+import (
+	"maps"
+	"slices"
+	"sync"
+	"time"
+)
+
+// defaultBucketCount is 168 hourly buckets covering 7 days of retention.
+const defaultBucketCount = 168
+
+// Metric key prefixes for health counters. Used by both the collector
+// (recording) and health checks (querying) to ensure consistency.
+const (
+	MetricPrefixAudioDrops     = "audio.drops."
+	MetricPrefixAudioOverruns  = "audio.overruns."
+	MetricPrefixStreamRestarts = "stream.restarts."
+)
+
+// HourlyBucket holds the aggregated event count for a single hour.
+type HourlyBucket struct {
+	Start time.Time `json:"t"`
+	Count int64     `json:"v"`
+}
+
+// hourlyRing is a fixed-size circular buffer of hourly buckets.
+type hourlyRing struct {
+	buckets []HourlyBucket
+	head    int
+	size    int
+	last    time.Time // last event timestamp (any delta > 0)
+}
+
+func newHourlyRing(capacity int) *hourlyRing {
+	return &hourlyRing{
+		buckets: make([]HourlyBucket, capacity),
+	}
+}
+
+// bucketStart returns the start-of-hour for a given time.
+func bucketStart(t time.Time) time.Time {
+	return t.Truncate(time.Hour)
+}
+
+// record adds a delta to the current hour's bucket, rolling over as needed.
+func (r *hourlyRing) record(delta int64, now time.Time) {
+	hour := bucketStart(now)
+
+	if r.size == 0 {
+		r.buckets[r.head] = HourlyBucket{Start: hour, Count: delta}
+		r.size = 1
+		if delta > 0 {
+			r.last = now
+		}
+		return
+	}
+
+	cur := r.current()
+	if cur.Start.Equal(hour) {
+		cur.Count += delta
+		if delta > 0 {
+			r.last = now
+		}
+		return
+	}
+
+	// Advance head to a new bucket
+	r.head = (r.head + 1) % len(r.buckets)
+	r.buckets[r.head] = HourlyBucket{Start: hour, Count: delta}
+	if r.size < len(r.buckets) {
+		r.size++
+	}
+	if delta > 0 {
+		r.last = now
+	}
+}
+
+// current returns a pointer to the most recent bucket.
+func (r *hourlyRing) current() *HourlyBucket {
+	return &r.buckets[r.head]
+}
+
+// sum returns the total count of events within the given window ending at now.
+func (r *hourlyRing) sum(window time.Duration, now time.Time) int64 {
+	if r.size == 0 {
+		return 0
+	}
+	cutoff := now.Add(-window)
+	var total int64
+	for i := range r.size {
+		idx := (r.head - i + len(r.buckets)) % len(r.buckets)
+		b := &r.buckets[idx]
+		if b.Start.Before(cutoff) {
+			break
+		}
+		total += b.Count
+	}
+	return total
+}
+
+// recentBuckets returns the last n hourly buckets in chronological order.
+// Returns fewer than n if the ring has fewer entries.
+func (r *hourlyRing) recentBuckets(n int) []HourlyBucket {
+	if r.size == 0 {
+		return nil
+	}
+	count := n
+	if count > r.size {
+		count = r.size
+	}
+	result := make([]HourlyBucket, count)
+	for i := range count {
+		idx := (r.head - count + 1 + i + len(r.buckets)) % len(r.buckets)
+		result[i] = r.buckets[idx]
+	}
+	return result
+}
+
+// HealthMetricsStore provides thread-safe, hourly-bucketed aggregation of
+// health counter metrics with 7-day retention. Each metric key maps to an
+// independent ring of hourly buckets.
+type HealthMetricsStore struct {
+	mu     sync.RWMutex
+	series map[string]*hourlyRing
+	size   int
+}
+
+// NewHealthMetricsStore creates a store with the default 7-day (168 hourly buckets) retention.
+func NewHealthMetricsStore() *HealthMetricsStore {
+	return NewHealthMetricsStoreWithSize(defaultBucketCount)
+}
+
+// NewHealthMetricsStoreWithSize creates a store with a custom bucket count per metric.
+func NewHealthMetricsStoreWithSize(bucketsPerMetric int) *HealthMetricsStore {
+	if bucketsPerMetric <= 0 {
+		bucketsPerMetric = defaultBucketCount
+	}
+	return &HealthMetricsStore{
+		series: make(map[string]*hourlyRing),
+		size:   bucketsPerMetric,
+	}
+}
+
+// Record adds a delta to the specified metric key, aggregating into the
+// current hour's bucket. Thread-safe.
+func (s *HealthMetricsStore) Record(key string, delta int64) {
+	s.RecordAt(key, delta, time.Now())
+}
+
+// RecordAt adds a delta at a specific time. Primarily for testing.
+func (s *HealthMetricsStore) RecordAt(key string, delta int64, now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ring, ok := s.series[key]
+	if !ok {
+		ring = newHourlyRing(s.size)
+		s.series[key] = ring
+	}
+	ring.record(delta, now)
+}
+
+// Sum returns the total event count for a metric within the given window.
+func (s *HealthMetricsStore) Sum(key string, window time.Duration) int64 {
+	return s.SumAt(key, window, time.Now())
+}
+
+// SumAt returns the total event count for a metric within the given window ending at now.
+func (s *HealthMetricsStore) SumAt(key string, window time.Duration, now time.Time) int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ring, ok := s.series[key]
+	if !ok {
+		return 0
+	}
+	return ring.sum(window, now)
+}
+
+// Buckets returns the last n hourly buckets for a metric in chronological order.
+func (s *HealthMetricsStore) Buckets(key string, n int) []HourlyBucket {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ring, ok := s.series[key]
+	if !ok {
+		return nil
+	}
+	return ring.recentBuckets(n)
+}
+
+// LastEventTime returns the time of the most recent non-zero delta for a metric.
+// Returns the zero time if no events have been recorded.
+func (s *HealthMetricsStore) LastEventTime(key string) time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ring, ok := s.series[key]
+	if !ok {
+		return time.Time{}
+	}
+	return ring.last
+}
+
+// LatestBucketTime returns the start time of the most recent bucket for a metric.
+// Returns the zero time if no data exists.
+func (s *HealthMetricsStore) LatestBucketTime(key string) time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ring, ok := s.series[key]
+	if !ok || ring.size == 0 {
+		return time.Time{}
+	}
+	return ring.current().Start
+}
+
+// Keys returns all metric keys with data in the store.
+func (s *HealthMetricsStore) Keys() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return slices.Collect(maps.Keys(s.series))
+}
+
+// KeysWithPrefix returns all metric keys matching the given prefix.
+func (s *HealthMetricsStore) KeysWithPrefix(prefix string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var keys []string
+	for k := range s.series {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// LifetimeTotal returns the sum of all buckets for a metric (entire retention window).
+func (s *HealthMetricsStore) LifetimeTotal(key string) int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ring, ok := s.series[key]
+	if !ok || ring.size == 0 {
+		return 0
+	}
+
+	var total int64
+	for i := range ring.size {
+		idx := (ring.head - i + len(ring.buckets)) % len(ring.buckets)
+		total += ring.buckets[idx].Count
+	}
+	return total
+}

--- a/internal/observability/health_metrics_store.go
+++ b/internal/observability/health_metrics_store.go
@@ -83,6 +83,10 @@ func (r *hourlyRing) current() *HourlyBucket {
 }
 
 // sum returns the total count of events within the given window ending at now.
+// Buckets are hourly: a bucket is included as long as any part of it overlaps
+// the window, so a 1h window evaluated mid-hour includes the bucket that
+// contains the cutoff. This over-counts by up to one bucket-width of older
+// data, but never under-counts recent activity at hour boundaries.
 func (r *hourlyRing) sum(window time.Duration, now time.Time) int64 {
 	if r.size == 0 {
 		return 0
@@ -92,7 +96,7 @@ func (r *hourlyRing) sum(window time.Duration, now time.Time) int64 {
 	for i := range r.size {
 		idx := (r.head - i + len(r.buckets)) % len(r.buckets)
 		b := &r.buckets[idx]
-		if b.Start.Before(cutoff) {
+		if !b.Start.Add(time.Hour).After(cutoff) {
 			break
 		}
 		total += b.Count
@@ -103,7 +107,7 @@ func (r *hourlyRing) sum(window time.Duration, now time.Time) int64 {
 // recentBuckets returns the last n hourly buckets in chronological order.
 // Returns fewer than n if the ring has fewer entries.
 func (r *hourlyRing) recentBuckets(n int) []HourlyBucket {
-	if r.size == 0 {
+	if r.size == 0 || n <= 0 {
 		return nil
 	}
 	count := n

--- a/internal/observability/health_metrics_store_test.go
+++ b/internal/observability/health_metrics_store_test.go
@@ -32,8 +32,12 @@ func TestHealthMetricsStore_SumWindowBoundary(t *testing.T) {
 
 	now := base.Add(2*time.Hour + 30*time.Minute)
 
-	assert.Equal(t, int64(30), s.SumAt("drops", time.Hour, now))
-	assert.Equal(t, int64(50), s.SumAt("drops", 2*time.Hour, now))
+	// At 12:30 with a 1h window (cutoff 11:30), both the 12:00 bucket and
+	// the 11:00 bucket overlap the window, so both are included. This
+	// over-counts by up to one bucket-width of older data but never
+	// under-counts recent activity at hour boundaries.
+	assert.Equal(t, int64(50), s.SumAt("drops", time.Hour, now))
+	assert.Equal(t, int64(60), s.SumAt("drops", 2*time.Hour, now))
 	assert.Equal(t, int64(60), s.SumAt("drops", 3*time.Hour, now))
 }
 

--- a/internal/observability/health_metrics_store_test.go
+++ b/internal/observability/health_metrics_store_test.go
@@ -1,0 +1,211 @@
+package observability
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthMetricsStore_RecordAndSum(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	now := time.Date(2026, 5, 24, 10, 30, 0, 0, time.UTC)
+
+	s.RecordAt("audio.drops.src1", 5, now)
+	s.RecordAt("audio.drops.src1", 3, now.Add(10*time.Minute))
+
+	assert.Equal(t, int64(8), s.SumAt("audio.drops.src1", time.Hour, now.Add(10*time.Minute)))
+}
+
+func TestHealthMetricsStore_SumWindowBoundary(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	s.RecordAt("drops", 10, base)
+	s.RecordAt("drops", 20, base.Add(time.Hour))
+	s.RecordAt("drops", 30, base.Add(2*time.Hour))
+
+	now := base.Add(2*time.Hour + 30*time.Minute)
+
+	assert.Equal(t, int64(30), s.SumAt("drops", time.Hour, now))
+	assert.Equal(t, int64(50), s.SumAt("drops", 2*time.Hour, now))
+	assert.Equal(t, int64(60), s.SumAt("drops", 3*time.Hour, now))
+}
+
+func TestHealthMetricsStore_BucketRollover(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStoreWithSize(4)
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	for i := range 6 {
+		s.RecordAt("m", int64(i+1), base.Add(time.Duration(i)*time.Hour))
+	}
+
+	buckets := s.Buckets("m", 10)
+	require.Len(t, buckets, 4)
+	assert.Equal(t, int64(3), buckets[0].Count)
+	assert.Equal(t, int64(6), buckets[3].Count)
+}
+
+func TestHealthMetricsStore_SevenDayEviction(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	base := time.Date(2026, 5, 17, 0, 0, 0, 0, time.UTC)
+
+	s.RecordAt("m", 100, base)
+
+	for i := 1; i <= 168; i++ {
+		s.RecordAt("m", 1, base.Add(time.Duration(i)*time.Hour))
+	}
+
+	buckets := s.Buckets("m", 200)
+	require.Len(t, buckets, 168)
+	assert.Equal(t, int64(1), buckets[0].Count)
+}
+
+func TestHealthMetricsStore_LastEventTime(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	now := time.Date(2026, 5, 24, 10, 30, 0, 0, time.UTC)
+
+	assert.True(t, s.LastEventTime("missing").IsZero())
+
+	s.RecordAt("m", 5, now)
+	assert.Equal(t, now, s.LastEventTime("m"))
+
+	later := now.Add(5 * time.Minute)
+	s.RecordAt("m", 0, later)
+	assert.Equal(t, now, s.LastEventTime("m"))
+
+	laterEvent := now.Add(10 * time.Minute)
+	s.RecordAt("m", 1, laterEvent)
+	assert.Equal(t, laterEvent, s.LastEventTime("m"))
+}
+
+func TestHealthMetricsStore_Keys(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	now := time.Now()
+
+	s.RecordAt("audio.drops.src1", 1, now)
+	s.RecordAt("audio.drops.src2", 1, now)
+	s.RecordAt("stream.restarts.abc", 1, now)
+
+	keys := s.Keys()
+	assert.Len(t, keys, 3)
+	assert.ElementsMatch(t, []string{"audio.drops.src1", "audio.drops.src2", "stream.restarts.abc"}, keys)
+}
+
+func TestHealthMetricsStore_KeysWithPrefix(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	now := time.Now()
+
+	s.RecordAt("audio.drops.src1", 1, now)
+	s.RecordAt("audio.drops.src2", 1, now)
+	s.RecordAt("audio.overruns.src1", 1, now)
+	s.RecordAt("stream.restarts.abc", 1, now)
+
+	keys := s.KeysWithPrefix("audio.drops.")
+	assert.Len(t, keys, 2)
+	assert.ElementsMatch(t, []string{"audio.drops.src1", "audio.drops.src2"}, keys)
+}
+
+func TestHealthMetricsStore_LifetimeTotal(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	s.RecordAt("m", 10, base)
+	s.RecordAt("m", 20, base.Add(time.Hour))
+	s.RecordAt("m", 30, base.Add(2*time.Hour))
+
+	assert.Equal(t, int64(60), s.LifetimeTotal("m"))
+	assert.Equal(t, int64(0), s.LifetimeTotal("nonexistent"))
+}
+
+func TestHealthMetricsStore_SumUnknownKey(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	assert.Equal(t, int64(0), s.Sum("nonexistent", time.Hour))
+}
+
+func TestHealthMetricsStore_BucketsUnknownKey(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	assert.Nil(t, s.Buckets("nonexistent", 10))
+}
+
+func TestHealthMetricsStore_LatestBucketTime(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	now := time.Date(2026, 5, 24, 10, 30, 0, 0, time.UTC)
+
+	assert.True(t, s.LatestBucketTime("missing").IsZero())
+
+	s.RecordAt("m", 5, now)
+	assert.Equal(t, bucketStart(now), s.LatestBucketTime("m"))
+}
+
+func TestHealthMetricsStore_SameHourAggregation(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	s.RecordAt("m", 5, base)
+	s.RecordAt("m", 3, base.Add(15*time.Minute))
+	s.RecordAt("m", 2, base.Add(45*time.Minute))
+
+	buckets := s.Buckets("m", 10)
+	require.Len(t, buckets, 1)
+	assert.Equal(t, int64(10), buckets[0].Count)
+}
+
+func TestHealthMetricsStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	now := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := fmt.Sprintf("metric.%d", n%5)
+			s.RecordAt(key, 1, now.Add(time.Duration(n)*time.Minute))
+			_ = s.SumAt(key, time.Hour, now.Add(time.Hour))
+			_ = s.Buckets(key, 10)
+			_ = s.LastEventTime(key)
+			_ = s.Keys()
+		}(i)
+	}
+	wg.Wait()
+
+	var total int64
+	for i := range 5 {
+		total += s.SumAt(fmt.Sprintf("metric.%d", i), 24*time.Hour, now.Add(24*time.Hour))
+	}
+	assert.Equal(t, int64(100), total)
+}
+
+func TestHealthMetricsStore_Buckets_ChronologicalOrder(t *testing.T) {
+	t.Parallel()
+	s := NewHealthMetricsStore()
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	s.RecordAt("m", 1, base)
+	s.RecordAt("m", 2, base.Add(time.Hour))
+	s.RecordAt("m", 3, base.Add(2*time.Hour))
+
+	buckets := s.Buckets("m", 3)
+	require.Len(t, buckets, 3)
+	assert.True(t, buckets[0].Start.Before(buckets[1].Start))
+	assert.True(t, buckets[1].Start.Before(buckets[2].Start))
+	assert.Equal(t, int64(1), buckets[0].Count)
+	assert.Equal(t, int64(3), buckets[2].Count)
+}


### PR DESCRIPTION
## Summary

Replaces cumulative lifetime counter evaluation in health checks with time-windowed evaluation. A past burst of errors no longer marks the system as Critical forever until restart. The System Health page is also redesigned to match the visual language of the System Overview page.

### Backend

- New `HealthMetricsStore` with hourly bucket aggregation (168 slots, ~40 KB for 10 metrics, 7-day retention)
- New `HealthEventBuffer` ring buffer for recent health events
- Extended `observability.Collector` with health counter collection: delta computation, counter reset handling, source removal cleanup
- New `WindowedCheck` interface plus `Registry.RunAllWithWindow`
- New `evalWindowedStats` helper with sparkline generation, stale-source exclusion, temporal message formatting
- Updated `BufferDropsCheck`, `BufferOverrunCheck`, `StreamErrorRateCheck` to use windowed evaluation with per-window thresholds (drops: 10/100, overruns: 10/50, restarts: 3/10)
- New `?window=` query parameter on `/api/v2/system/diagnostics/run` (15m, 30m, 1h, 6h, 24h, 7d; default 1h)
- Shared metric prefix constants for collector/check consistency

### Frontend

- Auto-runs diagnostics on page mount; no manual button click required
- Replaced decorative hero card and separate summary card with a single status metric strip (Healthy / Warning / Critical / Skipped) plus a Diagnostics control card, matching the System Overview design language
- Segmented window selector persists to localStorage
- Inline SVG sparkline (24 hourly bars, colored by status) on counter-based check rows
- Expandable detail panel with "Last event" callout and recent events table
- Compact icon-only refresh button with last-run timestamp
- Full i18n: 22 new translation keys, fully translated across all 15 locales

### Resource budget

| Resource | Cost |
|----------|------|
| HealthMetricsStore (7d hourly buckets, 10 metrics) | ~40 KB |
| Health event ring buffers (3 types x 100) | ~30 KB |
| CPU | Existing collector goroutine, no new goroutine |
| API response size | +2-4 KB per counter check |

## Test plan

- [x] Unit tests: 193 tests pass (\`go test -race ./internal/health/... ./internal/observability/\`)
- [x] Lint clean: \`golangci-lint run\` zero issues
- [x] Frontend: \`svelte-check\` zero errors / zero warnings
- [x] i18n in sync across all 15 locales
- [x] Deployed to a test system (rpi5, Pi 5 with audio_card source) and verified visually: metric cards render, status counts accurate, sparkline visible on Buffer Drops after injecting drops, window selector switches and re-runs diagnostics, expandable detail panel shows recent events
- [ ] Visually verify on a system with multiple RTSP streams and accumulating errors over a multi-hour window
- [ ] Verify 7d window response payload size stays under the existing diagnostics report budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned System Health UI with a status metric strip and collapsible per-check rows.
  * Time-window selector (15m–7d) that persists selection and refreshes diagnostics.
  * Sparklines, “last event” callouts, recent-events table, and richer expanded detail panels.
  * Actions: refresh, copy-to-clipboard, and explicit JSON download for diagnostics reports.

* **Localization**
  * Updated System Health translations across multiple languages to support the new UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->