### PR TITLE
refactor(audio): unify FFmpeg arg construction so tests cover the runtime path

### DIFF
--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -393,15 +393,28 @@ func ProcessAudioToFile(ctx context.Context, filePath, ffmpegPath string, filter
 }
 
 // BuildFFmpegArgs constructs the complete FFmpeg argument list for a streaming source.
-// It is a pure function suitable for unit testing. The Stream.startProcess method
-// delegates to this function after constructing the input and output format parameters.
+// It is a pure function suitable for unit testing. It produces the same output
+// arguments as the runtime path (Stream.startProcess) by sharing buildOutputArgs;
+// only the input-argument timeout warning logging differs between the two.
 //
 // RTSP-specific flags like -rtsp_transport are only added for RTSP sources.
 // A default -timeout is added unless the caller supplies one via ffmpegParameters.
 func BuildFFmpegArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
-	sampleRate, numChannels, format := GetFFmpegFormat(cfg.SampleRate, cfg.Channels, cfg.BitDepth)
-
 	args := buildInputArgs(cfg, ffmpegParameters)
+	return buildOutputArgs(args, cfg)
+}
+
+// buildOutputArgs appends the post-input FFmpeg flags: the input URL, decode
+// format, channel selection, conditional output resampling, and the stdout pipe.
+// It is shared by BuildFFmpegArgs and Stream.startProcess so the unit-tested
+// argument construction matches the runtime path exactly.
+//
+// -ac (channel count) is always emitted via appendChannelArgs so multi-channel
+// sources are downmixed to mono. -ar (sample rate) is only emitted when the
+// source rate is unknown or differs from the target, avoiding a needless
+// resample when the source already matches.
+func buildOutputArgs(args []string, cfg *StreamConfig) []string {
+	sampleRate, numChannels, format := GetFFmpegFormat(cfg.SampleRate, cfg.Channels, cfg.BitDepth)
 
 	logLevel := cfg.LogLevel
 	if logLevel == "" {
@@ -413,9 +426,11 @@ func BuildFFmpegArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
 		"-loglevel", logLevel,
 		"-vn",
 		"-f", format,
-		"-ar", sampleRate,
 	)
 	args = appendChannelArgs(args, cfg.ChannelMode, cfg.SourceChannels, numChannels)
+	if cfg.needsOutputResampling() {
+		args = append(args, "-ar", sampleRate)
+	}
 	args = append(args, "-hide_banner", "pipe:1")
 
 	return args

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -180,7 +180,7 @@ func TestBuildFFmpegArgs_ChannelModeLeft(t *testing.T) {
 	require.NotEqual(t, -1, afIdx, "expected -af flag for left channel extraction")
 	require.Less(t, afIdx+1, len(args), "-af must have a value")
 	assert.Equal(t, "pan=mono|c0=c0", args[afIdx+1])
-	assert.Contains(t, args, "-ac")
+	assertFlagValue(t, args, "-ac", "1")
 }
 
 // TestBuildFFmpegArgs_ChannelModeRight verifies that a stereo source with
@@ -206,10 +206,11 @@ func TestBuildFFmpegArgs_ChannelModeRight(t *testing.T) {
 	require.NotEqual(t, -1, afIdx, "expected -af flag for right channel extraction")
 	require.Less(t, afIdx+1, len(args), "-af must have a value")
 	assert.Equal(t, "pan=mono|c0=c1", args[afIdx+1])
+	assertFlagValue(t, args, "-ac", "1")
 }
 
 // TestBuildFFmpegArgs_ChannelModeDownmix verifies that "downmix" mode uses
-// simple -ac without a pan filter.
+// simple -ac 1 (mono downmix) without a pan filter.
 func TestBuildFFmpegArgs_ChannelModeDownmix(t *testing.T) {
 	t.Parallel()
 
@@ -228,7 +229,76 @@ func TestBuildFFmpegArgs_ChannelModeDownmix(t *testing.T) {
 	args := BuildFFmpegArgs(cfg, nil)
 
 	assert.NotContains(t, args, "-af")
-	assert.Contains(t, args, "-ac")
+	assertFlagValue(t, args, "-ac", "1")
+}
+
+// TestBuildFFmpegArgs_ChannelModeEmpty verifies that an unset channel mode (the
+// default for existing streams that predate the feature) downmixes a stereo
+// source to mono with -ac 1 and no pan filter, matching pre-feature behavior.
+func TestBuildFFmpegArgs_ChannelModeEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfg := &StreamConfig{
+		URL:            "rtsp://camera.example.com/live",
+		Type:           "rtsp",
+		SampleRate:     48000,
+		BitDepth:       16,
+		Channels:       1,
+		SourceChannels: 2,
+		ChannelMode:    "",
+		Transport:      "tcp",
+		LogLevel:       "error",
+	}
+
+	args := BuildFFmpegArgs(cfg, nil)
+
+	assert.NotContains(t, args, "-af")
+	assertFlagValue(t, args, "-ac", "1")
+}
+
+// TestBuildFFmpegArgs_OutputResampling verifies that -ar is emitted only when
+// the source sample rate is unknown or differs from the target, and omitted
+// when the probed source rate already matches the target. -ac must always be
+// present so multi-channel sources still downmix to mono regardless of -ar.
+func TestBuildFFmpegArgs_OutputResampling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		sourceSampleRate int
+		wantAr           bool
+	}{
+		{"unknown_source_rate_resamples", 0, true},
+		{"differing_rate_resamples", 44100, true},
+		{"matching_rate_skips_ar", 48000, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &StreamConfig{
+				URL:              "rtsp://camera.example.com/live",
+				Type:             "rtsp",
+				SampleRate:       48000,
+				SourceSampleRate: tt.sourceSampleRate,
+				BitDepth:         16,
+				Channels:         1,
+				Transport:        "tcp",
+				LogLevel:         "error",
+			}
+
+			args := BuildFFmpegArgs(cfg, nil)
+
+			if tt.wantAr {
+				assertFlagValue(t, args, "-ar", "48000")
+			} else {
+				assert.NotContains(t, args, "-ar", "expected no -ar when source rate matches target")
+			}
+			// -ac must always be present so stereo sources downmix to mono.
+			assertFlagValue(t, args, "-ac", "1")
+		})
+	}
 }
 
 // TestBuildFFmpegArgs_ChannelModeLeftOnMonoSource verifies the safety guard:
