### PR TITLE
fix: self-heal orphaned geomodel range-filter config and migrate on load

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -810,6 +810,11 @@ const DefaultRangeFilterV2ModelName = "BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP1
 
 // Geomodel v3 local file names used for auto-selection when the geomodel
 // has been downloaded as a shared companion file by the model gallery.
+//
+// These are MIRRORED in internal/conf/range_filter_migration.go as
+// geomodelSharedONNXLocalName / geomodelSharedLabelsLocalName, because conf
+// cannot import classifier (classifier imports conf). If these filenames
+// change, update both places.
 const (
 	geomodelONNXLocalName   = "geomodel_v3.0.2_fp16.onnx"
 	geomodelLabelsLocalName = "geomodel_v3.0.2_labels.txt"

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -217,9 +217,57 @@ func (mm *ModelManager) ScanInstalled() {
 	}
 }
 
+// geomodelOrphanAction is the decision the orphan self-heal makes for a
+// gallery-managed geomodel range filter config when no installed geomodel-capable
+// model was matched.
+type geomodelOrphanAction int
+
+const (
+	// geomodelOrphanNone leaves the config untouched (custom paths, or already
+	// consistent with the on-disk reality).
+	geomodelOrphanNone geomodelOrphanAction = iota
+	// geomodelOrphanPromote sets Model to the v3 literal because the gallery
+	// shared files exist on disk.
+	geomodelOrphanPromote
+	// geomodelOrphanClear wipes the dead geomodel references because the gallery
+	// shared files are absent.
+	geomodelOrphanClear
+)
+
+// geomodelRangeFilterVersion is the literal that the runtime, status code, and
+// UI key off to recognize the geomodel v3 range filter (matches the catalog
+// entry GeomodelVersion for every geomodel-capable model).
+const geomodelRangeFilterVersion = "v3"
+
+// decideGeomodelOrphanAction is the pure decision for the orphan self-heal. It
+// only acts when the range filter points at the EXACT gallery-managed shared
+// paths; custom or hand-edited paths yield geomodelOrphanNone. When the shared
+// files exist it promotes to v3 (no-op if already v3); when they are absent it
+// clears the dead references (no-op if already cleared).
+func decideGeomodelOrphanAction(rf *conf.RangeFilterSettings, expectedModelPath, expectedLabelsPath string, filesPresent bool) geomodelOrphanAction {
+	// Only reconcile gallery-managed configs (exact match on both shared paths).
+	if rf.ModelPath != expectedModelPath || rf.LabelsPath != expectedLabelsPath {
+		return geomodelOrphanNone
+	}
+
+	if filesPresent {
+		if rf.Model == geomodelRangeFilterVersion {
+			return geomodelOrphanNone
+		}
+		return geomodelOrphanPromote
+	}
+
+	// Files absent: the gallery paths are still set (the guard above required an
+	// exact, non-empty match), so clearing them is always a real change.
+	return geomodelOrphanClear
+}
+
 // ensureGeomodelConfig checks if any installed model has geomodel companion
 // files on disk and, if the range filter config doesn't already reflect them,
