### PR TITLE
fix: route geomodel-shaped ONNX range filter through the mapped path (fail-open fix)

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -76,6 +76,7 @@
     Bird,
     CalendarClock,
     Activity,
+    TriangleAlert,
   } from '@lucide/svelte';
   import { toastActions } from '$lib/stores/toast';
 
@@ -214,6 +215,34 @@
     data: null,
     locationNotConfigured: false,
     initialized: false,
+  });
+
+  // Range-filter health, fetched from /api/v2/range/status. Surfaces the silent
+  // fail-open and fallback states from the range-filter robustness fixes so the user
+  // is never unknowingly running unfiltered or with the wrong filter.
+  let rangeFilterHealth = $state<{
+    active: boolean;
+    fellBack: boolean;
+    geomodelActive: boolean;
+    mappedSpecies: number;
+    locationConfigured: boolean;
+  } | null>(null);
+
+  // Derived banner descriptor for the Active tab. Null when the range filter is healthy
+  // (or not applicable because no location is configured).
+  let rangeFilterWarning = $derived.by(() => {
+    const h = rangeFilterHealth;
+    if (!h || !h.locationConfigured) return null;
+    if (!h.active) {
+      return { level: 'error' as const, key: 'inactive' as const };
+    }
+    if (h.fellBack) {
+      return { level: 'warning' as const, key: 'fellBack' as const };
+    }
+    if (h.geomodelActive && h.mappedSpecies === 0) {
+      return { level: 'warning' as const, key: 'mappedZero' as const };
+    }
+    return null;
   });
 
   // Search/filter/expand state is now handled inside SpeciesTable component
@@ -588,9 +617,14 @@
     if (!locationConfigured) {
       activeSpeciesState.loading = false;
       activeSpeciesState.data = null;
+      rangeFilterHealth = null;
       isLoadingActiveSpecies = false;
       return;
     }
+
+    // Fetch range-filter health alongside the species list so the Active tab can warn
+    // about a fail-open or fallback state. Independent of the species fetch below.
+    void loadRangeFilterStatus();
 
     try {
       const response = await api.post<{
@@ -653,6 +687,30 @@
     } finally {
       activeSpeciesState.loading = false;
       isLoadingActiveSpecies = false;
+    }
+  }
+
+  // Fetch range-filter health from the status endpoint. Failures are non-fatal: the
+  // banner simply does not render if the status cannot be read.
+  async function loadRangeFilterStatus() {
+    try {
+      const status = await api.get<{
+        active: boolean;
+        fellBack: boolean;
+        mappedSpecies: number;
+        locationConfigured: boolean;
+        geomodel: { version: string } | null;
+      }>('/api/v2/range/status');
+      rangeFilterHealth = {
+        active: status.active,
+        fellBack: status.fellBack,
+        geomodelActive: status.geomodel != null,
+        mappedSpecies: status.mappedSpecies,
+        locationConfigured: status.locationConfigured,
+      };
+    } catch (error) {
+      logger.error('Failed to load range filter status:', error);
+      rangeFilterHealth = null;
     }
   }
 
@@ -1014,9 +1072,58 @@
   ]);
 </script>
 
