### PR TITLE
refactor: remove dead bat high-pass filter code

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -273,8 +273,6 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleQuietHoursStopSoundCard()
 	case schedule.SignalQuietHoursStartSoundCard:
 		cm.handleQuietHoursStartSoundCard()
-	case "reconfigure_bat_filter":
-		cm.handleReconfigureBatFilter()
 	case signalReconfigureLogDeduplication:
 		cm.handleReconfigureLogDeduplication()
 	case signalReconfigureRTSPHealth:
@@ -286,14 +284,6 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleReconfigureLiveStream()
 	default:
 		GetLogger().Warn("Received unknown control signal", logger.String("signal", signal))
-	}
-}
-
-// handleReconfigureBatFilter rebuilds the bat model's high-pass filter from current settings.
-func (cm *ControlMonitor) handleReconfigureBatFilter() {
-	if cm.bn != nil {
-		cm.bn.ReloadBatFilter()
-		emitHotReload("bat_filter")
 	}
 }
 

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -69,7 +69,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"Perch": {categories: []hotReloadCategory{hotReloadRestart}},
 
 	// --- Bat ---
-	"Bat": {categories: []hotReloadCategory{hotReloadFresh}, action: "reconfigure_bat_filter"},
+	"Bat": {categories: []hotReloadCategory{hotReloadFresh}},
 
 	// --- BSG ---
 	"BSG": {categories: []hotReloadCategory{hotReloadRestart}},

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2148,7 +2148,6 @@ var settingsChangeChecks = []settingsChangeCheck{
 	{"Push notifications", "reconfigure_push_notifications", pushNotificationSettingsChanged, "Reconfiguring push notification providers...", notification.MsgSettingsReconfiguringPushNotifications, "info", toastDurationMedium},
 	{"Quiet hours", schedule.SignalReconfigureQuietHours, quietHoursSettingsChanged, "Updating quiet hours schedule...", "", "info", toastDurationShort},
 	{"Web server", "", webserverSettingsChanged, "Web server settings changed. Restart required to apply.", notification.MsgSettingsWebserverRestart, "warning", toastDurationExtended},
-	{"Bat filter", "reconfigure_bat_filter", batFilterSettingsChanged, "", "", "", 0},
 	{"Log deduplication", "reconfigure_log_deduplication", logDeduplicationSettingsChanged, "Reconfiguring log deduplication...", "", "info", toastDurationShort},
 	{"RTSP health", "reconfigure_rtsp_health", rtspHealthSettingsChanged, "Reconfiguring RTSP health monitoring...", "", "info", toastDurationShort},
 	{"Monitoring", "reconfigure_monitoring", monitoringSettingsChanged, "Reconfiguring system monitoring...", "", "info", toastDurationShort},
@@ -2519,13 +2518,6 @@ func webserverSettingsChanged(oldSettings, currentSettings *conf.Settings) bool 
 	}
 
 	return false
-}
-
-// batFilterSettingsChanged checks if bat high-pass filter settings have changed.
-func batFilterSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
-	return oldSettings.Bat.FilterEnabled != currentSettings.Bat.FilterEnabled ||
-		oldSettings.Bat.FilterCutoffHz != currentSettings.Bat.FilterCutoffHz ||
-		oldSettings.Bat.FilterPassCount != currentSettings.Bat.FilterPassCount
 }
 
 // logDeduplicationSettingsChanged checks if log deduplication settings have changed.

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -3,22 +3,14 @@ package classifier
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
-	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
-)
-
-const (
-	butterworthQ           = 1.0 / math.Sqrt2
-	defaultFilterCutoffHz  = 4000.0
-	defaultFilterPassCount = 1
 )
 
 // Bat represents a loaded bat detection model that chains BirdNET v2.4
@@ -28,7 +20,6 @@ type Bat struct {
 	embeddingExtractor inference.EmbeddingExtractor
 	batClassifier      inference.CustomClassifier
 	info               ModelInfo
-	hpFilter           *equalizer.FilterChain
 	mu                 sync.Mutex
 }
 
