### PR TITLE
fix: PrivateMode (#3122) follow-ups — exempt-route constants and fetchWithCSRF hardening

### DIFF
--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -403,7 +403,7 @@ describe('API utilities', () => {
 
       await expect(fetchWithCSRF('/api/test')).rejects.toMatchObject({
         status: 401,
-        message: 'Session expired; login redirect suppressed to prevent a reload loop',
+        message: 'errors.api.unauthorized',
       });
       // The suppressed branch must not navigate.
       expect(window.location.href).not.toBe('/ui/');

--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -220,6 +220,21 @@ describe('API utilities', () => {
       const result = await fetchWithCSRF('/api/test');
       expect(result).toBe('Plain text response');
     });
+
+    it('rejects protocol-relative and backslash-trick URLs to prevent CSRF token leakage', async () => {
+      // "//evil.com/x" satisfies includes('//') yet also starts with '/', so it
+      // would slip past the absolute-URL SSRF guard. Backslash variants like
+      // "/\evil.com" resolve to a foreign origin via URL normalization. Both
+      // must be rejected before any fetch so the CSRF-bearing request can never
+      // target a foreign origin.
+      for (const evil of ['//evil.com/steal', '/\\evil.com/steal']) {
+        await expect(fetchWithCSRF(evil)).rejects.toMatchObject({
+          status: 400,
+          message: 'Protocol-relative URLs are not allowed',
+        });
+      }
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('401 redirect to login', () => {
@@ -370,6 +385,28 @@ describe('API utilities', () => {
 
       expect(result).toBe('pending');
       expect(window.location.href).toBe('/ui/');
+    });
+
+    it('throws ApiError instead of hanging when the redirect is suppressed by the cooldown', async () => {
+      // A very recent prior redirect trips the reload-loop cooldown, so
+      // redirectToLogin suppresses navigation. In that branch it must reject
+      // (not return a never-resolving promise) so the awaiting caller can stop
+      // its loading state. Regression test for the never-resolving-promise hang.
+      sessionStorage.setItem('last_401_redirect', Date.now().toString());
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers(),
+      });
+
+      await expect(fetchWithCSRF('/api/test')).rejects.toMatchObject({
+        status: 401,
+        message: 'Session expired; login redirect suppressed to prevent a reload loop',
+      });
+      // The suppressed branch must not navigate.
+      expect(window.location.href).not.toBe('/ui/');
     });
   });
 

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -89,8 +89,8 @@ export class ApiError extends Error {
  * When a redirect actually starts, this returns a Promise that never resolves,
  * so callers awaiting fetchWithCSRF simply hang until the browser navigates
  * away. When the redirect is suppressed by the reload-loop cooldown (no
- * navigation happens), it throws an ApiError instead so awaiting callers can
- * stop their loading state rather than hang forever.
+ * navigation happens), it returns a rejected promise (ApiError) instead so
+ * awaiting callers can stop their loading state rather than hang forever.
  */
 function redirectToLogin(): Promise<never> {
   if (!_redirectingToLogin) {
@@ -117,11 +117,12 @@ function redirectToLogin(): Promise<never> {
     if (redirectSuppressed) {
       // We are NOT navigating in this branch, so returning a never-resolving
       // promise would leave awaiting callers stuck in a loading state forever.
-      // Throw instead so the caller can surface the error and stop loading.
-      throw new ApiError(
-        'Session expired; login redirect suppressed to prevent a reload loop',
-        401,
-        new Response(null, { status: 401 })
+      // Reject so the caller can surface the error and stop loading. Return a
+      // rejected promise (not a synchronous throw) to honour the Promise<never>
+      // return type, and use the canonical 401 message; the reload-loop reason
+      // is already logged above.
+      return Promise.reject(
+        new ApiError(getSecureErrorMessage(401), 401, new Response(null, { status: 401 }))
       );
     }
 

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -17,7 +17,7 @@ import {
   isSentryEnabled,
   refreshCsrfToken,
 } from '$lib/stores/appState.svelte';
-import { buildAppUrl } from '$lib/utils/urlHelpers';
+import { buildAppUrl, isRelativePath } from '$lib/utils/urlHelpers';
 import { t } from '$lib/i18n';
 import { markOnline } from '$lib/stores/connectionState.svelte';
 
@@ -35,7 +35,7 @@ let _redirectingToLogin = false;
 /** Minimum interval between 401 redirects (ms) to prevent infinite reload loops */
 const REDIRECT_COOLDOWN_MS = 5_000;
 
-// Lazy Sentry capture — only loaded when telemetry is enabled.
+// Lazy Sentry capture: only loaded when telemetry is enabled.
 // Uses ApiErrorLike interface to avoid coupling to the ApiError class.
 type ApiErrorLike = { message: string; status: number; isNetworkError: boolean };
 let _captureApiError: ((error: ApiErrorLike, context?: Record<string, string>) => void) | null =
@@ -43,7 +43,7 @@ let _captureApiError: ((error: ApiErrorLike, context?: Record<string, string>) =
 let _captureAttempted = false;
 
 async function getSentryCaptureApiError(): Promise<typeof _captureApiError> {
-  // Check opt-in state first — if disabled (or not yet initialized), return null
+  // Check opt-in state first; if disabled (or not yet initialized), return null
   // without caching the failure, so we can retry after initApp() completes.
   if (!isSentryEnabled()) return null;
 
@@ -53,7 +53,7 @@ async function getSentryCaptureApiError(): Promise<typeof _captureApiError> {
     const mod = await import('$lib/telemetry/sentry');
     _captureApiError = mod.captureApiError;
   } catch {
-    // Sentry not available — allow retry on later errors
+    // Sentry not available; allow retry on later errors
     _captureAttempted = false;
   }
   return _captureApiError;
@@ -86,8 +86,11 @@ export class ApiError extends Error {
  * expired-session errors), we redirect the whole page to the login URL.
  * The full-page navigation clears all in-memory state (stores, etc.).
  *
- * Returns a Promise that never resolves, so callers awaiting fetchWithCSRF
- * simply hang until the browser navigates away.
+ * When a redirect actually starts, this returns a Promise that never resolves,
+ * so callers awaiting fetchWithCSRF simply hang until the browser navigates
+ * away. When the redirect is suppressed by the reload-loop cooldown (no
+ * navigation happens), it throws an ApiError instead so awaiting callers can
+ * stop their loading state rather than hang forever.
  */
 function redirectToLogin(): Promise<never> {
   if (!_redirectingToLogin) {
@@ -97,19 +100,32 @@ function redirectToLogin(): Promise<never> {
     // the server keeps returning 401 due to IPv6 subnet bypass failure), stop and
     // let the user see the current page rather than looping endlessly.
     // sessionStorage survives page reloads but not tab close.
+    let redirectSuppressed = false;
     try {
       const lastRedirect = sessionStorage.getItem('last_401_redirect');
       if (lastRedirect && Date.now() - parseInt(lastRedirect, 10) < REDIRECT_COOLDOWN_MS) {
         logger.warn('Suppressing rapid 401 redirect to prevent reload loop');
         _redirectingToLogin = false; // Reset so future legitimate 401s can redirect
-        return new Promise<never>(() => {});
+        redirectSuppressed = true;
+      } else {
+        sessionStorage.setItem('last_401_redirect', Date.now().toString());
       }
-      sessionStorage.setItem('last_401_redirect', Date.now().toString());
     } catch {
-      // sessionStorage unavailable (e.g., Safari private browsing) — proceed with redirect
+      // sessionStorage unavailable (e.g., Safari private browsing): proceed with redirect
     }
 
-    logger.info('Session expired (401) — redirecting to login');
+    if (redirectSuppressed) {
+      // We are NOT navigating in this branch, so returning a never-resolving
+      // promise would leave awaiting callers stuck in a loading state forever.
+      // Throw instead so the caller can surface the error and stop loading.
+      throw new ApiError(
+        'Session expired; login redirect suppressed to prevent a reload loop',
+        401,
+        new Response(null, { status: 401 })
+      );
+    }
+
+    logger.info('Session expired (401): redirecting to login');
     // Reload the SPA from a public route. The SPA inspects the latest
     // /api/v2/app/config on bootstrap and either renders the dashboard
     // (when accessAllowed) or the full-screen login form (when PrivateMode
@@ -334,6 +350,19 @@ export async function fetchWithCSRF<T = unknown>(
     throw new ApiError('Invalid URL provided', 400, new Response());
   }
 
+  // SECURITY: Reject protocol-relative and backslash-trick URLs ("//evil.com",
+  // "/\evil.com") that look relative but resolve to a foreign origin. Any URL
+  // beginning with "/" must be a genuine same-origin relative path; reuse
+  // isRelativePath(), which resolves it with the URL parser and so catches the
+  // backslash and control-character variants a literal "//" check would miss.
+  // Absolute URLs (http://...) do not start with "/" and are validated by the
+  // same-origin block below. buildAppUrl() enforces this again downstream, but
+  // failing fast here gives callers a clear error instead of a silently
+  // misrouted, CSRF-bearing request.
+  if (url.startsWith('/') && !isRelativePath(url)) {
+    throw new ApiError('Protocol-relative URLs are not allowed', 400, new Response());
+  }
+
   // SECURITY: Enhanced SSRF protection with comprehensive URL validation
   if (url.includes('//') && !url.startsWith('/')) {
     // For absolute URLs, perform strict validation
@@ -476,7 +505,7 @@ export async function fetchWithCSRF<T = unknown>(
   } catch (error) {
     clearTimeout(timeoutId);
 
-    // Fire-and-forget Sentry capture — never blocks error flow
+    // Fire-and-forget Sentry capture; never blocks error flow
     const method = (finalOptions.method ?? 'GET').toUpperCase();
     if (error instanceof ApiError) {
       getSentryCaptureApiError().then(capture => {

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -44,6 +44,12 @@ import (
 // Tunnel provider constant for unknown providers
 const tunnelProviderUnknown = "unknown"
 
+// apiV2Prefix is the base path prefix for all v2 API routes (the Echo group
+// prefix; see Controller.Group). It is the single source of truth used to
+// compose full route paths for PrivateMode exemption matching, so the exempt
+// allow-list in isPrivateModeExempt cannot drift from the registered routes.
+const apiV2Prefix = "/api/v2"
+
 // Controller manages the API routes and handlers
 type Controller struct {
 	Echo              *echo.Echo
@@ -489,7 +495,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	}
 
 	// Create v2 API group
-	c.Group = e.Group("/api/v2")
+	c.Group = e.Group(apiV2Prefix)
 
 	// Configure middlewares
 	c.Group.Use(middleware.Recover())          // Recover should be early

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -96,10 +96,14 @@ func (c *Controller) initAppRoutes() {
 	// that was previously injected server-side into the HTML template.
 	c.Group.GET(AppConfigEndpoint, c.GetAppConfig)
 
-	// Wizard dismiss endpoint - always public.
+	// Wizard dismiss endpoint - public in the default configuration.
 	// Only writes last_seen_version to app_metadata (no data exposure, no privilege
-	// escalation). Must be accessible pre-auth so the onboarding wizard can be
-	// dismissed before login.
+	// escalation), and is reachable pre-auth so the onboarding wizard can be
+	// dismissed before login. When Security.PrivateMode is enabled this route is
+	// gated like every other UI/API route: an unauthenticated user is shown the
+	// login form rather than the wizard, so dismissing it pre-auth serves no
+	// purpose and it is intentionally NOT on the privateModeAuth exempt allow-list
+	// (see isPrivateModeExempt).
 	c.Group.POST(WizardDismissEndpoint, c.DismissWizard)
 }
 

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -193,29 +193,43 @@ var hlsMgr = &hlsManager{
 	verboseLogging: os.Getenv(hlsVerboseEnvVar) != "",
 }
 
+// HLS route path fragments, registered relative to the v2 API group in
+// initHLSRoutes. They are reused by isPrivateModeExempt so the PrivateMode
+// exempt allow-list cannot drift from the registered routes.
+const (
+	hlsGroupPath      = "/streams/hls"
+	hlsTokenGroupPath = "/t"
+	hlsStartPath      = "/:sourceID/start"
+	hlsStopPath       = "/:sourceID/stop"
+	hlsHeartbeatPath  = "/heartbeat"
+	hlsStatusPath     = "/status"
+	hlsPlaylistPath   = "/:streamToken/playlist.m3u8"
+	hlsContentPath    = "/:streamToken/*"
+)
+
 // initHLSRoutes registers HLS streaming endpoints
 func (c *Controller) initHLSRoutes() {
 	// Get authentication middleware
 	authMiddleware := c.authMiddleware
 
 	// HLS base group (no auth by default)
-	hlsGroup := c.Group.Group("/streams/hls")
+	hlsGroup := c.Group.Group(hlsGroupPath)
 
 	// Stream control endpoints
 	// Start uses dynamic middleware that checks PublicAccess.LiveAudio per-request,
 	// so changes take effect immediately without server restart.
 	// Stop always requires authentication to prevent abuse.
-	hlsGroup.POST("/:sourceID/start", c.StartHLSStream, c.publicLiveAudioAuth)
-	hlsGroup.POST("/:sourceID/stop", c.StopHLSStream, authMiddleware)
+	hlsGroup.POST(hlsStartPath, c.StartHLSStream, c.publicLiveAudioAuth)
+	hlsGroup.POST(hlsStopPath, c.StopHLSStream, authMiddleware)
 
 	// Auth-gated endpoints
-	hlsGroup.POST("/heartbeat", c.HLSHeartbeat, c.publicLiveAudioAuth)
-	hlsGroup.GET("/status", c.GetHLSStatus, c.publicLiveAudioAuth)
+	hlsGroup.POST(hlsHeartbeatPath, c.HLSHeartbeat, c.publicLiveAudioAuth)
+	hlsGroup.GET(hlsStatusPath, c.GetHLSStatus, c.publicLiveAudioAuth)
 
 	// Token-based content serving
-	hlsTokenGroup := hlsGroup.Group("/t")
-	hlsTokenGroup.GET("/:streamToken/playlist.m3u8", c.ServeHLSPlaylist)
-	hlsTokenGroup.GET("/:streamToken/*", c.ServeHLSContent)
+	hlsTokenGroup := hlsGroup.Group(hlsTokenGroupPath)
+	hlsTokenGroup.GET(hlsPlaylistPath, c.ServeHLSPlaylist)
+	hlsTokenGroup.GET(hlsContentPath, c.ServeHLSContent)
 
 	// Start the HLS activity sync goroutine (only once across all controller instances)
 	hlsMgr.activitySyncOnce.Do(func() {
@@ -296,22 +310,30 @@ func (c *Controller) privateModeAuth(next echo.HandlerFunc) echo.HandlerFunc {
 // The allow-list is keyed on method + path so any future handler added
 // at one of these paths under a different verb is fail-closed by default.
 func isPrivateModeExempt(method, path string) bool {
+	// Compose the exempt paths from the same constants used at the route
+	// registration sites (see initHLSRoutes, initAuthRoutes and the app config
+	// route in initAppRoutes) so the allow-list cannot silently drift from the
+	// actual routes. TestPrivateModeExemptPathsAreRegisteredRoutes asserts this
+	// correspondence.
+	authBase := apiV2Prefix + authGroupPath
+	hlsBase := apiV2Prefix + hlsGroupPath
+	hlsTokenBase := hlsBase + hlsTokenGroupPath
 	switch {
-	case method == http.MethodGet && path == "/api/v2/app/config":
+	case method == http.MethodGet && path == apiV2Prefix+AppConfigEndpoint:
 		return true
-	case method == http.MethodPost && path == "/api/v2/auth/login":
+	case method == http.MethodPost && path == authBase+authLoginPath:
 		return true
-	case method == http.MethodGet && path == "/api/v2/auth/callback":
+	case method == http.MethodGet && path == authBase+authCallbackPath:
 		return true
-	case method == http.MethodPost && path == "/api/v2/streams/hls/:sourceID/start":
+	case method == http.MethodPost && path == hlsBase+hlsStartPath:
 		return true
-	case method == http.MethodPost && path == "/api/v2/streams/hls/heartbeat":
+	case method == http.MethodPost && path == hlsBase+hlsHeartbeatPath:
 		return true
-	case method == http.MethodGet && path == "/api/v2/streams/hls/status":
+	case method == http.MethodGet && path == hlsBase+hlsStatusPath:
 		return true
-	case method == http.MethodGet && path == "/api/v2/streams/hls/t/:streamToken/playlist.m3u8":
+	case method == http.MethodGet && path == hlsTokenBase+hlsPlaylistPath:
 		return true
-	case method == http.MethodGet && path == "/api/v2/streams/hls/t/:streamToken/*":
+	case method == http.MethodGet && path == hlsTokenBase+hlsContentPath:
 		return true
 	}
 	return false

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -207,6 +207,15 @@ const (
 	hlsContentPath    = "/:streamToken/*"
 )
 
+// hlsPlaylistURL builds the client-facing playlist URL for a stream token from
+// the same route constants used to register the playlist route (see
+// initHLSRoutes), so the emitted URL cannot drift from the actual route on a
+// prefix or fragment rename.
+func hlsPlaylistURL(token string) string {
+	tokenPath := strings.Replace(hlsPlaylistPath, ":streamToken", token, 1)
+	return apiV2Prefix + hlsGroupPath + hlsTokenGroupPath + tokenPath
+}
+
 // initHLSRoutes registers HLS streaming endpoints
 func (c *Controller) initHLSRoutes() {
 	// Get authentication middleware
@@ -315,9 +324,11 @@ func isPrivateModeExempt(method, path string) bool {
 	// route in initAppRoutes) so the allow-list cannot silently drift from the
 	// actual routes. TestPrivateModeExemptPathsAreRegisteredRoutes asserts this
 	// correspondence.
-	authBase := apiV2Prefix + authGroupPath
-	hlsBase := apiV2Prefix + hlsGroupPath
-	hlsTokenBase := hlsBase + hlsTokenGroupPath
+	const (
+		authBase     = apiV2Prefix + authGroupPath
+		hlsBase      = apiV2Prefix + hlsGroupPath
+		hlsTokenBase = hlsBase + hlsTokenGroupPath
+	)
 	switch {
 	case method == http.MethodGet && path == apiV2Prefix+AppConfigEndpoint:
 		return true
@@ -478,7 +489,7 @@ func (c *Controller) buildHLSStreamResponse(ctx echo.Context, sourceID string, s
 	}
 
 	// Build the API URL using the stream token (not the sourceID)
-	playlistURL := fmt.Sprintf("/api/v2/streams/hls/t/%s/playlist.m3u8", token)
+	playlistURL := hlsPlaylistURL(token)
 
 	// Determine playlist ready status
 	var isReady bool
@@ -637,7 +648,7 @@ func (c *Controller) GetHLSStatus(ctx echo.Context) error {
 		token, hasToken := hlsMgr.sourceTokens[sourceID]
 		hlsMgr.tokensMu.RUnlock()
 		if hasToken {
-			playlistURL = fmt.Sprintf("/api/v2/streams/hls/t/%s/playlist.m3u8", token)
+			playlistURL = hlsPlaylistURL(token)
 		}
 
 		// Check actual playlist readiness instead of hardcoding true

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -638,18 +638,20 @@ func TestHLSConsumer_WriteDoesNotRetainFrameData(t *testing.T) {
 func TestIsPrivateModeExempt(t *testing.T) {
 	t.Parallel()
 
+	// Exempt paths are composed from the same route constants the controllers
+	// register with, so this allow-list cannot drift from production routing.
 	exempt := []struct {
 		method string
 		path   string
 	}{
-		{http.MethodGet, "/api/v2/app/config"},
-		{http.MethodPost, "/api/v2/auth/login"},
-		{http.MethodGet, "/api/v2/auth/callback"},
-		{http.MethodPost, "/api/v2/streams/hls/:sourceID/start"},
-		{http.MethodPost, "/api/v2/streams/hls/heartbeat"},
-		{http.MethodGet, "/api/v2/streams/hls/status"},
-		{http.MethodGet, "/api/v2/streams/hls/t/:streamToken/playlist.m3u8"},
-		{http.MethodGet, "/api/v2/streams/hls/t/:streamToken/*"},
+		{http.MethodGet, apiV2Prefix + AppConfigEndpoint},
+		{http.MethodPost, apiV2Prefix + authGroupPath + authLoginPath},
+		{http.MethodGet, apiV2Prefix + authGroupPath + authCallbackPath},
+		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsStartPath},
+		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsHeartbeatPath},
+		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsStatusPath},
+		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsTokenGroupPath + hlsPlaylistPath},
+		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsTokenGroupPath + hlsContentPath},
 	}
 	for _, tt := range exempt {
 		t.Run("exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
@@ -667,16 +669,17 @@ func TestIsPrivateModeExempt(t *testing.T) {
 		{http.MethodGet, "/api/v2/detections"},
 		{http.MethodGet, "/api/v2/notifications"},
 		{http.MethodGet, "/api/v2/settings/dashboard"},
-		{http.MethodPost, "/api/v2/auth/logout"},
-		{http.MethodGet, "/api/v2/auth/status"},
-		{http.MethodPost, "/api/v2/streams/hls/:sourceID/stop"}, // mutation, always auth-gated
+		{http.MethodPost, apiV2Prefix + authGroupPath + authLogoutPath},
+		{http.MethodGet, apiV2Prefix + authGroupPath + authStatusPath},
+		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsStopPath}, // mutation, always auth-gated
+		{http.MethodPost, apiV2Prefix + WizardDismissEndpoint},      // gated under PrivateMode by design
 		{http.MethodGet, "/api/v2/streams/audio-level"},
 		{http.MethodGet, "/api/v2/streams/sources"},
 		{http.MethodGet, "/health"},
 		// Method mismatches must NOT match the allow-list.
-		{http.MethodGet, "/api/v2/auth/login"},  // login is POST-only
-		{http.MethodPost, "/api/v2/app/config"}, // config is GET-only
-		{http.MethodDelete, "/api/v2/app/config"},
+		{http.MethodGet, apiV2Prefix + authGroupPath + authLoginPath}, // login is POST-only
+		{http.MethodPost, apiV2Prefix + AppConfigEndpoint},            // config is GET-only
+		{http.MethodDelete, apiV2Prefix + AppConfigEndpoint},
 	}
 	for _, tt := range notExempt {
 		t.Run("not_exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
@@ -684,5 +687,76 @@ func TestIsPrivateModeExempt(t *testing.T) {
 			assert.False(t, isPrivateModeExempt(tt.method, tt.path),
 				"expected %s %q to NOT be exempt", tt.method, tt.path)
 		})
+	}
+}
+
+// TestPrivateModeExemptPathsAreRegisteredRoutes mounts the routes that the
+// PrivateMode exempt allow-list cares about (using the same path constants the
+// controllers register them with) and asserts that isPrivateModeExempt's
+// verdict matches the intended policy for every registered route. This closes
+// the drift risk from Forgejo follow-up #890: if a route constant is renamed
+// the registered path and the exempt composition move together, and if
+// isPrivateModeExempt's composition is edited incorrectly the verdict no longer
+// matches a real route and this test fails.
+func TestPrivateModeExemptPathsAreRegisteredRoutes(t *testing.T) {
+	t.Parallel()
+
+	noop := func(echo.Context) error { return nil }
+
+	e := echo.New()
+	g := e.Group(apiV2Prefix)
+
+	// App config (public bootstrap endpoint, registered in initAppRoutes).
+	g.GET(AppConfigEndpoint, noop)
+	g.POST(WizardDismissEndpoint, noop) // registered but NOT exempt under PrivateMode
+
+	// Auth flow (mirrors initAuthRoutes).
+	authGroup := g.Group(authGroupPath)
+	authGroup.POST(authLoginPath, noop)
+	authGroup.GET(authCallbackPath, noop)
+	authGroup.POST(authLogoutPath, noop)
+	authGroup.GET(authStatusPath, noop)
+
+	// HLS streaming (mirrors initHLSRoutes).
+	hlsGroup := g.Group(hlsGroupPath)
+	hlsGroup.POST(hlsStartPath, noop)
+	hlsGroup.POST(hlsStopPath, noop)
+	hlsGroup.POST(hlsHeartbeatPath, noop)
+	hlsGroup.GET(hlsStatusPath, noop)
+	hlsTokenGroup := hlsGroup.Group(hlsTokenGroupPath)
+	hlsTokenGroup.GET(hlsPlaylistPath, noop)
+	hlsTokenGroup.GET(hlsContentPath, noop)
+
+	key := func(method, path string) string { return method + " " + path }
+
+	// Expected exempt set, with paths composed from the same constants the
+	// production code and isPrivateModeExempt use.
+	wantExempt := map[string]bool{
+		key(http.MethodGet, apiV2Prefix+AppConfigEndpoint):                              true,
+		key(http.MethodPost, apiV2Prefix+authGroupPath+authLoginPath):                   true,
+		key(http.MethodGet, apiV2Prefix+authGroupPath+authCallbackPath):                 true,
+		key(http.MethodPost, apiV2Prefix+hlsGroupPath+hlsStartPath):                     true,
+		key(http.MethodPost, apiV2Prefix+hlsGroupPath+hlsHeartbeatPath):                 true,
+		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsStatusPath):                     true,
+		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsTokenGroupPath+hlsPlaylistPath): true,
+		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsTokenGroupPath+hlsContentPath):  true,
+	}
+
+	registered := make(map[string]bool)
+	for _, r := range e.Routes() {
+		// Echo can register auxiliary entries; only assert on the verbs we use.
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
+			continue
+		}
+		k := key(r.Method, r.Path)
+		registered[k] = true
+		assert.Equalf(t, wantExempt[k], isPrivateModeExempt(r.Method, r.Path),
+			"isPrivateModeExempt verdict mismatch for registered route %s", k)
+	}
+
+	// Every expected-exempt entry must correspond to an actually registered
+	// route (catches an exempt path that no real route serves).
+	for k := range wantExempt {
+		assert.Truef(t, registered[k], "exempt route %q is not a registered route", k)
 	}
 }

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -261,7 +261,11 @@ func (c *Controller) Login(ctx echo.Context) error {
 	if requestBase != "" {
 		finalRedirect = ensurePathWithinBase(finalRedirect, requestBase+"/")
 	}
-	redirectURL := fmt.Sprintf("%s/api/v2/auth/callback?code=%s&redirect=%s", requestBase, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
+	// Compose the callback path from the same constants used to register the
+	// route (see initAuthRoutes) so the client-facing redirect URL cannot drift
+	// from the actual route on a prefix or fragment rename.
+	callbackPath := apiV2Prefix + authGroupPath + authCallbackPath
+	redirectURL := fmt.Sprintf("%s%s?code=%s&redirect=%s", requestBase, callbackPath, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
 
 	c.logInfoIfEnabled("Returning successful login response with redirect",
 		logger.Username(req.Username),

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -61,10 +61,21 @@ type AuthStatus struct {
 	Method        string `json:"auth_method,omitempty"`
 }
 
+// Auth route path fragments, registered relative to the v2 API group in
+// initAuthRoutes. They are reused by isPrivateModeExempt so the PrivateMode
+// exempt allow-list cannot drift from the registered routes.
+const (
+	authGroupPath    = "/auth"
+	authLoginPath    = "/login"
+	authCallbackPath = "/callback"
+	authLogoutPath   = "/logout"
+	authStatusPath   = "/status"
+)
+
 // initAuthRoutes registers all authentication-related API endpoints
 func (c *Controller) initAuthRoutes() {
 	// Create auth API group
-	authGroup := c.Group.Group("/auth")
+	authGroup := c.Group.Group(authGroupPath)
 
 	// Create rate limiter for login endpoint to prevent brute force attacks
 	// Allow 5 login attempts per 15 minutes per IP address
@@ -102,16 +113,16 @@ func (c *Controller) initAuthRoutes() {
 	})
 
 	// Routes that don't require authentication (but are rate limited)
-	authGroup.POST("/login", c.Login, loginRateLimiter)
+	authGroup.POST(authLoginPath, c.Login, loginRateLimiter)
 
 	// OAuth callback endpoint - public, completes the OAuth flow
 	// This is the V2 replacement for /api/v1/oauth2/callback
-	authGroup.GET("/callback", c.OAuthCallback)
+	authGroup.GET(authCallbackPath, c.OAuthCallback)
 
 	// Routes that require authentication
 	protectedGroup := authGroup.Group("", c.authMiddleware)
-	protectedGroup.POST("/logout", c.Logout)
-	protectedGroup.GET("/status", c.GetAuthStatus)
+	protectedGroup.POST(authLogoutPath, c.Logout)
+	protectedGroup.GET(authStatusPath, c.GetAuthStatus)
 }
 
 // Login handles POST /api/v2/auth/login

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -100,7 +100,7 @@ func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterfa
 	// Create a controller with the test datastore and default settings
 	// to prevent nil pointer panics if a handler accesses c.Settings.
 	controller := &Controller{
-		Group:    e.Group("/api/v2"),
+		Group:    e.Group(apiV2Prefix),
 		DS:       mockDS,
 		Settings: newValidTestSettings(),
 	}


### PR DESCRIPTION
Three small follow-ups surfaced while reviewing PR #3122 (opt-in `Security.PrivateMode`). All are low-risk and additive; none change behavior for users who leave PrivateMode off.

## Backend: derive PrivateMode exempt paths from route constants

`isPrivateModeExempt` hardcoded full route-path literals (e.g. `/api/v2/streams/hls/t/:streamToken/playlist.m3u8`) that duplicated the paths registered in `initHLSRoutes`, `initAuthRoutes`, and `initAppRoutes`. A route rename would silently desync the allow-list. The matching is fail-closed (a drifted path becomes auth-gated, never silently public), so this was a maintenance trap rather than a security hole.

- Introduce a shared `apiV2Prefix` constant plus auth/HLS route-fragment constants, and use them at both the registration sites and in the exempt allow-list, so the two cannot drift.
- Add `TestPrivateModeExemptPathsAreRegisteredRoutes`, which mounts the routes and asserts every exempt pattern maps to a registered Echo route.
- Correct the `/app/wizard/dismiss` comment: under PrivateMode the route is gated by design (an unauthenticated user sees the login form, not the wizard), so it is intentionally not on the exempt allow-list.

The composed paths are byte-for-byte identical to the previous literals (verified by reconstruction and by the new test), so no route's auth-exemption changed.

## Frontend: harden `fetchWithCSRF` URL handling and the 401 redirect

Two pre-existing defensive gaps in `api.ts`:

- **Protocol-relative URLs.** `//evil.com/x` satisfies `includes('//')` yet also starts with `/`, so it slipped past the absolute-URL SSRF guard. `buildAppUrl` already neutralises such URLs (same-origin relative paths only), so no CSRF token actually leaked, but the request was silently misrouted. Now rejected up front by reusing the canonical `isRelativePath()` helper, which also catches backslash variants like `/\evil.com`.
- **401 redirect hang.** When the reload-loop cooldown suppressed a 401 redirect, `redirectToLogin` returned a never-resolving promise without navigating, leaving any awaiting caller stuck in a loading state. It now throws an `ApiError` in that branch so the caller can recover. (The 401 `ApiError` is filtered from Sentry by the existing `isExpectedApiError` guard, so this adds no telemetry noise.)

Adds Vitest regression tests for both paths (each fails on the old code). Also removes stray em dashes from comments in the touched file.

## Preflight Status

- Single concern (PrivateMode follow-ups), two commits
- golangci-lint clean; `npm run check:all` clean; `go test -race ./internal/api/v2/` and 26 frontend tests pass
- No config/API/DB/CLI contract changes; no breaking changes on upgrade
- Secondary-model (Gemini) cross-validation: no regressions, paths byte-identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests no longer hang when login redirect suppression occurs; failed requests return clear errors.
  * Rejected malformed relative URLs (protocol-relative/backslash tricks) to avoid unintended requests.

* **Security**
  * Tightened CSRF and URL validation to prevent token leakage and cross-origin resolution.
  * Made private-mode route access decisions consistent across endpoints.

* **Tests**
  * Added regression and route-registration tests to validate URL handling and private-mode exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->