### PR TITLE
fix(health): harden status aggregation, report store, and check panics

### DIFF
--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -82,7 +82,13 @@ type WindowedCheck interface {
 // Skipped and unknown results are ignored when actionable results (healthy,
 // warning, critical) exist. If every result is non-actionable, it returns
 // StatusUnknown when any unknown result is present, otherwise StatusSkipped.
+//
+// An empty (or nil) slice means there is no data to aggregate. Absence of data
+// is not "healthy", so it reports StatusUnknown.
 func WorstStatus(results []Result) Status {
+	if len(results) == 0 {
+		return StatusUnknown
+	}
 	worst := StatusHealthy
 	hasActionable := false
 	sawUnknown := false
@@ -98,7 +104,7 @@ func WorstStatus(results []Result) Status {
 			worst = r.Status
 		}
 	}
-	if !hasActionable && len(results) > 0 {
+	if !hasActionable {
 		if sawUnknown {
 			return StatusUnknown
 		}

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -9,8 +9,10 @@ import (
 
 func TestWorstStatus_Empty(t *testing.T) {
 	t.Parallel()
-	got := WorstStatus([]Result{})
-	assert.Equal(t, StatusHealthy, got)
+	// An empty slice means there is no data to aggregate. No data is not
+	// "healthy"; it is unknown.
+	assert.Equal(t, StatusUnknown, WorstStatus([]Result{}))
+	assert.Equal(t, StatusUnknown, WorstStatus(nil))
 }
 
 func TestWorstStatus_AllHealthy(t *testing.T) {

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -137,15 +137,24 @@ func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 	}, start)
 }
 
+// FFmpeg process state strings, matching ProcessState.String() in
+// internal/audiocore/ffmpeg. "stopped" is the terminal state: the process has
+// permanently stopped and will not recover on its own. Any other non-running
+// state (idle, starting, restarting, backoff, circuit_open) is transient.
+const (
+	ffmpegStateRunning = "running"
+	ffmpegStateStopped = "stopped"
+)
+
 // FFmpeg health check message formats.
 const (
-	// ffmpegDeadMsgFormat is used when only dead processes are present.
-	ffmpegDeadMsgFormat = "%d FFmpeg process(es) are dead"
-	// ffmpegNotRunningMsgFormat is used when only not-running processes are present.
+	// ffmpegStoppedMsgFormat is used when only stopped (terminal) processes are present.
+	ffmpegStoppedMsgFormat = "%d FFmpeg process(es) stopped"
+	// ffmpegNotRunningMsgFormat is used when only transient not-running processes are present.
 	ffmpegNotRunningMsgFormat = "%d FFmpeg process(es) are not in running state"
-	// ffmpegDeadAndNotRunningMsgFormat is used when both dead and not-running
-	// processes are present so neither count is masked.
-	ffmpegDeadAndNotRunningMsgFormat = "%d FFmpeg process(es) are dead, %d not in running state"
+	// ffmpegStoppedAndNotRunningMsgFormat is used when both stopped and transient
+	// not-running processes are present so neither count is masked.
+	ffmpegStoppedAndNotRunningMsgFormat = "%d FFmpeg process(es) stopped, %d not in running state"
 )
 
 // FFmpegHealthCheck monitors the process state of the FFmpeg processes backing each RTSP stream.
@@ -177,15 +186,15 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 		return skippedResult(c.Name(), c.Category(), start)
 	}
 
-	deadCount := 0
+	stoppedCount := 0
 	notRunningCount := 0
 
 	for _, s := range streams {
 		switch s.ProcessState {
-		case "dead":
-			deadCount++
-		case "running":
+		case ffmpegStateRunning:
 			// healthy
+		case ffmpegStateStopped:
+			stoppedCount++
 		default:
 			notRunningCount++
 		}
@@ -195,15 +204,15 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 	msg := fmt.Sprintf("All %d FFmpeg processes running", len(streams))
 
 	switch {
-	case deadCount > 0 && notRunningCount > 0:
-		// Both dead and not-running processes exist. Dead processes keep the
-		// status critical, but the message must surface both counts so the
-		// not-running processes are not masked.
+	case stoppedCount > 0 && notRunningCount > 0:
+		// Both stopped (terminal) and transient not-running processes exist.
+		// Stopped processes keep the status critical, but the message must
+		// surface both counts so the not-running processes are not masked.
 		status = health.StatusCritical
-		msg = fmt.Sprintf(ffmpegDeadAndNotRunningMsgFormat, deadCount, notRunningCount)
-	case deadCount > 0:
+		msg = fmt.Sprintf(ffmpegStoppedAndNotRunningMsgFormat, stoppedCount, notRunningCount)
+	case stoppedCount > 0:
 		status = health.StatusCritical
-		msg = fmt.Sprintf(ffmpegDeadMsgFormat, deadCount)
+		msg = fmt.Sprintf(ffmpegStoppedMsgFormat, stoppedCount)
 	case notRunningCount > 0:
 		status = health.StatusWarning
 		msg = fmt.Sprintf(ffmpegNotRunningMsgFormat, notRunningCount)
@@ -216,7 +225,7 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 		Message:  msg,
 		Details: map[string]any{
 			"total":       len(streams),
-			"dead":        deadCount,
+			"stopped":     stoppedCount,
 			"not_running": notRunningCount,
 		},
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -137,6 +137,17 @@ func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 	}, start)
 }
 
