### PR TITLE
feat(api): add hot-reload detectors for 5 settings gaps

### DIFF
--- a/internal/analysis/api_service.go
+++ b/internal/analysis/api_service.go
@@ -301,6 +301,16 @@ func (s *APIServerService) SunCalc() *suncalc.SunCalc {
 	return s.sunCalc
 }
 
+// ReconfigureMonitoring stops the current SystemMonitor (if any) and recreates
+// it from current settings. Called by ControlMonitor on hot-reload.
+func (s *APIServerService) ReconfigureMonitoring() {
+	if s.systemMonitor != nil {
+		s.systemMonitor.Stop()
+		s.systemMonitor = nil
+	}
+	s.systemMonitor = initializeSystemMonitor(conf.Setting())
+}
+
 // initializeBackupSystem sets up the backup manager and scheduler.
 func initializeBackupSystem(settings *conf.Settings, backupLog logger.Logger) (*backup.Manager, *backup.Scheduler, error) {
 	backupLog.Info("Initializing backup system...")

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -364,8 +364,9 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 		p.reconfigureChangedSources(apiAudioLevelChan)
 	}
 	reconfigureSoundLevelFn := p.ReconfigureSoundLevel
+	reconfigureMonitoringFn := p.apiService.ReconfigureMonitoring
 	apiController := p.apiService.APIController()
