### PR TITLE
fix(api): read live settings snapshot in api/v2 handlers (races, stale reads)

### DIFF
--- a/internal/api/auth/adapter_test.go
+++ b/internal/api/auth/adapter_test.go
@@ -1,7 +1,7 @@
 // adapter_test.go: Regression tests for SecurityAdapter ensuring basic-auth
 // credentials configured via the web UI take effect without a server restart
 // (GitHub issue #3370). The bug was that AuthenticateBasic read the
-// construction-time OAuth2Server.Settings pointer instead of the live snapshot.
+// construction-time OAuth2Server.settings pointer instead of the live snapshot.
 
 package auth
 
@@ -20,12 +20,12 @@ import (
 // TestAuthenticateBasicHotReloadAfterEnable reproduces issue #3370: a user starts
 // BirdNET-Go without security, then enables basic auth and sets a password through
 // the web portal. The save publishes a new settings snapshot via the atomic
-// pointer, but the construction-time OAuth2Server.Settings pointer remains the
+// pointer, but the construction-time OAuth2Server.settings pointer remains the
 // (disabled) startup snapshot. Login must succeed against the freshly configured
 // credentials without restarting the process.
 func TestAuthenticateBasicHotReloadAfterEnable(t *testing.T) {
 	// Startup snapshot: basic auth disabled, no credentials. This becomes the
-	// construction-time OAuth2Server.Settings pointer.
+	// construction-time OAuth2Server.settings pointer.
 	startup := &conf.Settings{}
 
 	server := security.NewOAuth2ServerForTesting(t, startup)

--- a/internal/api/server_oauth_test.go
+++ b/internal/api/server_oauth_test.go
@@ -39,9 +39,10 @@ func TestIsValidOAuthProvider(t *testing.T) {
 	}
 }
 
-// Not parallel: isAllowedOAuthUser reads the live settings snapshot
-// (conf.GetSettings), and the sibling TestIsAllowedOAuthUserHotReload mutates that
-// global snapshot. Running serially keeps the two tests from coupling.
+// Not parallel: each subtest publishes its own snapshot to the process-global
+// settings (read by isAllowedOAuthUser via conf.GetSettings) and restores it on
+// cleanup, so the subtests neither depend on the global being nil nor couple
+// with the sibling TestIsAllowedOAuthUserHotReload.
 func TestIsAllowedOAuthUser(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -150,6 +151,12 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 				}
 			}
 			s := &Server{settings: settings}