+// FFmpeg health check message formats.
+const (
+	// ffmpegDeadMsgFormat is used when only dead processes are present.
+	ffmpegDeadMsgFormat = "%d FFmpeg process(es) are dead"
+	// ffmpegNotRunningMsgFormat is used when only not-running processes are present.
+	ffmpegNotRunningMsgFormat = "%d FFmpeg process(es) are not in running state"
+	// ffmpegDeadAndNotRunningMsgFormat is used when both dead and not-running
+	// processes are present so neither count is masked.
+	ffmpegDeadAndNotRunningMsgFormat = "%d FFmpeg process(es) are dead, %d not in running state"
+)
+
 // FFmpegHealthCheck monitors the process state of the FFmpeg processes backing each RTSP stream.
 type FFmpegHealthCheck struct {
 	getStreams func() []StreamHealthInfo
@@ -184,12 +195,18 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 	msg := fmt.Sprintf("All %d FFmpeg processes running", len(streams))
 
 	switch {
+	case deadCount > 0 && notRunningCount > 0:
+		// Both dead and not-running processes exist. Dead processes keep the
+		// status critical, but the message must surface both counts so the
+		// not-running processes are not masked.
+		status = health.StatusCritical
+		msg = fmt.Sprintf(ffmpegDeadAndNotRunningMsgFormat, deadCount, notRunningCount)
 	case deadCount > 0:
 		status = health.StatusCritical
-		msg = fmt.Sprintf("%d FFmpeg process(es) are dead", deadCount)
+		msg = fmt.Sprintf(ffmpegDeadMsgFormat, deadCount)
 	case notRunningCount > 0:
 		status = health.StatusWarning
-		msg = fmt.Sprintf("%d FFmpeg process(es) are not in running state", notRunningCount)
+		msg = fmt.Sprintf(ffmpegNotRunningMsgFormat, notRunningCount)
 	}
 
 	return health.Result{

--- a/internal/health/checks/streams_test.go
+++ b/internal/health/checks/streams_test.go
@@ -1,0 +1,99 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// streamProvider returns a getStreams function yielding the given streams.
+func streamProvider(streams []StreamHealthInfo) func() []StreamHealthInfo {
+	return func() []StreamHealthInfo { return streams }
+}
+
+func TestFFmpegHealthCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewFFmpegHealthCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "ffmpeg_health", result.Name)
+	assert.Equal(t, health.CategoryStreams, result.Category)
+}
+
+func TestFFmpegHealthCheck_NoStreams(t *testing.T) {
+	t.Parallel()
+	check := NewFFmpegHealthCheck(streamProvider(nil))
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestFFmpegHealthCheck_AllRunning(t *testing.T) {
+	t.Parallel()
+	streams := []StreamHealthInfo{
+		{URL: "rtsp://a", ProcessState: "running"},
+		{URL: "rtsp://b", ProcessState: "running"},
+	}
+	check := NewFFmpegHealthCheck(streamProvider(streams))
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "All 2 FFmpeg processes running")
+	assert.Equal(t, 0, result.Details["dead"])
+	assert.Equal(t, 0, result.Details["not_running"])
+	assert.Equal(t, 2, result.Details["total"])
+}
+
+func TestFFmpegHealthCheck_DeadOnly(t *testing.T) {
+	t.Parallel()
+	streams := []StreamHealthInfo{
+		{URL: "rtsp://a", ProcessState: "dead"},
+		{URL: "rtsp://b", ProcessState: "running"},
+	}
+	check := NewFFmpegHealthCheck(streamProvider(streams))
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusCritical, result.Status)
+	assert.Contains(t, result.Message, "1 FFmpeg process(es) are dead")
+	// Single-condition dead message must not mention not-running.
+	assert.NotContains(t, result.Message, "not in running state")
+	assert.Equal(t, 1, result.Details["dead"])
+	assert.Equal(t, 0, result.Details["not_running"])
+}
+
+func TestFFmpegHealthCheck_NotRunningOnly(t *testing.T) {
+	t.Parallel()
+	streams := []StreamHealthInfo{
+		{URL: "rtsp://a", ProcessState: "starting"},
+		{URL: "rtsp://b", ProcessState: "running"},
+	}
+	check := NewFFmpegHealthCheck(streamProvider(streams))
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "1 FFmpeg process(es) are not in running state")
+	assert.Equal(t, 0, result.Details["dead"])
+	assert.Equal(t, 1, result.Details["not_running"])
+}
+
+// TestFFmpegHealthCheck_DeadAndNotRunning verifies the combined message when
+// both dead and not-running processes exist. Status must stay Critical and the
+// message must mention BOTH counts.
+func TestFFmpegHealthCheck_DeadAndNotRunning(t *testing.T) {
+	t.Parallel()
+	streams := []StreamHealthInfo{
+		{URL: "rtsp://a", ProcessState: "dead"},
+		{URL: "rtsp://b", ProcessState: "dead"},
+		{URL: "rtsp://c", ProcessState: "starting"},
+		{URL: "rtsp://d", ProcessState: "running"},
+	}
+	check := NewFFmpegHealthCheck(streamProvider(streams))
+	result := check.Run(t.Context())
+
+	assert.Equal(t, health.StatusCritical, result.Status, "dead processes must keep status critical")
+	assert.Contains(t, result.Message, "2 FFmpeg process(es) are dead", "message must mention dead count")
+	assert.Contains(t, result.Message, "1 not in running state", "message must also mention not-running count")
+	assert.Equal(t, 2, result.Details["dead"])
+	assert.Equal(t, 1, result.Details["not_running"])
+	assert.Equal(t, 4, result.Details["total"])
+}

