### PR TITLE
fix: remove unnecessary time-info write

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -147,6 +147,7 @@ if [ -n "$TZ" ]; then
         echo "❌ ERROR: Timezone '$TZ' not found in /usr/share/zoneinfo"
         echo "   Install tzdata-legacy if using US/*, Etc/*, or other legacy names"
         echo "   Falling back to UTC"
+        export TZ="UTC"
     fi
 else
     echo "No TZ environment variable set, using container default (UTC)"

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -141,19 +141,12 @@ if [ -n "$TZ" ]; then
         echo "    Legacy names may be removed in future Debian releases"
     fi
 
-    # Validate timezone exists in tzdata
     if [ -f "/usr/share/zoneinfo/$TZ" ]; then
-        ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
-        echo "$TZ" > /etc/timezone
         echo "✓ Timezone configured: $TZ"
     else
-        echo "❌ ERROR: Timezone '$TZ' not found"
-        echo "   Available timezones: ls /usr/share/zoneinfo/"
+        echo "❌ ERROR: Timezone '$TZ' not found in /usr/share/zoneinfo"
         echo "   Install tzdata-legacy if using US/*, Etc/*, or other legacy names"
         echo "   Falling back to UTC"
-        # Actually configure UTC as fallback
-        ln -snf "/usr/share/zoneinfo/UTC" /etc/localtime
-        echo "UTC" > /etc/timezone
     fi
 else
     echo "No TZ environment variable set, using container default (UTC)"


### PR DESCRIPTION
Everything involved should be reading the TZ env var just fine; it just needs /usr/share/zoneinfo to be -present-, but doesn't care about whether it's linked to /etc/localtime or such.

The reason I got here is because the `ln` is incompatible with a rootless container, which I somehow missed in my previous PR. 
I'd love to add a smoke test that starts up the container image with a nonroot user, but I can't find a suitable place to slot it in, if you've got any feedback on that I'd love to hear it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker startup handling for unresolved timezones: clearer error guidance and a notification that the container will fall back to UTC.
  * Removed attempts to modify system timezone files and verbose listings during this fallback, reducing unexpected system changes and noisy output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->