### PR TITLE
fix(security): gate forwarded client-IP headers behind trusted proxies

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"14957442-a262-4ecd-b115-35571563112c","pid":866410,"procStart":"146190726","acquiredAt":1778431496034}
+{"sessionId":"cd2d13a5-d14f-402a-ab11-5cc2a9078630","pid":3623053,"procStart":"376362816","acquiredAt":1780731306810}

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -301,46 +301,6 @@ func parseIPFromHeader(headerValue string) string {
 	return ""
 }
 
-// parseFirstIPFromXFF extracts the first valid IP from X-Forwarded-For header.
-func parseFirstIPFromXFF(xff string) string {
-	if xff == "" {
-		return ""
-	}
-	parts := strings.SplitSeq(xff, ",")
-	for part := range parts {
-		if ip := parseIPFromHeader(strings.TrimSpace(part)); ip != "" {
-			return ip
-		}
-	}
-	return ""
-}
-
-// Custom IP Extractor prioritizing CF-Connecting-IP
-func ipExtractorFromCloudflareHeader(req *http.Request) string {
-	// 1. Check CF-Connecting-IP
-	if ip := parseIPFromHeader(req.Header.Get("CF-Connecting-IP")); ip != "" {
-		return ip
-	}
-
-	// 2. Check X-Forwarded-For (taking the first valid IP)
-	if ip := parseFirstIPFromXFF(req.Header.Get(echo.HeaderXForwardedFor)); ip != "" {
-		return ip
-	}
-
-	// 3. Check X-Real-IP
-	if ip := parseIPFromHeader(req.Header.Get(echo.HeaderXRealIP)); ip != "" {
-		return ip
-	}
-
-	// 4. Fallback to Remote Address (might be proxy)
-	remoteAddr, _, _ := net.SplitHostPort(req.RemoteAddr)
-	if ip := parseIPFromHeader(remoteAddr); ip != "" {
-		return ip
-	}
-
-	return remoteAddr
-}
-
 // TunnelDetectionMiddleware inspects headers to determine if the request is likely proxied
 // and sets context values for logging.
 func (c *Controller) TunnelDetectionMiddleware() echo.MiddlewareFunc {
@@ -350,14 +310,21 @@ func (c *Controller) TunnelDetectionMiddleware() echo.MiddlewareFunc {
 			tunneled := false
 			provider := tunnelProviderUnknown
 
-			// Check Cloudflare header first
-			if req.Header.Get("CF-Connecting-IP") != "" {
-				tunneled = true
-				provider = "cloudflare"
-			} else if req.Header.Get(echo.HeaderXForwardedFor) != "" || req.Header.Get(echo.HeaderXRealIP) != "" {
-				// If other proxy headers exist, mark as tunneled but provider is generic
-				tunneled = true
-				provider = "generic"
+			// Only classify the request as tunneled when the IP extractor actually
+			// honored a forwarded header, i.e. the resolved client IP differs from
+			// the immediate connection peer. That happens only for a trusted proxy,
+			// so a directly-connected client cannot spoof a "tunneled" label by
+			// sending forwarded headers from an untrusted address.
+			if peerIP, _ := peerAddrFromRequest(req); peerIP != nil && peerIP.String() != ctx.RealIP() {
+				switch {
+				case req.Header.Get(headerCFConnectingIP) != "":
+					tunneled = true
+					provider = "cloudflare"
+				case req.Header.Get(echo.HeaderXForwardedFor) != "" || req.Header.Get(echo.HeaderXRealIP) != "":
+					// Other proxy headers present: tunneled, but provider is generic.
+					tunneled = true
+					provider = "generic"
+				}
 			}
 
 			ctx.Set("is_tunneled", tunneled)
@@ -449,9 +416,13 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	controlChan chan string,
 	metrics *observability.Metrics, initializeRoutes bool, opts ...Option) (*Controller, error) {
 
-	// Configure IP extractor for Cloudflare proxy support
-	e.IPExtractor = ipExtractorFromCloudflareHeader
-	GetLogger().Info("Configured custom IP extractor prioritizing CF-Connecting-IP")
+	// Configure trusted-proxy-gated IP extractor. Forwarded client-IP headers
+	// (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) are honored only when the
+	// connection peer is a trusted proxy (loopback/link-local/private by default,
+	// plus Security.TrustedProxies); otherwise the real peer address is used.
+	// Reads the trusted set per request from the global settings, so it is hot-reloadable.
+	e.IPExtractor = newTrustedProxyIPExtractor(conf.GetSettings)
+	GetLogger().Info("Configured trusted-proxy-gated IP extractor (forwarded client IP honored only from trusted proxies)")
 
 	// Validate and resolve media export path
 	mediaPath, err := resolveAndValidateMediaPath(settings.Realtime.Audio.Export.Path)

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -416,14 +416,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	controlChan chan string,
 	metrics *observability.Metrics, initializeRoutes bool, opts ...Option) (*Controller, error) {
 
-	// Configure trusted-proxy-gated IP extractor. Forwarded client-IP headers
-	// (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) are honored only when the
-	// connection peer is a trusted proxy (loopback/link-local/private by default,
-	// plus Security.TrustedProxies); otherwise the real peer address is used.
-	// Reads the trusted set per request from the global settings, so it is hot-reloadable.
-	e.IPExtractor = newTrustedProxyIPExtractor(conf.GetSettings)
-	GetLogger().Info("Configured trusted-proxy-gated IP extractor (forwarded client IP honored only from trusted proxies)")
-
 	// Validate and resolve media export path
 	mediaPath, err := resolveAndValidateMediaPath(settings.Realtime.Audio.Export.Path)
 	if err != nil {
@@ -466,6 +458,16 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// lock-free. Kept in sync with the c.Settings field on every save; see the
 	// settingsAtomic field doc and the settings update handlers.
 	c.settingsAtomic.Store(settings)
+
+	// Configure the trusted-proxy-gated IP extractor. Forwarded client-IP headers
+	// (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) are honored only when the
+	// connection peer is a trusted proxy (loopback/link-local/private by default,
+	// plus Security.TrustedProxies); otherwise the real peer address is used. It
+	// reads this controller's own settings snapshot per request (published above
+	// and on every save), so it honors the controller's TrustedProxies and
+	// hot-reloads without a restart.
+	e.IPExtractor = newTrustedProxyIPExtractor(c.controllerSettings)
+	GetLogger().Info("Configured trusted-proxy-gated IP extractor (forwarded client IP honored only from trusted proxies)")
 
 	// Propagate the derived FFprobe path from config validation to the
 	// ffmpeg package so executeFFprobe can find it without PATH lookup.

--- a/internal/api/v2/ip_extractor.go
+++ b/internal/api/v2/ip_extractor.go
@@ -107,21 +107,24 @@ func (tc *trustedProxyChecker) appendCIDRs(entries []string) {
 }
 
 // parseProxyCIDR parses a trusted-proxy entry as either a CIDR or a bare IP
-// (treated as a single-host /32 for IPv4 or /128 for IPv6). Returns false if the
-// entry is neither. net.ParseCIDR normalizes the returned network for both forms.
+// (treated as a single host: /32 for IPv4, /128 for IPv6). Returns false if the
+// entry is neither.
+//
+// The single-host network is built directly from the parsed IP rather than by
+// appending a suffix and re-parsing: an IPv4-mapped IPv6 string (e.g.
+// "::ffff:192.0.2.1") has a non-nil To4(), so a naive "/32" suffix would make
+// net.ParseCIDR read it as a 128-bit address with a 32-bit mask, trusting a /32
+// IPv6 range (2^96 hosts) instead of one host. Using To4() yields a true /32.
 func parseProxyCIDR(entry string) (*net.IPNet, bool) {
 	entry = strings.TrimSpace(entry)
 	if _, network, err := net.ParseCIDR(entry); err == nil {
 		return network, true
 	}
 	if ip := net.ParseIP(entry); ip != nil {
-		suffix := "/32"
-		if ip.To4() == nil {
-			suffix = "/128"
+		if v4 := ip.To4(); v4 != nil {
+			return &net.IPNet{IP: v4, Mask: net.CIDRMask(32, 32)}, true
 		}
-		if _, network, err := net.ParseCIDR(entry + suffix); err == nil {
-			return network, true
-		}
+		return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}, true
 	}
 	return nil, false
 }

--- a/internal/api/v2/ip_extractor.go
+++ b/internal/api/v2/ip_extractor.go
@@ -86,13 +86,34 @@ func buildTrustedProxyChecker(trustedProxies []string) *trustedProxyChecker {
 	return tc
 }
 
-// appendCIDRs parses and appends valid CIDR ranges, skipping any that fail to parse.
-func (tc *trustedProxyChecker) appendCIDRs(cidrs []string) {
-	for _, cidr := range cidrs {
-		if _, network, err := net.ParseCIDR(strings.TrimSpace(cidr)); err == nil {
+// appendCIDRs parses and appends valid trusted-proxy entries, skipping any that
+// fail to parse. Each entry may be a CIDR or a bare IP (a single host).
+func (tc *trustedProxyChecker) appendCIDRs(entries []string) {
+	for _, entry := range entries {
+		if network, ok := parseProxyCIDR(entry); ok {
 			tc.ranges = append(tc.ranges, network)
 		}
 	}
+}
+
+// parseProxyCIDR parses a trusted-proxy entry as either a CIDR or a bare IP
+// (treated as a single-host /32 for IPv4 or /128 for IPv6). Returns false if the
+// entry is neither. net.ParseCIDR normalizes the returned network for both forms.
+func parseProxyCIDR(entry string) (*net.IPNet, bool) {
+	entry = strings.TrimSpace(entry)
+	if _, network, err := net.ParseCIDR(entry); err == nil {
+		return network, true
+	}
+	if ip := net.ParseIP(entry); ip != nil {
+		suffix := "/32"
+		if ip.To4() == nil {
+			suffix = "/128"
+		}
+		if _, network, err := net.ParseCIDR(entry + suffix); err == nil {
+			return network, true
+		}
+	}
+	return nil, false
 }
 
 // trust reports whether ip is a trusted proxy peer.
@@ -194,7 +215,10 @@ func resolveTrustedProxyChecker(cache *atomic.Pointer[trustedProxyChecker], getS
 func peerAddrFromRequest(req *http.Request) (peerIP net.IP, host string) {
 	var err error
 	if host, _, err = net.SplitHostPort(req.RemoteAddr); err != nil {
-		host = req.RemoteAddr
+		// No port (e.g. a bare "[::1]" or "127.0.0.1"). Strip IPv6 brackets so
+		// net.ParseIP can parse it, otherwise a bracketed loopback/private peer
+		// would fail to parse and be treated as untrusted.
+		host = strings.TrimSuffix(strings.TrimPrefix(req.RemoteAddr, "["), "]")
 	}
 	if before, _, found := strings.Cut(host, "%"); found {
 		host = before

--- a/internal/api/v2/ip_extractor.go
+++ b/internal/api/v2/ip_extractor.go
@@ -23,6 +23,16 @@ import (
 // for it (it only defines X-Forwarded-For and X-Real-IP), so it is named here.
 const headerCFConnectingIP = "CF-Connecting-IP"
 
+// Canonical map keys for the forwarded headers. http.Header stores keys in
+// canonical MIME form, so direct map lookups (used on the per-request untrusted
+// path) must use the canonical spelling. "CF-Connecting-IP" is not already
+// canonical, so precomputing it avoids re-canonicalizing on every request.
+var (
+	canonicalCFConnectingIP = http.CanonicalHeaderKey(headerCFConnectingIP)
+	canonicalXForwardedFor  = http.CanonicalHeaderKey(echo.HeaderXForwardedFor)
+	canonicalXRealIP        = http.CanonicalHeaderKey(echo.HeaderXRealIP)
+)
+
 // cloudflareEdgeCIDRs lists Cloudflare's published proxy IP ranges
 // (https://www.cloudflare.com/ips/). These ranges are stable and change rarely;
 // kept in sync manually. Expanded from the Security.TrustedProxies "cloudflare"
@@ -175,17 +185,22 @@ func (tc *trustedProxyChecker) clientIPFromXFF(xff string) string {
 	}
 	parts := strings.Split(xff, ",")
 	for i, part := range slices.Backward(parts) {
-		ipStr := parseIPFromHeader(strings.TrimSpace(part))
-		if ipStr == "" {
+		hop := strings.TrimSpace(part)
+		// Strip an IPv6 zone id (e.g. fe80::1%eth0) before parsing.
+		if before, _, found := strings.Cut(hop, "%"); found {
+			hop = before
+		}
+		ip := net.ParseIP(hop)
+		if ip == nil {
 			// Malformed hop: nothing further left can be trusted; fall back.
 			return ""
 		}
-		if !tc.trustForwardedHop(net.ParseIP(ipStr)) {
-			return ipStr // nearest non-proxy hop = real client
+		if !tc.trustForwardedHop(ip) {
+			return ip.String() // nearest non-proxy hop = real client
 		}
 		if i == 0 {
 			// All hops are configured proxies; the leftmost is the original client.
-			return ipStr
+			return ip.String()
 		}
 	}
 	return ""
@@ -273,21 +288,33 @@ func newTrustedProxyIPExtractor(getSettings func() *conf.Settings) echo.IPExtrac
 // only built when a forwarded header is actually present, keeping the
 // no-header untrusted path (ordinary direct clients) allocation-free.
 func logIgnoredForwardedHeader(req *http.Request, peerHost string) {
-	var present []string
-	if req.Header.Get(headerCFConnectingIP) != "" {
+	h := req.Header
+	cfPresent := headerNonEmpty(h, canonicalCFConnectingIP)
+	xffPresent := headerNonEmpty(h, canonicalXForwardedFor)
+	xriPresent := headerNonEmpty(h, canonicalXRealIP)
+	if !cfPresent && !xffPresent && !xriPresent {
+		return // fast path: no forwarded headers, zero allocation
+	}
+	present := make([]string, 0, 3)
+	if cfPresent {
 		present = append(present, headerCFConnectingIP)
 	}
-	if req.Header.Get(echo.HeaderXForwardedFor) != "" {
+	if xffPresent {
 		present = append(present, echo.HeaderXForwardedFor)
 	}
-	if req.Header.Get(echo.HeaderXRealIP) != "" {
+	if xriPresent {
 		present = append(present, echo.HeaderXRealIP)
-	}
-	if len(present) == 0 {
-		return
 	}
 	GetLogger().Debug("Ignoring forwarded client-IP header from untrusted peer; if this peer is your reverse proxy, add its CIDR (or \"cloudflare\") to security.trustedproxies",
 		logger.String("peer", peerHost),
 		logger.String("headers", strings.Join(present, ",")),
 	)
+}
+
+// headerNonEmpty reports whether a canonical header key has a non-empty first
+// value, via a direct map lookup that avoids the key canonicalization (and
+// allocation) http.Header.Get performs for a non-canonical key.
+func headerNonEmpty(h http.Header, canonicalKey string) bool {
+	values := h[canonicalKey]
+	return len(values) > 0 && values[0] != ""
 }

--- a/internal/api/v2/ip_extractor.go
+++ b/internal/api/v2/ip_extractor.go
@@ -1,0 +1,269 @@
+// ip_extractor.go provides a trusted-proxy-gated client IP extractor for Echo.
+//
+// The extractor only honors proxy-supplied client-IP headers (CF-Connecting-IP,
+// X-Forwarded-For, X-Real-IP) when the immediate connection peer is a trusted
+// reverse proxy. On a directly-exposed instance this prevents a client from
+// spoofing its source IP, which feeds rate limiting, ban/allow lists, and logs.
+package api
+
+import (
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"sync/atomic"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// headerCFConnectingIP is Cloudflare's client-IP header. Echo has no constant
+// for it (it only defines X-Forwarded-For and X-Real-IP), so it is named here.
+const headerCFConnectingIP = "CF-Connecting-IP"
+
+// cloudflareEdgeCIDRs lists Cloudflare's published proxy IP ranges
+// (https://www.cloudflare.com/ips/). These ranges are stable and change rarely;
+// kept in sync manually. Expanded from the Security.TrustedProxies "cloudflare"
+// preset (conf.TrustedProxyCloudflarePreset).
+var cloudflareEdgeCIDRs = []string{
+	// IPv4
+	"173.245.48.0/20",
+	"103.21.244.0/22",
+	"103.22.200.0/22",
+	"103.31.4.0/22",
+	"141.101.64.0/18",
+	"108.162.192.0/18",
+	"190.93.240.0/20",
+	"188.114.96.0/20",
+	"197.234.240.0/22",
+	"198.41.128.0/17",
+	"162.158.0.0/15",
+	"104.16.0.0/13",
+	"104.24.0.0/14",
+	"172.64.0.0/13",
+	"131.0.72.0/22",
+	// IPv6
+	"2400:cb00::/32",
+	"2606:4700::/32",
+	"2803:f800::/32",
+	"2405:b500::/32",
+	"2405:8100::/32",
+	"2a06:98c0::/29",
+	"2c0f:f248::/32",
+}
+
+// trustedProxyChecker decides whether an immediate peer address is a trusted
+// reverse proxy whose forwarded client-IP headers may be honored. Loopback,
+// link-local, and private (RFC1918/ULA) addresses are always trusted, matching
+// Echo's default TrustOption behavior, plus any operator-configured CIDR ranges.
+type trustedProxyChecker struct {
+	// raw is the Security.TrustedProxies slice this checker was built from. It is
+	// used to detect configuration changes for hot-reload so the CIDR list is not
+	// re-parsed on every request.
+	raw    []string
+	ranges []*net.IPNet
+}
+
+// buildTrustedProxyChecker parses the configured trusted-proxy entries into a
+// checker. Blank entries are skipped and the reserved "cloudflare" preset
+// expands to Cloudflare's published ranges. Invalid CIDRs are silently skipped
+// here (conf validation rejects them at load time; this is defense in depth).
+func buildTrustedProxyChecker(trustedProxies []string) *trustedProxyChecker {
+	tc := &trustedProxyChecker{raw: slices.Clone(trustedProxies)}
+	for _, entry := range trustedProxies {
+		trimmed := strings.TrimSpace(entry)
+		switch {
+		case trimmed == "":
+			continue
+		case strings.EqualFold(trimmed, conf.TrustedProxyCloudflarePreset):
+			tc.appendCIDRs(cloudflareEdgeCIDRs)
+		default:
+			tc.appendCIDRs([]string{trimmed})
+		}
+	}
+	return tc
+}
+
+// appendCIDRs parses and appends valid CIDR ranges, skipping any that fail to parse.
+func (tc *trustedProxyChecker) appendCIDRs(cidrs []string) {
+	for _, cidr := range cidrs {
+		if _, network, err := net.ParseCIDR(strings.TrimSpace(cidr)); err == nil {
+			tc.ranges = append(tc.ranges, network)
+		}
+	}
+}
+
+// trust reports whether ip is a trusted proxy peer.
+func (tc *trustedProxyChecker) trust(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() {
+		return true
+	}
+	for _, network := range tc.ranges {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// trustForwardedHop reports whether an X-Forwarded-For hop is an explicitly
+// configured trusted proxy. It is deliberately NARROWER than trust(): it does
+// not trust loopback/link-local/private by default, only operator-configured
+// CIDRs (including the cloudflare preset, whose ranges are in tc.ranges).
+//
+// The asymmetry is intentional. The immediate peer (trust()) is the real TCP
+// socket and cannot be forged, so trusting private/loopback peers by default is
+// safe and keeps home-LAN setups zero-config. An X-Forwarded-For hop is
+// attacker-supplied, and a real client is frequently on a private address; if
+// private hops were skipped as proxies, a LAN client could prepend a forged
+// entry and have its real (private) hop skipped, spoofing its attributed IP.
+func (tc *trustedProxyChecker) trustForwardedHop(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	for _, network := range tc.ranges {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientIPFromXFF resolves the real client IP from an X-Forwarded-For header,
+// assuming the immediate peer is already known to be a trusted proxy. It walks
+// the hop chain from the rightmost (closest to this server) entry leftward,
+// skipping hops that are explicitly configured proxies (trustForwardedHop), and
+// returns the first non-proxy address: the real external client. If every hop
+// is a configured proxy, the leftmost entry is returned as the original client.
+//
+// Walking from the right, and skipping only configured proxies, defeats
+// spoofing: a client cannot forge a leftmost entry, because proxies append the
+// address they actually saw, so the attacker's real address sits to the right
+// of any value they injected and is never skipped. Multi-hop chains with
+// internal proxies therefore require those proxies' CIDRs in
+// security.trustedproxies for correct attribution. Returns "" for an empty or
+// malformed header, letting the caller fall back to the next source.
+func (tc *trustedProxyChecker) clientIPFromXFF(xff string) string {
+	if xff == "" {
+		return ""
+	}
+	parts := strings.Split(xff, ",")
+	for i, part := range slices.Backward(parts) {
+		ipStr := parseIPFromHeader(strings.TrimSpace(part))
+		if ipStr == "" {
+			// Malformed hop: nothing further left can be trusted; fall back.
+			return ""
+		}
+		if !tc.trustForwardedHop(net.ParseIP(ipStr)) {
+			return ipStr // nearest non-proxy hop = real client
+		}
+		if i == 0 {
+			// All hops are configured proxies; the leftmost is the original client.
+			return ipStr
+		}
+	}
+	return ""
+}
+
+// resolveTrustedProxyChecker returns the checker for the current configuration,
+// rebuilding and caching it only when the Security.TrustedProxies list changes.
+// This keeps the trusted set hot-reloadable without re-parsing CIDRs per request.
+func resolveTrustedProxyChecker(cache *atomic.Pointer[trustedProxyChecker], getSettings func() *conf.Settings) *trustedProxyChecker {
+	var trustedProxies []string
+	if getSettings != nil {
+		if settings := getSettings(); settings != nil {
+			trustedProxies = settings.Security.TrustedProxies
+		}
+	}
+	if cached := cache.Load(); cached != nil && slices.Equal(cached.raw, trustedProxies) {
+		return cached
+	}
+	checker := buildTrustedProxyChecker(trustedProxies)
+	cache.Store(checker)
+	return checker
+}
+
+// peerAddrFromRequest extracts the immediate peer address from req.RemoteAddr,
+// returning the parsed IP (nil if unparseable) and the raw host string for
+// fallback. An IPv6 zone identifier, if present, is stripped before parsing.
+func peerAddrFromRequest(req *http.Request) (peerIP net.IP, host string) {
+	var err error
+	if host, _, err = net.SplitHostPort(req.RemoteAddr); err != nil {
+		host = req.RemoteAddr
+	}
+	if before, _, found := strings.Cut(host, "%"); found {
+		host = before
+	}
+	peerIP = net.ParseIP(host)
+	return peerIP, host
+}
+
+// newTrustedProxyIPExtractor returns an Echo IPExtractor that honors proxy
+// client-IP headers (CF-Connecting-IP, then X-Forwarded-For, then X-Real-IP)
+// only when the immediate peer is a trusted proxy, otherwise falling back to the
+// real connection address. The trusted set is read from Security.TrustedProxies
+// via getSettings on each request so changes take effect without a restart.
+func newTrustedProxyIPExtractor(getSettings func() *conf.Settings) echo.IPExtractor {
+	var cache atomic.Pointer[trustedProxyChecker]
+	return func(req *http.Request) string {
+		peerIP, peerHost := peerAddrFromRequest(req)
+
+		// Only honor forwarded client-IP headers from a trusted proxy peer.
+		if checker := resolveTrustedProxyChecker(&cache, getSettings); checker.trust(peerIP) {
+			if ip := parseIPFromHeader(req.Header.Get(headerCFConnectingIP)); ip != "" {
+				return ip
+			}
+			if ip := checker.clientIPFromXFF(req.Header.Get(echo.HeaderXForwardedFor)); ip != "" {
+				return ip
+			}
+			if ip := parseIPFromHeader(req.Header.Get(echo.HeaderXRealIP)); ip != "" {
+				return ip
+			}
+		} else {
+			// Untrusted peer: forwarded headers are ignored. Leave a DEBUG
+			// breadcrumb naming the peer so a misconfigured trusted proxy is
+			// self-diagnosing, without flooding logs (a public instance gets
+			// constant scanner header noise, so this stays at DEBUG).
+			logIgnoredForwardedHeader(req, peerHost)
+		}
+
+		// Untrusted peer, or trusted peer with no forwarded headers: use the
+		// real peer address.
+		if peerIP != nil {
+			return peerIP.String()
+		}
+		return peerHost
+	}
+}
+
+// logIgnoredForwardedHeader emits a DEBUG breadcrumb when forwarded client-IP
+// headers arrive from an untrusted peer and are therefore ignored, naming the
+// peer address an operator would add to security.trustedproxies. It is DEBUG
+// (not WARN) on purpose: a directly-exposed instance receives constant scanner
+// header noise, so a louder level would flood logs and alarm users. Fields are
+// only built when a forwarded header is actually present, keeping the
+// no-header untrusted path (ordinary direct clients) allocation-free.
+func logIgnoredForwardedHeader(req *http.Request, peerHost string) {
+	var present []string
+	if req.Header.Get(headerCFConnectingIP) != "" {
+		present = append(present, headerCFConnectingIP)
+	}
+	if req.Header.Get(echo.HeaderXForwardedFor) != "" {
+		present = append(present, echo.HeaderXForwardedFor)
+	}
+	if req.Header.Get(echo.HeaderXRealIP) != "" {
+		present = append(present, echo.HeaderXRealIP)
+	}
+	if len(present) == 0 {
+		return
+	}
+	GetLogger().Debug("Ignoring forwarded client-IP header from untrusted peer; if this peer is your reverse proxy, add its CIDR (or \"cloudflare\") to security.trustedproxies",
+		logger.String("peer", peerHost),
+		logger.String("headers", strings.Join(present, ",")),
+	)
+}

--- a/internal/api/v2/ip_extractor_test.go
+++ b/internal/api/v2/ip_extractor_test.go
@@ -337,6 +337,44 @@ func TestTrustedProxyChecker_TrustForwardedHop(t *testing.T) {
 	assert.False(t, checker.trustForwardedHop(nil), "nil IP must never be a trusted hop")
 }
 
+// TestParseProxyCIDR verifies bare IPs become single-host networks, including
+// the IPv4-mapped IPv6 case that must not widen into a /32 over 128 bits.
+func TestParseProxyCIDR(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entry    string
+		ok       bool
+		wantOnes int
+		wantBits int
+		contains string
+		excludes string
+	}{
+		{name: "IPv4 CIDR", entry: "203.0.113.0/24", ok: true, wantOnes: 24, wantBits: 32, contains: "203.0.113.9", excludes: "203.0.114.1"},
+		{name: "bare IPv4", entry: "203.0.113.5", ok: true, wantOnes: 32, wantBits: 32, contains: "203.0.113.5", excludes: "203.0.113.6"},
+		{name: "bare IPv6", entry: "2001:db8::1", ok: true, wantOnes: 128, wantBits: 128, contains: "2001:db8::1", excludes: "2001:db8::2"},
+		{name: "IPv4-mapped IPv6 stays single host", entry: "::ffff:198.51.100.7", ok: true, wantOnes: 32, wantBits: 32, contains: "198.51.100.7", excludes: "198.51.100.8"},
+		{name: "garbage", entry: "not-an-ip", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			network, ok := parseProxyCIDR(tt.entry)
+			require.Equal(t, tt.ok, ok)
+			if !tt.ok {
+				return
+			}
+			ones, bits := network.Mask.Size()
+			assert.Equal(t, tt.wantOnes, ones, "mask ones")
+			assert.Equal(t, tt.wantBits, bits, "mask bits")
+			assert.True(t, network.Contains(mustParseIP(t, tt.contains)), "should contain %s", tt.contains)
+			assert.False(t, network.Contains(mustParseIP(t, tt.excludes)), "should not contain %s", tt.excludes)
+		})
+	}
+}
+
 // TestResolveTrustedProxyChecker_CacheReuse verifies the checker is reused while
 // the configuration is unchanged and rebuilt when it changes.
 func TestResolveTrustedProxyChecker_CacheReuse(t *testing.T) {

--- a/internal/api/v2/ip_extractor_test.go
+++ b/internal/api/v2/ip_extractor_test.go
@@ -132,6 +132,33 @@ func TestTrustedProxyIPExtractor(t *testing.T) {
 			want:           "203.0.113.9",
 		},
 		{
+			name:           "configured bare IPv4 trusts that single host",
+			trustedProxies: []string{"198.51.100.7"},
+			remoteAddr:     "198.51.100.7:40000",
+			headers:        map[string]string{cfHeader: "203.0.113.9"},
+			want:           "203.0.113.9",
+		},
+		{
+			name:           "configured bare IPv4 does not trust a different host",
+			trustedProxies: []string{"198.51.100.7"},
+			remoteAddr:     "198.51.100.8:40000",
+			headers:        map[string]string{cfHeader: "1.2.3.4"},
+			want:           "198.51.100.8",
+		},
+		{
+			name:           "configured bare IPv6 trusts that single host",
+			trustedProxies: []string{"2001:db8::1"},
+			remoteAddr:     "[2001:db8::1]:40000",
+			headers:        map[string]string{cfHeader: "203.0.113.9"},
+			want:           "203.0.113.9",
+		},
+		{
+			name:       "IPv6 loopback peer bracketed without port honors header",
+			remoteAddr: "[::1]",
+			headers:    map[string]string{cfHeader: "203.0.113.5"},
+			want:       "203.0.113.5",
+		},
+		{
 			name:           "cloudflare preset trusts cloudflare edge range",
 			trustedProxies: []string{conf.TrustedProxyCloudflarePreset},
 			remoteAddr:     "173.245.48.10:40000", // within 173.245.48.0/20

--- a/internal/api/v2/ip_extractor_test.go
+++ b/internal/api/v2/ip_extractor_test.go
@@ -381,6 +381,21 @@ func TestLogIgnoredForwardedHeader(t *testing.T) {
 	})
 }
 
+// TestHeaderNonEmpty_CanonicalKey verifies the direct-map header check uses the
+// canonical stored key. "CF-Connecting-IP" is not in canonical MIME form, so a
+// naive req.Header["CF-Connecting-IP"] lookup would miss the value http.Header
+// stores under "Cf-Connecting-Ip".
+func TestHeaderNonEmpty_CanonicalKey(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req.Header.Set("CF-Connecting-IP", "1.2.3.4")
+
+	assert.True(t, headerNonEmpty(req.Header, canonicalCFConnectingIP), "CF-Connecting-IP must be detected via its canonical key")
+	assert.False(t, headerNonEmpty(req.Header, canonicalXForwardedFor), "absent X-Forwarded-For must be false")
+	assert.False(t, headerNonEmpty(req.Header, canonicalXRealIP), "absent X-Real-IP must be false")
+}
+
 func mustParseIP(t *testing.T, s string) net.IP {
 	t.Helper()
 	ip := net.ParseIP(s)

--- a/internal/api/v2/ip_extractor_test.go
+++ b/internal/api/v2/ip_extractor_test.go
@@ -1,0 +1,362 @@
+// ip_extractor_test.go: tests for the trusted-proxy-gated client IP extractor.
+
+package api
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// testPublicPeerAddr is a public (untrusted-by-default) RemoteAddr reused across
+// the spoofing and breadcrumb test cases.
+const testPublicPeerAddr = "203.0.113.50:40000"
+
+// settingsGetterWithProxies returns a getSettings function whose
+// Security.TrustedProxies is set to the given entries.
+func settingsGetterWithProxies(trustedProxies ...string) func() *conf.Settings {
+	settings := &conf.Settings{}
+	settings.Security.TrustedProxies = trustedProxies
+	return func() *conf.Settings { return settings }
+}
+
+func TestTrustedProxyIPExtractor(t *testing.T) {
+	t.Parallel()
+
+	const (
+		cfHeader  = "CF-Connecting-IP"
+		xffHeader = "X-Forwarded-For"
+		xriHeader = "X-Real-IP"
+	)
+
+	tests := []struct {
+		name           string
+		trustedProxies []string
+		remoteAddr     string
+		headers        map[string]string
+		want           string
+	}{
+		{
+			name:       "loopback peer honors CF-Connecting-IP",
+			remoteAddr: "127.0.0.1:54321",
+			headers:    map[string]string{cfHeader: "203.0.113.5"},
+			want:       "203.0.113.5",
+		},
+		{
+			// Single-hop XFF (the common reverse-proxy case): the sole entry is the
+			// real client and is returned with no proxy config needed.
+			name:       "trusted peer single-hop XFF returns client",
+			remoteAddr: "192.168.1.10:40000",
+			headers:    map[string]string{xffHeader: "203.0.113.7"},
+			want:       "203.0.113.7",
+		},
+		{
+			// XFF append-spoofing: an attacker prepends a forged value; the trusted
+			// proxy appends the attacker's real address to the right. The walk
+			// returns the real (rightmost non-proxy) IP, not the forged leftmost.
+			name:       "trusted peer ignores forged leftmost XFF entry",
+			remoteAddr: "127.0.0.1:40000",
+			headers:    map[string]string{xffHeader: "127.0.0.1, 203.0.113.99"},
+			want:       "203.0.113.99",
+		},
+		{
+			// LAN-client spoof: a private real client prepends a forged public IP.
+			// With no configured proxy CIDRs, the real private hop is NOT treated
+			// as a proxy, so it is returned and the forged leftmost never wins.
+			name:       "trusted peer does not let a LAN client spoof via XFF prepend",
+			remoteAddr: "192.168.1.5:40000",
+			headers:    map[string]string{xffHeader: "8.8.8.8, 192.168.1.99"},
+			want:       "192.168.1.99",
+		},
+		{
+			// Configured intermediate proxies are skipped to reach the real client.
+			name:           "trusted peer skips configured proxy hops to reach client",
+			trustedProxies: []string{"10.0.0.0/8"},
+			remoteAddr:     "10.0.0.2:40000",
+			headers:        map[string]string{xffHeader: "203.0.113.7, 10.0.0.1, 10.0.0.2"},
+			want:           "203.0.113.7",
+		},
+		{
+			// Every hop is a configured proxy (internal chain): the leftmost entry
+			// is the original client.
+			name:           "trusted peer all configured-proxy hops returns leftmost client",
+			trustedProxies: []string{"10.0.0.0/8"},
+			remoteAddr:     "10.0.0.5:40000",
+			headers:        map[string]string{xffHeader: "10.0.0.50, 10.0.0.6"},
+			want:           "10.0.0.50",
+		},
+		{
+			name:       "private peer honors X-Real-IP",
+			remoteAddr: "10.0.0.5:40000",
+			headers:    map[string]string{xriHeader: "203.0.113.9"},
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "CF-Connecting-IP takes precedence over XFF for trusted peer",
+			remoteAddr: "127.0.0.1:40000",
+			headers:    map[string]string{cfHeader: "203.0.113.5", xffHeader: "198.51.100.9"},
+			want:       "203.0.113.5",
+		},
+		{
+			// The security fix: a directly-exposed instance must not trust a
+			// spoofed CF-Connecting-IP header from an untrusted public peer.
+			name:       "public peer ignores spoofed CF-Connecting-IP",
+			remoteAddr: testPublicPeerAddr,
+			headers:    map[string]string{cfHeader: "1.2.3.4"},
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "public peer ignores spoofed XFF",
+			remoteAddr: "198.51.100.7:40000",
+			headers:    map[string]string{xffHeader: "1.2.3.4"},
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "public peer ignores spoofed X-Real-IP",
+			remoteAddr: "198.51.100.7:40000",
+			headers:    map[string]string{xriHeader: "1.2.3.4"},
+			want:       "198.51.100.7",
+		},
+		{
+			name:           "configured CIDR trusts public proxy",
+			trustedProxies: []string{"198.51.100.0/24"},
+			remoteAddr:     "198.51.100.7:40000",
+			headers:        map[string]string{cfHeader: "203.0.113.9"},
+			want:           "203.0.113.9",
+		},
+		{
+			name:           "cloudflare preset trusts cloudflare edge range",
+			trustedProxies: []string{conf.TrustedProxyCloudflarePreset},
+			remoteAddr:     "173.245.48.10:40000", // within 173.245.48.0/20
+			headers:        map[string]string{cfHeader: "203.0.113.11"},
+			want:           "203.0.113.11",
+		},
+		{
+			name:           "cloudflare preset does not trust non-cloudflare public peer",
+			trustedProxies: []string{conf.TrustedProxyCloudflarePreset},
+			remoteAddr:     testPublicPeerAddr,
+			headers:        map[string]string{cfHeader: "1.2.3.4"},
+			want:           "203.0.113.50",
+		},
+		{
+			name:       "no forwarded headers returns peer address",
+			remoteAddr: testPublicPeerAddr,
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "trusted peer with no forwarded headers returns peer address",
+			remoteAddr: "127.0.0.1:40000",
+			want:       "127.0.0.1",
+		},
+		{
+			name:       "remote addr without port is parsed",
+			remoteAddr: "127.0.0.1",
+			headers:    map[string]string{cfHeader: "203.0.113.5"},
+			want:       "203.0.113.5",
+		},
+		{
+			name:       "IPv6 private peer honors CF header",
+			remoteAddr: "[fd00::1]:40000",
+			headers:    map[string]string{cfHeader: "203.0.113.5"},
+			want:       "203.0.113.5",
+		},
+		{
+			name:       "IPv6 public peer ignores spoofed CF header",
+			remoteAddr: "[2001:db8::1]:40000",
+			headers:    map[string]string{cfHeader: "1.2.3.4"},
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "invalid XFF entries fall through to peer address",
+			remoteAddr: "192.168.1.10:40000",
+			headers:    map[string]string{xffHeader: "not-an-ip"},
+			want:       "192.168.1.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			extractor := newTrustedProxyIPExtractor(settingsGetterWithProxies(tt.trustedProxies...))
+
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			req.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			assert.Equal(t, tt.want, extractor(req))
+		})
+	}
+}
+
+// TestTrustedProxyIPExtractor_HotReload verifies that changing
+// Security.TrustedProxies between requests takes effect without rebuilding the
+// extractor (hot-reload), and that the parsed-CIDR cache is refreshed on change.
+func TestTrustedProxyIPExtractor_HotReload(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	extractor := newTrustedProxyIPExtractor(func() *conf.Settings { return settings })
+
+	newReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.RemoteAddr = "198.51.100.7:40000" // public peer
+		req.Header.Set("CF-Connecting-IP", "203.0.113.9")
+		return req
+	}
+
+	// Initially no trusted proxies: the public peer is untrusted, so the spoofed
+	// header is ignored and the real peer address is returned.
+	assert.Equal(t, "198.51.100.7", extractor(newReq()), "untrusted peer should not honor forwarded header")
+
+	// Hot-reload: trust the peer's subnet. The next request must honor the header.
+	settings.Security.TrustedProxies = []string{"198.51.100.0/24"}
+	assert.Equal(t, "203.0.113.9", extractor(newReq()), "newly trusted peer should honor forwarded header")
+
+	// Hot-reload back to empty: the peer is untrusted again.
+	settings.Security.TrustedProxies = nil
+	assert.Equal(t, "198.51.100.7", extractor(newReq()), "removing trust should ignore forwarded header again")
+}
+
+// TestTrustedProxyIPExtractor_NilSettings verifies the extractor is safe when
+// the settings getter is nil or returns nil (falls back to default trust set).
+func TestTrustedProxyIPExtractor_NilSettings(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]func() *conf.Settings{
+		"nil getter":         nil,
+		"getter returns nil": func() *conf.Settings { return nil },
+		"empty settings":     func() *conf.Settings { return &conf.Settings{} },
+	}
+
+	for name, getter := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			extractor := newTrustedProxyIPExtractor(getter)
+
+			// Loopback is always trusted, so the header is honored.
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			req.RemoteAddr = "127.0.0.1:40000"
+			req.Header.Set("CF-Connecting-IP", "203.0.113.5")
+			assert.Equal(t, "203.0.113.5", extractor(req))
+
+			// Public peer is untrusted by default.
+			req2 := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			req2.RemoteAddr = testPublicPeerAddr
+			req2.Header.Set("CF-Connecting-IP", "1.2.3.4")
+			assert.Equal(t, "203.0.113.50", extractor(req2))
+		})
+	}
+}
+
+func TestTrustedProxyChecker_Trust(t *testing.T) {
+	t.Parallel()
+
+	checker := buildTrustedProxyChecker([]string{"198.51.100.0/24", "  ", conf.TrustedProxyCloudflarePreset})
+
+	trusted := []string{
+		"127.0.0.1",     // loopback
+		"::1",           // IPv6 loopback
+		"10.1.2.3",      // private
+		"192.168.0.5",   // private
+		"fd00::1",       // IPv6 ULA (private)
+		"fe80::1",       // link-local
+		"198.51.100.42", // configured CIDR
+		"173.245.48.10", // cloudflare range
+	}
+	for _, ip := range trusted {
+		assert.Truef(t, checker.trust(mustParseIP(t, ip)), "expected %s to be trusted", ip)
+	}
+
+	untrusted := []string{
+		"203.0.113.1", // public, not configured
+		"8.8.8.8",     // public
+		"2001:db8::1", // public IPv6
+	}
+	for _, ip := range untrusted {
+		assert.Falsef(t, checker.trust(mustParseIP(t, ip)), "expected %s to be untrusted", ip)
+	}
+
+	assert.False(t, checker.trust(nil), "nil IP must never be trusted")
+}
+
+// TestTrustedProxyChecker_TrustForwardedHop verifies that X-Forwarded-For hop
+// trust is narrower than peer trust: only explicitly configured CIDRs count as
+// proxy hops, while loopback/private/link-local are trusted peers but NOT
+// skippable forwarded hops (so a private real client can't be spoofed past).
+func TestTrustedProxyChecker_TrustForwardedHop(t *testing.T) {
+	t.Parallel()
+
+	checker := buildTrustedProxyChecker([]string{"203.0.113.0/24"})
+
+	assert.True(t, checker.trustForwardedHop(mustParseIP(t, "203.0.113.9")), "configured CIDR is a trusted hop")
+
+	// Default-trusted peer addresses must NOT be skippable forwarded hops.
+	for _, ip := range []string{"127.0.0.1", "::1", "192.168.1.1", "10.0.0.1", "fe80::1"} {
+		assert.Falsef(t, checker.trustForwardedHop(mustParseIP(t, ip)), "%s must not be a trusted forwarded hop", ip)
+		assert.Truef(t, checker.trust(mustParseIP(t, ip)), "%s should still be a trusted peer", ip)
+	}
+
+	assert.False(t, checker.trustForwardedHop(nil), "nil IP must never be a trusted hop")
+}
+
+// TestResolveTrustedProxyChecker_CacheReuse verifies the checker is reused while
+// the configuration is unchanged and rebuilt when it changes.
+func TestResolveTrustedProxyChecker_CacheReuse(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.Security.TrustedProxies = []string{"198.51.100.0/24"}
+	getSettings := func() *conf.Settings { return settings }
+
+	var cache atomic.Pointer[trustedProxyChecker]
+
+	first := resolveTrustedProxyChecker(&cache, getSettings)
+	second := resolveTrustedProxyChecker(&cache, getSettings)
+	assert.Same(t, first, second, "checker should be cached while config is unchanged")
+
+	settings.Security.TrustedProxies = []string{"203.0.113.0/24"}
+	third := resolveTrustedProxyChecker(&cache, getSettings)
+	assert.NotSame(t, second, third, "checker should be rebuilt when config changes")
+}
+
+// TestLogIgnoredForwardedHeader exercises the DEBUG breadcrumb helper for both
+// the header-present and header-absent (early-return) branches. It asserts the
+// path is panic-safe; the log line itself is a side effect on the global logger
+// and is not captured here.
+func TestLogIgnoredForwardedHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with forwarded headers", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.RemoteAddr = testPublicPeerAddr
+		req.Header.Set("CF-Connecting-IP", "1.2.3.4")
+		req.Header.Set("X-Forwarded-For", "1.2.3.4")
+		assert.NotPanics(t, func() { logIgnoredForwardedHeader(req, "203.0.113.50") })
+	})
+
+	t.Run("without forwarded headers", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.RemoteAddr = testPublicPeerAddr
+		assert.NotPanics(t, func() { logIgnoredForwardedHeader(req, "203.0.113.50") })
+	})
+}
+
+func mustParseIP(t *testing.T, s string) net.IP {
+	t.Helper()
+	ip := net.ParseIP(s)
+	require.NotNil(t, ip, "test IP %q must parse", s)
+	return ip
+}

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -96,6 +96,7 @@ func CloneSettings(src *Settings) *Settings {
 
 	// Security.
 	dst.Security.OAuthProviders = cloneOAuthProviders(src.Security.OAuthProviders)
+	dst.Security.TrustedProxies = slices.Clone(src.Security.TrustedProxies)
 
 	// Backup.
 	dst.Backup.Targets = cloneBackupTargets(src.Backup.Targets)

--- a/internal/conf/clone_test.go
+++ b/internal/conf/clone_test.go
@@ -134,6 +134,7 @@ func newPopulatedSettings() *Settings {
 	s.Security.OAuthProviders = []OAuthProviderConfig{
 		{Provider: "google", Scopes: []string{"openid", "email"}},
 	}
+	s.Security.TrustedProxies = []string{"cloudflare", "10.0.0.0/8"}
 
 	// Include nested slices and nested maps inside the Settings map[string]any
 	// so the clone test catches a regression if the deep copy ever degrades
@@ -250,6 +251,7 @@ func mutateCloneEverywhere(dst *Settings) {
 	dst.Realtime.SpeciesTracking.SeasonalTracking.Seasons[mutated] = Season{}
 
 	dst.Security.OAuthProviders[0].Scopes[0] = mutated
+	dst.Security.TrustedProxies[0] = mutated
 
 	dst.Backup.Targets[0].Settings["path"] = mutated
 	// Mutate nested slice and nested map inside the any-typed Settings so
@@ -385,6 +387,7 @@ func assertSourceUnchanged(t *testing.T, src *Settings) {
 
 	require.Len(t, src.Security.OAuthProviders, 1)
 	assert.Equal(t, []string{"openid", "email"}, src.Security.OAuthProviders[0].Scopes)
+	assert.Equal(t, []string{"cloudflare", "10.0.0.0/8"}, src.Security.TrustedProxies)
 
 	require.Len(t, src.Backup.Targets, 1)
 	assert.Equal(t, "/backups", src.Backup.Targets[0].Settings["path"])

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1301,6 +1301,11 @@ type AllowSubnetBypass struct {
 	Subnet  string `yaml:"subnet" json:"subnet"`   // disable OAuth2 in subnet
 }
 
+// TrustedProxyCloudflarePreset is the reserved Security.TrustedProxies entry
+// that expands to Cloudflare's published edge IP ranges, sparing operators from
+// pasting the full CIDR list when fronting BirdNET-Go with Cloudflare.
+const TrustedProxyCloudflarePreset = "cloudflare"
+
 // PublicAccess defines which features are accessible without authentication.
 // Each field corresponds to a feature that can be individually made public.
 type PublicAccess struct {
@@ -1373,7 +1378,18 @@ type Security struct {
 	TLSPort           string            `yaml:"tlsport" json:"tlsPort"`                     // port for HTTPS (default: 8443)
 	RedirectToHTTPS   bool              `yaml:"redirecttohttps" json:"redirectToHttps"`     // true to redirect to HTTPS
 	AllowSubnetBypass AllowSubnetBypass `yaml:"allowsubnetbypass" json:"allowSubnetBypass"` // subnet bypass configuration
-	PublicAccess      PublicAccess      `yaml:"publicaccess" json:"publicAccess"`           // features accessible without authentication
+
+	// TrustedProxies lists CIDR ranges of reverse proxies whose forwarded
+	// client-IP headers (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) may be
+	// trusted. Loopback, link-local, and private (RFC1918/ULA) peers are always
+	// trusted in addition to these, so a default port-forwarded install and the
+	// common local cloudflared topology work without configuration. When the
+	// immediate peer is not trusted, forwarded headers are ignored and the real
+	// connection address is used, preventing source-IP spoofing on a directly
+	// exposed instance. The reserved value "cloudflare" (TrustedProxyCloudflarePreset)
+	// expands to Cloudflare's published edge ranges. Hot-reloadable.
+	TrustedProxies []string     `yaml:"trustedproxies" json:"trustedProxies"`
+	PublicAccess   PublicAccess `yaml:"publicaccess" json:"publicAccess"` // features accessible without authentication
 	// PrivateMode, when true, requires the user to authenticate before any
 	// UI data is shown. Enforcement lives at the v2 API data layer, which
 	// returns 401 to unauthenticated requests; the public SPA shell is still

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1379,9 +1379,9 @@ type Security struct {
 	RedirectToHTTPS   bool              `yaml:"redirecttohttps" json:"redirectToHttps"`     // true to redirect to HTTPS
 	AllowSubnetBypass AllowSubnetBypass `yaml:"allowsubnetbypass" json:"allowSubnetBypass"` // subnet bypass configuration
 
-	// TrustedProxies lists CIDR ranges of reverse proxies whose forwarded
-	// client-IP headers (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) may be
-	// trusted. Loopback, link-local, and private (RFC1918/ULA) peers are always
+	// TrustedProxies lists reverse proxies (CIDR ranges or bare IPs) whose
+	// forwarded client-IP headers (CF-Connecting-IP, X-Forwarded-For, X-Real-IP)
+	// may be trusted. Loopback, link-local, and private (RFC1918/ULA) peers are always
 	// trusted in addition to these, so a default port-forwarded install and the
 	// common local cloudflared topology work without configuration. When the
 	// immediate peer is not trusted, forwarded headers are ignored and the real

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -408,6 +408,14 @@ security:
   allowsubnetbypass:
     enabled: false           # true to disable OAuth in subnet
     subnet: ""               # comma-separated list of CIDR ranges (e.g., "192.168.1.0/24,10.0.0.0/8")
+  # CIDR ranges of reverse proxies whose forwarded client-IP headers
+  # (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) may be trusted. Loopback,
+  # link-local, and private addresses are always trusted, so a local cloudflared
+  # or same-host reverse proxy needs no entry here. Add a proxy that connects
+  # from a PUBLIC IP (e.g. Cloudflare's edge in front of a directly-exposed
+  # instance, or an external load balancer) so its headers are honored. The
+  # special value "cloudflare" expands to Cloudflare's published edge ranges.
+  trustedproxies: []         # e.g. ["cloudflare"] or ["203.0.113.0/24"]
   basicauth:
     enabled: false           # true to enable basic auth
     password: ""             # password hash for the settings interface

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -415,7 +415,12 @@ security:
   # from a PUBLIC IP (e.g. Cloudflare's edge in front of a directly-exposed
   # instance, or an external load balancer) so its headers are honored. The
   # special value "cloudflare" expands to Cloudflare's published edge ranges.
-  trustedproxies: []         # e.g. ["cloudflare"] or ["203.0.113.0/24"]
+  # Multi-hop: for a chain such as an external load balancer in front of a local
+  # reverse proxy, list every intermediate proxy whose address appears in
+  # X-Forwarded-For (including private ones). Only explicitly listed hops are
+  # skipped when resolving the real client; otherwise the request is attributed
+  # to the nearest unlisted hop.
+  trustedproxies: []         # e.g. ["cloudflare"], ["203.0.113.0/24"] or a bare IP ["203.0.113.5"]
   basicauth:
     enabled: false           # true to enable basic auth
     password: ""             # password hash for the settings interface

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -370,6 +370,7 @@ func setDefaultConfig() {
 	viper.SetDefault("security.redirecttohttps", false)
 	viper.SetDefault("security.allowsubnetbypass.enabled", false)
 	viper.SetDefault("security.allowsubnetbypass.subnet", "")
+	viper.SetDefault("security.trustedproxies", []string{})
 	viper.SetDefault("security.publicaccess.liveaudio", false)
 	viper.SetDefault("security.sessionduration", "168h") // 7 days
 

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -52,6 +52,23 @@ func validateSecuritySettings(settings *Security) error {
 		}
 	}
 
+	// Validate trusted-proxy entries. Each must be a valid CIDR or the reserved
+	// "cloudflare" preset token. Empty entries (blank list items) are skipped,
+	// matching the lenient parsing used by the subnet bypass check above.
+	for _, entry := range settings.TrustedProxies {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" || strings.EqualFold(trimmed, TrustedProxyCloudflarePreset) {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(trimmed); err != nil {
+			return errors.New(err).
+				Category(errors.CategoryValidation).
+				Context("validation_type", "security-trustedproxies-format").
+				Context("entry", trimmed).
+				Build()
+		}
+	}
+
 	// Normalize session duration: viper nested defaults can be lost when the
 	// parent key exists in the config file but sessionduration is absent.
 	if settings.SessionDuration <= 0 {

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -52,13 +52,17 @@ func validateSecuritySettings(settings *Security) error {
 		}
 	}
 
-	// Validate trusted-proxy entries. Each must be a valid CIDR or the reserved
-	// "cloudflare" preset token. Empty entries (blank list items) are skipped,
-	// matching the lenient parsing used by the subnet bypass check above.
+	// Validate trusted-proxy entries. Each must be a valid CIDR, a bare IP (a
+	// single host), or the reserved "cloudflare" preset token. Empty entries
+	// (blank list items) are skipped, matching the lenient parsing used by the
+	// subnet bypass check above.
 	for _, entry := range settings.TrustedProxies {
 		trimmed := strings.TrimSpace(entry)
 		if trimmed == "" || strings.EqualFold(trimmed, TrustedProxyCloudflarePreset) {
 			continue
+		}
+		if net.ParseIP(trimmed) != nil {
+			continue // bare IP, treated as a single-host /32 or /128
 		}
 		if _, _, err := net.ParseCIDR(trimmed); err != nil {
 			return errors.New(err).

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -497,9 +497,25 @@ func TestValidateSecuritySettings_TrustedProxies(t *testing.T) {
 			errType: "security-trustedproxies-format",
 		},
 		{
-			name: "Bare IP without CIDR notation - should fail",
+			name: "Bare IPv4 without CIDR notation - should pass",
 			security: Security{
 				TrustedProxies:  []string{"192.168.1.1"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Bare IPv6 without CIDR notation - should pass",
+			security: Security{
+				TrustedProxies:  []string{"2001:db8::1"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Garbage entry - should fail",
+			security: Security{
+				TrustedProxies:  []string{"not-an-ip-or-cidr"},
 				SessionDuration: 24 * time.Hour,
 			},
 			wantErr: true,

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -437,6 +437,92 @@ func TestValidateSecuritySettings_SubnetBypass(t *testing.T) {
 	}
 }
 
+// TestValidateSecuritySettings_TrustedProxies tests trusted-proxy CIDR validation.
+func TestValidateSecuritySettings_TrustedProxies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		security Security
+		wantErr  bool
+		errType  string
+	}{
+		{
+			name: "Empty list - should pass",
+			security: Security{
+				TrustedProxies:  nil,
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid IPv4 and IPv6 CIDRs - should pass",
+			security: Security{
+				TrustedProxies:  []string{"10.0.0.0/8", "2001:db8::/32"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Cloudflare preset token - should pass",
+			security: Security{
+				TrustedProxies:  []string{TrustedProxyCloudflarePreset},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Cloudflare preset is case-insensitive - should pass",
+			security: Security{
+				TrustedProxies:  []string{"CloudFlare"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Blank entries are skipped - should pass",
+			security: Security{
+				TrustedProxies:  []string{"", "  ", "192.168.0.0/24"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid CIDR mask - should fail",
+			security: Security{
+				TrustedProxies:  []string{"192.168.1.0/33"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: true,
+			errType: "security-trustedproxies-format",
+		},
+		{
+			name: "Bare IP without CIDR notation - should fail",
+			security: Security{
+				TrustedProxies:  []string{"192.168.1.1"},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: true,
+			errType: "security-trustedproxies-format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateSecuritySettings(&tt.security)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assertValidationError(t, err, tt.errType)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestValidateSecuritySettings_SessionDuration tests session duration validation
 func TestValidateSecuritySettings_SessionDuration(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

The Echo client-IP extractor honored `CF-Connecting-IP`, `X-Forwarded-For`, and `X-Real-IP` from **any** peer unconditionally. On a directly-exposed instance, any client could send those headers and forge its source IP, which feeds login rate limiting, subnet-bypass auth, and request logs.

This change honors forwarded headers **only when the connection peer is a trusted proxy**:

- Loopback, link-local, and private (RFC1918/ULA) peers are trusted by default, so the common setups work with zero config (local `cloudflared`, same-host/LAN reverse proxy, direct LAN).
- A new hot-reloadable `Security.TrustedProxies` config field (list of CIDRs) lets operators add proxies that connect from a public IP. The reserved value `"cloudflare"` expands to Cloudflare's published edge ranges.
- Untrusted peers fall back to the real connection address, blocking the spoof.

`X-Forwarded-For` resolution walks the chain right-to-left and returns the nearest hop that is **not a configured proxy**, so a client cannot forge a leftmost entry when proxies append to the header. Hop-skipping is intentionally narrower than the peer-trust check (configured CIDRs only, not private-by-default): a real client is frequently on a private address and must not be skipped past. Multi-hop internal chains therefore need their proxy CIDRs listed for correct attribution.

Additional hardening in the same area:
- `TunnelDetectionMiddleware` now marks a request "tunneled" only when the resolved client IP differs from the peer, so a direct client cannot spoof a tunneled log label.
- A `DEBUG` breadcrumb names the peer when forwarded headers from an untrusted peer are ignored, so a misconfigured proxy is self-diagnosing without flooding logs with scanner noise.
- The new field is added to `CloneSettings` deep-copy + its guardrail test, and documented in the example `config.yaml`.

## Behavior change (upgrade note)

Deployments whose reverse proxy connects from a **public IP** will stop having forwarded headers honored until they opt the proxy in:

- **Cloudflare "orange-cloud" / DNS proxy in front of a directly-exposed origin** (Cloudflare's edge connects from public ranges). Note: `cloudflared` tunnel users are **not** affected (the tunnel connects from loopback/private).
- **External reverse proxy / load balancer** reaching the instance over a public IP.

Symptoms if unmigrated: request logs show the proxy IP, the login rate limiter keys all visitors to the proxy IP, and `AllowSubnetBypass` no longer matches. Migration is one line:

```yaml
security:
  trustedproxies: ["cloudflare"]      # Cloudflare in front of a public origin
  # or
  trustedproxies: ["203.0.113.0/24"]  # an external proxy's CIDR
```

Common setups (local `cloudflared`, same-host/LAN proxy, direct LAN) need no change.

## Test Plan

- [x] New extractor tests: trusted vs untrusted peers, CF/XFF/X-Real-IP precedence, XFF append-spoofing, LAN-client XFF prepend spoof, configured-proxy multi-hop, IPv6, hot-reload, nil settings.
- [x] New validation tests: CIDR + `cloudflare` preset (case-insensitive), blanks skipped, bad CIDR rejected.
- [x] `CloneSettings` deep-independence guardrail extended to the new field.
- [x] `golangci-lint run` clean; `go test -race` and full `internal/conf` + `internal/api/v2` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable trusted-proxy support (Cloudflare preset) and refined tunnel detection to mark a request tunneled only when the resolved client IP differs from the connection peer.

* **Bug Fixes**
  * Prevents IP spoofing by ignoring forwarded client-IP headers from untrusted peers and honoring them only for trusted proxies; logs ignored headers for debugging.

* **Documentation**
  * Added config docs and validation guidance for trusted-proxy settings.

* **Tests**
  * Added comprehensive tests for IP extraction, hot-reload, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->