### PR TITLE
fix(search): match common names in v2 detection search (#3378)

### DIFF
--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -626,11 +626,27 @@ func (r *detectionRepository) buildSearchFilters(query *gorm.DB, filters *Search
 
 // buildSearchJoins applies JOIN clauses for filters requiring related tables.
 func (r *detectionRepository) buildSearchJoins(query *gorm.DB, filters *SearchFilters) *gorm.DB {
-	// Text search on scientific name (requires labels join)
-	if filters.Query != "" {
+	// Text search: scientific name LIKE (unbounded, requires labels join) OR-ed with
+	// CommonLabelIDs (labels whose active-locale common name matched the query, resolved in Go
+	// because the labels table has no common_name column). label_id lives on the detections table,
+	// so the common-name branch alone needs no join.
+	hasQuery := filters.Query != ""
+	hasCommon := len(filters.CommonLabelIDs) > 0
+	switch {
+	case hasQuery && hasCommon:
+		// Both predicates reference the joined labels table (labels.id = detections.label_id under
+		// the INNER join), keeping the whole OR on the small labels table so the planner can filter
+		// labels first and index-join into detections.
+		query = query.Joins(fmt.Sprintf("JOIN %s ON %s.id = %s.label_id",
+			r.labelsTable(), r.labelsTable(), r.tableName())).
+			Where(fmt.Sprintf("(%s.scientific_name LIKE ? OR %s.id IN ?)",
+				r.labelsTable(), r.labelsTable()), "%"+filters.Query+"%", filters.CommonLabelIDs)
+	case hasQuery:
 		query = query.Joins(fmt.Sprintf("JOIN %s ON %s.id = %s.label_id",
 			r.labelsTable(), r.labelsTable(), r.tableName())).
 			Where(fmt.Sprintf("%s.scientific_name LIKE ?", r.labelsTable()), "%"+filters.Query+"%")
+	case hasCommon:
+		query = query.Where(fmt.Sprintf("%s.label_id IN ?", r.tableName()), filters.CommonLabelIDs)
 	}
 
 	// Verified filter (requires reviews join for specific status)

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -55,6 +56,97 @@ func createBulkDetections(t *testing.T, db *gorm.DB, count int) (dets []*entitie
 		ids[i] = d.ID
 	}
 	return dets, ids
+}
+
+// setupDetectionTestDBWithLabels migrates the labels table alongside the detection tables so
+// text-search joins can be exercised.
+func setupDetectionTestDBWithLabels(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := setupDetectionTestDB(t)
+	require.NoError(t, db.AutoMigrate(&entities.Label{}), "failed to migrate labels table")
+	return db
+}
+
+func createTestLabel(t *testing.T, db *gorm.DB, scientificName string, modelID uint) *entities.Label {
+	t.Helper()
+	label := &entities.Label{ScientificName: scientificName, ModelID: modelID, LabelTypeID: 1}
+	require.NoError(t, db.Table(tableLabels).Create(label).Error)
+	return label
+}
+
+func createDetectionForLabel(t *testing.T, db *gorm.DB, labelID uint, detectedAt int64) *entities.Detection {
+	t.Helper()
+	det := &entities.Detection{LabelID: labelID, ModelID: 1, Confidence: 0.9, DetectedAt: detectedAt}
+	require.NoError(t, db.Table(tableDetections).Create(det).Error)
+	return det
+}
+
+// TestSearch_QueryAndCommonLabelIDs verifies buildSearchJoins ORs the unbounded scientific_name
+// LIKE (Query) with common-name-resolved label IDs (CommonLabelIDs). See issue #3378.
+func TestSearch_QueryAndCommonLabelIDs(t *testing.T) {
+	db := setupDetectionTestDBWithLabels(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	corone := createTestLabel(t, db, "Corvus corone", 1)
+	cornix := createTestLabel(t, db, "Corvus cornix", 1)
+	robin := createTestLabel(t, db, "Erithacus rubecula", 1)
+
+	dCorone := createDetectionForLabel(t, db, corone.ID, 1000)
+	_ = createDetectionForLabel(t, db, cornix.ID, 1001)
+	dRobin := createDetectionForLabel(t, db, robin.ID, 1002)
+
+	t.Run("scientific substring matches via Query LIKE", func(t *testing.T) {
+		_, total, err := repo.Search(ctx, &SearchFilters{Query: "Corvus", Limit: 100})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total)
+	})
+
+	t.Run("common-only label IDs match when Query has no scientific hit", func(t *testing.T) {
+		results, total, err := repo.Search(ctx, &SearchFilters{
+			Query: "Corneille", CommonLabelIDs: []uint{corone.ID}, Limit: 100,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		require.Len(t, results, 1)
+		assert.Equal(t, dCorone.ID, results[0].ID)
+	})
+
+	t.Run("scientific LIKE OR common label IDs returns the union", func(t *testing.T) {
+		_, total, err := repo.Search(ctx, &SearchFilters{
+			Query: "Corvus", CommonLabelIDs: []uint{robin.ID}, Limit: 100,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+	})
+
+	t.Run("common label IDs without Query need no join", func(t *testing.T) {
+		results, total, err := repo.Search(ctx, &SearchFilters{
+			CommonLabelIDs: []uint{robin.ID}, Limit: 100,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		require.Len(t, results, 1)
+		assert.Equal(t, dRobin.ID, results[0].ID)
+	})
+}
+
+// TestSearch_ScientificLikeNotTruncated guards against the prior 100-row cap: the scientific
+// LIKE runs in SQL and must return all matches, not a capped subset. See issue #3378.
+func TestSearch_ScientificLikeNotTruncated(t *testing.T) {
+	db := setupDetectionTestDBWithLabels(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	const n = 150
+	for i := range n {
+		l := createTestLabel(t, db, fmt.Sprintf("Owlspecies%03d aves", i), 1)
+		createDetectionForLabel(t, db, l.ID, int64(1000+i))
+	}
+
+	_, total, err := repo.Search(ctx, &SearchFilters{Query: "Owlspecies", Limit: 1000})
+	require.NoError(t, err)
+	assert.Equal(t, int64(n), total, "scientific LIKE must not be capped at 100 labels")
 }
 
 func TestDeleteBatch_SkipsLockedDetections(t *testing.T) {

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -441,29 +441,31 @@ func ResolveCommonNameToLabelIDs(ctx context.Context, deps *FilterLookupDeps, sp
 
 	needle := strings.ToLower(norm.NFC.String(species))
 	matchedScientific := make([]string, 0, 16)
-	// Returns true once enough matches are collected to fill the cap, so the caller stops early.
-	collect := func(sci, foldedCommon string) bool {
+	collect := func(sci, foldedCommon string) {
 		if strings.Contains(foldedCommon, needle) {
 			matchedScientific = append(matchedScientific, sci)
-			return len(matchedScientific) >= maxCommonNameLabelIDs
 		}
-		return false
 	}
 	if len(deps.SciToCommonFolded) > 0 {
 		for sci, folded := range deps.SciToCommonFolded {
-			if collect(sci, folded) {
-				break
-			}
+			collect(sci, folded)
 		}
 	} else {
 		for sci, common := range deps.SciToCommon {
-			if collect(sci, strings.ToLower(norm.NFC.String(common))) {
-				break
-			}
+			collect(sci, strings.ToLower(norm.NFC.String(common)))
 		}
 	}
 	if len(matchedScientific) == 0 {
 		return nil, nil
+	}
+
+	// Sort then cap before the DB lookup so a degenerate query (e.g. a single letter matching
+	// thousands of species) is bounded AND returns a STABLE subset across calls. Map iteration
+	// order is randomized, so without sorting both the matched scientific set and the final label
+	// IDs would vary per query.
+	slices.Sort(matchedScientific)
+	if len(matchedScientific) > maxCommonNameLabelIDs {
+		matchedScientific = matchedScientific[:maxCommonNameLabelIDs]
 	}
 
 	commonLabels, err := deps.LabelRepo.GetByScientificNames(ctx, matchedScientific)
@@ -481,6 +483,7 @@ func ResolveCommonNameToLabelIDs(ctx context.Context, deps *FilterLookupDeps, sp
 		return nil, nil
 	}
 	ids := slices.Collect(maps.Keys(labelIDSet))
+	slices.Sort(ids)
 	if len(ids) > maxCommonNameLabelIDs {
 		ids = ids[:maxCommonNameLabelIDs]
 	}

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -262,9 +262,15 @@ var sentinelNoMatchIDs = []uint{0}
 
 // FilterLookupDeps contains dependencies for filter entity lookups.
 type FilterLookupDeps struct {
-	LabelRepo   LabelRepository
-	SourceRepo  AudioSourceRepository
+	LabelRepo  LabelRepository
+	SourceRepo AudioSourceRepository
+	// SciToCommon maps scientific name -> common name (active locale). Used by
+	// ResolveCommonNameToLabelIDs when SciToCommonFolded is not supplied.
 	SciToCommon map[string]string
+	// SciToCommonFolded maps scientific name -> lower-cased NFC-normalized common name.
+	// Precomputed once per locale change so common-name search does not normalize every
+	// map value on every query. When present it is preferred over SciToCommon.
+	SciToCommonFolded map[string]string
 }
 
 // ResolveSpeciesToLabelIDs converts species names to label IDs.
@@ -403,58 +409,82 @@ func singleTimeOfDayToHours(timeOfDay string) []int {
 	}
 }
 
-// ResolveSpeciesToLabelIDsWithCommonName converts a species search string to label IDs.
-// Searches both scientific names (via LabelRepo.Search LIKE) and common names
-// (via deps.SciToCommon) for partial matches.
-// Returns nil if species is empty (no filtering).
-// Returns sentinel []uint{0} if species is non-empty but no labels are found.
-func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLookupDeps, species string) ([]uint, error) {
+// maxCommonNameLabelIDs bounds the number of common-name-matched label IDs returned. This keeps
+// the resulting `label_id IN (...)` clause in buildSearchJoins well under SQLite's default 999
+// bound-variable limit even for a very broad query (e.g. a single letter) that matches thousands
+// of species across multiple models. Scientific-name matches are unaffected: they go through the
+// unbounded scientific_name LIKE. A query broad enough to hit this cap is already degenerate, so
+// returning a bounded subset (still OR-ed with the scientific LIKE) is acceptable.
+const maxCommonNameLabelIDs = 500
+
+// ResolveCommonNameToLabelIDs returns the label IDs whose common name (active locale) contains the
+// query as a case-insensitive substring. It prefers deps.SciToCommonFolded (precomputed lower-case
+// NFC form) and falls back to normalizing deps.SciToCommon on the fly.
+//
+// Scientific-name matching is deliberately NOT done here: it is handled by the unbounded
+// scientific_name LIKE in buildSearchJoins (via SearchFilters.Query), so this resolver covers
+// only the common-name dimension. The two are OR-ed together downstream.
+//
+// Returns nil (NOT the no-match sentinel) when the query is empty, deps/name maps are unavailable,
+// or no common name matches, because the result is OR-ed with the scientific LIKE and must not
+// force an empty result set. The returned slice is capped at maxCommonNameLabelIDs.
+func ResolveCommonNameToLabelIDs(ctx context.Context, deps *FilterLookupDeps, species string) ([]uint, error) {
 	if species == "" {
 		return nil, nil
 	}
 	if deps == nil || deps.LabelRepo == nil {
 		return nil, nil
 	}
+	if len(deps.SciToCommonFolded) == 0 && len(deps.SciToCommon) == 0 {
+		return nil, nil
+	}
 
-	normalized := norm.NFC.String(species)
+	needle := strings.ToLower(norm.NFC.String(species))
+	matchedScientific := make([]string, 0, 16)
+	// Returns true once enough matches are collected to fill the cap, so the caller stops early.
+	collect := func(sci, foldedCommon string) bool {
+		if strings.Contains(foldedCommon, needle) {
+			matchedScientific = append(matchedScientific, sci)
+			return len(matchedScientific) >= maxCommonNameLabelIDs
+		}
+		return false
+	}
+	if len(deps.SciToCommonFolded) > 0 {
+		for sci, folded := range deps.SciToCommonFolded {
+			if collect(sci, folded) {
+				break
+			}
+		}
+	} else {
+		for sci, common := range deps.SciToCommon {
+			if collect(sci, strings.ToLower(norm.NFC.String(common))) {
+				break
+			}
+		}
+	}
+	if len(matchedScientific) == 0 {
+		return nil, nil
+	}
 
-	labels, err := deps.LabelRepo.Search(ctx, normalized, 100)
+	commonLabels, err := deps.LabelRepo.GetByScientificNames(ctx, matchedScientific)
 	if err != nil {
 		return nil, err
 	}
 
-	labelIDSet := make(map[uint]struct{}, len(labels))
-	for _, label := range labels {
-		labelIDSet[label.ID] = struct{}{}
-	}
-
-	// Also search common names for partial matches.
-	if len(deps.SciToCommon) > 0 {
-		needle := strings.ToLower(normalized)
-		matchedScientific := make([]string, 0, 16)
-		for sci, common := range deps.SciToCommon {
-			if strings.Contains(strings.ToLower(norm.NFC.String(common)), needle) {
-				matchedScientific = append(matchedScientific, sci)
-			}
-		}
-		if len(matchedScientific) > 0 {
-			commonLabels, err := deps.LabelRepo.GetByScientificNames(ctx, matchedScientific)
-			if err != nil {
-				return nil, err
-			}
-			for _, labelsForSci := range commonLabels {
-				for _, label := range labelsForSci {
-					labelIDSet[label.ID] = struct{}{}
-				}
-			}
+	labelIDSet := make(map[uint]struct{}, len(commonLabels))
+	for _, labelsForSci := range commonLabels {
+		for _, label := range labelsForSci {
+			labelIDSet[label.ID] = struct{}{}
 		}
 	}
-
 	if len(labelIDSet) == 0 {
-		return sentinelNoMatchIDs, nil
+		return nil, nil
 	}
-
-	return slices.Collect(maps.Keys(labelIDSet)), nil
+	ids := slices.Collect(maps.Keys(labelIDSet))
+	if len(ids) > maxCommonNameLabelIDs {
+		ids = ids[:maxCommonNameLabelIDs]
+	}
+	return ids, nil
 }
 
 // ResolveDeviceToSourceIDs converts a device name to audio source IDs.
@@ -605,10 +635,11 @@ func ConvertSearchFilters(
 	sf.Limit = perPage
 	sf.Offset = (page - 1) * perPage
 
-	// Entity lookups (require deps)
+	// Species text search: scientific names matched by the unbounded LIKE on Query, common
+	// names (active locale) matched via CommonLabelIDs. buildSearchJoins ORs the two branches.
+	sf.Query = filters.Species
 	if deps != nil {
-		// Convert species string to label IDs (LIKE search on scientific + common names)
-		sf.LabelIDs, err = ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, filters.Species)
+		sf.CommonLabelIDs, err = ResolveCommonNameToLabelIDs(ctx, deps, filters.Species)
 		if err != nil {
 			return nil, err
 		}
@@ -711,6 +742,13 @@ func ConvertAdvancedFilters(
 
 		// Convert species names to label IDs
 		sf.LabelIDs, err = ResolveSpeciesToLabelIDs(ctx, deps, filters.Species)
+		if err != nil {
+			return nil, err
+		}
+
+		// Free-text query also matches common names (active locale); scientific names are
+		// matched by the unbounded LIKE on sf.Query (= filters.TextQuery) in buildSearchJoins.
+		sf.CommonLabelIDs, err = ResolveCommonNameToLabelIDs(ctx, deps, filters.TextQuery)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1023,10 +1024,11 @@ func TestConvertSearchFilters(t *testing.T) {
 }
 
 // =============================================================================
-// ResolveSpeciesToLabelIDsWithCommonName Tests
+// ResolveCommonNameToLabelIDs Tests
 // =============================================================================
 
-// Extended mock that also implements Search
+// Extended mock that also implements Search (kept for interface completeness; the
+// common-name resolver does not call Search, so searchResults is left unset here).
 type mockLabelRepositoryWithSearch struct {
 	mockLabelRepository
 	searchResults []*entities.Label
@@ -1036,7 +1038,7 @@ func (m *mockLabelRepositoryWithSearch) Search(_ context.Context, _ string, _ in
 	return m.searchResults, nil
 }
 
-func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
+func TestResolveCommonNameToLabelIDs(t *testing.T) {
 	ctx := t.Context()
 
 	t.Run("empty species returns nil", func(t *testing.T) {
@@ -1044,42 +1046,50 @@ func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
 			LabelRepo: &mockLabelRepositoryWithSearch{},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "")
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "")
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("nil deps returns nil", func(t *testing.T) {
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, nil, "robin")
+		result, err := ResolveCommonNameToLabelIDs(ctx, nil, "robin")
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
-	t.Run("found species returns label IDs", func(t *testing.T) {
+	t.Run("no SciToCommon map returns nil", func(t *testing.T) {
 		deps := &FilterLookupDeps{
 			LabelRepo: &mockLabelRepositoryWithSearch{
-				searchResults: []*entities.Label{
-					{ID: 1},
-					{ID: 2},
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Erithacus rubecula": {ID: 1, ScientificName: "Erithacus rubecula"},
+					},
 				},
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "robin")
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "robin")
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []uint{1, 2}, result)
+		assert.Nil(t, result)
 	})
 
-	t.Run("no results returns sentinel", func(t *testing.T) {
+	t.Run("no common-name match returns nil (not sentinel)", func(t *testing.T) {
 		deps := &FilterLookupDeps{
 			LabelRepo: &mockLabelRepositoryWithSearch{
-				searchResults: []*entities.Label{},
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Parus major": {ID: 1, ScientificName: "Parus major"},
+					},
+				},
+			},
+			SciToCommon: map[string]string{
+				"Parus major": "talitiainen",
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "unknown")
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "unknown")
 		require.NoError(t, err)
-		assert.Equal(t, []uint{0}, result)
+		assert.Nil(t, result)
 	})
 
 	t.Run("partial common name match returns label IDs", func(t *testing.T) {
@@ -1100,7 +1110,7 @@ func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "rastas")
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "rastas")
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []uint{10, 11}, result)
 	})
@@ -1120,31 +1130,54 @@ func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "tiainen")
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "tiainen")
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []uint{20}, result)
 	})
 
-	t.Run("combines scientific and common name matches", func(t *testing.T) {
+	t.Run("matches only common names (scientific handled by SQL LIKE)", func(t *testing.T) {
+		// The scientific-name dimension is matched by the unbounded LIKE in buildSearchJoins,
+		// not here, so a label whose common name does not match is not returned even if its
+		// scientific name contains the query.
 		deps := &FilterLookupDeps{
 			LabelRepo: &mockLabelRepositoryWithSearch{
 				mockLabelRepository: mockLabelRepository{
 					labels: map[string]*entities.Label{
 						"Turdus migratorius": {ID: 30, ScientificName: "Turdus migratorius"},
+						"Erithacus rubecula": {ID: 5, ScientificName: "Erithacus rubecula"},
 					},
-				},
-				searchResults: []*entities.Label{
-					{ID: 5, ScientificName: "Erithacus rubecula"},
 				},
 			},
 			SciToCommon: map[string]string{
 				"Turdus migratorius": "american robin",
+				"Erithacus rubecula": "european robin",
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "robin")
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "robin")
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []uint{5, 30}, result)
+	})
+
+	t.Run("regression #3378: partial match of French common name", func(t *testing.T) {
+		// French-locale instance: displayed name "Corneille noire" for Corvus corone.
+		// Typing the partial "Corneille" must resolve to the label.
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepositoryWithSearch{
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Corvus corone": {ID: 7, ScientificName: "Corvus corone"},
+					},
+				},
+			},
+			SciToCommon: map[string]string{
+				"Corvus corone": "Corneille noire",
+			},
+		}
+
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "Corneille")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{7}, result)
 	})
 
 	t.Run("NFC normalization matches decomposed input", func(t *testing.T) {
@@ -1164,9 +1197,51 @@ func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, nfdQuery)
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, nfdQuery)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []uint{40}, result)
+	})
+
+	t.Run("prefers precomputed SciToCommonFolded map", func(t *testing.T) {
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepositoryWithSearch{
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Corvus corone": {ID: 7, ScientificName: "Corvus corone"},
+					},
+				},
+			},
+			// Only the folded (already lower-cased, NFC) map is supplied.
+			SciToCommonFolded: map[string]string{
+				"Corvus corone": "corneille noire",
+			},
+		}
+
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "Corneille")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{7}, result)
+	})
+
+	t.Run("caps result at maxCommonNameLabelIDs for a very broad query", func(t *testing.T) {
+		// A degenerate query (matches every common name) must not produce an unbounded
+		// label_id IN (...) clause that exceeds SQLite's bound-variable limit.
+		const total = maxCommonNameLabelIDs * 2
+		sciToCommon := make(map[string]string, total)
+		labels := make(map[string]*entities.Label, total)
+		for i := range total {
+			sci := fmt.Sprintf("Genus species%04d", i)
+			sciToCommon[sci] = fmt.Sprintf("bird %04d", i)
+			labels[sci] = &entities.Label{ID: uint(i) + 1, ScientificName: sci}
+		}
+		deps := &FilterLookupDeps{
+			LabelRepo:   &mockLabelRepositoryWithSearch{mockLabelRepository: mockLabelRepository{labels: labels}},
+			SciToCommon: sciToCommon,
+		}
+
+		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "bird")
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+		assert.LessOrEqual(t, len(result), maxCommonNameLabelIDs)
 	})
 }
 

