### PR TITLE
fix(audio): adaptive per-stream channel controls and clear stream format

### DIFF
--- a/frontend/src/lib/desktop/components/README.md
+++ b/frontend/src/lib/desktop/components/README.md
@@ -73,6 +73,7 @@ This folder contains **shared components** used across the application. Feature-
 - `SoundCardCard.svelte` - Individual sound card source card with device, gain, model, equalizer, quiet hours
 - `SoundCardManager.svelte` - Manage multiple sound card audio sources
 - `StreamCard.svelte` - Individual stream card for stream management
+- `StreamChannelControls.svelte` - Adaptive channel handling UI (format display, downmix/left/right selector, stereo energy analysis) shared by the stream add and edit forms
 - `StreamManager.svelte` - Manage multiple video/audio streams
 - `SubnetInput.svelte` - Subnet input with validation
 - `TextInput.svelte` - Text input field

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -30,9 +30,6 @@
     Radio,
     ChevronDown,
     Moon,
-    Search,
-    Loader2,
-    CircleCheck,
   } from '@lucide/svelte';
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
@@ -57,12 +54,9 @@
   import type { StreamHealthResponse } from './StreamManager.svelte';
   import StreamTestButton from './StreamTestButton.svelte';
   import StreamTimeline from './StreamTimeline.svelte';
