### PR TITLE
fix(telemetry): suppress Wikipedia rate-limit and circuit-breaker Sentry noise

### DIFF
--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -67,6 +67,25 @@ var (
 		"context deadline exceeded", // Upload/request timeout
 		"tls handshake timeout",
 		"eof", // Connection lost (e.g., MQTT broker disconnect)
+
+		// imageprovider Wikipedia rate-limit / circuit-breaker noise.
+		// Wikipedia rate-limits the image fetcher (HTTP 429) and the circuit
+		// breaker then throttles further calls, so forwarding a Sentry event for
+		// each rejected request is pure noise. These are built with CategoryNetwork
+		// in internal/imageprovider/wikipedia.go. The patterns are Wikipedia-specific
+		// full signatures (not loose substrings like "rate limit exceeded") so
+		// network-category errors from other components are never collaterally
+		// suppressed, matching the rtspSilenceTimeoutSignature approach above.
+		// HTTP 429 is purely environmental throttling so every occurrence is
+		// suppressed; 403/500/503 still report at least the first event because
+		// those can indicate a real problem (policy violation, server fault).
+		// Lowercase substrings of the real messages produced there:
+		//   - handleHTTPStatusError: "Wikipedia API returned status 429: <body>"
+		//   - checkCircuitBreaker:   "Wikipedia API circuit breaker open: <reason>"
+		//   - diagnostic path:       "Wikipedia rate limit exceeded: <message>"
+		"wikipedia api returned status 429",  // direct HTTP 429 from the API
+		"wikipedia api circuit breaker open", // repeated rejection while breaker is open
+		"wikipedia rate limit exceeded",      // diagnostic rate-limit error
 	}
 )
 
@@ -181,7 +200,7 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 	// Notification circuit-breaker open/half-open conditions are operational
 	// throttling state, not bugs. BirdWeather reuses the notification package's
 	// PushCircuitBreaker, whose sentinel ErrCircuitBreakerOpen is tagged with
-	// component="notification" regardless of the caller — so this single check
+	// component="notification" regardless of the caller, so this single check
 	// also covers BirdWeather's breaker-open errors. The breaker state transitions
 	// themselves are surfaced via the dedicated CircuitBreakerStateTransition
 	// telemetry path, so the per-call "circuit breaker is open" errors are pure
@@ -214,7 +233,7 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 		}
 	}
 
-	// Filter out "image not found" errors — expected when Wikipedia lacks an image for a species
+	// Filter out "image not found" errors, expected when Wikipedia lacks an image for a species
 	if ee.Category == CategoryImageFetch {
 		if strings.Contains(errorMsg, "image not found") {
 			return false
@@ -256,7 +275,7 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 		return false
 	}
 
-	// Rate-limit disk-full errors — a single root cause creates cascading
+	// Rate-limit disk-full errors: a single root cause creates cascading
 	// errors across many subsystems (database, FFmpeg, alerting, etc.)
 	if strings.Contains(errorMsg, "disk is full") ||
 		strings.Contains(errorMsg, "no space left on device") {

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -126,12 +126,84 @@ func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 	assert.True(t, shouldReportToSentry(ee))
 }
 
+// TestShouldReportToSentry_FiltersWikipediaRateLimitNoise verifies that the
+// imageprovider Wikipedia rate-limit (HTTP 429) and circuit-breaker-open
+// failures are suppressed. These are built with CategoryNetwork (see
+// internal/imageprovider/wikipedia.go: checkCircuitBreaker, handleHTTPStatusError,
+// handleCircuitBreaker, and the diagnostic rate-limit path). The circuit breaker
+// already throttles requests when Wikipedia rate-limits the client, so forwarding
+// a Sentry event for every rejected request is pure noise. The exact wordings
+// asserted here are real substrings of the messages those code paths produce,
+// lowercased to match how shouldReportToSentry compares against
+// networkNoisePatterns.
+func TestShouldReportToSentry_FiltersWikipediaRateLimitNoise(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantReport bool
+	}{
+		{
+			// Direct HTTP 429 from handleHTTPStatusError:
+			// "Wikipedia API returned status %d: %s". This is the original,
+			// highest-volume noise (the breaker has not opened yet). 429 is
+			// purely environmental throttling, so every occurrence is suppressed.
+			name:       "direct HTTP 429 is suppressed",
+			err:        fmt.Errorf("Wikipedia API returned status 429: too many requests"),
+			wantReport: false,
+		},
+		{
+			// Produced by checkCircuitBreaker: "Wikipedia API circuit breaker open: %s"
+			// (repeated per-call rejection while the breaker is open).
+			name:       "circuit breaker open rejection is suppressed",
+			err:        fmt.Errorf("Wikipedia API circuit breaker open: Rate limited (HTTP 429): too many requests"),
+			wantReport: false,
+		},
+		{
+			// Produced by the diagnostic path: "Wikipedia rate limit exceeded: %s"
+			name:       "rate limit exceeded diagnostic error is suppressed",
+			err:        fmt.Errorf("Wikipedia rate limit exceeded: Rate limit exceeded (HTTP 429)"),
+			wantReport: false,
+		},
+		{
+			// Regression guard: a genuine server-side failure in the same
+			// category must still reach Sentry so real bugs stay visible.
+			name:       "genuine HTTP 500 is still reported",
+			err:        fmt.Errorf("Wikipedia API returned status 500: internal server error"),
+			wantReport: true,
+		},
+		{
+			// Regression guard: a 403 user-agent policy violation is a real,
+			// actionable signal (not benign throttling) and must still report.
+			// This pins that the suppression is scoped to 429, not all statuses.
+			name:       "HTTP 403 policy violation is still reported",
+			err:        fmt.Errorf("Wikipedia API returned status 403: user-agent policy violation"),
+			wantReport: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ee := New(tt.err).
+				Component("imageprovider").
+				Category(CategoryNetwork).
+				Context("operation", "api_error").
+				Build()
+			got := shouldReportToSentry(ee)
+			assert.Equal(t, tt.wantReport, got,
+				"shouldReportToSentry(%q) = %v, want %v", tt.err, got, tt.wantReport)
+		})
+	}
+}
+
 // TestShouldReportToSentry_CategoryLimitNotificationOnly verifies that the
 // CategoryLimit suppression is scoped to the notification component. The
 // notification.PushCircuitBreaker's ErrCircuitBreakerOpen sentinel is tagged
 // component="notification", and that single sentinel is what every caller
 // (notification push providers AND birdweather uploads, which reuse the
