### PR TITLE
fix(frontend): preserve query string in post-login redirect (#3306)

### DIFF
--- a/frontend/src/lib/desktop/components/modals/LoginModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.svelte
@@ -70,8 +70,9 @@
         return false;
       }
 
-      // Prevent protocol-relative URLs
-      if (url.startsWith('//')) {
+      // Prevent protocol-relative URLs, including the backslash variant ('/\')
+      // that browsers normalize to '//' (open-redirect vector).
+      if (url.startsWith('//') || url.startsWith('/\\')) {
         return false;
       }
 
@@ -212,7 +213,9 @@
       }, 500);
     } catch {
       error = 'Invalid credentials. Please try again.';
-    } finally {
+      // Only re-enable on failure. On success the page navigates away (OAuth
+      // callback redirect) or reloads, so keeping the control disabled here
+      // prevents a double-submit firing redundant login requests mid-navigation.
       loadingState = 'idle';
     }
   }

--- a/frontend/src/lib/desktop/components/modals/LoginModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.svelte
@@ -65,14 +65,8 @@
   // SECURITY: Validate redirect URL to prevent open redirects
   function validateRedirectUrl(url: string): boolean {
     try {
-      // Only allow relative URLs starting with /
-      if (!url.startsWith('/')) {
-        return false;
-      }
-
-      // Prevent protocol-relative URLs, including the backslash variant ('/\')
-      // that browsers normalize to '//' (open-redirect vector).
-      if (url.startsWith('//') || url.startsWith('/\\')) {
+      // Only allow relative URLs starting with a single '/' (not protocol-relative).
+      if (!url.startsWith('/') || url.startsWith('//')) {
         return false;
       }
 
@@ -83,6 +77,15 @@
 
       // Check length
       if (url.length > MAX_REDIRECT_LENGTH) {
+        return false;
+      }
+
+      // Robust open-redirect guard: resolve against a sentinel origin and require
+      // the result to stay same-origin. The browser's URL parser catches backslash
+      // variants ('/\host' -> '//host'), mixed slashes, and control-character tricks
+      // that manual string checks can miss.
+      const base = 'http://relative-check.internal';
+      if (new URL(url, base).origin !== base) {
         return false;
       }
 
@@ -196,8 +199,11 @@
           action: 'handlePasswordLogin',
         });
 
-        // Backend returned OAuth callback URL to complete authentication
-        // Redirect immediately to complete the OAuth flow
+        // Backend returned OAuth callback URL to complete authentication.
+        // Close the modal first: its cleanup resets the loading state and removes
+        // the submit button, so if the navigation never commits we avoid both a UI
+        // deadlock (controls stuck disabled) and a double-submit during navigation.
+        onClose();
         window.location.href = response.redirectUrl;
         return; // Exit early - OAuth callback will handle the rest
       }