@@ -120,11 +111,6 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		return nil, errors.Newf("bat classifier is not initialized").
 			Category(errors.CategoryModelInit).
 			Build()
-	}
-
-	if b.hpFilter != nil {
-		b.hpFilter.Reset()
-		b.hpFilter.ApplyBatchFloat32(samples[0])
 	}
 
 	log.Debug("bat predict starting",
@@ -240,62 +226,6 @@ func (b *Bat) Labels() []string {
 		return nil
 	}
 	return b.batClassifier.Labels()
-}
-
-// UpdateFilter rebuilds the high-pass filter from current settings.
-// Currently a no-op: the filter is disabled pending bat classifier retraining
-// because it increases false positives with the current model. The filter
-// infrastructure is retained for future use.
-func (b *Bat) UpdateFilter() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.hpFilter != nil {
-		GetLogger().Info("bat high-pass filter disabled")
-		b.hpFilter = nil
-	}
-}
-
-// buildBatHPFilter creates a high-pass filter chain from current bat settings.
-// Returns nil if filter creation fails (errors are logged).
-func buildBatHPFilter() *equalizer.FilterChain {
-	log := GetLogger()
-	settings := conf.Setting()
-
-	cutoff := settings.Bat.FilterCutoffHz
-	if cutoff <= 0 {
-		cutoff = defaultFilterCutoffHz
-	}
-	passes := settings.Bat.FilterPassCount
-	if passes < 1 {
-		passes = defaultFilterPassCount
-	}
-
-	hp, err := equalizer.NewHighPass(
-		float64(ModelRegistry[RegistryIDBat].Spec.SampleRate),
-		cutoff,
-		butterworthQ,
-		passes,
-	)
-	if err != nil {
-		log.Error("failed to create bat high-pass filter",
-			logger.Error(err),
-			logger.Float64("cutoff_hz", cutoff),
-			logger.Int("passes", passes))
-		return nil
-	}
-
-	chain := equalizer.NewFilterChain()
-	if addErr := chain.AddFilter(hp); addErr != nil {
-		log.Error("failed to add bat high-pass filter to chain",
-			logger.Error(addErr))
-		return nil
-	}
-
-	log.Info("bat high-pass filter configured",
-		logger.Float64("cutoff_hz", cutoff),
-		logger.Int("passes", passes))
-	return chain
 }
 
 // Close releases resources held by the bat model.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -724,23 +724,6 @@ func (o *Orchestrator) notifyRangeFilterReload() {
 	}
 }
 
-// ReloadBatFilter rebuilds the bat model's high-pass filter from current settings.
-func (o *Orchestrator) ReloadBatFilter() {
-	o.mu.RLock()
-	entry, ok := o.models[RegistryIDBat]
-	o.mu.RUnlock()
-	if !ok || entry == nil {
-		return
-	}
-	entry.mu.Lock()
-	defer entry.mu.Unlock()
-	bat, ok := entry.instance.(*Bat)
-	if !ok || bat == nil {
-		return
-	}
-	bat.UpdateFilter()
-}
-
 // RunFilterProcess executes the filter process on demand and prints results.
 func (o *Orchestrator) RunFilterProcess(dateStr string, week float32) {
 	o.primary.RunFilterProcess(dateStr, week)

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1233,9 +1233,6 @@ type BatConfig struct {
 	LabelPath           string                      `yaml:"labelpath,omitempty" json:"labelPath,omitempty"`             // path to bat species labels file
 	Threshold           float64                     `yaml:"threshold" json:"threshold"`                                 // confidence threshold for bat detections
 	Locale              string                      `yaml:"locale,omitempty" json:"locale,omitempty"`                   // locale for species label translation
-	FilterEnabled       bool                        `yaml:"filterenabled" json:"filterEnabled"`                         // enable high-pass filter for bat audio
-	FilterCutoffHz      float64                     `yaml:"filtercutoffhz,omitempty" json:"filterCutoffHz,omitempty"`   // high-pass filter cutoff frequency in Hz
-	FilterPassCount     int                         `yaml:"filterpasscount,omitempty" json:"filterPassCount,omitempty"` // number of filter passes for steeper rolloff
 	NighttimeOnly       bool                        `yaml:"nighttimeonly" json:"nighttimeOnly"`                         // restrict bat detection to nighttime (civil dusk to civil dawn)
 	FalsePositiveFilter FalsePositiveFilterSettings `yaml:"falsepositivefilter" json:"falsePositiveFilter"`             // false positive filtering for bat detections (level 0-5)
 	UltrasonicFilter    UltrasonicFilterConfig      `yaml:"ultrasonicfilter" json:"ultrasonicFilter"`                   // post-detection ultrasonic validation filter

--- a/internal/conf/config_test.go
+++ b/internal/conf/config_test.go
@@ -1,9 +1,12 @@
 package conf
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAudioSettings_NeedsFfprobeWorkaround(t *testing.T) {
@@ -127,4 +130,33 @@ func TestAudioSettings_HasFfmpegVersion(t *testing.T) {
 				"AudioSettings.HasFfmpegVersion() mismatch")
 		})
 	}
