### PR TITLE
feat(ui): respect global threshold in recent detections

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/API_ENDPOINTS.md
+++ b/frontend/src/lib/desktop/features/dashboard/API_ENDPOINTS.md
@@ -42,6 +42,9 @@ const dailySummary = await response.json();
 **Query Parameters:**
 
 - `limit` (optional): Number of recent detections to return, default: 10
+- `aboveThreshold` (optional): When `true`, only return detections at or above the global BirdNET confidence threshold
+
+By default, this endpoint returns the latest detections without threshold filtering. The dashboard uses `aboveThreshold=true` so recent detections match notification-worthy detections.
 
 **Response:**
 
@@ -68,7 +71,7 @@ const dailySummary = await response.json();
 **Usage in Svelte:**
 
 ```typescript
-const response = await fetch('/api/v2/detections/recent?limit=10');
+const response = await fetch('/api/v2/detections/recent?limit=10&aboveThreshold=true');
 const recentDetections = await response.json();
 ```
 

--- a/frontend/src/lib/desktop/features/dashboard/API_ENDPOINTS.md
+++ b/frontend/src/lib/desktop/features/dashboard/API_ENDPOINTS.md
@@ -44,7 +44,7 @@ const dailySummary = await response.json();
 - `limit` (optional): Number of recent detections to return, default: 10
 - `aboveThreshold` (optional): When `true`, only return detections at or above the global BirdNET confidence threshold
 