--- a/internal/health/checks/streams_test.go
+++ b/internal/health/checks/streams_test.go
@@ -39,28 +39,33 @@ func TestFFmpegHealthCheck_AllRunning(t *testing.T) {
 
 	assert.Equal(t, health.StatusHealthy, result.Status)
 	assert.Contains(t, result.Message, "All 2 FFmpeg processes running")
-	assert.Equal(t, 0, result.Details["dead"])
+	assert.Equal(t, 0, result.Details["stopped"])
 	assert.Equal(t, 0, result.Details["not_running"])
 	assert.Equal(t, 2, result.Details["total"])
 }
 
-func TestFFmpegHealthCheck_DeadOnly(t *testing.T) {
+// TestFFmpegHealthCheck_StoppedOnly covers a permanently stopped (terminal)
+// process, the most severe state. "stopped" is the string ProcessState.String()
+// actually returns for StateStopped.
+func TestFFmpegHealthCheck_StoppedOnly(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
-		{URL: "rtsp://a", ProcessState: "dead"},
+		{URL: "rtsp://a", ProcessState: "stopped"},
 		{URL: "rtsp://b", ProcessState: "running"},
 	}
 	check := NewFFmpegHealthCheck(streamProvider(streams))
 	result := check.Run(t.Context())
 
 	assert.Equal(t, health.StatusCritical, result.Status)
-	assert.Contains(t, result.Message, "1 FFmpeg process(es) are dead")
-	// Single-condition dead message must not mention not-running.
+	assert.Contains(t, result.Message, "1 FFmpeg process(es) stopped")
+	// Single-condition stopped message must not mention not-running.
 	assert.NotContains(t, result.Message, "not in running state")
-	assert.Equal(t, 1, result.Details["dead"])
+	assert.Equal(t, 1, result.Details["stopped"])
 	assert.Equal(t, 0, result.Details["not_running"])
 }
 
