### PR TITLE
feat(alerting): allow users to match exact value lists in rules

### DIFF
--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -2647,6 +2647,8 @@ export type TranslationKey =
   | 'settings.alerts.schema.properties.broker'
   | 'settings.alerts.schema.operators.is'
   | 'settings.alerts.schema.operators.is_not'
+  | 'settings.alerts.schema.operators.in'
+  | 'settings.alerts.schema.operators.not_in'
   | 'settings.alerts.schema.operators.contains'
   | 'settings.alerts.schema.operators.not_contains'
   | 'settings.alerts.schema.operators.greater_than'

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "je",
           "is_not": "není",
+          "in": "je v seznamu",
+          "not_in": "není v seznamu",
           "contains": "obsahuje",
           "not_contains": "neobsahuje",
           "greater_than": "větší než",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "er",
           "is_not": "er ikke",
+          "in": "er på listen",
+          "not_in": "er ikke på listen",
           "contains": "indeholder",
           "not_contains": "indeholder ikke",
           "greater_than": "større end",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "ist",
           "is_not": "ist nicht",
+          "in": "ist in der Liste",
+          "not_in": "ist nicht in der Liste",
           "contains": "enthält",
           "not_contains": "enthält nicht",
           "greater_than": "größer als",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "is",
           "is_not": "is not",
+          "in": "is in list",
+          "not_in": "is not in list",
           "contains": "contains",
           "not_contains": "does not contain",
           "greater_than": "greater than",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "es",
           "is_not": "no es",
+          "in": "está en la lista",
+          "not_in": "no está en la lista",
           "contains": "contiene",
           "not_contains": "no contiene",
           "greater_than": "mayor que",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "on",
           "is_not": "ei ole",
+          "in": "on luettelossa",
+          "not_in": "ei ole luettelossa",
           "contains": "sisältää",
           "not_contains": "ei sisällä",
           "greater_than": "suurempi kuin",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "est",
           "is_not": "n'est pas",
+          "in": "est dans la liste",
+          "not_in": "n'est pas dans la liste",
           "contains": "contient",
           "not_contains": "ne contient pas",
           "greater_than": "supérieur à",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "egyenlő",
           "is_not": "nem egyenlő",
+          "in": "szerepel a listában",
+          "not_in": "nem szerepel a listában",
           "contains": "tartalmazza",
           "not_contains": "nem tartalmazza",
           "greater_than": "nagyobb mint",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "è",
           "is_not": "non è",
+          "in": "è nell'elenco",
+          "not_in": "non è nell'elenco",
           "contains": "contiene",
           "not_contains": "non contiene",
           "greater_than": "maggiore di",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "ir",
           "is_not": "nav",
+          "in": "ir sarakstā",
+          "not_in": "nav sarakstā",
           "contains": "satur",
           "not_contains": "nesatur",
           "greater_than": "lielāks par",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "is",
           "is_not": "is niet",
+          "in": "staat in de lijst",
+          "not_in": "staat niet in de lijst",
           "contains": "bevat",
           "not_contains": "bevat niet",
           "greater_than": "groter dan",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "jest",
           "is_not": "nie jest",
+          "in": "jest na liście",
+          "not_in": "nie jest na liście",
           "contains": "zawiera",
           "not_contains": "nie zawiera",
           "greater_than": "większe niż",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "é",
           "is_not": "não é",
+          "in": "está na lista",
+          "not_in": "não está na lista",
           "contains": "contém",
           "not_contains": "não contém",
           "greater_than": "maior que",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "je",
           "is_not": "nie je",
