### PR TITLE
fix(classifier): use current settings in ReloadModel to fix stale locale

### DIFF
--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -231,9 +231,7 @@ func (c *Controller) initHLSRoutes() {
 // to take effect immediately without a server restart.
 func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		c.settingsMutex.RLock()
-		isPublic := c.Settings.Security.PublicAccess.LiveAudio
-		c.settingsMutex.RUnlock()
+		isPublic := c.currentSettings().Security.PublicAccess.LiveAudio
 		if isPublic {
 			return next(ctx)
 		}
@@ -953,7 +951,7 @@ func (c *Controller) setHLSHeaders(ctx echo.Context) {
 
 // getEffectiveSegmentLength returns the configured segment length with defaults and limits applied
 func (c *Controller) getEffectiveSegmentLength() int {
-	segmentLength := c.Settings.WebServer.LiveStream.SegmentLength
+	segmentLength := c.currentSettings().WebServer.LiveStream.SegmentLength
 	switch {
 	case segmentLength < hlsMinSegmentLen:
 		return hlsDefaultSegmentLen // Default
@@ -1125,7 +1123,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	}
 
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
-	ffmpegPath := c.Settings.Realtime.Audio.FfmpegPath
+	ffmpegPath := c.currentSettings().Realtime.Audio.FfmpegPath
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegPath); err != nil {
 		streamCancel()
 		return nil, fmt.Errorf("invalid FFmpeg path: %w", err)
@@ -1323,7 +1321,7 @@ func (c *Controller) setupHLSFFmpeg(ctx context.Context, ffmpegPath, inputSource
 
 // buildFFmpegArgs constructs FFmpeg command line arguments
 func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string) []string {
-	settings := c.Settings.WebServer.LiveStream
+	settings := c.currentSettings().WebServer.LiveStream
 
 	// Apply defaults and limits
 	bitrate := 128
@@ -1583,8 +1581,9 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	consumerID := fmt.Sprintf("hls_%s_%s", privacy.SanitizeStreamUrl(sourceID), uuid.New().String()[:8])
 	// Use the configured live stream sample rate, falling back to the default HLS sample rate.
 	sampleRate := hlsDefaultSampleRate
-	if c.Settings.WebServer.LiveStream.SampleRate > 0 {
-		sampleRate = c.Settings.WebServer.LiveStream.SampleRate
+	liveStream := c.currentSettings().WebServer.LiveStream
+	if liveStream.SampleRate > 0 {
+		sampleRate = liveStream.SampleRate
 	}
 
 	consumer := &hlsConsumer{

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -942,18 +942,20 @@ func (bn *BirdNET) ReloadModel() error {
 	defer bn.mu.Unlock()
 	bn.Debug("Acquired mutex for model reload")
 
+	// Get fresh settings so sub-methods see the latest config.
+	fresh := bn.currentSettings()
+	settingsCopy := *fresh
+	oldSettings := bn.Settings
+	bn.Settings = &settingsCopy
+
 	// Snapshot all mutable state for transactional rollback on failure.
 	oldClassifier := bn.classifier
 	oldRangeFilter := bn.rangeFilter
 	oldModelInfo := bn.ModelInfo
 	oldTaxonomyMap := bn.TaxonomyMap
 	oldScientificIndex := bn.ScientificIndex
-	oldLabels := slices.Clone(bn.Settings.BirdNET.Labels)
-	oldLocale := bn.Settings.BirdNET.Locale
 
 	rollback := func() {
-		// Close any newly created backends that differ from the originals
-		// to avoid leaking resources during failed reloads
 		if bn.classifier != nil && bn.classifier != oldClassifier {
 			bn.classifier.Close()
 		}
@@ -965,11 +967,10 @@ func (bn *BirdNET) ReloadModel() error {
 		bn.ModelInfo = oldModelInfo
 		bn.TaxonomyMap = oldTaxonomyMap
 		bn.ScientificIndex = oldScientificIndex
-		bn.Settings.BirdNET.Labels = oldLabels
-		bn.Settings.BirdNET.Locale = oldLocale
+		bn.Settings = oldSettings
 	}
 
-	// Check if model version changed — if so, the orchestrator must handle
+	// Check if model version changed; if so, the orchestrator must handle
 	// the switch via pipeline cold restart, not ReloadModel.
 	if bn.Settings.BirdNET.Version != "" {
 		newInfo, ok := ResolveBirdNETVersion(bn.Settings.BirdNET.Version)

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -62,9 +62,15 @@ type Orchestrator struct {
 	scheduler atomic.Pointer[nighttimeScheduler]
 }
 
+// currentSettings returns the latest settings snapshot so hot-reloaded
+// values (threads, locale, etc.) take effect without restarting.
+func (o *Orchestrator) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(o.Settings)
+}
+
 // NewOrchestrator creates a new Orchestrator with BirdNET as the primary model
 // and loads any additional models from configuration.
-// This is the primary constructor — callers should use this instead of NewBirdNET.
+// This is the primary constructor - callers should use this instead of NewBirdNET.
 func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// Resolve primary model identity from config
 	var primaryInfo *ModelInfo
@@ -786,7 +792,7 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 
 	// Give the new model the full thread budget. Inference is serialized by
 	// inferenceMu so concurrent CPU contention cannot occur.
-	dynamicThreads := o.Settings.BirdNET.Threads
+	dynamicThreads := o.currentSettings().BirdNET.Threads
 	if dynamicThreads <= 0 {
 		dynamicThreads = runtime.NumCPU()
 	}


### PR DESCRIPTION
## Summary

- Fix stale `bn.Settings` pointer reads in `ReloadModel()` by snapshotting `currentSettings()` into a shallow copy at the top of the method; all sub-methods (loadLabels, loadModel, initializeModel, etc.) now see fresh config values
- Add `currentSettings()` method to `Orchestrator` and fix thread count read in dynamic `LoadModel()`
- Replace 5 stale `c.Settings` reads in HLS streaming (`audio_hls.go`) with `c.currentSettings()`, including removing a now-redundant mutex lock in `publicLiveAudioAuth`

Fixes #3232

## Test plan

- [x] `go test -race ./internal/classifier/...` (2630 tests pass)
- [x] `go test -race ./internal/api/v2/...` (included above)
- [x] `golangci-lint run -v` (zero issues)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic handling of configuration settings for audio streaming and model loading, ensuring that configuration changes are reflected more promptly without requiring server restarts.

* **Chores**
  * Internal updates to settings management to use live configuration snapshots instead of static snapshots across audio, classifier, and orchestrator components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->