### PR TITLE
fix: eliminate drift-prone code patterns across three packages

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1977,14 +1977,7 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	if settings.Realtime.MQTT.Enabled {
 		mqttClient := p.GetMQTTClient()
 		if mqttClient != nil {
-			// Create MQTT retry config from settings
-			mqttRetryConfig := jobqueue.RetryConfig{
-				Enabled:      settings.Realtime.MQTT.RetrySettings.Enabled,
-				MaxRetries:   settings.Realtime.MQTT.RetrySettings.MaxRetries,
-				InitialDelay: time.Duration(settings.Realtime.MQTT.RetrySettings.InitialDelay) * time.Second,
-				MaxDelay:     time.Duration(settings.Realtime.MQTT.RetrySettings.MaxDelay) * time.Second,
-				Multiplier:   settings.Realtime.MQTT.RetrySettings.BackoffMultiplier,
-			}
+			mqttRetryConfig := retryConfigFromSettings(settings.Realtime.MQTT.RetrySettings)
 
 			mqttAction = &MqttAction{
 				Settings:       settings,
@@ -2061,14 +2054,7 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	if settings.Realtime.Birdweather.Enabled {
 		bwClient := p.GetBwClient() // Use getter for thread safety
 		if bwClient != nil {
-			// Create BirdWeather retry config from settings
-			bwRetryConfig := jobqueue.RetryConfig{
-				Enabled:      settings.Realtime.Birdweather.RetrySettings.Enabled,
-				MaxRetries:   settings.Realtime.Birdweather.RetrySettings.MaxRetries,
-				InitialDelay: time.Duration(settings.Realtime.Birdweather.RetrySettings.InitialDelay) * time.Second,
-				MaxDelay:     time.Duration(settings.Realtime.Birdweather.RetrySettings.MaxDelay) * time.Second,
-				Multiplier:   settings.Realtime.Birdweather.RetrySettings.BackoffMultiplier,
-			}
+			bwRetryConfig := retryConfigFromSettings(settings.Realtime.Birdweather.RetrySettings)
 
 			actions = append(actions, &BirdWeatherAction{
 				Settings:      settings,
@@ -2098,6 +2084,17 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	}
 
 	return actions
+}
+
+// retryConfigFromSettings converts user-facing retry settings into a jobqueue RetryConfig.
+func retryConfigFromSettings(rs conf.RetrySettings) jobqueue.RetryConfig {
+	return jobqueue.RetryConfig{
+		Enabled:      rs.Enabled,
+		MaxRetries:   rs.MaxRetries,
+		InitialDelay: time.Duration(rs.InitialDelay) * time.Second,
+		MaxDelay:     time.Duration(rs.MaxDelay) * time.Second,
+		Multiplier:   rs.BackoffMultiplier,
+	}
 }
 
 // buildSaveAudioAction creates a SaveAudioAction for the given detection.

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -24,8 +24,8 @@ var (
 )
 
 // CandidateSampleRates are the rates tested during device probing.
-// Must remain sorted ascending.
-var CandidateSampleRates = []int{48000, 96000, 192000, 256000, 384000}
+// Derived from conf.ValidSampleRates to keep validation and probing in sync.
+var CandidateSampleRates = conf.ValidSampleRates
 
 // MinCaptureSampleRate is the lowest rate considered useful for capture.
 const MinCaptureSampleRate = 48000

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -25,7 +25,7 @@ var (
 
 // CandidateSampleRates are the rates tested during device probing.
 // Derived from conf.ValidSampleRates to keep validation and probing in sync.
-var CandidateSampleRates = slices.Clone(conf.ValidSampleRates)
+var CandidateSampleRates = conf.ValidSampleRates()
 
 // MinCaptureSampleRate is the lowest rate considered useful for capture.
 const MinCaptureSampleRate = 48000

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -25,7 +25,7 @@ var (
 
 // CandidateSampleRates are the rates tested during device probing.
 // Derived from conf.ValidSampleRates to keep validation and probing in sync.
-var CandidateSampleRates = conf.ValidSampleRates
+var CandidateSampleRates = slices.Clone(conf.ValidSampleRates)
 
 // MinCaptureSampleRate is the lowest rate considered useful for capture.
 const MinCaptureSampleRate = 48000

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -100,6 +100,18 @@ func getStreamLogger() logger.Logger {
 	return audiocore.GetLogger()
 }
 
+// String representations of ProcessState values, exported so that other
+// packages can compare against them without duplicating raw literals.
+const (
+	ProcessStateIdle        = "idle"
+	ProcessStateStarting    = "starting"
+	ProcessStateRunning     = "running"
+	ProcessStateRestarting  = "restarting"
+	ProcessStateBackoff     = "backoff"
+	ProcessStateCircuitOpen = "circuit_open"
+	ProcessStateStopped     = "stopped"
+)
+
 // ProcessState represents the current lifecycle state of an FFmpeg process.
 type ProcessState int
 
@@ -124,19 +136,19 @@ const (
 func (s ProcessState) String() string {
 	switch s {
 	case StateIdle:
-		return "idle"
+		return ProcessStateIdle
 	case StateStarting:
-		return "starting"
+		return ProcessStateStarting
 	case StateRunning:
-		return "running"
+		return ProcessStateRunning
 	case StateRestarting:
-		return "restarting"
+		return ProcessStateRestarting
 	case StateBackoff:
-		return "backoff"
+		return ProcessStateBackoff
 	case StateCircuitOpen:
-		return "circuit_open"
+		return ProcessStateCircuitOpen
 	case StateStopped:
-		return "stopped"
+		return ProcessStateStopped
 	default:
 		return fmt.Sprintf("unknown(%d)", s)
 	}

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -98,6 +99,10 @@ var ValidStreamTypes = map[string]bool{
 	StreamTypeRTMP: true,
 	StreamTypeUDP:  true,
 }
+
+// ValidSampleRates is the canonical list of supported capture sample rates (sorted ascending).
+// Used by both validation and audiocore device probing to prevent drift.
+var ValidSampleRates = []int{48000, 96000, 192000, 256000, 384000}
 
 // Validate validates a single stream configuration
 func (s *StreamConfig) Validate() error {
@@ -309,13 +314,9 @@ func (a *AudioSourceConfig) Validate() error {
 	}
 
 	// Validate sample rate if specified (0 means use default 48000)
-	// NOTE: These rates must stay in sync with audiocore.CandidateSampleRates.
 	if a.SampleRate != 0 {
-		validRates := map[int]struct{}{
-			48000: {}, 96000: {}, 192000: {}, 256000: {}, 384000: {},
-		}
-		if _, ok := validRates[a.SampleRate]; !ok {
-			return fmt.Errorf("audio source '%s': sample rate %d Hz is not a supported value (valid: 48000, 96000, 192000, 256000, 384000)", a.Name, a.SampleRate)
+		if !slices.Contains(ValidSampleRates, a.SampleRate) {
+			return fmt.Errorf("audio source '%s': sample rate %d Hz is not a supported value (valid: %v)", a.Name, a.SampleRate, ValidSampleRates)
 		}
 	}
 

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -100,9 +100,14 @@ var ValidStreamTypes = map[string]bool{
 	StreamTypeUDP:  true,
 }
 
-// ValidSampleRates is the canonical list of supported capture sample rates (sorted ascending).
-// Used by both validation and audiocore device probing to prevent drift.
-var ValidSampleRates = []int{48000, 96000, 192000, 256000, 384000}
+// validSampleRates is the canonical list of supported capture sample rates (sorted ascending).
+var validSampleRates = []int{48000, 96000, 192000, 256000, 384000}
+
+// ValidSampleRates returns a copy of the canonical sample rate list.
+// Returning a clone prevents callers from mutating the shared source of truth.
+func ValidSampleRates() []int {
+	return slices.Clone(validSampleRates)
+}
 
 // Validate validates a single stream configuration
 func (s *StreamConfig) Validate() error {
@@ -315,9 +320,9 @@ func (a *AudioSourceConfig) Validate() error {
 
 	// Validate sample rate if specified (0 means use default 48000)
 	if a.SampleRate != 0 {
-		if !slices.Contains(ValidSampleRates, a.SampleRate) {
-			rateStrs := make([]string, len(ValidSampleRates))
-			for i, r := range ValidSampleRates {
+		if !slices.Contains(validSampleRates, a.SampleRate) {
+			rateStrs := make([]string, len(validSampleRates))
+			for i, r := range validSampleRates {
 				rateStrs[i] = strconv.Itoa(r)
 			}
 			return fmt.Errorf("audio source '%s': sample rate %d Hz is not a supported value (valid: %s)", a.Name, a.SampleRate, strings.Join(rateStrs, ", "))

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -316,7 +316,11 @@ func (a *AudioSourceConfig) Validate() error {
 	// Validate sample rate if specified (0 means use default 48000)
 	if a.SampleRate != 0 {
 		if !slices.Contains(ValidSampleRates, a.SampleRate) {
-			return fmt.Errorf("audio source '%s': sample rate %d Hz is not a supported value (valid: %v)", a.Name, a.SampleRate, ValidSampleRates)
+			rateStrs := make([]string, len(ValidSampleRates))
+			for i, r := range ValidSampleRates {
+				rateStrs[i] = strconv.Itoa(r)
+			}
+			return fmt.Errorf("audio source '%s': sample rate %d Hz is not a supported value (valid: %s)", a.Name, a.SampleRate, strings.Join(rateStrs, ", "))
 		}
 	}
 

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -138,15 +138,6 @@ func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 	}, start)
 }
 
-// FFmpeg process state strings, matching ProcessState.String() in
-// internal/audiocore/ffmpeg. "stopped" is the terminal state: the process has
-// permanently stopped and will not recover on its own. Any other non-running
-// state (idle, starting, restarting, backoff, circuit_open) is transient.
-const (
-	ffmpegStateRunning = ffmpeg.ProcessStateRunning
-	ffmpegStateStopped = ffmpeg.ProcessStateStopped
-)
-
 // FFmpeg health check message formats.
 const (
 	// ffmpegStoppedMsgFormat is used when only stopped (terminal) processes are present.
@@ -192,9 +183,9 @@ func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
 
 	for _, s := range streams {
 		switch s.ProcessState {
-		case ffmpegStateRunning:
+		case ffmpeg.ProcessStateRunning:
 			// healthy
-		case ffmpegStateStopped:
+		case ffmpeg.ProcessStateStopped:
 			stoppedCount++
 		default:
 			notRunningCount++

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
@@ -15,7 +16,7 @@ type StreamHealthInfo struct {
 	URL string
 	// IsHealthy indicates whether the stream is considered healthy.
 	IsHealthy bool
-	// ProcessState is the current state of the underlying FFmpeg process (e.g. "running", "dead").
+	// ProcessState is the current state of the underlying FFmpeg process (e.g. "running", "stopped").
 	ProcessState string
 	// RestartCount is the number of times this stream has been restarted.
 	RestartCount int
@@ -142,8 +143,8 @@ func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
 // permanently stopped and will not recover on its own. Any other non-running
 // state (idle, starting, restarting, backoff, circuit_open) is transient.
 const (
-	ffmpegStateRunning = "running"
-	ffmpegStateStopped = "stopped"
+	ffmpegStateRunning = ffmpeg.ProcessStateRunning
+	ffmpegStateStopped = ffmpeg.ProcessStateStopped
 )
 
 // FFmpeg health check message formats.


### PR DESCRIPTION
## Summary

- Export `ProcessState` string constants from the ffmpeg package and import them in the health check, replacing raw string literals that could silently diverge
- Define `ValidSampleRates` as a single source of truth in the conf package, replacing hand-copied lists in both validation and device probing that could drift independently
- Extract `retryConfigFromSettings` helper to deduplicate identical `RetryConfig` construction for MQTT and BirdWeather integrations
- Use `slices.Clone` when deriving `CandidateSampleRates` from `conf.ValidSampleRates` to prevent shared backing-array mutation risk
- Preserve comma-separated error message format for invalid sample rate validation

## Test Plan
- [x] `golangci-lint run -v` passes with 0 issues (full project)
- [x] `go test -race -count=1 ./internal/audiocore/ ./internal/conf/ ./internal/health/checks/` all pass
- [x] Pre-commit hooks pass on both commits
- [x] Gate review (6 agents + Gemini cross-validation) completed clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate retry configuration handling across integrations to ensure consistent retry behavior.
  * Centralized audio sample-rate validation to keep probed/accepted rates synchronized with a single source.
  * Unified audio process-state identifiers used by health checks and stream handling for more consistent status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->