### PR TITLE
fix(auth): harden post-login redirect validation and base-path handling

### DIFF
--- a/frontend/src/lib/desktop/components/modals/LoginModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.svelte
@@ -106,11 +106,11 @@
   // SECURITY: Sanitize and validate password input
   function validatePassword(pwd: string): { isValid: boolean; error?: string } {
     if (!pwd) {
-      return { isValid: false, error: 'Password is required' };
+      return { isValid: false, error: t('auth.errors.passwordRequired') };
     }
 
     if (pwd.length > MAX_PASSWORD_LENGTH) {
-      return { isValid: false, error: 'Password is too long' };
+      return { isValid: false, error: t('auth.errors.passwordTooLong') };
     }
 
     // Check for control characters (ASCII < 32) and other dangerous characters
@@ -118,7 +118,7 @@
       const charCode = pwd.charCodeAt(i);
       if (charCode < 32 && charCode !== 9) {
         // Allow tab (9) but reject other control chars
-        return { isValid: false, error: 'Password contains invalid characters' };
+        return { isValid: false, error: t('auth.errors.invalidCharacters') };
       }
     }
 
@@ -134,7 +134,7 @@
     const trimmedPassword = password.trim();
     const passwordValidation = validatePassword(trimmedPassword);
     if (!passwordValidation.isValid) {
-      error = passwordValidation.error || 'Invalid input';
+      error = passwordValidation.error || t('auth.errors.invalidInput');
       return;
     }
 
@@ -200,7 +200,7 @@
         window.location.reload();
       }, 500);
     } catch {
-      error = 'Invalid credentials. Please try again.';
+      error = t('auth.errors.loginFailed');
       // Only re-enable on failure. On success the page navigates away (OAuth
       // callback redirect) or reloads, so keeping the control disabled here
       // prevents a double-submit firing redundant login requests mid-navigation.
@@ -213,7 +213,7 @@
     // Get provider from registry
     const provider = getProvider(providerId);
     if (!provider) {
-      error = 'Unknown authentication provider.';
+      error = t('auth.errors.configurationError');
       return;
     }
 
@@ -223,7 +223,7 @@
 
     // SECURITY: Basic endpoint validation - accept OAuth and API v2 auth formats
     if (!endpoint || (!endpoint.startsWith('/auth/') && !endpoint.startsWith('/api/v2/auth/'))) {
-      error = 'Configuration error. Please contact your administrator.';
+      error = t('auth.errors.configurationError');
       return;
     }
 

--- a/frontend/src/lib/desktop/components/modals/LoginModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.svelte
@@ -10,8 +10,8 @@
 -->
 <script lang="ts">
   import { api } from '$lib/utils/api';
-  import { safeGet, safeArrayAccess, safeElementAccess } from '$lib/utils/security';
-  import { extractRelativePath } from '$lib/utils/urlHelpers';
+  import { safeGet, safeElementAccess } from '$lib/utils/security';
+  import { extractRelativePath, getUiBasePath } from '$lib/utils/urlHelpers';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
   import { X, ShieldCheck, KeyRound } from '@lucide/svelte';
@@ -20,6 +20,9 @@
 
   // SECURITY: Define maximum password length to prevent DoS
   const MAX_PASSWORD_LENGTH = 512; // Reasonable limit for security
+  // Client-side cap on the captured redirect (path + query). Intentionally a bit
+  // tighter than the backend's authoritative security.MaxSafeRedirectLength (2048)
+  // so anything the client sends comfortably passes server validation.
   const MAX_REDIRECT_LENGTH = 2000;
 
   // Logger for authentication debugging
@@ -51,7 +54,7 @@
 
   // Compute safe redirect URL immediately
   let safeRedirectUrl = $derived(
-    redirectUrl && validateRedirectUrl(redirectUrl) ? redirectUrl : detectBasePath()
+    redirectUrl && validateRedirectUrl(redirectUrl) ? redirectUrl : getUiBasePath()
   );
 
   // Get enabled OAuth providers from registry
@@ -70,13 +73,18 @@
         return false;
       }
 
