### PR TITLE
fix(audio): always apply channel downmix for FFmpeg streams

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1453,6 +1453,13 @@ func (p *AudioPipelineService) probeStreamSampleRate(url, name string) int {
 		logger.Int("channels", info.Channels),
 		logger.String("operation", "probe_stream"))
 
+	if info.Channels > 1 {
+		log.Warn("stream sends multi-channel audio; FFmpeg will downmix to mono but phase differences between channels can cause comb filtering that reduces detection accuracy. Configure the source to send mono if possible.",
+			logger.String("stream", name),
+			logger.Int("channels", info.Channels),
+			logger.String("operation", "probe_stream"))
+	}
+
 	if ffmpeg.IsLossyCodec(info.Codec) {
 		log.Warn("stream uses lossy codec that destroys ultrasonic content",
 			logger.String("stream", name),

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -817,10 +817,10 @@ func (s *Stream) startProcess() error {
 		"-loglevel", logLevel,
 		"-vn",
 		"-f", format,
+		"-ac", numChannels,
 	)
-
 	if s.config.needsOutputResampling() {
-		args = append(args, "-ar", sampleRate, "-ac", numChannels)
+		args = append(args, "-ar", sampleRate)
 	}
 
 	args = append(args, "-hide_banner", "pipe:1")


### PR DESCRIPTION
## Summary

- Always pass `-ac` (channel count) to FFmpeg regardless of whether sample rate resampling is needed. PR #3256 accidentally tied `-ac 1` to the `-ar` flag behind `needsOutputResampling()`, which skips both when source and target rates match (both 48kHz). Stereo RTSP streams passed through without mono downmix, causing the pipeline to read interleaved L,R samples as mono, halving effective sample rate and corrupting frequency content.
- Add a warning log when a stream sends multi-channel audio, since stereo phase differences cause comb filtering that reduces detection accuracy even with correct downmix.

Fixes #3278, fixes #3277.

## Test plan

- [x] Existing `TestBuildFFmpegArgs` and `TestStream_NeedsOutputResampling` tests pass
- [x] All 360 tests in `internal/audiocore/ffmpeg/` pass with `-race`
- [x] `golangci-lint` clean
- [ ] Verify with a stereo RTSP source that audio sounds correct and data rate shows ~96 KB/s (not ~192 KB/s)
- [ ] Verify new warning appears in logs for stereo streams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio channel handling to ensure consistent processing regardless of resampling requirements
  * Added warning notifications when processing multi-channel audio files, informing users that channels will be downmixed to mono, which may impact detection accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->