+<!-- Range-filter health banner: surfaces fail-open / fallback / no-match states -->
+{#snippet rangeFilterHealthBanner(isError: boolean, title: string, description: string)}
+  <div
+    role="alert"
+    class="p-4 rounded-lg border {isError
+      ? 'bg-[color-mix(in_srgb,var(--color-error)_10%,transparent)] border-[color-mix(in_srgb,var(--color-error)_20%,transparent)]'
+      : 'bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border-[color-mix(in_srgb,var(--color-warning)_20%,transparent)]'}"
+  >
+    <div class="flex items-start gap-3">
+      <TriangleAlert
+        class="w-5 h-5 shrink-0 mt-0.5 {isError
+          ? 'text-[var(--color-error)]'
+          : 'text-[var(--color-warning)]'}"
+      />
+      <div>
+        <p
+          class="font-medium {isError
+            ? 'text-[var(--color-error)]'
+            : 'text-[var(--color-warning)]'}"
+        >
+          {title}
+        </p>
+        <p class="text-sm text-muted mt-1">{description}</p>
+      </div>
+    </div>
+  </div>
+{/snippet}
+
 <!-- Active Species Tab Content -->
 {#snippet activeTabContent()}
   <div class="space-y-4">
+    <!-- Range filter health warning (fail-open, fallback, or no species matched) -->
+    {#if rangeFilterWarning?.key === 'inactive'}
+      {@render rangeFilterHealthBanner(
+        true,
+        t('settings.species.activeSpecies.rangeFilterHealth.inactive.title'),
+        t('settings.species.activeSpecies.rangeFilterHealth.inactive.description')
+      )}
+    {:else if rangeFilterWarning?.key === 'fellBack'}
+      {@render rangeFilterHealthBanner(
+        false,
+        t('settings.species.activeSpecies.rangeFilterHealth.fellBack.title'),
+        t('settings.species.activeSpecies.rangeFilterHealth.fellBack.description')
+      )}
+    {:else if rangeFilterWarning?.key === 'mappedZero'}
+      {@render rangeFilterHealthBanner(
+        false,
+        t('settings.species.activeSpecies.rangeFilterHealth.mappedZero.title'),
+        t('settings.species.activeSpecies.rangeFilterHealth.mappedZero.description')
+      )}
+    {/if}
+
     <!-- Stats Bar -->
     {#if activeSpeciesState.data}
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3535,6 +3535,20 @@
           "description": "Nastavte svou polohu v Hlavních nastaveních, abyste viděli druhy dostupné ve vaší oblasti. Filtr rozsahu používá vaši polohu k určení, které druhy se pravděpodobně vyskytují v okolí.",
           "action": "Nakonfigurovat polohu"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filtr rozsahu je neaktivní",
+            "description": "Detekce nejsou momentálně filtrovány podle vaší polohy, takže mohou být hlášeny i druhy mimo vaši oblast. Zkontrolujte konfiguraci modelu filtru rozsahu v Nastavení."
+          },
+          "fellBack": {
+            "title": "Používá se vestavěný filtr rozsahu",
+            "description": "Nakonfigurovaný filtr rozsahu geomodelu se nepodařilo načíst, takže BirdNET-Go přešel na vestavěný filtr rozsahu. Filtrování stále funguje, ale zkontrolujte Nastavení, abyste obnovili geomodel."
+          },
+          "mappedZero": {
+            "title": "Filtr rozsahu neodpovídá žádnému druhu",
+            "description": "Filtr rozsahu geomodelu neodpovídá žádnému z druhů aktivního modelu, takže by byla odfiltrována každá detekce. Zkontrolujte, zda soubor štítků filtru rozsahu odpovídá aktivnímu modelu."
+          }
+        },
         "columns": {
           "commonName": "Název",
           "scientificName": "Vědecký název",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3535,6 +3535,20 @@
           "description": "Indstil din placering under Hovedindstillinger for at se arter tilgængelige i dit område. Områdefilteret bruger din placering til at bestemme, hvilke arter der sandsynligvis findes i nærheden.",
           "action": "Konfigurer placering"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Områdefilter inaktivt",
+            "description": "Detektioner filtreres lige nu ikke efter din placering, så arter fra områder uden for dit eget kan blive rapporteret. Kontrollér indstillingerne for områdefiltermodellen under Indstillinger."
+          },
+          "fellBack": {
+            "title": "Bruger det indbyggede områdefilter",
+            "description": "Det konfigurerede områdefilter med geomodel kunne ikke indlæses, så BirdNET-Go faldt tilbage til det indbyggede områdefilter. Filtreringen virker stadig, men kontrollér Indstillinger for at gendanne geomodellen."
+          },
+          "mappedZero": {
+            "title": "Områdefilteret matchede ingen arter",
+            "description": "Områdefilteret med geomodel matchede ingen af den aktive models arter, så alle detektioner ville blive filtreret fra. Kontrollér, at områdefilterets labelfil passer til den aktive model."
+          }
+        },
         "columns": {
           "commonName": "Almindeligt navn",
           "scientificName": "Videnskabeligt navn",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3535,6 +3535,20 @@
           "description": "Legen Sie Ihren Standort in den Haupteinstellungen fest, um Arten in Ihrer Umgebung zu sehen. Der Bereichsfilter verwendet Ihren Standort, um zu bestimmen, welche Arten in der Nähe wahrscheinlich vorkommen.",
           "action": "Standort konfigurieren"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Bereichsfilter inaktiv",
+            "description": "Erkennungen werden derzeit nicht nach Ihrem Standort gefiltert, daher können auch Arten von außerhalb Ihrer Umgebung gemeldet werden. Überprüfen Sie die Bereichsfilter-Modellkonfiguration in den Haupteinstellungen."
+          },
+          "fellBack": {
+            "title": "Eingebauter Bereichsfilter wird verwendet",
+            "description": "Der konfigurierte Geomodell-Bereichsfilter konnte nicht geladen werden, daher hat BirdNET-Go auf den eingebauten Bereichsfilter zurückgegriffen. Die Filterung funktioniert weiterhin, aber überprüfen Sie die Haupteinstellungen, um das Geomodell wiederherzustellen."
+          },
+          "mappedZero": {
+            "title": "Bereichsfilter hat keine Arten gefunden",
+            "description": "Der Geomodell-Bereichsfilter stimmte mit keiner der Arten des aktiven Modells überein, daher würde jede Erkennung herausgefiltert. Stellen Sie sicher, dass die Bereichsfilter-Labeldatei zum aktiven Modell passt."
+          }
+        },
         "columns": {
           "commonName": "Name",
           "scientificName": "Wissenschaftlicher Name",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3535,6 +3535,20 @@
           "description": "Set your location in Main Settings to see species available in your area. The range filter uses your location to determine which species are likely to be found nearby.",
           "action": "Configure Location"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Range filter inactive",
+            "description": "Detections are not being filtered by your location right now, so species from outside your area can be reported. Check the range filter model configuration in Settings."
+          },
+          "fellBack": {
+            "title": "Using the built-in range filter",
+            "description": "The configured geomodel range filter could not be loaded, so BirdNET-Go fell back to the built-in range filter. Filtering still works, but check Settings to restore the geomodel."
+          },
+          "mappedZero": {
+            "title": "Range filter matched no species",
+            "description": "The geomodel range filter did not match any of the active model's species, so every detection would be filtered out. Check that the range filter labels file matches the active model."
+          }
+        },
         "columns": {
           "commonName": "Common Name",
           "scientificName": "Scientific Name",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3535,6 +3535,20 @@
           "description": "Configura tu ubicación en Ajustes Principales para ver las especies disponibles en tu área. El filtro de rango utiliza tu ubicación para determinar qué especies es probable encontrar cerca.",
           "action": "Configurar ubicación"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filtro de rango inactivo",
+            "description": "Las detecciones no se están filtrando según tu ubicación en este momento, por lo que se pueden notificar especies de fuera de tu área. Revisa la configuración del modelo de filtro de rango en Ajustes."
+          },
+          "fellBack": {
+            "title": "Usando el filtro de rango integrado",
+            "description": "No se pudo cargar el filtro de rango del geomodelo configurado, por lo que BirdNET-Go recurrió al filtro de rango integrado. El filtrado sigue funcionando, pero revisa Ajustes para restaurar el geomodelo."
+          },
+          "mappedZero": {
+            "title": "El filtro de rango no coincidió con ninguna especie",
+            "description": "El filtro de rango del geomodelo no coincidió con ninguna de las especies del modelo activo, por lo que se filtraría toda detección. Comprueba que el archivo de etiquetas del filtro de rango coincide con el modelo activo."
+          }
+        },
         "columns": {
           "commonName": "Nombre común",
           "scientificName": "Nombre científico",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3535,6 +3535,20 @@
           "description": "Määritä sijaintisi pääasetuksissa nähdäksesi alueellasi esiintyvät lajit. Aluesuodatin käyttää sijaintiasi määrittääkseen, mitkä lajit todennäköisesti esiintyvät lähistölläsi.",
           "action": "Määritä sijainti"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Aluesuodatin ei ole käytössä",
+            "description": "Havaintoja ei tällä hetkellä suodateta sijaintisi perusteella, joten myös alueesi ulkopuolisia lajeja voidaan raportoida. Tarkista aluesuodattimen mallin asetukset Asetukset-sivulta."
+          },
+          "fellBack": {
+            "title": "Käytössä sisäänrakennettu aluesuodatin",
+            "description": "Määritettyä geomallin aluesuodatinta ei voitu ladata, joten BirdNET-Go siirtyi käyttämään sisäänrakennettua aluesuodatinta. Suodatus toimii edelleen, mutta tarkista Asetukset-sivulta, miten saat geomallin takaisin käyttöön."
+          },
+          "mappedZero": {
+            "title": "Aluesuodatin ei vastannut yhtäkään lajia",
+            "description": "Geomallin aluesuodatin ei vastannut yhtäkään aktiivisen mallin lajia, joten kaikki havainnot suodatettaisiin pois. Tarkista, että aluesuodattimen nimiötiedosto vastaa aktiivista mallia."
+          }
+        },
         "columns": {
           "commonName": "Nimi",
           "scientificName": "Tieteellinen nimi",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3535,6 +3535,20 @@
           "description": "Définissez votre emplacement dans les Paramètres Principaux pour voir les espèces disponibles dans votre région. Le filtre de portée utilise votre emplacement pour déterminer quelles espèces sont susceptibles d'être présentes à proximité.",
           "action": "Configurer l'emplacement"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filtre de portée inactif",
+            "description": "Les détections ne sont pas filtrées selon votre emplacement pour le moment, des espèces extérieures à votre région peuvent donc être signalées. Vérifiez la configuration du modèle de filtre de portée dans les Paramètres."
+          },
+          "fellBack": {
+            "title": "Utilisation du filtre de portée intégré",
+            "description": "Le filtre de portée du géomodèle configuré n'a pas pu être chargé, BirdNET-Go s'est donc rabattu sur le filtre de portée intégré. Le filtrage fonctionne toujours, mais vérifiez les Paramètres pour restaurer le géomodèle."
+          },
+          "mappedZero": {
+            "title": "Le filtre de portée n'a correspondu à aucune espèce",
+            "description": "Le filtre de portée du géomodèle ne correspond à aucune des espèces du modèle actif, toutes les détections seraient donc filtrées. Vérifiez que le fichier d'étiquettes du filtre de portée correspond au modèle actif."
+          }
+        },
         "columns": {
           "commonName": "Nom commun",
           "scientificName": "Nom scientifique",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3535,6 +3535,20 @@
           "description": "Állítsa be a helyszínét a Fő beállításokban a környékén elérhető fajok megtekintéséhez. A tartomány szűrő az Ön helyszíne alapján határozza meg, mely fajok valószínűsíthetők a közelben.",
           "action": "Helyszín konfigurálása"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "A tartomány szűrő nem aktív",
+            "description": "A detektálásokat jelenleg nem szűri a helyszíned, így a területeden kívüli fajok is jelentésre kerülhetnek. Ellenőrizd a tartomány szűrő modell beállítását a Beállítások oldalon."
+          },
+          "fellBack": {
+            "title": "A beépített tartomány szűrő használata",
+            "description": "A beállított geomodell tartomány szűrőt nem sikerült betölteni, ezért a BirdNET-Go a beépített tartomány szűrőre váltott. A szűrés továbbra is működik, de a geomodell visszaállításához ellenőrizd a Beállítások oldalt."
+          },
+          "mappedZero": {
+            "title": "A tartomány szűrő egyetlen fajra sem illeszkedett",
+            "description": "A geomodell tartomány szűrő az aktív modell egyetlen fajára sem illeszkedett, így minden detektálás kiszűrésre kerülne. Ellenőrizd, hogy a tartomány szűrő címkefájlja megegyezik-e az aktív modellel."
+          }
+        },
         "columns": {
           "commonName": "Közhasználatú név",
           "scientificName": "Tudományos név",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3535,6 +3535,20 @@
           "description": "Imposta la tua posizione in Impostazioni Principali per vedere specie disponibili nella tua area. Il filtro intervallo usa la tua posizione per determinare quali specie sono probabilmente presenti nelle vicinanze.",
           "action": "Configura Posizione"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filtro intervallo inattivo",
+            "description": "Al momento i rilevamenti non vengono filtrati in base alla tua posizione, quindi possono essere segnalate specie esterne alla tua zona. Controlla la configurazione del modello del filtro intervallo nelle Impostazioni."
+          },
+          "fellBack": {
+            "title": "Uso del filtro intervallo integrato",
+            "description": "Non è stato possibile caricare il filtro intervallo del geomodello configurato, quindi BirdNET-Go è ricorso al filtro intervallo integrato. Il filtraggio funziona ancora, ma controlla le Impostazioni per ripristinare il geomodello."
+          },
+          "mappedZero": {
+            "title": "Il filtro intervallo non ha trovato corrispondenze con nessuna specie",
+            "description": "Il filtro intervallo del geomodello non corrisponde a nessuna delle specie del modello attivo, quindi ogni rilevamento verrebbe filtrato. Verifica che il file delle etichette del filtro intervallo corrisponda al modello attivo."
+          }
+        },
         "columns": {
           "commonName": "Nome comune",
           "scientificName": "Nome scientifico",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3535,6 +3535,20 @@
           "description": "Iestatiet savu atrašanās vietu galvenajos iestatījumos, lai redzētu jūsu apkārtnē pieejamās sugas. Diapazona filtrs izmanto jūsu atrašanās vietu, lai noteiktu, kuras sugas, visticamāk, atrodamas tuvumā.",
           "action": "Konfigurēt atrašanās vietu"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Areāla filtrs nav aktīvs",
+            "description": "Noteikšanas pašlaik netiek filtrētas pēc jūsu atrašanās vietas, tāpēc var tikt ziņots arī par sugām, kas sastopamas ārpus jūsu apgabala. Pārbaudiet areāla filtra modeļa konfigurāciju Iestatījumu lapā."
+          },
+          "fellBack": {
+            "title": "Tiek izmantots iebūvētais areāla filtrs",
+            "description": "Konfigurēto ģeomodeļa areāla filtru neizdevās ielādēt, tāpēc BirdNET-Go pārslēdzās uz iebūvēto areāla filtru. Filtrēšana joprojām darbojas, taču pārbaudiet Iestatījumu lapu, lai atjaunotu ģeomodeli."
+          },
+          "mappedZero": {
+            "title": "Areāla filtrs neatbilda nevienai sugai",
+            "description": "Ģeomodeļa areāla filtrs neatbilda nevienai aktīvā modeļa sugai, tāpēc tiktu izfiltrētas visas noteikšanas. Pārbaudiet, vai areāla filtra etiķešu fails atbilst aktīvajam modelim."
+          }
+        },
         "columns": {
           "commonName": "Parastais nosaukums",
           "scientificName": "Zinātniskais nosaukums",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3535,6 +3535,20 @@
           "description": "Stel uw locatie in bij Hoofdinstellingen om soorten in uw omgeving te zien. Het bereikfilter gebruikt uw locatie om te bepalen welke soorten waarschijnlijk in de buurt voorkomen.",
           "action": "Locatie configureren"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Bereikfilter inactief",
+            "description": "Detecties worden op dit moment niet gefilterd op basis van uw locatie, dus soorten van buiten uw omgeving kunnen worden gemeld. Controleer de configuratie van het bereikfiltermodel in Hoofdinstellingen."
+          },
+          "fellBack": {
+            "title": "Ingebouwd bereikfilter wordt gebruikt",
+            "description": "Het geconfigureerde geomodel-bereikfilter kon niet worden geladen, dus BirdNET-Go is teruggevallen op het ingebouwde bereikfilter. Het filteren werkt nog steeds, maar controleer Hoofdinstellingen om het geomodel te herstellen."
+          },
+          "mappedZero": {
+            "title": "Bereikfilter kwam met geen enkele soort overeen",
+            "description": "Het geomodel-bereikfilter kwam met geen enkele soort van het actieve model overeen, dus elke detectie zou worden weggefilterd. Controleer of het labelbestand van het bereikfilter overeenkomt met het actieve model."
+          }
+        },
         "columns": {
           "commonName": "Naam",
           "scientificName": "Wetenschappelijke naam",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3535,6 +3535,20 @@
           "description": "Ustaw swoją lokalizację w Ustawieniach Głównych, aby zobaczyć gatunki dostępne w Twojej okolicy. Filtr zasięgu wykorzystuje Twoją lokalizację do określenia, które gatunki prawdopodobnie występują w pobliżu.",
           "action": "Skonfiguruj lokalizację"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filtr zasięgu jest nieaktywny",
+            "description": "Wykrycia nie są obecnie filtrowane według Twojej lokalizacji, więc mogą być zgłaszane gatunki spoza Twojej okolicy. Sprawdź konfigurację modelu filtra zasięgu w Ustawieniach."
+          },
+          "fellBack": {
+            "title": "Używany jest wbudowany filtr zasięgu",
+            "description": "Nie udało się załadować skonfigurowanego filtra zasięgu geomodelu, więc BirdNET-Go przełączył się na wbudowany filtr zasięgu. Filtrowanie nadal działa, ale sprawdź Ustawienia, aby przywrócić geomodel."
+          },
+          "mappedZero": {
+            "title": "Filtr zasięgu nie dopasował żadnego gatunku",
+            "description": "Filtr zasięgu geomodelu nie dopasował żadnego z gatunków aktywnego modelu, więc każde wykrycie zostałoby odfiltrowane. Sprawdź, czy plik etykiet filtra zasięgu odpowiada aktywnemu modelowi."
+          }
+        },
         "columns": {
           "commonName": "Nazwa",
           "scientificName": "Nazwa naukowa",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3535,6 +3535,20 @@
           "description": "Defina sua localização nas Configurações Principais para ver as espécies disponíveis na sua área. O filtro de alcance usa sua localização para determinar quais espécies provavelmente serão encontradas nas proximidades.",
           "action": "Configurar localização"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filtro de alcance inativo",
+            "description": "As deteções não estão a ser filtradas pela sua localização neste momento, pelo que podem ser comunicadas espécies de fora da sua área. Verifique a configuração do modelo de filtro de alcance nas Configurações."
+          },
+          "fellBack": {
+            "title": "A usar o filtro de alcance integrado",
+            "description": "Não foi possível carregar o filtro de alcance do geomodelo configurado, pelo que o BirdNET-Go recorreu ao filtro de alcance integrado. A filtragem continua a funcionar, mas verifique as Configurações para restaurar o geomodelo."
+          },
+          "mappedZero": {
+            "title": "O filtro de alcance não correspondeu a nenhuma espécie",
+            "description": "O filtro de alcance do geomodelo não correspondeu a nenhuma das espécies do modelo ativo, pelo que todas as deteções seriam filtradas. Verifique se o ficheiro de etiquetas do filtro de alcance corresponde ao modelo ativo."
+          }
+        },
         "columns": {
           "commonName": "Nome comum",
           "scientificName": "Nome científico",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3535,6 +3535,20 @@
           "description": "Nastavte svoju polohu v Hlavných nastaveniach, aby ste videli druhy dostupné vo vašej oblasti. Filter rozsahu používa vašu polohu na určenie toho, ktoré druhy sa pravdepodobne nachádzajú v blízkosti.",
           "action": "Konfigurovať polohu"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Filter rozsahu je neaktívny",
+            "description": "Detekcie momentálne nie sú filtrované podľa vašej polohy, takže môžu byť hlásené aj druhy mimo vašej oblasti. Skontrolujte konfiguráciu modelu filtra rozsahu v Nastaveniach."
+          },
+          "fellBack": {
+            "title": "Používa sa vstavaný filter rozsahu",
+            "description": "Nakonfigurovaný filter rozsahu geomodelu sa nepodarilo načítať, takže BirdNET-Go prešiel na vstavaný filter rozsahu. Filtrovanie stále funguje, ale skontrolujte Nastavenia, aby ste obnovili geomodel."
+          },
+          "mappedZero": {
+            "title": "Filter rozsahu nezodpovedá žiadnemu druhu",
+            "description": "Filter rozsahu geomodelu nezodpovedá žiadnemu z druhov aktívneho modelu, takže by sa odfiltrovala každá detekcia. Skontrolujte, či súbor štítkov filtra rozsahu zodpovedá aktívnemu modelu."
+          }
+        },
         "columns": {
           "commonName": "Názov",
           "scientificName": "Vedecký názov",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3535,6 +3535,20 @@
           "description": "Ange din plats i Huvudinställningar för att se arter tillgängliga i ditt område. Intervallfiltret använder din plats för att avgöra vilka arter som sannolikt finns i närheten.",
           "action": "Konfigurera plats"
         },
