### PR TITLE
feat(alerting): allow users to re-alert on higher confidence detections

### DIFF
--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -113,8 +113,8 @@ func cooldownKey(rule *entities.AlertRule, event *AlertEvent) string {
 	if rule.TriggerType == TriggerTypeMetric {
 		return fmt.Sprintf("%d|%s", rule.ID, metricBufferKey(rule.MetricName, event.Properties))
 	}
-	if isSpeciesScopedDetectionRule(rule, event) {
-		return fmt.Sprintf("%d|%s", rule.ID, detectionSpeciesKey(event))
+	if speciesKey := detectionSpeciesKey(event); isSpeciesScopedDetectionRule(rule, event, speciesKey) {
+		return fmt.Sprintf("%d|%s", rule.ID, speciesKey)
 	}
 	return fmt.Sprintf("%d", rule.ID)
 }
@@ -137,27 +137,24 @@ func detectionSpeciesKey(event *AlertEvent) string {
 	return unknownDetectionSpeciesKey
 }
 
-func isNoveltyProperty(property string) bool {
-	switch property {
-	case PropertyDaysSinceLastSeen, PropertyNoveltyEpisodeDays, PropertyNoveltyEpisodeStart:
-		return true
-	default:
-		return false
-	}
-}
-
-func isSpeciesScopedDetectionRule(rule *entities.AlertRule, event *AlertEvent) bool {
+// isSpeciesScopedDetectionRule reports whether a detection rule's cooldown and
+// escalation state should be tracked per species rather than per rule. The
+// caller passes speciesKey from detectionSpeciesKey(event); species-less
+// detections (unknownDetectionSpeciesKey) always use per-rule scoping. Novelty
+// conditions reuse detectionMetadataProperties as the single source of truth
+// for which properties scope a rule to a species.
+func isSpeciesScopedDetectionRule(rule *entities.AlertRule, event *AlertEvent, speciesKey string) bool {
 	if rule.TriggerType != TriggerTypeEvent || !isDetectionEvent(event.EventName) {
 		return false
 	}
-	if detectionSpeciesKey(event) == unknownDetectionSpeciesKey {
+	if speciesKey == unknownDetectionSpeciesKey {
 		return false
 	}
 	if len(rule.EscalationSteps) > 0 {
 		return true
 	}
 	for i := range rule.Conditions {
-		if isNoveltyProperty(rule.Conditions[i].Property) {
+		if slices.Contains(detectionMetadataProperties, rule.Conditions[i].Property) {
 			return true
 		}
 	}
@@ -165,8 +162,20 @@ func isSpeciesScopedDetectionRule(rule *entities.AlertRule, event *AlertEvent) b
 }
 
 func detectionEscalationKey(rule *entities.AlertRule, event *AlertEvent, speciesKey string) string {
+	// Derive a stable per-episode component. NoveltyEpisodeStart is contractually
+	// a string today, but format time.Time explicitly so a future type change
+	// can't break episode grouping via fmt's verbose %v (monotonic clock, nanos).
 	var episodeStart string
-	if value, ok := event.Properties[PropertyNoveltyEpisodeStart]; ok && value != nil {
+	switch value := event.Properties[PropertyNoveltyEpisodeStart].(type) {
+	case time.Time:
+		if !value.IsZero() {
+			episodeStart = value.UTC().Format(time.RFC3339)
+		}
+	case string:
+		episodeStart = strings.TrimSpace(value)
+	case nil:
+		// No episode metadata; fall back to the event day below.
+	default:
 		episodeStart = strings.TrimSpace(fmt.Sprintf("%v", value))
 	}
 	if episodeStart == "" {
@@ -223,6 +232,20 @@ func (e *Engine) clearEscalationIfRecovered(rules []entities.AlertRule, event *A
 	}
 }
 
+// highestStepExceeded returns the highest escalation step that value meets or
+// exceeds. found is false when value is below every step. Explicit max tracking
+// keeps the result correct for unsorted steps and negative thresholds (e.g.
+// temperature), where a plain running max with a zero sentinel would be wrong.
+func highestStepExceeded(steps []float64, value float64) (step float64, found bool) {
+	for _, s := range steps {
+		if value >= s && (!found || s > step) {
+			step = s
+			found = true
+		}
+	}
+	return step, found
+}
+
 // shouldSuppressEscalation checks if a metric rule should be suppressed
 // because the metric hasn't crossed a new escalation step. Returns true
 // if the rule should NOT fire. When it returns false (allow fire), it also
@@ -241,18 +264,7 @@ func (e *Engine) shouldSuppressEscalation(rule *entities.AlertRule, event *Alert
 		return false, event.Properties
 	}
 
-	// Find the highest step the current value exceeds.
-	// Uses explicit max tracking so the result is correct even if
-	// EscalationSteps is not sorted ascending. A boolean flag avoids
-	// issues with negative step values (e.g., temperature thresholds).
-	var currentStep float64
-	stepFound := false
-	for _, step := range rule.EscalationSteps {
-		if floatVal >= step && (!stepFound || step > currentStep) {
-			currentStep = step
-			stepFound = true
-		}
-	}
+	currentStep, stepFound := highestStepExceeded(rule.EscalationSteps, floatVal)
 	if !stepFound {
 		return true, nil
 	}
@@ -295,14 +307,7 @@ func (e *Engine) shouldSuppressDetectionEscalation(rule *entities.AlertRule, eve
 		return true, nil
 	}
 
-	var currentStep float64
-	stepFound := false
-	for _, step := range rule.EscalationSteps {
-		if confidenceFloat >= step && (!stepFound || step > currentStep) {
-			currentStep = step
-			stepFound = true
-		}
-	}
+	currentStep, stepFound := highestStepExceeded(rule.EscalationSteps, confidenceFloat)
 	if !stepFound {
 		return true, nil
 	}
@@ -334,6 +339,8 @@ func (e *Engine) shouldSuppressDetectionEscalation(rule *entities.AlertRule, eve
 	return false, propsCopy
 }
 
+// cooldownExpiredLocked reports whether the cooldown for key has elapsed (or is
+// disabled). Callers must hold e.cooldownsMu.
 func (e *Engine) cooldownExpiredLocked(key string, cooldownSec int, now time.Time) bool {
 	if cooldownSec <= 0 {
 		return true
@@ -342,6 +349,9 @@ func (e *Engine) cooldownExpiredLocked(key string, cooldownSec int, now time.Tim
 	return !exists || now.Sub(lastFired) >= time.Duration(cooldownSec)*time.Second
 }
 
+// pruneDetectionEscalationsLocked removes escalation entries for older episodes
+// of the same rule and species, keeping only currentKey. Callers must hold
+// e.escalationsMu.
 func (e *Engine) pruneDetectionEscalationsLocked(ruleID uint, speciesKey, currentKey string) {
 	prefix := detectionEscalationKeyPrefix(ruleID, speciesKey)
 	for key := range e.escalations {

--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"runtime/debug"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +28,8 @@ const (
 	cleanupMaxRetries = 3
 	// cleanupBaseDelay is the base delay for exponential backoff between cleanup retries.
 	cleanupBaseDelay = 100 * time.Millisecond
+	// unknownDetectionSpeciesKey is used when detection events lack species metadata.
+	unknownDetectionSpeciesKey = "unknown"
 )
 
 // ActionFunc is called when a rule fires. Receives the rule and triggering event.
@@ -110,6 +113,9 @@ func cooldownKey(rule *entities.AlertRule, event *AlertEvent) string {
 	if rule.TriggerType == TriggerTypeMetric {
 		return fmt.Sprintf("%d|%s", rule.ID, metricBufferKey(rule.MetricName, event.Properties))
 	}
+	if isSpeciesScopedDetectionRule(rule, event) {
+		return fmt.Sprintf("%d|%s", rule.ID, detectionSpeciesKey(event))
+	}
 	return fmt.Sprintf("%d", rule.ID)
 }
 
@@ -117,6 +123,64 @@ func cooldownKey(rule *entities.AlertRule, event *AlertEvent) string {
 // instance (path). Multiple mount points are tracked independently.
 func escalationKey(ruleID uint, metricName string, properties map[string]any) string {
 	return fmt.Sprintf("%d|%s", ruleID, metricBufferKey(metricName, properties))
+}
+
+func detectionSpeciesKey(event *AlertEvent) string {
+	for _, propertyName := range []string{PropertyScientificName, PropertySpeciesName} {
+		if value, ok := event.Properties[propertyName].(string); ok {
+			key := strings.TrimSpace(strings.ToLower(value))
+			if key != "" {
+				return key
+			}
+		}
+	}
+	return unknownDetectionSpeciesKey
+}
+
+func isNoveltyProperty(property string) bool {
+	switch property {
+	case PropertyDaysSinceLastSeen, PropertyNoveltyEpisodeDays, PropertyNoveltyEpisodeStart:
+		return true
+	default:
+		return false
+	}
+}
+
+func isSpeciesScopedDetectionRule(rule *entities.AlertRule, event *AlertEvent) bool {
+	if rule.TriggerType != TriggerTypeEvent || !isDetectionEvent(event.EventName) {
+		return false
+	}
+	if detectionSpeciesKey(event) == unknownDetectionSpeciesKey {
+		return false
+	}
+	if len(rule.EscalationSteps) > 0 {
+		return true
+	}
+	for i := range rule.Conditions {
+		if isNoveltyProperty(rule.Conditions[i].Property) {
+			return true
+		}
+	}
+	return false
+}
+
+func detectionEscalationKey(rule *entities.AlertRule, event *AlertEvent, speciesKey string) string {
+	var episodeStart string
+	if value, ok := event.Properties[PropertyNoveltyEpisodeStart]; ok && value != nil {
+		episodeStart = strings.TrimSpace(fmt.Sprintf("%v", value))
+	}
+	if episodeStart == "" {
+		eventTime := event.Timestamp
+		if eventTime.IsZero() {
+			eventTime = time.Now()
+		}
+		episodeStart = eventTime.Format(time.DateOnly)
+	}
+	return fmt.Sprintf("%d|%s|%s", rule.ID, speciesKey, episodeStart)
+}
+
+func detectionEscalationKeyPrefix(ruleID uint, speciesKey string) string {
+	return fmt.Sprintf("%d|%s|", ruleID, speciesKey)
 }
 
 // clearEscalationIfRecovered clears escalation state for rules whose metric
@@ -214,6 +278,79 @@ func (e *Engine) shouldSuppressEscalation(rule *entities.AlertRule, event *Alert
 	return false, propsCopy
 }
 
+// shouldSuppressDetectionEscalation applies confidence laddering to detection
+// event rules. It is keyed by species and novelty episode, so a higher
+// confidence step can notify again without waiting for the rule cooldown.
+func (e *Engine) shouldSuppressDetectionEscalation(rule *entities.AlertRule, event *AlertEvent, cdKey, speciesKey string) (suppress bool, props map[string]any) {
+	if len(rule.EscalationSteps) == 0 {
+		return false, event.Properties
+	}
+
+	confidence, ok := event.Properties[PropertyConfidence]
+	if !ok {
+		return true, nil
+	}
+	confidenceFloat, err := toFloat64(confidence)
+	if err != nil {
+		return true, nil
+	}
+
+	var currentStep float64
+	stepFound := false
+	for _, step := range rule.EscalationSteps {
+		if confidenceFloat >= step && (!stepFound || step > currentStep) {
+			currentStep = step
+			stepFound = true
+		}
+	}
+	if !stepFound {
+		return true, nil
+	}
+
+	key := detectionEscalationKey(rule, event, speciesKey)
+	now := time.Now()
+
+	e.cooldownsMu.Lock()
+	e.escalationsMu.Lock()
+	lastStep, exists := e.escalations[key]
+	cooldownExpired := e.cooldownExpiredLocked(cdKey, rule.CooldownSec, now)
+	if exists && lastStep >= currentStep && !cooldownExpired {
+		e.escalationsMu.Unlock()
+		e.cooldownsMu.Unlock()
+		return true, nil
+	}
+	e.pruneDetectionEscalationsLocked(rule.ID, speciesKey, key)
+	e.escalations[key] = currentStep
+	e.escalationsMu.Unlock()
+	if rule.CooldownSec > 0 {
+		e.cooldowns[cdKey] = now
+	}
+	e.cooldownsMu.Unlock()
+
+	propsCopy := make(map[string]any, len(event.Properties)+1)
+	maps.Copy(propsCopy, event.Properties)
+	propsCopy[PropertyThresholdStep] = currentStep
+
+	return false, propsCopy
+}
+
+func (e *Engine) cooldownExpiredLocked(key string, cooldownSec int, now time.Time) bool {
+	if cooldownSec <= 0 {
+		return true
+	}
+	lastFired, exists := e.cooldowns[key]
+	return !exists || now.Sub(lastFired) >= time.Duration(cooldownSec)*time.Second
+}
+
+func (e *Engine) pruneDetectionEscalationsLocked(ruleID uint, speciesKey, currentKey string) {
+	prefix := detectionEscalationKeyPrefix(ruleID, speciesKey)
+	for key := range e.escalations {
+		if key != currentKey && strings.HasPrefix(key, prefix) {
+			delete(e.escalations, key)
+		}
+	}
+}
+
 // HandleEvent evaluates an event against all enabled rules.
 func (e *Engine) HandleEvent(event *AlertEvent) {
 	// Record metric sample once before rule iteration to avoid duplicates
@@ -276,6 +413,31 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 			}
 			e.fireRule(rule, augmentedEvent)
 			continue
+		}
+
+		if rule.TriggerType == TriggerTypeEvent && isDetection && len(rule.EscalationSteps) > 0 {
+			speciesKey := detectionSpeciesKey(event)
+			if speciesKey != unknownDetectionSpeciesKey {
+				suppress, props := e.shouldSuppressDetectionEscalation(rule, event, cdKey, speciesKey)
+				if suppress {
+					continue
+				}
+				augmentedEvent := &AlertEvent{
+					ObjectType: event.ObjectType,
+					EventName:  event.EventName,
+					MetricName: event.MetricName,
+					Properties: props,
+					Timestamp:  event.Timestamp,
+				}
+				e.log.Debug("Detection rule fired at confidence escalation step",
+					logger.String("component", "alerting.engine"),
+					logger.String("event_name", event.EventName),
+					logger.Uint64("rule_id", uint64(rule.ID)),
+					logger.String("rule_name", rule.Name),
+					logger.String("operation", "fire_detection_escalation_rule"))
+				e.fireRule(rule, augmentedEvent)
+				continue
+			}
 		}
 
 		if e.tryAcquireCooldown(cdKey, rule.CooldownSec) {

--- a/internal/alerting/engine_test.go
+++ b/internal/alerting/engine_test.go
@@ -558,6 +558,345 @@ func TestEngine_EscalationSteps_FiresAtEachStep(t *testing.T) {
 	assert.Equal(t, []float64{86, 91, 96, 99.5}, fired, "top step should be suppressed")
 }
 
+func TestEngine_DetectionEscalationSteps_FiresAtHigherConfidence(t *testing.T) {
+	const (
+		bayBreastedWarblerSci = "Setophaga castanea"
+		noveltyEpisodeStart   = "2026-05-23T12:00:00Z"
+		detectionCooldownSec  = 24 * 60 * 60
+		firstConfidenceStep   = 0.75
+		secondConfidenceStep  = 0.85
+		thirdConfidenceStep   = 0.90
+		firstStepDetection    = 0.76
+		sameStepDetection     = 0.80
+		secondStepDetection   = 0.86
+		thirdStepDetection    = 0.91
+		noveltyEpisodeDays    = 12
+	)
+
+	rule := entities.AlertRule{
+		ID:              1,
+		Enabled:         true,
+		ObjectType:      ObjectTypeDetection,
+		TriggerType:     TriggerTypeEvent,
+		EventName:       EventDetectionOccurred,
+		CooldownSec:     detectionCooldownSec,
+		EscalationSteps: []float64{firstConfidenceStep, secondConfidenceStep, thirdConfidenceStep},
+		Conditions: []entities.AlertCondition{
+			{Property: PropertyConfidence, Operator: OperatorGreaterOrEqual, Value: "0.75"},
+			{Property: PropertyNoveltyEpisodeDays, Operator: OperatorGreaterOrEqual, Value: "7"},
+		},
+	}
+
+	var fired []float64
+	repo := newMockRepo(rule)
+	engine := NewEngine(repo, func(_ *entities.AlertRule, event *AlertEvent) {
+		fired = append(fired, event.Properties[PropertyThresholdStep].(float64))
+	}, testLogger(), nil)
+	require.NoError(t, engine.RefreshRules(t.Context()))
+
+	emit := func(confidence float64) {
+		engine.HandleEvent(&AlertEvent{
+			ObjectType: ObjectTypeDetection,
+			EventName:  EventDetectionOccurred,
+			Properties: map[string]any{
+				PropertySpeciesName:         "Bay-breasted Warbler",
+				PropertyScientificName:      bayBreastedWarblerSci,
+				PropertyConfidence:          confidence,
+				PropertyNoveltyEpisodeDays:  noveltyEpisodeDays,
+				PropertyNoveltyEpisodeStart: noveltyEpisodeStart,
+				PropertyDaysSinceLastSeen:   noveltyEpisodeDays,
+			},
+			Timestamp: time.Now(),
+		})
+	}
+
+	emit(firstStepDetection)
+	assert.Equal(t, []float64{firstConfidenceStep}, fired)
+
+	emit(sameStepDetection)
+	assert.Equal(t, []float64{firstConfidenceStep}, fired, "same confidence step should be suppressed")
+
+	emit(secondStepDetection)
+	assert.Equal(t, []float64{firstConfidenceStep, secondConfidenceStep}, fired)
+
+	emit(thirdStepDetection)
+	assert.Equal(t, []float64{firstConfidenceStep, secondConfidenceStep, thirdConfidenceStep}, fired)
+}
+
+func TestEngine_DetectionEscalationSteps_AllowsRepeatAfterCooldown(t *testing.T) {
+	const (
+		bayBreastedWarblerSci = "Setophaga castanea"
+		noveltyEpisodeStart   = "2026-05-23T12:00:00Z"
+		detectionCooldownSec  = 60
+		firstConfidenceStep   = 0.75
+		secondConfidenceStep  = 0.85
+		firstStepDetection    = 0.80
+		secondStepDetection   = 0.86
+		noveltyEpisodeDays    = 12
+	)
+
+	rule := entities.AlertRule{
+		ID:              1,
+		Enabled:         true,
+		ObjectType:      ObjectTypeDetection,
+		TriggerType:     TriggerTypeEvent,
+		EventName:       EventDetectionOccurred,
+		CooldownSec:     detectionCooldownSec,
+		EscalationSteps: []float64{firstConfidenceStep, secondConfidenceStep},
+		Conditions: []entities.AlertCondition{
+			{Property: PropertyConfidence, Operator: OperatorGreaterOrEqual, Value: "0.75"},
+			{Property: PropertyNoveltyEpisodeDays, Operator: OperatorGreaterOrEqual, Value: "7"},
+		},
+	}
+
+	var fired []float64
+	repo := newMockRepo(rule)
+	engine := NewEngine(repo, func(_ *entities.AlertRule, event *AlertEvent) {
+		fired = append(fired, event.Properties[PropertyThresholdStep].(float64))
+	}, testLogger(), nil)
+	require.NoError(t, engine.RefreshRules(t.Context()))
+
+	newEvent := func(confidence float64) *AlertEvent {
+		return &AlertEvent{
+			ObjectType: ObjectTypeDetection,
+			EventName:  EventDetectionOccurred,
+			Properties: map[string]any{
+				PropertySpeciesName:         "Bay-breasted Warbler",
+				PropertyScientificName:      bayBreastedWarblerSci,
+				PropertyConfidence:          confidence,
+				PropertyNoveltyEpisodeDays:  noveltyEpisodeDays,
+				PropertyNoveltyEpisodeStart: noveltyEpisodeStart,
+			},
+			Timestamp: time.Now(),
+		}
+	}
+
+	secondStepEvent := newEvent(secondStepDetection)
+	engine.HandleEvent(secondStepEvent)
+	assert.Equal(t, []float64{secondConfidenceStep}, fired)
+
+	engine.HandleEvent(newEvent(firstStepDetection))
+	assert.Equal(t, []float64{secondConfidenceStep}, fired, "lower step should respect cooldown")
+
+	cdKey := cooldownKey(&rule, secondStepEvent)
+	engine.cooldownsMu.Lock()
+	engine.cooldowns[cdKey] = time.Now().Add(-2 * time.Duration(detectionCooldownSec) * time.Second)
+	engine.cooldownsMu.Unlock()
+
+	engine.HandleEvent(newEvent(firstStepDetection))
+	assert.Equal(t, []float64{secondConfidenceStep, firstConfidenceStep}, fired)
+
+	engine.HandleEvent(newEvent(secondStepDetection))
+	assert.Equal(t, []float64{secondConfidenceStep, firstConfidenceStep, secondConfidenceStep}, fired, "higher step should bypass active cooldown")
+}
+
+func TestEngine_DetectionEscalationSteps_SuppressesMissingConfidence(t *testing.T) {
+	const (
+		detectionCooldownSec = 24 * 60 * 60
+		firstConfidenceStep  = 0.75
+		secondConfidenceStep = 0.85
+	)
+
+	tests := []struct {
+		name       string
+		properties map[string]any
+	}{
+		{
+			name: "missing confidence",
+			properties: map[string]any{
+				PropertySpeciesName: "Bay-breasted Warbler",
+			},
+		},
+		{
+			name: "invalid confidence",
+			properties: map[string]any{
+				PropertySpeciesName: "Bay-breasted Warbler",
+				PropertyConfidence:  "not-a-number",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rule := entities.AlertRule{
+				ID:              1,
+				Enabled:         true,
+				ObjectType:      ObjectTypeDetection,
+				TriggerType:     TriggerTypeEvent,
+				EventName:       EventDetectionOccurred,
+				CooldownSec:     detectionCooldownSec,
+				EscalationSteps: []float64{firstConfidenceStep, secondConfidenceStep},
+			}
+
+			var fireCount int
+			repo := newMockRepo(rule)
+			engine := NewEngine(repo, func(_ *entities.AlertRule, _ *AlertEvent) {
+				fireCount++
+			}, testLogger(), nil)
+			require.NoError(t, engine.RefreshRules(t.Context()))
+
+			engine.HandleEvent(&AlertEvent{
+				ObjectType: ObjectTypeDetection,
+				EventName:  EventDetectionOccurred,
+				Properties: tt.properties,
+				Timestamp:  time.Now(),
+			})
+
+			assert.Zero(t, fireCount, "confidence escalation should not fire without a usable confidence value")
+		})
+	}
+}
+
+func TestEngine_DetectionEscalationSteps_UnknownSpeciesUsesCooldown(t *testing.T) {
+	const (
+		detectionCooldownSec = 3600
+		firstConfidenceStep  = 0.75
+		secondConfidenceStep = 0.85
+		detectionConfidence  = 0.90
+	)
+
+	rule := entities.AlertRule{
+		ID:              1,
+		Enabled:         true,
+		ObjectType:      ObjectTypeDetection,
+		TriggerType:     TriggerTypeEvent,
+		EventName:       EventDetectionOccurred,
+		CooldownSec:     detectionCooldownSec,
+		EscalationSteps: []float64{firstConfidenceStep, secondConfidenceStep},
+		Conditions: []entities.AlertCondition{
+			{Property: PropertyConfidence, Operator: OperatorGreaterOrEqual, Value: "0.75"},
+		},
+	}
+
+	var fired []bool
+	repo := newMockRepo(rule)
+	engine := NewEngine(repo, func(_ *entities.AlertRule, event *AlertEvent) {
+		_, hasThresholdStep := event.Properties[PropertyThresholdStep]
+		fired = append(fired, hasThresholdStep)
+	}, testLogger(), nil)
+	require.NoError(t, engine.RefreshRules(t.Context()))
+
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertyConfidence: detectionConfidence,
+		},
+		Timestamp: time.Now(),
+	}
+
+	engine.HandleEvent(event)
+	engine.HandleEvent(event)
+
+	assert.Equal(t, []bool{false}, fired, "species-less detections should use regular cooldown without threshold metadata")
+}
+
+func TestEngine_DetectionEscalationSteps_PrunesPreviousEpisode(t *testing.T) {
+	const (
+		bayBreastedWarblerSci = "Setophaga castanea"
+		oldEpisodeStart       = "2026-05-23T12:00:00Z"
+		newEpisodeStart       = "2026-06-02T12:00:00Z"
+		confidenceStep        = 0.75
+		detectionConfidence   = 0.80
+		noveltyEpisodeDays    = 12
+	)
+
+	rule := entities.AlertRule{
+		ID:              1,
+		Enabled:         true,
+		ObjectType:      ObjectTypeDetection,
+		TriggerType:     TriggerTypeEvent,
+		EventName:       EventDetectionOccurred,
+		EscalationSteps: []float64{confidenceStep},
+		Conditions: []entities.AlertCondition{
+			{Property: PropertyConfidence, Operator: OperatorGreaterOrEqual, Value: "0.75"},
+			{Property: PropertyNoveltyEpisodeDays, Operator: OperatorGreaterOrEqual, Value: "7"},
+		},
+	}
+
+	repo := newMockRepo(rule)
+	engine := NewEngine(repo, func(_ *entities.AlertRule, _ *AlertEvent) {}, testLogger(), nil)
+	require.NoError(t, engine.RefreshRules(t.Context()))
+
+	buildEvent := func(episodeStart string) *AlertEvent {
+		return &AlertEvent{
+			ObjectType: ObjectTypeDetection,
+			EventName:  EventDetectionOccurred,
+			Properties: map[string]any{
+				PropertySpeciesName:         "Bay-breasted Warbler",
+				PropertyScientificName:      bayBreastedWarblerSci,
+				PropertyConfidence:          detectionConfidence,
+				PropertyNoveltyEpisodeDays:  noveltyEpisodeDays,
+				PropertyNoveltyEpisodeStart: episodeStart,
+			},
+			Timestamp: time.Now(),
+		}
+	}
+
+	oldEvent := buildEvent(oldEpisodeStart)
+	newEpisodeEvent := buildEvent(newEpisodeStart)
+	speciesKey := detectionSpeciesKey(oldEvent)
+	oldKey := detectionEscalationKey(&rule, oldEvent, speciesKey)
+	newKey := detectionEscalationKey(&rule, newEpisodeEvent, speciesKey)
+
+	engine.HandleEvent(oldEvent)
+	engine.HandleEvent(newEpisodeEvent)
+
+	engine.escalationsMu.RLock()
+	_, oldExists := engine.escalations[oldKey]
+	_, newExists := engine.escalations[newKey]
+	engine.escalationsMu.RUnlock()
+
+	assert.False(t, oldExists, "old episode escalation key should be pruned")
+	assert.True(t, newExists, "current episode escalation key should remain")
+}
+
+func TestEngine_DetectionNoveltyCooldownIsSpeciesScoped(t *testing.T) {
+	const noveltyEpisodeStart = "2026-05-23T12:00:00Z"
+
+	rule := entities.AlertRule{
+		ID:          1,
+		Enabled:     true,
+		ObjectType:  ObjectTypeDetection,
+		TriggerType: TriggerTypeEvent,
+		EventName:   EventDetectionOccurred,
+		CooldownSec: 3600,
+		Conditions: []entities.AlertCondition{
+			{Property: PropertyNoveltyEpisodeDays, Operator: OperatorGreaterOrEqual, Value: "7"},
+		},
+	}
+
+	var fired []string
+	repo := newMockRepo(rule)
+	engine := NewEngine(repo, func(_ *entities.AlertRule, event *AlertEvent) {
+		fired = append(fired, event.Properties[PropertyScientificName].(string))
+	}, testLogger(), nil)
+	require.NoError(t, engine.RefreshRules(t.Context()))
+
+	emit := func(scientificName string) {
+		engine.HandleEvent(&AlertEvent{
+			ObjectType: ObjectTypeDetection,
+			EventName:  EventDetectionOccurred,
+			Properties: map[string]any{
+				PropertySpeciesName:         scientificName,
+				PropertyScientificName:      scientificName,
+				PropertyConfidence:          0.8,
+				PropertyNoveltyEpisodeDays:  9,
+				PropertyNoveltyEpisodeStart: noveltyEpisodeStart,
+			},
+			Timestamp: time.Now(),
+		})
+	}
+
+	emit("Setophaga castanea")
+	emit("Setophaga castanea")
+	emit("Bubo virginianus")
+
+	assert.Equal(t, []string{"Setophaga castanea", "Bubo virginianus"}, fired)
+}
+
 func TestEngine_EscalationSteps_ResetOnRecovery(t *testing.T) {
 	rule := entities.AlertRule{
 		ID:              1,


### PR DESCRIPTION
## Summary

Adds detection-rule confidence escalation and species-scoped cooldown behavior.

## Rationale

A rare or returning bird often starts as a lower-confidence detection and becomes more convincing as more audio comes in. The existing rule cooldown suppresses later notifications during the cooldown window, and the existing escalation logic only applies to metric rules, not detection confidence. This PR lets detection rules notify again when confidence crosses a higher configured step, scoped to the species and novelty episode, while preserving the rule cooldown for same-step or lower-step repeats.

## Stack Context

Builds on the merged novelty metadata PR: https://github.com/tphakala/birdnet-go/pull/3275. Follow-up context remains split in my fork:

- https://github.com/keithkml/birdnet-go/pull/4: novelty reason metadata for alert rules and templates

## Changes

- Keys novelty detection cooldowns by species when a detection rule uses novelty properties.
- Lets detection rules with `EscalationSteps` fire again when confidence crosses a higher configured step.
- Preserves regular cooldown behavior for same-step/lower-step repeats.
- Updates the cooldown timestamp when a detection escalation rule fires.
- Prunes stale detection escalation entries for older episodes of the same rule/species.
- Routes species-less detections through the regular cooldown path instead of a shared escalation bucket.
- Requires a usable confidence value before using detection confidence escalation.

## Screenshots

N/A: this PR changes alert-engine behavior only and does not alter frontend or schema-visible UI strings.

## Pi 5 Runtime Validation

I am running this feature series on a Raspberry Pi 5 with live USB audio. For this PR, the relevant live check is that the rule has confidence escalation steps and alert history shows the same novelty episode alerting again after a higher confidence step is reached.

```text
$ curl -fsS http://localhost:8080/api/v2/alerts/rules | jq '.rules[] | select(.name=="Interesting Bird (novelty)") | {name, escalation_steps, cooldown_sec}'
{
  "name": "Interesting Bird (novelty)",
  "escalation_steps": [0.75, 0.85, 0.9],
  "cooldown_sec": 86400
}

$ curl -fsS 'http://localhost:8080/api/v2/alerts/history?limit=20' | jq -r '.history[] | select(.rule_id==17) | (.event_data|fromjson) | select(.species_name=="Common Raven") | {species_name, confidence, threshold_step, novelty_episode_start} | @json'
{"species_name":"Common Raven","confidence":0.87,"threshold_step":0.85,"novelty_episode_start":"2026-05-24T18:39:16-04:00"}
{"species_name":"Common Raven","confidence":0.79,"threshold_step":0.75,"novelty_episode_start":"2026-05-24T18:39:16-04:00"}
```

## Testing

- [x] Go lint passes: `golangci-lint run --build-tags=noembed,skipfrontend -v` with local TensorFlow Lite CGO paths and writable local caches reported 0 issues.
- [x] Frontend check exits 0: `npm --prefix frontend run check:all`. Caveat: ESLint reports 3 pre-existing warnings in unrelated frontend files.
- [x] Frontend tests pass: `npm --prefix frontend test`, 107 files / 1968 tests.
- [x] Focused Go race tests pass: `go test -race ./internal/alerting -count=1`.
- [x] Full Go race suite passes: `go test -race ./... -count=1` with local TensorFlow Lite paths, `FFMPEG_PATH`, and `GOFLAGS=-parallel=1`.

## Related Issues

None.

## Preflight Status

- Single concern: yes, one alert-engine behavior feature.
- Review feedback addressed: same/lower confidence repeats now respect cooldown, escalation fires update cooldown state, stale detection escalation entries are pruned, species-less detections use regular cooldown, nil formatting was simplified, and the table subtests now run in parallel.
- Preflight review: completed manually against `.agents/skills/preflight`; no changed-code findings remain.
- No unrelated changes: diff is limited to alert engine cooldown/escalation behavior and tests.
- Scope complete: no TODO/FIXME for core functionality.
- Breaking changes: none.
- i18n: not applicable; no frontend or schema labels changed in this PR.
- Secrets/PII: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection rules now escalate per species and episode, firing at confidence thresholds, attaching the fired threshold step to events, and suppressing duplicate alerts at the same threshold. Higher-confidence steps can bypass prior cooldowns.
  * Cooldowns and escalation state are scoped by species and episode, with stale episode state pruned automatically.

* **Tests**
  * Added tests for escalation steps, suppression, unknown-species behavior, episode pruning, species-scoped cooldowns, and cooldown expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->