### PR TITLE
feat(health): render severity signals in health detail panel

### DIFF
--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -13,6 +13,10 @@
     Info,
     ChevronDown,
     RefreshCw,
+    TrendingUp,
+    TrendingDown,
+    Minus,
+    Activity,
   } from '@lucide/svelte';
   import { onMount } from 'svelte';
   import { t, getLocale } from '$lib/i18n';
@@ -174,6 +178,50 @@
     }
   }
 
+  function velocityLabel(velocity: string): string {
+    switch (velocity) {
+      case 'increasing':
+        return t('health.detail.velocityIncreasing');
+      case 'decreasing':
+        return t('health.detail.velocityDecreasing');
+      default:
+        return t('health.detail.velocityStable');
+    }
+  }
+
+  function velocityColor(velocity: string): string {
+    switch (velocity) {
+      case 'increasing':
+        return 'var(--color-error)';
+      case 'decreasing':
+        return 'var(--color-success)';
+      default:
+        return 'var(--color-base-content)';
+    }
+  }
+
+  function patternLabel(pattern: string): string {
+    switch (pattern) {
+      case 'sustained':
+        return t('health.detail.patternSustained');
+      case 'transient':
+        return t('health.detail.patternTransient');
+      default:
+        return t('health.detail.patternNone');
+    }
+  }
+
+  function patternColor(pattern: string): string {
+    switch (pattern) {
+      case 'sustained':
+        return 'var(--color-error)';
+      case 'transient':
+        return 'var(--color-warning)';
+      default:
+        return 'var(--color-base-content)';
+    }
+  }
+
   function formatTimeAgo(isoTime: string): string {
     const now = Date.now();
     const then = new Date(isoTime).getTime();
@@ -284,6 +332,19 @@
       for (const r of results) {
         const statusLabel = t(`health.status.${r.status}`);
         lines.push(`  [${statusLabel}] ${formatCheckName(r.name)}: ${r.message}`);
+        const d = r.details;
+        if (d) {
+          const parts: string[] = [];
+          if (typeof d.window_total === 'number' && d.window_total > 0)
+            parts.push(`${t('health.detail.windowTotal')}: ${d.window_total}`);
+          if (typeof d.active_hours === 'number' && d.active_hours > 0)
+            parts.push(`${t('health.detail.activeHours')}: ${d.active_hours}`);
+          if (typeof d.pattern === 'string' && d.pattern !== 'none')
+            parts.push(`${t('health.detail.pattern')}: ${patternLabel(d.pattern)}`);
+          if (typeof d.velocity === 'string' && d.velocity !== 'n/a')
+            parts.push(`${t('health.detail.velocity')}: ${velocityLabel(d.velocity)}`);
+          if (parts.length > 0) lines.push(`    ${parts.join(' | ')}`);
+        }
       }
       lines.push('');
     }
@@ -366,7 +427,7 @@
           <span class="text-xs font-medium text-muted">{t('health.summary.healthy')}</span>
         </div>
         <span class="font-mono tabular-nums text-2xl font-semibold text-[var(--color-success)]">
-          {report?.count_by_status?.healthy ?? (running ? '…' : '—')}
+          {report?.count_by_status?.healthy ?? (running ? '…' : '-')}
         </span>
       </div>
       <div class="mt-auto text-xs text-muted">
@@ -399,7 +460,7 @@
             ? 'text-[var(--color-warning)]'
             : 'opacity-40'}"
         >
-          {report?.count_by_status?.warning ?? (running ? '…' : '—')}
+          {report?.count_by_status?.warning ?? (running ? '…' : '-')}
         </span>
       </div>
       <div class="mt-auto text-xs text-muted">
@@ -432,7 +493,7 @@
             ? 'text-[var(--color-error)]'
             : 'opacity-40'}"
         >
-          {report?.count_by_status?.critical ?? (running ? '…' : '—')}
+          {report?.count_by_status?.critical ?? (running ? '…' : '-')}
         </span>
       </div>
       <div class="mt-auto text-xs text-muted">
