### PR TITLE
feat(analysis): allow users to target new and returning species in alert rules

### DIFF
--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -2639,6 +2639,8 @@ export type TranslationKey =
   | 'settings.alerts.schema.properties.species_name'
   | 'settings.alerts.schema.properties.scientific_name'
   | 'settings.alerts.schema.properties.confidence'
+  | 'settings.alerts.schema.properties.days_since_last_seen'
+  | 'settings.alerts.schema.properties.novelty_episode_days'
   | 'settings.alerts.schema.properties.location'
   | 'settings.alerts.schema.properties.stream_name'
   | 'settings.alerts.schema.properties.stream_url'

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3937,6 +3937,8 @@
           "species_name": "Název druhu",
           "scientific_name": "Vědecký název",
           "confidence": "Spolehlivost",
+          "days_since_last_seen": "Dny od posledního pozorování",
+          "novelty_episode_days": "Dny epizody novosti",
           "location": "Poloha",
           "stream_name": "Název streamu",
           "stream_url": "URL streamu",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3937,6 +3937,8 @@
           "species_name": "Artsnavn",
           "scientific_name": "Videnskabeligt navn",
           "confidence": "Tillid",
+          "days_since_last_seen": "Dage siden sidst set",
+          "novelty_episode_days": "Dage i nyhedsepisode",
           "location": "Placering",
           "stream_name": "Strømnavn",
           "stream_url": "Strøm-URL",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3937,6 +3937,8 @@
           "species_name": "Artname",
           "scientific_name": "Wissenschaftlicher Name",
           "confidence": "Konfidenz",
+          "days_since_last_seen": "Tage seit letzter Sichtung",
+          "novelty_episode_days": "Tage der Neuheitsepisode",
           "location": "Standort",
           "stream_name": "Stream-Name",
           "stream_url": "Stream-URL",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3937,6 +3937,8 @@
           "species_name": "Species Name",
           "scientific_name": "Scientific Name",
           "confidence": "Confidence",
+          "days_since_last_seen": "Days Since Last Seen",
+          "novelty_episode_days": "Novelty Episode Days",
           "location": "Location",
           "stream_name": "Stream Name",
           "stream_url": "Stream URL",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3937,6 +3937,8 @@
           "species_name": "Nombre de especie",
           "scientific_name": "Nombre científico",
           "confidence": "Confianza",
+          "days_since_last_seen": "Días desde la última detección",
+          "novelty_episode_days": "Días del episodio de novedad",
           "location": "Ubicación",
           "stream_name": "Nombre del stream",
           "stream_url": "URL del stream",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3937,6 +3937,8 @@
           "species_name": "Lajin nimi",
           "scientific_name": "Tieteellinen nimi",
           "confidence": "Luotettavuus",
+          "days_since_last_seen": "Päiviä edellisestä havainnosta",
+          "novelty_episode_days": "Uutuusjakson päivät",
           "location": "Sijainti",
           "stream_name": "Striimin nimi",
           "stream_url": "Striimin URL",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3937,6 +3937,8 @@
           "species_name": "Nom de l'espèce",
           "scientific_name": "Nom scientifique",
           "confidence": "Confiance",
+          "days_since_last_seen": "Jours depuis la dernière détection",
+          "novelty_episode_days": "Jours de l'épisode de nouveauté",
           "location": "Emplacement",
           "stream_name": "Nom du flux",
           "stream_url": "URL du flux",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3937,6 +3937,8 @@
           "species_name": "Faj neve",
           "scientific_name": "Tudományos név",
           "confidence": "Megbízhatóság",
+          "days_since_last_seen": "Napok az utolsó észlelés óta",
+          "novelty_episode_days": "Újdonsági epizód napjai",
           "location": "Helyszín",
           "stream_name": "Stream neve",
           "stream_url": "Adatfolyam URL",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3937,6 +3937,8 @@
           "species_name": "Nome specie",
           "scientific_name": "Nome scientifico",
           "confidence": "Confidenza",
+          "days_since_last_seen": "Giorni dall'ultimo rilevamento",
+          "novelty_episode_days": "Giorni dell'episodio di novità",
           "location": "Posizione",
           "stream_name": "Nome flusso",
           "stream_url": "URL flusso",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3937,6 +3937,8 @@
           "species_name": "Sugas nosaukums",
           "scientific_name": "Zinātniskais nosaukums",
           "confidence": "Ticamība",
+          "days_since_last_seen": "Dienas kopš pēdējā novērojuma",
+          "novelty_episode_days": "Jaunuma epizodes dienas",
           "location": "Atrašanās vieta",
           "stream_name": "Straumes nosaukums",
           "stream_url": "Straumes URL",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3937,6 +3937,8 @@
           "species_name": "Soortnaam",
           "scientific_name": "Wetenschappelijke naam",
           "confidence": "Betrouwbaarheid",
+          "days_since_last_seen": "Dagen sinds laatst gezien",
+          "novelty_episode_days": "Dagen van nieuwheidsepisode",
           "location": "Locatie",
           "stream_name": "Streamnaam",
           "stream_url": "Stream-URL",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3937,6 +3937,8 @@
           "species_name": "Nazwa gatunku",
           "scientific_name": "Nazwa naukowa",
           "confidence": "Pewność",
+          "days_since_last_seen": "Dni od ostatniego wykrycia",
+          "novelty_episode_days": "Dni epizodu nowości",
           "location": "Lokalizacja",
           "stream_name": "Nazwa strumienia",
           "stream_url": "URL strumienia",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3937,6 +3937,8 @@
           "species_name": "Nome da espécie",
           "scientific_name": "Nome científico",
           "confidence": "Confiança",
+          "days_since_last_seen": "Dias desde a última detecção",
+          "novelty_episode_days": "Dias do episódio de novidade",
           "location": "Localização",
           "stream_name": "Nome do fluxo",
           "stream_url": "URL do fluxo",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3937,6 +3937,8 @@
           "species_name": "Názov druhu",
           "scientific_name": "Vedecký názov",
           "confidence": "Spoľahlivosť",
+          "days_since_last_seen": "Dni od posledného pozorovania",
+          "novelty_episode_days": "Dni epizódy novosti",
           "location": "Poloha",
           "stream_name": "Názov streamu",
           "stream_url": "URL streamu",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3937,6 +3937,8 @@
           "species_name": "Artnamn",
           "scientific_name": "Vetenskapligt namn",
           "confidence": "Konfidens",
+          "days_since_last_seen": "Dagar sedan senast sedd",
+          "novelty_episode_days": "Dagar i nyhetsepisod",
           "location": "Plats",
           "stream_name": "Strömmens namn",
           "stream_url": "Strömmens URL",

--- a/internal/alerting/constants.go
+++ b/internal/alerting/constants.go
@@ -1,6 +1,8 @@
 // Package alerting provides the notification alerting rules engine.
 package alerting
 
+import "github.com/tphakala/birdnet-go/internal/events"
+
 // Object types define the categories of things that can be monitored.
 const (
 	ObjectTypeStream      = "stream"
@@ -75,13 +77,15 @@ const (
 	PropertyBroker         = "broker"
 	PropertyThresholdStep  = "threshold_step"
 
-	// Properties for detection event metadata passthrough.
-	// These are not used for condition evaluation but carry data
-	// needed by the notification adapter for webhook template enrichment.
-	PropertyEventMetadata      = "event_metadata"
-	PropertyEventTimestamp     = "event_timestamp"
-	PropertyDaysSinceFirstSeen = "days_since_first_seen"
-	PropertyIsNewSpecies       = "is_new_species"
+	// Properties for detection event metadata passthrough and optional
+	// alert condition/template data.
+	PropertyEventMetadata       = "event_metadata"
+	PropertyEventTimestamp      = "event_timestamp"
+	PropertyDaysSinceFirstSeen  = "days_since_first_seen"
+	PropertyDaysSinceLastSeen   = events.DetectionMetadataDaysSinceLastSeen
+	PropertyNoveltyEpisodeDays  = events.DetectionMetadataNoveltyEpisodeDays
+	PropertyNoveltyEpisodeStart = events.DetectionMetadataNoveltyEpisodeStart
+	PropertyIsNewSpecies        = "is_new_species"
 )
 
 // Action targets identify where notifications are sent.

--- a/internal/alerting/detection_bridge.go
+++ b/internal/alerting/detection_bridge.go
@@ -7,6 +7,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+var detectionMetadataProperties = []string{
+	PropertyDaysSinceLastSeen,
+	PropertyNoveltyEpisodeDays,
+	PropertyNoveltyEpisodeStart,
+}
+
 // DetectionAlertBridge bridges the events.EventBus detection events to the
 // alerting event bus. It registers as an events.EventConsumer and publishes
 // alert events for each detection.
@@ -59,6 +65,11 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 
 	if meta := event.GetMetadata(); len(meta) > 0 {
 		properties[PropertyEventMetadata] = maps.Clone(meta)
+		for _, propertyName := range detectionMetadataProperties {
+			if value, ok := meta[propertyName]; ok {
+				properties[propertyName] = value
+			}
+		}
 	}
 
 	var newSpeciesProps map[string]any
@@ -70,6 +81,7 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 		ObjectType: ObjectTypeDetection,
 		EventName:  EventDetectionOccurred,
 		Properties: properties,
+		Timestamp:  event.GetTimestamp(),
 	})
 
 	if newSpeciesProps != nil {
@@ -77,6 +89,7 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 			ObjectType: ObjectTypeDetection,
 			EventName:  EventDetectionNewSpecies,
 			Properties: newSpeciesProps,
+			Timestamp:  event.GetTimestamp(),
 		})
 	}
 

