### PR TITLE
feat(health): intelligent severity assessment for windowed health checks

### DIFF
--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -204,10 +204,11 @@ func (c *BufferDropsCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
 	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
-		warnThreshold: 10,
-		critThreshold: 100,
-		metricPrefix:  observability.MetricPrefixAudioDrops,
-		window:        c.window,
+		baseWarnThreshold: 10,
+		baseCritThreshold: 50,
+		sustainedHours:    3,
+		metricPrefix:      observability.MetricPrefixAudioDrops,
+		window:            c.window,
 	}, start)
 }
 
@@ -326,10 +327,11 @@ func (c *BufferOverrunCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
 	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
-		warnThreshold: 10,
-		critThreshold: 50,
-		metricPrefix:  observability.MetricPrefixAudioOverruns,
-		window:        c.window,
+		baseWarnThreshold: 5,
+		baseCritThreshold: 25,
+		sustainedHours:    3,
+		metricPrefix:      observability.MetricPrefixAudioOverruns,
+		window:            c.window,
 	}, start)
 }
 

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -166,6 +166,14 @@ func (c *PipelineLivenessCheck) Run(_ context.Context) health.Result {
 // DefaultWindow is the default evaluation window for windowed checks.
 const DefaultWindow = time.Hour
 
+// Threshold constants for audio health checks.
+const (
+	dropsBaseWarnThreshold   = 10
+	dropsBaseCritThreshold   = 50
+	overrunBaseWarnThreshold = 5
+	overrunBaseCritThreshold = 25
+)
+
 // BufferDropsCheck monitors audio buffer drop statistics using time-windowed evaluation.
 type BufferDropsCheck struct {
 	store     *observability.HealthMetricsStore
@@ -204,9 +212,9 @@ func (c *BufferDropsCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
 	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
-		baseWarnThreshold: 10,
-		baseCritThreshold: 50,
-		sustainedHours:    3,
+		baseWarnThreshold: dropsBaseWarnThreshold,
+		baseCritThreshold: dropsBaseCritThreshold,
+		sustainedHours:    defaultSustainedHours,
 		metricPrefix:      observability.MetricPrefixAudioDrops,
 		window:            c.window,
 	}, start)
@@ -327,9 +335,9 @@ func (c *BufferOverrunCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
 	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
-		baseWarnThreshold: 5,
-		baseCritThreshold: 25,
-		sustainedHours:    3,
+		baseWarnThreshold: overrunBaseWarnThreshold,
+		baseCritThreshold: overrunBaseCritThreshold,
+		sustainedHours:    defaultSustainedHours,
 		metricPrefix:      observability.MetricPrefixAudioOverruns,
 		window:            c.window,
 	}, start)