-// updates the config and reloads the range filter.
+// updates the config and reloads the range filter. When NO installed
+// geomodel-capable model is matched, it runs the orphan self-heal so a persisted
+// config that references the gallery shared geomodel paths stays consistent with
+// reality (promote when the shared files exist, clear when they are absent).
 func (mm *ModelManager) ensureGeomodelConfig(log logger.Logger, installedIDs []string) {
 	if mm.orchestrator == nil {
 		return
@@ -247,53 +295,124 @@ func (mm *ModelManager) ensureGeomodelConfig(log logger.Logger, installedIDs []s
 			continue
 		}
 
-		// Build expected paths from catalog entry.
-		expectedModelPath := ""
-		expectedLabelsPath := ""
-		for _, f := range entry.Files {
-			switch f.Role {
-			case RoleGeomodelModel:
-				expectedModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			case RoleGeomodelLabels:
-				expectedLabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			}
-		}
-
-		// Files exist. Check if the config already matches expected paths.
-		currentSettings := conf.GetSettings()
-		rf := currentSettings.BirdNET.RangeFilter
-		if rf.Model == entry.GeomodelVersion &&
-			rf.ModelPath == expectedModelPath &&
-			rf.LabelsPath == expectedLabelsPath {
-			// Config already set; initializeMetaModel handled it at startup.
-			return
-		}
-
-		// Config is stale or missing; update it under settingsMu to
-		// serialize with concurrent install/uninstall config writes.
-		log.Info("Applying geomodel config for installed model",
-			logger.String("catalog_id", catalogID),
-			logger.String("geomodel_version", entry.GeomodelVersion))
-
-		mm.settingsMu.Lock()
-		updated := conf.CloneSettings(conf.GetSettings())
-		updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
-		updated.BirdNET.RangeFilter.ModelPath = expectedModelPath
-		updated.BirdNET.RangeFilter.LabelsPath = expectedLabelsPath
-		conf.StoreSettings(updated)
-		if err := conf.SaveSettings(); err != nil {
-			log.Warn("Failed to persist geomodel config",
-				logger.String("catalog_id", catalogID),
-				logger.Error(err))
-		}
-		mm.settingsMu.Unlock()
-
-		if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
-			log.Warn("Failed to reload range filter after geomodel config update",
-				logger.String("catalog_id", catalogID),
-				logger.Error(err))
-		}
+		// A geomodel-capable model is installed with its files present. Apply
+		// the install promote behavior and stop; the orphan self-heal must not run.
+		mm.applyInstalledGeomodelConfig(log, &entry, catalogID)
 		return
+	}
+
+	// No installed geomodel-capable model was matched. Reconcile a possibly
+	// orphaned gallery-managed config with the shared files on disk.
+	mm.healOrphanGeomodelConfig(log)
+}
+
+// applyInstalledGeomodelConfig promotes the range filter config to match an
+// installed geomodel-capable model whose shared files are present on disk. It is
+// a no-op when the config already matches the expected paths and version.
+func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *CatalogEntry, catalogID string) {
+	// Build expected paths from catalog entry.
+	expectedModelPath := ""
+	expectedLabelsPath := ""
+	for _, f := range entry.Files {
+		switch f.Role {
+		case RoleGeomodelModel:
+			expectedModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+		case RoleGeomodelLabels:
+			expectedLabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+		}
+	}
+
+	// Files exist. Check if the config already matches expected paths.
+	rf := conf.GetSettings().BirdNET.RangeFilter
+	if rf.Model == entry.GeomodelVersion &&
+		rf.ModelPath == expectedModelPath &&
+		rf.LabelsPath == expectedLabelsPath {
+		// Config already set; initializeMetaModel handled it at startup.
+		return
+	}
+
+	// Config is stale or missing; update it under settingsMu to
+	// serialize with concurrent install/uninstall config writes.
+	log.Info("Applying geomodel config for installed model",
+		logger.String("catalog_id", catalogID),
+		logger.String("geomodel_version", entry.GeomodelVersion))
+
+	mm.settingsMu.Lock()
+	updated := conf.CloneSettings(conf.GetSettings())
+	updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
+	updated.BirdNET.RangeFilter.ModelPath = expectedModelPath
+	updated.BirdNET.RangeFilter.LabelsPath = expectedLabelsPath
+	conf.StoreSettings(updated)
+	if err := conf.SaveSettings(); err != nil {
+		log.Warn("Failed to persist geomodel config",
+			logger.String("catalog_id", catalogID),
+			logger.Error(err))
+	}
+	mm.settingsMu.Unlock()
+
+	if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
+		log.Warn("Failed to reload range filter after geomodel config update",
+			logger.String("catalog_id", catalogID),
+			logger.Error(err))
+	}
+}
+
+// healOrphanGeomodelConfig reconciles a gallery-managed geomodel range filter
+// config when no geomodel-capable model is installed. It promotes the config to
+// v3 when the shared files are present (e.g. an upgrade that left Model unset),
+// or clears the dead references when the shared files are absent (e.g. the user
+// removed the only geomodel-capable model, leaving BirdNET v2.4 which cleanly
+// uses the embedded TFLite filter). Custom paths are never touched. It only
+// persists and reloads when something actually changed.
+//
+// On a normal startup, conf.Load's MigrateOrphanGeomodelRangeFilter has usually
+// already applied the same promote/clear at config-load time, so this path is
+// then a no-op. It still runs here to reload the range filter on the running
+// orchestrator and to cover cases where the config migration did not persist
+// (e.g. no config file on disk).
+func (mm *ModelManager) healOrphanGeomodelConfig(log logger.Logger) {
+	expectedModelPath := filepath.Join(mm.modelsDir, "shared", geomodelONNXLocalName)
+	expectedLabelsPath := filepath.Join(mm.modelsDir, "shared", geomodelLabelsLocalName)
+
+	filesPresent := true
+	for _, path := range []string{expectedModelPath, expectedLabelsPath} {
+		if _, err := os.Stat(path); err != nil {
+			filesPresent = false
+			break
+		}
+	}
+
+	rf := conf.GetSettings().BirdNET.RangeFilter
+	action := decideGeomodelOrphanAction(&rf, expectedModelPath, expectedLabelsPath, filesPresent)
+	if action == geomodelOrphanNone {
+		return
+	}
+
+	mm.settingsMu.Lock()
+	updated := conf.CloneSettings(conf.GetSettings())
+	switch action {
+	case geomodelOrphanPromote:
+		log.Info("Promoting orphaned geomodel range filter config to v3 (shared files present)")
+		updated.BirdNET.RangeFilter.Model = geomodelRangeFilterVersion
+	case geomodelOrphanClear:
+		log.Info("Clearing orphaned geomodel range filter config (shared files absent)")
+		updated.BirdNET.RangeFilter.Model = ""
+		updated.BirdNET.RangeFilter.ModelPath = ""
+		updated.BirdNET.RangeFilter.LabelsPath = ""
+		updated.BirdNET.RangeFilter.PassUnmappedSpecies = false
+	case geomodelOrphanNone:
+		// Unreachable: handled by the early return above.
+	}
+	conf.StoreSettings(updated)
+	if err := conf.SaveSettings(); err != nil {
+		log.Warn("Failed to persist orphan geomodel config self-heal",
+			logger.Error(err))
+	}
+	mm.settingsMu.Unlock()
+
+	if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
+		log.Warn("Failed to reload range filter after orphan geomodel self-heal",
+			logger.Error(err))
 	}
 }
 

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -322,23 +322,27 @@ func (mm *ModelManager) applyInstalledGeomodelConfig(log logger.Logger, entry *C
 		}
 	}
 