+			// Publish this subtest's snapshot so isAllowedOAuthUser (which reads
+			// conf.GetSettings via currentSettings) resolves to it rather than
+			// depending on the global being nil. Restored on cleanup.
+			prev := conf.GetSettings()
+			conf.SetTestSettings(settings)
+			t.Cleanup(func() { conf.SetTestSettings(prev) })
 			got := s.isAllowedOAuthUser(tt.gothProvider, tt.userID, tt.email)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -165,8 +165,35 @@ type ShutdownRequester interface {
 
 // currentSettings returns the latest settings snapshot so UI changes
 // take effect in API responses without restarting the service.
+//
+// It resolves the lock-free global atomic snapshot first and only falls back
+// to c.Settings when no snapshot has been published (standalone unit-test
+// controllers). The fallback is read lazily, so in production (where a
+// snapshot is always published) c.Settings is never dereferenced here. That
+// keeps the accessor race-free against the c.Settings reassignment the
+// settings update handlers perform under c.settingsMutex: the equivalent
+// conf.CurrentOrFallback(c.Settings) would evaluate c.Settings eagerly and
+// race that write.
 func (c *Controller) currentSettings() *conf.Settings {
-	return conf.CurrentOrFallback(c.Settings)
+	if latest := conf.GetSettings(); latest != nil {
+		return latest
+	}
+	return c.Settings
+}
+
+// lockedSettings returns this controller's own cached settings snapshot, read
+// under settingsMutex so it cannot race the c.Settings reassignment the settings
+// update handlers perform. Unlike currentSettings(), it deliberately does NOT
+// consult the process-global atomic snapshot: use it for reads whose result is
+// asserted per-controller (e.g. debug-gated response verbosity), where the
+// shared global snapshot would couple otherwise-independent parallel tests.
+// c.Settings is repointed on every save, so it stays live for such reads. The
+// returned snapshot is immutable (copy-on-write), so callers may dereference its
+// fields after the lock is released.
+func (c *Controller) lockedSettings() *conf.Settings {
+	c.settingsMutex.RLock()
+	defer c.settingsMutex.RUnlock()
+	return c.Settings
 }
 
 // Option is a functional option for configuring the Controller.
@@ -695,16 +722,26 @@ func (c *Controller) initRoutes() {
 
 // HealthCheck handles the API health check endpoint
 func (c *Controller) HealthCheck(ctx echo.Context) error {
+	// Read version/build/debug from this controller's own snapshot (nil-safe for
+	// standalone test controllers).
+	var version, buildDate string
+	debug := false
+	if settings := c.lockedSettings(); settings != nil {
+		version = settings.Version
+		buildDate = settings.BuildDate
+		debug = settings.WebServer.Debug
+	}
+
 	// Create response structure
 	response := map[string]any{
 		"status":     "healthy",
-		"version":    c.Settings.Version,
-		"build_date": c.Settings.BuildDate,
+		"version":    version,
+		"build_date": buildDate,
 		"timestamp":  time.Now().Format(time.RFC3339),
 	}
 
-	// Add environment if available in settings
-	if c.Settings != nil && c.Settings.WebServer.Debug {
+	// Add environment based on debug mode
+	if debug {
 		response["environment"] = "development"
 	} else {
 		response["environment"] = "production"
@@ -854,10 +891,16 @@ func (c *Controller) newErrorResponse(err error, message string, code int) *Erro
 	// Generate a random correlation ID (8 characters should be sufficient)
 	correlationID := generateCorrelationID()
 
-	// Only expose raw err.Error() in debug mode — it can contain internal
+	// Only expose raw err.Error() in debug mode: it can contain internal
 	// paths, SQL errors, stack traces, etc. In production, use the
 	// sanitized message parameter instead.
 	var errorStr string
+	// Read the controller's own debug flag without locking: this is reached from
+	// HandleError while UpdateSettings holds c.settingsMutex, so it must not
+	// acquire the lock, and the flag must remain per-controller (handlers assert
+	// debug-gated error verbosity per controller, not via the shared global
+	// snapshot). A fully race-free per-controller read would require making
+	// c.Settings an atomic pointer; left as a focused follow-up.
 	if err != nil && c.Settings != nil && c.Settings.WebServer.Debug {
 		errorStr = err.Error()
 	} else {

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -128,23 +128,28 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to generate CSRF token", http.StatusInternalServerError)
 	}
 
+	// Snapshot the live settings once so the response reflects the latest
+	// published configuration and every read below is race-free against a
+	// concurrent settings save (see currentSettings).
+	settings := c.currentSettings()
+
 	// Get enabled OAuth providers from the new array-based config
 	// This returns provider IDs for all enabled providers with valid credentials
-	enabledProviders := c.Settings.GetEnabledOAuthProviders()
+	enabledProviders := settings.GetEnabledOAuthProviders()
 	// Ensure we always return an array (not null) for JSON serialization
 	if enabledProviders == nil {
 		enabledProviders = []string{}
 	}
 
 	// Determine if any security method is enabled
-	securityEnabled := c.Settings.Security.BasicAuth.Enabled || len(enabledProviders) > 0
+	securityEnabled := settings.Security.BasicAuth.Enabled || len(enabledProviders) > 0
 
 	// Determine if access is currently allowed
 	accessAllowed := c.determineAccessAllowed(ctx, securityEnabled)
 
 	// Determine the effective base path for reverse proxy support.
 	// Priority: X-Ingress-Path > X-Forwarded-Prefix > config BasePath > empty.
-	basePath := requestBasePath(ctx, c.Settings)
+	basePath := requestBasePath(ctx, settings)
 
 	// Determine wizard state (freshInstall, newVersion, previousVersion)
 	freshInstall, newVersion, previousVersion := c.determineWizardState(ctx.Request().Context())
@@ -156,36 +161,36 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 			Enabled:       securityEnabled,
 			AccessAllowed: accessAllowed,
 			AuthConfig: AuthConfigDTO{
-				BasicEnabled:     c.Settings.Security.BasicAuth.Enabled,
+				BasicEnabled:     settings.Security.BasicAuth.Enabled,
 				EnabledProviders: enabledProviders,
 			},
 			PublicAccess: PublicAccessDTO{
-				LiveAudio: c.Settings.Security.PublicAccess.LiveAudio,
+				LiveAudio: settings.Security.PublicAccess.LiveAudio,
 			},
-			PrivateMode: c.Settings.Security.PrivateMode,
+			PrivateMode: settings.Security.PrivateMode,
 		},
-		Version:         c.Settings.Version,
+		Version:         settings.Version,
 		BasePath:        basePath,
-		ColorScheme:     c.Settings.Realtime.Dashboard.ColorScheme,
-		CustomColors:    c.Settings.Realtime.Dashboard.CustomColors,
-		LogoStyle:       c.Settings.Realtime.Dashboard.LogoStyle,
-		LiveSpectrogram: c.Settings.Realtime.Dashboard.LiveSpectrogram,
+		ColorScheme:     settings.Realtime.Dashboard.ColorScheme,
+		CustomColors:    settings.Realtime.Dashboard.CustomColors,
+		LogoStyle:       settings.Realtime.Dashboard.LogoStyle,
+		LiveSpectrogram: settings.Realtime.Dashboard.LiveSpectrogram,
 		FreshInstall:    freshInstall,
 		NewVersion:      newVersion,
 		PreviousVersion: previousVersion,
 	}
 
 	// Include dashboard layout for guest/pre-auth rendering if configured
-	if len(c.Settings.Realtime.Dashboard.Layout.Elements) > 0 {
-		response.Layout = &c.Settings.Realtime.Dashboard.Layout
+	if len(settings.Realtime.Dashboard.Layout.Elements) > 0 {
+		response.Layout = &settings.Realtime.Dashboard.Layout
 	}
 
 	// Include Sentry frontend config when telemetry is enabled
-	if c.Settings.Sentry.Enabled {
+	if settings.Sentry.Enabled {
 		response.Sentry = &SentryFrontendConfig{
 			Enabled:  true,
 			DSN:      telemetry.GetFrontendDSN(),
-			SystemID: c.Settings.SystemID,
+			SystemID: settings.SystemID,
 		}
 	}
 
@@ -207,8 +212,10 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 //   - If last_seen_version is missing and no install signals: freshInstall = true.
 //   - If last_seen_version differs from the current version: newVersion = true.
 func (c *Controller) determineWizardState(ctx context.Context) (freshInstall, newVersion bool, previousVersion string) {
+	settings := c.currentSettings()
+
 	// Skip wizard triggers for dev builds
-	if isDevBuild(c.Settings.Version) {
+	if isDevBuild(settings.Version) {
 		return false, false, ""
 	}
 
@@ -228,16 +235,16 @@ func (c *Controller) determineWizardState(ctx context.Context) (freshInstall, ne
 		if c.isExistingInstall(ctx) {
 			// Auto-seed: existing install predates wizard tracking.
 			// Intentional write inside GET handler (idempotent upsert, fires once per install).
-			if err := c.appMetadataRepo.Set(ctx, appMetadataKeyLastSeenVersion, c.Settings.Version); err != nil {
+			if err := c.appMetadataRepo.Set(ctx, appMetadataKeyLastSeenVersion, settings.Version); err != nil {
 				c.logWarnIfEnabled("Failed to auto-seed last_seen_version", logger.Error(err))
 			}
-			return false, false, c.Settings.Version
+			return false, false, settings.Version
 		}
 		return true, false, ""
 	}
 
 	// If versions differ, this is an upgrade
-	if lastSeenVersion != c.Settings.Version {
+	if lastSeenVersion != settings.Version {
 		return false, true, lastSeenVersion
 	}
 
@@ -272,13 +279,14 @@ func (c *Controller) hasZeroDetections(ctx context.Context) bool {
 // isExistingInstall returns true if multiple signals indicate this is a configured
 // installation rather than a genuinely fresh one. Checks are ordered cheapest-first.
 func (c *Controller) isExistingInstall(ctx context.Context) bool {
-	if c.Settings.BirdNET.Latitude != 0 || c.Settings.BirdNET.Longitude != 0 {
+	settings := c.currentSettings()
+	if settings.BirdNET.Latitude != 0 || settings.BirdNET.Longitude != 0 {
 		return true
 	}
-	if len(c.Settings.Realtime.Audio.Sources) > 0 {
+	if len(settings.Realtime.Audio.Sources) > 0 {
 		return true
 	}
-	if c.Settings.Security.BasicAuth.Enabled || len(c.Settings.GetEnabledOAuthProviders()) > 0 {
+	if settings.Security.BasicAuth.Enabled || len(settings.GetEnabledOAuthProviders()) > 0 {
 		return true
 	}
 	if !c.hasZeroDetections(ctx) {
@@ -324,7 +332,7 @@ func (c *Controller) DismissWizard(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "App metadata not available", http.StatusServiceUnavailable)
 	}
 
-	if err := c.appMetadataRepo.Set(ctx.Request().Context(), appMetadataKeyLastSeenVersion, c.Settings.Version); err != nil {
+	if err := c.appMetadataRepo.Set(ctx.Request().Context(), appMetadataKeyLastSeenVersion, c.currentSettings().Version); err != nil {
 		return c.HandleError(ctx, err, "Failed to dismiss wizard", http.StatusInternalServerError)
 	}
 

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -132,6 +132,9 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 	// published configuration and every read below is race-free against a
 	// concurrent settings save (see currentSettings).
 	settings := c.currentSettings()
+	if settings == nil {
+		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
+	}
 
 	// Get enabled OAuth providers from the new array-based config
 	// This returns provider IDs for all enabled providers with valid credentials
@@ -151,8 +154,9 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 	// Priority: X-Ingress-Path > X-Forwarded-Prefix > config BasePath > empty.
 	basePath := requestBasePath(ctx, settings)
 
-	// Determine wizard state (freshInstall, newVersion, previousVersion)
-	freshInstall, newVersion, previousVersion := c.determineWizardState(ctx.Request().Context())
+	// Determine wizard state (freshInstall, newVersion, previousVersion) from the
+	// same snapshot so the whole response is internally consistent.
+	freshInstall, newVersion, previousVersion := c.determineWizardState(ctx.Request().Context(), settings)
 
 	// Build response
 	response := AppConfigResponse{
@@ -211,9 +215,7 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 //   - If last_seen_version is missing and isExistingInstall returns true: auto-seed and skip wizard.
 //   - If last_seen_version is missing and no install signals: freshInstall = true.
 //   - If last_seen_version differs from the current version: newVersion = true.
-func (c *Controller) determineWizardState(ctx context.Context) (freshInstall, newVersion bool, previousVersion string) {
-	settings := c.currentSettings()
-
+func (c *Controller) determineWizardState(ctx context.Context, settings *conf.Settings) (freshInstall, newVersion bool, previousVersion string) {
 	// Skip wizard triggers for dev builds
 	if isDevBuild(settings.Version) {
 		return false, false, ""
@@ -232,7 +234,7 @@ func (c *Controller) determineWizardState(ctx context.Context) (freshInstall, ne
 
 	// If last_seen_version has never been set, distinguish fresh from existing install
 	if lastSeenVersion == "" {
-		if c.isExistingInstall(ctx) {
+		if c.isExistingInstall(ctx, settings) {
 			// Auto-seed: existing install predates wizard tracking.
 			// Intentional write inside GET handler (idempotent upsert, fires once per install).
 			if err := c.appMetadataRepo.Set(ctx, appMetadataKeyLastSeenVersion, settings.Version); err != nil {
@@ -278,8 +280,7 @@ func (c *Controller) hasZeroDetections(ctx context.Context) bool {
 
 // isExistingInstall returns true if multiple signals indicate this is a configured
 // installation rather than a genuinely fresh one. Checks are ordered cheapest-first.
-func (c *Controller) isExistingInstall(ctx context.Context) bool {
-	settings := c.currentSettings()
+func (c *Controller) isExistingInstall(ctx context.Context, settings *conf.Settings) bool {
 	if settings.BirdNET.Latitude != 0 || settings.BirdNET.Longitude != 0 {
 		return true
 	}
@@ -332,7 +333,11 @@ func (c *Controller) DismissWizard(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "App metadata not available", http.StatusServiceUnavailable)
 	}
 
-	if err := c.appMetadataRepo.Set(ctx.Request().Context(), appMetadataKeyLastSeenVersion, c.currentSettings().Version); err != nil {
+	settings := c.currentSettings()
+	if settings == nil {
+		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
+	}
+	if err := c.appMetadataRepo.Set(ctx.Request().Context(), appMetadataKeyLastSeenVersion, settings.Version); err != nil {
 		return c.HandleError(ctx, err, "Failed to dismiss wizard", http.StatusInternalServerError)
 	}
 

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -74,6 +74,8 @@ func setupAppConfigTest(t *testing.T, securityConfig *conf.Security) (*echo.Echo
 	controlChan := make(chan string, testControlChannelBuf)
 	mockMetrics, _ := observability.NewMetrics()
 
+	publishTestSettings(t, settings)
+
 	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, false)
 	require.NoError(t, err, "Failed to create test API controller")
 
@@ -950,6 +952,7 @@ func FuzzGetAppConfig_Headers(f *testing.F) {
 			Settings:    settings,
 			authService: nil,
 		}
+		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		if accept != "" {
@@ -1077,6 +1080,7 @@ func FuzzGetAppConfig_CSRFToken(f *testing.F) {
 			Settings:    settings,
 			authService: nil,
 		}
+		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1142,6 +1146,7 @@ func FuzzGetAppConfig_Version(f *testing.F) {
 			Settings:    settings,
 			authService: nil,
 		}
+		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1295,6 +1300,7 @@ func FuzzGetAppConfig_SecurityConfig(f *testing.F) {
 			Settings:    settings,
 			authService: nil,
 		}
+		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1374,8 +1380,8 @@ func TestGetAppConfig_LiveSpectrogramField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
+			// Not parallel: setupAppConfigTest publishes settings to the
+			// process-global snapshot that GetAppConfig reads via currentSettings.
 			e, controller := setupAppConfigTest(t, nil)
 
 			// Set the LiveSpectrogram value for this test case
@@ -1400,8 +1406,8 @@ func TestGetAppConfig_LiveSpectrogramField(t *testing.T) {
 
 // TestGetAppConfig_SentryConfigWhenEnabled tests that Sentry config is included when telemetry is enabled.
 func TestGetAppConfig_SentryConfigWhenEnabled(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: publishes settings to the process-global snapshot that
+	// GetAppConfig reads via currentSettings.
 	_, controller := setupAppConfigTest(t, nil)
 
 	// Enable Sentry in settings
@@ -1429,8 +1435,8 @@ func TestGetAppConfig_SentryConfigWhenEnabled(t *testing.T) {
 
 // TestGetAppConfig_SentryConfigWhenDisabled tests that Sentry config is omitted when telemetry is disabled.
 func TestGetAppConfig_SentryConfigWhenDisabled(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: publishes settings to the process-global snapshot that
+	// GetAppConfig reads via currentSettings.
 	_, controller := setupAppConfigTest(t, nil)
 
 	// Sentry disabled (default)

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -126,6 +126,10 @@ func setupAppConfigTestWithAuth(t *testing.T, securityConfig *conf.Security) (*e
 	controlChan := make(chan string, testControlChannelBuf)
 	mockMetrics, _ := observability.NewMetrics()
 
+	// Publish settings to the global snapshot so GetAppConfig (which reads via
+	// currentSettings) observes this controller's settings, not a leaked snapshot.
+	publishTestSettings(t, settings)
+
 	// Create OAuth2Server for auth
 	oauth2Server := security.NewOAuth2ServerForTesting(t, settings)
 	authService := auth.NewSecurityAdapter(oauth2Server)

--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -125,8 +125,8 @@ func TestIsDevBuild(t *testing.T) {
 // =============================================================================
 
 func TestDetermineWizardState(t *testing.T) {
-	// Not parallel: each subtest publishes its own settings to the global
-	// snapshot (read via currentSettings), which is process-wide.
+	t.Parallel()
+
 	tests := []struct {
 		name            string
 		version         string                            // Settings.Version
@@ -210,6 +210,7 @@ func TestDetermineWizardState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := &Controller{
 				Settings: &conf.Settings{Version: tt.version},
 			}
@@ -217,11 +218,9 @@ func TestDetermineWizardState(t *testing.T) {
 			if tt.v2Manager != nil {
 				c.V2Manager = tt.v2Manager(t)
 			}
-			// determineWizardState reads the live snapshot via currentSettings();
-			// publish this subtest's settings so the read resolves to them.
-			publishTestSettings(t, c.Settings)
-
-			freshInstall, newVersion, previousVersion := c.determineWizardState(t.Context())
+			// determineWizardState now takes the settings snapshot directly, so
+			// the subtest stays fully per-controller and parallel-safe.
+			freshInstall, newVersion, previousVersion := c.determineWizardState(t.Context(), c.Settings)
 
 			assert.Equal(t, tt.wantFresh, freshInstall, "freshInstall mismatch")
 			assert.Equal(t, tt.wantNew, newVersion, "newVersion mismatch")

--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -125,8 +125,8 @@ func TestIsDevBuild(t *testing.T) {
 // =============================================================================
 
 func TestDetermineWizardState(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: each subtest publishes its own settings to the global
+	// snapshot (read via currentSettings), which is process-wide.
 	tests := []struct {
 		name            string
 		version         string                            // Settings.Version
@@ -210,8 +210,6 @@ func TestDetermineWizardState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			c := &Controller{
 				Settings: &conf.Settings{Version: tt.version},
 			}
@@ -219,6 +217,9 @@ func TestDetermineWizardState(t *testing.T) {
 			if tt.v2Manager != nil {
 				c.V2Manager = tt.v2Manager(t)
 			}
+			// determineWizardState reads the live snapshot via currentSettings();
+			// publish this subtest's settings so the read resolves to them.
+			publishTestSettings(t, c.Settings)
 
 			freshInstall, newVersion, previousVersion := c.determineWizardState(t.Context())
 
@@ -234,14 +235,14 @@ func TestDetermineWizardState(t *testing.T) {
 // =============================================================================
 
 func TestDismissWizard_Success(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: publishes settings to the process-wide global snapshot.
 	mockRepo := newMockAppMetadataRepo()
 	e := echo.New()
 	c := &Controller{
 		Settings:        &conf.Settings{Version: "v0.9.0"},
 		appMetadataRepo: mockRepo,
 	}
+	publishTestSettings(t, c.Settings)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/app/wizard/dismiss", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -449,6 +449,9 @@ func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audi
 func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*audiocore.AudioSource {
 	var sources []*audiocore.AudioSource
 	settings := c.currentSettings()
+	if settings == nil {
+		return nil
+	}
 	for i := range settings.Realtime.Audio.Sources {
 		src := &settings.Realtime.Audio.Sources[i]
 		if src.Device == "" {
@@ -463,7 +466,11 @@ func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*
 
 // addStreamSourcesToLevels adds all configured stream sources to the levels map.
 func (c *Controller) addStreamSourcesToLevels(registry *audiocore.SourceRegistry, levels map[string]audiocore.AudioLevelData, isAuthenticated bool) {
-	for i, stream := range c.currentSettings().Realtime.RTSP.EnabledStreams() {
+	settings := c.currentSettings()
+	if settings == nil {
+		return
+	}
+	for i, stream := range settings.Realtime.RTSP.EnabledStreams() {
 		source, ok := registry.GetByConnection(stream.URL)
 		if !ok {
 			continue

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -448,8 +448,9 @@ func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audi
 // getAudioCardSources retrieves all configured audio card sources from the registry.
 func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*audiocore.AudioSource {
 	var sources []*audiocore.AudioSource
-	for i := range c.Settings.Realtime.Audio.Sources {
-		src := &c.Settings.Realtime.Audio.Sources[i]
+	settings := c.currentSettings()
+	for i := range settings.Realtime.Audio.Sources {
+		src := &settings.Realtime.Audio.Sources[i]
 		if src.Device == "" {
 			continue
 		}
@@ -462,7 +463,7 @@ func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*
 
 // addStreamSourcesToLevels adds all configured stream sources to the levels map.
 func (c *Controller) addStreamSourcesToLevels(registry *audiocore.SourceRegistry, levels map[string]audiocore.AudioLevelData, isAuthenticated bool) {
-	for i, stream := range c.Settings.Realtime.RTSP.EnabledStreams() {
+	for i, stream := range c.currentSettings().Realtime.RTSP.EnabledStreams() {
 		source, ok := registry.GetByConnection(stream.URL)
 		if !ok {
 			continue

--- a/internal/api/v2/backup.go
+++ b/internal/api/v2/backup.go
@@ -362,8 +362,9 @@ func (c *Controller) initBackupRoutes() {
 		// Scan database directories where backup files are now written,
 		// plus os.TempDir() for files created by older versions.
 		var dbDirs []string
-		if c.Settings.Output.SQLite.Path != "" {
-			dbDirs = append(dbDirs, filepath.Dir(c.Settings.Output.SQLite.Path))
+		settings := c.currentSettings()
+		if settings.Output.SQLite.Path != "" {
+			dbDirs = append(dbDirs, filepath.Dir(settings.Output.SQLite.Path))
 		}
 		if c.V2Manager != nil && !c.V2Manager.IsMySQL() {
 			dbDirs = append(dbDirs, filepath.Dir(c.V2Manager.Path()))
@@ -636,7 +637,8 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 // getBackupDBInfo returns the database path and GORM DB for the given type.
 func (c *Controller) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
 	if dbType == dbTypeLegacy {
-		if c.Settings.Output.SQLite.Path == "" {
+		settings := c.currentSettings()
+		if settings.Output.SQLite.Path == "" {
 			return "", nil, fmt.Errorf("backup only available for SQLite databases")
 		}
 		if c.DS == nil {
@@ -646,7 +648,7 @@ func (c *Controller) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
 		if !ok {
 			return "", nil, fmt.Errorf("cannot perform backup on this datastore type")
 		}
-		return c.Settings.Output.SQLite.Path, sqliteStore.DB, nil
+		return settings.Output.SQLite.Path, sqliteStore.DB, nil
 	}
 
 	// V2 database

--- a/internal/api/v2/backup.go
+++ b/internal/api/v2/backup.go
@@ -363,7 +363,7 @@ func (c *Controller) initBackupRoutes() {
 		// plus os.TempDir() for files created by older versions.
 		var dbDirs []string
 		settings := c.currentSettings()
-		if settings.Output.SQLite.Path != "" {
+		if settings != nil && settings.Output.SQLite.Path != "" {
 			dbDirs = append(dbDirs, filepath.Dir(settings.Output.SQLite.Path))
 		}
 		if c.V2Manager != nil && !c.V2Manager.IsMySQL() {
@@ -638,7 +638,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 func (c *Controller) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
 	if dbType == dbTypeLegacy {
 		settings := c.currentSettings()
-		if settings.Output.SQLite.Path == "" {
+		if settings == nil || settings.Output.SQLite.Path == "" {
 			return "", nil, fmt.Errorf("backup only available for SQLite databases")
 		}
 		if c.DS == nil {

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -48,7 +48,7 @@ type DebugSystemStatus struct {
 // This is defense-in-depth — debug routes are already conditionally registered.
 func (c *Controller) requireDebugMode(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		if c.Settings == nil || !c.Settings.Debug {
+		if s := c.lockedSettings(); s == nil || !s.Debug {
 			return c.HandleErrorWithKey(ctx, nil, "Debug mode not enabled", http.StatusForbidden, notification.MsgErrDebugNotEnabled, nil)
 		}
 		return next(ctx)
@@ -185,13 +185,18 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 
 // DebugSystemStatus returns current system status for debugging
 func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
+	settings := c.lockedSettings()
+	debug := false
+	if settings != nil {
+		debug = settings.Debug
+	}
 	status := DebugSystemStatus{
 		Timestamp: time.Now().Format(time.RFC3339),
-		Debug:     c.Settings.Debug,
+		Debug:     debug,
 	}
 
 	// Get telemetry status
-	if telemetryStatus := getTelemetryStatus(c.Settings); telemetryStatus != nil {
+	if telemetryStatus := getTelemetryStatus(settings); telemetryStatus != nil {
 		status.Telemetry = telemetryStatus
 	}
 

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1277,7 +1277,7 @@ func (c *Controller) removeDetectionFiles(clipName string) {
 	log := c.apiLogger
 
 	// Normalize the clip path to get a relative path within SecureFS
-	clipsPrefix := c.Settings.Realtime.Audio.Export.Path
+	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
 	normalized := NormalizeClipPath(clipName, clipsPrefix)
 	if normalized == "" {
 		log.Warn("Cannot remove detection files: empty normalized clip path",

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -457,8 +457,9 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 		})
 	}
 
-	lat := c.Settings.BirdNET.Latitude
-	lng := c.Settings.BirdNET.Longitude
+	settings := c.currentSettings()
+	lat := settings.BirdNET.Latitude
+	lng := settings.BirdNET.Longitude
 	if lat == 0 && lng == 0 {
 		return ctx.JSON(http.StatusOK, ExpectedTodayRegionalResponse{
 			Species:   []RegionalSpeciesItem{},

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -458,6 +458,12 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 	}
 
 	settings := c.currentSettings()
+	if settings == nil {
+		return ctx.JSON(http.StatusOK, ExpectedTodayRegionalResponse{
+			Species:   []RegionalSpeciesItem{},
+			Available: false,
+		})
+	}
 	lat := settings.BirdNET.Latitude
 	lng := settings.BirdNET.Longitude
 	if lat == 0 && lng == 0 {

--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -72,7 +72,7 @@ func (c *Controller) tableExistsMySQL(db *gorm.DB, tableName string) (bool, erro
 	var count int64
 	err := db.Raw(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
-		c.Settings.Output.MySQL.Database, tableName,
+		c.currentSettings().Output.MySQL.Database, tableName,
 	).Scan(&count).Error
 	if err != nil {
 		return false, err
@@ -180,7 +180,7 @@ func (c *Controller) GetLegacyStatus(ctx echo.Context) error {
 
 // getLegacyStatusSQLite handles legacy status for SQLite deployments.
 func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacyStatusResponse) error {
-	legacyPath := c.Settings.Output.SQLite.Path
+	legacyPath := c.currentSettings().Output.SQLite.Path
 	response.Location = legacyPath
 
 	// Check if legacy file exists
@@ -249,7 +249,7 @@ func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacySta
 
 // getLegacyStatusMySQL handles legacy status for MySQL deployments.
 func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStatusResponse) error {
-	response.Location = c.Settings.Output.MySQL.Database
+	response.Location = c.currentSettings().Output.MySQL.Database
 
 	// Check if we're in v2-only mode (required for cleanup)
 	if !isV2OnlyMode {
@@ -307,7 +307,7 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 			SELECT COALESCE(data_length, 0), COALESCE(index_length, 0)
 			FROM information_schema.tables
 			WHERE table_schema = ? AND table_name = ?`,
-			c.Settings.Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
+			c.currentSettings().Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
 		if err != nil {
 			c.logWarnIfEnabled("Legacy cleanup: failed to query table size",
 				logger.String("table", tableName),
@@ -416,7 +416,7 @@ func (c *Controller) cleanupSQLiteLegacy(ctx context.Context) error {
 	default:
 	}
 
-	legacyPath := c.Settings.Output.SQLite.Path
+	legacyPath := c.currentSettings().Output.SQLite.Path
 
 	c.logInfoIfEnabled("Starting SQLite legacy database cleanup",
 		logger.String("path", legacyPath))
@@ -511,7 +511,7 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 
 // getSQLiteLegacySize returns the total size of SQLite legacy files.
 func (c *Controller) getSQLiteLegacySize() int64 {
-	legacyPath := c.Settings.Output.SQLite.Path
+	legacyPath := c.currentSettings().Output.SQLite.Path
 	var totalSize int64
 
 	if info, err := os.Stat(legacyPath); err == nil {
@@ -553,7 +553,7 @@ func (c *Controller) getMySQLLegacySize() int64 {
 			SELECT COALESCE(data_length, 0), COALESCE(index_length, 0)
 			FROM information_schema.tables
 			WHERE table_schema = ? AND table_name = ?`,
-			c.Settings.Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
+			c.currentSettings().Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
 		if err != nil {
 			c.logWarnIfEnabled("Legacy cleanup: failed to query table size",
 				logger.String("table", tableName),

--- a/internal/api/v2/legacy_cleanup_test.go
+++ b/internal/api/v2/legacy_cleanup_test.go
@@ -28,7 +28,11 @@ func createTestSettings(legacyPath string) *conf.Settings {
 }
 
 // createLegacyTestController creates a controller with initialized cleanupStatus for testing.
-func createLegacyTestController(e *echo.Echo, settings *conf.Settings) *Controller {
+func createLegacyTestController(tb testing.TB, e *echo.Echo, settings *conf.Settings) *Controller {
+	tb.Helper()
+	// Handlers read the live snapshot via currentSettings(); publish the test's
+	// settings so the read resolves to them (restored on cleanup).
+	publishTestSettings(tb, settings)
 	return &Controller{
 		Settings:      settings,
 		Echo:          e,
@@ -47,7 +51,7 @@ func TestGetLegacyStatus_V2OnlyMode_NoLegacy(t *testing.T) {
 
 	// Create settings with non-existent legacy path
 	settings := createTestSettings(filepath.Join(tmpDir, "nonexistent.db"))
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	// Set v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -85,7 +89,7 @@ func TestGetLegacyStatus_V2OnlyMode_WithLegacy(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	// Set v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -123,7 +127,7 @@ func TestGetLegacyStatus_NotV2OnlyMode(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	// NOT in v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -160,7 +164,7 @@ func TestStartLegacyCleanup_NotV2OnlyMode(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	// NOT in v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -203,7 +207,7 @@ func TestStartLegacyCleanup_SQLite_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	// Set v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -284,7 +288,7 @@ func TestStartLegacyCleanup_SQLite_V2DatabaseSafetyCheck(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	prevV2OnlyMode := isV2OnlyMode
 	isV2OnlyMode = true
@@ -327,7 +331,7 @@ func TestStartLegacyCleanup_AlreadyInProgress(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 
 	prevV2OnlyMode := isV2OnlyMode
 	isV2OnlyMode = true
@@ -368,7 +372,7 @@ func TestGetLegacyStatus_MySQL_NoDBProvider(t *testing.T) {
 
 	e := echo.New()
 	settings := createMySQLTestSettings()
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 	// Repo is nil, so gormDBProvider cast will fail
 
 	prevV2OnlyMode := isV2OnlyMode
@@ -399,7 +403,7 @@ func TestStartLegacyCleanup_MySQL_NoDBProvider(t *testing.T) {
 
 	e := echo.New()
 	settings := createMySQLTestSettings()
-	controller := createLegacyTestController(e, settings)
+	controller := createLegacyTestController(t, e, settings)
 	// Repo is nil, so gormDBProvider cast will fail
 
 	prevV2OnlyMode := isV2OnlyMode

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -716,7 +716,7 @@ func (c *Controller) ExtractAudioClipByID(ctx echo.Context) error {
 		End:        req.End,
 		Format:     req.Format,
 		Filters:    filters,
-		FFmpegPath: c.Settings.Realtime.Audio.FfmpegPath,
+		FFmpegPath: c.currentSettings().Realtime.Audio.FfmpegPath,
 	})
 	if err != nil {
 		if ctx.Request().Context().Err() != nil {
@@ -853,7 +853,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 	defer os.Remove(tmpPath) //nolint:errcheck // best-effort cleanup
 
 	if err := ffmpeg.ProcessAudioToFile(ctx.Request().Context(), absolutePath,
-		c.Settings.Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
+		c.currentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
@@ -964,7 +964,7 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 	defer func() { _ = os.Remove(tmpPath) }()
 
 	if err := ffmpeg.ProcessAudioToFile(ctx.Request().Context(), absolutePath,
-		c.Settings.Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
+		c.currentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
@@ -1068,12 +1068,13 @@ type spectrogramParameters struct {
 // global settings that affect the visual appearance of all spectrograms. Including them
 // in the filename prevents serving stale cached spectrograms when these settings change.
 func (c *Controller) parseSpectrogramParameters(ctx echo.Context) spectrogramParameters {
+	spec := c.currentSettings().Realtime.Dashboard.Spectrogram
 	params := spectrogramParameters{
 		width:        SpectrogramSizeLg, // Default width (lg) - single render size for all contexts
 		sizeStr:      ctx.QueryParam("size"),
 		raw:          parseRawParameter(ctx.QueryParam("raw")),
-		style:        c.Settings.Realtime.Dashboard.Spectrogram.Style,
-		dynamicRange: c.Settings.Realtime.Dashboard.Spectrogram.DynamicRange,
+		style:        spec.Style,
+		dynamicRange: spec.DynamicRange,
 	}
 
 	// Parse size parameter
@@ -1151,7 +1152,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 // Returns true if the request was handled (either success or error response sent).
 func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters) (bool, error) {
 	// Normalize and validate the audio path
-	clipsPrefix := c.Settings.Realtime.Audio.Export.Path
+	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(clipPath, clipsPrefix)
 	relAudioPath, err := c.SFS.ValidateRelativePath(normalizedPath)
 
@@ -1373,7 +1374,7 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 		logger.String("ip", ctx.RealIP()))
 
 	// Check spectrogram generation mode
-	spectrogramMode := c.Settings.Realtime.Dashboard.Spectrogram.GetMode()
+	spectrogramMode := c.currentSettings().Realtime.Dashboard.Spectrogram.GetMode()
 
 	// Handle user-requested mode
 	if spectrogramMode == conf.SpectrogramModeUserRequested {
@@ -1440,8 +1441,9 @@ func (c *Controller) ServeSpectrogram(ctx echo.Context) error {
 	raw := parseRawParameter(ctx.QueryParam("raw"))
 
 	// Read style settings for filename generation (prevents serving stale cached spectrograms)
-	style := c.Settings.Realtime.Dashboard.Spectrogram.Style
-	dynamicRange := c.Settings.Realtime.Dashboard.Spectrogram.DynamicRange
+	spec := c.currentSettings().Realtime.Dashboard.Spectrogram
+	style := spec.Style
+	dynamicRange := spec.DynamicRange
 
 	// Pass the request context for cancellation/timeout
 	spectrogramPath, err := c.generateSpectrogram(ctx.Request().Context(), filename, width, raw, style, dynamicRange)
@@ -1508,7 +1510,7 @@ func (c *Controller) GetSpectrogramStatus(ctx echo.Context) error {
 	// Build spectrogram path and key for status lookup
 	// Must compute relSpectrogramPath BEFORE checking queue to ensure consistent key format
 	audioPath := detection.ClipName
-	clipsPrefix := c.Settings.Realtime.Audio.Export.Path
+	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(audioPath, clipsPrefix)
 	relAudioPath, err := c.SFS.ValidateRelativePath(normalizedPath)
 	if err != nil {
@@ -1625,7 +1627,7 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 
 	// Check if spectrogram already exists (fast path)
 	// Also compute spectrogramKey for queue management
-	clipsPrefix := c.Settings.Realtime.Audio.Export.Path
+	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(clipPath, clipsPrefix)
 	relAudioPath, err := c.SFS.ValidateRelativePath(normalizedPath)
 	if err != nil {
@@ -2178,7 +2180,7 @@ func (c *Controller) normalizeAndValidatePath(audioPath string) (string, error) 
 //
 // This reduces duplication across the codebase where this pattern is used.
 func (c *Controller) normalizeAndValidatePathWithLogger(audioPath string, log logger.Logger) (string, error) {
-	clipsPrefix := c.Settings.Realtime.Audio.Export.Path
+	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(audioPath, clipsPrefix)
 
 	if log != nil && normalizedPath != audioPath {

--- a/internal/api/v2/migration_test.go
+++ b/internal/api/v2/migration_test.go
@@ -123,6 +123,7 @@ func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *data
 		DS:       testDS,
 		Repo:     mockRepo,
 	}
+	publishTestSettings(t, controller.Settings)
 
 	return e, controller, sm
 }

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -643,7 +643,7 @@ func (c *Controller) logNotificationConnection(clientID, ip, userAgent string, c
 		action = "disconnected"
 	}
 
-	if c.Settings != nil && c.Settings.WebServer.Debug && connected {
+	if s := c.currentSettings(); s != nil && s.WebServer.Debug && connected {
 		c.logDebugIfEnabled("notification SSE client "+action,
 			logger.String("clientId", clientID),
 			logger.String("ip", privacy.AnonymizeIP(ip)),
@@ -664,7 +664,7 @@ func (c *Controller) logNotificationError(message string, err error, clientID st
 
 // logToastSent logs successful toast sending
 func (c *Controller) logToastSent(clientID string, notif *notification.Notification) {
-	if c.Settings != nil && c.Settings.WebServer.Debug {
+	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
 		toastType, _ := notif.Metadata["toastType"].(string)
 		c.logDebugIfEnabled("toast sent via SSE",
 			logger.String("clientId", clientID),
@@ -676,7 +676,7 @@ func (c *Controller) logToastSent(clientID string, notif *notification.Notificat
 
 // logNotificationSent logs successful notification sending
 func (c *Controller) logNotificationSent(clientID string, notif *notification.Notification) {
-	if c.Settings != nil && c.Settings.WebServer.Debug {
+	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
 		c.logDebugIfEnabled("notification sent via SSE",
 			logger.String("clientId", clientID),
 			logger.String("notification_id", notif.ID),
@@ -744,7 +744,7 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 		}
 	}
 
-	if c.Settings != nil && c.Settings.WebServer.Debug {
+	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
 		c.logDebugIfEnabled("listing notifications",
 			logger.Any("status", filter.Status),
 			logger.Any("types", filter.Types),
@@ -779,7 +779,7 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 		notifications = filtered
 	}
 
-	if c.Settings != nil && c.Settings.WebServer.Debug {
+	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
 		unreadCount, err := service.GetUnreadCount()
 		if err != nil {
 			c.logErrorIfEnabled("failed to get unread count", logger.Error(err))
@@ -903,19 +903,20 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 
 // CreateTestNewSpeciesNotification creates a test new species detection notification
 func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
-	if c.Settings == nil {
+	settings := c.currentSettings()
+	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
 	}
 
 	service := notification.GetService()
 
 	// Build base URL for links
-	baseURL := c.Settings.Security.GetBaseURL(c.Settings.WebServer.Port)
+	baseURL := settings.Security.GetBaseURL(settings.WebServer.Port)
 
 	// Format detection time according to user's time format preference
 	now := time.Now()
 	var detectionTime string
-	if c.Settings.Main.TimeAs24h {
+	if settings.Main.TimeAs24h {
 		detectionTime = now.Format(time.TimeOnly)
 	} else {
 		detectionTime = now.Format("3:04:05 PM")
@@ -941,12 +942,12 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 
 	// Render notification using templates with defaults
 	title := renderTemplateWithDefault("title",
-		c.Settings.Notification.Templates.NewSpecies.Title,
+		settings.Notification.Templates.NewSpecies.Title,
 		"New Species: Test Bird Species",
 		testTemplateData, nil)
 
 	message := renderTemplateWithDefault("message",
-		c.Settings.Notification.Templates.NewSpecies.Message,
+		settings.Notification.Templates.NewSpecies.Message,
 		"First detection of Test Bird Species (Testus birdicus) at Fake Test Location",
 		testTemplateData, nil)
 
@@ -972,7 +973,7 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to create test notification", http.StatusInternalServerError)
 	}
 
-	if c.Settings != nil && c.Settings.WebServer.Debug {
+	if settings.WebServer.Debug {
 		c.logDebugIfEnabled("test new species notification created",
 			logger.String("notification_id", testNotification.ID),
 			logger.String("species", testTemplateData.CommonName),

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -77,6 +77,9 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	// Set default templates from config.yaml
 	controller.Settings.Notification.Templates.NewSpecies.Title = "New Species: {{.CommonName}}"
 	controller.Settings.Notification.Templates.NewSpecies.Message = "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}"
+	// CreateTestNewSpeciesNotification reads the live snapshot via currentSettings();
+	// publish the controller's settings so the read resolves to them.
+	publishTestSettings(t, controller.Settings)
 
 	err = controller.CreateTestNewSpeciesNotification(c)
 	require.NoError(t, err)

--- a/internal/api/v2/prerequisites.go
+++ b/internal/api/v2/prerequisites.go
@@ -139,10 +139,11 @@ func (c *Controller) GetPrerequisites(ctx echo.Context) error {
 
 // isUsingMySQL returns true if the application is configured to use MySQL.
 func (c *Controller) isUsingMySQL() bool {
-	if c.Settings == nil {
+	settings := c.currentSettings()
+	if settings == nil {
 		return false
 	}
-	return c.Settings.Output.MySQL.Enabled
+	return settings.Output.MySQL.Enabled
 }
 
 // checkStateIdle verifies the migration is in IDLE state.
@@ -211,8 +212,8 @@ func (c *Controller) checkDiskSpace() PrerequisiteCheck {
 	requiredSpace := uint64(MinDiskSpaceBytes)
 	dbSizeInfo := ""
 
-	if c.Settings != nil && !c.Settings.Output.MySQL.Enabled {
-		dbPath := c.Settings.Output.SQLite.Path
+	if settings := c.currentSettings(); settings != nil && !settings.Output.MySQL.Enabled {
+		dbPath := settings.Output.SQLite.Path
 		if !filepath.IsAbs(dbPath) {
 			dbPath, _ = filepath.Abs(dbPath)
 		}
@@ -253,16 +254,17 @@ func (c *Controller) checkDiskSpace() PrerequisiteCheck {
 // Returns an error if the directory cannot be determined or verified.
 // For MySQL, returns empty string with nil error (disk space check not applicable to remote DB).
 func (c *Controller) getDatabaseDirectoryResolved() (string, error) {
-	if c.Settings == nil {
+	settings := c.currentSettings()
+	if settings == nil {
 		return "", fmt.Errorf("settings not available")
 	}
 
-	if c.Settings.Output.MySQL.Enabled {
+	if settings.Output.MySQL.Enabled {
 		// For MySQL, disk space check is not applicable (remote database)
 		return "", nil
 	}
 
-	dbPath := c.Settings.Output.SQLite.Path
+	dbPath := settings.Output.SQLite.Path
 	if dbPath == "" {
 		return "", fmt.Errorf("SQLite database path not configured")
 	}

--- a/internal/api/v2/prerequisites_test.go
+++ b/internal/api/v2/prerequisites_test.go
@@ -407,6 +407,9 @@ func TestGetDatabaseDirectoryResolved_NilSettings(t *testing.T) {
 	t.Attr("feature", "prerequisites")
 
 	controller := &Controller{Settings: nil}
+	// Publish a nil global so currentSettings() falls back to the controller's
+	// nil c.Settings and exercises the "settings not available" path.
+	publishTestSettings(t, nil)
 
 	_, err := controller.getDatabaseDirectoryResolved()
 
@@ -521,6 +524,7 @@ func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *
 		DS:       testDS,
 		Repo:     mockRepo,
 	}
+	publishTestSettings(t, controller.Settings)
 
 	return e, controller, sm
 }

--- a/internal/api/v2/settings_race_test.go
+++ b/internal/api/v2/settings_race_test.go
@@ -1,0 +1,124 @@
+// settings_race_test.go: regression coverage for the api/v2 Controller settings
+// data race and transient stale-read window.
+//
+// The api/v2 Controller repoints c.Settings on every save under
+// c.settingsMutex.Lock(). Runtime handlers that read bare c.Settings.X without
+// holding the lock (or routing through c.currentSettings()) both race that
+// write and can observe a transient stale snapshot. These tests pin the
+// contract: a handler must reflect the live published snapshot, and concurrent
+// reads must be race-free against a save.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// withRestoredGlobalSettings snapshots the package-global settings pointer and
+// restores it on cleanup so a test that publishes its own snapshot via
+// conf.SetTestSettings does not leak into sibling tests.
+func withRestoredGlobalSettings(t *testing.T) {
+	t.Helper()
+	orig := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(orig) })
+}
+
+// TestGetAppConfigReadsLiveSnapshot proves GetAppConfig serves the latest
+// published settings snapshot rather than the construction-time c.Settings
+// pointer. On the pre-fix code the handler reads bare c.Settings.X and returns
+// the stale construction-time values, so the assertions on the live values
+// fail.
+func TestGetAppConfigReadsLiveSnapshot(t *testing.T) {
+	withRestoredGlobalSettings(t)
+
+	e, controller := setupAppConfigTest(t, nil)
+
+	// Publish a divergent live snapshot to the global atomic pointer. The
+	// controller's own c.Settings still holds the construction-time snapshot
+	// (Version "1.0.0-test", empty ColorScheme), so a stale read and a live
+	// read return different values.
+	live := conf.CloneSettings(controller.Settings)
+	live.Version = "9.9.9-live"
+	live.Realtime.Dashboard.ColorScheme = "live-scheme"
+	conf.SetTestSettings(live)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/api/v2/app/config")
+
+	require.NoError(t, controller.GetAppConfig(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var response AppConfigResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+
+	assert.Equal(t, "9.9.9-live", response.Version,
+		"GetAppConfig must reflect the live published version, not the stale construction-time snapshot")
+	assert.Equal(t, "live-scheme", response.ColorScheme,
+		"GetAppConfig must reflect the live published color scheme, not the stale construction-time snapshot")
+}
+
+// TestGetAppConfigConcurrentSaveIsRaceFree hammers GetAppConfig from multiple
+// readers while a writer repeatedly republishes the settings snapshot the same
+// way UpdateSettings does (StoreSettings + c.Settings reassignment under
+// c.settingsMutex). Under `go test -race`, the pre-fix bare c.Settings.X reads
+// in the handler are flagged as a data race against the c.Settings write.
+func TestGetAppConfigConcurrentSaveIsRaceFree(t *testing.T) {
+	withRestoredGlobalSettings(t)
+
+	e, controller := setupAppConfigTest(t, nil)
+
+	// Ensure the global snapshot is never nil for the duration of the test so
+	// currentSettings() always resolves via the atomic pointer.
+	base := conf.CloneSettings(controller.Settings)
+	conf.SetTestSettings(base)
+
+	const (
+		writers        = 2
+		readers        = 4
+		itersPerWriter = 50
+		itersPerReader = 50
+	)
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Go(func() {
+			for i := range itersPerWriter {
+				snap := conf.CloneSettings(base)
+				snap.Version = "rev-" + string(rune('a'+w)) + "-" + string(rune('0'+i%10))
+				// Mirror UpdateSettings: publish to the global atomic, then keep
+				// the controller-cached pointer in sync, both under the mutex.
+				controller.settingsMutex.Lock()
+				conf.StoreSettings(snap)
+				controller.Settings = snap
+				controller.settingsMutex.Unlock()
+			}
+		})
+	}
+
+	for range readers {
+		wg.Go(func() {
+			for range itersPerReader {
+				req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
+				rec := httptest.NewRecorder()
+				ctx := e.NewContext(req, rec)
+				ctx.SetPath("/api/v2/app/config")
+				if err := controller.GetAppConfig(ctx); err != nil {
+					t.Errorf("GetAppConfig returned error: %v", err)
+					return
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+}

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -922,9 +922,9 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 
 	// Get active audio device from settings (first configured source)
 	var deviceName string
-	sources := c.currentSettings().Realtime.Audio.Sources
-	if len(sources) > 0 {
-		deviceName = sources[0].Device
+	settings := c.currentSettings()
+	if settings != nil && len(settings.Realtime.Audio.Sources) > 0 {
+		deviceName = settings.Realtime.Audio.Sources[0].Device
 	}
 
 	// Check if no device is configured
@@ -1651,7 +1651,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	if dbType == dbTypeLegacy {
 		// Check if it's SQLite
 		settings := c.currentSettings()
-		if settings.Output.SQLite.Path == "" {
+		if settings == nil || settings.Output.SQLite.Path == "" {
 			return c.HandleError(ctx, fmt.Errorf("not sqlite"),
 				"Backup download only available for SQLite databases. Use MySQL tools for MySQL backup.",
 				http.StatusBadRequest)

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -922,8 +922,9 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 
 	// Get active audio device from settings (first configured source)
 	var deviceName string
-	if len(c.Settings.Realtime.Audio.Sources) > 0 {
-		deviceName = c.Settings.Realtime.Audio.Sources[0].Device
+	sources := c.currentSettings().Realtime.Audio.Sources
+	if len(sources) > 0 {
+		deviceName = sources[0].Device
 	}
 
 	// Check if no device is configured
@@ -1649,12 +1650,13 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 
 	if dbType == dbTypeLegacy {
 		// Check if it's SQLite
-		if c.Settings.Output.SQLite.Path == "" {
+		settings := c.currentSettings()
+		if settings.Output.SQLite.Path == "" {
 			return c.HandleError(ctx, fmt.Errorf("not sqlite"),
 				"Backup download only available for SQLite databases. Use MySQL tools for MySQL backup.",
 				http.StatusBadRequest)
 		}
-		dbPath = c.Settings.Output.SQLite.Path
+		dbPath = settings.Output.SQLite.Path
 
 		// Get the underlying GORM DB from the datastore
 		ds := c.DS

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -34,6 +34,22 @@ func newMinimalController() *Controller {
 	}
 }
 
+// publishTestSettings publishes settings as the global atomic snapshot so that
+// handlers reading via c.currentSettings() observe them, and restores the
+// previous snapshot on cleanup so the publish does not leak into sibling tests.
+//
+// Routing handler reads through currentSettings() makes every
+// handler read the lock-free global snapshot rather than the controller-cached
+// c.Settings field. Tests that inject a per-controller *conf.Settings must
+// therefore publish it here (pass nil to exercise a handler's nil-settings
+// fallback path).
+func publishTestSettings(tb testing.TB, settings *conf.Settings) {
+	tb.Helper()
+	prev := conf.GetSettings()
+	conf.SetTestSettings(settings)
+	tb.Cleanup(func() { conf.SetTestSettings(prev) })
+}
+
 // safeSlice is a helper for mock methods returning slices.
 // It safely handles nil arguments and performs type assertion.
 func safeSlice[T any](args mock.Arguments, index int) []T {
@@ -179,8 +195,10 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 
 	// Sync controller settings with the global conf.settingsInstance so that
 	// functions like conf.SaveSettings() (called by toggleSpeciesInIgnoredList)
-	// operate on the same instance the controller uses.
-	conf.SetTestSettings(settings)
+	// operate on the same instance the controller uses, and so handlers reading
+	// via currentSettings() observe this controller's settings. Restored on
+	// cleanup so it does not leak into sibling tests.
+	publishTestSettings(t, settings)
 
 	// Create API controller without initializing routes to avoid starting background goroutines
 	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, false)

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -38,6 +38,10 @@ func newMinimalController() *Controller {
 // handlers reading via c.currentSettings() observe them, and restores the
 // previous snapshot on cleanup so the publish does not leak into sibling tests.
 //
+// IMPORTANT: tests using this helper must NOT call t.Parallel(). It mutates the
+// process-global settings snapshot, so parallel tests would observe each
+// other's settings and flake.
+//
 // Routing handler reads through currentSettings() makes every
 // handler read the lock-free global snapshot rather than the controller-cached
 // c.Settings field. Tests that inject a per-controller *conf.Settings must

--- a/internal/security/basic_test.go
+++ b/internal/security/basic_test.go
@@ -42,7 +42,7 @@ func setupOAuth2ServerTest(t *testing.T, requestClientID, requestRedirectURI, ex
 	c := e.NewContext(req, rec)
 
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					ClientID:    expectedClientID,
@@ -57,7 +57,7 @@ func setupOAuth2ServerTest(t *testing.T, requestClientID, requestRedirectURI, ex
 	// Publish the settings as the global snapshot so currentSettings() (used by
 	// the basic-auth handlers after the issue #3370 fix) returns these values
 	// rather than a snapshot leaked by a sibling test.
-	conf.SetTestSettings(server.Settings)
+	conf.SetTestSettings(server.settings)
 	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
 	return server, c, rec
@@ -135,7 +135,7 @@ func TestHandleBasicAuthTokenSuccess(t *testing.T) {
 	gothic.Store = sessions.NewFilesystemStore(os.TempDir(), []byte("secret-key"))
 
 	s := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					ClientID:       "validClientID",
@@ -152,7 +152,7 @@ func TestHandleBasicAuthTokenSuccess(t *testing.T) {
 
 	// Publish the settings as the global snapshot so currentSettings() (used by
 	// HandleBasicAuthToken after the issue #3370 fix) returns these values.
-	conf.SetTestSettings(s.Settings)
+	conf.SetTestSettings(s.settings)
 	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
 	// Pre-populate a valid auth code
@@ -182,7 +182,7 @@ func TestHandleBasicAuthTokenMissingFields(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	s := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					ClientID:     "validClientID",
@@ -196,7 +196,7 @@ func TestHandleBasicAuthTokenMissingFields(t *testing.T) {
 
 	// Publish the settings as the global snapshot so currentSettings() (used by
 	// HandleBasicAuthToken after the issue #3370 fix) returns these values.
-	conf.SetTestSettings(s.Settings)
+	conf.SetTestSettings(s.settings)
 	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
 	c.SetParamNames("grant_type", "code", "redirect_uri")
@@ -217,7 +217,7 @@ func TestHandleBasicAuthTokenMissingFields(t *testing.T) {
 // TestHandleBasicAuthTokenHotReloadAfterEnable reproduces the issue #3370 class
 // for the OAuth token path: credentials configured through the web UI after
 // startup must be accepted without a restart. The construction-time
-// OAuth2Server.Settings holds the (empty) startup snapshot while the live
+// OAuth2Server.settings holds the (empty) startup snapshot while the live
 // snapshot, published via the atomic pointer, carries the new credentials.
 // Not parallel: it mutates the global settings snapshot.
 func TestHandleBasicAuthTokenHotReloadAfterEnable(t *testing.T) {
@@ -233,7 +233,7 @@ func TestHandleBasicAuthTokenHotReloadAfterEnable(t *testing.T) {
 
 	// Startup snapshot: basic auth not configured (no client credentials).
 	s := &OAuth2Server{
-		Settings:     &conf.Settings{},
+		settings:     &conf.Settings{},
 		authCodes:    make(map[string]AuthCode),
 		accessTokens: make(map[string]AccessToken),
 	}
@@ -467,7 +467,7 @@ func TestHandleBasicAuthCallback(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			server := &OAuth2Server{
-				Settings: &conf.Settings{
+				settings: &conf.Settings{
 					Security: conf.Security{
 						BasicAuth: conf.BasicAuth{
 							Enabled:        true,
@@ -510,7 +510,7 @@ func TestHandleBasicAuthCallbackSessionRegeneration(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					Enabled:        true,
@@ -700,7 +700,7 @@ func TestExchangeCodeWithTimeout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &OAuth2Server{
-				Settings: &conf.Settings{
+				settings: &conf.Settings{
 					Security: conf.Security{
 						BasicAuth: conf.BasicAuth{
 							AccessTokenExp: time.Hour,
@@ -762,7 +762,7 @@ func TestHandleTokenExchangeError(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			server := &OAuth2Server{
-				Settings: &conf.Settings{},
+				settings: &conf.Settings{},
 			}
 
 			log := newTestBasicLogger()
@@ -802,7 +802,7 @@ func TestRegenerateAndStoreToken(t *testing.T) {
 			c := e.NewContext(req, rec)
 
 			server := &OAuth2Server{
-				Settings: &conf.Settings{},
+				settings: &conf.Settings{},
 			}
 
 			log := newTestBasicLogger()
@@ -823,7 +823,7 @@ func TestRegenerateAndStoreToken(t *testing.T) {
 // TestExchangeCodeWithTimeoutContextCancellation tests context cancellation
 func TestExchangeCodeWithTimeoutContextCancellation(t *testing.T) {
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					AccessTokenExp: time.Hour,

--- a/internal/security/fuzz_test.go
+++ b/internal/security/fuzz_test.go
@@ -455,7 +455,7 @@ func FuzzIsRequestFromAllowedSubnet(f *testing.F) {
 		conf.SetTestSettings(settings)
 		t.Cleanup(func() { conf.SetTestSettings(nil) })
 
-		server := &OAuth2Server{Settings: settings}
+		server := &OAuth2Server{settings: settings}
 
 		// Should never panic
 		result := server.IsRequestFromAllowedSubnet(ipStr)

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -131,7 +131,11 @@ type providerAuthConfig struct {
 }
 
 type OAuth2Server struct {
-	Settings     *conf.Settings
+	// settings is the construction-time snapshot. It is unexported so external
+	// callers cannot read it directly and observe a stale value: all runtime
+	// reads must go through currentSettings() / CurrentSettings(), which resolve
+	// the live atomic snapshot (GitHub #3370).
+	settings     *conf.Settings
 	authCodes    map[string]AuthCode
 	accessTokens map[string]AccessToken
 	mutex        sync.RWMutex
@@ -150,7 +154,7 @@ type OAuth2Server struct {
 // currentSettings returns the latest settings snapshot so security
 // configuration changes take effect without recreating the OAuth2Server.
 func (s *OAuth2Server) currentSettings() *conf.Settings {
-	return conf.CurrentOrFallback(s.Settings)
+	return conf.CurrentOrFallback(s.settings)
 }
 
 // CurrentSettings returns the latest settings snapshot for callers outside the
@@ -175,7 +179,7 @@ func NewOAuth2Server() *OAuth2Server {
 	settings := conf.GetSettings()
 
 	server := &OAuth2Server{
-		Settings:     settings,
+		settings:     settings,
 		authCodes:    make(map[string]AuthCode),
 		accessTokens: make(map[string]AccessToken),
 	}

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -115,7 +115,7 @@ func TestOAuth2Server(t *testing.T) {
 			test: func(t *testing.T, s *OAuth2Server) {
 				t.Helper()
 				// Override settings and publish as global so currentSettings() returns them
-				s.Settings = &conf.Settings{
+				s.settings = &conf.Settings{
 					Security: conf.Security{
 						BasicAuth: conf.BasicAuth{
 							Enabled:        true,
@@ -126,7 +126,7 @@ func TestOAuth2Server(t *testing.T) {
 						},
 					},
 				}
-				conf.SetTestSettings(s.Settings)
+				conf.SetTestSettings(s.settings)
 
 				// Generate and immediately use the auth code
 				code, err := s.GenerateAuthCode()
@@ -146,11 +146,11 @@ func TestOAuth2Server(t *testing.T) {
 			name: "subnet bypass validation",
 			test: func(t *testing.T, s *OAuth2Server) {
 				t.Helper()
-				s.Settings.Security.AllowSubnetBypass = conf.AllowSubnetBypass{
+				s.settings.Security.AllowSubnetBypass = conf.AllowSubnetBypass{
 					Enabled: true,
 					Subnet:  "192.168.1.0/24",
 				}
-				conf.SetTestSettings(s.Settings)
+				conf.SetTestSettings(s.settings)
 
 				assert.True(t, s.IsRequestFromAllowedSubnet("192.168.1.100"), "expected IP to be allowed")
 				assert.False(t, s.IsRequestFromAllowedSubnet("10.0.0.1"), "expected IP to be denied")
@@ -184,7 +184,7 @@ func TestNewOAuth2ServerForTesting(t *testing.T) {
 	server := NewOAuth2ServerForTesting(t, settings)
 
 	require.NotNil(t, server)
-	assert.Equal(t, settings, server.Settings)
+	assert.Equal(t, settings, server.settings)
 	assert.NotNil(t, server.authCodes)
 	assert.NotNil(t, server.accessTokens)
 	assert.NotNil(t, server.throttledMessages)
@@ -450,7 +450,7 @@ func TestIsValidUserId(t *testing.T) {
 // TestValidateAccessToken tests the ValidateAccessToken method
 func TestValidateAccessToken(t *testing.T) {
 	server := &OAuth2Server{
-		Settings:     &conf.Settings{},
+		settings:     &conf.Settings{},
 		accessTokens: make(map[string]AccessToken),
 	}
 
@@ -513,7 +513,7 @@ func TestGenerateAuthCode(t *testing.T) {
 	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 	server := &OAuth2Server{
-		Settings:     settings,
+		settings:     settings,
 		authCodes:    make(map[string]AuthCode),
 		accessTokens: make(map[string]AccessToken),
 	}
@@ -534,7 +534,7 @@ func TestGenerateAuthCode(t *testing.T) {
 // TestExchangeAuthCode tests the ExchangeAuthCode method
 func TestExchangeAuthCode(t *testing.T) {
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					AuthCodeExp:    10 * time.Minute,
@@ -606,7 +606,7 @@ func TestExchangeAuthCode(t *testing.T) {
 // TestExchangeAuthCodeContextCancellation tests context cancellation handling
 func TestExchangeAuthCodeContextCancellation(t *testing.T) {
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				BasicAuth: conf.BasicAuth{
 					AccessTokenExp: time.Hour,
@@ -1028,7 +1028,7 @@ func TestCheckBasicAuthToken(t *testing.T) {
 			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
 
 			server := &OAuth2Server{
-				Settings:     &conf.Settings{},
+				settings:     &conf.Settings{},
 				accessTokens: make(map[string]AccessToken),
 			}
 			tt.setupServer(server)
@@ -1093,7 +1093,7 @@ func TestCheckSocialAuthSessions(t *testing.T) {
 			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
 
 			server := &OAuth2Server{
-				Settings: &conf.Settings{
+				settings: &conf.Settings{
 					Security: conf.Security{
 						OAuthProviders: tt.providers,
 					},
@@ -1229,7 +1229,7 @@ func TestCheckSocialAuthDirect(t *testing.T) {
 			conf.SetTestSettings(settings)
 			t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
-			server := &OAuth2Server{Settings: settings}
+			server := &OAuth2Server{settings: settings}
 
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 			req = tt.setupSession(t, req)
@@ -1284,7 +1284,7 @@ func TestCheckSocialAuthFallback(t *testing.T) {
 			conf.SetTestSettings(settings)
 			t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
-			server := &OAuth2Server{Settings: settings}
+			server := &OAuth2Server{settings: settings}
 
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 			req = tt.setupSession(t, req)
@@ -1311,7 +1311,7 @@ func TestCheckSocialAuthSessionsWithAuthProviderKey(t *testing.T) {
 	conf.SetTestSettings(settings)
 	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
-	server := &OAuth2Server{Settings: settings}
+	server := &OAuth2Server{settings: settings}
 
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req = storeMultipleInSession(t, req,
@@ -1369,7 +1369,7 @@ func TestCheckProviderAuth(t *testing.T) {
 			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
 
 			server := &OAuth2Server{
-				Settings: &conf.Settings{},
+				settings: &conf.Settings{},
 			}
 
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)

--- a/internal/security/oauth_testing.go
+++ b/internal/security/oauth_testing.go
@@ -16,7 +16,7 @@ func NewOAuth2ServerForTesting(tb testing.TB, settings *conf.Settings) *OAuth2Se
 	conf.SetTestSettings(settings)
 	tb.Cleanup(func() { conf.SetTestSettings(nil) })
 	return &OAuth2Server{
-		Settings:          settings,
+		settings:          settings,
 		authCodes:         make(map[string]AuthCode),
 		accessTokens:      make(map[string]AccessToken),
 		throttledMessages: make(map[string]time.Time),

--- a/internal/security/persistence_test.go
+++ b/internal/security/persistence_test.go
@@ -25,7 +25,7 @@ func TestTokenPersistence(t *testing.T) {
 
 	// Create test server with custom token file
 	server := &OAuth2Server{
-		Settings:      &conf.Settings{Security: conf.Security{BasicAuth: conf.BasicAuth{AccessTokenExp: time.Hour}}},
+		settings:      &conf.Settings{Security: conf.Security{BasicAuth: conf.BasicAuth{AccessTokenExp: time.Hour}}},
 		accessTokens:  make(map[string]AccessToken),
 		authCodes:     make(map[string]AuthCode),
 		tokensFile:    filepath.Join(tempDir, "tokens.json"),
@@ -52,7 +52,7 @@ func TestTokenPersistence(t *testing.T) {
 
 	// Create a new server instance to load tokens
 	newServer := &OAuth2Server{
-		Settings:      &conf.Settings{},
+		settings:      &conf.Settings{},
 		accessTokens:  make(map[string]AccessToken),
 		tokensFile:    filepath.Join(tempDir, "tokens.json"),
 		persistTokens: true,
@@ -124,7 +124,7 @@ func TestFilesystemStore(t *testing.T) {
 func TestLocalNetworkCookieStore(t *testing.T) {
 	// Create test server with settings
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				SessionSecret: "test-secret",
 			},
@@ -133,7 +133,7 @@ func TestLocalNetworkCookieStore(t *testing.T) {
 
 	// Test with CookieStore
 	gothic.Store = sessions.NewCookieStore([]byte("test-secret"))
-	server.configureLocalNetworkCookieStore(server.Settings)
+	server.configureLocalNetworkCookieStore(server.settings)
 
 	cookieStore, ok := gothic.Store.(*sessions.CookieStore)
 	assert.True(t, ok, "Gothic store should be a CookieStore")
@@ -143,7 +143,7 @@ func TestLocalNetworkCookieStore(t *testing.T) {
 	tempDir := t.TempDir()
 
 	gothic.Store = sessions.NewFilesystemStore(tempDir, []byte("test-secret"))
-	server.configureLocalNetworkCookieStore(server.Settings)
+	server.configureLocalNetworkCookieStore(server.settings)
 
 	fileStore, ok := gothic.Store.(*sessions.FilesystemStore)
 	assert.True(t, ok, "Gothic store should be a FilesystemStore")
@@ -159,7 +159,7 @@ func TestConfigureLocalNetworkWithUnknownStore(t *testing.T) {
 
 	// Create test server with settings
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				SessionSecret: "test-secret",
 			},
@@ -171,7 +171,7 @@ func TestConfigureLocalNetworkWithUnknownStore(t *testing.T) {
 
 	// This should not panic - the function handles unknown store types gracefully
 	assert.NotPanics(t, func() {
-		server.configureLocalNetworkCookieStore(server.Settings)
+		server.configureLocalNetworkCookieStore(server.settings)
 	}, "configureLocalNetworkCookieStore should not panic with unknown store type")
 }
 
@@ -181,7 +181,7 @@ func TestConfigureLocalNetworkWithUnknownStore(t *testing.T) {
 func TestConfigureLocalNetworkWithMissingSessionSecret(t *testing.T) {
 	// Create test server with empty session secret
 	server := &OAuth2Server{
-		Settings: &conf.Settings{
+		settings: &conf.Settings{
 			Security: conf.Security{
 				SessionSecret: "", // Empty session secret - should not cause issues with unknown store
 			},
@@ -199,7 +199,7 @@ func TestConfigureLocalNetworkWithMissingSessionSecret(t *testing.T) {
 	// This should not panic - the function handles unknown store types gracefully
 	// even with an empty session secret
 	assert.NotPanics(t, func() {
-		server.configureLocalNetworkCookieStore(server.Settings)
+		server.configureLocalNetworkCookieStore(server.settings)
 	}, "configureLocalNetworkCookieStore should not panic with unknown store type and empty session secret")
 }
 
@@ -213,7 +213,7 @@ func TestLoadCorruptedTokensFile(t *testing.T) {
 	require.NoError(t, err, "Failed to write corrupted tokens file")
 
 	server := &OAuth2Server{
-		Settings: &conf.Settings{},
+		settings: &conf.Settings{},
 		accessTokens: map[string]AccessToken{
 			"test_token": {
 				Token:     "test_token",
@@ -255,7 +255,7 @@ func TestUnwritableTokensDirectory(t *testing.T) {
 	}()
 
 	server := &OAuth2Server{
-		Settings: &conf.Settings{},
+		settings: &conf.Settings{},
 		accessTokens: map[string]AccessToken{
 			"test_token": {
 				Token:     "test_token",
@@ -283,7 +283,7 @@ func TestAtomicTokenSaving(t *testing.T) {
 	tokensFile := filepath.Join(tempDir, "tokens.json")
 
 	server := &OAuth2Server{
-		Settings: &conf.Settings{},
+		settings: &conf.Settings{},
 		accessTokens: map[string]AccessToken{
 			"test_token": {
 				Token:     "test_token",


### PR DESCRIPTION
## Summary

The api/v2 Controller repoints `c.Settings` on every settings save under `c.settingsMutex.Lock()`. Many request-time handlers read bare `c.Settings.X` without holding that lock or going through the live-snapshot accessor, which both races the concurrent save (flagged by `go test -race`) and can return a transient stale snapshot during a save.

- Route request-time reads through `c.currentSettings()` (the lock-free live global atomic snapshot) so UI edits take effect without a restart and the reads are race-free: app config + wizard state, insights, media (ffmpeg path, spectrogram style/range/mode, export path), audio level sources/streams, active audio device, detection file cleanup, notification base URL/templates, and the restart-class DB-path reads in prerequisites, legacy cleanup, backup, and database backup download.
- Harden `currentSettings()` to resolve the global atomic first and only fall back to `c.Settings` lazily, so it never eagerly dereferences `c.Settings` when a snapshot is published (removes a residual race for every caller).
- Read debug-gated response content (health check, debug routes and status) from the controller's own snapshot under `settingsMutex.RLock()` via a new `lockedSettings()` helper. Those reads are reached outside the settings write lock, and parallel tests assert this content, so it stays per-controller rather than coupling through the shared global snapshot.
- Unexport `security.OAuth2Server.Settings` to `settings` so external callers cannot read the construction-time pointer and bypass `CurrentSettings()`.
- Tests: add a stale-vs-live regression test and a concurrent read/write `-race` test for the app config handler; route test settings through a `publishTestSettings` helper that publishes and restores the global snapshot for isolation; serialize the few tests that publish to the process-global snapshot and assert handler output.

Extends the hot-reload fix from #3370 to the rest of the api/v2 handlers. No config, REST, DB, or CLI contract changes.

## Test Plan

- [x] `go test -race ./internal/api/v2/... ./internal/api/... ./internal/security/...` all green
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New regression tests fail on the pre-fix code (stale read + data race) and pass after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure API endpoints consistently read live configuration to avoid stale settings during concurrent saves, improving reliability for auth, media, backups, notifications, and prerequisites.
* **Tests**
  * Added and strengthened regression and concurrency tests to validate race-free behavior and prevent cross-test settings leakage.
* **Chores**
  * Stabilized test helpers to publish/restore per-test settings snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->