### PR TITLE
fix: deduplicate multi-model species in insights endpoints

### DIFF
--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -578,17 +578,17 @@ func (c *Controller) getDawnChorusImpl(ctx echo.Context) error {
 		earliestSeconds int
 		daysObserved    int
 	}
-	speciesMap := make(map[uint]*speciesData)
+	speciesMap := make(map[string]*speciesData)
 	loc := time.Local
 
 	for _, entry := range rawEntries {
-		sd, ok := speciesMap[entry.LabelID]
+		sd, ok := speciesMap[entry.ScientificName]
 		if !ok {
 			sd = &speciesData{
 				scientificName:  entry.ScientificName,
 				earliestSeconds: 24 * 3600, // sentinel max
 			}
-			speciesMap[entry.LabelID] = sd
+			speciesMap[entry.ScientificName] = sd
 		}
 
 		t := time.Unix(entry.EarliestAt, 0).In(loc)

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -73,7 +73,7 @@ func TestGetPhantomSpecies_Handler(t *testing.T) {
 	t.Parallel()
 	mockRepo := &mockInsightsRepo{
 		phantomSpecies: []repository.PhantomSpecies{
-			{LabelID: 1, ScientificName: "Parus major", DetectionCount: 5, AvgConfidence: 0.42, MaxConfidence: 0.58},
+			{ScientificName: "Parus major", DetectionCount: 5, AvgConfidence: 0.42, MaxConfidence: 0.58},
 		},
 	}
 	e, controller := setupInsightsTestController(t, mockRepo)
@@ -130,10 +130,10 @@ func TestGetMigration_Handler(t *testing.T) {
 	now := time.Now()
 	mockRepo := &mockInsightsRepo{
 		newArrivals: []repository.NewArrival{
-			{LabelID: 1, ScientificName: "Parus major", FirstDetected: now.AddDate(0, 0, -3).Unix(), DetectionCount: 5},
+			{ScientificName: "Parus major", FirstDetected: now.AddDate(0, 0, -3).Unix(), DetectionCount: 5},
 		},
 		goneQuiet: []repository.GoneQuietSpecies{
-			{LabelID: 2, ScientificName: "Turdus merula", LastDetected: now.AddDate(0, 0, -20).Unix(), TotalDetections: 15},
+			{ScientificName: "Turdus merula", LastDetected: now.AddDate(0, 0, -20).Unix(), TotalDetections: 15},
 		},
 	}
 	e, controller := setupInsightsTestController(t, mockRepo)

--- a/internal/datastore/v2/repository/insights_impl.go
+++ b/internal/datastore/v2/repository/insights_impl.go
@@ -90,7 +90,7 @@ func (r *insightsRepository) GetExpectedSpeciesToday(ctx context.Context, yearRa
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
-		Select(fmt.Sprintf("d.label_id, %s.scientific_name, COUNT(DISTINCT %s) as years_seen, MAX(%s) as last_seen_date",
+		Select(fmt.Sprintf("%s.scientific_name, COUNT(DISTINCT %s) as years_seen, MAX(%s) as last_seen_date",
 			lab, yearExpr, dateExpr)).
 		Joins(fmt.Sprintf("JOIN %s ON %s.id = d.label_id", lab, lab)).
 		Joins(fpJoin).
@@ -107,7 +107,7 @@ func (r *insightsRepository) GetExpectedSpeciesToday(ctx context.Context, yearRa
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group("d.label_id").Order("years_seen DESC")
+	query = query.Group(lab + ".scientific_name").Order("years_seen DESC")
 
 	var results []ExpectedSpecies
 	if err := query.Scan(&results).Error; err != nil {
@@ -123,7 +123,7 @@ func (r *insightsRepository) GetPhantomSpecies(ctx context.Context, since int64,
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
-		Select(fmt.Sprintf("d.label_id, %s.scientific_name, COUNT(*) as detection_count, AVG(d.confidence) as avg_confidence, MAX(d.confidence) as max_confidence", lab)).
+		Select(fmt.Sprintf("%s.scientific_name, COUNT(*) as detection_count, AVG(d.confidence) as avg_confidence, MAX(d.confidence) as max_confidence", lab)).
 		Joins(fmt.Sprintf("JOIN %s ON %s.id = d.label_id", lab, lab)).
 		Joins(fpJoin).
 		Where("d.detected_at >= ?", since).
@@ -133,7 +133,7 @@ func (r *insightsRepository) GetPhantomSpecies(ctx context.Context, since int64,
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group("d.label_id").
+	query = query.Group(lab + ".scientific_name").
 		Having("COUNT(*) >= ? AND AVG(d.confidence) < ?", minDetections, maxAvgConfidence).
 		Order("avg_confidence ASC")
 
@@ -153,7 +153,7 @@ func (r *insightsRepository) GetDawnChorusRaw(ctx context.Context, since int64, 
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
-		Select(fmt.Sprintf("d.label_id, %s.scientific_name, %s as date, MIN(d.detected_at) as earliest_at",
+		Select(fmt.Sprintf("%s.scientific_name, %s as date, MIN(d.detected_at) as earliest_at",
 			lab, dateExpr)).
 		Joins(fmt.Sprintf("JOIN %s ON %s.id = d.label_id", lab, lab)).
 		Joins(fpJoin).
@@ -165,7 +165,7 @@ func (r *insightsRepository) GetDawnChorusRaw(ctx context.Context, since int64, 
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group(fmt.Sprintf("d.label_id, %s", dateExpr))
+	query = query.Group(fmt.Sprintf("%s.scientific_name, %s", lab, dateExpr))
 
 	var results []DawnChorusRawEntry
 	if err := query.Scan(&results).Error; err != nil {
@@ -181,7 +181,7 @@ func (r *insightsRepository) GetNewArrivals(ctx context.Context, recentSince int
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
-		Select(fmt.Sprintf("d.label_id, %s.scientific_name, MIN(d.detected_at) as first_detected, COUNT(*) as detection_count", lab)).
+		Select(fmt.Sprintf("%s.scientific_name, MIN(d.detected_at) as first_detected, COUNT(*) as detection_count", lab)).
 		Joins(fmt.Sprintf("JOIN %s ON %s.id = d.label_id", lab, lab)).
 		Joins(fpJoin).
 		Where(fpWhere)
@@ -190,7 +190,7 @@ func (r *insightsRepository) GetNewArrivals(ctx context.Context, recentSince int
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group("d.label_id").
+	query = query.Group(lab + ".scientific_name").
 		Having("MIN(d.detected_at) >= ?", recentSince).
 		Order("first_detected DESC")
 
@@ -208,7 +208,7 @@ func (r *insightsRepository) GetGoneQuiet(ctx context.Context, recentSince int64
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
-		Select(fmt.Sprintf("d.label_id, %s.scientific_name, MAX(d.detected_at) as last_detected, COUNT(*) as total_detections", lab)).
+		Select(fmt.Sprintf("%s.scientific_name, MAX(d.detected_at) as last_detected, COUNT(*) as total_detections", lab)).
 		Joins(fmt.Sprintf("JOIN %s ON %s.id = d.label_id", lab, lab)).
 		Joins(fpJoin).
 		Where(fpWhere)
@@ -217,7 +217,7 @@ func (r *insightsRepository) GetGoneQuiet(ctx context.Context, recentSince int64
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group("d.label_id").
+	query = query.Group(lab + ".scientific_name").
 		Having("COUNT(*) >= ? AND MAX(d.detected_at) < ?", minTotalDetections, recentSince).
 		Order("last_detected DESC")
 
@@ -244,8 +244,12 @@ func (r *insightsRepository) GetDashboardKPIs(ctx context.Context, todaySince in
 		return q
 	}
 
-	// 1. Lifetime species
-	if err := baseQuery().Select("COUNT(DISTINCT d.label_id)").Scan(&kpis.LifetimeSpecies).Error; err != nil {
+	// 1. Lifetime species (join labels to count distinct scientific names across models)
+	lab := r.labelsTable()
+	if err := baseQuery().
+		Joins(fmt.Sprintf("JOIN %s ON %s.id = d.label_id", lab, lab)).
+		Select(fmt.Sprintf("COUNT(DISTINCT %s.scientific_name)", lab)).
+		Scan(&kpis.LifetimeSpecies).Error; err != nil {
 		return nil, fmt.Errorf("lifetime species: %w", err)
 	}
 

--- a/internal/datastore/v2/repository/insights_impl_test.go
+++ b/internal/datastore/v2/repository/insights_impl_test.go
@@ -499,6 +499,28 @@ func TestGetDashboardKPIs_MultiModel(t *testing.T) {
 	assert.Equal(t, int64(3), kpis.TodayDetections)
 }
 
+func TestGetNewArrivals_MultiModel_FilterByModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	now := time.Now()
+	fourteenDaysAgo := now.AddDate(0, 0, -14).Unix()
+
+	labelA1 := seedLabelForModel(t, db, "Chordeiles minor", 1)
+	labelA2 := seedLabelForModel(t, db, "Chordeiles minor", 2)
+
+	seedDetectionForModel(t, db, labelA1, 1, now.AddDate(0, 0, -5).Unix(), 0.9)
+	seedDetectionForModel(t, db, labelA2, 2, now.AddDate(0, 0, -3).Unix(), 0.85)
+
+	modelID := uint(1)
+	results, err := repo.GetNewArrivals(ctx, fourteenDaysAgo, &modelID)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "filtering by model should return only that model's detections")
+	assert.Equal(t, "Chordeiles minor", results[0].ScientificName)
+	assert.Equal(t, int64(1), results[0].DetectionCount, "should only count model 1 detections")
+}
+
 func TestGetExpectedSpeciesToday_EmptyRanges(t *testing.T) {
 	db := setupInsightsTestDB(t)
 	repo := NewInsightsRepository(db, false, false)

--- a/internal/datastore/v2/repository/insights_impl_test.go
+++ b/internal/datastore/v2/repository/insights_impl_test.go
@@ -319,6 +319,186 @@ func TestGetDashboardKPIs_Empty(t *testing.T) {
 	assert.Equal(t, int64(0), kpis.TodayDetections)
 }
 
+// seedLabelForModel creates a test label for a specific model and returns its ID.
+func seedLabelForModel(t *testing.T, db *gorm.DB, scientificName string, modelID uint) uint {
+	t.Helper()
+	label := entities.Label{
+		ScientificName: scientificName,
+		ModelID:        modelID,
+		LabelTypeID:    1,
+	}
+	require.NoError(t, db.Create(&label).Error)
+	return label.ID
+}
+
+// seedDetectionForModel creates a test detection for a specific model.
+func seedDetectionForModel(t *testing.T, db *gorm.DB, labelID, modelID uint, detectedAt int64, confidence float64) uint {
+	t.Helper()
+	det := entities.Detection{
+		LabelID:    labelID,
+		DetectedAt: detectedAt,
+		Confidence: confidence,
+		ModelID:    modelID,
+	}
+	require.NoError(t, db.Create(&det).Error)
+	return det.ID
+}
+
+// setupInsightsTestDBMultiModel creates a test DB with two AI models seeded.
+func setupInsightsTestDBMultiModel(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := setupInsightsTestDB(t)
+	require.NoError(t, db.Create(&entities.AIModel{ID: 2, Name: "Perch", Version: "1.0"}).Error)
+	return db
+}
+
+func TestGetNewArrivals_MultiModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	now := time.Now()
+	fourteenDaysAgo := now.AddDate(0, 0, -14).Unix()
+
+	labelA1 := seedLabelForModel(t, db, "Chordeiles minor", 1)
+	labelA2 := seedLabelForModel(t, db, "Chordeiles minor", 2)
+
+	seedDetectionForModel(t, db, labelA1, 1, now.AddDate(0, 0, -5).Unix(), 0.9)
+	seedDetectionForModel(t, db, labelA2, 2, now.AddDate(0, 0, -3).Unix(), 0.85)
+
+	results, err := repo.GetNewArrivals(ctx, fourteenDaysAgo, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "same species from two models should produce one result")
+	assert.Equal(t, "Chordeiles minor", results[0].ScientificName)
+	assert.Equal(t, int64(2), results[0].DetectionCount)
+}
+
+func TestGetGoneQuiet_MultiModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	now := time.Now()
+	fourteenDaysAgo := now.AddDate(0, 0, -14).Unix()
+
+	labelA1 := seedLabelForModel(t, db, "Setophaga americana", 1)
+	labelA2 := seedLabelForModel(t, db, "Setophaga americana", 2)
+
+	for i := 20; i < 25; i++ {
+		seedDetectionForModel(t, db, labelA1, 1, now.AddDate(0, 0, -i).Unix(), 0.85)
+	}
+	for i := 22; i < 27; i++ {
+		seedDetectionForModel(t, db, labelA2, 2, now.AddDate(0, 0, -i).Unix(), 0.80)
+	}
+
+	results, err := repo.GetGoneQuiet(ctx, fourteenDaysAgo, 5, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "same species from two models should produce one result")
+	assert.Equal(t, "Setophaga americana", results[0].ScientificName)
+	assert.Equal(t, int64(10), results[0].TotalDetections)
+}
+
+func TestGetDawnChorusRaw_MultiModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	now := time.Now()
+	since := now.AddDate(0, 0, -30).Unix()
+
+	labelA1 := seedLabelForModel(t, db, "Turdus merula", 1)
+	labelA2 := seedLabelForModel(t, db, "Turdus merula", 2)
+
+	day1 := time.Date(now.Year(), now.Month(), now.Day()-5, 0, 0, 0, 0, time.Local)
+	seedDetectionForModel(t, db, labelA1, 1, day1.Add(5*time.Hour).Unix(), 0.9)
+	seedDetectionForModel(t, db, labelA2, 2, day1.Add(6*time.Hour).Unix(), 0.85)
+
+	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "same species on same day from two models should produce one result")
+	assert.Equal(t, "Turdus merula", results[0].ScientificName)
+	entryTime := time.Unix(results[0].EarliestAt, 0).In(time.Local)
+	assert.Equal(t, 5, entryTime.Hour(), "should pick the earliest detection across models")
+}
+
+func TestGetPhantomSpecies_MultiModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	now := time.Now()
+	since := now.AddDate(0, 0, -30).Unix()
+
+	labelA1 := seedLabelForModel(t, db, "Parus major", 1)
+	labelA2 := seedLabelForModel(t, db, "Parus major", 2)
+
+	seedDetectionForModel(t, db, labelA1, 1, now.AddDate(0, 0, -1).Unix(), 0.45)
+	seedDetectionForModel(t, db, labelA1, 1, now.AddDate(0, 0, -2).Unix(), 0.40)
+	seedDetectionForModel(t, db, labelA2, 2, now.AddDate(0, 0, -3).Unix(), 0.50)
+
+	results, err := repo.GetPhantomSpecies(ctx, since, 3, 0.6, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "same species from two models should produce one result")
+	assert.Equal(t, "Parus major", results[0].ScientificName)
+	assert.Equal(t, int64(3), results[0].DetectionCount)
+}
+
+func TestGetExpectedSpeciesToday_MultiModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	labelA1 := seedLabelForModel(t, db, "Turdus merula", 1)
+	labelA2 := seedLabelForModel(t, db, "Turdus merula", 2)
+
+	y1Start := time.Date(2024, 3, 8, 0, 0, 0, 0, time.Local)
+	seedDetectionForModel(t, db, labelA1, 1, y1Start.Unix(), 0.9)
+
+	y2Start := time.Date(2025, 3, 7, 0, 0, 0, 0, time.Local)
+	seedDetectionForModel(t, db, labelA2, 2, y2Start.Unix(), 0.88)
+
+	yearRanges := []TimeRange{
+		{
+			Start: time.Date(2024, 3, 6, 0, 0, 0, 0, time.Local).Unix(),
+			End:   time.Date(2024, 3, 12, 23, 59, 59, 0, time.Local).Unix(),
+		},
+		{
+			Start: time.Date(2025, 3, 6, 0, 0, 0, 0, time.Local).Unix(),
+			End:   time.Date(2025, 3, 12, 23, 59, 59, 0, time.Local).Unix(),
+		},
+	}
+
+	results, err := repo.GetExpectedSpeciesToday(ctx, yearRanges, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "same species from two models should produce one result")
+	assert.Equal(t, "Turdus merula", results[0].ScientificName)
+	assert.Equal(t, 2, results[0].YearsSeen)
+}
+
+func TestGetDashboardKPIs_MultiModel(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+
+	labelA1 := seedLabelForModel(t, db, "Turdus merula", 1)
+	labelA2 := seedLabelForModel(t, db, "Turdus merula", 2)
+
+	seedDetectionForModel(t, db, labelA1, 1, today.Add(2*time.Hour).Unix(), 0.9)
+	seedDetectionForModel(t, db, labelA2, 2, today.Add(3*time.Hour).Unix(), 0.85)
+
+	labelB := seedLabelForModel(t, db, "Parus major", 1)
+	seedDetectionForModel(t, db, labelB, 1, today.Add(4*time.Hour).Unix(), 0.8)
+
+	kpis, err := repo.GetDashboardKPIs(ctx, today.Unix(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, kpis)
+	assert.Equal(t, int64(2), kpis.LifetimeSpecies, "same species from two models should count as one")
+	assert.Equal(t, int64(3), kpis.TodayDetections)
+}
+
 func TestGetExpectedSpeciesToday_EmptyRanges(t *testing.T) {
 	db := setupInsightsTestDB(t)
 	repo := NewInsightsRepository(db, false, false)

--- a/internal/datastore/v2/repository/insights_types.go
+++ b/internal/datastore/v2/repository/insights_types.go
@@ -8,7 +8,6 @@ type TimeRange struct {
 
 // ExpectedSpecies represents a species expected today based on historical data.
 type ExpectedSpecies struct {
-	LabelID        uint
 	ScientificName string
 	YearsSeen      int
 	LastSeenDate   string // YYYY-MM-DD
@@ -16,7 +15,6 @@ type ExpectedSpecies struct {
 
 // PhantomSpecies represents a species with frequent but low-confidence detections.
 type PhantomSpecies struct {
-	LabelID        uint
 	ScientificName string
 	DetectionCount int64
 	AvgConfidence  float64
@@ -26,7 +24,6 @@ type PhantomSpecies struct {
 // DawnChorusRawEntry represents one species' earliest detection on a single day.
 // Time-of-day averaging is done in Go for correct DST handling.
 type DawnChorusRawEntry struct {
-	LabelID        uint
 	ScientificName string
 	Date           string // YYYY-MM-DD
 	EarliestAt     int64  // Unix timestamp of earliest detection that day
@@ -34,7 +31,6 @@ type DawnChorusRawEntry struct {
 
 // NewArrival represents a species detected for the first time recently.
 type NewArrival struct {
-	LabelID        uint
 	ScientificName string
 	FirstDetected  int64 // Unix timestamp
 	DetectionCount int64
@@ -42,7 +38,6 @@ type NewArrival struct {
 
 // GoneQuietSpecies represents a previously regular species that has gone silent.
 type GoneQuietSpecies struct {
-	LabelID         uint
 	ScientificName  string
 	LastDetected    int64 // Unix timestamp
 	TotalDetections int64


### PR DESCRIPTION
## Summary

Fixes #3291.

Insights SQL queries grouped by label_id, but the labels table indexes (scientific_name, model_id) together. When multiple AI models (BirdNET + Perch) are active, the same species gets separate label IDs, causing duplicate entries in migration (new arrivals, gone quiet), dawn chorus, phantom species, and expected species endpoints.

## Changes

- Change GROUP BY from `d.label_id` to `labels.scientific_name` in all five insights repository methods (GetExpectedSpeciesToday, GetPhantomSpecies, GetDawnChorusRaw, GetNewArrivals, GetGoneQuiet)
- Remove `d.label_id` from SELECT clauses to prevent non-deterministic values and MySQL ONLY_FULL_GROUP_BY errors
- Update dawn chorus handler to key its aggregation map by ScientificName (string) instead of LabelID (uint)
- Fix GetDashboardKPIs lifetime species count to use `COUNT(DISTINCT labels.scientific_name)` instead of `COUNT(DISTINCT d.label_id)`

## Testing

- Added multi-model tests for all five insights methods plus GetDashboardKPIs, each seeding the same species under two different AI models and asserting exactly one merged result per species
- All 789 existing datastore tests continue to pass
- Linter passes with zero issues

_This PR was generated by an automated fix agent based on the technical analysis in #3291. Please review carefully._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Species insights are now consolidated by scientific name, yielding more accurate aggregated metrics (including lifetime species counts) across all detections.
  * Species records simplified for clearer reporting and consistency across views.
* **Tests**
  * Added multi-model test coverage and updated fixtures to ensure results are correctly merged across different AI models and optional model filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->