-	// Files exist. Check if the config already matches expected paths.
-	rf := conf.GetSettings().BirdNET.RangeFilter
+	// Decide and write under settingsMu so the already-matches check and the
+	// store operate on one consistent snapshot. Reading outside the lock would
+	// let a concurrent install/uninstall publish a newer config between the
+	// check and the store, overwriting it with stale data.
+	mm.settingsMu.Lock()
+	current := conf.GetSettings()
+	rf := current.BirdNET.RangeFilter
 	if rf.Model == entry.GeomodelVersion &&
 		rf.ModelPath == expectedModelPath &&
 		rf.LabelsPath == expectedLabelsPath {
 		// Config already set; initializeMetaModel handled it at startup.
+		mm.settingsMu.Unlock()
 		return
 	}
 
-	// Config is stale or missing; update it under settingsMu to
-	// serialize with concurrent install/uninstall config writes.
+	// Config is stale or missing; update it.
 	log.Info("Applying geomodel config for installed model",
 		logger.String("catalog_id", catalogID),
 		logger.String("geomodel_version", entry.GeomodelVersion))
 
-	mm.settingsMu.Lock()
-	updated := conf.CloneSettings(conf.GetSettings())
+	updated := conf.CloneSettings(current)
 	updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
 	updated.BirdNET.RangeFilter.ModelPath = expectedModelPath
 	updated.BirdNET.RangeFilter.LabelsPath = expectedLabelsPath
@@ -382,14 +386,21 @@ func (mm *ModelManager) healOrphanGeomodelConfig(log logger.Logger) {
 		}
 	}
 
-	rf := conf.GetSettings().BirdNET.RangeFilter
+	// Decide and write under settingsMu so the decision and the store operate on
+	// one consistent snapshot. Reading the config outside the lock would let a
+	// concurrent install publish a valid geomodel config between the decision
+	// and the store, after which a stale "clear" would wipe it. The filesystem
+	// check above is independent of settings, so it stays outside the lock.
+	mm.settingsMu.Lock()
+	current := conf.GetSettings()
+	rf := current.BirdNET.RangeFilter
 	action := decideGeomodelOrphanAction(&rf, expectedModelPath, expectedLabelsPath, filesPresent)
 	if action == geomodelOrphanNone {
+		mm.settingsMu.Unlock()
 		return
 	}
 