+        "rangeFilterHealth": {
+          "inactive": {
+            "title": "Områdesfiltret är inaktivt",
+            "description": "Detektioner filtreras just nu inte efter din plats, så arter från områden utanför ditt eget kan rapporteras. Kontrollera inställningarna för områdesfiltermodellen under Inställningar."
+          },
+          "fellBack": {
+            "title": "Använder det inbyggda områdesfiltret",
+            "description": "Det konfigurerade områdesfiltret med geomodell kunde inte laddas, så BirdNET-Go gick tillbaka till det inbyggda områdesfiltret. Filtreringen fungerar fortfarande, men kontrollera Inställningar för att återställa geomodellen."
+          },
+          "mappedZero": {
+            "title": "Områdesfiltret matchade inga arter",
+            "description": "Områdesfiltret med geomodell matchade inga av den aktiva modellens arter, så alla detektioner skulle filtreras bort. Kontrollera att områdesfiltrets etikettfil stämmer överens med den aktiva modellen."
+          }
+        },
         "columns": {
           "commonName": "Vanligt namn",
           "scientificName": "Vetenskapligt namn",

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -118,6 +118,20 @@ func (c *Controller) registerHealthChecks() {
 			status := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
 			return status.Available, status.Initialized, status.Version, status.LibraryPath, status.Error
 		}),