+          "in": "je v zozname",
+          "not_in": "nie je v zozname",
           "contains": "obsahuje",
           "not_contains": "neobsahuje",
           "greater_than": "väčšie ako",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3946,6 +3946,8 @@
         "operators": {
           "is": "är",
           "is_not": "är inte",
+          "in": "finns i listan",
+          "not_in": "finns inte i listan",
           "contains": "innehåller",
           "not_contains": "innehåller inte",
           "greater_than": "större än",

--- a/internal/alerting/constants.go
+++ b/internal/alerting/constants.go
@@ -50,6 +50,8 @@ const (
 const (
 	OperatorIs             = "is"
 	OperatorIsNot          = "is_not"
+	OperatorIn             = "in"
+	OperatorNotIn          = "not_in"
 	OperatorContains       = "contains"
 	OperatorNotContains    = "not_contains"
 	OperatorGreaterThan    = "greater_than"

--- a/internal/alerting/evaluator.go
+++ b/internal/alerting/evaluator.go
@@ -34,6 +34,10 @@ func evaluateCondition(cond *entities.AlertCondition, properties map[string]any)
 		return strings.EqualFold(propStr, condVal)
 	case OperatorIsNot:
 		return !strings.EqualFold(propStr, condVal)
+	case OperatorIn:
+		return listContains(condVal, propStr)
+	case OperatorNotIn:
+		return !listContains(condVal, propStr)
 	case OperatorContains:
 		return strings.Contains(strings.ToLower(propStr), strings.ToLower(condVal))
 	case OperatorNotContains:
@@ -43,6 +47,28 @@ func evaluateCondition(cond *entities.AlertCondition, properties map[string]any)
 	default:
 		return false
 	}
+}
+
+// listContains checks whether propValue appears in a comma, semicolon, or newline
+// delimited list. Items are trimmed, empty items are skipped, and comparisons are
+// case-insensitive.
+func listContains(listValue, propValue string) bool {
+	if propValue == "" {
+		return false
+	}
+
+	for item := range strings.FieldsFuncSeq(listValue, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\r'
+	}) {
+		trimmed := strings.TrimSpace(item)
+		if trimmed == "" {
+			continue
+		}
+		if strings.EqualFold(trimmed, propValue) {
+			return true
+		}
+	}
+	return false
 }
 
 func evaluateNumeric(operator string, propVal any, condVal string) bool {

--- a/internal/alerting/evaluator_test.go
+++ b/internal/alerting/evaluator_test.go
@@ -13,6 +13,12 @@ func TestEvaluateConditions_EmptyConditions(t *testing.T) {
 }
 
 func TestEvaluateConditions_StringOperators(t *testing.T) {
+	const (
+		commonSpeciesList     = "Turdus migratorius, Sitta carolinensis"
+		bayBreastedWarblerSci = "Setophaga castanea"
+		whiteBreastedNuthatch = "Sitta carolinensis"
+	)
+
 	tests := []struct {
 		name     string
 		operator string
@@ -26,6 +32,18 @@ func TestEvaluateConditions_StringOperators(t *testing.T) {
 		{"is no match", OperatorIs, "species_name", "Eagle", "Robin", false},
 		{"is_not match", OperatorIsNot, "species_name", "Eagle", "Robin", true},
 		{"is_not no match", OperatorIsNot, "species_name", "Robin", "Robin", false},
+		{"in match", OperatorIn, PropertyScientificName, commonSpeciesList, whiteBreastedNuthatch, true},
+		{"in no match", OperatorIn, PropertyScientificName, commonSpeciesList, bayBreastedWarblerSci, false},
+		{"in case insensitive", OperatorIn, PropertyScientificName, commonSpeciesList, "SITTA CAROLINENSIS", true},
+		{"in semicolon separator", OperatorIn, PropertyScientificName, "Turdus migratorius;Sitta carolinensis", whiteBreastedNuthatch, true},
+		{"in newline separator", OperatorIn, PropertyScientificName, "Turdus migratorius\nSitta carolinensis", whiteBreastedNuthatch, true},
+		{"in trims whitespace", OperatorIn, PropertyScientificName, "Turdus migratorius , Sitta carolinensis", whiteBreastedNuthatch, true},
+		{"in empty list", OperatorIn, PropertyScientificName, "", whiteBreastedNuthatch, false},
+		{"in ignores empty list items", OperatorIn, PropertyScientificName, "Turdus migratorius, ,\n", "", false},
+		{"not_in match", OperatorNotIn, PropertyScientificName, commonSpeciesList, bayBreastedWarblerSci, true},
+		{"not_in no match", OperatorNotIn, PropertyScientificName, commonSpeciesList, whiteBreastedNuthatch, false},
+		{"not_in empty list", OperatorNotIn, PropertyScientificName, "", whiteBreastedNuthatch, true},
+		{"not_in ignores empty list items", OperatorNotIn, PropertyScientificName, "Turdus migratorius, ,\n", "", true},
 		{"contains match", OperatorContains, "species_name", "Owl", "Great Horned Owl", true},
 		{"contains case insensitive", OperatorContains, "species_name", "owl", "Great Horned Owl", true},
 		{"contains no match", OperatorContains, "species_name", "Eagle", "Great Horned Owl", false},

--- a/internal/alerting/schema.go
+++ b/internal/alerting/schema.go
@@ -46,7 +46,7 @@ type OperatorSchema struct {
 }
 
 // stringOperators are operators valid for string properties.
-var stringOperators = []string{OperatorIs, OperatorIsNot, OperatorContains, OperatorNotContains}
+var stringOperators = []string{OperatorIs, OperatorIsNot, OperatorIn, OperatorNotIn, OperatorContains, OperatorNotContains}
 
 // numericOperators are operators valid for numeric properties.
 var numericOperators = []string{OperatorGreaterThan, OperatorLessThan, OperatorGreaterOrEqual, OperatorLessOrEqual}
@@ -112,6 +112,8 @@ func GetSchema() Schema {
 		Operators: []OperatorSchema{
 			{Name: OperatorIs, Label: "is", Type: "string"},
 			{Name: OperatorIsNot, Label: "is not", Type: "string"},
+			{Name: OperatorIn, Label: "is in list", Type: "string"},
+			{Name: OperatorNotIn, Label: "is not in list", Type: "string"},
 			{Name: OperatorContains, Label: "contains", Type: "string"},
 			{Name: OperatorNotContains, Label: "does not contain", Type: "string"},
 			{Name: OperatorGreaterThan, Label: "greater than", Type: "number"},

--- a/internal/alerting/schema_test.go
+++ b/internal/alerting/schema_test.go
@@ -55,7 +55,7 @@ func TestGetSchema_AllOperatorsPresent(t *testing.T) {
 		names[i] = op.Name
 	}
 	assert.ElementsMatch(t, []string{
-		OperatorIs, OperatorIsNot, OperatorContains, OperatorNotContains,
+		OperatorIs, OperatorIsNot, OperatorIn, OperatorNotIn, OperatorContains, OperatorNotContains,
 		OperatorGreaterThan, OperatorLessThan, OperatorGreaterOrEqual, OperatorLessOrEqual,
 	}, names)
 }
@@ -63,7 +63,7 @@ func TestGetSchema_AllOperatorsPresent(t *testing.T) {
 func TestGetSchema_PropertiesHaveValidOperators(t *testing.T) {
 	schema := GetSchema()
 	validOps := map[string]bool{
-		OperatorIs: true, OperatorIsNot: true, OperatorContains: true, OperatorNotContains: true,
+		OperatorIs: true, OperatorIsNot: true, OperatorIn: true, OperatorNotIn: true, OperatorContains: true, OperatorNotContains: true,
 		OperatorGreaterThan: true, OperatorLessThan: true, OperatorGreaterOrEqual: true, OperatorLessOrEqual: true,
 	}
 	for _, ot := range schema.ObjectTypes {


### PR DESCRIPTION
## Summary

Adds generic `in` and `not_in` string condition operators for alert rules.

## Rationale

Alert rules can currently match a single string or use broad substring checks. That works for one species name, but it does not cover exact allow/deny lists such as "notify only if the detected species is not in my common-bird list" without creating many near-duplicate rules or relying on fragile `contains` matching. Exact list membership gives rule authors a small reusable primitive for species lists, stream lists, broker names, and similar schema fields.

## Split Feature Context

This PR is intentionally the first small, standalone piece of a broader "interesting bird" alerting workflow. If maintainers are curious where this is going, the stacked follow-up branches are visible in my fork:

- [keithkml/birdnet-go#1](https://github.com/keithkml/birdnet-go/pull/1): exact list operators for alert rules (this PR's fork mirror)
- [keithkml/birdnet-go#2](https://github.com/keithkml/birdnet-go/pull/2): novelty episode metadata for detection alert rules
- [keithkml/birdnet-go#3](https://github.com/keithkml/birdnet-go/pull/3): confidence-step re-alerting for detection rules
- [keithkml/birdnet-go#4](https://github.com/keithkml/birdnet-go/pull/4): novelty reason metadata for alert rules and templates

## Changes

- Defines reusable `in` and `not_in` alert condition operators.
- Evaluates comma, semicolon, and newline separated list values case-insensitively.
- Skips empty list entries after trimming so blank separators cannot match empty properties.
- Documents and tests list parsing edge cases for separators, whitespace, case-insensitivity, empty lists, and empty items.
- Exposes the operators in the alerting schema and covers them with evaluator/schema tests.
- Adds translated schema labels for the new operators in all frontend locale files.

## Screenshots

![Alert rule editor showing the new list operator](https://raw.githubusercontent.com/keithkml/birdnet-go/codex-pr-screenshots/pr-screenshots/pr1-alert-list-operators.png)

## Pi 5 Runtime Validation

I am running this feature series on a Raspberry Pi 5 with live USB audio. For this PR, the relevant live check is that the deployed "Interesting Bird (novelty)" rule uses the new exact list operator to keep common species in comma-delimited exclusion lists instead of many repeated `not_contains` conditions.

```text
$ curl -fsS http://localhost:8080/api/v2/alerts/rules | jq '.rules[] | select(.name=="Interesting Bird (novelty)") | {name, enabled, event_name, list_conditions:[.conditions[] | select(.property=="scientific_name") | {property, operator, value:(.value | split(", ") | .[0:4])}]}'
{
  "name": "Interesting Bird (novelty)",
  "enabled": true,
  "event_name": "detection.occurred",
  "list_conditions": [
    {
      "property": "scientific_name",
      "operator": "not_in",
      "value": ["Turdus migratorius", "Zenaida macroura", "Cardinalis cardinalis", "Cyanocitta cristata"]
    },
    {
      "property": "scientific_name",
      "operator": "not_in",
      "value": ["Haemorhous mexicanus", "Spinus tristis", "Quiscalus quiscula", "Molothrus ater"]
    }
  ]
}

$ curl -fsS 'http://localhost:8080/api/v2/alerts/history?limit=20' | jq -r '.history[] | select(.rule_id==17) | (.event_data|fromjson) | {species_name, scientific_name, confidence, threshold_step} | @json' | head -n 3
{"species_name":"Ring-necked Pheasant","scientific_name":"Phasianus colchicus","confidence":0.93,"threshold_step":0.9}
{"species_name":"Common Raven","scientific_name":"Corvus corax","confidence":0.87,"threshold_step":0.85}
{"species_name":"Eurasian Scops-Owl","scientific_name":"Otus scops","confidence":0.78,"threshold_step":0.75}
```


## Testing

- [x] Go lint passes: `golangci-lint run -v --build-tags=noembed,skipfrontend` with CI-pinned v2.10.1, local TensorFlow Lite CGO paths, and writable local caches reported 0 issues.
- [x] Frontend check exits 0: `npm --prefix frontend run check:all` under Node 24. Caveat: ESLint reports 3 pre-existing warnings in unrelated frontend files.
- [x] Frontend tests pass: `npm --prefix frontend test`, 107 files / 1968 tests.
- [x] i18n sync passes: `npm --prefix frontend run i18n:sync:check`.
- [x] i18n validation exits 0: `npm --prefix frontend run i18n:validate`; existing untranslated-string warnings remain in locale files.
- [x] Focused Go race tests pass: `go test -race ./internal/alerting ./internal/analysis/processor ./internal/analysis/species`.
- [ ] Full Go race suite: `go test -race ./...` was rerun outside the sandbox with local TensorFlow Lite CGO paths. It still fails only in pre-existing, unrelated local-environment cases: `internal/birdweather TestEncodeFlacUsingFFmpeg` expects `/usr/bin/ffmpeg` or `/usr/local/bin/ffmpeg` but this host has FFmpeg at `/opt/homebrew/bin/ffmpeg`, and `internal/monitor TestGroupPathsWithPartitions_MixedRootAndVolumePaths` expects `/dev/sda1` on macOS where the resolver returns `""`.

## Related Issues

None.

## Preflight Status

- Single concern: yes, one alerting evaluator/schema feature.
- Preflight review: completed manually against `.agents/skills/preflight`; fixed the robot-reviewed empty-list-entry edge case, helper documentation, and list parsing edge-case coverage.
- No unrelated changes: diff is limited to alerting operators, schema exposure, translated schema labels, and tests.
- Scope complete: no TODO/FIXME for core functionality.
- Breaking changes: none.
- i18n complete: new schema operator labels are present in all 15 locale files and `types.generated.ts`.
- Secrets/PII: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two alert-rule operators: "is in list" and "is not in list" for list-membership filtering in alert conditions.
* **Localization**
  * Added localized labels for the new operators across multiple locales so the UI displays translated operator names.
* **Tests**
  * Extended unit tests and schema coverage to include the new operators and their expected behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

