### PR TITLE
fix(support): increase timeouts for support dump collection and upload

### DIFF
--- a/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
+++ b/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
@@ -17,6 +17,9 @@
 
   const logger = loggers.settings;
 
+  // Must exceed backend supportDumpTimeout (120s) in internal/api/v2/support.go
+  const SUPPORT_DUMP_TIMEOUT_MS = 130_000;
+
   const instanceId = Math.random().toString(36).slice(2, 10);
   const githubIssueInputId = `githubIssueNumber-${instanceId}`;
   const userMessageInputId = `userMessage-${instanceId}`;
@@ -127,14 +130,18 @@
         download_url?: string;
         message?: string;
       }
-      const data = await api.post<SupportDumpResponse>('/api/v2/support/generate', {
-        include_logs: supportDump.includeLogs,
-        include_config: supportDump.includeConfig,
-        include_system_info: supportDump.includeSystemInfo,
-        github_issue_number: hasValidGithubIssue ? normalizedGithubIssue.replace(/^#/, '') : '',
-        user_message: supportDump.userMessage,
-        upload_to_sentry: supportDump.uploadToSentry,
-      });
+      const data = await api.post<SupportDumpResponse>(
+        '/api/v2/support/generate',
+        {
+          include_logs: supportDump.includeLogs,
+          include_config: supportDump.includeConfig,
+          include_system_info: supportDump.includeSystemInfo,
+          github_issue_number: hasValidGithubIssue ? normalizedGithubIssue.replace(/^#/, '') : '',
+          user_message: supportDump.userMessage,
+          upload_to_sentry: supportDump.uploadToSentry,
+        },
+        { timeout: SUPPORT_DUMP_TIMEOUT_MS }
+      );
       generating = false;
 
       if (data.success) {
@@ -206,9 +213,9 @@
     if (type === 'info' && percent < 90) {
       safeTimeout(() => {
         if (generating && progressPercent < 90) {
-          updateStatus(message, type, Math.min(progressPercent + 10, 90));
+          updateStatus(message, type, Math.min(progressPercent + 3, 90));
         }
-      }, 1000);
+      }, 2500);
     }
   }
 </script>

--- a/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
+++ b/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
@@ -19,6 +19,9 @@
 
   // Must exceed backend supportDumpTimeout (120s) in internal/api/v2/support.go
   const SUPPORT_DUMP_TIMEOUT_MS = 130_000;
+  const PROGRESS_MAX = 90;
+  const PROGRESS_STEP = 3;
+  const PROGRESS_INTERVAL_MS = 2_500;
 
   const instanceId = Math.random().toString(36).slice(2, 10);
   const githubIssueInputId = `githubIssueNumber-${instanceId}`;
@@ -210,12 +213,12 @@
     statusType = type;
     progressPercent = percent;
 
-    if (type === 'info' && percent < 90) {
+    if (type === 'info' && percent < PROGRESS_MAX) {
       safeTimeout(() => {
-        if (generating && progressPercent < 90) {
-          updateStatus(message, type, Math.min(progressPercent + 3, 90));
+        if (generating && progressPercent < PROGRESS_MAX) {
+          updateStatus(message, type, Math.min(progressPercent + PROGRESS_STEP, PROGRESS_MAX));
         }
-      }, 2500);
+      }, PROGRESS_INTERVAL_MS);
     }
   }
 </script>