-      // Prevent javascript: or data: URLs
-      if (url.toLowerCase().includes('javascript:') || url.toLowerCase().includes('data:')) {
+      // Check length (path + query). A generous cap covers heavily-filtered views.
+      if (url.length > MAX_REDIRECT_LENGTH) {
         return false;
       }
 
-      // Check length
-      if (url.length > MAX_REDIRECT_LENGTH) {
+      // Prevent javascript:/data: schemes, but check only the PATH component. A
+      // query value may legitimately contain a literal 'javascript:'/'data:' (e.g.
+      // a free-text search term); since the redirect is always navigated as a
+      // same-origin relative URL, such a query value is inert. Checking the whole
+      // string would falsely drop the user back to the base path.
+      const pathPart = url.split('?', 1)[0].toLowerCase();
+      if (pathPart.includes('javascript:') || pathPart.includes('data:')) {
         return false;
       }
 
@@ -117,32 +125,6 @@
     return { isValid: true };
   }
 
-  // SECURITY: Extract current base path from window location
-  function detectBasePath(): string {
-    // Ensure we have a valid pathname (for tests and SSR)
-    const pathname = window.location?.pathname || '/';
-
-    // Common UI base paths to check
-    const commonBasePaths = ['/ui/', '/app/', '/admin/', '/dashboard/'];
-
-    for (const basePath of commonBasePaths) {
-      if (pathname.startsWith(basePath)) {
-        return basePath;
-      }
-    }
-
-    // If no common base path found, check if we're in a subfolder
-    const pathSegments = pathname.split('/').filter(Boolean);
-    if (pathSegments.length > 0) {
-      // Return the first segment as base path
-      const firstSegment = safeArrayAccess(pathSegments, 0);
-      return firstSegment ? `/${firstSegment}/` : '/';
-    }
-
-    // Default to root
-    return '/';
-  }
-
   async function handlePasswordLogin() {
     if (loadingState !== 'idle') {
       return;
@@ -156,8 +138,8 @@
       return;
     }
 
-    // SECURITY: Detect current base path
-    const currentBasePath = detectBasePath();
+    // SECURITY: Detect current base path (proxy-aware, shared helper)
+    const currentBasePath = getUiBasePath();
 
     error = '';
     loadingState = 'password';

--- a/frontend/src/lib/desktop/components/modals/LoginModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.svelte
@@ -41,7 +41,10 @@
   let {
     isOpen = false,
     onClose,
-    redirectUrl = '/ui/',
+    // Empty by default so an omitted prop falls through to the proxy-aware
+    // getUiBasePath() fallback instead of a hardcoded '/ui/' that ignores any
+    // reverse-proxy prefix.
+    redirectUrl = '',
     authConfig = {
       basicEnabled: true,
       enabledProviders: [],
@@ -78,13 +81,15 @@
         return false;
       }
 
-      // Prevent javascript:/data: schemes, but check only the PATH component. A
-      // query value may legitimately contain a literal 'javascript:'/'data:' (e.g.
-      // a free-text search term); since the redirect is always navigated as a
-      // same-origin relative URL, such a query value is inert. Checking the whole
-      // string would falsely drop the user back to the base path.
-      const pathPart = url.split('?', 1)[0].toLowerCase();
-      if (pathPart.includes('javascript:') || pathPart.includes('data:')) {
+      // Reject javascript:/data: schemes, but only when the PATH itself starts
+      // with one. A query value may legitimately contain a literal
+      // 'javascript:'/'data:' (e.g. a free-text search term), and a same-origin
+      // route may contain it mid-path (e.g. /ui/help/javascript:basics); both are
+      // inert because the redirect is navigated as a same-origin relative URL and
+      // the same-origin guard below is the real check. Scanning the whole string
+      // would falsely drop the user back to the base path.
+      const pathPart = url.split(/[?#]/, 1)[0].toLowerCase();
+      if (/^\/(?:javascript|data):/.test(pathPart)) {
         return false;
       }
 

--- a/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
@@ -230,9 +230,40 @@ describe('LoginModal', () => {
         redirectUrl: '/javascript:alert(1)/foo',
       });
 
-      // A dangerous scheme in the PATH must still fall back to the base path.
+      // A dangerous scheme at the start of the PATH must still fall back.
       const redirectInput = screen.getByDisplayValue('/ui/') as HTMLInputElement;
       expect(redirectInput.value).toBe('/ui/');
+    });
+
+    it('should accept a same-origin path containing a scheme-like segment', () => {
+      // The scheme check is anchored to the path start, so a mid-path
+      // 'javascript:' on a same-origin route must not be rejected.
+      mockWindowLocation('/ui/');
+
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+        redirectUrl: '/ui/help/javascript:basics',
+      });
+
+      const redirectInput = screen.getByDisplayValue(
+        '/ui/help/javascript:basics'
+      ) as HTMLInputElement;
+      expect(redirectInput.value).toBe('/ui/help/javascript:basics');
+    });
+
+    it('falls back to the proxy-aware UI root when no redirectUrl prop is given', () => {
+      // With no redirectUrl prop, the derived value must fall through to the
+      // proxy-aware getUiBasePath() rather than a hardcoded '/ui/'.
+      mockWindowLocation('/proxy/birdnet/ui/dashboard');
+
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+      });
+
+      const redirectInput = screen.getByDisplayValue('/proxy/birdnet/ui/') as HTMLInputElement;
+      expect(redirectInput.value).toBe('/proxy/birdnet/ui/');
     });
   });
 

--- a/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
@@ -169,9 +169,9 @@ describe('LoginModal', () => {
       expect(redirectInput.value).toBe('/ui/');
     });
 