--- a/internal/health/checks/audio_test.go
+++ b/internal/health/checks/audio_test.go
@@ -66,7 +66,7 @@ func TestBufferDropsCheck_Warning(t *testing.T) {
 	check := NewBufferDropsCheck(store, nil)
 	result := check.Run(t.Context())
 	assert.Equal(t, health.StatusWarning, result.Status)
-	assert.Contains(t, result.Message, "15 drops in last 1h")
+	assert.Contains(t, result.Message, "15 drops in 1h")
 }
 
 func TestBufferDropsCheck_Critical(t *testing.T) {
@@ -165,6 +165,46 @@ func TestBufferOverrunCheck_WithWindow(t *testing.T) {
 	check := NewBufferOverrunCheck(store, nil)
 	narrowed := check.WithWindow(15 * time.Minute)
 	assert.NotNil(t, narrowed)
+}
+
+func TestBufferDropsCheck_CritAt50(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+
+	// baseCritThreshold is 50; maxHourly(50) >= baseCrit(50) triggers peak safety net.
+	store.RecordAt("audio.drops.src1", 50, time.Now())
+
+	check := NewBufferDropsCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+}
+
+func TestBufferOverrunCheck_LowerThresholds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WarnAt5", func(t *testing.T) {
+		t.Parallel()
+		store := newTestHealthStore(t)
+
+		// baseWarnThreshold is 5; maxHourly(5) >= baseWarn(5) -> peakEscalated -> Warning.
+		store.RecordAt("audio.overruns.src1", 5, time.Now())
+
+		check := NewBufferOverrunCheck(store, nil)
+		result := check.Run(t.Context())
+		assert.Equal(t, health.StatusWarning, result.Status)
+	})
+
+	t.Run("CritAt25", func(t *testing.T) {
+		t.Parallel()
+		store := newTestHealthStore(t)
+
+		// baseCritThreshold is 25; maxHourly(25) >= baseCrit(25) -> peak safety net -> Critical.
+		store.RecordAt("audio.overruns.src1", 25, time.Now())
+
+		check := NewBufferOverrunCheck(store, nil)
+		result := check.Run(t.Context())
+		assert.Equal(t, health.StatusCritical, result.Status)
+	})
 }
 
 func TestAudioLevelCheck_NilProvider(t *testing.T) {

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -237,6 +237,94 @@ func extractMetricType(prefix string) string {
 	return trimmed
 }
 
+// velocityTrend describes whether error activity is growing, shrinking, or flat
+// over the most recent consecutive in-window sparkline buckets.
+type velocityTrend int
+
+const (
+	// velocityStable means the two most recent in-window buckets are equal,
+	// or fewer than two in-window buckets exist.
+	velocityStable velocityTrend = iota
+	// velocityIncreasing means the current bucket count exceeds the previous one.
+	velocityIncreasing
+	// velocityDecreasing means the current bucket count is below the previous one.
+	velocityDecreasing
+)
+
+// countActiveHours returns the number of sparkline buckets within the given
+// window that recorded at least one event. A bucket is considered in-window
+// if its hour-long interval ends after cutoff (now - window).
+func countActiveHours(buckets []observability.HourlyBucket, window time.Duration, now time.Time) int {
+	cutoff := now.Add(-window)
+	count := 0
+	for _, b := range buckets {
+		if !b.Start.Add(time.Hour).Before(cutoff) && b.Count > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// detectVelocity examines the two most recent consecutive in-window sparkline
+// buckets and returns whether activity is increasing, decreasing, or stable.
+// Zero-count buckets are NOT skipped so the comparison reflects the true
+// trajectory (e.g. a drop to zero is decreasing, not stable).
+// Returns velocityStable when fewer than two in-window buckets are found.
+func detectVelocity(buckets []observability.HourlyBucket, window time.Duration, now time.Time) velocityTrend {
+	cutoff := now.Add(-window)
+
+	// Collect in-window buckets in forward order, then examine the last two.
+	var inWindow []observability.HourlyBucket
+	for _, b := range buckets {
+		if !b.Start.Add(time.Hour).Before(cutoff) {
+			inWindow = append(inWindow, b)
+		}
+	}
+
+	if len(inWindow) < 2 {
+		return velocityStable
+	}
+
+	current := inWindow[len(inWindow)-1]
+	previous := inWindow[len(inWindow)-2]
+
+	switch {
+	case current.Count > previous.Count:
+		return velocityIncreasing
+	case current.Count < previous.Count:
+		return velocityDecreasing
+	default:
+		return velocityStable
+	}
+}
+
+// maxBucketCount returns the highest Count value across all in-window sparkline
+// buckets. Used as a peak hourly rate safety net for severity decisions.
+// Returns 0 when no in-window buckets are present.
+func maxBucketCount(buckets []observability.HourlyBucket, window time.Duration, now time.Time) int64 {
+	cutoff := now.Add(-window)
+	var peak int64
+	for _, b := range buckets {
+		if !b.Start.Add(time.Hour).Before(cutoff) && b.Count > peak {
+			peak = b.Count
+		}
+	}
+	return peak
+}
+
+// velocityString returns a human-readable label for a velocityTrend value,
+// suitable for inclusion in a health result details map.
+func velocityString(v velocityTrend) string {
+	switch v {
+	case velocityIncreasing:
+		return "increasing"
+	case velocityDecreasing:
+		return "decreasing"
+	default:
+		return "stable"
+	}
+}
+
 // buildMergedSparkline merges multiple metric keys into a single sparkline
 // of n hourly buckets, with zeros for hours without data.
 func buildMergedSparkline(store *observability.HealthMetricsStore, keys []string, n int, now time.Time) []observability.HourlyBucket {

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -141,14 +141,21 @@ func evalWindowedStats(
 	warnThreshold := cfg.baseWarnThreshold * windowHours
 	critThreshold := cfg.baseCritThreshold * windowHours
 
+	// For windows larger than the sparkline display (24h), build a wider
+	// bucket set so signals cover the full evaluation window.
+	signalBuckets := sparkline
+	if windowBuckets := int(windowHours); windowBuckets > sparklineBuckets {
+		signalBuckets = buildMergedSparkline(store, keys, windowBuckets, now)
+	}
+
 	recurrenceEnabled := cfg.window >= minWindowForRecurrence
-	activeHours := countActiveHours(sparkline, cfg.window, now)
-	maxHourly := maxBucketCount(sparkline, cfg.window, now)
+	activeHours := countActiveHours(signalBuckets, cfg.window, now)
+	maxHourly := maxBucketCount(signalBuckets, cfg.window, now)
 
 	var velocity velocityTrend
 	velocityDetail := "n/a"
 	if recurrenceEnabled {
-		velocity = detectVelocity(sparkline, cfg.window, now)
+		velocity = detectVelocity(signalBuckets, cfg.window, now)
 		velocityDetail = velocityString(velocity)
 	}
 
@@ -167,15 +174,17 @@ func evalWindowedStats(
 		window:            cfg.window,
 	}, msg)
 
-	// Determine pattern classification.
+	// Determine pattern classification (aligned with the sustained-signal
+	// conditions: recurrence must be enabled and volume must exceed the floor).
+	sustainedVolumeFloor := warnThreshold / 2
 	var pattern string
 	switch {
 	case windowTotal == 0:
 		pattern = "none"
-	case activeHours < sustainedHrs:
-		pattern = "transient"
-	default:
+	case recurrenceEnabled && activeHours >= sustainedHrs && windowTotal >= sustainedVolumeFloor:
 		pattern = "sustained"
+	default:
+		pattern = "transient"
 	}
 
 	details := map[string]any{
@@ -400,25 +409,23 @@ func countActiveHours(buckets []observability.HourlyBucket, window time.Duration
 func detectVelocity(buckets []observability.HourlyBucket, window time.Duration, now time.Time) velocityTrend {
 	cutoff := now.Add(-window)
 
-	// Collect in-window buckets in forward order, then examine the last two.
-	var inWindow []observability.HourlyBucket
+	var prev, curr observability.HourlyBucket
+	n := 0
 	for _, b := range buckets {
 		if !b.Start.Add(time.Hour).Before(cutoff) {
-			inWindow = append(inWindow, b)
+			prev, curr = curr, b
+			n++
 		}
 	}
 
-	if len(inWindow) < 2 {
+	if n < 2 {
 		return velocityStable
 	}
 
-	current := inWindow[len(inWindow)-1]
-	previous := inWindow[len(inWindow)-2]
-
 	switch {
-	case current.Count > previous.Count:
+	case curr.Count > prev.Count:
 		return velocityIncreasing
-	case current.Count < previous.Count:
+	case curr.Count < prev.Count:
 		return velocityDecreasing
 	default:
 		return velocityStable

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -52,12 +52,19 @@ func skippedResult(name string, category health.Category, start time.Time) healt
 	}
 }
 
+// defaultSustainedHours is the number of active hours required before events
+// are considered a sustained pattern rather than transient spikes.
+const defaultSustainedHours = 3
+
 // windowedStatsConfig parameterises evalWindowedStats for counter-based checks.
 type windowedStatsConfig struct {
-	warnThreshold int64
-	critThreshold int64
-	metricPrefix  string
-	window        time.Duration
+	baseWarnThreshold int64
+	baseCritThreshold int64
+	metricPrefix      string
+	window            time.Duration
+	// sustainedHours is the minimum number of active hourly buckets for the
+	// pattern to be classified as "sustained". Zero means use defaultSustainedHours.
+	sustainedHours int
 }
 
 // sparklineBuckets is the number of hourly buckets included in the sparkline response.
@@ -108,14 +115,6 @@ func evalWindowedStats(
 		return skippedResult(name, category, start)
 	}
 
-	status := health.StatusHealthy
-	switch {
-	case windowTotal >= cfg.critThreshold:
-		status = health.StatusCritical
-	case windowTotal >= cfg.warnThreshold:
-		status = health.StatusWarning
-	}
-
 	msg := formatWindowedMessage(name, windowTotal, lifetimeTotal, activeSources, lastEvent, cfg.window, now)
 
 	metricType := extractMetricType(cfg.metricPrefix)
@@ -127,12 +126,106 @@ func evalWindowedStats(
 		recentEvents = getEvents(metricType, recentEventsLimit)
 	}
 
+	// Four-signal evaluation: scaled thresholds, peak spike, sustained pattern, velocity.
+	sustainedHrs := cfg.sustainedHours
+	if sustainedHrs <= 0 {
+		sustainedHrs = defaultSustainedHours
+	}
+
+	windowHours := max(int64(cfg.window/time.Hour), 1)
+	warnThreshold := cfg.baseWarnThreshold * windowHours
+	critThreshold := cfg.baseCritThreshold * windowHours
+
+	recurrenceEnabled := cfg.window >= 3*time.Hour
+	activeHours := countActiveHours(sparkline, cfg.window, now)
+	maxHourly := maxBucketCount(sparkline, cfg.window, now)
+
+	var velocity velocityTrend
+	if recurrenceEnabled {
+		velocity = detectVelocity(sparkline, cfg.window, now)
+	}
+
+	status := health.StatusHealthy
+
+	if windowTotal > 0 {
+		peakEscalated := false
+
+		// Safety net: severe hourly spike overrides window-scaled thresholds.
+		if maxHourly >= cfg.baseCritThreshold {
+			status = health.StatusCritical
+			label := checkNameLabel(name)
+			msg = fmt.Sprintf("%d %s in %s, peak hour: %d %s",
+				windowTotal, label, formatDuration(cfg.window), maxHourly, label)
+		}
+
+		if status == health.StatusHealthy && maxHourly >= cfg.baseWarnThreshold {
+			peakEscalated = true
+		}
+
+		sustainedVolumeFloor := warnThreshold / 2
+
+		// Sustained recurrence pattern.
+		if status == health.StatusHealthy && recurrenceEnabled &&
+			activeHours >= sustainedHrs && windowTotal >= sustainedVolumeFloor {
+			label := checkNameLabel(name)
+			if windowTotal >= critThreshold || velocity == velocityIncreasing {
+				status = health.StatusCritical
+				msg = fmt.Sprintf("Sustained %s across %d hours, worsening", label, activeHours)
+			} else {
+				status = health.StatusWarning
+				msg = fmt.Sprintf("Sustained %s across %d hours", label, activeHours)
+			}
+		}
+
+		// Absolute threshold checks.
+		if status == health.StatusHealthy && windowTotal >= critThreshold {
+			status = health.StatusCritical
+			label := checkNameLabel(name)
+			msg = fmt.Sprintf("%d %s in %s, concentrated in %d hour(s)",
+				windowTotal, label, formatDuration(cfg.window), max(activeHours, 1))
+		}
+
+		if status == health.StatusHealthy && (windowTotal >= warnThreshold || peakEscalated) {
+			label := checkNameLabel(name)
+			if recurrenceEnabled && velocity == velocityIncreasing {
+				status = health.StatusWarning
+				msg = fmt.Sprintf("%d %s in %s, rate increasing",
+					windowTotal, label, formatDuration(cfg.window))
+			} else {
+				status = health.StatusWarning
+				msg = fmt.Sprintf("%d %s in %s",
+					windowTotal, label, formatDuration(cfg.window))
+			}
+		}
+
+		// Low volume within tolerance.
+		if status == health.StatusHealthy && activeHours > 0 {
+			label := checkNameLabel(name)
+			msg = fmt.Sprintf("%d %s in %s, within tolerance",
+				windowTotal, label, formatDuration(cfg.window))
+		}
+	}
+
+	// Determine pattern classification.
+	var pattern string
+	switch {
+	case windowTotal == 0:
+		pattern = "none"
+	case activeHours < sustainedHrs:
+		pattern = "transient"
+	default:
+		pattern = "sustained"
+	}
+
 	details := map[string]any{
 		"window":         formatDuration(cfg.window),
 		"window_total":   windowTotal,
 		"lifetime_total": lifetimeTotal,
 		"sources":        activeSources,
 		"per_source":     perSource,
+		"active_hours":   activeHours,
+		"velocity":       velocityString(velocity),
+		"pattern":        pattern,
 	}
 	if !lastEvent.IsZero() {
 		details["last_event"] = lastEvent.Format(time.RFC3339)

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -56,6 +56,11 @@ func skippedResult(name string, category health.Category, start time.Time) healt
 // are considered a sustained pattern rather than transient spikes.
 const defaultSustainedHours = 3
 
+// minWindowForRecurrence is the minimum evaluation window for recurrence and
+// velocity analysis to be meaningful. Hourly bucket resolution is too coarse
+// for shorter windows.
+const minWindowForRecurrence = 3 * time.Hour
+
 // windowedStatsConfig parameterises evalWindowedStats for counter-based checks.
 type windowedStatsConfig struct {
 	baseWarnThreshold int64
@@ -136,13 +141,15 @@ func evalWindowedStats(
 	warnThreshold := cfg.baseWarnThreshold * windowHours
 	critThreshold := cfg.baseCritThreshold * windowHours
 
-	recurrenceEnabled := cfg.window >= 3*time.Hour
+	recurrenceEnabled := cfg.window >= minWindowForRecurrence
 	activeHours := countActiveHours(sparkline, cfg.window, now)
 	maxHourly := maxBucketCount(sparkline, cfg.window, now)
 
 	var velocity velocityTrend
+	velocityDetail := "n/a"
 	if recurrenceEnabled {
 		velocity = detectVelocity(sparkline, cfg.window, now)
+		velocityDetail = velocityString(velocity)
 	}
 
 	status := health.StatusHealthy
@@ -162,6 +169,8 @@ func evalWindowedStats(
 			peakEscalated = true
 		}
 
+		// Volume floor prevents classifying negligible noise as sustained
+		// (e.g. 1 drop/hr for 3 hrs = 3 total, below floor of 5 with baseWarn=10).
 		sustainedVolumeFloor := warnThreshold / 2
 
 		// Sustained recurrence pattern.
@@ -223,9 +232,9 @@ func evalWindowedStats(
 		"lifetime_total": lifetimeTotal,
 		"sources":        activeSources,
 		"per_source":     perSource,
-		"active_hours":   activeHours,
-		"velocity":       velocityString(velocity),
-		"pattern":        pattern,
+		"active_hours": activeHours,
+		"velocity":     velocityDetail,
+		"pattern":      pattern,
 	}
 	if !lastEvent.IsZero() {
 		details["last_event"] = lastEvent.Format(time.RFC3339)

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -61,6 +61,13 @@ const defaultSustainedHours = 3
 // for shorter windows.
 const minWindowForRecurrence = 3 * time.Hour
 
+// Pattern classification labels for the details map.
+const (
+	patternNone      = "none"
+	patternTransient = "transient"
+	patternSustained = "sustained"
+)
+
 // windowedStatsConfig parameterises evalWindowedStats for counter-based checks.
 type windowedStatsConfig struct {
 	baseWarnThreshold int64
@@ -169,6 +176,8 @@ func evalWindowedStats(
 		maxHourly:         maxHourly,
 		activeHours:       activeHours,
 		sustainedHrs:      sustainedHrs,
+		sources:           activeSources,
+		lastEventSuffix:   formatLastEventSuffix(lastEvent, now),
 		recurrenceEnabled: recurrenceEnabled,
 		velocity:          velocity,
 		window:            cfg.window,
@@ -180,11 +189,11 @@ func evalWindowedStats(
 	var pattern string
 	switch {
 	case windowTotal == 0:
-		pattern = "none"
+		pattern = patternNone
 	case recurrenceEnabled && activeHours >= sustainedHrs && windowTotal >= sustainedVolumeFloor:
-		pattern = "sustained"
+		pattern = patternSustained
 	default:
-		pattern = "transient"
+		pattern = patternTransient
 	}
 
 	details := map[string]any{
@@ -229,6 +238,8 @@ type severitySignals struct {
 	maxHourly         int64
 	activeHours       int
 	sustainedHrs      int
+	sources           int
+	lastEventSuffix   string
 	recurrenceEnabled bool
 	velocity          velocityTrend
 	window            time.Duration
@@ -244,14 +255,15 @@ func applySeveritySignals(s *severitySignals, defaultMsg string) (status health.
 
 	label := checkNameLabel(s.name)
 	windowStr := formatDuration(s.window)
+	ctx := fmt.Sprintf(" across %d source(s)%s", s.sources, s.lastEventSuffix)
 	status = health.StatusHealthy
 	msg = defaultMsg
 	peakEscalated := false
 
 	// Safety net: severe hourly spike overrides window-scaled thresholds.
 	if s.maxHourly >= s.baseCritThreshold {
-		return health.StatusCritical, fmt.Sprintf("%d %s in %s, peak hour: %d %s",
-			s.windowTotal, label, windowStr, s.maxHourly, label)
+		return health.StatusCritical, fmt.Sprintf("%d %s in %s, peak hour: %d %s%s",
+			s.windowTotal, label, windowStr, s.maxHourly, label, ctx)
 	}
 
 	if s.maxHourly >= s.baseWarnThreshold {
@@ -265,27 +277,27 @@ func applySeveritySignals(s *severitySignals, defaultMsg string) (status health.
 	// Sustained recurrence pattern.
 	if s.recurrenceEnabled && s.activeHours >= s.sustainedHrs && s.windowTotal >= sustainedVolumeFloor {
 		if s.windowTotal >= s.critThreshold || s.velocity == velocityIncreasing {
-			return health.StatusCritical, fmt.Sprintf("Sustained %s across %d hours, worsening", label, s.activeHours)
+			return health.StatusCritical, fmt.Sprintf("Sustained %s across %d hours, worsening%s", label, s.activeHours, ctx)
 		}
-		return health.StatusWarning, fmt.Sprintf("Sustained %s across %d hours", label, s.activeHours)
+		return health.StatusWarning, fmt.Sprintf("Sustained %s across %d hours%s", label, s.activeHours, ctx)
 	}
 
 	// Absolute threshold checks.
 	if s.windowTotal >= s.critThreshold {
-		return health.StatusCritical, fmt.Sprintf("%d %s in %s, concentrated in %d hour(s)",
-			s.windowTotal, label, windowStr, max(s.activeHours, 1))
+		return health.StatusCritical, fmt.Sprintf("%d %s in %s, concentrated in %d hour(s)%s",
+			s.windowTotal, label, windowStr, max(s.activeHours, 1), ctx)
 	}
 
 	if s.windowTotal >= s.warnThreshold || peakEscalated {
 		if s.recurrenceEnabled && s.velocity == velocityIncreasing {
-			return health.StatusWarning, fmt.Sprintf("%d %s in %s, rate increasing", s.windowTotal, label, windowStr)
+			return health.StatusWarning, fmt.Sprintf("%d %s in %s, rate increasing%s", s.windowTotal, label, windowStr, ctx)
 		}
-		return health.StatusWarning, fmt.Sprintf("%d %s in %s", s.windowTotal, label, windowStr)
+		return health.StatusWarning, fmt.Sprintf("%d %s in %s%s", s.windowTotal, label, windowStr, ctx)
 	}
 
 	// Low volume within tolerance.
 	if s.activeHours > 0 {
-		msg = fmt.Sprintf("%d %s in %s, within tolerance", s.windowTotal, label, windowStr)
+		msg = fmt.Sprintf("%d %s in %s, within tolerance%s", s.windowTotal, label, windowStr, ctx)
 	}
 
 	return status, msg
@@ -364,6 +376,14 @@ func formatTimeAgo(t, now time.Time) string {
 	}
 }
 
+// formatLastEventSuffix returns " (last: Xh ago)" or empty string when no event recorded.
+func formatLastEventSuffix(lastEvent, now time.Time) string {
+	if lastEvent.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf(" (last: %s)", formatTimeAgo(lastEvent, now))
+}
+
 // extractMetricType extracts the metric type from a prefix like "audio.drops." -> "drops".
 func extractMetricType(prefix string) string {
 	trimmed := strings.TrimSuffix(prefix, ".")
@@ -408,10 +428,14 @@ func countActiveHours(buckets []observability.HourlyBucket, window time.Duration
 // Returns velocityStable when fewer than two in-window buckets are found.
 func detectVelocity(buckets []observability.HourlyBucket, window time.Duration, now time.Time) velocityTrend {
 	cutoff := now.Add(-window)
+	currentHourStart := now.Truncate(time.Hour)
 
 	var prev, curr observability.HourlyBucket
 	n := 0
 	for _, b := range buckets {
+		if !b.Start.Before(currentHourStart) {
+			continue
+		}
 		if !b.Start.Add(time.Hour).Before(cutoff) {
 			prev, curr = curr, b
 			n++

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -261,13 +261,17 @@ func applySeveritySignals(s *severitySignals, defaultMsg string) (status health.
 	peakEscalated := false
 
 	// Safety net: severe hourly spike overrides window-scaled thresholds.
-	if s.maxHourly >= s.baseCritThreshold {
-		return health.StatusCritical, fmt.Sprintf("%d %s in %s, peak hour: %d %s%s",
-			s.windowTotal, label, windowStr, s.maxHourly, label, ctx)
-	}
+	// Only enabled for windows >= 1h; sub-hour windows share a single bucket
+	// with events outside the window, causing false positives.
+	if s.window >= time.Hour {
+		if s.maxHourly >= s.baseCritThreshold {
+			return health.StatusCritical, fmt.Sprintf("%d %s in %s, peak hour: %d %s%s",
+				s.windowTotal, label, windowStr, s.maxHourly, label, ctx)
+		}
 
-	if s.maxHourly >= s.baseWarnThreshold {
-		peakEscalated = true
+		if s.maxHourly >= s.baseWarnThreshold {
+			peakEscalated = true
+		}
 	}
 
 	// Volume floor prevents classifying negligible noise as sustained

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -152,68 +152,20 @@ func evalWindowedStats(
 		velocityDetail = velocityString(velocity)
 	}
 
-	status := health.StatusHealthy
-
-	if windowTotal > 0 {
-		peakEscalated := false
-
-		// Safety net: severe hourly spike overrides window-scaled thresholds.
-		if maxHourly >= cfg.baseCritThreshold {
-			status = health.StatusCritical
-			label := checkNameLabel(name)
-			msg = fmt.Sprintf("%d %s in %s, peak hour: %d %s",
-				windowTotal, label, formatDuration(cfg.window), maxHourly, label)
-		}
-
-		if status == health.StatusHealthy && maxHourly >= cfg.baseWarnThreshold {
-			peakEscalated = true
-		}
-
-		// Volume floor prevents classifying negligible noise as sustained
-		// (e.g. 1 drop/hr for 3 hrs = 3 total, below floor of 5 with baseWarn=10).
-		sustainedVolumeFloor := warnThreshold / 2
-
-		// Sustained recurrence pattern.
-		if status == health.StatusHealthy && recurrenceEnabled &&
-			activeHours >= sustainedHrs && windowTotal >= sustainedVolumeFloor {
-			label := checkNameLabel(name)
-			if windowTotal >= critThreshold || velocity == velocityIncreasing {
-				status = health.StatusCritical
-				msg = fmt.Sprintf("Sustained %s across %d hours, worsening", label, activeHours)
-			} else {
-				status = health.StatusWarning
-				msg = fmt.Sprintf("Sustained %s across %d hours", label, activeHours)
-			}
-		}
-
-		// Absolute threshold checks.
-		if status == health.StatusHealthy && windowTotal >= critThreshold {
-			status = health.StatusCritical
-			label := checkNameLabel(name)
-			msg = fmt.Sprintf("%d %s in %s, concentrated in %d hour(s)",
-				windowTotal, label, formatDuration(cfg.window), max(activeHours, 1))
-		}
-
-		if status == health.StatusHealthy && (windowTotal >= warnThreshold || peakEscalated) {
-			label := checkNameLabel(name)
-			if recurrenceEnabled && velocity == velocityIncreasing {
-				status = health.StatusWarning
-				msg = fmt.Sprintf("%d %s in %s, rate increasing",
-					windowTotal, label, formatDuration(cfg.window))
-			} else {
-				status = health.StatusWarning
-				msg = fmt.Sprintf("%d %s in %s",
-					windowTotal, label, formatDuration(cfg.window))
-			}
-		}
-
-		// Low volume within tolerance.
-		if status == health.StatusHealthy && activeHours > 0 {
-			label := checkNameLabel(name)
-			msg = fmt.Sprintf("%d %s in %s, within tolerance",
-				windowTotal, label, formatDuration(cfg.window))
-		}
-	}
+	status, msg := applySeveritySignals(&severitySignals{
+		name:              name,
+		windowTotal:       windowTotal,
+		warnThreshold:     warnThreshold,
+		critThreshold:     critThreshold,
+		baseWarnThreshold: cfg.baseWarnThreshold,
+		baseCritThreshold: cfg.baseCritThreshold,
+		maxHourly:         maxHourly,
+		activeHours:       activeHours,
+		sustainedHrs:      sustainedHrs,
+		recurrenceEnabled: recurrenceEnabled,
+		velocity:          velocity,
+		window:            cfg.window,
+	}, msg)
 
 	// Determine pattern classification.
 	var pattern string
@@ -232,9 +184,9 @@ func evalWindowedStats(
 		"lifetime_total": lifetimeTotal,
 		"sources":        activeSources,
 		"per_source":     perSource,
-		"active_hours": activeHours,
-		"velocity":     velocityDetail,
-		"pattern":      pattern,
+		"active_hours":   activeHours,
+		"velocity":       velocityDetail,
+		"pattern":        pattern,
 	}
 	if !lastEvent.IsZero() {
 		details["last_event"] = lastEvent.Format(time.RFC3339)
@@ -255,6 +207,79 @@ func evalWindowedStats(
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}
+}
+
+// severitySignals holds the pre-computed inputs for the four-signal severity evaluation.
+type severitySignals struct {
+	name              string
+	windowTotal       int64
+	warnThreshold     int64
+	critThreshold     int64
+	baseWarnThreshold int64
+	baseCritThreshold int64
+	maxHourly         int64
+	activeHours       int
+	sustainedHrs      int
+	recurrenceEnabled bool
+	velocity          velocityTrend
+	window            time.Duration
+}
+
+// applySeveritySignals runs the four-signal evaluation (peak spike, sustained
+// recurrence, absolute volume, velocity) and returns the resulting status and
+// message. The defaultMsg is returned unchanged when no signal fires.
+func applySeveritySignals(s *severitySignals, defaultMsg string) (status health.Status, msg string) {
+	if s.windowTotal == 0 {
+		return health.StatusHealthy, defaultMsg
+	}
+
+	label := checkNameLabel(s.name)
+	windowStr := formatDuration(s.window)
+	status = health.StatusHealthy
+	msg = defaultMsg
+	peakEscalated := false
+
+	// Safety net: severe hourly spike overrides window-scaled thresholds.
+	if s.maxHourly >= s.baseCritThreshold {
+		return health.StatusCritical, fmt.Sprintf("%d %s in %s, peak hour: %d %s",
+			s.windowTotal, label, windowStr, s.maxHourly, label)
+	}
+
+	if s.maxHourly >= s.baseWarnThreshold {
+		peakEscalated = true
+	}
+
+	// Volume floor prevents classifying negligible noise as sustained
+	// (e.g. 1 drop/hr for 3 hrs = 3 total, below floor of 5 with baseWarn=10).
+	sustainedVolumeFloor := s.warnThreshold / 2
+
+	// Sustained recurrence pattern.
+	if s.recurrenceEnabled && s.activeHours >= s.sustainedHrs && s.windowTotal >= sustainedVolumeFloor {
+		if s.windowTotal >= s.critThreshold || s.velocity == velocityIncreasing {
+			return health.StatusCritical, fmt.Sprintf("Sustained %s across %d hours, worsening", label, s.activeHours)
+		}
+		return health.StatusWarning, fmt.Sprintf("Sustained %s across %d hours", label, s.activeHours)
+	}
+
+	// Absolute threshold checks.
+	if s.windowTotal >= s.critThreshold {
+		return health.StatusCritical, fmt.Sprintf("%d %s in %s, concentrated in %d hour(s)",
+			s.windowTotal, label, windowStr, max(s.activeHours, 1))
+	}
+
+	if s.windowTotal >= s.warnThreshold || peakEscalated {
+		if s.recurrenceEnabled && s.velocity == velocityIncreasing {
+			return health.StatusWarning, fmt.Sprintf("%d %s in %s, rate increasing", s.windowTotal, label, windowStr)
+		}
+		return health.StatusWarning, fmt.Sprintf("%d %s in %s", s.windowTotal, label, windowStr)
+	}
+
+	// Low volume within tolerance.
+	if s.activeHours > 0 {
+		msg = fmt.Sprintf("%d %s in %s, within tolerance", s.windowTotal, label, windowStr)
+	}
+
+	return status, msg
 }
 
 // formatWindowedMessage builds a human-readable message with temporal context.

--- a/internal/health/checks/helpers_test.go
+++ b/internal/health/checks/helpers_test.go
@@ -1,0 +1,450 @@
+package checks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// makeBuckets builds a slice of HourlyBuckets anchored to a reference time.
+// The last bucket starts at now.Truncate(time.Hour). Earlier buckets are
+// spaced one hour apart, oldest first. len(counts) buckets are produced.
+func makeBuckets(t *testing.T, counts []int64, now time.Time) []observability.HourlyBucket {
+	t.Helper()
+	if len(counts) == 0 {
+		return nil
+	}
+	n := len(counts)
+	baseHour := now.Truncate(time.Hour).Add(-time.Duration(n-1) * time.Hour)
+	buckets := make([]observability.HourlyBucket, n)
+	for i, c := range counts {
+		buckets[i] = observability.HourlyBucket{
+			Start: baseHour.Add(time.Duration(i) * time.Hour),
+			Count: c,
+		}
+	}
+	return buckets
+}
+
+// TestCountActiveHours verifies that countActiveHours counts only in-window
+// buckets with a non-zero Count.
+//
+// Boundary semantics: a bucket is "in-window" when b.Start+1h >= cutoff,
+// i.e., when any part of its hour-long interval overlaps [cutoff, now].
+func TestCountActiveHours(t *testing.T) {
+	t.Parallel()
+
+	// Use a truncated time to make boundary reasoning exact.
+	now := time.Now().Truncate(time.Hour)
+
+	tests := []struct {
+		name   string
+		counts []int64
+		window time.Duration
+		want   int
+	}{
+		{
+			name:   "zero buckets",
+			counts: nil,
+			window: time.Hour,
+			want:   0,
+		},
+		{
+			name:   "all-zero counts",
+			counts: []int64{0, 0, 0},
+			window: 3 * time.Hour,
+			want:   0,
+		},
+		{
+			name:   "some nonzero in window",
+			counts: []int64{0, 5, 0, 3},
+			window: 4 * time.Hour,
+			want:   2,
+		},
+		{
+			// 4 buckets (starts: now-3h, now-2h, now-1h, now).
+			// 3h window: cutoff = now-3h.
+			// Oldest bucket end = (now-3h)+1h = now-2h, which is >= cutoff (now-3h). Included.
+			// All 4 buckets are in-window; counts 10, 5, 3 are non-zero = 3 active hours.
+			name:   "four bucket window boundary all included",
+			counts: []int64{10, 5, 0, 3},
+			window: 3 * time.Hour,
+			want:   3,
+		},
+		{
+			// 5 buckets (starts: now-4h, now-3h, now-2h, now-1h, now).
+			// 3h window: cutoff = now-3h.
+			// Oldest bucket end = (now-4h)+1h = now-3h, which equals cutoff exactly.
+			// The condition is !Before(cutoff), so now-3h is NOT before now-3h -> included.
+			// That bucket has count 10, so all 5 buckets are in window; counts {10,5,0,3} active = 4.
+			// NOTE: we use count 0 in slot 1 to verify exclusion only happens beyond strict cutoff.
+			name:   "oldest bucket end equals cutoff is included",
+			counts: []int64{10, 5, 0, 3, 7},
+			window: 4 * time.Hour,
+			want:   4,
+		},
+		{
+			// Sub-hour window: cutoff = now - 15m.
+			// Oldest (n-1) bucket ends at now-3h+1h = now-2h < cutoff (now-15m). Excluded.
+			// Only the newest bucket (now, now+1h) overlaps. count=9 -> 1 active.
+			name:   "sub-hour window covers only current bucket",
+			counts: []int64{7, 0, 0, 9},
+			window: 15 * time.Minute,
+			want:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			buckets := makeBuckets(t, tt.counts, now)
+			got := countActiveHours(buckets, tt.window, now)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestDetectVelocity verifies that detectVelocity correctly classifies the
+// trend of the two most recent in-window buckets.
+func TestDetectVelocity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Hour)
+
+	tests := []struct {
+		name   string
+		counts []int64
+		window time.Duration
+		want   velocityTrend
+	}{
+		{
+			name:   "insufficient data - empty",
+			counts: nil,
+			window: time.Hour,
+			want:   velocityStable,
+		},
+		{
+			name:   "insufficient data - one bucket",
+			counts: []int64{10},
+			window: time.Hour,
+			want:   velocityStable,
+		},
+		{
+			name:   "increasing",
+			counts: []int64{5, 10},
+			window: 2 * time.Hour,
+			want:   velocityIncreasing,
+		},
+		{
+			name:   "decreasing",
+			counts: []int64{10, 5},
+			window: 2 * time.Hour,
+			want:   velocityDecreasing,
+		},
+		{
+			name:   "stable",
+			counts: []int64{7, 7},
+			window: 2 * time.Hour,
+			want:   velocityStable,
+		},
+		{
+			// Pattern [100, 0, 0, 10]: last two in-window buckets are [0, 10].
+			// current=10 > previous=0, so velocity is increasing.
+			name:   "zero-gap pattern increasing at end",
+			counts: []int64{100, 0, 0, 10},
+			window: 4 * time.Hour,
+			want:   velocityIncreasing,
+		},
+		{
+			// 5 buckets, 2h window: cutoff = now-2h.
+			// Oldest bucket starts now-4h, ends now-3h; NOT in window.
+			// In-window buckets (3): counts [5, 3] -> last two [5, 3] -> decreasing.
+			// Use 2h window so oldest 2 buckets are excluded.
+			name:   "old bucket excluded by window uses last two in-window",
+			counts: []int64{100, 99, 5, 3, 0},
+			window: 2 * time.Hour,
+			// Last 2 in-window: counts 3, 0 -> decreasing.
+			want: velocityDecreasing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			buckets := makeBuckets(t, tt.counts, now)
+			got := detectVelocity(buckets, tt.window, now)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestMaxBucketCount verifies that maxBucketCount returns the peak in-window
+// bucket count.
+func TestMaxBucketCount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Hour)
+
+	tests := []struct {
+		name   string
+		counts []int64
+		window time.Duration
+		want   int64
+	}{
+		{
+			name:   "empty buckets",
+			counts: nil,
+			window: time.Hour,
+			want:   0,
+		},
+		{
+			name:   "single bucket",
+			counts: []int64{42},
+			window: time.Hour,
+			want:   42,
+		},
+		{
+			name:   "peak in middle",
+			counts: []int64{5, 100, 20},
+			window: 3 * time.Hour,
+			want:   100,
+		},
+		{
+			// 6 buckets; 2h window: cutoff = now-2h.
+			// Bucket[0].end = now-4h < cutoff -> excluded.
+			// Bucket[1].end = now-3h < cutoff -> excluded.
+			// In-window: 4 buckets with counts [3, 7, 2, 5]. Peak = 7.
+			name:   "window filtering excludes old peak",
+			counts: []int64{999, 888, 3, 7, 2, 5},
+			window: 2 * time.Hour,
+			want:   7,
+		},
+		{
+			name:   "all zeros",
+			counts: []int64{0, 0, 0},
+			window: 3 * time.Hour,
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			buckets := makeBuckets(t, tt.counts, now)
+			got := maxBucketCount(buckets, tt.window, now)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// dropsConfig builds a windowedStatsConfig matching BufferDropsCheck thresholds.
+func dropsConfig(window time.Duration) *windowedStatsConfig {
+	return &windowedStatsConfig{
+		baseWarnThreshold: 10,
+		baseCritThreshold: 50,
+		sustainedHours:    3,
+		metricPrefix:      observability.MetricPrefixAudioDrops,
+		window:            window,
+	}
+}
+
+// recordDropsPerHour records the given drop counts into the store, one per
+// hour. counts[0] is the oldest; counts[len-1] lands at endTime.Truncate(hour).
+func recordDropsPerHour(t *testing.T, store *observability.HealthMetricsStore, key string, counts []int64, endTime time.Time) {
+	t.Helper()
+	base := endTime.Truncate(time.Hour)
+	n := len(counts)
+	for i, c := range counts {
+		ts := base.Add(-time.Duration(n-1-i) * time.Hour)
+		store.RecordAt(key, c, ts)
+	}
+}
+
+// TestEvalWindowedStats_SeverityMatrix exercises the four-signal severity
+// evaluation across representative operational scenarios.
+func TestEvalWindowedStats_SeverityMatrix(t *testing.T) {
+	t.Parallel()
+
+	// Use a truncated baseline to avoid boundary effects at hour rollover.
+	baseNow := time.Now().Truncate(time.Hour)
+
+	tests := []struct {
+		name        string
+		window      time.Duration
+		setup       func(t *testing.T, store *observability.HealthMetricsStore, now time.Time)
+		wantStatus  health.Status
+		wantPattern *string
+	}{
+		{
+			name:   "ZeroDrops",
+			window: time.Hour,
+			setup:  nil,
+			// No keys registered in the store -> skipped result.
+			wantStatus: health.StatusSkipped,
+		},
+		{
+			name:   "TransientBelowThreshold",
+			window: time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				// 8 drops in current hour; baseWarn=10, warnThreshold=10*1=10. Below threshold.
+				store.RecordAt("audio.drops.src1", 8, now)
+			},
+			wantStatus: health.StatusHealthy,
+		},
+		{
+			name:   "TransientAboveWarn",
+			window: time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				// 15 drops; warnThreshold=10. Above warn -> Warning.
+				store.RecordAt("audio.drops.src1", 15, now)
+			},
+			wantStatus: health.StatusWarning,
+		},
+		{
+			name:   "TransientAboveCrit",
+			window: time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				// 55 drops; baseCrit=50. Peak safety net fires -> Critical.
+				store.RecordAt("audio.drops.src1", 55, now)
+			},
+			wantStatus: health.StatusCritical,
+		},
+		{
+			// Sub-hour window (15m): recurrence disabled (window < 3h).
+			// 3 buckets are recorded but the 15m window sees only the current hour.
+			// That hour has 3 drops, below baseWarn(10) -> Healthy.
+			name:   "SubHourNoRecurrence",
+			window: 15 * time.Minute,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				recordDropsPerHour(t, store, "audio.drops.src1", []int64{5, 5, 3}, now)
+			},
+			wantStatus: health.StatusHealthy,
+		},
+		{
+			// 10 drops/hr across 4 active hours in a 6h window.
+			// windowHours=6, warnThreshold=60, critThreshold=300.
+			// total=40, activeHours(4) >= sustainedHrs(3), total(40) >= floor(30).
+			// total(40) < crit(300) and stable velocity -> Warning (sustained).
+			name:   "SustainedAboveFloor",
+			window: 6 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 0, 10, 10, 10, 10}, now)
+			},
+			wantStatus: health.StatusWarning,
+		},
+		{
+			// 1 drop/hr for 4 hours = 4 total in a 6h window.
+			// warnThreshold=60, floor=30. total(4) < floor(30) -> sustained not triggered.
+			// total(4) < warnThreshold(60) -> Healthy.
+			name:   "SustainedBelowFloor",
+			window: 6 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 0, 1, 1, 1, 1}, now)
+			},
+			wantStatus: health.StatusHealthy,
+		},
+		{
+			// 5, 10, 20 drops across last 3 hours = 35 total, 6h window.
+			// activeHours(3) >= sustainedHrs(3), total(35) >= floor(30).
+			// velocity: last two buckets [10, 20] -> increasing.
+			// Sustained + increasing velocity -> Critical.
+			name:   "SustainedWorsening",
+			window: 6 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 0, 0, 5, 10, 20}, now)
+			},
+			wantStatus: health.StatusCritical,
+		},
+		{
+			// 60 drops/hr for 5 hours = 300 total in a 6h window.
+			// critThreshold = 50*6 = 300. total(300) >= crit(300).
+			// But also maxHourly(60) >= baseCrit(50) -> safety net fires first -> Critical.
+			name:   "SustainedCritical",
+			window: 6 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 60, 60, 60, 60, 60}, now)
+			},
+			wantStatus: health.StatusCritical,
+		},
+		{
+			// 7d window: one hour with 2000 drops. maxHourly(2000) >= baseCrit(50).
+			// Safety net fires -> Critical.
+			name:   "PeakOverridesLargeWindow",
+			window: 7 * 24 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				store.RecordAt("audio.drops.src1", 2000, now)
+			},
+			wantStatus: health.StatusCritical,
+		},
+		{
+			// 24h window: 15 drops in 1 hour. maxHourly(15) >= baseWarn(10) -> peakEscalated.
+			// total(15) < critThreshold(1200). activeHours(1) < sustainedHrs(3).
+			// peakEscalated path -> Warning. (15 < baseCrit=50 so safety net does not fire)
+			name:   "PeakWarnInLargeWindow",
+			window: 24 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				store.RecordAt("audio.drops.src1", 15, now)
+			},
+			wantStatus: health.StatusWarning,
+		},
+		{
+			// 24h window: 120 drops spread across 12 hours (10/hr).
+			// warnThreshold = 10*24 = 240, critThreshold = 50*24 = 1200.
+			// activeHours(12) >= sustainedHrs(3), floor = 240/2 = 120.
+			// total(120) >= floor(120). Sustained triggered.
+			// total(120) < crit(1200) and velocity stable -> Warning.
+			name:   "WindowScaling",
+			window: 24 * time.Hour,
+			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
+				t.Helper()
+				for i := range 12 {
+					ts := now.Add(-time.Duration(11-i) * time.Hour)
+					store.RecordAt("audio.drops.src1", 10, ts)
+				}
+			},
+			wantStatus: health.StatusWarning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newTestHealthStore(t)
+			now := baseNow
+
+			if tt.setup != nil {
+				tt.setup(t, store, now)
+			}
+
+			cfg := dropsConfig(tt.window)
+			result := evalWindowedStats("buffer_drops", health.CategoryAudio, store, nil, cfg, time.Now())
+
+			assert.Equal(t, tt.wantStatus, result.Status, "status mismatch: message=%q", result.Message)
+
+			if tt.wantStatus == health.StatusSkipped {
+				return
+			}
+
+			require.NotNil(t, result.Details)
+
+			if tt.wantPattern != nil {
+				assert.Equal(t, *tt.wantPattern, result.Details["pattern"], "pattern mismatch")
+			}
+		})
+	}
+}

--- a/internal/health/checks/helpers_test.go
+++ b/internal/health/checks/helpers_test.go
@@ -80,11 +80,10 @@ func TestCountActiveHours(t *testing.T) {
 			// 3h window: cutoff = now-3h.
 			// Oldest bucket end = (now-4h)+1h = now-3h, which equals cutoff exactly.
 			// The condition is !Before(cutoff), so now-3h is NOT before now-3h -> included.
-			// That bucket has count 10, so all 5 buckets are in window; counts {10,5,0,3} active = 4.
-			// NOTE: we use count 0 in slot 1 to verify exclusion only happens beyond strict cutoff.
+			// That bucket has count 10, so all 5 buckets are in window; counts {10,5,0,3,7} active = 4.
 			name:   "oldest bucket end equals cutoff is included",
 			counts: []int64{10, 5, 0, 3, 7},
-			window: 4 * time.Hour,
+			window: 3 * time.Hour,
 			want:   4,
 		},
 		{
@@ -164,15 +163,13 @@ func TestDetectVelocity(t *testing.T) {
 			want:   velocityIncreasing,
 		},
 		{
-			// 5 buckets, 2h window: cutoff = now-2h.
-			// Oldest bucket starts now-4h, ends now-3h; NOT in window.
-			// In-window buckets (3): counts [5, 3] -> last two [5, 3] -> decreasing.
-			// Use 2h window so oldest 2 buckets are excluded.
+			// 5 buckets, 2h window: cutoff = bucketNow-2h.
+			// Oldest bucket starts bucketNow-4h, ends bucketNow-3h; NOT in window.
+			// In-window buckets (3): counts [5, 3, 0] -> last two [3, 0] -> decreasing.
 			name:   "old bucket excluded by window uses last two in-window",
 			counts: []int64{100, 99, 5, 3, 0},
 			window: 2 * time.Hour,
-			// Last 2 in-window: counts 3, 0 -> decreasing.
-			want: velocityDecreasing,
+			want:   velocityDecreasing,
 		},
 	}
 

--- a/internal/health/checks/helpers_test.go
+++ b/internal/health/checks/helpers_test.go
@@ -113,7 +113,11 @@ func TestCountActiveHours(t *testing.T) {
 func TestDetectVelocity(t *testing.T) {
 	t.Parallel()
 
+	// makeBuckets anchors the newest bucket at now.Truncate(1h). detectVelocity
+	// skips the bucket starting at now.Truncate(1h) (current incomplete hour).
+	// Shift bucketNow back one hour from now so the newest bucket is completed.
 	now := time.Now().Truncate(time.Hour)
+	bucketNow := now.Add(-time.Hour)
 
 	tests := []struct {
 		name   string
@@ -175,7 +179,7 @@ func TestDetectVelocity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			buckets := makeBuckets(t, tt.counts, now)
+			buckets := makeBuckets(t, tt.counts, bucketNow)
 			got := detectVelocity(buckets, tt.window, now)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/health/checks/helpers_test.go
+++ b/internal/health/checks/helpers_test.go
@@ -269,7 +269,6 @@ func recordDropsPerHour(t *testing.T, store *observability.HealthMetricsStore, k
 func TestEvalWindowedStats_SeverityMatrix(t *testing.T) {
 	t.Parallel()
 
-	// Use a truncated baseline to avoid boundary effects at hour rollover.
 	baseNow := time.Now().Truncate(time.Hour)
 
 	tests := []struct {
@@ -277,13 +276,12 @@ func TestEvalWindowedStats_SeverityMatrix(t *testing.T) {
 		window      time.Duration
 		setup       func(t *testing.T, store *observability.HealthMetricsStore, now time.Time)
 		wantStatus  health.Status
-		wantPattern *string
+		wantPattern string
 	}{
 		{
-			name:   "ZeroDrops",
-			window: time.Hour,
-			setup:  nil,
-			// No keys registered in the store -> skipped result.
+			name:       "ZeroDrops",
+			window:     time.Hour,
+			setup:      nil,
 			wantStatus: health.StatusSkipped,
 		},
 		{
@@ -291,122 +289,102 @@ func TestEvalWindowedStats_SeverityMatrix(t *testing.T) {
 			window: time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
-				// 8 drops in current hour; baseWarn=10, warnThreshold=10*1=10. Below threshold.
 				store.RecordAt("audio.drops.src1", 8, now)
 			},
-			wantStatus: health.StatusHealthy,
+			wantStatus:  health.StatusHealthy,
+			wantPattern: "transient",
 		},
 		{
 			name:   "TransientAboveWarn",
 			window: time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
-				// 15 drops; warnThreshold=10. Above warn -> Warning.
 				store.RecordAt("audio.drops.src1", 15, now)
 			},
-			wantStatus: health.StatusWarning,
+			wantStatus:  health.StatusWarning,
+			wantPattern: "transient",
 		},
 		{
 			name:   "TransientAboveCrit",
 			window: time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
-				// 55 drops; baseCrit=50. Peak safety net fires -> Critical.
 				store.RecordAt("audio.drops.src1", 55, now)
 			},
-			wantStatus: health.StatusCritical,
+			wantStatus:  health.StatusCritical,
+			wantPattern: "transient",
 		},
 		{
-			// Sub-hour window (15m): recurrence disabled (window < 3h).
-			// 3 buckets are recorded but the 15m window sees only the current hour.
-			// That hour has 3 drops, below baseWarn(10) -> Healthy.
 			name:   "SubHourNoRecurrence",
 			window: 15 * time.Minute,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				recordDropsPerHour(t, store, "audio.drops.src1", []int64{5, 5, 3}, now)
 			},
-			wantStatus: health.StatusHealthy,
+			wantStatus:  health.StatusHealthy,
+			wantPattern: "transient",
 		},
 		{
-			// 10 drops/hr across 4 active hours in a 6h window.
-			// windowHours=6, warnThreshold=60, critThreshold=300.
-			// total=40, activeHours(4) >= sustainedHrs(3), total(40) >= floor(30).
-			// total(40) < crit(300) and stable velocity -> Warning (sustained).
 			name:   "SustainedAboveFloor",
 			window: 6 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 0, 10, 10, 10, 10}, now)
 			},
-			wantStatus: health.StatusWarning,
+			wantStatus:  health.StatusWarning,
+			wantPattern: "sustained",
 		},
 		{
-			// 1 drop/hr for 4 hours = 4 total in a 6h window.
-			// warnThreshold=60, floor=30. total(4) < floor(30) -> sustained not triggered.
-			// total(4) < warnThreshold(60) -> Healthy.
 			name:   "SustainedBelowFloor",
 			window: 6 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 0, 1, 1, 1, 1}, now)
 			},
-			wantStatus: health.StatusHealthy,
+			wantStatus:  health.StatusHealthy,
+			wantPattern: "transient",
 		},
 		{
-			// 5, 10, 20 drops across last 3 hours = 35 total, 6h window.
-			// activeHours(3) >= sustainedHrs(3), total(35) >= floor(30).
-			// velocity: last two buckets [10, 20] -> increasing.
-			// Sustained + increasing velocity -> Critical.
 			name:   "SustainedWorsening",
 			window: 6 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 0, 0, 5, 10, 20}, now)
 			},
-			wantStatus: health.StatusCritical,
+			wantStatus:  health.StatusCritical,
+			wantPattern: "sustained",
 		},
 		{
-			// 60 drops/hr for 5 hours = 300 total in a 6h window.
-			// critThreshold = 50*6 = 300. total(300) >= crit(300).
-			// But also maxHourly(60) >= baseCrit(50) -> safety net fires first -> Critical.
 			name:   "SustainedCritical",
 			window: 6 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				recordDropsPerHour(t, store, "audio.drops.src1", []int64{0, 60, 60, 60, 60, 60}, now)
 			},
-			wantStatus: health.StatusCritical,
+			wantStatus:  health.StatusCritical,
+			wantPattern: "sustained",
 		},
 		{
-			// 7d window: one hour with 2000 drops. maxHourly(2000) >= baseCrit(50).
-			// Safety net fires -> Critical.
 			name:   "PeakOverridesLargeWindow",
 			window: 7 * 24 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				store.RecordAt("audio.drops.src1", 2000, now)
 			},
-			wantStatus: health.StatusCritical,
+			wantStatus:  health.StatusCritical,
+			wantPattern: "transient",
 		},
 		{
-			// 24h window: 15 drops in 1 hour. maxHourly(15) >= baseWarn(10) -> peakEscalated.
-			// total(15) < critThreshold(1200). activeHours(1) < sustainedHrs(3).
-			// peakEscalated path -> Warning. (15 < baseCrit=50 so safety net does not fire)
 			name:   "PeakWarnInLargeWindow",
 			window: 24 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
 				t.Helper()
 				store.RecordAt("audio.drops.src1", 15, now)
 			},
-			wantStatus: health.StatusWarning,
+			wantStatus:  health.StatusWarning,
+			wantPattern: "transient",
 		},
 		{
-			// 24h window: 120 drops spread across 12 hours (10/hr).
-			// warnThreshold = 10*24 = 240, critThreshold = 50*24 = 1200.
-			// activeHours(12) >= sustainedHrs(3), floor = 240/2 = 120.
-			// total(120) >= floor(120). Sustained triggered.
-			// total(120) < crit(1200) and velocity stable -> Warning.
 			name:   "WindowScaling",
 			window: 24 * time.Hour,
 			setup: func(t *testing.T, store *observability.HealthMetricsStore, now time.Time) {
@@ -416,7 +394,8 @@ func TestEvalWindowedStats_SeverityMatrix(t *testing.T) {
 					store.RecordAt("audio.drops.src1", 10, ts)
 				}
 			},
-			wantStatus: health.StatusWarning,
+			wantStatus:  health.StatusWarning,
+			wantPattern: "sustained",
 		},
 	}
 
@@ -441,10 +420,7 @@ func TestEvalWindowedStats_SeverityMatrix(t *testing.T) {
 			}
 
 			require.NotNil(t, result.Details)
-
-			if tt.wantPattern != nil {
-				assert.Equal(t, *tt.wantPattern, result.Details["pattern"], "pattern mismatch")
-			}
+			assert.Equal(t, tt.wantPattern, result.Details["pattern"], "pattern mismatch")
 		})
 	}
 }

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -123,10 +123,11 @@ func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
 	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