--- a/internal/alerting/detection_bridge_test.go
+++ b/internal/alerting/detection_bridge_test.go
@@ -76,6 +76,26 @@ func TestBridge_OrdinaryDetection_EmitsOccurredOnly(t *testing.T) {
 	assert.False(t, result[0].Properties[PropertyIsNewSpecies].(bool))
 }
 
+func TestBridge_DetectionMetadataPromotedForConditions(t *testing.T) {
+	const noveltyEpisodeStart = "2026-05-23T12:00:00Z"
+
+	bridge, mu, captured := setupBridgeWithCapture(t)
+
+	event, err := events.NewDetectionEvent("Bay-breasted Warbler", "Setophaga castanea", 0.86, "mic", false, 30)
+	require.NoError(t, err)
+	event.GetMetadata()[PropertyDaysSinceLastSeen] = 12
+	event.GetMetadata()[PropertyNoveltyEpisodeDays] = 12
+	event.GetMetadata()[PropertyNoveltyEpisodeStart] = noveltyEpisodeStart
+
+	require.NoError(t, bridge.ProcessDetectionEvent(event))
+
+	result := waitForEvents(t, mu, captured, 1)
+	require.Len(t, result, 1)
+	assert.Equal(t, 12, result[0].Properties[PropertyDaysSinceLastSeen])
+	assert.Equal(t, 12, result[0].Properties[PropertyNoveltyEpisodeDays])
+	assert.Equal(t, noveltyEpisodeStart, result[0].Properties[PropertyNoveltyEpisodeStart])
+}
+
 func TestBridge_NewSpecies_EmitsBothEvents(t *testing.T) {
 	bridge, mu, captured := setupBridgeWithCapture(t)
 

--- a/internal/alerting/schema.go
+++ b/internal/alerting/schema.go
@@ -142,6 +142,8 @@ func detectionProperties() []PropertySchema {
 		{Name: PropertySpeciesName, Label: "Species Name", Type: "string", Operators: stringOperators},
 		{Name: PropertyScientificName, Label: "Scientific Name", Type: "string", Operators: stringOperators},
 		{Name: PropertyConfidence, Label: "Confidence", Type: "number", Operators: numericOperators},
+		{Name: PropertyDaysSinceLastSeen, Label: "Days Since Last Seen", Type: "number", Operators: numericOperators},
+		{Name: PropertyNoveltyEpisodeDays, Label: "Novelty Episode Days", Type: "number", Operators: numericOperators},
 		{Name: PropertyLocation, Label: "Location", Type: "string", Operators: stringOperators},
 	}
 }

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
@@ -87,10 +88,11 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	// Check if this is a new species and update atomically to prevent race conditions
 	var isNewSpecies bool
 	var daysSinceFirstSeen int
+	var novelty species.NoveltyStatus
 	if a.NewSpeciesTracker != nil {
 		// Use atomic check-and-update to prevent duplicate "new species" notifications
 		// when multiple detections of the same species arrive concurrently
-		isNewSpecies, daysSinceFirstSeen = a.NewSpeciesTracker.CheckAndUpdateSpecies(a.Result.Species.ScientificName, a.Result.BeginTime)
+		isNewSpecies, daysSinceFirstSeen, novelty = a.NewSpeciesTracker.CheckAndUpdateSpeciesWithNovelty(a.Result.Species.ScientificName, a.Result.BeginTime)
 	}
 
 	// Save detection to database using preferred path
@@ -168,7 +170,7 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	}
 
 	// After successful save, publish detection event to the event bus.
-	a.publishDetectionEvent(isNewSpecies, daysSinceFirstSeen)
+	a.publishDetectionEvent(isNewSpecies, daysSinceFirstSeen, novelty)
 
 	// NOTE: Audio export is intentionally NOT performed here.
 	// It runs as a separate action (SaveAudioAction) outside the CompositeAction
@@ -236,7 +238,7 @@ func (a *DatabaseAction) createDetectionEvent(isNewSpecies bool, daysSinceFirstS
 }
 
 // populateEventMetadata adds location, time, note ID, and image URL to event metadata.
