### PR TITLE
fix(security): log OAuth login flow to security module and clarify allowed-users UX (#3381)

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -46,7 +46,7 @@
   import { hasSettingsChanged } from '$lib/utils/settingsChanges';
   import { settingsAPI, type TLSCertificateInfo } from '$lib/utils/settingsApi';
   import { toastActions } from '$lib/stores/toast';
-  import { ExternalLink, Server, KeyRound, Users, Plus, Pencil, Trash2, Terminal, ShieldCheck, Upload, Globe, RefreshCw } from '@lucide/svelte';
+  import { ExternalLink, Server, KeyRound, Users, Plus, Pencil, Trash2, Terminal, ShieldCheck, Upload, Globe, RefreshCw, TriangleAlert } from '@lucide/svelte';
   import { t } from '$lib/i18n';
   import { GoogleIcon, AUTH_PROVIDERS } from '$lib/auth';
   import type { Component } from 'svelte';
@@ -502,6 +502,13 @@
     if (!/^https?:\/\/[^/\s]+/.test(url)) return t('settings.security.oauth.oidc.issuerUrlInvalid');
     return '';
   });
+
+  // Mirror the backend allowlist check (isAllowedOAuthUser): a userId made up of
+  // only blank/comma entries (e.g. "" or ",") allows no one, so an enabled
+  // provider with such a value denies every login (issue #3381).
+  function hasNoAllowedUsers(userId: string | undefined): boolean {
+    return !(userId ?? '').split(',').some(entry => entry.trim() !== '');
+  }
 
   function saveProvider() {
     // Build the provider config
@@ -1159,6 +1166,18 @@
                   onchange={(value) => (providerFormData.userId = value)}
                 />
 
+                <!-- Warn (do not block) when no allowed users are set: an enabled
+                     provider with an empty allowlist denies every login (issue #3381). -->
+                {#if hasNoAllowedUsers(providerFormData.userId)}
+                  <p
+                    class="text-xs text-[var(--color-warning)] -mt-2 flex items-start gap-1.5"
+                    role="status"
+                  >
+                    <TriangleAlert class="size-3.5 shrink-0 mt-0.5" />
+                    <span>{t('settings.security.oauth.allowedUsersEmptyWarning')}</span>
+                  </p>
+                {/if}
+
                 <Checkbox
                   checked={providerFormData.enabled}
                   label={t('settings.security.oauth.enableProviderLabel')}
@@ -1235,6 +1254,19 @@
                           {#if provider.userId}
                             <div class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
                               {provider.userId}
+                            </div>
+                          {/if}
+                          <!-- Flag enabled providers whose allowlist is empty: nobody
+                               can log in with them (issue #3381). -->
+                          {#if provider.enabled && hasNoAllowedUsers(provider.userId)}
+                            <div
+                              class="text-xs text-[var(--color-warning)] flex items-center gap-1 mt-0.5"
+                              role="status"
+                            >
+                              <TriangleAlert class="size-3 shrink-0" />
+                              <span class="truncate"
+                                >{t('settings.security.oauth.allowedUsersMissingBadge')}</span
+                              >
                             </div>
                           {/if}
                         </div>

--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -1166,9 +1166,10 @@
                   onchange={(value) => (providerFormData.userId = value)}
                 />
 
-                <!-- Warn (do not block) when no allowed users are set: an enabled
-                     provider with an empty allowlist denies every login (issue #3381). -->
-                {#if hasNoAllowedUsers(providerFormData.userId)}
+                <!-- Warn (do not block) when an enabled provider has no allowed users:
+                     such a provider denies every login (issue #3381). Gated on enabled to
+                     match the providers-list badge and avoid noise for draft/disabled providers. -->
+                {#if providerFormData.enabled && hasNoAllowedUsers(providerFormData.userId)}
                   <p
                     class="text-xs text-[var(--color-warning)] -mt-2 flex items-start gap-1.5"
                     role="status"

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "OAuth 2.0 Client ID z vývojářské konzole vašeho poskytovatele",
         "clientSecretLabel": "Client Secret",
         "clientSecretHelpText": "OAuth 2.0 Client Secret z vývojářské konzole vašeho poskytovatele",
-        "userIdLabel": "ID uživatele (volitelné)",
-        "userIdHelpText": "Omezit přístup na konkrétní uživatelský účet podle e-mailu nebo ID",
+        "userIdLabel": "Povolení uživatelé",
+        "userIdHelpText": "E-maily nebo ID uživatelů oddělené čárkami, kteří se mohou přihlásit přes tohoto poskytovatele. Pokud zůstane prázdné, nikdo se nepřihlásí.",
+        "allowedUsersEmptyWarning": "Tento poskytovatel nemá žádné povolené uživatele, takže každý pokus o přihlášení bude odmítnut. Přidejte alespoň jeden e-mail nebo ID uživatele pro povolení přístupu.",
+        "allowedUsersMissingBadge": "Nejsou nastaveni žádní povolení uživatelé - přihlášení selže",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Povolit přihlášení OAuth2 přes Google",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "OAuth 2.0 klient-ID fra din udbyders udviklerkonsol",
         "clientSecretLabel": "Klienthemmelighed",
         "clientSecretHelpText": "OAuth 2.0 klienthemmelighed fra din udbyders udviklerkonsol",
-        "userIdLabel": "Bruger-ID (valgfrit)",
-        "userIdHelpText": "Begræns adgang til en bestemt brugerkonto via e-mail eller ID",
+        "userIdLabel": "Tilladte brugere",
+        "userIdHelpText": "Kommaseparerede e-mails eller bruger-id'er, der må logge ind med denne udbyder. Hvis feltet er tomt, kan ingen logge ind.",
+        "allowedUsersEmptyWarning": "Denne udbyder har ingen tilladte brugere, så alle loginforsøg afvises. Tilføj mindst én e-mail eller et bruger-id for at give adgang.",
+        "allowedUsersMissingBadge": "Ingen tilladte brugere angivet - login vil mislykkes",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Tillad OAuth2-login via Google",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "Die OAuth 2.0 Client-ID aus der Entwicklerkonsole Ihres Anbieters",
         "clientSecretLabel": "Client-Geheimnis",
         "clientSecretHelpText": "Das OAuth 2.0 Client-Geheimnis aus der Entwicklerkonsole Ihres Anbieters",
-        "userIdLabel": "Benutzer-ID (optional)",
-        "userIdHelpText": "Zugriff auf ein bestimmtes Benutzerkonto per E-Mail oder ID beschränken",
+        "userIdLabel": "Zugelassene Benutzer",
+        "userIdHelpText": "Kommagetrennte E-Mails oder Benutzer-IDs, die sich mit diesem Anbieter anmelden dürfen. Wenn leer, kann sich niemand anmelden.",
+        "allowedUsersEmptyWarning": "Dieser Anbieter hat keine zugelassenen Benutzer, daher wird jeder Anmeldeversuch abgelehnt. Fügen Sie mindestens eine E-Mail oder Benutzer-ID hinzu, um den Zugriff zu erlauben.",
+        "allowedUsersMissingBadge": "Keine zugelassenen Benutzer festgelegt - Anmeldung schlägt fehl",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "OAuth2-Anmeldung über Google erlauben",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "The OAuth 2.0 Client ID from your provider's developer console",
         "clientSecretLabel": "Client Secret",
         "clientSecretHelpText": "The OAuth 2.0 Client Secret from your provider's developer console",
-        "userIdLabel": "User ID (optional)",
-        "userIdHelpText": "Restrict access to a specific user account by email or ID",
+        "userIdLabel": "Allowed Users",
+        "userIdHelpText": "Comma-separated emails or user IDs allowed to sign in with this provider. If left empty, no one can log in.",
+        "allowedUsersEmptyWarning": "This provider has no allowed users, so every login attempt will be denied. Add at least one email or user ID to allow access.",
+        "allowedUsersMissingBadge": "No allowed users set - login will fail",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Allow OAuth2 Login via Google",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "El ID de cliente OAuth 2.0 de la consola de desarrollador de tu proveedor",
         "clientSecretLabel": "Secreto de cliente",
         "clientSecretHelpText": "El secreto de cliente OAuth 2.0 de la consola de desarrollador de tu proveedor",
-        "userIdLabel": "ID de usuario (opcional)",
-        "userIdHelpText": "Restringir el acceso a una cuenta de usuario específica por correo electrónico o ID",
+        "userIdLabel": "Usuarios permitidos",
+        "userIdHelpText": "Correos o ID de usuario separados por comas que pueden iniciar sesión con este proveedor. Si se deja vacío, nadie podrá iniciar sesión.",
+        "allowedUsersEmptyWarning": "Este proveedor no tiene usuarios permitidos, por lo que se rechazará cada intento de inicio de sesión. Añade al menos un correo o ID de usuario para permitir el acceso.",
+        "allowedUsersMissingBadge": "No hay usuarios permitidos - el inicio de sesión fallará",
         "google": {
           "title": "OAuth de Google",
           "enableLabel": "Permitir inicio de sesión OAuth2 a través de Google",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "OAuth 2.0 -asiakastunnus tarjoajasi kehittäjäkonsolista",
         "clientSecretLabel": "Asiakassalaisuus",
         "clientSecretHelpText": "OAuth 2.0 -asiakassalaisuus tarjoajasi kehittäjäkonsolista",
-        "userIdLabel": "Käyttäjätunnus (valinnainen)",
-        "userIdHelpText": "Rajoita pääsy tiettyyn käyttäjätiliin sähköpostiosoitteen tai tunnuksen perusteella",
+        "userIdLabel": "Sallitut käyttäjät",
+        "userIdHelpText": "Pilkuilla erotellut sähköpostit tai käyttäjätunnukset, jotka voivat kirjautua tällä palveluntarjoajalla. Jos kenttä on tyhjä, kukaan ei voi kirjautua.",
+        "allowedUsersEmptyWarning": "Tällä palveluntarjoajalla ei ole sallittuja käyttäjiä, joten jokainen kirjautumisyritys hylätään. Lisää vähintään yksi sähköposti tai käyttäjätunnus salliaksesi pääsyn.",
+        "allowedUsersMissingBadge": "Sallittuja käyttäjiä ei ole määritetty - kirjautuminen epäonnistuu",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Salli OAuth2-kirjautuminen Googlen kautta",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "L'ID client OAuth 2.0 de la console développeur de votre fournisseur",
         "clientSecretLabel": "Secret client",
         "clientSecretHelpText": "Le secret client OAuth 2.0 de la console développeur de votre fournisseur",
-        "userIdLabel": "ID utilisateur (optionnel)",
-        "userIdHelpText": "Restreindre l'accès à un compte utilisateur spécifique par e-mail ou ID",
+        "userIdLabel": "Utilisateurs autorisés",
+        "userIdHelpText": "E-mails ou identifiants d'utilisateur séparés par des virgules autorisés à se connecter avec ce fournisseur. Si vide, personne ne peut se connecter.",
+        "allowedUsersEmptyWarning": "Ce fournisseur n'a aucun utilisateur autorisé, donc chaque tentative de connexion sera refusée. Ajoutez au moins un e-mail ou un identifiant d'utilisateur pour autoriser l'accès.",
+        "allowedUsersMissingBadge": "Aucun utilisateur autorisé défini - la connexion échouera",
         "google": {
           "title": "OAuth Google",
           "enableLabel": "Autoriser la connexion OAuth2 via Google",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "Az OAuth 2.0 Client ID a szolgáltató fejlesztői konzoljáról",
         "clientSecretLabel": "Kliens titok",
         "clientSecretHelpText": "Az OAuth 2.0 Client Secret a szolgáltató fejlesztői konzoljáról",
-        "userIdLabel": "Felhasználói ID (opcionális)",
-        "userIdHelpText": "Korlátozza a hozzáférést egy adott felhasználói fiókhoz e-mail vagy ID szerint",
+        "userIdLabel": "Engedélyezett felhasználók",
+        "userIdHelpText": "Vesszővel elválasztott e-mailek vagy felhasználói azonosítók, akik bejelentkezhetnek ezzel a szolgáltatóval. Ha üres, senki sem tud bejelentkezni.",
+        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet elutasításra kerül. Adjon meg legalább egy e-mailt vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
+        "allowedUsersMissingBadge": "Nincsenek engedélyezett felhasználók - a bejelentkezés sikertelen lesz",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Google OAuth2 bejelentkezés engedélyezése",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "L'ID Client OAuth 2.0 dalla console sviluppatori del tuo fornitore",
         "clientSecretLabel": "Segreto Client",
         "clientSecretHelpText": "Il Segreto Client OAuth 2.0 dalla console sviluppatori del tuo fornitore",
-        "userIdLabel": "ID Utente (opzionale)",
-        "userIdHelpText": "Limita accesso a specifico account utente per email o ID",
+        "userIdLabel": "Utenti consentiti",
+        "userIdHelpText": "Email o ID utente separati da virgole autorizzati ad accedere con questo provider. Se vuoto, nessuno può accedere.",
+        "allowedUsersEmptyWarning": "Questo provider non ha utenti consentiti, quindi ogni tentativo di accesso verrà rifiutato. Aggiungi almeno un'email o un ID utente per consentire l'accesso.",
+        "allowedUsersMissingBadge": "Nessun utente consentito impostato - l'accesso fallirà",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Consenti Login OAuth2 via Google",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "OAuth 2.0 klienta ID no jūsu nodrošinātāja izstrādātāju konsoles",
         "clientSecretLabel": "Klienta noslēpums",
         "clientSecretHelpText": "OAuth 2.0 klienta noslēpums no jūsu nodrošinātāja izstrādātāju konsoles",
-        "userIdLabel": "Lietotāja ID (neobligāts)",
-        "userIdHelpText": "Ierobežot piekļuvi konkrētam lietotāja kontam pēc e-pasta vai ID",
+        "userIdLabel": "Atļautie lietotāji",
+        "userIdHelpText": "Ar komatu atdalīti e-pasti vai lietotāju ID, kuriem atļauts pieteikties ar šo pakalpojumu sniedzēju. Ja atstāts tukšs, neviens nevarēs pieteikties.",
+        "allowedUsersEmptyWarning": "Šim pakalpojumu sniedzējam nav atļauto lietotāju, tāpēc katrs pieteikšanās mēģinājums tiks noraidīts. Pievienojiet vismaz vienu e-pastu vai lietotāja ID, lai atļautu piekļuvi.",
+        "allowedUsersMissingBadge": "Nav iestatīts neviens atļautais lietotājs - pieteikšanās neizdosies",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Atļaut OAuth2 pieteikšanos caur Google",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "De OAuth 2.0 Client-ID van de ontwikkelaarsconsole van uw provider",
         "clientSecretLabel": "Clientgeheim",
         "clientSecretHelpText": "Het OAuth 2.0 Client Secret van de ontwikkelaarsconsole van uw provider",
-        "userIdLabel": "Gebruikers-ID (optioneel)",
-        "userIdHelpText": "Beperk toegang tot een specifiek gebruikersaccount via e-mail of ID",
+        "userIdLabel": "Toegestane gebruikers",
+        "userIdHelpText": "Door komma's gescheiden e-mails of gebruikers-ID's die mogen inloggen met deze provider. Als dit leeg is, kan niemand inloggen.",
+        "allowedUsersEmptyWarning": "Deze provider heeft geen toegestane gebruikers, dus elke inlogpoging wordt geweigerd. Voeg ten minste één e-mail of gebruikers-ID toe om toegang te verlenen.",
+        "allowedUsersMissingBadge": "Geen toegestane gebruikers ingesteld - inloggen mislukt",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Sta OAuth2 Inloggen via Google toe",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "ID klienta OAuth 2.0 z konsoli deweloperskiej dostawcy",
         "clientSecretLabel": "Sekret klienta",
         "clientSecretHelpText": "Sekret klienta OAuth 2.0 z konsoli deweloperskiej dostawcy",
-        "userIdLabel": "ID użytkownika (opcjonalnie)",
-        "userIdHelpText": "Ogranicz dostęp do określonego konta użytkownika według adresu e-mail lub ID",
+        "userIdLabel": "Dozwoleni użytkownicy",
+        "userIdHelpText": "Rozdzielone przecinkami adresy e-mail lub identyfikatory użytkowników, którzy mogą logować się za pomocą tego dostawcy. Jeśli pole jest puste, nikt nie może się zalogować.",
+        "allowedUsersEmptyWarning": "Ten dostawca nie ma dozwolonych użytkowników, więc każda próba logowania zostanie odrzucona. Dodaj co najmniej jeden adres e-mail lub identyfikator użytkownika, aby zezwolić na dostęp.",
+        "allowedUsersMissingBadge": "Nie ustawiono dozwolonych użytkowników - logowanie się nie powiedzie",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Zezwalaj na Logowanie OAuth2 przez Google",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "O ID do cliente OAuth 2.0 do console de desenvolvedor do seu provedor",
         "clientSecretLabel": "Segredo do cliente",
         "clientSecretHelpText": "O segredo do cliente OAuth 2.0 do console de desenvolvedor do seu provedor",
-        "userIdLabel": "ID do usuário (opcional)",
-        "userIdHelpText": "Restringir acesso a uma conta de usuário específica por e-mail ou ID",
+        "userIdLabel": "Utilizadores permitidos",
+        "userIdHelpText": "E-mails ou IDs de utilizador separados por vírgulas autorizados a iniciar sessão com este fornecedor. Se vazio, ninguém pode iniciar sessão.",
+        "allowedUsersEmptyWarning": "Este fornecedor não tem utilizadores permitidos, por isso todas as tentativas de início de sessão serão recusadas. Adicione pelo menos um e-mail ou ID de utilizador para permitir o acesso.",
+        "allowedUsersMissingBadge": "Nenhum utilizador permitido definido - o início de sessão falhará",
         "google": {
           "title": "OAuth do Google",
           "enableLabel": "Permitir login OAuth2 via Google",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "OAuth 2.0 Client ID z vývojárskej konzoly vášho poskytovateľa",
         "clientSecretLabel": "Tajný kľúč klienta",
         "clientSecretHelpText": "OAuth 2.0 Client Secret z vývojárskej konzoly vášho poskytovateľa",
-        "userIdLabel": "ID používateľa (voliteľné)",
-        "userIdHelpText": "Obmedziť prístup ku konkrétnemu používateľskému účtu podľa e-mailu alebo ID",
+        "userIdLabel": "Povolení používatelia",
+        "userIdHelpText": "Čiarkami oddelené e-maily alebo ID používateľov, ktorí sa môžu prihlásiť cez tohto poskytovateľa. Ak zostane prázdne, nikto sa nemôže prihlásiť.",
+        "allowedUsersEmptyWarning": "Tento poskytovateľ nemá žiadnych povolených používateľov, takže každý pokus o prihlásenie bude zamietnutý. Pridajte aspoň jeden e-mail alebo ID používateľa na povolenie prístupu.",
+        "allowedUsersMissingBadge": "Nie sú nastavení žiadni povolení používatelia - prihlásenie zlyhá",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Povoliť prihlásenie OAuth2 cez Google",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3337,8 +3337,10 @@
         "clientIdHelpText": "OAuth 2.0 Klient-ID från din leverantörs utvecklarkonsol",
         "clientSecretLabel": "Klienthemlighet",
         "clientSecretHelpText": "OAuth 2.0 Klienthemlighet från din leverantörs utvecklarkonsol",
-        "userIdLabel": "Användar-ID (valfritt)",
-        "userIdHelpText": "Begränsa åtkomst till ett specifikt användarkonto via e-post eller ID",
+        "userIdLabel": "Tillåtna användare",
+        "userIdHelpText": "Kommaseparerade e-postadresser eller användar-ID:n som får logga in med denna leverantör. Om fältet lämnas tomt kan ingen logga in.",
+        "allowedUsersEmptyWarning": "Den här leverantören har inga tillåtna användare, så varje inloggningsförsök nekas. Lägg till minst en e-postadress eller ett användar-ID för att tillåta åtkomst.",
+        "allowedUsersMissingBadge": "Inga tillåtna användare angivna - inloggningen misslyckas",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Tillåt OAuth2-inloggning via Google",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -51,10 +51,11 @@ var ImageProviderRegistry *imageprovider.ImageProviderRegistry
 // It manages the Echo framework instance, middleware, and all HTTP routes.
 type Server struct {
 	// Core components
-	echo     *echo.Echo
-	config   *Config
-	settings *conf.Settings
-	slogger  logger.Logger // Centralized structured logger
+	echo           *echo.Echo
+	config         *Config
+	settings       *conf.Settings
+	slogger        logger.Logger // Centralized structured logger (Module("api"))
+	securityLogger logger.Logger // OAuth login-flow logger (Module("security"), issue #3381)
 
 	// Dependencies
 	dataStore      datastore.Interface
@@ -293,8 +294,9 @@ func New(settings *conf.Settings, opts ...ServerOption) (*Server, error) {
 	// This must happen before any settings validation that checks locale values.
 	conf.SetValidUILocales(conf.DiscoverUILocales(frontend.DistFS))
 
-	// Initialize structured logger
-	s.slogger = GetLogger() // Uses Module("api")
+	// Initialize structured loggers
+	s.slogger = GetLogger()                 // Uses Module("api")
+	s.securityLogger = security.GetLogger() // Uses Module("security") for the OAuth login flow (issue #3381)
 
 	// Initialize Echo
 	s.echo = echo.New()
@@ -889,6 +891,22 @@ func (s *Server) getAuthMiddleware() echo.MiddlewareFunc {
 	return s.authMiddleware
 }
 
+// securityLog returns the logger scoped to the "security" module. The OAuth
+// login flow uses it so authentication events land in logs/security.log next to
+// the provider-init logging, instead of logs/api.log where admins do not think
+// to look (issue #3381). The detail it records is for server-side diagnostics
+// only and must never be reflected back to unauthenticated visitors.
+//
+// It returns the cached securityLogger (set in the constructor, matching how
+// s.slogger is cached) and falls back to a fresh module logger when the Server
+// was built without the constructor (e.g. in unit tests).
+func (s *Server) securityLog() logger.Logger {
+	if s.securityLogger != nil {
+		return s.securityLogger
+	}
+	return security.GetLogger()
+}
+
 // registerOAuthRoutes registers social OAuth provider routes.
 // These routes handle OAuth flow for Google, GitHub, and Microsoft providers.
 func (s *Server) registerOAuthRoutes() {
@@ -908,18 +926,16 @@ func (s *Server) registerOAuthRoutes() {
 // GET /auth/:provider
 func (s *Server) handleOAuthBegin(c echo.Context) error {
 	provider := c.Param("provider")
-
-	s.slogger.Info("OAuth begin request",
+	log := s.securityLog().With(
 		logger.String("provider", provider),
 		logger.String("ip", c.RealIP()),
 	)
 
+	log.Info("OAuth login begin request")
+
 	// Validate provider is one we support
 	if !s.isValidOAuthProvider(provider) {
-		s.slogger.Warn("Invalid OAuth provider requested",
-			logger.String("provider", provider),
-			logger.String("ip", c.RealIP()),
-		)
+		log.Warn("OAuth login rejected: unsupported or unrecognized provider requested")
 		return c.String(http.StatusBadRequest, "Invalid OAuth provider")
 	}
 
@@ -928,8 +944,7 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 
 	// Try to complete auth if user already has a valid session
 	if user, err := gothic.CompleteUserAuth(c.Response(), req); err == nil {
-		s.slogger.Info("User already authenticated via OAuth",
-			logger.String("provider", provider),
+		log.Info("OAuth login: user already authenticated, redirecting to dashboard",
 			logger.String("user_id", user.UserID),
 			logger.String("email", user.Email),
 		)
@@ -938,6 +953,7 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 	}
 
 	// Begin OAuth flow - this will redirect to the provider
+	log.Debug("Redirecting to OAuth provider to begin authentication")
 	gothic.BeginAuthHandler(c.Response(), req)
 	return nil
 }
@@ -946,11 +962,12 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 // GET /auth/:provider/callback
 func (s *Server) handleOAuthCallback(c echo.Context) error {
 	provider := c.Param("provider")
-
-	s.slogger.Info("OAuth callback received",
+	log := s.securityLog().With(
 		logger.String("provider", provider),
 		logger.String("ip", c.RealIP()),
 	)
+
+	log.Info("OAuth login callback received")
 
 	// Add provider to request context for gothic
 	req := gothic.GetContextWithProvider(c.Request(), provider)
@@ -958,30 +975,35 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 	// Complete the OAuth flow and get user info
 	user, err := gothic.CompleteUserAuth(c.Response(), req)
 	if err != nil {
-		s.slogger.Error("OAuth authentication failed",
-			logger.String("provider", provider),
+		// Log the detailed provider/token error for the admin, but return a
+		// generic message so internal details are not exposed to the visitor.
+		log.Error("OAuth login failed: could not complete authentication with provider",
 			logger.Error(err),
-			logger.String("ip", c.RealIP()),
 		)
-		return c.String(http.StatusUnauthorized, "Authentication failed: "+err.Error())
+		return c.String(http.StatusUnauthorized, "Authentication failed")
 	}
 
-	s.slogger.Info("OAuth authentication successful",
-		logger.String("provider", provider),
+	log.Info("OAuth provider authentication succeeded, checking authorization",
 		logger.String("user_id", user.UserID),
 		logger.String("email", user.Email),
 		logger.String("name", user.Name),
-		logger.String("ip", c.RealIP()),
 	)
 
-	// Validate user is allowed (check against configured allowed user IDs)
-	if !s.isAllowedOAuthUser(provider, user.UserID, user.Email) {
-		s.slogger.Warn("OAuth user not in allowed list",
-			logger.String("provider", provider),
+	// Validate user is allowed (check against configured allowed user IDs).
+	// The deny reason is for server-side diagnostics only; the response to the
+	// visitor stays generic so configuration problems are not disclosed to
+	// unauthenticated users (issue #3381).
+	if allowed, reason := s.isAllowedOAuthUser(provider, user.UserID, user.Email); !allowed {
+		log.Warn("OAuth login denied: user not authorized",
+			logger.String("reason", string(reason)),
 			logger.String("user_id", user.UserID),
 			logger.String("email", user.Email),
-			logger.String("ip", c.RealIP()),
 		)
+		if reason == oauthDenyAllowlistEmpty {
+			// The single most common misconfiguration (issue #3381): the provider
+			// is enabled but has no allowed users, so nobody can ever log in.
+			log.Warn("OAuth provider has no allowed users configured; no one can log in until at least one allowed user or email is added under Settings > Security > Authentication")
+		}
 		return c.String(http.StatusForbidden, "Access denied: user not authorized")
 	}
 
@@ -993,48 +1015,32 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 	}
 
 	if err := gothic.StoreInSession("userId", userId, req, c.Response()); err != nil {
-		s.slogger.Error("Failed to store userId in session",
-			logger.Error(err),
-			logger.String("provider", provider),
-		)
+		log.Error("Failed to store userId in session", logger.Error(err))
 	}
 
 	// Store provider name in session for later reference
 	if err := gothic.StoreInSession(provider, user.UserID, req, c.Response()); err != nil {
-		s.slogger.Error("Failed to store provider session",
-			logger.Error(err),
-			logger.String("provider", provider),
-		)
+		log.Error("Failed to store provider session", logger.Error(err))
 	}
 
 	// Store active provider name for direct lookup (avoids iterating all providers)
 	if err := gothic.StoreInSession(security.SessionKeyAuthProvider, provider, req, c.Response()); err != nil {
-		s.slogger.Error("Failed to store active auth provider in session",
-			logger.Error(err),
-			logger.String("provider", provider),
-		)
+		log.Error("Failed to store active auth provider in session", logger.Error(err))
 	}
 
 	// Store or clear ID token for RP-Initiated Logout (OIDC providers)
 	if user.IDToken != "" {
 		if err := gothic.StoreInSession("id_token", user.IDToken, req, c.Response()); err != nil {
-			s.slogger.Error("Failed to store ID token in session",
-				logger.Error(err),
-				logger.String("provider", provider),
-			)
+			log.Error("Failed to store ID token in session", logger.Error(err))
 		}
 	} else {
 		// Clear stale ID token to prevent reuse across auth flows
 		if err := gothic.StoreInSession("id_token", "", req, c.Response()); err != nil {
-			s.slogger.Error("Failed to clear ID token in session",
-				logger.Error(err),
-				logger.String("provider", provider),
-			)
+			log.Error("Failed to clear ID token in session", logger.Error(err))
 		}
 	}
 
-	s.slogger.Info("OAuth session established, redirecting to dashboard",
-		logger.String("provider", provider),
+	log.Info("OAuth login successful, session established, redirecting to dashboard",
 		logger.String("user_id", userId),
 	)
 
@@ -1053,18 +1059,45 @@ func (s *Server) isValidOAuthProvider(provider string) bool {
 	return false
 }
 
-// isAllowedOAuthUser checks if the OAuth user is in the allowed users list for the provider.
-// Uses the OAuthProviders array with a reverse lookup from goth provider name to config provider ID.
-func (s *Server) isAllowedOAuthUser(gothProvider, userID, email string) bool {
+// oauthDenyReason classifies why an OAuth user was not authorized to log in.
+// It is recorded in logs/security.log for admin-side diagnostics only and is
+// never returned to the client, so it cannot disclose configuration problems to
+// unauthenticated visitors (issue #3381).
+type oauthDenyReason string
+
+const (
+	// oauthAuthorized indicates the user is allowed (no denial).
+	oauthAuthorized oauthDenyReason = ""
+	// oauthDenySettingsMissing: the live settings snapshot was unavailable.
+	oauthDenySettingsMissing oauthDenyReason = "settings_unavailable"
+	// oauthDenyProviderUnknown: the goth provider name is not in the config map.
+	oauthDenyProviderUnknown oauthDenyReason = "provider_not_recognized"
+	// oauthDenyProviderMissing: no matching provider entry exists in settings.
+	oauthDenyProviderMissing oauthDenyReason = "provider_not_configured"
+	// oauthDenyProviderDisabled: the provider exists but is disabled.
+	oauthDenyProviderDisabled oauthDenyReason = "provider_disabled"
+	// oauthDenyAllowlistEmpty: the provider is enabled but has no allowed users,
+	// so nobody can ever log in. This is the most common misconfiguration.
+	oauthDenyAllowlistEmpty oauthDenyReason = "allowed_users_empty"
+	// oauthDenyUserNotAllowed: the user is not present in a non-empty allowlist.
+	oauthDenyUserNotAllowed oauthDenyReason = "user_not_in_allowed_list"
+)
+
+// isAllowedOAuthUser reports whether the authenticated OAuth user may log in,
+// together with an oauthDenyReason describing the cause when access is denied.
+// It uses the OAuthProviders array with a reverse lookup from the goth provider
+// name to the config provider ID. The reason is for server-side logging only;
+// callers must keep the response to the client generic (issue #3381).
+func (s *Server) isAllowedOAuthUser(gothProvider, userID, email string) (allowed bool, reason oauthDenyReason) {
 	// Read the live snapshot so changes to the allowed OAuth users (or a
 	// provider's enabled flag) made through the UI apply without a restart
 	// (issue #3370).
 	settings := s.currentSettings()
 	if settings == nil {
-		return false
+		return false, oauthDenySettingsMissing
 	}
 
-	// Reverse lookup: goth provider name → config provider ID
+	// Reverse lookup: goth provider name -> config provider ID
 	configProvider := ""
 	for cfg, gothName := range security.ConfigToGothProvider {
 		if strings.EqualFold(gothName, gothProvider) {
@@ -1073,23 +1106,33 @@ func (s *Server) isAllowedOAuthUser(gothProvider, userID, email string) bool {
 		}
 	}
 	if configProvider == "" {
-		return false
+		return false, oauthDenyProviderUnknown
 	}
 
 	provider := settings.GetOAuthProvider(configProvider)
-	if provider == nil || !provider.Enabled || provider.UserID == "" {
-		return false
+	if provider == nil {
+		return false, oauthDenyProviderMissing
+	}
+	if !provider.Enabled {
+		return false, oauthDenyProviderDisabled
 	}
 
-	// Check if user ID or email matches any allowed user
+	// Walk the configured allowlist. Track whether any non-empty entry exists so
+	// an empty allowlist (a misconfiguration where nobody can log in) is reported
+	// distinctly from a genuine non-match.
+	hasAllowedEntry := false
 	for allowed := range strings.SplitSeq(provider.UserID, ",") {
 		trimmed := strings.TrimSpace(allowed)
 		if trimmed == "" {
 			continue
 		}
+		hasAllowedEntry = true
 		if strings.EqualFold(trimmed, userID) || strings.EqualFold(trimmed, email) {
-			return true
+			return true, oauthAuthorized
 		}
 	}
-	return false
+	if !hasAllowedEntry {
+		return false, oauthDenyAllowlistEmpty
+	}
+	return false, oauthDenyUserNotAllowed
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -943,7 +943,8 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 	// sending the user on the provider round-trip, so a disabled or half-configured
 	// provider fails fast with a clear security.log entry here instead of an opaque
 	// error after the redirect (issue #3381). The visitor only sees a generic message.
-	if settings := s.currentSettings(); settings == nil || !settings.IsOAuthProviderEnabled(s.configProviderFor(provider)) {
+	configProvider := s.configProviderFor(provider)
+	if settings := s.currentSettings(); settings == nil || configProvider == "" || !settings.IsOAuthProviderEnabled(configProvider) {
 		log.Warn("OAuth login rejected: provider is disabled or not fully configured")
 		return c.String(http.StatusBadRequest, "OAuth provider not available")
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -939,14 +939,22 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 		return c.String(http.StatusBadRequest, "Invalid OAuth provider")
 	}
 
+	// Reject providers that are not currently enabled and fully configured before
+	// sending the user on the provider round-trip, so a disabled or half-configured
+	// provider fails fast with a clear security.log entry here instead of an opaque
+	// error after the redirect (issue #3381). The visitor only sees a generic message.
+	if settings := s.currentSettings(); settings == nil || !settings.IsOAuthProviderEnabled(s.configProviderFor(provider)) {
+		log.Warn("OAuth login rejected: provider is disabled or not fully configured")
+		return c.String(http.StatusBadRequest, "OAuth provider not available")
+	}
+
 	// Add provider to request context for gothic
 	req := gothic.GetContextWithProvider(c.Request(), provider)
 
 	// Try to complete auth if user already has a valid session
 	if user, err := gothic.CompleteUserAuth(c.Response(), req); err == nil {
 		log.Info("OAuth login: user already authenticated, redirecting to dashboard",
-			logger.String("user_id", user.UserID),
-			logger.String("email", user.Email),
+			logger.Username(oauthIdentity(user.Email, user.UserID)),
 		)
 		// User is already authenticated, redirect to dashboard
 		return c.Redirect(http.StatusFound, ingressPath(c, s.currentSettings())+"/ui/dashboard")
@@ -983,10 +991,11 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 		return c.String(http.StatusUnauthorized, "Authentication failed")
 	}
 
+	// Log a hashed identity (logger.Username) rather than the raw email/name so
+	// security.log stays free of plaintext PII while still allowing an admin to
+	// correlate repeated attempts by the same user (matches the basic-auth flow).
 	log.Info("OAuth provider authentication succeeded, checking authorization",
-		logger.String("user_id", user.UserID),
-		logger.String("email", user.Email),
-		logger.String("name", user.Name),
+		logger.Username(oauthIdentity(user.Email, user.UserID)),
 	)
 
 	// Validate user is allowed (check against configured allowed user IDs).
@@ -996,8 +1005,7 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 	if allowed, reason := s.isAllowedOAuthUser(provider, user.UserID, user.Email); !allowed {
 		log.Warn("OAuth login denied: user not authorized",
 			logger.String("reason", string(reason)),
-			logger.String("user_id", user.UserID),
-			logger.String("email", user.Email),
+			logger.Username(oauthIdentity(user.Email, user.UserID)),
 		)
 		if reason == oauthDenyAllowlistEmpty {
 			// The single most common misconfiguration (issue #3381): the provider
@@ -1007,28 +1015,32 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 		return c.String(http.StatusForbidden, "Access denied: user not authorized")
 	}
 
-	// Store user info in session
-	// Use email as userId if available, otherwise use provider's UserID
-	userId := user.Email
-	if userId == "" {
-		userId = user.UserID
-	}
+	// Persist the authenticated session. The userId, provider, and active-provider
+	// keys are read by the auth middleware on every subsequent request, so a write
+	// failure here means the redirect would land on a page that immediately bounces
+	// the user back. Fail fast with a generic error instead of redirecting into a
+	// broken session.
+	userId := oauthIdentity(user.Email, user.UserID)
 
 	if err := gothic.StoreInSession("userId", userId, req, c.Response()); err != nil {
-		log.Error("Failed to store userId in session", logger.Error(err))
+		log.Error("OAuth login failed: could not persist userId in session", logger.Error(err))
+		return c.String(http.StatusInternalServerError, "Authentication failed")
 	}
 
 	// Store provider name in session for later reference
 	if err := gothic.StoreInSession(provider, user.UserID, req, c.Response()); err != nil {
-		log.Error("Failed to store provider session", logger.Error(err))
+		log.Error("OAuth login failed: could not persist provider session", logger.Error(err))
+		return c.String(http.StatusInternalServerError, "Authentication failed")
 	}
 
 	// Store active provider name for direct lookup (avoids iterating all providers)
 	if err := gothic.StoreInSession(security.SessionKeyAuthProvider, provider, req, c.Response()); err != nil {
-		log.Error("Failed to store active auth provider in session", logger.Error(err))
+		log.Error("OAuth login failed: could not persist active auth provider in session", logger.Error(err))
+		return c.String(http.StatusInternalServerError, "Authentication failed")
 	}
 
-	// Store or clear ID token for RP-Initiated Logout (OIDC providers)
+	// Store or clear ID token for RP-Initiated Logout (OIDC providers). Best-effort:
+	// a failure here does not break authentication, only later RP-initiated logout.
 	if user.IDToken != "" {
 		if err := gothic.StoreInSession("id_token", user.IDToken, req, c.Response()); err != nil {
 			log.Error("Failed to store ID token in session", logger.Error(err))
@@ -1041,7 +1053,7 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 	}
 
 	log.Info("OAuth login successful, session established, redirecting to dashboard",
-		logger.String("user_id", userId),
+		logger.Username(userId),
 	)
 
 	// Redirect to dashboard after successful authentication
@@ -1057,6 +1069,29 @@ func (s *Server) isValidOAuthProvider(provider string) bool {
 		}
 	}
 	return false
+}
+
+// configProviderFor maps a goth provider name back to its config provider ID
+// (the reverse of ConfigToGothProvider), or returns "" when the goth name is not
+// recognized. The match is case-insensitive to tolerate proxies or clients that
+// alter the path casing.
+func (s *Server) configProviderFor(gothProvider string) string {
+	for cfg, gothName := range security.ConfigToGothProvider {
+		if strings.EqualFold(gothName, gothProvider) {
+			return cfg
+		}
+	}
+	return ""
+}
+
+// oauthIdentity returns the identifier used both as the session userId and as
+// the hashed identity logged to security.log: the email when present, else the
+// provider's opaque user ID.
+func oauthIdentity(email, userID string) string {
+	if email != "" {
+		return email
+	}
+	return userID
 }
 
 // oauthDenyReason classifies why an OAuth user was not authorized to log in.
@@ -1097,14 +1132,7 @@ func (s *Server) isAllowedOAuthUser(gothProvider, userID, email string) (allowed
 		return false, oauthDenySettingsMissing
 	}
 
-	// Reverse lookup: goth provider name -> config provider ID
-	configProvider := ""
-	for cfg, gothName := range security.ConfigToGothProvider {
-		if strings.EqualFold(gothName, gothProvider) {
-			configProvider = cfg
-			break
-		}
-	}
+	configProvider := s.configProviderFor(gothProvider)
 	if configProvider == "" {
 		return false, oauthDenyProviderUnknown
 	}

--- a/internal/api/server_oauth_test.go
+++ b/internal/api/server_oauth_test.go
@@ -51,6 +51,7 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 		email        string
 		providers    []conf.OAuthProviderConfig
 		want         bool
+		wantReason   oauthDenyReason
 	}{
 		{
 			name:         "OIDC user allowed by email",
@@ -60,7 +61,8 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "oidc", Enabled: true, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: "user@example.com"},
 			},
-			want: true,
+			want:       true,
+			wantReason: oauthAuthorized,
 		},
 		{
 			name:         "OIDC user allowed by userID (sub claim)",
@@ -70,7 +72,8 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "oidc", Enabled: true, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: "sub-123"},
 			},
-			want: true,
+			want:       true,
+			wantReason: oauthAuthorized,
 		},
 		{
 			name:         "OIDC user not in allowed list",
@@ -80,7 +83,8 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "oidc", Enabled: true, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: "user@example.com"},
 			},
-			want: false,
+			want:       false,
+			wantReason: oauthDenyUserNotAllowed,
 		},
 		{
 			name:         "OIDC provider disabled",
@@ -90,17 +94,30 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "oidc", Enabled: false, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: "user@example.com"},
 			},
-			want: false,
+			want:       false,
+			wantReason: oauthDenyProviderDisabled,
 		},
 		{
-			name:         "OIDC empty UserID configured - deny all",
+			name:         "OIDC empty UserID configured - deny all (issue #3381)",
 			gothProvider: security.ProviderOIDC,
 			userID:       "sub-123",
 			email:        "user@example.com",
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "oidc", Enabled: true, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: ""},
 			},
-			want: false,
+			want:       false,
+			wantReason: oauthDenyAllowlistEmpty,
+		},
+		{
+			name:         "OIDC whitespace-only UserID treated as empty allowlist",
+			gothProvider: security.ProviderOIDC,
+			userID:       "sub-123",
+			email:        "user@example.com",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: "oidc", Enabled: true, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: "  ,  "},
+			},
+			want:       false,
+			wantReason: oauthDenyAllowlistEmpty,
 		},
 		{
 			name:         "Google user via OAuthProviders array",
@@ -110,7 +127,8 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "google", Enabled: true, ClientID: "id", ClientSecret: "s", UserID: "user@gmail.com"},
 			},
-			want: true,
+			want:       true,
+			wantReason: oauthAuthorized,
 		},
 		{
 			name:         "multiple allowed users comma separated",
@@ -120,7 +138,8 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			providers: []conf.OAuthProviderConfig{
 				{Provider: "oidc", Enabled: true, ClientID: "id", ClientSecret: "s", IssuerURL: "https://idp.example.com", UserID: "first@example.com, second@example.com"},
 			},
-			want: true,
+			want:       true,
+			wantReason: oauthAuthorized,
 		},
 		{
 			name:         "unknown goth provider name",
@@ -129,6 +148,16 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			email:        "user@fb.com",
 			providers:    []conf.OAuthProviderConfig{},
 			want:         false,
+			wantReason:   oauthDenyProviderUnknown,
+		},
+		{
+			name:         "provider recognized but not configured in settings",
+			gothProvider: security.ProviderGoogle,
+			userID:       "google-123",
+			email:        "user@gmail.com",
+			providers:    []conf.OAuthProviderConfig{},
+			want:         false,
+			wantReason:   oauthDenyProviderMissing,
 		},
 		{
 			name:         "nil settings",
@@ -137,6 +166,7 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			email:        "user@example.com",
 			providers:    nil,
 			want:         false,
+			wantReason:   oauthDenySettingsMissing,
 		},
 	}
 
@@ -157,8 +187,9 @@ func TestIsAllowedOAuthUser(t *testing.T) {
 			prev := conf.GetSettings()
 			conf.SetTestSettings(settings)
 			t.Cleanup(func() { conf.SetTestSettings(prev) })
-			got := s.isAllowedOAuthUser(tt.gothProvider, tt.userID, tt.email)
+			got, reason := s.isAllowedOAuthUser(tt.gothProvider, tt.userID, tt.email)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantReason, reason, "deny reason should classify the cause for security.log diagnostics")
 		})
 	}
 }
@@ -182,8 +213,8 @@ func TestIsAllowedOAuthUserHotReload(t *testing.T) {
 
 	// Sanity: with only the stale startup snapshot, the user is not allowed.
 	conf.SetTestSettings(startup)
-	assert.False(t, s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com"),
-		"user should not be allowed under the startup snapshot")
+	allowed, _ := s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com")
+	assert.False(t, allowed, "user should not be allowed under the startup snapshot")
 
 	// Simulate a UI save: enable the provider and allow the user, published via
 	// the atomic pointer.
@@ -197,6 +228,6 @@ func TestIsAllowedOAuthUserHotReload(t *testing.T) {
 	conf.SetTestSettings(updated)
 	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
-	assert.True(t, s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com"),
-		"allowlist change made via UI must apply without a restart")
+	allowedAfter, _ := s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com")
+	assert.True(t, allowedAfter, "allowlist change made via UI must apply without a restart")
 }

--- a/internal/api/server_oauth_test.go
+++ b/internal/api/server_oauth_test.go
@@ -39,6 +39,53 @@ func TestIsValidOAuthProvider(t *testing.T) {
 	}
 }
 
+func TestConfigProviderFor(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+
+	tests := []struct {
+		name         string
+		gothProvider string
+		want         string
+	}{
+		{name: "google", gothProvider: security.ProviderGoogle, want: security.ConfigGoogle},
+		{name: "oidc", gothProvider: security.ProviderOIDC, want: security.ConfigOIDC},
+		{name: "case insensitive", gothProvider: "OpenID-Connect", want: security.ConfigOIDC},
+		{name: "unknown goth provider", gothProvider: "facebook", want: ""},
+		{name: "empty", gothProvider: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, s.configProviderFor(tt.gothProvider))
+		})
+	}
+}
+
+func TestOAuthIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		email  string
+		userID string
+		want   string
+	}{
+		{name: "prefers email", email: "user@example.com", userID: "sub-123", want: "user@example.com"},
+		{name: "falls back to userID", email: "", userID: "sub-123", want: "sub-123"},
+		{name: "both empty", email: "", userID: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, oauthIdentity(tt.email, tt.userID))
+		})
+	}
+}
+
 // Not parallel: each subtest publishes its own snapshot to the process-global
 // settings (read by isAllowedOAuthUser via conf.GetSettings) and restores it on
 // cleanup, so the subtests neither depend on the global being nil nor couple
@@ -211,6 +258,11 @@ func TestIsAllowedOAuthUserHotReload(t *testing.T) {
 	}
 	s := &Server{settings: startup}
 
+	// Save and restore the prior global snapshot so this test does not leave the
+	// process-global settings mutated for sibling tests, regardless of ordering.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
 	// Sanity: with only the stale startup snapshot, the user is not allowed.
 	conf.SetTestSettings(startup)
 	allowed, _ := s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com")
@@ -226,7 +278,6 @@ func TestIsAllowedOAuthUserHotReload(t *testing.T) {
 		},
 	}
 	conf.SetTestSettings(updated)
-	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
 	allowedAfter, _ := s.isAllowedOAuthUser(security.ProviderGoogle, "google-123", "user@gmail.com")
 	assert.True(t, allowedAfter, "allowlist change made via UI must apply without a restart")


### PR DESCRIPTION
## Summary

Fixes the OAuth/OIDC logging gap reported in #3381 and clears up the misleading "Allowed Users" configuration UX that caused it.

### Logging

OAuth/OIDC login attempts were logged only to the `api` module (`logs/api.log`). An admin who enabled `security.log`/`auth.log` to debug a failing login saw nothing there, which is exactly what the reporter hit. The whole login flow (begin, callback, success, denial, session-store errors) now logs to the `security` module, next to the existing provider-init logging.

Denials are now classified and the specific reason is logged: empty allowlist, genuine non-match, disabled provider, or unconfigured/unrecognized provider. For the most common misconfiguration (an enabled provider with no allowed users, so nobody can ever log in) an extra actionable hint is logged pointing the admin at Settings > Security.

### Security

The denial reason is server-side only. The HTTP responses shown to the unauthenticated visitor stay generic (`Access denied: user not authorized`, `Authentication failed`), so configuration problems are never disclosed to unauthenticated users. The callback failure response also no longer echoes the raw provider/token error back to the browser.

### UI/UX (protected Settings page only)

The "Allowed Users" field was labeled "User ID (optional)" even though an enabled provider with an empty allowlist denies every login. Changes:
- Relabel to "Allowed Users" and rewrite the help text to explain that an empty value blocks all logins.
- Inline warning under the field when it is empty (warn only, does not block saving, per design).
- Badge on enabled providers in the providers list whose allowlist is empty.
- The frontend empty-allowlist check mirrors the backend (treats comma/whitespace-only values as empty).

All new/changed strings translated for the 15 locales.

## Behavioral note for upgraders

OAuth events now land in `logs/security.log` instead of `logs/api.log`. Any log monitoring (Fail2Ban, Loki/Promtail, grep alerts) that watched `api.log` for OAuth events should be pointed at `security.log`.

## Related Issues

Fixes #3381

## Test Plan

- [x] `go test -race ./internal/api/` passes; extended `TestIsAllowedOAuthUser` with deny-reason assertions (empty allowlist vs non-match vs disabled vs unconfigured).
- [x] `golangci-lint run` clean; `gofmt`/`go vet` clean.
- [x] Frontend `npm run check:all` clean (svelte-check 0 errors, eslint, prettier, ast-grep, i18n in sync).
- [ ] Manual: enable an OIDC provider with empty Allowed Users, confirm the inline warning + list badge appear in Settings > Security, and that a failed login logs a classified `allowed_users_empty` warning in `security.log` while the browser sees only the generic message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a warning under the OAuth "Allowed Users" field and a badge for enabled providers with an empty allowlist.

* **Bug Fixes**
  * Visitors now see a generic "Authentication failed" message on auth errors; critical session storage failures return an explicit server error.

* **Documentation**
  * Updated "Allowed Users" labels, help text, and added warning/badge messages across translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->