### PR TITLE
test(classifier): guard model reload against inference use-after-free (#3336)

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -44,6 +44,11 @@ type speciesCacheEntry struct {
 
 // BirdNET struct represents the BirdNET model with interpreters and configuration.
 type BirdNET struct {
+	// classifier and rangeFilter are the native inference backends (TFLite/ONNX).
+	// They are NOT goroutine-safe and free native resources in Close(). Per the mu
+	// invariant below, callers read the field and run the native call (Predict /
+	// PredictSpeciesScores) under mu, and Close() the backend under mu, so a
+	// concurrent reload or Delete can never free an interpreter mid-call (issue #3336).
 	classifier  inference.Classifier  // species classification backend
 	rangeFilter inference.RangeFilter // geographic range filter backend (may be nil)
 	// rangeFilterFellBack is true when the configured ONNX geomodel could not be loaded
@@ -58,9 +63,14 @@ type BirdNET struct {
 	TaxonomyPath        string              // Path to custom taxonomy file, if used
 	modelVersion        string              // Human-readable model version string (per-instance to avoid shared global state)
 	modelsDir           string              // base directory for gallery-installed models (set by Orchestrator)
-	mu                  sync.Mutex
-	resultsBuffer       []datastore.Results // Pre-allocated buffer for results to reduce allocations
-	confidenceBuffer    []float32           // Pre-allocated buffer for confidence values to reduce allocations
+	// mu guards the inference backends (classifier, rangeFilter, rangeFilterFellBack)
+	// and the model metadata reloaded with them. Inference holds mu for the full
+	// duration of the native call, not just the field read: the backends are not
+	// goroutine-safe and reload/Delete Close() them under mu, so dropping mu before
+	// the native call would reintroduce the issue #3336 use-after-free segfault.
+	mu               sync.Mutex
+	resultsBuffer    []datastore.Results // Pre-allocated buffer for results to reduce allocations
+	confidenceBuffer []float32           // Pre-allocated buffer for confidence values to reduce allocations
 
 	// Species occurrence cache to avoid repeated GetProbableSpecies calls within same day
 	speciesCacheMu sync.RWMutex
@@ -760,7 +770,9 @@ func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]floa
 	return out, nil
 }
 
-// Delete releases resources used by the inference backends.
+// Delete releases resources used by the inference backends. The backends are
+// Closed under mu so the native free cannot race with an in-flight inference,
+// which would otherwise be a use-after-free segfault (issue #3336).
 func (bn *BirdNET) Delete() {
 	bn.mu.Lock()
 	if bn.classifier != nil {
@@ -1214,7 +1226,9 @@ func (bn *BirdNET) reloadModelInternal() error {
 			Build()
 	}
 
-	// Explicitly close old backends to release native resources promptly.
+	// Explicitly close old backends to release native resources promptly. This runs
+	// under mu (held for the whole reload), so it cannot race with an in-flight
+	// inference, which also holds mu across its native call (issue #3336).
 	// ONNX Close() calls session.Destroy() which frees via ort_api->ReleaseSession().
 	// TFLite Close() calls interpreter.Delete() which immediately frees native
 	// resources via C.TfLiteInterpreterDelete and cascades to model/options/delegates.

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -63,11 +63,13 @@ type BirdNET struct {
 	TaxonomyPath        string              // Path to custom taxonomy file, if used
 	modelVersion        string              // Human-readable model version string (per-instance to avoid shared global state)
 	modelsDir           string              // base directory for gallery-installed models (set by Orchestrator)
-	// mu guards the inference backends (classifier, rangeFilter, rangeFilterFellBack)
-	// and the model metadata reloaded with them. Inference holds mu for the full
-	// duration of the native call, not just the field read: the backends are not
-	// goroutine-safe and reload/Delete Close() them under mu, so dropping mu before
-	// the native call would reintroduce the issue #3336 use-after-free segfault.
+	// mu guards the inference backends (classifier, rangeFilter, rangeFilterFellBack).
+	// Inference holds mu for the full duration of the native call, not just the field
+	// read: the backends are not goroutine-safe and reload/Delete Close() them under
+	// mu, so dropping mu before the native call would reintroduce the issue #3336
+	// use-after-free segfault. (mu is not a complete guard for ModelInfo, which
+	// reloadModelInternal writes under mu but the Spec/ModelID/ModelName getters read
+	// without it.)
 	mu               sync.Mutex
 	resultsBuffer    []datastore.Results // Pre-allocated buffer for results to reduce allocations
 	confidenceBuffer []float32           // Pre-allocated buffer for confidence values to reduce allocations

--- a/internal/classifier/birdnet_backend_lifecycle_race_test.go
+++ b/internal/classifier/birdnet_backend_lifecycle_race_test.go
@@ -2,9 +2,11 @@ package classifier
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/inference"
 )
@@ -23,18 +25,29 @@ import (
 // inference call that no longer holds bn.mu races on `live` against the
 // concurrent Close(), so this test fails the moment the invariant is broken.
 
+// lifecycleStats counts inference calls that actually reached a live backend
+// (nil backends short-circuit before Predict), shared across every fake instance
+// installed during one subtest. The final assertions use it to confirm the test
+// did not pass vacuously by only ever hitting nil-backend fast paths.
+type lifecycleStats struct {
+	classifierCalls  atomic.Int64
+	rangeFilterCalls atomic.Int64
+}
+
 // lifecycleClassifier implements inference.Classifier and models a native
 // classifier whose Close() frees a buffer that Predict() reads.
 type lifecycleClassifier struct {
 	numSpecies int
+	stats      *lifecycleStats
 	live       []float32 // native interpreter buffer; freed by Close, read by Predict
 }
 
-func newLifecycleClassifier(numSpecies int) *lifecycleClassifier {
-	return &lifecycleClassifier{numSpecies: numSpecies, live: make([]float32, numSpecies)}
+func newLifecycleClassifier(numSpecies int, stats *lifecycleStats) *lifecycleClassifier {
+	return &lifecycleClassifier{numSpecies: numSpecies, stats: stats, live: make([]float32, numSpecies)}
 }
 
 func (c *lifecycleClassifier) Predict(_ []float32) ([]float32, error) {
+	c.stats.classifierCalls.Add(1)
 	out := make([]float32, c.numSpecies)
 	copy(out, c.live) // touch the freed-on-Close resource
 	return out, nil
@@ -46,14 +59,16 @@ func (c *lifecycleClassifier) Close()          { c.live = nil }
 // path: GetProbableSpecies -> predictFilter -> rangeFilter.Predict).
 type lifecycleRangeFilter struct {
 	numSpecies int
+	stats      *lifecycleStats
 	live       []float32
 }
 
-func newLifecycleRangeFilter(numSpecies int) *lifecycleRangeFilter {
-	return &lifecycleRangeFilter{numSpecies: numSpecies, live: make([]float32, numSpecies)}
+func newLifecycleRangeFilter(numSpecies int, stats *lifecycleStats) *lifecycleRangeFilter {
+	return &lifecycleRangeFilter{numSpecies: numSpecies, stats: stats, live: make([]float32, numSpecies)}
 }
 
 func (r *lifecycleRangeFilter) Predict(_, _, _ float32) ([]float32, error) {
+	r.stats.rangeFilterCalls.Add(1)
 	out := make([]float32, r.numSpecies)
 	copy(out, r.live) // touch the freed-on-Close resource
 	return out, nil
@@ -65,14 +80,16 @@ func (r *lifecycleRangeFilter) Close()          { r.live = nil }
 // so GetProbableSpecies takes the universal (PredictSpeciesScores) path.
 type lifecycleUniversalRangeFilter struct {
 	labels []string
+	stats  *lifecycleStats
 	live   []float32
 }
 
-func newLifecycleUniversalRangeFilter(labels []string) *lifecycleUniversalRangeFilter {
-	return &lifecycleUniversalRangeFilter{labels: labels, live: make([]float32, len(labels))}
+func newLifecycleUniversalRangeFilter(labels []string, stats *lifecycleStats) *lifecycleUniversalRangeFilter {
+	return &lifecycleUniversalRangeFilter{labels: labels, stats: stats, live: make([]float32, len(labels))}
 }
 
 func (r *lifecycleUniversalRangeFilter) Predict(_, _, _ float32) ([]float32, error) {
+	r.stats.rangeFilterCalls.Add(1)
 	out := make([]float32, len(r.labels))
 	copy(out, r.live)
 	return out, nil
@@ -82,6 +99,7 @@ func (r *lifecycleUniversalRangeFilter) Close()                   { r.live = nil
 func (r *lifecycleUniversalRangeFilter) GeomodelLabels() []string { return r.labels }
 
 func (r *lifecycleUniversalRangeFilter) PredictSpeciesScores(_, _, _, _ float32) ([]SpeciesScore, error) {
+	r.stats.rangeFilterCalls.Add(1)
 	probe := make([]float32, len(r.labels))
 	copy(probe, r.live) // touch the freed-on-Close resource
 	scores := make([]SpeciesScore, len(r.labels))
@@ -104,20 +122,26 @@ func TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		newFilter func() inference.RangeFilter
+		newFilter func(stats *lifecycleStats) inference.RangeFilter
 	}{
 		{
-			name:      "legacy range filter Predict path",
-			newFilter: func() inference.RangeFilter { return newLifecycleRangeFilter(len(labels)) },
+			name: "legacy range filter Predict path",
+			newFilter: func(stats *lifecycleStats) inference.RangeFilter {
+				return newLifecycleRangeFilter(len(labels), stats)
+			},
 		},
 		{
-			name:      "universal range filter PredictSpeciesScores path",
-			newFilter: func() inference.RangeFilter { return newLifecycleUniversalRangeFilter(labels) },
+			name: "universal range filter PredictSpeciesScores path",
+			newFilter: func(stats *lifecycleStats) inference.RangeFilter {
+				return newLifecycleUniversalRangeFilter(labels, stats)
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			stats := &lifecycleStats{}
+
 			// Build via struct literal (not NewBirdNET) so the test runs without an
 			// embedded model. The explicit-settings range-filter call below uses this
 			// snapshot directly, so location/labels take effect regardless of any
@@ -133,8 +157,8 @@ func TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace(t *testing.T) {
 				Settings:     settings,
 				speciesCache: make(map[string]*speciesCacheEntry),
 				ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
-				classifier:   newLifecycleClassifier(len(labels)),
-				rangeFilter:  tt.newFilter(),
+				classifier:   newLifecycleClassifier(len(labels), stats),
+				rangeFilter:  tt.newFilter(stats),
 			}
 			bn.settingsAtomic.Store(settings)
 
@@ -142,6 +166,15 @@ func TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace(t *testing.T) {
 			ctx := t.Context()
 			sample := [][]float32{{0.1}}
 			now := time.Now()
+
+			// Warm up both inference paths on the initial live backends before the
+			// concurrent storm. The fakes count the call as they enter the native
+			// step, so this guarantees each path is exercised at least once even if
+			// the Delete writer below keeps the backends nil for much of the run.
+			// It makes the call-count assertions deterministic rather than relying
+			// on the scheduler to land a read on a live backend.
+			_, _ = bn.Predict(ctx, sample)
+			_, _ = bn.GetProbableSpeciesWithSettings(now, 0, settings)
 
 			var wg sync.WaitGroup
 			start := make(chan struct{})
@@ -174,11 +207,11 @@ func TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace(t *testing.T) {
 					if bn.classifier != nil {
 						bn.classifier.Close()
 					}
-					bn.classifier = newLifecycleClassifier(len(labels))
+					bn.classifier = newLifecycleClassifier(len(labels), stats)
 					if bn.rangeFilter != nil {
 						bn.rangeFilter.Close()
 					}
-					bn.rangeFilter = tt.newFilter()
+					bn.rangeFilter = tt.newFilter(stats)
 					bn.mu.Unlock()
 				}
 			})
@@ -195,6 +228,14 @@ func TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace(t *testing.T) {
 
 			close(start)
 			wg.Wait()
+
+			// Guard against a vacuous pass: confirm both inference paths actually ran
+			// on a live backend (nil backends short-circuit before the native call),
+			// so the race window above was genuinely exercised.
+			require.Positive(t, stats.classifierCalls.Load(),
+				"classifier Predict path never ran on a live backend")
+			require.Positive(t, stats.rangeFilterCalls.Load(),
+				"range-filter inference path never ran on a live backend")
 		})
 	}
 }

--- a/internal/classifier/birdnet_backend_lifecycle_race_test.go
+++ b/internal/classifier/birdnet_backend_lifecycle_race_test.go
@@ -1,0 +1,200 @@
+package classifier
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/inference"
+)
+
+// Regression guard for issue #3336: potential CGO segfault on model reload.
+//
+// The TFLite/ONNX classifier and range-filter interpreters are not
+// goroutine-safe and free their native resources in Close(). BirdNET protects
+// them with bn.mu: every native inference call (Predict / PredictSpeciesScores)
+// and every backend Close() must hold bn.mu for its full duration. If a path
+// dropped the lock before calling into the backend, a concurrent reload/Delete
+// could Close() the interpreter mid-call, a use-after-free segfault.
+//
+// The fakes below model that native lifecycle: Predict() reads `live` (the
+// interpreter buffer) and Close() frees it. Run under `go test -race`, an
+// inference call that no longer holds bn.mu races on `live` against the
+// concurrent Close(), so this test fails the moment the invariant is broken.
+
+// lifecycleClassifier implements inference.Classifier and models a native
+// classifier whose Close() frees a buffer that Predict() reads.
+type lifecycleClassifier struct {
+	numSpecies int
+	live       []float32 // native interpreter buffer; freed by Close, read by Predict
+}
+
+func newLifecycleClassifier(numSpecies int) *lifecycleClassifier {
+	return &lifecycleClassifier{numSpecies: numSpecies, live: make([]float32, numSpecies)}
+}
+
+func (c *lifecycleClassifier) Predict(_ []float32) ([]float32, error) {
+	out := make([]float32, c.numSpecies)
+	copy(out, c.live) // touch the freed-on-Close resource
+	return out, nil
+}
+func (c *lifecycleClassifier) NumSpecies() int { return c.numSpecies }
+func (c *lifecycleClassifier) Close()          { c.live = nil }
+
+// lifecycleRangeFilter implements inference.RangeFilter (legacy, non-universal
+// path: GetProbableSpecies -> predictFilter -> rangeFilter.Predict).
+type lifecycleRangeFilter struct {
+	numSpecies int
+	live       []float32
+}
+
+func newLifecycleRangeFilter(numSpecies int) *lifecycleRangeFilter {
+	return &lifecycleRangeFilter{numSpecies: numSpecies, live: make([]float32, numSpecies)}
+}
+
+func (r *lifecycleRangeFilter) Predict(_, _, _ float32) ([]float32, error) {
+	out := make([]float32, r.numSpecies)
+	copy(out, r.live) // touch the freed-on-Close resource
+	return out, nil
+}
+func (r *lifecycleRangeFilter) NumSpecies() int { return r.numSpecies }
+func (r *lifecycleRangeFilter) Close()          { r.live = nil }
+
+// lifecycleUniversalRangeFilter additionally implements UniversalSpeciesPredictor
+// so GetProbableSpecies takes the universal (PredictSpeciesScores) path.
+type lifecycleUniversalRangeFilter struct {
+	labels []string
+	live   []float32
+}
+
+func newLifecycleUniversalRangeFilter(labels []string) *lifecycleUniversalRangeFilter {
+	return &lifecycleUniversalRangeFilter{labels: labels, live: make([]float32, len(labels))}
+}
+
+func (r *lifecycleUniversalRangeFilter) Predict(_, _, _ float32) ([]float32, error) {
+	out := make([]float32, len(r.labels))
+	copy(out, r.live)
+	return out, nil
+}
+func (r *lifecycleUniversalRangeFilter) NumSpecies() int          { return len(r.labels) }
+func (r *lifecycleUniversalRangeFilter) Close()                   { r.live = nil }
+func (r *lifecycleUniversalRangeFilter) GeomodelLabels() []string { return r.labels }
+
+func (r *lifecycleUniversalRangeFilter) PredictSpeciesScores(_, _, _, _ float32) ([]SpeciesScore, error) {
+	probe := make([]float32, len(r.labels))
+	copy(probe, r.live) // touch the freed-on-Close resource
+	scores := make([]SpeciesScore, len(r.labels))
+	for i, label := range r.labels {
+		scores[i] = SpeciesScore{Score: 0, Label: label}
+	}
+	return scores, nil
+}
+
+// TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace exercises classifier and
+// range-filter inference concurrently with reload-style close+swap and Delete()
+// teardown, verifying (under -race) that bn.mu serializes inference against
+// backend destruction so the issue #3336 use-after-free cannot occur.
+func TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace(t *testing.T) {
+	labels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Corvus corax_Northern Raven",
+	}
+
+	tests := []struct {
+		name      string
+		newFilter func() inference.RangeFilter
+	}{
+		{
+			name:      "legacy range filter Predict path",
+			newFilter: func() inference.RangeFilter { return newLifecycleRangeFilter(len(labels)) },
+		},
+		{
+			name:      "universal range filter PredictSpeciesScores path",
+			newFilter: func() inference.RangeFilter { return newLifecycleUniversalRangeFilter(labels) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build via struct literal (not NewBirdNET) so the test runs without an
+			// embedded model. The explicit-settings range-filter call below uses this
+			// snapshot directly, so location/labels take effect regardless of any
+			// global test settings left by other tests.
+			settings := conf.GetTestSettings()
+			settings.BirdNET.Labels = labels
+			settings.BirdNET.LocationConfigured = true
+			settings.BirdNET.Latitude = 60.17
+			settings.BirdNET.Longitude = 24.94
+			settings.BirdNET.RangeFilter.Threshold = 0.0
+
+			bn := &BirdNET{
+				Settings:     settings,
+				speciesCache: make(map[string]*speciesCacheEntry),
+				ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+				classifier:   newLifecycleClassifier(len(labels)),
+				rangeFilter:  tt.newFilter(),
+			}
+			bn.settingsAtomic.Store(settings)
+
+			const iterations = 250
+			ctx := t.Context()
+			sample := [][]float32{{0.1}}
+			now := time.Now()
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			// Reader: classifier inference (analyze.go Predict path).
+			wg.Go(func() {
+				<-start
+				for range iterations {
+					_, _ = bn.Predict(ctx, sample)
+				}
+			})
+
+			// Reader: range-filter inference. The explicit-settings variant uses the
+			// location-configured snapshot deterministically so the native Predict /
+			// PredictSpeciesScores call is actually reached every iteration.
+			wg.Go(func() {
+				<-start
+				for range iterations {
+					_, _ = bn.GetProbableSpeciesWithSettings(now, 0, settings)
+				}
+			})
+
+			// Writer: simulate ReloadModel / ReloadRangeFilter by closing the old
+			// backends and installing fresh ones under bn.mu, exactly as the
+			// production reload paths do (the Close happens while the lock is held).
+			wg.Go(func() {
+				<-start
+				for range iterations {
+					bn.mu.Lock()
+					if bn.classifier != nil {
+						bn.classifier.Close()
+					}
+					bn.classifier = newLifecycleClassifier(len(labels))
+					if bn.rangeFilter != nil {
+						bn.rangeFilter.Close()
+					}
+					bn.rangeFilter = tt.newFilter()
+					bn.mu.Unlock()
+				}
+			})
+
+			// Writer: exercise the Delete() teardown path. Delete closes and nils both
+			// backends under bn.mu; the reload writer reinstalls them and the readers
+			// tolerate a nil backend.
+			wg.Go(func() {
+				<-start
+				for range iterations {
+					bn.Delete()
+				}
+			})
+
+			close(start)
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Issue #3336 reports a potential CGO segfault: `ReloadModel`/`Delete` call `Close()` on the active classifier and range-filter backends, which could be a use-after-free if inference runs concurrently.

After auditing every native call site, this cannot happen in the current code. Every native inference call holds `bn.mu` for the full duration of the call, and every backend `Close()` also holds `bn.mu`, so inference and destruction are mutually exclusive:

| Path | Native call | Holds `bn.mu` during call |
|------|-------------|---------------------------|
| `Predict` (analyze.go) | `classifier.Predict` | yes |
| `getProbableSpecies` legacy | `rangeFilter.Predict` | yes |
| `getProbableSpecies` universal | `PredictSpeciesScores` | yes |
| `BuildRangeFilter` | `PredictSpeciesScores` | yes |
| `Delete` / `reloadModelInternal` / `ReloadRangeFilter` | `Close()` | yes |

The alternative the issue suggests (reference counting, or an `RWMutex` with `RLock` for inference) would actually be unsafe: the TFLite/ONNX interpreters are not goroutine-safe, so allowing concurrent `Predict` on one interpreter is itself a data race.

The real gap is that this safety is implicit and untested, so a future "optimization" that snapshots the backend pointer and drops the lock before the native call would silently reintroduce the segfault. This PR makes the guarantee explicit and enforced, with **no change to runtime behavior**:

- Documents the `bn.mu` invariant on the struct fields and at the `Delete`/reload close sites: native inference calls and backend `Close()` must both hold `bn.mu`.
- Adds a concurrent regression test (`TestBirdNET_ConcurrentInferenceAndBackendReload_NoRace`) that runs classifier and range-filter inference (both the legacy and universal range-filter paths) against reload-style close+swap and `Delete` teardown. Under `go test -race` it fails if any inference path stops holding `bn.mu` across its native call.

## Test plan

- `go test -tags noembed,skipfrontend ./internal/classifier/` passes.
- `golangci-lint` clean.
- The new test is a `-race` guard (matching the existing `*_NoRace` tests in the package); CI runs the suite with `-race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race that could cause crashes during simultaneous model inference and backend reload/teardown.

* **Documentation**
  * Clarified concurrency and backend lifecycle guidance to explicitly describe required locking/usage for safe native interactions.

* **Tests**
  * Added a regression race test that simulates concurrent inference and backend lifecycle changes to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->