### PR TITLE
fix: score non-primary species through the primary geomodel

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -7,13 +7,16 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -374,9 +377,31 @@ func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float
 }
 
 // GetAllProbableSpeciesWithSettings returns species from all active classifiers.
-// The primary BirdNET model's species are filtered by the range filter using the
-// supplied settings. Additional models (except bat) contribute their full label
-// set since they have no range filter. Results are deduplicated by label.
+//
+// The primary BirdNET model's species are filtered by the range filter using
+// the supplied settings. When the primary uses a v3 geomodel, those primary
+// scores already contain the full geomodel label set above the configured
+// threshold ("ScientificName_CommonName"), exclude-filtered.
+//
+// Additional models (except bat) emit labels in their own convention (Perch v2
+// uses scientific-name-only labels). To decide whether a non-primary species
+// should be added, the geomodel's coverage is consulted by scientific name:
+//
+//   - already represented (present in the primary scores) -> skip (no duplicate)
+//   - geomodel-covered but NOT above threshold            -> skip; the range
+//     filter excludes it (this is the core fix for the active-species balloon
+//     in issue #3250, where exact-string dedup let geomodel-covered Perch
+//     species slip back in at score 1.0)
+//   - geomodel-unmapped (no scientific-name match)        -> pass through at
+//     score 1.0 only when PassUnmappedSpecies is enabled and the species is not
+//     excluded
+//
+// When the primary is not a universal predictor (legacy TFLite range filter
+// with no geomodel) there is no coverage set to consult, so every non-primary
+// label whose scientific name is not already represented is added at score 1.0
+// (exclude honored), preserving prior multi-classifier behavior. Deduplication
+// is by scientific name throughout, never exact label, because the geomodel and
+// Perch use different label conventions for the same species.
 func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
 	// Snapshot primary under read lock to avoid racing with Delete().
 	o.mu.RLock()
@@ -391,9 +416,27 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 		return nil, err
 	}
 
-	seen := make(map[string]bool, len(scores))
+	// Read the primary's geomodel coverage the same way BuildRangeFilter does.
+	// geoLabels covers every scientific name the geomodel knows, regardless of
+	// threshold; it is empty when the primary is not a universal predictor.
+	primary.mu.Lock()
+	up, isUniversal := primary.rangeFilter.(UniversalSpeciesPredictor)
+	var geoLabels []string
+	if isUniversal {
+		geoLabels = up.GeomodelLabels()
+	}
+	primary.mu.Unlock()
+
+	// Dedup by scientific name (lowercased). seenSci holds species already
+	// represented via the primary scores; geoCovered holds every scientific
+	// name the geomodel can predict at all.
+	seenSci := make(map[string]bool, len(scores))
 	for _, s := range scores {
-		seen[s.Label] = true
+		seenSci[strings.ToLower(detection.ExtractScientificName(s.Label))] = true
+	}
+	geoCovered := make(map[string]bool, len(geoLabels))
+	for _, label := range geoLabels {
+		geoCovered[strings.ToLower(detection.ExtractScientificName(label))] = true
 	}
 
 	type entryRef struct {
@@ -401,9 +444,9 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 		entry *modelEntry
 	}
 
-	var refs []entryRef
 	o.mu.RLock()
 	primaryID := primary.ModelInfo.ID