--- a/internal/datastore/v2/repository/types.go
+++ b/internal/datastore/v2/repository/types.go
@@ -8,8 +8,14 @@ type VerificationFilter entities.VerificationStatus
 // SearchFilters provides advanced search criteria for detections.
 // All timestamps are Unix int64 for consistency and indexing performance.
 type SearchFilters struct {
-	// Query provides text search across scientific names.
+	// Query provides text search across scientific names (unbounded SQL LIKE).
 	Query string
+
+	// CommonLabelIDs holds label IDs whose common name (active locale) matched the free-text
+	// query. It is OR-ed with the scientific_name LIKE produced by Query in buildSearchJoins,
+	// so common-name search works even though the labels table has no common_name column.
+	// nil or empty means no common-name match (the OR branch is omitted).
+	CommonLabelIDs []uint
 
 	// LabelIDs filters by specific label IDs.
 	LabelIDs []uint

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -41,6 +41,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 	obmetrics "github.com/tphakala/birdnet-go/internal/observability/metrics"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
+	"golang.org/x/text/unicode/norm"
 	"gorm.io/gorm"
 )
 
@@ -109,6 +110,10 @@ func parseDetectionTimestamp(date, timeStr string, tz *time.Location) int64 {
 type nameMaps struct {
 	// common maps scientific name → common name (display lookup).
 	common map[string]string
+	// commonFolded maps scientific name → lower-cased NFC-normalized common name. Precomputed
+	// once here so common-name search (ResolveCommonNameToLabelIDs) does not normalize every map
+	// value on every query.
+	commonFolded map[string]string
 	// species maps lowercase common name → scientific name (reverse lookup).
 	species map[string]string
 }
@@ -309,6 +314,7 @@ func New(cfg *Config) (*Datastore, error) {
 func buildNameMaps(labels []string) *nameMaps {
 	speciesMap := make(map[string]string, len(labels))
 	commonMap := make(map[string]string, len(labels))
+	commonFoldedMap := make(map[string]string, len(labels))
 	for _, label := range labels {
 		if scientificName, commonName, found := strings.Cut(label, "_"); found {
 			scientificName = strings.TrimSpace(scientificName)
@@ -316,10 +322,11 @@ func buildNameMaps(labels []string) *nameMaps {
 			if commonName != "" && scientificName != "" {
 				speciesMap[strings.ToLower(commonName)] = scientificName
 				commonMap[scientificName] = commonName
+				commonFoldedMap[scientificName] = strings.ToLower(norm.NFC.String(commonName))
 			}
 		}
 	}
-	return &nameMaps{common: commonMap, species: speciesMap}
+	return &nameMaps{common: commonMap, commonFolded: commonFoldedMap, species: speciesMap}
 }
 
 // UpdateNameMaps rebuilds species name lookup maps from updated BirdNET labels.
@@ -342,8 +349,21 @@ func (ds *Datastore) loadNameMaps() *nameMaps {
 		return m
 	}
 	return &nameMaps{
-		common:  make(map[string]string),
-		species: make(map[string]string),
+		common:       make(map[string]string),
+		commonFolded: make(map[string]string),
+		species:      make(map[string]string),
+	}
+}
+
+// filterLookupDeps builds the dependency set used by repository filter resolution (species and
+// device lookups, plus common-name search via the active-locale name maps).
+func (ds *Datastore) filterLookupDeps() *repository.FilterLookupDeps {
+	nm := ds.loadNameMaps()
+	return &repository.FilterLookupDeps{
+		LabelRepo:         ds.label,
+		SourceRepo:        ds.source,
+		SciToCommon:       nm.common,
+		SciToCommonFolded: nm.commonFolded,
 	}
 }
 
@@ -1406,6 +1426,15 @@ func (ds *Datastore) SearchNotes(query string, sortAscending bool, limit, offset
 		SortDesc: !sortAscending,
 	}
 
+	// Resolve common names (active locale) so the free-text search matches both scientific and
+	// common names. Scientific names stay on the unbounded LIKE via filters.Query; common-name
+	// matches are OR-ed in via CommonLabelIDs. See issue #3378.
+	commonIDs, err := repository.ResolveCommonNameToLabelIDs(ctx, ds.filterLookupDeps(), query)
+	if err != nil {
+		return nil, 0, err
+	}
+	filters.CommonLabelIDs = commonIDs
+
 	dets, total, err := ds.detection.Search(ctx, filters)
 	if err != nil {
 		return nil, 0, err
@@ -1426,11 +1455,9 @@ func (ds *Datastore) SearchNotes(query string, sortAscending bool, limit, offset
 func (ds *Datastore) SearchNotesAdvanced(filters *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
 	ctx := context.Background()
 
-	// Set up dependencies for entity lookups
-	deps := &repository.FilterLookupDeps{
-		LabelRepo:  ds.label,
-		SourceRepo: ds.source,
-	}
+	// Set up dependencies for entity lookups. The name maps enable common-name resolution for the
+	// free-text query (active locale), matching the dashboard search behavior. See issue #3378.
+	deps := ds.filterLookupDeps()
 
 	// Convert API-level filters to repository filters
 	repoFilters, err := repository.ConvertAdvancedFilters(ctx, filters, deps, ds.timezone)
@@ -1954,12 +1981,8 @@ func (ds *Datastore) SearchDetections(filters *datastore.SearchFilters) ([]datas
 	// Note: Validation is handled by ConvertSearchFilters which applies defaults
 	// for Page, PerPage, ConfidenceMax, etc.
 
-	// Set up dependencies for entity lookups
-	deps := &repository.FilterLookupDeps{
-		LabelRepo:   ds.label,
-		SourceRepo:  ds.source,
-		SciToCommon: ds.loadNameMaps().common,
-	}
+	// Set up dependencies for entity lookups (species/common-name and device resolution).
+	deps := ds.filterLookupDeps()
 
 	// Convert API-level filters to repository filters
 	repoFilters, err := repository.ConvertSearchFilters(ctx, filters, deps, ds.timezone)

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -750,6 +750,7 @@ func TestV2OnlyDatastore_SearchNotes_CommonName(t *testing.T) {
 		notes, total, err := ds.SearchNotes("Corvus", false, 10, 0)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), total)
+		require.Len(t, notes, 1)
 		assert.Equal(t, "Corvus corone", notes[0].ScientificName)
 	})
 
@@ -757,6 +758,7 @@ func TestV2OnlyDatastore_SearchNotes_CommonName(t *testing.T) {
 		notes, total, err := ds.SearchNotes("Corneille", false, 10, 0)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), total, "partial French common name should match (issue #3378)")
+		require.Len(t, notes, 1)
 		assert.Equal(t, "Corvus corone", notes[0].ScientificName)
 	})
 