-// same breaker) receives — so the notification-only filter suppresses both
+// same breaker) receives, so the notification-only filter suppresses both
 // in practice. Other CategoryLimit producers (eBird API quota, analysis job
 // queue full, spectrogram pre-render memory limits) are legitimate
 // operational signals that ops needs to see and must still reach Sentry.
@@ -258,7 +330,7 @@ func TestShouldReportToSentry_AllowsRTSPCodeBugs(t *testing.T) {
 }
 
 func TestShouldReportToSentry_RateLimitsDiskFull(t *testing.T) {
-	// Not parallel — mutates package-level state
+	// Not parallel: mutates package-level state
 	lastDiskFullReport.Store(0)
 	t.Cleanup(func() { lastDiskFullReport.Store(0) })
 
@@ -272,7 +344,7 @@ func TestShouldReportToSentry_RateLimitsDiskFull(t *testing.T) {
 }
 
 func TestShouldReportToSentry_DiskFullCooldownExpiry(t *testing.T) {
-	// Not parallel — mutates package-level state
+	// Not parallel: mutates package-level state
 	// Simulate a disk-full report from past the cooldown window
 	lastDiskFullReport.Store(time.Now().Unix() - diskFullCooldown - 1)
 	t.Cleanup(func() { lastDiskFullReport.Store(0) })


### PR DESCRIPTION
## Summary

The imageprovider builds Wikipedia HTTP 429 and circuit-breaker-open failures with `CategoryNetwork`. These are environment-origin and already throttled by the circuit breaker, so forwarding a Sentry event per rejected request is pure noise.

`shouldReportToSentry` now suppresses three Wikipedia-specific message signatures:
- the direct HTTP 429 (`"Wikipedia API returned status 429"`), the original, highest-volume noise,
- the breaker-open rejection (`"Wikipedia API circuit breaker open"`),
- the diagnostic rate-limit error (`"Wikipedia rate limit exceeded"`).

Using full Wikipedia-specific signatures rather than loose substrings keeps network-category errors from other components from being collaterally suppressed, matching the existing `rtspSilenceTimeoutSignature` approach in the same file. HTTP 429 is purely environmental so every occurrence is suppressed; 403/500/503 still report at least the first event because those can indicate a real problem (policy violation, server fault).

## Test Plan

- [x] `go test -race ./internal/errors/...` (new table-driven test: direct 429, breaker-open, and diagnostic paths suppressed; regression guards that HTTP 500 and HTTP 403 policy-violation errors still report)
- [x] `go vet ./internal/errors/...`
- [x] `golangci-lint run ./...` reports 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of network-related errors from external services to reduce noise in error reports while maintaining visibility of genuine failures.

* **Tests**
  * Added test coverage for enhanced error suppression rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->