-  import {
-    streamTypeOptions,
-    transportOptions,
-    getChannelModeOptions,
-    analyzeStreamChannels,
-  } from './streamOptions';
+  import StreamChannelControls from './StreamChannelControls.svelte';
+  import { streamTypeOptions, transportOptions, analyzeStreamChannels } from './streamOptions';
+  import { normalizeChannelMode } from './streamChannel';
 
   interface LocalEqualizerSettings {
     enabled: boolean;
@@ -125,7 +119,9 @@
 
   // Utility functions for formatting
   function formatBytes(bytes: number): string {
-    if (!bytes || bytes === 0) return '--';
+    // Guard <= 0 (not just === 0): a negative value would make Math.log return
+    // NaN and render "NaN undefined".
+    if (!bytes || bytes <= 0) return '--';
     const units = ['B', 'KB', 'MB', 'GB'];
     // Clamp index to valid array bounds (0 to 3) to prevent out-of-bounds access
     const rawIndex = Math.floor(Math.log(bytes) / Math.log(1024));
@@ -182,9 +178,11 @@
 
   let testResult = $state<{ sampleRate: number; channels: number } | null>(null);
 
-  // Show a warning when a stereo source is still set to downmix mode
+  // Show a warning when a stereo source is still set to downmix mode.
+  // normalizeChannelMode treats an unset/empty mode as the real default (downmix),
+  // which a bare `?? 'downmix'` misses because the API returns "" not undefined.
   let showStereoWarning = $derived(
-    (health?.source_channels ?? 0) >= 2 && (stream.channelMode ?? 'downmix') === 'downmix'
+    (health?.source_channels ?? 0) >= 2 && normalizeChannelMode(stream.channelMode) === 'downmix'
   );
 
   // Local editing state - initialized with defaults, synced from props in startEdit()
@@ -320,7 +318,7 @@
     editName = stream.name;
     editUrl = stream.url;
     editTransport = stream.transport ?? 'tcp';
-    editChannelMode = stream.channelMode ?? 'downmix';
+    editChannelMode = normalizeChannelMode(stream.channelMode);
     editStreamType = stream.type;
     editEnabled = stream.enabled;
     editModels = stream.models?.length ? [...stream.models] : [DEFAULT_MODEL_ID];
@@ -329,10 +327,13 @@
       : { enabled: false, filters: [] };
     editQuietHours = { ...defaultQuietHoursConfig, ...stream.quietHours };
     showEqualizer = false;
-    testResult =
-      health?.source_channels && health.source_channels > 0
-        ? { sampleRate: 48000, channels: health.source_channels }
-        : null;
+    // Channel count for an already-running stream comes from the live probe
+    // (health.source_channels) via detectedChannels; a fresh test result, when
+    // present, takes precedence and also carries the source sample rate.
+    testResult = null;
+    // Invalidate any analysis still in flight from a previous edit session so a
+    // late result cannot write editChannelMode/analysisResult into this one.
+    analysisSeq++;
     analysisResult = null;
     analysisError = null;
     isEditing = true;
@@ -341,6 +342,9 @@
   function cancelEdit() {
     isEditing = false;
     showDeleteConfirm = false;
+    // Cancel any pending channel analysis so its late result is discarded.
+    analysisSeq++;
+    isAnalyzing = false;
   }
 
   function saveEdit() {
@@ -425,6 +429,12 @@
   let urlChanged = $derived(editUrl.trim() !== stream.url);
   let needsTest = $derived(urlChanged && !testResult);
   let sourceSampleRate = $derived(testResult?.sampleRate ?? 48000);
+
+  // Detected channel count: a fresh stream test wins; otherwise fall back to the
+  // running stream's probe (health). 0 means "not yet known". Sample rate is only
+  // surfaced when it comes from an actual test (health does not report it).
+  let detectedChannels = $derived(testResult?.channels ?? health?.source_channels ?? 0);
+  let detectedSampleRate = $derived(testResult?.sampleRate);
 
   function handleTestResult(result: { sampleRate: number; channels: number } | null) {
     testResult = result;
@@ -556,93 +566,19 @@
           {/if}
         </div>
 
-        <!-- Channel mode selector -->
-        <SelectDropdown
-          value={editChannelMode}
-          label={t('settings.audio.streams.channelMode.label')}
-          options={getChannelModeOptions()}
+        <!-- Channel handling: format display, selector, and stereo analysis -->
+        <StreamChannelControls
+          channelMode={editChannelMode}
+          channels={detectedChannels}
+          sampleRate={detectedSampleRate}
+          analyzeUrl={editUrl || stream.url}
+          {isAnalyzing}
+          {analysisResult}
+          {analysisError}
           {disabled}
-          onChange={value => (editChannelMode = value as ChannelMode)}
-          groupBy={false}
-          menuSize="sm"
-          helpText={t('settings.audio.streams.channelMode.description')}
+          onChange={mode => (editChannelMode = mode)}
+          onAnalyze={url => analyzeChannels(url)}
         />
-
-        <!-- Channel analysis and warnings (shown when stream is stereo) -->
-        {#if testResult && testResult.channels > 1}
-          <div class="space-y-2">
-            <button
-              type="button"
-              class="inline-flex items-center gap-1.5 h-8 px-3 text-sm font-medium rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] transition-colors disabled:opacity-50"
-              onclick={() => analyzeChannels(editUrl || stream.url)}
-              disabled={isAnalyzing || !(editUrl.trim() || stream.url)}
-            >
-              {#if isAnalyzing}
-                <Loader2 class="size-4 animate-spin" />
-                {t('settings.audio.streams.channelMode.analyzing')}
-              {:else}
-                <Search class="size-4" />
-                {t('settings.audio.streams.channelMode.detectBest')}
-              {/if}
-            </button>
-
-            {#if analysisResult}
-              <div class="space-y-1 text-xs">
-                {#each analysisResult.energy as ch (ch.channel)}
-                  <div class="flex items-center gap-2">
-                    <span class="w-20 text-[var(--color-base-content)]/70"
-                      >{ch.channel === 0
-                        ? t('settings.audio.streams.channelMode.energyLeft')
-                        : t('settings.audio.streams.channelMode.energyRight')}:</span
-                    >
-                    <div class="flex-1 h-2 bg-[var(--color-base-200)] rounded-full overflow-hidden">
-                      <div
-                        class="h-full rounded-full {(ch.channel === 0 ? 'left' : 'right') ===
-                        analysisResult.recommended
-                          ? 'bg-[var(--color-success)]'
-                          : 'bg-[var(--color-base-400)]'}"
-                        style:width="{Math.max(2, Math.min(100, ((ch.rmsDbfs + 96) / 96) * 100))}%"
-                      ></div>
-                    </div>
-                    <span class="font-mono w-16 text-right">{ch.rmsDbfs.toFixed(1)} dBFS</span>
-                  </div>
-                {/each}
-                {#if analysisResult.recommended !== 'downmix'}
-                  <p class="text-[var(--color-success)] font-medium">
-                    {t('settings.audio.streams.channelMode.recommended', {
-                      channel:
-                        analysisResult.recommended === 'left'
-                          ? t('settings.audio.streams.channelMode.energyLeft')
-                          : t('settings.audio.streams.channelMode.energyRight'),
-                    })}
-                  </p>
-                {/if}
-              </div>
-            {/if}
-
-            {#if analysisError}
-              <p class="text-xs text-[var(--color-error)]">
-                {t('settings.audio.streams.channelMode.analyzeError')}: {analysisError}
-              </p>
-            {/if}
-
-            {#if editChannelMode === 'downmix'}
-              <div
-                class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
-              >
-                <AlertTriangle class="size-4 shrink-0 mt-0.5 text-[var(--color-warning)]" />
-                <span>{t('settings.audio.streams.channelMode.downmixWarning')}</span>
-              </div>
-            {:else}
-              <div
-                class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-success)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-success)_30%,transparent)]"
-              >
-                <CircleCheck class="size-4 shrink-0 mt-0.5 text-[var(--color-success)]" />
-                <span>{t('settings.audio.streams.channelMode.singleChannelGood')}</span>
-              </div>
-            {/if}
-          </div>
-        {/if}
 
         <Checkbox
           checked={editEnabled}

--- a/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
@@ -158,7 +158,9 @@
                 )}%"
               ></div>
             </div>
-            <span class="font-mono w-16 text-right">{ch.rmsDbfs.toFixed(1)} dBFS</span>
+            <span class="font-mono w-16 text-right"
+              >{(ch.rmsDbfs ?? -DBFS_RANGE).toFixed(1)} dBFS</span
+            >
           </div>
         {/each}
         {#if analysisResult.recommended !== 'downmix'}
@@ -175,7 +177,7 @@
     {/if}
 
     {#if analysisError}
-      <p class="text-xs text-[var(--color-error)]">
+      <p class="text-xs text-[var(--color-error)]" role="alert">
         {t('settings.audio.streams.channelMode.analyzeError')}: {analysisError}
       </p>
     {/if}

--- a/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
@@ -75,7 +75,16 @@
     return channelsText;
   });
 
-  let canAnalyze = $derived(!isAnalyzing && analyzeUrl.trim().length > 0);
+  // Also honor the parent form's disabled state so the detect button cannot be
+  // triggered while the whole form is disabled.
+  let canAnalyze = $derived(!disabled && !isAnalyzing && analyzeUrl.trim().length > 0);
+
+  // Energy bar geometry: dBFS spans -96 (silence) to 0 (full scale); clamp the
+  // rendered width between a minimum (so a near-silent channel stays visible)
+  // and the full track width.
+  const DBFS_RANGE = 96;
+  const MIN_BAR_PERCENT = 2;
+  const MAX_BAR_PERCENT = 100;
 </script>
 
 <div class="space-y-2">
@@ -140,7 +149,13 @@
                 analysisResult.recommended
                   ? 'bg-[var(--color-success)]'
                   : 'bg-[var(--color-base-400)]'}"
-                style:width="{Math.max(2, Math.min(100, ((ch.rmsDbfs + 96) / 96) * 100))}%"
+                style:width="{Math.max(
+                  MIN_BAR_PERCENT,
+                  Math.min(
+                    MAX_BAR_PERCENT,
+                    ((ch.rmsDbfs + DBFS_RANGE) / DBFS_RANGE) * MAX_BAR_PERCENT
+                  )
+                )}%"
               ></div>
             </div>
             <span class="font-mono w-16 text-right">{ch.rmsDbfs.toFixed(1)} dBFS</span>

--- a/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
@@ -1,0 +1,184 @@
+<!--
+  Stream Channel Controls
+
+  Purpose: Render the per-stream channel handling UI (downmix/left/right selector,
+  detected audio format, energy analysis and warnings) and adapt it to the
+  detected channel count.
+
+  Gating rules (see channelUIState in ./streamChannel.ts):
+  - Unknown channel count (stream not tested): hide the selector, prompt to test.
+  - Mono source: hide the selector (all modes are identical), show a short note.
+  - Multi-channel source: show the selector plus the energy analysis and warnings.
+  - A stream already set to left/right keeps the selector visible even when the
+    source is offline or probes as mono, so the existing choice stays editable.
+
+  Analysis state (isAnalyzing/analysisResult/analysisError) is owned by the parent
+  form because it drives the API call and request-cancellation logic.
+
+  @component
+-->
+<script lang="ts">
+  import { Search, Loader2, AlertTriangle, CircleCheck } from '@lucide/svelte';
+  import { t } from '$lib/i18n';
+  import SelectDropdown from './SelectDropdown.svelte';
+  import { getChannelModeOptions } from './streamOptions';
+  import { channelUIState, sampleRateKhz } from './streamChannel';
+  import type { ChannelMode, ChannelAnalysis } from '$lib/stores/settings';
+
+  interface Props {
+    /** Currently selected channel mode. */
+    channelMode: ChannelMode;
+    /** Detected channel count: 0 = unknown/untested, 1 = mono, >1 = multi-channel. */
+    channels: number;
+    /** Detected source sample rate in Hz, when known from a stream test. */
+    sampleRate?: number;
+    /** URL passed to the channel analyzer when "Detect best channel" is clicked. */
+    analyzeUrl: string;
+    isAnalyzing: boolean;
+    analysisResult: ChannelAnalysis | null;
+    analysisError: string | null;
+    disabled?: boolean;
+    onChange: (_mode: ChannelMode) => void;
+    onAnalyze: (_url: string) => void;
+  }
+
+  let {
+    channelMode,
+    channels,
+    sampleRate,
+    analyzeUrl,
+    isAnalyzing,
+    analysisResult,
+    analysisError,
+    disabled = false,
+    onChange,
+    onAnalyze,
+  }: Props = $props();
+
+  let ui = $derived(channelUIState(channels, channelMode));
+
+  // Localized "Mono (1 channel)" / "Stereo (2 channels)" / "N channels" label.
+  let channelsText = $derived.by(() => {
+    if (channels === 1) return t('settings.audio.streams.format.mono');
+    if (channels === 2) return t('settings.audio.streams.format.stereo');
+    return t('settings.audio.streams.format.multi', { count: channels });
+  });
+
+  // Render kHz without trailing zeros: 48000 -> "48", 44100 -> "44.1".
+  let formatText = $derived.by(() => {
+    if (sampleRate && sampleRate > 0) {
+      return t('settings.audio.streams.format.withSampleRate', {
+        rate: sampleRateKhz(sampleRate),
+        channels: channelsText,
+      });
+    }
+    return channelsText;
+  });
+
+  let canAnalyze = $derived(!isAnalyzing && analyzeUrl.trim().length > 0);
+</script>
+
+<div class="space-y-2">
+  <!-- Detected audio format -->
+  <p class="text-xs text-[var(--color-base-content)]/70">
+    <span class="font-medium text-[var(--color-base-content)]"
+      >{t('settings.audio.streams.format.label')}:</span
+    >
+    {channels < 1 ? t('settings.audio.streams.format.untested') : formatText}
+  </p>
+
+  {#if ui.showSelector}
+    <SelectDropdown
+      value={channelMode}
+      label={t('settings.audio.streams.channelMode.label')}
+      options={getChannelModeOptions()}
+      {disabled}
+      onChange={value => onChange(value as ChannelMode)}
+      groupBy={false}
+      menuSize="sm"
+      helpText={t('settings.audio.streams.channelMode.description')}
+    />
+  {/if}
+
+  {#if ui.isMono}
+    <div
+      class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-success)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-success)_30%,transparent)]"
+    >
+      <CircleCheck class="size-4 shrink-0 mt-0.5 text-[var(--color-success)]" />
+      <span>{t('settings.audio.streams.channelMode.monoNoSelection')}</span>
+    </div>
+  {/if}
+
+  {#if ui.showAnalysis}
+    <button
+      type="button"
+      class="inline-flex items-center gap-1.5 h-8 px-3 text-sm font-medium rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] transition-colors disabled:opacity-50"
+      onclick={() => onAnalyze(analyzeUrl)}
+      disabled={!canAnalyze}
+    >
+      {#if isAnalyzing}
+        <Loader2 class="size-4 animate-spin" />
+        {t('settings.audio.streams.channelMode.analyzing')}
+      {:else}
+        <Search class="size-4" />
+        {t('settings.audio.streams.channelMode.detectBest')}
+      {/if}
+    </button>
+
+    {#if analysisResult}
+      <div class="space-y-1 text-xs">
+        {#each analysisResult.energy as ch (ch.channel)}
+          <div class="flex items-center gap-2">
+            <span class="w-20 text-[var(--color-base-content)]/70"
+              >{ch.channel === 0
+                ? t('settings.audio.streams.channelMode.energyLeft')
+                : t('settings.audio.streams.channelMode.energyRight')}:</span
+            >
+            <div class="flex-1 h-2 bg-[var(--color-base-200)] rounded-full overflow-hidden">
+              <div
+                class="h-full rounded-full {(ch.channel === 0 ? 'left' : 'right') ===
+                analysisResult.recommended
+                  ? 'bg-[var(--color-success)]'
+                  : 'bg-[var(--color-base-400)]'}"
+                style:width="{Math.max(2, Math.min(100, ((ch.rmsDbfs + 96) / 96) * 100))}%"
+              ></div>
+            </div>
+            <span class="font-mono w-16 text-right">{ch.rmsDbfs.toFixed(1)} dBFS</span>
+          </div>
+        {/each}
+        {#if analysisResult.recommended !== 'downmix'}
+          <p class="text-[var(--color-success)] font-medium">
+            {t('settings.audio.streams.channelMode.recommended', {
+              channel:
+                analysisResult.recommended === 'left'
+                  ? t('settings.audio.streams.channelMode.energyLeft')
+                  : t('settings.audio.streams.channelMode.energyRight'),
+            })}
+          </p>
+        {/if}
+      </div>
+    {/if}
+
+    {#if analysisError}
+      <p class="text-xs text-[var(--color-error)]">
+        {t('settings.audio.streams.channelMode.analyzeError')}: {analysisError}
+      </p>
+    {/if}
+
+    {#if channelMode === 'downmix'}
+      <div
+        class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
+      >
+        <AlertTriangle class="size-4 shrink-0 mt-0.5 text-[var(--color-warning)]" />
+        <span>{t('settings.audio.streams.channelMode.downmixWarning')}</span>
+      </div>
+    {:else}
+      <div
+        class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-success)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-success)_30%,transparent)]"
+      >
+        <CircleCheck class="size-4 shrink-0 mt-0.5 text-[var(--color-success)]" />
+        <span>{t('settings.audio.streams.channelMode.singleChannelGood')}</span>
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamChannelControls.svelte
@@ -77,7 +77,7 @@
 
   // Also honor the parent form's disabled state so the detect button cannot be
   // triggered while the whole form is disabled.
-  let canAnalyze = $derived(!disabled && !isAnalyzing && analyzeUrl.trim().length > 0);
+  let canAnalyze = $derived(!disabled && !isAnalyzing && (analyzeUrl ?? '').trim().length > 0);
 
   // Energy bar geometry: dBFS spans -96 (silence) to 0 (full scale); clamp the
   // rendered width between a minimum (so a near-silent channel stays visible)
@@ -153,7 +153,7 @@
                   MIN_BAR_PERCENT,
                   Math.min(
                     MAX_BAR_PERCENT,
-                    ((ch.rmsDbfs + DBFS_RANGE) / DBFS_RANGE) * MAX_BAR_PERCENT
+                    (((ch.rmsDbfs ?? -DBFS_RANGE) + DBFS_RANGE) / DBFS_RANGE) * MAX_BAR_PERCENT
                   )
                 )}%"
               ></div>