@@ -788,6 +790,7 @@ func TestV2OnlyDatastore_SearchNotesAdvanced_CommonName(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total, "advanced search free-text should match common name (issue #3378)")
+	require.Len(t, notes, 1)
 	assert.Equal(t, "Corvus corone", notes[0].ScientificName)
 }
 

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -729,6 +729,68 @@ func TestV2OnlyDatastore_SearchNotes(t *testing.T) {
 	assert.Equal(t, int64(len(notes)), total, "total should match returned rows for limit=10, offset=0")
 }
 
+// TestV2OnlyDatastore_SearchNotes_CommonName reproduces issue #3378: a French-locale instance
+// must find detections by a partial of the displayed common name, not only by scientific name.
+func TestV2OnlyDatastore_SearchNotes_CommonName(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{
+		"Corvus corone_Corneille noire",
+		"Erithacus rubecula_Rougegorge familier",
+	})
+	defer cleanup()
+
+	require.NoError(t, ds.Save(&datastore.Note{
+		Date:           "2026-06-04",
+		Time:           "09:44:26",
+		ScientificName: "Corvus corone",
+		CommonName:     "Corneille noire",
+		Confidence:     0.9,
+	}, nil))
+
+	t.Run("scientific name still matches", func(t *testing.T) {
+		notes, total, err := ds.SearchNotes("Corvus", false, 10, 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		assert.Equal(t, "Corvus corone", notes[0].ScientificName)
+	})
+
+	t.Run("partial common name (active locale) matches", func(t *testing.T) {
+		notes, total, err := ds.SearchNotes("Corneille", false, 10, 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total, "partial French common name should match (issue #3378)")
+		assert.Equal(t, "Corvus corone", notes[0].ScientificName)
+	})
+
+	t.Run("unrelated query returns nothing", func(t *testing.T) {
+		notes, total, err := ds.SearchNotes("Pinson", false, 10, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total)
+		assert.Empty(t, notes)
+	})
+}
+
+// TestV2OnlyDatastore_SearchNotesAdvanced_CommonName ensures the advanced-search free-text query
+// also resolves common names (active locale). See issue #3378.
+func TestV2OnlyDatastore_SearchNotesAdvanced_CommonName(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Corvus corone_Corneille noire"})
+	defer cleanup()
+
+	require.NoError(t, ds.Save(&datastore.Note{
+		Date:           "2026-06-04",
+		Time:           "09:44:26",
+		ScientificName: "Corvus corone",
+		CommonName:     "Corneille noire",
+		Confidence:     0.9,
+	}, nil))
+
+	notes, total, err := ds.SearchNotesAdvanced(&datastore.AdvancedSearchFilters{
+		TextQuery: "Corneille",
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total, "advanced search free-text should match common name (issue #3378)")
+	assert.Equal(t, "Corvus corone", notes[0].ScientificName)
+}
+
 func TestV2OnlyDatastore_GetLastDetections(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

The Detections page search bar (`GET /api/v2/detections?queryType=search`) and the dedicated search page (`POST /api/v2/search`) only matched **scientific names** in the v2 datastore. A user on a non-English locale could not find detections by the common name shown in the UI. For example, a French instance displays "Corneille noire" (Corvus corone): searching `Corvus` worked, but `Corneille` returned "No detections found".

Root cause: the free-text query was matched only against `labels.scientific_name` (LIKE), and the controller pre-resolution handled only *exact, full* common names in a single locale, so partial common names never resolved.

## Fix

Scoped to the v2 schema (the legacy datastore already searches both name types and is being retired). The v2 `labels` table has no `common_name` column; common names live in an in-memory scientific to common map for the configured locale.

Keep the unbounded `scientific_name LIKE` in SQL and OR it with the set of label IDs whose active-locale common name matches the query:

- Add `SearchFilters.CommonLabelIDs`; `buildSearchJoins` ORs the scientific LIKE with it (predicate kept on the small `labels` table for a better query plan).
- Add `ResolveCommonNameToLabelIDs` (common-name only), replacing `ResolveSpeciesToLabelIDsWithCommonName`, which capped scientific matches at 100 labels (a latent truncation on the existing search page).
- `ConvertSearchFilters` and `ConvertAdvancedFilters` resolve common names; v2only `SearchNotes`/`SearchNotesAdvanced`/`SearchDetections` pass the active-locale name map.
- Precompute a lower-cased NFC common-name map once per locale change instead of normalizing every label on every query.
- Cap common-name matches so a degenerate broad query cannot exceed SQLite's bound-variable limit.

### Known limitation

Common-name search covers the **configured locale** (the names actually displayed). Cross-locale search (finding an English name while running French) needs persistent multi-locale common-name data and is out of scope here.

## Related issues

Fixes #3378

## Test plan

- [x] `ResolveCommonNameToLabelIDs` unit tests: empty/nil, partial match, NFC normalization, no-match returns nil (not the no-match sentinel), folded-map preference, and the param cap.
- [x] Repository tests: `buildSearchJoins` ORs scientific LIKE with `CommonLabelIDs`; unbounded scientific LIKE (150-label no-truncation guard).
- [x] v2only end-to-end regression: `SearchNotes("Corneille")` and `SearchNotesAdvanced{TextQuery:"Corneille"}` return the Corvus corone detection; scientific search and "no match returns nothing" still hold.
- [x] `golangci-lint run` full project: 0 issues.
- [x] `go test -race ./internal/datastore/... ./internal/api/v2/...`: pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection search now matches localized common names (e.g., French) as well as scientific names; free-text queries combine results from both.
  * Advanced and datastore searches now consistently resolve common-name matches across endpoints.

* **Bug Fixes**
  * Scientific-name free-text search no longer truncates results; all matching detections are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->