### PR TITLE
feat(spectrogram): bat-aware generation with configurable frequency profiles

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -486,6 +486,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 			ClipPath:   outputPath, // Use full path to audio file
 			NoteID:     a.NoteID,
 			Timestamp:  time.Now(),
+			ModelType:  string(detection.ResolveModelType(a.modelName, "")),
 		}
 
 		// Non-blocking submission - errors logged but don't fail action

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -124,6 +124,7 @@ type PreRenderJob struct {
 	ClipPath   string    // Full absolute path to audio clip file
 	NoteID     uint      // For logging correlation
 	Timestamp  time.Time // Job submission time
+	ModelType  string    // AI model type ("bird", "bat", "multi") for frequency profile selection
 }
 
 // Methods to expose fields (allows prerenderer to access without importing processor)
@@ -132,6 +133,7 @@ func (j *PreRenderJob) GetSampleRate() int      { return j.SampleRate }
 func (j *PreRenderJob) GetClipPath() string     { return j.ClipPath }
 func (j *PreRenderJob) GetNoteID() uint         { return j.NoteID }
 func (j *PreRenderJob) GetTimestamp() time.Time { return j.Timestamp }
+func (j *PreRenderJob) GetModelType() string    { return j.ModelType }
 
 // PreRendererSubmit is an interface for submitting pre-render jobs.
 // Callers create PreRenderJob instances, and the implementation adapts them