-	p.ctrlMonitor = NewControlMonitor(&p.wg, p.apiService.ControlChan(), p.done, p.restartChan, p.bufferMgr, proc, apiAudioLevelChan, p.soundLevelChan, apiController, metrics, p.quietHoursScheduler, p.engine, reconfigureFn, reconfigureSoundLevelFn)
+	p.ctrlMonitor = NewControlMonitor(&p.wg, p.apiService.ControlChan(), p.done, p.restartChan, p.bufferMgr, proc, apiAudioLevelChan, p.soundLevelChan, apiController, metrics, p.quietHoursScheduler, p.engine, reconfigureFn, reconfigureSoundLevelFn, reconfigureMonitoringFn)
 	p.ctrlMonitor.Start()
 
 	// Start restart loop goroutine.

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -27,6 +27,13 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
+const (
+	signalReconfigureLogDeduplication = "reconfigure_log_deduplication"
+	signalReconfigureRTSPHealth       = "reconfigure_rtsp_health"
+	signalReconfigureMonitoring       = "reconfigure_monitoring"
+	signalReconfigureLivestream       = "reconfigure_livestream"
+)
+
 // ControlMonitor handles control signals for realtime analysis mode
 type ControlMonitor struct {
 	wg             *sync.WaitGroup
@@ -268,14 +275,14 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleQuietHoursStartSoundCard()
 	case "reconfigure_bat_filter":
 		cm.handleReconfigureBatFilter()
-	case "reconfigure_log_deduplication":
+	case signalReconfigureLogDeduplication:
 		cm.handleReconfigureLogDeduplication()
-	case "reconfigure_rtsp_health":
+	case signalReconfigureRTSPHealth:
 		cm.handleReconfigureStreams()
 		emitHotReload("rtsp_health")
-	case "reconfigure_monitoring":
+	case signalReconfigureMonitoring:
 		cm.handleReconfigureMonitoring()
-	case "reconfigure_livestream":
+	case signalReconfigureLivestream:
 		cm.handleReconfigureLiveStream()
 	default:
 		GetLogger().Warn("Received unknown control signal", logger.String("signal", signal))

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -53,6 +53,10 @@ type ControlMonitor struct {
 	// the downstream publisher via soundLevelManager.
 	reconfigureSoundLevelFn func()
 
+	// reconfigureMonitoringFn stops and recreates the SystemMonitor from current
+	// settings. Provided by APIServerService because it owns the monitor lifecycle.
+	reconfigureMonitoringFn func()
+
 	// Sound level manager for lifecycle management
 	soundLevelManager *SoundLevelManager
 
@@ -78,7 +82,11 @@ type ControlMonitor struct {
 // sound level manager is restarted so that router routes exist when the
 // publisher starts (enable) or are gone before the publisher stops (disable).
 // May be nil in contexts where no sound level pipeline is owned.
-func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, restartChan chan struct{}, bufferManager *BufferManager, proc *processor.Processor, audioLevelChan chan audiocore.AudioLevelData, soundLevelChan chan soundlevel.SoundLevelData, apiController *apiv2.Controller, metrics *observability.Metrics, quietHoursScheduler *schedule.QuietHoursScheduler, audioEngine *engine.AudioEngine, reconfigureSourcesFn, reconfigureSoundLevelFn func()) *ControlMonitor {
+//
+// reconfigureMonitoringFn stops and recreates the SystemMonitor from current
+// settings. Provided by APIServerService because it owns the monitor lifecycle.
+// May be nil in contexts where no system monitor is owned.
+func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, restartChan chan struct{}, bufferManager *BufferManager, proc *processor.Processor, audioLevelChan chan audiocore.AudioLevelData, soundLevelChan chan soundlevel.SoundLevelData, apiController *apiv2.Controller, metrics *observability.Metrics, quietHoursScheduler *schedule.QuietHoursScheduler, audioEngine *engine.AudioEngine, reconfigureSourcesFn, reconfigureSoundLevelFn, reconfigureMonitoringFn func()) *ControlMonitor {
 	cm := &ControlMonitor{
 		wg:                      wg,
 		controlChan:             controlChan,
@@ -95,6 +103,7 @@ func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, re
 		engine:                  audioEngine,
 		reconfigureSourcesFn:    reconfigureSourcesFn,
 		reconfigureSoundLevelFn: reconfigureSoundLevelFn,
+		reconfigureMonitoringFn: reconfigureMonitoringFn,
 	}
 
 	// Initialize the sound level manager but don't start it yet
@@ -259,6 +268,15 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleQuietHoursStartSoundCard()
 	case "reconfigure_bat_filter":
 		cm.handleReconfigureBatFilter()
+	case "reconfigure_log_deduplication":
+		cm.handleReconfigureLogDeduplication()
+	case "reconfigure_rtsp_health":
+		cm.handleReconfigureStreams()
+		emitHotReload("rtsp_health")
+	case "reconfigure_monitoring":
+		cm.handleReconfigureMonitoring()
+	case "reconfigure_livestream":
+		cm.handleReconfigureLiveStream()
 	default:
 		GetLogger().Warn("Received unknown control signal", logger.String("signal", signal))
 	}
@@ -270,6 +288,31 @@ func (cm *ControlMonitor) handleReconfigureBatFilter() {
 		cm.bn.ReloadBatFilter()
 		emitHotReload("bat_filter")
 	}
+}
+
+// handleReconfigureLogDeduplication reinitializes the log deduplicator from current settings.
+func (cm *ControlMonitor) handleReconfigureLogDeduplication() {
+	if cm.proc == nil {
+		return
+	}
+	cm.proc.ReconfigureLogDeduplicator()
+	emitHotReload("log_deduplication")
+}
+
+// handleReconfigureMonitoring stops and recreates the SystemMonitor from current settings.
+func (cm *ControlMonitor) handleReconfigureMonitoring() {
+	if cm.reconfigureMonitoringFn != nil {
+		cm.reconfigureMonitoringFn()
+	}
+	emitHotReload("monitoring")
+}
+
+// handleReconfigureLiveStream restarts active HLS streams so they pick up new settings.
+func (cm *ControlMonitor) handleReconfigureLiveStream() {
+	if cm.apiController != nil {
+		cm.apiController.RestartHLSStreams()
+	}
+	emitHotReload("livestream")
 }
 
 // handleRebuildRangeFilter rebuilds the range filter

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -2336,6 +2336,12 @@ func (p *Processor) GetBackupScheduler() any {
 	return p.backupScheduler
 }
 
+// ReconfigureLogDeduplicator reinitializes the log deduplicator from current settings.
+func (p *Processor) ReconfigureLogDeduplicator() {
+	settings := p.currentSettings()
+	p.logDedup = initLogDeduplicator(settings)
+}
+
 // CleanupLogDeduplicator removes stale log deduplication entries to prevent memory growth.
 // Returns the number of entries removed.
 func (p *Processor) CleanupLogDeduplicator(staleAfter time.Duration) int {

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -129,7 +129,8 @@ type Processor struct {
 	backupMutex     sync.RWMutex
 
 	// Log deduplication (extracted to separate type for SRP)
-	logDedup *LogDeduplicator // Handles log deduplication logic
+	logDedupMu sync.RWMutex
+	logDedup   *LogDeduplicator
 
 	// Periodic pipeline stats (inference activity per source/model)
 	pipelineStats *PipelineStats
@@ -2339,16 +2340,22 @@ func (p *Processor) GetBackupScheduler() any {
 // ReconfigureLogDeduplicator reinitializes the log deduplicator from current settings.
 func (p *Processor) ReconfigureLogDeduplicator() {
 	settings := p.currentSettings()
-	p.logDedup = initLogDeduplicator(settings)
+	newDedup := initLogDeduplicator(settings)
+	p.logDedupMu.Lock()
+	p.logDedup = newDedup
+	p.logDedupMu.Unlock()
 }
 
 // CleanupLogDeduplicator removes stale log deduplication entries to prevent memory growth.
 // Returns the number of entries removed.
 func (p *Processor) CleanupLogDeduplicator(staleAfter time.Duration) int {
-	if p.logDedup == nil {
+	p.logDedupMu.RLock()
+	dedup := p.logDedup
+	p.logDedupMu.RUnlock()
+	if dedup == nil {
 		return 0
 	}
-	removed := p.logDedup.Cleanup(staleAfter)
+	removed := dedup.Cleanup(staleAfter)
 	if removed > 0 {
 		GetLogger().Debug("Cleaned stale log deduplication entries",
 			logger.Int("removed_count", removed),
@@ -2527,13 +2534,14 @@ func (p *Processor) ShutdownWithContext(ctx context.Context) error {
 // This prevents ~40,000+ identical "filtered_detections_count:0" logs per day
 // while still allowing debug-mode visibility into the detection pipeline.
 func (p *Processor) logDetectionResults(source string, rawCount, filteredCount int) {
-	// Guard against nil logDedup (can occur in tests or partial initialization)
-	if p.logDedup == nil {
+	p.logDedupMu.RLock()
+	dedup := p.logDedup
+	p.logDedupMu.RUnlock()
+	if dedup == nil {
 		return
 	}
 
-	// Use the LogDeduplicator to determine if we should log
-	shouldLog, reason := p.logDedup.ShouldLog(source, rawCount, filteredCount)
+	shouldLog, reason := dedup.ShouldLog(source, rawCount, filteredCount)
 
 	if shouldLog {
 		// Log all processing results at DEBUG level to avoid flooding console.

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1964,6 +1964,17 @@ func (c *Controller) cleanupExistingHLSStream(sourceID string) {
 	}
 }
 
+// RestartHLSStreams stops all active HLS streams so they restart with fresh settings.
+func (c *Controller) RestartHLSStreams() {
+	hlsMgr.streamsMu.Lock()
+	sourceIDs := slices.Collect(maps.Keys(hlsMgr.streams))
+	hlsMgr.streamsMu.Unlock()
+
+	for _, id := range sourceIDs {
+		c.stopHLSStream(id, "settings changed")
+	}
+}
+
 // stopHLSStream stops a stream with a specific reason
 func (c *Controller) stopHLSStream(sourceID, reason string) {
 	hlsMgr.streamsMu.Lock()

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -136,7 +136,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// -- LogDeduplication --
 	"Realtime.LogDeduplication": {
 		categories: []hotReloadCategory{hotReloadFresh},
-		todoAction: "reconfigure_log_deduplication",
+		action:     "reconfigure_log_deduplication",
 	},
 
 	// -- Birdweather --
@@ -166,7 +166,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Realtime.RTSP.Transport":            {categories: []hotReloadCategory{hotReloadRuntime}},
 	"Realtime.RTSP.Health": {
 		categories: []hotReloadCategory{hotReloadFresh},
-		todoAction: "reconfigure_rtsp_health",
+		action:     "reconfigure_rtsp_health",
 	},
 	"Realtime.RTSP.FFmpegParameters": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_rtsp_sources"},
 
@@ -182,7 +182,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Realtime.MQTT.TLS":           {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_mqtt"},
 	"Realtime.MQTT.HomeAssistant": {
 		categories: []hotReloadCategory{hotReloadFresh},
-		todoAction: "reconfigure_mqtt",
+		action:     "reconfigure_mqtt",
 	},
 
 	// -- Telemetry --
@@ -191,7 +191,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// -- Monitoring --
 	"Realtime.Monitoring": {
 		categories: []hotReloadCategory{hotReloadFresh},
-		todoAction: "reconfigure_monitoring",
+		action:     "reconfigure_monitoring",
 	},
 
 	// -- Species --
@@ -217,7 +217,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"WebServer.AllowEmbedding": {categories: []hotReloadCategory{hotReloadFresh}},
 	"WebServer.LiveStream": {
 		categories: []hotReloadCategory{hotReloadFresh},
-		todoAction: "reconfigure_livestream",
+		action:     "reconfigure_livestream",
 	},
 	"WebServer.EnableTerminal": {categories: []hotReloadCategory{hotReloadNotify}},
 
@@ -241,7 +241,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 }
 
 // Ceiling decreases as TODO actions are implemented; target is zero.
-const maxTodoActions = 5
+const maxTodoActions = 0
 
 // TestSettingsHotReloadCoverage ensures every leaf field in conf.Settings has
 // a declared hot-reload behavior in the registry. Fails CI when a new field

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2149,6 +2149,10 @@ var settingsChangeChecks = []settingsChangeCheck{
 	{"Quiet hours", schedule.SignalReconfigureQuietHours, quietHoursSettingsChanged, "Updating quiet hours schedule...", "", "info", toastDurationShort},
 	{"Web server", "", webserverSettingsChanged, "Web server settings changed. Restart required to apply.", notification.MsgSettingsWebserverRestart, "warning", toastDurationExtended},
 	{"Bat filter", "reconfigure_bat_filter", batFilterSettingsChanged, "", "", "", 0},
+	{"Log deduplication", "reconfigure_log_deduplication", logDeduplicationSettingsChanged, "Reconfiguring log deduplication...", "", "info", toastDurationShort},
+	{"RTSP health", "reconfigure_rtsp_health", rtspHealthSettingsChanged, "Reconfiguring RTSP health monitoring...", "", "info", toastDurationShort},
+	{"Monitoring", "reconfigure_monitoring", monitoringSettingsChanged, "Reconfiguring system monitoring...", "", "info", toastDurationShort},
+	{"Live stream", "reconfigure_livestream", liveStreamSettingsChanged, "Reconfiguring live stream settings...", "", "info", toastDurationShort},
 }
 
 // handleSettingsChanges checks if important settings have changed and triggers appropriate actions
@@ -2299,7 +2303,7 @@ func mqttSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 	newMQTT := currentSettings.Realtime.MQTT
 
 	// Check for changes in MQTT settings
-	return oldMQTT.Enabled != newMQTT.Enabled ||
+	if oldMQTT.Enabled != newMQTT.Enabled ||
 		oldMQTT.Broker != newMQTT.Broker ||
 		oldMQTT.Topic != newMQTT.Topic ||
 		oldMQTT.Username != newMQTT.Username ||
@@ -2308,7 +2312,15 @@ func mqttSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 		oldMQTT.TLS.InsecureSkipVerify != newMQTT.TLS.InsecureSkipVerify ||
 		oldMQTT.TLS.CACert != newMQTT.TLS.CACert ||
 		oldMQTT.TLS.ClientCert != newMQTT.TLS.ClientCert ||
-		oldMQTT.TLS.ClientKey != newMQTT.TLS.ClientKey
+		oldMQTT.TLS.ClientKey != newMQTT.TLS.ClientKey {
+		return true
+	}
+
+	if !reflect.DeepEqual(oldMQTT.HomeAssistant, newMQTT.HomeAssistant) {
+		return true
+	}
+
+	return false
 }
 
 // streamsSettingsChanged checks if stream settings have changed in a way that
@@ -2513,6 +2525,26 @@ func batFilterSettingsChanged(oldSettings, currentSettings *conf.Settings) bool 
 	return oldSettings.Bat.FilterEnabled != currentSettings.Bat.FilterEnabled ||
 		oldSettings.Bat.FilterCutoffHz != currentSettings.Bat.FilterCutoffHz ||
 		oldSettings.Bat.FilterPassCount != currentSettings.Bat.FilterPassCount
+}
+
+// logDeduplicationSettingsChanged checks if log deduplication settings have changed.
+func logDeduplicationSettingsChanged(old, current *conf.Settings) bool {
+	return old.Realtime.LogDeduplication != current.Realtime.LogDeduplication
+}
+
+// rtspHealthSettingsChanged checks if RTSP health monitoring settings have changed.
+func rtspHealthSettingsChanged(old, current *conf.Settings) bool {
+	return old.Realtime.RTSP.Health != current.Realtime.RTSP.Health
+}
+
+// monitoringSettingsChanged checks if system monitoring settings have changed.
+func monitoringSettingsChanged(old, current *conf.Settings) bool {
+	return !reflect.DeepEqual(old.Realtime.Monitoring, current.Realtime.Monitoring)
+}
+
+// liveStreamSettingsChanged checks if live stream settings have changed.
+func liveStreamSettingsChanged(old, current *conf.Settings) bool {
+	return old.WebServer.LiveStream != current.WebServer.LiveStream
 }
 
 // LocaleData represents a locale with its code and full name


### PR DESCRIPTION
## Summary

- Add detectors and handlers for 5 settings that were saved to disk but had no runtime effect: LogDeduplication, RTSP Health, MQTT HomeAssistant, Monitoring, LiveStream
- Convert all 5 `todoAction` entries to `action` in the hot-reload coverage registry, bringing `maxTodoActions` from 5 to 0
- Use callback pattern (`reconfigureMonitoringFn`) for SystemMonitor lifecycle, consistent with existing `reconfigureSourcesFn`

## Test plan

- [x] `go test -race ./internal/api/v2/... ./internal/analysis/...` (3673 tests pass)
- [x] `TestSettingsHotReloadCoverage` passes (all fields covered)
- [x] `TestHotReloadRegistryActionsExist` passes (all new actions in detector table)
- [x] `TestTodoActionCeiling` passes with `maxTodoActions = 0`
- [x] `golangci-lint run -v` (zero issues)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System monitoring, log deduplication, RTSP health, and HLS livestream settings can be reconfigured at runtime and applied without restarting services.
  * Added a way to restart active HLS streams when livestream settings change.

* **Reliability / Bug Fixes**
  * Log-deduplication access made thread-safe to prevent races during reconfiguration.

* **Tests**
  * Hot-reload coverage tests tightened to require implemented actions (no TODOs allowed).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->