--- a/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
@@ -35,10 +35,11 @@ describe('LoginModal', () => {
   const loginModalTest = createComponentTestFactory(LoginModal);
 
   // Helper function to mock window.location
-  function mockWindowLocation(pathname = '/ui/') {
+  function mockWindowLocation(pathname = '/ui/', search = '') {
     const mockLocation = {
       href: '',
       pathname,
+      search,
       reload: vi.fn(),
     };
     Object.defineProperty(window, 'location', {
@@ -384,6 +385,38 @@ describe('LoginModal', () => {
   });
 
   describe('Redirect URL Duplication Prevention', () => {
+    it('should preserve the query string when extracting the relative redirect path', async () => {
+      const { api } = await import('$lib/utils/api');
+      const postSpy = vi.mocked(api.post);
+      postSpy.mockResolvedValue({ success: true, message: 'Login successful' });
+
+      mockWindowLocation('/ui/detections', '?queryType=species&species=Phoenicurus+phoenicurus');
+
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+        redirectUrl: '/ui/detections?queryType=species&species=Phoenicurus+phoenicurus',
+        authConfig: { basicEnabled: true, enabledProviders: [] },
+      });
+
+      const passwordInput = screen.getByLabelText('auth.password');
+      const loginButton = screen.getByRole('button', { name: /continue with password/i });
+
+      await fireEvent.input(passwordInput, { target: { value: 'valid-password' } });
+      await fireEvent.click(loginButton);
+
+      await waitFor(() => {
+        expect(postSpy).toHaveBeenCalledWith(
+          '/api/v2/auth/login',
+          expect.objectContaining({
+            // Base path stripped, query string preserved.
+            redirectUrl: '/detections?queryType=species&species=Phoenicurus+phoenicurus',
+            basePath: '/ui/',
+          })
+        );
+      });
+    });
+
     it('should extract relative path when redirectUrl contains base path', async () => {
       const { api } = await import('$lib/utils/api');
       const postSpy = vi.mocked(api.post);

--- a/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
@@ -789,6 +789,7 @@ describe('LoginModal', () => {
     it('should handle OAuth callback redirect preserving original URL', async () => {
       const { api } = await import('$lib/utils/api');
       const postSpy = vi.mocked(api.post);
+      const onCloseMock = vi.fn();
       const mockLocation = mockWindowLocation('/ui/settings/main');
 
       // Mock successful login with OAuth callback
@@ -800,7 +801,7 @@ describe('LoginModal', () => {
 
       loginModalTest.render({
         isOpen: true,
-        onClose: vi.fn(),
+        onClose: onCloseMock,
         redirectUrl: '/ui/settings/main', // User was on settings page
         authConfig: { basicEnabled: true, enabledProviders: [] },
       });
@@ -825,6 +826,10 @@ describe('LoginModal', () => {
 
       // Verify OAuth redirect happens immediately
       expect(mockLocation.href).toBe('/api/v2/auth/callback?code=123&state=settings%2Fmain');
+
+      // Modal is closed before navigating so its cleanup resets loading state and
+      // the submit button is gone (prevents deadlock / double-submit on navigation).
+      expect(onCloseMock).toHaveBeenCalled();
     });
 
     it('should handle edge case of user on root path', async () => {

--- a/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
@@ -116,6 +116,19 @@ describe('LoginModal', () => {
       expect(redirectInput.value).toBe('/ui/');
     });
 
+    it('should reject backslash protocol-relative URLs and fallback to base path', () => {
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+        redirectUrl: '/\\evil.com/malicious',
+      });
+
+      // Browsers normalize '/\' to '//', so this must fall back to the base path.
+      const redirectInput = screen.getByDisplayValue('/ui/') as HTMLInputElement;
+      expect(redirectInput).toBeDefined();
+      expect(redirectInput.value).toBe('/ui/');
+    });
+
     it('should reject javascript: URLs and fallback to base path', () => {
       loginModalTest.render({
         isOpen: true,

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -83,6 +83,7 @@ Performance Optimizations:
   import { GITHUB_REPO_URL, GITHUB_DISCUSSIONS_URL } from '$lib/utils/externalUrls';
   import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
   import { resetDateToToday } from '$lib/utils/datePersistence';
+  import { getCurrentPathWithQuery } from '$lib/utils/urlHelpers';
   import LoginModal from '../components/modals/LoginModal.svelte';
   import LogoBadge from '$lib/components/LogoBadge.svelte';
   import { scheme } from '$lib/stores/scheme';
@@ -120,6 +121,9 @@ Performance Optimizations:
 
   // State for login modal and collapsible sections
   let showLoginModal = $state(false);
+  // Snapshot of the URL (path + query) the user was on when they opened the login
+  // modal, so a login from a filtered view returns them to that exact view (#3306).
+  let loginRedirectUrl = $state('/ui/');
   let analyticsExpanded = $state(false);
   let settingsExpanded = $state(false);
   let systemExpanded = $state(false);
@@ -403,6 +407,9 @@ Performance Optimizations:
   }
 
   function handleLogin() {
+    // Capture the full current location (path + query) at click time so the
+    // post-login redirect returns the user to the exact filtered view (#3306).
+    loginRedirectUrl = getCurrentPathWithQuery();
     showLoginModal = true;
   }
 
@@ -746,7 +753,7 @@ Performance Optimizations:
 <LoginModal
   isOpen={showLoginModal}
   onClose={() => (showLoginModal = false)}
-  redirectUrl={window.location.pathname}
+  redirectUrl={loginRedirectUrl}
   {authConfig}
 />
 

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createComponentTestFactory,
+  fireEvent,
+  screen,
+  waitFor,
+} from '../../../test/render-helpers';
+import DesktopSidebar from './DesktopSidebar.svelte';
+
+// Translation mock: return the key so aria-labels are stable and queryable.
+vi.mock('$lib/i18n', () => ({
+  t: vi.fn((key: string) => key),
+  getLocale: vi.fn(() => 'en'),
+}));
+
+describe('DesktopSidebar - post-login redirect wiring (#3306)', () => {
+  const sidebarTest = createComponentTestFactory(DesktopSidebar);
+  const originalLocationDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+
+  function setLocation(pathname: string, search: string) {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { href: '', pathname, search, reload: vi.fn() },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The LoginModal focus trap reads layout/styles; stub them for jsdom.
+    Object.defineProperty(window, 'getComputedStyle', {
+      value: vi.fn(() => ({
+        getPropertyValue: vi.fn(() => ''),
+        visibility: 'visible',
+        display: 'block',
+      })),
+      writable: true,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'focus', { value: vi.fn(), writable: true });
+  });
+
+  afterEach(() => {
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, 'location', originalLocationDescriptor);
+    }
+  });
+
+  it('passes the full path + query string of the current view to LoginModal on login click', async () => {
+    setLocation(
+      '/ui/detections',
+      '?queryType=species&species=Phoenicurus+phoenicurus&date=2026-06-02'
+    );
+
+    sidebarTest.render({
+      securityEnabled: true,
+      accessAllowed: false, // not logged in -> the login button is shown
+      authConfig: { basicEnabled: true, enabledProviders: [] },
+    });
+
+    // Open the login modal via the login button.
+    const loginButton = screen.getByRole('button', { name: 'auth.openLoginModal' });
+    await fireEvent.click(loginButton);
+
+    // LoginModal renders a hidden <input name="redirect"> bound to the redirect target.
+    // It must carry the FULL current URL, query string included (the #3306 fix).
+    await waitFor(() => {
+      const redirectInput = screen.getByDisplayValue(
+        '/ui/detections?queryType=species&species=Phoenicurus+phoenicurus&date=2026-06-02'
+      ) as HTMLInputElement;
+      expect(redirectInput.name).toBe('redirect');
+    });
+  });
+
+  it('passes only the path when the current view has no query string', async () => {
+    setLocation('/ui/dashboard', '');
+
+    sidebarTest.render({
+      securityEnabled: true,
+      accessAllowed: false,
+      authConfig: { basicEnabled: true, enabledProviders: [] },
+    });
+
+    const loginButton = screen.getByRole('button', { name: 'auth.openLoginModal' });
+    await fireEvent.click(loginButton);
+
+    await waitFor(() => {
+      const redirectInput = screen.getByDisplayValue('/ui/dashboard') as HTMLInputElement;
+      expect(redirectInput.name).toBe('redirect');
+    });
+  });
+});

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -25,7 +25,7 @@
   import type { Detection, ImageAttribution } from '$lib/types/detection.types';
   import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
   import { formatLocalDateTime } from '$lib/utils/date';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { buildAppUrl, getCurrentPathWithQuery } from '$lib/utils/urlHelpers';
   import { loggers } from '$lib/utils/logger';
   import {
     Download,
@@ -394,7 +394,7 @@
       }
 
       const newUrl = url.pathname + url.search;
-      if (newUrl !== window.location.pathname + window.location.search) {
+      if (newUrl !== getCurrentPathWithQuery()) {
         window.history.replaceState(null, '', newUrl);
       }
     }

--- a/frontend/src/lib/utils/urlHelpers.test.ts
+++ b/frontend/src/lib/utils/urlHelpers.test.ts
@@ -173,6 +173,12 @@ describe('URL Helpers', () => {
       expect(isRelativePath('//example.com/path')).toBe(false);
     });
 
+    it('should return false for backslash protocol-relative URLs', () => {
+      // Browsers normalize '/\' to '//', so these are open-redirect vectors.
+      expect(isRelativePath('/\\evil.com')).toBe(false);
+      expect(isRelativePath('/\\\\evil.com')).toBe(false);
+    });
+
     it('should return false for absolute URLs', () => {
       expect(isRelativePath('http://example.com')).toBe(false);
       expect(isRelativePath('https://example.com')).toBe(false);

--- a/frontend/src/lib/utils/urlHelpers.test.ts
+++ b/frontend/src/lib/utils/urlHelpers.test.ts
@@ -7,6 +7,7 @@ import {
   buildAppUrl,
   setBasePath,
   resetBasePath,
+  getCurrentPathWithQuery,
 } from './urlHelpers';
 import { loggers } from './logger';
 
@@ -578,6 +579,47 @@ describe('URL Helpers', () => {
 
       expect(buildAppUrl('/api/v2/detections/123')).toBe('/api/v2/detections/123');
       expect(buildAppUrl('/ui/assets/messages/en.json')).toBe('/ui/assets/messages/en.json');
+    });
+  });
+
+  describe('getCurrentPathWithQuery', () => {
+    // window.location's assignment target is effectively `string & Location`, so a
+    // `search` property in an object literal collides with String.prototype.search.
+    // Defining the property directly sidesteps that setter typing (same approach as
+    // LoginModal.test.ts) and keeps the literal prettier-stable.
+    function setLocation(pathname: string, search: string) {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: { pathname, search },
+      });
+    }
+
+    it('returns path plus query string when a query is present', () => {
+      setLocation(
+        '/ui/detections',
+        '?queryType=species&species=Phoenicurus+phoenicurus&date=2026-06-02&hour=7'
+      );
+      expect(getCurrentPathWithQuery()).toBe(
+        '/ui/detections?queryType=species&species=Phoenicurus+phoenicurus&date=2026-06-02&hour=7'
+      );
+    });
+
+    it('returns only the path when there is no query string', () => {
+      setLocation('/ui/dashboard', '');
+      expect(getCurrentPathWithQuery()).toBe('/ui/dashboard');
+    });
+
+    it('returns the bare base path with its query string from the root UI path', () => {
+      setLocation('/ui/', '?date=2026-06-02');
+      expect(getCurrentPathWithQuery()).toBe('/ui/?date=2026-06-02');
+    });
+
+    it('preserves an already-encoded query string verbatim', () => {
+      setLocation('/ui/detections', '?species=Erithacus%20rubecula&offset=0');
+      expect(getCurrentPathWithQuery()).toBe(
+        '/ui/detections?species=Erithacus%20rubecula&offset=0'
+      );
     });
   });
 });

--- a/frontend/src/lib/utils/urlHelpers.ts
+++ b/frontend/src/lib/utils/urlHelpers.ts
@@ -74,7 +74,9 @@ export function isRelativePath(path: string): boolean {
     return false;
   }
 
-  return path.startsWith('/') && !path.startsWith('//');
+  // Reject protocol-relative URLs ('//host') and the backslash variant ('/\\host'),
+  // which browsers normalize to '//host' and would enable an open redirect.
+  return path.startsWith('/') && !path.startsWith('//') && !path.startsWith('/\\');
 }
 
 /**

--- a/frontend/src/lib/utils/urlHelpers.ts
+++ b/frontend/src/lib/utils/urlHelpers.ts
@@ -207,3 +207,31 @@ export function buildAppUrl(path: string): string {
 
   return basePath + path;
 }
+
+/**
+ * Returns the current location's path together with its query string
+ * (e.g. '/ui/detections?species=Foo&date=2026-06-02'), excluding origin and hash.
+ *
+ * Use this to capture a post-login redirect target so a user who logs in from a
+ * filtered view returns to the exact same view. The hash fragment is intentionally
+ * omitted: it is never sent to the server and would not survive the server-driven
+ * OAuth callback redirect that completes the login.
+ *
+ * @returns The current relative URL (path + query), or '/' when window is unavailable (SSR/tests).
+ *
+ * @example
+ * // location: /ui/detections?species=Foo&offset=0
+ * getCurrentPathWithQuery() // returns '/ui/detections?species=Foo&offset=0'
+ *
+ * @example
+ * // location: /ui/dashboard (no query)
+ * getCurrentPathWithQuery() // returns '/ui/dashboard'
+ */
+export function getCurrentPathWithQuery(): string {
+  if (typeof window === 'undefined') {
+    return '/';
+  }
+  // window.location.search is '' when there is no query string and always
+  // includes the leading '?' when one is present.
+  return window.location.pathname + window.location.search;
+}

--- a/frontend/src/lib/utils/urlHelpers.ts
+++ b/frontend/src/lib/utils/urlHelpers.ts
@@ -74,9 +74,21 @@ export function isRelativePath(path: string): boolean {
     return false;
   }
 
-  // Reject protocol-relative URLs ('//host') and the backslash variant ('/\\host'),
-  // which browsers normalize to '//host' and would enable an open redirect.
-  return path.startsWith('/') && !path.startsWith('//') && !path.startsWith('/\\');
+  // Must start with a single '/' and not be protocol-relative.
+  if (!path.startsWith('/') || path.startsWith('//')) {
+    return false;
+  }
+
+  // Robust open-redirect guard: resolve against a sentinel origin and require
+  // the result to stay same-origin. This delegates to the browser's URL parser,
+  // which catches backslash variants ('/\host' -> '//host'), mixed slashes, and
+  // control-character tricks that manual string checks can miss.
+  try {
+    const base = 'http://relative-check.internal';
+    return new URL(path, base).origin === base;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Logging in from a filtered detections view (for example `/ui/detections?queryType=species&species=...&date=...&hour=...`) dropped the user back on the bare `/ui/detections` instead of the filtered view they were looking at.

Root cause: `DesktopSidebar.svelte` passed `redirectUrl={window.location.pathname}` to `LoginModal`, which omits `window.location.search`, so the query string was lost before the login request was even built. The rest of the chain (the modal's redirect validation, `extractRelativePath`, the backend login handler's `url.QueryEscape`, and the OAuth callback's `validateAndSanitizeRedirect`) all already preserve query strings, so the fix is purely at the capture point.

### Changes

- Add an SSR-safe `getCurrentPathWithQuery()` helper to `urlHelpers.ts` (`pathname + search`).
- `DesktopSidebar.handleLogin()` now snapshots the full current URL at click time into a `$state` and passes it to `LoginModal`, instead of reading a query-less `window.location.pathname` inline.
- Reuse the new helper in `DetectionDetail.svelte` (replaces an inline `pathname + search` duplicate).

### Hardening surfaced by review (bonus, same area)

- Reject backslash protocol-relative redirect URLs (`/\host`, which browsers normalize to `//`) in both `validateRedirectUrl` and `isRelativePath`. The backend already rejected these; this closes the client-side gap.
- Reset the login button's loading state only on failure. On success the page navigates (OAuth callback) or reloads, so keeping the control disabled prevents a double-submit firing redundant login requests during navigation.

### Scope notes

- Only basic/password login is fixed. OAuth social logins (Google/GitHub) do not yet preserve the current page; that needs backend OAuth `state` handling and is tracked separately.

## Related Issues

Fixes #3306

## Test Plan

- [x] `npm run check:all` passes (typecheck, eslint, stylelint, prettier, ast-grep).
- [x] New unit tests for `getCurrentPathWithQuery` (path+query, no-query, encoded query).
- [x] New `LoginModal` test asserting a query-bearing `redirectUrl` is forwarded with the query intact, plus a backslash open-redirect rejection test.
- [x] New `DesktopSidebar` seam test (verified it fails on the pre-fix code) asserting the login button forwards the full path+query to the modal.
- [ ] Manual: log in from a filtered detections view and confirm you return to the same filtered URL; confirm an unfiltered page still returns to the same page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login now returns users to their exact prior view (path + query) after signing in.

* **Security**
  * Strengthened redirect validation to block malformed or protocol-relative redirect inputs.

* **Bug Fixes**
  * Modal closes reliably before navigating on successful OAuth redirects to avoid stuck submit/loading states.

* **Tests**
  * Expanded tests to cover redirect validation, query preservation, and post-login wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->