### PR TITLE
chore: stop tracking .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"2526795e-3ffc-4cb3-8b7e-07de18deb5b3","pid":549979,"procStart":"378263721","acquiredAt":1780757049966}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ spectrograms/
 .mcp.json
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 tmp
 *.log
 *.log.*


### PR DESCRIPTION
## Summary

`.claude/scheduled_tasks.lock` is a transient local agent lock file that was accidentally committed in #3395 via an overly broad `git add`. This untracks it (`git rm --cached`) and adds it to `.gitignore` (next to the existing `.claude/` ignore entries) so it cannot be re-committed.

No code change.

## Test Plan
- [x] `git ls-files .claude/scheduled_tasks.lock` returns nothing (untracked)
- [x] `git check-ignore .claude/scheduled_tasks.lock` matches (ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude internal lock files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->