### PR TITLE
refactor: unify geomodel constants and modelsDir resolution, fix Orchestrator.TaxonomyMap race

### DIFF
--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -2,8 +2,6 @@ package analysis
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 
 	"github.com/tphakala/birdnet-go/internal/app"
 	"github.com/tphakala/birdnet-go/internal/classifier"
@@ -107,25 +105,11 @@ func (a *BirdNETAnalyzer) ModelManager() *classifier.ModelManager {
 func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator) {
 	log := GetLogger()
 
-	modelsDir := a.settings.Models.Directory
-	if modelsDir == "" {
-		configDir, err := os.UserConfigDir()
-		if err != nil {
-			homeDir, homeErr := conf.GetUserHomeDir()
-			if homeErr != nil {
-				log.Warn("could not determine config or home directory; model gallery disabled",
-					logger.Error(err),
-					logger.String("home_error", homeErr.Error()),
-					logger.String("service", birdNETAnalyzerName))
-				return
-			}
-			configDir = filepath.Join(homeDir, ".config")
-			log.Warn("UserConfigDir unavailable, falling back to home directory",
-				logger.Error(err),
-				logger.String("fallback", configDir),
-				logger.String("service", birdNETAnalyzerName))
-		}
-		modelsDir = filepath.Join(configDir, "birdnet-go", "models")
+	modelsDir, ok := a.settings.ResolveModelsDir()
+	if !ok {
+		log.Warn("could not determine config or home directory; model gallery disabled",
+			logger.String("service", birdNETAnalyzerName))
+		return
 	}
 
 	a.modelManager = classifier.NewModelManager(modelsDir, bn, a.settings)

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -604,7 +604,7 @@ func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
 
 	// Get species name from the taxonomy map using the species code
 	bn := proc.Bn
-	speciesName, exists := classifier.GetSpeciesNameFromCode(bn.TaxonomyMap, speciesCode)
+	speciesName, exists := bn.GetSpeciesNameFromCode(speciesCode)
 
 	if !exists {
 		return c.HandleError(ctx, errors.Newf("species code '%s' not found in taxonomy", speciesCode).

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -811,13 +811,11 @@ const DefaultRangeFilterV2ModelName = "BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP1
 // Geomodel v3 local file names used for auto-selection when the geomodel
 // has been downloaded as a shared companion file by the model gallery.
 //
-// These are MIRRORED in internal/conf/range_filter_migration.go as
-// geomodelSharedONNXLocalName / geomodelSharedLabelsLocalName, because conf
-// cannot import classifier (classifier imports conf). If these filenames
-// change, update both places.
+// These refer directly to the source of truth constants in the internal/conf
+// package.
 const (
-	geomodelONNXLocalName   = "geomodel_v3.0.2_fp16.onnx"
-	geomodelLabelsLocalName = "geomodel_v3.0.2_labels.txt"
+	geomodelONNXLocalName   = conf.GeomodelONNXLocalName
+	geomodelLabelsLocalName = conf.GeomodelLabelsLocalName
 )
 
 // DefaultModelDirectory is the default directory name where model files are expected to be found.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -559,6 +559,8 @@ func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
 }
 
 // GetSpeciesNameFromCode returns the species name for a given eBird species code.
+// The second return value reports whether the code was found in the TaxonomyMap
+// by calling GetSpeciesNameFromCode(o.TaxonomyMap, code).
 func (o *Orchestrator) GetSpeciesNameFromCode(code string) (string, bool) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -558,6 +558,13 @@ func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
 	return o.primary.GetSpeciesCode(label)
 }
 
+// GetSpeciesNameFromCode returns the species name for a given eBird species code.
+func (o *Orchestrator) GetSpeciesNameFromCode(code string) (string, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return GetSpeciesNameFromCode(o.TaxonomyMap, code)
+}
+
 // GetSpeciesWithScientificAndCommonName returns the scientific and common name for a label.
 func (o *Orchestrator) GetSpeciesWithScientificAndCommonName(label string) (scientific, common string) {
 	return o.primary.GetSpeciesWithScientificAndCommonName(label)

--- a/internal/conf/range_filter_migration.go
+++ b/internal/conf/range_filter_migration.go
@@ -5,15 +5,12 @@ import (
 	"path/filepath"
 )
 
-// Shared geomodel filenames. These MIRROR internal/classifier/birdnet.go
-// geomodelONNXLocalName and geomodelLabelsLocalName. The conf package cannot
-// import classifier (classifier imports conf; importing back would create an
-// import cycle), so the constants are duplicated here. They MUST stay in sync
-// with the classifier definitions; if the gallery changes the shared geomodel
-// filenames, update both places.
+// Shared geomodel filenames. These are defined in the conf package because
+// conf cannot import classifier (classifier imports conf). The classifier package
+// references these constants to avoid duplication.
 const (
-	geomodelSharedONNXLocalName   = "geomodel_v3.0.2_fp16.onnx"
-	geomodelSharedLabelsLocalName = "geomodel_v3.0.2_labels.txt"
+	GeomodelONNXLocalName   = "geomodel_v3.0.2_fp16.onnx"
+	GeomodelLabelsLocalName = "geomodel_v3.0.2_labels.txt"
 )
 
 // rangeFilterGeomodelV3 is the literal that the runtime, status code, and UI
@@ -21,14 +18,12 @@ const (
 // internal/classifier/birdnet.go and internal/conf/validate_services.go).
 const rangeFilterGeomodelV3 = "v3"
 
-// resolveModelsDir computes the model gallery directory the same way
-// internal/analysis/birdnet_service.go initModelManager does, WITHOUT importing
-// the classifier package. If Models.Directory is set, it is used verbatim;
-// otherwise the OS user config directory is used (falling back to
+// ResolveModelsDir computes the model gallery directory. If Models.Directory is set,
+// it is used verbatim; otherwise the OS user config directory is used (falling back to
 // <home>/.config when os.UserConfigDir fails), joined with "birdnet-go/models".
 // The second return value is false when the directory cannot be resolved, in
 // which case callers should do nothing.
-func (s *Settings) resolveModelsDir() (string, bool) {
+func (s *Settings) ResolveModelsDir() (string, bool) {
 	if s.Models.Directory != "" {
 		return s.Models.Directory, true
 	}
@@ -59,14 +54,14 @@ func (s *Settings) resolveModelsDir() (string, bool) {
 //
 // Returns true if the config was changed, false otherwise.
 func (s *Settings) MigrateOrphanGeomodelRangeFilter() bool {
-	modelsDir, ok := s.resolveModelsDir()
+	modelsDir, ok := s.ResolveModelsDir()
 	if !ok {
 		return false
 	}
 
 	sharedDir := filepath.Join(modelsDir, "shared")
-	expectedModelPath := filepath.Join(sharedDir, geomodelSharedONNXLocalName)
-	expectedLabelsPath := filepath.Join(sharedDir, geomodelSharedLabelsLocalName)
+	expectedModelPath := filepath.Join(sharedDir, GeomodelONNXLocalName)
+	expectedLabelsPath := filepath.Join(sharedDir, GeomodelLabelsLocalName)
 
 	rf := &s.BirdNET.RangeFilter
 

--- a/internal/conf/range_filter_migration_test.go
+++ b/internal/conf/range_filter_migration_test.go
@@ -15,15 +15,15 @@ func writeSharedGeomodelFiles(t *testing.T, modelsDir string) {
 	t.Helper()
 	sharedDir := filepath.Join(modelsDir, "shared")
 	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, geomodelSharedONNXLocalName), []byte("onnx"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, geomodelSharedLabelsLocalName), []byte("labels"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, GeomodelONNXLocalName), []byte("onnx"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, GeomodelLabelsLocalName), []byte("labels"), 0o644))
 }
 
 // sharedGeomodelPaths returns the gallery-managed shared ONNX and labels paths
 // under modelsDir.
 func sharedGeomodelPaths(modelsDir string) (onnxPath, labelsPath string) {
 	sharedDir := filepath.Join(modelsDir, "shared")
-	return filepath.Join(sharedDir, geomodelSharedONNXLocalName), filepath.Join(sharedDir, geomodelSharedLabelsLocalName)
+	return filepath.Join(sharedDir, GeomodelONNXLocalName), filepath.Join(sharedDir, GeomodelLabelsLocalName)
 }
 
 func TestMigrateOrphanGeomodelRangeFilter(t *testing.T) {


### PR DESCRIPTION
## Summary
- Consolidates the geomodel file constants `geomodelSharedONNXLocalName` and `geomodelSharedLabelsLocalName` into `internal/conf/range_filter_migration.go` as exported constants `GeomodelONNXLocalName` / `GeomodelLabelsLocalName` to serve as a single source of truth.
- Exports the model directory resolution helper as `ResolveModelsDir()` method on `Settings`, and reuses it in `internal/analysis/birdnet_service.go` to remove duplicate fallback logic.
- Implements `GetSpeciesNameFromCode` on `Orchestrator` to synchronize taxonomy map retrieval under the orchestrator's `mu` read lock.
- Refactors the `GetSpeciesThumbnail` API handler to use `Orchestrator.GetSpeciesNameFromCode`, resolving a data race between model reload updates and API reads.

## Test Plan
- Run Go unit tests: `go test -race ./...`
- Run linting: `golangci-lint run -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized model gallery directory resolution to use a single settings API, improving reliability and early-disable behavior when the models directory can't be determined.
  * Standardized species code → name lookup to use a single orchestrator-backed method.
  * Consolidated geomodel filename constants to a shared source-of-truth, reducing duplication and test updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->