--- a/frontend/src/lib/utils/settingsApi.ts
+++ b/frontend/src/lib/utils/settingsApi.ts
@@ -160,13 +160,6 @@ export const settingsAPI = {
     ffmpegStatus: (): Promise<{ available: boolean; version?: string }> => {
       return api.get('/api/v2/system/ffmpeg');
     },
-
-    /**
-     * Generate system support dump
-     */
-    supportDump: (options: { includePrivateInfo: boolean }): Promise<{ downloadUrl: string }> => {
-      return api.post('/api/v2/system/support-dump', options);
-    },
   },
 
   /**

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -26,6 +26,19 @@ const (
 	supportDumpTimeout      = 120 * time.Second
 )
 
+// valueContext wraps a cancellation-bearing context while delegating
+// Value lookups to a separate context. This lets the support dump
+// handler use the server lifecycle context (c.ctx) for cancellation
+// while still reading trace IDs from the HTTP request context.
+type valueContext struct {
+	context.Context
+	values context.Context
+}
+
+func (vc valueContext) Value(key any) any {
+	return vc.values.Value(key)
+}
+
 // GenerateSupportDumpRequest represents the request for generating a support dump
 type GenerateSupportDumpRequest struct {
 	IncludeLogs         bool   `json:"include_logs"`
@@ -61,16 +74,27 @@ func sanitizeGitHubIssueNumber(issueNum string) string {
 func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	c.logDebugIfEnabled("Support dump generation started")
 
-	// Use a dedicated timeout that outlives Echo's WriteTimeout.
-	// Collection, archiving, and Sentry upload can take well over 30s
-	// on low-powered devices or slow upstream connections.
-	// WithoutCancel preserves context values (trace IDs) while
-	// decoupling from the HTTP request's cancellation signal.
+	// Use the server lifecycle context for cancellation so the dump
+	// stops on shutdown, but delegate Value lookups to the request
+	// context so trace IDs remain accessible.
+	parentCtx := c.ctx
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
 	dumpCtx, cancel := context.WithTimeout(
-		context.WithoutCancel(ctx.Request().Context()),
+		valueContext{Context: parentCtx, values: ctx.Request().Context()},
 		supportDumpTimeout,
 	)
 	defer cancel()
+
+	// Extend the HTTP write deadline so the server does not close the
+	// TCP connection before the handler finishes (default WriteTimeout
+	// is 30s, but the dump can take much longer).
+	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
+		if err := conn.SetWriteDeadline(time.Now().Add(supportDumpTimeout)); err != nil {
+			c.logDebugIfEnabled("Failed to extend write deadline for support dump", logger.Error(err))
+		}
+	}
 
 	// Parse JSON request
 	var req GenerateSupportDumpRequest

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -22,8 +22,8 @@ import (
 const (
 	supportLogDurationWeeks = 4           // Weeks of logs to collect
 	supportMaxLogSizeMB     = 50          // Maximum log size in MB
-	supportBytesPerKB       = 1024        // Bytes per kilobyte
 	supportBytesPerMB       = 1024 * 1024 // Bytes per megabyte
+	supportDumpTimeout      = 120 * time.Second
 )
 
 // GenerateSupportDumpRequest represents the request for generating a support dump
@@ -60,6 +60,17 @@ func sanitizeGitHubIssueNumber(issueNum string) string {
 // GenerateSupportDump handles the generation and optional upload of support dumps
 func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	c.logDebugIfEnabled("Support dump generation started")
+
+	// Use a dedicated timeout that outlives Echo's WriteTimeout.
+	// Collection, archiving, and Sentry upload can take well over 30s
+	// on low-powered devices or slow upstream connections.
+	// WithoutCancel preserves context values (trace IDs) while
+	// decoupling from the HTTP request's cancellation signal.
+	dumpCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx.Request().Context()),
+		supportDumpTimeout,
+	)
+	defer cancel()
 
 	// Parse JSON request
 	var req GenerateSupportDumpRequest
@@ -111,7 +122,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	)
 
 	// Wire database info provider if V2Manager is available
-	if req.IncludeDatabaseInfo && c.V2Manager != nil {
+	if req.IncludeDatabaseInfo && c.V2Manager != nil && c.DS != nil {
 		dialect := datastore.DialectSQLite
 		if c.V2Manager.IsMySQL() {
 			dialect = datastore.DialectMySQL
@@ -147,7 +158,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 
 	// Collect data
 	c.logDebugIfEnabled("Starting support data collection", logger.String("system_id", settings.SystemID))
-	dump, err := collector.Collect(ctx.Request().Context(), opts)
+	dump, err := collector.Collect(dumpCtx, opts)
 	if err != nil {
 		c.logErrorIfEnabled("Failed to collect support data",
 			logger.Error(err),
@@ -160,12 +171,12 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 
 	// Create archive
 	c.logDebugIfEnabled("Creating support archive", logger.String("dump_id", dump.ID))
-	archiveData, err := collector.CreateArchive(ctx.Request().Context(), dump, opts)
+	archiveData, err := collector.CreateArchive(dumpCtx, dump, opts)
 	if err != nil {
 		c.logErrorIfEnabled("Failed to create support archive",
 			logger.Error(err),
 			logger.String("dump_id", dump.ID),
-			logger.Any("context_err", ctx.Request().Context().Err()),
+			logger.Any("context_err", dumpCtx.Err()),
 		)
 		return c.HandleError(ctx, err, "Failed to create support archive", http.StatusInternalServerError)
 	}
@@ -196,7 +207,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		// Proceed with upload if still requested
 		if req.UploadToSentry {
 			uploader := telemetry.GetAttachmentUploader()
-			if err := uploader.UploadSupportDump(ctx.Request().Context(), archiveData, settings.SystemID, req.UserMessage, req.GitHubIssueNumber); err != nil {
+			if err := uploader.UploadSupportDump(dumpCtx, archiveData, settings.SystemID, req.UserMessage, req.GitHubIssueNumber); err != nil {
 				// Log error but don't fail the request
 				c.logErrorIfEnabled("Failed to upload support dump to Sentry",
 					logger.Error(err),
@@ -235,7 +246,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	c.logInfoIfEnabled("Support dump generated",
 		logger.String("dump_id", dump.ID),
 		logger.Int("size", len(archiveData)),
-		logger.Bool("uploaded", req.UploadToSentry && settings.Sentry.Enabled),
+		logger.Bool("uploaded", response.UploadedAt != ""),
 	)
 
 	return ctx.JSON(http.StatusOK, response)

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -36,7 +36,10 @@ type valueContext struct {
 }
 
 func (vc valueContext) Value(key any) any {
-	return vc.values.Value(key)
+	if val := vc.values.Value(key); val != nil {
+		return val
+	}
+	return vc.Context.Value(key)
 }
 
 // GenerateSupportDumpRequest represents the request for generating a support dump
@@ -90,10 +93,9 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	// Extend the HTTP write deadline so the server does not close the
 	// TCP connection before the handler finishes (default WriteTimeout
 	// is 30s, but the dump can take much longer).
-	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
-		if err := conn.SetWriteDeadline(time.Now().Add(supportDumpTimeout)); err != nil {
-			c.logDebugIfEnabled("Failed to extend write deadline for support dump", logger.Error(err))
-		}
+	rc := http.NewResponseController(ctx.Response().Writer)
+	if err := rc.SetWriteDeadline(time.Now().Add(supportDumpTimeout)); err != nil {
+		c.logDebugIfEnabled("Failed to extend write deadline for support dump", logger.Error(err))
 	}
 
 	// Parse JSON request

--- a/internal/telemetry/attachments.go
+++ b/internal/telemetry/attachments.go
@@ -15,8 +15,9 @@ import (
 const (
 	// maxBreadcrumbs defines the maximum number of breadcrumbs to keep in Sentry events
 	maxBreadcrumbs = 10
-	// sentryFlushTimeout is the timeout for flushing events to Sentry
-	sentryFlushTimeout = 5 * time.Second
+	// sentryFlushTimeout is the timeout for flushing events to Sentry.
+	// Support dumps can be several MB; 30s accommodates slow upstream links.
+	sentryFlushTimeout = 30 * time.Second
 )
 
 // flushWithContext flushes Sentry events with context cancellation awareness.
@@ -247,10 +248,18 @@ func (au *AttachmentUploader) CreateSupportEvent(ctx context.Context, systemID, 
 			Build()
 	}
 
+	if !au.enabled {
+		log.Warn("support event blocked - telemetry not enabled")
+		return errors.Newf("telemetry is not enabled - cannot create support event").
+			Component("telemetry").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "create_support_event").
+			Build()
+	}
+
 	// Extract trace ID from context if available
 	traceID := extractTraceID(ctx)
 	if traceID != "" {
-		// Log trace ID for observability
 		log.Debug("trace ID found", logger.String("trace_id", traceID))
 		sentry.ConfigureScope(func(scope *sentry.Scope) {
 			scope.SetTag("trace_id", traceID)
@@ -259,16 +268,6 @@ func (au *AttachmentUploader) CreateSupportEvent(ctx context.Context, systemID, 
 
 	// Scrub message for privacy
 	scrubbedMessage := privacy.ScrubMessage(message)
-
-	if !au.enabled {
-		log.Warn("support event blocked - telemetry not enabled")
-		return errors.Newf("telemetry is not enabled - cannot create support event").
-			Component("telemetry").
-			Category(errors.CategoryConfiguration).
-			Context("operation", "create_support_event").
-			Context("trace_id", traceID).
-			Build()
-	}
 
 	// Create event
 	event := sentry.NewEvent()


### PR DESCRIPTION
## Summary

- Support dump submissions were timing out for users on slow connections or low-powered devices (RPi). The collection + archive + Sentry upload pipeline could easily exceed Echo's 30s WriteTimeout, especially after recent additions of DeploymentInfo, AppEvents, and DatabaseInfo collectors.
- Adds a 120s dedicated context (`context.WithoutCancel`) for the dump handler, decoupled from Echo's WriteTimeout while preserving trace IDs.
- Increases Sentry flush timeout from 5s to 30s for multi-MB uploads over slow upstream links.
- Sets frontend fetch timeout to 130s (slightly exceeds backend to ensure the server always responds before the client aborts).
- Slows progress bar animation (+3% every 2.5s instead of +10% every 1s) to match the longer operation window.
- Fixes potential nil dereference: guards `c.DS` before calling `c.DS.SchemaVersion()`.
- Fixes incorrect `uploaded` log field that showed false when minimal Sentry was used for upload.
- Fixes guard ordering in `CreateSupportEvent` where `ConfigureScope` mutated global Sentry state before the `enabled` check.
- Removes dead `settingsApi.supportDump` method (called nonexistent URL, zero callers).
- Removes unused `supportBytesPerKB` constant.

## Test Plan

- [ ] Trigger support dump from Settings > Support on a device with slow upstream
- [ ] Verify dump completes without timeout error
- [ ] Verify progress bar animates smoothly through the operation
- [ ] Verify dump uploads to Sentry successfully with telemetry disabled (minimal Sentry path)
- [ ] Verify download path still works when upload is not selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Longer timeout for support dump generation requests.
  * Progress updates during dump generation advance in smaller steps and occur less frequently.

* **Refactor**
  * Support dump endpoint removed from the settings API surface.
  * Support dump lifecycle uses an independent timeout and an extended response write deadline.
  * Telemetry handling adjusted; Sentry flush timeout increased to reduce premature send failures.

* **Improvements**
  * Database collection included only when explicitly requested; uploaded status reporting made more accurate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->