--- a/frontend/src/lib/desktop/components/forms/StreamChannelControls.test.ts
+++ b/frontend/src/lib/desktop/components/forms/StreamChannelControls.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createComponentTestFactory, screen } from '../../../../test/render-helpers';
+import StreamChannelControls from './StreamChannelControls.svelte';
+
+// The global i18n mock returns the key when no translation is registered, so the
+// rendered text equals the translation key. Assert on keys to detect which parts
+// of the UI rendered.
+const LABEL_KEY = 'settings.audio.streams.channelMode.label';
+const DETECT_KEY = 'settings.audio.streams.channelMode.detectBest';
+const MONO_KEY = 'settings.audio.streams.channelMode.monoNoSelection';
+const DOWNMIX_WARN_KEY = 'settings.audio.streams.channelMode.downmixWarning';
+const UNTESTED_KEY = 'settings.audio.streams.format.untested';
+const FORMAT_MONO_KEY = 'settings.audio.streams.format.mono';
+
+const factory = createComponentTestFactory(StreamChannelControls);
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  return {
+    channelMode: 'downmix',
+    channels: 0,
+    analyzeUrl: 'rtsp://example/stream',
+    isAnalyzing: false,
+    analysisResult: null,
+    analysisError: null,
+    onChange: vi.fn(),
+    onAnalyze: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('StreamChannelControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prompts to test and hides the selector when the channel count is unknown', () => {
+    factory.render(baseProps({ channels: 0, channelMode: 'downmix' }));
+    expect(screen.getByText(UNTESTED_KEY)).toBeInTheDocument();
+    expect(screen.queryByText(LABEL_KEY)).not.toBeInTheDocument();
+    expect(screen.queryByText(DETECT_KEY)).not.toBeInTheDocument();
+  });
+
+  it('shows a single-channel note and hides the selector for a mono source', () => {
+    factory.render(baseProps({ channels: 1, channelMode: 'downmix' }));
+    expect(screen.getByText(FORMAT_MONO_KEY)).toBeInTheDocument();
+    expect(screen.getByText(MONO_KEY)).toBeInTheDocument();
+    expect(screen.queryByText(LABEL_KEY)).not.toBeInTheDocument();
+    expect(screen.queryByText(DETECT_KEY)).not.toBeInTheDocument();
+  });
+
+  it('shows the selector, detect button and downmix warning for a multi-channel source', () => {
+    factory.render(baseProps({ channels: 2, channelMode: 'downmix' }));
+    expect(screen.getByText(LABEL_KEY)).toBeInTheDocument();
+    expect(screen.getByText(DETECT_KEY)).toBeInTheDocument();
+    expect(screen.getByText(DOWNMIX_WARN_KEY)).toBeInTheDocument();
+    expect(screen.queryByText(MONO_KEY)).not.toBeInTheDocument();
+  });
+
+  it('keeps the selector visible for a left-configured stream even when offline (unknown channels)', () => {
+    factory.render(baseProps({ channels: 0, channelMode: 'left' }));
+    expect(screen.getByText(LABEL_KEY)).toBeInTheDocument();
+    // No live probe, so the analysis (detect button) stays hidden.
+    expect(screen.queryByText(DETECT_KEY)).not.toBeInTheDocument();
+    // Format is still unknown without a probe.
+    expect(screen.getByText(UNTESTED_KEY)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -16,7 +16,7 @@
 -->
 <script lang="ts">
   import { onMount, onDestroy, setContext } from 'svelte';
-  import { Plus, Radio, RefreshCw, Loader2, AlertTriangle, CircleCheck } from '@lucide/svelte';
+  import { Plus, Radio, RefreshCw } from '@lucide/svelte';
   import { ReconnectingEventSource } from '$lib/utils/ReconnectingEventSource';
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
@@ -43,12 +43,8 @@
   import type { ChannelAnalysis } from '$lib/stores/settings';
   import { defaultQuietHoursConfig } from '$lib/stores/settings';
   import StreamTestButton from './StreamTestButton.svelte';
-  import {
-    streamTypeOptions,
-    transportOptions,
-    getChannelModeOptions,
-    analyzeStreamChannels,
-  } from './streamOptions';
+  import StreamChannelControls from './StreamChannelControls.svelte';
+  import { streamTypeOptions, transportOptions, analyzeStreamChannels } from './streamOptions';
 
   const logger = loggers.audio;
 
@@ -141,6 +137,10 @@
   let urlError = $state<string | null>(null);
   let newTestResult = $state<{ sampleRate: number; channels: number } | null>(null);
   let newSourceSampleRate = $derived(newTestResult?.sampleRate ?? 48000);
+  // Detected channel count for a new stream comes only from a stream test
+  // (0 = not yet tested). Drives the adaptive channel controls.
+  let newDetectedChannels = $derived(newTestResult?.channels ?? 0);
+  let newDetectedSampleRate = $derived(newTestResult?.sampleRate);
   let isAnalyzing = $state(false);
   let analysisResult = $state<ChannelAnalysis | null>(null);
   let analysisError = $state<string | null>(null);
@@ -728,95 +728,19 @@
               {/if}
             </div>
 
-            <!-- Channel Mode -->
-            <SelectDropdown
-              value={newChannelMode}
-              label={t('settings.audio.streams.channelMode.label')}
-              options={getChannelModeOptions()}
+            <!-- Channel handling: format display, selector, and stereo analysis -->
+            <StreamChannelControls
+              channelMode={newChannelMode}
+              channels={newDetectedChannels}
+              sampleRate={newDetectedSampleRate}
+              analyzeUrl={newUrl}
+              {isAnalyzing}
+              {analysisResult}
+              {analysisError}
               {disabled}
-              onChange={value => (newChannelMode = value as ChannelMode)}
-              groupBy={false}
-              menuSize="sm"
-              helpText={t('settings.audio.streams.channelMode.description')}
+              onChange={mode => (newChannelMode = mode)}
+              onAnalyze={url => analyzeChannels(url)}
             />
-
-            <!-- Channel analysis results (shown after testing a stereo stream) -->
-            {#if newTestResult && newTestResult.channels > 1}
-              <div class="space-y-2">
-                {#if isAnalyzing}
-                  <div
-                    class="flex items-center gap-1.5 text-sm text-[var(--color-base-content)]/70"
-                  >
-                    <Loader2 class="size-4 animate-spin" />
-                    {t('settings.audio.streams.channelMode.analyzing')}
-                  </div>
-                {/if}
-
-                {#if analysisResult}
-                  <div class="space-y-1 text-xs">
-                    {#each analysisResult.energy as ch (ch.channel)}
-                      <div class="flex items-center gap-2">
-                        <span class="w-20 text-[var(--color-base-content)]/70"
-                          >{ch.channel === 0
-                            ? t('settings.audio.streams.channelMode.energyLeft')
-                            : t('settings.audio.streams.channelMode.energyRight')}:</span
-                        >
-                        <div
-                          class="flex-1 h-2 bg-[var(--color-base-200)] rounded-full overflow-hidden"
-                        >
-                          <div
-                            class="h-full rounded-full {(ch.channel === 0 ? 'left' : 'right') ===
-                            analysisResult.recommended
-                              ? 'bg-[var(--color-success)]'
-                              : 'bg-[var(--color-base-400)]'}"
-                            style:width="{Math.max(
-                              2,
-                              Math.min(100, ((ch.rmsDbfs + 96) / 96) * 100)
-                            )}%"
-                          ></div>
-                        </div>
-                        <span class="font-mono w-16 text-right">{ch.rmsDbfs.toFixed(1)} dBFS</span>
-                      </div>
-                    {/each}
-                    {#if analysisResult.recommended !== 'downmix'}
-                      <p class="text-[var(--color-success)] font-medium">
-                        {t('settings.audio.streams.channelMode.recommended', {
-                          channel:
-                            analysisResult.recommended === 'left'
-                              ? t('settings.audio.streams.channelMode.energyLeft')
-                              : t('settings.audio.streams.channelMode.energyRight'),
-                        })}
-                      </p>
-                    {/if}
-                  </div>
-                {/if}
-
-                {#if analysisError}
-                  <p class="text-xs text-[var(--color-error)]">
-                    {t('settings.audio.streams.channelMode.analyzeError')}: {analysisError}
-                  </p>
-                {/if}
-              </div>
-            {/if}
-
-            <!-- Channel mode warnings (shown after stereo stream detected) -->
-            {#if newTestResult && newTestResult.channels > 1}
-              {#if newChannelMode === 'downmix'}
-                <div
-                  class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-warning)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-warning)_30%,transparent)]"
-                >
-                  <AlertTriangle class="size-4 shrink-0 mt-0.5 text-[var(--color-warning)]" />
-                  <span>{t('settings.audio.streams.channelMode.downmixWarning')}</span>
-                </div>
-              {:else}
-                <div
-                  class="flex items-start gap-2 p-2.5 rounded-lg text-sm leading-relaxed bg-[color-mix(in_srgb,var(--color-success)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-success)_30%,transparent)]"
-                >
-                  <CircleCheck class="size-4 shrink-0 mt-0.5 text-[var(--color-success)]" />
-                  <span>{t('settings.audio.streams.channelMode.singleChannelGood')}</span>
-                </div>
-              {/if}
-            {/if}
 
             <!-- Model Selection -->
             <ModelCheckboxList

--- a/frontend/src/lib/desktop/components/forms/streamChannel.test.ts
+++ b/frontend/src/lib/desktop/components/forms/streamChannel.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeChannelMode, channelUIState, sampleRateKhz } from './streamChannel';
+
+describe('sampleRateKhz', () => {
+  it('converts 48000 Hz to 48 kHz with no trailing zeros', () => {
+    expect(sampleRateKhz(48000)).toBe(48);
+  });
+
+  it('keeps one decimal for 44100 Hz (44.1 kHz)', () => {
+    expect(sampleRateKhz(44100)).toBe(44.1);
+  });
+
+  it('converts 16000 Hz to 16 kHz', () => {
+    expect(sampleRateKhz(16000)).toBe(16);
+  });
+});
+
+describe('normalizeChannelMode', () => {
+  it('maps an empty string to downmix (the documented default)', () => {
+    expect(normalizeChannelMode('')).toBe('downmix');
+  });
+
+  it('maps undefined to downmix', () => {
+    expect(normalizeChannelMode(undefined)).toBe('downmix');
+  });
+
+  it('maps null to downmix', () => {
+    expect(normalizeChannelMode(null)).toBe('downmix');
+  });
+
+  it('maps an unknown value to downmix', () => {
+    expect(normalizeChannelMode('stereo')).toBe('downmix');
+  });
+
+  it('preserves explicit downmix', () => {
+    expect(normalizeChannelMode('downmix')).toBe('downmix');
+  });
+
+  it('preserves left', () => {
+    expect(normalizeChannelMode('left')).toBe('left');
+  });
+
+  it('preserves right', () => {
+    expect(normalizeChannelMode('right')).toBe('right');
+  });
+});
+
+describe('channelUIState', () => {
+  it('hides the selector for an untested stream (0 channels, default mode)', () => {
+    expect(channelUIState(0, 'downmix')).toEqual({
+      showSelector: false,
+      showAnalysis: false,
+      isMono: false,
+    });
+  });
+
+  it('treats a mono stream as single-channel: no selector, no analysis', () => {
+    expect(channelUIState(1, 'downmix')).toEqual({
+      showSelector: false,
+      showAnalysis: false,
+      isMono: true,
+    });
+  });
+
+  it('shows the full selector and analysis for a multi-channel stream', () => {
+    expect(channelUIState(2, 'downmix')).toEqual({
+      showSelector: true,
+      showAnalysis: true,
+      isMono: false,
+    });
+  });
+
+  it('shows the selector for a stream explicitly set to left even when offline (0 channels)', () => {
+    // A configured left/right stream must remain editable when no live probe exists,
+    // otherwise the user cannot review or change a setting they already made.
+    expect(channelUIState(0, 'left')).toEqual({
+      showSelector: true,
+      showAnalysis: false,
+      isMono: false,
+    });
+  });
+
+  it('shows the selector but not analysis for a right-configured stream that probes as mono', () => {
+    expect(channelUIState(1, 'right')).toEqual({
+      showSelector: true,
+      showAnalysis: false,
+      isMono: false,
+    });
+  });
+
+  it('shows selector and analysis for a multi-channel stream set to left', () => {
+    expect(channelUIState(2, 'left')).toEqual({
+      showSelector: true,
+      showAnalysis: true,
+      isMono: false,
+    });
+  });
+});

--- a/frontend/src/lib/desktop/components/forms/streamChannel.ts
+++ b/frontend/src/lib/desktop/components/forms/streamChannel.ts
@@ -1,0 +1,59 @@
+import type { ChannelMode } from '$lib/stores/settings';
+
+/**
+ * Normalize a channel mode value coming from the API or config into a concrete
+ * {@link ChannelMode}.
+ *
+ * The backend tags `ChannelMode` with `omitempty` for YAML but not for JSON, so
+ * an unset mode arrives over the API as the empty string `""` rather than
+ * `undefined`. A plain `?? 'downmix'` fallback does not catch `""`, which is why
+ * the edit form previously rendered a blank "Select..." placeholder instead of
+ * the documented default. Treat any empty/unknown value as downmix.
+ */
+export function normalizeChannelMode(mode: string | null | undefined): ChannelMode {
+  return mode === 'left' || mode === 'right' ? mode : 'downmix';
+}
+
+/**
+ * Convert a sample rate in Hz to kHz, dropping insignificant trailing zeros
+ * (48000 -> 48, 44100 -> 44.1) for compact display in the stream format line.
+ */
+export function sampleRateKhz(hz: number): number {
+  return Number((hz / 1000).toFixed(1));
+}
+
+/**
+ * Describes how the channel controls should render for a given stream, based on
+ * the detected channel count and the currently selected mode.
+ */
+export interface ChannelUIState {
+  /** Show the downmix/left/right selector. */
+  showSelector: boolean;
+  /** Show the energy analysis (detect-best-channel button, bars, stereo warnings). */
+  showAnalysis: boolean;
+  /** Source is confirmed single-channel: no channel selection is meaningful. */
+  isMono: boolean;
+}
+
+/**
+ * Decide which channel controls to surface for a stream.
+ *
+ * - `channels === 0`: unknown (not yet probed). Hide the selector and prompt to
+ *   test, unless an explicit left/right mode is already configured.
+ * - `channels === 1`: mono. All modes produce identical audio, so hide the
+ *   selector and show a "single channel" note, unless left/right is configured.
+ * - `channels > 1`: multi-channel. Show the selector plus the energy analysis.
+ *
+ * An explicit `left`/`right` selection always keeps the selector visible so a
+ * setting made while the source was multi-channel remains reviewable and
+ * editable even when the stream is currently offline or probes as mono.
+ */
+export function channelUIState(channels: number, mode: ChannelMode): ChannelUIState {
+  const explicit = mode === 'left' || mode === 'right';
+  const multiChannel = channels > 1;
+  return {
+    showSelector: multiChannel || explicit,
+    showAnalysis: multiChannel,
+    isMono: channels === 1 && !explicit,
+  };
+}

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Pravý kanál",
           "label": "Režim kanálu",
           "left": "Pouze levý kanál",
+          "monoNoSelection": "Jednokanálový zdroj. Všechny režimy kanálů produkují stejný zvuk, takže není třeba nic vybírat.",
           "recommended": "Doporučeno: {channel}",
           "right": "Pouze pravý kanál",
           "singleChannelGood": "Vybrán jeden kanál, optimální pro přesnost detekce."
+        },
+        "format": {
+          "label": "Formát zvuku",
+          "mono": "Mono (1 kanál)",
+          "multi": "{count} kanálů",
+          "stereo": "Stereo (2 kanály)",
+          "untested": "Otestujte stream pro zjištění formátu zvuku",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Detekován stereo stream. Smíchání více kanálů může snížit přesnost detekce kvůli fázovým rozdílům mezi kanály. Pro nejlepší výsledky vyberte konkrétní kanál (levý/pravý) nebo použijte detektor kanálů.",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Højre kanal",
           "label": "Kanaltilstand",
           "left": "Kun venstre kanal",
+          "monoNoSelection": "Enkeltkanalskilde. Alle kanaltilstande giver identisk lyd, så der er ikke behov for at vælge.",
           "recommended": "Anbefalet: {channel}",
           "right": "Kun højre kanal",
           "singleChannelGood": "Enkelt kanal valgt, optimalt for detektionsnøjagtighed."
+        },
+        "format": {
+          "label": "Lydformat",
+          "mono": "Mono (1 kanal)",
+          "multi": "{count} kanaler",
+          "stereo": "Stereo (2 kanaler)",
+          "untested": "Test streamen for at registrere lydformatet",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stereostream detekteret. Downmixing af flere kanaler kan reducere detektionsnøjagtigheden på grund af faseforskelle mellem kanaler. Vælg en specifik kanal (venstre/højre) eller brug kanaldetektoren for bedste resultater.",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Rechter Kanal",
           "label": "Kanalmodus",
           "left": "Nur linker Kanal",
+          "monoNoSelection": "Einkanalige Quelle. Alle Kanalmodi erzeugen identischen Ton, eine Auswahl ist daher nicht nötig.",
           "recommended": "Empfohlen: {channel}",
           "right": "Nur rechter Kanal",
           "singleChannelGood": "Einzelkanal ausgewählt, optimal für die Erkennungsgenauigkeit."
+        },
+        "format": {
+          "label": "Audioformat",
+          "mono": "Mono (1 Kanal)",
+          "multi": "{count} Kanäle",
+          "stereo": "Stereo (2 Kanäle)",
+          "untested": "Stream testen, um das Audioformat zu erkennen",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stereo-Stream erkannt. Das Abmischen mehrerer Kanäle kann die Erkennungsgenauigkeit aufgrund von Phasenunterschieden zwischen den Kanälen verringern. Wählen Sie einen bestimmten Kanal (links/rechts) oder verwenden Sie den Kanaldetektor für beste Ergebnisse.",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Right channel",
           "label": "Channel mode",
           "left": "Left channel only",
+          "monoNoSelection": "Single channel source. All channel modes produce identical audio, so no selection is needed.",
           "recommended": "Recommended: {channel}",
           "right": "Right channel only",
           "singleChannelGood": "Single channel selected, optimal for detection accuracy."
+        },
+        "format": {
+          "label": "Audio format",
+          "mono": "Mono (1 channel)",
+          "multi": "{count} channels",
+          "stereo": "Stereo (2 channels)",
+          "untested": "Test the stream to detect its audio format",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stereo stream detected. Downmixing multiple channels can reduce detection accuracy due to phase differences between channels. Select a specific channel (left/right) or use the channel detector for best results.",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Canal derecho",
           "label": "Modo de canal",
           "left": "Solo canal izquierdo",
+          "monoNoSelection": "Fuente de un solo canal. Todos los modos de canal producen el mismo audio, por lo que no es necesario seleccionar nada.",
           "recommended": "Recomendado: {channel}",
           "right": "Solo canal derecho",
           "singleChannelGood": "Canal único seleccionado, óptimo para la precisión de detección."
+        },
+        "format": {
+          "label": "Formato de audio",
+          "mono": "Mono (1 canal)",
+          "multi": "{count} canales",
+          "stereo": "Estéreo (2 canales)",
+          "untested": "Prueba el stream para detectar su formato de audio",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Transmisión estéreo detectada. La mezcla de múltiples canales puede reducir la precisión de detección debido a diferencias de fase entre canales. Seleccione un canal específico (izquierdo/derecho) o use el detector de canales para mejores resultados.",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Oikea kanava",
           "label": "Kanavatila",
           "left": "Vain vasen kanava",
+          "monoNoSelection": "Yksikanavainen lähde. Kaikki kanavatilat tuottavat saman äänen, joten valintaa ei tarvita.",
           "recommended": "Suositeltu: {channel}",
           "right": "Vain oikea kanava",
           "singleChannelGood": "Yksittäinen kanava valittu, optimaalinen tunnistustarkkuudelle."
+        },
+        "format": {
+          "label": "Äänimuoto",
+          "mono": "Mono (1 kanava)",
+          "multi": "{count} kanavaa",
+          "stereo": "Stereo (2 kanavaa)",
+          "untested": "Testaa striimi tunnistaaksesi sen äänimuodon",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stereovirta havaittu. Useiden kanavien sekoittaminen voi heikentää tunnistustarkkuutta kanavien välisten vaihe-erojen vuoksi. Valitse tietty kanava (vasen/oikea) tai käytä kanavatunnistinta parhaiden tulosten saavuttamiseksi.",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Canal droit",
           "label": "Mode canal",
           "left": "Canal gauche uniquement",
+          "monoNoSelection": "Source monocanal. Tous les modes de canal produisent un son identique, aucune sélection n'est donc nécessaire.",
           "recommended": "Recommandé : {channel}",
           "right": "Canal droit uniquement",
           "singleChannelGood": "Canal unique sélectionné, optimal pour la précision de détection."
+        },
+        "format": {
+          "label": "Format audio",
+          "mono": "Mono (1 canal)",
+          "multi": "{count} canaux",
+          "stereo": "Stéréo (2 canaux)",
+          "untested": "Testez le flux pour détecter son format audio",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Flux stéréo détecté. Le mixage de plusieurs canaux peut réduire la précision de détection en raison des différences de phase entre les canaux. Sélectionnez un canal spécifique (gauche/droit) ou utilisez le détecteur de canaux pour de meilleurs résultats.",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Jobb csatorna",
           "label": "Csatornamód",
           "left": "Csak bal csatorna",
+          "monoNoSelection": "Egycsatornás forrás. Minden csatornamód azonos hangot ad, ezért nincs szükség választásra.",
           "recommended": "Ajánlott: {channel}",
           "right": "Csak jobb csatorna",
           "singleChannelGood": "Egycsatornás kiválasztva, optimális az érzékelési pontossághoz."
+        },
+        "format": {
+          "label": "Hangformátum",
+          "mono": "Mono (1 csatorna)",
+          "multi": "{count} csatorna",
+          "stereo": "Sztereó (2 csatorna)",
+          "untested": "Tesztelje a streamet a hangformátum felismeréséhez",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Sztereó stream észlelve. A több csatorna keverése csökkentheti az érzékelési pontosságot a csatornák közötti fáziskülönbségek miatt. Válasszon konkrét csatornát (bal/jobb) vagy használja a csatornadetektort a legjobb eredményekhez.",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Canale destro",
           "label": "Modalità canale",
           "left": "Solo canale sinistro",
+          "monoNoSelection": "Sorgente a canale singolo. Tutte le modalità di canale producono lo stesso audio, quindi non è necessaria alcuna selezione.",
           "recommended": "Consigliato: {channel}",
           "right": "Solo canale destro",
           "singleChannelGood": "Canale singolo selezionato, ottimale per la precisione del rilevamento."
+        },
+        "format": {
+          "label": "Formato audio",
+          "mono": "Mono (1 canale)",
+          "multi": "{count} canali",
+          "stereo": "Stereo (2 canali)",
+          "untested": "Prova lo stream per rilevare il formato audio",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stream stereo rilevato. Il downmix di più canali può ridurre la precisione del rilevamento a causa delle differenze di fase tra i canali. Seleziona un canale specifico (sinistro/destro) o usa il rilevatore di canali per i migliori risultati.",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Labais kanāls",
           "label": "Kanāla režīms",
           "left": "Tikai kreisais kanāls",
+          "monoNoSelection": "Viena kanāla avots. Visi kanālu režīmi rada identisku skaņu, tāpēc izvēle nav nepieciešama.",
           "recommended": "Ieteicamais: {channel}",
           "right": "Tikai labais kanāls",
           "singleChannelGood": "Izvēlēts viens kanāls, optimāli noteikšanas precizitātei."
+        },
+        "format": {
+          "label": "Audio formāts",
+          "mono": "Mono (1 kanāls)",
+          "multi": "{count} kanāli",
+          "stereo": "Stereo (2 kanāli)",
+          "untested": "Pārbaudiet straumi, lai noteiktu tās audio formātu",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Konstatēta stereo straume. Vairāku kanālu samazināšana var pazemināt noteikšanas precizitāti fāzu atšķirību dēļ starp kanāliem. Izvēlieties konkrētu kanālu (kreiso/labo) vai izmantojiet kanālu detektoru labākajiem rezultātiem.",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Rechterkanaal",
           "label": "Kanaalmodus",
           "left": "Alleen linkerkanaal",
+          "monoNoSelection": "Bron met één kanaal. Alle kanaalmodi leveren identieke audio, dus selecteren is niet nodig.",
           "recommended": "Aanbevolen: {channel}",
           "right": "Alleen rechterkanaal",
           "singleChannelGood": "Enkel kanaal geselecteerd, optimaal voor detectienauwkeurigheid."
+        },
+        "format": {
+          "label": "Audioformaat",
+          "mono": "Mono (1 kanaal)",
+          "multi": "{count} kanalen",
+          "stereo": "Stereo (2 kanalen)",
+          "untested": "Test de stream om het audioformaat te detecteren",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stereostream gedetecteerd. Het downmixen van meerdere kanalen kan de detectienauwkeurigheid verminderen door faseverschillen tussen kanalen. Selecteer een specifiek kanaal (links/rechts) of gebruik de kanaaldetector voor de beste resultaten.",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Prawy kanał",
           "label": "Tryb kanału",
           "left": "Tylko lewy kanał",
+          "monoNoSelection": "Źródło jednokanałowe. Wszystkie tryby kanałów dają identyczny dźwięk, więc wybór nie jest potrzebny.",
           "recommended": "Zalecane: {channel}",
           "right": "Tylko prawy kanał",
           "singleChannelGood": "Wybrany pojedynczy kanał, optymalny dla dokładności detekcji."
+        },
+        "format": {
+          "label": "Format dźwięku",
+          "mono": "Mono (1 kanał)",
+          "multi": "{count} kanałów",
+          "stereo": "Stereo (2 kanały)",
+          "untested": "Przetestuj strumień, aby wykryć jego format dźwięku",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Wykryto strumień stereo. Miksowanie wielu kanałów może zmniejszyć dokładność detekcji z powodu różnic fazowych między kanałami. Wybierz konkretny kanał (lewy/prawy) lub użyj detektora kanałów, aby uzyskać najlepsze wyniki.",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Canal direito",
           "label": "Modo de canal",
           "left": "Apenas canal esquerdo",
+          "monoNoSelection": "Fonte de canal único. Todos os modos de canal produzem o mesmo áudio, por isso não é necessária qualquer seleção.",
           "recommended": "Recomendado: {channel}",
           "right": "Apenas canal direito",
           "singleChannelGood": "Canal único selecionado, ótimo para a precisão de detecção."
+        },
+        "format": {
+          "label": "Formato de áudio",
+          "mono": "Mono (1 canal)",
+          "multi": "{count} canais",
+          "stereo": "Estéreo (2 canais)",
+          "untested": "Teste o stream para detetar o formato de áudio",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stream estéreo detectado. A mistura de múltiplos canais pode reduzir a precisão de detecção devido a diferenças de fase entre canais. Selecione um canal específico (esquerdo/direito) ou use o detector de canais para melhores resultados.",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Pravý kanál",
           "label": "Režim kanálu",
           "left": "Len ľavý kanál",
+          "monoNoSelection": "Jednokanálový zdroj. Všetky režimy kanálov produkujú rovnaký zvuk, takže nie je potrebné nič vyberať.",
           "recommended": "Odporúčané: {channel}",
           "right": "Len pravý kanál",
           "singleChannelGood": "Vybraný jeden kanál, optimálne pre presnosť detekcie."
+        },
+        "format": {
+          "label": "Formát zvuku",
+          "mono": "Mono (1 kanál)",
+          "multi": "{count} kanálov",
+          "stereo": "Stereo (2 kanály)",
+          "untested": "Otestujte stream na zistenie formátu zvuku",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Detekovaný stereo stream. Zmiešanie viacerých kanálov môže znížiť presnosť detekcie kvôli fázovým rozdielom medzi kanálmi. Pre najlepšie výsledky vyberte konkrétny kanál (ľavý/pravý) alebo použite detektor kanálov.",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3069,9 +3069,18 @@
           "energyRight": "Höger kanal",
           "label": "Kanalläge",
           "left": "Endast vänster kanal",
+          "monoNoSelection": "Enkanalig källa. Alla kanallägen ger identiskt ljud, så inget val behövs.",
           "recommended": "Rekommenderad: {channel}",
           "right": "Endast höger kanal",
           "singleChannelGood": "Enskild kanal vald, optimalt för detektionsnoggrannhet."
+        },
+        "format": {
+          "label": "Ljudformat",
+          "mono": "Mono (1 kanal)",
+          "multi": "{count} kanaler",
+          "stereo": "Stereo (2 kanaler)",
+          "untested": "Testa strömmen för att identifiera ljudformatet",
+          "withSampleRate": "{rate} kHz, {channels}"
         },
         "stereoWarning": {
           "message": "Stereoström detekterad. Nedmixning av flera kanaler kan minska detektionsnoggrannheten på grund av fasskillnader mellan kanaler. Välj en specifik kanal (vänster/höger) eller använd kanaldetektorn för bästa resultat.",

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1017,11 +1017,16 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 		running.SourceSampleRate != desired.SourceSampleRate
 	sourceChannelsChanged := desired.SourceChannels != 0 &&
 		running.SourceChannels != desired.SourceChannels
+	// Compare canonical channel modes so an unset value and an explicit "downmix"
+	// (which build identical FFmpeg args) are not treated as a change that would
+	// needlessly restart the stream.
+	channelModeChanged := conf.ChannelMode(running.ChannelMode).Canonical() !=
+		conf.ChannelMode(desired.ChannelMode).Canonical()
 	return running.SampleRate != desired.SampleRate ||
 		sourceSampleRateChanged ||
 		running.BitDepth != desired.BitDepth ||
 		running.Channels != desired.Channels ||
-		running.ChannelMode != desired.ChannelMode ||
+		channelModeChanged ||
 		sourceChannelsChanged
 }
 

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -77,6 +77,38 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			// Unset and explicit "downmix" produce identical FFmpeg args, so the
+			// transition must not trigger a stream restart.
+			name: "channel mode unset to downmix is a no-op",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, ChannelMode: "",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 1, ChannelMode: "downmix",
+			},
+			expected: false,
+		},
+		{
+			name: "channel mode downmix to left changes",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "downmix",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "left",
+			},
+			expected: true,
+		},
+		{
+			name: "channel mode left to right changes",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "left",
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "right",
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -85,27 +86,27 @@ func TestSourceNeedsReconfigure(t *testing.T) {
 				SampleRate: 48000, BitDepth: 16, Channels: 1, ChannelMode: "",
 			},
 			desired: &audiocore.SourceConfig{
-				SampleRate: 48000, BitDepth: 16, Channels: 1, ChannelMode: "downmix",
+				SampleRate: 48000, BitDepth: 16, Channels: 1, ChannelMode: string(conf.ChannelModeDownmix),
 			},
 			expected: false,
 		},
 		{
 			name: "channel mode downmix to left changes",
 			running: &audiocore.AudioSource{
-				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "downmix",
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: string(conf.ChannelModeDownmix),
 			},
 			desired: &audiocore.SourceConfig{
-				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "left",
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: string(conf.ChannelModeLeft),
 			},
 			expected: true,
 		},
 		{
 			name: "channel mode left to right changes",
 			running: &audiocore.AudioSource{
-				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "left",
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: string(conf.ChannelModeLeft),
 			},
 			desired: &audiocore.SourceConfig{
-				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: "right",
+				SampleRate: 48000, BitDepth: 16, Channels: 2, ChannelMode: string(conf.ChannelModeRight),
 			},
 			expected: true,
 		},

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2351,7 +2351,7 @@ func streamsSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 			oldStream.IsEnabled() != newStream.IsEnabled() ||
 			oldStream.Type != newStream.Type ||
 			oldStream.Transport != newStream.Transport ||