-By default, this endpoint returns the latest detections without threshold filtering. The dashboard uses `aboveThreshold=true` so recent detections match notification-worthy detections.
+By default, this endpoint returns the latest detections without threshold filtering. The dashboard uses `aboveThreshold=true` to exclude detections below the global confidence threshold.
 
 **Response:**
 

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -456,7 +456,7 @@ Performance Optimizations:
     try {
       const response = await fetch(
         buildAppUrl(
-          `/api/v2/detections/recent?limit=${Math.max(detectionLimit, MIN_FETCH_LIMIT)}&includeWeather=true`
+          `/api/v2/detections/recent?limit=${Math.max(detectionLimit, MIN_FETCH_LIMIT)}&includeWeather=true&aboveThreshold=true`
         )
       );
       if (!response.ok) {

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -166,6 +166,9 @@ func (m *ActionMockDatastore) SpeciesDetections(_, _, _ string, _ int, _ bool, _
 func (m *ActionMockDatastore) GetLastDetections(_ int) ([]datastore.Note, error) {
 	return nil, nil
 }
+func (m *ActionMockDatastore) GetLastDetectionsWithMinimumConfidence(_ int, _ float64) ([]datastore.Note, error) {
+	return nil, nil
+}
 func (m *ActionMockDatastore) GetAllDetectedSpecies() ([]datastore.Note, error) {
 	return nil, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -68,6 +68,9 @@ func (m *MockDatastore) SpeciesDetections(string, string, string, int, bool, int
 func (m *MockDatastore) GetLastDetections(int) ([]datastore.Note, error) {
 	return make([]datastore.Note, 0), nil
 }
+func (m *MockDatastore) GetLastDetectionsWithMinimumConfidence(int, float64) ([]datastore.Note, error) {
+	return make([]datastore.Note, 0), nil
+}
 func (m *MockDatastore) GetAllDetectedSpecies() ([]datastore.Note, error) {
 	return make([]datastore.Note, 0), nil
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -118,7 +118,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | ------ | ----------------------------- | ----------------------- | ---- | ------------------------------------------ |
 | GET    | `/detections`                 | `GetDetections`         | ❌   | List bird detections                       |
 | GET    | `/detections/:id`             | `GetDetection`          | ❌   | Get specific detection                     |
-| GET    | `/detections/recent`          | `GetRecentDetections`   | ❌   | Recent detections                         |
+| GET    | `/detections/recent`          | `GetRecentDetections`   | ❌   | Recent detections                          |
 | GET    | `/detections/:id/time-of-day` | `GetDetectionTimeOfDay` | ❌   | Detection time context                     |
 | DELETE | `/detections/:id`             | `DeleteDetection`       | ✅   | Delete detection record                    |
 | POST   | `/detections/:id/review`      | `ReviewDetection`       | ✅   | Review/verify detection                    |

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -118,7 +118,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | ------ | ----------------------------- | ----------------------- | ---- | ------------------------------------------ |
 | GET    | `/detections`                 | `GetDetections`         | ❌   | List bird detections                       |
 | GET    | `/detections/:id`             | `GetDetection`          | ❌   | Get specific detection                     |
-| GET    | `/detections/recent`          | `GetRecentDetections`   | ❌   | Recent detections                          |
+| GET    | `/detections/recent`          | `GetRecentDetections`   | ❌   | Recent detections                         |
 | GET    | `/detections/:id/time-of-day` | `GetDetectionTimeOfDay` | ❌   | Detection time context                     |
 | DELETE | `/detections/:id`             | `DeleteDetection`       | ✅   | Delete detection record                    |
 | POST   | `/detections/:id/review`      | `ReviewDetection`       | ✅   | Review/verify detection                    |

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -246,8 +246,9 @@ func TestGetRecentDetections_DefaultParams(t *testing.T) {
 
 	notes := testNotes()
 
-	// Default limit is 10
-	mockDS.On("GetLastDetections", 10).Return(notes, nil).Once()
+	mockDS.On("GetLastDetections", defaultRecentLimit).
+		Return(notes, nil).
+		Once()
 
 	rec := executeRequest(t, e, http.MethodGet, "/api/v2/detections/recent", controller.GetRecentDetections)
 

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -39,6 +39,7 @@ const (
 	detectionCacheExpiry  = 5 * time.Minute  // Default cache expiration
 	detectionCacheCleanup = 10 * time.Minute // Cache cleanup interval
 	defaultNumResults     = 100              // Default number of results
+	defaultRecentLimit    = 10               // Default number of recent detections
 	maxNumResults         = 1000             // Maximum number of results
 	sunEventWindowMinutes = 30               // Minutes before/after sunrise/sunset
 	minHourRangeParts     = 2                // Minimum parts for hour range parsing
@@ -1206,22 +1207,39 @@ func (c *Controller) GetDetection(ctx echo.Context) error {
 // Query parameters:
 // - limit: number of detections to return (default: 10)
 // - includeWeather: whether to include weather data (default: false)
+// - aboveThreshold: whether to only return detections at or above the global BirdNET threshold (default: false)
 func (c *Controller) GetRecentDetections(ctx echo.Context) error {
 	limit, _ := strconv.Atoi(ctx.QueryParam("limit"))
 	if limit <= 0 {
-		limit = 10
+		limit = defaultRecentLimit
 	}
 
 	// Check if weather data should be included
 	includeWeather := ctx.QueryParam("includeWeather") == QueryValueTrue
 
-	notes, err := c.DS.GetLastDetections(limit)
+	var (
+		notes []datastore.Note
+		err   error
+	)
+	if ctx.QueryParam("aboveThreshold") == QueryValueTrue {
+		notes, err = c.DS.GetLastDetectionsWithMinimumConfidence(limit, c.recentDetectionsMinConfidence())
+	} else {
+		notes, err = c.DS.GetLastDetections(limit)
+	}
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to get recent detections", http.StatusInternalServerError)
 	}
 
 	detections := c.convertNotesToDetectionResponses(notes, includeWeather)
 	return ctx.JSON(http.StatusOK, detections)
+}
+
+func (c *Controller) recentDetectionsMinConfidence() float64 {
+	settings := c.currentSettings()
+	if settings == nil {
+		return 0
+	}
+	return settings.BirdNET.Threshold
 }
 
 // DeleteDetection deletes a detection by ID

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1234,6 +1234,9 @@ func (c *Controller) GetRecentDetections(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, detections)
 }
 
+// recentDetectionsMinConfidence returns the global BirdNET threshold used by the
+// dashboard's opt-in recent-detections filter, falling back to no threshold when
+// settings are unavailable.
 func (c *Controller) recentDetectionsMinConfidence() float64 {
 	settings := c.currentSettings()
 	if settings == nil {

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -865,6 +865,7 @@ func TestGetRecentDetections(t *testing.T) {
 	testCases := []struct {
 		name           string
 		limit          string
+		aboveThreshold bool
 		mockSetup      func(*mock.Mock)
 		expectedStatus int
 		expectedCount  int
@@ -873,7 +874,8 @@ func TestGetRecentDetections(t *testing.T) {
 			name:  "Default limit",
 			limit: "",
 			mockSetup: func(m *mock.Mock) {
-				m.On("GetLastDetections", 10).Return(mockNotes, nil)
+				m.On("GetLastDetections", defaultRecentLimit).
+					Return(mockNotes, nil)
 			},
 			expectedStatus: http.StatusOK,
 			expectedCount:  2,
@@ -882,7 +884,19 @@ func TestGetRecentDetections(t *testing.T) {
 			name:  "Custom limit",
 			limit: "5",
 			mockSetup: func(m *mock.Mock) {
-				m.On("GetLastDetections", 5).Return(mockNotes, nil)
+				m.On("GetLastDetections", 5).
+					Return(mockNotes, nil)
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
+		},
+		{
+			name:           "Above global threshold",
+			limit:          "5",
+			aboveThreshold: true,
+			mockSetup: func(m *mock.Mock) {
+				m.On("GetLastDetectionsWithMinimumConfidence", 5, 0.8).
+					Return(mockNotes, nil)
 			},
 			expectedStatus: http.StatusOK,
 			expectedCount:  2,
@@ -891,7 +905,8 @@ func TestGetRecentDetections(t *testing.T) {
 			name:  "Database error",
 			limit: "5",
 			mockSetup: func(m *mock.Mock) {
-				m.On("GetLastDetections", 5).Return([]datastore.Note{}, errors.New("database error"))
+				m.On("GetLastDetections", 5).
+					Return([]datastore.Note{}, errors.New("database error"))
 			},
 			expectedStatus: http.StatusInternalServerError,
 			expectedCount:  0,
@@ -906,11 +921,14 @@ func TestGetRecentDetections(t *testing.T) {
 
 			// Create request
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/recent", http.NoBody)
+			q := req.URL.Query()
 			if tc.limit != "" {
-				q := req.URL.Query()
 				q.Add("limit", tc.limit)
-				req.URL.RawQuery = q.Encode()
 			}
+			if tc.aboveThreshold {
+				q.Add("aboveThreshold", QueryValueTrue)
+			}
+			req.URL.RawQuery = q.Encode()
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -908,6 +908,8 @@ func (ds *DataStore) GetLastDetectionsWithMinimumConfidence(numDetections int, m
 	return ds.getLastDetections(numDetections, minConfidence, true)
 }
 
+// getLastDetections keeps the relation preloads and ordering identical for raw
+// and confidence-filtered recent detection queries.
 func (ds *DataStore) getLastDetections(numDetections int, minConfidence float64, filterConfidence bool) ([]Note, error) {
 	var notes []Note
 	now := time.Now()

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -939,7 +939,8 @@ func (ds *DataStore) getLastDetections(numDetections int, minConfidence float64,
 
 	elapsed := time.Since(now)
 	GetLogger().Debug("Retrieved detections",
-		logger.Int("count", numDetections),
+		logger.Int("count", len(notes)),
+		logger.Int("limit", numDetections),
 		logger.Duration("elapsed", elapsed))
 
 	return notes, nil

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -110,6 +110,7 @@ type Interface interface {
 	GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error)
 	SpeciesDetections(species, date, hour string, duration int, sortAscending bool, limit int, offset int) ([]Note, error)
 	GetLastDetections(numDetections int) ([]Note, error)
+	GetLastDetectionsWithMinimumConfidence(numDetections int, minConfidence float64) ([]Note, error)
 	GetAllDetectedSpecies() ([]Note, error)
 	SearchNotes(query string, sortAscending bool, limit int, offset int) ([]Note, int64, error)
 	SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note, int64, error)
@@ -898,13 +899,28 @@ func (ds *DataStore) SpeciesDetections(species, date, hour string, duration int,
 
 // GetLastDetections retrieves the most recent bird detections.
 func (ds *DataStore) GetLastDetections(numDetections int) ([]Note, error) {
+	return ds.getLastDetections(numDetections, 0, false)
+}
+
+// GetLastDetectionsWithMinimumConfidence retrieves the most recent bird detections
+// whose confidence is at or above minConfidence.
+func (ds *DataStore) GetLastDetectionsWithMinimumConfidence(numDetections int, minConfidence float64) ([]Note, error) {
+	return ds.getLastDetections(numDetections, minConfidence, true)
+}
+
+func (ds *DataStore) getLastDetections(numDetections int, minConfidence float64, filterConfidence bool) ([]Note, error) {
 	var notes []Note
 	now := time.Now()
 
-	// Retrieve the most recent detections based on the ID in descending order
-	if result := ds.DB.Preload("Review").Preload("Lock").Preload("Comments", func(db *gorm.DB) *gorm.DB {
+	query := ds.DB.Preload("Review").Preload("Lock").Preload("Comments", func(db *gorm.DB) *gorm.DB {
 		return db.Order("created_at DESC") // Order comments by creation time, newest first
-	}).Order("id DESC").Limit(numDetections).Find(&notes); result.Error != nil {
+	})
+	if filterConfidence {
+		query = query.Where("confidence >= ?", minConfidence)
+	}
+
+	// Retrieve the most recent detections based on the ID in descending order
+	if result := query.Order("id DESC").Limit(numDetections).Find(&notes); result.Error != nil {
 		return nil, errors.New(result.Error).
 			Component("datastore").
 			Category(errors.CategoryDatabase).

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -2630,6 +2630,65 @@ func (_c *MockInterface_GetLastDetections_Call) RunAndReturn(run func(int) ([]da
 	return _c
 }
 
+// GetLastDetectionsWithMinimumConfidence provides a mock function with given fields: numDetections, minConfidence
+func (_m *MockInterface) GetLastDetectionsWithMinimumConfidence(numDetections int, minConfidence float64) ([]datastore.Note, error) {
+	ret := _m.Called(numDetections, minConfidence)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastDetectionsWithMinimumConfidence")
+	}
+
+	var r0 []datastore.Note
+	var r1 error
+	if rf, ok := ret.Get(0).(func(int, float64) ([]datastore.Note, error)); ok {
+		return rf(numDetections, minConfidence)
+	}
+	if rf, ok := ret.Get(0).(func(int, float64) []datastore.Note); ok {
+		r0 = rf(numDetections, minConfidence)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.Note)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(int, float64) error); ok {
+		r1 = rf(numDetections, minConfidence)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetLastDetectionsWithMinimumConfidence_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastDetectionsWithMinimumConfidence'
+type MockInterface_GetLastDetectionsWithMinimumConfidence_Call struct {
+	*mock.Call
+}
+
+// GetLastDetectionsWithMinimumConfidence is a helper method to define mock.On call
+//   - numDetections int
+//   - minConfidence float64
+func (_e *MockInterface_Expecter) GetLastDetectionsWithMinimumConfidence(numDetections interface{}, minConfidence interface{}) *MockInterface_GetLastDetectionsWithMinimumConfidence_Call {
+	return &MockInterface_GetLastDetectionsWithMinimumConfidence_Call{Call: _e.mock.On("GetLastDetectionsWithMinimumConfidence", numDetections, minConfidence)}
+}
+
+func (_c *MockInterface_GetLastDetectionsWithMinimumConfidence_Call) Run(run func(numDetections int, minConfidence float64)) *MockInterface_GetLastDetectionsWithMinimumConfidence_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int), args[1].(float64))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetLastDetectionsWithMinimumConfidence_Call) Return(_a0 []datastore.Note, _a1 error) *MockInterface_GetLastDetectionsWithMinimumConfidence_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetLastDetectionsWithMinimumConfidence_Call) RunAndReturn(run func(int, float64) ([]datastore.Note, error)) *MockInterface_GetLastDetectionsWithMinimumConfidence_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLockedNotesClipPaths provides a mock function with no fields
 func (_m *MockInterface) GetLockedNotesClipPaths() ([]string, error) {
 	ret := _m.Called()

--- a/internal/datastore/recent_detections_test.go
+++ b/internal/datastore/recent_detections_test.go
@@ -1,0 +1,35 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetLastDetectionsWithMinimumConfidence(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Note{}, &NoteReview{}, &NoteComment{}, &NoteLock{}))
+
+	ds := &DataStore{DB: db}
+	notes := []Note{
+		{Date: "2026-05-25", Time: "10:00:00", ScientificName: "Turdus migratorius", CommonName: "American Robin", Confidence: 0.95},
+		{Date: "2026-05-25", Time: "10:01:00", ScientificName: "Corvus brachyrhynchos", CommonName: "American Crow", Confidence: 0.60},
+		{Date: "2026-05-25", Time: "10:02:00", ScientificName: "Cyanocitta cristata", CommonName: "Blue Jay", Confidence: 0.85},
+	}
+	for i := range notes {
+		require.NoError(t, db.Create(&notes[i]).Error)
+	}
+
+	got, err := ds.GetLastDetectionsWithMinimumConfidence(10, 0.8)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "Blue Jay", got[0].CommonName)
+	assert.Equal(t, "American Robin", got[1].CommonName)
+	for i := range got {
+		assert.GreaterOrEqual(t, got[i].Confidence, 0.8)
+	}
+}

--- a/internal/datastore/recent_detections_test.go
+++ b/internal/datastore/recent_detections_test.go
@@ -9,6 +9,8 @@ import (
 	"gorm.io/gorm"
 )
 
+// TestGetLastDetectionsWithMinimumConfidence verifies confidence filtering keeps
+// newest-first ordering while excluding below-threshold notes.
 func TestGetLastDetectionsWithMinimumConfidence(t *testing.T) {
 	const (
 		highConfidence = 0.95

--- a/internal/datastore/recent_detections_test.go
+++ b/internal/datastore/recent_detections_test.go
@@ -10,26 +10,42 @@ import (
 )
 
 func TestGetLastDetectionsWithMinimumConfidence(t *testing.T) {
+	const (
+		highConfidence = 0.95
+		lowConfidence  = 0.60
+		midConfidence  = 0.85
+		resultLimit    = 10
+		minConfidence  = 0.8
+		expectedCount  = 2
+	)
+
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		require.NoError(t, sqlDB.Close())
+	})
+
 	require.NoError(t, db.AutoMigrate(&Note{}, &NoteReview{}, &NoteComment{}, &NoteLock{}))
 
 	ds := &DataStore{DB: db}
 	notes := []Note{
-		{Date: "2026-05-25", Time: "10:00:00", ScientificName: "Turdus migratorius", CommonName: "American Robin", Confidence: 0.95},
-		{Date: "2026-05-25", Time: "10:01:00", ScientificName: "Corvus brachyrhynchos", CommonName: "American Crow", Confidence: 0.60},
-		{Date: "2026-05-25", Time: "10:02:00", ScientificName: "Cyanocitta cristata", CommonName: "Blue Jay", Confidence: 0.85},
+		{Date: "2026-05-25", Time: "10:00:00", ScientificName: "Turdus migratorius", CommonName: "American Robin", Confidence: highConfidence},
+		{Date: "2026-05-25", Time: "10:01:00", ScientificName: "Corvus brachyrhynchos", CommonName: "American Crow", Confidence: lowConfidence},
+		{Date: "2026-05-25", Time: "10:02:00", ScientificName: "Cyanocitta cristata", CommonName: "Blue Jay", Confidence: midConfidence},
 	}
 	for i := range notes {
 		require.NoError(t, db.Create(&notes[i]).Error)
 	}
 
-	got, err := ds.GetLastDetectionsWithMinimumConfidence(10, 0.8)
+	got, err := ds.GetLastDetectionsWithMinimumConfidence(resultLimit, minConfidence)
 	require.NoError(t, err)
-	require.Len(t, got, 2)
+	require.Len(t, got, expectedCount)
 	assert.Equal(t, "Blue Jay", got[0].CommonName)
 	assert.Equal(t, "American Robin", got[1].CommonName)
 	for i := range got {
-		assert.GreaterOrEqual(t, got[i].Confidence, 0.8)
+		assert.GreaterOrEqual(t, got[i].Confidence, minConfidence)
 	}
 }

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -683,7 +683,10 @@ func (s *testLegacyInterface) SpeciesDetections(_, _, _ string, _ int, _ bool, _
 	return nil, nil
 }
 func (s *testLegacyInterface) GetLastDetections(_ int) ([]datastore.Note, error) { return nil, nil }
-func (s *testLegacyInterface) GetAllDetectedSpecies() ([]datastore.Note, error)  { return nil, nil }
+func (s *testLegacyInterface) GetLastDetectionsWithMinimumConfidence(_ int, _ float64) ([]datastore.Note, error) {
+	return nil, nil
+}
+func (s *testLegacyInterface) GetAllDetectedSpecies() ([]datastore.Note, error) { return nil, nil }
 func (s *testLegacyInterface) SearchNotes(_ string, _ bool, _, _ int) ([]datastore.Note, int64, error) {
 	return nil, 0, nil
 }

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -56,6 +56,9 @@ type DetectionRepository interface {
 	// GetRecent retrieves the most recent detections with preloaded relations.
 	GetRecent(ctx context.Context, limit int) ([]*entities.Detection, error)
 
+	// GetRecentWithMinimumConfidence retrieves the most recent detections at or above minConfidence.
+	GetRecentWithMinimumConfidence(ctx context.Context, limit int, minConfidence float64) ([]*entities.Detection, error)
+
 	// GetByLabel retrieves detections for a specific label.
 	// Returns results, total count, and any error.
 	GetByLabel(ctx context.Context, labelID uint, limit, offset int) ([]*entities.Detection, int64, error)

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -417,6 +417,24 @@ func (r *detectionRepository) GetRecent(ctx context.Context, limit int) ([]*enti
 	return dets, nil
 }
 
+// GetRecentWithMinimumConfidence retrieves the most recent detections at or above minConfidence with relations.
+func (r *detectionRepository) GetRecentWithMinimumConfidence(ctx context.Context, limit int, minConfidence float64) ([]*entities.Detection, error) {
+	var dets []*entities.Detection
+	err := r.db.WithContext(ctx).Table(r.tableName()).
+		Where("confidence >= ?", minConfidence).
+		Order("detected_at DESC").
+		Limit(limit).
+		Find(&dets).Error
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.loadRelationsForDetections(ctx, dets); err != nil {
+		return nil, err
+	}
+	return dets, nil
+}
+
 // loadRelationsForDetections loads Label, Model, Source for multiple detections.
 // Returns error if any relation lookup fails.
 func (r *detectionRepository) loadRelationsForDetections(ctx context.Context, dets []*entities.Detection) error {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1347,6 +1347,16 @@ func (ds *Datastore) GetLastDetections(numDetections int) ([]datastore.Note, err
 	return ds.detectionsToNotes(dets), nil
 }
 
+// GetLastDetectionsWithMinimumConfidence retrieves the last N detections at or above minConfidence.
+func (ds *Datastore) GetLastDetectionsWithMinimumConfidence(numDetections int, minConfidence float64) ([]datastore.Note, error) {
+	ctx := context.Background()
+	dets, err := ds.detection.GetRecentWithMinimumConfidence(ctx, numDetections, minConfidence)
+	if err != nil {
+		return nil, err
+	}
+	return ds.detectionsToNotes(dets), nil
+}
+
 // GetAllDetectedSpecies retrieves all detected species.
 func (ds *Datastore) GetAllDetectedSpecies() ([]datastore.Note, error) {
 	ctx := context.Background()

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -688,6 +688,30 @@ func TestV2OnlyDatastore_GetLastDetections(t *testing.T) {
 	assert.Len(t, notes, 5)
 }
 
+func TestV2OnlyDatastore_GetLastDetectionsWithMinimumConfidence(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	testNotes := []datastore.Note{
+		{Date: "2024-01-15", Time: "12:30:00", ScientificName: "Passer domesticus", Confidence: 0.95},
+		{Date: "2024-01-15", Time: "12:31:00", ScientificName: "Turdus migratorius", Confidence: 0.60},
+		{Date: "2024-01-15", Time: "12:32:00", ScientificName: "Corvus brachyrhynchos", Confidence: 0.85},
+	}
+	for i := range testNotes {
+		err := ds.Save(&testNotes[i], nil)
+		require.NoError(t, err)
+	}
+
+	notes, err := ds.GetLastDetectionsWithMinimumConfidence(10, 0.8)
+	require.NoError(t, err)
+	require.Len(t, notes, 2)
+	assert.Equal(t, "Corvus brachyrhynchos", notes[0].ScientificName)
+	assert.Equal(t, "Passer domesticus", notes[1].ScientificName)
+	for i := range notes {
+		assert.GreaterOrEqual(t, notes[i].Confidence, 0.8)
+	}
+}
+
 func TestV2OnlyDatastore_GetDatabaseStats(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -688,6 +688,8 @@ func TestV2OnlyDatastore_GetLastDetections(t *testing.T) {
 	assert.Len(t, notes, 5)
 }
 
+// TestV2OnlyDatastore_GetLastDetectionsWithMinimumConfidence verifies the v2-only
+// datastore applies the confidence threshold while preserving recent ordering.
 func TestV2OnlyDatastore_GetLastDetectionsWithMinimumConfidence(t *testing.T) {
 	const (
 		highConfidence = 0.95

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -689,26 +689,35 @@ func TestV2OnlyDatastore_GetLastDetections(t *testing.T) {
 }
 
 func TestV2OnlyDatastore_GetLastDetectionsWithMinimumConfidence(t *testing.T) {
+	const (
+		highConfidence = 0.95
+		lowConfidence  = 0.60
+		midConfidence  = 0.85
+		resultLimit    = 10
+		minConfidence  = 0.8
+		expectedCount  = 2
+	)
+
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
 
 	testNotes := []datastore.Note{
-		{Date: "2024-01-15", Time: "12:30:00", ScientificName: "Passer domesticus", Confidence: 0.95},
-		{Date: "2024-01-15", Time: "12:31:00", ScientificName: "Turdus migratorius", Confidence: 0.60},
-		{Date: "2024-01-15", Time: "12:32:00", ScientificName: "Corvus brachyrhynchos", Confidence: 0.85},
+		{Date: "2024-01-15", Time: "12:30:00", ScientificName: "Passer domesticus", Confidence: highConfidence},
+		{Date: "2024-01-15", Time: "12:31:00", ScientificName: "Turdus migratorius", Confidence: lowConfidence},
+		{Date: "2024-01-15", Time: "12:32:00", ScientificName: "Corvus brachyrhynchos", Confidence: midConfidence},
 	}
 	for i := range testNotes {
 		err := ds.Save(&testNotes[i], nil)
 		require.NoError(t, err)
 	}
 
-	notes, err := ds.GetLastDetectionsWithMinimumConfidence(10, 0.8)
+	notes, err := ds.GetLastDetectionsWithMinimumConfidence(resultLimit, minConfidence)
 	require.NoError(t, err)
-	require.Len(t, notes, 2)
+	require.Len(t, notes, expectedCount)
 	assert.Equal(t, "Corvus brachyrhynchos", notes[0].ScientificName)
 	assert.Equal(t, "Passer domesticus", notes[1].ScientificName)
 	for i := range notes {
-		assert.GreaterOrEqual(t, notes[i].Confidence, 0.8)
+		assert.GreaterOrEqual(t, notes[i].Confidence, minConfidence)
 	}
 }
 

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -176,7 +176,10 @@ func (m *mockStore) SpeciesDetections(species, date, hour string, duration int, 
 	return nil, nil
 }
 func (m *mockStore) GetLastDetections(num int) ([]datastore.Note, error) { return nil, nil }
-func (m *mockStore) GetAllDetectedSpecies() ([]datastore.Note, error)    { return nil, nil }
+func (m *mockStore) GetLastDetectionsWithMinimumConfidence(num int, minConfidence float64) ([]datastore.Note, error) {
+	return nil, nil
+}
+func (m *mockStore) GetAllDetectedSpecies() ([]datastore.Note, error) { return nil, nil }
 func (m *mockStore) SearchNotes(query string, asc bool, limit, offset int) ([]datastore.Note, int64, error) {
 	return nil, 0, nil
 }


### PR DESCRIPTION
## Summary

- Keep `/api/v2/detections/recent` backwards-compatible by returning raw recent detections by default.
- Add `aboveThreshold=true` as an opt-in query parameter that filters recent detections by the configured global BirdNET confidence threshold.
- Update the dashboard's recent detections request to use `aboveThreshold=true`, so the dashboard excludes detections below the global confidence threshold.
- Add legacy datastore and v2-only datastore/repository paths for retrieving recent detections above a minimum confidence.
- Cover the default and threshold-filtered recent-detection paths with API, legacy datastore, and v2-only datastore tests, and update endpoint docs.

## Root Cause

The dashboard's recent detections widget used the raw `/api/v2/detections/recent` endpoint, so it could show detections below the global threshold even though alerting ignores detections below that threshold. The first version changed the endpoint default; this version keeps the API default stable and makes the dashboard opt into threshold filtering.

## Behavior Change

`GET /api/v2/detections/recent` keeps its existing default behavior.

Clients that want global-threshold filtering can call:

```text
/api/v2/detections/recent?aboveThreshold=true
```

When `aboveThreshold=true`, results include only detections with `confidence >= BirdNET.Threshold`. If settings are unavailable, the threshold floor falls back to `0`.

## Review Feedback Addressed

- Pin the in-memory SQLite datastore test to a single connection and close the DB in `t.Cleanup`.
- Log the actual retrieved detection count and requested limit separately.
- Replace threshold/count literals in the new datastore tests with named constants.
- Tighten dashboard endpoint docs so they describe the global-threshold behavior without overstating notification semantics.
- Add doc comments for the new threshold helper/test paths flagged by CodeRabbit's docstring coverage warning.

## Preflight Status

- [x] Single concern: one user-facing dashboard behavior change, with API/datastore support kept to that behavior.
- [x] Preflight Phase 1-3 review completed; no additional in-scope findings remain.
- [x] No unrelated PR diff: final PR diff is 16 files, all tied to dashboard recent-detections threshold behavior or required interface/test plumbing.
- [x] Scope complete: no TODO/FIXME added for core functionality.
- [x] Breaking changes documented: no backwards-incompatible API default change; opt-in behavior is documented here and in endpoint docs.
- [x] i18n complete: no user-facing frontend strings were added.
- [x] No secrets or PII in the diff.
- [x] `git diff --check` passed.
- [x] `golangci-lint run -v` passed with local TensorFlow Lite CGO paths: 0 issues.
- [x] `npm run check:all` passed; it still reports 3 pre-existing ESLint security warnings in unchanged frontend files.
- [x] `npm test` passed: 107 files, 1968 tests.
- [x] Focused Go tests passed outside the sandbox:
  - `go test -tags noembed,skipfrontend ./internal/datastore ./internal/datastore/v2only ./internal/datastore/v2/repository ./internal/datastore/v2/migration/testutil`
  - `go test -tags noembed,skipfrontend ./internal/api/v2 -run 'TestGetRecentDetections|TestGetRecentDetections_DefaultParams' -count=1 -v`
- [x] In-scope Go race tests passed outside the sandbox before the doc-comment-only follow-up:
  - `go test -race -tags noembed,skipfrontend ./internal/datastore ./internal/datastore/v2only ./internal/datastore/v2/repository ./internal/datastore/v2/migration/testutil ./internal/api/v2`
- [ ] `go test -tags noembed,skipfrontend ./internal/api/v2 -count=1` is not green locally due to unrelated date-sensitive weather test behavior:
  - `internal/api/v2`: `TestGetHourlyWeatherForDayFutureDate` expected `No weather data available for future date` but received `No weather data found for the specified date`.
- [ ] `go test -race ./...` was run outside the sandbox with TensorFlow Lite CGO paths and is not green locally due to unrelated macOS/environment-sensitive failures:
  - `internal/birdweather`: `TestEncodeFlacUsingFFmpeg` expects `ffmpeg` to be accepted, but local validation requires an absolute FFmpeg path.
  - `internal/monitor`: `TestGroupPathsWithPartitions_MixedRootAndVolumePaths` expected Linux mount data (`/dev/sda1`) that is unavailable on this macOS runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional filtering for recent detections by the global confidence threshold; dashboard shows detections meeting or exceeding the configured BirdNET threshold.

* **Documentation**
  * API docs updated to describe the new above-threshold query parameter and example usage.

* **Tests**
  * Added and updated tests to cover threshold-filtered recent detections and default limit behavior.

* **Refactor**
  * Detection retrieval logic consolidated to support confidence-based filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->