### PR TITLE
fix(classifier): fix reload-vs-reload data race on ModelInfo and Taxonomy

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1211,7 +1211,11 @@ func (bn *BirdNET) ReloadModel() error {
 
 // GetSpeciesCode returns the eBird species code for a given label
 func (bn *BirdNET) GetSpeciesCode(label string) (string, bool) {
-	return GetSpeciesCodeFromName(bn.TaxonomyMap, bn.ScientificIndex, label)
+	bn.mu.Lock()
+	taxMap := bn.TaxonomyMap
+	sciIndex := bn.ScientificIndex
+	bn.mu.Unlock()
+	return GetSpeciesCodeFromName(taxMap, sciIndex, label)
 }
 
 // GetSpeciesWithScientificAndCommonName returns the scientific name and common name for a label
@@ -1332,6 +1336,14 @@ func (bn *BirdNET) Labels() []string {
 	return slices.Clone(bn.Settings.BirdNET.Labels)
 }
 
+// ReloadSnapshot returns a copy of the model metadata and taxonomy maps safely under bn.mu.
+// Used by the Orchestrator to update its shared state after a model reload.
+func (bn *BirdNET) ReloadSnapshot() (info ModelInfo, taxMap TaxonomyMap, taxPath string, sciIndex ScientificNameIndex) {
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+	return bn.ModelInfo, bn.TaxonomyMap, bn.TaxonomyPath, bn.ScientificIndex
+}
+
 // Close releases resources held by the BirdNET model.
 // Implements ModelInstance (io.Closer compatible).
 func (bn *BirdNET) Close() error {
@@ -1344,8 +1356,13 @@ func (bn *BirdNET) Close() error {
 func (bn *BirdNET) EnrichResultWithTaxonomy(speciesLabel string) (scientific, common, code string) {
 	scientific, common = SplitSpeciesName(speciesLabel)
 
+	bn.mu.Lock()
+	taxMap := bn.TaxonomyMap
+	sciIndex := bn.ScientificIndex
+	bn.mu.Unlock()
+
 	// Try to get the eBird code
-	code, exists := GetSpeciesCodeFromName(bn.TaxonomyMap, bn.ScientificIndex, speciesLabel)
+	code, exists := GetSpeciesCodeFromName(taxMap, sciIndex, speciesLabel)
 	if !exists {
 		// We got a placeholder code for a species not in our taxonomy
 		if bn.Settings.BirdNET.Debug {

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1341,7 +1341,7 @@ func (bn *BirdNET) Labels() []string {
 func (bn *BirdNET) ReloadSnapshot() (info ModelInfo, taxMap TaxonomyMap, taxPath string, sciIndex ScientificNameIndex) {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
-	return bn.ModelInfo, bn.TaxonomyMap, bn.TaxonomyPath, bn.ScientificIndex
+	return bn.ModelInfo, maps.Clone(bn.TaxonomyMap), bn.TaxonomyPath, maps.Clone(bn.ScientificIndex)
 }
 
 // Close releases resources held by the BirdNET model.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -779,10 +779,11 @@ func (o *Orchestrator) ReloadModel() error {
 			Build()
 	}
 
-	o.ModelInfo = o.primary.ModelInfo
-	o.TaxonomyMap = o.primary.TaxonomyMap
-	o.TaxonomyPath = o.primary.TaxonomyPath
-	o.ScientificIndex = o.primary.ScientificIndex
+	info, taxMap, taxPath, sciIndex := o.primary.ReloadSnapshot()
+	o.ModelInfo = info
+	o.TaxonomyMap = taxMap
+	o.TaxonomyPath = taxPath
+	o.ScientificIndex = sciIndex
 
 	// Re-key the models map in case the model ID changed after reload (Forgejo #270).
 	newModels := make(map[string]*modelEntry, len(o.models))

--- a/internal/classifier/orchestrator_race_test.go
+++ b/internal/classifier/orchestrator_race_test.go
@@ -165,3 +165,45 @@ func TestOrchestrator_ConcurrentResolverRegistrationAndResolve_NoRace(t *testing
 	}
 	assert.Equal(t, 1, count, "exactly one taxonomy resolver must be registered under concurrent registration")
 }
+
+// TestOrchestrator_ConcurrentReloadSnapshot_NoRace verifies that calling ReloadSnapshot
+// on the primary model concurrently with writes to its ModelInfo / Taxonomy fields does not race.
+func TestOrchestrator_ConcurrentReloadSnapshot_NoRace(t *testing.T) {
+	bn := &BirdNET{}
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
+	bn.TaxonomyMap = TaxonomyMap{"test": "test"}
+	bn.TaxonomyPath = "path/to/taxonomy"
+	bn.ScientificIndex = ScientificNameIndex{"test": "test"}
+
+	start := make(chan struct{})
+	const iterations = 500
+	var wg sync.WaitGroup
+
+	// Writer goroutine: simulates ReloadModel writing to BirdNET fields under bn.mu
+	wg.Go(func() {
+		<-start
+		for range iterations {
+			bn.mu.Lock()
+			bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
+			bn.TaxonomyMap = TaxonomyMap{"test": "test"}
+			bn.TaxonomyPath = "path/to/taxonomy"
+			bn.ScientificIndex = ScientificNameIndex{"test": "test"}
+			bn.mu.Unlock()
+		}
+	})
+
+	// Reader goroutine: simulates Step-2 reading the fields via ReloadSnapshot
+	wg.Go(func() {
+		<-start
+		for range iterations {
+			info, taxMap, taxPath, sciIndex := bn.ReloadSnapshot()
+			_ = info
+			_ = taxMap
+			_ = taxPath
+			_ = sciIndex
+		}
+	})
+
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
Fixes a data race in `Orchestrator.ReloadModel` (Step 2) where the orchestrator would read metadata from `o.primary` (e.g., `o.primary.ModelInfo`, `o.primary.TaxonomyMap`) without acquiring `bn.mu`. In concurrent reload scenarios, another goroutine executing `primary.ReloadModel()` could write to these same fields under `bn.mu`, causing a data race.

To resolve this, a new `ReloadSnapshot()` method is added to `BirdNET` to return all required metadata fields safely under the protection of the `bn.mu` lock. Additionally:
- `GetSpeciesCode()` and `EnrichResultWithTaxonomy()` are updated to read `TaxonomyMap` and `ScientificIndex` under the `bn.mu` lock.
- Added a new concurrency test `TestOrchestrator_ConcurrentReloadSnapshot_NoRace` to verify that concurrent writes and reads to metadata and taxonomy maps do not race.

## Related Issues
Fixes #861

## Test Plan
- Run the newly added unit test: `go test -race -v -run TestOrchestrator_ConcurrentReloadSnapshot_NoRace ./internal/classifier`
- Run the full classifier test suite: `go test -race ./internal/classifier/...`

## Preflight Status

### Preflight Certification

- [x] Single concern: PR contains exactly ONE feature, ONE fix, or ONE refactor
- [x] Preflight passed: All Phase 1-3 findings resolved or filed as issues
- [x] Linters clean: golangci-lint run -v and npm run check:all pass (zero warnings)
- [x] Tests pass: go test -race ./... and npm test pass
- [x] No unrelated changes: diff contains only changes relevant to the stated goal
- [x] Scope complete: PR fully implements what it claims; no TODO/FIXME for core functionality
- [x] Breaking changes documented: if API/config/behavior changes, noted in PR description
- [x] i18n complete: new user-facing strings have translations in all locale files
- [x] No secrets or PII: no hardcoded credentials, API keys, or personal data in diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety around model metadata and taxonomy handling to prevent race conditions during concurrent reloads and queries, increasing stability and consistency.
  * Ensured synchronized access to taxonomy and scientific-name data so concurrent requests observe a consistent taxonomy state.

* **Tests**
  * Added a regression test that validates concurrent snapshotting and updates of model metadata operate safely without data races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->