### PR TITLE
fix(audio): use -stimeout for RTSP streams, add stereo downmix warning

### DIFF
--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -177,6 +177,11 @@
 
   let testResult = $state<{ sampleRate: number; channels: number } | null>(null);
 
+  // Show a warning when a stereo source is still set to downmix mode
+  let showStereoWarning = $derived(
+    (health?.source_channels ?? 0) >= 2 && (stream.channelMode ?? 'downmix') === 'downmix'
+  );
+
   // Local editing state - initialized with defaults, synced from props in startEdit()
   let isEditing = $state(false);
   let editName = $state('');
@@ -884,6 +889,17 @@
           </div>
         </div>
       </div>
+
+      <!-- Stereo downmix warning: shown when a stereo source is still using downmix -->
+      {#if showStereoWarning}
+        <div
+          class="flex items-center gap-2 px-3 py-1.5 border-t border-[var(--color-warning)]/20 bg-[var(--color-warning)]/5 text-[var(--color-warning)]"
+          title={t('settings.audio.streams.stereoWarning.tooltip')}
+        >
+          <AlertTriangle class="size-3.5 flex-shrink-0" />
+          <span class="text-xs">{t('settings.audio.streams.stereoWarning.short')}</span>
+        </div>
+      {/if}
 
       <!-- Expandable Diagnostics Panel -->
       {#if expanded}

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -89,6 +89,7 @@
     total_bytes_received: number;
     bytes_per_second: number;
     is_receiving_data: boolean;
+    source_channels?: number; // Detected channel count (0 or absent if unknown)
     // Error diagnostics
     last_error_context?: ErrorContext | null;
     error_history?: ErrorContext[];

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -52,6 +52,8 @@ type StreamHealthResponse struct {
 	TotalBytesReceived int64   `json:"total_bytes_received"` // Total bytes received
 	BytesPerSecond     float64 `json:"bytes_per_second"`     // Current data rate
 	IsReceivingData    bool    `json:"is_receiving_data"`    // Whether stream is actively receiving data
+	// Audio info
+	SourceChannels int `json:"source_channels,omitempty"` // Detected channel count of the remote source (0 if unknown)
 	// Error diagnostics (from PR #1380)
 	LastErrorContext *ErrorContextResponse   `json:"last_error_context,omitempty"` // Most recent error with troubleshooting
 	ErrorHistory     []*ErrorContextResponse `json:"error_history,omitempty"`      // Recent errors (last 10)
@@ -385,6 +387,7 @@ func convertStreamHealthToResponse(rawURL string, health *ffmpeg.StreamHealth) S
 		TotalBytesReceived: health.TotalBytesReceived,
 		BytesPerSecond:     health.BytesPerSecond,
 		IsReceivingData:    health.IsReceivingData,
+		SourceChannels:     health.SourceChannels,
 	}
 
 	// Handle LastDataReceived (may be zero time if never received data)
@@ -791,6 +794,7 @@ func (c *Controller) sendStreamStatsUpdate(ctx echo.Context, rawURL string, heal
 		TotalBytesReceived: health.TotalBytesReceived,
 		BytesPerSecond:     health.BytesPerSecond,
 		IsReceivingData:    health.IsReceivingData,
+		SourceChannels:     health.SourceChannels,
 		TimeSinceData:      timeSinceData,
 		// Explicitly omit: ErrorHistory, StateHistory, LastErrorContext
 	}

--- a/internal/audiocore/ffmpeg/analyze.go
+++ b/internal/audiocore/ffmpeg/analyze.go
@@ -109,7 +109,7 @@ func buildAnalysisArgs(url string) []string {
 
 	timeoutKey := ffmpegTimeoutParam
 	if isRTSP {
-		timeoutKey = "-stimeout"
+		timeoutKey = ffmpegRTSPTimeoutParam
 	}
 
 	args = append(args,

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -24,6 +24,36 @@ import (
 // ffmpegTimeoutParam is the FFmpeg flag name for the connection timeout parameter.
 const ffmpegTimeoutParam = "-timeout"
 
+// ffmpegRTSPTimeoutParam is the RTSP-specific stream timeout flag.
+// FFmpeg ignores -timeout for the RTSP protocol; -stimeout must be used instead.
+const ffmpegRTSPTimeoutParam = "-stimeout"
+
+// timeoutParamForSource returns the correct FFmpeg timeout flag for the given source type.
+func timeoutParamForSource(st audiocore.SourceType) string {
+	if st == audiocore.SourceTypeRTSP {
+		return ffmpegRTSPTimeoutParam
+	}
+	return ffmpegTimeoutParam
+}
+
+// stripTimeoutParams returns a copy of params with any -timeout/-stimeout key-value pairs removed.
+func stripTimeoutParams(params []string) []string {
+	out := make([]string, 0, len(params))
+	skipNext := false
+	for _, param := range params {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if param == ffmpegTimeoutParam || param == ffmpegRTSPTimeoutParam {
+			skipNext = true
+			continue
+		}
+		out = append(out, param)
+	}
+	return out
+}
+
 // AudioFilters defines optional processing filters for clip extraction and preview.
 type AudioFilters struct {
 	// Denoise preset name: "", "light", "medium", or "heavy".
@@ -402,8 +432,10 @@ func appendChannelArgs(args []string, channelMode string, sourceChannels int, nu
 
 // buildInputArgs constructs the pre-input FFmpeg flags (transport, timeout, extra parameters).
 // This mirrors the logic in Stream.buildFFmpegInputArgs but accepts explicit parameters.
+// RTSP streams use -stimeout (FFmpeg ignores -timeout for the RTSP protocol).
 func buildInputArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
 	args := make([]string, 0, 8+len(ffmpegParameters))
+	timeoutFlag := timeoutParamForSource(cfg.sourceType())
 
 	if cfg.sourceType() == audiocore.SourceTypeRTSP {
 		args = append(args, "-rtsp_transport", cfg.Transport)
@@ -412,33 +444,19 @@ func buildInputArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
 	hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters)
 
 	if !hasUserTimeout {
-		args = append(args, ffmpegTimeoutParam, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
-	}
-
-	if len(ffmpegParameters) > 0 {
-		if hasUserTimeout {
-			if err := validateTimeout(userTimeoutValue); err != nil {
-				// Invalid user timeout: fall back to default and strip the bad -timeout pair.
-				args = append(args, ffmpegTimeoutParam, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
-				skipNext := false
-				for _, param := range ffmpegParameters {
-					if skipNext {
-						skipNext = false
-						continue
-					}
-					if param == ffmpegTimeoutParam {
-						skipNext = true
-						continue
-					}
-					args = append(args, param)
-				}
-			} else {
-				args = append(args, ffmpegParameters...)
-			}
-		} else {
+		args = append(args, timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
+		if len(ffmpegParameters) > 0 {
 			args = append(args, ffmpegParameters...)
 		}
+		return args
 	}
+
+	if err := validateTimeout(userTimeoutValue); err != nil {
+		args = append(args, timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
+	} else {
+		args = append(args, timeoutFlag, userTimeoutValue)
+	}
+	args = append(args, stripTimeoutParams(ffmpegParameters)...)
 
 	return args
 }

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
 // TestBuildFFmpegArgs_RTSP verifies that BuildFFmpegArgs produces the correct
@@ -32,9 +33,10 @@ func TestBuildFFmpegArgs_RTSP(t *testing.T) {
 	require.Less(t, rtspIdx+1, len(args), "-rtsp_transport must have a value")
 	assert.Equal(t, "tcp", args[rtspIdx+1])
 
-	// Default timeout must be present when no user timeout is supplied.
-	timeoutIdx := slices.Index(args, "-timeout")
-	require.NotEqual(t, -1, timeoutIdx, "expected -timeout flag")
+	// RTSP must use -stimeout, not -timeout.
+	stimeoutIdx := slices.Index(args, "-stimeout")
+	require.NotEqual(t, -1, stimeoutIdx, "expected -stimeout flag for RTSP")
+	assert.Equal(t, -1, slices.Index(args, "-timeout"), "RTSP must not use -timeout")
 
 	// Input URL must be present.
 	iIdx := slices.Index(args, "-i")
@@ -72,8 +74,9 @@ func TestBuildFFmpegArgs_HTTP(t *testing.T) {
 	// RTSP transport flag must NOT be present for HTTP sources.
 	assert.Equal(t, -1, slices.Index(args, "-rtsp_transport"), "HTTP source must not include -rtsp_transport")
 
-	// Default timeout should still be present.
-	assert.NotEqual(t, -1, slices.Index(args, "-timeout"), "expected -timeout flag")
+	// HTTP must use -timeout, not -stimeout.
+	assert.NotEqual(t, -1, slices.Index(args, "-timeout"), "expected -timeout flag for HTTP")
+	assert.Equal(t, -1, slices.Index(args, "-stimeout"), "HTTP must not use -stimeout")
 
 	// Input URL must be present.
 	iIdx := slices.Index(args, "-i")
@@ -86,7 +89,7 @@ func TestBuildFFmpegArgs_HTTP(t *testing.T) {
 }
 
 // TestBuildFFmpegArgs_CustomTimeout verifies that a user-provided valid timeout
-// replaces the default and is included in the output args.
+// is converted to the correct flag for the source type.
 func TestBuildFFmpegArgs_CustomTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -96,23 +99,62 @@ func TestBuildFFmpegArgs_CustomTimeout(t *testing.T) {
 		Transport: "tcp",
 	}
 
-	// 5 seconds in microseconds — above the 1-second minimum.
+	// User provides -timeout but RTSP needs -stimeout.
 	customParams := []string{"-timeout", "5000000"}
 	args := BuildFFmpegArgs(cfg, customParams)
 
-	timeoutIdx := slices.Index(args, "-timeout")
-	require.NotEqual(t, -1, timeoutIdx)
-	require.Less(t, timeoutIdx+1, len(args), "-timeout must have a value")
-	assert.Equal(t, "5000000", args[timeoutIdx+1])
+	// Must be converted to -stimeout with the user's value.
+	stimeoutIdx := slices.Index(args, "-stimeout")
+	require.NotEqual(t, -1, stimeoutIdx, "expected -stimeout for RTSP")
+	require.Less(t, stimeoutIdx+1, len(args), "-stimeout must have a value")
+	assert.Equal(t, "5000000", args[stimeoutIdx+1])
 
-	// Must appear only once.
+	// -timeout must not appear (stripped and converted).
+	assert.Equal(t, -1, slices.Index(args, "-timeout"), "RTSP must not contain -timeout")
+
+	// -stimeout must appear only once.
 	count := 0
 	for _, a := range args {
-		if a == ffmpegTimeoutFlag {
+		if a == "-stimeout" {
 			count++
 		}
 	}
-	assert.Equal(t, 1, count, "timeout flag must appear exactly once")
+	assert.Equal(t, 1, count, "-stimeout must appear exactly once")
+}
+
+func TestTimeoutParamForSource(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "-stimeout", timeoutParamForSource(audiocore.SourceTypeRTSP))
+	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeHTTP))
+	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeHLS))
+	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeRTMP))
+	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeUDP))
+}
+
+func TestStripTimeoutParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{"empty", []string{}, []string{}},
+		{"no_timeout", []string{"-loglevel", "debug"}, []string{"-loglevel", "debug"}},
+		{"strip_timeout", []string{"-timeout", "5000000", "-loglevel", "debug"}, []string{"-loglevel", "debug"}},
+		{"strip_stimeout", []string{"-stimeout", "5000000", "-loglevel", "debug"}, []string{"-loglevel", "debug"}},
+		{"strip_both", []string{"-timeout", "3000000", "-stimeout", "5000000"}, []string{}},
+		{"timeout_at_end", []string{"-loglevel", "debug", "-timeout", "5000000"}, []string{"-loglevel", "debug"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := stripTimeoutParams(tt.input)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
 }
 
 // TestBuildFFmpegArgs_ChannelModeLeft verifies that a stereo source with

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -288,6 +288,7 @@ type StreamHealth struct {
 	StateHistory       []StateTransition
 	LastErrorContext   *ErrorContext
 	ErrorHistory       []*ErrorContext
+	SourceChannels     int
 }
 
 // dataRateCalculator tracks data rate over a sliding window.
@@ -892,8 +893,10 @@ func (s *Stream) startProcess() error {
 
 // buildFFmpegInputArgs constructs the FFmpeg input arguments for this stream.
 // RTSP-specific flags like -rtsp_transport are only added for RTSP streams.
+// RTSP streams use -stimeout (FFmpeg ignores -timeout for the RTSP protocol).
 func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
 	args := []string{}
+	timeoutFlag := timeoutParamForSource(s.config.sourceType())
 
 	if s.config.sourceType() == audiocore.SourceTypeRTSP {
 		args = append(args, "-rtsp_transport", s.config.Transport)
@@ -902,38 +905,25 @@ func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
 	hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters)
 
 	if !hasUserTimeout {
-		args = append(args, "-timeout", strconv.FormatInt(defaultTimeoutMicroseconds, 10))
-	}
-
-	if len(ffmpegParameters) > 0 {
-		if hasUserTimeout {
-			if err := s.validateUserTimeout(userTimeoutValue); err != nil {
-				getStreamLogger().Warn("invalid user timeout, using default",
-					logger.String("url", s.config.safeURL()),
-					logger.String("user_timeout", userTimeoutValue),
-					logger.Error(err),
-					logger.String("component", "ffmpeg-stream"),
-					logger.String("operation", "validate_timeout"))
-				args = append(args, "-timeout", strconv.FormatInt(defaultTimeoutMicroseconds, 10))
-				skipNext := false
-				for _, param := range ffmpegParameters {
-					if skipNext {
-						skipNext = false
-						continue
-					}
-					if param == "-timeout" {
-						skipNext = true
-						continue
-					}
-					args = append(args, param)
-				}
-			} else {
-				args = append(args, ffmpegParameters...)
-			}
-		} else {
+		args = append(args, timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
+		if len(ffmpegParameters) > 0 {
 			args = append(args, ffmpegParameters...)
 		}
+		return args
 	}
+
+	if err := s.validateUserTimeout(userTimeoutValue); err != nil {
+		getStreamLogger().Warn("invalid user timeout, using default",
+			logger.String("url", s.config.safeURL()),
+			logger.String("user_timeout", userTimeoutValue),
+			logger.Error(err),
+			logger.String("component", "ffmpeg-stream"),
+			logger.String("operation", "validate_timeout"))
+		args = append(args, timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
+	} else {
+		args = append(args, timeoutFlag, userTimeoutValue)
+	}
+	args = append(args, stripTimeoutParams(ffmpegParameters)...)
 
 	return args
 }
@@ -1716,6 +1706,7 @@ func (s *Stream) GetHealth() StreamHealth {
 		StateHistory:       recentHistory,
 		LastErrorContext:   lastError,
 		ErrorHistory:       recentErrors,
+		SourceChannels:     s.config.SourceChannels,
 	}
 }
 
@@ -1934,9 +1925,11 @@ func (s *Stream) conditionalFailureReset(totalBytesReceived int64) {
 }
 
 // detectUserTimeout scans FFmpeg parameters for an existing timeout setting.
+// Detects both -timeout and -stimeout so user-provided values are honoured
+// regardless of which flag the user specified.
 func detectUserTimeout(params []string) (found bool, value string) {
 	for i, param := range params {
-		if param == "-timeout" && i+1 < len(params) {
+		if (param == ffmpegTimeoutParam || param == ffmpegRTSPTimeoutParam) && i+1 < len(params) {
 			return true, params[i+1]
 		}
 	}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -1926,11 +1926,16 @@ func (s *Stream) conditionalFailureReset(totalBytesReceived int64) {
 
 // detectUserTimeout scans FFmpeg parameters for an existing timeout setting.
 // Detects both -timeout and -stimeout so user-provided values are honoured
-// regardless of which flag the user specified.
+// regardless of which flag the user specified. A dangling flag with no
+// following value is reported as found with an empty value so callers can
+// strip it and fall back to the default.
 func detectUserTimeout(params []string) (found bool, value string) {
 	for i, param := range params {
-		if (param == ffmpegTimeoutParam || param == ffmpegRTSPTimeoutParam) && i+1 < len(params) {
-			return true, params[i+1]
+		if param == ffmpegTimeoutParam || param == ffmpegRTSPTimeoutParam {
+			if i+1 < len(params) {
+				return true, params[i+1]
+			}
+			return true, ""
 		}
 	}
 	return false, ""

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -771,11 +771,11 @@ func TestDetectUserTimeout(t *testing.T) {
 		{"empty_params", []string{}, false, ""},
 		{"no_timeout_param", []string{"-loglevel", "debug"}, false, ""},
 		{"timeout_with_value", []string{"-timeout", "5000000"}, true, "5000000"},
-		{"timeout_without_value", []string{"-timeout"}, false, ""},
+		{"timeout_without_value", []string{"-timeout"}, true, ""},
 		{"timeout_in_middle", []string{"-loglevel", "debug", "-timeout", "10000000", "-rtsp_flags", "prefer_tcp"}, true, "10000000"},
 		{"first_timeout_wins", []string{"-timeout", "5000000", "-timeout", "10000000"}, true, "5000000"},
 		{"stimeout_with_value", []string{"-stimeout", "5000000"}, true, "5000000"},
-		{"stimeout_without_value", []string{"-stimeout"}, false, ""},
+		{"stimeout_without_value", []string{"-stimeout"}, true, ""},
 		{"stimeout_in_middle", []string{"-loglevel", "debug", "-stimeout", "8000000"}, true, "8000000"},
 		{"timeout_before_stimeout", []string{"-timeout", "3000000", "-stimeout", "7000000"}, true, "3000000"},
 	}

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -15,8 +15,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 )
 
-// ffmpegTimeoutFlag is the FFmpeg flag name for connection timeout used in tests.
+// ffmpegTimeoutFlag is the FFmpeg flag name for connection timeout used in tests (non-RTSP).
 const ffmpegTimeoutFlag = "-timeout"
+
+// ffmpegRTSPTimeoutFlag is the RTSP-specific stream timeout flag used in tests.
+const ffmpegRTSPTimeoutFlag = "-stimeout"
 
 // newTestConfig returns a minimal StreamConfig suitable for unit tests.
 func newTestConfig() StreamConfig {
@@ -771,6 +774,10 @@ func TestDetectUserTimeout(t *testing.T) {
 		{"timeout_without_value", []string{"-timeout"}, false, ""},
 		{"timeout_in_middle", []string{"-loglevel", "debug", "-timeout", "10000000", "-rtsp_flags", "prefer_tcp"}, true, "10000000"},
 		{"first_timeout_wins", []string{"-timeout", "5000000", "-timeout", "10000000"}, true, "5000000"},
+		{"stimeout_with_value", []string{"-stimeout", "5000000"}, true, "5000000"},
+		{"stimeout_without_value", []string{"-stimeout"}, false, ""},
+		{"stimeout_in_middle", []string{"-loglevel", "debug", "-stimeout", "8000000"}, true, "8000000"},
+		{"timeout_before_stimeout", []string{"-timeout", "3000000", "-stimeout", "7000000"}, true, "3000000"},
 	}
 
 	for _, tt := range tests {
@@ -794,7 +801,8 @@ func TestStream_BuildFFmpegInputArgs_RTSP(t *testing.T) {
 
 	assert.Contains(t, args, "-rtsp_transport")
 	assert.Contains(t, args, "tcp")
-	assert.Contains(t, args, ffmpegTimeoutFlag)
+	assert.Contains(t, args, ffmpegRTSPTimeoutFlag, "RTSP must use -stimeout, not -timeout")
+	assert.NotContains(t, args, ffmpegTimeoutFlag, "RTSP must not use -timeout")
 }
 
 func TestStream_BuildFFmpegInputArgs_HTTP(t *testing.T) {
@@ -808,37 +816,34 @@ func TestStream_BuildFFmpegInputArgs_HTTP(t *testing.T) {
 	args := stream.buildFFmpegInputArgs(nil)
 
 	assert.NotContains(t, args, "-rtsp_transport", "HTTP stream should not have RTSP transport")
-	assert.Contains(t, args, ffmpegTimeoutFlag)
+	assert.Contains(t, args, ffmpegTimeoutFlag, "HTTP must use -timeout")
+	assert.NotContains(t, args, ffmpegRTSPTimeoutFlag, "HTTP must not use -stimeout")
 }
 
 func TestStream_BuildFFmpegInputArgs_InvalidTimeout(t *testing.T) {
 	t.Parallel()
 
-	cfg := newTestConfig()
+	cfg := newTestConfig() // default is RTSP
 	stream := newTestStreamWithConfig(t, &cfg)
 
 	params := []string{"-timeout", "abc", "-loglevel", "debug"}
 	args := stream.buildFFmpegInputArgs(params)
 
-	timeoutIdx := -1
-	for i, a := range args {
-		if a == ffmpegTimeoutFlag {
-			timeoutIdx = i
-			break
-		}
-	}
-	require.NotEqual(t, -1, timeoutIdx, "-timeout flag must be present")
-	require.Less(t, timeoutIdx+1, len(args), "-timeout must have a following value")
+	// RTSP stream: invalid user -timeout should be replaced with -stimeout default.
+	timeoutIdx := slices.Index(args, ffmpegRTSPTimeoutFlag)
+	require.NotEqual(t, -1, timeoutIdx, "-stimeout flag must be present for RTSP")
+	require.Less(t, timeoutIdx+1, len(args), "-stimeout must have a following value")
 	assert.NotEqual(t, "abc", args[timeoutIdx+1], "invalid timeout value must not reach FFmpeg")
 
 	count := 0
 	for _, a := range args {
-		if a == ffmpegTimeoutFlag {
+		if a == ffmpegRTSPTimeoutFlag {
 			count++
 		}
 	}
-	assert.Equal(t, 1, count, "-timeout must appear exactly once")
+	assert.Equal(t, 1, count, "-stimeout must appear exactly once")
 
+	assert.NotContains(t, args, ffmpegTimeoutFlag, "RTSP must not contain -timeout")
 	assert.Contains(t, args, "-loglevel")
 	assert.Contains(t, args, "debug")
 }
@@ -853,43 +858,48 @@ func TestStream_BuildFFmpegInputArgs_ProtocolSpecific(t *testing.T) {
 		transport         string
 		ffmpegParams      []string
 		wantRTSPTransport bool
-		wantTimeout       bool
+		wantStimeout      bool // RTSP uses -stimeout
+		wantTimeout       bool // non-RTSP uses -timeout
 	}{
 		{
-			name:              "rtsp_stream_includes_rtsp_transport",
+			name:              "rtsp_stream_uses_stimeout",
 			url:               "rtsp://192.168.1.100/stream",
 			sourceType:        "rtsp",
 			transport:         "tcp",
 			ffmpegParams:      []string{},
 			wantRTSPTransport: true,
-			wantTimeout:       true,
+			wantStimeout:      true,
+			wantTimeout:       false,
 		},
 		{
-			name:              "http_stream_excludes_rtsp_transport",
+			name:              "http_stream_uses_timeout",
 			url:               "http://192.168.1.183/stream",
 			sourceType:        "http",
 			transport:         "tcp",
 			ffmpegParams:      []string{"-f", "s16le", "-ar", "48000", "-ac", "1"},
 			wantRTSPTransport: false,
+			wantStimeout:      false,
 			wantTimeout:       true,
 		},
 		{
-			name:              "hls_stream_excludes_rtsp_transport",
+			name:              "hls_stream_uses_timeout",
 			url:               "http://example.com/stream.m3u8",
 			sourceType:        "hls",
 			transport:         "tcp",
 			ffmpegParams:      []string{},
 			wantRTSPTransport: false,
+			wantStimeout:      false,
 			wantTimeout:       true,
 		},
 		{
-			name:              "rtsp_with_user_timeout",
+			name:              "rtsp_with_user_timeout_converts_to_stimeout",
 			url:               "rtsp://192.168.1.100/stream",
 			sourceType:        "rtsp",
 			transport:         "udp",
 			ffmpegParams:      []string{"-timeout", "5000000"},
 			wantRTSPTransport: true,
-			wantTimeout:       true,
+			wantStimeout:      true,
+			wantTimeout:       false,
 		},
 	}
 
@@ -906,10 +916,12 @@ func TestStream_BuildFFmpegInputArgs_ProtocolSpecific(t *testing.T) {
 			args := stream.buildFFmpegInputArgs(tt.ffmpegParams)
 
 			hasRTSPTransport := slices.Contains(args, "-rtsp_transport")
+			hasStimeout := slices.Contains(args, ffmpegRTSPTimeoutFlag)
 			hasTimeout := slices.Contains(args, ffmpegTimeoutFlag)
 
 			assert.Equal(t, tt.wantRTSPTransport, hasRTSPTransport, "rtsp_transport flag presence mismatch")
-			assert.Equal(t, tt.wantTimeout, hasTimeout, "timeout flag presence mismatch")
+			assert.Equal(t, tt.wantStimeout, hasStimeout, "-stimeout flag presence mismatch")
+			assert.Equal(t, tt.wantTimeout, hasTimeout, "-timeout flag presence mismatch")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Fix RTSP streams to use `-stimeout` instead of `-timeout` (FFmpeg ignores `-timeout` for RTSP protocol, so streams had no timeout protection beyond the context deadline)
- Add stereo downmix warning bar on stream cards in view mode when a stereo source is still set to downmix mode
- Thread `SourceChannels` through the health API (REST + SSE) to the frontend

Fixes #3277

## Changes

### RTSP `-stimeout` fix
- New `timeoutParamForSource()` helper selects the correct FFmpeg timeout flag per source type
- New `stripTimeoutParams()` strips timeout key-value pairs from user parameters
- `detectUserTimeout()` now recognizes both `-timeout` and `-stimeout`
- User-provided `-timeout` for RTSP streams is automatically converted to `-stimeout`
- `analyze.go` updated to use the `ffmpegRTSPTimeoutParam` constant instead of a hardcoded string

### Stereo warning
- `SourceChannels` field added to `StreamHealth`, `StreamHealthResponse`, and frontend type
- Warning bar appears below stream header when `source_channels >= 2` and `channelMode` is `downmix`
- Uses existing `stereoWarning.short` and `stereoWarning.tooltip` i18n keys (all 15 locales already translated)

## Test plan

- [x] 391 Go tests pass with `-race` in ffmpeg package (12 new tests)
- [x] Zero linter issues (`golangci-lint`, `eslint`, `svelte-check`, `ast-grep`)
- [x] Frontend type-checks with 0 errors, 0 warnings
- [ ] Manual: verify RTSP stream uses `-stimeout` in FFmpeg args (check logs)
- [ ] Manual: verify stereo warning appears on stream card when a stereo source uses downmix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stereo downmix warning banner shown in stream diagnostics when a stereo source is downmixed.
  * Protocol-aware timeout handling for stream connections (RTSP vs non-RTSP).

* **Bug Fixes**
  * Stream health now reports detected source channel count more accurately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->