@@ -463,7 +524,7 @@
           class="font-mono tabular-nums text-2xl font-semibold"
           class:opacity-40={!((report?.count_by_status?.skipped ?? 0) > 0)}
         >
-          {report?.count_by_status?.skipped ?? (running ? '…' : '—')}
+          {report?.count_by_status?.skipped ?? (running ? '…' : '-')}
         </span>
       </div>
       <div class="mt-auto text-xs text-muted">
@@ -716,6 +777,66 @@
                           <span class="text-xs opacity-50">
                             ({result.details.lifetime_total}
                             {t('health.detail.lifetime')})
+                          </span>
+                        {/if}
+                      </div>
+                    {/if}
+
+                    <!-- Severity Signal Metadata -->
+                    {@const activeHours = result.details?.active_hours}
+                    {@const velocity = result.details?.velocity}
+                    {@const pattern = result.details?.pattern}
+                    {@const windowTotal = result.details?.window_total}
+                    {#if (typeof activeHours === 'number' && activeHours > 0) || (typeof velocity === 'string' && velocity !== 'n/a') || (typeof pattern === 'string' && pattern !== 'none')}
+                      <div
+                        class="px-3 py-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-[var(--color-base-200)]/50"
+                      >
+                        {#if windowTotal != null && typeof windowTotal === 'number' && windowTotal > 0}
+                          <span class="inline-flex items-center gap-1.5 text-xs">
+                            <Activity class="size-3 opacity-50" />
+                            <span class="opacity-60">{t('health.detail.windowTotal')}:</span>
+                            <span class="font-medium font-mono">{windowTotal}</span>
+                          </span>
+                        {/if}
+
+                        {#if typeof activeHours === 'number' && activeHours > 0}
+                          <span class="inline-flex items-center gap-1.5 text-xs">
+                            <Clock class="size-3 opacity-50" />
+                            <span class="opacity-60">{t('health.detail.activeHours')}:</span>
+                            <span class="font-medium font-mono">{activeHours}</span>
+                          </span>
+                        {/if}
+
+                        {#if typeof pattern === 'string' && pattern !== 'none'}
+                          <span class="inline-flex items-center gap-1.5 text-xs">
+                            <span class="opacity-60">{t('health.detail.pattern')}:</span>
+                            <span
+                              class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                              style:color={patternColor(pattern)}
+                              style:background="color-mix(in srgb, {patternColor(pattern)} 10%, transparent)"
+                            >
+                              {patternLabel(pattern)}
+                            </span>
+                          </span>
+                        {/if}
+
+                        {#if typeof velocity === 'string' && velocity !== 'n/a'}
+                          <span class="inline-flex items-center gap-1.5 text-xs">
+                            <span class="opacity-60">{t('health.detail.velocity')}:</span>
+                            <span
+                              class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium"
+                              style:color={velocityColor(velocity)}
+                              style:background="color-mix(in srgb, {velocityColor(velocity)} 10%, transparent)"
+                            >
+                              {#if velocity === 'increasing'}
+                                <TrendingUp class="size-3" />
+                              {:else if velocity === 'decreasing'}
+                                <TrendingDown class="size-3" />
+                              {:else}
+                                <Minus class="size-3" />
+                              {/if}
+                              {velocityLabel(velocity)}
+                            </span>
                           </span>
                         {/if}
                       </div>

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -83,6 +83,13 @@
 
   const windowPresets = ['15m', '30m', '1h', '6h', '24h', '7d'] as const;
 
+  const VELOCITY_INCREASING = 'increasing';
+  const VELOCITY_DECREASING = 'decreasing';
+  const VELOCITY_NA = 'n/a';
+  const PATTERN_NONE = 'none';
+  const PATTERN_TRANSIENT = 'transient';
+  const PATTERN_SUSTAINED = 'sustained';
+
   let report = $state<DiagnosticsReport | null>(null);
   let running = $state(false);
   let error = $state<string | null>(null);
@@ -180,9 +187,9 @@
 
   function velocityLabel(velocity: string): string {
     switch (velocity) {
-      case 'increasing':
+      case VELOCITY_INCREASING:
         return t('health.detail.velocityIncreasing');
-      case 'decreasing':
+      case VELOCITY_DECREASING:
         return t('health.detail.velocityDecreasing');
       default:
         return t('health.detail.velocityStable');
@@ -191,9 +198,9 @@
 
   function velocityColor(velocity: string): string {
     switch (velocity) {
-      case 'increasing':
+      case VELOCITY_INCREASING:
         return 'var(--color-error)';
-      case 'decreasing':
+      case VELOCITY_DECREASING:
         return 'var(--color-success)';
       default:
         return 'var(--color-base-content)';
@@ -202,9 +209,9 @@
 
   function patternLabel(pattern: string): string {
     switch (pattern) {
-      case 'sustained':
+      case PATTERN_SUSTAINED:
         return t('health.detail.patternSustained');
-      case 'transient':
+      case PATTERN_TRANSIENT:
         return t('health.detail.patternTransient');
       default:
         return t('health.detail.patternNone');
@@ -213,9 +220,9 @@
 
   function patternColor(pattern: string): string {
     switch (pattern) {
-      case 'sustained':
+      case PATTERN_SUSTAINED:
         return 'var(--color-error)';
-      case 'transient':
+      case PATTERN_TRANSIENT:
         return 'var(--color-warning)';
       default:
         return 'var(--color-base-content)';
@@ -339,9 +346,9 @@
             parts.push(`${t('health.detail.windowTotal')}: ${d.window_total}`);
           if (typeof d.active_hours === 'number' && d.active_hours > 0)
             parts.push(`${t('health.detail.activeHours')}: ${d.active_hours}`);
-          if (typeof d.pattern === 'string' && d.pattern !== 'none')
+          if (typeof d.pattern === 'string' && d.pattern !== PATTERN_NONE)
             parts.push(`${t('health.detail.pattern')}: ${patternLabel(d.pattern)}`);
-          if (typeof d.velocity === 'string' && d.velocity !== 'n/a')
+          if (typeof d.velocity === 'string' && d.velocity !== VELOCITY_NA)
             parts.push(`${t('health.detail.velocity')}: ${velocityLabel(d.velocity)}`);
           if (parts.length > 0) lines.push(`    ${parts.join(' | ')}`);
         }
@@ -787,7 +794,7 @@
                     {@const velocity = result.details?.velocity}
                     {@const pattern = result.details?.pattern}
                     {@const windowTotal = result.details?.window_total}
-                    {#if (typeof activeHours === 'number' && activeHours > 0) || (typeof velocity === 'string' && velocity !== 'n/a') || (typeof pattern === 'string' && pattern !== 'none')}
+                    {#if (typeof windowTotal === 'number' && windowTotal > 0) || (typeof activeHours === 'number' && activeHours > 0) || (typeof velocity === 'string' && velocity !== VELOCITY_NA) || (typeof pattern === 'string' && pattern !== PATTERN_NONE)}
                       <div
                         class="px-3 py-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-[var(--color-base-200)]/50"
                       >
@@ -807,7 +814,7 @@
                           </span>
                         {/if}
 
-                        {#if typeof pattern === 'string' && pattern !== 'none'}
+                        {#if typeof pattern === 'string' && pattern !== PATTERN_NONE}
                           <span class="inline-flex items-center gap-1.5 text-xs">
                             <span class="opacity-60">{t('health.detail.pattern')}:</span>
                             <span
@@ -820,7 +827,7 @@
                           </span>
                         {/if}
 
-                        {#if typeof velocity === 'string' && velocity !== 'n/a'}
+                        {#if typeof velocity === 'string' && velocity !== VELOCITY_NA}
                           <span class="inline-flex items-center gap-1.5 text-xs">
                             <span class="opacity-60">{t('health.detail.velocity')}:</span>
                             <span
@@ -828,9 +835,9 @@
                               style:color={velocityColor(velocity)}
                               style:background="color-mix(in srgb, {velocityColor(velocity)} 10%, transparent)"
                             >
-                              {#if velocity === 'increasing'}
+                              {#if velocity === VELOCITY_INCREASING}
                                 <TrendingUp class="size-3" />
-                              {:else if velocity === 'decreasing'}
+                              {:else if velocity === VELOCITY_DECREASING}
                                 <TrendingDown class="size-3" />
                               {:else}
                                 <Minus class="size-3" />

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4927,7 +4927,17 @@
       "source": "Zdroj",
       "count": "Počet",
       "lifetime": "celkem",
-      "sparklineLabel": "Graf aktivity"
+      "sparklineLabel": "Graf aktivity",
+      "activeHours": "Aktivní hodiny",
+      "windowTotal": "V okně",
+      "velocity": "Trend",
+      "velocityStable": "Stabilní",
+      "velocityIncreasing": "Stoupající",
+      "velocityDecreasing": "Klesající",
+      "pattern": "Vzor",
+      "patternNone": "Žádný",
+      "patternTransient": "Přechodný",
+      "patternSustained": "Trvalý"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4927,7 +4927,17 @@
       "source": "Kilde",
       "count": "Antal",
       "lifetime": "i alt",
-      "sparklineLabel": "Aktivitetsgraf"
+      "sparklineLabel": "Aktivitetsgraf",
+      "activeHours": "Aktive timer",
+      "windowTotal": "I vindue",
+      "velocity": "Tendens",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Stigende",
+      "velocityDecreasing": "Faldende",
+      "pattern": "Mønster",
+      "patternNone": "Ingen",
+      "patternTransient": "Forbigående",
+      "patternSustained": "Vedvarende"
     }
   }
 }

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4927,7 +4927,17 @@
       "source": "Quelle",
       "count": "Anzahl",
       "lifetime": "gesamt",
-      "sparklineLabel": "Aktivitäts-Sparkline"
+      "sparklineLabel": "Aktivitäts-Sparkline",
+      "activeHours": "Aktive Stunden",
+      "windowTotal": "Im Fenster",
+      "velocity": "Trend",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Steigend",
+      "velocityDecreasing": "Fallend",
+      "pattern": "Muster",
+      "patternNone": "Keines",
+      "patternTransient": "Vorübergehend",
+      "patternSustained": "Anhaltend"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4927,7 +4927,17 @@
       "source": "Source",
       "count": "Count",
       "lifetime": "lifetime",
-      "sparklineLabel": "Activity sparkline"
+      "sparklineLabel": "Activity sparkline",
+      "activeHours": "Active hours",
+      "windowTotal": "In window",
+      "velocity": "Trend",
+      "velocityStable": "Stable",
+      "velocityIncreasing": "Increasing",
+      "velocityDecreasing": "Decreasing",
+      "pattern": "Pattern",
+      "patternNone": "None",
+      "patternTransient": "Transient",
+      "patternSustained": "Sustained"
     }
   }
 }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4927,7 +4927,17 @@
       "source": "Fuente",
       "count": "Cantidad",
       "lifetime": "total",
-      "sparklineLabel": "Gráfico de actividad"
+      "sparklineLabel": "Gráfico de actividad",
+      "activeHours": "Horas activas",
+      "windowTotal": "En ventana",
+      "velocity": "Tendencia",
+      "velocityStable": "Estable",
+      "velocityIncreasing": "En aumento",
+      "velocityDecreasing": "En descenso",
+      "pattern": "Patrón",
+      "patternNone": "Ninguno",
+      "patternTransient": "Transitorio",
+      "patternSustained": "Persistente"
     }
   }
 }

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4927,7 +4927,17 @@
       "source": "Lähde",
       "count": "Määrä",
       "lifetime": "yhteensä",
-      "sparklineLabel": "Aktiivisuuskaavio"
+      "sparklineLabel": "Aktiivisuuskaavio",
+      "activeHours": "Aktiiviset tunnit",
+      "windowTotal": "Ikkunassa",
+      "velocity": "Suunta",
+      "velocityStable": "Vakaa",
+      "velocityIncreasing": "Kasvava",
+      "velocityDecreasing": "Laskeva",
+      "pattern": "Kaava",
+      "patternNone": "Ei mitään",
+      "patternTransient": "Ohimenevä",
+      "patternSustained": "Jatkuva"
     }
   }
 }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4927,7 +4927,17 @@
       "source": "Source",
       "count": "Nombre",
       "lifetime": "total",
-      "sparklineLabel": "Graphique d'activité"
+      "sparklineLabel": "Graphique d'activité",
+      "activeHours": "Heures actives",
+      "windowTotal": "Dans la fenêtre",
+      "velocity": "Tendance",
+      "velocityStable": "Stable",
+      "velocityIncreasing": "En hausse",
+      "velocityDecreasing": "En baisse",
+      "pattern": "Modèle",
+      "patternNone": "Aucun",
+      "patternTransient": "Transitoire",
+      "patternSustained": "Persistant"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4927,7 +4927,17 @@
       "source": "Forrás",
       "count": "Darab",
       "lifetime": "összesen",
-      "sparklineLabel": "Aktivitási diagram"
+      "sparklineLabel": "Aktivitási diagram",
+      "activeHours": "Aktív órák",
+      "windowTotal": "Az ablakban",
+      "velocity": "Tendencia",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Növekvő",
+      "velocityDecreasing": "Csökkenő",
+      "pattern": "Minta",
+      "patternNone": "Nincs",
+      "patternTransient": "Átmeneti",
+      "patternSustained": "Tartós"
     }
   }
 }

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4927,7 +4927,17 @@
       "source": "Sorgente",
       "count": "Conteggio",
       "lifetime": "totale",
-      "sparklineLabel": "Grafico di attività"
+      "sparklineLabel": "Grafico di attività",
+      "activeHours": "Ore attive",
+      "windowTotal": "Nella finestra",
+      "velocity": "Tendenza",
+      "velocityStable": "Stabile",
+      "velocityIncreasing": "In aumento",
+      "velocityDecreasing": "In calo",
+      "pattern": "Schema",
+      "patternNone": "Nessuno",
+      "patternTransient": "Transitorio",
+      "patternSustained": "Persistente"
     }
   }
 }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4927,7 +4927,17 @@
       "source": "Avots",
       "count": "Skaits",
       "lifetime": "kopā",
-      "sparklineLabel": "Aktivitātes diagramma"
+      "sparklineLabel": "Aktivitātes diagramma",
+      "activeHours": "Aktīvās stundas",
+      "windowTotal": "Logā",
+      "velocity": "Tendence",
+      "velocityStable": "Stabila",
+      "velocityIncreasing": "Pieaugoša",
+      "velocityDecreasing": "Dilstoša",
+      "pattern": "Raksts",
+      "patternNone": "Nav",
+      "patternTransient": "Īslaicīgs",
+      "patternSustained": "Ilgstošs"
     }
   }
 }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4927,7 +4927,17 @@
       "source": "Bron",
       "count": "Aantal",
       "lifetime": "totaal",