-func (a *DatabaseAction) populateEventMetadata(detectionEvent events.DetectionEvent) {
+func (a *DatabaseAction) populateEventMetadata(detectionEvent events.DetectionEvent, novelty species.NoveltyStatus) {
 	metadata := detectionEvent.GetMetadata()
 	if metadata == nil {
 		GetLogger().Error("Detection event metadata is nil",
@@ -252,12 +254,29 @@ func (a *DatabaseAction) populateEventMetadata(detectionEvent events.DetectionEv
 	metadata["latitude"] = a.Result.Latitude
 	metadata["longitude"] = a.Result.Longitude
 	metadata["begin_time"] = a.Result.BeginTime
+	if hasNoveltyStatus(novelty) {
+		if novelty.DaysSinceLastSeen >= 0 {
+			metadata[events.DetectionMetadataDaysSinceLastSeen] = novelty.DaysSinceLastSeen
+		}
+		if novelty.NoveltyEpisodeActive {
+			metadata[events.DetectionMetadataNoveltyEpisodeDays] = novelty.NoveltyEpisodeDays
+			if !novelty.NoveltyEpisodeStart.IsZero() {
+				metadata[events.DetectionMetadataNoveltyEpisodeStart] = novelty.NoveltyEpisodeStart.Format(time.RFC3339)
+			}
+		}
+	}
 
 	if a.processor != nil && a.processor.BirdImageCache != nil {
 		if birdImage, err := a.processor.BirdImageCache.Get(a.Result.Species.ScientificName); err == nil && birdImage.URL != "" {
 			metadata["image_url"] = birdImage.URL
 		}
 	}
+}
+
+func hasNoveltyStatus(novelty species.NoveltyStatus) bool {
+	// Inactive same-day detections intentionally omit novelty metadata; active
+	// episodes still publish days_since_last_seen=0 for same-day episode repeats.
+	return novelty.NoveltyEpisodeActive || novelty.DaysSinceLastSeen > 0
 }
 
 // recordNotificationSent records that a notification was sent and logs debug info.
@@ -281,7 +300,7 @@ func (a *DatabaseAction) recordNotificationSent(notificationTime time.Time) {
 // publishDetectionEvent publishes a detection event to the event bus.
 // All detections are published so that alert rules on detection.occurred can fire.
 // New species detections additionally go through suppression and notification recording.
-func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirstSeen int) {
+func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirstSeen int, novelty species.NoveltyStatus) {
 	if !events.IsInitialized() {
 		return
 	}
@@ -296,7 +315,7 @@ func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirst
 		if !suppress {
 			detectionEvent := a.createDetectionEvent(true, daysSinceFirstSeen)
 			if detectionEvent != nil {
-				a.populateEventMetadata(detectionEvent)
+				a.populateEventMetadata(detectionEvent, novelty)
 				if published := eventBus.TryPublishDetection(detectionEvent); published {
 					a.recordNotificationSent(notificationTime)
 				}
@@ -312,7 +331,7 @@ func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirst
 		return
 	}
 
-	a.populateEventMetadata(detectionEvent)
+	a.populateEventMetadata(detectionEvent, novelty)
 	eventBus.TryPublishDetection(detectionEvent)
 }
 

--- a/internal/analysis/processor/detection_event_test.go
+++ b/internal/analysis/processor/detection_event_test.go
@@ -173,7 +173,7 @@ func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
 		CorrelationID: "test-ordinary-det",
 	}
 
-	action.publishDetectionEvent(false, 30)
+	action.publishDetectionEvent(false, 30, species.NoveltyStatus{})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
@@ -184,6 +184,67 @@ func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
 	assert.Equal(t, det.Result.Species.CommonName, received[0].GetSpeciesName())
 	assert.Equal(t, det.Result.Species.ScientificName, received[0].GetScientificName())
 	assert.False(t, received[0].IsNewSpecies())
+	metadata := received[0].GetMetadata()
+	assert.NotContains(t, metadata, events.DetectionMetadataDaysSinceLastSeen)
+	assert.NotContains(t, metadata, events.DetectionMetadataNoveltyEpisodeDays)
+}
+
+func TestPublishDetectionEvent_InactiveNoveltyOmitsEpisodeSentinel(t *testing.T) {
+	const inactiveNoveltyEpisodeDays = -1
+
+	consumer := setupEventBusWithConsumer(t)
+
+	det := testDetection()
+	action := &DatabaseAction{
+		Settings:      &conf.Settings{Debug: true},
+		Result:        det.Result,
+		CorrelationID: "test-inactive-novelty",
+	}
+
+	action.publishDetectionEvent(false, 30, species.NoveltyStatus{
+		DaysSinceLastSeen:    0,
+		NoveltyEpisodeDays:   inactiveNoveltyEpisodeDays,
+		NoveltyEpisodeActive: false,
+	})
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		received := consumer.GetReceivedEvents()
+		assert.Len(collect, received, 1)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	metadata := consumer.GetReceivedEvents()[0].GetMetadata()
+	assert.NotContains(t, metadata, events.DetectionMetadataDaysSinceLastSeen)
+	assert.NotContains(t, metadata, events.DetectionMetadataNoveltyEpisodeDays)
+	assert.NotContains(t, metadata, events.DetectionMetadataNoveltyEpisodeStart)
+}
+
+func TestPublishDetectionEvent_ActiveNoveltyIncludesSameDayLastSeen(t *testing.T) {
+	consumer := setupEventBusWithConsumer(t)
+
+	det := testDetection()
+	action := &DatabaseAction{
+		Settings:      &conf.Settings{Debug: true},
+		Result:        det.Result,
+		CorrelationID: "test-active-novelty-same-day",
+	}
+
+	episodeStart := time.Date(2026, 5, 23, 8, 0, 0, 0, time.UTC)
+	action.publishDetectionEvent(false, 30, species.NoveltyStatus{
+		DaysSinceLastSeen:    0,
+		NoveltyEpisodeDays:   12,
+		NoveltyEpisodeStart:  episodeStart,
+		NoveltyEpisodeActive: true,
+	})
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		received := consumer.GetReceivedEvents()
+		assert.Len(collect, received, 1)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	metadata := consumer.GetReceivedEvents()[0].GetMetadata()
+	assert.Equal(t, 0, metadata[events.DetectionMetadataDaysSinceLastSeen])
+	assert.Equal(t, 12, metadata[events.DetectionMetadataNoveltyEpisodeDays])
+	assert.Equal(t, episodeStart.Format(time.RFC3339), metadata[events.DetectionMetadataNoveltyEpisodeStart])
 }
 
 // TestPublishDetectionEvent_NewSpecies verifies that new-species detections
@@ -198,7 +259,7 @@ func TestPublishDetectionEvent_NewSpecies(t *testing.T) {
 		CorrelationID: "test-new-species-det",
 	}
 
-	action.publishDetectionEvent(true, 0)
+	action.publishDetectionEvent(true, 0, species.NoveltyStatus{})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
@@ -244,7 +305,7 @@ func TestPublishDetectionEvent_SuppressedNewSpecies(t *testing.T) {
 		NewSpeciesTracker: tracker,
 	}
 
-	action.publishDetectionEvent(true, 0)
+	action.publishDetectionEvent(true, 0, species.NoveltyStatus{})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
@@ -271,7 +332,7 @@ func TestPublishDetectionEvent_NoEventBus(t *testing.T) {
 
 	// Should not panic when event bus is not initialized
 	assert.NotPanics(t, func() {
-		action.publishDetectionEvent(false, 10)
-		action.publishDetectionEvent(true, 0)
+		action.publishDetectionEvent(false, 10, species.NoveltyStatus{})
+		action.publishDetectionEvent(true, 0, species.NoveltyStatus{})
 	})
 }

--- a/internal/analysis/species/database.go
+++ b/internal/analysis/species/database.go
@@ -4,6 +4,7 @@ package species
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -38,6 +39,13 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 			Context("operation", "load_lifetime_data").
 			Context("sync_time", now.Format(time.DateTime)).
 			Build()
+	}
+
+	if err := t.loadNoveltyEpisodesFromDatabase(now); err != nil {
+		getLog().Error("Failed to restore novelty episodes from database",
+			logger.Error(err),
+			logger.String("operation", "load_novelty_episodes"),
+			logger.String("impact", "Novelty episode metadata may restart from the next detection"))
 	}
 
 	// Step 2: Load yearly tracking data if enabled
@@ -84,6 +92,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 
 	getLog().Debug("Database initialization complete",
 		logger.Int("lifetime_species", len(t.speciesFirstSeen)),
+		logger.Int("novelty_episodes", len(t.noveltyEpisodes)),
 		logger.Int("yearly_species", len(t.speciesThisYear)),
 		logger.Int("total_seasons", len(t.speciesBySeason)),
 		logger.Int("notification_history_loaded", len(t.notificationLastSent)))
@@ -116,6 +125,7 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
 	case len(newSpeciesData) > 0:
 		// Clear and populate lifetime tracking map with new data
 		t.speciesFirstSeen = make(map[string]time.Time, len(newSpeciesData))
+		t.speciesLastSeen = make(map[string]time.Time, len(newSpeciesData))
 		for _, species := range newSpeciesData {
 			if species.FirstSeenDate != "" {
 				firstSeen, err := time.Parse(time.DateOnly, species.FirstSeenDate)
@@ -127,6 +137,18 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
 					continue
 				}
 				t.speciesFirstSeen[species.ScientificName] = firstSeen
+				t.speciesLastSeen[species.ScientificName] = firstSeen
+			}
+			if species.LastSeenDate != "" {
+				lastSeen, err := time.Parse(time.DateOnly, species.LastSeenDate)
+				if err != nil {
+					getLog().Debug("Failed to parse last seen date",
+						logger.String("species", species.ScientificName),
+						logger.String("date", species.LastSeenDate),
+						logger.Error(err))
+					continue
+				}
+				t.speciesLastSeen[species.ScientificName] = lastSeen
 			}
 		}
 		getLog().Debug("Loaded species data from database",
@@ -134,6 +156,7 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
 	case len(t.speciesFirstSeen) == 0:
 		// No data from database and no existing data - initialize empty map
 		t.speciesFirstSeen = make(map[string]time.Time, initialSpeciesCapacity)
+		t.speciesLastSeen = make(map[string]time.Time, initialSpeciesCapacity)
 		getLog().Debug("No species data from database, initialized empty tracking")
 	default:
 		// Database returned empty data but we have existing data - keep it
@@ -142,6 +165,156 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
 	}
 
 	return nil
+}
+
+// loadNoveltyEpisodesFromDatabase reconstructs active novelty episodes from detection dates.
+func (t *SpeciesTracker) loadNoveltyEpisodesFromDatabase(now time.Time) error {
+	history, ok := t.ds.(speciesDetectionHistoryDatastore)
+	if !ok {
+		return nil
+	}
+
+	ctx := context.Background()
+	endDate := trackerDateOnly(now)
+	startDate := endDate.AddDate(0, 0, -(t.windowDays + 1))
+
+	detections, err := history.GetSpeciesDetectionDatesInPeriod(ctx, startDate.Format(time.DateOnly), endDate.Format(time.DateOnly), defaultDBQueryLimit, 0)
+	if err != nil {
+		return errors.Newf("failed to load novelty detection dates from database: %w", err).
+			Component("new-species-tracker").
+			Category(errors.CategoryDatabase).
+			Context("operation", "load_novelty_detection_dates").
+			Context("start_date", startDate.Format(time.DateOnly)).
+			Context("end_date", endDate.Format(time.DateOnly)).
+			Build()
+	}
+
+	datesBySpecies := make(map[string][]time.Time, len(detections))
+	for _, detection := range detections {
+		if detection.ScientificName == "" || detection.Date == "" {
+			continue
+		}
+		detectionDate, parseErr := time.Parse(time.DateOnly, detection.Date)
+		if parseErr != nil {
+			getLog().Debug("Failed to parse novelty detection date",
+				logger.String("species", detection.ScientificName),
+				logger.String("date", detection.Date),
+				logger.Error(parseErr))
+			continue
+		}
+		datesBySpecies[detection.ScientificName] = append(datesBySpecies[detection.ScientificName], detectionDate)
+	}
+
+	episodes := make(map[string]NoveltyStatus, len(datesBySpecies))
+	for scientificName, dates := range datesBySpecies {
+		dates = normalizeNoveltyDetectionDates(dates)
+		if len(dates) == 0 {
+			continue
+		}
+
+		latestDate := dates[len(dates)-1]
+		runStart := findContiguousNoveltyRunStart(dates)
+		if calculateDaysSince(now, runStart) > t.windowDays {
+			continue
+		}
+
+		episodeDays, restored, restoreErr := t.restoredNoveltyEpisodeDays(ctx, history, scientificName, runStart)
+		if restoreErr != nil {
+			return restoreErr
+		}
+		if !restored {
+			continue
+		}
+
+		episodes[scientificName] = NoveltyStatus{
+			DaysSinceLastSeen:    calculateDaysSince(now, latestDate),
+			NoveltyEpisodeDays:   episodeDays,
+			NoveltyEpisodeStart:  runStart,
+			NoveltyEpisodeActive: true,
+		}
+	}
+
+	t.noveltyEpisodes = episodes
+	getLog().Debug("Restored active novelty episodes from database",
+		logger.Int("episodes", len(episodes)))
+
+	return nil
+}
+
+func (t *SpeciesTracker) restoredNoveltyEpisodeDays(ctx context.Context, history speciesDetectionHistoryDatastore, scientificName string, runStart time.Time) (episodeDays int, restored bool, err error) {
+	if firstSeen, exists := t.speciesFirstSeen[scientificName]; exists && sameTrackerDate(firstSeen, runStart) {
+		return firstEverNoveltyEpisodeDays, true, nil
+	}
+
+	previousDate, err := history.GetSpeciesLastDetectionDateBefore(ctx, scientificName, runStart.Format(time.DateOnly))
+	if err != nil {
+		return 0, false, errors.Newf("failed to load previous novelty detection date from database: %w", err).
+			Component("new-species-tracker").
+			Category(errors.CategoryDatabase).
+			Context("operation", "load_previous_novelty_detection_date").
+			Context("scientific_name", scientificName).
+			Context("before_date", runStart.Format(time.DateOnly)).
+			Build()
+	}
+	if previousDate == "" {
+		return 0, false, nil
+	}
+
+	previous, parseErr := time.Parse(time.DateOnly, previousDate)
+	if parseErr != nil {
+		getLog().Debug("Failed to parse previous novelty detection date",
+			logger.String("species", scientificName),
+			logger.String("date", previousDate),
+			logger.Error(parseErr))
+		return 0, false, nil
+	}
+
+	absenceDays := calculateDaysSince(runStart, previous)
+	if absenceDays <= 0 {
+		return 0, false, nil
+	}
+
+	return absenceDays, true, nil
+}
+
+func findContiguousNoveltyRunStart(dates []time.Time) time.Time {
+	runStart := dates[len(dates)-1]
+	for i := len(dates) - 2; i >= 0; i-- {
+		if calculateDaysSince(runStart, dates[i]) != 1 {
+			break
+		}
+		runStart = dates[i]
+	}
+	return runStart
+}
+
+func normalizeNoveltyDetectionDates(dates []time.Time) []time.Time {
+	sort.Slice(dates, func(i, j int) bool {
+		return dates[i].Before(dates[j])
+	})
+
+	unique := dates[:0]
+	var lastDate string
+	for _, date := range dates {
+		dateKey := date.Format(time.DateOnly)
+		if dateKey == lastDate {
+			continue
+		}
+		unique = append(unique, date)
+		lastDate = dateKey
+	}
+	return unique
+}
+
+func trackerDateOnly(ts time.Time) time.Time {
+	year, month, day := ts.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, ts.Location())
+}
+
+func sameTrackerDate(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
 }
 
 // loadYearlyDataFromDatabase loads first detection data for the current year