-    it('should use different base paths based on current location', () => {
-      // Change the mock location to /app/
-      mockWindowLocation('/app/settings');
+    it('should fall back to the proxy-aware UI base path when the redirect is invalid', () => {
+      // Simulate a reverse-proxy deployment under a custom subpath.
+      mockWindowLocation('/proxy/birdnet/ui/settings');
 
       loginModalTest.render({
         isOpen: true,
@@ -179,10 +179,60 @@ describe('LoginModal', () => {
         redirectUrl: 'invalid-url', // No leading slash
       });
 
-      // Should fallback to /app/ based on current location
-      const redirectInput = screen.getByDisplayValue('/app/') as HTMLInputElement;
+      // Fallback must include the reverse-proxy prefix (via the shared
+      // getUiBasePath helper), not a hand-rolled, prefix-unaware guess.
+      const redirectInput = screen.getByDisplayValue('/proxy/birdnet/ui/') as HTMLInputElement;
       expect(redirectInput).toBeDefined();
-      expect(redirectInput.value).toBe('/app/');
+      expect(redirectInput.value).toBe('/proxy/birdnet/ui/');
+    });
+
+    it('should accept a query string containing path-like sequences', () => {
+      // '..' and '//' inside a query are meaningful only as a path; they must not
+      // cause an otherwise-safe redirect to be rejected.
+      mockWindowLocation('/ui/detections', '?queryType=search&q=a..b//c');
+
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+        redirectUrl: '/ui/detections?queryType=search&q=a..b//c',
+      });
+
+      const redirectInput = screen.getByDisplayValue(
+        '/ui/detections?queryType=search&q=a..b//c'
+      ) as HTMLInputElement;
+      expect(redirectInput.value).toBe('/ui/detections?queryType=search&q=a..b//c');
+    });
+
+    it('should accept a query value containing a literal javascript: term', () => {
+      // A free-text search term may legitimately contain 'javascript:'. The
+      // redirect is navigated as a same-origin relative URL, so the query is
+      // inert and must not trip the path-oriented scheme check.
+      mockWindowLocation('/ui/detections', '?q=javascript:tutorial');
+
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+        redirectUrl: '/ui/detections?q=javascript:tutorial',
+      });
+
+      const redirectInput = screen.getByDisplayValue(
+        '/ui/detections?q=javascript:tutorial'
+      ) as HTMLInputElement;
+      expect(redirectInput.value).toBe('/ui/detections?q=javascript:tutorial');
+    });
+
+    it('should still reject a dangerous scheme in the path component', () => {
+      mockWindowLocation('/ui/');
+
+      loginModalTest.render({
+        isOpen: true,
+        onClose: vi.fn(),
+        redirectUrl: '/javascript:alert(1)/foo',
+      });
+
+      // A dangerous scheme in the PATH must still fall back to the base path.
+      const redirectInput = screen.getByDisplayValue('/ui/') as HTMLInputElement;
+      expect(redirectInput.value).toBe('/ui/');
     });
   });
 
@@ -587,17 +637,17 @@ describe('LoginModal', () => {
       });
     });
 
