### PR TITLE
classifier: fix model reload data races, uninstall/reinstall safety, and FreeOSMemory lock

### DIFF
--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -57,7 +57,7 @@ func (a *BirdNETAnalyzer) Start(_ context.Context) error {
 	a.bn = bn
 
 	events.Emit(context.Background(), "detection", "model_loaded", "BirdNET model loaded", map[string]any{
-		"species_count": len(bn.Settings.BirdNET.Labels),
+		"species_count": bn.NumSpecies(),
 	})
 
 	// Initialize ModelManager for the model gallery. Failure is non-fatal

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -356,7 +356,7 @@ func (cm *ControlMonitor) handleReloadBirdnet() {
 	}
 
 	// Rebuild name maps with new locale labels (use fresh settings, not stale pointer)
-	labels := conf.CurrentOrFallback(cm.bn.Settings).BirdNET.Labels
+	labels := cm.bn.Labels()
 	if cm.proc != nil && cm.proc.Ds != nil {
 		cm.proc.Ds.UpdateNameMaps(labels)
 		GetLogger().Info("Datastore name maps updated with new labels")

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -127,7 +127,9 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
+	c.settingsMutex.RLock()
 	labels := c.Settings.BirdNET.Labels
+	c.settingsMutex.RUnlock()
 	speciesList := make([]RangeFilterSpecies, 0, len(labels))
 
 	for _, label := range labels {
@@ -198,7 +200,8 @@ func (c *Controller) getSpeciesInfo(ctx context.Context, scientificName string) 
 	var matchedLabel string
 	var commonName string
 
-	for _, label := range bn.Settings.BirdNET.Labels {
+	settings := bn.CurrentSettings()
+	for _, label := range settings.BirdNET.Labels {
 		sp := detection.ParseSpeciesString(label)
 		if strings.EqualFold(sp.ScientificName, scientificName) {
 			matchedLabel = label
@@ -258,16 +261,17 @@ func (c *Controller) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLa
 	}
 
 	// Create rarity info
+	settings := bn.CurrentSettings()
 	rarityInfo := &SpeciesRarityInfo{
 		Date:             today.Format(time.DateOnly),
-		LocationBased:    bn.Settings.BirdNET.LocationConfigured,
-		ThresholdApplied: float64(bn.Settings.BirdNET.RangeFilter.Threshold),
+		LocationBased:    settings.BirdNET.LocationConfigured,
+		ThresholdApplied: float64(settings.BirdNET.RangeFilter.Threshold),
 	}
 
 	// Add location if available
 	if rarityInfo.LocationBased {
-		rarityInfo.Latitude = bn.Settings.BirdNET.Latitude
-		rarityInfo.Longitude = bn.Settings.BirdNET.Longitude
+		rarityInfo.Latitude = settings.BirdNET.Latitude
+		rarityInfo.Longitude = settings.BirdNET.Longitude
 	}
 
 	// Find the species score

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1093,6 +1093,11 @@ func (bn *BirdNET) reloadModelInternal() error {
 		bn.TaxonomyMap = oldTaxonomyMap
 		bn.ScientificIndex = oldScientificIndex
 		bn.updateSettings(oldSettings)
+		// Degraded-but-recovered: make it explicit in the log that the previous
+		// model was restored, so a failed reload is not mistaken for a dead
+		// detector. The caller logs the underlying error separately.
+		GetLogger().Warn("BirdNET model reload failed; rolled back to previous model",
+			logger.String("model_id", oldModelInfo.ID))
 	}
 
 	// Check if model version changed; if so, the orchestrator must handle

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -49,7 +50,8 @@ type BirdNET struct {
 	// and the classifier fell back to its embedded TFLite range filter. Read for health
 	// reporting; guarded by mu alongside rangeFilter.
 	rangeFilterFellBack bool
-	Settings            *conf.Settings
+	Settings            *conf.Settings // Deprecated: use settingsAtomic instead. Kept for struct-literal compatibility in tests.
+	settingsAtomic      atomic.Pointer[conf.Settings]
 	ModelInfo           ModelInfo           // Information about the current model
 	TaxonomyMap         TaxonomyMap         // Mapping of species codes to names and vice versa
 	ScientificIndex     ScientificNameIndex // Index for fast scientific name lookups
@@ -68,7 +70,16 @@ type BirdNET struct {
 // currentSettings returns the latest settings snapshot so UI changes to
 // sensitivity, location, and labels take effect without restarting the service.
 func (bn *BirdNET) currentSettings() *conf.Settings {
+	if s := bn.settingsAtomic.Load(); s != nil {
+		return conf.CurrentOrFallback(s)
+	}
 	return conf.CurrentOrFallback(bn.Settings)
+}
+
+// updateSettings updates the settings pointer safely and atomically.
+func (bn *BirdNET) updateSettings(s *conf.Settings) {
+	bn.Settings = s
+	bn.settingsAtomic.Store(s)
 }
 
 // NewBirdNET initializes a new BirdNET instance with given settings.
@@ -81,6 +92,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 		modelVersion: defaultModelVersionString,
 		speciesCache: make(map[string]*speciesCacheEntry),
 	}
+	bn.settingsAtomic.Store(settings)
 
 	// Resolve model identity via the resolution chain
 	var err error
@@ -136,7 +148,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Build()
 	}
 
-	// Load labels before model initialization — ONNX models require labels
+	// Load labels before model initialization; ONNX models require labels
 	// at construction time for output dimension validation.
 	if err := bn.loadLabels(); err != nil {
 		return nil, errors.New(err).
@@ -157,7 +169,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Build()
 	}
 
-	if err := bn.initializeMetaModel(); err != nil {
+	if err := bn.initializeMetaModel(settings); err != nil {
 		GetLogger().Warn("Range filter initialization failed, starting without species filtering (fix via Settings > Species)",
 			logger.Error(err),
 			logger.String("range_filter_model", settings.BirdNET.RangeFilter.Model),
@@ -248,7 +260,7 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 
 	// Update the human-readable model version string for display when a custom
 	// model path is provided. Model identity (ModelInfo.ID) is never modified
-	// here — it was fully resolved by NewBirdNET's 4-tier resolution chain.
+	// here, as it was fully resolved by NewBirdNET's 4-tier resolution chain.
 	if bn.Settings.BirdNET.ModelPath != "" {
 		bn.modelVersion = bn.Settings.BirdNET.ModelPath
 	}
@@ -410,9 +422,8 @@ func (bn *BirdNET) hasNativeRangeFilter() bool {
 	return bn.ModelInfo.Backend == BackendTFLite && bn.ModelInfo.ID == DefaultModelVersion
 }
 
-func (bn *BirdNET) initializeMetaModel() error {
+func (bn *BirdNET) initializeMetaModel(settings *conf.Settings) error {
 	log := GetLogger()
-	settings := bn.currentSettings()
 	rf := settings.BirdNET.RangeFilter
 
 	log.Info("Initializing range filter",
@@ -600,11 +611,22 @@ func (bn *BirdNET) loadExternalLabels() error {
 		"birdnet-label-loading",
 	)
 
-	file, err := os.Open(bn.Settings.BirdNET.LabelPath)
+	labelPath := os.ExpandEnv(bn.Settings.BirdNET.LabelPath)
+	expandedPath, err := conf.ExpandTildePath(labelPath)
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryFileIO).
 			Context("label_path", bn.Settings.BirdNET.LabelPath).
+			Context("operation", "expand_path").
+			Timing("label-file-open", time.Since(start)).
+			Build()
+	}
+
+	file, err := os.Open(expandedPath)
+	if err != nil {
+		return errors.New(err).
+			Category(errors.CategoryFileIO).
+			Context("label_path", expandedPath).
 			Context("operation", "open").
 			Timing("label-file-open", time.Since(start)).
 			Build()
@@ -613,7 +635,7 @@ func (bn *BirdNET) loadExternalLabels() error {
 		if err := file.Close(); err != nil {
 			GetLogger().Warn("Failed to close label file",
 				logger.Error(err),
-				logger.String("path", bn.Settings.BirdNET.LabelPath))
+				logger.String("path", expandedPath))
 		}
 	}()
 
@@ -622,7 +644,7 @@ func (bn *BirdNET) loadExternalLabels() error {
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryLabelLoad).
-			Context("label_path", bn.Settings.BirdNET.LabelPath).
+			Context("label_path", expandedPath).
 			Context("operation", "parse").
 			Timing("label-file-load", time.Since(start)).
 			Build()
@@ -769,7 +791,7 @@ func (bn *BirdNET) ReloadRangeFilter() error {
 	oldRangeFilter := bn.rangeFilter
 	oldFellBack := bn.rangeFilterFellBack
 
-	if err := bn.initializeMetaModel(); err != nil {
+	if err := bn.initializeMetaModel(bn.currentSettings()); err != nil {
 		// Rollback: restore old range filter (and its fallback state) if init created a
 		// partial one. initializeMetaModel resets rangeFilterFellBack on entry, so the
 		// flag must be restored alongside the filter to keep the health report accurate.
@@ -1023,6 +1045,19 @@ func (bn *BirdNET) validateModelAndLabels() error {
 
 // ReloadModel safely reloads the BirdNET model and labels while handling ongoing analysis
 func (bn *BirdNET) ReloadModel() error {
+	err := bn.reloadModelInternal()
+	if err == nil {
+		// Return freed native pages to the OS. Both backends free native memory in
+		// Close(), but libc may retain freed pages. FreeOSMemory hints the
+		// runtime and libc to release them, reducing RSS after reload.
+		// Run outside the exclusive lock region because synchronous GC and memory
+		// release can take >100ms and stall concurrent requests.
+		debug.FreeOSMemory()
+	}
+	return err
+}
+
+func (bn *BirdNET) reloadModelInternal() error {
 	bn.Debug("Acquiring mutex for model reload")
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
@@ -1030,9 +1065,9 @@ func (bn *BirdNET) ReloadModel() error {
 
 	// Get fresh settings so sub-methods see the latest config.
 	fresh := bn.currentSettings()
-	settingsCopy := *fresh
+	settingsCopy := conf.CloneSettings(fresh)
 	oldSettings := bn.Settings
-	bn.Settings = &settingsCopy
+	bn.Settings = settingsCopy
 
 	// Snapshot all mutable state for transactional rollback on failure.
 	oldClassifier := bn.classifier
@@ -1057,7 +1092,7 @@ func (bn *BirdNET) ReloadModel() error {
 		bn.ModelInfo = oldModelInfo
 		bn.TaxonomyMap = oldTaxonomyMap
 		bn.ScientificIndex = oldScientificIndex
-		bn.Settings = oldSettings
+		bn.updateSettings(oldSettings)
 	}
 
 	// Check if model version changed; if so, the orchestrator must handle
@@ -1126,7 +1161,7 @@ func (bn *BirdNET) ReloadModel() error {
 	}
 	bn.Debug("Taxonomy data reloaded successfully")
 
-	// Reload labels before model initialization — ONNX models require labels
+	// Reload labels before model initialization; ONNX models require labels
 	// at construction time for output dimension validation.
 	if err := bn.loadLabels(); err != nil {
 		rollback()
@@ -1152,7 +1187,7 @@ func (bn *BirdNET) ReloadModel() error {
 	bn.Debug("Model initialized successfully")
 
 	// Initialize new meta model
-	if err := bn.initializeMetaModel(); err != nil {
+	if err := bn.initializeMetaModel(settingsCopy); err != nil {
 		rollback()
 		return errors.New(err).
 			Component("birdnet").
@@ -1185,10 +1220,8 @@ func (bn *BirdNET) ReloadModel() error {
 		oldRangeFilter.Close()
 	}
 
-	// Return freed native pages to the OS. Both backends free native memory in
-	// Close() above, but libc may retain freed pages. FreeOSMemory hints the
-	// runtime and libc to release them, reducing RSS after reload.
-	debug.FreeOSMemory()
+	// Publish the new settings atomically
+	bn.updateSettings(settingsCopy)
 
 	// Clear species cache as model/labels have changed
 	bn.clearSpeciesCache()
@@ -1214,7 +1247,7 @@ func (bn *BirdNET) GetSpeciesWithScientificAndCommonName(label string) (scientif
 // Debug prints debug messages if debug mode is enabled.
 // Uses the centralized logger for structured logging.
 func (bn *BirdNET) Debug(format string, v ...any) {
-	if bn.Settings.BirdNET.Debug {
+	if bn.currentSettings().BirdNET.Debug {
 		GetLogger().Debug(fmt.Sprintf(format, v...))
 	}
 }
@@ -1353,7 +1386,7 @@ func (bn *BirdNET) EnrichResultWithTaxonomy(speciesLabel string) (scientific, co
 	code, exists := GetSpeciesCodeFromName(taxMap, sciIndex, speciesLabel)
 	if !exists {
 		// We got a placeholder code for a species not in our taxonomy
-		if bn.Settings.BirdNET.Debug {
+		if bn.currentSettings().BirdNET.Debug {
 			bn.Debug("Species '%s' not found in taxonomy, using generated placeholder code: %s", speciesLabel, code)
 		}
 	}

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -512,8 +512,10 @@ func (o *Orchestrator) GetHeatmapService() *HeatmapInferenceService {
 		return heatmapServiceInstance
 	}
 
-	// Get model path and labels from current range filter config
-	settings := o.Settings
+	// Get model path and labels from current range filter config.
+	// Use the atomic-safe accessor; o.Settings is reassigned at runtime by
+	// Orchestrator.ReloadModel (under o.mu) and a raw read would race with it.
+	settings := o.CurrentSettings()
 	rfSettings := settings.BirdNET.RangeFilter
 
 	if rfSettings.ModelPath == "" {

--- a/internal/classifier/label_loading_external_test.go
+++ b/internal/classifier/label_loading_external_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
+// testLabelsEnvVar is the environment variable the external-label tests use to
+// exercise os.ExpandEnv path expansion in loadExternalLabels.
+const testLabelsEnvVar = "BIRDNET_TEST_LABELS_DIR"
+
 // newExternalLabelBirdNET builds a minimal BirdNET wired to load labels from the
 // given external label path, without invoking the full NewBirdNET model load.
 func newExternalLabelBirdNET(labelPath string) *BirdNET {
@@ -52,9 +56,9 @@ func TestLoadExternalLabels_ExpandsEnvVar(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "labels.txt"), []byte(twoLabelFile), 0o644))
 
-	t.Setenv("BIRDNET_TEST_LABELS_DIR", dir)
+	t.Setenv(testLabelsEnvVar, dir)
 
-	bn := newExternalLabelBirdNET(filepath.Join("$BIRDNET_TEST_LABELS_DIR", "labels.txt"))
+	bn := newExternalLabelBirdNET(filepath.Join("$"+testLabelsEnvVar, "labels.txt"))
 	require.NoError(t, bn.loadLabels(), "loadExternalLabels must expand $VAR in the label path")
 	assert.Equal(t, twoLabelsExpected, bn.Settings.BirdNET.Labels)
 }
@@ -65,10 +69,10 @@ func TestLoadExternalLabels_ExpandsEnvVar(t *testing.T) {
 func TestLoadExternalLabels_MissingPathReportsExpandedPath(t *testing.T) {
 	// Not parallel: t.Setenv mutates process environment.
 	dir := t.TempDir()
-	t.Setenv("BIRDNET_TEST_LABELS_DIR", dir)
+	t.Setenv(testLabelsEnvVar, dir)
 
 	missing := filepath.Join(dir, "does-not-exist.txt")
-	bn := newExternalLabelBirdNET(filepath.Join("$BIRDNET_TEST_LABELS_DIR", "does-not-exist.txt"))
+	bn := newExternalLabelBirdNET(filepath.Join("$"+testLabelsEnvVar, "does-not-exist.txt"))
 	err := bn.loadLabels()
 	require.Error(t, err, "loading a non-existent external label file must fail")
 	assert.Contains(t, err.Error(), missing,

--- a/internal/classifier/label_loading_external_test.go
+++ b/internal/classifier/label_loading_external_test.go
@@ -1,0 +1,76 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// newExternalLabelBirdNET builds a minimal BirdNET wired to load labels from the
+// given external label path, without invoking the full NewBirdNET model load.
+func newExternalLabelBirdNET(labelPath string) *BirdNET {
+	settings := &conf.Settings{}
+	settings.BirdNET.LabelPath = labelPath
+	return &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+	}
+}
+
+const twoLabelFile = "Turdus merula_Common Blackbird\nParus major_Great Tit\n"
+
+var twoLabelsExpected = []string{
+	"Turdus merula_Common Blackbird",
+	"Parus major_Great Tit",
+}
+
+// TestLoadExternalLabels_LiteralPath is the regression guard ensuring the new
+// path-expansion logic does not break an ordinary (non-tilde, non-env) label
+// path: a plain absolute path must still load correctly.
+func TestLoadExternalLabels_LiteralPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	labelPath := filepath.Join(dir, "labels.txt")
+	require.NoError(t, os.WriteFile(labelPath, []byte(twoLabelFile), 0o644))
+
+	bn := newExternalLabelBirdNET(labelPath)
+	require.NoError(t, bn.loadLabels())
+	assert.Equal(t, twoLabelsExpected, bn.Settings.BirdNET.Labels)
+}
+
+// TestLoadExternalLabels_ExpandsEnvVar verifies that loadExternalLabels expands
+// an environment variable embedded in the label path via os.ExpandEnv before
+// opening the file. This is the behavior introduced by the change under review.
+func TestLoadExternalLabels_ExpandsEnvVar(t *testing.T) {
+	// Not parallel: t.Setenv mutates process environment.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "labels.txt"), []byte(twoLabelFile), 0o644))
+
+	t.Setenv("BIRDNET_TEST_LABELS_DIR", dir)
+
+	bn := newExternalLabelBirdNET(filepath.Join("$BIRDNET_TEST_LABELS_DIR", "labels.txt"))
+	require.NoError(t, bn.loadLabels(), "loadExternalLabels must expand $VAR in the label path")
+	assert.Equal(t, twoLabelsExpected, bn.Settings.BirdNET.Labels)
+}
+
+// TestLoadExternalLabels_MissingPathReportsExpandedPath verifies that when the
+// expanded path does not exist, loading fails (rather than silently succeeding)
+// and the error carries the expanded path, not the raw template.
+func TestLoadExternalLabels_MissingPathReportsExpandedPath(t *testing.T) {
+	// Not parallel: t.Setenv mutates process environment.
+	dir := t.TempDir()
+	t.Setenv("BIRDNET_TEST_LABELS_DIR", dir)
+
+	missing := filepath.Join(dir, "does-not-exist.txt")
+	bn := newExternalLabelBirdNET(filepath.Join("$BIRDNET_TEST_LABELS_DIR", "does-not-exist.txt"))
+	err := bn.loadLabels()
+	require.Error(t, err, "loading a non-existent external label file must fail")
+	assert.Contains(t, err.Error(), missing,
+		"error context should reference the expanded path, not the unexpanded $VAR template")
+}

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -599,7 +599,10 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 				continue
 			}
 			if !os.IsNotExist(err) {
-				log.Error("Failed to remove file during uninstall",
+				// Warn, not Error: a leftover file during best-effort uninstall is a
+				// recoverable/degraded condition (the model is still de-registered),
+				// matching cleanupSharedFiles and avoiding needless Error/Sentry noise.
+				log.Warn("Failed to remove file during uninstall",
 					logger.String("path", path),
 					logger.Error(err))
 				if deleteErr == nil {

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -568,6 +568,10 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	// running inference engine, so deleting the file could cause a segfault.
 	if mm.orchestrator != nil && entry.RegistryID != "" && mm.orchestrator.IsModelLoaded(entry.RegistryID) {
 		if err := mm.orchestrator.UnloadModel(entry.RegistryID); err != nil {
+			log.Warn("Uninstall refused: model could not be unloaded (still in use)",
+				logger.String("catalog_id", catalogID),
+				logger.String("registry_id", entry.RegistryID),
+				logger.Error(err))
 			return errors.Newf("cannot uninstall %s: model still in use", catalogID).
 				Component("classifier.model_manager").
 				Category(errors.CategorySystem).
@@ -639,16 +643,22 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 			logger.String("path", subdir))
 	}
 
-	log.Info("Model uninstalled",
-		logger.String("catalog_id", catalogID))
-
 	if deleteErr != nil {
+		// Best-effort uninstall: the model is de-registered and config cleared,
+		// but some files remain. Log at Warn (not the clean Info) so the record
+		// matches the returned error and the actual on-disk state.
+		log.Warn("Model uninstalled, but some files could not be removed",
+			logger.String("catalog_id", catalogID),
+			logger.Error(deleteErr))
 		return errors.Newf("model uninstalled, but failed to remove some files: %v", deleteErr).
 			Component("classifier.model_manager").
 			Category(errors.CategoryFileIO).
 			Context("catalog_id", catalogID).
 			Build()
 	}
+
+	log.Info("Model uninstalled",
+		logger.String("catalog_id", catalogID))
 
 	return nil
 }
@@ -771,6 +781,14 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 	if mm.orchestrator != nil && entry.RegistryID != "" && mm.orchestrator.IsModelLoaded(entry.RegistryID) {
 		if err := mm.orchestrator.UnloadModel(entry.RegistryID); err != nil {
 			mm.mu.Unlock()
+			// Reinstall runs asynchronously, so the HTTP caller cannot surface
+			// this. Log at the always-on manager logger; the API logger that the
+			// handler uses may be disabled, which would otherwise leave a refused
+			// reinstall completely silent.
+			GetLogger().Warn("Reinstall refused: model could not be unloaded (still in use)",
+				logger.String("catalog_id", entry.ID),
+				logger.String("registry_id", entry.RegistryID),
+				logger.Error(err))
 			return errors.Newf("cannot reinstall %s: model still in use", entry.ID).
 				Component("classifier.model_manager").
 				Category(errors.CategorySystem).

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -580,22 +580,28 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 
 	subdir := filepath.Join(mm.modelsDir, catalogID)
 
+	var deleteErr error
+
 	// Delete model ONNX files and associated data files (calibration, distribution, etc.).
 	for _, f := range entry.Files {
 		if f.Role == RoleModel || f.Role == RoleData {
 			path := filepath.Join(subdir, f.LocalName)
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return errors.Newf("failed to remove file %s: %v", path, err).
-					Component("classifier.model_manager").
-					Category(errors.CategoryFileIO).
-					Context("catalog_id", catalogID).
-					Context("file", path).
-					Build()
+			err := os.Remove(path)
+			if err == nil {
+				log.Info("Removed file",
+					logger.String("catalog_id", catalogID),
+					logger.String("role", f.Role),
+					logger.String("path", path))
+				continue
 			}
-			log.Info("Removed file",
-				logger.String("catalog_id", catalogID),
-				logger.String("role", f.Role),
-				logger.String("path", path))
+			if !os.IsNotExist(err) {
+				log.Error("Failed to remove file during uninstall",
+					logger.String("path", path),
+					logger.Error(err))
+				if deleteErr == nil {
+					deleteErr = err
+				}
+			}
 		}
 	}
 
@@ -635,6 +641,14 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 
 	log.Info("Model uninstalled",
 		logger.String("catalog_id", catalogID))
+
+	if deleteErr != nil {
+		return errors.Newf("model uninstalled, but failed to remove some files: %v", deleteErr).
+			Component("classifier.model_manager").
+			Category(errors.CategoryFileIO).
+			Context("catalog_id", catalogID).
+			Build()
+	}
 
 	return nil
 }
@@ -751,6 +765,20 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 			Category(errors.CategoryValidation).
 			Context("catalog_id", entry.ID).
 			Build()
+	}
+
+	// Unload from orchestrator BEFORE overwriting files to avoid crashes.
+	if mm.orchestrator != nil && entry.RegistryID != "" && mm.orchestrator.IsModelLoaded(entry.RegistryID) {
+		if err := mm.orchestrator.UnloadModel(entry.RegistryID); err != nil {
+			mm.mu.Unlock()
+			return errors.Newf("cannot reinstall %s: model still in use", entry.ID).
+				Component("classifier.model_manager").
+				Category(errors.CategorySystem).
+				Context("catalog_id", entry.ID).
+				Context("registry_id", entry.RegistryID).
+				Context("unload_error", err.Error()).
+				Build()
+		}
 	}
 
 	// Record download as in-progress.

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -597,6 +597,124 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 	}
 }
 
+// TestModelManager_UninstallDeregistersWhenFileDeletionFails covers the
+// best-effort uninstall behavior: when a model file cannot be removed (here
+// simulated by replacing it with a non-empty directory so os.Remove returns a
+// non-ENOENT error), Uninstall must NOT abort early. It still de-registers the
+// model from the installed map and clears config, then surfaces the deletion
+// failure as an error. Before this change, the first failed os.Remove returned
+// immediately, leaving the model registered.
+func TestModelManager_UninstallDeregistersWhenFileDeletionFails(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.RegistryID, "perch-v2 must have a RegistryID for this test")
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	for _, f := range entry.Files {
+		var dir string
+		if isSharedRole(f.Role) {
+			dir = filepath.Join(modelsDir, "shared")
+		} else {
+			dir = subdir
+		}
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
+	}
+
+	// Empty models map: IsModelLoaded returns false, so unload is skipped and
+	// Uninstall proceeds to delete files.
+	orch := &Orchestrator{
+		models: make(map[string]*modelEntry),
+	}
+
+	mm := NewModelManager(modelsDir, orch, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID), "model must be installed before uninstall")
+
+	// Remove the standalone geomodel entry so shared files are not retained,
+	// mirroring TestModelManager_UninstallSucceedsWhenModelNotLoaded.
+	if mm.IsInstalled("birdnet-geomodel-v3") {
+		require.NoError(t, mm.Uninstall("birdnet-geomodel-v3"))
+	}
+
+	// Sabotage one model/data file so os.Remove fails with a non-ENOENT error:
+	// replace the file with a non-empty directory (os.Remove returns ENOTEMPTY).
+	var sabotaged string
+	for _, f := range entry.Files {
+		if f.Role != RoleModel && f.Role != RoleData {
+			continue
+		}
+		path := filepath.Join(subdir, f.LocalName)
+		require.NoError(t, os.Remove(path))
+		require.NoError(t, os.MkdirAll(path, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(path, "blocker"), []byte("x"), 0o644))
+		sabotaged = path
+		break
+	}
+	require.NotEmpty(t, sabotaged, "perch-v2 must have a model or data file to sabotage")
+
+	err := mm.Uninstall(entry.ID)
+	require.Error(t, err, "Uninstall must surface the file-deletion failure")
+	assert.Contains(t, err.Error(), "failed to remove some files")
+	assert.False(t, mm.IsInstalled(entry.ID),
+		"model must be de-registered even when some files could not be deleted")
+}
+
+// TestModelManager_ReinstallRefusesLoadedPrimary documents and guards the
+// behavior of the new pre-overwrite unload step in Reinstall: when the target
+// is the loaded primary model (which UnloadModel refuses to unload), Reinstall
+// aborts with "model still in use" before touching any files, and the model
+// stays installed. This is a deliberate behavior change from the prior code,
+// which overwrote files in place even while the primary was loaded.
+func TestModelManager_ReinstallRefusesLoadedPrimary(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.RegistryID, "perch-v2 must have a RegistryID for this test")
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	for _, f := range entry.Files {
+		var dir string
+		if isSharedRole(f.Role) {
+			dir = filepath.Join(modelsDir, "shared")
+		} else {
+			dir = subdir
+		}
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
+	}
+
+	// Model loaded AND set as primary: UnloadModel refuses the primary, so the
+	// new pre-overwrite guard must abort the reinstall.
+	primaryBN := &BirdNET{ModelInfo: ModelInfo{ID: entry.RegistryID}}
+	orch := &Orchestrator{
+		ModelInfo: primaryBN.ModelInfo, // mirror the primary, as NewOrchestrator does
+		models: map[string]*modelEntry{
+			entry.RegistryID: {instance: primaryBN},
+		},
+		primary: primaryBN,
+	}
+
+	mm := NewModelManager(modelsDir, orch, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID), "model must be installed before reinstall attempt")
+
+	entryCopy := entry
+	// baseURL is never reached: the unload guard aborts before any download.
+	err := mm.Reinstall(t.Context(), &entryCopy, "http://unused.invalid", nil)
+	require.Error(t, err, "Reinstall must abort when the loaded primary cannot be unloaded")
+	assert.Contains(t, err.Error(), "model still in use")
+	assert.True(t, mm.IsInstalled(entry.ID), "model must remain installed after a refused reinstall")
+}
+
 func TestModelManager_Install_SharedGeomodel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -15,7 +15,7 @@ import (
 func (bn *BirdNET) initializeONNXModel() error {
 	start := time.Now()
 	log := GetLogger()
-	settings := bn.currentSettings()
+	settings := bn.Settings
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "ONNX classifier", "onnx_classifier", ""); err != nil {
 		return err

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -40,8 +40,9 @@ type modelEntry struct {
 //
 // Delete/UnloadModel acquire mu + entry.mu but NOT inferenceMu.
 type Orchestrator struct {
-	// Public fields — same layout as BirdNET for drop-in caller migration.
-	Settings        *conf.Settings
+	// Public fields, same layout as BirdNET for drop-in caller migration.
+	Settings        *conf.Settings // Deprecated: use CurrentSettings() instead.
+	settingsAtomic  atomic.Pointer[conf.Settings]
 	ModelInfo       ModelInfo
 	TaxonomyMap     TaxonomyMap
 	TaxonomyPath    string
@@ -65,10 +66,26 @@ type Orchestrator struct {
 	scheduler atomic.Pointer[nighttimeScheduler]
 }
 
+// CurrentSettings returns the latest settings snapshot published via
+// conf.StoreSettings, or the Orchestrator's constructor-provided settings when none
+// has been published.
+func (o *Orchestrator) CurrentSettings() *conf.Settings {
+	if s := o.settingsAtomic.Load(); s != nil {
+		return conf.CurrentOrFallback(s)
+	}
+	return conf.CurrentOrFallback(o.Settings)
+}
+
 // currentSettings returns the latest settings snapshot so hot-reloaded
 // values (threads, locale, etc.) take effect without restarting.
 func (o *Orchestrator) currentSettings() *conf.Settings {
-	return conf.CurrentOrFallback(o.Settings)
+	return o.CurrentSettings()
+}
+
+// updateSettings updates the settings pointer safely and atomically.
+func (o *Orchestrator) updateSettings(s *conf.Settings) {
+	o.Settings = s
+	o.settingsAtomic.Store(s)
 }
 
 // NewOrchestrator creates a new Orchestrator with BirdNET as the primary model
@@ -105,6 +122,7 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 		},
 		primary: bn,
 	}
+	o.settingsAtomic.Store(settings)
 
 	// Pre-compute thread allocation so model constructors receive their share.
 	// BirdNET already uses settings.BirdNET.Threads at construction; additional
@@ -553,6 +571,16 @@ func (o *Orchestrator) GetSpeciesOccurrenceAtTime(species string, detectionTime 
 	return o.primary.GetSpeciesOccurrenceAtTime(species, detectionTime)
 }
 
+// NumSpecies returns the number of species labels of the primary model.
+func (o *Orchestrator) NumSpecies() int {
+	return o.primary.NumSpecies()
+}
+
+// Labels returns a copy of the species labels of the primary model.
+func (o *Orchestrator) Labels() []string {
+	return o.primary.Labels()
+}
+
 // GetSpeciesCode returns the eBird species code for a given label.
 func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
 	return o.primary.GetSpeciesCode(label)
@@ -803,6 +831,9 @@ func (o *Orchestrator) ReloadModel() error {
 		newModels[e.instance.ModelID()] = e
 	}
 	o.models = newModels
+
+	// Update settings atomically
+	o.updateSettings(o.primary.currentSettings())
 
 	return nil
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -163,7 +163,10 @@ func (o *Orchestrator) SetModelsDir(dir string) {
 // goroutines calling ResolveName. Registration is idempotent via a
 // double-checked guard.
 func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
-	if o.Settings == nil {
+	// Read settings via the atomic-safe accessor; o.Settings is reassigned at
+	// runtime by ReloadModel (under o.mu), so raw field reads would race.
+	settings := o.CurrentSettings()
+	if settings == nil {
 		return
 	}
 
@@ -179,7 +182,7 @@ func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
 	log := GetLogger()
 	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
 
-	locale := o.Settings.BirdNET.Locale
+	locale := settings.BirdNET.Locale
 	// Load the resolver outside the lock; NewTaxonomyResolver does file I/O.
 	resolver, err := NewTaxonomyResolver(taxonomyPath, locale)
 	if err != nil {

--- a/internal/classifier/orchestrator_race_test.go
+++ b/internal/classifier/orchestrator_race_test.go
@@ -207,3 +207,77 @@ func TestOrchestrator_ConcurrentReloadSnapshot_NoRace(t *testing.T) {
 	close(start)
 	wg.Wait()
 }
+
+// TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace verifies that calling currentSettings
+// and Debug concurrently with simulated ReloadModel settings updates does not cause a data race.
+func TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
+	settings := &conf.Settings{}
+	bn, err := NewBirdNET(settings, nil)
+	require.NoError(t, err)
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	// Writer: simulates ReloadModel() updating Settings copy
+	wg.Go(func() {
+		<-start
+		for i := range iterations {
+			settingsCopy := conf.CloneSettings(settings)
+			settingsCopy.BirdNET.Debug = i%2 == 0
+			bn.mu.Lock()
+			bn.updateSettings(settingsCopy)
+			bn.mu.Unlock()
+		}
+	})
+
+	// Reader: concurrently calls currentSettings, Debug, and EnrichResultWithTaxonomy
+	wg.Go(func() {
+		<-start
+		for range iterations {
+			_ = bn.currentSettings()
+			bn.Debug("test debug message")
+			_, _, _ = bn.EnrichResultWithTaxonomy("Turdus merula_Common Blackbird")
+		}
+	})
+
+	close(start)
+	wg.Wait()
+}
+
+// TestOrchestrator_ConcurrentSettingsReadsAndWrites_NoRace verifies that calling CurrentSettings
+// concurrently with simulated ReloadModel settings updates on the Orchestrator does not cause a data race.
+func TestOrchestrator_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
+	settings := &conf.Settings{}
+	o, err := NewOrchestrator(settings)
+	require.NoError(t, err)
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	// Writer: simulates ReloadModel() updating settings on Orchestrator
+	wg.Go(func() {
+		<-start
+		for i := range iterations {
+			settingsCopy := conf.CloneSettings(settings)
+			settingsCopy.BirdNET.Debug = i%2 == 0
+			o.mu.Lock()
+			o.updateSettings(settingsCopy)
+			o.mu.Unlock()
+		}
+	})
+
+	// Reader: concurrently calls CurrentSettings, Labels, and NumSpecies
+	wg.Go(func() {
+		<-start
+		for range iterations {
+			_ = o.CurrentSettings()
+			_ = o.Labels()
+			_ = o.NumSpecies()
+		}
+	})
+
+	close(start)
+	wg.Wait()
+}

--- a/internal/classifier/orchestrator_race_test.go
+++ b/internal/classifier/orchestrator_race_test.go
@@ -212,8 +212,16 @@ func TestOrchestrator_ConcurrentReloadSnapshot_NoRace(t *testing.T) {
 // and Debug concurrently with simulated ReloadModel settings updates does not cause a data race.
 func TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 	settings := &conf.Settings{}
-	bn, err := NewBirdNET(settings, nil)
-	require.NoError(t, err)
+	// Construct via struct literal (not NewBirdNET) so the test runs under the
+	// noembed build tag, where the embedded model is unavailable. The settings
+	// accessors and reader methods exercised below do not require a loaded model;
+	// GetProbableSpecies returns early when the range filter is nil.
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+	}
+	bn.settingsAtomic.Store(settings)
 
 	const iterations = 1000
 	var wg sync.WaitGroup
@@ -254,8 +262,21 @@ func TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 // concurrently with simulated ReloadModel settings updates on the Orchestrator does not cause a data race.
 func TestOrchestrator_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 	settings := &conf.Settings{}
-	o, err := NewOrchestrator(settings)
-	require.NoError(t, err)
+	// Construct via struct literals (not NewOrchestrator) so the test runs under
+	// the noembed build tag, where the embedded model is unavailable.
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+	}
+	bn.settingsAtomic.Store(settings)
+	o := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo,
+		primary:   bn,
+		models:    map[string]*modelEntry{bn.ModelInfo.ID: {instance: bn}},
+	}
+	o.settingsAtomic.Store(settings)
 
 	const iterations = 1000
 	var wg sync.WaitGroup

--- a/internal/classifier/orchestrator_race_test.go
+++ b/internal/classifier/orchestrator_race_test.go
@@ -231,13 +231,18 @@ func TestBirdNET_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 		}
 	})
 
-	// Reader: concurrently calls currentSettings, Debug, and EnrichResultWithTaxonomy
+	// Reader: concurrently calls currentSettings, Debug, EnrichResultWithTaxonomy,
+	// and GetProbableSpecies. GetProbableSpecies is the path that previously read
+	// bn.Settings without synchronization; it now reads via the atomic accessor
+	// and this exercises that fix under -race.
 	wg.Go(func() {
 		<-start
+		now := time.Now()
 		for range iterations {
 			_ = bn.currentSettings()
 			bn.Debug("test debug message")
 			_, _, _ = bn.EnrichResultWithTaxonomy("Turdus merula_Common Blackbird")
+			_, _ = bn.GetProbableSpecies(now, 0)
 		}
 	})
 
@@ -268,13 +273,16 @@ func TestOrchestrator_ConcurrentSettingsReadsAndWrites_NoRace(t *testing.T) {
 		}
 	})
 
-	// Reader: concurrently calls CurrentSettings, Labels, and NumSpecies
+	// Reader: concurrently calls CurrentSettings, Labels, NumSpecies, and
+	// GetProbableSpecies (which delegates to the primary's settings-reading path).
 	wg.Go(func() {
 		<-start
+		now := time.Now()
 		for range iterations {
 			_ = o.CurrentSettings()
 			_ = o.Labels()
 			_ = o.NumSpecies()
+			_, _ = o.GetProbableSpecies(now, 0)
 		}
 	})
 

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -44,7 +44,10 @@ type UniversalSpeciesPredictor interface {
 func BuildRangeFilter(o *Orchestrator) error {
 	start := time.Now()
 	today := start.Truncate(24 * time.Hour)
-	settings := conf.CurrentOrFallback(o.Settings)
+	// Read settings via the atomic-safe accessor: o.Settings is reassigned at
+	// runtime by Orchestrator.ReloadModel (under o.mu), so a raw field read here
+	// would race with concurrent reloads.
+	settings := o.CurrentSettings()
 
 	var includedSpecies []string
 
@@ -254,7 +257,7 @@ func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, 
 // so that UI changes to coordinates, threshold, or LocationConfigured take
 // effect immediately without restarting the service.
 func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
-	scores, _, err := bn.getProbableSpecies(date, week, conf.CurrentOrFallback(bn.Settings))
+	scores, _, err := bn.getProbableSpecies(date, week, bn.currentSettings())
 	return scores, err
 }
 

--- a/internal/classifier/range_filter_dispatch_onnx_test.go
+++ b/internal/classifier/range_filter_dispatch_onnx_test.go
@@ -61,7 +61,7 @@ func TestInitializeMetaModel_OrphanGeomodelOnV24(t *testing.T) {
 	}
 	t.Cleanup(bn.Delete)
 
-	require.NoError(t, bn.initializeMetaModel())
+	require.NoError(t, bn.initializeMetaModel(settings))
 
 	mapped, ok := bn.rangeFilter.(*mappedRangeFilter)
 	require.True(t, ok, "orphan geomodel config must produce a mappedRangeFilter, got %T", bn.rangeFilter)

--- a/internal/classifier/settings_accessor_test.go
+++ b/internal/classifier/settings_accessor_test.go
@@ -1,0 +1,72 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestBirdNET_UpdateSettings_SyncsBothFields verifies updateSettings keeps the
+// deprecated bn.Settings field and the lock-free settingsAtomic pointer pointing
+// at the same snapshot. currentSettings() and the lock-guarded readers
+// (NumSpecies/Labels/initialize*) rely on this invariant; if the two ever
+// diverged, lock-free and lock-guarded readers would observe different settings,
+// reintroducing the class of bug this branch set out to fix.
+func TestBirdNET_UpdateSettings_SyncsBothFields(t *testing.T) {
+	t.Parallel()
+
+	bn := &BirdNET{}
+
+	s1 := &conf.Settings{}
+	bn.updateSettings(s1)
+	assert.Same(t, s1, bn.Settings, "Settings field must point at the published snapshot")
+	assert.Same(t, s1, bn.settingsAtomic.Load(), "atomic pointer must point at the published snapshot")
+
+	// A subsequent update (e.g. a reload, or a rollback restoring the old
+	// pointer) must move BOTH fields together.
+	s2 := &conf.Settings{}
+	bn.updateSettings(s2)
+	assert.Same(t, s2, bn.Settings)
+	assert.Same(t, s2, bn.settingsAtomic.Load())
+}
+
+// TestOrchestrator_UpdateSettings_SyncsBothFields is the Orchestrator counterpart
+// of the BirdNET dual-write invariant.
+func TestOrchestrator_UpdateSettings_SyncsBothFields(t *testing.T) {
+	t.Parallel()
+
+	o := &Orchestrator{}
+
+	s1 := &conf.Settings{}
+	o.updateSettings(s1)
+	assert.Same(t, s1, o.Settings, "Settings field must point at the published snapshot")
+	assert.Same(t, s1, o.settingsAtomic.Load(), "atomic pointer must point at the published snapshot")
+
+	s2 := &conf.Settings{}
+	o.updateSettings(s2)
+	assert.Same(t, s2, o.Settings)
+	assert.Same(t, s2, o.settingsAtomic.Load())
+}
+
+// TestBirdNET_CurrentSettings_PrefersAtomicOverDeprecatedField verifies that
+// currentSettings() reads through the atomic pointer, not the raw bn.Settings
+// field, when no global snapshot is published. This is the test-mode contract
+// that lets struct-literal test fixtures (which set Settings but not the atomic)
+// keep working while production code relies on the atomic for race-free reads.
+func TestBirdNET_CurrentSettings_PrefersAtomicOverDeprecatedField(t *testing.T) {
+	// Not parallel: temporarily clears the conf global snapshot, which is
+	// process-wide. Restored on cleanup.
+	saved := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(saved) })
+	conf.SetTestSettings(nil)
+
+	atomicSnapshot := &conf.Settings{}
+	bn := &BirdNET{}
+	bn.settingsAtomic.Store(atomicSnapshot)
+	// Deliberately leave bn.Settings pointing elsewhere to prove the atomic wins.
+	bn.Settings = &conf.Settings{}
+
+	assert.Same(t, atomicSnapshot, bn.currentSettings(),
+		"currentSettings must return the atomic snapshot when no global is published")
+}


### PR DESCRIPTION
## Summary

Resolves a set of concurrency and lifecycle bugs in the classifier model-reload path, plus follow-up fixes found during review.

Core changes:
- Settings reads during concurrent model reloads are now race-free. A per-instance atomic settings pointer backs the `currentSettings()` / `CurrentSettings()` accessors, and the concurrent readers (range-filter build, heatmap service, probable-species, taxonomy resolver, REST species endpoints) go through them instead of the raw `Settings` field.
- `ReloadModel` is split into a locked `reloadModelInternal` plus an outer wrapper that runs `debug.FreeOSMemory()` outside the mutex, so memory release no longer stalls concurrent requests.
- `Uninstall` is now best-effort: it de-registers the model and clears config even when some files cannot be deleted, then reports the deletion failure, instead of aborting early and leaving inconsistent state.
- `Reinstall` and `Uninstall` unload the model from the orchestrator before overwriting or deleting files, avoiding file-lock crashes while a model is in use.
- `loadExternalLabels` now expands `$VAR` and `~` in the label path, matching the existing `ModelPath` behavior.

Review follow-ups (second commit):
- Fixed a new data race the atomic-settings work introduced: `BuildRangeFilter` and `GetHeatmapService` read the now-mutable `o.Settings` field without synchronization. Routed through `CurrentSettings()`, along with `GetProbableSpecies` and `registerTaxonomyResolver`.
- Fixed the `onnx` build: the onnx-tagged test called `initializeMetaModel()` without the new settings argument.
- Logging: always-on Warn for uninstall/reinstall unload refusals (reinstall is async, so the API logger may drop it), Warn instead of Info on partial-uninstall file failures, and a Warn when a failed reload rolls back to the previous model.
- Tests: external label loading, the `updateSettings` dual-write invariant, uninstall-on-delete-failure, reinstall-refuses-primary, and the concurrent settings-race tests now also exercise `GetProbableSpecies`.

## Related Issues

Fixes #3337
Fixes #3338
Fixes #3339
Relates to #3336 (adds unload-before-overwrite/delete guards that remove the reinstall/uninstall file-overwrite crash path; broader reload-segfault hardening is partial)

## Notes / known behavior changes

- Reinstalling the currently-loaded primary model now fails with "model still in use" (the orchestrator refuses to unload the primary). This is the safe-but-stricter consequence of the unload-before-overwrite guard; a dedicated primary-reinstall path is a possible follow-up.
- A reinstall that fails after the pre-download unload leaves the model unloaded until restart; re-load-on-failure is a possible follow-up.
- A partially-failing uninstall returns an error even though the model is de-registered; the REST handler currently maps that to a 500.

## Test Plan

- [x] `go build ./...` and `go vet` (default and `-tags onnx`)
- [x] `golangci-lint run`: 0 issues
- [x] `go test -race` for `internal/classifier`, `internal/analysis`, `internal/api/v2`
- [x] New regression tests for each fixed path
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected species count reporting to reflect the actual loaded model state.
  * Removed races and stale-settings reads during model reloads and runtime operations.
  * Improved label-loading to expand environment variables and report expanded paths.
  * Improved model install/uninstall error handling and logging; file removals are now best-effort.

* **Tests**
  * Added regression tests for external label paths, concurrency/race safety, settings snapshot behavior, and model-manager uninstall/reinstall scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->