+	refs := make([]entryRef, 0, len(o.models))
 	for id, entry := range o.models {
 		if id == primaryID || id == RegistryIDBat {
 			continue
@@ -411,6 +454,15 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 		refs = append(refs, entryRef{id: id, entry: entry})
 	}
 	o.mu.RUnlock()
+
+	// Sort non-primary models by ID so dedup-by-scientific-name is
+	// deterministic. When two secondary models emit different labels for the
+	// same scientific name, the surviving label must not depend on Go's
+	// randomized map iteration order.
+	sort.Slice(refs, func(i, j int) bool { return refs[i].id < refs[j].id })
+
+	passUnmapped := settings.BirdNET.RangeFilter.PassUnmappedSpecies
+	excludeList := settings.Realtime.Species.Exclude
 
 	for _, ref := range refs {
 		ref.entry.mu.Lock()
@@ -421,10 +473,38 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 		labels := ref.entry.instance.Labels()
 		ref.entry.mu.Unlock()
 
+		// Grow scores capacity once per model; an upper bound is one new entry
+		// per non-primary label.
+		if len(labels) > 0 {
+			scores = slices.Grow(scores, len(labels))
+		}
+
 		for _, label := range labels {
-			if !seen[label] {
-				scores = append(scores, SpeciesScore{Label: label, Score: 1.0})
-				seen[label] = true
+			sci := strings.ToLower(detection.ExtractScientificName(label))
+			switch {
+			case seenSci[sci]:
+				// Already represented via the primary (or an earlier model).
+				continue
+			case isUniversal && geoCovered[sci]:
+				// Geomodel covers this species but it is not in the
+				// above-threshold set, so the range filter excludes it. Skip.
+				continue
+			default:
+				// Geomodel-unmapped, or the primary is not universal.
+				if !isUniversal {
+					// Legacy path: no geomodel to consult. Preserve prior
+					// behavior and include the species, deduped by scientific
+					// name, without gating on PassUnmappedSpecies.
+					if !isSpeciesExcluded(label, excludeList) {
+						scores = append(scores, SpeciesScore{Label: label, Score: 1.0})
+						seenSci[sci] = true
+					}
+					continue
+				}
+				if passUnmapped && !isSpeciesExcluded(label, excludeList) {
+					scores = append(scores, SpeciesScore{Label: label, Score: 1.0})
+					seenSci[sci] = true
+				}
 			}
 		}
 	}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -411,21 +411,16 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 		return nil, nil
 	}
 
-	scores, err := primary.GetProbableSpeciesWithSettings(date, week, settings)
+	// Get the primary's range-filtered scores together with the geomodel's full
+	// label set, both from the same range-filter snapshot so a concurrent
+	// ReloadRangeFilter cannot desync them. geoLabels is non-nil only on the
+	// universal (v3 geomodel) path, where it covers every scientific name the
+	// geomodel knows regardless of threshold.
+	scores, geoLabels, err := primary.getProbableSpecies(date, week, settings)
 	if err != nil {
 		return nil, err
 	}
-
-	// Read the primary's geomodel coverage the same way BuildRangeFilter does.
-	// geoLabels covers every scientific name the geomodel knows, regardless of
-	// threshold; it is empty when the primary is not a universal predictor.
-	primary.mu.Lock()
-	up, isUniversal := primary.rangeFilter.(UniversalSpeciesPredictor)
-	var geoLabels []string
-	if isUniversal {
-		geoLabels = up.GeomodelLabels()
-	}
-	primary.mu.Unlock()
+	isUniversal := geoLabels != nil
 
 	// Dedup by scientific name (lowercased). seenSci holds species already
 	// represented via the primary scores; geoCovered holds every scientific
@@ -459,7 +454,7 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	// deterministic. When two secondary models emit different labels for the
 	// same scientific name, the surviving label must not depend on Go's
 	// randomized map iteration order.
-	sort.Slice(refs, func(i, j int) bool { return refs[i].id < refs[j].id })
+	slices.SortFunc(refs, func(a, b entryRef) int { return strings.Compare(a.id, b.id) })
 
 	passUnmapped := settings.BirdNET.RangeFilter.PassUnmappedSpecies
 	excludeList := settings.Realtime.Species.Exclude

--- a/internal/classifier/orchestrator_allspecies_test.go
+++ b/internal/classifier/orchestrator_allspecies_test.go
@@ -1,0 +1,331 @@
+package classifier
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/detection"
+)
+
+// scoreForLabel returns the SpeciesScore matching label, or false if absent.
+func scoreForLabel(scores []SpeciesScore, label string) (SpeciesScore, bool) {
+	for _, s := range scores {
+		if s.Label == label {
+			return s, true
+		}
+	}
+	return SpeciesScore{}, false
+}
+
+// hasScientificName reports whether any score's scientific name matches sci
+// (case-insensitive). Used to assert deduplication by scientific name across
+// the geomodel ("ScientificName_CommonName") and Perch (scientific-name-only)
+// label conventions.
+func hasScientificName(scores []SpeciesScore, sci string) bool {
+	for _, s := range scores {
+		// Compare case-insensitively to match the production dedup, which keys
+		// on the lowercased scientific name.
+		if strings.EqualFold(detection.ExtractScientificName(s.Label), sci) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildAllSpeciesOrchestrator wires a primary BirdNET whose range filter is the
+// supplied universal predictor plus a single non-primary model returning the
+// given labels. The primary is excluded from the non-primary loop by its ID.
+func buildAllSpeciesOrchestrator(t *testing.T, settings *conf.Settings, rf *fakeUniversalRangeFilter, nonPrimaryID string, nonPrimaryLabels []string) *Orchestrator {
+	t.Helper()
+
+	const primaryID = "BirdNET_V3"
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo.ID = primaryID
+	bn.rangeFilter = rf
+
+	nonPrimary := &mockModelInstance{
+		id:     nonPrimaryID,
+		labels: nonPrimaryLabels,
+	}
+
+	return &Orchestrator{
+		Settings: settings,
+		primary:  bn,
+		models: map[string]*modelEntry{
+			primaryID:    {instance: bn},
+			nonPrimaryID: {instance: nonPrimary},
+		},
+	}
+}
+
+// universalSettings returns settings configured so the primary routes through
+// the universal geomodel path in getProbableSpecies.
+func universalSettings(t *testing.T) *conf.Settings {
+	t.Helper()
+	settings := conf.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	return settings
+}
+
+// TestGetAllProbableSpecies_GeomodelCoveredBelowThreshold is the regression
+// guard for issue #3250: a non-primary species the geomodel knows about but
+// that is below the range-filter threshold must NOT be re-added at 1.0. This
+// is the bug that ballooned the active species count.
+func TestGetAllProbableSpecies_GeomodelCoveredBelowThreshold(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	// Geomodel knows both species (geoCovered), but only Turdus merula is above
+	// the threshold (returned by PredictSpeciesScores).
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{
+			"Turdus merula_Common Blackbird",
+			"Parus major_Great Tit",
+		},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9, 0.0},
+	}
+
+	// Perch (non-primary) emits scientific-name-only labels. Parus major is
+	// geomodel-covered-but-below-threshold and must be skipped.
+	o := buildAllSpeciesOrchestrator(t, settings, rf, "Perch_V2",
+		[]string{"Turdus merula", "Parus major"})
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	// Turdus merula is present once (via the primary, ScientificName_CommonName).
+	assert.True(t, hasScientificName(scores, "Turdus merula"),
+		"above-threshold species should be present from primary")
+	// Parus major is geomodel-covered but below threshold: range filter excludes
+	// it, so it must NOT appear from the non-primary at all.
+	assert.False(t, hasScientificName(scores, "Parus major"),
+		"geomodel-covered, below-threshold species must not be re-added (regression #3250)")
+}
+
+// TestGetAllProbableSpecies_NoDuplicateByScientificName verifies that a
+// non-primary species already present via the primary (as
+// ScientificName_CommonName) is not duplicated when the non-primary emits the
+// scientific name only.
+func TestGetAllProbableSpecies_NoDuplicateByScientificName(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9},
+	}
+
+	o := buildAllSpeciesOrchestrator(t, settings, rf, "Perch_V2",
+		[]string{"Turdus merula"})
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	count := 0
+	for _, s := range scores {
+		if detection.ExtractScientificName(s.Label) == "Turdus merula" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "species present via primary must not be duplicated by the non-primary")
+}
+
+// TestGetAllProbableSpecies_UnmappedPassThrough verifies that a non-primary
+// species the geomodel does not know about is passed through at score 1.0 when
+// PassUnmappedSpecies is enabled.
+func TestGetAllProbableSpecies_UnmappedPassThrough(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9},
+	}
+
+	// Aratinga is not in the geomodel at all (unmapped).
+	o := buildAllSpeciesOrchestrator(t, settings, rf, "Perch_V2",
+		[]string{"Aratinga solstitialis"})
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	got, ok := scoreForLabel(scores, "Aratinga solstitialis")
+	require.True(t, ok, "geomodel-unmapped species should be added when PassUnmappedSpecies is true")
+	assert.InDelta(t, 1.0, got.Score, 0.0001, "pass-through species must be scored 1.0")
+}
+
+// TestGetAllProbableSpecies_UnmappedBlockedWhenDisabled verifies that a
+// geomodel-unmapped non-primary species is NOT added when PassUnmappedSpecies
+// is disabled.
+func TestGetAllProbableSpecies_UnmappedBlockedWhenDisabled(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = false
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9},
+	}
+
+	o := buildAllSpeciesOrchestrator(t, settings, rf, "Perch_V2",
+		[]string{"Aratinga solstitialis"})
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	_, ok := scoreForLabel(scores, "Aratinga solstitialis")
+	assert.False(t, ok, "geomodel-unmapped species must be blocked when PassUnmappedSpecies is false")
+}
+
+// TestGetAllProbableSpecies_ExcludeHonored verifies that an excluded
+// non-primary species is never added regardless of mapping state.
+func TestGetAllProbableSpecies_ExcludeHonored(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+	settings.Realtime.Species.Exclude = []string{"Aratinga solstitialis"}
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9},
+	}
+
+	o := buildAllSpeciesOrchestrator(t, settings, rf, "Perch_V2",
+		[]string{"Aratinga solstitialis"})
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	_, ok := scoreForLabel(scores, "Aratinga solstitialis")
+	assert.False(t, ok, "excluded species must never be added even when unmapped and pass-through is enabled")
+}
+
+// TestGetAllProbableSpecies_NonUniversalPrimary verifies that when the primary
+// has no geomodel (legacy TFLite range filter, not universal), non-primary
+// labels are added at 1.0, deduped by scientific name, and exclude is honored
+// without gating on PassUnmappedSpecies. This preserves prior behavior for
+// multi-classifier setups that have no geomodel.
+func TestGetAllProbableSpecies_NonUniversalPrimary(t *testing.T) {
+	settings := universalSettings(t)
+	// PassUnmappedSpecies is irrelevant on the non-universal path; set false to
+	// prove the non-primary labels are still added.
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = false
+	settings.Realtime.Species.Exclude = []string{"Corvus corax"}
+	settings.BirdNET.Labels = []string{"Turdus merula_Common Blackbird"}
+
+	// A non-universal range filter: implements inference.RangeFilter only.
+	primaryRF := &fakeRangeFilter{scores: []float32{0.9}}
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo.ID = "BirdNET_V2.4"
+	bn.rangeFilter = primaryRF
+
+	nonPrimary := &mockModelInstance{
+		id: "Perch_V2",
+		labels: []string{
+			"Turdus merula", // already present via primary (deduped by sci)
+			"Parus major",   // new, should be added at 1.0
+			"Corvus corax",  // excluded, must not be added
+		},
+	}
+
+	o := &Orchestrator{
+		Settings: settings,
+		primary:  bn,
+		models: map[string]*modelEntry{
+			"BirdNET_V2.4": {instance: bn},
+			"Perch_V2":     {instance: nonPrimary},
+		},
+	}
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	// Parus major is new and added at 1.0.
+	got, ok := scoreForLabel(scores, "Parus major")
+	require.True(t, ok, "non-universal primary: new non-primary label should be added")
+	assert.InDelta(t, 1.0, got.Score, 0.0001, "non-universal primary: added label scored 1.0")
+
+	// Turdus merula present exactly once (deduped by scientific name).
+	count := 0
+	for _, s := range scores {
+		if detection.ExtractScientificName(s.Label) == "Turdus merula" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "non-universal primary: species present via primary must not be duplicated")
+
+	// Corvus corax excluded.
+	assert.False(t, hasScientificName(scores, "Corvus corax"),
+		"non-universal primary: excluded species must not be added")
+}
+
+// TestGetAllProbableSpecies_BatModelSkipped verifies the bat model is never
+// iterated when collecting non-primary species.
+func TestGetAllProbableSpecies_BatModelSkipped(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9},
+	}
+
+	const primaryID = "BirdNET_V3"
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo.ID = primaryID
+	bn.rangeFilter = rf
+
+	batModel := &mockModelInstance{
+		id:     RegistryIDBat,
+		labels: []string{"Myotis daubentonii"},
+	}
+
+	o := &Orchestrator{
+		Settings: settings,
+		primary:  bn,
+		models: map[string]*modelEntry{
+			primaryID:     {instance: bn},
+			RegistryIDBat: {instance: batModel},
+		},
+	}
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	assert.False(t, hasScientificName(scores, "Myotis daubentonii"),
+		"bat model species must never be collected")
+}

