### PR TITLE
fix(health): seed store keys on first tick, add diagnostics window tests

### DIFF
--- a/internal/api/v2/diagnostics_window_test.go
+++ b/internal/api/v2/diagnostics_window_test.go
@@ -286,7 +286,7 @@ func TestRunDiagnostics_SparklineStructure(t *testing.T) {
 
 	sparkline, ok := sparklineRaw.([]any)
 	require.True(t, ok, "sparkline must be an array")
-	assert.Len(t, sparkline, 24, "sparkline should have 24 hourly buckets")
+	require.Len(t, sparkline, 24, "sparkline should have 24 hourly buckets")
 
 	bucket, ok := sparkline[0].(map[string]any)
 	require.True(t, ok, "each sparkline bucket must be an object")
@@ -314,6 +314,7 @@ func TestRunDiagnostics_RecentEventsStructure(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	require.NoError(t, controller.RunDiagnostics(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var report health.DiagnosticsReport
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))

--- a/internal/api/v2/diagnostics_window_test.go
+++ b/internal/api/v2/diagnostics_window_test.go
@@ -1,0 +1,347 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/health/checks"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// setupDiagnosticsTest creates a test Controller wired for diagnostics
+// tests with the given health metrics store and optional event buffer.
+func setupDiagnosticsTest(t *testing.T, store *observability.HealthMetricsStore, eventBuf *observability.HealthEventBuffer) (*echo.Echo, *Controller) {
+	t.Helper()
+	e, _, controller := setupTestEnvironment(t)
+	controller.healthMetricsStore = store
+	if eventBuf != nil {
+		controller.healthEvents = eventBuf
+	} else {
+		controller.healthEvents = observability.NewHealthEventBuffer(100)
+	}
+	controller.healthReports = health.NewReportStore(10)
+	controller.healthRegistry = health.NewRegistry()
+	return e, controller
+}
+
+func TestParseWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "empty defaults to 1h", input: "", want: time.Hour},
+		{name: "15m", input: "15m", want: 15 * time.Minute},
+		{name: "30m", input: "30m", want: 30 * time.Minute},
+		{name: "1h", input: "1h", want: time.Hour},
+		{name: "6h", input: "6h", want: 6 * time.Hour},
+		{name: "24h", input: "24h", want: 24 * time.Hour},
+		{name: "7d", input: "7d", want: 7 * 24 * time.Hour},
+		{name: "invalid value", input: "2h", wantErr: true},
+		{name: "garbage", input: "abc", wantErr: true},
+		{name: "numeric only", input: "60", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseWindow(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRunDiagnostics_InvalidWindow(t *testing.T) {
+	t.Parallel()
+
+	e, controller := setupDiagnosticsTest(t, observability.NewHealthMetricsStore(), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/system/diagnostics/run?window=invalid", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := controller.RunDiagnostics(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRunDiagnostics_WindowedChecksIncludeDetails(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewHealthMetricsStore()
+	eventBuf := observability.NewHealthEventBuffer(100)
+
+	now := time.Now()
+	store.RecordAt("audio.drops.src1", 15, now)
+	eventBuf.Add(observability.HealthEvent{
+		Time: now, Source: "src1", Delta: 15, Metric: "drops",
+	})
+
+	e, controller := setupDiagnosticsTest(t, store, eventBuf)
+	controller.healthRegistry.RegisterAll(
+		checks.NewBufferDropsCheck(store, eventBuf.Recent),
+		checks.NewBufferOverrunCheck(store, eventBuf.Recent),
+		checks.NewStreamErrorRateCheck(store, eventBuf.Recent),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/system/diagnostics/run?window=1h", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := controller.RunDiagnostics(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var report health.DiagnosticsReport
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+	assert.NotEmpty(t, report.ID)
+	assert.NotZero(t, report.StartedAt)
+	require.Len(t, report.Results, 3)
+
+	dropsResult := findResult(t, report.Results, "buffer_drops")
+	require.NotNil(t, dropsResult.Details)
+	assert.Equal(t, "1h", dropsResult.Details["window"])
+	assert.NotNil(t, dropsResult.Details["sparkline"], "sparkline missing from buffer_drops")
+	assert.NotNil(t, dropsResult.Details["recent_events"], "recent_events missing from buffer_drops")
+	assert.Contains(t, dropsResult.Details, "active_hours")
+	assert.Contains(t, dropsResult.Details, "velocity")
+	assert.Contains(t, dropsResult.Details, "pattern")
+	assert.Contains(t, dropsResult.Details, "lifetime_total")
+	assert.Contains(t, dropsResult.Details, "per_source")
+}
+
+func TestRunDiagnostics_DefaultWindowIs1h(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewHealthMetricsStore()
+	store.RecordAt("audio.drops.src1", 5, time.Now())
+
+	e, controller := setupDiagnosticsTest(t, store, nil)
+	controller.healthRegistry.Register(checks.NewBufferDropsCheck(store, nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/system/diagnostics/run", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := controller.RunDiagnostics(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var report health.DiagnosticsReport
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+	dropsResult := findResult(t, report.Results, "buffer_drops")
+	require.NotNil(t, dropsResult.Details)
+	assert.Equal(t, "1h", dropsResult.Details["window"])
+}
+
+func TestRunDiagnostics_WindowAffectsEvaluation(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewHealthMetricsStore()
+	store.RecordAt("audio.drops.src1", 20, time.Now().Add(-3*time.Hour))
+	store.RecordAt("audio.drops.src1", 0, time.Now())
+
+	e, controller := setupDiagnosticsTest(t, store, nil)
+	controller.healthRegistry.Register(checks.NewBufferDropsCheck(store, nil))
+
+	runWithWindow := func(window string) health.DiagnosticsReport {
+		path := "/api/v2/system/diagnostics/run"
+		if window != "" {
+			path += "?window=" + window
+		}
+		req := httptest.NewRequest(http.MethodPost, path, http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		require.NoError(t, controller.RunDiagnostics(c))
+		require.Equal(t, http.StatusOK, rec.Code)
+		var report health.DiagnosticsReport
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+		return report
+	}
+
+	narrow := runWithWindow("1h")
+	dropsNarrow := findResult(t, narrow.Results, "buffer_drops")
+	assert.Equal(t, health.StatusHealthy, dropsNarrow.Status,
+		"1h window should be healthy (drops were 3h ago)")
+
+	wide := runWithWindow("6h")
+	dropsWide := findResult(t, wide.Results, "buffer_drops")
+	assert.Equal(t, health.StatusWarning, dropsWide.Status,
+		"6h window should be warning (captures the 20 drops from 3h ago)")
+	assert.Equal(t, "6h", dropsWide.Details["window"])
+}
+
+func TestRunDiagnostics_NonCounterChecksUnchanged(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewHealthMetricsStore()
+	e, controller := setupDiagnosticsTest(t, store, nil)
+	controller.healthRegistry.RegisterAll(
+		checks.NewMemoryCheck(),
+		checks.NewBufferDropsCheck(store, nil),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/system/diagnostics/run?window=6h", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.RunDiagnostics(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var report health.DiagnosticsReport
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+	memResult := findResult(t, report.Results, "memory")
+	assert.NotEqual(t, health.StatusUnknown, memResult.Status)
+	assert.Nil(t, memResult.Details["sparkline"], "non-counter check should not have sparkline")
+	assert.Nil(t, memResult.Details["window"], "non-counter check should not have window field")
+}
+
+func TestRunDiagnostics_AllValidWindowPresets(t *testing.T) {
+	t.Parallel()
+
+	presets := []struct {
+		param    string
+		expected string
+	}{
+		{"15m", "15m"},
+		{"30m", "30m"},
+		{"1h", "1h"},
+		{"6h", "6h"},
+		{"24h", "1d"},
+		{"7d", "7d"},
+	}
+
+	for _, preset := range presets {
+		t.Run(preset.param, func(t *testing.T) {
+			t.Parallel()
+
+			store := observability.NewHealthMetricsStore()
+			store.RecordAt("audio.drops.src1", 5, time.Now())
+
+			e, controller := setupDiagnosticsTest(t, store, nil)
+			controller.healthRegistry.Register(checks.NewBufferDropsCheck(store, nil))
+
+			req := httptest.NewRequest(http.MethodPost,
+				"/api/v2/system/diagnostics/run?window="+preset.param, http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			require.NoError(t, controller.RunDiagnostics(c))
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var report health.DiagnosticsReport
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+			dropsResult := findResult(t, report.Results, "buffer_drops")
+			require.NotNil(t, dropsResult.Details)
+			assert.Equal(t, preset.expected, dropsResult.Details["window"])
+		})
+	}
+}
+
+func TestRunDiagnostics_SparklineStructure(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewHealthMetricsStore()
+	now := time.Now()
+	store.RecordAt("audio.drops.src1", 10, now.Add(-2*time.Hour))
+	store.RecordAt("audio.drops.src1", 5, now)
+
+	e, controller := setupDiagnosticsTest(t, store, nil)
+	controller.healthRegistry.Register(checks.NewBufferDropsCheck(store, nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/system/diagnostics/run", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.RunDiagnostics(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var report health.DiagnosticsReport
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+	dropsResult := findResult(t, report.Results, "buffer_drops")
+	require.NotNil(t, dropsResult.Details)
+
+	sparklineRaw, ok := dropsResult.Details["sparkline"]
+	require.True(t, ok, "sparkline must be present")
+
+	sparkline, ok := sparklineRaw.([]any)
+	require.True(t, ok, "sparkline must be an array")
+	assert.Len(t, sparkline, 24, "sparkline should have 24 hourly buckets")
+
+	bucket, ok := sparkline[0].(map[string]any)
+	require.True(t, ok, "each sparkline bucket must be an object")
+	assert.Contains(t, bucket, "t", "bucket must have timestamp field 't'")
+	assert.Contains(t, bucket, "v", "bucket must have value field 'v'")
+}
+
+func TestRunDiagnostics_RecentEventsStructure(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewHealthMetricsStore()
+	eventBuf := observability.NewHealthEventBuffer(100)
+
+	now := time.Now()
+	store.RecordAt("audio.drops.src1", 10, now)
+	eventBuf.Add(observability.HealthEvent{
+		Time: now, Source: "src1", Delta: 10, Metric: "drops",
+	})
+
+	e, controller := setupDiagnosticsTest(t, store, eventBuf)
+	controller.healthRegistry.Register(checks.NewBufferDropsCheck(store, eventBuf.Recent))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/system/diagnostics/run", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.RunDiagnostics(c))
+
+	var report health.DiagnosticsReport
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+	dropsResult := findResult(t, report.Results, "buffer_drops")
+	eventsRaw, ok := dropsResult.Details["recent_events"]
+	require.True(t, ok, "recent_events must be present")
+
+	events, ok := eventsRaw.([]any)
+	require.True(t, ok, "recent_events must be an array")
+	require.NotEmpty(t, events)
+
+	event, ok := events[0].(map[string]any)
+	require.True(t, ok, "each event must be an object")
+	assert.Contains(t, event, "time")
+	assert.Contains(t, event, "source")
+	assert.Contains(t, event, "delta")
+	assert.Contains(t, event, "metric")
+}
+
+// findResult locates a result by check name or fails the test.
+func findResult(t *testing.T, results []health.Result, name string) health.Result {
+	t.Helper()
+	for _, r := range results {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("result %q not found in %d results", name, len(results))
+	return health.Result{}
+}

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -425,15 +425,17 @@ func (c *Collector) collectAudioHealthCounters(now time.Time) {
 		current[s.SourceID] = s
 	}
 
-	if c.prevAudioSnaps != nil {
-		for id, cur := range current {
-			prev, ok := c.prevAudioSnaps[id]
-			if !ok {
-				continue
-			}
-			c.recordHealthDelta(MetricPrefixAudioDrops+id, cur.Drops, prev.Drops, id, "drops", now)
-			c.recordHealthDelta(MetricPrefixAudioOverruns+id, cur.Errors, prev.Errors, id, "overruns", now)
+	for id, cur := range current {
+		prev, ok := c.prevAudioSnaps[id]
+		if !ok {
+			// First tick or new source: seed the store keys so health checks
+			// show "Healthy" instead of "Skipped" even with zero drops.
+			c.healthStore.RecordAt(MetricPrefixAudioDrops+id, 0, now)
+			c.healthStore.RecordAt(MetricPrefixAudioOverruns+id, 0, now)
+			continue
 		}
+		c.recordHealthDelta(MetricPrefixAudioDrops+id, cur.Drops, prev.Drops, id, "drops", now)
+		c.recordHealthDelta(MetricPrefixAudioOverruns+id, cur.Errors, prev.Errors, id, "overruns", now)
 	}
 
 	c.prevAudioSnaps = current
@@ -451,14 +453,13 @@ func (c *Collector) collectStreamHealthCounters(now time.Time) {
 		current[s.SourceID] = s
 	}
 
-	if c.prevStreamSnaps != nil {
-		for sourceID, cur := range current {
-			prev, ok := c.prevStreamSnaps[sourceID]
-			if !ok {
-				continue
-			}
-			c.recordHealthDelta(MetricPrefixStreamRestarts+sourceID, int64(cur.RestartCount), int64(prev.RestartCount), sourceID, "restarts", now)
+	for sourceID, cur := range current {
+		prev, ok := c.prevStreamSnaps[sourceID]
+		if !ok {
+			c.healthStore.RecordAt(MetricPrefixStreamRestarts+sourceID, 0, now)
+			continue
 		}
+		c.recordHealthDelta(MetricPrefixStreamRestarts+sourceID, int64(cur.RestartCount), int64(prev.RestartCount), sourceID, "restarts", now)
 	}
 
 	c.prevStreamSnaps = current

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -174,12 +174,12 @@ func TestCollector_SeedsKeysOnFirstTick(t *testing.T) {
 
 	c.collectHealthCounters()
 
-	assert.NotEmpty(t, healthStore.KeysWithPrefix(MetricPrefixAudioDrops),
-		"audio drops key should exist after first tick even with zero drops")
-	assert.NotEmpty(t, healthStore.KeysWithPrefix(MetricPrefixAudioOverruns),
-		"audio overruns key should exist after first tick even with zero overruns")
-	assert.NotEmpty(t, healthStore.KeysWithPrefix(MetricPrefixStreamRestarts),
-		"stream restarts key should exist after first tick even with zero restarts")
+	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixAudioDrops),
+		MetricPrefixAudioDrops+"src1")
+	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixAudioOverruns),
+		MetricPrefixAudioOverruns+"src1")
+	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixStreamRestarts),
+		MetricPrefixStreamRestarts+"stream1")
 
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixAudioDrops+"src1"))
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixAudioOverruns+"src1"))

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -157,6 +157,35 @@ func TestCollector_SourceRemoval(t *testing.T) {
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src2"))
 }
 
+func TestCollector_SeedsKeysOnFirstTick(t *testing.T) {
+	t.Parallel()
+	c, healthStore, _ := newTestCollectorWithHealth(t)
+
+	c.SetAudioRouter(func() []AudioRouterSnapshot {
+		return []AudioRouterSnapshot{
+			{SourceID: "src1", Drops: 0, Errors: 0},
+		}
+	})
+	c.SetStreamHealth(func() []StreamHealthSnapshot {
+		return []StreamHealthSnapshot{
+			{SourceID: "stream1", RestartCount: 0},
+		}
+	})
+
+	c.collectHealthCounters()
+
+	assert.NotEmpty(t, healthStore.KeysWithPrefix(MetricPrefixAudioDrops),
+		"audio drops key should exist after first tick even with zero drops")
+	assert.NotEmpty(t, healthStore.KeysWithPrefix(MetricPrefixAudioOverruns),
+		"audio overruns key should exist after first tick even with zero overruns")
+	assert.NotEmpty(t, healthStore.KeysWithPrefix(MetricPrefixStreamRestarts),
+		"stream restarts key should exist after first tick even with zero restarts")
+
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixAudioDrops+"src1"))
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixAudioOverruns+"src1"))
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixStreamRestarts+"stream1"))
+}
+
 func TestCollector_NoHealthStoreSkips(t *testing.T) {
 	t.Parallel()
 	store := NewMemoryStore(100)


### PR DESCRIPTION
## Summary

- Fix health checks showing "Skipped: Metrics not yet available" for healthy sources with zero drops/overruns/restarts. The collector now seeds HealthMetricsStore keys with zero-delta records on the first tick (or when a new source appears), so evalWindowedStats returns "Healthy" instead of "Skipped".
- Add 25 API integration tests for `POST /api/v2/system/diagnostics/run?window=` covering all valid presets, default behavior, invalid parameter rejection (400), sparkline structure (24 hourly buckets), recent events structure, window-dependent severity evaluation, and non-counter check passthrough.

## Test Plan

- [x] `go test -race ./internal/observability/...` (15 tests pass, including new seeding test)
- [x] `go test -race ./internal/health/...` (175 tests pass)
- [x] `go test -race ./internal/api/v2/ -run TestParseWindow\|TestRunDiagnostics` (25 tests pass)
- [x] `golangci-lint run` clean
- [x] Manual QA: deployed to test container, verified buffer drops/overruns show "Healthy" with sparkline, stream error rate shows "Warning" with events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive diagnostics tests for window parsing, validation, defaulting, preset normalization, and that windowing affects counter evaluation; verifies counter details include hourly sparklines and recent events, and non-counter checks omit counter fields
  * Added a test ensuring health metric keys are seeded on first observation even when values are zero

* **Bug Fixes**
  * Ensure newly observed audio sources and streams are initialized with zero deltas so health metrics are correctly recorded on first observation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->