### PR TITLE
refactor(audio): dedupe restart backoff against CalculateBackoff

### DIFF
--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -533,8 +533,7 @@ func applyBackoffJitter(backoff time.Duration) time.Duration {
 		return backoff
 	}
 
-	factor := float64(restartJitterPercentMax) / 100.0
-	jitterRange := time.Duration(float64(backoff) * factor)
+	jitterRange := backoff * restartJitterPercentMax / 100
 	if jitterRange <= 0 {
 		return backoff
 	}

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -3,11 +3,10 @@ package ffmpeg
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"math"
-	"math/big"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -528,7 +527,7 @@ func computeBaseBackoff(restartCount int, base, maxBackoff time.Duration) time.D
 
 // applyBackoffJitter adds a random jitter of up to restartJitterPercentMax percent
 // on top of backoff to prevent a thundering herd of simultaneous reconnects. A
-// non-positive backoff or a failed random read returns backoff unchanged.
+// non-positive backoff (or jitter range) returns backoff unchanged.
 func applyBackoffJitter(backoff time.Duration) time.Duration {
 	if backoff <= 0 {
 		return backoff
@@ -540,9 +539,5 @@ func applyBackoffJitter(backoff time.Duration) time.Duration {
 		return backoff
 	}
 
-	n, err := rand.Int(rand.Reader, big.NewInt(jitterRange.Nanoseconds()))
-	if err != nil {
-		return backoff
-	}
-	return backoff + time.Duration(n.Int64())
+	return backoff + time.Duration(rand.Int64N(jitterRange.Nanoseconds())) //nolint:gosec // G404: non-cryptographic jitter to spread out reconnects
 }

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -511,23 +511,38 @@ func validateTimeout(timeoutStr string) error {
 
 // CalculateBackoff computes the exponential backoff duration for a given restart count.
 // It adds a random jitter of up to restartJitterPercentMax percent of the base backoff.
-// The returned duration is always at least base and at most maxBackoff + maxJitter.
+// The returned duration is always at least base and at most maxBackoff plus that jitter.
 func CalculateBackoff(restartCount int, base, maxBackoff time.Duration) time.Duration {
+	return applyBackoffJitter(computeBaseBackoff(restartCount, base, maxBackoff))
+}
+
+// computeBaseBackoff returns the capped exponential backoff for a restart count,
+// without jitter. The exponent is clamped to [0, maxBackoffExponent] and the
+// result is capped at maxBackoff.
+func computeBaseBackoff(restartCount int, base, maxBackoff time.Duration) time.Duration {
 	exponent := max(restartCount-1, 0)
 	exponent = min(exponent, maxBackoffExponent)
 
-	backoff := min(base*time.Duration(1<<uint(exponent)), maxBackoff) //nolint:gosec // G115: exponent is capped by maxBackoffExponent
+	return min(base*time.Duration(1<<uint(exponent)), maxBackoff) //nolint:gosec // G115: exponent is capped by maxBackoffExponent
+}
 
-	wait := backoff
-	if backoff > 0 {
-		factor := float64(restartJitterPercentMax) / 100.0
-		jitterRange := time.Duration(float64(backoff) * factor)
-		if jitterRange > 0 {
-			if n, err := rand.Int(rand.Reader, big.NewInt(jitterRange.Nanoseconds())); err == nil {
-				wait = backoff + time.Duration(n.Int64())
-			}
-		}
+// applyBackoffJitter adds a random jitter of up to restartJitterPercentMax percent
+// on top of backoff to prevent a thundering herd of simultaneous reconnects. A
+// non-positive backoff or a failed random read returns backoff unchanged.
+func applyBackoffJitter(backoff time.Duration) time.Duration {
+	if backoff <= 0 {
+		return backoff
 	}
 
-	return wait
+	factor := float64(restartJitterPercentMax) / 100.0
+	jitterRange := time.Duration(float64(backoff) * factor)
+	if jitterRange <= 0 {
+		return backoff
+	}
+
+	n, err := rand.Int(rand.Reader, big.NewInt(jitterRange.Nanoseconds()))
+	if err != nil {
+		return backoff
+	}
+	return backoff + time.Duration(n.Int64())
 }

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -399,3 +399,73 @@ func TestBackoffCalculation_ZeroRestarts(t *testing.T) {
 	assert.GreaterOrEqual(t, got, base)
 	assert.LessOrEqual(t, got, base+base/5)
 }
+
+// TestComputeBaseBackoff verifies the jitter-free exponential backoff: doubling
+// per restart, exponent clamped at zero, and capped at maxBackoff.
+func TestComputeBaseBackoff(t *testing.T) {
+	t.Parallel()
+
+	base := 5 * time.Second
+	maxDur := 2 * time.Minute
+
+	tests := []struct {
+		name         string
+		restartCount int
+		want         time.Duration
+	}{
+		{"zero clamps to base", 0, 5 * time.Second},
+		{"first restart", 1, 5 * time.Second},
+		{"second restart", 2, 10 * time.Second},
+		{"third restart", 3, 20 * time.Second},
+		{"capped at maxBackoff", 20, maxDur},
+		{"large count stays capped", 1000, maxDur},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, computeBaseBackoff(tt.restartCount, base, maxDur))
+		})
+	}
+}
+
+// TestExtremeFailurePenalty verifies the escalating delay applied once the
+// restart count exceeds extremeFailureThreshold, including the cap.
+func TestExtremeFailurePenalty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		restartCount int
+		want         time.Duration
+	}{
+		{"below threshold", extremeFailureThreshold - 1, 0},
+		{"at threshold", extremeFailureThreshold, 0},
+		{"one past threshold", extremeFailureThreshold + 1, extremeFailureDelayStep},
+		{"ten past threshold", extremeFailureThreshold + 10, 10 * extremeFailureDelayStep},
+		{"capped", extremeFailureThreshold + 1000, extremeFailureDelayCap},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, extremeFailurePenalty(tt.restartCount))
+		})
+	}
+}
+
+// TestApplyBackoffJitter verifies jitter stays within the [backoff, backoff+20%]
+// band and that non-positive inputs pass through unchanged.
+func TestApplyBackoffJitter(t *testing.T) {
+	t.Parallel()
+
+	const backoff = 10 * time.Second
+	for range 100 {
+		got := applyBackoffJitter(backoff)
+		assert.GreaterOrEqual(t, got, backoff)
+		assert.LessOrEqual(t, got, backoff+backoff/5)
+	}
+
+	assert.Equal(t, time.Duration(0), applyBackoffJitter(0))
+	assert.Equal(t, -time.Second, applyBackoffJitter(-time.Second))
+}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -1480,14 +1480,17 @@ func (s *Stream) handleRestartBackoff() {
 	// failed enough times that it is probably broken, so it stops hammering the
 	// source. backoffDuration and maxBackoff are immutable after construction,
 	// so this needs no lock.
-	backoff := computeBaseBackoff(currentRestartCount, s.backoffDuration, s.maxBackoff) +
-		extremeFailurePenalty(currentRestartCount)
+	baseBackoff := computeBaseBackoff(currentRestartCount, s.backoffDuration, s.maxBackoff)
+	penalty := extremeFailurePenalty(currentRestartCount)
+	backoff := baseBackoff + penalty
 
 	// Jitter the full delay (including any extreme-failure penalty) to avoid a
 	// thundering herd of reconnects.
 	wait := applyBackoffJitter(backoff)
 
-	s.transitionState(StateBackoff, fmt.Sprintf("restart #%d: waiting %s (base backoff: %s)", currentRestartCount, formatDuration(wait), formatDuration(backoff)))
+	s.transitionState(StateBackoff, fmt.Sprintf(
+		"restart #%d: waiting %s (base: %s, penalty: %s, pre-jitter: %s)",
+		currentRestartCount, formatDuration(wait), formatDuration(baseBackoff), formatDuration(penalty), formatDuration(backoff)))
 
 	getStreamLogger().Info("waiting before restart attempt",
 		logger.String("url", s.config.safeURL()),

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -3,10 +3,8 @@ package ffmpeg
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"fmt"
 	"io"
-	"math/big"
 	"os/exec"
 	"slices"
 	"strings"
@@ -75,6 +73,14 @@ const (
 
 	// Restart jitter to prevent thundering herd effect.
 	restartJitterPercentMax = 20
+
+	// Extreme failure penalty: once a stream has restarted more than
+	// extremeFailureThreshold times, add an escalating delay on top of the
+	// capped exponential backoff, growing by extremeFailureDelayStep per
+	// restart up to extremeFailureDelayCap.
+	extremeFailureThreshold = 50
+	extremeFailureDelayStep = 10 * time.Second
+	extremeFailureDelayCap  = 5 * time.Minute
 
 	// Timeout settings for FFmpeg streams.
 	defaultTimeoutMicroseconds = 10000000
@@ -1468,26 +1474,18 @@ func (s *Stream) handleRestartBackoff() {
 	s.restartCountMu.Lock()
 	s.restartCount++
 	currentRestartCount := s.restartCount
-
-	exponent := min(s.restartCount-1, maxBackoffExponent)
-	backoff := min(s.backoffDuration*time.Duration(1<<uint(exponent)), s.maxBackoff) //nolint:gosec // G115: exponent is capped by maxBackoffExponent
-
-	if currentRestartCount > 50 {
-		additionalDelay := min(time.Duration(currentRestartCount-50)*10*time.Second, 5*time.Minute)
-		backoff += additionalDelay
-	}
 	s.restartCountMu.Unlock()
 
-	wait := backoff
-	if backoff > 0 {
-		factor := float64(restartJitterPercentMax) / 100.0
-		jitterRange := time.Duration(float64(backoff) * factor)
-		if jitterRange > 0 {
-			if n, err := rand.Int(rand.Reader, big.NewInt(jitterRange.Nanoseconds())); err == nil {
-				wait = backoff + time.Duration(n.Int64())
-			}
-		}
-	}
+	// Capped exponential backoff plus an escalating penalty once a stream has
+	// failed enough times that it is probably broken, so it stops hammering the
+	// source. backoffDuration and maxBackoff are immutable after construction,
+	// so this needs no lock.
+	backoff := computeBaseBackoff(currentRestartCount, s.backoffDuration, s.maxBackoff) +
+		extremeFailurePenalty(currentRestartCount)
+
+	// Jitter the full delay (including any extreme-failure penalty) to avoid a
+	// thundering herd of reconnects.
+	wait := applyBackoffJitter(backoff)
 
 	s.transitionState(StateBackoff, fmt.Sprintf("restart #%d: waiting %s (base backoff: %s)", currentRestartCount, formatDuration(wait), formatDuration(backoff)))
 
@@ -1507,6 +1505,23 @@ func (s *Stream) handleRestartBackoff() {
 	case <-s.stopChan:
 		// Stop requested.
 	}
+}
+
+// extremeFailurePenalty returns the escalating delay added on top of the capped
+// exponential backoff once restartCount exceeds extremeFailureThreshold. It is
+// zero at or below the threshold and grows by extremeFailureDelayStep per
+// restart beyond it, capped at extremeFailureDelayCap. The step count is clamped
+// before the multiplication so a pathologically large restartCount cannot
+// overflow time.Duration.
+func extremeFailurePenalty(restartCount int) time.Duration {
+	if restartCount <= extremeFailureThreshold {
+		return 0
+	}
+	steps := restartCount - extremeFailureThreshold
+	if maxSteps := int(extremeFailureDelayCap / extremeFailureDelayStep); steps >= maxSteps {
+		return extremeFailureDelayCap
+	}
+	return time.Duration(steps) * extremeFailureDelayStep
 }
 
 // Stop gracefully stops the FFmpeg stream.


### PR DESCRIPTION
## Summary

`Stream.handleRestartBackoff` reimplemented the exponential-backoff and `crypto/rand` jitter math that already lived in the pure, unit-tested `CalculateBackoff`, plus its own inline ">50 restart" escalating penalty using bare magic numbers. The two implementations could silently diverge over time.

This change removes that duplication:

- Split `CalculateBackoff` into two composable pure helpers, `computeBaseBackoff` (capped exponential, no jitter) and `applyBackoffJitter`, and route both `CalculateBackoff` and `handleRestartBackoff` through them.
- Extract the extreme-failure penalty into a pure, tested `extremeFailurePenalty` helper, and replace the inline `50` / `10s` / `5min` literals with named constants `extremeFailureThreshold`, `extremeFailureDelayStep`, `extremeFailureDelayCap`.

Runtime backoff behavior is unchanged: jitter is still applied to `base + penalty`, and the penalty still triggers strictly above the threshold.

Two small hardenings surfaced during review:
- Shrink the `restartCountMu` critical section to just the counter increment (`backoffDuration`/`maxBackoff` are immutable after construction, so the math needs no lock).
- Clamp the penalty step count before multiplying so a pathological restart count cannot overflow `time.Duration`.

Adds deterministic tests for `computeBaseBackoff`, `extremeFailurePenalty` (including the cap), and `applyBackoffJitter`.

## Test Plan

- [x] `go test -race ./internal/audiocore/ffmpeg/` (410 pass)
- [x] `golangci-lint run` clean on full project
- [x] Verified equivalence vs. the previous inline backoff math (penalty-before-jitter ordering, strict threshold, exponent clamping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved audio restart/backoff: capped exponential backoff, escalating penalties after repeated failures, jitter applied via a simpler randomness approach, and clearer timing reported in logs.

* **Tests**
  * Added unit tests covering base backoff, extreme-failure penalties, and jitter to validate delay ranges and clamping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->