--- a/internal/classifier/orchestrator_allspecies_test.go
+++ b/internal/classifier/orchestrator_allspecies_test.go
@@ -329,3 +329,61 @@ func TestGetAllProbableSpecies_BatModelSkipped(t *testing.T) {
 	assert.False(t, hasScientificName(scores, "Myotis daubentonii"),
 		"bat model species must never be collected")
 }
+
+// TestGetAllProbableSpecies_DeterministicDedupByModelID verifies that when two
+// non-primary models emit different labels for the same scientific name, the
+// surviving label is deterministic: refs are sorted by model ID, so the
+// lower-ID model is processed first and its label wins the scientific-name
+// dedup (independent of Go's randomized map iteration order).
+func TestGetAllProbableSpecies_DeterministicDedupByModelID(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.9},
+	}
+
+	const primaryID = "BirdNET_V3"
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo.ID = primaryID
+	bn.rangeFilter = rf
+
+	// Both secondary models emit the same scientific name (geomodel-unmapped, so
+	// it passes through) but with different label strings. The lower model ID
+	// ("aaa_model") is processed first and its label survives.
+	lower := &mockModelInstance{id: "aaa_model", labels: []string{"Aratinga solstitialis"}}
+	higher := &mockModelInstance{id: "zzz_model", labels: []string{"Aratinga solstitialis_Sun Parakeet"}}
+
+	o := &Orchestrator{
+		Settings: settings,
+		primary:  bn,
+		models: map[string]*modelEntry{
+			primaryID:   {instance: bn},
+			"aaa_model": {instance: lower},
+			"zzz_model": {instance: higher},
+		},
+	}
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	count := 0
+	for _, s := range scores {
+		if strings.EqualFold(detection.ExtractScientificName(s.Label), "Aratinga solstitialis") {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "shared scientific name must appear exactly once")
+
+	_, lowerPresent := scoreForLabel(scores, "Aratinga solstitialis")
+	assert.True(t, lowerPresent, "lower model ID label must survive the scientific-name dedup")
+	_, higherPresent := scoreForLabel(scores, "Aratinga solstitialis_Sun Parakeet")
+	assert.False(t, higherPresent, "higher model ID label must be deduped away")
+}

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -16,6 +16,7 @@ import (
 type mockModelInstance struct {
 	id      string
 	spec    ModelSpec
+	labels  []string // optional; when nil a single default label is returned
 	predict func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
 }
 
@@ -33,8 +34,13 @@ func (m *mockModelInstance) ModelName() string {
 }
 func (m *mockModelInstance) ModelVersion() string { return "1.0" }
 func (m *mockModelInstance) NumSpecies() int      { return 1 }
-func (m *mockModelInstance) Labels() []string     { return []string{"Turdus merula_Common Blackbird"} }
-func (m *mockModelInstance) Close() error         { return nil }
+func (m *mockModelInstance) Labels() []string {
+	if m.labels != nil {
+		return m.labels
+	}
+	return []string{"Turdus merula_Common Blackbird"}
+}
+func (m *mockModelInstance) Close() error { return nil }
 
 // newTestOrchestrator creates an Orchestrator with mock models for unit testing.
 // It does not require real model files.

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -253,7 +253,8 @@ func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, 
 // so that UI changes to coordinates, threshold, or LocationConfigured take
 // effect immediately without restarting the service.
 func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
-	return bn.getProbableSpecies(date, week, conf.CurrentOrFallback(bn.Settings))
+	scores, _, err := bn.getProbableSpecies(date, week, conf.CurrentOrFallback(bn.Settings))
+	return scores, err
 }
 
 // GetProbableSpeciesWithSettings filters species using the supplied settings