+		checks.NewRangeFilterCheck(func() checks.RangeFilterStatusInfo {
+			orch, err := c.getBirdNETInstance()
+			if err != nil || orch == nil {
+				return checks.RangeFilterStatusInfo{}
+			}
+			st := orch.RangeFilterStatus()
+			return checks.RangeFilterStatusInfo{
+				LocationConfigured: st.LocationConfigured,
+				Active:             st.Active,
+				FellBack:           st.FellBack,
+				GeomodelActive:     st.Geomodel != nil,
+				MappedSpecies:      st.MappedSpecies,
+			}
+		}),
 
 		// Stream checks
 		checks.NewStreamConnectivityCheck(getStreamHealthInfos),

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -43,18 +43,22 @@ type speciesCacheEntry struct {
 
 // BirdNET struct represents the BirdNET model with interpreters and configuration.
 type BirdNET struct {
-	classifier       inference.Classifier  // species classification backend
-	rangeFilter      inference.RangeFilter // geographic range filter backend (may be nil)
-	Settings         *conf.Settings
-	ModelInfo        ModelInfo           // Information about the current model
-	TaxonomyMap      TaxonomyMap         // Mapping of species codes to names and vice versa
-	ScientificIndex  ScientificNameIndex // Index for fast scientific name lookups
-	TaxonomyPath     string              // Path to custom taxonomy file, if used
-	modelVersion     string              // Human-readable model version string (per-instance to avoid shared global state)
-	modelsDir        string              // base directory for gallery-installed models (set by Orchestrator)
-	mu               sync.Mutex
-	resultsBuffer    []datastore.Results // Pre-allocated buffer for results to reduce allocations
-	confidenceBuffer []float32           // Pre-allocated buffer for confidence values to reduce allocations
+	classifier  inference.Classifier  // species classification backend
+	rangeFilter inference.RangeFilter // geographic range filter backend (may be nil)
+	// rangeFilterFellBack is true when the configured ONNX geomodel could not be loaded
+	// and the classifier fell back to its embedded TFLite range filter. Read for health
+	// reporting; guarded by mu alongside rangeFilter.
+	rangeFilterFellBack bool
+	Settings            *conf.Settings
+	ModelInfo           ModelInfo           // Information about the current model
+	TaxonomyMap         TaxonomyMap         // Mapping of species codes to names and vice versa
+	ScientificIndex     ScientificNameIndex // Index for fast scientific name lookups
+	TaxonomyPath        string              // Path to custom taxonomy file, if used
+	modelVersion        string              // Human-readable model version string (per-instance to avoid shared global state)
+	modelsDir           string              // base directory for gallery-installed models (set by Orchestrator)
+	mu                  sync.Mutex
+	resultsBuffer       []datastore.Results // Pre-allocated buffer for results to reduce allocations
+	confidenceBuffer    []float32           // Pre-allocated buffer for confidence values to reduce allocations
 
 	// Species occurrence cache to avoid repeated GetProbableSpecies calls within same day
 	speciesCacheMu sync.RWMutex
@@ -275,8 +279,7 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 }
 
 // getMetaModelData returns the appropriate meta model data based on the settings.
-func (bn *BirdNET) getMetaModelData() ([]byte, error) {
-	settings := bn.currentSettings()
+func (bn *BirdNET) getMetaModelData(settings *conf.Settings) ([]byte, error) {
 	rf := settings.BirdNET.RangeFilter
 
 	// Check if external model path is specified
@@ -355,6 +358,52 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 // Auto-selection of the v3 geomodel is used only for local routing; settings are
 // NOT published here. The caller (ensureGeomodelConfig, applyConfigForInstall)
 // is responsible for persisting config after the backend is confirmed working.
+// rangeFilterBackend identifies which range-filter implementation a config resolves to.
+type rangeFilterBackend int
+
+const (
+	// rangeFilterBackendTFLite uses the classifier's embedded TFLite MData range filter.
+	rangeFilterBackendTFLite rangeFilterBackend = iota
+	// rangeFilterBackendONNXStrict uses an ONNX range filter whose output dimension must
+	// match the classifier label count (no companion labels file).
+	rangeFilterBackendONNXStrict
+	// rangeFilterBackendMappedGeomodel uses the ONNX geomodel with its own labels file and
+	// name-matches its scores onto the classifier labels (mappedRangeFilter).
+	rangeFilterBackendMappedGeomodel
+)
+
+// resolveRangeFilterBackend decides which range-filter backend a config resolves to.
+//
+// A geomodel-shaped ONNX config routes through the name-matching mapped path so a
+// difference between the geomodel's output dimension (e.g. 12,012 species) and the
+// classifier's label count (e.g. ~6,559 for BirdNET v2.4) is resolved by scientific-name
+// matching instead of failing as a fatal LabelCountError. A config is geomodel-shaped
+// when rangefilter.model is "v3" or when an ONNX model path is paired with a companion
+// labels file (rangefilter.labelspath), which is the documented discriminator for "the
+// geomodel differs from the classifier labels". An ONNX model path without a companion
+// labels file keeps the strict path, where the model output must match the classifier
+// labels one-to-one. Everything else uses the classifier's embedded TFLite range filter.
+func resolveRangeFilterBackend(rf *conf.RangeFilterSettings) rangeFilterBackend {
+	if rf.Model == "v3" {
+		return rangeFilterBackendMappedGeomodel
+	}
+	if isONNXModel(rf.ModelPath) {
+		if rf.LabelsPath != "" {
+			return rangeFilterBackendMappedGeomodel
+		}
+		return rangeFilterBackendONNXStrict
+	}
+	return rangeFilterBackendTFLite
+}
+
+// hasNativeRangeFilter reports whether the active classifier ships with an embedded
+// native range filter to fall back to when an ONNX geomodel cannot be loaded. Only
+// BirdNET v2.4 (TFLite backend) carries the embedded MData range filter; Perch v2 and
+// BirdNET v3.0 (ONNX backends) rely solely on the geomodel.
+func (bn *BirdNET) hasNativeRangeFilter() bool {
+	return bn.ModelInfo.Backend == BackendTFLite
+}
+
 func (bn *BirdNET) initializeMetaModel() error {
 	log := GetLogger()
 	settings := bn.currentSettings()
@@ -367,42 +416,76 @@ func (bn *BirdNET) initializeMetaModel() error {
 		logger.String("classifier", bn.ModelInfo.ID),
 		logger.String("models_dir", bn.modelsDir))
 
+	// Reset fallback state so reloads recompute it from scratch.
+	bn.rangeFilterFellBack = false
+
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
 	// Only applies locally for routing; does NOT publish settings to avoid
 	// inconsistency if the backend fails to initialize.
 	if rf.Model == "" && bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
 		localSettings := conf.CloneSettings(settings)
 		applyAutoSelectedGeomodelPaths(localSettings, bn.modelsDir)
-		rf = localSettings.BirdNET.RangeFilter
+		settings = localSettings
+		rf = settings.BirdNET.RangeFilter
 		log.Info("Auto-selected v3.0 geomodel for compatible classifier",
 			logger.String("classifier", bn.ModelInfo.ID),
 			logger.String("models_dir", bn.modelsDir))
 	}
 
-	// V3 geomodel is always ONNX; route to ONNX backend even if ModelPath is empty
-	// (initializeV3GeoModel will return a clear error about missing paths).
-	if rf.Model == "v3" {
-		log.Debug("Routing to ONNX v3 geomodel backend")
-		return bn.initializeONNXMetaModel()
+	switch resolveRangeFilterBackend(&rf) {
+	case rangeFilterBackendMappedGeomodel, rangeFilterBackendONNXStrict:
+		// Both subpaths run through the ONNX backend. A genuine load failure (ORT
+		// unavailable, missing/corrupt model or labels file) falls back to the embedded
+		// TFLite range filter when the classifier has one (BirdNET v2.4); otherwise it
+		// surfaces as unhealthy instead of silently running unfiltered.
+		if err := bn.initializeONNXMetaModel(settings); err != nil {
+			return bn.fallbackToEmbeddedRangeFilter(settings, err)
+		}
+		return nil
+	default:
+		return bn.initializeTFLiteMetaModel(settings)
+	}
+}
+
+// fallbackToEmbeddedRangeFilter attempts to recover from an ONNX range-filter load
+// failure by using the classifier's embedded TFLite range filter. Only BirdNET v2.4 has
+// one; for classifiers without a native filter (Perch v2, BirdNET v3.0) the original
+// error is propagated so the failure surfaces via the range_filter health check and the
+// Species page banner instead of silently running unfiltered.
+func (bn *BirdNET) fallbackToEmbeddedRangeFilter(settings *conf.Settings, cause error) error {
+	if !bn.hasNativeRangeFilter() {
+		return cause
 	}
 
-	// If range filter model path ends with .onnx, use the ONNX backend
-	if isONNXModel(rf.ModelPath) {
-		log.Debug("Routing to ONNX range filter backend",
-			logger.String("model_path", rf.ModelPath))
-		return bn.initializeONNXMetaModel()
+	GetLogger().Warn("Range filter (ONNX geomodel) failed to load; falling back to the classifier's embedded TFLite range filter",
+		logger.Error(cause),
+		logger.String("classifier", bn.ModelInfo.ID))
+
+	// getMetaModelData honors a non-empty rangefilter.modelpath first and would re-read
+	// the failing geomodel file, so force the embedded MData model via empty paths.
+	fallbackSettings := conf.CloneSettings(settings)
+	fallbackSettings.BirdNET.RangeFilter.Model = ""
+	fallbackSettings.BirdNET.RangeFilter.ModelPath = ""
+	fallbackSettings.BirdNET.RangeFilter.LabelsPath = ""
+
+	if err := bn.initializeTFLiteMetaModel(fallbackSettings); err != nil {
+		return errors.New(err).
+			Component("birdnet").
+			Category(errors.CategoryModelInit).
+			Context("operation", "range_filter_embedded_fallback").
+			Build()
 	}
 
-	log.Debug("Routing to TFLite range filter backend")
-	return bn.initializeTFLiteMetaModel()
+	bn.rangeFilterFellBack = true
+	return nil
 }
 
 // initializeTFLiteMetaModel loads and initializes a TFLite range filter model.
-func (bn *BirdNET) initializeTFLiteMetaModel() error {
+func (bn *BirdNET) initializeTFLiteMetaModel(settings *conf.Settings) error {
 	start := time.Now()
 	log := GetLogger()
 
-	metaModelData, err := bn.getMetaModelData()
+	metaModelData, err := bn.getMetaModelData(settings)
 	if err != nil {
 		return err
 	}
@@ -414,7 +497,7 @@ func (bn *BirdNET) initializeTFLiteMetaModel() error {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("model_type", "range_filter").
-			Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.Model).
+			Context("range_filter_model", settings.BirdNET.RangeFilter.Model).
 			Timing("meta-model-init", time.Since(start)).
 			Build()
 	}
@@ -678,13 +761,17 @@ func (bn *BirdNET) ReloadRangeFilter() error {
 	defer bn.mu.Unlock()
 
 	oldRangeFilter := bn.rangeFilter
+	oldFellBack := bn.rangeFilterFellBack
 
 	if err := bn.initializeMetaModel(); err != nil {
-		// Rollback: restore old range filter if init created a partial one
+		// Rollback: restore old range filter (and its fallback state) if init created a
+		// partial one. initializeMetaModel resets rangeFilterFellBack on entry, so the
+		// flag must be restored alongside the filter to keep the health report accurate.
 		if bn.rangeFilter != nil && bn.rangeFilter != oldRangeFilter {
 			bn.rangeFilter.Close()
 		}
 		bn.rangeFilter = oldRangeFilter
+		bn.rangeFilterFellBack = oldFellBack
 
 		return errors.New(err).
 			Component("birdnet").
@@ -951,6 +1038,7 @@ func (bn *BirdNET) ReloadModel() error {
 	// Snapshot all mutable state for transactional rollback on failure.
 	oldClassifier := bn.classifier
 	oldRangeFilter := bn.rangeFilter
+	oldFellBack := bn.rangeFilterFellBack
 	oldModelInfo := bn.ModelInfo
 	oldTaxonomyMap := bn.TaxonomyMap
 	oldScientificIndex := bn.ScientificIndex
@@ -964,6 +1052,9 @@ func (bn *BirdNET) ReloadModel() error {
 		}
 		bn.classifier = oldClassifier
 		bn.rangeFilter = oldRangeFilter
+		// initializeMetaModel resets rangeFilterFellBack on entry; restore it so a failed
+		// reload does not leave the health report claiming the geomodel is active.
+		bn.rangeFilterFellBack = oldFellBack
 		bn.ModelInfo = oldModelInfo
 		bn.TaxonomyMap = oldTaxonomyMap
 		bn.ScientificIndex = oldScientificIndex
@@ -1280,6 +1371,16 @@ type RangeFilterStatusResponse struct {
 	Threshold           float32              `json:"threshold"`
 	LocationConfigured  bool                 `json:"locationConfigured"`
 	LastUpdated         time.Time            `json:"lastUpdated"`
+	// Active reports whether a range-filter backend is loaded. False means the app runs
+	// fail-open (detections are not filtered by location).
+	Active bool `json:"active"`
+	// FellBack reports that the configured ONNX geomodel could not be loaded and the
+	// classifier fell back to its embedded TFLite range filter.
+	FellBack bool `json:"fellBack"`
+	// MappedSpecies is the number of primary-classifier species matched to the geomodel
+	// (only meaningful when Geomodel is non-nil). Zero means the geomodel filters out all
+	// detections for the primary classifier.
+	MappedSpecies int `json:"mappedSpecies"`
 }
 
 // PrimaryRangeFilterCoverage returns the geomodel info and coverage stats for
@@ -1327,6 +1428,15 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 	}
 
 	return geomodel, primary, geoLabels, autoSelected
+}
+
+// rangeFilterRuntimeState reports whether a range-filter backend is loaded and whether
+// it is the embedded TFLite fallback engaged after an ONNX geomodel failed to load.
+// Reads are guarded by mu alongside rangeFilter mutations.
+func (bn *BirdNET) rangeFilterRuntimeState() (active, fellBack bool) {
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+	return bn.rangeFilter != nil, bn.rangeFilterFellBack
 }
 
 // SetModelsDir sets the base directory for gallery-installed models.

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -400,8 +400,14 @@ func resolveRangeFilterBackend(rf *conf.RangeFilterSettings) rangeFilterBackend 
 // native range filter to fall back to when an ONNX geomodel cannot be loaded. Only
 // BirdNET v2.4 (TFLite backend) carries the embedded MData range filter; Perch v2 and
 // BirdNET v3.0 (ONNX backends) rely solely on the geomodel.
+// hasNativeRangeFilter reports whether the active classifier ships with an embedded
+// native range filter to fall back to when an ONNX geomodel cannot be loaded. The
+// embedded MData range filter is BirdNET v2.4 specific, so only that classifier qualifies.
+// Perch v2 and BirdNET v3.0 (ONNX backends) rely solely on the geomodel, and any other
+// TFLite-backed (custom or future) classifier must surface as unhealthy rather than
+// silently filtering against the v2.4 labels.
 func (bn *BirdNET) hasNativeRangeFilter() bool {
-	return bn.ModelInfo.Backend == BackendTFLite
+	return bn.ModelInfo.Backend == BackendTFLite && bn.ModelInfo.ID == DefaultModelVersion
 }
 
 func (bn *BirdNET) initializeMetaModel() error {

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -545,7 +545,7 @@ func (o *Orchestrator) GetHeatmapService() *HeatmapInferenceService {
 		return nil
 	}
 
-	// Resolve model path (same logic as initializeV3GeoModel)
+	// Resolve model path (same logic as initializeMappedGeoModel)
 	modelPath := os.ExpandEnv(rfSettings.ModelPath)
 	modelPath, err := conf.ExpandTildePath(modelPath)
 	if err != nil {

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -51,27 +51,37 @@ func (bn *BirdNET) initializeONNXModel() error {
 	return nil
 }
 
-// initializeONNXMetaModel loads and initializes an ONNX range filter meta model.
-// For v3 geomodel, delegates to initializeV3GeoModel which loads the geomodel
-// with its own 12K labels and wraps it in a mappedRangeFilter.
-func (bn *BirdNET) initializeONNXMetaModel() error {
-	settings := bn.currentSettings()
+// initializeONNXMetaModel loads and initializes an ONNX range filter meta model from
+// the given resolved settings. A geomodel-shaped config (model=="v3" or an ONNX model
+// path paired with a companion labels file) delegates to initializeMappedGeoModel, which
+// loads the geomodel with its own labels and wraps it in a mappedRangeFilter that scores
+// by scientific name. An ONNX model path without a companion labels file uses the strict
+// path, where the model output dimension must match the classifier label count.
+func (bn *BirdNET) initializeONNXMetaModel(settings *conf.Settings) error {
 	start := time.Now()
+	rf := settings.BirdNET.RangeFilter
+	mapped := resolveRangeFilterBackend(&rf) == rangeFilterBackendMappedGeomodel
 
 	modelName := "ONNX range filter"
 	modelCtx := "range_filter"
-	if settings.BirdNET.RangeFilter.Model == "v3" {
+	switch {
+	case rf.Model == "v3":
 		modelName = "v3 geomodel"
 		modelCtx = "v3_geomodel"
+	case mapped:
+		modelName = "geomodel range filter"
+		modelCtx = "geomodel"
 	}
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, modelName, modelCtx, ""); err != nil {
 		return err
 	}
 
-	if settings.BirdNET.RangeFilter.Model == "v3" {
-		return bn.initializeV3GeoModel()
+	if mapped {
+		return bn.initializeMappedGeoModel(settings)
 	}
 
+	// Strict path: no companion labels file, so the classifier labels must match the
+	// model output dimension one-to-one.
 	// Ensure ONNX Runtime is initialized (idempotent - may already be init from classifier)
 	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
@@ -82,7 +92,7 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 	}
 
 	rangeFilter, err := inference.NewONNXRangeFilter(
-		settings.BirdNET.RangeFilter.ModelPath,
+		rf.ModelPath,
 		inference.ONNXRangeFilterOptions{
 			Labels: settings.BirdNET.Labels,
 		},
@@ -91,7 +101,7 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("model_type", "range_filter").
-			Context("range_filter_model", settings.BirdNET.RangeFilter.ModelPath).
+			Context("range_filter_model", rf.ModelPath).
 			Timing("onnx-meta-model-init", time.Since(start)).
 			Build()
 	}
@@ -100,31 +110,33 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 	return nil
 }
 
-// initializeV3GeoModel loads the v3.0 geomodel ONNX with its own 12K labels,
-// then wraps the raw ONNX range filter in a mappedRangeFilter that remaps
-// geomodel output scores to the classifier's label order by matching scientific
-// names. This enables the 12K-species geomodel to work with any classifier.
-func (bn *BirdNET) initializeV3GeoModel() error {
+// initializeMappedGeoModel loads the geomodel ONNX with its own labels (e.g. 12K
+// species), then wraps the raw ONNX range filter in a mappedRangeFilter that remaps
+// geomodel output scores to the classifier's label order by matching scientific names.
+// This enables the geomodel to work with any classifier and makes a label-count
+// difference a name-matching problem rather than a fatal LabelCountError. Used for both
+// the explicit v3 config and orphaned geomodel configs (model=="" with a labels file).
+func (bn *BirdNET) initializeMappedGeoModel(settings *conf.Settings) error {
 	start := time.Now()
 	log := GetLogger()
-	settings := bn.currentSettings()
 	rfSettings := settings.BirdNET.RangeFilter
 
-	log.Info("V3 geomodel: starting initialization",
+	log.Info("Geomodel range filter: starting initialization",
+		logger.String("model", rfSettings.Model),
 		logger.String("model_path", rfSettings.ModelPath),
 		logger.String("labels_path", rfSettings.LabelsPath),
 		logger.Int("classifier_labels", len(settings.BirdNET.Labels)))
 
 	if rfSettings.ModelPath == "" {
-		return errors.Newf("v3 geomodel requires rangefilter.modelpath to be set").
+		return errors.Newf("geomodel range filter requires rangefilter.modelpath to be set").
 			Category(errors.CategoryModelInit).
-			Context("model", "v3").
+			Context("model_type", "geomodel").
 			Build()
 	}
 	if rfSettings.LabelsPath == "" {
-		return errors.Newf("v3 geomodel requires rangefilter.labelspath to be set").
+		return errors.Newf("geomodel range filter requires rangefilter.labelspath to be set").
 			Category(errors.CategoryModelInit).
-			Context("model", "v3").
+			Context("model_type", "geomodel").
 			Build()
 	}
 
@@ -148,7 +160,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 
 	// Ensure ONNX Runtime is initialized (ORT availability checked by initializeONNXMetaModel)
-	log.Debug("V3 geomodel: initializing ONNX Runtime")
+	log.Debug("Geomodel range filter: initializing ONNX Runtime")
 	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
@@ -158,29 +170,29 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 
 	// Load geomodel labels from file
-	log.Debug("V3 geomodel: loading labels", logger.String("path", labelsPath))
+	log.Debug("Geomodel range filter: loading labels", logger.String("path", labelsPath))
 	geoLabels, err := onnx.LoadLabels(labelsPath)
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			Context("model_type", "v3_geomodel").
+			Context("model_type", "geomodel").
 			Context("labels_path", labelsPath).
 			Build()
 	}
 
 	if len(geoLabels) == 0 {
-		return errors.Newf("v3 geomodel labels file is empty: %s", labelsPath).
+		return errors.Newf("geomodel labels file is empty: %s", labelsPath).
 			Category(errors.CategoryModelInit).
-			Context("model_type", "v3_geomodel").
+			Context("model_type", "geomodel").
 			Build()
 	}
 
-	log.Debug("V3 geomodel: loaded labels",
+	log.Debug("Geomodel range filter: loaded labels",
 		logger.Int("count", len(geoLabels)),
 		logger.String("first", geoLabels[0]))
 
 	// Create ONNX range filter using the geomodel's own labels
-	log.Debug("V3 geomodel: creating ONNX range filter", logger.String("model_path", modelPath))
+	log.Debug("Geomodel range filter: creating ONNX range filter", logger.String("model_path", modelPath))
 	innerFilter, err := inference.NewONNXRangeFilter(
 		modelPath,
 		inference.ONNXRangeFilterOptions{
@@ -190,9 +202,9 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			Context("model_type", "v3_geomodel").
+			Context("model_type", "geomodel").
 			Context("range_filter_model", modelPath).
-			Timing("onnx-v3-geomodel-init", time.Since(start)).
+			Timing("onnx-geomodel-init", time.Since(start)).
 			Build()
 	}
 
@@ -204,11 +216,11 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	mapped := newMappedRangeFilter(innerFilter, classifierLabels, geoLabels, unmappedScore)
 
 	if mapped.mappedCount == 0 && len(classifierLabels) > 0 {
-		log.Warn("V3 geomodel: no species matched classifier labels, range filter will filter out all detections (check labels file)",
+		log.Warn("Geomodel range filter: no species matched classifier labels, range filter will filter out all detections (check labels file)",
 			logger.Int("classifier_species", len(classifierLabels)),
 			logger.String("labels_path", labelsPath))
 	}
-	log.Info("V3 geomodel initialized with species mapping",
+	log.Info("Geomodel range filter initialized with species mapping",
 		logger.Int("geomodel_species", len(geoLabels)),
 		logger.Int("classifier_species", len(classifierLabels)),
 		logger.Int("mapped_species", mapped.mappedCount),

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -485,6 +485,7 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 	rf := settings.BirdNET.RangeFilter
 
 	geomodel, primaryCoverage, geoLabels, _ := primary.PrimaryRangeFilterCoverage()
+	active, fellBack := primary.rangeFilterRuntimeState()
 
 	resp := RangeFilterStatusResponse{
 		Geomodel:            geomodel,
@@ -492,6 +493,9 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 		Threshold:           rf.Threshold,
 		LocationConfigured:  settings.BirdNET.LocationConfigured,
 		LastUpdated:         rf.LastUpdated,
+		Active:              active,
+		FellBack:            fellBack,
+		MappedSpecies:       primaryCoverage.WithRangeData,
 	}
 
 	// Always include the primary classifier.

--- a/internal/classifier/range_filter_dispatch_onnx_test.go
+++ b/internal/classifier/range_filter_dispatch_onnx_test.go
@@ -1,0 +1,70 @@
+//go:build onnx
+
+package classifier
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	onnx "github.com/tphakala/birdnet-go/internal/inference/onnx"
+)
+
+// geomodelPathsFromEnv returns the geomodel model + labels paths from the standard QA
+// environment variables, skipping the test when they are not configured or missing.
+func geomodelPathsFromEnv(t *testing.T) (modelPath, labelsPath string) {
+	t.Helper()
+	modelPath = os.Getenv("BIRDNET_GEOMODEL_PATH")
+	labelsPath = os.Getenv("BIRDNET_GEOMODEL_LABELS_PATH")
+	if modelPath == "" || labelsPath == "" {
+		t.Skip("set BIRDNET_GEOMODEL_PATH and BIRDNET_GEOMODEL_LABELS_PATH to run the geomodel dispatch integration test")
+	}
+	if _, err := os.Stat(modelPath); err != nil {
+		t.Skipf("geomodel not found at %s: %v", modelPath, err)
+	}
+	if _, err := os.Stat(labelsPath); err != nil {
+		t.Skipf("geomodel labels not found at %s: %v", labelsPath, err)
+	}
+	return modelPath, labelsPath
+}
+
+// TestInitializeMetaModel_OrphanGeomodelOnV24 is matrix row A: BirdNET v2.4 with an
+// orphaned geomodel config (rangefilter.model="" but modelpath/labelspath still pointing
+// at the geomodel). The dispatch fix must route this through the name-matching mapped
+// path and produce a working mappedRangeFilter with mappedCount>0, NOT a nil filter
+// (silent fail-open) and NOT a downgrade to the embedded TFLite range filter.
+func TestInitializeMetaModel_OrphanGeomodelOnV24(t *testing.T) {
+	modelPath, labelsPath := geomodelPathsFromEnv(t)
+
+	// Use a subset of the geomodel's own labels as the classifier labels so that
+	// scientific-name matching is guaranteed to map at least these species.
+	geoLabels, err := onnx.LoadLabels(labelsPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, geoLabels)
+	classifierLabels := geoLabels
+	if len(classifierLabels) > 16 {
+		classifierLabels = classifierLabels[:16]
+	}
+
+	settings := &conf.Settings{}
+	settings.BirdNET.Labels = classifierLabels
+	settings.BirdNET.RangeFilter.Model = "" // orphan: model cleared, paths left behind
+	settings.BirdNET.RangeFilter.ModelPath = modelPath
+	settings.BirdNET.RangeFilter.LabelsPath = labelsPath
+
+	bn := &BirdNET{
+		Settings:     settings,
+		ModelInfo:    ModelRegistry[DefaultModelVersion], // BirdNET v2.4 (TFLite)
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	t.Cleanup(bn.Delete)
+
+	require.NoError(t, bn.initializeMetaModel())
+
+	mapped, ok := bn.rangeFilter.(*mappedRangeFilter)
+	require.True(t, ok, "orphan geomodel config must produce a mappedRangeFilter, got %T", bn.rangeFilter)
+	assert.Positive(t, mapped.mappedCount, "expected at least one classifier species mapped to the geomodel")
+	assert.False(t, bn.rangeFilterFellBack, "must not fall back to embedded TFLite when the geomodel loads")
+}

--- a/internal/classifier/range_filter_dispatch_test.go
+++ b/internal/classifier/range_filter_dispatch_test.go
@@ -123,4 +123,13 @@ func TestHasNativeRangeFilter(t *testing.T) {
 			assert.Equal(t, tt.want, bn.hasNativeRangeFilter())
 		})
 	}
+
+	// A custom or future TFLite-backed classifier is not BirdNET v2.4, so it must not
+	// fall back to the v2.4-specific embedded MData range filter; it should surface as
+	// unhealthy instead of silently filtering against mismatched labels.
+	t.Run("custom non-v2.4 TFLite model has no native range filter", func(t *testing.T) {
+		t.Parallel()
+		bn := &BirdNET{ModelInfo: ModelInfo{ID: "Custom_TFLite", Backend: BackendTFLite}}
+		assert.False(t, bn.hasNativeRangeFilter())
+	})
 }

--- a/internal/classifier/range_filter_dispatch_test.go
+++ b/internal/classifier/range_filter_dispatch_test.go
@@ -1,0 +1,126 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestResolveRangeFilterBackend verifies the dispatch decision that routes a
+// range-filter config to the TFLite, strict-ONNX, or mapped-geomodel backend.
+//
+// The critical case is the orphaned geomodel config (GitHub #3320): BirdNET v2.4
+// with rangefilter.model="" but modelpath/labelspath still pointing at the 12,012
+// species geomodel. It MUST route through the name-matching mapped path (which
+// scores by scientific name and honors passunmappedspecies) instead of the strict
+// ONNX path, where the geomodel's 12,012 outputs vs the classifier's ~6,559 labels
+// produce a fatal LabelCountError and a silent fail-open.
+func TestResolveRangeFilterBackend(t *testing.T) {
+	t.Parallel()
+
+	const (
+		geomodelONNX   = "/data/model/shared/geomodel_v3.0.2_fp16.onnx"
+		geomodelLabels = "/data/model/shared/geomodel_v3.0.2_labels.txt"
+		customONNX     = "/data/model/custom_rangefilter.onnx"
+	)
+
+	tests := []struct {
+		name string
+		rf   conf.RangeFilterSettings
+		want rangeFilterBackend
+	}{
+		{
+			name: "orphaned geomodel on v2.4 routes to mapped path",
+			rf: conf.RangeFilterSettings{
+				Model:      "",
+				ModelPath:  geomodelONNX,
+				LabelsPath: geomodelLabels,
+			},
+			want: rangeFilterBackendMappedGeomodel,
+		},
+		{
+			name: "explicit v3 geomodel routes to mapped path",
+			rf: conf.RangeFilterSettings{
+				Model:      "v3",
+				ModelPath:  geomodelONNX,
+				LabelsPath: geomodelLabels,
+			},
+			want: rangeFilterBackendMappedGeomodel,
+		},
+		{
+			name: "v3 with empty paths still routes to mapped path (init reports missing paths)",
+			rf: conf.RangeFilterSettings{
+				Model:      "v3",
+				ModelPath:  "",
+				LabelsPath: "",
+			},
+			want: rangeFilterBackendMappedGeomodel,
+		},
+		{
+			name: "custom onnx without labels file uses strict ONNX path",
+			rf: conf.RangeFilterSettings{
+				Model:      "",
+				ModelPath:  customONNX,
+				LabelsPath: "",
+			},
+			want: rangeFilterBackendONNXStrict,
+		},
+		{
+			name: "default empty config uses embedded TFLite",
+			rf: conf.RangeFilterSettings{
+				Model:      "",
+				ModelPath:  "",
+				LabelsPath: "",
+			},
+			want: rangeFilterBackendTFLite,
+		},
+		{
+			name: "legacy model uses embedded TFLite",
+			rf: conf.RangeFilterSettings{
+				Model:     "legacy",
+				ModelPath: "",
+			},
+			want: rangeFilterBackendTFLite,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rf := tt.rf
+			got := resolveRangeFilterBackend(&rf)
+			assert.Equal(t, tt.want, got, "backend for %+v", tt.rf)
+		})
+	}
+}
+
+// TestHasNativeRangeFilter verifies which classifiers can fall back to an embedded
+// TFLite range filter when an ONNX geomodel cannot be loaded (ORT missing, file
+// missing, corrupt). Only BirdNET v2.4 ships the embedded MData range filter; Perch
+// v2 and BirdNET v3.0 rely solely on the ONNX geomodel, so a load failure for them
+// must surface as unhealthy instead of silently falling back.
+func TestHasNativeRangeFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		{name: "BirdNET v2.4 has embedded TFLite range filter", modelID: "BirdNET_V2.4", want: true},
+		{name: "Perch v2 has no native range filter", modelID: RegistryIDPerchV2, want: false},
+		{name: "BirdNET v3.0 has no native range filter", modelID: RegistryIDBirdNETV3, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info, ok := ModelRegistry[tt.modelID]
+			require.True(t, ok, "model %s must exist in registry", tt.modelID)
+			bn := &BirdNET{ModelInfo: info}
+			assert.Equal(t, tt.want, bn.hasNativeRangeFilter())
+		})
+	}
+}

--- a/internal/health/checks/range_filter_check.go
+++ b/internal/health/checks/range_filter_check.go
@@ -1,0 +1,93 @@
+package checks
+
+import (
+	"context"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// RangeFilterStatusInfo is a minimal snapshot of range-filter state for health reporting.
+// It is populated from the classifier's range-filter status so the health package does
+// not depend on classifier internals.
+type RangeFilterStatusInfo struct {
+	// LocationConfigured reports whether a location is set; range filtering only filters
+	// by location, so without one it is not applicable.
+	LocationConfigured bool
+	// Active reports whether a range-filter backend is loaded. False means the app runs
+	// fail-open (no species filtering) which, with a location configured, is a fault.
+	Active bool
+	// FellBack reports that the configured ONNX geomodel could not be loaded and the
+	// classifier fell back to its embedded TFLite range filter.
+	FellBack bool
+	// GeomodelActive reports that the active backend is the mapped geomodel.
+	GeomodelActive bool
+	// MappedSpecies is the number of classifier species matched to the geomodel; only
+	// meaningful when GeomodelActive. Zero means the geomodel filters out everything.
+	MappedSpecies int
+}
+
+// RangeFilterCheck reports whether geographic range filtering is active when expected.
+// It surfaces the silent fail-open described in the range-filter robustness work: when a
+// location is configured but no range filter is loaded, detections run unfiltered without
+// any visible signal.
+type RangeFilterCheck struct {
+	getStatus func() RangeFilterStatusInfo
+}
+
+// NewRangeFilterCheck creates a RangeFilterCheck using the given status provider.
+func NewRangeFilterCheck(getStatus func() RangeFilterStatusInfo) *RangeFilterCheck {
+	return &RangeFilterCheck{getStatus: getStatus}
+}
+
+// Name returns the check identifier.
+func (c *RangeFilterCheck) Name() string { return "range_filter" }
+
+// Category returns the analysis category.
+func (c *RangeFilterCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// Run evaluates range-filter health.
+func (c *RangeFilterCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getStatus == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	s := c.getStatus()
+
+	status := health.StatusHealthy
+	message := "Range filter active"
+	switch {
+	case !s.LocationConfigured:
+		// Range filtering only filters by location; without one it is not applicable.
+		message = "Range filtering not applicable (no location configured)"
+	case !s.Active:
+		// A location is set but no filter loaded: detections run unfiltered with no
+		// other visible signal. This is the silent fail-open the fix must surface.
+		status = health.StatusCritical
+		message = "Range filter inactive: detections are not filtered by location (running unfiltered)"
+	case s.FellBack:
+		status = health.StatusWarning
+		message = "Configured geomodel range filter failed to load; using the classifier's embedded range filter"
+	case s.GeomodelActive && s.MappedSpecies == 0:
+		status = health.StatusWarning
+		message = "Range filter geomodel matched no classifier species; all detections would be filtered out (check the labels file)"
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     status,
+		Message:    message,
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+		Details: map[string]any{
+			"location_configured": s.LocationConfigured,
+			"active":              s.Active,
+			"fell_back":           s.FellBack,
+			"geomodel_active":     s.GeomodelActive,
+			"mapped_species":      s.MappedSpecies,
+		},
+	}
+}

--- a/internal/health/checks/range_filter_check_test.go
+++ b/internal/health/checks/range_filter_check_test.go
@@ -1,0 +1,75 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// TestRangeFilterCheck covers the range-filter health states from the #852 fix plan:
+// a silent fail-open (no filter active while a location is configured) must be flagged
+// critical; a fallback to the embedded TFLite filter or a geomodel that matched zero
+// species must warn; and the no-location and fully-healthy cases must stay healthy.
+func TestRangeFilterCheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		info       RangeFilterStatusInfo
+		wantStatus health.Status
+	}{
+		{
+			name:       "no location configured is not applicable",
+			info:       RangeFilterStatusInfo{LocationConfigured: false, Active: false},
+			wantStatus: health.StatusHealthy,
+		},
+		{
+			name:       "location configured but no filter active is fail-open",
+			info:       RangeFilterStatusInfo{LocationConfigured: true, Active: false},
+			wantStatus: health.StatusCritical,
+		},
+		{
+			name:       "fell back to embedded filter warns",
+			info:       RangeFilterStatusInfo{LocationConfigured: true, Active: true, FellBack: true},
+			wantStatus: health.StatusWarning,
+		},
+		{
+			name:       "geomodel mapped zero species warns",
+			info:       RangeFilterStatusInfo{LocationConfigured: true, Active: true, GeomodelActive: true, MappedSpecies: 0},
+			wantStatus: health.StatusWarning,
+		},
+		{
+			name:       "active geomodel with mapped species is healthy",
+			info:       RangeFilterStatusInfo{LocationConfigured: true, Active: true, GeomodelActive: true, MappedSpecies: 6500},
+			wantStatus: health.StatusHealthy,
+		},
+		{
+			name:       "active embedded filter is healthy",
+			info:       RangeFilterStatusInfo{LocationConfigured: true, Active: true},
+			wantStatus: health.StatusHealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			check := NewRangeFilterCheck(func() RangeFilterStatusInfo { return tt.info })
+			assert.Equal(t, "range_filter", check.Name())
+			assert.Equal(t, health.CategoryAnalysis, check.Category())
+
+			result := check.Run(t.Context())
+			assert.Equal(t, tt.wantStatus, result.Status, "status for %+v", tt.info)
+			assert.NotEmpty(t, result.Message)
+		})
+	}
+}
+
+// TestRangeFilterCheck_NoProvider verifies the check is skipped when no status provider
+// is wired (e.g. before the analysis pipeline is ready).
+func TestRangeFilterCheck_NoProvider(t *testing.T) {
+	t.Parallel()
+	check := NewRangeFilterCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}


### PR DESCRIPTION
## Problem

On BirdNET v2.4, a leftover geomodel range-filter config (`rangefilter.model: ""` but `modelpath`/`labelspath` still pointing at the v3 geomodel, e.g. after installing then removing Perch v2 or BirdNET v3.0) made the Active Species table empty and detections run unfiltered, with nothing in the UI or health report explaining why.

Root cause was a dispatch bug: that config routed to the strict ONNX range filter, which built the geomodel with the classifier's `~6,559` labels instead of the geomodel's own `12,012`. The label-count mismatch returned an error, the error was swallowed, and the range filter was left `nil` (fail-open).

## Fix

- **Route geomodel-shaped ONNX configs through the existing mapped path.** A config is geomodel-shaped when `rangefilter.model == "v3"` or when an ONNX `modelpath` is paired with a companion `labelspath`. The mapped path loads the geomodel with its own labels and matches scores to the classifier by scientific name, honoring `passunmappedspecies`, so a label-count difference is no longer fatal.
- **Graceful fallback for genuine load failures only.** When the ONNX filter truly cannot be constructed (ONNX Runtime missing, model/labels file missing, parse error), fall back to the classifier's embedded TFLite range filter if it has one (BirdNET v2.4). Classifiers with no native filter (Perch v2, BirdNET v3.0) surface as unhealthy instead of silently running unfiltered. Covers startup and both hot-reload paths.
- **Surface the state.** A new `range_filter` health check plus a banner on the Species page (Active tab) report when filtering is inactive, when the embedded fallback is in use, or when the geomodel matched no species. Adds `active`, `fellBack`, and `mappedSpecies` to the existing `/api/v2/range/status` response (additive only).

## Tests

- `TestResolveRangeFilterBackend` (TDD) drives the dispatch decision, including the orphaned-geomodel case that previously failed open.
- `TestHasNativeRangeFilter` covers which classifiers may fall back.
- `TestRangeFilterCheck` covers the health states (inactive, fell-back, mapped-zero, healthy, no-location).
- An ONNX-tagged integration test asserts the orphaned config produces a working mapped filter (`mappedCount > 0`).

New translation keys added across all 15 locales.

Fixes #3320
Fixes #3151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Species Settings now show a range-filter health banner above Active species: inactive, fallback-to-built-in, or no-species-mapped states.

* **Localization**
  * Added translated range-filter status titles and descriptions across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->