### PR TITLE
refactor(api/v2): single atomic.Pointer source of truth for Controller.Settings

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"2526795e-3ffc-4cb3-8b7e-07de18deb5b3","pid":549979,"procStart":"378263721","acquiredAt":1780757049966}

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -527,10 +527,10 @@ func TestGetInvalidAnalyticsRequests(t *testing.T) {
 			t.Parallel()
 			controller := &Controller{
 				DS:             mockDS,
-				Settings:       appSettings,
 				BirdImageCache: mockImageCache,
 				// sunCalc and controlChan might be needed depending on handlers tested
 			}
+			controller.Settings.Store(appSettings)
 
 			e := echo.New()
 			// Register routes needed for this test run

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -52,19 +52,19 @@ const apiV2Prefix = "/api/v2"
 
 // Controller manages the API routes and handlers
 type Controller struct {
-	Echo     *echo.Echo
-	Group    *echo.Group
-	DS       datastore.Interface           // Deprecated: Use Repo for new detection operations
-	Repo     datastore.DetectionRepository // New: Preferred for detection CRUD operations
-	Settings *conf.Settings
-	// settingsAtomic mirrors Settings as a lock-free per-controller snapshot.
-	// The settings update handlers publish it alongside the Settings field on
-	// every save (under settingsMutex), so reads that must stay per-controller
-	// but cannot take the mutex (newErrorResponse is reached from HandleError
-	// while UpdateSettings holds the write lock, so an RLock would deadlock) read
-	// it via controllerSettings() instead of the bare Settings field, which would
-	// race the reassignment. See controllerSettings.
-	settingsAtomic    atomic.Pointer[conf.Settings]
+	Echo  *echo.Echo
+	Group *echo.Group
+	DS    datastore.Interface           // Deprecated: Use Repo for new detection operations
+	Repo  datastore.DetectionRepository // New: Preferred for detection CRUD operations
+	// Settings holds this controller's settings snapshot as a lock-free atomic
+	// pointer (copy-on-write). Update handlers publish a fresh *conf.Settings via
+	// Settings.Store under settingsMutex; every reader Loads it, directly or
+	// through the currentSettings()/controllerSettings() accessors. Storing it
+	// atomically (rather than as a plain *conf.Settings field) is what lets
+	// newErrorResponse read it from HandleError while UpdateSettings holds
+	// settingsMutex.Lock without deadlocking on a non-reentrant RLock. The sibling
+	// engine and audioWatchdog fields use the same atomic-pointer pattern.
+	Settings          atomic.Pointer[conf.Settings]
 	BirdImageCache    *imageprovider.BirdImageCache
 	SunCalc           *suncalc.SunCalc
 	Processor         *processor.Processor
@@ -79,7 +79,7 @@ type Controller struct {
 	// Thread-safe: should be set before controller initialization.
 	DisableSaveSettings  bool         // disables disk persistence of settings
 	isGlobalOwner        bool         // true when this controller owns the global settings singleton
-	settingsMutex        sync.RWMutex // Mutex for settings operations
+	settingsMutex        sync.RWMutex // Serializes the read-modify-write in settings update handlers; reads are lock-free via the atomic Settings pointer
 	detectionCache       *cache.Cache // Cache for detection queries
 	startTime            *time.Time
 	SFS                  *securefs.SecureFS     // Add SecureFS instance
@@ -176,54 +176,34 @@ type ShutdownRequester interface {
 // take effect in API responses without restarting the service.
 //
 // It resolves the lock-free global atomic snapshot first and only falls back
-// to c.Settings when no snapshot has been published (standalone unit-test
-// controllers). The fallback is read lazily, so in production (where a
-// snapshot is always published) c.Settings is never dereferenced here. That
-// keeps the accessor race-free against the c.Settings reassignment the
-// settings update handlers perform under c.settingsMutex: the equivalent
-// conf.CurrentOrFallback(c.Settings) would evaluate c.Settings eagerly and
-// race that write.
+// to this controller's own snapshot when no global snapshot has been published
+// (standalone unit-test controllers). Both reads are lock-free (the per-controller
+// fallback is an atomic Load), so the accessor is race-free against the
+// Settings.Store the update handlers perform under c.settingsMutex.
 func (c *Controller) currentSettings() *conf.Settings {
 	if latest := conf.GetSettings(); latest != nil {
 		return latest
 	}
-	return c.Settings
+	return c.Settings.Load()
 }
 
 // controllerSettings returns this controller's own settings snapshot, read
-// lock-free from the settingsAtomic mirror that the settings update handlers
-// publish alongside c.Settings on every save. Unlike currentSettings(), it
-// deliberately does NOT consult the process-global atomic snapshot: use it for
-// reads whose result is asserted per-controller (e.g. debug-gated response
-// verbosity), where the shared global snapshot would couple otherwise-independent
-// parallel tests.
+// lock-free from the atomic Settings pointer that the update handlers publish on
+// every save. Unlike currentSettings(), it deliberately does NOT consult the
+// process-global atomic snapshot: use it for reads whose result is asserted
+// per-controller (e.g. debug-gated response verbosity), where the shared global
+// snapshot would couple otherwise-independent parallel tests.
 //
-// Reading the atomic mirror (rather than the bare c.Settings field under
+// Loading the atomic pointer (rather than reading a plain field under
 // settingsMutex.RLock) is what makes this safe to call from newErrorResponse,
 // which is reached from HandleError while UpdateSettings already holds
-// settingsMutex.Lock: a non-reentrant RLock there would deadlock. The mirror is
-// published under that same write lock, so the read sees a consistent snapshot.
-//
-// The c.Settings fallback only runs for standalone test controllers that never
-// published the mirror; production always publishes it at construction, so the
-// fallback never races a concurrent write. The returned snapshot is immutable
-// (copy-on-write), so callers may dereference its fields freely.
+// settingsMutex.Lock: a non-reentrant RLock there would deadlock. The snapshot is
+// published under that same write lock, so the read sees a consistent value. The
+// returned snapshot is immutable (copy-on-write), so callers may dereference its
+// fields freely. Returns nil only on a controller that never stored settings
+// (standalone tests); callers that may hit that path nil-check or fall back.
 func (c *Controller) controllerSettings() *conf.Settings {
-	if s := c.settingsAtomic.Load(); s != nil {
-		return s
-	}
-	return c.Settings
-}
-
-// publishSettings repoints this controller's settings snapshot to s, updating
-// both the c.Settings field and the lock-free settingsAtomic mirror together so
-// per-controller readers (controllerSettings) never observe a mirror that has
-// drifted from the field. It is the single write path for the snapshot: routing
-// every save and rollback through it keeps the dual-write invariant in one place.
-// Callers must hold c.settingsMutex (the field write is not itself synchronized).
-func (c *Controller) publishSettings(s *conf.Settings) {
-	c.Settings = s
-	c.settingsAtomic.Store(s)
+	return c.Settings.Load()
 }
 
 // Option is a functional option for configuring the Controller.
@@ -441,7 +421,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		Echo:                 e,
 		DS:                   ds,
 		Repo:                 repo, // Bridge to new domain model (nil if datastore disabled)
-		Settings:             settings,
 		isGlobalOwner:        settings == conf.GetSettings(),
 		BirdImageCache:       birdImageCache,
 		SunCalc:              sunCalc,
@@ -454,10 +433,10 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()),
 		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
 	}
-	// Publish the per-controller settings mirror so controllerSettings() reads it
-	// lock-free. Kept in sync with the c.Settings field on every save; see the
-	// settingsAtomic field doc and the settings update handlers.
-	c.settingsAtomic.Store(settings)
+	// Publish the initial settings snapshot so controllerSettings() reads it
+	// lock-free. Every save republishes via Settings.Store; see the Settings
+	// field doc and the settings update handlers.
+	c.Settings.Store(settings)
 
 	// Configure the trusted-proxy-gated IP extractor. Forwarded client-IP headers
 	// (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) are honored only when the
@@ -938,7 +917,7 @@ func (c *Controller) newErrorResponse(err error, message string, code int) *Erro
 	// paths, SQL errors, stack traces, etc. In production, use the
 	// sanitized message parameter instead.
 	var errorStr string
-	// Read the controller's own debug flag via the lock-free atomic mirror: this
+	// Read the controller's own debug flag via the lock-free atomic Settings pointer: this
 	// is reached from HandleError while UpdateSettings holds c.settingsMutex, so
 	// it must not acquire the lock (a non-reentrant RLock would deadlock), and the
 	// flag must remain per-controller (handlers assert debug-gated error verbosity
@@ -1088,19 +1067,16 @@ func (c *Controller) HandleErrorForTest(ctx echo.Context, err error, message str
 
 // Debug logs debug messages when debug mode is enabled.
 //
-// Reads the debug flag via conf.GetSettings() rather than c.Settings so the
-// check is race-free against concurrent c.Settings writes in the settings
-// handlers: c.Settings is a plain *conf.Settings field with no locking on
-// the Debug read path, while conf.GetSettings() is a lock-free atomic.Load.
-// Returns silently when the global snapshot has not been set (e.g. in unit
-// tests with a standalone Controller).
+// Reads the debug flag from the process-global snapshot via conf.GetSettings()
+// (a lock-free atomic.Load), so process-wide debug logging follows the latest
+// published global settings. Returns silently when the global snapshot has not
+// been set (e.g. in unit tests with a standalone Controller); the per-controller
+// c.Settings snapshot is deliberately not consulted here.
 func (c *Controller) Debug(format string, v ...any) {
 	settings := conf.GetSettings()
 	if settings == nil {
 		// Skip debug logging when the global snapshot hasn't been set
-		// (e.g. in unit tests with a standalone Controller). Reading
-		// c.Settings here would race with concurrent writes in the
-		// settings update handlers.
+		// (e.g. in unit tests with a standalone Controller).
 		return
 	}
 	if settings.WebServer.Debug {

--- a/internal/api/v2/api_datastore_guard_test.go
+++ b/internal/api/v2/api_datastore_guard_test.go
@@ -105,14 +105,15 @@ func TestInitDebugRoutesReadsSettingsNilSafely(t *testing.T) {
 	settings.Debug = false // debug mode off -> initDebugRoutes takes the skip path
 
 	controller := &Controller{
-		Echo:     e,
-		Group:    e.Group("/api/v2"),
-		Settings: nil, // raw field nil; controllerSettings() must be used instead
+		Echo:  e,
+		Group: e.Group("/api/v2"),
 	}
-	controller.settingsAtomic.Store(settings)
+	// initDebugRoutes must read settings through the nil-safe controllerSettings()
+	// accessor (an atomic Load), not assume a non-nil snapshot.
+	controller.Settings.Store(settings)
 
 	require.NotPanics(t, func() { controller.initDebugRoutes() },
-		"initDebugRoutes must not dereference a nil c.Settings")
+		"initDebugRoutes must not dereference a nil settings snapshot")
 	for _, r := range e.Routes() {
 		assert.NotContains(t, r.Path, "/debug",
 			"debug routes must not register when debug mode is off: %s %s", r.Method, r.Path)

--- a/internal/api/v2/api_debug_race_test.go
+++ b/internal/api/v2/api_debug_race_test.go
@@ -24,9 +24,8 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 		conftest.SetTestSettings(previous)
 	})
 
-	controller := &Controller{
-		Settings: newValidTestSettings(),
-	}
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	stopWriter := make(chan struct{})
 	writerDone := make(chan struct{})
@@ -39,7 +38,7 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 			default:
 				updated := newValidTestSettings()
 				updated.WebServer.Debug = true
-				controller.Settings = updated
+				controller.Settings.Store(updated)
 			}
 		}
 	}()

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -362,15 +362,15 @@ func setupPostMigrationTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInt
 	e, mockDS, controller := setupTestEnvironment(t)
 
 	// Run migration — moves SummaryLimit into layout element, zeros deprecated field
-	migrated := controller.Settings.MigrateDashboardLayout()
+	migrated := controller.Settings.Load().MigrateDashboardLayout()
 	require.True(t, migrated, "migration should have occurred (no pre-existing layout)")
 
 	// Verify the deprecated field is actually zeroed
-	assert.Equal(t, 0, controller.Settings.Realtime.Dashboard.SummaryLimit,
+	assert.Equal(t, 0, controller.Settings.Load().Realtime.Dashboard.SummaryLimit,
 		"deprecated SummaryLimit should be zeroed after migration")
 
 	// Verify GetEffectiveSummaryLimit still returns a valid value
-	effectiveLimit := controller.Settings.GetEffectiveSummaryLimit()
+	effectiveLimit := controller.Settings.Load().GetEffectiveSummaryLimit()
 	assert.Positive(t, effectiveLimit,
 		"GetEffectiveSummaryLimit should return positive value after migration")
 

--- a/internal/api/v2/api_error_response_race_test.go
+++ b/internal/api/v2/api_error_response_race_test.go
@@ -4,8 +4,8 @@
 // newErrorResponse decides whether to expose raw err.Error() based on this
 // controller's own WebServer.Debug flag. That read must stay per-controller (the
 // shared global snapshot would couple otherwise-independent parallel tests) yet
-// must not race the c.Settings republish UpdateSettings performs on every save,
-// and it must not take c.settingsMutex (it is reached from HandleError while
+// must not race the Settings.Store UpdateSettings performs on every save, and it
+// must not take c.settingsMutex (it is reached from HandleError while
 // UpdateSettings already holds the write lock, so an RLock would deadlock).
 package api
 
@@ -19,17 +19,14 @@ import (
 
 // TestNewErrorResponseConcurrentSettingsPublishIsRaceFree hammers
 // newErrorResponse from multiple readers while writers republish the settings
-// snapshot the same way UpdateSettings does (c.Settings reassignment plus the
-// per-controller atomic mirror, under c.settingsMutex). Under `go test -race`,
-// the pre-fix bare c.Settings.WebServer.Debug read in newErrorResponse is
-// flagged as a data race against the c.Settings write.
+// snapshot the same way UpdateSettings does (Settings.Store under c.settingsMutex).
+// Under `go test -race`, a non-atomic read of the debug flag in newErrorResponse
+// would be flagged as a data race against the concurrent Settings.Store.
 func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
 	withRestoredGlobalSettings(t)
 
-	controller := &Controller{Settings: newValidTestSettings()}
-	// Mirror production construction so the per-controller debug read resolves
-	// via the lock-free atomic snapshot rather than the bare c.Settings field.
-	controller.settingsAtomic.Store(controller.Settings)
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	testErr := echo.NewHTTPError(http.StatusInternalServerError, "raw internal detail")
 
@@ -46,11 +43,11 @@ func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
 			for i := range itersPerWorker {
 				snap := newValidTestSettings()
 				snap.WebServer.Debug = (w+i)%2 == 0
-				// Republish through the production single write path so this test
-				// also guards against publishSettings updating only one of the two
-				// fields. publishSettings requires the settings mutex held.
+				// Republish the same way UpdateSettings does: Settings.Store while
+				// holding settingsMutex. The mutex serialises writers; the read side
+				// in newErrorResponse stays lock-free via the atomic Load.
 				controller.settingsMutex.Lock()
-				controller.publishSettings(snap)
+				controller.Settings.Store(snap)
 				controller.settingsMutex.Unlock()
 			}
 		})

--- a/internal/api/v2/api_test.go
+++ b/internal/api/v2/api_test.go
@@ -67,8 +67,9 @@ func TestHealthCheck(t *testing.T) {
 	mockDS.On("GetLastDetections", 1).Return([]datastore.Note{}, nil)
 
 	// Add system metrics to the controller settings
-	controller.Settings.Version = "1.2.3"
-	controller.Settings.BuildDate = "2023-05-15"
+	settings := controller.Settings.Load()
+	settings.Version = "1.2.3"
+	settings.BuildDate = "2023-05-15"
 
 	// Create a request to the health check endpoint
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/health", http.NoBody)
@@ -175,16 +176,17 @@ func TestNewErrorResponseDebugMode(t *testing.T) {
 	testErr := echo.NewHTTPError(http.StatusBadRequest, "Test error")
 
 	// Test 1: Non-debug mode — Error field should use sanitized message
-	c := &Controller{Settings: &conf.Settings{
+	c := &Controller{}
+	c.Settings.Store(&conf.Settings{
 		WebServer: conf.WebServerSettings{Debug: false},
-	}}
+	})
 
 	resp := c.newErrorResponse(testErr, "Safe message", http.StatusBadRequest)
 	assert.Equal(t, "Safe message", resp.Error, "Non-debug mode should use sanitized message")
 	assert.Equal(t, "Safe message", resp.Message)
 
 	// Test 2: Debug mode — Error field should expose raw err.Error()
-	c.Settings.WebServer.Debug = true
+	c.Settings.Load().WebServer.Debug = true
 
 	resp = c.newErrorResponse(testErr, "Safe message", http.StatusBadRequest)
 	assert.Equal(t, "code=400, message=Test error", resp.Error, "Debug mode should expose raw error")

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -953,9 +953,9 @@ func FuzzGetAppConfig_Headers(f *testing.F) {
 
 		controller := &Controller{
 			DS:          mockDS,
-			Settings:    settings,
 			authService: nil,
 		}
+		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
@@ -1016,9 +1016,9 @@ func FuzzGetAppConfig_QueryParams(f *testing.F) {
 
 		controller := &Controller{
 			DS:          mockDS,
-			Settings:    settings,
 			authService: nil,
 		}
+		controller.Settings.Store(settings)
 
 		// Build URL safely - query string must be URL-encoded
 		url := "/api/v2/app/config"
@@ -1081,9 +1081,9 @@ func FuzzGetAppConfig_CSRFToken(f *testing.F) {
 
 		controller := &Controller{
 			DS:          mockDS,
-			Settings:    settings,
 			authService: nil,
 		}
+		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
@@ -1147,9 +1147,9 @@ func FuzzGetAppConfig_Version(f *testing.F) {
 
 		controller := &Controller{
 			DS:          mockDS,
-			Settings:    settings,
 			authService: nil,
 		}
+		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
@@ -1301,9 +1301,9 @@ func FuzzGetAppConfig_SecurityConfig(f *testing.F) {
 
 		controller := &Controller{
 			DS:          mockDS,
-			Settings:    settings,
 			authService: nil,
 		}
+		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
@@ -1343,7 +1343,7 @@ func TestGetAppConfig_PublicAccessFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			controller.Settings.Security.PublicAccess.LiveAudio = tt.enabled
+			controller.Settings.Load().Security.PublicAccess.LiveAudio = tt.enabled
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 			rec := httptest.NewRecorder()
@@ -1389,7 +1389,7 @@ func TestGetAppConfig_LiveSpectrogramField(t *testing.T) {
 			e, controller := setupAppConfigTest(t, nil)
 
 			// Set the LiveSpectrogram value for this test case
-			controller.Settings.Realtime.Dashboard.LiveSpectrogram = tt.enabled
+			controller.Settings.Load().Realtime.Dashboard.LiveSpectrogram = tt.enabled
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 			rec := httptest.NewRecorder()
@@ -1415,8 +1415,8 @@ func TestGetAppConfig_SentryConfigWhenEnabled(t *testing.T) {
 	_, controller := setupAppConfigTest(t, nil)
 
 	// Enable Sentry in settings
-	controller.Settings.Sentry.Enabled = true
-	controller.Settings.SystemID = "test-system-id-123"
+	controller.Settings.Load().Sentry.Enabled = true
+	controller.Settings.Load().SystemID = "test-system-id-123"
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
@@ -1444,7 +1444,7 @@ func TestGetAppConfig_SentryConfigWhenDisabled(t *testing.T) {
 	_, controller := setupAppConfigTest(t, nil)
 
 	// Sentry disabled (default)
-	controller.Settings.Sentry.Enabled = false
+	controller.Settings.Load().Sentry.Enabled = false
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)

--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -211,16 +211,15 @@ func TestDetermineWizardState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := &Controller{
-				Settings: &conf.Settings{Version: tt.version},
-			}
+			c := &Controller{}
+			c.Settings.Store(&conf.Settings{Version: tt.version})
 			c.appMetadataRepo = tt.metadataRepo
 			if tt.v2Manager != nil {
 				c.V2Manager = tt.v2Manager(t)
 			}
 			// determineWizardState now takes the settings snapshot directly, so
 			// the subtest stays fully per-controller and parallel-safe.
-			freshInstall, newVersion, previousVersion := c.determineWizardState(t.Context(), c.Settings)
+			freshInstall, newVersion, previousVersion := c.determineWizardState(t.Context(), c.Settings.Load())
 
 			assert.Equal(t, tt.wantFresh, freshInstall, "freshInstall mismatch")
 			assert.Equal(t, tt.wantNew, newVersion, "newVersion mismatch")
@@ -238,10 +237,10 @@ func TestDismissWizard_Success(t *testing.T) {
 	mockRepo := newMockAppMetadataRepo()
 	e := echo.New()
 	c := &Controller{
-		Settings:        &conf.Settings{Version: "v0.9.0"},
 		appMetadataRepo: mockRepo,
 	}
-	publishTestSettings(t, c.Settings)
+	c.Settings.Store(&conf.Settings{Version: "v0.9.0"})
+	publishTestSettings(t, c.Settings.Load())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/app/wizard/dismiss", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -260,12 +259,12 @@ func TestDismissWizard_NilRepo(t *testing.T) {
 
 	e := echo.New()
 	c := &Controller{
-		Settings: &conf.Settings{
-			Version:   "v0.9.0",
-			WebServer: conf.WebServerSettings{Debug: true},
-		},
 		// appMetadataRepo intentionally nil
 	}
+	c.Settings.Store(&conf.Settings{
+		Version:   "v0.9.0",
+		WebServer: conf.WebServerSettings{Debug: true},
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/app/wizard/dismiss", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -286,12 +285,12 @@ func TestDismissWizard_SetError(t *testing.T) {
 
 	e := echo.New()
 	c := &Controller{
-		Settings: &conf.Settings{
-			Version:   "v0.9.0",
-			WebServer: conf.WebServerSettings{Debug: true},
-		},
 		appMetadataRepo: mockRepo,
 	}
+	c.Settings.Store(&conf.Settings{
+		Version:   "v0.9.0",
+		WebServer: conf.WebServerSettings{Debug: true},
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/app/wizard/dismiss", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -272,9 +272,9 @@ func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc
 // restart.
 func (c *Controller) privateModeAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		// Read the live snapshot (race-free, hot-reloading) to match the sibling
-		// publicLiveAudioAuth middleware; the bare c.Settings field under RLock
-		// would not pick up out-of-band StoreSettings republishes.
+		// Read the live global snapshot (race-free, hot-reloading) via
+		// currentSettings() to match the sibling publicLiveAudioAuth middleware; the
+		// per-controller snapshot would miss out-of-band StoreSettings republishes.
 		privateMode := c.currentSettings().Security.PrivateMode
 
 		if !privateMode {

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -525,7 +525,8 @@ func TestResolveClientID(t *testing.T) {
 	const testRemoteAddr = "192.168.1.100:12345"
 
 	t.Run("prefers session ID when provided", func(t *testing.T) {
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr
@@ -538,7 +539,8 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("falls back to generateClientID when no session", func(t *testing.T) {
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr
@@ -552,7 +554,8 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("different sessions from same IP get different IDs", func(t *testing.T) {
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 
 		req1 := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -569,7 +572,8 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("rejects invalid session ID format", func(t *testing.T) {
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr

--- a/internal/api/v2/audio_level_test.go
+++ b/internal/api/v2/audio_level_test.go
@@ -67,7 +67,8 @@ func TestAudioLevelSSEDataFormat(t *testing.T) {
 // TestIsSourceInactive tests the source inactivity detection logic
 func TestIsSourceInactive(t *testing.T) {
 	// Create a minimal controller for testing
-	controller := &Controller{Settings: newValidTestSettings()}
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	t.Run("new source is active", func(t *testing.T) {
 		lastUpdate := make(map[string]time.Time)
@@ -121,7 +122,8 @@ func TestIsSourceInactive(t *testing.T) {
 
 // TestCheckSourceActivity tests the source activity checking for multiple sources
 func TestCheckSourceActivity(t *testing.T) {
-	controller := &Controller{Settings: newValidTestSettings()}
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	t.Run("no inactive sources", func(t *testing.T) {
 		now := time.Now()
@@ -176,7 +178,8 @@ func TestCheckSourceActivity(t *testing.T) {
 
 // TestGetAnonymizedSourceNameFallback tests the fallback source name anonymization
 func TestGetAnonymizedSourceNameFallback(t *testing.T) {
-	controller := &Controller{Settings: newValidTestSettings()}
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	t.Run("audio card source", func(t *testing.T) {
 		name := controller.getAnonymizedSourceNameFallback("audio_card_default")

--- a/internal/api/v2/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio_level_write_deadline_test.go
@@ -67,7 +67,8 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{Settings: newValidTestSettings()}
+		controller := &Controller{}
+		controller.Settings.Store(newValidTestSettings())
 
 		// Create test audio level data
 		levels := map[string]audiocore.AudioLevelData{
@@ -107,7 +108,8 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		ctx.Response().Writer = mockWriter
 
-		controller := &Controller{Settings: newValidTestSettings()}
+		controller := &Controller{}
+		controller.Settings.Store(newValidTestSettings())
 		levels := map[string]audiocore.AudioLevelData{
 			"test_source": {Level: 50, Name: "Test Source", Source: "test_source"},
 		}
@@ -139,7 +141,8 @@ func TestSendAudioLevelHeartbeatSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{Settings: newValidTestSettings()}
+		controller := &Controller{}
+		controller.Settings.Store(newValidTestSettings())
 
 		// Call sendAudioLevelHeartbeat
 		err := controller.sendAudioLevelHeartbeat(ctx)

--- a/internal/api/v2/audio_sources_test.go
+++ b/internal/api/v2/audio_sources_test.go
@@ -38,10 +38,10 @@ func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (
 
 	e := echo.New()
 	controller := &Controller{
-		Echo:     e,
-		Group:    e.Group("/api/v2"),
-		Settings: &conf.Settings{},
+		Echo:  e,
+		Group: e.Group("/api/v2"),
 	}
+	controller.Settings.Store(&conf.Settings{})
 	controller.engine.Store(eng)
 	return e, controller
 }
@@ -55,10 +55,10 @@ func TestListAudioSources(t *testing.T) {
 	t.Run("No engine returns empty list", func(t *testing.T) {
 		e := echo.New()
 		controller := &Controller{
-			Echo:     e,
-			Group:    e.Group("/api/v2"),
-			Settings: &conf.Settings{},
+			Echo:  e,
+			Group: e.Group("/api/v2"),
 		}
+		controller.Settings.Store(&conf.Settings{})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/sources", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -125,10 +125,10 @@ func TestListStreamSources(t *testing.T) {
 	t.Run("No engine returns empty list", func(t *testing.T) {
 		e := echo.New()
 		controller := &Controller{
-			Echo:     e,
-			Group:    e.Group("/api/v2"),
-			Settings: &conf.Settings{},
+			Echo:  e,
+			Group: e.Group("/api/v2"),
 		}
+		controller.Settings.Store(&conf.Settings{})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/sources", http.NoBody)
 		rec := httptest.NewRecorder()

--- a/internal/api/v2/clip_test.go
+++ b/internal/api/v2/clip_test.go
@@ -90,7 +90,7 @@ func TestExtractAudioClipByID(t *testing.T) {
 				if ffmpegErr != nil {
 					t.Skip("FFmpeg not available, skipping extraction test")
 				}
-				controller.Settings.Realtime.Audio.FfmpegPath = ffmpegPath
+				controller.Settings.Load().Realtime.Audio.FfmpegPath = ffmpegPath
 			}
 
 			path := "/api/v2/audio/" + tc.noteID + "/clip"

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -58,8 +58,8 @@ func (c *Controller) requireDebugMode(next echo.HandlerFunc) echo.HandlerFunc {
 // initDebugRoutes registers debug-related routes
 func (c *Controller) initDebugRoutes() {
 	// Only register debug routes if debug mode is enabled. Read via controllerSettings()
-	// (nil-safe snapshot) to match requireDebugMode and avoid dereferencing a nil
-	// c.Settings on standalone/test controllers.
+	// (a nil-safe atomic Load) to match requireDebugMode; it returns nil when no
+	// snapshot has been stored (standalone/test controllers), which the guard handles.
 	if s := c.controllerSettings(); s == nil || !s.Debug {
 		GetLogger().Debug("Debug mode not enabled, skipping debug routes")
 		return

--- a/internal/api/v2/debug_test.go
+++ b/internal/api/v2/debug_test.go
@@ -18,11 +18,9 @@ func TestDebugTriggerError(t *testing.T) {
 
 	e := echo.New()
 	c := &Controller{
-		Settings: &conf.Settings{
-			Debug: true,
-		},
 		apiLogger: nil,
 	}
+	c.Settings.Store(&conf.Settings{Debug: true})
 
 	tests := []struct {
 		name     string
@@ -69,11 +67,9 @@ func TestDebugEndpointsRequireDebugMode(t *testing.T) {
 	// Create controller with debug disabled
 	e := echo.New()
 	c := &Controller{
-		Settings: &conf.Settings{
-			Debug: false, // Debug mode disabled
-		},
 		apiLogger: nil,
 	}
+	c.Settings.Store(&conf.Settings{Debug: false})
 
 	// Table-driven tests for all debug endpoints returning 403 when debug mode is disabled
 	endpoints := []struct {

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1554,9 +1554,7 @@ func (c *Controller) IgnoreSpecies(ctx echo.Context) error {
 
 // GetExcludedSpecies returns the list of excluded species
 func (c *Controller) GetExcludedSpecies(ctx echo.Context) error {
-	c.settingsMutex.RLock()
 	species := slices.Clone(c.getSettingsOrFallback().Realtime.Species.Exclude)
-	c.settingsMutex.RUnlock()
 
 	return ctx.JSON(http.StatusOK, ExcludedSpeciesResponse{
 		Species: species,
@@ -1580,14 +1578,14 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 		return "", false, nil
 	}
 
-	// Serialise against concurrent settings saves so that out-of-band
-	// StoreSettings calls (range filter rebuild, etc.) cannot desynchronise
-	// c.Settings from the live atomic pointer between read and publish.
+	// Serialise this read-modify-write against concurrent settings saves so an
+	// out-of-band StoreSettings (range filter rebuild, etc.) cannot interleave
+	// between reading current and publishing the update.
 	c.settingsMutex.Lock()
 	defer c.settingsMutex.Unlock()
 
-	// Always read the live atomic snapshot; c.Settings may be stale after
-	// UpdateIncludedSpecies or other out-of-band StoreSettings calls.
+	// Read the latest snapshot; getSettingsOrFallback prefers the global when
+	// this controller owns it, so out-of-band StoreSettings calls are seen.
 	current := c.getSettingsOrFallback()
 
 	wasExcluded := slices.Contains(current.Realtime.Species.Exclude, species)
@@ -1766,8 +1764,8 @@ func calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTime
 // Returns "imperial" for Fahrenheit or "metric" for Celsius to match frontend expectations.
 func (c *Controller) getWeatherUnits() string {
 	// Use dashboard temperature unit preference for display. Read the live
-	// snapshot (race-free, hot-reloading) rather than the bare c.Settings field,
-	// matching the rest of the Dashboard subtree reads.
+	// snapshot (race-free, hot-reloading) via currentSettings() so out-of-band
+	// global republishes are picked up, matching the rest of the Dashboard reads.
 	// All temperatures are now stored in Celsius internally.
 	switch c.currentSettings().Realtime.Dashboard.TemperatureUnit {
 	case conf.TemperatureUnitFahrenheit:

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -1372,7 +1372,7 @@ func TestIgnoreSpecies(t *testing.T) {
 	// Test cases for error scenarios
 	t.Run("Error cases", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		errorCases := []struct {
 			name           string
@@ -1425,7 +1425,7 @@ func TestIgnoreSpecies(t *testing.T) {
 	// Test toggle behavior: add then remove
 	t.Run("Toggle behavior - add species", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		// First request: add species (should not be in list initially)
 		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/ignore",
@@ -1448,7 +1448,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Toggle behavior - remove species", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		// First, add the species
 		req1 := httptest.NewRequest(http.MethodPost, "/api/v2/detections/ignore",
@@ -1488,7 +1488,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Multiple toggle operations", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 		speciesName := "Northern Cardinal"
 
 		// Perform add-remove-add cycle
@@ -1513,7 +1513,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Special characters in species name", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		// Test with special characters (properly JSON encoded)
 		// Note: Use proper JSON encoding for special chars
@@ -1541,7 +1541,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Long species name", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		longName := strings.Repeat("Very Long Bird Name ", 50)
 		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/ignore",
@@ -1565,7 +1565,7 @@ func TestIgnoreSpecies(t *testing.T) {
 func TestGetExcludedSpecies(t *testing.T) {
 	t.Run("Empty excluded list", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/ignored", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1584,7 +1584,7 @@ func TestGetExcludedSpecies(t *testing.T) {
 
 	t.Run("Excluded list with species", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		// First add some species
 		speciesList := []string{"American Crow", "Red-bellied Woodpecker", "Blue Jay"}
@@ -1616,7 +1616,7 @@ func TestGetExcludedSpecies(t *testing.T) {
 
 	t.Run("Excluded list reflects toggle operations", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t, controller.Settings)
+		clearExcludedSpeciesList(t, controller.Settings.Load())
 
 		// Add two species
 		for _, s := range []string{"Species A", "Species B"} {
@@ -1659,7 +1659,7 @@ func TestGetExcludedSpecies(t *testing.T) {
 // TestIgnoreSpeciesConcurrency tests concurrent access to the IgnoreSpecies endpoint
 func TestIgnoreSpeciesConcurrency(t *testing.T) {
 	e, _, controller := setupTestEnvironment(t)
-	clearExcludedSpeciesList(t, controller.Settings)
+	clearExcludedSpeciesList(t, controller.Settings.Load())
 
 	// Use WaitGroup.Go() for automatic Add/Done management (Go 1.25+)
 	var wg sync.WaitGroup
@@ -2345,7 +2345,8 @@ func TestNoteToDetectionResponse_SourceInfo(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "source-info")
 
-	controller := &Controller{Settings: newValidTestSettings()}
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
 		name        string

--- a/internal/api/v2/dynamic_thresholds_test.go
+++ b/internal/api/v2/dynamic_thresholds_test.go
@@ -52,9 +52,9 @@ func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
 
 	controller := &Controller{
 		DS:        mockDS,
-		Settings:  proc.Settings,
 		Processor: proc,
 	}
+	controller.Settings.Store(proc.Settings)
 
 	result := controller.getMergedThresholdData()
 
@@ -104,9 +104,9 @@ func TestGetMergedThresholdData_MemoryOnlySpecies(t *testing.T) {
 
 	controller := &Controller{
 		DS:        mockDS,
-		Settings:  proc.Settings,
 		Processor: proc,
 	}
+	controller.Settings.Store(proc.Settings)
 
 	result := controller.getMergedThresholdData()
 
@@ -151,9 +151,9 @@ func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
 
 	controller := &Controller{
 		DS:        mockDS,
-		Settings:  proc.Settings,
 		Processor: proc,
 	}
+	controller.Settings.Store(proc.Settings)
 
 	result := controller.getMergedThresholdData()
 

--- a/internal/api/v2/events_test.go
+++ b/internal/api/v2/events_test.go
@@ -41,7 +41,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty entries returns empty response", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		result := c.aggregateDetectionEvents(nil, baseTime)
 
@@ -56,7 +57,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("single approve creates one bucket and one species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{
@@ -94,7 +96,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple operations same bucket same species accumulate", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Sparrow", map[string]any{"confidence": 0.7, "match_count": float64(1)}),
@@ -123,7 +126,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple species same bucket grouped correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.9, "match_count": float64(2)}),
@@ -139,7 +143,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple buckets separated by hour and sorted newest first", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
 		hour14 := time.Date(2024, 6, 15, 14, 45, 0, 0, time.UTC)
@@ -159,7 +164,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pre-filters counted in bucket but not in species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "dog_bark_filter", "", nil),
@@ -184,7 +190,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pending count from create_pending_detection hourly array", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(time.Date(2024, 6, 15, 8, 0, 0, 0, time.UTC), "create_pending_detection", "", nil),
@@ -201,7 +208,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species sorting approved first then by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			// Crow: 3 discards (no approvals)
@@ -228,7 +236,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("top discarded species top 3", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			// 5 discards for Alpha
@@ -261,7 +270,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("audio clip matching attached to correct species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.9, "match_count": float64(1)}),
@@ -293,7 +303,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("peak confidence tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.7, "match_count": float64(1)}),
@@ -310,7 +321,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("max match count tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.8, "match_count": float64(2)}),
@@ -327,7 +339,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty species name entries are skipped", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "", map[string]any{"confidence": 0.9, "match_count": float64(1)}),
@@ -347,7 +360,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("approved per hour metric calculated correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
 		hour14 := time.Date(2024, 6, 15, 14, 45, 0, 0, time.UTC)
@@ -367,7 +381,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("timestamps are recorded for approve and discard", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		approveTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
 		discardTime := time.Date(2024, 6, 15, 10, 35, 0, 0, time.UTC)
@@ -388,7 +403,8 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species summary sorted by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Settings: newValidTestSettings()}
+		c := &Controller{}
+		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
 			// Robin: 3 total

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -373,8 +373,8 @@ func (c *Controller) initInsightsRoutes() {
 	c.insightsRepo = repository.NewInsightsRepository(db, useV2Prefix, isMySQL)
 
 	// Build both name maps once and cache on Controller
-	if c.Settings != nil {
-		c.UpdateCommonNameMap(c.Settings.BirdNET.Labels)
+	if s := c.controllerSettings(); s != nil {
+		c.UpdateCommonNameMap(s.BirdNET.Labels)
 	}
 
 	insightsGroup := c.Group.Group("/insights")

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -53,19 +53,20 @@ func (m *mockInsightsRepo) GetDashboardKPIs(_ context.Context, _ int64, _ *uint)
 func setupInsightsTestController(t *testing.T, mock *mockInsightsRepo) (*echo.Echo, *Controller) {
 	t.Helper()
 	e := echo.New()
-	controller := &Controller{
-		Group: e.Group("/api/v2"),
-		Settings: &conf.Settings{
-			BirdNET: conf.BirdNETConfig{
-				Labels: []string{
-					"Turdus merula_Eurasian Blackbird",
-					"Parus major_Great Tit",
-				},
+	settingsVal := &conf.Settings{
+		BirdNET: conf.BirdNETConfig{
+			Labels: []string{
+				"Turdus merula_Eurasian Blackbird",
+				"Parus major_Great Tit",
 			},
 		},
+	}
+	controller := &Controller{
+		Group:        e.Group("/api/v2"),
 		insightsRepo: mock,
 	}
-	controller.UpdateCommonNameMap(controller.Settings.BirdNET.Labels)
+	controller.Settings.Store(settingsVal)
+	controller.UpdateCommonNameMap(controller.Settings.Load().BirdNET.Labels)
 	return e, controller
 }
 

--- a/internal/api/v2/integrations_test.go
+++ b/internal/api/v2/integrations_test.go
@@ -46,7 +46,7 @@ func runIntegrationConnectionHandlerTest(t *testing.T, handlerFunc func(*Control
 			var req *http.Request
 			if strings.Contains(endpoint, "birdweather") {
 				// BirdWeather endpoint expects JSON body matching the controller settings
-				bwSettings := controller.Settings.Realtime.Birdweather
+				bwSettings := controller.Settings.Load().Realtime.Birdweather
 				bodyJSON := fmt.Sprintf(`{"enabled":%t,"id":%q,"threshold":%f,"locationAccuracy":%f}`,
 					bwSettings.Enabled, bwSettings.ID, bwSettings.Threshold, bwSettings.LocationAccuracy)
 				req = httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(bodyJSON))
@@ -245,10 +245,10 @@ func TestGetMQTTStatus(t *testing.T) {
 			e, _, controller := setupTestEnvironment(t)
 
 			// Configure settings
-			controller.Settings.Realtime.MQTT.Enabled = tc.mqttEnabled
-			controller.Settings.Realtime.MQTT.Broker = tc.mqttBroker
-			controller.Settings.Realtime.MQTT.Topic = tc.mqttTopic
-			controller.Settings.Main.Name = testBirdNetName
+			controller.Settings.Load().Realtime.MQTT.Enabled = tc.mqttEnabled
+			controller.Settings.Load().Realtime.MQTT.Broker = tc.mqttBroker
+			controller.Settings.Load().Realtime.MQTT.Topic = tc.mqttTopic
+			controller.Settings.Load().Main.Name = testBirdNetName
 
 			// Create request
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/integrations/mqtt/status", http.NoBody)
@@ -323,10 +323,10 @@ func TestGetBirdWeatherStatus(t *testing.T) {
 			e, _, controller := setupTestEnvironment(t)
 
 			// Configure settings for the test case
-			controller.Settings.Realtime.Birdweather.Enabled = tc.bwEnabled
-			controller.Settings.Realtime.Birdweather.ID = tc.bwID
-			controller.Settings.Realtime.Birdweather.Threshold = tc.bwThreshold
-			controller.Settings.Realtime.Birdweather.LocationAccuracy = tc.bwLocationAcc
+			controller.Settings.Load().Realtime.Birdweather.Enabled = tc.bwEnabled
+			controller.Settings.Load().Realtime.Birdweather.ID = tc.bwID
+			controller.Settings.Load().Realtime.Birdweather.Threshold = tc.bwThreshold
+			controller.Settings.Load().Realtime.Birdweather.LocationAccuracy = tc.bwLocationAcc
 
 			// Create request context
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/integrations/birdweather/status", http.NoBody)
@@ -363,8 +363,8 @@ func TestTestMQTTConnection(t *testing.T) {
 		{
 			name: "MQTT Not Enabled",
 			setupSettings: func(controller *Controller) {
-				controller.Settings.Realtime.MQTT.Enabled = false
-				controller.Settings.Realtime.MQTT.Broker = testMQTTBroker
+				controller.Settings.Load().Realtime.MQTT.Enabled = false
+				controller.Settings.Load().Realtime.MQTT.Broker = testMQTTBroker
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody:   `{"success":false,"message":"MQTT is not enabled in settings"}`,
@@ -372,8 +372,8 @@ func TestTestMQTTConnection(t *testing.T) {
 		{
 			name: "Broker Not Configured",
 			setupSettings: func(controller *Controller) {
-				controller.Settings.Realtime.MQTT.Enabled = true
-				controller.Settings.Realtime.MQTT.Broker = ""
+				controller.Settings.Load().Realtime.MQTT.Enabled = true
+				controller.Settings.Load().Realtime.MQTT.Broker = ""
 			},
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"success":false,"message":"MQTT broker not configured"}`,
@@ -395,8 +395,8 @@ func TestTestBirdWeatherConnection(t *testing.T) {
 		{
 			name: "BirdWeather Not Enabled",
 			setupSettings: func(controller *Controller) {
-				controller.Settings.Realtime.Birdweather.Enabled = false
-				controller.Settings.Realtime.Birdweather.ID = "ABC123"
+				controller.Settings.Load().Realtime.Birdweather.Enabled = false
+				controller.Settings.Load().Realtime.Birdweather.ID = "ABC123"
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody:   `{"success":false,"message":"BirdWeather integration is not enabled","state":"failed"}`,
@@ -404,8 +404,8 @@ func TestTestBirdWeatherConnection(t *testing.T) {
 		{
 			name: "Station ID Not Configured",
 			setupSettings: func(controller *Controller) {
-				controller.Settings.Realtime.Birdweather.Enabled = true
-				controller.Settings.Realtime.Birdweather.ID = ""
+				controller.Settings.Load().Realtime.Birdweather.Enabled = true
+				controller.Settings.Load().Realtime.Birdweather.ID = ""
 			},
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"success":false,"message":"BirdWeather station ID not configured","state":"failed"}`,
@@ -537,16 +537,16 @@ func TestWriteJSONResponse(t *testing.T) {
 // Advanced test for MQTT connection with client disconnection
 func TestMQTTConnectionWithClientDisconnection(t *testing.T) {
 	runIntegrationConnectionWithDisconnectionTest(t, (*Controller).TestMQTTConnection, "/api/v2/integrations/mqtt/test", func(controller *Controller) {
-		controller.Settings.Realtime.MQTT.Enabled = true
-		controller.Settings.Realtime.MQTT.Broker = testMQTTBroker
+		controller.Settings.Load().Realtime.MQTT.Enabled = true
+		controller.Settings.Load().Realtime.MQTT.Broker = testMQTTBroker
 	})
 }
 
 // Advanced test for BirdWeather connection with client disconnection
 func TestBirdWeatherConnectionWithClientDisconnection(t *testing.T) {
 	runIntegrationConnectionWithDisconnectionTest(t, (*Controller).TestBirdWeatherConnection, "/api/v2/integrations/birdweather/test", func(controller *Controller) {
-		controller.Settings.Realtime.Birdweather.Enabled = true
-		controller.Settings.Realtime.Birdweather.ID = "ABC123"
+		controller.Settings.Load().Realtime.Birdweather.Enabled = true
+		controller.Settings.Load().Realtime.Birdweather.ID = "ABC123"
 	})
 }
 
@@ -556,10 +556,10 @@ func TestGetMQTTStatusWithControlChannel(t *testing.T) {
 	e, _, controller := setupTestEnvironment(t)
 
 	// Configure settings
-	controller.Settings.Realtime.MQTT.Enabled = true
-	controller.Settings.Realtime.MQTT.Broker = testMQTTBroker
-	controller.Settings.Realtime.MQTT.Topic = "birdnet/detections"
-	controller.Settings.Main.Name = testBirdNetName
+	controller.Settings.Load().Realtime.MQTT.Enabled = true
+	controller.Settings.Load().Realtime.MQTT.Broker = testMQTTBroker
+	controller.Settings.Load().Realtime.MQTT.Topic = "birdnet/detections"
+	controller.Settings.Load().Main.Name = testBirdNetName
 
 	// Create a mock control channel
 	controlChan := make(chan string, 1)
@@ -599,8 +599,8 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
 
 		// Configure settings to enable MQTT
-		controller.Settings.Realtime.MQTT.Enabled = true
-		controller.Settings.Realtime.MQTT.Broker = "tcp://invalid-broker.example.com:1883"
+		controller.Settings.Load().Realtime.MQTT.Enabled = true
+		controller.Settings.Load().Realtime.MQTT.Broker = "tcp://invalid-broker.example.com:1883"
 
 		// Create a test HTTP request
 		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/mqtt/test", http.NoBody)
@@ -622,8 +622,8 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
 
 		// Configure settings to enable BirdWeather but with invalid configuration
-		controller.Settings.Realtime.Birdweather.Enabled = true
-		controller.Settings.Realtime.Birdweather.ID = "INVALID_ID"
+		controller.Settings.Load().Realtime.Birdweather.Enabled = true
+		controller.Settings.Load().Realtime.Birdweather.ID = "INVALID_ID"
 
 		// Create JSON request body for BirdWeather test
 		requestBody := `{
@@ -653,8 +653,8 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
 
 		// Configure settings to enable MQTT
-		controller.Settings.Realtime.MQTT.Enabled = true
-		controller.Settings.Realtime.MQTT.Broker = testMQTTBroker
+		controller.Settings.Load().Realtime.MQTT.Enabled = true
+		controller.Settings.Load().Realtime.MQTT.Broker = testMQTTBroker
 
 		// Create a cancellable context
 		ctx, cancel := context.WithCancel(t.Context())
@@ -681,8 +681,8 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
 
 		// Configure settings to enable BirdWeather
-		controller.Settings.Realtime.Birdweather.Enabled = true
-		controller.Settings.Realtime.Birdweather.ID = "VALID_ID" // Use a valid-looking ID
+		controller.Settings.Load().Realtime.Birdweather.Enabled = true
+		controller.Settings.Load().Realtime.Birdweather.ID = "VALID_ID" // Use a valid-looking ID
 
 		// Create a cancellable context
 		ctx, cancel := context.WithCancel(t.Context())
@@ -717,10 +717,10 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
 
 		// Configure settings to enable MQTT with an invalid broker
-		controller.Settings.Realtime.MQTT.Enabled = true
-		controller.Settings.Realtime.MQTT.Broker = "tcp://nonexistent.broker:1883"
-		controller.Settings.Realtime.MQTT.Topic = "birdnet/detections"
-		controller.Settings.Main.Name = testBirdNetName
+		controller.Settings.Load().Realtime.MQTT.Enabled = true
+		controller.Settings.Load().Realtime.MQTT.Broker = "tcp://nonexistent.broker:1883"
+		controller.Settings.Load().Realtime.MQTT.Topic = "birdnet/detections"
+		controller.Settings.Load().Main.Name = testBirdNetName
 
 		// Create request
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/integrations/mqtt/status", http.NoBody)

--- a/internal/api/v2/legacy_cleanup_test.go
+++ b/internal/api/v2/legacy_cleanup_test.go
@@ -33,11 +33,12 @@ func createLegacyTestController(tb testing.TB, e *echo.Echo, settings *conf.Sett
 	// Handlers read the live snapshot via currentSettings(); publish the test's
 	// settings so the read resolves to them (restored on cleanup).
 	publishTestSettings(tb, settings)
-	return &Controller{
-		Settings:      settings,
+	c := &Controller{
 		Echo:          e,
 		cleanupStatus: NewCleanupStatus(),
 	}
+	c.Settings.Store(settings)
+	return c
 }
 
 // TestGetLegacyStatus_V2OnlyMode_NoLegacy tests status when in v2-only mode with no legacy DB.

--- a/internal/api/v2/media_spectrogram_queuekey_test.go
+++ b/internal/api/v2/media_spectrogram_queuekey_test.go
@@ -57,12 +57,11 @@ func TestGetSpectrogramStatusFindsInFlightJobAfterExportPathChange(t *testing.T)
 	mockDS := mocks.NewMockInterface(t)
 
 	controller := &Controller{
-		Settings: settings,
-		SFS:      sfs,
-		ctx:      t.Context(),
-		DS:       mockDS,
+		SFS: sfs,
+		ctx: t.Context(),
+		DS:  mockDS,
 	}
-	controller.settingsAtomic.Store(settings)
+	controller.Settings.Store(settings)
 	conftest.SetTestSettings(settings)
 
 	// Simulate an in-flight generation enqueued under the immutable queue key.
@@ -77,7 +76,7 @@ func TestGetSpectrogramStatusFindsInFlightJobAfterExportPathChange(t *testing.T)
 	changed := conf.CloneSettings(settings)
 	changed.Realtime.Audio.Export.Path = filepath.Join(tmp, "changed")
 	conftest.SetTestSettings(changed)
-	controller.settingsAtomic.Store(changed)
+	controller.Settings.Store(changed)
 
 	// Poll the status endpoint.
 	e := echo.New()
@@ -118,11 +117,10 @@ func TestGenerateSpectrogramFromRelRetainsFailedStatusForPolling(t *testing.T) {
 
 	settings := newValidTestSettings()
 	controller := &Controller{
-		Settings: settings,
-		SFS:      sfs,
-		ctx:      ctx,
+		SFS: sfs,
+		ctx: ctx,
 	}
-	controller.settingsAtomic.Store(settings)
+	controller.Settings.Store(settings)
 	conftest.SetTestSettings(settings)
 
 	const queueKey = "queuekey-failtest:1026:true"

--- a/internal/api/v2/media_spectrogram_toctou_test.go
+++ b/internal/api/v2/media_spectrogram_toctou_test.go
@@ -42,11 +42,10 @@ func TestGenerateSpectrogramFromRelIgnoresLiveExportPath(t *testing.T) {
 	ctx := t.Context()
 
 	controller := &Controller{
-		Settings: newValidTestSettings(),
-		SFS:      sfs,
-		ctx:      ctx,
+		SFS: sfs,
+		ctx: ctx,
 	}
-	controller.settingsAtomic.Store(controller.Settings)
+	controller.Settings.Store(newValidTestSettings())
 
 	const (
 		width = SpectrogramSizeLg
@@ -63,10 +62,10 @@ func TestGenerateSpectrogramFromRelIgnoresLiveExportPath(t *testing.T) {
 	// Publish a divergent live export path. A worker that re-read Export.Path to
 	// derive its path/key (the pre-fix behaviour) would normalize the clip path
 	// differently and miss the pre-created spectrogram.
-	live := conf.CloneSettings(controller.Settings)
+	live := conf.CloneSettings(controller.Settings.Load())
 	live.Realtime.Audio.Export.Path = filepath.Join(tmp, "changed-prefix")
 	conftest.SetTestSettings(live)
-	controller.settingsAtomic.Store(live)
+	controller.Settings.Store(live)
 
 	got, err := controller.generateSpectrogramFromRel(ctx, relAudioPath, "irrelevant/clip/path.wav", "", width, raw, "", "")
 	require.NoError(t, err)

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -432,7 +432,7 @@ func setupMediaTestEnvironment(t *testing.T) (*echo.Echo, *Controller, string) {
 
 	// Assign the tempDir to settings just in case any *other* part relies on it
 	// (though SecureFS should make this less necessary)
-	controller.Settings.Realtime.Audio.Export.Path = tempDir
+	controller.Settings.Load().Realtime.Audio.Export.Path = tempDir
 
 	// Inject passthrough auth middleware so authenticated routes (e.g. clip extraction)
 	// can be registered and tested without a real auth service

--- a/internal/api/v2/migration_test.go
+++ b/internal/api/v2/migration_test.go
@@ -117,13 +117,13 @@ func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *data
 	}
 
 	controller := &Controller{
-		Echo:     e,
-		Group:    e.Group("/api/v2"),
-		Settings: getTestSettings(t),
-		DS:       testDS,
-		Repo:     mockRepo,
+		Echo:  e,
+		Group: e.Group("/api/v2"),
+		DS:    testDS,
+		Repo:  mockRepo,
 	}
-	publishTestSettings(t, controller.Settings)
+	controller.Settings.Store(getTestSettings(t))
+	publishTestSettings(t, controller.Settings.Load())
 
 	return e, controller, sm
 }
@@ -574,10 +574,10 @@ func TestGetMigrationStatus_NoStateManager(t *testing.T) {
 
 	e := echo.New()
 	controller := &Controller{
-		Echo:     e,
-		Group:    e.Group("/api/v2"),
-		Settings: getTestSettings(t),
+		Echo:  e,
+		Group: e.Group("/api/v2"),
 	}
+	controller.Settings.Store(getTestSettings(t))
 
 	// Save and clear the global state manager
 	prevSM := stateManager

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -134,8 +134,9 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 
 	tlsMgr := conf.GetTLSManager()
 
-	// Serialise the entire cert-save-settings sequence. Cannot use defer
-	// because GetMQTTTLSCertificate on the success path acquires a read lock.
+	// Serialise the entire cert-save-settings sequence. Unlock explicitly at
+	// each exit (rather than defer) so the write lock is released as soon as the
+	// publish completes, before the success path builds its response.
 	c.settingsMutex.Lock()
 
 	// Stage 1: Save new cert files. On failure, clean up newly written files.
@@ -230,8 +231,8 @@ func (c *Controller) UploadMQTTTLSCertificate(ctx echo.Context) error {
 		_ = tlsMgr.RemoveCertificate(mqttTLSServiceName, conf.TLSCertTypeKey)
 	}
 
-	// Release the write lock before calling GetMQTTTLSCertificate which
-	// acquires a read lock (sync.RWMutex is not reentrant).
+	// Release the write lock once the settings publish is done, before building
+	// the response via GetMQTTTLSCertificate (a lock-free read).
 	c.settingsMutex.Unlock()
 
 	return c.GetMQTTTLSCertificate(ctx)

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -30,22 +30,24 @@ type MQTTTLSCertificateUpload struct {
 // getMQTTCertPath returns the path to an MQTT certificate, checking settings paths first,
 // then falling back to TLSManager's managed directory.
 func (c *Controller) getMQTTCertPath(certType conf.TLSCertificateType) string {
-	c.settingsMutex.RLock()
-	mqttTLS := c.Settings.Realtime.MQTT.TLS
-	c.settingsMutex.RUnlock()
-
-	// Check settings paths first (covers manually configured certs)
+	// Check settings-configured paths first (covers manually configured certs).
+	// controllerSettings() can be nil on a standalone/test controller that never
+	// stored a snapshot; in that case skip the configured paths and still allow
+	// the TLSManager-managed cert fallback below.
 	var settingsPath string
-	switch certType {
-	case conf.TLSCertTypeCA:
-		settingsPath = mqttTLS.CACert
-	case conf.TLSCertTypeClient:
-		settingsPath = mqttTLS.ClientCert
-	case conf.TLSCertTypeKey:
-		settingsPath = mqttTLS.ClientKey
-	default:
-		// Server cert types are not applicable for MQTT client configuration
-		return ""
+	if settings := c.controllerSettings(); settings != nil {
+		mqttTLS := settings.Realtime.MQTT.TLS
+		switch certType {
+		case conf.TLSCertTypeCA:
+			settingsPath = mqttTLS.CACert
+		case conf.TLSCertTypeClient:
+			settingsPath = mqttTLS.ClientCert
+		case conf.TLSCertTypeKey:
+			settingsPath = mqttTLS.ClientKey
+		default:
+			// Server cert types are not applicable for MQTT client configuration
+			return ""
+		}
 	}
 
 	if settingsPath != "" {

--- a/internal/api/v2/mqtt_tls_test.go
+++ b/internal/api/v2/mqtt_tls_test.go
@@ -48,9 +48,7 @@ func TestGetMQTTTLSCertificate_WithManualPaths(t *testing.T) {
 	require.NoError(t, os.WriteFile(certFile, []byte(certPEM), 0o644))
 
 	// Point settings to this file
-	controller.settingsMutex.Lock()
-	controller.Settings.Realtime.MQTT.TLS.CACert = certFile
-	controller.settingsMutex.Unlock()
+	controller.Settings.Load().Realtime.MQTT.TLS.CACert = certFile
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/integrations/mqtt/tls/certificate", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -310,11 +308,9 @@ func TestDeleteMQTTTLSCertificate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update settings paths
-	controller.settingsMutex.Lock()
-	controller.Settings.Realtime.MQTT.TLS.CACert = tlsMgr.GetCertificatePath(mqttTLSServiceName, conf.TLSCertTypeCA)
-	controller.Settings.Realtime.MQTT.TLS.ClientCert = tlsMgr.GetCertificatePath(mqttTLSServiceName, conf.TLSCertTypeClient)
-	controller.Settings.Realtime.MQTT.TLS.ClientKey = tlsMgr.GetCertificatePath(mqttTLSServiceName, conf.TLSCertTypeKey)
-	controller.settingsMutex.Unlock()
+	controller.Settings.Load().Realtime.MQTT.TLS.CACert = tlsMgr.GetCertificatePath(mqttTLSServiceName, conf.TLSCertTypeCA)
+	controller.Settings.Load().Realtime.MQTT.TLS.ClientCert = tlsMgr.GetCertificatePath(mqttTLSServiceName, conf.TLSCertTypeClient)
+	controller.Settings.Load().Realtime.MQTT.TLS.ClientKey = tlsMgr.GetCertificatePath(mqttTLSServiceName, conf.TLSCertTypeKey)
 
 	// DELETE
 	req := httptest.NewRequest(http.MethodDelete, "/api/v2/integrations/mqtt/tls/certificate", http.NoBody)
@@ -331,11 +327,9 @@ func TestDeleteMQTTTLSCertificate(t *testing.T) {
 	assert.False(t, tlsMgr.CertificateExists(mqttTLSServiceName, conf.TLSCertTypeKey), "client key should be removed")
 
 	// Verify settings paths cleared
-	controller.settingsMutex.RLock()
-	assert.Empty(t, controller.Settings.Realtime.MQTT.TLS.CACert)
-	assert.Empty(t, controller.Settings.Realtime.MQTT.TLS.ClientCert)
-	assert.Empty(t, controller.Settings.Realtime.MQTT.TLS.ClientKey)
-	controller.settingsMutex.RUnlock()
+	assert.Empty(t, controller.Settings.Load().Realtime.MQTT.TLS.CACert)
+	assert.Empty(t, controller.Settings.Load().Realtime.MQTT.TLS.ClientCert)
+	assert.Empty(t, controller.Settings.Load().Realtime.MQTT.TLS.ClientKey)
 
 	// GET should show nothing installed
 	req2 := httptest.NewRequest(http.MethodGet, "/api/v2/integrations/mqtt/tls/certificate", http.NoBody)
@@ -365,9 +359,7 @@ func TestDeleteMQTTTLSCertificate_ExternalPaths(t *testing.T) {
 	require.NoError(t, os.WriteFile(certFile, []byte(certPEM), 0o644))
 
 	// Point settings to this external file
-	controller.settingsMutex.Lock()
-	controller.Settings.Realtime.MQTT.TLS.CACert = certFile
-	controller.settingsMutex.Unlock()
+	controller.Settings.Load().Realtime.MQTT.TLS.CACert = certFile
 
 	// DELETE
 	req := httptest.NewRequest(http.MethodDelete, "/api/v2/integrations/mqtt/tls/certificate", http.NoBody)
@@ -383,9 +375,7 @@ func TestDeleteMQTTTLSCertificate_ExternalPaths(t *testing.T) {
 	require.NoError(t, statErr, "external cert file should not be deleted")
 
 	// Settings path should be cleared
-	controller.settingsMutex.RLock()
-	assert.Empty(t, controller.Settings.Realtime.MQTT.TLS.CACert, "settings path should be cleared")
-	controller.settingsMutex.RUnlock()
+	assert.Empty(t, controller.Settings.Load().Realtime.MQTT.TLS.CACert, "settings path should be cleared")
 }
 
 // TestMQTTTLSRouteRegistration verifies that all three MQTT TLS routes are registered

--- a/internal/api/v2/notifications_helpers_test.go
+++ b/internal/api/v2/notifications_helpers_test.go
@@ -44,14 +44,15 @@ func assertNoNilAction(t *testing.T, result, metadata map[string]any) {
 
 // mockController creates a controller with minimal setup for testing
 func mockController() *Controller {
-	return &Controller{
-		Settings: &conf.Settings{
-			WebServer: conf.WebServerSettings{
-				Debug: true,
-			},
-		},
+	c := &Controller{
 		apiLogger: nil, // Will skip logging in tests
 	}
+	c.Settings.Store(&conf.Settings{
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+	})
+	return c
 }
 
 func TestController_createToastEventData(t *testing.T) {
@@ -318,16 +319,16 @@ func TestController_logNotificationConnection(t *testing.T) {
 
 	// Test with nil logger (should not panic)
 	c := &Controller{
-		Settings:  mockController().Settings,
 		apiLogger: nil,
 	}
+	c.Settings.Store(mockController().Settings.Load())
 
 	// These should not panic
 	c.logNotificationConnection("test-client", "192.168.1.1", "test-agent", true)
 	c.logNotificationConnection("test-client", "192.168.1.1", "", false)
 
 	// Test with different debug settings
-	c.Settings.WebServer.Debug = false
+	c.Settings.Load().WebServer.Debug = false
 	c.logNotificationConnection("test-client", "192.168.1.1", "test-agent", true)
 }
 
@@ -360,7 +361,7 @@ func TestController_logToastSent(t *testing.T) {
 	c.logToastSent("test-client", notif)
 
 	// Test with debug disabled
-	c.Settings.WebServer.Debug = false
+	c.Settings.Load().WebServer.Debug = false
 	c.logToastSent("test-client", notif)
 }
 
@@ -379,7 +380,7 @@ func TestController_logNotificationSent(t *testing.T) {
 	c.logNotificationSent("test-client", notif)
 
 	// Test with debug disabled
-	c.Settings.WebServer.Debug = false
+	c.Settings.Load().WebServer.Debug = false
 	c.logNotificationSent("test-client", notif)
 }
 

--- a/internal/api/v2/notifications_mark_read_test.go
+++ b/internal/api/v2/notifications_mark_read_test.go
@@ -43,30 +43,40 @@ func setupNotificationTestService(t *testing.T) *notification.Service {
 	return service
 }
 
-func TestMarkNotificationRead_NotFound(t *testing.T) {
+// runMarkNotificationNotFoundTest exercises a mark-state handler against a
+// missing notification ID and asserts the idempotent 200 response with the
+// handler's confirmation message. Shared by the read and acknowledge NotFound
+// cases, which are identical apart from the path suffix, handler, and message.
+func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage string, handler func(*Controller, echo.Context) error) {
+	t.Helper()
+
 	service := setupNotificationTestService(t)
 	require.NotNil(t, service)
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications/non-existent-id/read", http.NoBody)
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications/non-existent-id/"+pathSuffix, http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 	ctx.SetParamNames("id")
 	ctx.SetParamValues("non-existent-id")
 
-	controller := &Controller{
-		Settings: &conf.Settings{},
-	}
+	controller := &Controller{}
+	controller.Settings.Store(&conf.Settings{})
 
-	err := controller.MarkNotificationRead(ctx)
+	err := handler(controller, ctx)
 	require.NoError(t, err, "handler should return nil")
 
-	assert.Equal(t, http.StatusOK, rec.Code, "mark-as-read is idempotent: missing notification returns 200")
+	assert.Equal(t, http.StatusOK, rec.Code, "missing notification returns 200 (idempotent)")
 
 	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	require.NoError(t, err)
-	assert.Contains(t, body["message"], "Notification marked as read")
+	assert.Contains(t, body["message"], expectedMessage)
+}
+
+func TestMarkNotificationRead_NotFound(t *testing.T) {
+	runMarkNotificationNotFoundTest(t, "read", "Notification marked as read",
+		(*Controller).MarkNotificationRead)
 }
 
 func TestMarkNotificationRead_EmptyID(t *testing.T) {
@@ -80,9 +90,8 @@ func TestMarkNotificationRead_EmptyID(t *testing.T) {
 	ctx.SetParamNames("id")
 	ctx.SetParamValues("")
 
-	controller := &Controller{
-		Settings: &conf.Settings{},
-	}
+	controller := &Controller{}
+	controller.Settings.Store(&conf.Settings{})
 
 	err := controller.MarkNotificationRead(ctx)
 	require.NoError(t, err)
@@ -106,9 +115,8 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 	ctx.SetParamNames("id")
 	ctx.SetParamValues(notif.ID)
 
-	controller := &Controller{
-		Settings: &conf.Settings{},
-	}
+	controller := &Controller{}
+	controller.Settings.Store(&conf.Settings{})
 
 	err = controller.MarkNotificationRead(ctx)
 	require.NoError(t, err)
@@ -117,27 +125,6 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 }
 
 func TestMarkNotificationAcknowledged_NotFound(t *testing.T) {
-	service := setupNotificationTestService(t)
-	require.NotNil(t, service)
-
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications/non-existent-id/acknowledge", http.NoBody)
-	rec := httptest.NewRecorder()
-	ctx := e.NewContext(req, rec)
-	ctx.SetParamNames("id")
-	ctx.SetParamValues("non-existent-id")
-
-	controller := &Controller{
-		Settings: &conf.Settings{},
-	}
-
-	err := controller.MarkNotificationAcknowledged(ctx)
-	require.NoError(t, err, "handler should return nil")
-
-	assert.Equal(t, http.StatusOK, rec.Code, "mark-as-acknowledged is idempotent: missing notification returns 200")
-
-	var body map[string]any
-	err = json.Unmarshal(rec.Body.Bytes(), &body)
-	require.NoError(t, err)
-	assert.Contains(t, body["message"], "Notification marked as acknowledged")
+	runMarkNotificationNotFoundTest(t, "acknowledge", "Notification marked as acknowledged",
+		(*Controller).MarkNotificationAcknowledged)
 }

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -31,9 +31,8 @@ func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{
-		Settings: &conf.Settings{},
-	}
+	controller := &Controller{}
+	controller.Settings.Store(&conf.Settings{})
 
 	// Call through middleware to test the guard
 	handler := controller.requireNotificationService(controller.CreateTestNewSpeciesNotification)
@@ -74,17 +73,20 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{Settings: newValidTestSettings()}
-	controller.Settings = &conf.Settings{}
-	controller.Settings.Security.Host = "localhost"
-	controller.Settings.WebServer.Port = "8080"
-	controller.Settings.Main.TimeAs24h = true
+	controller := &Controller{}
+	// Build a minimal settings snapshot with only the fields this test needs,
+	// then publish it once (the empty base matches the original test).
+	settings := &conf.Settings{}
+	settings.Security.Host = "localhost"
+	settings.WebServer.Port = "8080"
+	settings.Main.TimeAs24h = true
 	// Set default templates from config.yaml
-	controller.Settings.Notification.Templates.NewSpecies.Title = "New Species: {{.CommonName}}"
-	controller.Settings.Notification.Templates.NewSpecies.Message = "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}"
+	settings.Notification.Templates.NewSpecies.Title = "New Species: {{.CommonName}}"
+	settings.Notification.Templates.NewSpecies.Message = "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}"
+	controller.Settings.Store(settings)
 	// CreateTestNewSpeciesNotification reads the live snapshot via currentSettings();
 	// publish the controller's settings so the read resolves to them.
-	publishTestSettings(t, controller.Settings)
+	publishTestSettings(t, settings)
 
 	err := controller.CreateTestNewSpeciesNotification(c)
 	require.NoError(t, err)

--- a/internal/api/v2/notifications_ntfy_check_test.go
+++ b/internal/api/v2/notifications_ntfy_check_test.go
@@ -22,7 +22,8 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{Settings: newValidTestSettings()}
+	ctrl := &Controller{}
+	ctrl.Settings.Store(newValidTestSettings())
 	// ts.Listener.Addr().String() returns "127.0.0.1:PORT"
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
@@ -41,7 +42,8 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 
 func TestCheckNtfyServer_MissingHost(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Settings: newValidTestSettings()}
+	ctrl := &Controller{}
+	ctrl.Settings.Store(newValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -53,7 +55,8 @@ func TestCheckNtfyServer_MissingHost(t *testing.T) {
 
 func TestCheckNtfyServer_InvalidHost_Unreachable(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Settings: newValidTestSettings()}
+	ctrl := &Controller{}
+	ctrl.Settings.Store(newValidTestSettings())
 	// Use a reserved/invalid IP that will not respond (TEST-NET-1, RFC 5737)
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=192.0.2.1", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -79,7 +82,8 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{Settings: newValidTestSettings()}
+	ctrl := &Controller{}
+	ctrl.Settings.Store(newValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -95,7 +99,8 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 
 func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Settings: newValidTestSettings()}
+	ctrl := &Controller{}
+	ctrl.Settings.Store(newValidTestSettings())
 	// Slash injection attempt
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=evil.com%2F%40good.com", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -108,7 +113,8 @@ func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 
 func TestCheckNtfyServer_CloudMetadataBlocked(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Settings: newValidTestSettings()}
+	ctrl := &Controller{}
+	ctrl.Settings.Store(newValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=169.254.169.254", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)

--- a/internal/api/v2/ntfy_integration_test.go
+++ b/internal/api/v2/ntfy_integration_test.go
@@ -54,7 +54,8 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 	t.Run("handler_integration", func(t *testing.T) {
 		// Test the full CheckNtfyServer handler via Echo context
 		e := echo.New()
-		ctrl := &Controller{Settings: newValidTestSettings()}
+		ctrl := &Controller{}
+		ctrl.Settings.Store(newValidTestSettings())
 
 		req := httptest.NewRequest(http.MethodGet,
 			"/api/v2/notifications/check-ntfy-server?host="+host, http.NoBody)

--- a/internal/api/v2/prerequisites_test.go
+++ b/internal/api/v2/prerequisites_test.go
@@ -302,7 +302,8 @@ func TestCheckMemoryAvailable(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Settings: newValidTestSettings()}
+	controller := &Controller{}
+	controller.Settings.Store(newValidTestSettings())
 
 	check := controller.checkMemoryAvailable()
 
@@ -379,7 +380,7 @@ func TestIsUsingMySQL_NilSettings(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Settings: nil}
+	controller := &Controller{}
 
 	result := controller.isUsingMySQL()
 
@@ -406,7 +407,7 @@ func TestGetDatabaseDirectoryResolved_NilSettings(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Settings: nil}
+	controller := &Controller{}
 	// Publish a nil global so currentSettings() falls back to the controller's
 	// nil c.Settings and exercises the "settings not available" path.
 	publishTestSettings(t, nil)
@@ -518,13 +519,13 @@ func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *
 	}
 
 	controller := &Controller{
-		Echo:     e,
-		Group:    e.Group("/api/v2"),
-		Settings: getTestSettings(t),
-		DS:       testDS,
-		Repo:     mockRepo,
+		Echo:  e,
+		Group: e.Group("/api/v2"),
+		DS:    testDS,
+		Repo:  mockRepo,
 	}
-	publishTestSettings(t, controller.Settings)
+	controller.Settings.Store(getTestSettings(t))
+	publishTestSettings(t, controller.Settings.Load())
 
 	return e, controller, sm
 }

--- a/internal/api/v2/quiet_hours.go
+++ b/internal/api/v2/quiet_hours.go
@@ -40,8 +40,9 @@ func (c *Controller) initQuietHoursRoutes() {
 // indicator count active suppressions. Authenticated requests (e.g. the
 // StreamManager settings form) continue to receive the sanitized URL map.
 func (c *Controller) GetQuietHoursStatus(ctx echo.Context) error {
-	// Read the live snapshot (race-free, hot-reloading) rather than the bare
-	// c.Settings field, which races the c.Settings republish in UpdateSettings.
+	// Read the live global snapshot (race-free, hot-reloading) via
+	// currentSettings() so out-of-band republishes are seen and the read never
+	// races the Settings.Store in UpdateSettings.
 	settings := c.currentSettings()
 	var scheduler *schedule.QuietHoursScheduler
 	if eng := c.engine.Load(); eng != nil {

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -79,9 +79,7 @@ func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
 
 // currentLocale returns the BirdNET locale from the current settings.
 func (c *Controller) currentLocale() string {
-	c.settingsMutex.RLock()
-	locale := conf.CurrentOrFallback(c.Settings).BirdNET.Locale
-	c.settingsMutex.RUnlock()
+	locale := c.currentSettings().BirdNET.Locale
 	return locale
 }
 
@@ -90,9 +88,7 @@ func (c *Controller) currentLocale() string {
 // current settings with only the test values overridden, so it can be passed
 // directly to GetProbableSpeciesWithSettings without modifying global state.
 func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *conf.Settings {
-	c.settingsMutex.RLock()
-	testSnapshot := conf.CloneSettings(conf.CurrentOrFallback(c.Settings))
-	c.settingsMutex.RUnlock()
+	testSnapshot := conf.CloneSettings(c.currentSettings())
 
 	testSnapshot.BirdNET.Latitude = lat
 	testSnapshot.BirdNET.Longitude = lon
@@ -273,12 +269,10 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 
 	// Read defaults from latest published settings snapshot so UI changes
 	// to coordinates take effect without restart.
-	c.settingsMutex.RLock()
-	settings := conf.CurrentOrFallback(c.Settings)
+	settings := c.currentSettings()
 	lat := settings.BirdNET.Latitude
 	lon := settings.BirdNET.Longitude
 	locale := settings.BirdNET.Locale
-	c.settingsMutex.RUnlock()
 
 	// Override with query params if provided
 	if latStr := ctx.QueryParam("lat"); latStr != "" {
@@ -353,9 +347,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/count [get]
 func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
-	c.settingsMutex.RLock()
-	settings := conf.CurrentOrFallback(c.Settings)
-	c.settingsMutex.RUnlock()
+	settings := c.currentSettings()
 	includedSpecies := settings.GetIncludedSpecies()
 
 	response := RangeFilterSpeciesCount{
@@ -380,9 +372,7 @@ func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/list [get]
 func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
-	c.settingsMutex.RLock()
-	settings := conf.CurrentOrFallback(c.Settings)
-	c.settingsMutex.RUnlock()
+	settings := c.currentSettings()
 	includedSpecies := settings.GetIncludedSpecies()
 
 	birdnetInstance, _ := c.getBirdNETInstance()
@@ -568,9 +558,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		var testReq RangeFilterTestRequest
 
 		// Read current settings under lock for defaults
-		c.settingsMutex.RLock()
-		defaults := conf.CurrentOrFallback(c.Settings)
-		c.settingsMutex.RUnlock()
+		defaults := c.currentSettings()
 		testReq.Latitude = defaults.BirdNET.Latitude
 		testReq.Longitude = defaults.BirdNET.Longitude
 		testReq.Threshold = defaults.BirdNET.RangeFilter.Threshold
@@ -616,9 +604,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 			return c.HandleError(ctx, err, "Failed to get species list", http.StatusInternalServerError)
 		}
 	} else {
-		c.settingsMutex.RLock()
-		settings := conf.CurrentOrFallback(c.Settings)
-		c.settingsMutex.RUnlock()
+		settings := c.currentSettings()
 
 		birdnetInstance, _ := c.getBirdNETInstance()
 		speciesList = convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale)
@@ -787,9 +773,7 @@ func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
 
 	// Read from the latest published snapshot so the just-published rebuild
 	// result is reflected immediately.
-	c.settingsMutex.RLock()
-	settings := conf.CurrentOrFallback(c.Settings)
-	c.settingsMutex.RUnlock()
+	settings := c.currentSettings()
 	includedSpecies := settings.GetIncludedSpecies()
 	lastUpdated := settings.BirdNET.RangeFilter.LastUpdated
 

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -557,7 +557,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		// Parse custom parameters
 		var testReq RangeFilterTestRequest
 
-		// Read current settings under lock for defaults
+		// Read current settings from the lock-free atomic snapshot for defaults
 		defaults := c.currentSettings()
 		testReq.Latitude = defaults.BirdNET.Latitude
 		testReq.Longitude = defaults.BirdNET.Longitude

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -54,13 +54,13 @@ func setupRangeTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, 
 	e, mockDS, controller := setupTestEnvironment(t)
 
 	// Set up mock settings with range filter data
-	controller.Settings.BirdNET.Latitude = 60.1699
-	controller.Settings.BirdNET.Longitude = 24.9384
-	controller.Settings.BirdNET.RangeFilter.Threshold = 0.01
-	controller.Settings.BirdNET.RangeFilter.LastUpdated = time.Now()
+	controller.Settings.Load().BirdNET.Latitude = 60.1699
+	controller.Settings.Load().BirdNET.Longitude = 24.9384
+	controller.Settings.Load().BirdNET.RangeFilter.Threshold = 0.01
+	controller.Settings.Load().BirdNET.RangeFilter.LastUpdated = time.Now()
 
 	// Set the included species list directly for test setup
-	controller.Settings.BirdNET.RangeFilter.Species = []string{
+	controller.Settings.Load().BirdNET.RangeFilter.Species = []string{
 		"Turdus merula_Eurasian Blackbird",
 		"Parus major_Great Tit",
 		"Corvus cornix_Hooded Crow",
@@ -373,9 +373,9 @@ func TestRebuildRangeFilterWithoutProcessor(t *testing.T) {
 func TestBuildTestSettingsDoesNotMutateGlobal(t *testing.T) {
 	_, _, controller := setupRangeTestEnvironment(t)
 
-	originalLat := controller.Settings.BirdNET.Latitude
-	originalLon := controller.Settings.BirdNET.Longitude
-	originalThreshold := controller.Settings.BirdNET.RangeFilter.Threshold
+	originalLat := controller.Settings.Load().BirdNET.Latitude
+	originalLon := controller.Settings.Load().BirdNET.Longitude
+	originalThreshold := controller.Settings.Load().BirdNET.RangeFilter.Threshold
 
 	testSettings := controller.buildTestSettings(40.7128, -74.0060, 0.05)
 
@@ -386,12 +386,12 @@ func TestBuildTestSettingsDoesNotMutateGlobal(t *testing.T) {
 	assert.True(t, testSettings.BirdNET.LocationConfigured)
 
 	// Controller's settings are unchanged
-	assert.InDelta(t, originalLat, controller.Settings.BirdNET.Latitude, 0.0001)
-	assert.InDelta(t, originalLon, controller.Settings.BirdNET.Longitude, 0.0001)
-	assert.InDelta(t, originalThreshold, controller.Settings.BirdNET.RangeFilter.Threshold, 0.001)
+	assert.InDelta(t, originalLat, controller.Settings.Load().BirdNET.Latitude, 0.0001)
+	assert.InDelta(t, originalLon, controller.Settings.Load().BirdNET.Longitude, 0.0001)
+	assert.InDelta(t, originalThreshold, controller.Settings.Load().BirdNET.RangeFilter.Threshold, 0.001)
 
 	// Published snapshot (what handlers read via CurrentOrFallback) is also unchanged
-	published := conf.CurrentOrFallback(controller.Settings)
+	published := conf.CurrentOrFallback(controller.Settings.Load())
 	assert.InDelta(t, originalLat, published.BirdNET.Latitude, 0.0001)
 	assert.InDelta(t, originalLon, published.BirdNET.Longitude, 0.0001)
 	assert.InDelta(t, originalThreshold, published.BirdNET.RangeFilter.Threshold, 0.001)
@@ -404,8 +404,8 @@ func TestBuildTestSettingsDoesNotMutateGlobal(t *testing.T) {
 func TestBuildTestSettingsConcurrentWithCountEndpoint(t *testing.T) {
 	e, _, controller := setupRangeTestEnvironment(t)
 
-	originalLat := controller.Settings.BirdNET.Latitude
-	originalLon := controller.Settings.BirdNET.Longitude
+	originalLat := controller.Settings.Load().BirdNET.Latitude
+	originalLon := controller.Settings.Load().BirdNET.Longitude
 
 	const iterations = 50
 	var wg sync.WaitGroup

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -25,12 +25,12 @@ func setupSearchTestController(t *testing.T, labels []string) *Controller {
 	e := echo.New()
 	c := &Controller{
 		Group: e.Group("/api/v2"),
-		Settings: &conf.Settings{
-			BirdNET: conf.BirdNETConfig{
-				Labels: labels,
-			},
-		},
 	}
+	c.Settings.Store(&conf.Settings{
+		BirdNET: conf.BirdNETConfig{
+			Labels: labels,
+		},
+	})
 	c.nameMaps.Store(buildNameMaps(labels))
 	return c
 }

--- a/internal/api/v2/security_test.go
+++ b/internal/api/v2/security_test.go
@@ -699,7 +699,7 @@ func TestDDoSProtection(t *testing.T) {
 
 	// In production, we would expect some rate limiting to occur under high load
 	// This is a soft assertion since test environments may not have rate limiting enabled
-	if controller.Settings != nil && controller.Settings.WebServer.Debug {
+	if controller.Settings.Load() != nil && controller.Settings.Load().WebServer.Debug {
 		// In debug mode, we can log that rate limiting should be tested in production
 		t.Log("Note: Rate limiting should be verified in production environment")
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -92,11 +92,8 @@ func (c *Controller) GetAllSettings(ctx echo.Context) error {
 		logger.String("ip", ctx.RealIP()),
 	)
 
-	// Acquire read lock to ensure settings aren't being modified during read
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
-	settings := c.Settings
+	// Read the controller's lock-free settings snapshot.
+	settings := c.controllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set
 		settings = conf.Setting()
@@ -134,11 +131,8 @@ const dashboardSectionName = "dashboard"
 func (c *Controller) GetDashboardSettings(ctx echo.Context) error {
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting public dashboard settings")
 
-	// Acquire read lock to ensure settings aren't being modified during read.
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
-	settings := c.Settings
+	// Read the controller's lock-free settings snapshot.
+	settings := c.controllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set.
 		settings = conf.Setting()
@@ -171,16 +165,13 @@ func (c *Controller) GetSectionSettings(ctx echo.Context) error {
 	section := ctx.Param("section")
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting settings for section", logger.String("section", section))
 
-	// Acquire read lock to ensure settings aren't being modified during read
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
 	if section == "" {
 		c.logAPIRequest(ctx, logger.LogLevelError, "Missing section parameter")
 		return c.HandleError(ctx, fmt.Errorf("section not specified"), "Section parameter is required", http.StatusBadRequest)
 	}
 
-	settings := c.Settings
+	// Read the controller's lock-free settings snapshot.
+	settings := c.controllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set
 		settings = conf.Setting()
@@ -218,10 +209,10 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	c.settingsMutex.Lock()
 	defer c.settingsMutex.Unlock()
 
-	// Read the controller-cached snapshot when set (tests inject this
+	// Read the controller's own snapshot when set (tests inject this
 	// directly); fall back to the global publisher. In production these are
 	// the same pointer at boot and stay in sync because every successful
-	// publish below updates both c.Settings and conf.settingsInstance.
+	// publish below updates both the atomic Settings pointer and conf.settingsInstance.
 	current := c.getSettingsOrFallback()
 	if current == nil {
 		c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized during update attempt")
@@ -285,16 +276,15 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 
 	// Publish the new snapshot. conf.StoreSettings publishes atomically to
 	// the global (readers via conf.GetSettings immediately see this version;
-	// existing pointer holders stay on the old). c.Settings keeps the
-	// controller-cached pointer in sync so read handlers that still
-	// dereference c.Settings return the freshly published snapshot. The
-	// write is safe under c.settingsMutex which all c.Settings readers
-	// also acquire, except for c.Debug which deliberately reads via
-	// conf.GetSettings() to stay race-free without grabbing the lock.
+	// existing pointer holders stay on the old). c.Settings.Store republishes
+	// the controller's own atomic snapshot so per-controller readers
+	// (controllerSettings) return the freshly published value. Both stores are
+	// lock-free; settingsMutex here only serialises this read-modify-write
+	// against other update handlers, not against readers.
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}
-	c.publishSettings(updated)
+	c.Settings.Store(updated)
 
 	// Run cross-field side-effects (interval tracking, telemetry toggles, etc.)
 	// against the published pair. handleSettingsChanges is read-only on both.
@@ -304,20 +294,20 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		if publishGlobal {
 			conf.StoreSettings(current)
 		}
-		c.publishSettings(current)
+		c.Settings.Store(current)
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to apply settings changes, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
 	// Persist to disk only when this controller owns the global snapshot
 	// (production path) AND DisableSaveSettings is not set. conf.SaveSettings
-	// reads conf.GetSettings internally; persisting from a test that injected
-	// a standalone c.Settings would save an unrelated snapshot.
+	// reads conf.GetSettings internally; persisting from a test that stored a
+	// standalone snapshot via c.Settings.Store would save an unrelated snapshot.
 	if publishGlobal && !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
 			// Rollback in-memory; disk write never happened successfully.
 			conf.StoreSettings(current)
-			c.publishSettings(current)
+			c.Settings.Store(current)
 			c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
@@ -569,18 +559,18 @@ func handlePrimitiveField(
 }
 
 // publishAndSaveSettings publishes updated settings and persists to disk.
-// Must be called while c.settingsMutex is held. On save failure, both the
-// atomic pointer and c.Settings are rolled back to current.
+// Must be called while c.settingsMutex is held. On save failure, the atomic
+// Settings snapshot is rolled back to current.
 func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) error {
 	if c.isGlobalOwner {
 		conf.StoreSettings(updated)
 	}
-	c.publishSettings(updated)
+	c.Settings.Store(updated)
 
 	if c.isGlobalOwner && !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
 			conf.StoreSettings(current)
-			c.publishSettings(current)
+			c.Settings.Store(current)
 			return fmt.Errorf("failed to save settings: %w", err)
 		}
 	}
@@ -601,16 +591,16 @@ func (c *Controller) publishAndSaveSettings(current, updated *conf.Settings) err
 // When this controller owns the global singleton (production), it reads from
 // conf.GetSettings() so that out-of-band publishers (range filter rebuild,
 // ShouldUpdateRangeFilterToday, etc.) are not silently overwritten by a stale
-// c.Settings pointer. For test controllers that inject a standalone *Settings,
-// the cached c.Settings is returned as-is.
+// per-controller pointer. For test controllers that inject a standalone *Settings,
+// the controller's own atomic snapshot is returned as-is.
 func (c *Controller) getSettingsOrFallback() *conf.Settings {
 	if c.isGlobalOwner {
 		if s := conf.GetSettings(); s != nil {
 			return s
 		}
 	}
-	if c.Settings != nil {
-		return c.Settings
+	if s := c.Settings.Load(); s != nil {
+		return s
 	}
 	return conf.Setting()
 }
@@ -698,30 +688,31 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 			fmt.Sprintf("Invalid %s settings", section), http.StatusBadRequest)
 	}
 
-	// Publish the new snapshot atomically when we own the global; keep
-	// c.Settings in sync. See the matching comment in UpdateSettings for
-	// why c.Debug reads via conf.GetSettings() rather than c.Settings.
+	// Publish the new snapshot atomically when we own the global, then
+	// republish the controller's own atomic snapshot. See the matching comment
+	// in UpdateSettings for why Debug reads via conf.GetSettings() (the global)
+	// rather than the per-controller snapshot.
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}
-	c.publishSettings(updated)
+	c.Settings.Store(updated)
 
 	if err := c.handleSettingsChanges(current, updated); err != nil {
 		if publishGlobal {
 			conf.StoreSettings(current)
 		}
-		c.publishSettings(current)
+		c.Settings.Store(current)
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
 	// Persist to disk only when this controller owns the global snapshot
 	// AND the test did not disable save. conf.SaveSettings persists the
 	// conf.GetSettings value, which would be wrong under a standalone
-	// c.Settings injected by a test that bypassed the global publish.
+	// snapshot injected by a test that bypassed the global publish.
 	if publishGlobal && !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
 			conf.StoreSettings(current)
-			c.publishSettings(current)
+			c.Settings.Store(current)
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
 		c.logAPIRequest(ctx, logger.LogLevelInfo, "Section settings saved successfully",
@@ -2180,7 +2171,7 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 
 	// Trigger reconfigurations asynchronously.
 	// Capture debug flag from the settings snapshot so the goroutine never
-	// reads c.Settings (which may be overwritten by a concurrent update).
+	// reloads settings (which may be republished by a concurrent update).
 	if len(reconfigActions) > 0 {
 		debugEnabled := currentSettings.WebServer.Debug
 		c.wg.Go(func() {
@@ -2621,11 +2612,8 @@ func (c *Controller) GetImageProviders(ctx echo.Context) error {
 func (c *Controller) GetSystemID(ctx echo.Context) error {
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting system ID")
 
-	// Acquire read lock to ensure settings aren't being modified during read
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
-	settings := c.Settings
+	// Read the controller's lock-free settings snapshot.
+	settings := c.controllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set
 		settings = conf.Setting()

--- a/internal/api/v2/settings_concurrent_test.go
+++ b/internal/api/v2/settings_concurrent_test.go
@@ -74,10 +74,10 @@ func TestConcurrentUpdates(t *testing.T) {
 			e := echo.New()
 			controller := &Controller{
 				Echo:                e,
-				Settings:            getTestSettings(t),
 				controlChan:         make(chan string, 100),
 				DisableSaveSettings: true,
 			}
+			controller.Settings.Store(getTestSettings(t))
 
 			var wg sync.WaitGroup
 			errorsChan := make(chan error, tt.concurrency)
@@ -107,7 +107,7 @@ func TestConcurrentUpdates(t *testing.T) {
 			assert.Empty(t, errors, "Concurrent operations should not produce errors")
 
 			// Verify final state is consistent
-			settings := controller.Settings
+			settings := controller.Settings.Load()
 			assert.NotNil(t, settings)
 
 			// For same-section updates, verify one of the values "won"
@@ -320,7 +320,7 @@ func TestRaceConditionScenarios(t *testing.T) {
 				wg.Wait()
 
 				// Verify both fields were updated
-				settings := controller.Settings
+				settings := controller.Settings.Load()
 				assert.NotNil(t, settings.Realtime.Dashboard.Thumbnails)
 			},
 		},
@@ -333,10 +333,10 @@ func TestRaceConditionScenarios(t *testing.T) {
 			e := echo.New()
 			controller := &Controller{
 				Echo:                e,
-				Settings:            getTestSettings(t),
 				controlChan:         make(chan string, 100),
 				DisableSaveSettings: true,
 			}
+			controller.Settings.Store(getTestSettings(t))
 
 			tt.scenario(t, controller)
 		})

--- a/internal/api/v2/settings_edge_test.go
+++ b/internal/api/v2/settings_edge_test.go
@@ -385,9 +385,9 @@ func TestComplexNestedPreservation(t *testing.T) {
 
 	// Update controller settings with complex initial state
 	// Use lowercase keys since that's what a real config would have after normalization
-	controller.Settings.Realtime.Species.Include = []string{"Robin", "Eagle", "Owl"}
-	controller.Settings.Realtime.Species.Exclude = []string{"Crow", "Pigeon"}
-	controller.Settings.Realtime.Species.Config["robin"] = conf.SpeciesConfig{
+	controller.Settings.Load().Realtime.Species.Include = []string{"Robin", "Eagle", "Owl"}
+	controller.Settings.Load().Realtime.Species.Exclude = []string{"Crow", "Pigeon"}
+	controller.Settings.Load().Realtime.Species.Config["robin"] = conf.SpeciesConfig{
 		Threshold: 0.8,
 		Interval:  30,
 		Actions: []conf.SpeciesAction{{
@@ -395,16 +395,16 @@ func TestComplexNestedPreservation(t *testing.T) {
 			Command: "/usr/bin/notify",
 		}},
 	}
-	controller.Settings.Realtime.Species.Config["eagle"] = conf.SpeciesConfig{
+	controller.Settings.Load().Realtime.Species.Config["eagle"] = conf.SpeciesConfig{
 		Threshold: 0.9,
 		Interval:  60,
 	}
 
 	// Capture initial state
-	initialInclude := make([]string, len(controller.Settings.Realtime.Species.Include))
-	copy(initialInclude, controller.Settings.Realtime.Species.Include)
-	initialExclude := make([]string, len(controller.Settings.Realtime.Species.Exclude))
-	copy(initialExclude, controller.Settings.Realtime.Species.Exclude)
+	initialInclude := make([]string, len(controller.Settings.Load().Realtime.Species.Include))
+	copy(initialInclude, controller.Settings.Load().Realtime.Species.Include)
+	initialExclude := make([]string, len(controller.Settings.Load().Realtime.Species.Exclude))
+	copy(initialExclude, controller.Settings.Load().Realtime.Species.Exclude)
 
 	// Update only one deeply nested field
 	update := map[string]any{
@@ -430,7 +430,7 @@ func TestComplexNestedPreservation(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify preservation
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 
 	// Include/Exclude lists preserved
 	assert.Equal(t, initialInclude, settings.Realtime.Species.Include)

--- a/internal/api/v2/settings_eq_roundtrip_test.go
+++ b/internal/api/v2/settings_eq_roundtrip_test.go
@@ -56,10 +56,10 @@ func TestEQFilterRoundTrip_PUT(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initial,
 		controlChan:         make(chan string, testControlChanBuffer),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initial)
 
 	eqConfig := map[string]any{
 		"enabled": true,
@@ -96,7 +96,7 @@ func TestEQFilterRoundTrip_PUT(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code, "PUT should succeed")
 
 	// Verify global EQ filters persisted
-	eq := controller.Settings.Realtime.Audio.Equalizer
+	eq := controller.Settings.Load().Realtime.Audio.Equalizer
 	assert.True(t, eq.Enabled, "Equalizer should be enabled")
 	require.Len(t, eq.Filters, 2, "Should have 2 filters")
 	assert.Equal(t, "HighPass", eq.Filters[0].Type)
@@ -166,10 +166,10 @@ func TestEQFilterRoundTrip_PUT_PerSource(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initial,
 		controlChan:         make(chan string, testControlChanBuffer),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initial)
 
 	sourceEQ := map[string]any{
 		"enabled": true,
@@ -198,8 +198,8 @@ func TestEQFilterRoundTrip_PUT_PerSource(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code, "PUT should succeed")
 
 	// Verify per-source EQ
-	require.Len(t, controller.Settings.Realtime.Audio.Sources, 1)
-	srcEQ := controller.Settings.Realtime.Audio.Sources[0].Equalizer
+	require.Len(t, controller.Settings.Load().Realtime.Audio.Sources, 1)
+	srcEQ := controller.Settings.Load().Realtime.Audio.Sources[0].Equalizer
 	require.NotNil(t, srcEQ, "Per-source equalizer should not be nil")
 	assert.True(t, srcEQ.Enabled, "Per-source equalizer should be enabled")
 	require.Len(t, srcEQ.Filters, 1, "Per-source should have 1 filter")
@@ -208,7 +208,7 @@ func TestEQFilterRoundTrip_PUT_PerSource(t *testing.T) {
 	assert.Equal(t, 2, srcEQ.Filters[0].Passes)
 
 	// Global EQ should remain unchanged
-	assert.False(t, controller.Settings.Realtime.Audio.Equalizer.Enabled)
+	assert.False(t, controller.Settings.Load().Realtime.Audio.Equalizer.Enabled)
 }
 
 // TestEQFilterRoundTrip_PATCH verifies the PATCH path (section update) for
@@ -225,10 +225,10 @@ func TestEQFilterRoundTrip_PATCH(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initial,
 		controlChan:         make(chan string, testControlChanBuffer),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initial)
 
 	payload := map[string]any{
 		"audio": map[string]any{
@@ -270,7 +270,7 @@ func TestEQFilterRoundTrip_PATCH(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code, "PATCH should succeed")
 
-	eq := controller.Settings.Realtime.Audio.Equalizer
+	eq := controller.Settings.Load().Realtime.Audio.Equalizer
 	assert.True(t, eq.Enabled, "Equalizer should be enabled")
 	require.Len(t, eq.Filters, 2, "Should have 2 filters")
 	assert.Equal(t, "HighPass", eq.Filters[0].Type)
@@ -307,10 +307,10 @@ func TestEQFilterRoundTrip_PUT_PerStream(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initial,
 		controlChan:         make(chan string, testControlChanBuffer),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initial)
 
 	streamEQ := map[string]any{
 		"enabled": true,
@@ -339,8 +339,8 @@ func TestEQFilterRoundTrip_PUT_PerStream(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code, "PUT should succeed")
 
 	// Verify per-stream EQ survived the round-trip
-	require.Len(t, controller.Settings.Realtime.RTSP.Streams, 1)
-	stEQ := controller.Settings.Realtime.RTSP.Streams[0].Equalizer
+	require.Len(t, controller.Settings.Load().Realtime.RTSP.Streams, 1)
+	stEQ := controller.Settings.Load().Realtime.RTSP.Streams[0].Equalizer
 	require.NotNil(t, stEQ, "Per-stream equalizer should not be nil")
 	assert.True(t, stEQ.Enabled, "Per-stream equalizer should be enabled")
 	require.Len(t, stEQ.Filters, 1, "Per-stream should have 1 filter")
@@ -349,7 +349,7 @@ func TestEQFilterRoundTrip_PUT_PerStream(t *testing.T) {
 	assert.Equal(t, 2, stEQ.Filters[0].Passes)
 
 	// Global EQ should remain unchanged
-	assert.False(t, controller.Settings.Realtime.Audio.Equalizer.Enabled)
+	assert.False(t, controller.Settings.Load().Realtime.Audio.Equalizer.Enabled)
 }
 
 func TestEQFilterRoundTrip_PUT_WithFrontendIDField(t *testing.T) {
@@ -359,10 +359,10 @@ func TestEQFilterRoundTrip_PUT_WithFrontendIDField(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initial,
 		controlChan:         make(chan string, testControlChanBuffer),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initial)
 
 	eqConfig := map[string]any{
 		"enabled": true,
@@ -390,7 +390,7 @@ func TestEQFilterRoundTrip_PUT_WithFrontendIDField(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	eq := controller.Settings.Realtime.Audio.Equalizer
+	eq := controller.Settings.Load().Realtime.Audio.Equalizer
 	assert.True(t, eq.Enabled)
 	require.Len(t, eq.Filters, 1)
 	assert.Equal(t, "HighPass", eq.Filters[0].Type)

--- a/internal/api/v2/settings_race_test.go
+++ b/internal/api/v2/settings_race_test.go
@@ -45,7 +45,7 @@ func TestGetAppConfigReadsLiveSnapshot(t *testing.T) {
 	// controller's own c.Settings still holds the construction-time snapshot
 	// (Version "1.0.0-test", empty ColorScheme), so a stale read and a live
 	// read return different values.
-	live := conf.CloneSettings(controller.Settings)
+	live := conf.CloneSettings(controller.Settings.Load())
 	live.Version = "9.9.9-live"
 	live.Realtime.Dashboard.ColorScheme = "live-scheme"
 	conftest.SetTestSettings(live)
@@ -79,7 +79,7 @@ func TestGetAppConfigConcurrentSaveIsRaceFree(t *testing.T) {
 
 	// Ensure the global snapshot is never nil for the duration of the test so
 	// currentSettings() always resolves via the atomic pointer.
-	base := conf.CloneSettings(controller.Settings)
+	base := conf.CloneSettings(controller.Settings.Load())
 	conftest.SetTestSettings(base)
 
 	const (
@@ -100,7 +100,7 @@ func TestGetAppConfigConcurrentSaveIsRaceFree(t *testing.T) {
 				// the controller-cached pointer in sync, both under the mutex.
 				controller.settingsMutex.Lock()
 				conf.StoreSettings(snap)
-				controller.Settings = snap
+				controller.Settings.Store(snap)
 				controller.settingsMutex.Unlock()
 			}
 		})

--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -127,7 +127,7 @@ func TestPatchMissingSections(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, rec.Code)
 
-			tt.verify(t, controller.Settings)
+			tt.verify(t, controller.Settings.Load())
 		})
 	}
 }
@@ -138,7 +138,7 @@ func TestPatchTaxonomySynonymsMerge(t *testing.T) {
 	e := echo.New()
 	controller := getTestController(t, e)
 
-	controller.Settings.TaxonomySynonyms = map[string]string{
+	controller.Settings.Load().TaxonomySynonyms = map[string]string{
 		"Corvus corax": "Common Raven",
 	}
 
@@ -158,9 +158,9 @@ func TestPatchTaxonomySynonymsMerge(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	assert.Equal(t, "Common Raven", controller.Settings.TaxonomySynonyms["Corvus corax"],
+	assert.Equal(t, "Common Raven", controller.Settings.Load().TaxonomySynonyms["Corvus corax"],
 		"existing entry must be preserved after PATCH")
-	assert.Equal(t, "Great Tit", controller.Settings.TaxonomySynonyms["Parus major"],
+	assert.Equal(t, "Great Tit", controller.Settings.Load().TaxonomySynonyms["Parus major"],
 		"new entry must be added by PATCH")
 }
 
@@ -170,7 +170,7 @@ func TestPatchAlertingValidation(t *testing.T) {
 	e := echo.New()
 	controller := getTestController(t, e)
 	// Enable debug so the raw validation error is exposed in the "error" field
-	controller.Settings.WebServer.Debug = true
+	controller.Settings.Load().WebServer.Debug = true
 
 	body, err := json.Marshal(map[string]any{
 		"historyRetentionDays": -1,
@@ -200,7 +200,7 @@ func TestPatchAlertingValidation(t *testing.T) {
 func TestPatchAlertingZeroRetention(t *testing.T) {
 	e := echo.New()
 	controller := getTestController(t, e)
-	controller.Settings.Alerting.HistoryRetentionDays = 30
+	controller.Settings.Load().Alerting.HistoryRetentionDays = 30
 
 	body, err := json.Marshal(map[string]any{
 		"historyRetentionDays": 0,
@@ -217,7 +217,7 @@ func TestPatchAlertingZeroRetention(t *testing.T) {
 	err = controller.UpdateSectionSettings(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, 0, controller.Settings.Alerting.HistoryRetentionDays)
+	assert.Equal(t, 0, controller.Settings.Load().Alerting.HistoryRetentionDays)
 }
 
 func TestPatchWebServerLiveStreamValidation(t *testing.T) {
@@ -284,7 +284,7 @@ func TestPatchWebServerLiveStreamValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := echo.New()
 			controller := getTestController(t, e)
-			controller.Settings.WebServer.Debug = true
+			controller.Settings.Load().WebServer.Debug = true
 
 			body, err := json.Marshal(tt.payload)
 			require.NoError(t, err)

--- a/internal/api/v2/settings_species_test.go
+++ b/internal/api/v2/settings_species_test.go
@@ -118,7 +118,7 @@ func TestUpdateSpeciesSettingsWithZeroValues(t *testing.T) {
 
 			// Verify the settings were updated correctly
 			// Note: Keys are normalized to lowercase after API update
-			actualConfig := controller.Settings.Realtime.Species.Config[strings.ToLower(birdName)]
+			actualConfig := controller.Settings.Load().Realtime.Species.Config[strings.ToLower(birdName)]
 			assert.InDelta(t, tt.expectedConfig.Threshold, actualConfig.Threshold, 0.0001,
 				"%s: Threshold should match", tt.description)
 			assert.Equal(t, tt.expectedConfig.Interval, actualConfig.Interval,
@@ -163,9 +163,9 @@ func TestSpeciesSettingsUpdate(t *testing.T) {
 		},
 	}
 	controller := &Controller{
-		Settings:            settings,
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(settings)
 
 	// Update with zero values
 	// Note: Keys can be any case in payload - they will be normalized to lowercase
@@ -195,13 +195,13 @@ func TestSpeciesSettingsUpdate(t *testing.T) {
 	// Verify zero values are preserved in the controller's settings
 	// Zero threshold and interval values should persist after update operations
 	// Note: Keys are normalized to lowercase after API update
-	initialBird := controller.Settings.Realtime.Species.Config["initial bird"]
+	initialBird := controller.Settings.Load().Realtime.Species.Config["initial bird"]
 	assert.InDelta(t, 0.0, initialBird.Threshold, 0.0001, "initial bird threshold should be zero")
 	assert.Equal(t, 0, initialBird.Interval, "initial bird interval should be zero")
 	assert.Empty(t, initialBird.Actions, "initial bird actions should be empty")
 	assert.NotNil(t, initialBird.Actions, "initial bird actions should be empty slice, not nil")
 
-	newBird := controller.Settings.Realtime.Species.Config["new bird"]
+	newBird := controller.Settings.Load().Realtime.Species.Config["new bird"]
 	assert.InDelta(t, 0.0, newBird.Threshold, 0.0001, "new bird threshold should be zero")
 	assert.Equal(t, 0, newBird.Interval, "new bird interval should be zero")
 	assert.Empty(t, newBird.Actions, "new bird actions should be empty")
@@ -248,9 +248,9 @@ func TestPartialSpeciesConfigUpdate(t *testing.T) {
 		},
 	}
 	controller := &Controller{
-		Settings:            settings,
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(settings)
 
 	// Update only Bird A with zero values, Bird B should remain unchanged
 	// Note: Keys in payload can be any case - they will be normalized to lowercase
@@ -275,14 +275,14 @@ func TestPartialSpeciesConfigUpdate(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify Bird A was updated with zero values (keys normalized to lowercase)
-	birdA := controller.Settings.Realtime.Species.Config["bird a"]
+	birdA := controller.Settings.Load().Realtime.Species.Config["bird a"]
 	assert.InDelta(t, 0.0, birdA.Threshold, 0.0001, "bird a threshold should be zero")
 	assert.Equal(t, 0, birdA.Interval, "bird a interval should be zero")
 	assert.Empty(t, birdA.Actions, "bird a actions should be cleared")
 	assert.NotNil(t, birdA.Actions, "bird a actions should be empty slice, not nil")
 
 	// Verify Bird B remains unchanged
-	birdB := controller.Settings.Realtime.Species.Config["bird b"]
+	birdB := controller.Settings.Load().Realtime.Species.Config["bird b"]
 	assert.InDelta(t, 0.8, birdB.Threshold, 0.0001, "bird b threshold should be unchanged")
 	assert.Equal(t, 60, birdB.Interval, "bird b interval should be unchanged")
 	assert.NotNil(t, birdB.Actions, "bird b actions should be empty slice, not nil")
@@ -310,9 +310,9 @@ func TestSpeciesSettingsPatchGetSync(t *testing.T) {
 		},
 	}
 	controller := &Controller{
-		Settings:            settings,
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(settings)
 
 	// Step 1: PATCH update with zero values
 	// Note: Keys in payload can be any case - they will be normalized to lowercase
@@ -332,7 +332,7 @@ func TestSpeciesSettingsPatchGetSync(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify controller settings were updated (keys normalized to lowercase)
-	testBird := controller.Settings.Realtime.Species.Config["test bird"]
+	testBird := controller.Settings.Load().Realtime.Species.Config["test bird"]
 	assert.InDelta(t, 0.0, testBird.Threshold, 0.0001, "Controller should have zero threshold")
 	assert.Equal(t, 0, testBird.Interval, "Controller should have zero interval")
 
@@ -433,9 +433,9 @@ func newAPIContext(t *testing.T, e *echo.Echo, method, path string, body any) (e
 		Config:  map[string]conf.SpeciesConfig{},
 	}
 	controller := &Controller{
-		Settings:            settings,
 		DisableSaveSettings: true, // Disable file save for testing
 	}
+	controller.Settings.Store(settings)
 
 	// Use default values if method or path are empty
 	if method == "" {
@@ -507,9 +507,9 @@ func TestSpeciesConfigNormalizationOnAPIUpdate(t *testing.T) {
 		Config:  make(map[string]conf.SpeciesConfig),
 	}
 	controller := &Controller{
-		Settings:            settings,
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(settings)
 
 	// Update with mixed-case species names (as UI would send)
 	updatePayload := map[string]any{
@@ -544,18 +544,18 @@ func TestSpeciesConfigNormalizationOnAPIUpdate(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify keys are normalized to lowercase in controller settings
-	_, hasLowercaseRobin := controller.Settings.Realtime.Species.Config["american robin"]
+	_, hasLowercaseRobin := controller.Settings.Load().Realtime.Species.Config["american robin"]
 	assert.True(t, hasLowercaseRobin, "should have lowercase 'american robin' key after API update")
 
-	_, hasLowercaseSparrow := controller.Settings.Realtime.Species.Config["house sparrow"]
+	_, hasLowercaseSparrow := controller.Settings.Load().Realtime.Species.Config["house sparrow"]
 	assert.True(t, hasLowercaseSparrow, "should have lowercase 'house sparrow' key after API update")
 
 	// Verify mixed-case keys don't exist
-	_, hasMixedCaseRobin := controller.Settings.Realtime.Species.Config["American Robin"]
+	_, hasMixedCaseRobin := controller.Settings.Load().Realtime.Species.Config["American Robin"]
 	assert.False(t, hasMixedCaseRobin, "should not have mixed-case 'American Robin' key")
 
 	// Verify config values are preserved
-	robin := controller.Settings.Realtime.Species.Config["american robin"]
+	robin := controller.Settings.Load().Realtime.Species.Config["american robin"]
 	assert.InDelta(t, 0.75, robin.Threshold, 0.0001)
 	assert.Equal(t, 30, robin.Interval)
 }
@@ -571,8 +571,9 @@ func createTestController(t *testing.T) *Controller {
 		Config:  map[string]conf.SpeciesConfig{},
 	}
 
-	return &Controller{
-		Settings:            settings,
+	c := &Controller{
 		DisableSaveSettings: true,
 	}
+	c.Settings.Store(settings)
+	return c
 }

--- a/internal/api/v2/settings_update_test.go
+++ b/internal/api/v2/settings_update_test.go
@@ -30,10 +30,10 @@ func TestDashboardLayoutWidthPersistence(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Simulate the frontend save: elements without width field (user set to full)
 	update := map[string]any{
@@ -61,7 +61,7 @@ func TestDashboardLayoutWidthPersistence(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// The width fields must be cleared (empty string = full width default)
-	elements := controller.Settings.Realtime.Dashboard.Layout.Elements
+	elements := controller.Settings.Load().Realtime.Dashboard.Layout.Elements
 	require.Len(t, elements, 3)
 	assert.Empty(t, elements[0].Width, "daily-summary width should be empty")
 	assert.Empty(t, elements[1].Width, "currently-hearing width should be empty (was 'half')")
@@ -92,7 +92,7 @@ func TestDashboardLayoutWidthPersistence(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec2.Code)
 
-	elements2 := controller.Settings.Realtime.Dashboard.Layout.Elements
+	elements2 := controller.Settings.Load().Realtime.Dashboard.Layout.Elements
 	require.Len(t, elements2, 3)
 	assert.Equal(t, "full", elements2[1].Width, "currently-hearing should have explicit 'full'")
 	assert.Equal(t, "half", elements2[2].Width, "detections-grid should have 'half'")
@@ -108,10 +108,10 @@ func TestMergePreservesJSONDashFields(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// PATCH birdnet section — Labels (json:"-") must survive
 	update := map[string]any{"sensitivity": 1.0}
@@ -131,7 +131,7 @@ func TestMergePreservesJSONDashFields(t *testing.T) {
 
 	// Runtime field must be preserved — Labels is json:"-" and would be
 	// destroyed if zeroJSONSliceFields zeroed json:"-" tagged slices.
-	assert.Equal(t, []string{"species1", "species2"}, controller.Settings.BirdNET.Labels,
+	assert.Equal(t, []string{"species1", "species2"}, controller.Settings.Load().BirdNET.Labels,
 		"BirdNET.Labels (json:\"-\") must survive merge")
 }
 
@@ -151,10 +151,10 @@ func TestDashboardPartialUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only summary field
 	update := map[string]any{
@@ -185,7 +185,7 @@ func TestDashboardPartialUpdate(t *testing.T) {
 	assert.Contains(t, response["message"], "dashboard settings updated successfully")
 
 	// Verify only the summary field changed, others preserved
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.False(t, settings.Realtime.Dashboard.Thumbnails.Summary)                        // Changed
 	assert.Equal(t, initialRecent, settings.Realtime.Dashboard.Thumbnails.Recent)          // Preserved
 	assert.Equal(t, initialProvider, settings.Realtime.Dashboard.Thumbnails.ImageProvider) // Preserved
@@ -206,10 +206,10 @@ func TestWeatherPartialUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only provider
 	update := map[string]any{
@@ -232,7 +232,7 @@ func TestWeatherPartialUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify settings were preserved
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.Equal(t, "openweather", settings.Realtime.Weather.Provider)           // Changed
 	assert.Equal(t, initialPollInterval, settings.Realtime.Weather.PollInterval) // Preserved
 	assert.Equal(t, initialDebug, settings.Realtime.Weather.Debug)               // Preserved
@@ -256,10 +256,10 @@ func TestMQTTPartialUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only broker
 	update := map[string]any{
@@ -282,7 +282,7 @@ func TestMQTTPartialUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify settings were preserved
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.Equal(t, "tcp://newbroker:1883", settings.Realtime.MQTT.Broker) // Changed
 	assert.Equal(t, initialEnabled, settings.Realtime.MQTT.Enabled)        // Preserved
 	assert.Equal(t, initialTopic, settings.Realtime.MQTT.Topic)            // Preserved
@@ -299,10 +299,10 @@ func TestBirdNETCoordinatesUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only coordinates
 	update := map[string]any{
@@ -326,7 +326,7 @@ func TestBirdNETCoordinatesUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify settings were preserved
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.InDelta(t, 51.5074, settings.BirdNET.Latitude, 0.0001)                    // Changed
 	assert.InDelta(t, -0.1278, settings.BirdNET.Longitude, 0.0001)                   // Changed
 	assert.InDelta(t, 1.0, settings.BirdNET.Sensitivity, 0.0001)                     // Preserved
@@ -344,10 +344,10 @@ func TestNestedRangeFilterUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only range filter threshold
 	update := map[string]any{
@@ -372,7 +372,7 @@ func TestNestedRangeFilterUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify settings were preserved
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.InDelta(t, float32(0.05), settings.BirdNET.RangeFilter.Threshold, 0.0001) // Changed
 	assert.InDelta(t, 40.7128, settings.BirdNET.Latitude, 0.0001)                    // Preserved
 	assert.InDelta(t, -74.0060, settings.BirdNET.Longitude, 0.0001)                  // Preserved
@@ -388,10 +388,10 @@ func TestAudioExportPartialUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only export type
 	update := map[string]any{
@@ -416,7 +416,7 @@ func TestAudioExportPartialUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify settings were preserved
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.Equal(t, "mp3", settings.Realtime.Audio.Export.Type)     // Changed
 	assert.True(t, settings.Realtime.Audio.Export.Enabled)          // Preserved
 	assert.Equal(t, "clips", settings.Realtime.Audio.Export.Path)   // Preserved
@@ -443,10 +443,10 @@ func TestSpeciesConfigUpdate(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only threshold
 	update := map[string]any{
@@ -473,7 +473,7 @@ func TestSpeciesConfigUpdate(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify settings were preserved (keys normalized to lowercase after API update)
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	robinConfig := settings.Realtime.Species.Config["american robin"]
 	assert.InDelta(t, 0.9, robinConfig.Threshold, 0.0001) // Changed
 	assert.Equal(t, 30, robinConfig.Interval)             // Preserved
@@ -500,10 +500,10 @@ func TestEmptyUpdatePreservesEverything(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Send empty update
 	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/dashboard", bytes.NewReader([]byte("{}")))
@@ -519,7 +519,7 @@ func TestEmptyUpdatePreservesEverything(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify nothing changed
-	updatedSettings := controller.Settings
+	updatedSettings := controller.Settings.Load()
 	updatedJSON, err := json.Marshal(updatedSettings.Realtime.Dashboard)
 	require.NoError(t, err)
 
@@ -611,10 +611,10 @@ func TestDeepNestedUpdates(t *testing.T) {
 	e := echo.New()
 	controller := &Controller{
 		Echo:                e,
-		Settings:            initialSettings,
 		controlChan:         make(chan string, 10),
 		DisableSaveSettings: true,
 	}
+	controller.Settings.Store(initialSettings)
 
 	// Update only one deeply nested field
 	update := map[string]any{
@@ -638,7 +638,7 @@ func TestDeepNestedUpdates(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Verify only the targeted field changed
-	settings := controller.Settings
+	settings := controller.Settings.Load()
 	assert.Equal(t, 30, settings.Realtime.MQTT.RetrySettings.InitialDelay)                           // Changed
 	assert.Equal(t, initialMaxRetries, settings.Realtime.MQTT.RetrySettings.MaxRetries)              // Preserved
 	assert.InDelta(t, initialBackoff, settings.Realtime.MQTT.RetrySettings.BackoffMultiplier, 0.001) // Preserved

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -127,9 +127,10 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
-	c.settingsMutex.RLock()
-	labels := c.Settings.BirdNET.Labels
-	c.settingsMutex.RUnlock()
+	var labels []string
+	if settings := c.controllerSettings(); settings != nil {
+		labels = settings.BirdNET.Labels
+	}
 	speciesList := make([]RangeFilterSpecies, 0, len(labels))
 
 	for _, label := range labels {

--- a/internal/api/v2/species_taxonomy_test.go
+++ b/internal/api/v2/species_taxonomy_test.go
@@ -25,9 +25,9 @@ func TestGetGenusSpecies(t *testing.T) {
 
 	// Create a minimal controller with taxonomy DB
 	c := &Controller{
-		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 	}
+	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -125,9 +125,9 @@ func TestGetFamilySpecies(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{
-		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 	}
+	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -206,9 +206,9 @@ func TestGetSpeciesTree(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{
-		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 	}
+	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -311,11 +311,11 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{
-		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 		// No EBirdClient - testing local DB only
 		EBirdClient: nil,
 	}
+	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -368,11 +368,11 @@ func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
 	c := &Controller{
-		Settings: newValidTestSettings(),
 		// No TaxonomyDB and no EBirdClient
 		TaxonomyDB:  nil,
 		EBirdClient: nil,
 	}
+	c.Settings.Store(newValidTestSettings())
 
 	// This should fail gracefully
 	_, err := c.getDetailedTaxonomy(t.Context(), "Turdus migratorius", "", false, true)

--- a/internal/api/v2/species_test.go
+++ b/internal/api/v2/species_test.go
@@ -455,10 +455,10 @@ func TestGetAllSpecies(t *testing.T) {
 			settings.BirdNET.Labels = tt.labels
 
 			controller := &Controller{
-				Echo:     e,
-				Group:    e.Group("/api/v2"),
-				Settings: settings,
+				Echo:  e,
+				Group: e.Group("/api/v2"),
 			}
+			controller.Settings.Store(settings)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/species/all", http.NoBody)
 			rec := httptest.NewRecorder()

--- a/internal/api/v2/sse_panic_recovery_test.go
+++ b/internal/api/v2/sse_panic_recovery_test.go
@@ -21,13 +21,13 @@ func TestSendSSEMessagePanicRecovery(t *testing.T) {
 	t.Parallel()
 
 	c := &Controller{
-		Settings: &conf.Settings{
-			WebServer: conf.WebServerSettings{
-				Debug: true,
-			},
-		},
 		apiLogger: nil, // Will skip logging in tests
 	}
+	c.Settings.Store(&conf.Settings{
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+	})
 
 	// Create echo context with response recorder
 	e := echo.New()

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -175,13 +175,10 @@ type streamInfo struct {
 
 // getStreamInfo looks up stream name and type from config by URL.
 // Returns empty values if stream is not found in config.
-// Uses c.Settings (injected via Controller constructor) which points to the
-// shared settings instance — mutations are visible immediately.
+// Reads the controller's lock-free settings snapshot, so a hot-reload that
+// republishes settings is visible on the next call.
 func (c *Controller) getStreamInfo(rawURL string) streamInfo {
-	c.settingsMutex.RLock()
-	settings := c.Settings
-	c.settingsMutex.RUnlock()
-
+	settings := c.controllerSettings()
 	if settings == nil {
 		return streamInfo{}
 	}

--- a/internal/api/v2/streams_test_handler_test.go
+++ b/internal/api/v2/streams_test_handler_test.go
@@ -87,7 +87,8 @@ func TestTestStreamHandler_ValidationErrors(t *testing.T) {
 			rec := httptest.NewRecorder()
 			ctx := e.NewContext(req, rec)
 
-			ctrl := &Controller{Settings: &conf.Settings{}}
+			ctrl := &Controller{}
+			ctrl.Settings.Store(&conf.Settings{})
 			err := ctrl.TestStream(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.status, rec.Code)

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -127,8 +127,9 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		c.logDebugIfEnabled("Set default options for support dump")
 	}
 
-	// Read the live snapshot (race-free, hot-reloading) rather than the bare
-	// c.Settings field, which races the c.Settings republish in UpdateSettings.
+	// Read the live global snapshot (race-free, hot-reloading) via
+	// currentSettings() so out-of-band republishes are seen and the read never
+	// races the Settings.Store in UpdateSettings.
 	settings := c.currentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
@@ -315,8 +316,9 @@ func (c *Controller) DownloadSupportDump(ctx echo.Context) error {
 
 // GetSupportStatus returns the current support/telemetry configuration status
 func (c *Controller) GetSupportStatus(ctx echo.Context) error {
-	// Read the live snapshot (race-free, hot-reloading) rather than the bare
-	// c.Settings field, which races the c.Settings republish in UpdateSettings.
+	// Read the live global snapshot (race-free, hot-reloading) via
+	// currentSettings() so out-of-band republishes are seen and the read never
+	// races the Settings.Store in UpdateSettings.
 	settings := c.currentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)

--- a/internal/api/v2/system_test.go
+++ b/internal/api/v2/system_test.go
@@ -32,10 +32,10 @@ func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
 	}
 
 	controller := &Controller{
-		Echo:     e,
-		Group:    e.Group("/api/v2"),
-		Settings: settings,
+		Echo:  e,
+		Group: e.Group("/api/v2"),
 	}
+	controller.Settings.Store(settings)
 
 	return e, controller
 }
@@ -584,10 +584,10 @@ func TestGetActiveAudioDevice(t *testing.T) {
 			},
 		}
 		controller := &Controller{
-			Echo:     e,
-			Group:    e.Group("/api/v2"),
-			Settings: settings,
+			Echo:  e,
+			Group: e.Group("/api/v2"),
 		}
+		controller.Settings.Store(settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)
 		rec := httptest.NewRecorder()

--- a/internal/api/v2/telemetry_test.go
+++ b/internal/api/v2/telemetry_test.go
@@ -42,7 +42,8 @@ func newTestContext(t *testing.T, method, path string) (echo.Context, *httptest.
 func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
 
 	err := c.HandleError(ctx, fmt.Errorf("database failure"), "Internal server error", http.StatusInternalServerError)
@@ -63,7 +64,8 @@ func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodPost, "/api/v2/settings")
 
 	err := c.HandleError(ctx, fmt.Errorf("missing field"), "Bad request", http.StatusBadRequest)
@@ -78,7 +80,8 @@ func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
 func TestHandleError_NilError_5xxReported(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/health")
 
 	err := c.HandleError(ctx, nil, "Service unavailable", http.StatusServiceUnavailable)
@@ -97,7 +100,8 @@ func TestHandleError_NilError_5xxReported(t *testing.T) {
 func TestHandleErrorWithKey_5xxReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodDelete, "/api/v2/detections/123")
 
 	err := c.HandleErrorWithKey(
@@ -129,7 +133,8 @@ func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
 	// Now install the hook (after pre-reporting, so the Build() call above is not counted).
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
 
 	err := c.HandleError(ctx, preReported, "Internal server error", http.StatusInternalServerError)
@@ -144,7 +149,8 @@ func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
 func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections/99999")
 
 	err := c.HandleError(ctx, fmt.Errorf("record not found"), "Not found", http.StatusNotFound)
@@ -159,7 +165,8 @@ func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
 func TestHandleError_502BadGatewayReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{Settings: getTestSettings(t)}
+	c := &Controller{}
+	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/system")
 
 	err := c.HandleError(ctx, fmt.Errorf("upstream timeout"), "Bad gateway", http.StatusBadGateway)

--- a/internal/api/v2/test_helpers_test.go
+++ b/internal/api/v2/test_helpers_test.go
@@ -28,12 +28,13 @@ const (
 // Note: DisableHTTPKeepAlivesForTesting() is called in TestMain before any tests run
 func getTestController(t *testing.T, e *echo.Echo) *Controller {
 	t.Helper()
-	return &Controller{
+	c := &Controller{
 		Echo:                e,
-		Settings:            getTestSettings(t),
 		controlChan:         make(chan string, testControlChanBuffer),
 		DisableSaveSettings: true, // Disable saving to disk during tests
 	}
+	c.Settings.Store(getTestSettings(t))
+	return c
 }
 
 // getTestSettings returns a valid Settings instance for testing

--- a/internal/api/v2/test_utils_test.go
+++ b/internal/api/v2/test_utils_test.go
@@ -29,9 +29,9 @@ const (
 // Use this for tests that only need to call handler methods without database or full infrastructure.
 // Includes default settings to prevent nil pointer panics if a handler accesses c.Settings.
 func newMinimalController() *Controller {
-	return &Controller{
-		Settings: newValidTestSettings(),
-	}
+	c := &Controller{}
+	c.Settings.Store(newValidTestSettings())
+	return c
 }
 
 // publishTestSettings publishes settings as the global atomic snapshot so that
@@ -92,10 +92,10 @@ func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterfa
 	// Create a controller with the test datastore and default settings
 	// to prevent nil pointer panics if a handler accesses c.Settings.
 	controller := &Controller{
-		Group:    e.Group(apiV2Prefix),
-		DS:       mockDS,
-		Settings: newValidTestSettings(),
+		Group: e.Group(apiV2Prefix),
+		DS:    mockDS,
 	}
+	controller.Settings.Store(newValidTestSettings())
 
 	// Don't initialize routes as it causes nil pointer dereference in tests
 	// controller.initRoutes()

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -81,10 +81,11 @@ func (c *Controller) GetTLSCertificate(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to parse TLS certificate", http.StatusInternalServerError)
 	}
 
-	// Include current TLS mode from settings
-	c.settingsMutex.RLock()
-	info.Mode = string(c.Settings.Security.TLSMode)
-	c.settingsMutex.RUnlock()
+	// Include current TLS mode from settings (skip when no snapshot is stored,
+	// e.g. a standalone/test controller; controllerSettings() may then be nil).
+	if settings := c.controllerSettings(); settings != nil {
+		info.Mode = string(settings.Security.TLSMode)
+	}
 
 	return ctx.JSON(http.StatusOK, info)
 }
@@ -227,11 +228,9 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 	}
 
 	// Collect SANs from settings
-	c.settingsMutex.RLock()
 	snap := c.getSettingsOrFallback()
 	host := snap.Security.Host
 	baseURL := snap.Security.BaseURL
-	c.settingsMutex.RUnlock()
 
 	sans := tlspkg.CollectSANs(host, baseURL)
 

--- a/internal/api/v2/tls_test.go
+++ b/internal/api/v2/tls_test.go
@@ -77,9 +77,7 @@ func TestTLSGetCertificate_WithCert(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set TLS mode in settings
-	controller.settingsMutex.Lock()
-	controller.Settings.Security.TLSMode = conf.TLSModeSelfSigned
-	controller.settingsMutex.Unlock()
+	controller.Settings.Load().Security.TLSMode = conf.TLSModeSelfSigned
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/tls/certificate", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -129,9 +127,7 @@ func TestTLSUploadCertificate_ValidPEM(t *testing.T) {
 	assert.Equal(t, "CN=BirdNET-Go", info.Subject)
 
 	// Verify settings were updated
-	controller.settingsMutex.RLock()
-	assert.Equal(t, conf.TLSModeManual, controller.Settings.Security.TLSMode)
-	controller.settingsMutex.RUnlock()
+	assert.Equal(t, conf.TLSModeManual, controller.Settings.Load().Security.TLSMode)
 }
 
 func TestTLSUploadCertificate_InvalidPEM(t *testing.T) {
@@ -188,9 +184,7 @@ func TestTLSDeleteCertificate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set TLS mode
-	controller.settingsMutex.Lock()
-	controller.Settings.Security.TLSMode = conf.TLSModeManual
-	controller.settingsMutex.Unlock()
+	controller.Settings.Load().Security.TLSMode = conf.TLSModeManual
 
 	// Delete the certificate
 	req := httptest.NewRequest(http.MethodDelete, "/api/v2/tls/certificate", http.NoBody)
@@ -206,9 +200,7 @@ func TestTLSDeleteCertificate(t *testing.T) {
 	assert.False(t, tlsMgr.CertificateExists(tlsServiceName, conf.TLSCertTypeServerKey))
 
 	// Verify TLS mode was reset
-	controller.settingsMutex.RLock()
-	assert.Equal(t, conf.TLSModeNone, controller.Settings.Security.TLSMode)
-	controller.settingsMutex.RUnlock()
+	assert.Equal(t, conf.TLSModeNone, controller.Settings.Load().Security.TLSMode)
 }
 
 func TestTLSGenerateSelfSignedCertificate(t *testing.T) {
@@ -237,9 +229,7 @@ func TestTLSGenerateSelfSignedCertificate(t *testing.T) {
 	assert.Positive(t, info.DaysUntilExpiry)
 
 	// Verify settings were updated
-	controller.settingsMutex.RLock()
-	assert.Equal(t, conf.TLSModeSelfSigned, controller.Settings.Security.TLSMode)
-	controller.settingsMutex.RUnlock()
+	assert.Equal(t, conf.TLSModeSelfSigned, controller.Settings.Load().Security.TLSMode)
 }
 
 func TestTLSGenerateSelfSignedCertificate_DefaultValidity(t *testing.T) {

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -119,10 +119,10 @@ func setupWeatherTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface
 
 	// Create a controller with the test datastore
 	controller := &Controller{
-		Settings: newValidTestSettings(),
-		Group:    e.Group("/api/v2"),
-		DS:       mockDS,
+		Group: e.Group("/api/v2"),
+		DS:    mockDS,
 	}
+	controller.Settings.Store(newValidTestSettings())
 
 	// We don't need to initialize routes for unit tests
 	// But we could initialize the weather routes specifically if needed


### PR DESCRIPTION
## Summary

Converts the exported `Controller.Settings` field in `internal/api/v2` from a plain `*conf.Settings` field plus a hand-maintained `settingsAtomic` mirror and `publishSettings()` dual-write into a single `Settings atomic.Pointer[conf.Settings]` field.

Why:
- **One source of truth, one write path.** Saves call `c.Settings.Store(...)`; the mirror and `publishSettings()` are gone, so the field and a shadow copy can no longer drift, and there is no dual-write invariant to maintain.
- **Lock-free reads everywhere.** All reads go through `currentSettings()` (global-first) or `controllerSettings()` (per-controller). Read-side `settingsMutex.RLock()` is removed; writers keep `settingsMutex.Lock()` to serialize the read-modify-write (clone-then-`Store`, never in-place mutation, so lock-free readers stay race-free). This is also what lets `newErrorResponse` read the debug flag from `HandleError` while `UpdateSettings` holds the write lock without deadlocking on a non-reentrant RLock.
- **Matches the sibling `engine` / `audioWatchdog` atomic-pointer fields** on the same struct.

This completes the consolidation started in #3382, which added the mirror as a minimal race fix. The change is mechanical and compiler-verified: an `atomic.Pointer` field has no struct-literal form, so every read/write site must convert or fail to compile.

No public/external API change: the field is package-internal in practice (construction passes settings as a constructor parameter; nothing outside `internal/api/v2` reads it). Behavior is preserved (`controllerSettings()` equals the old per-controller field read; `currentSettings()` equals the old `conf.CurrentOrFallback(c.Settings)`), so hot-reload is unaffected.

### Bonus hardening (found during review)
- Nil guards on three previously-unguarded `controllerSettings()` dereferences (MQTT cert path, TLS mode, species labels), preserving the existing managed-cert fallback.
- Removed now-pointless `settingsMutex` locks from the MQTT/TLS tests (reads are lock-free now).
- Refreshed stale comments that referenced the removed mirror.

## Test Plan
- [x] `go build ./...`
- [x] `go vet ./internal/api/v2/` (no copylocks from the atomic field)
- [x] `golangci-lint run ./internal/api/v2/` (0 issues)
- [x] `go test -race ./internal/api/v2/` (full suite green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved settings management for safer, lock-free concurrent updates and hot-reload behavior.
  * Reduces risk of race conditions during configuration changes, improving runtime stability and reliability without changing public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->