-	mm.settingsMu.Lock()
-	updated := conf.CloneSettings(conf.GetSettings())
+	updated := conf.CloneSettings(current)
 	switch action {
 	case geomodelOrphanPromote:
 		log.Info("Promoting orphaned geomodel range filter config to v3 (shared files present)")

--- a/internal/classifier/range_filter_self_heal_test.go
+++ b/internal/classifier/range_filter_self_heal_test.go
@@ -1,0 +1,253 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// writeSharedGeomodel creates the shared geomodel ONNX and labels files under
+// <modelsDir>/shared/ using the runtime's expected local filenames.
+func writeSharedGeomodel(t *testing.T, modelsDir string) (onnxPath, labelsPath string) {
+	t.Helper()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	onnxPath = filepath.Join(sharedDir, geomodelONNXLocalName)
+	labelsPath = filepath.Join(sharedDir, geomodelLabelsLocalName)
+	require.NoError(t, os.WriteFile(onnxPath, []byte("onnx"), 0o644))
+	require.NoError(t, os.WriteFile(labelsPath, []byte("labels"), 0o644))
+	return onnxPath, labelsPath
+}
+
+// sharedGeomodelExpectedPaths returns the gallery-managed shared paths under
+// modelsDir without creating the files.
+func sharedGeomodelExpectedPaths(modelsDir string) (onnxPath, labelsPath string) {
+	sharedDir := filepath.Join(modelsDir, "shared")
+	return filepath.Join(sharedDir, geomodelONNXLocalName), filepath.Join(sharedDir, geomodelLabelsLocalName)
+}
+
+// redirectConfigFile points conf persistence at a throwaway file so the orphan
+// self-heal's conf.SaveSettings call cannot touch the real user config during
+// tests. conf.ConfigPath is checked first by FindConfigFile, so setting it
+// fully redirects the write. The original value is restored on cleanup.
+func redirectConfigFile(t *testing.T) {
+	t.Helper()
+	cfg := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfg, []byte("{}\n"), 0o600))
+	orig := conf.ConfigPath
+	conf.ConfigPath = cfg
+	t.Cleanup(func() { conf.ConfigPath = orig })
+}
+
+func TestDecideGeomodelOrphanAction(t *testing.T) {
+	t.Parallel()
+
+	const modelPath = "/models/shared/geomodel_v3.0.2_fp16.onnx"
+	const labelsPath = "/models/shared/geomodel_v3.0.2_labels.txt"
+
+	tests := []struct {
+		name         string
+		rf           conf.RangeFilterSettings
+		filesPresent bool
+		want         geomodelOrphanAction
+	}{
+		{
+			name:         "gallery paths, files present, model empty -> promote",
+			rf:           conf.RangeFilterSettings{Model: "", ModelPath: modelPath, LabelsPath: labelsPath},
+			filesPresent: true,
+			want:         geomodelOrphanPromote,
+		},
+		{
+			name:         "gallery paths, files present, already v3 -> none",
+			rf:           conf.RangeFilterSettings{Model: "v3", ModelPath: modelPath, LabelsPath: labelsPath},
+			filesPresent: true,
+			want:         geomodelOrphanNone,
+		},
+		{
+			name:         "gallery paths, files absent, dead refs -> clear",
+			rf:           conf.RangeFilterSettings{Model: "v3", ModelPath: modelPath, LabelsPath: labelsPath},
+			filesPresent: false,
+			want:         geomodelOrphanClear,
+		},
+		{
+			name:         "gallery paths, files absent, model empty but paths still set -> clear",
+			rf:           conf.RangeFilterSettings{Model: "", ModelPath: modelPath, LabelsPath: labelsPath},
+			filesPresent: false,
+			want:         geomodelOrphanClear,
+		},
+		{
+			name:         "custom model path -> none",
+			rf:           conf.RangeFilterSettings{Model: "v3", ModelPath: "/custom/geo.onnx", LabelsPath: labelsPath},
+			filesPresent: true,
+			want:         geomodelOrphanNone,
+		},
+		{
+			name:         "custom labels path -> none",
+			rf:           conf.RangeFilterSettings{Model: "v3", ModelPath: modelPath, LabelsPath: "/custom/labels.txt"},
+			filesPresent: false,
+			want:         geomodelOrphanNone,
+		},
+		{
+			name:         "empty paths -> none",
+			rf:           conf.RangeFilterSettings{Model: "", ModelPath: "", LabelsPath: ""},
+			filesPresent: false,
+			want:         geomodelOrphanNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rf := tt.rf
+			got := decideGeomodelOrphanAction(&rf, modelPath, labelsPath, tt.filesPresent)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// newSelfHealManager builds a ModelManager wired to a minimal orchestrator
+// (no primary, so ReloadRangeFilter is a safe no-op) and to the global test
+// settings snapshot. installedIDs are returned for passing to ensureGeomodelConfig.
+func newSelfHealManager(t *testing.T, modelsDir string) *ModelManager {
+	t.Helper()
+	orch := &Orchestrator{models: make(map[string]*modelEntry)}
+	settings := conf.GetSettings()
+	return NewModelManager(modelsDir, orch, settings)
+}
+
+func TestEnsureGeomodelConfig_OrphanSelfHeal(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings and the
+	// process-global conf.ConfigPath.
+	redirectConfigFile(t)
+
+	t.Run("orphan files present promotes config to v3", func(t *testing.T) {
+		origSettings := conf.GetSettings()
+		t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+		modelsDir := t.TempDir()
+		onnxPath, labelsPath := writeSharedGeomodel(t, modelsDir)
+
+		settings := conf.GetTestSettings()
+		settings.Models.Directory = modelsDir
+		settings.BirdNET.RangeFilter.Model = ""
+		settings.BirdNET.RangeFilter.ModelPath = onnxPath
+		settings.BirdNET.RangeFilter.LabelsPath = labelsPath
+		conf.StoreSettings(settings)
+
+		mm := newSelfHealManager(t, modelsDir)
+		// No geomodel-capable model installed (orphan scenario).
+		mm.ensureGeomodelConfig(GetLogger(), nil)
+
+		current := conf.GetSettings()
+		assert.Equal(t, "v3", current.BirdNET.RangeFilter.Model)
+		assert.Equal(t, onnxPath, current.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, labelsPath, current.BirdNET.RangeFilter.LabelsPath)
+	})
+
+	t.Run("orphan files absent clears config", func(t *testing.T) {
+		origSettings := conf.GetSettings()
+		t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+		modelsDir := t.TempDir()
+		onnxPath, labelsPath := sharedGeomodelExpectedPaths(modelsDir)
+
+		settings := conf.GetTestSettings()
+		settings.Models.Directory = modelsDir
+		settings.BirdNET.RangeFilter.Model = "v3"
+		settings.BirdNET.RangeFilter.ModelPath = onnxPath
+		settings.BirdNET.RangeFilter.LabelsPath = labelsPath
+		settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+		conf.StoreSettings(settings)
+
+		mm := newSelfHealManager(t, modelsDir)
+		mm.ensureGeomodelConfig(GetLogger(), nil)
+
+		current := conf.GetSettings()
+		assert.Empty(t, current.BirdNET.RangeFilter.Model)
+		assert.Empty(t, current.BirdNET.RangeFilter.ModelPath)
+		assert.Empty(t, current.BirdNET.RangeFilter.LabelsPath)
+		assert.False(t, current.BirdNET.RangeFilter.PassUnmappedSpecies)
+	})
+
+	t.Run("custom paths are not touched", func(t *testing.T) {
+		origSettings := conf.GetSettings()
+		t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+		modelsDir := t.TempDir()
+		writeSharedGeomodel(t, modelsDir)
+
+		const customModel = "/custom/geo.onnx"
+		const customLabels = "/custom/labels.txt"
+
+		settings := conf.GetTestSettings()
+		settings.Models.Directory = modelsDir
+		settings.BirdNET.RangeFilter.Model = "v3"
+		settings.BirdNET.RangeFilter.ModelPath = customModel
+		settings.BirdNET.RangeFilter.LabelsPath = customLabels
+		conf.StoreSettings(settings)
+
+		mm := newSelfHealManager(t, modelsDir)
+		mm.ensureGeomodelConfig(GetLogger(), nil)
+
+		current := conf.GetSettings()
+		assert.Equal(t, "v3", current.BirdNET.RangeFilter.Model)
+		assert.Equal(t, customModel, current.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, customLabels, current.BirdNET.RangeFilter.LabelsPath)
+	})
+
+	t.Run("already v3 with present files is a no-op", func(t *testing.T) {
+		origSettings := conf.GetSettings()
+		t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+		modelsDir := t.TempDir()
+		onnxPath, labelsPath := writeSharedGeomodel(t, modelsDir)
+
+		settings := conf.GetTestSettings()
+		settings.Models.Directory = modelsDir
+		settings.BirdNET.RangeFilter.Model = "v3"
+		settings.BirdNET.RangeFilter.ModelPath = onnxPath
+		settings.BirdNET.RangeFilter.LabelsPath = labelsPath
+		conf.StoreSettings(settings)
+
+		// Capture the snapshot pointer so we can verify no new snapshot was published.
+		before := conf.GetSettings()
+
+		mm := newSelfHealManager(t, modelsDir)
+		mm.ensureGeomodelConfig(GetLogger(), nil)
+
+		after := conf.GetSettings()
+		assert.Same(t, before, after, "no-op must not publish a new settings snapshot")
+		assert.Equal(t, "v3", after.BirdNET.RangeFilter.Model)
+	})
+
+	t.Run("installed geomodel model preserves promote and skips orphan path", func(t *testing.T) {
+		origSettings := conf.GetSettings()
+		t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+		modelsDir := t.TempDir()
+		onnxPath, labelsPath := writeSharedGeomodel(t, modelsDir)
+
+		// Config stale (model empty) but a geomodel-capable model IS installed:
+		// existing promote behavior must set v3 via the loop, not the orphan path.
+		settings := conf.GetTestSettings()
+		settings.Models.Directory = modelsDir
+		settings.BirdNET.RangeFilter.Model = ""
+		settings.BirdNET.RangeFilter.ModelPath = onnxPath
+		settings.BirdNET.RangeFilter.LabelsPath = labelsPath
+		conf.StoreSettings(settings)
+
+		// perch-v2 is a real catalog entry with geomodel files whose LocalNames
+		// match the shared geomodel files created above.
+		mm := newSelfHealManager(t, modelsDir)
+		mm.ensureGeomodelConfig(GetLogger(), []string{"perch-v2"})
+
+		current := conf.GetSettings()
+		assert.Equal(t, "v3", current.BirdNET.RangeFilter.Model, "installed-model promote must still apply")
+		assert.Equal(t, onnxPath, current.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, labelsPath, current.BirdNET.RangeFilter.LabelsPath)
+	})
+}

--- a/internal/conf/range_filter_migration.go
+++ b/internal/conf/range_filter_migration.go
@@ -1,0 +1,109 @@
+package conf
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Shared geomodel filenames. These MIRROR internal/classifier/birdnet.go
+// geomodelONNXLocalName and geomodelLabelsLocalName. The conf package cannot
+// import classifier (classifier imports conf; importing back would create an
+// import cycle), so the constants are duplicated here. They MUST stay in sync
+// with the classifier definitions; if the gallery changes the shared geomodel
+// filenames, update both places.
+const (
+	geomodelSharedONNXLocalName   = "geomodel_v3.0.2_fp16.onnx"
+	geomodelSharedLabelsLocalName = "geomodel_v3.0.2_labels.txt"
+)
+
+// rangeFilterGeomodelV3 is the literal that the runtime, status code, and UI
+// key off to recognize the geomodel v3 range filter (see
+// internal/classifier/birdnet.go and internal/conf/validate_services.go).
+const rangeFilterGeomodelV3 = "v3"
+
+// resolveModelsDir computes the model gallery directory the same way
+// internal/analysis/birdnet_service.go initModelManager does, WITHOUT importing
+// the classifier package. If Models.Directory is set, it is used verbatim;
+// otherwise the OS user config directory is used (falling back to
+// <home>/.config when os.UserConfigDir fails), joined with "birdnet-go/models".
+// The second return value is false when the directory cannot be resolved, in
+// which case callers should do nothing.
+func (s *Settings) resolveModelsDir() (string, bool) {
+	if s.Models.Directory != "" {
+		return s.Models.Directory, true
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		homeDir, homeErr := GetUserHomeDir()
+		if homeErr != nil {
+			return "", false
+		}
+		configDir = filepath.Join(homeDir, ".config")
+	}
+	return filepath.Join(configDir, "birdnet-go", "models"), true
+}
+
+// MigrateOrphanGeomodelRangeFilter reconciles a persisted geomodel-shaped range
+// filter config with the gallery-managed shared files on disk. It is a one-time
+// migration applied at config load; the caller persists the result when this
+// method returns true.
+//
+// It only acts when the range filter points at the EXACT gallery-managed shared
+// paths (<modelsDir>/shared/<geomodel files>); custom or hand-edited paths are
+// never touched. When both shared files exist on disk, the config is promoted
+// to Model="v3". When the shared files are absent (an orphaned reference, e.g.
+// the user removed the only geomodel-capable model), the geomodel range filter
+// fields are cleared so BirdNET v2.4 cleanly falls back to the embedded TFLite
+// filter. If the config already matches the on-disk reality, it is a no-op.
+//
+// Returns true if the config was changed, false otherwise.
+func (s *Settings) MigrateOrphanGeomodelRangeFilter() bool {
+	modelsDir, ok := s.resolveModelsDir()
+	if !ok {
+		return false
+	}
+
+	sharedDir := filepath.Join(modelsDir, "shared")
+	expectedModelPath := filepath.Join(sharedDir, geomodelSharedONNXLocalName)
+	expectedLabelsPath := filepath.Join(sharedDir, geomodelSharedLabelsLocalName)
+
+	rf := &s.BirdNET.RangeFilter
+
+	// Only reconcile gallery-managed configs. An exact match on both shared
+	// paths is the signal that the gallery owns this config; anything else
+	// (custom paths, empty paths) is left alone.
+	if rf.ModelPath != expectedModelPath || rf.LabelsPath != expectedLabelsPath {
+		return false
+	}
+
+	if sharedGeomodelFilesPresent(expectedModelPath, expectedLabelsPath) {
+		// Files exist: ensure the config keys off v3. No-op if already v3.
+		if rf.Model == rangeFilterGeomodelV3 {
+			return false
+		}
+		rf.Model = rangeFilterGeomodelV3
+		return true
+	}
+
+	// Files are absent: clear the dead references so v2.4 uses the embedded
+	// filter. The gallery paths are still set (the guard above required an exact,
+	// non-empty match), so clearing them is always a real change.
+	rf.Model = ""
+	rf.ModelPath = ""
+	rf.LabelsPath = ""
+	rf.PassUnmappedSpecies = false
+	return true
+}
+
+// sharedGeomodelFilesPresent reports whether both shared geomodel files exist
+// on disk.
+func sharedGeomodelFilesPresent(modelPath, labelsPath string) bool {
+	if _, err := os.Stat(modelPath); err != nil {
+		return false
+	}
+	if _, err := os.Stat(labelsPath); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/conf/range_filter_migration_test.go
+++ b/internal/conf/range_filter_migration_test.go
@@ -1,0 +1,131 @@
+package conf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSharedGeomodelFiles creates the shared geomodel ONNX and labels files
+// under <modelsDir>/shared/ so resolution and os.Stat checks succeed.
+func writeSharedGeomodelFiles(t *testing.T, modelsDir string) {
+	t.Helper()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, geomodelSharedONNXLocalName), []byte("onnx"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, geomodelSharedLabelsLocalName), []byte("labels"), 0o644))
+}
+
+// sharedGeomodelPaths returns the gallery-managed shared ONNX and labels paths
+// under modelsDir.
+func sharedGeomodelPaths(modelsDir string) (onnxPath, labelsPath string) {
+	sharedDir := filepath.Join(modelsDir, "shared")
+	return filepath.Join(sharedDir, geomodelSharedONNXLocalName), filepath.Join(sharedDir, geomodelSharedLabelsLocalName)
+}
+
+func TestMigrateOrphanGeomodelRangeFilter(t *testing.T) {
+	// Not parallel: mutates settings fields and relies on Models.Directory
+	// for deterministic resolution.
+
+	t.Run("orphan shared paths with both files present promotes to v3", func(t *testing.T) {
+		modelsDir := t.TempDir()
+		writeSharedGeomodelFiles(t, modelsDir)
+		onnxPath, labelsPath := sharedGeomodelPaths(modelsDir)
+
+		s := GetTestSettings()
+		s.Models.Directory = modelsDir
+		s.BirdNET.RangeFilter.Model = ""
+		s.BirdNET.RangeFilter.ModelPath = onnxPath
+		s.BirdNET.RangeFilter.LabelsPath = labelsPath
+
+		changed := s.MigrateOrphanGeomodelRangeFilter()
+
+		assert.True(t, changed, "promote must report a change")
+		assert.Equal(t, "v3", s.BirdNET.RangeFilter.Model)
+		assert.Equal(t, onnxPath, s.BirdNET.RangeFilter.ModelPath, "model path must be left intact")
+		assert.Equal(t, labelsPath, s.BirdNET.RangeFilter.LabelsPath, "labels path must be left intact")
+	})
+
+	t.Run("orphan shared paths with files absent clears config", func(t *testing.T) {
+		modelsDir := t.TempDir()
+		// Intentionally do NOT create the shared files.
+		onnxPath, labelsPath := sharedGeomodelPaths(modelsDir)
+
+		s := GetTestSettings()
+		s.Models.Directory = modelsDir
+		s.BirdNET.RangeFilter.Model = "v3"
+		s.BirdNET.RangeFilter.ModelPath = onnxPath
+		s.BirdNET.RangeFilter.LabelsPath = labelsPath
+		s.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+		changed := s.MigrateOrphanGeomodelRangeFilter()
+
+		assert.True(t, changed, "clear must report a change")
+		assert.Empty(t, s.BirdNET.RangeFilter.Model)
+		assert.Empty(t, s.BirdNET.RangeFilter.ModelPath)
+		assert.Empty(t, s.BirdNET.RangeFilter.LabelsPath)
+		assert.False(t, s.BirdNET.RangeFilter.PassUnmappedSpecies)
+	})
+
+	t.Run("custom paths are never touched", func(t *testing.T) {
+		modelsDir := t.TempDir()
+		writeSharedGeomodelFiles(t, modelsDir)
+
+		const customModel = "/custom/geomodel.onnx"
+		const customLabels = "/custom/geomodel_labels.txt"
+
+		s := GetTestSettings()
+		s.Models.Directory = modelsDir
+		s.BirdNET.RangeFilter.Model = "v3"
+		s.BirdNET.RangeFilter.ModelPath = customModel
+		s.BirdNET.RangeFilter.LabelsPath = customLabels
+		s.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+		changed := s.MigrateOrphanGeomodelRangeFilter()
+
+		assert.False(t, changed, "custom paths must not be migrated")
+		assert.Equal(t, "v3", s.BirdNET.RangeFilter.Model)
+		assert.Equal(t, customModel, s.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, customLabels, s.BirdNET.RangeFilter.LabelsPath)
+		assert.True(t, s.BirdNET.RangeFilter.PassUnmappedSpecies)
+	})
+
+	t.Run("already v3 with shared paths and files present is a no-op", func(t *testing.T) {
+		modelsDir := t.TempDir()
+		writeSharedGeomodelFiles(t, modelsDir)
+		onnxPath, labelsPath := sharedGeomodelPaths(modelsDir)
+
+		s := GetTestSettings()
+		s.Models.Directory = modelsDir
+		s.BirdNET.RangeFilter.Model = "v3"
+		s.BirdNET.RangeFilter.ModelPath = onnxPath
+		s.BirdNET.RangeFilter.LabelsPath = labelsPath
+
+		changed := s.MigrateOrphanGeomodelRangeFilter()
+
+		assert.False(t, changed, "matching config must be a no-op")
+		assert.Equal(t, "v3", s.BirdNET.RangeFilter.Model)
+		assert.Equal(t, onnxPath, s.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, labelsPath, s.BirdNET.RangeFilter.LabelsPath)
+	})
+
+	t.Run("already cleared with shared paths and files absent is a no-op", func(t *testing.T) {
+		modelsDir := t.TempDir()
+		// No shared files, config already empty for all geomodel fields.
+		s := GetTestSettings()
+		s.Models.Directory = modelsDir
+		s.BirdNET.RangeFilter.Model = ""
+		s.BirdNET.RangeFilter.ModelPath = ""
+		s.BirdNET.RangeFilter.LabelsPath = ""
+
+		changed := s.MigrateOrphanGeomodelRangeFilter()
+
+		assert.False(t, changed, "non-gallery (empty) paths must not be migrated")
+		assert.Empty(t, s.BirdNET.RangeFilter.Model)
+		assert.Empty(t, s.BirdNET.RangeFilter.ModelPath)
+		assert.Empty(t, s.BirdNET.RangeFilter.LabelsPath)
+	})
+}

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -106,6 +106,13 @@ func Load() (*Settings, error) {
 		persistMigration(settings, "dashboard layout")
 	}
 
+	// Reconcile an orphaned geomodel-shaped range filter config with the
+	// gallery-managed shared files on disk (promote to v3 when present, clear
+	// dead references when absent).
+	if settings.MigrateOrphanGeomodelRangeFilter() {
+		persistMigration(settings, "orphan geomodel range filter")
+	}
+
 	// Apply default transport to RTSP/RTMP streams that don't specify one
 	settings.Realtime.RTSP.ApplyStreamDefaults()
 


### PR DESCRIPTION
Follow-up config hygiene for the range-filter robustness work merged in #3324 (which closed #3320 / #3151). #3324 made the runtime correct by routing geomodel-shaped configs through the mapped path; this PR keeps the persisted config consistent with reality so the Species-page status banner and the heatmap, which key off `rangefilter.model == "v3"`, report correctly.

## Problem

When the only geomodel-capable model is removed (for example Perch or BirdNET v3 uninstalled, leaving BirdNET v2.4), a gallery-managed range-filter config can be left pointing at the shared geomodel paths with no model to back them. The persisted config then drifts from on-disk reality. `ensureGeomodelConfig` previously only promoted config for an installed geomodel-capable model; it did not handle this orphan case.

## Fix

**Runtime self-heal** (`internal/classifier/model_manager.go`): `ensureGeomodelConfig` is split into `applyInstalledGeomodelConfig` (the existing install-time promote, behavior unchanged) and `healOrphanGeomodelConfig`, which runs only when no installed geomodel-capable model is matched during the gallery scan. It reconciles a config pointing at the EXACT gallery shared geomodel paths:

- shared files present -> promote `model` to `"v3"`
- shared files absent -> clear `model` / `modelpath` / `labelspath` / `passunmappedspecies` so BirdNET v2.4 cleanly uses the embedded TFLite filter
- custom or hand-edited paths are never touched

The decision is a pure, table-tested helper (`decideGeomodelOrphanAction`); persistence and reload reuse the existing `settingsMu` clone-store-save pattern and only fire when something actually changed.

**One-time migration** (`internal/conf/range_filter_migration.go`, `MigrateOrphanGeomodelRangeFilter`) applies the same safe promote/clear at config load, so installs already affected before this change are reconciled on upgrade.

## Note on the duplicated constants

`conf` cannot import `classifier` (classifier imports conf, so importing back would create a cycle). The two shared geomodel filename constants are therefore duplicated in `conf` with a keep-in-sync comment on both sides, and `modelsDir` is resolved the same way `internal/analysis/birdnet_service.go` resolves it. The exact-path guard makes the migration safe against directory mis-resolution: if the recomputed gallery path does not match the persisted path, the config is left untouched.

## Testing

- `internal/conf`: `TestMigrateOrphanGeomodelRangeFilter` (promote, clear, custom-untouched, already-v3 no-op, empty-paths no-op).
- `internal/classifier`: `TestDecideGeomodelOrphanAction` (7 cases) and `TestEnsureGeomodelConfig_OrphanSelfHeal` (orphan promote/clear, custom untouched, already-v3 no-op via snapshot-identity check, installed-model still promotes). The integration test redirects the config path to a temp file so it never touches the real user config.
- `task lint` clean; `internal/classifier` and `internal/conf` suites pass with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects and recovers orphaned geomodel range-filter configuration by synchronizing with shared gallery-managed model files on disk; migration runs during config load.
  * Improved prioritization: installed geomodels are promoted when present, avoiding stale orphan handling.

* **Tests**
  * Added comprehensive tests covering orphan detection, promotion, clearing, and installed-model promotion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->