@@ -262,7 +263,8 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 // publishing temporary values into the global settings, eliminating the race
 // where a concurrent BuildRangeFilter could pick up test data.
 func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
-	return bn.getProbableSpecies(date, week, settings)
+	scores, _, err := bn.getProbableSpecies(date, week, settings)
+	return scores, err
 }
 
 // getProbableSpecies is the shared implementation for both the global-settings
@@ -273,7 +275,13 @@ func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, 
 // includes all taxa the geomodel covers (birds, mammals, insects, etc.)
 // regardless of which classifier is active. Otherwise, the legacy path maps
 // geomodel scores to the classifier's label set.
-func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
+//
+// The second return value is the geomodel's full label set, captured from the
+// same range-filter snapshot that produced the scores. It is non-nil only on
+// the universal path. Returning it here lets callers that need both avoid a
+// second lock that could observe a different range-filter instance after a
+// concurrent ReloadRangeFilter.
+func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, []string, error) {
 	bn.Debug("Applying range filter")
 
 	// Skip filtering if range filter backend is not initialized.
@@ -283,13 +291,13 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	bn.mu.Unlock()
 	if !hasRangeFilter {
 		bn.Debug("Range filter model not loaded, returning zero scores for all labels")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil, nil
 	}
 
 	// Skip filtering if location is not configured
 	if !settings.BirdNET.LocationConfigured {
 		bn.Debug("Location not configured, not using location based prediction filter")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil, nil
 	}
 
 	threshold := settings.BirdNET.RangeFilter.Threshold
@@ -323,7 +331,7 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		bn.mu.Unlock()
 
 		if err != nil {
-			return nil, errors.New(err).
+			return nil, nil, errors.New(err).
 				Category(errors.CategoryValidation).
 				Context("date", date.Format(time.DateOnly)).
 				Context("week", week).
@@ -361,14 +369,14 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 
 		sort.Sort(ByScore(speciesScores))
-		return speciesScores, nil
+		return speciesScores, allGeoLabels, nil
 	}
 	bn.mu.Unlock()
 
 	// Legacy path: map geomodel scores to the classifier's label set.
 	filters, err := bn.predictFilter(date, week, settings, threshold)
 	if err != nil {
-		return nil, errors.New(err).
+		return nil, nil, errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("date", date.Format(time.DateOnly)).
 			Context("week", week).
@@ -400,7 +408,7 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	}
 
 	sort.Sort(ByScore(speciesScores))
-	return speciesScores, nil
+	return speciesScores, nil, nil
 }
 
 // zeroScoresForAllLabels creates a slice of SpeciesScore with zero scores for all provided labels,