--- a/internal/analysis/species/novelty_test.go
+++ b/internal/analysis/species/novelty_test.go
@@ -1,0 +1,165 @@
+package species
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+func testNoveltyTracker(windowDays int) *SpeciesTracker {
+	return NewTrackerFromSettings(nil, &conf.SpeciesTrackingSettings{
+		Enabled:              true,
+		NewSpeciesWindowDays: windowDays,
+		YearlyTracking: conf.YearlyTrackingSettings{
+			Enabled: false,
+		},
+		SeasonalTracking: conf.SeasonalTrackingSettings{
+			Enabled: false,
+		},
+	})
+}
+
+func TestCheckAndUpdateSpeciesWithNovelty_FirstEverEpisode(t *testing.T) {
+	t.Parallel()
+
+	tracker := testNoveltyTracker(7)
+	detectionTime := time.Date(2026, 5, 23, 8, 0, 0, 0, time.UTC)
+
+	isNew, daysSinceFirst, novelty := tracker.CheckAndUpdateSpeciesWithNovelty("Setophaga castanea", detectionTime)
+
+	assert.True(t, isNew)
+	assert.Equal(t, 0, daysSinceFirst)
+	assert.True(t, novelty.NoveltyEpisodeActive)
+	assert.Equal(t, inactiveNoveltyValue, novelty.DaysSinceLastSeen)
+	assert.Equal(t, firstEverNoveltyEpisodeDays, novelty.NoveltyEpisodeDays)
+	assert.Equal(t, detectionTime, novelty.NoveltyEpisodeStart)
+}
+
+func TestCheckAndUpdateSpeciesWithNovelty_ReturnAfterAbsenceEpisode(t *testing.T) {
+	t.Parallel()
+
+	tracker := testNoveltyTracker(7)
+	firstTime := time.Date(2026, 5, 1, 8, 0, 0, 0, time.UTC)
+	returnTime := firstTime.AddDate(0, 0, 12)
+
+	_, _, _ = tracker.CheckAndUpdateSpeciesWithNovelty("Setophaga castanea", firstTime)
+	_, daysSinceFirst, novelty := tracker.CheckAndUpdateSpeciesWithNovelty("Setophaga castanea", returnTime)
+
+	assert.Equal(t, 12, daysSinceFirst)
+	assert.True(t, novelty.NoveltyEpisodeActive)
+	assert.Equal(t, 12, novelty.DaysSinceLastSeen)
+	assert.Equal(t, 12, novelty.NoveltyEpisodeDays)
+	assert.Equal(t, returnTime, novelty.NoveltyEpisodeStart)
+}
+
+func TestCheckAndUpdateSpeciesWithNovelty_EpisodePersistsForWindow(t *testing.T) {
+	t.Parallel()
+
+	tracker := testNoveltyTracker(7)
+	firstTime := time.Date(2026, 5, 1, 8, 0, 0, 0, time.UTC)
+	returnTime := firstTime.AddDate(0, 0, 12)
+	nextDay := returnTime.AddDate(0, 0, 1)
+
+	_, _, _ = tracker.CheckAndUpdateSpeciesWithNovelty("Setophaga castanea", firstTime)
+	_, _, _ = tracker.CheckAndUpdateSpeciesWithNovelty("Setophaga castanea", returnTime)
+	_, _, novelty := tracker.CheckAndUpdateSpeciesWithNovelty("Setophaga castanea", nextDay)
+
+	assert.True(t, novelty.NoveltyEpisodeActive)
+	assert.Equal(t, 1, novelty.DaysSinceLastSeen)
+	assert.Equal(t, 12, novelty.NoveltyEpisodeDays)
+	assert.Equal(t, returnTime, novelty.NoveltyEpisodeStart)
+}
+
+func TestCheckAndUpdateSpeciesWithNovelty_NoEpisodeForSameDayDetection(t *testing.T) {
+	t.Parallel()
+
+	tracker := testNoveltyTracker(7)
+	detectionTime := time.Date(2026, 5, 23, 8, 0, 0, 0, time.UTC)
+	const scientificName = "Setophaga castanea"
+
+	tracker.speciesFirstSeen[scientificName] = detectionTime.AddDate(0, 0, -30)
+	tracker.speciesLastSeen[scientificName] = detectionTime
+
+	_, _, novelty := tracker.CheckAndUpdateSpeciesWithNovelty(scientificName, detectionTime.Add(2*time.Hour))
+
+	assert.False(t, novelty.NoveltyEpisodeActive)
+	assert.Equal(t, 0, novelty.DaysSinceLastSeen)
+	assert.Equal(t, inactiveNoveltyValue, novelty.NoveltyEpisodeDays)
+}
+
+func TestLoadNoveltyEpisodesFromDatabase_RestoresActiveEpisode(t *testing.T) {
+	t.Parallel()
+
+	const scientificName = "Setophaga castanea"
+	now := time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC)
+	runStart := trackerDateOnly(now)
+	previousDate := runStart.AddDate(0, 0, -12)
+
+	ds := &noveltyHistoryDatastore{
+		lifetime: []datastore.NewSpeciesData{
+			{
+				ScientificName: scientificName,
+				CommonName:     "Bay-breasted Warbler",
+				FirstSeenDate:  previousDate.Format(time.DateOnly),
+				LastSeenDate:   runStart.Format(time.DateOnly),
+			},
+		},
+		detectionDates: []datastore.SpeciesDetectionDate{
+			{ScientificName: scientificName, Date: runStart.Format(time.DateOnly)},
+		},
+		previousDates: map[string]string{
+			scientificName + "|" + runStart.Format(time.DateOnly): previousDate.Format(time.DateOnly),
+		},
+	}
+
+	tracker := testNoveltyTracker(7)
+	tracker.ds = ds
+	require.NoError(t, tracker.loadLifetimeDataFromDatabase(now))
+	require.NoError(t, tracker.loadNoveltyEpisodesFromDatabase(now))
+
+	_, _, novelty := tracker.CheckAndUpdateSpeciesWithNovelty(scientificName, now.Add(2*time.Hour))
+
+	assert.True(t, novelty.NoveltyEpisodeActive)
+	assert.Equal(t, 0, novelty.DaysSinceLastSeen)
+	assert.Equal(t, 12, novelty.NoveltyEpisodeDays)
+	assert.Equal(t, runStart.Format(time.DateOnly), novelty.NoveltyEpisodeStart.Format(time.DateOnly))
+}
+
+type noveltyHistoryDatastore struct {
+	lifetime       []datastore.NewSpeciesData
+	detectionDates []datastore.SpeciesDetectionDate
+	previousDates  map[string]string
+}
+
+func (d *noveltyHistoryDatastore) GetNewSpeciesDetections(context.Context, string, string, int, int) ([]datastore.NewSpeciesData, error) {
+	return d.lifetime, nil
+}
+
+func (d *noveltyHistoryDatastore) GetSpeciesFirstDetectionInPeriod(context.Context, string, string, int, int) ([]datastore.NewSpeciesData, error) {
+	return nil, nil
+}
+
+func (d *noveltyHistoryDatastore) GetActiveNotificationHistory(time.Time) ([]datastore.NotificationHistory, error) {
+	return nil, nil
+}
+
+func (d *noveltyHistoryDatastore) SaveNotificationHistory(*datastore.NotificationHistory) error {
+	return nil
+}
+
+func (d *noveltyHistoryDatastore) DeleteExpiredNotificationHistory(time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (d *noveltyHistoryDatastore) GetSpeciesDetectionDatesInPeriod(context.Context, string, string, int, int) ([]datastore.SpeciesDetectionDate, error) {
+	return d.detectionDates, nil
+}
+
+func (d *noveltyHistoryDatastore) GetSpeciesLastDetectionDateBefore(_ context.Context, scientificName, beforeDate string) (string, error) {
+	return d.previousDates[scientificName+"|"+beforeDate], nil
+}

--- a/internal/analysis/species/species_tracker.go
+++ b/internal/analysis/species/species_tracker.go
@@ -57,6 +57,10 @@ const (
 	defaultNotificationSuppressionWindow = 168 * time.Hour // Default suppression window (7 days)
 	notificationTypeNewSpecies           = "new_species"   // Notification type for new species alerts
 
+	// Novelty episode tracking
+	firstEverNoveltyEpisodeDays = 36500 // Treat first-ever detections as a very large absence (~100 years)
+	inactiveNoveltyValue        = -1    // Sentinel used when no novelty episode is active
+
 	// Cache management
 	maxStatusCacheSize           = 1000 // Maximum number of species to cache
 	targetCacheSize              = 800  // Target size after cleanup (80% of max)
@@ -86,6 +90,11 @@ type SpeciesDatastore interface {
 	DeleteExpiredNotificationHistory(before time.Time) (int64, error)
 }
 
+type speciesDetectionHistoryDatastore interface {
+	GetSpeciesDetectionDatesInPeriod(ctx context.Context, startDate, endDate string, limit, offset int) ([]datastore.SpeciesDetectionDate, error)
+	GetSpeciesLastDetectionDateBefore(ctx context.Context, scientificName, beforeDate string) (string, error)
+}
+
 // SpeciesStatus represents the tracking status of a species across multiple periods
 type SpeciesStatus struct {
 	// Existing lifetime tracking
@@ -106,6 +115,17 @@ type SpeciesStatus struct {
 	DaysThisSeason  int  // Days since first this season
 }
 
+// NoveltyStatus describes the current absence-return episode for a species.
+// A novelty episode starts when a species is first detected, or when it returns
+// after at least one calendar day without detections. The episode remains active
+// for the same window used by new-species tracking.
+type NoveltyStatus struct {
+	DaysSinceLastSeen    int
+	NoveltyEpisodeDays   int
+	NoveltyEpisodeStart  time.Time
+	NoveltyEpisodeActive bool
+}
+
 // cachedSpeciesStatus represents a cached species status result with timestamp
 type cachedSpeciesStatus struct {
 	status    SpeciesStatus
@@ -119,7 +139,11 @@ type SpeciesTracker struct {
 
 	// Lifetime tracking (existing)
 	speciesFirstSeen map[string]time.Time // scientificName -> first detection time
+	speciesLastSeen  map[string]time.Time // scientificName -> most recent detection time
 	windowDays       int                  // Days to consider a species "new"
+
+	// Novelty episode tracking
+	noveltyEpisodes map[string]NoveltyStatus // scientificName -> active novelty episode
 
 	// Multi-period tracking
 	speciesThisYear map[string]time.Time            // scientificName -> first detection this year
@@ -189,7 +213,11 @@ func NewTrackerFromSettings(ds SpeciesDatastore, settings *conf.SpeciesTrackingS
 	tracker := &SpeciesTracker{
 		// Lifetime tracking
 		speciesFirstSeen: make(map[string]time.Time, initialSpeciesCapacity),
+		speciesLastSeen:  make(map[string]time.Time, initialSpeciesCapacity),
 		windowDays:       settings.NewSpeciesWindowDays,
+
+		// Novelty episode tracking
+		noveltyEpisodes: make(map[string]NoveltyStatus, initialSpeciesCapacity),
 
 		// Multi-period tracking
 		speciesThisYear: make(map[string]time.Time, initialSpeciesCapacity),

--- a/internal/analysis/species/update.go
+++ b/internal/analysis/species/update.go
@@ -31,6 +31,68 @@ func (t *SpeciesTracker) updateLifetimeTrackingLocked(scientificName string, det
 	return false
 }
 
+// updateLastSeenLocked updates the most recent detection time for a species.
+// Assumes lock is held.
+func (t *SpeciesTracker) updateLastSeenLocked(scientificName string, detectionTime time.Time) {
+	lastSeen, exists := t.speciesLastSeen[scientificName]
+	if !exists || detectionTime.After(lastSeen) {
+		t.speciesLastSeen[scientificName] = detectionTime
+	}
+}
+
+// inactiveNoveltyStatus returns the sentinel status used when no novelty
+// episode is active for the current detection.
+func inactiveNoveltyStatus(daysSinceLastSeen int) NoveltyStatus {
+	return NoveltyStatus{
+		DaysSinceLastSeen:    daysSinceLastSeen,
+		NoveltyEpisodeDays:   inactiveNoveltyValue,
+		NoveltyEpisodeActive: false,
+	}
+}
+
+// calculateNoveltyStatusLocked calculates and updates novelty episode state.
+// It must be called before speciesLastSeen is updated for the current detection.
+// Assumes lock is held.
+func (t *SpeciesTracker) calculateNoveltyStatusLocked(scientificName string, detectionTime time.Time) NoveltyStatus {
+	daysSinceLastSeen := inactiveNoveltyValue
+	if lastSeen, exists := t.speciesLastSeen[scientificName]; exists {
+		daysSinceLastSeen = calculateDaysSince(detectionTime, lastSeen)
+	}
+
+	if episode, exists := t.noveltyEpisodes[scientificName]; exists {
+		episode.DaysSinceLastSeen = daysSinceLastSeen
+		daysActive := calculateDaysSince(detectionTime, episode.NoveltyEpisodeStart)
+		if daysActive <= t.windowDays {
+			t.noveltyEpisodes[scientificName] = episode
+			return episode
+		}
+		delete(t.noveltyEpisodes, scientificName)
+	}
+
+	var status NoveltyStatus
+	switch {
+	case daysSinceLastSeen == inactiveNoveltyValue:
+		status = NoveltyStatus{
+			DaysSinceLastSeen:    inactiveNoveltyValue,
+			NoveltyEpisodeDays:   firstEverNoveltyEpisodeDays,
+			NoveltyEpisodeStart:  detectionTime,
+			NoveltyEpisodeActive: true,
+		}
+	case daysSinceLastSeen > 0:
+		status = NoveltyStatus{
+			DaysSinceLastSeen:    daysSinceLastSeen,
+			NoveltyEpisodeDays:   daysSinceLastSeen,
+			NoveltyEpisodeStart:  detectionTime,
+			NoveltyEpisodeActive: true,
+		}
+	default:
+		return inactiveNoveltyStatus(daysSinceLastSeen)
+	}
+
+	t.noveltyEpisodes[scientificName] = status
+	return status
+}
+
 // updateYearlyTrackingLocked updates yearly tracking data. Assumes lock is held.
 func (t *SpeciesTracker) updateYearlyTrackingLocked(scientificName string, detectionTime time.Time) {
 	if !t.yearlyEnabled || !t.isWithinCurrentYear(detectionTime) {
@@ -85,6 +147,7 @@ func (t *SpeciesTracker) UpdateSpecies(scientificName string, detectionTime time
 
 	// Update all tracking systems
 	isNewSpecies := t.updateLifetimeTrackingLocked(scientificName, detectionTime)
+	t.updateLastSeenLocked(scientificName, detectionTime)
 	t.updateYearlyTrackingLocked(scientificName, detectionTime)
 	t.updateSeasonalTrackingLocked(scientificName, detectionTime)
 
@@ -157,12 +220,21 @@ func (t *SpeciesTracker) addSeasonalIfNewLocked(scientificName string, detection
 // could all be considered "new" before any of them update the tracker.
 // Returns (isNew, daysSinceFirstSeen)
 func (t *SpeciesTracker) CheckAndUpdateSpecies(scientificName string, detectionTime time.Time) (isNew bool, daysSinceFirstSeen int) {
+	isNew, daysSinceFirstSeen, _ = t.CheckAndUpdateSpeciesWithNovelty(scientificName, detectionTime)
+	return
+}
+
+// CheckAndUpdateSpeciesWithNovelty atomically checks species status, updates
+// tracking, and returns novelty episode details for alert rules.
+func (t *SpeciesTracker) CheckAndUpdateSpeciesWithNovelty(scientificName string, detectionTime time.Time) (isNew bool, daysSinceFirstSeen int, novelty NoveltyStatus) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.checkAndResetPeriods(detectionTime)
 
+	novelty = t.calculateNoveltyStatusLocked(scientificName, detectionTime)
 	isNew, daysSinceFirstSeen = t.checkAndUpdateLifetimeLocked(scientificName, detectionTime)
+	t.updateLastSeenLocked(scientificName, detectionTime)
 	t.addYearlyIfNewLocked(scientificName, detectionTime)
 	t.addSeasonalIfNewLocked(scientificName, detectionTime)
 

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -56,7 +56,15 @@ type NewSpeciesData struct {
 	ScientificName string `json:"scientific_name"`
 	CommonName     string `json:"common_name"`
 	FirstSeenDate  string `json:"first_seen_date"` // The absolute first date
+	LastSeenDate   string `json:"last_seen_date"`  // The most recent detection date
 	CountInPeriod  int    `json:"count_in_period"` // Optional: How many times seen in the query period
+}
+
+// SpeciesDetectionDate represents a species detected on a specific calendar date.
+type SpeciesDetectionDate struct {
+	ScientificName string `json:"scientific_name"`
+	CommonName     string `json:"common_name"`
+	Date           string `json:"date"`
 }
 
 // GetSpeciesSummaryData retrieves overall statistics for all bird species
@@ -617,6 +625,81 @@ func (ds *DataStore) GetSpeciesFirstDetectionInPeriod(ctx context.Context, start
 	return speciesData, nil
 }
 
+// GetSpeciesDetectionDatesInPeriod returns distinct species/date pairs within a period.
+func (ds *DataStore) GetSpeciesDetectionDatesInPeriod(ctx context.Context, startDate, endDate string, limit, offset int) ([]SpeciesDetectionDate, error) {
+	if startDate != "" && endDate != "" && startDate > endDate {
+		return nil, errors.Newf("start date cannot be after end date").
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "get_species_detection_dates_in_period").
+			Context("start_date", startDate).
+			Context("end_date", endDate).
+			Build()
+	}
+
+	if limit <= 0 {
+		limit = 10000
+	}
+
+	query := fmt.Sprintf(`
+	SELECT
+		notes.scientific_name,
+		MAX(notes.common_name) as common_name,
+		notes.date
+	FROM notes
+	LEFT JOIN note_reviews ON notes.id = note_reviews.note_id
+	WHERE notes.date BETWEEN ? AND ?
+		AND notes.date != ''
+		AND notes.date IS NOT NULL
+		AND (note_reviews.verified IS NULL OR note_reviews.verified != '%s')
+	GROUP BY notes.scientific_name, notes.date
+	ORDER BY notes.date ASC, notes.scientific_name ASC
+	LIMIT ? OFFSET ?
+	`, entities.VerificationFalsePositive)
+
+	var results []SpeciesDetectionDate
+	if err := ds.DB.WithContext(ctx).Raw(query, startDate, endDate, limit, offset).Scan(&results).Error; err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_species_detection_dates_in_period").
+			Context("start_date", startDate).
+			Context("end_date", endDate).
+			Build()
+	}
+
+	return results, nil
+}
+
+// GetSpeciesLastDetectionDateBefore returns the last detection date before the given date.
+func (ds *DataStore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scientificName, beforeDate string) (string, error) {
+	query := fmt.Sprintf(`
+	SELECT COALESCE(MAX(notes.date), '') as last_seen_date
+	FROM notes
+	LEFT JOIN note_reviews ON notes.id = note_reviews.note_id
+	WHERE notes.scientific_name = ?
+		AND notes.date < ?
+		AND notes.date != ''
+		AND notes.date IS NOT NULL
+		AND (note_reviews.verified IS NULL OR note_reviews.verified != '%s')
+	`, entities.VerificationFalsePositive)
+
+	var result struct {
+		LastSeenDate string `gorm:"column:last_seen_date"`
+	}
+	if err := ds.DB.WithContext(ctx).Raw(query, scientificName, beforeDate).Scan(&result).Error; err != nil {
+		return "", errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_species_last_detection_date_before").
+			Context("scientific_name", scientificName).
+			Context("before_date", beforeDate).
+			Build()
+	}
+
+	return result.LastSeenDate, nil
+}
+
 // GetNewSpeciesDetections finds species whose absolute first detection falls within the specified date range.
 // This is suitable for lifetime tracking only - NOT for seasonal or yearly tracking.
 // It supports pagination with limit and offset parameters.
@@ -627,6 +710,7 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 		ScientificName     string
 		CommonName         string
 		FirstDetectionDate string // Scan directly into string
+		LastDetectionDate  string
 		CountInPeriod      int
 	}
 	var rawResults []RawNewSpeciesResult
@@ -655,7 +739,8 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 	WITH SpeciesFirstSeen AS (
 	    SELECT
 	        notes.scientific_name,
-	        MIN(CASE WHEN notes.date != '' AND notes.date IS NOT NULL THEN notes.date ELSE NULL END) as first_detection_date
+	        MIN(CASE WHEN notes.date != '' AND notes.date IS NOT NULL THEN notes.date ELSE NULL END) as first_detection_date,
+	        MAX(CASE WHEN notes.date != '' AND notes.date IS NOT NULL THEN notes.date ELSE NULL END) as last_detection_date
 	    FROM notes
 	    LEFT JOIN note_reviews ON notes.id = note_reviews.note_id
 	    WHERE (note_reviews.verified IS NULL OR note_reviews.verified != '%s')
@@ -677,6 +762,7 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 	    sfs.scientific_name,
 	    COALESCE(sip.common_name, sfs.scientific_name) as common_name,
 	    sfs.first_detection_date,
+	    sfs.last_detection_date,
 	    sip.count_in_period
 	FROM SpeciesFirstSeen sfs
 	JOIN SpeciesInPeriod sip ON sfs.scientific_name = sip.scientific_name
@@ -707,6 +793,7 @@ func (ds *DataStore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 				ScientificName: raw.ScientificName,
 				CommonName:     raw.CommonName,
 				FirstSeenDate:  raw.FirstDetectionDate, // Assign only if valid
+				LastSeenDate:   raw.LastDetectionDate,
 				CountInPeriod:  raw.CountInPeriod,
 			})
 		} else {

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1555,10 +1555,14 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 			MIN(d.label_id) as label_id,
 			species_first.scientific_name,
 			species_first.lifetime_first as first_detected,
+			species_first.lifetime_last as last_detected,
 			MIN(d.id) as detection_id,
 			MAX(d.confidence) as confidence
 		FROM (
-			SELECT l2.scientific_name, MIN(d2.detected_at) as lifetime_first
+			SELECT
+				l2.scientific_name,
+				MIN(d2.detected_at) as lifetime_first,
+				MAX(d2.detected_at) as lifetime_last
 			FROM %s d2
 			JOIN %s l2 ON l2.id = d2.label_id
 			GROUP BY l2.scientific_name

--- a/internal/datastore/v2/repository/types.go
+++ b/internal/datastore/v2/repository/types.go
@@ -207,6 +207,9 @@ type NewSpeciesData struct {
 	// FirstDetected is the Unix timestamp of the very first detection.
 	FirstDetected int64
 
+	// LastDetected is the Unix timestamp of the most recent detection.
+	LastDetected int64
+
 	// DetectionID is the ID of the first detection.
 	DetectionID uint
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -61,7 +61,9 @@ const (
 	maxHour = 23
 	// saveTransactionTimeout is the maximum duration for a Save transaction.
 	// This prevents indefinite lock holding during slow I/O operations.
-	saveTransactionTimeout = 30 * time.Second
+	saveTransactionTimeout  = 30 * time.Second
+	sqliteDetectionDateExpr = "date(d.detected_at, 'unixepoch', 'localtime')"
+	mysqlDetectionDateExpr  = "DATE(FROM_UNIXTIME(d.detected_at))"
 )
 
 // parseHour validates and parses an hour string to an integer.
@@ -2479,6 +2481,7 @@ type speciesFirstSeenInfo struct {
 	LabelID        uint
 	ScientificName string
 	FirstDetected  int64
+	LastDetected   int64
 }
 
 // convertToNewSpeciesData converts species first-seen data to NewSpeciesData with common name resolution.
@@ -2497,10 +2500,15 @@ func (ds *Datastore) convertToNewSpeciesData(_ context.Context, data []speciesFi
 		commonName := ds.resolveCommonName(sciName)
 
 		firstSeenDate := time.Unix(d.FirstDetected, 0).In(ds.timezone).Format(time.DateOnly)
+		var lastSeenDate string
+		if d.LastDetected > 0 {
+			lastSeenDate = time.Unix(d.LastDetected, 0).In(ds.timezone).Format(time.DateOnly)
+		}
 		result = append(result, datastore.NewSpeciesData{
 			ScientificName: sciName,
 			CommonName:     commonName,
 			FirstSeenDate:  firstSeenDate,
+			LastSeenDate:   lastSeenDate,
 			CountInPeriod:  0,
 		})
 	}
@@ -2526,6 +2534,7 @@ func (ds *Datastore) GetNewSpeciesDetections(ctx context.Context, startDate, end
 			LabelID:        d.LabelID,
 			ScientificName: d.ScientificName,
 			FirstDetected:  d.FirstDetected,
+			LastDetected:   d.LastDetected,
 		}
 	}
 
@@ -2557,6 +2566,103 @@ func (ds *Datastore) GetSpeciesFirstDetectionInPeriod(ctx context.Context, start
 	return ds.convertToNewSpeciesData(ctx, data), nil
 }
 
+// GetSpeciesDetectionDatesInPeriod returns distinct species/date pairs within a period.
+func (ds *Datastore) GetSpeciesDetectionDatesInPeriod(ctx context.Context, startDate, endDate string, limit, offset int) ([]datastore.SpeciesDetectionDate, error) {
+	start, end, err := ds.parseDateRange(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 10000
+	}
+
+	dateExpr := sqliteDetectionDateExpr
+	if ds.manager.IsMySQL() {
+		dateExpr = mysqlDetectionDateExpr
+	}
+
+	type result struct {
+		ScientificName string `gorm:"column:scientific_name"`
+		Date           string `gorm:"column:date"`
+	}
+	var rows []result
+
+	prefix := ds.manager.TablePrefix()
+	query := ds.manager.DB().WithContext(ctx).
+		Table(prefix+"detections d").
+		Select(fmt.Sprintf("l.scientific_name as scientific_name, %s as date", dateExpr)).
+		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
+		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
+		Where("d.detected_at >= ? AND d.detected_at < ?", start, end).
+		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
+		Group(fmt.Sprintf("l.scientific_name, %s", dateExpr)).
+		Order("date ASC, l.scientific_name ASC").
+		Limit(limit).
+		Offset(offset)
+
+	if err := query.Scan(&rows).Error; err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_species_detection_dates_in_period").
+			Context("start_date", startDate).
+			Context("end_date", endDate).
+			Build()
+	}
+
+	results := make([]datastore.SpeciesDetectionDate, 0, len(rows))
+	for _, row := range rows {
+		scientificName := detection.ExtractScientificName(row.ScientificName)
+		results = append(results, datastore.SpeciesDetectionDate{
+			ScientificName: scientificName,
+			CommonName:     ds.resolveCommonName(scientificName),
+			Date:           row.Date,
+		})
+	}
+
+	return results, nil
+}
+
+// GetSpeciesLastDetectionDateBefore returns the last detection date before the given date.
+func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scientificName, beforeDate string) (string, error) {
+	before, err := time.ParseInLocation(time.DateOnly, beforeDate, ds.timezone)
+	if err != nil {
+		return "", fmt.Errorf("invalid before date format: %w", err)
+	}
+
+	dateExpr := sqliteDetectionDateExpr
+	if ds.manager.IsMySQL() {
+		dateExpr = mysqlDetectionDateExpr
+	}
+
+	var result struct {
+		LastSeenDate string `gorm:"column:last_seen_date"`
+	}
+
+	escapedScientificName := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(scientificName)
+	prefix := ds.manager.TablePrefix()
+	query := ds.manager.DB().WithContext(ctx).
+		Table(prefix+"detections d").
+		Select(fmt.Sprintf("COALESCE(MAX(%s), '') as last_seen_date", dateExpr)).
+		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
+		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
+		Where("d.detected_at < ?", before.Unix()).
+		Where("(l.scientific_name = ? OR l.scientific_name LIKE ? ESCAPE '\\')", scientificName, escapedScientificName+`\_%`).
+		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive))
+
+	if err := query.Scan(&result).Error; err != nil {
+		return "", errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_species_last_detection_date_before").
+			Context("scientific_name", scientificName).
+			Context("before_date", beforeDate).
+			Build()
+	}
+
+	return result.LastSeenDate, nil
+}
+
 // GetSpeciesDiversityData returns unique species count per day.
 func (ds *Datastore) GetSpeciesDiversityData(ctx context.Context, startDate, endDate string) ([]datastore.DailyAnalyticsData, error) {
 	// Validate date formats before using in SQL
@@ -2576,11 +2682,9 @@ func (ds *Datastore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 	// Generate database-agnostic date expression
 	// MySQL: DATE(FROM_UNIXTIME(d.detected_at))
 	// SQLite: date(d.detected_at, 'unixepoch', 'localtime') - localtime for timezone-aware bucketing
-	var dateExpr string
+	dateExpr := sqliteDetectionDateExpr
 	if ds.manager.IsMySQL() {
-		dateExpr = "DATE(FROM_UNIXTIME(d.detected_at))"
-	} else {
-		dateExpr = "date(d.detected_at, 'unixepoch', 'localtime')"
+		dateExpr = mysqlDetectionDateExpr
 	}
 
 	// Build query to count distinct species per day, excluding false positives

--- a/internal/events/detection_event.go
+++ b/internal/events/detection_event.go
@@ -8,6 +8,13 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+// Detection metadata keys shared by event producers and consumers.
+const (
+	DetectionMetadataDaysSinceLastSeen   = "days_since_last_seen"
+	DetectionMetadataNoveltyEpisodeDays  = "novelty_episode_days"
+	DetectionMetadataNoveltyEpisodeStart = "novelty_episode_start"
+)
+
 // DetectionEvent represents a bird detection event that can be processed asynchronously
 type DetectionEvent interface {
 	// GetSpeciesName returns the common name of the detected species


### PR DESCRIPTION
## Summary

Adds detection novelty episode metadata derived from species tracking.

## Rationale

Existing new-species state only answers "is this species new in the configured window?" It cannot express the common alerting case where a bird is interesting because it has returned after being absent for days or weeks, and alert templates/rules currently have no last-seen or episode data to use. This PR supplies the minimal metadata needed for those rules while leaving policy decisions to alert configuration.

## Stack Context

Builds on the merged exact-list-operator PR: https://github.com/tphakala/birdnet-go/pull/3267. Follow-up branches remain split in my fork for reviewer context:

- https://github.com/keithkml/birdnet-go/pull/3: confidence-step re-alerting for detection rules
- https://github.com/keithkml/birdnet-go/pull/4: novelty reason metadata for alert rules and templates

## Changes

- Tracks per-species last seen dates and active novelty episodes.
- Restores active novelty episodes from existing detection history during tracker startup, so a restart does not reset the metadata while the configured novelty window is still active.
- Adds detection metadata for `days_since_last_seen`, `novelty_episode_days`, and `novelty_episode_start`.
- Promotes novelty metadata into alert event properties so alert rules and templates can use it.
- Carries last-seen data through legacy and v2 datastore new-species paths.
- Avoids leaking the inactive novelty sentinel as alert episode metadata.
- Adds translated schema labels for the new novelty fields in all frontend locale files.

## Screenshots

![Alert rule editor showing novelty day fields](https://raw.githubusercontent.com/keithkml/birdnet-go/codex-pr-screenshots/pr-screenshots/pr2-novelty-fields.png)

## Pi 5 Runtime Validation

I am running this feature series on a Raspberry Pi 5 with live USB audio. For this PR, the relevant live check is that alert rules can filter on the novelty episode metadata and alert history records the same metadata when the rule fires.

```text
$ curl -fsS http://localhost:8080/api/v2/alerts/rules | jq '.rules[] | select(.name=="Interesting Bird (novelty)") | {name, novelty_condition:(.conditions[] | select(.property=="novelty_episode_days") | {property, operator, value})}'
{
  "name": "Interesting Bird (novelty)",
  "novelty_condition": {
    "property": "novelty_episode_days",
    "operator": "greater_or_equal",
    "value": "7"
  }
}

$ curl -fsS 'http://localhost:8080/api/v2/alerts/history?limit=20' | jq -r '.history[] | select(.rule_id==17) | (.event_data|fromjson) | {species_name, confidence, days_since_last_seen, novelty_episode_days, novelty_episode_start} | @json' | head -n 4
{"species_name":"Ring-necked Pheasant","confidence":0.93,"days_since_last_seen":8,"novelty_episode_days":8,"novelty_episode_start":"2026-05-25T17:52:47-04:00"}
{"species_name":"Common Raven","confidence":0.87,"days_since_last_seen":1,"novelty_episode_days":11,"novelty_episode_start":"2026-05-24T18:39:16-04:00"}
{"species_name":"Eurasian Scops-Owl","confidence":0.78,"days_since_last_seen":8,"novelty_episode_days":8,"novelty_episode_start":"2026-05-24T23:11:50-04:00"}
{"species_name":"Common Raven","confidence":0.79,"days_since_last_seen":11,"novelty_episode_days":11,"novelty_episode_start":"2026-05-24T18:39:16-04:00"}
```

## Testing

- [x] Go lint passes: `golangci-lint run -v --build-tags=noembed,skipfrontend` with temporary local TensorFlow Lite CGO paths and writable local caches reported 0 issues.
- [x] Frontend check exits 0: `npm --prefix frontend run check:all` under Node 22.22.3. Caveat: ESLint reports 3 pre-existing warnings in unrelated frontend files.
- [x] Frontend tests pass: `npm --prefix frontend test`, 107 files / 1968 tests.
- [x] i18n sync passes: `npm --prefix frontend run i18n:sync:check`.
- [x] i18n validation exits 0: `npm --prefix frontend run i18n:validate`; existing untranslated-string warnings remain in locale files.
- [x] PR-specific Go checks pass with temporary local TensorFlow Lite CGO paths:
  - `go test -race ./internal/analysis/species -run 'Test(CheckAndUpdateSpeciesWithNovelty|LoadNoveltyEpisodesFromDatabase)'`
  - `go test ./internal/datastore ./internal/datastore/v2only -run '^$'`
  - `go test -race ./internal/alerting -run 'TestBridge_DetectionMetadataPromotedForConditions'`
  - `go test -race ./internal/analysis/processor -run 'TestPublishDetectionEvent_(OrdinaryDetection|InactiveNoveltyOmitsEpisodeSentinel|ActiveNoveltyIncludesSameDayLastSeen|NewSpecies|SuppressedNewSpecies|NoEventBus)$'`
- [ ] Full Go race suite: `go test -race ./...` was rerun with temporary local TensorFlow Lite CGO paths and an rpath for `libtensorflowlite_c`. Changed packages passed. The remaining failures appear pre-existing/unrelated to this PR on this macOS host:
  - `internal/birdweather TestEncodeFlacUsingFFmpeg`: rejects relative `ffmpeg` path when `FFMPEG_PATH` is not set.
  - `internal/classifier TestMemoryLeaks`: aggregate heap growth exceeded the test threshold.
  - `internal/monitor TestGroupPathsWithPartitions_MixedRootAndVolumePaths`: expects Linux mount metadata that is unavailable on this host.

## Related Issues

None.

## Preflight Status

- Single concern: yes, one detection metadata feature.
- Review feedback addressed: active novelty episodes now restore from persisted detection history on tracker startup instead of being in-memory only.
- Preflight review: completed manually against `.agents/skills/preflight` after rebasing on upstream `main`; no changed-code findings remain.
- No unrelated changes: diff is limited to novelty episode tracking, detection metadata promotion, datastore last-seen plumbing, translated schema labels, and tests.
- Scope complete: no TODO/FIXME for core functionality.
- Breaking changes: none.
- i18n complete: new schema property labels are present in all 15 locale files and `types.generated.ts`.
- Secrets/PII: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two alert condition fields: "Days Since Last Seen" and "Novelty Episode Days".
  * Alerts now surface those metadata fields for condition evaluation and templates.
  * Species/new-species views and analytics now expose each species’ last-seen date; novelty-episode tracking restored/persisted where applicable.

* **Localization**
  * Added translations for the new alert fields in cs, da, de, en, es, fi, fr, hu, it, lv, nl, pl, pt, sk, sv.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