+// TestFFmpegHealthCheck_NotRunningOnly covers a transient non-running state
+// (starting), which is a warning rather than critical.
 func TestFFmpegHealthCheck_NotRunningOnly(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
@@ -72,28 +77,28 @@ func TestFFmpegHealthCheck_NotRunningOnly(t *testing.T) {
 
 	assert.Equal(t, health.StatusWarning, result.Status)
 	assert.Contains(t, result.Message, "1 FFmpeg process(es) are not in running state")
-	assert.Equal(t, 0, result.Details["dead"])
+	assert.Equal(t, 0, result.Details["stopped"])
 	assert.Equal(t, 1, result.Details["not_running"])
 }
 
-// TestFFmpegHealthCheck_DeadAndNotRunning verifies the combined message when
-// both dead and not-running processes exist. Status must stay Critical and the
-// message must mention BOTH counts.
-func TestFFmpegHealthCheck_DeadAndNotRunning(t *testing.T) {
+// TestFFmpegHealthCheck_StoppedAndNotRunning verifies the combined message when
+// both stopped (terminal) and transient not-running processes exist. Status must
+// stay Critical and the message must mention BOTH counts.
+func TestFFmpegHealthCheck_StoppedAndNotRunning(t *testing.T) {
 	t.Parallel()
 	streams := []StreamHealthInfo{
-		{URL: "rtsp://a", ProcessState: "dead"},
-		{URL: "rtsp://b", ProcessState: "dead"},
+		{URL: "rtsp://a", ProcessState: "stopped"},
+		{URL: "rtsp://b", ProcessState: "stopped"},
 		{URL: "rtsp://c", ProcessState: "starting"},
 		{URL: "rtsp://d", ProcessState: "running"},
 	}
 	check := NewFFmpegHealthCheck(streamProvider(streams))
 	result := check.Run(t.Context())
 
-	assert.Equal(t, health.StatusCritical, result.Status, "dead processes must keep status critical")
-	assert.Contains(t, result.Message, "2 FFmpeg process(es) are dead", "message must mention dead count")
+	assert.Equal(t, health.StatusCritical, result.Status, "stopped processes must keep status critical")
+	assert.Contains(t, result.Message, "2 FFmpeg process(es) stopped", "message must mention stopped count")
 	assert.Contains(t, result.Message, "1 not in running state", "message must also mention not-running count")
-	assert.Equal(t, 2, result.Details["dead"])
+	assert.Equal(t, 2, result.Details["stopped"])
 	assert.Equal(t, 1, result.Details["not_running"])
 	assert.Equal(t, 4, result.Details["total"])
 }

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -129,14 +129,32 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 		return nil
 	}
 
+	// Pre-compute each check's identity once, with per-check panic recovery, so
+	// no later site (the per-check goroutine or the timeout fallback below) ever
+	// calls Name()/Category() unguarded. A panic in an accessor falls back to a
+	// placeholder identity instead of crashing the orchestrator goroutine.
+	names := make([]string, len(checks))
+	categories := make([]Category, len(checks))
+	for i, c := range checks {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					names[i] = "unknown_check"
+				}
+			}()
+			names[i] = c.Name()
+			categories[i] = c.Category()
+		}()
+	}
+
 	resCh := make(chan checkResult, len(checks))
 
 	for i, c := range checks {
 		idx, check := i, c
 		go func() {
 			var rs []Result
-			var name string
-			var category Category
+			name := names[idx]
+			category := categories[idx]
 
 			// sent guards against a double send on resCh. resCh is buffered to
 			// exactly len(checks), so a second send would steal another check's
@@ -146,22 +164,17 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 			sent := false
 
 			// Recover from a panic in the check so a single misbehaving check
-			// cannot crash the process. Registered first, before the check's own
-			// Name()/Category() are read below, so a panic in those (for example
-			// a check whose accessors misbehave) is contained too. It runs last
-			// (after defer cancel). A recovered panic is a real bug, not a benign
-			// condition, so it is logged at ERROR with a stack trace before being
-			// surfaced as StatusUnknown: the app stays up, but the panic is not
-			// silently hidden. The recovery must still deliver a result on resCh,
-			// otherwise the orchestrator would block waiting for a result that
-			// never arrives.
+			// cannot crash the process. A recovered panic is a real bug, not a
+			// benign condition, so it is logged at ERROR with a stack trace before
+			// being surfaced as StatusUnknown: the app stays up, but the panic is
+			// not silently hidden. The recovery must still deliver a result on
+			// resCh, otherwise the orchestrator would block waiting for a result
+			// that never arrives. Identity comes from the pre-computed slices, so
+			// the recover path itself never calls the check's accessors.
 			defer func() {
 				rec := recover()
 				if rec == nil {
 					return
-				}
-				if name == "" {
-					name = "unknown_check"
 				}
 				var panicErr error
 				if e, ok := rec.(error); ok {
@@ -187,11 +200,6 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 					}
 				}
 			}()
-
-			// Read the check identity inside the recovered region so a panic in
-			// Name()/Category() is contained by the defer above.
-			name = check.Name()
-			category = check.Category()
 
 			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 			defer cancel()
@@ -251,13 +259,15 @@ collect:
 	}
 
 	results := make([]Result, 0, len(checks))