-      "sparklineLabel": "Activiteitsgrafiek"
+      "sparklineLabel": "Activiteitsgrafiek",
+      "activeHours": "Actieve uren",
+      "windowTotal": "In venster",
+      "velocity": "Trend",
+      "velocityStable": "Stabiel",
+      "velocityIncreasing": "Stijgend",
+      "velocityDecreasing": "Dalend",
+      "pattern": "Patroon",
+      "patternNone": "Geen",
+      "patternTransient": "Voorbijgaand",
+      "patternSustained": "Aanhoudend"
     }
   }
 }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4927,7 +4927,17 @@
       "source": "Źródło",
       "count": "Liczba",
       "lifetime": "łącznie",
-      "sparklineLabel": "Wykres aktywności"
+      "sparklineLabel": "Wykres aktywności",
+      "activeHours": "Aktywne godziny",
+      "windowTotal": "W oknie",
+      "velocity": "Trend",
+      "velocityStable": "Stabilny",
+      "velocityIncreasing": "Rosnący",
+      "velocityDecreasing": "Malejący",
+      "pattern": "Wzorzec",
+      "patternNone": "Brak",
+      "patternTransient": "Przejściowy",
+      "patternSustained": "Utrzymujący się"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4927,7 +4927,17 @@
       "source": "Fonte",
       "count": "Contagem",
       "lifetime": "total",
