### PR TITLE
fix(api): close api/v2 settings data races and spectrogram queue-key TOCTOU

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -52,11 +52,19 @@ const apiV2Prefix = "/api/v2"
 
 // Controller manages the API routes and handlers
 type Controller struct {
-	Echo              *echo.Echo
-	Group             *echo.Group
-	DS                datastore.Interface           // Deprecated: Use Repo for new detection operations
-	Repo              datastore.DetectionRepository // New: Preferred for detection CRUD operations
-	Settings          *conf.Settings
+	Echo     *echo.Echo
+	Group    *echo.Group
+	DS       datastore.Interface           // Deprecated: Use Repo for new detection operations
+	Repo     datastore.DetectionRepository // New: Preferred for detection CRUD operations
+	Settings *conf.Settings
+	// settingsAtomic mirrors Settings as a lock-free per-controller snapshot.
+	// The settings update handlers publish it alongside the Settings field on
+	// every save (under settingsMutex), so reads that must stay per-controller
+	// but cannot take the mutex (newErrorResponse is reached from HandleError
+	// while UpdateSettings holds the write lock, so an RLock would deadlock) read
+	// it via controllerSettings() instead of the bare Settings field, which would
+	// race the reassignment. See controllerSettings.
+	settingsAtomic    atomic.Pointer[conf.Settings]
 	BirdImageCache    *imageprovider.BirdImageCache
 	SunCalc           *suncalc.SunCalc
 	Processor         *processor.Processor
@@ -181,19 +189,40 @@ func (c *Controller) currentSettings() *conf.Settings {
 	return c.Settings
 }
 
-// lockedSettings returns this controller's own cached settings snapshot, read
-// under settingsMutex so it cannot race the c.Settings reassignment the settings
-// update handlers perform. Unlike currentSettings(), it deliberately does NOT
-// consult the process-global atomic snapshot: use it for reads whose result is
-// asserted per-controller (e.g. debug-gated response verbosity), where the
-// shared global snapshot would couple otherwise-independent parallel tests.
-// c.Settings is repointed on every save, so it stays live for such reads. The
-// returned snapshot is immutable (copy-on-write), so callers may dereference its
-// fields after the lock is released.
-func (c *Controller) lockedSettings() *conf.Settings {
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
+// controllerSettings returns this controller's own settings snapshot, read
+// lock-free from the settingsAtomic mirror that the settings update handlers
+// publish alongside c.Settings on every save. Unlike currentSettings(), it
+// deliberately does NOT consult the process-global atomic snapshot: use it for
+// reads whose result is asserted per-controller (e.g. debug-gated response
+// verbosity), where the shared global snapshot would couple otherwise-independent
+// parallel tests.
+//
+// Reading the atomic mirror (rather than the bare c.Settings field under
+// settingsMutex.RLock) is what makes this safe to call from newErrorResponse,
+// which is reached from HandleError while UpdateSettings already holds
+// settingsMutex.Lock: a non-reentrant RLock there would deadlock. The mirror is
+// published under that same write lock, so the read sees a consistent snapshot.
+//
+// The c.Settings fallback only runs for standalone test controllers that never
+// published the mirror; production always publishes it at construction, so the
+// fallback never races a concurrent write. The returned snapshot is immutable
+// (copy-on-write), so callers may dereference its fields freely.
+func (c *Controller) controllerSettings() *conf.Settings {
+	if s := c.settingsAtomic.Load(); s != nil {
+		return s
+	}
 	return c.Settings
+}
+
+// publishSettings repoints this controller's settings snapshot to s, updating
+// both the c.Settings field and the lock-free settingsAtomic mirror together so
+// per-controller readers (controllerSettings) never observe a mirror that has
+// drifted from the field. It is the single write path for the snapshot: routing
+// every save and rollback through it keeps the dual-write invariant in one place.
+// Callers must hold c.settingsMutex (the field write is not itself synchronized).
+func (c *Controller) publishSettings(s *conf.Settings) {
+	c.Settings = s
+	c.settingsAtomic.Store(s)
 }
 
 // Option is a functional option for configuring the Controller.
@@ -461,6 +490,10 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()),
 		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
 	}
