### PR TITLE
Fix HLS playback slowdown for non-48kHz sources

### DIFF
--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1615,8 +1615,14 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	}
 	eqChain := equalizer.ResolveAndBuildFilterChain(settings, sourceName, sampleRate)
 
+	// Determine the actual sample rate of the capture source
+	sourceSampleRate := sampleRate // Fallback to target rate
+	if src != nil && src.SampleRate > 0 {
+		sourceSampleRate = src.SampleRate
+	}
+
 	// Add route on the AudioRouter
-	if routeErr := eng.Router().AddRoute(sourceID, consumer, sampleRate, gainDB, eqChain); routeErr != nil {
+	if routeErr := eng.Router().AddRoute(sourceID, consumer, sourceSampleRate, gainDB, eqChain); routeErr != nil {
 		return nil, nil, fmt.Errorf("failed to add HLS route: %w", routeErr)
 	}
 


### PR DESCRIPTION
## Summary
Fix HLS playback slowdown for non-48kHz sources.
Passes the actual capture source sample rate instead of the target rate to AudioRouter.AddRoute. This triggers internal downsampling before dispatching to the FFmpeg process, fixing the 4x playback slowdown when capturing at 192kHz.

## Related Issues
N/A

## Test Plan
- [x] Configure capture device to 192kHz.
- [x] Stream via HLS endpoint.
- [x] Verify audio plays back at regular speed.
- [x] Preflight checks pass (linters, tests).

## Preflight Certification

- [x] Single concern: PR contains exactly ONE feature, ONE fix, or ONE refactor
- [x] Preflight passed: All Phase 1-3 findings resolved or filed as issues
- [x] Linters clean: golangci-lint run -v and npm run check:all pass (zero warnings)
- [x] Tests pass: go test -race ./... and npm test pass
- [x] No unrelated changes: diff contains only changes relevant to the stated goal
- [x] Scope complete: PR fully implements what it claims; no TODO/FIXME for core functionality
- [x] No regression/backward-compat break: no orphaned config keys, removed/renamed API fields, destructive migrations, changed detection defaults, or read-time filters that hide data an existing feature kept on purpose (Reviewer 6)
- [x] Breaking changes documented: if API/config/behavior changes, noted in PR description
- [x] Maintainer-confirm items resolved: any category (d) behavioral/intent conflict or security bypass has been confirmed by the maintainer, not silently auto-fixed
- [x] i18n complete: new user-facing strings have translations in all locale files
- [x] No secrets or PII: no hardcoded credentials, API keys, or personal data in diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio streaming by ensuring the correct source sample rate is detected and applied during capture and playback for optimal audio quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->