@@ -143,6 +145,7 @@ type PreRendererSubmit interface {
 		GetClipPath() string
 		GetNoteID() uint
 		GetTimestamp() time.Time
+		GetModelType() string
 	}) error
 	Stop() // Graceful shutdown
 }

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -178,6 +178,9 @@ func (m *ActionMockDatastore) SearchNotesAdvanced(_ *datastore.AdvancedSearchFil
 func (m *ActionMockDatastore) GetNoteClipPath(_ string) (string, error) {
 	return "", nil
 }
+func (m *ActionMockDatastore) GetNoteModelType(_ string) (string, error) {
+	return "bird", nil
+}
 func (m *ActionMockDatastore) DeleteNoteClipPath(_ string) error {
 	return nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -80,7 +80,8 @@ func (m *MockDatastore) SearchNotesAdvanced(*datastore.AdvancedSearchFilters) ([
 func (m *MockDatastore) GetNoteClipPath(string) (string, error) {
 	return "", datastore.ErrNoteReviewNotFound
 }
-func (m *MockDatastore) DeleteNoteClipPath(string) error { return nil }
+func (m *MockDatastore) GetNoteModelType(_ string) (string, error) { return "bird", nil }
+func (m *MockDatastore) DeleteNoteClipPath(string) error           { return nil }
 func (m *MockDatastore) GetNoteReview(string) (*datastore.NoteReview, error) {
 	return nil, datastore.ErrNoteReviewNotFound
 }

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -1692,15 +1692,6 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 	// Initialize queue status BEFORE spawning goroutine (prevents "not_started" flicker)
 	c.initializeQueueStatus(spectrogramKey)
 
-	// Resolve frequency profile from detection's model type
-	modelType, err := c.DS.GetNoteModelType(noteID)
-	if err != nil {
-		c.logDebugIfEnabled("GetNoteModelType failed, defaulting to bird",
-			logger.String("note_id", noteID),
-			logger.Error(err))
-	}
-	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
-
 	// Start async generation in background with proper cleanup and panic recovery
 	// Track goroutine lifecycle for graceful shutdown
 	c.wg.Go(func() {
@@ -1716,6 +1707,15 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 		// Use controller context (respects shutdown signals) with timeout
 		bgCtx, cancel := context.WithTimeout(c.ctx, spectrogramGenerationTimeout)
 		defer cancel()
+
+		// Resolve frequency profile inside goroutine to avoid blocking the HTTP handler
+		modelType, mtErr := c.DS.GetNoteModelType(noteID)
+		if mtErr != nil {
+			c.logDebugIfEnabled("GetNoteModelType failed, defaulting to bird",
+				logger.String("note_id", noteID),
+				logger.Error(mtErr))
+		}
+		profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
 
 		spectrogramPath, err := c.generateSpectrogram(bgCtx, clipPath, params.width, params.raw, params.style, params.dynamicRange, profileOpt)
 

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -981,7 +981,12 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 	defer func() { _ = os.Remove(tmpSpectrogramPath) }()
 
 	params := c.parseSpectrogramParameters(ctx)
-	if err := c.spectrogramGenerator.GenerateFromFile(ctx.Request().Context(), tmpPath, tmpSpectrogramPath, params.width, params.raw); err != nil {
+
+	// Resolve frequency profile from detection's model type
+	modelType, _ := c.DS.GetNoteModelType(noteID)
+	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
+
+	if err := c.spectrogramGenerator.GenerateFromFile(ctx.Request().Context(), tmpPath, tmpSpectrogramPath, params.width, params.raw, profileOpt); err != nil {
 		if ctx.Request().Context().Err() != nil {
 			return nil
 		}
@@ -1214,10 +1219,10 @@ func (c *Controller) returnSpectrogramNotGeneratedError(ctx echo.Context) (bool,
 }
 
 // handleAutoPreRenderMode handles spectrogram generation and serving in auto/prerender modes.
-func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters) error {
+func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters, extraOpts ...spectrogram.GenerateOption) error {
 	// Auto or prerender mode - generate on-demand if needed
 	generationStart := time.Now()
-	spectrogramPath, err := c.generateSpectrogram(ctx.Request().Context(), clipPath, params.width, params.raw, params.style, params.dynamicRange)
+	spectrogramPath, err := c.generateSpectrogram(ctx.Request().Context(), clipPath, params.width, params.raw, params.style, params.dynamicRange, extraOpts...)
 	generationDuration := time.Since(generationStart)
 
 	if err != nil {
@@ -1342,6 +1347,10 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 	// Parse query parameters
 	params := c.parseSpectrogramParameters(ctx)
 
+	// Resolve frequency profile from detection's model type
+	modelType, _ := c.DS.GetNoteModelType(noteID)
+	profile := spectrogram.ProfileForModelType(modelType)
+
 	// Log request details
 	c.logDebugIfEnabled("Spectrogram requested by ID",
 		logger.String("note_id", noteID),
@@ -1349,11 +1358,14 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 		logger.Int("width", params.width),
 		logger.Bool("raw", params.raw),
 		logger.String("size_param", params.sizeStr),
+		logger.String("model_type", modelType),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()))
 
 	// Check spectrogram generation mode
 	spectrogramMode := c.Settings.Realtime.Dashboard.Spectrogram.GetMode()
+
+	profileOpt := spectrogram.WithFrequencyProfile(profile)
 
 	// Handle user-requested mode
 	if spectrogramMode == conf.SpectrogramModeUserRequested {
@@ -1364,7 +1376,7 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 	}
 
 	// Handle auto or prerender mode
-	return c.handleAutoPreRenderMode(ctx, noteID, clipPath, params)
+	return c.handleAutoPreRenderMode(ctx, noteID, clipPath, params, profileOpt)
 }
 
 // ServeAudioByQueryID serves an audio clip using query parameter for ID
@@ -1672,6 +1684,10 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 	// Initialize queue status BEFORE spawning goroutine (prevents "not_started" flicker)
 	c.initializeQueueStatus(spectrogramKey)
 
+	// Resolve frequency profile from detection's model type
+	modelType, _ := c.DS.GetNoteModelType(noteID)
+	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
+
 	// Start async generation in background with proper cleanup and panic recovery
 	// Track goroutine lifecycle for graceful shutdown
 	c.wg.Go(func() {
@@ -1688,7 +1704,7 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 		bgCtx, cancel := context.WithTimeout(c.ctx, spectrogramGenerationTimeout)
 		defer cancel()
 
-		spectrogramPath, err := c.generateSpectrogram(bgCtx, clipPath, params.width, params.raw, params.style, params.dynamicRange)
+		spectrogramPath, err := c.generateSpectrogram(bgCtx, clipPath, params.width, params.raw, params.style, params.dynamicRange, profileOpt)
 
 		if err != nil {
 			// Update queue status so polling clients see the failure
@@ -2427,7 +2443,7 @@ func (c *Controller) acquireSemaphoreSlot(ctx context.Context, spectrogramKey st
 }
 
 // performSpectrogramGeneration executes the actual spectrogram generation logic
-func (c *Controller) performSpectrogramGeneration(ctx context.Context, relSpectrogramPath, absAudioPath, absSpectrogramPath, spectrogramKey string, width int, raw bool, validatedDuration float64) (any, error) {
+func (c *Controller) performSpectrogramGeneration(ctx context.Context, relSpectrogramPath, absAudioPath, absSpectrogramPath, spectrogramKey string, width int, raw bool, validatedDuration float64, extraOpts ...spectrogram.GenerateOption) (any, error) {
 	// Fast path inside the group – now race-free
 	getSpectrogramLogger().Debug("Inside singleflight group, double-checking if spectrogram exists",
 		logger.String("spectrogram_key", spectrogramKey))
@@ -2482,7 +2498,7 @@ func (c *Controller) performSpectrogramGeneration(ctx context.Context, relSpectr
 		logger.Int("max_slots", maxConcurrentSpectrograms))
 
 	// Generate the spectrogram with SoX or FFmpeg fallback
-	if err := c.generateWithFallback(ctx, absAudioPath, absSpectrogramPath, spectrogramKey, width, raw, validatedDuration); err != nil {
+	if err := c.generateWithFallback(ctx, absAudioPath, absSpectrogramPath, spectrogramKey, width, raw, validatedDuration, extraOpts...); err != nil {
 		return nil, err
 	}
 
@@ -2560,7 +2576,7 @@ func (c *Controller) verifySpectrogramFile(absPath, relPath string) error {
 }
 
 // generateWithFallback attempts to generate a spectrogram with SoX, falling back to FFmpeg on failure
-func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, absSpectrogramPath, spectrogramKey string, width int, raw bool, validatedDuration float64) error {
+func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, absSpectrogramPath, spectrogramKey string, width int, raw bool, validatedDuration float64, extraOpts ...spectrogram.GenerateOption) error {
 	generationStart := time.Now()
 
 	getSpectrogramLogger().Debug("Starting spectrogram generation via shared generator",
@@ -2576,6 +2592,7 @@ func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, abs
 	if validatedDuration > 0 {
 		genOpts = append(genOpts, spectrogram.WithDuration(validatedDuration))
 	}
+	genOpts = append(genOpts, extraOpts...)
 	if err := c.spectrogramGenerator.GenerateFromFile(ctx, absAudioPath, absSpectrogramPath, width, raw, genOpts...); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
@@ -2610,7 +2627,7 @@ func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, abs
 // It accepts a context for cancellation and timeout.
 // It returns the relative path to the generated spectrogram, suitable for use with c.SFS.ServeFile.
 // Optimized: Fast path check happens before expensive audio validation.
-func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, width int, raw bool, style, dynamicRange string) (string, error) {
+func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, width int, raw bool, style, dynamicRange string, extraOpts ...spectrogram.GenerateOption) (string, error) {
 	start := time.Now()
 	getSpectrogramLogger().Debug("Spectrogram generation requested",
 		logger.String("audio_path", audioPath),
@@ -2726,7 +2743,7 @@ func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, 
 				logger.Int("slots_now_available", maxConcurrentSpectrograms-slotsAfterRelease),
 				logger.Int64("total_duration_ms", time.Since(start).Milliseconds()))
 		}()
-		return c.performSpectrogramGeneration(sharedCtx, relSpectrogramPath, absAudioPath, absSpectrogramPath, spectrogramKey, width, raw, validatedDuration)
+		return c.performSpectrogramGeneration(sharedCtx, relSpectrogramPath, absAudioPath, absSpectrogramPath, spectrogramKey, width, raw, validatedDuration, extraOpts...)
 	})
 
 	// Wait for either the singleflight result or caller's context cancellation.

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -983,7 +983,12 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 	params := c.parseSpectrogramParameters(ctx)
 
 	// Resolve frequency profile from detection's model type
-	modelType, _ := c.DS.GetNoteModelType(noteID)
+	modelType, mtErr := c.DS.GetNoteModelType(noteID)
+	if mtErr != nil {
+		c.logDebugIfEnabled("GetNoteModelType failed, defaulting to bird",
+			logger.String("note_id", noteID),
+			logger.Error(mtErr))
+	}
 	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
 
 	if err := c.spectrogramGenerator.GenerateFromFile(ctx.Request().Context(), tmpPath, tmpSpectrogramPath, params.width, params.raw, profileOpt); err != nil {
@@ -1348,8 +1353,13 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 	params := c.parseSpectrogramParameters(ctx)
 
 	// Resolve frequency profile from detection's model type
-	modelType, _ := c.DS.GetNoteModelType(noteID)
-	profile := spectrogram.ProfileForModelType(modelType)
+	modelType, err := c.DS.GetNoteModelType(noteID)
+	if err != nil {
+		c.logDebugIfEnabled("GetNoteModelType failed, defaulting to bird",
+			logger.String("note_id", noteID),
+			logger.Error(err))
+	}
+	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
 
 	// Log request details
 	c.logDebugIfEnabled("Spectrogram requested by ID",
@@ -1364,8 +1374,6 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 
 	// Check spectrogram generation mode
 	spectrogramMode := c.Settings.Realtime.Dashboard.Spectrogram.GetMode()
-
-	profileOpt := spectrogram.WithFrequencyProfile(profile)
 
 	// Handle user-requested mode
 	if spectrogramMode == conf.SpectrogramModeUserRequested {
@@ -1685,7 +1693,12 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 	c.initializeQueueStatus(spectrogramKey)
 
 	// Resolve frequency profile from detection's model type
-	modelType, _ := c.DS.GetNoteModelType(noteID)
+	modelType, err := c.DS.GetNoteModelType(noteID)
+	if err != nil {
+		c.logDebugIfEnabled("GetNoteModelType failed, defaulting to bird",
+			logger.String("note_id", noteID),
+			logger.Error(err))
+	}
 	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
 
 	// Start async generation in background with proper cleanup and panic recovery

--- a/internal/api/v2/media_ffmpeg_optimization_test.go
+++ b/internal/api/v2/media_ffmpeg_optimization_test.go
@@ -52,7 +52,7 @@ func checkDurationFlag(t *testing.T, args []string) bool {
 // checkRequiredSoxParams verifies essential SoX parameters are present.
 func checkRequiredSoxParams(t *testing.T, args []string) {
 	t.Helper()
-	requiredParams := []string{"-n", "rate", "24k", "spectrogram", "-x", "-y", "-z", "-o"}
+	requiredParams := []string{"-n", "rate", "24000", "spectrogram", "-x", "-y", "-z", "-o"}
 	for _, param := range requiredParams {
 		assert.Contains(t, args, param, "Required SoX parameter %q missing from args", param)
 	}
@@ -178,7 +178,7 @@ func TestGetSoxSpectrogramArgs_ArgumentOrder(t *testing.T) {
 
 	// Verify the base arguments are in correct order
 	// Height is FFT-friendly: fftFriendlyHeight(800) = 513 (2^9 + 1, DFT=1024)
-	expectedStart := []string{"-n", "rate", "24k", "spectrogram", "-x", "800", "-y", "513"}
+	expectedStart := []string{"-n", "rate", "24000", "spectrogram", "-x", "800", "-y", "513"}
 
 	require.GreaterOrEqual(t, len(args), len(expectedStart),
 		"Not enough arguments returned, got %d, expected at least %d", len(args), len(expectedStart))

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -1071,6 +1071,7 @@ func TestServeSpectrogramByIDRawParameter(t *testing.T) {
 	// Setup mock data store
 	mockDS := mocks.NewMockInterface(t)
 	mockDS.On("GetNoteClipPath", "123").Return(testFilename, nil)
+	mockDS.On("GetNoteModelType", "123").Return("bird", nil)
 	controller.DS = mockDS
 
 	// Test cases

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -114,6 +114,7 @@ type Interface interface {
 	SearchNotes(query string, sortAscending bool, limit int, offset int) ([]Note, int64, error)
 	SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note, int64, error)
 	GetNoteClipPath(noteID string) (string, error)
+	GetNoteModelType(noteID string) (string, error)
 	DeleteNoteClipPath(noteID string) error
 	GetNoteReview(noteID string) (*NoteReview, error)
 	SaveNoteReview(review *NoteReview) error
@@ -565,6 +566,12 @@ func (ds *DataStore) GetNoteClipPath(noteID string) (string, error) {
 	}
 
 	return clipPath.ClipName, nil
+}
+
+// GetNoteModelType returns the AI model type for a detection.
+// The legacy schema does not track model types, so this always returns "bird".
+func (ds *DataStore) GetNoteModelType(_ string) (string, error) {
+	return "bird", nil
 }
 
 // DeleteNoteClipPath deletes the field representing the path to the audio clip associated with a note.

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -2980,6 +2980,62 @@ func (_c *MockInterface_GetNoteLock_Call) RunAndReturn(run func(string) (*datast
 	return _c
 }
 
+// GetNoteModelType provides a mock function with given fields: noteID
+func (_m *MockInterface) GetNoteModelType(noteID string) (string, error) {
+	ret := _m.Called(noteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNoteModelType")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(noteID)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(noteID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(noteID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetNoteModelType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNoteModelType'
+type MockInterface_GetNoteModelType_Call struct {
+	*mock.Call
+}
+
+// GetNoteModelType is a helper method to define mock.On call
+//   - noteID string
+func (_e *MockInterface_Expecter) GetNoteModelType(noteID interface{}) *MockInterface_GetNoteModelType_Call {
+	return &MockInterface_GetNoteModelType_Call{Call: _e.mock.On("GetNoteModelType", noteID)}
+}
+
+func (_c *MockInterface_GetNoteModelType_Call) Run(run func(noteID string)) *MockInterface_GetNoteModelType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetNoteModelType_Call) Return(_a0 string, _a1 error) *MockInterface_GetNoteModelType_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetNoteModelType_Call) RunAndReturn(run func(string) (string, error)) *MockInterface_GetNoteModelType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNoteResults provides a mock function with given fields: noteID
 func (_m *MockInterface) GetNoteResults(noteID string) ([]datastore.Results, error) {
 	ret := _m.Called(noteID)

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -691,6 +691,7 @@ func (s *testLegacyInterface) SearchNotesAdvanced(_ *datastore.AdvancedSearchFil
 	return nil, 0, nil
 }
 func (s *testLegacyInterface) GetNoteClipPath(_ string) (string, error)              { return "", nil }
+func (s *testLegacyInterface) GetNoteModelType(_ string) (string, error)             { return "bird", nil }
 func (s *testLegacyInterface) DeleteNoteClipPath(_ string) error                     { return nil }
 func (s *testLegacyInterface) GetNoteReview(_ string) (*datastore.NoteReview, error) { return nil, nil } //nolint:nilnil // stub
 func (s *testLegacyInterface) SaveNoteReview(_ *datastore.NoteReview) error          { return nil }

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -259,6 +259,10 @@ type DetectionRepository interface {
 	// Returns ErrDetectionNotFound if not found.
 	GetClipPath(ctx context.Context, id uint) (string, error)
 
+	// GetModelType returns the AI model type for a detection by JOINing
+	// the detections table with ai_models. Returns "bird" if not found.
+	GetModelType(ctx context.Context, id uint) (string, error)
+
 	// Exists checks if a detection with the given ID exists.
 	Exists(ctx context.Context, id uint) (bool, error)
 

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1639,6 +1639,29 @@ func (r *detectionRepository) GetClipPath(ctx context.Context, id uint) (string,
 	return *result.ClipName, nil
 }
 
+// GetModelType returns the AI model type for a detection by JOINing with
+// the ai_models table. Returns "bird" as default if not found.
+func (r *detectionRepository) GetModelType(ctx context.Context, id uint) (string, error) {
+	var result struct {
+		ModelType *string `gorm:"column:model_type"`
+	}
+	err := r.db.WithContext(ctx).Table(r.tableName()).
+		Select(r.modelsTable()+".model_type").
+		Joins("JOIN "+r.modelsTable()+" ON "+r.modelsTable()+".id = "+r.tableName()+".model_id").
+		Where(r.tableName()+".id = ?", id).
+		Take(&result).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return string(entities.ModelTypeBird), nil
+		}
+		return string(entities.ModelTypeBird), err
+	}
+	if result.ModelType == nil || *result.ModelType == "" {
+		return string(entities.ModelTypeBird), nil
+	}
+	return *result.ModelType, nil
+}
+
 // Exists checks if a detection with the given ID exists.
 func (r *detectionRepository) Exists(ctx context.Context, id uint) (bool, error) {
 	var count int64

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1647,14 +1647,14 @@ func (r *detectionRepository) GetModelType(ctx context.Context, id uint) (string
 	}
 	err := r.db.WithContext(ctx).Table(r.tableName()).
 		Select(r.modelsTable()+".model_type").
-		Joins("JOIN "+r.modelsTable()+" ON "+r.modelsTable()+".id = "+r.tableName()+".model_id").
+		Joins("LEFT JOIN "+r.modelsTable()+" ON "+r.modelsTable()+".id = "+r.tableName()+".model_id").
 		Where(r.tableName()+".id = ?", id).
 		Take(&result).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return string(entities.ModelTypeBird), nil
 		}
-		return string(entities.ModelTypeBird), err
+		return "", err
 	}
 	if result.ModelType == nil || *result.ModelType == "" {
 		return string(entities.ModelTypeBird), nil

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1464,6 +1464,18 @@ func (ds *Datastore) GetNoteClipPath(noteID string) (string, error) {
 	return ds.detection.GetClipPath(ctx, id)
 }
 
+// GetNoteModelType returns the AI model type for a detection by note ID.
+// It JOINs detections with ai_models to retrieve the model_type field.
+// Returns "bird" as default if the model type cannot be determined.
+func (ds *Datastore) GetNoteModelType(noteID string) (string, error) {
+	ctx := context.Background()
+	id, err := parseID(noteID)
+	if err != nil {
+		return string(entities.ModelTypeBird), err
+	}
+	return ds.detection.GetModelType(ctx, id)
+}
+
 // DeleteNoteClipPath deletes the clip path for a note.
 func (ds *Datastore) DeleteNoteClipPath(noteID string) error {
 	ctx := context.Background()

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1471,7 +1471,7 @@ func (ds *Datastore) GetNoteModelType(noteID string) (string, error) {
 	ctx := context.Background()
 	id, err := parseID(noteID)
 	if err != nil {
-		return string(entities.ModelTypeBird), err
+		return "", fmt.Errorf("invalid note ID for model type lookup: %w", err)
 	}
 	return ds.detection.GetModelType(ctx, id)
 }

--- a/internal/imageprovider/cache_resilience_test.go
+++ b/internal/imageprovider/cache_resilience_test.go
@@ -125,6 +125,8 @@ func (m *mockCorruptStore) GetAllImageCaches(providerName string) ([]datastore.I
 	return m.mockStore.GetAllImageCaches(providerName)
 }
 
+func (m *mockCorruptStore) GetNoteModelType(_ string) (string, error) { return "bird", nil }
+
 // TestImageCacheDisablesReadsOnCorruption verifies that once GetImageCache
 // reports SQLite corruption, the cache stops issuing further reads or writes
 // for the rest of the session. Without this latch the same fatal error gets

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -184,6 +184,7 @@ func (m *mockStore) SearchNotesAdvanced(filters *datastore.AdvancedSearchFilters
 	return nil, 0, nil
 }
 func (m *mockStore) GetNoteClipPath(noteID string) (string, error) { return "", nil }
+func (m *mockStore) GetNoteModelType(_ string) (string, error)     { return "bird", nil }
 func (m *mockStore) DeleteNoteClipPath(noteID string) error        { return nil }
 func (m *mockStore) GetClipsQualifyingForRemoval(minHours, minClips int) ([]datastore.ClipForRemoval, error) {
 	return nil, nil

--- a/internal/spectrogram/frequency_profile.go
+++ b/internal/spectrogram/frequency_profile.go
@@ -1,0 +1,57 @@
+package spectrogram
+
+// FrequencyProfile controls spectrogram frequency range and resampling
+// per detection. The gate is the detection's model type: bat models get
+// bat settings (no resample, high-pass at 18 kHz), everything else gets
+// bird defaults (resample to 24 kHz, full range).
+type FrequencyProfile struct {
+	MinFreqHz    int // Lower bound of visible frequency range
+	MaxFreqHz    int // Upper bound of visible frequency range
+	ResampleRate int // Target sample rate in Hz; 0 means keep native rate
+	HighPassHz   int // High-pass filter cutoff in Hz; 0 means no filter
+}
+
+const (
+	batHighPassHz   = 18000
+	batMaxFreqHz    = 128000
+	birdMaxFreqHz   = 12000
+	birdResampleHz  = 24000
+	modelTypeBatStr = "bat"
+)
+
+// BirdProfile returns the default frequency profile for bird detections.
+func BirdProfile() FrequencyProfile {
+	return FrequencyProfile{
+		MinFreqHz:    0,
+		MaxFreqHz:    birdMaxFreqHz,
+		ResampleRate: birdResampleHz,
+		HighPassHz:   0,
+	}
+}
+
+// BatProfile returns the frequency profile for bat detections captured
+// at 256 kHz. No resampling is applied (keeps native rate), and a
+// high-pass filter at 18 kHz removes content below the bat echolocation
+// floor.
+func BatProfile() FrequencyProfile {
+	return FrequencyProfile{
+		MinFreqHz:    batHighPassHz,
+		MaxFreqHz:    batMaxFreqHz,
+		ResampleRate: 0,
+		HighPassHz:   batHighPassHz,
+	}
+}
+
+// ProfileForModelType selects the appropriate frequency profile based on
+// the AI model's type string (as stored in ai_models.model_type).
+func ProfileForModelType(modelType string) FrequencyProfile {
+	if modelType == modelTypeBatStr {
+		return BatProfile()
+	}
+	return BirdProfile()
+}
+
+// IsBird returns true if the profile uses bird-default settings.
+func (fp FrequencyProfile) IsBird() bool {
+	return fp.ResampleRate > 0
+}

--- a/internal/spectrogram/frequency_profile.go
+++ b/internal/spectrogram/frequency_profile.go
@@ -5,16 +5,12 @@ package spectrogram
 // bat settings (no resample, high-pass at 18 kHz), everything else gets
 // bird defaults (resample to 24 kHz, full range).
 type FrequencyProfile struct {
-	MinFreqHz    int // Lower bound of visible frequency range
-	MaxFreqHz    int // Upper bound of visible frequency range
 	ResampleRate int // Target sample rate in Hz; 0 means keep native rate
 	HighPassHz   int // High-pass filter cutoff in Hz; 0 means no filter
 }
 
 const (
 	batHighPassHz   = 18000
-	batMaxFreqHz    = 128000
-	birdMaxFreqHz   = 12000
 	birdResampleHz  = 24000
 	modelTypeBatStr = "bat"
 )
@@ -22,8 +18,6 @@ const (
 // BirdProfile returns the default frequency profile for bird detections.
 func BirdProfile() FrequencyProfile {
 	return FrequencyProfile{
-		MinFreqHz:    0,
-		MaxFreqHz:    birdMaxFreqHz,
 		ResampleRate: birdResampleHz,
 		HighPassHz:   0,
 	}
@@ -35,8 +29,6 @@ func BirdProfile() FrequencyProfile {
 // floor.
 func BatProfile() FrequencyProfile {
 	return FrequencyProfile{
-		MinFreqHz:    batHighPassHz,
-		MaxFreqHz:    batMaxFreqHz,
 		ResampleRate: 0,
 		HighPassHz:   batHighPassHz,
 	}
@@ -49,9 +41,4 @@ func ProfileForModelType(modelType string) FrequencyProfile {
 		return BatProfile()
 	}
 	return BirdProfile()
-}
-
-// IsBird returns true if the profile uses bird-default settings.
-func (fp FrequencyProfile) IsBird() bool {
-	return fp.ResampleRate > 0
 }

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -65,9 +65,6 @@ const (
 
 	// osWindows is the GOOS value for Windows operating system
 	osWindows = "windows"
-
-	// soxResampleRate is the target sample rate for Sox spectrogram generation
-	soxResampleRate = "24k"
 )
 
 // GenerateOption configures optional parameters for spectrogram generation.
@@ -77,6 +74,9 @@ type generateOptions struct {
 	// preValidatedDuration is the audio duration already obtained by the caller
 	// (e.g., from FFprobe validation). When set, skips the sox --info duration query.
 	preValidatedDuration float64
+	// freqProfile overrides the default bird frequency profile for spectrogram
+	// generation. When nil, BirdProfile() is used.
+	freqProfile *FrequencyProfile
 }
 
 // WithDuration provides a pre-validated audio duration (in seconds) to skip
@@ -85,6 +85,16 @@ type generateOptions struct {
 func WithDuration(seconds float64) GenerateOption {
 	return func(o *generateOptions) {
 		o.preValidatedDuration = seconds
+	}
+}
+
+// WithFrequencyProfile sets the frequency profile for spectrogram generation.
+// Bat detections use BatProfile() (no resample, high-pass at 18 kHz); bird
+// detections use BirdProfile() (resample to 24 kHz). When not set, defaults
+// to BirdProfile().
+func WithFrequencyProfile(fp FrequencyProfile) GenerateOption {
+	return func(o *generateOptions) {
+		o.freqProfile = &fp
 	}
 }
 
@@ -268,12 +278,19 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		opt(&options)
 	}
 
+	// Resolve frequency profile: explicit option > default bird
+	profile := BirdProfile()
+	if options.freqProfile != nil {
+		profile = *options.freqProfile
+	}
+
 	g.log().Debug("Starting spectrogram generation from file",
 		logger.String("audio_path", audioPath),
 		logger.String("output_path", outputPath),
 		logger.Int("width", width),
 		logger.Bool("raw", raw),
-		logger.Float64("pre_validated_duration", options.preValidatedDuration))
+		logger.Float64("pre_validated_duration", options.preValidatedDuration),
+		logger.Bool("bat_profile", !profile.IsBird()))
 
 	// Validate inputs before filesystem operations
 	if outputPath == "" {
@@ -322,7 +339,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 	defer soxCancel()
 
 	// Try Sox first (faster, direct processing)
-	if err := g.generateWithSoxFile(soxCtx, settings, audioPath, outputPath, width, raw, options.preValidatedDuration); err != nil {
+	if err := g.generateWithSoxFile(soxCtx, settings, audioPath, outputPath, width, raw, options.preValidatedDuration, profile); err != nil {
 		g.log().Warn("Sox spectrogram generation failed, falling back to FFmpeg",
 			logger.String("audio_path", audioPath),
 			logger.Error(err),
@@ -336,7 +353,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		defer ffmpegCancel()
 
 		// Fallback to FFmpeg pipeline with fresh context
-		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, settings, audioPath, outputPath, width, raw); ffmpegErr != nil {
+		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, settings, audioPath, outputPath, width, raw, profile); ffmpegErr != nil {
 			g.log().Error("Both Sox and FFmpeg generation failed",
 				logger.String("audio_path", audioPath),
 				logger.String("sox_error", err.Error()),
@@ -363,13 +380,27 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 // The pre-renderer also sets its own timeout (see prerenderer.go:416), so the
 // effective timeout will be whichever is shorter. This layered approach ensures
 // both the pre-renderer and generator have safety limits.
-func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputPath string, width int, raw bool, sampleRate int) error {
+func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputPath string, width int, raw bool, sampleRate int, opts ...GenerateOption) error {
 	start := time.Now()
+
+	// Apply options
+	var options generateOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	// Resolve frequency profile: explicit option > default bird
+	profile := BirdProfile()
+	if options.freqProfile != nil {
+		profile = *options.freqProfile
+	}
+
 	g.log().Debug("Starting spectrogram generation from PCM",
 		logger.String("output_path", outputPath),
 		logger.Int("pcm_bytes", len(pcmData)),
 		logger.Int("width", width),
-		logger.Bool("raw", raw))
+		logger.Bool("raw", raw),
+		logger.Bool("bat_profile", !profile.IsBird()))
 
 	// Validate inputs before filesystem operations
 	if outputPath == "" {
@@ -418,7 +449,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 	defer cancel()
 
 	// Generate directly from PCM stdin (no FFmpeg needed)
-	if err := g.generateWithSoxPCM(ctx, settings, pcmData, outputPath, width, raw, sampleRate); err != nil {
+	if err := g.generateWithSoxPCM(ctx, settings, pcmData, outputPath, width, raw, sampleRate, profile); err != nil {
 		return err
 	}
 
@@ -434,7 +465,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 // generateWithSoxFile generates a spectrogram using Sox from an audio file.
 // If the file format is supported by Sox, it uses Sox directly.
 // Otherwise, it uses FFmpeg to convert to Sox format and pipes to Sox.
-func (g *Generator) generateWithSoxFile(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
+func (g *Generator) generateWithSoxFile(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64, profile FrequencyProfile) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
 	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
 		return errors.Newf("invalid Sox path: %s", err).
@@ -459,16 +490,16 @@ func (g *Generator) generateWithSoxFile(ctx context.Context, settings *conf.Sett
 
 	// If file is supported by Sox, use Sox directly
 	if !useFFmpeg {
-		return g.generateWithSoxDirect(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)
+		return g.generateWithSoxDirect(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration, profile)
 	}
 
 	// Otherwise, use FFmpeg to convert to Sox format
-	return g.generateWithFFmpegSoxPipeline(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)
+	return g.generateWithFFmpegSoxPipeline(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration, profile)
 }
 
 // generateWithSoxDirect generates a spectrogram using only Sox (no FFmpeg).
 // Used when the audio file format is natively supported by Sox.
-func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
+func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64, profile FrequencyProfile) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
 	// Validate Sox path before exec (defense-in-depth against ingress path contamination)
 	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
@@ -481,7 +512,7 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 	}
 
 	// Build Sox arguments for file input
-	soxArgs := g.getSoxArgs(ctx, settings, audioPath, outputPath, width, raw, SoxInputFile, preValidatedDuration)
+	soxArgs := g.getSoxArgs(ctx, settings, audioPath, outputPath, width, raw, SoxInputFile, preValidatedDuration, profile)
 
 	g.log().Debug("Executing SoX command directly",
 		logger.String("sox_binary", soxBinary),
@@ -550,7 +581,7 @@ func (g *Generator) killSoxProcess(soxCmd *exec.Cmd, soxPid int) {
 
 // generateWithFFmpegSoxPipeline generates a spectrogram using FFmpeg piped to Sox.
 // Used when the audio file format is not natively supported by Sox.
-func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
+func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64, profile ...FrequencyProfile) error {
 	ffmpegBinary := settings.Realtime.Audio.FfmpegPath
 	soxBinary := settings.Realtime.Audio.SoxPath
 
@@ -574,7 +605,12 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 
 	// FFmpeg converts audio to Sox format and pipes to Sox
 	ffmpegArgs := []string{"-hide_banner", "-i", audioPath, "-f", "sox", "-"}
-	soxArgs := append([]string{"-t", "sox", "-"}, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)...)
+	// Resolve frequency profile for Sox args
+	fp := BirdProfile()
+	if len(profile) > 0 {
+		fp = profile[0]
+	}
+	soxArgs := append([]string{"-t", "sox", "-"}, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration, fp)...)
 
 	ffmpegCmd := createCommandWithNice(ctx, ffmpegBinary, ffmpegArgs)
 	soxCmd := createCommandWithNice(ctx, soxBinary, soxArgs)
@@ -700,7 +736,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 // This bypasses FFmpeg entirely, reducing CPU overhead and memory usage.
 // PCM format: s16le, mono. sampleRate is the source capture rate in Hz;
 // pass 0 to fall back to conf.SampleRate (48000 Hz).
-func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Settings, pcmData []byte, outputPath string, width int, raw bool, sampleRate int) error {
+func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Settings, pcmData []byte, outputPath string, width int, raw bool, sampleRate int, profile FrequencyProfile) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
 	if err := ffmpeg.ValidateSoxPath(soxBinary); err != nil {
 		return errors.Newf("invalid Sox path: %s", err).
@@ -725,15 +761,24 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 		"-e", "signed", // Encoding: signed integer
 		"-b", strconv.Itoa(conf.BitDepth), // Bit depth: 16-bit
 		"-c", strconv.Itoa(conf.NumChannels), // Channels: mono
-		"-",                     // Read from stdin
-		"-n",                    // No audio output (null output)
-		"rate", soxResampleRate, // Resample to 24kHz for spectrogram
-		"spectrogram",             // Effect: spectrogram
-		"-x", strconv.Itoa(width), // Width in pixels
-		"-y", strconv.Itoa(fftFriendlyHeight(width)), // Height in pixels (FFT-friendly 2^n + 1)
-		"-z", g.getDynamicRange(settings), // Dynamic range in dB
-		"-o", outputPath, // Output PNG file
+		"-",  // Read from stdin
+		"-n", // No audio output (null output)
 	}
+
+	// Frequency-dependent effects: resample (bird) or high-pass filter (bat)
+	if profile.HighPassHz > 0 {
+		args = append(args, "sinc", strconv.Itoa(profile.HighPassHz)+"-")
+	} else if profile.ResampleRate > 0 {
+		args = append(args, "rate", strconv.Itoa(profile.ResampleRate))
+	}
+
+	args = append(args,
+		"spectrogram",
+		"-x", strconv.Itoa(width),
+		"-y", strconv.Itoa(fftFriendlyHeight(width)),
+		"-z", g.getDynamicRange(settings),
+		"-o", outputPath,
+	)
 
 	// Add raw flag if requested (no axes/legend)
 	if raw {
@@ -790,7 +835,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 
 // generateWithFFmpeg generates a spectrogram using only FFmpeg (no Sox).
 // This is a fallback when Sox is not available or fails.
-func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool) error {
+func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, profile FrequencyProfile) error {
 	ffmpegBinary := settings.Realtime.Audio.FfmpegPath
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegBinary); err != nil {
@@ -810,13 +855,18 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 	style := settings.Realtime.Dashboard.Spectrogram.Style
 	colorMode := getFFmpegColorMode(style)
 
-	var filterStr string
 	legendFlag := 1
 	if raw {
 		legendFlag = 0
 	}
-	filterStr = fmt.Sprintf("showspectrumpic=s=%dx%d:legend=%d:gain=%s:drange=%s:color=%s",
+
+	filterStr := fmt.Sprintf("showspectrumpic=s=%dx%d:legend=%d:gain=%s:drange=%s:color=%s",
 		width, height, legendFlag, ffmpegGain, ffmpegDrange, colorMode)
+
+	// Bat profile: prepend high-pass filter to remove sub-ultrasonic content
+	if profile.HighPassHz > 0 {
+		filterStr = fmt.Sprintf("highpass=f=%d,%s", profile.HighPassHz, filterStr)
+	}
 
 	ffmpegArgs := []string{
 		"-hide_banner",
@@ -865,13 +915,13 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 
 // getSoxArgs builds Sox arguments for file input.
 // Used when Sox can directly read the audio file.
-func (g *Generator) getSoxArgs(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, inputType SoxInputType, preValidatedDuration float64) []string {
+func (g *Generator) getSoxArgs(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, inputType SoxInputType, preValidatedDuration float64, profile FrequencyProfile) []string {
 	args := make([]string, 0, 16) // Preallocate capacity for input path + spectrogram args
 	if inputType == SoxInputFile {
 		args = append(args, audioPath)
 	}
 
-	args = append(args, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)...)
+	args = append(args, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration, profile)...)
 	return args
 }
 
@@ -883,12 +933,20 @@ func (g *Generator) getSoxArgs(ctx context.Context, settings *conf.Settings, aud
 //
 // preValidatedDuration, when > 0, is used directly (e.g., from FFprobe validation),
 // skipping the sox --info duration query entirely.
-func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) []string {
+func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64, profile FrequencyProfile) []string {
 	heightStr := strconv.Itoa(fftFriendlyHeight(width))
 	widthStr := strconv.Itoa(width)
 
-	// Build base args without duration parameter
-	args := []string{"-n", "rate", soxResampleRate, "spectrogram", "-x", widthStr, "-y", heightStr}
+	// Build base args: either resample (bird) or high-pass filter (bat)
+	var args []string
+	switch {
+	case profile.HighPassHz > 0:
+		args = []string{"-n", "sinc", strconv.Itoa(profile.HighPassHz) + "-", "spectrogram", "-x", widthStr, "-y", heightStr}
+	case profile.ResampleRate > 0:
+		args = []string{"-n", "rate", strconv.Itoa(profile.ResampleRate), "spectrogram", "-x", widthStr, "-y", heightStr}
+	default:
+		args = []string{"-n", "spectrogram", "-x", widthStr, "-y", heightStr}
+	}
 
 	// Always provide explicit duration via -d parameter to ensure spectrogram
 	// shows the full audio duration regardless of image width (fixes #1484).
@@ -1170,7 +1228,7 @@ func getAudioDurationViaSox(ctx context.Context, soxPath, audioPath string) (flo
 // This method is exported to allow tests in other packages to verify the
 // FFmpeg version optimization logic.
 func (g *Generator) GetSoxSpectrogramArgsForTest(ctx context.Context, audioPath, outputPath string, width int, raw bool) []string {
-	return g.getSoxSpectrogramArgs(ctx, g.currentSettings(), audioPath, outputPath, width, raw, 0)
+	return g.getSoxSpectrogramArgs(ctx, g.currentSettings(), audioPath, outputPath, width, raw, 0, BirdProfile())
 }
 
 // CreateFreshFFmpegContext creates a new context for FFmpeg fallback with full timeout.

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -760,8 +760,9 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 		"-n", // No audio output (null output)
 	}
 
-	// Frequency-dependent effects: resample (bird) or high-pass filter (bat)
-	if profile.HighPassHz > 0 {
+	// Frequency-dependent effects: resample (bird) or high-pass filter (bat).
+	// Guard: sinc filter requires sample rate > 2*cutoff (Nyquist constraint).
+	if profile.HighPassHz > 0 && effectiveRate > 2*profile.HighPassHz {
 		args = append(args, "sinc", strconv.Itoa(profile.HighPassHz)+"-")
 	} else if profile.ResampleRate > 0 {
 		args = append(args, "rate", strconv.Itoa(profile.ResampleRate))

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -290,7 +290,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		logger.Int("width", width),
 		logger.Bool("raw", raw),
 		logger.Float64("pre_validated_duration", options.preValidatedDuration),
-		logger.Bool("bat_profile", !profile.IsBird()))
+		logger.Bool("bat_profile", profile.HighPassHz > 0))
 
 	// Validate inputs before filesystem operations
 	if outputPath == "" {
@@ -400,7 +400,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 		logger.Int("pcm_bytes", len(pcmData)),
 		logger.Int("width", width),
 		logger.Bool("raw", raw),
-		logger.Bool("bat_profile", !profile.IsBird()))
+		logger.Bool("bat_profile", profile.HighPassHz > 0))
 
 	// Validate inputs before filesystem operations
 	if outputPath == "" {
@@ -581,7 +581,7 @@ func (g *Generator) killSoxProcess(soxCmd *exec.Cmd, soxPid int) {
 
 // generateWithFFmpegSoxPipeline generates a spectrogram using FFmpeg piped to Sox.
 // Used when the audio file format is not natively supported by Sox.
-func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64, profile ...FrequencyProfile) error {
+func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64, profile FrequencyProfile) error {
 	ffmpegBinary := settings.Realtime.Audio.FfmpegPath
 	soxBinary := settings.Realtime.Audio.SoxPath
 
@@ -605,12 +605,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 
 	// FFmpeg converts audio to Sox format and pipes to Sox
 	ffmpegArgs := []string{"-hide_banner", "-i", audioPath, "-f", "sox", "-"}
-	// Resolve frequency profile for Sox args
-	fp := BirdProfile()
-	if len(profile) > 0 {
-		fp = profile[0]
-	}
-	soxArgs := append([]string{"-t", "sox", "-"}, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration, fp)...)
+	soxArgs := append([]string{"-t", "sox", "-"}, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration, profile)...)
 
 	ffmpegCmd := createCommandWithNice(ctx, ffmpegBinary, ffmpegArgs)
 	soxCmd := createCommandWithNice(ctx, soxBinary, soxArgs)

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -107,7 +107,7 @@ func TestGenerator_GetSoxSpectrogramArgs(t *testing.T) {
 			audioPath := filepath.Join(tempDir, "test.wav")
 			outputPath := filepath.Join(tempDir, "test.png")
 
-			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, tt.width, tt.raw, 0)
+			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, tt.width, tt.raw, 0, BirdProfile())
 			result := parseSoxSpectrogramArgs(args)
 
 			assert.Equal(t, tt.wantDuration, result.hasDuration, "duration parameter mismatch")
@@ -142,7 +142,7 @@ func TestGenerator_GetSoxArgs(t *testing.T) {
 	audioPath := filepath.Join(env.TempDir, "test.wav")
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
-	args := gen.getSoxArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 800, false, SoxInputFile, 0)
+	args := gen.getSoxArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 800, false, SoxInputFile, 0, BirdProfile())
 
 	// First argument should be the audio file path
 	require.NotEmpty(t, args, "getSoxArgs() should return args")
@@ -587,7 +587,7 @@ func TestGenerateWithSoxDirect_MissingBinary(t *testing.T) {
 	err := os.WriteFile(audioPath, []byte("fake audio"), 0o600)
 	require.NoError(t, err, "Failed to create test file")
 
-	err = gen.generateWithSoxDirect(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
+	err = gen.generateWithSoxDirect(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BirdProfile())
 	require.Error(t, err, "should error when Sox binary not configured")
 	assert.Contains(t, err.Error(), "invalid Sox path", "error should mention invalid sox path")
 }
@@ -626,7 +626,7 @@ func TestGenerateWithFFmpegSoxPipeline_MissingBinaries(t *testing.T) {
 			audioPath := filepath.Join(env.TempDir, "test.wav")
 			outputPath := filepath.Join(env.TempDir, "test.png")
 
-			err := gen.generateWithFFmpegSoxPipeline(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
+			err := gen.generateWithFFmpegSoxPipeline(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BirdProfile())
 			require.Error(t, err, "should error when binary not configured")
 			assert.Contains(t, err.Error(), tt.errContain, "error should mention missing binary")
 		})
@@ -643,7 +643,7 @@ func TestGenerateWithFFmpeg_MissingBinary(t *testing.T) {
 	audioPath := filepath.Join(env.TempDir, "test.wav")
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
-	err := gen.generateWithFFmpeg(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false)
+	err := gen.generateWithFFmpeg(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, BirdProfile())
 	require.Error(t, err, "should error when FFmpeg binary not configured")
 	assert.Contains(t, err.Error(), "invalid FFmpeg path", "error should mention ffmpeg binary")
 }
@@ -658,7 +658,7 @@ func TestGenerateWithSoxPCM_MissingBinary(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 	pcmData := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 
-	err := gen.generateWithSoxPCM(t.Context(), gen.currentSettings(), pcmData, outputPath, 400, false, 0)
+	err := gen.generateWithSoxPCM(t.Context(), gen.currentSettings(), pcmData, outputPath, 400, false, 0, BirdProfile())
 	require.Error(t, err, "should error when Sox binary not configured")
 	assert.Contains(t, err.Error(), "invalid Sox path", "error should mention invalid sox path")
 }
@@ -673,7 +673,7 @@ func TestGetSoxArgs_FileInput(t *testing.T) {
 	audioPath := filepath.Join(env.TempDir, "test.wav")
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
-	args := gen.getSoxArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 800, false, SoxInputFile, 0)
+	args := gen.getSoxArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 800, false, SoxInputFile, 0, BirdProfile())
 
 	// First argument should be the audio file for SoxInputFile
 	require.NotEmpty(t, args, "args should not be empty")
@@ -702,12 +702,12 @@ func TestGetSoxSpectrogramArgs_RawFlag(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
 	// Test with raw=false
-	argsNoRaw := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
+	argsNoRaw := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BirdProfile())
 	hasRaw := slices.Contains(argsNoRaw, "-r")
 	assert.False(t, hasRaw, "should not contain -r flag when raw=false")
 
 	// Test with raw=true
-	argsWithRaw := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, true, 0)
+	argsWithRaw := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, true, 0, BirdProfile())
 	hasRaw = slices.Contains(argsWithRaw, "-r")
 	assert.True(t, hasRaw, "should contain -r flag when raw=true")
 }
@@ -720,7 +720,7 @@ func TestGetSoxSpectrogramArgs_UsesProvidedDuration(t *testing.T) {
 	audioPath := filepath.Join(tempDir, "input.mp3")
 	outputPath := filepath.Join(tempDir, "out.png")
 
-	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 12.6)
+	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 12.6, BirdProfile())
 
 	idx := slices.Index(args, "-d")
 	require.NotEqual(t, -1, idx, "should contain -d parameter")
@@ -751,7 +751,7 @@ func TestGetSoxSpectrogramArgs_DimensionCalculation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("width_"+strconv.Itoa(tt.width), func(t *testing.T) {
-			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, tt.width, false, 0)
+			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, tt.width, false, 0, BirdProfile())
 
 			widthStr := strconv.Itoa(tt.width)
 			heightStr := strconv.Itoa(tt.expectedHeight)
@@ -898,7 +898,7 @@ func TestNewGenerator_WithNilLogger(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
 	// getSoxSpectrogramArgs uses g.log().Warn internally
-	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
+	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BirdProfile())
 	assert.NotEmpty(t, args, "should return valid args without panic")
 }
 
@@ -1104,7 +1104,7 @@ func TestGetSoxSpectrogramArgs_StyleArgs(t *testing.T) {
 			audioPath := filepath.Join(env.TempDir, "test.wav")
 			outputPath := filepath.Join(env.TempDir, "test.png")
 
-			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
+			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BirdProfile())
 
 			for _, want := range tt.wantContains {
 				assert.True(t, slices.Contains(args, want),

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -712,6 +712,69 @@ func TestGetSoxSpectrogramArgs_RawFlag(t *testing.T) {
 	assert.True(t, hasRaw, "should contain -r flag when raw=true")
 }
 
+// TestGetSoxSpectrogramArgs_BatProfile verifies that the bat frequency profile
+// produces a high-pass sinc filter instead of rate resampling.
+func TestGetSoxSpectrogramArgs_BatProfile(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Settings.Realtime.Audio.Export.Length = 15
+
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	audioPath := filepath.Join(env.TempDir, "test.wav")
+	outputPath := filepath.Join(env.TempDir, "test.png")
+
+	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BatProfile())
+
+	// Bat profile: sinc high-pass filter, no rate resampling
+	assert.Contains(t, args, "sinc", "bat profile should use sinc high-pass filter")
+	assert.Contains(t, args, "18000-", "bat profile should filter at 18 kHz")
+	assert.NotContains(t, args, "rate", "bat profile should not resample")
+}
+
+// TestGetSoxSpectrogramArgs_BirdProfile verifies that the bird frequency profile
+// produces rate resampling without a high-pass filter.
+func TestGetSoxSpectrogramArgs_BirdProfile(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Settings.Realtime.Audio.Export.Length = 15
+
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	audioPath := filepath.Join(env.TempDir, "test.wav")
+	outputPath := filepath.Join(env.TempDir, "test.png")
+
+	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0, BirdProfile())
+
+	// Bird profile: rate resampling, no sinc filter
+	assert.Contains(t, args, "rate", "bird profile should resample")
+	assert.Contains(t, args, "24000", "bird profile should resample to 24 kHz")
+	assert.NotContains(t, args, "sinc", "bird profile should not use sinc filter")
+}
+
+// TestProfileForModelType verifies model type to frequency profile mapping.
+func TestProfileForModelType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		modelType    string
+		wantResample int
+		wantHighPass int
+	}{
+		{"bird model", "bird", 24000, 0},
+		{"bat model", "bat", 0, 18000},
+		{"multi model defaults to bird", "multi", 24000, 0},
+		{"empty defaults to bird", "", 24000, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := ProfileForModelType(tt.modelType)
+			assert.Equal(t, tt.wantResample, p.ResampleRate)
+			assert.Equal(t, tt.wantHighPass, p.HighPassHz)
+		})
+	}
+}
+
 // TestGetSoxSpectrogramArgs_UsesProvidedDuration verifies that a non-zero preValidatedDuration
 // is used directly for the -d parameter, skipping the sox --info duration query.
 func TestGetSoxSpectrogramArgs_UsesProvidedDuration(t *testing.T) {

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -64,11 +64,12 @@ type PreRenderer struct {
 
 // Job represents a single spectrogram generation task.
 type Job struct {
-	PCMData    []byte    // Raw PCM data from memory (s16le, mono)
-	SampleRate int       // PCM sample rate in Hz (0 = use conf.SampleRate default)
-	ClipPath   string    // Full absolute path to audio clip; PNG path is derived by swapping extension
-	NoteID     uint      // For logging correlation
-	Timestamp  time.Time // Job submission time
+	PCMData          []byte           // Raw PCM data from memory (s16le, mono)
+	SampleRate       int              // PCM sample rate in Hz (0 = use conf.SampleRate default)
+	ClipPath         string           // Full absolute path to audio clip; PNG path is derived by swapping extension
+	NoteID           uint             // For logging correlation
+	Timestamp        time.Time        // Job submission time
+	FrequencyProfile FrequencyProfile // Frequency profile for spectrogram generation (bird vs bat)
 }
 
 // Methods to match the interface (allows Job to be submitted directly in tests)
@@ -77,6 +78,14 @@ func (j *Job) GetSampleRate() int      { return j.SampleRate }
 func (j *Job) GetClipPath() string     { return j.ClipPath }
 func (j *Job) GetNoteID() uint         { return j.NoteID }
 func (j *Job) GetTimestamp() time.Time { return j.Timestamp }
+
+// GetModelType returns the model type string for DTO interface compatibility.
+func (j *Job) GetModelType() string {
+	if j.FrequencyProfile.IsBird() {
+		return "bird"
+	}
+	return "bat"
+}
 
 // Stats tracks pre-rendering statistics.
 type Stats struct {
@@ -198,14 +207,16 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 	GetClipPath() string
 	GetNoteID() uint
 	GetTimestamp() time.Time
+	GetModelType() string
 }) (err error) {
 	// Convert DTO to internal Job type
 	job := &Job{
-		PCMData:    jobDTO.GetPCMData(),
-		SampleRate: jobDTO.GetSampleRate(),
-		ClipPath:   jobDTO.GetClipPath(),
-		NoteID:     jobDTO.GetNoteID(),
-		Timestamp:  jobDTO.GetTimestamp(),
+		PCMData:          jobDTO.GetPCMData(),
+		SampleRate:       jobDTO.GetSampleRate(),
+		ClipPath:         jobDTO.GetClipPath(),
+		NoteID:           jobDTO.GetNoteID(),
+		Timestamp:        jobDTO.GetTimestamp(),
+		FrequencyProfile: ProfileForModelType(jobDTO.GetModelType()),
 	}
 
 	// Early check: skip if spectrogram already exists (avoid queueing duplicate jobs)
@@ -431,7 +442,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 		logger.String("operation", "spectrogram_generation_start"))
 
 	// Generate spectrogram using shared generator
-	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, specSettings.Raw, job.SampleRate); err != nil {
+	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, specSettings.Raw, job.SampleRate, WithFrequencyProfile(job.FrequencyProfile)); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
 		if IsOperationalError(err) {

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -70,6 +70,7 @@ type Job struct {
 	NoteID           uint             // For logging correlation
 	Timestamp        time.Time        // Job submission time
 	FrequencyProfile FrequencyProfile // Frequency profile for spectrogram generation (bird vs bat)
+	modelType        string           // Original model type string for DTO getter
 }
 
 // Methods to match the interface (allows Job to be submitted directly in tests)
@@ -80,12 +81,7 @@ func (j *Job) GetNoteID() uint         { return j.NoteID }
 func (j *Job) GetTimestamp() time.Time { return j.Timestamp }
 
 // GetModelType returns the model type string for DTO interface compatibility.
-func (j *Job) GetModelType() string {
-	if j.FrequencyProfile.IsBird() {
-		return "bird"
-	}
-	return "bat"
-}
+func (j *Job) GetModelType() string { return j.modelType }
 
 // Stats tracks pre-rendering statistics.
 type Stats struct {
@@ -210,13 +206,15 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 	GetModelType() string
 }) (err error) {
 	// Convert DTO to internal Job type
+	modelType := jobDTO.GetModelType()
 	job := &Job{
 		PCMData:          jobDTO.GetPCMData(),
 		SampleRate:       jobDTO.GetSampleRate(),
 		ClipPath:         jobDTO.GetClipPath(),
 		NoteID:           jobDTO.GetNoteID(),
 		Timestamp:        jobDTO.GetTimestamp(),
-		FrequencyProfile: ProfileForModelType(jobDTO.GetModelType()),
+		FrequencyProfile: ProfileForModelType(modelType),
+		modelType:        modelType,
 	}
 
 	// Early check: skip if spectrogram already exists (avoid queueing duplicate jobs)


### PR DESCRIPTION
## Summary

- Add `FrequencyProfile` type that controls spectrogram frequency range and resampling per detection
- BattyBirdNET detections at 256 kHz get bat settings (no resample, high-pass at 18 kHz); everything else gets existing bird defaults (resample to 24 kHz)
- On-demand path: `GetNoteModelType` does a lightweight JOIN query to determine model type from the note ID
- Pre-render path: model type flows through the `PreRenderJob` DTO and gets converted to a `FrequencyProfile` at the spectrogram boundary

## Key design decisions

- Model type as gate, not species taxonomy: the spectrogram settings must match the audio characteristics, not the species
- `FrequencyProfile` is self-contained in the spectrogram package with no dependency on datastore entities
- Legacy filename-based spectrogram path defaults to bird profile (no note ID available)
- No cache invalidation needed: bat audio clips already have different filenames (exported at 256 kHz WAV)

## Files changed

| File | Change |
|------|--------|
| `internal/spectrogram/frequency_profile.go` | New: `FrequencyProfile` type, bird/bat presets, `ProfileForModelType` |
| `internal/spectrogram/generator.go` | Accept `FrequencyProfile` option; branch Sox/FFmpeg args |
| `internal/spectrogram/prerenderer.go` | Thread profile through `Job` to generator |
| `internal/analysis/processor/actions_types.go` | Add `ModelType` to `PreRenderJob` DTO |
| `internal/analysis/processor/actions_database.go` | Populate `ModelType` from detection |
| `internal/datastore/interfaces.go` | Add `GetNoteModelType` interface method |
| `internal/datastore/v2only/datastore.go` | v2 impl (JOIN detection + ai_model) |
| `internal/datastore/v2/repository/detection_impl.go` | `GetModelType` repo method |
| `internal/api/v2/media.go` | Look up model type, pass profile to generator |

## Test plan

- [x] Existing spectrogram tests pass with bird profile (default behavior preserved)
- [x] New tests verify bat profile produces `sinc 18000-` (high-pass) instead of `rate 24000` (resample)
- [x] New tests verify `ProfileForModelType` mapping for bird, bat, multi, and empty
- [x] Zero lint issues (`golangci-lint run -v`)
- [x] Full build passes (`go build ./...`)
- [ ] Manual test with BattyBirdNET detection audio (requires bat model setup)

## Preflight Status

- [x] Single concern: bat-aware spectrogram generation
- [x] Preflight passed: all gate findings resolved
- [x] Linters clean: golangci-lint and npm run check:all pass
- [x] Tests pass: go test -race passes
- [x] No unrelated changes
- [x] Scope complete
- [x] No regression/backward-compat break (bird defaults preserved, variadic opts backward compatible)
- [x] No secrets or PII

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spectrograms now pick a frequency profile (bird vs. bat) per detection’s model type and apply species-appropriate resampling/high-pass filtering across previews, ID requests, auto/prerender and user-triggered generation.
  * Pre-rendered spectrogram jobs now preserve the detection model type so background renders match inline previews.

* **Behavior**
  * Lookup failures default to the bird profile.

* **Tests**
  * Unit tests updated to validate profile mappings and spectrogram arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->