-      "sparklineLabel": "Gráfico de atividade"
+      "sparklineLabel": "Gráfico de atividade",
+      "activeHours": "Horas ativas",
+      "windowTotal": "Na janela",
+      "velocity": "Tendência",
+      "velocityStable": "Estável",
+      "velocityIncreasing": "Em aumento",
+      "velocityDecreasing": "Em queda",
+      "pattern": "Padrão",
+      "patternNone": "Nenhum",
+      "patternTransient": "Transitório",
+      "patternSustained": "Persistente"
     }
   }
 }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4927,7 +4927,17 @@
       "source": "Zdroj",
       "count": "Počet",
       "lifetime": "celkom",
-      "sparklineLabel": "Graf aktivity"
+      "sparklineLabel": "Graf aktivity",
+      "activeHours": "Aktívne hodiny",
+      "windowTotal": "V okne",
+      "velocity": "Trend",
+      "velocityStable": "Stabilný",
+      "velocityIncreasing": "Stúpajúci",
+      "velocityDecreasing": "Klesajúci",
+      "pattern": "Vzor",
+      "patternNone": "Žiadny",
+      "patternTransient": "Prechodný",
+      "patternSustained": "Trvalý"
     }
   }
 }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4927,7 +4927,17 @@
       "source": "Källa",
       "count": "Antal",
       "lifetime": "totalt",