+	// Publish the per-controller settings mirror so controllerSettings() reads it
+	// lock-free. Kept in sync with the c.Settings field on every save; see the
+	// settingsAtomic field doc and the settings update handlers.
+	c.settingsAtomic.Store(settings)
 
 	// Propagate the derived FFprobe path from config validation to the
 	// ffmpeg package so executeFFprobe can find it without PATH lookup.
@@ -726,7 +759,7 @@ func (c *Controller) HealthCheck(ctx echo.Context) error {
 	// standalone test controllers).
 	var version, buildDate string
 	debug := false
-	if settings := c.lockedSettings(); settings != nil {
+	if settings := c.controllerSettings(); settings != nil {
 		version = settings.Version
 		buildDate = settings.BuildDate
 		debug = settings.WebServer.Debug
@@ -895,13 +928,15 @@ func (c *Controller) newErrorResponse(err error, message string, code int) *Erro
 	// paths, SQL errors, stack traces, etc. In production, use the
 	// sanitized message parameter instead.
 	var errorStr string
-	// Read the controller's own debug flag without locking: this is reached from
-	// HandleError while UpdateSettings holds c.settingsMutex, so it must not
-	// acquire the lock, and the flag must remain per-controller (handlers assert
-	// debug-gated error verbosity per controller, not via the shared global
-	// snapshot). A fully race-free per-controller read would require making
-	// c.Settings an atomic pointer; left as a focused follow-up.
-	if err != nil && c.Settings != nil && c.Settings.WebServer.Debug {
+	// Read the controller's own debug flag via the lock-free atomic mirror: this
+	// is reached from HandleError while UpdateSettings holds c.settingsMutex, so
+	// it must not acquire the lock (a non-reentrant RLock would deadlock), and the
+	// flag must remain per-controller (handlers assert debug-gated error verbosity
+	// per controller, not via the shared global snapshot). controllerSettings()
+	// reads the per-controller snapshot published under that same write lock, so
+	// the read is race-free. See controllerSettings.
+	settings := c.controllerSettings()
+	if err != nil && settings != nil && settings.WebServer.Debug {
 		errorStr = err.Error()
 	} else {
 		errorStr = message

--- a/internal/api/v2/api_error_response_race_test.go
+++ b/internal/api/v2/api_error_response_race_test.go
@@ -1,0 +1,68 @@
+// api_error_response_race_test.go: regression coverage for the per-controller
+// debug-gated error verbosity read in newErrorResponse.
+//
+// newErrorResponse decides whether to expose raw err.Error() based on this
+// controller's own WebServer.Debug flag. That read must stay per-controller (the
+// shared global snapshot would couple otherwise-independent parallel tests) yet
+// must not race the c.Settings republish UpdateSettings performs on every save,
+// and it must not take c.settingsMutex (it is reached from HandleError while
+// UpdateSettings already holds the write lock, so an RLock would deadlock).
+package api
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TestNewErrorResponseConcurrentSettingsPublishIsRaceFree hammers
+// newErrorResponse from multiple readers while writers republish the settings
+// snapshot the same way UpdateSettings does (c.Settings reassignment plus the
+// per-controller atomic mirror, under c.settingsMutex). Under `go test -race`,
+// the pre-fix bare c.Settings.WebServer.Debug read in newErrorResponse is
+// flagged as a data race against the c.Settings write.
+func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
+	withRestoredGlobalSettings(t)
+
+	controller := &Controller{Settings: newValidTestSettings()}
+	// Mirror production construction so the per-controller debug read resolves
+	// via the lock-free atomic snapshot rather than the bare c.Settings field.
+	controller.settingsAtomic.Store(controller.Settings)
+
+	testErr := echo.NewHTTPError(http.StatusInternalServerError, "raw internal detail")
+
+	const (
+		writers        = 2
+		readers        = 4
+		itersPerWorker = 200
+	)
+
+	var wg sync.WaitGroup
+
+	for w := range writers {
+		wg.Go(func() {
+			for i := range itersPerWorker {
+				snap := newValidTestSettings()
+				snap.WebServer.Debug = (w+i)%2 == 0
+				// Republish through the production single write path so this test
+				// also guards against publishSettings updating only one of the two
+				// fields. publishSettings requires the settings mutex held.
+				controller.settingsMutex.Lock()
+				controller.publishSettings(snap)
+				controller.settingsMutex.Unlock()
+			}
+		})
+	}
+
+	for range readers {
+		wg.Go(func() {
+			for range itersPerWorker {
+				_ = controller.newErrorResponse(testErr, "sanitized message", http.StatusInternalServerError)
+			}
+		})
+	}
+
+	wg.Wait()
+}

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -272,9 +272,10 @@ func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc
 // restart.
 func (c *Controller) privateModeAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		c.settingsMutex.RLock()
-		privateMode := c.Settings.Security.PrivateMode
-		c.settingsMutex.RUnlock()
+		// Read the live snapshot (race-free, hot-reloading) to match the sibling
+		// publicLiveAudioAuth middleware; the bare c.Settings field under RLock
+		// would not pick up out-of-band StoreSettings republishes.
+		privateMode := c.currentSettings().Security.PrivateMode
 
 		if !privateMode {
 			return next(ctx)

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -48,7 +48,7 @@ type DebugSystemStatus struct {
 // This is defense-in-depth — debug routes are already conditionally registered.
 func (c *Controller) requireDebugMode(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		if s := c.lockedSettings(); s == nil || !s.Debug {
+		if s := c.controllerSettings(); s == nil || !s.Debug {
 			return c.HandleErrorWithKey(ctx, nil, "Debug mode not enabled", http.StatusForbidden, notification.MsgErrDebugNotEnabled, nil)
 		}
 		return next(ctx)
@@ -185,7 +185,7 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 
 // DebugSystemStatus returns current system status for debugging
 func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
-	settings := c.lockedSettings()
+	settings := c.controllerSettings()
 	debug := false
 	if settings != nil {
 		debug = settings.Debug

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1757,13 +1757,11 @@ func calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTime
 // All temperatures are stored in Celsius internally; this determines display format.
 // Returns "imperial" for Fahrenheit or "metric" for Celsius to match frontend expectations.
 func (c *Controller) getWeatherUnits() string {
-	// Read settings with mutex
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
-	// Use dashboard temperature unit preference for display
-	// All temperatures are now stored in Celsius internally
-	switch c.Settings.Realtime.Dashboard.TemperatureUnit {
+	// Use dashboard temperature unit preference for display. Read the live
+	// snapshot (race-free, hot-reloading) rather than the bare c.Settings field,
+	// matching the rest of the Dashboard subtree reads.
+	// All temperatures are now stored in Celsius internally.
+	switch c.currentSettings().Realtime.Dashboard.TemperatureUnit {
 	case conf.TemperatureUnitFahrenheit:
 		return "imperial"
 	case conf.TemperatureUnitCelsius:

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -1719,7 +1719,11 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 		}
 		profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
 
-		spectrogramPath, err := c.generateSpectrogram(bgCtx, clipPath, params.width, params.raw, params.style, params.dynamicRange, profileOpt)
+		// Thread the relative audio path the handler already validated against
+		// Export.Path so the worker derives the same queue key the client received,
+		// even if Export.Path changed after the handler returned. Re-deriving it
+		// here (via generateSpectrogram) would reopen the queue-key TOCTOU.
+		spectrogramPath, err := c.generateSpectrogramFromRel(bgCtx, relAudioPath, clipPath, params.width, params.raw, params.style, params.dynamicRange, profileOpt)
 
 		if err != nil {
 			// Update queue status so polling clients see the failure
@@ -2642,21 +2646,39 @@ func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, abs
 // It accepts a context for cancellation and timeout.
 // It returns the relative path to the generated spectrogram, suitable for use with c.SFS.ServeFile.
 // Optimized: Fast path check happens before expensive audio validation.
+//
+// It normalizes audioPath against the live Realtime.Audio.Export.Path and then
+// delegates to generateSpectrogramFromRel. Callers that have already validated
+// the relative path at a request boundary (e.g. GenerateSpectrogramByID) must
+// call generateSpectrogramFromRel directly and thread that path in, so the queue
+// key cannot drift if Export.Path changes mid-flight.
 func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, width int, raw bool, style, dynamicRange string, extraOpts ...spectrogram.GenerateOption) (string, error) {
-	start := time.Now()
-	getSpectrogramLogger().Debug("Spectrogram generation requested",
-		logger.String("audio_path", audioPath),
-		logger.Int("width", width),
-		logger.Bool("raw", raw),
-		logger.String("style", style),
-		logger.String("dynamic_range", dynamicRange),
-		logger.String("request_time", start.Format(time.DateTime)))
-
 	// Step 1: Normalize and validate path
 	relAudioPath, err := c.normalizeAndValidatePath(audioPath)
 	if err != nil {
 		return "", err
 	}
+	return c.generateSpectrogramFromRel(ctx, relAudioPath, audioPath, width, raw, style, dynamicRange, extraOpts...)
+}
+
+// generateSpectrogramFromRel generates a spectrogram for an already normalized,
+// SecureFS-validated relative audio path. It derives the spectrogram path and the
+// queue key purely from relAudioPath, so callers that resolved that path at a
+// request boundary get a stable key regardless of later Realtime.Audio.Export.Path
+// changes. This closes the TOCTOU where GenerateSpectrogramByID returned one key
+// to the client while the worker, re-reading Export.Path, ran (and cleaned up)
+// under a different key, orphaning the queued entry. audioPath is retained only
+// for log and error context.
+func (c *Controller) generateSpectrogramFromRel(ctx context.Context, relAudioPath, audioPath string, width int, raw bool, style, dynamicRange string, extraOpts ...spectrogram.GenerateOption) (string, error) {
+	start := time.Now()
+	getSpectrogramLogger().Debug("Spectrogram generation requested",
+		logger.String("audio_path", audioPath),
+		logger.String("relative_audio_path", relAudioPath),
+		logger.Int("width", width),
+		logger.Bool("raw", raw),
+		logger.String("style", style),
+		logger.String("dynamic_range", dynamicRange),
+		logger.String("request_time", start.Format(time.DateTime)))
 
 	// Step 2: Calculate spectrogram paths early (needed for fast path check)
 	relBaseFilename, relAudioDir, spectrogramFilename, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, width, raw, style, dynamicRange)

--- a/internal/api/v2/media_spectrogram_toctou_test.go
+++ b/internal/api/v2/media_spectrogram_toctou_test.go
@@ -1,0 +1,74 @@
+// media_spectrogram_toctou_test.go: regression coverage for the spectrogram
+// queue-key time-of-check/time-of-use bug.
+//
+// GenerateSpectrogramByID validates the clip path against Realtime.Audio.Export.Path
+// at the handler boundary, builds the queue key from it, and returns that key to
+// the client. The async worker must run under the SAME key. Before the fix the
+// worker re-derived the path inside generateSpectrogram by re-reading the live
+// Export.Path, so an export-path change between the handler and the worker made
+// the worker run under a different key, orphaning the handler's queued entry and
+// making GET /spectrogram/:id/status miss the in-flight job. The fix threads the
+// handler-validated relative path into generateSpectrogramFromRel.
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/securefs"
+)
+
+// TestGenerateSpectrogramFromRelIgnoresLiveExportPath pins that the worker entry
+// point derives the spectrogram path and queue key solely from the relative
+// audio path threaded in by the handler, never from the live
+// Realtime.Audio.Export.Path. It proves this via the fast path: the spectrogram
+// already exists at the path derived from relAudioPath, so the call returns it
+// without generation even though the live Export.Path has since changed. If the
+// worker re-read Export.Path it would normalize to a different path and miss the
+// pre-created file.
+func TestGenerateSpectrogramFromRelIgnoresLiveExportPath(t *testing.T) {
+	withRestoredGlobalSettings(t)
+
+	tmp := t.TempDir()
+	sfs, err := securefs.New(tmp)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sfs.Close() })
+
+	ctx := t.Context()
+
+	controller := &Controller{
+		Settings: newValidTestSettings(),
+		SFS:      sfs,
+		ctx:      ctx,
+	}
+	controller.settingsAtomic.Store(controller.Settings)
+
+	const (
+		width = SpectrogramSizeLg
+		raw   = true
+	)
+	relAudioPath := "2024/06/04/Turdus_merula_80p.wav"
+	_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, width, raw, "", "")
+
+	// Pre-create the spectrogram on disk so the fast path returns without ffmpeg.
+	full := filepath.Join(tmp, relSpectrogramPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+	require.NoError(t, os.WriteFile(full, []byte("PNG"), 0o600))
+
+	// Publish a divergent live export path. A worker that re-read Export.Path to
+	// derive its path/key (the pre-fix behaviour) would normalize the clip path
+	// differently and miss the pre-created spectrogram.
+	live := conf.CloneSettings(controller.Settings)
+	live.Realtime.Audio.Export.Path = filepath.Join(tmp, "changed-prefix")
+	conf.SetTestSettings(live)
+	controller.settingsAtomic.Store(live)
+
+	got, err := controller.generateSpectrogramFromRel(ctx, relAudioPath, "irrelevant/clip/path.wav", width, raw, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, relSpectrogramPath, got,
+		"generateSpectrogramFromRel must derive the spectrogram path from the threaded relAudioPath, not the live Export.Path")
+}

--- a/internal/api/v2/quiet_hours.go
+++ b/internal/api/v2/quiet_hours.go
@@ -40,7 +40,9 @@ func (c *Controller) initQuietHoursRoutes() {
 // indicator count active suppressions. Authenticated requests (e.g. the
 // StreamManager settings form) continue to receive the sanitized URL map.
 func (c *Controller) GetQuietHoursStatus(ctx echo.Context) error {
-	settings := c.Settings
+	// Read the live snapshot (race-free, hot-reloading) rather than the bare
+	// c.Settings field, which races the c.Settings republish in UpdateSettings.
+	settings := c.currentSettings()
 	var scheduler *schedule.QuietHoursScheduler
 	if eng := c.engine.Load(); eng != nil {
 		scheduler = eng.Scheduler()

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -294,7 +294,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}
-	c.Settings = updated
+	c.publishSettings(updated)
 
 	// Run cross-field side-effects (interval tracking, telemetry toggles, etc.)
 	// against the published pair. handleSettingsChanges is read-only on both.
@@ -304,7 +304,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		if publishGlobal {
 			conf.StoreSettings(current)
 		}
-		c.Settings = current
+		c.publishSettings(current)
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to apply settings changes, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
@@ -317,7 +317,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		if err := conf.SaveSettings(); err != nil {
 			// Rollback in-memory; disk write never happened successfully.
 			conf.StoreSettings(current)
-			c.Settings = current
+			c.publishSettings(current)
 			c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
@@ -575,12 +575,12 @@ func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) err
 	if c.isGlobalOwner {
 		conf.StoreSettings(updated)
 	}
-	c.Settings = updated
+	c.publishSettings(updated)
 
 	if c.isGlobalOwner && !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
 			conf.StoreSettings(current)
-			c.Settings = current
+			c.publishSettings(current)
 			return fmt.Errorf("failed to save settings: %w", err)
 		}
 	}
@@ -704,13 +704,13 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}
-	c.Settings = updated
+	c.publishSettings(updated)
 
 	if err := c.handleSettingsChanges(current, updated); err != nil {
 		if publishGlobal {
 			conf.StoreSettings(current)
 		}
-		c.Settings = current
+		c.publishSettings(current)
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
@@ -721,7 +721,7 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	if publishGlobal && !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
 			conf.StoreSettings(current)
-			c.Settings = current
+			c.publishSettings(current)
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
 		c.logAPIRequest(ctx, logger.LogLevelInfo, "Section settings saved successfully",

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -127,8 +127,9 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		c.logDebugIfEnabled("Set default options for support dump")
 	}
 
-	// Get current settings via dependency injection
-	settings := c.Settings
+	// Read the live snapshot (race-free, hot-reloading) rather than the bare
+	// c.Settings field, which races the c.Settings republish in UpdateSettings.
+	settings := c.currentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
 	}
@@ -314,7 +315,9 @@ func (c *Controller) DownloadSupportDump(ctx echo.Context) error {
 
 // GetSupportStatus returns the current support/telemetry configuration status
 func (c *Controller) GetSupportStatus(ctx echo.Context) error {
-	settings := c.Settings
+	// Read the live snapshot (race-free, hot-reloading) rather than the bare
+	// c.Settings field, which races the c.Settings republish in UpdateSettings.
+	settings := c.currentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #3380, closing the remaining request-time settings data races and the spectrogram queue-key time-of-check/time-of-use bug in `internal/api/v2`.

### 1. `newErrorResponse` data race (per-controller debug flag)

`newErrorResponse` read `c.Settings.WebServer.Debug` bare while the settings update handlers republish `c.Settings` under `settingsMutex` on every save, which the race detector flags. It cannot take the mutex (it is reached from `HandleError` while `UpdateSettings` already holds the write lock, so a non-reentrant `RLock` would deadlock), and the flag must stay per-controller (handlers assert debug-gated error verbosity per controller, not via the shared global snapshot).

Fix: add an unexported per-controller mirror `settingsAtomic atomic.Pointer[conf.Settings]`, written together with the `c.Settings` field through a single `publishSettings()` helper at every save/rollback site and at construction (all under `settingsMutex`). The per-controller debug reads now go through `controllerSettings()` (renamed from `lockedSettings`, now lock-free: reads the mirror, falls back to the bare field only for standalone test controllers that never published the mirror).

### 2. Remaining request-time bare `c.Settings` reads

`GetQuietHoursStatus`, the support handlers, `privateModeAuth`, and `getWeatherUnits` read `c.Settings` at request time without synchronization (some under a now-redundant `RLock`). Routed through `currentSettings()` so they read the live lock-free snapshot race-free and hot-reload; dropped the now-unneeded `settingsMutex.RLock` blocks.

### 3. Spectrogram queue-key TOCTOU (worker side)

`GenerateSpectrogramByID` validated the clip path against `Realtime.Audio.Export.Path` at the handler boundary, built the queue key from it, and returned that key to the client, but the async worker re-derived the path inside `generateSpectrogram` by re-reading the live `Export.Path`. If the export path changed between handler and worker, the worker ran (and cleaned up) under a different key, orphaning the client's queued entry.

Fix: extract `generateSpectrogramFromRel` and thread the handler-validated relative path into the worker so the worker's key matches the key the client received. The residual status-poll side (the status endpoint re-derives the key from live `Export.Path`) is tracked separately as a larger refactor.

## Test Plan

- [x] `golangci-lint run ./...` - 0 issues
- [x] `go test -race ./internal/api/v2/...` - full suite green (incl. the two new regression tests)
- [x] New `-race` regression test for the `newErrorResponse` data race (fails on the pre-fix bare read)
- [x] New regression test pinning that the spectrogram worker derives its key from the threaded relative path, not the live `Export.Path`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated race conditions and deadlocks in concurrent settings operations.
  * Fixed spectrogram generation stability when export paths change during processing.
  * Improved consistency of settings state across the application during simultaneous updates.

* **Tests**
  * Added regression tests for concurrent settings updates.
  * Added regression tests for spectrogram path stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->