--- a/internal/classifier/range_filter_test.go
+++ b/internal/classifier/range_filter_test.go
@@ -289,7 +289,7 @@ func TestGetProbableSpecies_PassUnmappedSpecies(t *testing.T) {
 				speciesCache: make(map[string]*speciesCacheEntry),
 			}
 
-			scores, err := bn.getProbableSpecies(time.Now(), 0, settings)
+			scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
 			require.NoError(t, err)
 			assert.GreaterOrEqual(t, len(scores), tt.wantMinSpecies)
 


### PR DESCRIPTION
## Problem

Fixes #3250. With a v3 geomodel primary (BirdNET) running alongside Perch v2, the active / "Current Species" count balloons to ~14,823 regardless of the range-filter threshold. Every Perch species shows a score of 1.0, so no threshold setting filters them out.

## Root cause

`Orchestrator.GetAllProbableSpeciesWithSettings` (the backend for the range-filter test endpoint and the "current species" display) range-filtered only the primary model, then appended every non-primary label at score 1.0, deduping by the exact label string. Geomodel labels are `ScientificName_CommonName` while Perch labels are scientific-name-only, so the exact-string dedup never matched and geomodel-covered Perch species were re-added at 1.0.

## Fix

Score non-primary species through the primary geomodel (`UniversalSpeciesPredictor`) by scientific name, mirroring the existing universal path in `getProbableSpecies` / `BuildRangeFilter`:

