### PR TITLE
fix(classifier): keep memory leak test serial

### DIFF
--- a/internal/classifier/genus_memory_test.go
+++ b/internal/classifier/genus_memory_test.go
@@ -91,10 +91,11 @@ func TestMemoryLeaks(t *testing.T) {
 		t.Skip("Skipping memory leak test in short mode")
 	}
 
-	t.Parallel()
 	t.Attr("component", "birdnet-genus")
 	t.Attr("category", "memory")
 
+	// This test measures process-wide heap state, so it must not run in
+	// parallel with classifier tests that load TFLite models in this process.
 	db, err := LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 


### PR DESCRIPTION
## Summary

`internal/classifier/TestMemoryLeaks` was measuring process-wide heap state while also calling `t.Parallel()`. In the full `go test -race ./...` run, other classifier tests can load TFLite models in the same test process, making unrelated heap growth visible to this memory assertion.

This PR keeps the memory leak test serial and documents why it must not run in parallel. The isolated test was already passing; the aggregate race suite now passes as well.

## Preflight Status

- Single concern: one test-stability fix for the classifier memory/race suite.
- Preflight review: no additional in-scope findings from reuse, correctness, quality, i18n, or integration wiring passes.
- Go lint: `golangci-lint run -v --build-tags=noembed,skipfrontend` passed with 0 issues. A literal no-build-tag `golangci-lint run -v` failed locally before diff-specific findings with pre-existing `gocritic` ruleguard setup errors across the repo.
- Frontend lint/check: `npm run check:all` passed. ESLint reported 3 pre-existing warnings in unrelated frontend files.
- Go tests: `go test -race ./...` passed with local TFLite CGO headers/libs and sandbox-safe cache/temp paths.
- Frontend tests: `npm test -- --run` passed: 107 files, 1968 tests.
- No unrelated changes: diff contains only `internal/classifier/genus_memory_test.go`.
- Scope complete: no TODO/FIXME added.
- Breaking changes: none.
- i18n: not applicable; no user-facing strings.
- Secrets/PII: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified test execution to prevent memory-based tests from running concurrently with model-loading tests, ensuring reliable test isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->