-    it('should handle different base paths correctly', async () => {
+    it('should handle reverse-proxy (Home Assistant Ingress) base paths correctly', async () => {
       const { api } = await import('$lib/utils/api');
       const postSpy = vi.mocked(api.post);
       postSpy.mockResolvedValue({ success: true, message: 'Login successful' });
 
-      mockWindowLocation('/app/dashboard');
+      mockWindowLocation('/api/hassio_ingress/abc123/ui/dashboard');
 
       loginModalTest.render({
         isOpen: true,
         onClose: vi.fn(),
-        redirectUrl: '/app/settings',
+        redirectUrl: '/api/hassio_ingress/abc123/ui/settings',
         authConfig: { basicEnabled: true, enabledProviders: [] },
       });
 
@@ -611,8 +661,10 @@ describe('LoginModal', () => {
         expect(postSpy).toHaveBeenCalledWith(
           '/api/v2/auth/login',
           expect.objectContaining({
+            // The reverse-proxy prefix is stripped along with the /ui/ segment,
+            // and the full proxy-aware base path is sent to the backend.
             redirectUrl: '/settings',
-            basePath: '/app/',
+            basePath: '/api/hassio_ingress/abc123/ui/',
           })
         );
       });

--- a/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.test.ts
@@ -283,7 +283,7 @@ describe('LoginModal', () => {
       // Check if error is displayed
       const errorElement = screen.queryByRole('alert');
       expect(errorElement).toBeInTheDocument();
-      expect(errorElement?.textContent).toBe('Password contains invalid characters');
+      expect(errorElement?.textContent).toBe('auth.errors.invalidCharacters');
 
       // Verify that the API was NOT called (validation should prevent it)
       expect(postSpy).not.toHaveBeenCalled();
@@ -782,7 +782,7 @@ describe('LoginModal', () => {
       await fireEvent.click(loginButton);
 
       await waitFor(() => {
-        expect(screen.getByText('Invalid credentials. Please try again.')).toBeInTheDocument();
+        expect(screen.getByText('auth.errors.loginFailed')).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/lib/utils/urlHelpers.test.ts
+++ b/frontend/src/lib/utils/urlHelpers.test.ts
@@ -377,6 +377,13 @@ describe('URL Helpers', () => {
       window.location = { pathname: '/anything/ui/dashboard' };
       expect(getUiBasePath()).toBe('/custom/prefix/ui/');
     });
+
+    it('should not produce a double slash when the base path ends with a slash', () => {
+      setBasePath('/custom/prefix/');
+      // @ts-expect-error - Mocking window.location
+      window.location = { pathname: '/anything/ui/dashboard' };
+      expect(getUiBasePath()).toBe('/custom/prefix/ui/');
+    });
   });
 
   describe('buildAppUrl', () => {

--- a/frontend/src/lib/utils/urlHelpers.test.ts
+++ b/frontend/src/lib/utils/urlHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   isRelativePath,
   normalizePath,
   getAppBasePath,
+  getUiBasePath,
   buildAppUrl,
   setBasePath,
   resetBasePath,
@@ -334,6 +335,47 @@ describe('URL Helpers', () => {
       // @ts-expect-error - Mocking window.location
       window.location = { pathname: '/ui' };
       expect(getAppBasePath()).toBe('');
+    });
+  });
+
+  describe('getUiBasePath', () => {
+    it('should return /ui/ for direct access', () => {
+      // @ts-expect-error - Mocking window.location
+      window.location = { pathname: '/ui/dashboard' };
+      expect(getUiBasePath()).toBe('/ui/');
+    });
+
+    it('should return /ui/ for the root /ui path', () => {
+      // @ts-expect-error - Mocking window.location
+      window.location = { pathname: '/ui/' };
+      expect(getUiBasePath()).toBe('/ui/');
+    });
+
+    it('should include the Home Assistant Ingress prefix', () => {
+      // @ts-expect-error - Mocking window.location
+      window.location = {
+        pathname: '/api/hassio_ingress/TOKEN123/ui/detections',
+      };
+      expect(getUiBasePath()).toBe('/api/hassio_ingress/TOKEN123/ui/');
+    });
+
+    it('should include a simple reverse-proxy prefix', () => {
+      // @ts-expect-error - Mocking window.location
+      window.location = { pathname: '/proxy/birdnet/ui/settings' };
+      expect(getUiBasePath()).toBe('/proxy/birdnet/ui/');
+    });
+
+    it('should fall back to /ui/ when pathname has no /ui segment', () => {
+      // @ts-expect-error - Mocking window.location
+      window.location = { pathname: '/some/other/path' };
+      expect(getUiBasePath()).toBe('/ui/');
+    });
+
+    it('should honor the backend-provided base path', () => {
+      setBasePath('/custom/prefix');
+      // @ts-expect-error - Mocking window.location
+      window.location = { pathname: '/anything/ui/dashboard' };
+      expect(getUiBasePath()).toBe('/custom/prefix/ui/');
     });
   });
 

--- a/frontend/src/lib/utils/urlHelpers.ts
+++ b/frontend/src/lib/utils/urlHelpers.ts
@@ -197,7 +197,13 @@ const UI_PATH_SEGMENT = '/ui/';
  * getUiBasePath() // returns '/api/hassio_ingress/TOKEN/ui/'
  */
 export function getUiBasePath(): string {
-  return `${getAppBasePath()}${UI_PATH_SEGMENT}`;
+  // Defensively strip a trailing slash from the prefix so a backend-provided
+  // base path that ends with '/' does not produce a double slash (e.g.
+  // '/prefix//ui/'). The URL heuristic never emits a trailing slash, but the
+  // cached value from the backend might.
+  const appBase = getAppBasePath();
+  const prefix = appBase.endsWith('/') ? appBase.slice(0, -1) : appBase;
+  return `${prefix}${UI_PATH_SEGMENT}`;
 }
 
 /**

--- a/frontend/src/lib/utils/urlHelpers.ts
+++ b/frontend/src/lib/utils/urlHelpers.ts
@@ -171,6 +171,35 @@ export function getAppBasePath(): string {
   return '/' + segments.slice(0, uiIndex).join('/');
 }
 
+// The Svelte UI is always served under the '/ui/' segment; getAppBasePath()
+// returns the reverse-proxy prefix that precedes it.
+const UI_PATH_SEGMENT = '/ui/';
+
+/**
+ * Returns the full base path under which the Svelte UI is served, including any
+ * reverse-proxy prefix and the trailing '/ui/' segment.
+ *
+ * This is the proxy-aware UI root: getAppBasePath() (the prefix before the 'ui'
+ * segment) combined with the 'ui' segment itself. Use it for a post-login
+ * fallback redirect target and for stripping the base from a captured location
+ * before sending a relative redirect to the backend, so reverse-proxy prefixes
+ * (e.g. Home Assistant Ingress) are handled consistently instead of by ad-hoc,
+ * prefix-unaware detection.
+ *
+ * @returns The UI base path, always ending in '/ui/'.
+ *
+ * @example
+ * // Direct access (pathname: '/ui/dashboard')
+ * getUiBasePath() // returns '/ui/'
+ *
+ * @example
+ * // Home Assistant Ingress (pathname: '/api/hassio_ingress/TOKEN/ui/dashboard')
+ * getUiBasePath() // returns '/api/hassio_ingress/TOKEN/ui/'
+ */
+export function getUiBasePath(): string {
+  return `${getAppBasePath()}${UI_PATH_SEGMENT}`;
+}
+
 /**
  * Builds a full URL path that works with any proxy configuration.
  * Automatically detects and prepends the app's base path (if behind a proxy).

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -627,28 +627,26 @@ func validateAndSanitizeRedirect(redirect string) string {
 
 	// Replace ALL backslashes with forward slashes for robust normalization
 	cleanedRedirect := strings.ReplaceAll(redirect, "\\", "/")
+
+	// Apply the authoritative, query-aware redirect validation so this OAuth
+	// callback entry point enforces the same rules as the login gate: length
+	// bounds, path-traversal on the path, and CRLF/null/control-character
+	// rejection on the query (including double- and triple-encoded variants).
+	// The query stays permissive for inert ".."/"//" sequences.
+	if !security.IsValidRedirect(cleanedRedirect) {
+		return "/"
+	}
+
+	// Re-parse to emit a properly percent-encoded path in the Location header.
+	// isValidRelativePath guards the parse result before EscapedPath is used.
 	parsedURL, err := url.Parse(cleanedRedirect)
 	if err != nil || !isValidRelativePath(parsedURL) {
 		return "/"
 	}
 
-	// Check for CR/LF injection in path and query
-	if containsCRLFCharacters(parsedURL.Path) || containsCRLFCharacters(parsedURL.RawQuery) {
-		return "/"
-	}
-
-	// Reject path-traversal in the PATH component (url.Parse decodes percent-encoded
-	// variants, so this catches "%2e%2e" too). The query is intentionally left
-	// permissive: ".."/"//" in a query are inert and must survive, matching the
-	// query-aware gate in security.IsValidRedirect.
-	if !security.IsSafePath(parsedURL.Path) {
-		return "/"
-	}
-
-	// Passed all checks, construct safe redirect preserving path and query.
 	// Use EscapedPath so special characters (spaces, raw Unicode) are properly
-	// encoded in the Location header per RFC 3986; IsSafePath validated the
-	// decoded path above.
+	// encoded in the Location header per RFC 3986; the decoded path was already
+	// validated by IsValidRedirect above.
 	if parsedURL.RawQuery != "" {
 		return parsedURL.EscapedPath() + "?" + parsedURL.RawQuery
 	}

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -645,11 +645,14 @@ func validateAndSanitizeRedirect(redirect string) string {
 		return "/"
 	}
 
-	// Passed all checks, construct safe redirect preserving path and query
+	// Passed all checks, construct safe redirect preserving path and query.
+	// Use EscapedPath so special characters (spaces, raw Unicode) are properly
+	// encoded in the Location header per RFC 3986; IsSafePath validated the
+	// decoded path above.
 	if parsedURL.RawQuery != "" {
-		return parsedURL.Path + "?" + parsedURL.RawQuery
+		return parsedURL.EscapedPath() + "?" + parsedURL.RawQuery
 	}
-	return parsedURL.Path
+	return parsedURL.EscapedPath()
 }
 
 // randomDelay introduces a random sleep duration within the specified range [minMs, maxMs).

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -625,8 +625,15 @@ func validateAndSanitizeRedirect(redirect string) string {
 		return "/"
 	}
 
-	// Replace ALL backslashes with forward slashes for robust normalization
-	cleanedRedirect := strings.ReplaceAll(redirect, "\\", "/")
+	// Normalize backslashes to forward slashes in the PATH only (this catches the
+	// "/\evil.com" protocol-relative trick). The query is left untouched so a
+	// legitimate backslash in a filter value (e.g. a Windows path the user
+	// searched for) survives instead of being mangled into forward slashes.
+	pathPart, queryPart, hasQuery := strings.Cut(redirect, "?")
+	cleanedRedirect := strings.ReplaceAll(pathPart, "\\", "/")
+	if hasQuery {
+		cleanedRedirect += "?" + queryPart
+	}
 
 	// Apply the authoritative, query-aware redirect validation so this OAuth
 	// callback entry point enforces the same rules as the login gate: length

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -637,6 +637,14 @@ func validateAndSanitizeRedirect(redirect string) string {
 		return "/"
 	}
 
+	// Reject path-traversal in the PATH component (url.Parse decodes percent-encoded
+	// variants, so this catches "%2e%2e" too). The query is intentionally left
+	// permissive: ".."/"//" in a query are inert and must survive, matching the
+	// query-aware gate in security.IsValidRedirect.
+	if !security.IsSafePath(parsedURL.Path) {
+		return "/"
+	}
+
 	// Passed all checks, construct safe redirect preserving path and query
 	if parsedURL.RawQuery != "" {
 		return parsedURL.Path + "?" + parsedURL.RawQuery

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -457,6 +457,11 @@ func TestV2AuthFlow_OpenRedirectPrevention(t *testing.T) {
 			maliciousURL:   "/ui/detections?queryType=search&q=a..b//c",
 			expectedResult: "/ui/detections?queryType=search&q=a..b//c",
 		},
+		{
+			name:           "special characters in the path are emitted percent-encoded",
+			maliciousURL:   "/ui/a%20b",
+			expectedResult: "/ui/a%20b",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -462,6 +462,16 @@ func TestV2AuthFlow_OpenRedirectPrevention(t *testing.T) {
 			maliciousURL:   "/ui/a%20b",
 			expectedResult: "/ui/a%20b",
 		},
+		{
+			name:           "double-encoded CRLF in the query is rejected",
+			maliciousURL:   "/ui/detections?x=a%250d%250aSet-Cookie:evil",
+			expectedResult: "/",
+		},
+		{
+			name:           "redirect over the length budget is rejected",
+			maliciousURL:   "/ui/detections?q=" + strings.Repeat("a", 3000),
+			expectedResult: "/",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -472,6 +472,11 @@ func TestV2AuthFlow_OpenRedirectPrevention(t *testing.T) {
 			maliciousURL:   "/ui/detections?q=" + strings.Repeat("a", 3000),
 			expectedResult: "/",
 		},
+		{
+			name:           "backslashes in the query value are preserved (not mangled to slashes)",
+			maliciousURL:   `/ui/search?q=C:\Temp\bird.wav`,
+			expectedResult: `/ui/search?q=C:\Temp\bird.wav`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -170,6 +171,90 @@ func TestV2AuthFlow_CompleteLogin(t *testing.T) {
 	})
 
 	_ = settings // Use settings if needed for additional assertions
+}
+
+// TestV2AuthFlow_FilterQueryRedirectSurvives verifies that a post-login redirect
+// to a filtered view whose query string legitimately contains path-like
+// sequences (".." / "//") survives validation instead of being silently dropped
+// back to the base path. Regression guard for the query-aware redirect fix:
+// path-traversal heuristics must only apply to the path, not to the query.
+func TestV2AuthFlow_FilterQueryRedirectSurvives(t *testing.T) {
+	e, controller, _ := setupAuthIntegrationTest(t)
+
+	const filteredRedirect = "/detections?queryType=species&q=a..b//c"
+	const wantFinalRedirect = "/ui/detections?queryType=species&q=a..b//c"
+
+	loginPayload := `{
+		"username": "birdnet-client",
+		"password": "testpassword123",
+		"redirectUrl": "` + filteredRedirect + `",
+		"basePath": "/ui/"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", strings.NewReader(loginPayload))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.Login(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var loginResp AuthResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &loginResp))
+	require.True(t, loginResp.Success)
+
+	// The callback URL must carry the full filtered target, not the bare base path.
+	callbackURL, err := url.Parse(loginResp.RedirectURL)
+	require.NoError(t, err)
+	gotRedirect := callbackURL.Query().Get("redirect")
+	assert.Equal(t, wantFinalRedirect, gotRedirect,
+		"filtered redirect with '..'/'//' in the query must survive login validation")
+
+	// Following the callback must 302 to the filtered view with the query intact.
+	callbackReq := httptest.NewRequest(http.MethodGet, loginResp.RedirectURL, http.NoBody)
+	callbackRec := httptest.NewRecorder()
+	require.NoError(t, controller.OAuthCallback(e.NewContext(callbackReq, callbackRec)))
+
+	assert.Equal(t, http.StatusFound, callbackRec.Code)
+	assert.Equal(t, wantFinalRedirect, callbackRec.Header().Get("Location"),
+		"callback must redirect to the filtered view, not the base path")
+}
+
+// TestV2AuthFlow_ProxyPrefixedBasePathRedirect verifies that a reverse-proxy
+// (Home Assistant Ingress) base path produced by the frontend's getUiBasePath()
+// is accepted end-to-end: the redirect is re-rooted under the proxy prefix
+// rather than dropped to the default base path. Regression guard for the
+// proxy-aware base-path handling.
+func TestV2AuthFlow_ProxyPrefixedBasePathRedirect(t *testing.T) {
+	e, controller, _ := setupAuthIntegrationTest(t)
+
+	// HA Ingress tokens are base64url (alphanumeric, '-', '_'), accepted by the
+	// backend basePath regex.
+	const basePath = "/api/hassio_ingress/aBcD-_1234567890/ui/"
+	const wantFinalRedirect = "/api/hassio_ingress/aBcD-_1234567890/ui/detections?queryType=species"
+
+	loginPayload := `{
+		"username": "birdnet-client",
+		"password": "testpassword123",
+		"redirectUrl": "/detections?queryType=species",
+		"basePath": "` + basePath + `"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", strings.NewReader(loginPayload))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	require.NoError(t, controller.Login(e.NewContext(req, rec)))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var loginResp AuthResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &loginResp))
+	require.True(t, loginResp.Success)
+
+	callbackURL, err := url.Parse(loginResp.RedirectURL)
+	require.NoError(t, err)
+	assert.Equal(t, wantFinalRedirect, callbackURL.Query().Get("redirect"),
+		"redirect must be re-rooted under the reverse-proxy base path")
 }
 
 // TestV2AuthFlow_InvalidCredentials tests login with wrong password.
@@ -356,6 +441,21 @@ func TestV2AuthFlow_OpenRedirectPrevention(t *testing.T) {
 			name:           "valid path with query",
 			maliciousURL:   "/ui/settings?tab=main",
 			expectedResult: "/ui/settings?tab=main",
+		},
+		{
+			name:           "path traversal in the path component is rejected",
+			maliciousURL:   "/ui/../../etc/passwd?x=1",
+			expectedResult: "/",
+		},
+		{
+			name:           "encoded path traversal in the path component is rejected",
+			maliciousURL:   "/ui/%2e%2e/secret",
+			expectedResult: "/",
+		},
+		{
+			name:           "path-like sequences in the query are preserved",
+			maliciousURL:   "/ui/detections?queryType=search&q=a..b//c",
+			expectedResult: "/ui/detections?queryType=search&q=a..b//c",
 		},
 	}
 

--- a/internal/security/constants.go
+++ b/internal/security/constants.go
@@ -53,6 +53,12 @@ const (
 	// Path validation limits
 	MaxSafePathLength = 512
 
+	// MaxSafeRedirectLength bounds a full redirect target (path plus query).
+	// The path component is bounded more tightly by MaxSafePathLength; the
+	// larger overall budget accommodates legitimate, heavily-filtered query
+	// strings without dropping the user back to the base path after login.
+	MaxSafeRedirectLength = 2048
+
 	// OIDC discovery retry settings
 	OIDCRetryInitialBackoff = 5 * time.Second
 	OIDCRetryMaxBackoff     = 60 * time.Second

--- a/internal/security/util.go
+++ b/internal/security/util.go
@@ -199,7 +199,8 @@ func IsValidRedirect(redirectPath string) bool {
 func isSafeRedirectTarget(redirect string) bool {
 	// Bound the full target. The path component is bounded more tightly by
 	// IsSafePath; this larger budget covers the path plus a long query string.
-	if len(redirect) >= MaxSafeRedirectLength {
+	// MaxSafeRedirectLength is the maximum allowed length (inclusive).
+	if len(redirect) > MaxSafeRedirectLength {
 		return false
 	}
 
@@ -229,8 +230,11 @@ func isSafeRedirectQuery(query string) bool {
 		return false
 	}
 
-	// Reject percent-encoded null bytes (a raw NUL is caught by the control scan below).
-	if strings.Contains(strings.ToLower(query), "%00") {
+	// Reject percent-encoded and double-encoded null bytes (a raw NUL is caught by
+	// the control scan below). Mirrors the encoded-null checks in IsSafePath so a
+	// downstream decode step cannot reintroduce a NUL.
+	lower := strings.ToLower(query)
+	if strings.Contains(lower, "%00") || strings.Contains(lower, "%2500") {
 		return false
 	}
 

--- a/internal/security/util.go
+++ b/internal/security/util.go
@@ -175,15 +175,73 @@ func IsSafePath(pathStr string) bool {
 	return true
 }
 
-// IsValidRedirect ensures the redirect path is safe and internal by checking IsSafePath.
-// It logs a warning if the path is deemed unsafe.
+// IsValidRedirect ensures the redirect path is safe and internal.
+// It is query-aware: strict path-traversal checks apply to the path component,
+// while the query string is validated more permissively (see isSafeRedirectTarget).
+// It logs a warning if the redirect is deemed unsafe.
 func IsValidRedirect(redirectPath string) bool {
-	isSafe := IsSafePath(redirectPath) // Use the exported function
+	isSafe := isSafeRedirectTarget(redirectPath)
 	if !isSafe {
 		// Log potentially unsafe redirect attempt using the security logger
 		GetLogger().Warn("invalid or potentially unsafe redirect path detected", logger.String("path", redirectPath))
 	}
 	return isSafe
+}
+
+// isSafeRedirectTarget reports whether redirect is a safe same-origin relative
+// redirect target. It is query-aware: the strict path-traversal heuristics in
+// IsSafePath are applied only to the path component, while the query component is
+// checked for response-splitting and control characters but is otherwise allowed
+// to contain sequences (such as ".." or "//") that are meaningful only as a path.
+// This prevents a legitimate filter query string (e.g. a free-text detections
+// search) from causing an otherwise-safe redirect to be rejected, which would
+// silently drop the user back to the base path after login.
+func isSafeRedirectTarget(redirect string) bool {
+	// Bound the full target. The path component is bounded more tightly by
+	// IsSafePath; this larger budget covers the path plus a long query string.
+	if len(redirect) >= MaxSafeRedirectLength {
+		return false
+	}
+
+	// Split the path from the query at the first '?'. The query never changes
+	// the redirect's same-origin target, so running traversal heuristics over it
+	// would only produce false rejections.
+	pathPart, queryPart, hasQuery := strings.Cut(redirect, "?")
+
+	if !IsSafePath(pathPart) {
+		return false
+	}
+
+	if hasQuery && !isSafeRedirectQuery(queryPart) {
+		return false
+	}
+
+	return true
+}
+
+// isSafeRedirectQuery reports whether a redirect query string is free of
+// sequences that could enable HTTP response splitting/smuggling when the
+// redirect is emitted in a Location header. Unlike the path, the query is not
+// subject to path-traversal checks.
+func isSafeRedirectQuery(query string) bool {
+	// Reject CR/LF and their percent-encoded variants (header injection).
+	if containsCRLF(query) {
+		return false
+	}
+
+	// Reject percent-encoded null bytes (a raw NUL is caught by the control scan below).
+	if strings.Contains(strings.ToLower(query), "%00") {
+		return false
+	}
+
+	// Reject raw C0 control characters (tab is permitted); this also covers a raw
+	// null byte. Legitimate query strings arrive percent-encoded, so raw control
+	// bytes are abnormal.
+	if strings.IndexFunc(query, func(r rune) bool { return r < 0x20 && r != '\t' }) >= 0 {
+		return false
+	}
+
+	return true
 }
 
 // ValidateAuthCallbackRedirect validates and sanitizes a redirect path for auth callbacks.

--- a/internal/security/util.go
+++ b/internal/security/util.go
@@ -149,6 +149,11 @@ func IsSafePath(pathStr string) bool {
 		return false
 	}
 
+	// Check for triple-encoded null byte (%252500)
+	if strings.Contains(lower, "%252500") {
+		return false
+	}
+
 	// Check for URL-encoded backslash (%5c)
 	if strings.Contains(lower, "%5c") {
 		return false
@@ -230,11 +235,12 @@ func isSafeRedirectQuery(query string) bool {
 		return false
 	}
 
-	// Reject percent-encoded and double-encoded null bytes (a raw NUL is caught by
-	// the control scan below). Mirrors the encoded-null checks in IsSafePath so a
-	// downstream decode step cannot reintroduce a NUL.
+	// Reject percent-encoded null bytes through triple encoding (a raw NUL is
+	// caught by the control scan below). Mirrors the encoded-null and encoded-CRLF
+	// checks in IsSafePath/containsCRLF so repeated downstream decodes cannot
+	// reintroduce a NUL.
 	lower := strings.ToLower(query)
-	if strings.Contains(lower, "%00") || strings.Contains(lower, "%2500") {
+	if strings.Contains(lower, "%00") || strings.Contains(lower, "%2500") || strings.Contains(lower, "%252500") {
 		return false
 	}
 

--- a/internal/security/util_test.go
+++ b/internal/security/util_test.go
@@ -687,6 +687,11 @@ func TestIsValidRedirect(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "double-encoded null byte in query is rejected",
+			path:     "/ui/detections?x=a%2500b",
+			expected: false,
+		},
+		{
 			name:     "redirect over total length budget is rejected",
 			path:     "/ui/detections?q=" + strings.Repeat("a", 3000),
 			expected: false,

--- a/internal/security/util_test.go
+++ b/internal/security/util_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -640,6 +641,54 @@ func TestIsValidRedirect(t *testing.T) {
 		{
 			name:     "invalid path without leading slash",
 			path:     "dashboard",
+			expected: false,
+		},
+
+		// Query-aware validation: path-traversal heuristics must apply
+		// only to the path component, not to a legitimate filter query string.
+		{
+			name:     "simple filter query is allowed",
+			path:     "/ui/detections?queryType=species&date=2026-06-02",
+			expected: true,
+		},
+		{
+			name:     "dotdot in query value is allowed",
+			path:     "/ui/detections?queryType=search&q=foo..bar",
+			expected: true,
+		},
+		{
+			name:     "double slash in query value is allowed",
+			path:     "/ui/detections?next=//example/path",
+			expected: true,
+		},
+		{
+			name:     "long filter query under total budget is allowed",
+			path:     "/ui/detections?q=" + strings.Repeat("a", 600),
+			expected: true,
+		},
+		{
+			name:     "traversal in path is rejected even with a query",
+			path:     "/ui/../secret?tab=1",
+			expected: false,
+		},
+		{
+			name:     "encoded CRLF in query is rejected",
+			path:     "/ui/detections?x=a%0d%0aSet-Cookie:evil",
+			expected: false,
+		},
+		{
+			name:     "raw newline in query is rejected",
+			path:     "/ui/detections?x=a\nb",
+			expected: false,
+		},
+		{
+			name:     "null byte in query is rejected",
+			path:     "/ui/detections?x=a\x00b",
+			expected: false,
+		},
+		{
+			name:     "redirect over total length budget is rejected",
+			path:     "/ui/detections?q=" + strings.Repeat("a", 3000),
 			expected: false,
 		},
 	}

--- a/internal/security/util_test.go
+++ b/internal/security/util_test.go
@@ -597,6 +597,11 @@ func TestIsSafePath(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "triple-encoded null byte",
+			path:     "/path%252500evil",
+			expected: false,
+		},
+		{
 			name:     "triple-encoded directory traversal",
 			path:     "/path/%25252e%25252e/etc",
 			expected: false,
@@ -689,6 +694,11 @@ func TestIsValidRedirect(t *testing.T) {
 		{
 			name:     "double-encoded null byte in query is rejected",
 			path:     "/ui/detections?x=a%2500b",
+			expected: false,
+		},
+		{
+			name:     "triple-encoded null byte in query is rejected",
+			path:     "/ui/detections?x=a%252500b",
 			expected: false,
 		},
 		{


### PR DESCRIPTION
## Summary

Follow-up hardening for the post-login redirect introduced in #3359. The redirect carries the full `pathname + query` of the view the user was on, but the validation guarding it treated the whole string as a path, so a legitimate filter query string could trip path-oriented checks and silently drop the user back to the base path.

## What changed

### Backend: query-aware redirect validation
- `security.IsValidRedirect` now splits the path from the query: the path is validated strictly via `IsSafePath` (traversal, encoded variants, length), while the query is validated permissively (rejects CR/LF, null bytes, and raw control characters to prevent response splitting, but allows `..`/`//`, which are inert in a query). Adds `MaxSafeRedirectLength` (2048) for the full target; the path stays bounded by `MaxSafePathLength` (512).
- `validateAndSanitizeRedirect` (the OAuth-callback emission point) now also rejects path traversal in the path component for consistency, while keeping the query permissive.

### Frontend
- `LoginModal.validateRedirectUrl` applies the `javascript:`/`data:` scheme check to the path component only. A query value is inert for a same-origin relative redirect and must not trip it; the same-origin `URL` guard is unchanged.
- Replaced the hand-rolled `detectBasePath()` (a fixed list of base segments that ignored reverse-proxy prefixes) with a shared, proxy-aware `getUiBasePath()` helper in `urlHelpers`. Deployments behind a reverse proxy (e.g. Home Assistant Ingress) now strip the correct prefix.
- Localized the remaining hardcoded English error strings in the login modal to existing `auth.errors.*` keys (present in all 15 locales).

## Why

A free-text detections search term containing `..`, or a heavily-filtered view at 512+ chars, previously failed validation and dropped the user on the unfiltered page after login. That is the same symptom the original redirect fix set out to solve, just for a narrower set of inputs.

## Tests

- Backend: query-aware path/query split, CR/LF rejection, length budget, path-traversal rejection in both validators, plus end-to-end integration tests (filtered query survives login; reverse-proxy-prefixed base path is accepted and re-rooted).
- Frontend: query-aware validation, proxy-aware base-path detection (HA Ingress), and `getUiBasePath` unit tests.
- `golangci-lint`: 0 issues. `npm run check:all`: clean. All backend `-race` tests and the full frontend suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger redirect validation preventing unsafe redirects while preserving safe query parameters and enforcing a maximum redirect length.
  * Post-login redirects now correctly respect proxy/ingress base paths and use a safer UI base-path fallback.
  * OAuth and login failures show localized, user-friendly error messages.

* **New Features**
  * Added a consistent UI base-path helper used for redirects.
  * Improved client-side password validation with localized error messages.

* **Tests**
  * Expanded authentication and redirect tests covering proxy/base-path, query-edge, encoding, and length cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->