### PR TITLE
chore(frontend): replace svelte-portal with the local portal action

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,8 +24,7 @@
         "hls.js": "^1.6.16",
         "maplibre-gl": "^5.23.0",
         "reconnecting-eventsource": "^1.6.5",
-        "svelte-dnd-action": "^0.9.69",
-        "svelte-portal": "^2.2.1"
+        "svelte-dnd-action": "^0.9.69"
       },
       "devDependencies": {
         "@ast-grep/cli": "^0.42.1",
@@ -9275,12 +9274,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/svelte-portal": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.1.tgz",
-      "integrity": "sha512-uF7is5sM4aq5iN7QF/67XLnTUvQCf2iiG/B1BHTqLwYVY1dsVmTeXZ/LeEyU6dLjApOQdbEG9lkqHzxiQtOLEQ==",
-      "license": "MIT"
     },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -141,8 +141,7 @@
     "hls.js": "^1.6.16",
     "maplibre-gl": "^5.23.0",
     "reconnecting-eventsource": "^1.6.5",
-    "svelte-dnd-action": "^0.9.69",
-    "svelte-portal": "^2.2.1"
+    "svelte-dnd-action": "^0.9.69"
   },
   "bundleDependencies": [
     "svelte"

--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -11,7 +11,7 @@
     - Positions below thumbnail when there's space
     - Positions above thumbnail when near bottom of viewport
     - Adjusts horizontally to stay within viewport bounds
-  - Uses svelte-portal to escape overflow containers
+  - Uses a local portal action to escape overflow containers
   - Handles image loading states and errors gracefully
   - Fully accessible with proper ARIA attributes
   - Responsive design that works on mobile (tap to show)
@@ -28,7 +28,7 @@
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import type { ImageAttribution } from '$lib/types/detection.types';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
-  import Portal from 'svelte-portal';
+  import { portal } from '$lib/utils/portal';
   import { dropdown } from '$lib/utils/transitions';
   import { Image } from '@lucide/svelte';
 
@@ -211,120 +211,116 @@
 
   <!-- Popup overlay -->
   {#if showPopup}
-    <Portal>
-      <div
-        bind:this={popupElement}
-        id="bird-popup"
-        in:dropdown
-        out:dropdown={{ duration: 100 }}
-        class="fixed z-50 bg-[var(--color-base-100)] border border-[var(--color-base-300)] rounded-lg shadow-xl p-4"
-        style:left="{popupX}px"
-        style:top="{popupY}px"
-        style:width="320px"
-        role="tooltip"
-        aria-live="polite"
-      >
-        <!-- Popup content -->
-        <div class="space-y-3">
-          <!-- Species information header -->
-          <div class="text-center space-y-1">
-            <h3 class="font-semibold text-[var(--color-base-content)] text-sm leading-tight">
-              {commonName}
-            </h3>
-            <p
-              class="text-xs italic"
-              style:color="color-mix(in srgb, var(--color-base-content) 70%, transparent)"
-            >
-              {scientificName}
-            </p>
-          </div>
-
-          <!-- Large image container -->
-          <div
-            class="relative w-full aspect-[4/3] bg-[var(--color-base-200)] rounded-lg overflow-hidden"
+    <div
+      bind:this={popupElement}
+      use:portal
+      id="bird-popup"
+      in:dropdown
+      out:dropdown={{ duration: 100 }}
+      class="fixed z-50 bg-[var(--color-base-100)] border border-[var(--color-base-300)] rounded-lg shadow-xl p-4"
+      style:left="{popupX}px"
+      style:top="{popupY}px"
+      style:width="320px"
+      role="tooltip"
+      aria-live="polite"
+    >
+      <!-- Popup content -->
+      <div class="space-y-3">
+        <!-- Species information header -->
+        <div class="text-center space-y-1">
+          <h3 class="font-semibold text-[var(--color-base-content)] text-sm leading-tight">
+            {commonName}
+          </h3>
+          <p
+            class="text-xs italic"
+            style:color="color-mix(in srgb, var(--color-base-content) 70%, transparent)"
           >
-            {#if !imageLoaded && !imageError}
-              <!-- Loading state -->
-              <div class="absolute inset-0 flex items-center justify-center">
-                <div class="loading loading-spinner loading-md"></div>
-              </div>
-            {/if}
-
-            {#if imageError}
-              <!-- Error state -->
-              <div
-                class="absolute inset-0 flex flex-col items-center justify-center"
-                style:color="color-mix(in srgb, var(--color-base-content) 50%, transparent)"
-              >
-                <Image class="size-8 mb-2" />
-                <p class="text-xs text-center">Image not available</p>
-              </div>
-            {:else}
-              <!-- Large image -->
-              <img
-                src={thumbnailUrl}
-                alt={`Large view of ${commonName}`}
-                class="w-full h-full object-contain transition-opacity duration-200"
-                class:opacity-0={!imageLoaded}
-                class:opacity-100={imageLoaded}
-                onload={handleImageLoad}
-                onerror={handleImageError}
-              />
-            {/if}
-
-            <!-- Photo credit overlay -->
-            {#if imageAttribution?.authorName && imageLoaded}
-              <div
-                class="thumbnail-credit"
-                aria-label="Image credit: {imageAttribution.authorName}"
-              >
-                <span class="credit-text">{imageAttribution.authorName}</span>
-                {#if imageAttribution.licenseName}
-                  <span class="credit-separator">·</span>
-                  {#if imageAttribution.licenseURL}
-                    <a
-                      href={imageAttribution.licenseURL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="credit-license">{imageAttribution.licenseName}</a
-                    >
-                  {:else}
-                    <span class="credit-license">{imageAttribution.licenseName}</span>
-                  {/if}
-                {/if}
-              </div>
-            {/if}
-          </div>
-
-          <!-- Action hint -->
-          <div class="text-center">
-            <p
-              class="text-xs"
-              style:color="color-mix(in srgb, var(--color-base-content) 50%, transparent)"
-            >
-              Click to view detections
-            </p>
-          </div>
+            {scientificName}
+          </p>
         </div>
 
-        <!-- Popup arrow pointing to trigger -->
-        {#if popupPosition === 'below'}
-          <!-- Arrow at top of popup -->
-          <div
-            class="absolute w-3 h-3 bg-[var(--color-base-100)] border-l border-t border-[var(--color-base-300)] rotate-45 -z-10"
-            style:left="20px"
-            style:top="-6px"
-          ></div>
-        {:else}
-          <!-- Arrow at bottom of popup -->
-          <div
-            class="absolute w-3 h-3 bg-[var(--color-base-100)] border-r border-b border-[var(--color-base-300)] rotate-45 -z-10"
-            style:left="20px"
-            style:bottom="-6px"
-          ></div>
-        {/if}
+        <!-- Large image container -->
+        <div
+          class="relative w-full aspect-[4/3] bg-[var(--color-base-200)] rounded-lg overflow-hidden"
+        >
+          {#if !imageLoaded && !imageError}
+            <!-- Loading state -->
+            <div class="absolute inset-0 flex items-center justify-center">
+              <div class="loading loading-spinner loading-md"></div>
+            </div>
+          {/if}
+
+          {#if imageError}
+            <!-- Error state -->
+            <div
+              class="absolute inset-0 flex flex-col items-center justify-center"
+              style:color="color-mix(in srgb, var(--color-base-content) 50%, transparent)"
+            >
+              <Image class="size-8 mb-2" />
+              <p class="text-xs text-center">Image not available</p>
+            </div>
+          {:else}
+            <!-- Large image -->
+            <img
+              src={thumbnailUrl}
+              alt={`Large view of ${commonName}`}
+              class="w-full h-full object-contain transition-opacity duration-200"
+              class:opacity-0={!imageLoaded}
+              class:opacity-100={imageLoaded}
+              onload={handleImageLoad}
+              onerror={handleImageError}
+            />
+          {/if}
+
+          <!-- Photo credit overlay -->
+          {#if imageAttribution?.authorName && imageLoaded}
+            <div class="thumbnail-credit" aria-label="Image credit: {imageAttribution.authorName}">
+              <span class="credit-text">{imageAttribution.authorName}</span>
+              {#if imageAttribution.licenseName}
+                <span class="credit-separator">·</span>
+                {#if imageAttribution.licenseURL}
+                  <a
+                    href={imageAttribution.licenseURL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="credit-license">{imageAttribution.licenseName}</a
+                  >
+                {:else}
+                  <span class="credit-license">{imageAttribution.licenseName}</span>
+                {/if}
+              {/if}
+            </div>
+          {/if}
+        </div>
+
+        <!-- Action hint -->
+        <div class="text-center">
+          <p
+            class="text-xs"
+            style:color="color-mix(in srgb, var(--color-base-content) 50%, transparent)"
+          >
+            Click to view detections
+          </p>
+        </div>
       </div>
-    </Portal>
+
+      <!-- Popup arrow pointing to trigger -->
+      {#if popupPosition === 'below'}
+        <!-- Arrow at top of popup -->
+        <div
+          class="absolute w-3 h-3 bg-[var(--color-base-100)] border-l border-t border-[var(--color-base-300)] rotate-45 -z-10"
+          style:left="20px"
+          style:top="-6px"
+        ></div>
+      {:else}
+        <!-- Arrow at bottom of popup -->
+        <div
+          class="absolute w-3 h-3 bg-[var(--color-base-100)] border-r border-b border-[var(--color-base-300)] rotate-45 -z-10"
+          style:left="20px"
+          style:bottom="-6px"
+        ></div>
+      {/if}
+    </div>
   {/if}
 </div>
 

--- a/frontend/src/lib/utils/portal.test.ts
+++ b/frontend/src/lib/utils/portal.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { portal } from './portal';
+
+describe('portal action', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('re-parents the node to document.body by default', () => {
+    const parent = document.createElement('div');
+    const node = document.createElement('span');
+    parent.appendChild(node);
+    document.body.appendChild(parent);
+
+    portal(node);
+
+    expect(node.parentNode).toBe(document.body);
+    expect(parent.contains(node)).toBe(false);
+  });
+
+  it('removes the node from the DOM on destroy', () => {
+    const node = document.createElement('div');
+    const action = portal(node);
+
+    expect(document.body.contains(node)).toBe(true);
+
+    action.destroy();
+
+    expect(document.body.contains(node)).toBe(false);
+  });
+
+  it('re-parents the node to an explicit target element', () => {
+    const target = document.createElement('section');
+    document.body.appendChild(target);
+    const node = document.createElement('div');
+
+    const action = portal(node, target);
+
+    expect(node.parentNode).toBe(target);
+
+    action.destroy();
+
+    expect(target.contains(node)).toBe(false);
+  });
+
+  it('does not remove the node on destroy if it was re-parented elsewhere', () => {
+    const target = document.createElement('section');
+    const other = document.createElement('aside');
+    document.body.append(target, other);
+    const node = document.createElement('div');
+
+    const action = portal(node, target);
+    // Simulate the node being moved to a different container after mount.
+    other.appendChild(node);
+
+    expect(() => action.destroy()).not.toThrow();
+    // The guard only removes when still attached to the original target,
+    // so the relocated node is left untouched.
+    expect(other.contains(node)).toBe(true);
+  });
+});

--- a/frontend/vitest.integration.config.ts
+++ b/frontend/vitest.integration.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   // Pre-bundle dependencies that are imported by app components to prevent
   // Vite from triggering a mid-test page reload when it discovers them.
   optimizeDeps: {
-    include: ['reconnecting-eventsource', '@lucide/svelte', 'hls.js', 'svelte-portal'],
+    include: ['reconnecting-eventsource', '@lucide/svelte', 'hls.js'],
   },
   server: {
     proxy: {


### PR DESCRIPTION
## What

Removes the `svelte-portal` runtime dependency, continuing the frontend supply-chain reduction effort.

A local `portal` action already lives in `src/lib/utils/portal.ts` (re-parents a node to a target, default `document.body`, on mount; removes it on destroy) and is already used by `SelectDropdown.svelte`. The only `svelte-portal` consumer, `BirdThumbnailPopup.svelte`, now uses that same local action, so no new action code was needed.

- **`BirdThumbnailPopup.svelte`**: swap `import Portal from 'svelte-portal'` for `import { portal } from '$lib/utils/portal'`, and apply `use:portal` to the `#bird-popup` element instead of wrapping it in `<Portal>`. The popup is `position: fixed` with viewport coordinates and was already portaled to `document.body`, so DOM topology and visible behavior are unchanged; this only drops svelte-portal's redundant wrapper `<div>`.
- **`portal.test.ts`** (new): the action had no test coverage and is now used in two places. Covers mount re-parenting, destroy removal, explicit targets, and the "only remove if still attached to the original target" guard.
- **`package.json`**: remove `svelte-portal`.

## Why

Fewer external npm runtime dependencies means less supply-chain attack surface. This replaces a third-party component with an existing, already-vendored local action.

## Note on the diff size

The large `BirdThumbnailPopup.svelte` diff is almost entirely Prettier reindenting the popup block after one level of nesting (`<Portal>`) was removed. The functional change is three lines: the import, the `use:portal` directive, and dropping the wrapper.

## Verification

- `npm run check:all` passes (typecheck 0 errors / 0 warnings).
- `npm run build` succeeds.
- `npm run test:ci` passes: 1972 tests across 108 files, including the 4 new portal-action tests.
- No `svelte-portal` references remain in `src/` or `package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed an external portal package and replaced it with a local portal action, preserving popup and tooltip behavior.
* **Tests**
  * Added tests verifying the new portal action’s mounting, re-parenting, and teardown behaviors, including edge cases.
* **Chores**
  * Updated test tooling configuration and dependency list to reflect the removal of the external portal package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->