### PR TITLE
fix(security): basic auth and OAuth settings now hot-reload (#3370)

### DIFF
--- a/internal/api/auth/adapter.go
+++ b/internal/api/auth/adapter.go
@@ -167,12 +167,17 @@ func (a *SecurityAdapter) ValidateToken(token string) error {
 func (a *SecurityAdapter) AuthenticateBasic(c echo.Context, username, password string) (string, error) {
 	a.log().Info("Basic authentication login attempt", logger.Username(username))
 
-	if err := a.validateBasicAuthEnabled(username); err != nil {
+	// Snapshot the live settings once so credentials configured through the web
+	// UI take effect without a restart (issue #3370), and so the enabled and
+	// credential checks observe a single consistent view (TOCTOU guard).
+	basicAuth := a.OAuth2Server.CurrentSettings().Security.BasicAuth
+
+	if err := a.validateBasicAuthEnabled(basicAuth.Enabled, username); err != nil {
 		return "", err
 	}
 
-	storedPassword := a.OAuth2Server.Settings.Security.BasicAuth.Password
-	storedClientID := a.OAuth2Server.Settings.Security.BasicAuth.ClientID
+	storedPassword := basicAuth.Password
+	storedClientID := basicAuth.ClientID
 
 	a.logDebugAuthConfig(username, storedClientID)
 
@@ -186,9 +191,11 @@ func (a *SecurityAdapter) AuthenticateBasic(c echo.Context, username, password s
 	return a.generateAuthCodeOnSuccess(username)
 }
 
-// validateBasicAuthEnabled checks if basic auth is enabled.
-func (a *SecurityAdapter) validateBasicAuthEnabled(username string) error {
-	if !a.OAuth2Server.Settings.Security.BasicAuth.Enabled {
+// validateBasicAuthEnabled checks if basic auth is enabled. The enabled flag is
+// read from a live settings snapshot by the caller so UI changes apply without a
+// restart (issue #3370).
+func (a *SecurityAdapter) validateBasicAuthEnabled(enabled bool, username string) error {
+	if !enabled {
 		a.log().Warn("Basic authentication failed: Basic auth not enabled",
 			logger.Username(username))
 		return ErrBasicAuthDisabled
@@ -303,8 +310,9 @@ func (a *SecurityAdapter) getProviderLogoutURLDirect(c echo.Context, postLogoutR
 // getProviderLogoutURLFallback iterates all configured providers to find the active session.
 // This handles sessions created before the auth_provider key was introduced.
 func (a *SecurityAdapter) getProviderLogoutURLFallback(c echo.Context, postLogoutRedirectURI string, log logger.Logger) string {
+	settings := a.OAuth2Server.CurrentSettings()
 	for configProvider, gothProviderName := range security.ConfigToGothProvider {
-		provider := a.OAuth2Server.Settings.GetOAuthProvider(configProvider)
+		provider := settings.GetOAuthProvider(configProvider)
 		if provider == nil || !provider.Enabled {
 			continue
 		}

--- a/internal/api/auth/adapter.go
+++ b/internal/api/auth/adapter.go
@@ -170,7 +170,12 @@ func (a *SecurityAdapter) AuthenticateBasic(c echo.Context, username, password s
 	// Snapshot the live settings once so credentials configured through the web
 	// UI take effect without a restart (issue #3370), and so the enabled and
 	// credential checks observe a single consistent view (TOCTOU guard).
-	basicAuth := a.OAuth2Server.CurrentSettings().Security.BasicAuth
+	settings := a.OAuth2Server.CurrentSettings()
+	if settings == nil {
+		a.log().Warn("Basic authentication failed: settings unavailable", logger.Username(username))
+		return "", ErrBasicAuthDisabled
+	}
+	basicAuth := settings.Security.BasicAuth
 
 	if err := a.validateBasicAuthEnabled(basicAuth.Enabled, username); err != nil {
 		return "", err
@@ -311,6 +316,9 @@ func (a *SecurityAdapter) getProviderLogoutURLDirect(c echo.Context, postLogoutR
 // This handles sessions created before the auth_provider key was introduced.
 func (a *SecurityAdapter) getProviderLogoutURLFallback(c echo.Context, postLogoutRedirectURI string, log logger.Logger) string {
 	settings := a.OAuth2Server.CurrentSettings()
+	if settings == nil {
+		return ""
+	}
 	for configProvider, gothProviderName := range security.ConfigToGothProvider {
 		provider := settings.GetOAuthProvider(configProvider)
 		if provider == nil || !provider.Enabled {

--- a/internal/api/auth/adapter_test.go
+++ b/internal/api/auth/adapter_test.go
@@ -1,0 +1,53 @@
+// adapter_test.go: Regression tests for SecurityAdapter ensuring basic-auth
+// credentials configured via the web UI take effect without a server restart
+// (GitHub issue #3370). The bug was that AuthenticateBasic read the
+// construction-time OAuth2Server.Settings pointer instead of the live snapshot.
+
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/security"
+)
+
+// TestAuthenticateBasicHotReloadAfterEnable reproduces issue #3370: a user starts
+// BirdNET-Go without security, then enables basic auth and sets a password through
+// the web portal. The save publishes a new settings snapshot via the atomic
+// pointer, but the construction-time OAuth2Server.Settings pointer remains the
+// (disabled) startup snapshot. Login must succeed against the freshly configured
+// credentials without restarting the process.
+func TestAuthenticateBasicHotReloadAfterEnable(t *testing.T) {
+	// Startup snapshot: basic auth disabled, no credentials. This becomes the
+	// construction-time OAuth2Server.Settings pointer.
+	startup := &conf.Settings{}
+
+	server := security.NewOAuth2ServerForTesting(t, startup)
+
+	// Simulate a UI save: enable basic auth with credentials and publish the new
+	// snapshot through the atomic pointer (what conf.StoreSettings does on save).
+	updated := &conf.Settings{}
+	updated.Security.BasicAuth.Enabled = true
+	updated.Security.BasicAuth.ClientID = "admin"
+	updated.Security.BasicAuth.Password = "correct-horse"
+	updated.Security.BasicAuth.AuthCodeExp = time.Minute
+	conf.SetTestSettings(updated)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	adapter := NewSecurityAdapter(server)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	authCode, err := adapter.AuthenticateBasic(c, "admin", "correct-horse")
+	require.NoError(t, err, "login should succeed with credentials configured via UI without restart")
+	require.NotEmpty(t, authCode, "a non-empty auth code should be generated on success")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1056,7 +1056,11 @@ func (s *Server) isValidOAuthProvider(provider string) bool {
 // isAllowedOAuthUser checks if the OAuth user is in the allowed users list for the provider.
 // Uses the OAuthProviders array with a reverse lookup from goth provider name to config provider ID.
 func (s *Server) isAllowedOAuthUser(gothProvider, userID, email string) bool {
-	if s.settings == nil {
+	// Read the live snapshot so changes to the allowed OAuth users (or a
+	// provider's enabled flag) made through the UI apply without a restart
+	// (issue #3370).
+	settings := s.currentSettings()
+	if settings == nil {
 		return false
 	}
 
@@ -1072,7 +1076,7 @@ func (s *Server) isAllowedOAuthUser(gothProvider, userID, email string) bool {
 		return false
 	}
 
-	provider := s.settings.GetOAuthProvider(configProvider)
+	provider := settings.GetOAuthProvider(configProvider)
 	if provider == nil || !provider.Enabled || provider.UserID == "" {
 		return false
 	}

--- a/internal/api/server_oauth_test.go
+++ b/internal/api/server_oauth_test.go
@@ -155,3 +155,41 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 		})
 	}
 }
+
+// TestIsAllowedOAuthUserHotReload reproduces the issue #3370 class for the OAuth
+// allowed-users check: the provider/user allowlist edited through the web UI must
+// apply without a restart. The construction-time Server.settings holds a startup
+// snapshot where the provider is disabled with no allowed users, while the live
+// snapshot (published via the atomic pointer) enables it and adds the user.
+// Not parallel: it mutates the global settings snapshot.
+func TestIsAllowedOAuthUserHotReload(t *testing.T) {
+	// Startup snapshot: provider disabled, no allowed users.
+	startup := &conf.Settings{
+		Security: conf.Security{
+			OAuthProviders: []conf.OAuthProviderConfig{
+				{Provider: "google", Enabled: false, ClientID: "id", ClientSecret: "s", UserID: ""},
+			},
+		},
+	}
+	s := &Server{settings: startup}
+
+	// Sanity: with only the stale startup snapshot, the user is not allowed.
+	conf.SetTestSettings(startup)
+	assert.False(t, s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com"),
+		"user should not be allowed under the startup snapshot")
+
+	// Simulate a UI save: enable the provider and allow the user, published via
+	// the atomic pointer.
+	updated := &conf.Settings{
+		Security: conf.Security{
+			OAuthProviders: []conf.OAuthProviderConfig{
+				{Provider: "google", Enabled: true, ClientID: "id", ClientSecret: "s", UserID: "user@gmail.com"},
+			},
+		},
+	}
+	conf.SetTestSettings(updated)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	assert.True(t, s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com"),
+		"allowlist change made via UI must apply without a restart")
+}

--- a/internal/api/server_oauth_test.go
+++ b/internal/api/server_oauth_test.go
@@ -39,9 +39,10 @@ func TestIsValidOAuthProvider(t *testing.T) {
 	}
 }
 
+// Not parallel: isAllowedOAuthUser reads the live settings snapshot
+// (conf.GetSettings), and the sibling TestIsAllowedOAuthUserHotReload mutates that
+// global snapshot. Running serially keeps the two tests from coupling.
 func TestIsAllowedOAuthUser(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name         string
 		gothProvider string
@@ -140,7 +141,6 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			var settings *conf.Settings
 			if tt.providers != nil {
 				settings = &conf.Settings{

--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -77,8 +77,10 @@ func buildSessionOptions(secure bool, maxAge int) *sessions.Options {
 	}
 }
 
-// configureLocalNetworkCookieStore configures the cookie store for local network access
-func (s *OAuth2Server) configureLocalNetworkCookieStore() {
+// configureLocalNetworkCookieStore configures the cookie store for local network access.
+// The caller passes its live settings snapshot so the whole request observes one
+// consistent view (issue #3370); session-duration changes apply without a restart.
+func (s *OAuth2Server) configureLocalNetworkCookieStore(settings *conf.Settings) {
 	GetLogger().Info("Configuring cookie store for local network access (allowing non-HTTPS cookies)")
 	// Configure session options based on store type
 	switch store := gothic.Store.(type) {
@@ -86,11 +88,11 @@ func (s *OAuth2Server) configureLocalNetworkCookieStore() {
 		// For CookieStore, use default session duration (session cookie if 0)
 		store.Options = buildSessionOptions(false, 0)
 	case *sessions.FilesystemStore:
-		// Calculate MaxAge in seconds from the configured session duration
-		// If not configured, default to 7 days
+		// Calculate MaxAge in seconds from the configured session duration.
+		// If not configured, default to 7 days.
 		maxAge := DefaultSessionMaxAgeSeconds
-		if s.Settings.Security.SessionDuration > 0 {
-			maxAge = int(s.Settings.Security.SessionDuration.Seconds())
+		if sessionDuration := settings.Security.SessionDuration; sessionDuration > 0 {
+			maxAge = int(sessionDuration.Seconds())
 		}
 		store.Options = buildSessionOptions(false, maxAge)
 	default:
@@ -106,8 +108,11 @@ func (s *OAuth2Server) HandleBasicAuthorize(c echo.Context) error {
 	secLog := GetLogger().With(logger.String("client_id", clientID), logger.String("redirect_uri", redirectURI))
 	secLog.Info("Handling basic authorization request")
 
-	if clientID != s.Settings.Security.BasicAuth.ClientID {
-		secLog.Warn("Invalid client_id provided", logger.String("expected", s.Settings.Security.BasicAuth.ClientID))
+	// Read the live snapshot so UI changes to the client id apply without a
+	// restart (issue #3370).
+	expectedClientID := s.currentSettings().Security.BasicAuth.ClientID
+	if clientID != expectedClientID {
+		secLog.Warn("Invalid client_id provided", logger.String("expected", expectedClientID))
 		return c.String(http.StatusBadRequest, "Invalid client_id")
 	}
 
@@ -144,11 +149,16 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Missing or malformed Authorization header"})
 	}
 
+	// Snapshot the live settings once so credentials and options configured
+	// through the web UI apply without a restart (issue #3370) and the whole
+	// request observes a single consistent view.
+	settings := s.currentSettings()
+
 	// Use constant-time comparison to prevent timing attacks on credentials.
 	// Both comparisons are performed and combined with bitwise AND to prevent
 	// short-circuit evaluation from leaking timing information about valid IDs.
-	clientIDMatch := subtle.ConstantTimeCompare([]byte(clientID), []byte(s.Settings.Security.BasicAuth.ClientID))
-	clientSecretMatch := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(s.Settings.Security.BasicAuth.ClientSecret))
+	clientIDMatch := subtle.ConstantTimeCompare([]byte(clientID), []byte(settings.Security.BasicAuth.ClientID))
+	clientSecretMatch := subtle.ConstantTimeCompare([]byte(clientSecret), []byte(settings.Security.BasicAuth.ClientSecret))
 	if (clientIDMatch & clientSecretMatch) != 1 {
 		secLog.Warn("Invalid client credentials provided")
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Invalid client id or secret"})
@@ -156,11 +166,11 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 
 	// Check if client is in local subnet and configure cookie store accordingly
 	// Only relax cookie security when subnet bypass is explicitly enabled
-	if s.Settings.Security.AllowSubnetBypass.Enabled {
+	if settings.Security.AllowSubnetBypass.Enabled {
 		if clientIP := parseIPWithZone(c.RealIP()); IsInLocalSubnet(clientIP) {
 			// For clients in the local subnet, allow non-HTTPS cookies
 			secLog.Info("Client is in local subnet, configuring cookie store for non-HTTPS")
-			s.configureLocalNetworkCookieStore()
+			s.configureLocalNetworkCookieStore(settings)
 		}
 	}
 
@@ -219,7 +229,7 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 	c.Response().Header().Set("Content-Type", "application/json")
 
 	// Return the access token in the response body
-	expiresInSeconds := int(s.Settings.Security.BasicAuth.AccessTokenExp.Seconds())
+	expiresInSeconds := int(settings.Security.BasicAuth.AccessTokenExp.Seconds())
 	resp := map[string]any{ // Use interface{} for mixed types
 		"access_token": accessToken, // This is sent to the client, unavoidable
 		"token_type":   "Bearer",

--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -111,6 +111,10 @@ func (s *OAuth2Server) HandleBasicAuthorize(c echo.Context) error {
 	// Read the live snapshot once so UI changes to the client id and redirect URI
 	// apply without a restart (issue #3370).
 	settings := s.currentSettings()
+	if settings == nil {
+		secLog.Error("Basic authorization failed: settings unavailable")
+		return c.String(http.StatusInternalServerError, "Internal server error")
+	}
 	expectedClientID := settings.Security.BasicAuth.ClientID
 	if clientID != expectedClientID {
 		secLog.Warn("Invalid client_id provided", logger.String("expected", expectedClientID))
@@ -154,6 +158,10 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 	// through the web UI apply without a restart (issue #3370) and the whole
 	// request observes a single consistent view.
 	settings := s.currentSettings()
+	if settings == nil {
+		secLog.Error("Basic auth token request failed: settings unavailable")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Internal server error"})
+	}
 
 	// Use constant-time comparison to prevent timing attacks on credentials.
 	// Both comparisons are performed and combined with bitwise AND to prevent

--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -108,16 +108,17 @@ func (s *OAuth2Server) HandleBasicAuthorize(c echo.Context) error {
 	secLog := GetLogger().With(logger.String("client_id", clientID), logger.String("redirect_uri", redirectURI))
 	secLog.Info("Handling basic authorization request")
 
-	// Read the live snapshot so UI changes to the client id apply without a
-	// restart (issue #3370).
-	expectedClientID := s.currentSettings().Security.BasicAuth.ClientID
+	// Read the live snapshot once so UI changes to the client id and redirect URI
+	// apply without a restart (issue #3370).
+	settings := s.currentSettings()
+	expectedClientID := settings.Security.BasicAuth.ClientID
 	if clientID != expectedClientID {
 		secLog.Warn("Invalid client_id provided", logger.String("expected", expectedClientID))
 		return c.String(http.StatusBadRequest, "Invalid client_id")
 	}
 
-	// Validate redirect URI using the shared function and pre-parsed expected URI
-	if err := ValidateRedirectURI(redirectURI, s.ExpectedBasicRedirectURI); err != nil {
+	// Validate redirect URI using the shared function and the live expected URI
+	if err := ValidateRedirectURI(redirectURI, parseBasicAuthRedirectURI(settings)); err != nil {
 		secLog.Warn("Redirect URI validation failed", logger.Error(err))
 		// Return the specific error message for better client-side debugging
 		return c.String(http.StatusBadRequest, err.Error())
@@ -192,8 +193,8 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Unsupported grant type"})
 	}
 
-	// Validate redirect URI using the shared function and pre-parsed expected URI
-	if err := ValidateRedirectURI(redirectURI, s.ExpectedBasicRedirectURI); err != nil {
+	// Validate redirect URI using the shared function and the live expected URI
+	if err := ValidateRedirectURI(redirectURI, parseBasicAuthRedirectURI(settings)); err != nil {
 		secLog.Warn("Redirect URI validation failed", logger.String("provided_uri", redirectURI), logger.Error(err))
 		// Return a generic error to the client, log the specific one internally
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid redirect_uri"})

--- a/internal/security/basic_test.go
+++ b/internal/security/basic_test.go
@@ -41,8 +41,6 @@ func setupOAuth2ServerTest(t *testing.T, requestClientID, requestRedirectURI, ex
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	parsedExpectedURI := parseURLOrFail(t, expectedRedirectURI)
-
 	server := &OAuth2Server{
 		Settings: &conf.Settings{
 			Security: conf.Security{
@@ -52,9 +50,8 @@ func setupOAuth2ServerTest(t *testing.T, requestClientID, requestRedirectURI, ex
 				},
 			},
 		},
-		authCodes:                make(map[string]AuthCode),
-		accessTokens:             make(map[string]AccessToken),
-		ExpectedBasicRedirectURI: parsedExpectedURI,
+		authCodes:    make(map[string]AuthCode),
+		accessTokens: make(map[string]AccessToken),
 	}
 
 	// Publish the settings as the global snapshot so currentSettings() (used by
@@ -137,22 +134,20 @@ func TestHandleBasicAuthTokenSuccess(t *testing.T) {
 	// Initialize Gothic session
 	gothic.Store = sessions.NewFilesystemStore(os.TempDir(), []byte("secret-key"))
 
-	parsedExpectedCallbackURI := parseURLOrFail(t, "http://example.com/callback")
-
 	s := &OAuth2Server{
 		Settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					ClientID:       "validClientID",
 					ClientSecret:   "validClientSecret",
+					RedirectURI:    "http://example.com/callback",
 					AccessTokenExp: time.Hour,
 				},
 				Host: "example.com",
 			},
 		},
-		authCodes:                make(map[string]AuthCode),
-		accessTokens:             make(map[string]AccessToken),
-		ExpectedBasicRedirectURI: parsedExpectedCallbackURI,
+		authCodes:    make(map[string]AuthCode),
+		accessTokens: make(map[string]AccessToken),
 	}
 
 	// Publish the settings as the global snapshot so currentSettings() (used by
@@ -236,23 +231,22 @@ func TestHandleBasicAuthTokenHotReloadAfterEnable(t *testing.T) {
 
 	gothic.Store = sessions.NewFilesystemStore(os.TempDir(), []byte("secret-key"))
 
-	parsedExpectedCallbackURI := parseURLOrFail(t, "http://example.com/callback")
-
 	// Startup snapshot: basic auth not configured (no client credentials).
 	s := &OAuth2Server{
-		Settings:                 &conf.Settings{},
-		authCodes:                make(map[string]AuthCode),
-		accessTokens:             make(map[string]AccessToken),
-		ExpectedBasicRedirectURI: parsedExpectedCallbackURI,
+		Settings:     &conf.Settings{},
+		authCodes:    make(map[string]AuthCode),
+		accessTokens: make(map[string]AccessToken),
 	}
 
-	// Simulate a UI save publishing new credentials through the atomic pointer.
+	// Simulate a UI save publishing new credentials (including the redirect URI)
+	// through the atomic pointer.
 	updated := &conf.Settings{
 		Security: conf.Security{
 			BasicAuth: conf.BasicAuth{
 				Enabled:        true,
 				ClientID:       "newClientID",
 				ClientSecret:   "newClientSecret",
+				RedirectURI:    "http://example.com/callback",
 				AccessTokenExp: time.Hour,
 			},
 			Host: "example.com",

--- a/internal/security/basic_test.go
+++ b/internal/security/basic_test.go
@@ -57,6 +57,12 @@ func setupOAuth2ServerTest(t *testing.T, requestClientID, requestRedirectURI, ex
 		ExpectedBasicRedirectURI: parsedExpectedURI,
 	}
 
+	// Publish the settings as the global snapshot so currentSettings() (used by
+	// the basic-auth handlers after the issue #3370 fix) returns these values
+	// rather than a snapshot leaked by a sibling test.
+	conf.SetTestSettings(server.Settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
 	return server, c, rec
 }
 
@@ -149,6 +155,11 @@ func TestHandleBasicAuthTokenSuccess(t *testing.T) {
 		ExpectedBasicRedirectURI: parsedExpectedCallbackURI,
 	}
 
+	// Publish the settings as the global snapshot so currentSettings() (used by
+	// HandleBasicAuthToken after the issue #3370 fix) returns these values.
+	conf.SetTestSettings(s.Settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
 	// Pre-populate a valid auth code
 	s.authCodes["validCode"] = AuthCode{
 		Code:      "validCode",
@@ -188,6 +199,11 @@ func TestHandleBasicAuthTokenMissingFields(t *testing.T) {
 		accessTokens: make(map[string]AccessToken),
 	}
 
+	// Publish the settings as the global snapshot so currentSettings() (used by
+	// HandleBasicAuthToken after the issue #3370 fix) returns these values.
+	conf.SetTestSettings(s.Settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
 	c.SetParamNames("grant_type", "code", "redirect_uri")
 	c.SetParamValues("", "", "")
 
@@ -201,6 +217,66 @@ func TestHandleBasicAuthTokenMissingFields(t *testing.T) {
 	require.NoError(t, err, "should unmarshal response JSON")
 
 	assert.Equal(t, "Missing required fields", response["error"])
+}
+
+// TestHandleBasicAuthTokenHotReloadAfterEnable reproduces the issue #3370 class
+// for the OAuth token path: credentials configured through the web UI after
+// startup must be accepted without a restart. The construction-time
+// OAuth2Server.Settings holds the (empty) startup snapshot while the live
+// snapshot, published via the atomic pointer, carries the new credentials.
+// Not parallel: it mutates the global settings snapshot.
+func TestHandleBasicAuthTokenHotReloadAfterEnable(t *testing.T) {
+	e := echo.New()
+	formData := strings.NewReader("grant_type=authorization_code&code=validCode&redirect_uri=http://example.com/callback")
+	req := httptest.NewRequest(http.MethodPost, "/", formData)
+	req.Header.Set(echo.HeaderAuthorization, "Basic "+base64.StdEncoding.EncodeToString([]byte("newClientID:newClientSecret")))
+	req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	gothic.Store = sessions.NewFilesystemStore(os.TempDir(), []byte("secret-key"))
+
+	parsedExpectedCallbackURI := parseURLOrFail(t, "http://example.com/callback")
+
+	// Startup snapshot: basic auth not configured (no client credentials).
+	s := &OAuth2Server{
+		Settings:                 &conf.Settings{},
+		authCodes:                make(map[string]AuthCode),
+		accessTokens:             make(map[string]AccessToken),
+		ExpectedBasicRedirectURI: parsedExpectedCallbackURI,
+	}
+
+	// Simulate a UI save publishing new credentials through the atomic pointer.
+	updated := &conf.Settings{
+		Security: conf.Security{
+			BasicAuth: conf.BasicAuth{
+				Enabled:        true,
+				ClientID:       "newClientID",
+				ClientSecret:   "newClientSecret",
+				AccessTokenExp: time.Hour,
+			},
+			Host: "example.com",
+		},
+	}
+	conf.SetTestSettings(updated)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	s.authCodes["validCode"] = AuthCode{
+		Code:      "validCode",
+		ExpiresAt: time.Now().Add(time.Minute),
+	}
+
+	err := s.HandleBasicAuthToken(c)
+	require.NoError(t, err, "HandleBasicAuthToken should not return error")
+
+	// Credentials configured via UI are accepted without restart: a 401 here
+	// would mean the stale (empty) startup credentials were used.
+	assert.Equal(t, http.StatusOK, rec.Code, "token request must accept UI-configured credentials without restart")
+
+	var response map[string]any
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err, "should unmarshal response JSON")
+	assert.NotEmpty(t, response["access_token"], "expected access token in response")
 }
 
 // TestHandleBasicAuthCallback tests the basic authorization callback handler

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -143,9 +143,6 @@ type OAuth2Server struct {
 	tokensFile    string
 	persistTokens bool
 
-	// Expected Redirect URI for Basic Auth (pre-parsed)
-	ExpectedBasicRedirectURI *url.URL
-
 	// Throttling
 	throttledMessages map[string]time.Time
 }
@@ -185,9 +182,6 @@ func NewOAuth2Server() *OAuth2Server {
 
 	// Validate and potentially fix session secret
 	validateSessionSecret(settings)
-
-	// Pre-parse the Basic Auth Redirect URI
-	server.ExpectedBasicRedirectURI = parseBasicAuthRedirectURI(settings)
 
 	// Initialize Gothic with the provided configuration
 	InitializeGoth(settings)
@@ -255,7 +249,10 @@ func handleWeakSessionSecret(settings *conf.Settings) {
 		Build()
 }
 
-// parseBasicAuthRedirectURI parses and validates the Basic Auth redirect URI
+// parseBasicAuthRedirectURI parses and validates the Basic Auth redirect URI from
+// the given settings snapshot. It is called per request from the basic-auth handlers
+// so that changes to Security.BasicAuth.RedirectURI made via the web UI take effect
+// without a restart (issue #3370). Returns nil on a missing or invalid configuration.
 func parseBasicAuthRedirectURI(settings *conf.Settings) *url.URL {
 	secLog := GetLogger().With(logger.String("uri", settings.Security.BasicAuth.RedirectURI))
 
@@ -276,7 +273,7 @@ func parseBasicAuthRedirectURI(settings *conf.Settings) *url.URL {
 		return nil
 	}
 
-	secLog.Info("Pre-parsed and validated Basic Auth Redirect URI")
+	secLog.Debug("Validated Basic Auth Redirect URI")
 	return parsedURI
 }
 

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -156,6 +156,13 @@ func (s *OAuth2Server) currentSettings() *conf.Settings {
 	return conf.CurrentOrFallback(s.Settings)
 }
 
+// CurrentSettings returns the latest settings snapshot for callers outside the
+// security package (e.g. the API auth adapter) so they read live configuration
+// instead of the construction-time pointer. See currentSettings.
+func (s *OAuth2Server) CurrentSettings() *conf.Settings {
+	return s.currentSettings()
+}
+
 // For testing purposes
 var testConfigPath string
 

--- a/internal/security/persistence_test.go
+++ b/internal/security/persistence_test.go
@@ -133,7 +133,7 @@ func TestLocalNetworkCookieStore(t *testing.T) {
 
 	// Test with CookieStore
 	gothic.Store = sessions.NewCookieStore([]byte("test-secret"))
-	server.configureLocalNetworkCookieStore()
+	server.configureLocalNetworkCookieStore(server.Settings)
 
 	cookieStore, ok := gothic.Store.(*sessions.CookieStore)
 	assert.True(t, ok, "Gothic store should be a CookieStore")
@@ -143,7 +143,7 @@ func TestLocalNetworkCookieStore(t *testing.T) {
 	tempDir := t.TempDir()
 
 	gothic.Store = sessions.NewFilesystemStore(tempDir, []byte("test-secret"))
-	server.configureLocalNetworkCookieStore()
+	server.configureLocalNetworkCookieStore(server.Settings)
 
 	fileStore, ok := gothic.Store.(*sessions.FilesystemStore)
 	assert.True(t, ok, "Gothic store should be a FilesystemStore")
@@ -171,7 +171,7 @@ func TestConfigureLocalNetworkWithUnknownStore(t *testing.T) {
 
 	// This should not panic - the function handles unknown store types gracefully
 	assert.NotPanics(t, func() {
-		server.configureLocalNetworkCookieStore()
+		server.configureLocalNetworkCookieStore(server.Settings)
 	}, "configureLocalNetworkCookieStore should not panic with unknown store type")
 }
 
@@ -199,7 +199,7 @@ func TestConfigureLocalNetworkWithMissingSessionSecret(t *testing.T) {
 	// This should not panic - the function handles unknown store types gracefully
 	// even with an empty session secret
 	assert.NotPanics(t, func() {
-		server.configureLocalNetworkCookieStore()
+		server.configureLocalNetworkCookieStore(server.Settings)
 	}, "configureLocalNetworkCookieStore should not panic with unknown store type and empty session secret")
 }
 


### PR DESCRIPTION
## Summary

Setting a basic-auth password through the web portal failed on login until the container was restarted (#3370). The basic-auth credential, enabled-flag, and OAuth token checks read the construction-time `OAuth2Server.Settings` pointer, which is never mutated after a UI save: `conf.StoreSettings()` swaps the global atomic snapshot and leaves the captured pointer stale. The auth gate (`IsAuthenticationEnabled`) already read the live snapshot, so the login page correctly appeared but the password was rejected, surfacing to the user as "incorrect password".

This routes the basic-auth flow and the OAuth allowed-users check through the live settings snapshot (`currentSettings()` / the new exported `CurrentSettings()`) so changes take effect immediately, matching the project's hot-reload-by-default contract.

The "missing quotes in config" mentioned in the report is a red herring: `SaveYAMLConfig` uses `yaml.Marshal` (auto-quotes when needed); the restart is what actually fixed it.

## Changes

- `internal/security/oauth.go`: add exported `CurrentSettings()` so the cross-package API auth adapter can read the live snapshot.
- `internal/api/auth/adapter.go`: `AuthenticateBasic` snapshots the basic-auth config once (TOCTOU guard); the logout provider fallback reads the live snapshot.
- `internal/security/basic.go`: `HandleBasicAuthToken` / `HandleBasicAuthorize` and the local-network cookie-store config snapshot once per request for a single consistent view.
- `internal/api/server.go`: `isAllowedOAuthUser` (OAuth allowed-users allowlist) reads the live snapshot.
- Tests: hot-reload regressions (`TestAuthenticateBasicHotReloadAfterEnable`, `TestHandleBasicAuthTokenHotReloadAfterEnable`, `TestIsAllowedOAuthUserHotReload`) that fail on the old code; existing basic-auth tests publish their settings to the global snapshot to match the live-read path.

## Test Plan

- [x] `go test -race ./internal/security/... ./internal/api/auth/... ./internal/api/`
- [x] `golangci-lint run` clean on changed packages
- [x] New regression tests fail on the pre-fix code and pass after
- [ ] Manual: enable basic auth via the web portal on a running instance, then log in without restarting

Fixes #3370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication and session settings (basic auth enablement/credentials, OAuth provider allow-list, redirect validation, and session duration) now use the latest configuration immediately; missing config is handled gracefully and prevents stale behavior.
* **Tests**
  * Added regression tests to verify hot-reload behavior for basic-auth, token endpoint, and OAuth allowed-user updates to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->