### PR TITLE
fix(autotls): persist Let's Encrypt certificates across restarts

### DIFF
--- a/Docker/docker-compose.autotls.yml
+++ b/Docker/docker-compose.autotls.yml
@@ -20,9 +20,10 @@ services:
       # - BIRDNET_SENSITIVITY=1.0
       # - BIRDNET_OVERLAP=1.5
     volumes:
+      # AutoTLS (Let's Encrypt) certificates are cached under /config/tls-acme,
+      # so they persist across restarts via this bind mount.
       - ./config:/config
       - ./data:/data
-      - ./certs:/certs  # For Let's Encrypt certificates
     # Mount HLS stream segment files directory as tmpfs (RAM disk)
     tmpfs:
       - /config/hls:exec,size=50M,uid=${BIRDNET_UID:-1000},gid=${BIRDNET_GID:-1000},mode=0755
@@ -58,6 +59,4 @@ volumes:
   config:
     driver: local
   data:
-    driver: local
-  certs:
     driver: local

--- a/Docker/docker-compose.autotls.yml
+++ b/Docker/docker-compose.autotls.yml
@@ -54,9 +54,3 @@ services:
   #   #   - ./cloudflared:/etc/cloudflared
   #   depends_on:
   #     - birdnet-go
-      
-volumes:
-  config:
-    driver: local
-  data:
-    driver: local

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -611,8 +611,8 @@ func (s *Server) startBlocking() error {
 		// Without this, Echo's AutoTLSManager has no storage backend and certs
 		// are lost on every shutdown, triggering a fresh ACME request each time
 		// and quickly exhausting Let's Encrypt's rate limit.
-		if configPaths, pathErr := conf.GetDefaultConfigPaths(); pathErr == nil && len(configPaths) > 0 {
-			cacheDir := filepath.Join(configPaths[0], "tls-acme")
+		if configFile, pathErr := conf.FindConfigFile(); pathErr == nil {
+			cacheDir := filepath.Join(filepath.Dir(configFile), "tls-acme")
 			s.echo.AutoTLSManager.Cache = autocert.DirCache(cacheDir)
 			s.slogger.Info("AutoTLS certificate cache configured", logger.String("path", cacheDir))
 		} else {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/security"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 // ImageDataFs holds the embedded image provider data filesystem.
@@ -604,6 +606,21 @@ func (s *Server) startBlocking() error {
 	case s.config.AutoTLS:
 		// AutoTLS with Let's Encrypt
 		s.slogger.Info("Starting with AutoTLS (Let's Encrypt)")
+		// Configure persistent cert cache so certificates survive restarts.
+		// Without this, Echo's AutoTLSManager has no storage backend and certs
+		// are lost on every shutdown, triggering a fresh ACME request each time
+		// and quickly exhausting Let's Encrypt's rate limit.
+		if configPaths, pathErr := conf.GetDefaultConfigPaths(); pathErr == nil {
+			cacheDir := filepath.Join(configPaths[0], "tls-acme")
+			s.echo.AutoTLSManager.Cache = autocert.DirCache(cacheDir)
+			s.slogger.Info("AutoTLS certificate cache configured", logger.String("path", cacheDir))
+		} else {
+			s.slogger.Warn("Could not determine config path for AutoTLS cache; certificates will not persist across restarts",
+				logger.Error(pathErr))
+		}
+		if s.settings.Security.Host != "" {
+			s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(s.settings.Security.Host)
+		}
 		err = s.echo.StartAutoTLS(addr)
 	case s.config.TLSEnabled:
 		// Manual/Self-signed TLS: HTTPS on TLSPort, HTTP stays on configured port

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/security"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
+
 	"golang.org/x/crypto/acme/autocert"
 )
 
@@ -610,16 +611,16 @@ func (s *Server) startBlocking() error {
 		// Without this, Echo's AutoTLSManager has no storage backend and certs
 		// are lost on every shutdown, triggering a fresh ACME request each time
 		// and quickly exhausting Let's Encrypt's rate limit.
-		if configFile, pathErr := conf.FindConfigFile(); pathErr == nil {
-			cacheDir := filepath.Join(filepath.Dir(configFile), "tls-acme")
+		if configPaths, pathErr := conf.GetDefaultConfigPaths(); pathErr == nil && len(configPaths) > 0 {
+			cacheDir := filepath.Join(configPaths[0], "tls-acme")
 			s.echo.AutoTLSManager.Cache = autocert.DirCache(cacheDir)
 			s.slogger.Info("AutoTLS certificate cache configured", logger.String("path", cacheDir))
 		} else {
 			s.slogger.Warn("Could not determine config path for AutoTLS cache; certificates will not persist across restarts",
 				logger.Error(pathErr))
 		}
-		if s.settings.Security.Host != "" {
-			s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(s.settings.Security.Host)
+		if h := s.settings.Security.GetHostnameForCertificates(); h != "" {
+			s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(h)
 		}
 		err = s.echo.StartAutoTLS(addr)
 	case s.config.TLSEnabled:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -610,8 +610,8 @@ func (s *Server) startBlocking() error {
 		// Without this, Echo's AutoTLSManager has no storage backend and certs
 		// are lost on every shutdown, triggering a fresh ACME request each time
 		// and quickly exhausting Let's Encrypt's rate limit.
-		if configPaths, pathErr := conf.GetDefaultConfigPaths(); pathErr == nil {
-			cacheDir := filepath.Join(configPaths[0], "tls-acme")
+		if configFile, pathErr := conf.FindConfigFile(); pathErr == nil {
+			cacheDir := filepath.Join(filepath.Dir(configFile), "tls-acme")
 			s.echo.AutoTLSManager.Cache = autocert.DirCache(cacheDir)
 			s.slogger.Info("AutoTLS certificate cache configured", logger.String("path", cacheDir))
 		} else {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -596,6 +596,10 @@ func (s *Server) Start() {
 	}
 }
 
+// autoTLSCacheDirName is the subdirectory under the config directory where
+// AutoTLS (Let's Encrypt) certificates are cached so they survive restarts.
+const autoTLSCacheDirName = "tls-acme"
+
 // startBlocking begins serving HTTP requests and blocks until the server is shut down.
 func (s *Server) startBlocking() error {
 	addr := s.config.Address()
@@ -612,16 +616,27 @@ func (s *Server) startBlocking() error {
 		// are lost on every shutdown, triggering a fresh ACME request each time
 		// and quickly exhausting Let's Encrypt's rate limit.
 		if configFile, pathErr := conf.FindConfigFile(); pathErr == nil {
-			cacheDir := filepath.Join(filepath.Dir(configFile), "tls-acme")
+			cacheDir := filepath.Join(filepath.Dir(configFile), autoTLSCacheDirName)
 			s.echo.AutoTLSManager.Cache = autocert.DirCache(cacheDir)
 			s.slogger.Info("AutoTLS certificate cache configured", logger.String("path", cacheDir))
 		} else {
 			s.slogger.Warn("Could not determine config path for AutoTLS cache; certificates will not persist across restarts",
 				logger.Error(pathErr))
 		}
-		if h := s.settings.Security.GetHostnameForCertificates(); h != "" {
-			s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(h)
+		// Restrict ACME issuance to the configured hostname. A nil HostPolicy
+		// lets autocert request a certificate for any SNI presented, which on a
+		// public host is a Let's Encrypt rate-limit exhaustion vector. Config
+		// validation (validateTLSMode) already requires a hostname for AutoTLS,
+		// so an empty value here means validation was bypassed: fail closed
+		// rather than start with an open policy.
+		host := s.settings.Security.GetHostnameForCertificates()
+		if host == "" {
+			return errors.Newf("AutoTLS enabled but no hostname configured; set security.host or a hostname in security.baseURL").
+				Category(errors.CategoryValidation).
+				Context("operation", "configure-autotls-host-policy").
+				Build()
 		}
+		s.echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(host)
 		err = s.echo.StartAutoTLS(addr)
 	case s.config.TLSEnabled:
 		// Manual/Self-signed TLS: HTTPS on TLSPort, HTTP stays on configured port


### PR DESCRIPTION
## Summary

- Restores `DirCache` and `HostPolicy` configuration on `AutoTLSManager` before calling `StartAutoTLS`, which were present in the legacy `httpcontroller` but not carried over when the HTTP server was rewritten in #1596 (December 2025)
- Without a cache backend, certificates lived in process memory only and were lost on every restart, triggering a fresh ACME request each time and quickly hitting Let's Encrypt's rate limit (5 duplicate certificates per rolling 7-day window)
- Certificates are now persisted to `<configDir>/tls-acme/` and survive restarts

## Root cause

`internal/httpcontroller/server.go` previously configured the autocert manager explicitly:

```go
s.Echo.AutoTLSManager.Cache = autocert.DirCache(configPaths[0])
s.Echo.AutoTLSManager.HostPolicy = autocert.HostWhitelist(s.Settings.Security.Host)
```

The new `internal/api/server.go` (introduced in #1596) just calls `s.echo.StartAutoTLS(addr)` with no cache or host policy configured. Echo's `AutoTLSManager` defaults to no storage backend, so every restart discards the certificate.

## Changes

- `FindConfigFile()` used for cache dir — resolves the active config file (honouring `--config` / `viper.ConfigFileUsed()`) and places `tls-acme/` next to it; falls back to a warning if no config path can be determined
- `GetHostnameForCertificates()` used for host policy (handles `BaseURL`-only configs, not just `Security.Host`)
- `golang.org/x/crypto/acme/autocert` import separated into its own group

## Test plan

- [ ] Enable AutoTLS with a valid `security.host` and accessible port 443
- [ ] Confirm `<configDir>/tls-acme/` is created and contains cert files after first startup
- [ ] Restart the server and confirm HTTPS works immediately without a new ACME request
- [x] Confirm the `tls-acme/` directory is not created when `tlsMode` is not `autotls`

## Preflight Status

Ran full 5-pass preflight review (Reuse, Correctness, Quality, i18n, Wiring). Three findings addressed in a follow-up commit:

| Finding | Action |
|---------|--------|
| Cache dir location on first run / custom `--config` | Settled on `FindConfigFile()` — respects `--config` and `viper.ConfigFileUsed()`, with graceful fallback when no config path resolves. (An interim switch to `GetDefaultConfigPaths()[0]` was reverted because it ignores custom config paths.) |
| `Security.Host` skips BaseURL-only configs | Replaced with `GetHostnameForCertificates()` |
| `golang.org/x/crypto` in wrong import group | Separated into own group |

`golangci-lint run ./internal/api/...` passes with no new warnings from changed lines.

Closes #3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic HTTPS via Let's Encrypt with persistent on-disk certificate caching so certificates survive restarts.
  * Configurable host-policy whitelist to restrict which hostnames may obtain certificates when a hostname is set.

* **Bug Fixes**
  * Startup now warns if a persistent cache path cannot be determined, noting certificates won’t persist across restarts.

* **Chores**
  * Docker compose updated to use the app's config directory for certificate caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
