### PR TITLE
fix(classifier): apply range filter to Perch detections

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -950,17 +950,18 @@ func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result data
 
 // shouldApplyRangeFilter returns true if the given model should have its
 // detections filtered by the geographic range filter.
-// BirdNET (any version) and unknown models: always filtered (DetectionModelInfoForID
-// returns DefaultModelInfo with Name="BirdNET" for unrecognized IDs).
-// Perch: filtered only when the v3.0 geomodel is active (it covers Perch species).
+// BirdNET (any version), Perch, and unknown models are filtered. Perch returns
+// scientific-name labels, and the included-species set stores scientific names
+// for O(1) lookup, so the normal range list applies even when the active range
+// model is the embedded BirdNET geomodel rather than v3.
 // Bat/BSG: never filtered (independent species sets, no geomodel coverage).
 func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
-	mInfo := classifier.DetectionModelInfoForID(modelID)
-	if mInfo.Name == detection.DefaultModelName {
-		return true
+	if settings == nil || !settings.BirdNET.LocationConfigured {
+		return false
 	}
-	if mInfo.Name == classifier.DetectionNamePerch {
-		return settings.BirdNET.RangeFilter.Model == "v3"
+	mInfo := classifier.DetectionModelInfoForID(modelID)
+	if mInfo.Name == detection.DefaultModelName || mInfo.Name == classifier.DetectionNamePerch {
+		return true
 	}
 	return false
 }

--- a/internal/analysis/processor/processor_filter_test.go
+++ b/internal/analysis/processor/processor_filter_test.go
@@ -5,82 +5,67 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
 func TestShouldApplyRangeFilter(t *testing.T) {
 	t.Parallel()
 
+	assert.False(t, shouldApplyRangeFilter("Perch_V2", nil))
+
 	tests := []struct {
-		name             string
-		modelID          string
-		rangeFilterModel string
-		expected         bool
+		name               string
+		modelID            string
+		locationConfigured bool
+		expected           bool
 	}{
 		{
-			name:             "BirdNET V2.4 always filtered",
-			modelID:          "BirdNET_V2.4",
-			rangeFilterModel: "",
-			expected:         true,
+			name:               "BirdNET V2.4 filtered when location configured",
+			modelID:            "BirdNET_V2.4",
+			locationConfigured: true,
+			expected:           true,
 		},
 		{
-			name:             "BirdNET V2.4 filtered with legacy range model",
-			modelID:          "BirdNET_V2.4",
-			rangeFilterModel: "legacy",
-			expected:         true,
+			name:               "BirdNET V2.4 not filtered when location not configured",
+			modelID:            "BirdNET_V2.4",
+			locationConfigured: false,
+			expected:           false,
 		},
 		{
-			name:             "BirdNET V2.4 filtered with v3 range model",
-			modelID:          "BirdNET_V2.4",
-			rangeFilterModel: "v3",
-			expected:         true,
+			name:               "BirdNET V3.0 filtered when location configured",
+			modelID:            "BirdNET_V3.0",
+			locationConfigured: true,
+			expected:           true,
 		},
 		{
-			name:             "BirdNET V3.0 always filtered",
-			modelID:          "BirdNET_V3.0",
-			rangeFilterModel: "",
-			expected:         true,
+			name:               "Perch V2 filtered when location configured",
+			modelID:            "Perch_V2",
+			locationConfigured: true,
+			expected:           true,
 		},
 		{
-			name:             "BirdNET V3.0 filtered with v3 range model",
-			modelID:          "BirdNET_V3.0",
-			rangeFilterModel: "v3",
-			expected:         true,
+			name:               "Perch V2 not filtered when location not configured",
+			modelID:            "Perch_V2",
+			locationConfigured: false,
+			expected:           false,
 		},
 		{
-			name:             "Perch V2 filtered when v3 geomodel active",
-			modelID:          "Perch_V2",
-			rangeFilterModel: "v3",
-			expected:         true,
+			name:               "Bat never filtered",
+			modelID:            "Bat",
+			locationConfigured: true,
+			expected:           false,
 		},
 		{
-			name:             "Perch V2 not filtered when range model empty",
-			modelID:          "Perch_V2",
-			rangeFilterModel: "",
-			expected:         false,
+			name:               "BSG never filtered",
+			modelID:            "BSG",
+			locationConfigured: true,
+			expected:           false,
 		},
 		{
-			name:             "Perch V2 not filtered when legacy range model",
-			modelID:          "Perch_V2",
-			rangeFilterModel: "legacy",
-			expected:         false,
-		},
-		{
-			name:             "Bat never filtered",
-			modelID:          "Bat",
-			rangeFilterModel: "v3",
-			expected:         false,
-		},
-		{
-			name:             "BSG never filtered",
-			modelID:          "BSG",
-			rangeFilterModel: "v3",
-			expected:         false,
-		},
-		{
-			name:             "unknown model ID defaults to BirdNET via DetectionModelInfoForID",
-			modelID:          "SomeUnknownModel",
-			rangeFilterModel: "",
-			expected:         true,
+			name:               "unknown model ID defaults to BirdNET via DetectionModelInfoForID",
+			modelID:            "SomeUnknownModel",
+			locationConfigured: true,
+			expected:           true,
 		},
 	}
 
@@ -89,10 +74,74 @@ func TestShouldApplyRangeFilter(t *testing.T) {
 			t.Parallel()
 
 			settings := &conf.Settings{}
-			settings.BirdNET.RangeFilter.Model = tt.rangeFilterModel
+			settings.BirdNET.LocationConfigured = tt.locationConfigured
 
 			result := shouldApplyRangeFilter(tt.modelID, settings)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShouldFilterDetection_AppliesRangeFilterToPerch(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Model = "latest"
+	settings.BirdNET.RangeFilter.IncludedScientificNames = map[string]struct{}{
+		"turdus migratorius": {},
+	}
+
+	p := &Processor{}
+	tests := []struct {
+		name           string
+		result         datastore.Results
+		commonName     string
+		scientificName string
+		speciesLower   string
+		expectedFilter bool
+	}{
+		{
+			name: "filters out-of-range Perch species",
+			result: datastore.Results{
+				Species:    "Pitangus sulphuratus",
+				Confidence: 0.95,
+			},
+			commonName:     "Great Kiskadee",
+			scientificName: "Pitangus sulphuratus",
+			speciesLower:   "great kiskadee",
+			expectedFilter: true,
+		},
+		{
+			name: "allows in-range Perch species",
+			result: datastore.Results{
+				Species:    "Turdus migratorius",
+				Confidence: 0.95,
+			},
+			commonName:     "American Robin",
+			scientificName: "Turdus migratorius",
+			speciesLower:   "american robin",
+			expectedFilter: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			shouldFilter, threshold := p.shouldFilterDetection(
+				settings,
+				tt.result,
+				tt.commonName,
+				tt.scientificName,
+				tt.speciesLower,
+				0.7,
+				"Backyard",
+				"Perch_V2",
+			)
+
+			assert.Equal(t, tt.expectedFilter, shouldFilter)
+			assert.InDelta(t, 0.7, threshold, 0.001)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Perch detections were bypassing the geographic range filter unless the range filter model was explicitly set to `v3`. Live config can use the default `latest` range model while Perch is enabled, which lets out-of-range Perch labels pass through to notifications.

This changes range-filter eligibility so Perch uses the same included-species scientific-name lookup as BirdNET whenever location filtering is configured. Bat/BSG remain excluded from the bird range filter path.

## Fix

- Apply the range filter to `Perch_V2` detections when `LocationConfigured` is true, independent of the configured range model name.
- Keep range filtering disabled when no location is configured.
- Add regression coverage for:
  - Perch with `latest` range model filtering an out-of-range scientific-name label.
  - Perch allowing an in-range scientific-name label.
  - Bat/BSG staying outside the range-filter path.

## Live Smoke Test

I checked a live Raspberry Pi deployment without replacing the running service:

- Confirmed Perch and BirdNET were both enabled with location filtering configured and `rangefilter.model: latest`.
- Confirmed the live range command, using the deployed config, produced a small local included-species set.
- Compared recent high-confidence Perch detections against that live included-species set and found out-of-range Perch labels that the current deployed build had accepted. This reproduces the reported notification behavior and matches the fixed code path.

## Preflight Status

Preflight review passes completed:

- Scope: one bug fix only; two Go files changed.
- Reuse/efficiency: uses existing `DetectionModelInfoForID` and `Settings.IsSpeciesIncluded` fast scientific-name lookup.
- Correctness: reviewer pass caught the need to guard on `LocationConfigured`; fixed before final checks.
- Quality/maintainability: no new abstraction, no config/API changes.
- i18n: not applicable, no user-facing text changed.
- Integration wiring: no endpoint/event/config schema changes.

Verification commands run and passed:

- `git diff --check`
- `golangci-lint run -v` with local CGO TFLite headers/libs configured
- `npm run check:all` under Node 24.14.0 from the Codex bundled runtime; exited 0 with three existing unrelated ESLint warnings
- `npm test` under Node 24.14.0
- `npm run build` under Node 24.14.0 to populate embedded frontend assets for Go checks
- `go test -tags noembed,skipfrontend ./internal/analysis/processor -run 'TestShouldApplyRangeFilter|TestShouldFilterDetection_AppliesRangeFilterToPerch'`
- `go test -race ./...` with local test environment settings: `GOFLAGS=-parallel=1`, `TMPDIR=/private/tmp`, `FFMPEG_PATH=/opt/homebrew/bin/ffmpeg`, plus local TFLite CGO headers/libs

Notes on local environment:

- The first exact full race run exposed local environment issues unrelated to this patch: sandbox-blocked `httptest` ports, missing absolute FFmpeg path, macOS `/var` symlink behavior in a mount test, and classifier memory-test noise under parallel `-race` execution.
- After setting the local environment values above, the full race suite passed.

## Breaking Changes

None. This only restores expected range-filter behavior for Perch detections when location filtering is configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved range filtering logic to properly account for location configuration settings
- Enhanced how different detection models interact with range-based filtering for more accurate results

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->