### PR TITLE
fix: stop imageprovider retrying negative cache entries

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1352,26 +1352,44 @@ func (ds *Datastore) GetLastDetections(numDetections int) ([]datastore.Note, err
 // GetAllDetectedSpecies retrieves all detected species.
 func (ds *Datastore) GetAllDetectedSpecies() ([]datastore.Note, error) {
 	ctx := context.Background()
-	labels, err := ds.label.GetAllByLabelType(ctx, ds.speciesLabelTypeID)
+	labelIDs, err := ds.detection.GetAllDetectedLabels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(labelIDs) == 0 {
+		return []datastore.Note{}, nil
+	}
+
+	labels, err := ds.label.GetByIDs(ctx, labelIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	// Use a map to deduplicate by scientific name (since labels are now per-model).
+	// Use a map to deduplicate by scientific name (since labels are per-model).
 	// Labels may contain legacy concatenated "ScientificName_CommonName" format,
 	// so extract only the scientific name portion.
 	seen := make(map[string]struct{}, len(labels))
-	notes := make([]datastore.Note, 0, len(labels))
-	for i := range labels {
-		sciName := detection.ExtractScientificName(labels[i].ScientificName)
-		if sciName != "" {
-			if _, exists := seen[sciName]; !exists {
-				seen[sciName] = struct{}{}
-				notes = append(notes, datastore.Note{
-					ScientificName: sciName,
-				})
-			}
+	for _, label := range labels {
+		if label == nil {
+			continue
 		}
+		if label.LabelTypeID != ds.speciesLabelTypeID {
+			continue
+		}
+		sciName := detection.ExtractScientificName(label.ScientificName)
+		if sciName != "" {
+			seen[sciName] = struct{}{}
+		}
+	}
+
+	names := slices.Collect(maps.Keys(seen))
+	slices.Sort(names)
+
+	notes := make([]datastore.Note, 0, len(names))
+	for _, sciName := range names {
+		notes = append(notes, datastore.Note{
+			ScientificName: sciName,
+		})
 	}
 	return notes, nil
 }

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1,6 +1,7 @@
 package v2only
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -111,6 +112,19 @@ func setupTestDatastoreWithLabels(t *testing.T, labels []string) (ds *Datastore,
 	return ds, func() { _ = ds.Close(); cfgCleanup() }
 }
 
+type nilInjectingLabelRepository struct {
+	repository.LabelRepository
+}
+
+func (r nilInjectingLabelRepository) GetByIDs(ctx context.Context, ids []uint) (map[uint]*entities.Label, error) {
+	labels, err := r.LabelRepository.GetByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	labels[0] = nil
+	return labels, nil
+}
+
 func TestV2OnlyDatastore_Open(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
@@ -164,6 +178,55 @@ func TestV2OnlyDatastore_SaveAndGet(t *testing.T) {
 	assert.Equal(t, "12:30:00", notes[0].Time)
 	assert.Equal(t, "Passer domesticus", notes[0].ScientificName)
 	assert.InDelta(t, 0.85, notes[0].Confidence, 0.001)
+}
+
+func TestV2OnlyDatastore_GetAllDetectedSpeciesReturnsOnlyDetectionLabels(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	note := &datastore.Note{
+		Date:           "2024-01-15",
+		Time:           "12:30:00",
+		ScientificName: "Passer domesticus",
+		Confidence:     0.85,
+	}
+	results := []datastore.Results{
+		{Species: "Passer domesticus", Confidence: 0.85},
+		{Species: "Passer montanus", Confidence: 0.10},
+	}
+	require.NoError(t, ds.Save(note, results))
+
+	ctx := t.Context()
+	_, err := ds.label.GetOrCreate(ctx, "Crack", ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+	_, err = ds.label.GetOrCreate(ctx, "Dishes", ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+
+	otherModel, err := ds.model.GetOrCreate(ctx, "Perch", "1.0", "default", entities.ModelTypeBird, nil)
+	require.NoError(t, err)
+	duplicateLabel, err := ds.label.GetOrCreate(ctx, "Passer domesticus", otherModel.ID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+	require.NoError(t, ds.detection.Save(ctx, &entities.Detection{
+		ModelID:    otherModel.ID,
+		LabelID:    duplicateLabel.ID,
+		DetectedAt: time.Now().Unix(),
+		Confidence: 0.91,
+	}))
+
+	ds.label = nilInjectingLabelRepository{LabelRepository: ds.label}
+
+	species, err := ds.GetAllDetectedSpecies()
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(species))
+	for _, note := range species {
+		names = append(names, note.ScientificName)
+	}
+
+	assert.ElementsMatch(t, []string{"Passer domesticus"}, names)
+	assert.NotContains(t, names, "Passer montanus", "prediction-only labels must not be warmed as detected species")
+	assert.NotContains(t, names, "Crack", "orphan species labels must not be warmed as detected species")
+	assert.NotContains(t, names, "Dishes", "orphan species labels must not be warmed as detected species")
 }
 
 func TestV2OnlyDatastore_Delete(t *testing.T) {

--- a/internal/imageprovider/helpers_test.go
+++ b/internal/imageprovider/helpers_test.go
@@ -78,6 +78,39 @@ func TestIsCacheEntryStale(t *testing.T) {
 	}
 }
 
+func TestFindStaleEntriesSkipsNegativeEntries(t *testing.T) {
+	t.Parallel()
+
+	cache := &BirdImageCache{providerName: "wikimedia"}
+	now := time.Now()
+	entries := []datastore.ImageCache{
+		{
+			ScientificName: "Turdus merula",
+			URL:            "https://example.com/blackbird.jpg",
+			CachedAt:       now.Add(-defaultCacheTTL - time.Hour),
+		},
+		{
+			ScientificName: "Parus major",
+			URL:            "https://example.com/great-tit.jpg",
+			CachedAt:       now.Add(-time.Hour),
+		},
+		{
+			ScientificName: "Crack",
+			URL:            negativeEntryMarker,
+			CachedAt:       now.Add(-negativeCacheTTL - time.Hour),
+		},
+		{
+			ScientificName: "Orchelimum concinnum",
+			URL:            negativeEntryMarker,
+			CachedAt:       now.Add(-defaultCacheTTL - time.Hour),
+		},
+	}
+
+	staleEntries := cache.findStaleEntries(entries)
+
+	assert.ElementsMatch(t, []string{"Turdus merula"}, staleEntries)
+}
+
 // TestDbEntryToBirdImage tests the conversion from datastore.ImageCache to BirdImage.
 func TestDbEntryToBirdImage(t *testing.T) {
 	t.Parallel()

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -338,17 +338,12 @@ func (c *BirdImageCache) findStaleEntries(entries []datastore.ImageCache) []stri
 			continue
 		}
 		isNegative := entries[i].URL == negativeEntryMarker
-		// Non-avian species (Siren, Dog, etc.) will never have images;
-		// skip their negative entries so they never expire and re-fetch.
-		if isNegative && isNonAvianClass(entries[i].ScientificName) {
+		// Negative entries expire for direct user-triggered lookups, but the
+		// hourly background refresh must not re-query providers for known misses.
+		if isNegative {
 			continue
 		}
-		if isCacheEntryStale(entries[i].CachedAt, isNegative) {
-			if isNegative {
-				log.Debug("Found stale negative entry",
-					logger.String("scientific_name", entries[i].ScientificName),
-					logger.Time("cached_at", entries[i].CachedAt))
-			}
+		if isCacheEntryStale(entries[i].CachedAt, false) {
 			staleEntries = append(staleEntries, entries[i].ScientificName)
 		}
 	}


### PR DESCRIPTION
## Summary

- Limit v2-only image cache warm-up species to labels that are actually referenced by detections, deduped by scientific name.
- Skip `__NOT_FOUND__` negative cache entries during the hourly imageprovider background refresh.
- Add focused regressions for orphan/prediction-only labels and stale negative refresh selection.

## Root Cause

The v2-only `GetAllDetectedSpecies()` implementation read every species label row, including labels created by image-cache saves for names that never had detections. Separately, the hourly refresh path treated expired negative cache rows as refresh candidates, so background refreshes could keep retrying known misses against Wikipedia/Wikimedia and trigger repeated 429 errors.

Direct user-triggered lookup behavior is preserved: negative entries can still expire and retry through the existing direct cache lookup path. The change only prevents the hourly background job from hammering providers for known misses.

## Preflight Status

- [x] Single concern: one bug fix for imageprovider background 429 spam.
- [x] Preflight passed: manual five-pass preflight review completed; one in-scope linter finding fixed (`sort.Strings` -> `slices.Sort` in new code); no tracking issues filed.
- [x] Linters pass: `/Users/keith/go/bin/golangci-lint run -v` passed with project CGO/TFLite env; `npm run check:all` exited 0. Note: frontend ESLint still reports 3 pre-existing warnings in files untouched by this PR.
- [x] Tests pass: `go test -race ./...` passed after building `frontend/dist`; `CI=true npm test` passed.
- [x] No unrelated changes: diff is limited to v2-only detected-species selection, imageprovider stale refresh selection, and matching tests.
- [x] Scope complete: no TODO/FIXME added for core functionality.
- [x] Breaking changes documented: no API, config, or behavior-breaking changes.
- [x] i18n complete: no user-facing strings added.
- [x] No secrets or PII: diff contains no credentials or personal data.

## Validation

- `git diff --check`
- `npm ci`
- `npm run check:all`
- `CI=true npm test`
- `npm run build`
- `/Users/keith/go/bin/golangci-lint run -v`
- `go test -race ./...`

The initial sandboxed `go test -race ./...` attempt failed because `frontend/dist` was not present and the sandbox blocked `httptest` listener setup. After building `frontend/dist`, the final full race suite passed outside the sandbox with the same project CGO/TFLite environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Species detection now returns only species found in actual detections, preventing unrelated labels from appearing in results
  * Image provider no longer unnecessarily re-queries for previously unfound species during background refresh cycles

* **Tests**
  * Added regression test verifying species filtering accuracy
  * Added test for negative cache entry handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->