-			oldStream.ChannelMode != newStream.ChannelMode ||
+			oldStream.ChannelMode.Canonical() != newStream.ChannelMode.Canonical() ||
 			!slices.Equal(oldStream.Models, newStream.Models) {
 			return true
 		}

--- a/internal/api/v2/settings_update_test.go
+++ b/internal/api/v2/settings_update_test.go
@@ -783,3 +783,52 @@ func TestStreamsSettingsChanged_BackwardCompatibility(t *testing.T) {
 		})
 	}
 }
+
+// TestStreamsSettingsChanged_ChannelMode verifies that a real channel-mode edit
+// triggers reconfiguration while a no-op transition between the empty default and
+// its canonical form ("" <-> "downmix") does NOT. An unset mode and an explicit
+// "downmix" produce identical FFmpeg arguments, so treating them as a change would
+// restart the stream (a brief audio drop) for no functional reason. The frontend
+// now sends an explicit "downmix" where it previously sent "", which is exactly
+// when this no-op transition occurs on the first save.
+func TestStreamsSettingsChanged_ChannelMode(t *testing.T) {
+	t.Parallel()
+
+	makeSettings := func(mode conf.ChannelMode) *conf.Settings {
+		s := &conf.Settings{}
+		s.Realtime.RTSP.Streams = []conf.StreamConfig{{
+			Name:        "Front Yard",
+			URL:         "rtsp://192.168.1.10/stream",
+			Type:        conf.StreamTypeRTSP,
+			Transport:   "tcp",
+			Enabled:     true,
+			ChannelMode: mode,
+			Models:      []string{"birdnet"},
+		}}
+		return s
+	}
+
+	tests := []struct {
+		name string
+		old  conf.ChannelMode
+		new  conf.ChannelMode
+		want bool
+	}{
+		{"unset to explicit downmix is a no-op", "", conf.ChannelModeDownmix, false},
+		{"explicit downmix to unset is a no-op", conf.ChannelModeDownmix, "", false},
+		{"identical left", conf.ChannelModeLeft, conf.ChannelModeLeft, false},
+		{"unset to left changes", "", conf.ChannelModeLeft, true},
+		{"downmix to left changes", conf.ChannelModeDownmix, conf.ChannelModeLeft, true},
+		{"left to right changes", conf.ChannelModeLeft, conf.ChannelModeRight, true},
+		{"left to downmix changes", conf.ChannelModeLeft, conf.ChannelModeDownmix, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			old := makeSettings(tc.old)
+			cur := makeSettings(tc.new)
+			assert.Equal(t, tc.want, streamsSettingsChanged(old, cur))
+		})
+	}
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -562,6 +562,18 @@ const (
 // DefaultChannelMode is used when no channel mode is specified.
 const DefaultChannelMode = ChannelModeDownmix
 
+// Canonical returns the effective channel mode, treating an empty value as the
+// default (downmix). An unset mode and an explicit "downmix" produce identical
+// FFmpeg arguments, so callers comparing modes (e.g. hot-reload change detection)
+// should compare canonical values to avoid treating that no-op transition as a
+// real change that would needlessly restart the stream.
+func (m ChannelMode) Canonical() ChannelMode {
+	if m == "" {
+		return DefaultChannelMode
+	}
+	return m
+}
+
 // ValidChannelModes is the set of accepted channel mode values.
 var ValidChannelModes = map[ChannelMode]bool{
 	ChannelModeDownmix: true,


### PR DESCRIPTION
## Summary

Fixes the per-stream channel mode UI reported in #3348. An unset channel mode comes back from the API as an empty string (the JSON tag has no `omitempty`), and the form's `?? 'downmix'` fallback did not catch `""`, so the dropdown showed a blank "Select..." after every reload. The selector was also shown on every stream, including mono sources where downmix/left/right are identical, and the detected stream format was never surfaced in the form.

### Changes
- New shared `StreamChannelControls` component used by both the add and edit stream forms, with adaptive gating:
  - Multi-channel source: channel-mode selector + energy analysis + warnings.
  - Mono source: detected format and a "single channel, no selection needed" note, no selector.
  - Untested stream: prompt to test first.
  - An explicit left/right keeps the selector visible even when the source is offline or probes as mono, so a prior choice stays editable.
- Surface the detected audio format (e.g. "Stereo (2 channels)", with sample rate when known from a test).
- Normalize an empty/unknown channel mode to downmix for display, fixing both the selector default and the stereo-downmix warning.
- Add `ChannelMode.Canonical()` and use it in the hot-reload change detection (`streamsSettingsChanged`, `sourceNeedsReconfigure`) so an empty vs explicit "downmix" transition no longer triggers a needless stream restart.
- Invalidate in-flight channel analysis on edit cancel/reopen.
- Translate the new strings into all 15 locales.

## Related Issues
Fixes #3348

## Test Plan
- [x] New unit tests for the gating helper (`streamChannel.ts`) and the shared component
- [x] New Go tests for `ChannelMode.Canonical()` in both change-detection paths
- [x] `npm run check:all` clean; full frontend test suite passes
- [x] `golangci-lint` 0 issues; `go test -race` passes for conf, api/v2, analysis
- [x] Verified live against real RTSP streams (stereo + mono): selector adapts to channel count, "Select..." is gone, an explicit channel mode persists and round-trips after reload, and FFmpeg restarts with the new channel filter when the mode changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New per-stream channel controls UI: format detection, analyze button, per-channel energy/ recommendation display, and sample-rate shown from analysis.

* **Bug Fixes**
  * Channel-mode equivalence normalized so unset vs explicit downmix won’t trigger needless reconfiguration.
  * In-progress analysis is invalidated when editing is cancelled to avoid stale results.
  * Byte-size display treats non-positive values as unknown.

* **Documentation**
  * Component inventory updated.

* **Tests**
  * Added unit and component tests covering channel UI, analysis, and normalization.

* **Localization**
  * Expanded channel/format translations for multiple locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->