### PR TITLE
fix: guard orchestrator ModelInfo and resolver reads against concurrent reload

### DIFF
--- a/internal/classifier/label_files.go
+++ b/internal/classifier/label_files.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path"
-	"path/filepath"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -175,24 +174,4 @@ func GetLabelFileDataWithLogger(modelVersion, localeCode string, logger Logger) 
 		return nil, result.Error
 	}
 	return result.Data, nil
-}
-
-// listAvailableFiles returns a list of available label files for debugging
-func listAvailableFiles() ([]string, error) {
-	availableFiles := []string{}
-	walkErr := fs.WalkDir(v24LabelFiles, "data/labels/V2.4", func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() {
-			availableFiles = append(availableFiles, filepath.Base(p))
-		}
-		return nil
-	})
-
-	if walkErr != nil {
-		return nil, fmt.Errorf("error listing available label files: %w", walkErr)
-	}
-
-	return availableFiles, nil
 }

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -884,7 +884,7 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 		}
 		mm.mu.Unlock()
 
-		if err := mm.downloadFile(ctx, entry.ID, url, destPath, f.SHA256, f.SizeBytes, completedBytes); err != nil {
+		if err := mm.downloadFile(ctx, entry.ID, url, destPath, f.SHA256, completedBytes); err != nil {
 			log.Error("Failed to download file",
 				logger.String("catalog_id", entry.ID),
 				logger.String("url", url),
@@ -1231,7 +1231,7 @@ var downloadHTTPClient = &http.Client{
 // polling. completedBytes is the cumulative size of previously downloaded
 // files, used so progress reflects total download, not just the current file.
 // On failure, any temporary file is cleaned up.
-func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPath, expectedSHA256 string, totalBytes, completedBytes int64) error {
+func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPath, expectedSHA256 string, completedBytes int64) error {
 	// Ensure parent directory exists.
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return errors.Newf("failed to create directory for %s: %v", destPath, err).

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -216,7 +216,7 @@ func TestModelManager_DownloadFile(t *testing.T) {
 	destPath := filepath.Join(mm.modelsDir, "test-model", "model.onnx")
 
 	mm.downloading["test-download"] = &DownloadState{CatalogID: "test-download", Status: StatusDownloading}
-	err := mm.downloadFile(t.Context(), "test-download", srv.URL+"/model.onnx", destPath, checksum, int64(len(content)), 0)
+	err := mm.downloadFile(t.Context(), "test-download", srv.URL+"/model.onnx", destPath, checksum, 0)
 	require.NoError(t, err)
 
 	// Verify file was written with correct content.
@@ -250,7 +250,7 @@ func TestModelManager_DownloadFile_BadChecksum(t *testing.T) {
 	destPath := filepath.Join(mm.modelsDir, "bad-checksum", "model.onnx")
 
 	mm.downloading["test-bad-checksum"] = &DownloadState{CatalogID: "test-bad-checksum", Status: StatusDownloading}
-	err := mm.downloadFile(t.Context(), "test-bad-checksum", srv.URL+"/model.onnx", destPath, wrongChecksum, int64(len(content)), 0)
+	err := mm.downloadFile(t.Context(), "test-bad-checksum", srv.URL+"/model.onnx", destPath, wrongChecksum, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checksum")
 
@@ -278,7 +278,7 @@ func TestModelManager_DownloadFile_EmptySHA256(t *testing.T) {
 	destPath := filepath.Join(mm.modelsDir, "no-checksum", "model.onnx")
 
 	mm.downloading["test-no-checksum"] = &DownloadState{CatalogID: "test-no-checksum", Status: StatusDownloading}
-	err := mm.downloadFile(t.Context(), "test-no-checksum", srv.URL+"/model.onnx", destPath, "", int64(len(content)), 0)
+	err := mm.downloadFile(t.Context(), "test-no-checksum", srv.URL+"/model.onnx", destPath, "", 0)
 	require.NoError(t, err, "empty expectedSHA256 should skip verification")
 
 	got, err := os.ReadFile(destPath)
@@ -302,7 +302,7 @@ func TestModelManager_DownloadFile_ContextCancelled(t *testing.T) {
 	cancel()
 
 	mm.downloading["test-cancelled"] = &DownloadState{CatalogID: "test-cancelled", Status: StatusDownloading}
-	err := mm.downloadFile(ctx, "test-cancelled", srv.URL+"/model.onnx", destPath, "", 4, 0)
+	err := mm.downloadFile(ctx, "test-cancelled", srv.URL+"/model.onnx", destPath, "", 0)
 	require.Error(t, err, "cancelled context should produce an error")
 
 	_, statErr := os.Stat(destPath)
@@ -567,6 +567,7 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 	// unload the primary model, simulating a "model still in use" failure.
 	primaryBN := &BirdNET{ModelInfo: ModelInfo{ID: entry.RegistryID}}
 	orch := &Orchestrator{
+		ModelInfo: primaryBN.ModelInfo, // mirror the primary, as NewOrchestrator does
 		models: map[string]*modelEntry{
 			entry.RegistryID: {instance: primaryBN},
 		},

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -140,23 +140,29 @@ func (o *Orchestrator) SetModelsDir(dir string) {
 // resolver chain. This provides multilingual common name resolution for
 // species not covered by BirdNET's label files.
 //
-// Called during initialization before inference goroutines start, so the
-// unsynchronized append to nameResolvers is safe.
+// The append and the ResolveName read are guarded by o.mu so a future dynamic
+// registration (e.g. a models-directory hot-reload) cannot race with inference
+// goroutines calling ResolveName. Registration is idempotent via a
+// double-checked guard.
 func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
 	if o.Settings == nil {
 		return
 	}
 
-	for _, r := range o.nameResolvers {
-		if _, ok := r.(*TaxonomyResolver); ok {
-			return
-		}
+	// Fast path: a taxonomy resolver is already registered. Read under RLock so
+	// this never races with a concurrent ResolveName on the inference path.
+	o.mu.RLock()
+	exists := o.hasTaxonomyResolverLocked()
+	o.mu.RUnlock()
+	if exists {
+		return
 	}
 
 	log := GetLogger()
 	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
 
 	locale := o.Settings.BirdNET.Locale
+	// Load the resolver outside the lock; NewTaxonomyResolver does file I/O.
 	resolver, err := NewTaxonomyResolver(taxonomyPath, locale)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -167,11 +173,31 @@ func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
 		return
 	}
 
+	// Append under the write lock, re-checking in case another caller registered
+	// a resolver while this one was loading. Keeps registration idempotent.
+	o.mu.Lock()
+	if o.hasTaxonomyResolverLocked() {
+		o.mu.Unlock()
+		return
+	}
 	o.nameResolvers = append(o.nameResolvers, resolver)
+	o.mu.Unlock()
+
 	log.Info("Taxonomy resolver registered",
 		logger.String("path", taxonomyPath),
 		logger.String("locale", locale),
 		logger.Int("species", len(resolver.index)))
+}
+
+// hasTaxonomyResolverLocked reports whether a TaxonomyResolver is already
+// present in the name-resolver chain. The caller must hold o.mu (read or write).
+func (o *Orchestrator) hasTaxonomyResolverLocked() bool {
+	for _, r := range o.nameResolvers {
+		if _, ok := r.(*TaxonomyResolver); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // SetSunCalc injects the sun calculator into the orchestrator and starts
@@ -356,7 +382,14 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 // ResolveName walks the resolver chain and returns the first non-empty
 // common name for the given scientific name and locale.
 func (o *Orchestrator) ResolveName(scientificName, locale string) string {
-	for _, r := range o.nameResolvers {
+	// Snapshot the resolver chain under RLock so a concurrent
+	// registerTaxonomyResolver append cannot corrupt the slice header.
+	// Resolvers are only ever appended (never mutated in place), so iterating
+	// the snapshot outside the lock is safe.
+	o.mu.RLock()
+	resolvers := o.nameResolvers
+	o.mu.RUnlock()
+	for _, r := range resolvers {
 		if name := r.Resolve(scientificName, locale); name != "" {
 			return name
 		}
@@ -440,7 +473,10 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	}
 
 	o.mu.RLock()
-	primaryID := primary.ModelInfo.ID
+	// Read o.ModelInfo.ID, the o.mu-guarded copy of the primary's identity, not
+	// primary.ModelInfo.ID: the latter is mutated by BirdNET.ReloadModel under
+	// bn.mu and would race with a concurrent reload.
+	primaryID := o.ModelInfo.ID
 	refs := make([]entryRef, 0, len(o.models))
 	for id, entry := range o.models {
 		if id == primaryID || id == RegistryIDBat {
@@ -591,8 +627,12 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 
 	var refs []entryRef
 	o.mu.RLock()
+	// Compare against o.ModelInfo.ID, the o.mu-guarded copy of the primary's
+	// identity, not primary.ModelInfo.ID which is mutated by BirdNET.ReloadModel
+	// under bn.mu and would race with a concurrent reload.
+	primaryID := o.ModelInfo.ID
 	for id, entry := range o.models {
-		if id == primary.ModelInfo.ID || id == RegistryIDBat {
+		if id == primaryID || id == RegistryIDBat {
 			continue
 		}
 		refs = append(refs, entryRef{id: id, entry: entry})
@@ -720,7 +760,11 @@ func (o *Orchestrator) ReloadModel() error {
 			Category(errors.CategoryValidation).
 			Build()
 	}
-	entry := o.models[primary.ModelInfo.ID]
+	// Key the lookup by o.ModelInfo.ID (o.mu-guarded), not primary.ModelInfo.ID
+	// which BirdNET.ReloadModel mutates under bn.mu. The two are always equal
+	// outside an in-progress reload (which holds o.mu.Lock), and the models map
+	// is keyed by this same ID, so the lookup is unchanged but race-free.
+	entry := o.models[o.ModelInfo.ID]
 	o.mu.RUnlock()
 
 	if entry == nil {
@@ -918,8 +962,10 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 			Build()
 	}
 
-	// Refuse to unload the primary model.
-	if o.primary != nil && o.primary.ModelInfo.ID == registryID {
+	// Refuse to unload the primary model. Compare against o.ModelInfo.ID
+	// (o.mu-guarded, held here as a write lock) rather than
+	// o.primary.ModelInfo.ID, which BirdNET.ReloadModel mutates under bn.mu.
+	if o.primary != nil && o.ModelInfo.ID == registryID {
 		o.mu.Unlock()
 		return errors.Newf("cannot unload the primary model %s", registryID).
 			Component("classifier.orchestrator").

--- a/internal/classifier/orchestrator_allspecies_test.go
+++ b/internal/classifier/orchestrator_allspecies_test.go
@@ -57,8 +57,9 @@ func buildAllSpeciesOrchestrator(t *testing.T, settings *conf.Settings, rf *fake
 	}
 
 	return &Orchestrator{
-		Settings: settings,
-		primary:  bn,
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo, // mirror the primary, as NewOrchestrator does
+		primary:   bn,
 		models: map[string]*modelEntry{
 			primaryID:    {instance: bn},
 			nonPrimaryID: {instance: nonPrimary},
@@ -257,8 +258,9 @@ func TestGetAllProbableSpecies_NonUniversalPrimary(t *testing.T) {
 	}
 
 	o := &Orchestrator{
-		Settings: settings,
-		primary:  bn,
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo, // mirror the primary, as NewOrchestrator does
+		primary:   bn,
 		models: map[string]*modelEntry{
 			"BirdNET_V2.4": {instance: bn},
 			"Perch_V2":     {instance: nonPrimary},
@@ -315,8 +317,9 @@ func TestGetAllProbableSpecies_BatModelSkipped(t *testing.T) {
 	}
 
 	o := &Orchestrator{
-		Settings: settings,
-		primary:  bn,
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo, // mirror the primary, as NewOrchestrator does
+		primary:   bn,
 		models: map[string]*modelEntry{
 			primaryID:     {instance: bn},
 			RegistryIDBat: {instance: batModel},
@@ -362,8 +365,9 @@ func TestGetAllProbableSpecies_DeterministicDedupByModelID(t *testing.T) {
 	higher := &mockModelInstance{id: "zzz_model", labels: []string{"Aratinga solstitialis_Sun Parakeet"}}
 
 	o := &Orchestrator{
-		Settings: settings,
-		primary:  bn,
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo, // mirror the primary, as NewOrchestrator does
+		primary:   bn,
 		models: map[string]*modelEntry{
 			primaryID:   {instance: bn},
 			"aaa_model": {instance: lower},

--- a/internal/classifier/orchestrator_race_test.go
+++ b/internal/classifier/orchestrator_race_test.go
@@ -1,0 +1,167 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestOrchestrator_ConcurrentReloadAndReads_NoRace is the regression guard for
+// the orchestrator ModelInfo reload-vs-read data race. The orchestrator must
+// read its own o.mu-guarded o.ModelInfo.ID,
+// not the primary BirdNET's bn.mu-guarded ModelInfo.ID, when it iterates the
+// models map under o.mu. BirdNET.ReloadModel mutates bn.ModelInfo under bn.mu
+// (never under o.mu), so a model reload running concurrently with
+// GetAllProbableSpeciesWithSettings / RangeFilterStatus is a data race on
+// ModelInfo unless the orchestrator consults its own synced copy.
+//
+// Must be run with -race. The reloader spins for the full duration of the
+// readers so the write window always overlaps the reads.
+func TestOrchestrator_ConcurrentReloadAndReads_NoRace(t *testing.T) {
+	const primaryID = "BirdNET_V3"
+
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores:    []SpeciesScore{{Score: 0.9, Label: "Turdus merula_Common Blackbird"}},
+		rawScores: []float32{0.9},
+	}
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		rangeFilter:  rf,
+	}
+	bn.ModelInfo = ModelInfo{ID: primaryID, Name: "BirdNET v3.0"}
+
+	nonPrimary := &mockModelInstance{id: "Perch_V2", labels: []string{"Aratinga solstitialis"}}
+
+	o := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo, // o.mu-guarded copy, mirrors the primary (as NewOrchestrator wires it)
+		primary:   bn,
+		models: map[string]*modelEntry{
+			primaryID:  {instance: bn},
+			"Perch_V2": {instance: nonPrimary},
+		},
+	}
+
+	const readsPerGoroutine = 200
+	const readerCount = 4
+
+	var readerWg sync.WaitGroup
+	var readersDone atomic.Bool
+	start := make(chan struct{})
+
+	// Reloader: mutate bn.ModelInfo under bn.mu exactly as BirdNET.ReloadModel
+	// does. The model identity never changes across reloads (ReloadModel rejects
+	// identity changes), so the ID stays primaryID; only the write matters here.
+	// It spins until every reader has finished so the write window always
+	// overlaps the reads. Joined via reloaderDone, so no WaitGroup is needed.
+	reloaderDone := make(chan struct{})
+	go func() {
+		defer close(reloaderDone)
+		<-start
+		for !readersDone.Load() {
+			bn.mu.Lock()
+			bn.ModelInfo = ModelInfo{ID: primaryID, Name: "BirdNET v3.0"}
+			bn.mu.Unlock()
+		}
+	}()
+
+	// Readers: hammer the two orchestrator methods that read the primary ID
+	// while iterating o.models under o.mu.
+	for range readerCount {
+		readerWg.Go(func() {
+			<-start
+			for range readsPerGoroutine {
+				if _, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings); err != nil {
+					t.Errorf("GetAllProbableSpeciesWithSettings returned error: %v", err)
+				}
+				_ = o.RangeFilterStatus()
+			}
+		})
+	}
+
+	close(start)
+	readerWg.Wait()
+	readersDone.Store(true)
+	<-reloaderDone
+}
+
+// TestOrchestrator_ConcurrentResolverRegistrationAndResolve_NoRace is the
+// regression guard for the nameResolvers append/read data race.
+// registerTaxonomyResolver appends to
+// o.nameResolvers and ResolveName iterates it from the inference path; both must
+// be synchronized with o.mu so a dynamic resolver registration cannot corrupt
+// the slice header for concurrent readers. The fix is also idempotent: exactly
+// one taxonomy resolver is registered even under concurrent registration.
+//
+// Must be run with -race. Readers spin for the full duration of the writers so
+// the append window always overlaps the reads.
+func TestOrchestrator_ConcurrentResolverRegistrationAndResolve_NoRace(t *testing.T) {
+	// Place a taxonomy fixture at {dir}/shared/taxonomy.csv so
+	// registerTaxonomyResolver loads a real resolver and performs the append.
+	dir := t.TempDir()
+	sharedDir := filepath.Join(dir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, "taxonomy.csv"), []byte(testTaxonomyCSV), 0o644))
+
+	settings := conf.GetTestSettings()
+	settings.BirdNET.Locale = "en-uk"
+
+	o := &Orchestrator{
+		Settings:      settings,
+		nameResolvers: []NameResolver{NewBirdNETLabelResolver([]string{"Struthio camelus_Common Ostrich"})},
+	}
+
+	const writerCount = 8
+	const readerCount = 4
+
+	var writerWg, readerWg sync.WaitGroup
+	var writersDone atomic.Bool
+	start := make(chan struct{})
+
+	// Writers: register the taxonomy resolver concurrently. Only the first
+	// should append; the guarded double-check keeps it race-free and idempotent.
+	for range writerCount {
+		writerWg.Go(func() {
+			<-start
+			o.registerTaxonomyResolver(dir)
+		})
+	}
+
+	// Readers: resolve names off the inference path while the append happens.
+	// They spin until every writer has finished registering.
+	for range readerCount {
+		readerWg.Go(func() {
+			<-start
+			for !writersDone.Load() {
+				_ = o.ResolveName("Struthio camelus", "")
+			}
+		})
+	}
+
+	close(start)
+	writerWg.Wait()
+	writersDone.Store(true)
+	readerWg.Wait()
+
+	// The double-checked append must register exactly one taxonomy resolver.
+	count := 0
+	for _, r := range o.nameResolvers {
+		if _, ok := r.(*TaxonomyResolver); ok {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "exactly one taxonomy resolver must be registered under concurrent registration")
+}

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -163,7 +163,8 @@ func BuildRangeFilter(o *Orchestrator) error {
 			time.Now().Format(time.DateTime),
 			len(includedSpecies))
 		for _, species := range includedSpecies {
-			content.WriteString(species + "\n")
+			content.WriteString(species)
+			content.WriteByte('\n')
 		}
 		if err := os.WriteFile(debugFile, []byte(content.String()), 0o600); err != nil {
 			GetLogger().Warn("Failed to write included species debug file",


### PR DESCRIPTION
## Summary

The classifier `Orchestrator` had two data races on the model-reload path, both surfaced by `-race`:

- **ModelInfo read vs. reload.** `GetAllProbableSpeciesWithSettings`, `RangeFilterStatus`, `ReloadModel`, and `UnloadModel` read the primary `BirdNET`'s `ModelInfo.ID` while holding only `o.mu`. `BirdNET.ReloadModel` mutates `bn.ModelInfo` under `bn.mu`, so a concurrent model reload races those reads. The four sites now read `o.ModelInfo.ID`, the `o.mu`-guarded copy that `NewOrchestrator` and `ReloadModel` keep in sync with the primary and that also keys the models map. The model identity never changes across a reload, so this is behavior-preserving.
- **Name-resolver chain.** `registerTaxonomyResolver` appended to `o.nameResolvers` without a lock while `ResolveName` iterated it from the inference path. The append is now guarded by `o.mu` with a double-checked, idempotent registration, and `ResolveName` snapshots the resolver slice under `RLock` before iterating.

Two `-race` regression tests are added: one reloads the primary concurrently with the accessor reads, the other registers resolvers concurrently with `ResolveName` (and asserts the registration stays idempotent).

Minor classifier cleanups found along the way:
- Avoid a per-iteration string concatenation in the range-filter debug dump (`strings.Builder.WriteByte`).
- Drop the unused `totalBytes` parameter from `ModelManager.downloadFile`.
- Remove the dead `listAvailableFiles` helper (and its now-unused import).

## Test Plan
- [x] `task lint` (golangci-lint, full project): 0 issues
- [x] `task test` (full suite, `-race`): green
- [x] New `-race` tests fail on the pre-fix code (race detected) and pass after the fix
- [x] Local CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved data race conditions occurring during concurrent model reloads and taxonomy resolver registration
  * Fixed model identity handling to prevent data corruption during simultaneous operations

* **Tests**
  * Added regression tests ensuring the system remains thread-safe during concurrent model operations

* **Chores**
  * Minor code optimizations in model download flow and debug file writing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->