-		warnThreshold: 3,
-		critThreshold: 10,
-		metricPrefix:  observability.MetricPrefixStreamRestarts,
-		window:        c.window,
+		baseWarnThreshold: 3,
+		baseCritThreshold: 10,
+		sustainedHours:    3,
+		metricPrefix:      observability.MetricPrefixStreamRestarts,
+		window:            c.window,
 	}, start)
 }
 

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -85,6 +85,12 @@ func (c *StreamConnectivityCheck) Run(_ context.Context) health.Result {
 	}
 }
 
+// Threshold constants for stream health checks.
+const (
+	streamBaseWarnThreshold = 3
+	streamBaseCritThreshold = 10
+)
+
 // StreamErrorRateCheck monitors RTSP stream restart counts using time-windowed evaluation.
 type StreamErrorRateCheck struct {
 	store     *observability.HealthMetricsStore
@@ -123,9 +129,9 @@ func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
 	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
-		baseWarnThreshold: 3,
-		baseCritThreshold: 10,
-		sustainedHours:    3,
+		baseWarnThreshold: streamBaseWarnThreshold,
+		baseCritThreshold: streamBaseCritThreshold,
+		sustainedHours:    defaultSustainedHours,
 		metricPrefix:      observability.MetricPrefixStreamRestarts,
 		window:            c.window,
 	}, start)