+}
+
+func TestBackwardCompatibility_RemovedBatFilterFields(t *testing.T) {
+	t.Parallel()
+
+	// YAML content containing the removed bat high-pass filter fields.
+	yamlContent := `
+bat:
+  threshold: 0.75
+  nighttimeonly: true
+  filterenabled: true
+  filtercutoffhz: 5000.0
+  filterpasscount: 2
+`
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+
+	err := v.ReadConfig(strings.NewReader(yamlContent))
+	require.NoError(t, err)
+
+	var settings Settings
+	err = v.Unmarshal(&settings, viper.DecodeHook(DurationDecodeHook()))
+	require.NoError(t, err)
+
+	// Verify that the parser successfully ignored the removed filter fields,
+	// but correctly loaded the other active BatConfig fields.
+	assert.InDelta(t, 0.75, settings.Bat.Threshold, 1e-9)
+	assert.True(t, settings.Bat.NighttimeOnly)
 }

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -85,9 +85,6 @@ func setDefaultConfig() {
 
 	// Bat detection configuration
 	viper.SetDefault("bat.threshold", 0.5)
-	viper.SetDefault("bat.filterenabled", false)
-	viper.SetDefault("bat.filtercutoffhz", 4000.0)
-	viper.SetDefault("bat.filterpasscount", 1)
 	viper.SetDefault("bat.nighttimeonly", true)
 	viper.SetDefault("bat.falsepositivefilter.level", 2)
 	viper.SetDefault("bat.ultrasonicfilter.enabled", true)


### PR DESCRIPTION
## Summary

This PR removes the dead bat high-pass filter code from the detection pipeline.
The `buildBatHPFilter()` function was never called, which meant that `Bat.hpFilter` was always nil, the apply block in `Bat.Predict` was never run, and `UpdateFilter` was a no-op.
The ultrasonic validation filter (`UltrasonicFilter`) and the false-positive filter (`FalsePositiveFilter`) are completely unaffected.
No frontend files were modified.

## Preflight Status

- **Build**: Successful
- **Linters**: `golangci-lint run -v` passed successfully with 0 issues.
- **Tests**: Full test suite run (`CGO_ENABLED=1 ... go test -tags noembed,skipfrontend -race ./...`) passed successfully.
- **Config Load**: Verified backward-compatibility for existing configuration files (added `TestBackwardCompatibility_RemovedBatFilterFields` to `config_test.go`).
- **Diff Cleanliness**: Confirmed the diff contains only changes relevant to the high-pass filter removal.

## Test Plan
- Run existing Go tests to verify no regressions in classification or pipeline configuration.
- Load configuration files with legacy filter fields to ensure backward-compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed bat high-pass filter configuration options from settings
  * Eliminated runtime reconfiguration capability for bat detection filters
  * Maintains backward compatibility with existing configuration files containing legacy filter parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->