### PR TITLE
fix(auth): per-issuer OIDC retry lifecycle and security-module auth logging

### DIFF
--- a/internal/analysis/api_service.go
+++ b/internal/analysis/api_service.go
@@ -44,6 +44,10 @@ type APIServerService struct {
 	systemMonitor  *monitor.SystemMonitor
 	controlChan    chan string
 	audioLevelChan chan audiocore.AudioLevelData
+
+	// cancel stops background goroutines owned by subsystems (e.g. the OAuth2
+	// server's periodic token cleanup). Created in Start, invoked in Stop.
+	cancel context.CancelFunc
 }
 
 // NewAPIServerService creates a new APIServerService with the given dependencies.
@@ -67,7 +71,7 @@ func (s *APIServerService) Name() string {
 // It fails fast if required dependencies (DataStore, BirdNET) are not available.
 //
 //nolint:gocognit // Orchestration function that initializes multiple subsystems in sequence.
-func (s *APIServerService) Start(_ context.Context) error {
+func (s *APIServerService) Start(ctx context.Context) error {
 	// If Start fails after creating resources, clean up to prevent leaks.
 	// The App framework only calls Stop() on services that started successfully,
 	// so the failing service must clean up after itself.
@@ -75,6 +79,10 @@ func (s *APIServerService) Start(_ context.Context) error {
 	defer func() {
 		if !startSucceeded {
 			// Best-effort cleanup of partially initialized resources.
+			if s.cancel != nil {
+				s.cancel()
+				s.cancel = nil
+			}
 			if s.systemMonitor != nil {
 				s.systemMonitor.Stop()
 				s.systemMonitor = nil
@@ -122,7 +130,7 @@ func (s *APIServerService) Start(_ context.Context) error {
 	s.proc = processor.New(s.settings, dataStore, bn, s.metrics, s.birdImageCache, GetLogger())
 	s.proc.SetSunCalc(s.sunCalc)
 
-	// Initialize backup system (optional — failure is non-fatal).
+	// Initialize backup system (optional; failure is non-fatal).
 	backupLog := logger.Global().Module("backup")
 	backupManager, backupScheduler, err := initializeBackupSystem(s.settings, backupLog)
 	if err != nil {
@@ -136,7 +144,7 @@ func (s *APIServerService) Start(_ context.Context) error {
 	}
 
 	// Initialize async services (event bus, notification workers, telemetry workers).
-	// This is fatal — the system cannot operate without these.
+	// This is fatal: the system cannot operate without these.
 	if err := telemetry.InitializeAsyncSystems(); err != nil {
 		GetLogger().Error("failed to initialize critical async services",
 			logger.Error(err),
@@ -148,15 +156,22 @@ func (s *APIServerService) Start(_ context.Context) error {
 			Build()
 	}
 
-	// Initialize system monitor (optional — failure is non-fatal).
+	// Initialize system monitor (optional; failure is non-fatal).
 	s.systemMonitor = initializeSystemMonitor(s.settings)
 
 	// Create channels.
 	s.controlChan = make(chan string, 1)
 	s.audioLevelChan = make(chan audiocore.AudioLevelData, 100)
 
+	// Derive a service lifecycle context, cancelled when the service stops (or
+	// when the parent context is cancelled), so background goroutines owned by
+	// subsystems (the OAuth2 server's periodic token cleanup) terminate on
+	// shutdown instead of running for the process lifetime.
+	serviceCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+
 	// Create OAuth2 server.
-	s.oauth2Server = security.NewOAuth2Server()
+	s.oauth2Server = security.NewOAuth2Server(serviceCtx)
 
 	// Create and start the HTTP API server.
 	GetLogger().Info("starting HTTP server")
@@ -207,6 +222,13 @@ func (s *APIServerService) Start(_ context.Context) error {
 // It is safe to call before Start() or multiple times.
 func (s *APIServerService) Stop(ctx context.Context) error {
 	log := GetLogger()
+
+	// Cancel the service lifecycle context first so background goroutines owned
+	// by subsystems (the OAuth2 server's periodic token cleanup) stop promptly.
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
 
 	// Stop system monitor.
 	if s.systemMonitor != nil {

--- a/internal/api/auth/service.go
+++ b/internal/api/auth/service.go
@@ -9,9 +9,13 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// GetLogger returns the auth package logger.
+// GetLogger returns the auth package logger. Authentication events (basic-auth
+// login attempts, failures, logout) are routed to the "security" log module so
+// they are co-located with the OAuth/OIDC and provider-init logging, where
+// admins look when debugging auth, instead of being split across the "api" and
+// "auth" modules (matching #3381/#3384).
 func GetLogger() logger.Logger {
-	return logger.Global().Module("auth")
+	return logger.Global().Module("security")
 }
 
 // Sentinel errors for authentication failures.

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -913,9 +913,12 @@ func (c *Controller) Shutdown() {
 		backupJobManager.Shutdown()
 	}
 
-	// Flush the API logger
-	if err := c.apiLogger.Flush(); err != nil {
-		GetLogger().Error("Error flushing API log", logger.Error(err))
+	// Flush all log writers (the main writer plus every module writer, including
+	// the security module added for auth events). A module logger's Flush is a
+	// no-op, so flush the central logger to actually persist buffered logs on
+	// shutdown.
+	if err := logger.Global().Flush(); err != nil {
+		GetLogger().Error("Error flushing logs", logger.Error(err))
 	}
 
 	// TODO: The go-cache library's janitor goroutine cannot be stopped.

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -84,6 +84,7 @@ type Controller struct {
 	startTime            *time.Time
 	SFS                  *securefs.SecureFS     // Add SecureFS instance
 	apiLogger            logger.Logger          // Structured logger for API operations
+	securityLogger       logger.Logger          // Logger scoped to the "security" module for authentication events
 	metrics              *observability.Metrics // Shared metrics instance
 	spectrogramGenerator *spectrogram.Generator // Shared spectrogram generator (initialized after SFS)
 
@@ -522,6 +523,11 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Initialize structured logger for API requests
 	c.apiLogger = logger.Global().Module("api")
 
+	// Authentication events (form login/logout, OAuth callback) log to the
+	// "security" module so they are co-located with the OAuth and provider-init
+	// logging, where admins look when debugging auth.
+	c.securityLogger = logger.Global().Module("security")
+
 	// Load local taxonomy database for fast species lookups
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	if err != nil {
@@ -649,7 +655,7 @@ func (c *Controller) LoggingMiddleware() echo.MiddlewareFunc {
 					status = he.Code
 				} else if status < http.StatusBadRequest {
 					// Non-HTTP errors (e.g. database errors) won't have a
-					// status set yet — Echo's error handler runs after this
+					// status set yet; Echo's error handler runs after this
 					// middleware. Default to 500 to avoid logging failures
 					// as successes.
 					status = http.StatusInternalServerError
@@ -1037,7 +1043,7 @@ func (c *Controller) handleErrorInternal(ctx echo.Context, err error, message st
 	c.logErrorIfEnabled("API Error", fields...)
 
 	// Report server-side errors (5xx) to Sentry telemetry.
-	// 4xx errors are client mistakes (bad input, not found) — not bugs — and are excluded.
+	// 4xx errors are client mistakes (bad input, not found), not bugs, and are excluded.
 	if code >= http.StatusInternalServerError {
 		c.reportErrorToTelemetry(ctx, err, message, code)
 	}

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -94,7 +94,7 @@ func (c *Controller) initAuthRoutes() {
 		},
 		ErrorHandler: func(ctx echo.Context, err error) error {
 			// Return a user-friendly error message when rate limit is exceeded
-			c.logWarnIfEnabled("Login rate limit exceeded",
+			c.logSecurityWarnIfEnabled("Login rate limit exceeded",
 				logger.String("ip", ctx.RealIP()),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("user_agent", ctx.Request().Header.Get("User-Agent")),
@@ -103,7 +103,7 @@ func (c *Controller) initAuthRoutes() {
 		},
 		DenyHandler: func(ctx echo.Context, identifier string, err error) error {
 			// This is called when the rate limit is exceeded
-			c.logWarnIfEnabled("Login attempt denied due to rate limit",
+			c.logSecurityWarnIfEnabled("Login attempt denied due to rate limit",
 				logger.String("identifier", identifier),
 				logger.String("ip", ctx.RealIP()),
 				logger.String("path", ctx.Request().URL.Path),
@@ -130,7 +130,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	// Parse login request
 	var req AuthRequest
 	if err := ctx.Bind(&req); err != nil {
-		c.logErrorIfEnabled("Invalid login request",
+		c.logSecurityErrorIfEnabled("Invalid login request",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -142,7 +142,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	authService := c.authService
 	if authService == nil {
 		// Handle case where auth might not be configured but login endpoint is hit
-		c.logErrorIfEnabled("Login attempt but AuthService is nil (auth not configured?)",
+		c.logSecurityErrorIfEnabled("Login attempt but AuthService is nil (auth not configured?)",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -153,7 +153,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 
 	// If authentication is not required, act as if the login was successful
 	if !authService.IsAuthRequired(ctx) {
-		c.logInfoIfEnabled("Authentication not required",
+		c.logSecurityInfoIfEnabled("Authentication not required",
 			logger.Username(req.Username),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -171,7 +171,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 		// Add a short, randomized delay to mitigate timing attacks on username enumeration
 		randomDelay(ctx.Request().Context(), authDelayMinMs, authDelayMaxMs)
 
-		c.logWarnIfEnabled("Login attempt with missing credentials",
+		c.logSecurityWarnIfEnabled("Login attempt with missing credentials",
 			logger.Bool("username_present", req.Username != ""),
 			logger.Bool("password_present", req.Password != ""),
 			logger.String("ip", ctx.RealIP()),
@@ -193,7 +193,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 		// Add a short, randomized delay to mitigate brute force/timing attacks
 		randomDelay(ctx.Request().Context(), authDelayMinMs, authDelayMaxMs)
 
-		c.logWarnIfEnabled("Failed login attempt",
+		c.logSecurityWarnIfEnabled("Failed login attempt",
 			logger.Username(req.Username),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -215,7 +215,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	}
 
 	// Successful login - auth code has been generated directly (V1 pattern)
-	c.logInfoIfEnabled("Successful login with auth code",
+	c.logSecurityInfoIfEnabled("Successful login with auth code",
 		logger.Username(req.Username),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -235,7 +235,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 
 			// Log if redirect was adjusted
 			if finalRedirect != req.RedirectURL {
-				c.logDebugIfEnabled("Adjusted redirect URL to stay within base path",
+				c.logSecurityDebugIfEnabled("Adjusted redirect URL to stay within base path",
 					logger.String("requested", req.RedirectURL),
 					logger.String("basePath", basePath),
 					logger.String("final", finalRedirect),
@@ -243,7 +243,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 			}
 		} else {
 			// Invalid redirect - log and use default
-			c.logWarnIfEnabled("Invalid redirect URL provided, using base path",
+			c.logSecurityWarnIfEnabled("Invalid redirect URL provided, using base path",
 				logger.String("requested", req.RedirectURL),
 				logger.String("basePath", basePath),
 				logger.String("default", finalRedirect),
@@ -267,7 +267,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	callbackPath := apiV2Prefix + authGroupPath + authCallbackPath
 	redirectURL := fmt.Sprintf("%s%s?code=%s&redirect=%s", requestBase, callbackPath, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
 
-	c.logInfoIfEnabled("Returning successful login response with redirect",
+	c.logSecurityInfoIfEnabled("Returning successful login response with redirect",
 		logger.Username(req.Username),
 		logger.String("redirect_url", redirectURL),
 		logger.String("final_redirect", finalRedirect),
@@ -288,7 +288,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 	// Use the stored auth service instance
 	authService := c.authService
 	if authService == nil {
-		c.logWarnIfEnabled("Logout requested but AuthService is nil (auth not configured?)",
+		c.logSecurityWarnIfEnabled("Logout requested but AuthService is nil (auth not configured?)",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -306,7 +306,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 
 	// Try to perform logout via auth service
 	if err := authService.Logout(ctx); err != nil {
-		c.logErrorIfEnabled("Logout failed",
+		c.logSecurityErrorIfEnabled("Logout failed",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -314,7 +314,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Logout failed", http.StatusInternalServerError)
 	}
 
-	c.logInfoIfEnabled("User logged out",
+	c.logSecurityInfoIfEnabled("User logged out",
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.Bool("has_provider_logout", providerLogoutURL != ""),
@@ -347,7 +347,7 @@ func (c *Controller) GetAuthStatus(ctx echo.Context) error {
 		Method:        authMethod,
 	}
 
-	c.logInfoIfEnabled("Auth status check",
+	c.logSecurityInfoIfEnabled("Auth status check",
 		logger.Bool("authenticated", status.Authenticated),
 		logger.Username(status.Username),
 		logger.String("method", status.Method),
@@ -538,7 +538,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	code := ctx.QueryParam("code")
 	redirect := ctx.QueryParam("redirect")
 
-	c.logInfoIfEnabled("Handling V2 OAuth callback",
+	c.logSecurityInfoIfEnabled("Handling V2 OAuth callback",
 		logger.String("redirect", redirect),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -546,7 +546,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 
 	// 1. Validate code parameter
 	if code == "" {
-		c.logWarnIfEnabled("Missing authorization code in callback",
+		c.logSecurityWarnIfEnabled("Missing authorization code in callback",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -555,7 +555,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 
 	// 2. Defensive check: ensure AuthService is available
 	if c.authService == nil {
-		c.logErrorIfEnabled("AuthService is nil in OAuthCallback - server misconfiguration",
+		c.logSecurityErrorIfEnabled("AuthService is nil in OAuthCallback - server misconfiguration",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -569,26 +569,26 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	accessToken, err := c.authService.ExchangeAuthCode(exchangeCtx, code)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			c.logWarnIfEnabled("Timeout exchanging authorization code",
+			c.logSecurityWarnIfEnabled("Timeout exchanging authorization code",
 				logger.Error(err),
 				logger.String("ip", ctx.RealIP()),
 			)
 			return c.HandleErrorWithKey(ctx, nil, "Login timed out. Please try again.", http.StatusGatewayTimeout, notification.MsgErrAuthTimeout, nil)
 		}
-		c.logWarnIfEnabled("Failed to exchange authorization code",
+		c.logSecurityWarnIfEnabled("Failed to exchange authorization code",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 		)
 		return c.HandleErrorWithKey(ctx, nil, "Unable to complete login at this time. Please try again.", http.StatusUnauthorized, notification.MsgErrAuthExchangeFailed, nil)
 	}
 
-	c.logInfoIfEnabled("Successfully exchanged authorization code for access token",
+	c.logSecurityInfoIfEnabled("Successfully exchanged authorization code for access token",
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	// 4. Establish session (handles session fixation mitigation)
 	if err := c.authService.EstablishSession(ctx, accessToken); err != nil {
-		c.logErrorIfEnabled("Failed to establish session",
+		c.logSecurityErrorIfEnabled("Failed to establish session",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -598,7 +598,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	// 5. Validate redirect path (prevent open redirects)
 	safeRedirect := validateAndSanitizeRedirect(redirect)
 
-	c.logInfoIfEnabled("Redirecting user to final destination",
+	c.logSecurityInfoIfEnabled("Redirecting user to final destination",
 		logger.String("destination", safeRedirect),
 		logger.String("ip", ctx.RealIP()),
 	)

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -873,6 +873,39 @@ func (c *Controller) logDebugIfEnabled(msg string, fields ...logger.Field) {
 	}
 }
 
+// The logSecurity* helpers mirror the api-module helpers above but write to the
+// "security" module logger, so authentication events (form login/logout, OAuth
+// callback) are co-located with the OAuth and provider-init logging where
+// admins look when debugging auth.
+
+// logSecurityInfoIfEnabled logs an info message to the security module if enabled.
+func (c *Controller) logSecurityInfoIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Info(msg, fields...)
+	}
+}
+
+// logSecurityWarnIfEnabled logs a warning message to the security module if enabled.
+func (c *Controller) logSecurityWarnIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Warn(msg, fields...)
+	}
+}
+
+// logSecurityErrorIfEnabled logs an error message to the security module if enabled.
+func (c *Controller) logSecurityErrorIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Error(msg, fields...)
+	}
+}
+
+// logSecurityDebugIfEnabled logs a debug message to the security module if enabled.
+func (c *Controller) logSecurityDebugIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Debug(msg, fields...)
+	}
+}
+
 // =============================================================================
 // Batch Response Helpers
 // =============================================================================

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -36,23 +36,43 @@ import (
 )
 
 var oidcRetryCancelMu sync.Mutex
-var oidcRetryCancelFunc context.CancelFunc
 
-// cancelOIDCRetry cancels any running OIDC discovery retry goroutine.
-func cancelOIDCRetry() {
+// oidcRetryCancels tracks in-flight OIDC discovery retry goroutines, keyed by
+// issuer URL. Keying per issuer (rather than a single package-global) lets
+// multiple OIDC providers retry independently: configuring a second provider no
+// longer cancels or orphans the first provider's retry. Guarded by
+// oidcRetryCancelMu.
+//
+// A retry goroutine that finishes on its own (provider registered, or the retry
+// deadline elapsed) leaves its now-inert cancel func in the map; these spent
+// entries are reaped by the next cancelAllOIDCRetries (settings reload or
+// shutdown). The map is therefore bounded by the number of distinct configured
+// issuer URLs, not by retry attempts.
+var oidcRetryCancels = make(map[string]context.CancelFunc)
+
+// cancelAllOIDCRetries cancels and forgets every in-flight OIDC discovery retry.
+// Used on settings reload, where InitializeGoth rebuilds all providers from
+// scratch, and on application shutdown.
+func cancelAllOIDCRetries() {
 	oidcRetryCancelMu.Lock()
 	defer oidcRetryCancelMu.Unlock()
-	if oidcRetryCancelFunc != nil {
-		oidcRetryCancelFunc()
-		oidcRetryCancelFunc = nil
+	for issuerURL, cancel := range oidcRetryCancels {
+		cancel()
+		delete(oidcRetryCancels, issuerURL)
 	}
 }
 
-// setOIDCRetryCancel stores the cancel function for the current OIDC retry goroutine.
-func setOIDCRetryCancel(cancel context.CancelFunc) {
+// setOIDCRetryCancel stores the cancel function for the retry goroutine of the
+// given issuer URL, cancelling and replacing any existing retry for that same
+// issuer first. Per-issuer keying prevents a second provider's init from
+// orphaning another provider's retry.
+func setOIDCRetryCancel(issuerURL string, cancel context.CancelFunc) {
 	oidcRetryCancelMu.Lock()
 	defer oidcRetryCancelMu.Unlock()
-	oidcRetryCancelFunc = cancel
+	if existing, ok := oidcRetryCancels[issuerURL]; ok {
+		existing()
+	}
+	oidcRetryCancels[issuerURL] = cancel
 }
 
 // startOIDCRetry starts a background goroutine that retries OIDC discovery with exponential backoff.
@@ -77,7 +97,7 @@ func startOIDCRetry(ctx context.Context, providerConfig conf.OAuthProviderConfig
 				return
 			case <-time.After(backoff):
 				if time.Now().After(deadline) {
-					secLog.Error("OIDC discovery retry exhausted — provider not available. Save settings to retry.",
+					secLog.Error("OIDC discovery retry exhausted; provider not available. Save settings to retry.",
 						logger.String("issuer_url", providerConfig.IssuerURL))
 					return
 				}
@@ -173,7 +193,11 @@ var (
 	ErrTokenExpired  = errors.NewStd("token expired")
 )
 
-func NewOAuth2Server() *OAuth2Server {
+// NewOAuth2Server creates and initializes an OAuth2Server. The supplied context
+// governs background goroutines owned by the server (currently the periodic
+// expired-token cleanup); cancelling it stops them, giving the cleanup goroutine
+// a proper shutdown path instead of running for the process lifetime.
+func NewOAuth2Server(ctx context.Context) *OAuth2Server {
 	// Use the security logger from the start
 	GetLogger().Info("Initializing OAuth2 server")
 	settings := conf.GetSettings()
@@ -193,9 +217,19 @@ func NewOAuth2Server() *OAuth2Server {
 	// Set up token persistence
 	server.setupTokenPersistence()
 
-	// Clean up expired tokens every hour
-	// TODO: Pass application shutdown context for graceful cleanup termination
-	server.StartAuthCleanup(context.Background(), time.Hour)
+	// Clean up expired tokens every hour. The caller's context terminates the
+	// goroutine on application shutdown.
+	server.StartAuthCleanup(ctx, time.Hour)
+
+	// Stop any in-flight OIDC discovery retries when the application shuts down.
+	// The retries are package-global (goth's provider registry is global), so a
+	// lightweight watcher on the lifecycle context cancels them, rather than
+	// threading a context field through the global provider-init path (which the
+	// fatcontext linter forbids).
+	go func() {
+		<-ctx.Done()
+		cancelAllOIDCRetries()
+	}()
 
 	GetLogger().Info("OAuth2 server initialization complete")
 	return server
@@ -539,10 +573,11 @@ func initializeOIDCProvider(providerConfig *conf.OAuthProviderConfig, redirectUR
 		providerLog.Error("Failed to initialize OIDC provider (is the issuer URL reachable?)",
 			logger.Error(err),
 			logger.String("issuer_url", providerConfig.IssuerURL))
-		// Cancel any previous retry and start a new one
-		cancelOIDCRetry()
+		// Cancel any previous retry for this issuer and start a new one.
+		// Keying by issuer URL keeps multiple OIDC providers' retries independent;
+		// setOIDCRetryCancel cancels and replaces only this issuer's prior retry.
 		ctx, cancel := context.WithCancel(context.Background())
-		setOIDCRetryCancel(cancel)
+		setOIDCRetryCancel(providerConfig.IssuerURL, cancel)
 		startOIDCRetry(ctx, *providerConfig, redirectURI, scopes)
 		return nil
 	}
@@ -567,7 +602,7 @@ func SetTestConfigPath(path string) {
 
 func (s *OAuth2Server) UpdateProviders() {
 	GetLogger().Info("Updating Goth providers based on potentially changed settings")
-	cancelOIDCRetry()
+	cancelAllOIDCRetries()
 	InitializeGoth(s.currentSettings())
 }
 

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -35,44 +35,85 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-var oidcRetryCancelMu sync.Mutex
+var (
+	oidcRetryCancelMu sync.Mutex
 
-// oidcRetryCancels tracks in-flight OIDC discovery retry goroutines, keyed by
-// issuer URL. Keying per issuer (rather than a single package-global) lets
-// multiple OIDC providers retry independently: configuring a second provider no
-// longer cancels or orphans the first provider's retry. Guarded by
-// oidcRetryCancelMu.
-//
-// A retry goroutine that finishes on its own (provider registered, or the retry
-// deadline elapsed) leaves its now-inert cancel func in the map; these spent
-// entries are reaped by the next cancelAllOIDCRetries (settings reload or
-// shutdown). The map is therefore bounded by the number of distinct configured
-// issuer URLs, not by retry attempts.
-var oidcRetryCancels = make(map[string]context.CancelFunc)
+	// oidcRetriesDisabled blocks new OIDC discovery retries once application
+	// shutdown has begun, so a late provider (re)initialization cannot spawn a
+	// retry goroutine that outlives the server. Reset for each new server
+	// instance via enableOIDCRetries. Guarded by oidcRetryCancelMu.
+	oidcRetriesDisabled bool
 
-// cancelAllOIDCRetries cancels and forgets every in-flight OIDC discovery retry.
-// Used on settings reload, where InitializeGoth rebuilds all providers from
-// scratch, and on application shutdown.
-func cancelAllOIDCRetries() {
-	oidcRetryCancelMu.Lock()
-	defer oidcRetryCancelMu.Unlock()
+	// oidcRetryCancels tracks in-flight OIDC discovery retry goroutines, keyed by
+	// issuer URL. Keying per issuer (rather than a single package-global) lets
+	// multiple OIDC providers retry independently: configuring a second provider
+	// no longer cancels or orphans the first provider's retry. Guarded by
+	// oidcRetryCancelMu.
+	//
+	// A retry goroutine that finishes on its own (provider registered, or the
+	// retry deadline elapsed) leaves its now-inert cancel func in the map; these
+	// spent entries are reaped by the next cancelAllOIDCRetries (settings reload
+	// or shutdown). The map is therefore bounded by the number of distinct
+	// configured issuer URLs, not by retry attempts.
+	oidcRetryCancels = make(map[string]context.CancelFunc)
+)
+
+// cancelAllOIDCRetriesLocked cancels and forgets every in-flight OIDC discovery
+// retry. The caller must hold oidcRetryCancelMu.
+func cancelAllOIDCRetriesLocked() {
 	for issuerURL, cancel := range oidcRetryCancels {
 		cancel()
 		delete(oidcRetryCancels, issuerURL)
 	}
 }
 
+// cancelAllOIDCRetries cancels and forgets every in-flight OIDC discovery retry.
+// Used on settings reload, where InitializeGoth rebuilds all providers from
+// scratch and any outstanding retries are superseded.
+func cancelAllOIDCRetries() {
+	oidcRetryCancelMu.Lock()
+	defer oidcRetryCancelMu.Unlock()
+	cancelAllOIDCRetriesLocked()
+}
+
+// shutdownOIDCRetries cancels every in-flight retry and blocks new ones for the
+// remaining lifetime of the current server instance. Called when the server's
+// context is cancelled (application shutdown), so a retry cannot be started
+// after shutdown has begun (e.g. by a late InitializeGoth/UpdateProviders).
+func shutdownOIDCRetries() {
+	oidcRetryCancelMu.Lock()
+	defer oidcRetryCancelMu.Unlock()
+	oidcRetriesDisabled = true
+	cancelAllOIDCRetriesLocked()
+}
+
+// enableOIDCRetries re-enables OIDC discovery retries for a fresh server
+// instance, clearing any disabled state left by a previous instance's shutdown
+// (relevant in tests that build servers sequentially).
+func enableOIDCRetries() {
+	oidcRetryCancelMu.Lock()
+	defer oidcRetryCancelMu.Unlock()
+	oidcRetriesDisabled = false
+}
+
 // setOIDCRetryCancel stores the cancel function for the retry goroutine of the
 // given issuer URL, cancelling and replacing any existing retry for that same
 // issuer first. Per-issuer keying prevents a second provider's init from
-// orphaning another provider's retry.
-func setOIDCRetryCancel(issuerURL string, cancel context.CancelFunc) {
+// orphaning another provider's retry. It returns false (after cancelling the
+// passed func) when retries are disabled because shutdown has begun, signalling
+// the caller not to start the goroutine.
+func setOIDCRetryCancel(issuerURL string, cancel context.CancelFunc) bool {
 	oidcRetryCancelMu.Lock()
 	defer oidcRetryCancelMu.Unlock()
+	if oidcRetriesDisabled {
+		cancel()
+		return false
+	}
 	if existing, ok := oidcRetryCancels[issuerURL]; ok {
 		existing()
 	}
 	oidcRetryCancels[issuerURL] = cancel
+	return true
 }
 
 // startOIDCRetry starts a background goroutine that retries OIDC discovery with exponential backoff.
@@ -90,12 +131,17 @@ func startOIDCRetry(ctx context.Context, providerConfig conf.OAuthProviderConfig
 
 	go func() {
 		defer close(done)
+		// A single reusable timer (Reset per iteration) instead of time.After
+		// inside the loop, so an early ctx cancellation does not leave an
+		// unexpired timer per backoff round waiting to be garbage collected.
+		timer := time.NewTimer(backoff)
+		defer timer.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				secLog.Info("OIDC discovery retry canceled")
 				return
-			case <-time.After(backoff):
+			case <-timer.C:
 				if time.Now().After(deadline) {
 					secLog.Error("OIDC discovery retry exhausted; provider not available. Save settings to retry.",
 						logger.String("issuer_url", providerConfig.IssuerURL))
@@ -115,10 +161,11 @@ func startOIDCRetry(ctx context.Context, providerConfig conf.OAuthProviderConfig
 					scopes...,
 				)
 				if err != nil {
+					backoff = min(backoff*OIDCRetryBackoffFactor, OIDCRetryMaxBackoff)
 					secLog.Warn("OIDC discovery retry failed",
 						logger.Error(err),
-						logger.Duration("next_backoff", min(backoff*OIDCRetryBackoffFactor, OIDCRetryMaxBackoff)))
-					backoff = min(backoff*OIDCRetryBackoffFactor, OIDCRetryMaxBackoff)
+						logger.Duration("next_backoff", backoff))
+					timer.Reset(backoff)
 					continue
 				}
 
@@ -198,6 +245,9 @@ var (
 // expired-token cleanup); cancelling it stops them, giving the cleanup goroutine
 // a proper shutdown path instead of running for the process lifetime.
 func NewOAuth2Server(ctx context.Context) *OAuth2Server {
+	// Re-enable OIDC discovery retries for this instance, clearing any disabled
+	// state a previous instance's shutdown left behind (sequential tests).
+	enableOIDCRetries()
 	// Use the security logger from the start
 	GetLogger().Info("Initializing OAuth2 server")
 	settings := conf.GetSettings()
@@ -221,14 +271,14 @@ func NewOAuth2Server(ctx context.Context) *OAuth2Server {
 	// goroutine on application shutdown.
 	server.StartAuthCleanup(ctx, time.Hour)
 
-	// Stop any in-flight OIDC discovery retries when the application shuts down.
-	// The retries are package-global (goth's provider registry is global), so a
-	// lightweight watcher on the lifecycle context cancels them, rather than
-	// threading a context field through the global provider-init path (which the
-	// fatcontext linter forbids).
+	// Stop in-flight OIDC discovery retries when the application shuts down and
+	// block any new ones. The retries are package-global (goth's provider
+	// registry is global), so a lightweight watcher on the lifecycle context
+	// drives shutdownOIDCRetries, rather than threading a context field through
+	// the global provider-init path (which the fatcontext linter forbids).
 	go func() {
 		<-ctx.Done()
-		cancelAllOIDCRetries()
+		shutdownOIDCRetries()
 	}()
 
 	GetLogger().Info("OAuth2 server initialization complete")
@@ -576,8 +626,12 @@ func initializeOIDCProvider(providerConfig *conf.OAuthProviderConfig, redirectUR
 		// Cancel any previous retry for this issuer and start a new one.
 		// Keying by issuer URL keeps multiple OIDC providers' retries independent;
 		// setOIDCRetryCancel cancels and replaces only this issuer's prior retry.
+		// If it reports that retries are disabled (shutdown has begun), it has
+		// already cancelled the context and we must not start the goroutine.
 		ctx, cancel := context.WithCancel(context.Background())
-		setOIDCRetryCancel(providerConfig.IssuerURL, cancel)
+		if !setOIDCRetryCancel(providerConfig.IssuerURL, cancel) {
+			return nil
+		}
 		startOIDCRetry(ctx, *providerConfig, redirectURI, scopes)
 		return nil
 	}

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -137,6 +137,17 @@ func startOIDCRetry(ctx context.Context, providerConfig conf.OAuthProviderConfig
 		timer := time.NewTimer(backoff)
 		defer timer.Stop()
 		for {
+			// Prioritize cancellation: a single select with both ctx.Done() and
+			// timer.C ready picks pseudo-randomly, so on shutdown the timer case
+			// could win and start one more (uncancellable) discovery request,
+			// delaying graceful shutdown. Check ctx first, then block on the timer.
+			select {
+			case <-ctx.Done():
+				secLog.Info("OIDC discovery retry canceled")
+				return
+			default:
+			}
+
 			select {
 			case <-ctx.Done():
 				secLog.Info("OIDC discovery retry canceled")

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -1434,6 +1434,9 @@ func TestInitializeProviders_OIDC_Success(t *testing.T) {
 func TestInitializeProviders_OIDC_DiscoveryFailure(t *testing.T) {
 	goth.ClearProviders()
 	t.Cleanup(goth.ClearProviders)
+	// A prior test's server shutdown may have disabled retries; re-enable so the
+	// discovery-failure path actually starts a background retry.
+	enableOIDCRetries()
 	t.Cleanup(cancelAllOIDCRetries)
 
 	settings := &conf.Settings{
@@ -1654,7 +1657,10 @@ func TestStartOIDCRetry_CanceledByContext(t *testing.T) {
 }
 
 func TestCancelOIDCRetry(t *testing.T) {
-	// Clean up the package-global retry map after the test (it is shared state).
+	// The retry map and disabled flag are package-global shared state; start
+	// enabled (a prior test's server shutdown may have disabled retries) and
+	// clean up afterwards.
+	enableOIDCRetries()
 	t.Cleanup(cancelAllOIDCRetries)
 
 	// cancelAllOIDCRetries must be safe to call when no retry is running.
@@ -1663,7 +1669,7 @@ func TestCancelOIDCRetry(t *testing.T) {
 	// Set a cancel function for an issuer and verify cancelAllOIDCRetries calls it.
 	const issuer = "https://issuer.example/single"
 	ctx, cancel := context.WithCancel(t.Context())
-	setOIDCRetryCancel(issuer, cancel)
+	require.True(t, setOIDCRetryCancel(issuer, cancel), "retry should register while enabled")
 
 	cancelAllOIDCRetries()
 
@@ -1681,8 +1687,10 @@ func TestCancelOIDCRetry(t *testing.T) {
 // first provider's retry. Per-issuer keying must keep each provider's retry
 // independent, and cancelAllOIDCRetries must cancel every outstanding retry.
 func TestOIDCRetryCancel_PerIssuer(t *testing.T) {
+	// Start from a clean slate; earlier tests may have left entries behind or
+	// disabled retries via a server shutdown.
+	enableOIDCRetries()
 	t.Cleanup(cancelAllOIDCRetries)
-	// Start from a clean slate; earlier tests may have left entries behind.
 	cancelAllOIDCRetries()
 
 	const issuerA = "https://issuer-a.example"
@@ -1693,8 +1701,8 @@ func TestOIDCRetryCancel_PerIssuer(t *testing.T) {
 
 	// Register the first provider's retry, then the second's. Under the old
 	// single-global design, registering B cancelled A. It must not now.
-	setOIDCRetryCancel(issuerA, cancelA)
-	setOIDCRetryCancel(issuerB, cancelB)
+	require.True(t, setOIDCRetryCancel(issuerA, cancelA), "issuer A retry should register")
+	require.True(t, setOIDCRetryCancel(issuerB, cancelB), "issuer B retry should register")
 
 	require.NoError(t, ctxA.Err(), "issuer A retry must survive issuer B registration")
 	require.NoError(t, ctxB.Err(), "issuer B retry must be active")
@@ -1702,7 +1710,7 @@ func TestOIDCRetryCancel_PerIssuer(t *testing.T) {
 	// Re-registering the same issuer cancels and replaces only that issuer's
 	// prior retry, leaving the other issuer untouched.
 	ctxB2, cancelB2 := context.WithCancel(t.Context())
-	setOIDCRetryCancel(issuerB, cancelB2)
+	require.True(t, setOIDCRetryCancel(issuerB, cancelB2), "issuer B retry should re-register")
 	require.Error(t, ctxB.Err(), "prior issuer B retry must be cancelled when replaced")
 	require.NoError(t, ctxB2.Err(), "replacement issuer B retry must be active")
 	require.NoError(t, ctxA.Err(), "issuer A must remain active when issuer B is replaced")
@@ -1711,4 +1719,37 @@ func TestOIDCRetryCancel_PerIssuer(t *testing.T) {
 	cancelAllOIDCRetries()
 	require.Error(t, ctxA.Err(), "cancelAllOIDCRetries must cancel issuer A")
 	assert.Error(t, ctxB2.Err(), "cancelAllOIDCRetries must cancel the replacement retry")
+}
+
+// TestOIDCRetry_DisabledAfterShutdown verifies that once shutdown has begun no
+// new OIDC discovery retry can start, closing the race where a late provider
+// (re)initialization would spawn a goroutine that outlives the server.
+func TestOIDCRetry_DisabledAfterShutdown(t *testing.T) {
+	// Restore enabled state for any later tests sharing this package-global.
+	t.Cleanup(enableOIDCRetries)
+	t.Cleanup(cancelAllOIDCRetries)
+	enableOIDCRetries()
+
+	const issuer = "https://issuer.example/shutdown"
+
+	// While enabled, a retry registers and stays active.
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	require.True(t, setOIDCRetryCancel(issuer, cancel1), "retry should register while enabled")
+	require.NoError(t, ctx1.Err(), "registered retry must stay active")
+
+	// Shutdown cancels in-flight retries and blocks new ones.
+	shutdownOIDCRetries()
+	require.Error(t, ctx1.Err(), "shutdown must cancel the in-flight retry")
+
+	// A registration after shutdown is refused and its context is cancelled,
+	// so initializeOIDCProvider will not start the goroutine.
+	ctx2, cancel2 := context.WithCancel(t.Context())
+	require.False(t, setOIDCRetryCancel(issuer, cancel2), "retry must be refused after shutdown")
+	require.Error(t, ctx2.Err(), "refused retry's context must be cancelled")
+
+	// A fresh server instance re-enables retries.
+	enableOIDCRetries()
+	_, cancel3 := context.WithCancel(t.Context())
+	t.Cleanup(cancel3)
+	require.True(t, setOIDCRetryCancel(issuer, cancel3), "retry should register again after re-enable")
 }

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -25,7 +25,7 @@ func TestIsUserAuthenticatedValidAccessToken(t *testing.T) {
 	settings := conf.NewTestSettings().Apply()
 	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
-	s := NewOAuth2Server()
+	s := NewOAuth2Server(t.Context())
 
 	// Initialize gothic exactly as in production
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
@@ -75,7 +75,7 @@ func TestIsUserAuthenticatedTableDriven(t *testing.T) {
 				},
 			}
 
-			s := NewOAuth2Server()
+			s := NewOAuth2Server(t.Context())
 
 			// Initialize gothic exactly as in production
 			gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
@@ -160,7 +160,7 @@ func TestOAuth2Server(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewOAuth2Server()
+			s := NewOAuth2Server(t.Context())
 			tt.test(t, s)
 		})
 	}
@@ -1434,7 +1434,7 @@ func TestInitializeProviders_OIDC_Success(t *testing.T) {
 func TestInitializeProviders_OIDC_DiscoveryFailure(t *testing.T) {
 	goth.ClearProviders()
 	t.Cleanup(goth.ClearProviders)
-	t.Cleanup(cancelOIDCRetry)
+	t.Cleanup(cancelAllOIDCRetries)
 
 	settings := &conf.Settings{
 		Security: conf.Security{
@@ -1654,14 +1654,18 @@ func TestStartOIDCRetry_CanceledByContext(t *testing.T) {
 }
 
 func TestCancelOIDCRetry(t *testing.T) {
-	// Verify cancelOIDCRetry is safe to call when no retry is running
-	cancelOIDCRetry()
+	// Clean up the package-global retry map after the test (it is shared state).
+	t.Cleanup(cancelAllOIDCRetries)
 
-	// Set a cancel function and verify it gets called
+	// cancelAllOIDCRetries must be safe to call when no retry is running.
+	cancelAllOIDCRetries()
+
+	// Set a cancel function for an issuer and verify cancelAllOIDCRetries calls it.
+	const issuer = "https://issuer.example/single"
 	ctx, cancel := context.WithCancel(t.Context())
-	setOIDCRetryCancel(cancel)
+	setOIDCRetryCancel(issuer, cancel)
 
-	cancelOIDCRetry()
+	cancelAllOIDCRetries()
 
 	select {
 	case <-ctx.Done():
@@ -1669,4 +1673,42 @@ func TestCancelOIDCRetry(t *testing.T) {
 	default:
 		t.Error("expected context to be canceled")
 	}
+}
+
+// TestOIDCRetryCancel_PerIssuer is the regression test for the per-issuer OIDC
+// retry fix: with a single
+// package-global cancel func, initializing a second OIDC provider cancelled the
+// first provider's retry. Per-issuer keying must keep each provider's retry
+// independent, and cancelAllOIDCRetries must cancel every outstanding retry.
+func TestOIDCRetryCancel_PerIssuer(t *testing.T) {
+	t.Cleanup(cancelAllOIDCRetries)
+	// Start from a clean slate; earlier tests may have left entries behind.
+	cancelAllOIDCRetries()
+
+	const issuerA = "https://issuer-a.example"
+	const issuerB = "https://issuer-b.example"
+
+	ctxA, cancelA := context.WithCancel(t.Context())
+	ctxB, cancelB := context.WithCancel(t.Context())
+
+	// Register the first provider's retry, then the second's. Under the old
+	// single-global design, registering B cancelled A. It must not now.
+	setOIDCRetryCancel(issuerA, cancelA)
+	setOIDCRetryCancel(issuerB, cancelB)
+
+	require.NoError(t, ctxA.Err(), "issuer A retry must survive issuer B registration")
+	require.NoError(t, ctxB.Err(), "issuer B retry must be active")
+
+	// Re-registering the same issuer cancels and replaces only that issuer's
+	// prior retry, leaving the other issuer untouched.
+	ctxB2, cancelB2 := context.WithCancel(t.Context())
+	setOIDCRetryCancel(issuerB, cancelB2)
+	require.Error(t, ctxB.Err(), "prior issuer B retry must be cancelled when replaced")
+	require.NoError(t, ctxB2.Err(), "replacement issuer B retry must be active")
+	require.NoError(t, ctxA.Err(), "issuer A must remain active when issuer B is replaced")
+
+	// cancelAllOIDCRetries cancels every remaining retry.
+	cancelAllOIDCRetries()
+	require.Error(t, ctxA.Err(), "cancelAllOIDCRetries must cancel issuer A")
+	assert.Error(t, ctxB2.Err(), "cancelAllOIDCRetries must cancel the replacement retry")
 }


### PR DESCRIPTION
## Summary

Two auth-subsystem fixes plus the shutdown wiring they need.

- **Per-issuer OIDC discovery retry.** OIDC discovery retry was tracked with a single package-global cancel func, so configuring a second OIDC provider cancelled the first provider's in-flight retry goroutine. Retries are now keyed per issuer URL in a map under the existing mutex, so each provider retries independently.
- **Shutdown-aware background goroutines.** `NewOAuth2Server` now takes a `context.Context`. The hourly OAuth2 token-cleanup goroutine (previously started with `context.Background()` and a standing TODO) and the OIDC discovery retries now stop on application shutdown. `APIServerService` owns a lifecycle context, derived from the start context and cancelled in `Stop` (and on start rollback).
- **Unified auth-event logging.** api/v2 form login/logout, the OAuth callback, the auth-status check, and the login rate-limit handlers, plus the `internal/api/auth` package logger, now route to the `security` log module so authentication events are co-located with the OAuth/OIDC and provider-init logging (matching the earlier #3381 / #3384 work).

## Behavior change

Auth events that previously logged under `module=api` and `module=auth` now log under `module=security`. Admins or log tooling filtering auth events by the old modules should switch to `module=security`. No API, config, or DB-schema changes.

## Test plan

- [x] `go test -race` green for `internal/security`, `internal/api/v2`, `internal/api/auth`, `internal/analysis`
- [x] `golangci-lint run` 0 issues on affected packages
- [x] New regression test `TestOIDCRetryCancel_PerIssuer` asserts two issuers' retries stay independent and that replace/cancel-all semantics hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown by canceling service lifecycle contexts promptly
  * Made OAuth/OIDC discovery safer by canceling in-flight retries on shutdown or settings reload

* **Refactor**
  * Authentication and V2 controller logging routed to a dedicated security logger for clearer observability
  * OAuth2 server and related background work now respect an application lifecycle context

* **Tests**
  * Added and updated tests for per-issuer OIDC retry behavior, shutdown, and cleanup scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->