### PR TITLE
refactor(v2/repository): drop dead LabelRepository.Search, fail loud on dual-write common-name search

### DIFF
--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -150,23 +150,23 @@ func (dw *DualWriteRepository) Shutdown() {
 // synced to v2; if it was deleted from legacy, the v2 ghost is removed.
 func (dw *DualWriteRepository) StartReconciliation() {
 	dw.reconcileOnce.Do(func() {
-		ticker := time.NewTicker(reconcileInterval)
-		done := make(chan struct{})
-
 		dw.reconcileMu.Lock()
 		// Re-check shutdown under the same lock Shutdown takes (Shutdown closes
 		// shutdownCh before acquiring reconcileMu). This closes a race where a
 		// concurrent Shutdown reads a still-nil reconcileTicker and returns
 		// without waiting on the goroutine: either Shutdown observes the
 		// registered ticker and waits on done, or we observe the close here and
-		// never start the goroutine.
+		// never start the goroutine. Defer creating the ticker until after this
+		// check so no timer is registered with the runtime when already shutting down.
 		select {
 		case <-dw.shutdownCh:
 			dw.reconcileMu.Unlock()
-			ticker.Stop()
 			return
 		default:
 		}
+
+		ticker := time.NewTicker(reconcileInterval)
+		done := make(chan struct{})
 		dw.reconcileTicker = ticker
 		dw.reconcileDone = done
 		dw.reconcileMu.Unlock()

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -19,8 +19,13 @@ import (
 
 // parseDetectionID converts a string ID to uint.
 // Returns 0 and error if the ID is invalid.
+//
+// Parses at strconv.IntSize (the width of uint on this platform) rather than a
+// fixed 64 bits, so on 32-bit targets (e.g. 32-bit Raspberry Pi OS) an ID that
+// overflows uint is rejected with an error instead of silently truncating the
+// uint64 down to 32 bits, which could collide with a different detection.
 func parseDetectionID(id string) (uint, error) {
-	parsed, err := strconv.ParseUint(id, 10, 64)
+	parsed, err := strconv.ParseUint(id, 10, strconv.IntSize)
 	if err != nil {
 		return 0, fmt.Errorf("invalid detection ID %q: %w", id, err)
 	}
@@ -145,16 +150,23 @@ func (dw *DualWriteRepository) Shutdown() {
 // synced to v2; if it was deleted from legacy, the v2 ghost is removed.
 func (dw *DualWriteRepository) StartReconciliation() {
 	dw.reconcileOnce.Do(func() {
-		select {
-		case <-dw.shutdownCh:
-			return
-		default:
-		}
-
 		ticker := time.NewTicker(reconcileInterval)
 		done := make(chan struct{})
 
 		dw.reconcileMu.Lock()
+		// Re-check shutdown under the same lock Shutdown takes (Shutdown closes
+		// shutdownCh before acquiring reconcileMu). This closes a race where a
+		// concurrent Shutdown reads a still-nil reconcileTicker and returns
+		// without waiting on the goroutine: either Shutdown observes the
+		// registered ticker and waits on done, or we observe the close here and
+		// never start the goroutine.
+		select {
+		case <-dw.shutdownCh:
+			dw.reconcileMu.Unlock()
+			ticker.Stop()
+			return
+		default:
+		}
 		dw.reconcileTicker = ticker
 		dw.reconcileDone = done
 		dw.reconcileMu.Unlock()
@@ -552,7 +564,10 @@ func (dw *DualWriteRepository) Search(ctx context.Context, filters *datastore.De
 	}
 
 	if readFromV2 {
-		v2Filters := dw.convertFilters(filters)
+		v2Filters, err := dw.convertFilters(filters)
+		if err != nil {
+			return nil, 0, err
+		}
 		dets, total, err := dw.v2.Search(ctx, v2Filters)
 		if err != nil {
 			return nil, 0, err
@@ -587,7 +602,10 @@ func (dw *DualWriteRepository) GetBySpecies(ctx context.Context, species string,
 		if filters == nil {
 			filters = &datastore.DetectionFilters{}
 		}
-		searchFilters := dw.convertFilters(filters)
+		searchFilters, err := dw.convertFilters(filters)
+		if err != nil {
+			return nil, 0, err
+		}
 		searchFilters.LabelIDs = labelIDs
 		if searchFilters.Limit == 0 {
 			searchFilters.Limit = 100
@@ -894,9 +912,28 @@ func (dw *DualWriteRepository) convertFromV2Detections(dets []*entities.Detectio
 }
 
 // convertFilters converts datastore filters to v2 SearchFilters.
-func (dw *DualWriteRepository) convertFilters(filters *datastore.DetectionFilters) *SearchFilters {
+//
+// Limitation: the dual-write read path cannot resolve common-name queries.
+// Unlike the live v2-only path (ConvertSearchFilters), this conversion has no
+// SciToCommon/SciToCommonFolded name-map source, so it cannot populate
+// SearchFilters.CommonLabelIDs. A free-text Query would therefore silently
+// degrade to scientific-name-only matching and return wrong results. Until a
+// name-map source is plumbed into DualWriteRepository and the dual-write read
+// path is reactivated, fail loud with ErrCommonNameSearchUnsupported on a
+// free-text query instead of degrading silently.
+func (dw *DualWriteRepository) convertFilters(filters *datastore.DetectionFilters) (*SearchFilters, error) {
+	// Tolerate nil filters like the sibling converters (ConvertSearchFilters,
+	// legacy Search): an absent filter set means "no constraints".
+	if filters == nil {
+		return &SearchFilters{}, nil
+	}
+	if filters.Query != "" {
+		return nil, ErrCommonNameSearchUnsupported
+	}
+
+	// Query intentionally omitted: a non-empty Query is rejected by the guard
+	// above, so it is always empty here and the field stays at its zero value.
 	sf := &SearchFilters{
-		Query:    filters.Query,
 		Limit:    filters.Limit,
 		Offset:   filters.Offset,
 		SortDesc: !filters.SortAscending,
@@ -949,7 +986,7 @@ func (dw *DualWriteRepository) convertFilters(filters *datastore.DetectionFilter
 		}
 	}
 
-	return sf
+	return sf, nil
 }
 
 // ============================================================================

--- a/internal/datastore/v2/repository/dual_write_test.go
+++ b/internal/datastore/v2/repository/dual_write_test.go
@@ -20,7 +20,6 @@ func TestConvertFilters_PreservesAllFields(t *testing.T) {
 	verified := true
 
 	filters := &datastore.DetectionFilters{
-		Query: "Turdus merula",
 		Confidence: &datastore.ConfidenceRange{
 			Operator: ">=",
 			Value:    minConf,
@@ -32,9 +31,9 @@ func TestConvertFilters_PreservesAllFields(t *testing.T) {
 	}
 
 	dw := &DualWriteRepository{}
-	sf := dw.convertFilters(filters)
+	sf, err := dw.convertFilters(filters)
+	require.NoError(t, err)
 
-	assert.Equal(t, "Turdus merula", sf.Query)
 	require.NotNil(t, sf.MinConfidence)
 	assert.InDelta(t, minConf, *sf.MinConfidence, 0.001)
 	require.NotNil(t, sf.IsLocked)
@@ -46,6 +45,40 @@ func TestConvertFilters_PreservesAllFields(t *testing.T) {
 	assert.True(t, sf.SortDesc)
 }
 
+// TestConvertFilters_FreeTextQueryFailsLoud pins the fail-loud guard: the
+// dual-write read path has no name-map source, so it cannot resolve a free-text
+// query to common-name label IDs. Rather than silently degrade to
+// scientific-name-only matching (returning wrong results), convertFilters must
+// reject a non-empty Query with ErrCommonNameSearchUnsupported.
+func TestConvertFilters_FreeTextQueryFailsLoud(t *testing.T) {
+	t.Parallel()
+
+	filters := &datastore.DetectionFilters{
+		Query: "robin",
+		Limit: 25,
+	}
+
+	dw := &DualWriteRepository{}
+	sf, err := dw.convertFilters(filters)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrCommonNameSearchUnsupported)
+	assert.Nil(t, sf)
+}
+
+// TestConvertFilters_NilFilters pins the defensive nil guard: like the sibling
+// converters, a nil filter set means "no constraints" and must not panic.
+func TestConvertFilters_NilFilters(t *testing.T) {
+	t.Parallel()
+
+	dw := &DualWriteRepository{}
+	sf, err := dw.convertFilters(nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, sf)
+	assert.Empty(t, sf.Query)
+}
+
 func TestConvertFilters_VerifiedFalse(t *testing.T) {
 	t.Parallel()
 
@@ -55,7 +88,8 @@ func TestConvertFilters_VerifiedFalse(t *testing.T) {
 	}
 
 	dw := &DualWriteRepository{}
-	sf := dw.convertFilters(filters)
+	sf, err := dw.convertFilters(filters)
+	require.NoError(t, err)
 
 	require.NotNil(t, sf.IsReviewed)
 	assert.False(t, *sf.IsReviewed)
@@ -70,7 +104,8 @@ func TestConvertFilters_DateRange(t *testing.T) {
 	}
 
 	dw := &DualWriteRepository{}
-	sf := dw.convertFilters(filters)
+	sf, err := dw.convertFilters(filters)
+	require.NoError(t, err)
 
 	require.NotNil(t, sf.StartTime)
 	require.NotNil(t, sf.EndTime)
@@ -90,7 +125,8 @@ func TestConvertFilters_SingleDate(t *testing.T) {
 	}
 
 	dw := &DualWriteRepository{}
-	sf := dw.convertFilters(filters)
+	sf, err := dw.convertFilters(filters)
+	require.NoError(t, err)
 
 	require.NotNil(t, sf.StartTime)
 	require.NotNil(t, sf.EndTime)
@@ -106,7 +142,8 @@ func TestConvertFilters_NoDates(t *testing.T) {
 	filters := &datastore.DetectionFilters{}
 
 	dw := &DualWriteRepository{}
-	sf := dw.convertFilters(filters)
+	sf, err := dw.convertFilters(filters)
+	require.NoError(t, err)
 
 	assert.Nil(t, sf.StartTime)
 	assert.Nil(t, sf.EndTime)
@@ -139,7 +176,8 @@ func TestConvertFilters_ConfidenceOperators(t *testing.T) {
 				},
 			}
 			dw := &DualWriteRepository{}
-			sf := dw.convertFilters(filters)
+			sf, err := dw.convertFilters(filters)
+			require.NoError(t, err)
 
 			if tt.wantMin {
 				require.NotNil(t, sf.MinConfidence)

--- a/internal/datastore/v2/repository/errors.go
+++ b/internal/datastore/v2/repository/errors.go
@@ -70,4 +70,11 @@ var (
 
 	// ErrAlertRuleNotFound indicates the requested alert rule does not exist.
 	ErrAlertRuleNotFound = errors.NewStd("alert rule not found")
+
+	// ErrCommonNameSearchUnsupported indicates a free-text query reached the
+	// dual-write read path, which has no name-map source to resolve common names
+	// to label IDs. Honoring the query would silently degrade to scientific-name-only
+	// matching and return wrong results, so the conversion fails loud instead.
+	// Remove once the dual-write read path is reactivated with a name-map source wired in.
+	ErrCommonNameSearchUnsupported = errors.NewStd("common-name search not supported on the dual-write read path")
 )

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -476,11 +476,6 @@ func (m *mockLabelRepository) GetAllByLabelType(_ context.Context, _ uint) ([]*e
 	return nil, nil //nolint:nilnil // mock implementation
 }
 
-// Search implements LabelRepository.
-func (m *mockLabelRepository) Search(_ context.Context, _ string, _ int) ([]*entities.Label, error) {
-	return nil, nil //nolint:nilnil // mock implementation
-}
-
 // Count implements LabelRepository.
 func (m *mockLabelRepository) Count(_ context.Context) (int64, error) { return 0, nil }
 
@@ -1027,23 +1022,12 @@ func TestConvertSearchFilters(t *testing.T) {
 // ResolveCommonNameToLabelIDs Tests
 // =============================================================================
 
-// Extended mock that also implements Search (kept for interface completeness; the
-// common-name resolver does not call Search, so searchResults is left unset here).
-type mockLabelRepositoryWithSearch struct {
-	mockLabelRepository
-	searchResults []*entities.Label
-}
-
-func (m *mockLabelRepositoryWithSearch) Search(_ context.Context, _ string, _ int) ([]*entities.Label, error) {
-	return m.searchResults, nil
-}
-
 func TestResolveCommonNameToLabelIDs(t *testing.T) {
 	ctx := t.Context()
 
 	t.Run("empty species returns nil", func(t *testing.T) {
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{},
+			LabelRepo: &mockLabelRepository{},
 		}
 
 		result, err := ResolveCommonNameToLabelIDs(ctx, deps, "")
@@ -1059,11 +1043,9 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 
 	t.Run("no SciToCommon map returns nil", func(t *testing.T) {
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Erithacus rubecula": {ID: 1, ScientificName: "Erithacus rubecula"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Erithacus rubecula": {ID: 1, ScientificName: "Erithacus rubecula"},
 				},
 			},
 		}
@@ -1075,11 +1057,9 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 
 	t.Run("no common-name match returns nil (not sentinel)", func(t *testing.T) {
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Parus major": {ID: 1, ScientificName: "Parus major"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Parus major": {ID: 1, ScientificName: "Parus major"},
 				},
 			},
 			SciToCommon: map[string]string{
@@ -1094,14 +1074,11 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 
 	t.Run("partial common name match returns label IDs", func(t *testing.T) {
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Turdus pilaris": {ID: 10, ScientificName: "Turdus pilaris"},
-						"Turdus merula":  {ID: 11, ScientificName: "Turdus merula"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Turdus pilaris": {ID: 10, ScientificName: "Turdus pilaris"},
+					"Turdus merula":  {ID: 11, ScientificName: "Turdus merula"},
 				},
-				searchResults: []*entities.Label{},
 			},
 			SciToCommon: map[string]string{
 				"Turdus pilaris": "räkättirastas",
@@ -1117,13 +1094,10 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 
 	t.Run("partial common name match is case-insensitive", func(t *testing.T) {
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Parus major": {ID: 20, ScientificName: "Parus major"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Parus major": {ID: 20, ScientificName: "Parus major"},
 				},
-				searchResults: []*entities.Label{},
 			},
 			SciToCommon: map[string]string{
 				"Parus major": "Talitiainen",
@@ -1140,12 +1114,10 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 		// not here, so a label whose common name does not match is not returned even if its
 		// scientific name contains the query.
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Turdus migratorius": {ID: 30, ScientificName: "Turdus migratorius"},
-						"Erithacus rubecula": {ID: 5, ScientificName: "Erithacus rubecula"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Turdus migratorius": {ID: 30, ScientificName: "Turdus migratorius"},
+					"Erithacus rubecula": {ID: 5, ScientificName: "Erithacus rubecula"},
 				},
 			},
 			SciToCommon: map[string]string{
@@ -1163,11 +1135,9 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 		// French-locale instance: displayed name "Corneille noire" for Corvus corone.
 		// Typing the partial "Corneille" must resolve to the label.
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Corvus corone": {ID: 7, ScientificName: "Corvus corone"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Corvus corone": {ID: 7, ScientificName: "Corvus corone"},
 				},
 			},
 			SciToCommon: map[string]string{
@@ -1184,13 +1154,10 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 		// "ö" as combining sequence (NFD): o + U+0308
 		nfdQuery := "lehtopöllö"
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Strix aluco": {ID: 40, ScientificName: "Strix aluco"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Strix aluco": {ID: 40, ScientificName: "Strix aluco"},
 				},
-				searchResults: []*entities.Label{},
 			},
 			SciToCommon: map[string]string{
 				"Strix aluco": "Lehtopöllö",
@@ -1204,11 +1171,9 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 
 	t.Run("prefers precomputed SciToCommonFolded map", func(t *testing.T) {
 		deps := &FilterLookupDeps{
-			LabelRepo: &mockLabelRepositoryWithSearch{
-				mockLabelRepository: mockLabelRepository{
-					labels: map[string]*entities.Label{
-						"Corvus corone": {ID: 7, ScientificName: "Corvus corone"},
-					},
+			LabelRepo: &mockLabelRepository{
+				labels: map[string]*entities.Label{
+					"Corvus corone": {ID: 7, ScientificName: "Corvus corone"},
 				},
 			},
 			// Only the folded (already lower-cased, NFC) map is supplied.
@@ -1234,7 +1199,7 @@ func TestResolveCommonNameToLabelIDs(t *testing.T) {
 			labels[sci] = &entities.Label{ID: uint(i) + 1, ScientificName: sci}
 		}
 		deps := &FilterLookupDeps{
-			LabelRepo:   &mockLabelRepositoryWithSearch{mockLabelRepository: mockLabelRepository{labels: labels}},
+			LabelRepo:   &mockLabelRepository{labels: labels},
 			SciToCommon: sciToCommon,
 		}
 

--- a/internal/datastore/v2/repository/label.go
+++ b/internal/datastore/v2/repository/label.go
@@ -42,10 +42,6 @@ type LabelRepository interface {
 	// GetAllByLabelType retrieves all labels of a specific label type.
 	GetAllByLabelType(ctx context.Context, labelTypeID uint) ([]*entities.Label, error)
 
-	// Search finds labels matching the query string.
-	// Searches in scientific_name field.
-	Search(ctx context.Context, query string, limit int) ([]*entities.Label, error)
-
 	// Count returns the total number of labels.
 	Count(ctx context.Context) (int64, error)
 

--- a/internal/datastore/v2/repository/label_impl.go
+++ b/internal/datastore/v2/repository/label_impl.go
@@ -264,18 +264,6 @@ func (r *labelRepository) GetAllByLabelType(ctx context.Context, labelTypeID uin
 	return labels, err
 }
 
-// Search finds labels matching the query string.
-func (r *labelRepository) Search(ctx context.Context, query string, limit int) ([]*entities.Label, error) {
-	var labels []*entities.Label
-	searchPattern := "%" + query + "%"
-	err := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("scientific_name LIKE ?", searchPattern).
-		Limit(limit).
-		Order("scientific_name ASC").
-		Find(&labels).Error
-	return labels, err
-}
-
 // Count returns the total number of labels.
 func (r *labelRepository) Count(ctx context.Context) (int64, error) {
 	var count int64


### PR DESCRIPTION
## Summary

Two follow-ups in `internal/datastore/v2/repository/` from the recent common-name search work.

- **Remove dead `LabelRepository.Search`.** The `Search(ctx, query, limit)` method has had no production callers since common-name resolution moved to `ResolveCommonNameToLabelIDs` / `GetByScientificNames`. Removed it from the interface and impl, and collapsed the `mockLabelRepositoryWithSearch` test mock back into `mockLabelRepository`.
- **Fail loud on dual-write common-name search.** `DualWriteRepository.convertFilters` has no `SciToCommon`/`SciToCommonFolded` name-map source, so it cannot populate `SearchFilters.CommonLabelIDs`. A free-text query would silently degrade to scientific-name-only matching and return wrong results. It now returns `(*SearchFilters, error)` and fails loud with a new `ErrCommonNameSearchUnsupported` sentinel. A nil-filters guard was added to match the sibling converters.

**Backward compatibility: preserved.** The removed method is on an internal-package interface with zero callers (compiler-verified, no public API). The `convertFilters` behavior change is on the dual-write read path, which has no non-test constructors today, so no live code path is affected.

### Latent hardening (same file)
- `parseDetectionID` now parses at `strconv.IntSize`, so detection IDs are not silently truncated on 32-bit builds (e.g. 32-bit Raspberry Pi OS).
- Closed a TOCTOU race between `StartReconciliation` and `Shutdown` by re-checking `shutdownCh` under `reconcileMu`, so `Shutdown` never returns before the reconciliation goroutine is cleaned up.

## Test Plan
- [x] `go test -race ./internal/datastore/v2/... ./internal/datastore/v2only/...` passes
- [x] `golangci-lint run` (full project): 0 issues
- [x] New tests: `TestConvertFilters_FreeTextQueryFailsLoud`, `TestConvertFilters_NilFilters`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reconciliation race so shutdown reliably waits for reconciliation to stop
  * Improved detection ID parsing to reject overflows instead of truncating
  * Search now surfaces an explicit error when free-text common-name queries are unsupported

* **Tests**
  * Added/updated tests to cover nil filters and free-text query failure cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->