@@ -250,9 +320,18 @@ func TestBuildFFmpegArgs_ChannelModeLeftOnMonoSource(t *testing.T) {
 
 	args := BuildFFmpegArgs(cfg, nil)
 
-	// Safety guard: mono source should NOT get pan filter.
+	// Safety guard: mono source should NOT get pan filter, and must downmix to mono.
 	assert.NotContains(t, args, "-af")
-	assert.Contains(t, args, "-ac")
+	assertFlagValue(t, args, "-ac", "1")
+}
+
+// assertFlagValue asserts that flag appears in args immediately followed by want.
+func assertFlagValue(t *testing.T, args []string, flag, want string) {
+	t.Helper()
+	idx := slices.Index(args, flag)
+	require.NotEqual(t, -1, idx, "expected %s flag", flag)
+	require.Less(t, idx+1, len(args), "%s must have a value", flag)
+	assert.Equal(t, want, args[idx+1], "unexpected value for %s", flag)
 }
 
 // TestBackoffCalculation verifies that CalculateBackoff implements exponential

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"os/exec"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -803,12 +802,7 @@ func (s *Stream) startProcess() error {
 			Build()
 	}
 
-	sampleRate, numChannels, format := GetFFmpegFormat(s.config.SampleRate, s.config.Channels, s.config.BitDepth)
-
-	args := s.buildFFmpegInputArgs(s.config.FFmpegParameters)
-
-	connStr := s.config.URL
-	if connStr == "" {
+	if s.config.URL == "" {
 		return errors.Newf("connection string is empty for source %s, cannot start FFmpeg", s.config.SourceID).
 			Category(errors.CategoryValidation).
 			Component("ffmpeg-stream").
@@ -817,23 +811,10 @@ func (s *Stream) startProcess() error {
 			Build()
 	}
 
-	logLevel := s.config.LogLevel
-	if logLevel == "" {
-		logLevel = "error"
-	}
-
-	args = append(args,
-		"-i", connStr,
-		"-loglevel", logLevel,
-		"-vn",
-		"-f", format,
-	)
-	args = appendChannelArgs(args, s.config.ChannelMode, s.config.SourceChannels, numChannels)
-	if s.config.needsOutputResampling() {
-		args = append(args, "-ar", sampleRate)
-	}
-
-	args = append(args, "-hide_banner", "pipe:1")
+	// Input args use the Stream's timeout-warning logging; output args are built
+	// by the shared buildOutputArgs so this runtime path matches BuildFFmpegArgs.
+	args := s.buildFFmpegInputArgs(s.config.FFmpegParameters)
+	args = buildOutputArgs(args, &s.config)
 
 	s.cmd = exec.CommandContext(s.ctx, s.config.FFmpegPath, args...) //nolint:gosec // G204: FFmpegPath from validated settings, args built internally
 
@@ -892,40 +873,22 @@ func (s *Stream) startProcess() error {
 }
 
 // buildFFmpegInputArgs constructs the FFmpeg input arguments for this stream.
-// RTSP-specific flags like -rtsp_transport are only added for RTSP streams.
-// RTSP streams use -timeout for connection timeout.
+// It delegates the actual argument construction to the shared buildInputArgs so
+// the runtime path stays in lockstep with the unit-tested BuildFFmpegArgs. The
+// only Stream-specific behavior is surfacing an invalid user-supplied timeout as
+// a warning log (buildInputArgs silently falls back to the default).
 func (s *Stream) buildFFmpegInputArgs(ffmpegParameters []string) []string {
-	args := []string{}
-	timeoutFlag := timeoutParamForSource(s.config.sourceType())
-
-	if s.config.sourceType() == audiocore.SourceTypeRTSP {
-		args = append(args, "-rtsp_transport", s.config.Transport)
-	}
-
-	hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters)
-
-	if !hasUserTimeout {
-		args = append(args, timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
-		if len(ffmpegParameters) > 0 {
-			args = append(args, ffmpegParameters...)
+	if hasUserTimeout, userTimeoutValue := detectUserTimeout(ffmpegParameters); hasUserTimeout {
+		if err := validateTimeout(userTimeoutValue); err != nil {
+			getStreamLogger().Warn("invalid user timeout, using default",
+				logger.String("url", s.config.safeURL()),
+				logger.String("user_timeout", userTimeoutValue),
+				logger.Error(err),
+				logger.String("component", "ffmpeg-stream"),
+				logger.String("operation", "validate_timeout"))
 		}
-		return args
 	}
-
-	if err := s.validateUserTimeout(userTimeoutValue); err != nil {
-		getStreamLogger().Warn("invalid user timeout, using default",
-			logger.String("url", s.config.safeURL()),
-			logger.String("user_timeout", userTimeoutValue),
-			logger.Error(err),
-			logger.String("component", "ffmpeg-stream"),
-			logger.String("operation", "validate_timeout"))
-		args = append(args, timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
-	} else {
-		args = append(args, timeoutFlag, userTimeoutValue)
-	}
-	args = append(args, stripTimeoutParams(ffmpegParameters)...)
-
-	return args
+	return buildInputArgs(&s.config, ffmpegParameters)
 }
 
 // readResult carries the outcome of a single stdout.Read call from the
@@ -1939,31 +1902,6 @@ func detectUserTimeout(params []string) (found bool, value string) {
 		}
 	}
 	return false, ""
-}
-
-// validateUserTimeout validates a user-provided timeout value.
-func (s *Stream) validateUserTimeout(timeoutStr string) error {
-	timeout, err := strconv.ParseInt(timeoutStr, 10, 64)
-	if err != nil {
-		return errors.Newf("invalid timeout format: %s (must be a number in microseconds)", timeoutStr).
-			Component("ffmpeg-stream").
-			Category(errors.CategoryValidation).
-			Context("operation", "validate_user_timeout").
-			Context("timeout_value", timeoutStr).
-			Build()
-	}
-
-	if timeout < minTimeoutMicroseconds {
-		return errors.Newf("timeout too short: %d microseconds (minimum: %d microseconds = 1 second)", timeout, minTimeoutMicroseconds).
-			Component("ffmpeg-stream").
-			Category(errors.CategoryValidation).
-			Context("operation", "validate_user_timeout").
-			Context("timeout_microseconds", timeout).
-			Context("minimum_microseconds", minTimeoutMicroseconds).
-			Build()
-	}
-
-	return nil
 }
 
 // recordErrorContext stores an error context in the history buffer.

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -720,10 +720,8 @@ func TestStream_ConditionalFailureReset_NotEnoughBytes(t *testing.T) {
 	assert.Equal(t, 5, stream.getConsecutiveFailures(), "Failures should NOT be reset without enough bytes")
 }
 
-func TestStream_ValidateUserTimeout(t *testing.T) {
+func TestValidateTimeout(t *testing.T) {
 	t.Parallel()
-
-	stream := newTestStream(t)
 
 	tests := []struct {
 		name          string
@@ -747,7 +745,7 @@ func TestStream_ValidateUserTimeout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := stream.validateUserTimeout(tt.timeoutStr)
+			err := validateTimeout(tt.timeoutStr)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error for timeout: %s", tt.timeoutStr)


### PR DESCRIPTION
## Summary

The per-stream channel-mode feature left two divergent FFmpeg argument builders:

- `BuildFFmpegArgs` in `process.go` (the unit-tested, pure function)
- inline construction in `Stream.startProcess` in `stream.go` (the actual runtime path)

The tested function emitted `-ar` unconditionally while the runtime path made it conditional on `needsOutputResampling()`, and a stale doc comment claimed `startProcess` delegated to `BuildFFmpegArgs` when it never did. The net effect: every channel-mode unit test was validating a function that does not run in production.

This refactor makes the tested path the runtime path:

- Extract a shared `buildOutputArgs` helper used by both `BuildFFmpegArgs` and `Stream.startProcess`, so post-input args (format, channel selection, conditional `-ar`, output pipe) are built once.
- Collapse the near-identical input-arg builders: `Stream.buildFFmpegInputArgs` now delegates to the shared `buildInputArgs`, keeping only the invalid-timeout warning log. The duplicate `Stream.validateUserTimeout` is removed in favor of the package-level `validateTimeout`.
- Runtime FFmpeg args are byte-for-byte unchanged; this is a structural refactor, not a behavior change.

Test improvements:

- Tighten the channel-mode tests to assert `-ac` is exactly `"1"` (the mono-downmix default for existing streams that select no channel side) instead of merely checking the flag is present, so a future `-ac 2` regression would actually fail.
- Add `TestBuildFFmpegArgs_ChannelModeEmpty` covering the default for pre-existing streams (no channel mode set).
- Add `TestBuildFFmpegArgs_OutputResampling` covering the conditional `-ar` branch (omitted when the probed source rate already matches the target).

## Context

While reviewing the channel-selection feature for a possible mono-downmix regression on existing streams, I confirmed there is none: `ChannelMode` defaults to downmix, target channels are pinned to 1 in the pipeline, and the pan filter only applies for explicit left/right on multi-channel sources. The real gap was that the tests guarding that invariant never exercised the shipped code path. This PR closes that gap.

## Test Plan

- [x] `go test -race ./internal/audiocore/ffmpeg/` (396 pass)
- [x] `golangci-lint run` clean on full project
- [x] Verified runtime arg sequence is unchanged vs. the previous inline builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal FFmpeg audio processing argument construction by consolidating shared logic and enhancing code organization across build and streaming paths.

* **Tests**
  * Strengthened FFmpeg argument validation tests with unified assertion helpers and expanded coverage for edge cases including unset channel modes and resampling conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->