-      "sparklineLabel": "Aktivitetsdiagram"
+      "sparklineLabel": "Aktivitetsdiagram",
+      "activeHours": "Aktiva timmar",
+      "windowTotal": "I fönster",
+      "velocity": "Trend",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Ökande",
+      "velocityDecreasing": "Minskande",
+      "pattern": "Mönster",
+      "patternNone": "Inget",
+      "patternTransient": "Övergående",
+      "patternSustained": "Ihållande"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add frontend rendering for `active_hours`, `velocity`, and `pattern` detail fields from the windowed health check severity assessment (merged in #3289)
- The expandable detail panel now shows a compact metadata strip with window total, active hours, pattern badge (transient/sustained), and velocity indicator (increasing/decreasing/stable) with trending icons
- Include severity metadata in the text report export for clipboard copy consistency
- Replace pre-existing em dash placeholders with plain dashes
- Add 10 new i18n keys (`health.detail.*`) with translations for all 15 locales

## Test Plan

- [ ] Run diagnostics on a system with active buffer drops; verify the detail panel shows active hours, pattern, and velocity badges
- [ ] Switch evaluation windows (15m, 30m, 1h, 6h, 24h, 7d); verify metadata updates accordingly
- [ ] Expand a healthy check with historical data; verify sparkline and metadata strip render
- [ ] Copy text report; verify severity metadata appears in clipboard output
- [ ] Verify all 15 locale translations render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Severity Signal Metadata" to system health detail view with active hours, window totals, velocity trends (stable/increasing/decreasing), pattern classifications (none/transient/sustained), and supporting iconography.
  * Enhanced exported text reports to include additional per-check detail fields when present.

* **Bug Fixes**
  * Small UI tweak: status summary metric cards use a simpler dash fallback for unavailable counts.

* **Localization**
  * Updated translations for new health detail labels across supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->