### PR DESCRIPTION
## Summary

- Replace flat count thresholds in `evalWindowedStats` with four-signal severity evaluation: window-scaled thresholds, peak hourly spike safety net, sustained recurrence detection, and velocity awareness
- Add helper functions (`countActiveHours`, `detectVelocity`, `maxBucketCount`) for analyzing sparkline bucket distributions
- Lower `BufferDropsCheck` critical threshold from 100 to 50, `BufferOverrunCheck` thresholds from warn=10/crit=50 to warn=5/crit=25
- Add `active_hours`, `velocity`, and `pattern` fields to health check detail responses
- Comprehensive table-driven tests covering 12 severity scenarios plus helper unit tests

## Context

The windowed evaluation infrastructure (PR #3185, #3187) works correctly, but the severity assessment uses flat count thresholds that fail to distinguish transient blips from sustained degradation. A single GC pause producing 10+ drops triggers a warning for the entire window, while a system dropping 5 frames every hour stays "healthy" because no single window reaches the threshold. This PR adds pattern-aware severity logic that considers how drops are distributed across time, not just their aggregate count.

## Test Plan

- [x] 12-scenario severity matrix test covering all evaluation paths
- [x] Unit tests for countActiveHours, detectVelocity, maxBucketCount helpers
- [x] Updated threshold tests for BufferDropsCheck (crit at 50) and BufferOverrunCheck (warn at 5, crit at 25)
- [x] All 213 tests pass with `-race` (health/checks + observability)
- [x] `golangci-lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks for audio/streams now use refined multi-signal evaluation: peak spikes, sustained patterns, active-hours and velocity affect severity and messages.
  * Adjusted thresholds for buffer drops and overruns (drops warn/crit: 10/50; overruns warn/crit: 5/25). Messages now include pattern and last-event details.

* **Tests**
  * New unit tests cover threshold edges, velocity detection, active-hour counting, peak overrides and severity matrix scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->