- dedup by `detection.ExtractScientificName`, not the exact label string
- drop geomodel-covered species that fall below the configured threshold (the range filter excludes them)
- pass through geomodel-unmapped species only when `PassUnmappedSpecies` is enabled, honoring `Realtime.Species.Exclude`
- when the primary has no geomodel (legacy TFLite filter), preserve prior behavior: include non-primary labels deduped by scientific name, with `Exclude` honored
- sort non-primary models by ID so the dedup result is deterministic

## Behavioral notes for existing users

- The legacy (non-geomodel) multi-classifier path now honors `Realtime.Species.Exclude` for non-primary species; previously excluded species could still appear at 1.0.
- On a v3 geomodel, genuinely geomodel-unmapped non-primary species are now gated by `PassUnmappedSpecies` (default off). Set it to true to pass them through, as documented for that setting.

## Scope

This addresses the display / test-endpoint inflation reported in #3250. A separate report in that thread about genuine out-of-range detections at runtime (pending a support dump) is not addressed here and remains open for investigation.

## Testing

- New table-driven `-race` tests in `orchestrator_allspecies_test.go` cover: geomodel-covered-below-threshold dropped (the regression guard), no duplicate by scientific name, unmapped pass-through gated on `PassUnmappedSpecies`, exclude honored, non-universal primary path, and bat model skipped. They fail against the old exact-string-dedup code.
- `task lint` clean; full `internal/classifier` suite passes with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved species deduplication across classifiers for more accurate combined results
  * Prevented below-threshold geomodel species from being re-added by secondary models
  * Respect pass-through/unmapped species settings and realtime exclusion consistently
  * Ensured deterministic ordering when multiple models report the same species

* **Tests**
  * Added extensive regression and behavior tests covering aggregation, dedupe, pass-through, exclusion, legacy vs universal behavior, and deterministic selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->