### PR TITLE
fix(dashboard): use single-column layout on mobile

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DashboardEditMode.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DashboardEditMode.svelte
@@ -18,6 +18,7 @@
   import { getElementLabel } from '$lib/desktop/features/dashboard/utils/elementLabels';
   import {
     getEffectiveWidth,
+    getResponsiveGridSpanClass,
     SUPPORTS_HALF,
   } from '$lib/desktop/features/dashboard/utils/elementWidths';
   import { api } from '$lib/utils/api';
@@ -272,10 +273,10 @@
     use:dndzone={{ items: editElements, flipDurationMs: 200 }}
     onconsider={handleDndConsider}
     onfinalize={handleDndFinalize}
-    class="relative z-40 grid grid-cols-2 gap-4 pt-16"
+    class="relative z-40 grid grid-cols-1 gap-4 pt-16 md:grid-cols-2"
   >
     {#each editElements as element, index (element.id)}
-      <div class={getEffectiveWidth(element) === 'half' ? 'col-span-1' : 'col-span-2'}>
+      <div class={getResponsiveGridSpanClass(element)}>
         {#if renderSettings && TYPES_WITH_SETTINGS.includes(element.type)}
           {#snippet localSettings()}
             {@render renderSettings(element, elementUpdater(index))}
@@ -308,9 +309,9 @@
   </div>
 {:else}
   <!-- Normal mode: render elements from layout with grid -->
-  <div class="grid grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
     {#each layout.elements.filter(e => e.enabled) as element (element.id ?? element.type)}
-      <div class={getEffectiveWidth(element) === 'half' ? 'col-span-1' : 'col-span-2'}>
+      <div class={getResponsiveGridSpanClass(element)}>
         {@render renderElement(element, false, noopUpdater)}
       </div>
     {/each}

--- a/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import type { DashboardElement } from '$lib/stores/settings';
+import { getEffectiveWidth, getResponsiveGridSpanClass } from './elementWidths';
+
+function element(
+  type: DashboardElement['type'],
+  width?: DashboardElement['width']
+): DashboardElement {
+  return {
+    id: `${type}-test`,
+    type,
+    enabled: true,
+    ...(width ? { width } : {}),
+  };
+}
+
+describe('dashboard element widths', () => {
+  it('keeps full-width-only elements full width even when half is configured', () => {
+    expect(getEffectiveWidth(element('daily-summary', 'half'))).toBe('full');
+    expect(getEffectiveWidth(element('live-spectrogram', 'half'))).toBe('full');
+  });
+
+  it('returns responsive span classes for mobile and wider dashboard grids', () => {
+    expect(getResponsiveGridSpanClass(element('currently-hearing', 'half'))).toBe('col-span-1');
+    expect(getResponsiveGridSpanClass(element('detections-grid'))).toBe('col-span-1 md:col-span-2');
+  });
+});

--- a/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.test.ts
@@ -14,14 +14,25 @@ function element(
   };
 }
 
+const TYPE_DAILY_SUMMARY: DashboardElement['type'] = 'daily-summary';
+const TYPE_LIVE_SPECTROGRAM: DashboardElement['type'] = 'live-spectrogram';
+const TYPE_CURRENTLY_HEARING: DashboardElement['type'] = 'currently-hearing';
+const TYPE_DETECTIONS_GRID: DashboardElement['type'] = 'detections-grid';
+const WIDTH_HALF: DashboardElement['width'] = 'half';
+const EFFECTIVE_WIDTH_FULL: ReturnType<typeof getEffectiveWidth> = 'full';
+const SPAN_HALF = 'col-span-1';
+const SPAN_FULL_RESPONSIVE = 'col-span-1 md:col-span-2';
+
 describe('dashboard element widths', () => {
   it('keeps full-width-only elements full width even when half is configured', () => {
-    expect(getEffectiveWidth(element('daily-summary', 'half'))).toBe('full');
-    expect(getEffectiveWidth(element('live-spectrogram', 'half'))).toBe('full');
+    expect(getEffectiveWidth(element(TYPE_DAILY_SUMMARY, WIDTH_HALF))).toBe(EFFECTIVE_WIDTH_FULL);
+    expect(getEffectiveWidth(element(TYPE_LIVE_SPECTROGRAM, WIDTH_HALF))).toBe(
+      EFFECTIVE_WIDTH_FULL
+    );
   });
 
   it('returns responsive span classes for mobile and wider dashboard grids', () => {
-    expect(getResponsiveGridSpanClass(element('currently-hearing', 'half'))).toBe('col-span-1');
-    expect(getResponsiveGridSpanClass(element('detections-grid'))).toBe('col-span-1 md:col-span-2');
+    expect(getResponsiveGridSpanClass(element(TYPE_CURRENTLY_HEARING, WIDTH_HALF))).toBe(SPAN_HALF);
+    expect(getResponsiveGridSpanClass(element(TYPE_DETECTIONS_GRID))).toBe(SPAN_FULL_RESPONSIVE);
   });
 });

--- a/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
+++ b/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
@@ -11,6 +11,9 @@ export const SUPPORTS_HALF: ReadonlySet<string> = new Set([
   'detections-grid',
 ]);
 
+const GRID_SPAN_HALF = 'col-span-1';
+const GRID_SPAN_FULL_RESPONSIVE = 'col-span-1 md:col-span-2';
+
 /**
  * Returns the effective display width for a dashboard element.
  * Full-width-only types always return 'full'.
@@ -22,5 +25,5 @@ export function getEffectiveWidth(el: DashboardElement): 'full' | 'half' {
 }
 
 export function getResponsiveGridSpanClass(el: DashboardElement): string {
-  return getEffectiveWidth(el) === 'half' ? 'col-span-1' : 'col-span-1 md:col-span-2';
+  return getEffectiveWidth(el) === 'half' ? GRID_SPAN_HALF : GRID_SPAN_FULL_RESPONSIVE;
 }

--- a/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
+++ b/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
@@ -21,10 +21,6 @@ export function getEffectiveWidth(el: DashboardElement): 'full' | 'half' {
   return el.width === 'half' ? 'half' : 'full';
 }
 
-/**
- * Returns responsive grid span classes for dashboard elements.
- * Full-width elements occupy the single mobile column and span both columns from md up.
- */
 export function getResponsiveGridSpanClass(el: DashboardElement): string {
   return getEffectiveWidth(el) === 'half' ? 'col-span-1' : 'col-span-1 md:col-span-2';
 }

--- a/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
+++ b/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
@@ -20,3 +20,11 @@ export function getEffectiveWidth(el: DashboardElement): 'full' | 'half' {
   if (FULL_WIDTH_ONLY.has(el.type)) return 'full';
   return el.width === 'half' ? 'half' : 'full';
 }
+
+/**
+ * Returns responsive grid span classes for dashboard elements.
+ * Full-width elements occupy the single mobile column and span both columns from md up.
+ */
+export function getResponsiveGridSpanClass(el: DashboardElement): string {
+  return getEffectiveWidth(el) === 'half' ? 'col-span-1' : 'col-span-1 md:col-span-2';
+}


### PR DESCRIPTION
## Summary

Fixes the dashboard grid so it stacks into a single column on mobile and keeps the existing two-column layout from `md` upward. Full-width dashboard elements now span the single mobile column and both desktop columns through a shared responsive span helper.

Root cause: `DashboardEditMode` always rendered a two-column grid, so half-width dashboard cards still tried to share narrow mobile rows.

## Screenshots

Mobile, 390px wide:

![Mobile dashboard single-column layout](https://raw.githubusercontent.com/keithkml/birdnet-go/63215381c0165ed91fda1e61163d507de11d35b3/mobile-dashboard-390.png)

Desktop, 1200px wide:

![Desktop dashboard two-column layout](https://raw.githubusercontent.com/keithkml/birdnet-go/63215381c0165ed91fda1e61163d507de11d35b3/desktop-dashboard-1200.png)

## Preflight Status

Preflight quality gate from `.agents/skills/preflight/SKILL.md` was run for this single-fix PR.

- Scope check: one bug fix only, limited to dashboard responsive grid behavior.
- Review passes: reuse, correctness, quality, i18n, and integration wiring found no changed-code issues.
- `npm run check:all`: passed. ESLint emitted existing warnings in unrelated files (`VerificationBadges.svelte`, `MetricStrip.svelte`).
- `npm test -- --run`: passed, 108 files / 1970 tests.
- `golangci-lint run -v`: passed with local TensorFlow Lite CGO headers/libs available.
- `go test -race ./...`: not green locally. After providing the local macOS test environment (`TZ=UTC`, `TMPDIR=/private/tmp`, `FFMPEG_PATH=/opt/homebrew/bin/ffmpeg`, TensorFlow Lite CGO headers/libs), the full run still failed in existing `internal/classifier/TestMemoryLeaks`; the same test passes in isolation.
- `npm run build`: passed, used for screenshot capture.

No API, config, or behavior-breaking changes. No secrets, credentials, or PII in the code diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard layout is now responsive: single-column on small screens and two-column on medium+, with improved spacing in edit mode.
  * Dashboard cards now use a unified responsive width rule so elements display consistently between edit (drag-and-drop) and normal modes.

* **Tests**
  * Added test coverage for dashboard element width and responsive span behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->