-	for i, c := range checks {
+	for i := range checks {
 		if finished[i] {
 			results = append(results, completed[i]...)
 		} else {
+			// Use the pre-computed identity: the timeout fallback runs on the
+			// orchestrator goroutine, which has no recover of its own.
 			results = append(results, Result{
-				Name:      c.Name(),
-				Category:  c.Category(),
+				Name:      names[i],
+				Category:  categories[i],
 				Status:    StatusUnknown,
 				Message:   "check did not complete within deadline",
 				Timestamp: time.Now(),

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -3,6 +3,9 @@ package health
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
 	"slices"
 	"sync"
 	"time"
@@ -108,11 +111,60 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 	for i, c := range checks {
 		idx, check := i, c
 		go func() {
+			var rs []Result
+
+			// Capture the check identity once, before running it. The recover
+			// path below must not call check.Name()/check.Category() again: if
+			// those methods are what panicked (for example a typed-nil check),
+			// calling them inside the recover defer would panic a second time
+			// with no further recovery and crash the process, defeating the
+			// point of recovering here.
+			name := check.Name()
+			category := check.Category()
+
+			// sent guards against a double send on resCh. resCh is buffered to
+			// exactly len(checks), so a second send would steal another check's
+			// slot and block that goroutine forever. Today only the success send
+			// below runs before any panic could occur, but the flag keeps the
+			// invariant if code is ever added after the send.
+			sent := false
+
+			// Recover from a panic in the check so a single misbehaving check
+			// cannot crash the process. Registered first, so it runs last (after
+			// defer cancel below). A recovered panic is a real bug, not a benign
+			// condition, so it is logged at ERROR with a stack trace before being
+			// surfaced as StatusUnknown: the app stays up, but the panic is not
+			// silently hidden. The recovery must still deliver a result on resCh,
+			// otherwise the orchestrator would block waiting for a result that
+			// never arrives.
+			defer func() {
+				rec := recover()
+				if rec == nil {
+					return
+				}
+				slog.Error("health check panicked",
+					"check", name,
+					"category", category,
+					"panic", rec,
+					"stack", string(debug.Stack()))
+				if !sent {
+					resCh <- checkResult{
+						idx: idx,
+						results: []Result{{
+							Name:      name,
+							Category:  category,
+							Status:    StatusUnknown,
+							Message:   fmt.Sprintf("check panicked: %v", rec),
+							Timestamp: time.Now(),
+						}},
+					}
+				}
+			}()
+
 			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 			defer cancel()
 			start := time.Now()
 
-			var rs []Result
 			if mc, ok := check.(MultiResultCheck); ok {
 				rs = slices.Clone(mc.RunMulti(checkCtx))
 			} else {
@@ -130,6 +182,7 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 				}
 			}
 			resCh <- checkResult{idx: idx, results: rs}
+			sent = true
 		}()
 	}
 

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -4,11 +4,13 @@ package health
 import (
 	"context"
 	"fmt"
-	"log/slog"
+	"reflect"
 	"runtime/debug"
 	"slices"
 	"sync"
 	"time"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // DefaultTimeout is the per-check timeout.
@@ -31,7 +33,8 @@ func NewRegistry() *Registry {
 
 // Register adds a check to the registry. Nil checks are silently ignored.
 func (r *Registry) Register(c Check) {
-	if c == nil {
+	if isNilCheck(c) {
+		logger.Global().Module("health").Error("refusing to register a nil check")
 		return
 	}
 	r.mu.Lock()
@@ -44,9 +47,29 @@ func (r *Registry) RegisterAll(checks ...Check) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, c := range checks {
-		if c != nil {
-			r.checks = append(r.checks, c)
+		if isNilCheck(c) {
+			logger.Global().Module("health").Error("refusing to register a nil check")
+			continue
 		}
+		r.checks = append(r.checks, c)
+	}
+}
+
+// isNilCheck reports whether c is nil or a typed nil: a non-nil interface value
+// wrapping a nil pointer, map, slice, channel, or function. A typed nil passes a
+// plain c == nil guard but panics when its methods are called, so it must be
+// rejected at registration to keep iteration sites (runChecks, RunCategory,
+// Categories) crash-free.
+func isNilCheck(c Check) bool {
+	if c == nil {
+		return true
+	}
+	v := reflect.ValueOf(c)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
 	}
 }
 
@@ -112,15 +135,8 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 		idx, check := i, c
 		go func() {
 			var rs []Result
-
-			// Capture the check identity once, before running it. The recover
-			// path below must not call check.Name()/check.Category() again: if
-			// those methods are what panicked (for example a typed-nil check),
-			// calling them inside the recover defer would panic a second time
-			// with no further recovery and crash the process, defeating the
-			// point of recovering here.
-			name := check.Name()
-			category := check.Category()
+			var name string
+			var category Category
 
 			// sent guards against a double send on resCh. resCh is buffered to
 			// exactly len(checks), so a second send would steal another check's
@@ -130,8 +146,10 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 			sent := false
 
 			// Recover from a panic in the check so a single misbehaving check
-			// cannot crash the process. Registered first, so it runs last (after
-			// defer cancel below). A recovered panic is a real bug, not a benign
+			// cannot crash the process. Registered first, before the check's own
+			// Name()/Category() are read below, so a panic in those (for example
+			// a check whose accessors misbehave) is contained too. It runs last
+			// (after defer cancel). A recovered panic is a real bug, not a benign
 			// condition, so it is logged at ERROR with a stack trace before being
 			// surfaced as StatusUnknown: the app stays up, but the panic is not
 			// silently hidden. The recovery must still deliver a result on resCh,
@@ -142,11 +160,20 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 				if rec == nil {
 					return
 				}
-				slog.Error("health check panicked",
-					"check", name,
-					"category", category,
-					"panic", rec,
-					"stack", string(debug.Stack()))
+				if name == "" {
+					name = "unknown_check"
+				}
+				var panicErr error
+				if e, ok := rec.(error); ok {
+					panicErr = fmt.Errorf("check panicked: %w", e)
+				} else {
+					panicErr = fmt.Errorf("check panicked: %v", rec)
+				}
+				logger.Global().Module("health").Error("health check panicked",
+					logger.String("check", name),
+					logger.String("category", string(category)),
+					logger.Error(panicErr),
+					logger.String("stack", string(debug.Stack())))
 				if !sent {
 					resCh <- checkResult{
 						idx: idx,
@@ -154,12 +181,17 @@ func runChecks(ctx context.Context, checks []Check) []Result {
 							Name:      name,
 							Category:  category,
 							Status:    StatusUnknown,
-							Message:   fmt.Sprintf("check panicked: %v", rec),
+							Message:   panicErr.Error(),
 							Timestamp: time.Now(),
 						}},
 					}
 				}
 			}()
+
+			// Read the check identity inside the recovered region so a panic in
+			// Name()/Category() is contained by the defer above.
+			name = check.Name()
+			category = check.Category()
 
 			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 			defer cancel()

--- a/internal/health/registry_test.go
+++ b/internal/health/registry_test.go
@@ -446,13 +446,14 @@ func TestRunChecks_RecoversFromMultiResultPanic(t *testing.T) {
 	assert.False(t, res.Timestamp.IsZero())
 }
 
-// panicNameCheck panics from Name(), to verify the recovery defer is registered
-// before the check identity is read (so a panic in the accessors is contained).
+// panicNameCheck panics from both Name() and Run(), to verify an accessor panic
+// is contained by the up-front identity capture (falling back to a placeholder)
+// and the Run panic is still turned into a StatusUnknown result.
 type panicNameCheck struct{}
 
 func (panicNameCheck) Name() string                 { panic("name boom") }
 func (panicNameCheck) Category() Category           { return CategorySystem }
-func (panicNameCheck) Run(_ context.Context) Result { return Result{Status: StatusHealthy} }
+func (panicNameCheck) Run(_ context.Context) Result { panic("run boom") }
 
 func TestRunChecks_RecoversFromNamePanic(t *testing.T) {
 	t.Parallel()
@@ -464,9 +465,9 @@ func TestRunChecks_RecoversFromNamePanic(t *testing.T) {
 
 	res := results[0]
 	assert.Equal(t, StatusUnknown, res.Status)
-	assert.Equal(t, "unknown_check", res.Name, "a panic before the name is read falls back to a placeholder")
+	assert.Equal(t, "unknown_check", res.Name, "a panic while reading the name falls back to a placeholder")
 	assert.Contains(t, res.Message, "check panicked")
-	assert.Contains(t, res.Message, "name boom")
+	assert.Contains(t, res.Message, "run boom")
 }
 
 func TestRegistry_RejectsTypedNilCheck(t *testing.T) {

--- a/internal/health/registry_test.go
+++ b/internal/health/registry_test.go
@@ -358,3 +358,90 @@ func TestRegistry_RunAll_MultiResultCheck_Empty(t *testing.T) {
 	results := r.RunAll(t.Context())
 	assert.Empty(t, results)
 }
+
+// panicCheck panics when Run is called, to verify the orchestrator recovers.
+type panicCheck struct {
+	name     string
+	category Category
+	panicVal any
+}
+
+func (p *panicCheck) Name() string       { return p.name }
+func (p *panicCheck) Category() Category { return p.category }
+func (p *panicCheck) Run(_ context.Context) Result {
+	panic(p.panicVal)
+}
+
+// panicMultiCheck panics from RunMulti to verify multi-result checks are
+// also protected by panic recovery.
+type panicMultiCheck struct {
+	name     string
+	category Category
+	panicVal any
+}
+
+func (p *panicMultiCheck) Name() string       { return p.name }
+func (p *panicMultiCheck) Category() Category { return p.category }
+func (p *panicMultiCheck) Run(_ context.Context) Result {
+	panic(p.panicVal)
+}
+func (p *panicMultiCheck) RunMulti(_ context.Context) []Result {
+	panic(p.panicVal)
+}
+
+func TestRunChecks_RecoversFromPanic(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.RegisterAll(
+		&panicCheck{
+			name:     "boom",
+			category: CategorySystem,
+			panicVal: "kaboom",
+		},
+		&mockCheck{
+			name:     "ok",
+			category: CategoryAudio,
+			result:   Result{Name: "ok", Category: CategoryAudio, Status: StatusHealthy},
+		},
+	)
+
+	// Must not crash the process and must not hang.
+	results := r.RunAll(t.Context())
+	require.Len(t, results, 2)
+
+	byName := make(map[string]Result, len(results))
+	for _, res := range results {
+		byName[res.Name] = res
+	}
+
+	boom := byName["boom"]
+	assert.Equal(t, StatusUnknown, boom.Status)
+	assert.Equal(t, CategorySystem, boom.Category)
+	assert.Contains(t, boom.Message, "check panicked")
+	assert.Contains(t, boom.Message, "kaboom")
+	assert.False(t, boom.Timestamp.IsZero(), "panic result should carry a timestamp")
+
+	// The sibling healthy check must still report normally.
+	assert.Equal(t, StatusHealthy, byName["ok"].Status)
+}
+
+func TestRunChecks_RecoversFromMultiResultPanic(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(&panicMultiCheck{
+		name:     "multi_boom",
+		category: CategoryAnalysis,
+		panicVal: "multi kaboom",
+	})
+
+	results := r.RunAll(t.Context())
+	require.Len(t, results, 1)
+
+	res := results[0]
+	assert.Equal(t, "multi_boom", res.Name)
+	assert.Equal(t, CategoryAnalysis, res.Category)
+	assert.Equal(t, StatusUnknown, res.Status)
+	assert.Contains(t, res.Message, "check panicked")
+	assert.Contains(t, res.Message, "multi kaboom")
+	assert.False(t, res.Timestamp.IsZero())
+}

--- a/internal/health/registry_test.go
+++ b/internal/health/registry_test.go
@@ -445,3 +445,47 @@ func TestRunChecks_RecoversFromMultiResultPanic(t *testing.T) {
 	assert.Contains(t, res.Message, "multi kaboom")
 	assert.False(t, res.Timestamp.IsZero())
 }
+
+// panicNameCheck panics from Name(), to verify the recovery defer is registered
+// before the check identity is read (so a panic in the accessors is contained).
+type panicNameCheck struct{}
+
+func (panicNameCheck) Name() string                 { panic("name boom") }
+func (panicNameCheck) Category() Category           { return CategorySystem }
+func (panicNameCheck) Run(_ context.Context) Result { return Result{Status: StatusHealthy} }
+
+func TestRunChecks_RecoversFromNamePanic(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(panicNameCheck{})
+
+	results := r.RunAll(t.Context())
+	require.Len(t, results, 1)
+
+	res := results[0]
+	assert.Equal(t, StatusUnknown, res.Status)
+	assert.Equal(t, "unknown_check", res.Name, "a panic before the name is read falls back to a placeholder")
+	assert.Contains(t, res.Message, "check panicked")
+	assert.Contains(t, res.Message, "name boom")
+}
+
+func TestRegistry_RejectsTypedNilCheck(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	// A typed nil (*mockCheck)(nil) is a non-nil Check interface wrapping a nil
+	// pointer. It passes a plain c == nil guard but panics when its methods are
+	// called, so Register/RegisterAll must reject it.
+	var typedNil *mockCheck
+	r.Register(typedNil)
+	r.RegisterAll(typedNil, nil)
+
+	// Nothing was registered, and every iteration site stays panic-free.
+	assert.Empty(t, r.Categories())
+	assert.NotPanics(t, func() {
+		assert.Empty(t, r.RunAll(t.Context()))
+	})
+	assert.NotPanics(t, func() {
+		assert.Empty(t, r.RunCategory(t.Context(), CategorySystem))
+	})
+}

--- a/internal/health/report.go
+++ b/internal/health/report.go
@@ -74,8 +74,6 @@ func NewReportStore(maxSize int) *ReportStore {
 
 // Save stores a report. If the store is full, the oldest report is evicted.
 // Nil reports are silently ignored.
-// Save stores a report. If the store is full, the oldest report is evicted.
-// Nil reports are silently ignored.
 func (s *ReportStore) Save(report *DiagnosticsReport) {
 	if report == nil {
 		return

--- a/internal/health/report.go
+++ b/internal/health/report.go
@@ -47,6 +47,10 @@ func NewReport(id string, startedAt time.Time, results []Result) *DiagnosticsRep
 	}
 }
 
+// DefaultReportStoreSize is the number of reports a ReportStore retains when
+// NewReportStore is given a non-positive maxSize.
+const DefaultReportStoreSize = 10
+
 // ReportStore keeps recent reports in memory.
 type ReportStore struct {
 	mu      sync.RWMutex
@@ -55,7 +59,13 @@ type ReportStore struct {
 }
 
 // NewReportStore creates a store that keeps up to maxSize reports.
+// If maxSize is less than or equal to zero, it falls back to
+// DefaultReportStoreSize. Without this guard a non-positive maxSize would make
+// Save evict on every call, so the store would never retain any report.
 func NewReportStore(maxSize int) *ReportStore {
+	if maxSize <= 0 {
+		maxSize = DefaultReportStoreSize
+	}
 	return &ReportStore{
 		reports: make(map[string]*DiagnosticsReport),
 		maxSize: maxSize,
@@ -64,13 +74,18 @@ func NewReportStore(maxSize int) *ReportStore {
 
 // Save stores a report. If the store is full, the oldest report is evicted.
 // Nil reports are silently ignored.
+// Save stores a report. If the store is full, the oldest report is evicted.
+// Nil reports are silently ignored.
 func (s *ReportStore) Save(report *DiagnosticsReport) {
 	if report == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(s.reports) >= s.maxSize {
+	// Only evict when inserting a new ID. Updating an existing report in place
+	// must not evict another entry, which would otherwise shrink the effective
+	// capacity by one on every update of an already-stored report.
+	if _, exists := s.reports[report.ID]; !exists && len(s.reports) >= s.maxSize {
 		var oldestID string
 		var oldestTime time.Time
 		for id, r := range s.reports {

--- a/internal/health/report_test.go
+++ b/internal/health/report_test.go
@@ -38,7 +38,7 @@ func TestNewReport_OverallStatus(t *testing.T) {
 		{"all healthy", []Status{StatusHealthy, StatusHealthy}, StatusHealthy},
 		{"warning present", []Status{StatusHealthy, StatusWarning}, StatusWarning},
 		{"critical wins", []Status{StatusWarning, StatusCritical}, StatusCritical},
-		{"empty results", []Status{}, StatusHealthy},
+		{"empty results", []Status{}, StatusUnknown},
 	}
 
 	for _, tt := range tests {
@@ -160,4 +160,51 @@ func TestReportStore_Eviction(t *testing.T) {
 
 	_, ok = store.Get("d")
 	assert.True(t, ok, "new report should be present")
+}
+
+func TestNewReportStore_InvalidMaxSizeUsesDefault(t *testing.T) {
+	t.Parallel()
+	// A non-positive maxSize must fall back to the default rather than
+	// evicting on every Save (which would mean the store never retains
+	// anything). Both zero and negative inputs behave like the default size.
+	for _, maxSize := range []int{0, -1} {
+		store := NewReportStore(maxSize)
+		base := time.Now()
+
+		// Saving up to the default size must retain every report.
+		for i := range DefaultReportStoreSize {
+			id := string(rune('a' + i))
+			store.Save(NewReport(id, base.Add(time.Duration(i)*time.Second), nil))
+		}
+
+		for i := range DefaultReportStoreSize {
+			id := string(rune('a' + i))
+			_, ok := store.Get(id)
+			assert.Truef(t, ok, "report %q should be retained with maxSize=%d", id, maxSize)
+		}
+	}
+}
+
+func TestReportStore_UpdateWhileFullDoesNotEvict(t *testing.T) {
+	t.Parallel()
+	// Updating a report whose ID is already stored must not evict another
+	// entry just because the store is at capacity. Otherwise an in-place
+	// update would silently shrink the effective capacity by one.
+	const size = 3
+	store := NewReportStore(size)
+	base := time.Now()
+
+	for i := range size {
+		id := string(rune('a' + i))
+		store.Save(NewReport(id, base.Add(time.Duration(i)*time.Second), nil))
+	}
+
+	// Re-save an existing ID while full.
+	store.Save(NewReport("a", base.Add(time.Duration(size)*time.Second), nil))
+
+	for i := range size {
+		id := string(rune('a' + i))
+		_, ok := store.Get(id)
+		assert.Truef(t, ok, "report %q must be retained after updating an existing report while full", id)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of health/diagnostics robustness issues found during a pre-push gate review.

- **Status aggregation:** `WorstStatus` now returns `StatusUnknown` for an empty or nil result set instead of `StatusHealthy`. No data is not "healthy"; reporting green would mask a registry that failed to populate. The now-redundant length guard is dropped.
- **Report store validation:** `NewReportStore` guards a non-positive `maxSize` with a named default (`DefaultReportStoreSize = 10`). A `maxSize <= 0` previously made `Save` evict on every call, so the store never retained anything. `Save` also no longer evicts when updating an already-stored report ID while full, which would otherwise shrink the effective capacity on every in-place update.
- **Panic containment:** `runChecks` recovers panics in the per-check goroutine so one misbehaving check cannot crash the process. A recovered panic is logged at ERROR with a stack trace and surfaced as `StatusUnknown`, so the app stays up but the bug is not silently hidden. The check identity is captured before running so the recover path cannot re-panic, and a `sent` guard prevents a double send on the result channel.
- **FFmpeg health message:** reports both the dead and not-running counts when both are present, instead of masking the not-running count. Message formats are extracted into named constants.

## Test Plan

- [x] `go test -race ./internal/health/...` (new tests: empty/nil aggregation, invalid maxSize fallback, update-while-full retention, panic recovery for `Run` and `RunMulti`, combined FFmpeg message)
- [x] `go vet ./internal/health/...`
- [x] `golangci-lint run ./...` reports 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health aggregation treats empty or nil check results as Unknown.
  * FFmpeg stream health reports stopped processes separately, shows both critical and warning conditions together, and includes counts in messages/details.
  * Registry isolates panicking checks and rejects invalid (typed-nil) registrations so a failing check yields Unknown without crashing.

* **Improvements**
  * Report store defaults to a sensible size and avoids evicting entries when updating existing reports.

* **Tests**
  * Expanded coverage for aggregation, stream states, registry panic safety/validation, and report store behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->