### PR TITLE
fix: allow running under arbitrary UID

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -81,8 +81,8 @@ else
     # Just ensure directories exist (permissions already set in Dockerfile)
     mkdir -p /config /data/clips /data/models 2>/dev/null || true
 
-    # Use current user
-    USER_NAME=$(whoami)
+    # K8s/OpenShift arbitrary-UID pods have no /etc/passwd entry, so id -un fails
+    USER_NAME=$(id -un 2>/dev/null || echo "uid-${CURRENT_UID}")
     echo "Running as user: $USER_NAME"
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup to reliably detect the effective user in rootless and arbitrary-UID environments (e.g., Kubernetes/OpenShift), adding a robust fallback for cases where standard user info is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->