### PR TITLE
feat(telemetry): externalize Sentry DSN from source

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -189,6 +189,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             BUILD_VERSION=${{ inputs.version }}
+            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             BUILDKIT_INLINE_CACHE=1
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,4 +74,5 @@ jobs:
             type=registry,ref=ghcr.io/${{ env.REPO }}:buildcache,mode=max
           provenance: false
           build-args: |
+            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             BUILDKIT_INLINE_CACHE=1

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -65,6 +65,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             VERSION=${{ env.VERSION }}
+            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             BUILDKIT_INLINE_CACHE=1
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -89,6 +89,9 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 1
           BUILD_VERSION: ${{ env.BUILD_VERSION }}
+          # Baked into the binary via ldflags. Empty if the secret is unset
+          # (e.g. fork PR builds), which leaves telemetry off by design.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           PUPPETEER_SKIP_DOWNLOAD: true
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -78,6 +78,9 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 1
           BUILD_VERSION: ${{ github.ref_name }}
+          # Baked into the binary via ldflags. Empty if the secret is unset
+          # (e.g. fork PR builds), which leaves telemetry off by design.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Setup Node.js for Sentry CLI
         if: matrix.goos == 'linux' && matrix.goarch == 'amd64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,13 @@ FROM --platform=$BUILDPLATFORM buildenv AS build
 ARG BUILD_VERSION
 ENV BUILD_VERSION=${BUILD_VERSION:-unknown}
 
+# Sentry DSN baked into the binary at link time (consumed by the Taskfile
+# SENTRY_DSN var). Empty by default so unofficial builds ship telemetry off;
+# official CI passes it via --build-arg SENTRY_DSN. The final runtime image is a
+# separate stage, so this build-time value never lingers as a runtime ENV.
+ARG SENTRY_DSN
+ENV SENTRY_DSN=${SENTRY_DSN:-}
+
 ARG TARGETPLATFORM
 ARG ONNXRUNTIME_VERSION
 
@@ -79,7 +86,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
     task check-tensorflow && \
     TARGET=$(echo ${TARGETPLATFORM} | tr '/' '_') && \
     echo "Building non-embedded version with BUILD_VERSION=${BUILD_VERSION}" && \
-    BUILD_VERSION="${BUILD_VERSION}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET}
+    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET}
 
 # Create final image using a multi-platform base image
 FROM --platform=$TARGETPLATFORM debian:trixie-slim

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,13 @@ vars:
   # Go version from go.mod (single source of truth)
   GO_VERSION:
     sh: awk '/^go /{print $2; found=1} END{if(!found) exit 1}' go.mod
+  # Sentry DSN baked into the binary at link time. Read from the SENTRY_DSN
+  # environment variable (mirrors how VERSION reads BUILD_VERSION). Defaults to
+  # empty: plain `task` builds and forks ship with telemetry off. Official CI
+  # builds inject the upstream DSN via this var; at runtime users can override it
+  # with BIRDNET_GO_SENTRY_DSN without rebuilding.
+  SENTRY_DSN:
+    sh: echo "${SENTRY_DSN:-}"
   # Common build flags
   CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I$HOME/src/tensorflow"
   EXTRA_BUILD_TAGS: '{{.EXTRA_BUILD_TAGS | default ""}}'
@@ -33,7 +40,7 @@ vars:
       if [ -n "{{.EXTRA_BUILD_TAGS}}" ]; then
         echo "-tags {{.EXTRA_BUILD_TAGS}}"
       fi
-  LDFLAGS: -ldflags "-s -w -X 'main.buildDate={{.BUILD_DATE}}' -X 'main.version={{.VERSION}}'"
+  LDFLAGS: -ldflags "-s -w -X 'main.buildDate={{.BUILD_DATE}}' -X 'main.version={{.VERSION}}' -X 'github.com/tphakala/birdnet-go/internal/telemetry.sentryDSN={{.SENTRY_DSN}}'"
   BUILD_FLAGS: '{{.BUILD_TAGS_FLAG}} {{.LDFLAGS}}'
   # System paths for native library installation (used by download/verify tasks)
   SYSTEM_LIB_DIR: /usr/lib

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -189,12 +189,17 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 		response.Layout = &settings.Realtime.Dashboard.Layout
 	}
 
-	// Include Sentry frontend config when telemetry is enabled
+	// Include Sentry frontend config when telemetry is enabled AND a DSN is
+	// actually configured for this build. Builds without a DSN (plain `go build`
+	// or forks) must not hand the frontend an empty DSN, which would make the
+	// browser SDK fail to initialize.
 	if settings.Sentry.Enabled {
-		response.Sentry = &SentryFrontendConfig{
-			Enabled:  true,
-			DSN:      telemetry.GetFrontendDSN(),
-			SystemID: settings.SystemID,
+		if dsn := telemetry.GetFrontendDSN(); dsn != "" {
+			response.Sentry = &SentryFrontendConfig{
+				Enabled:  true,
+				DSN:      dsn,
+				SystemID: settings.SystemID,
+			}
 		}
 	}
 
@@ -250,7 +255,7 @@ func (c *Controller) determineWizardState(ctx context.Context, settings *conf.Se
 		return false, true, lastSeenVersion
 	}
 
-	// Version matches — no wizard needed
+	// Version matches; no wizard needed
 	return false, false, lastSeenVersion
 }
 

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -1414,6 +1414,13 @@ func TestGetAppConfig_SentryConfigWhenEnabled(t *testing.T) {
 	// GetAppConfig reads via currentSettings.
 	_, controller := setupAppConfigTest(t, nil)
 
+	// The Sentry DSN is no longer hardcoded; it resolves from the
+	// BIRDNET_GO_SENTRY_DSN env var (or an ldflags-baked value). Inject one so
+	// the frontend config is populated, mirroring an official build with a
+	// baked-in DSN. Without it, from-source/test builds resolve an empty DSN
+	// and the Sentry block is intentionally omitted.
+	t.Setenv("BIRDNET_GO_SENTRY_DSN", "https://dummy@example.ingest.sentry.io/1")
+
 	// Enable Sentry in settings
 	controller.Settings.Load().Sentry.Enabled = true
 	controller.Settings.Load().SystemID = "test-system-id-123"

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -236,12 +236,16 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		if req.UploadToSentry {
 			uploader := telemetry.GetAttachmentUploader()
 			if err := uploader.UploadSupportDump(dumpCtx, archiveData, settings.SystemID, req.UserMessage, req.GitHubIssueNumber); err != nil {
-				// Log error but don't fail the request
+				// Log error but don't fail the request. Fall back to download so
+				// the user can still retrieve the dump: builds without a Sentry
+				// DSN (e.g. from-source) have a disabled uploader, and a
+				// transient upload failure should not strand the dump.
 				c.logErrorIfEnabled("Failed to upload support dump to Sentry",
 					logger.Error(err),
 					logger.String("dump_id", dump.ID),
 				)
 				response.Message = "Support dump generated successfully but upload failed"
+				req.UploadToSentry = false // fall back to download
 			} else {
 				response.UploadedAt = time.Now().UTC().Format(time.RFC3339)
 				response.Message = "Support dump generated and uploaded successfully"

--- a/internal/telemetry/attachments_test.go
+++ b/internal/telemetry/attachments_test.go
@@ -67,20 +67,76 @@ func TestExtractTraceID_NoCollisionWithStringKeys(t *testing.T) {
 }
 
 func TestSentryDSN_ValidFormat(t *testing.T) {
-	t.Parallel()
+	// Not parallel: reads the package-level sentryDSN var, which
+	// TestResolveSentryDSN_Precedence mutates. Sequential tests run before the
+	// parallel phase, so this cannot overlap with parallel readers either.
 
-	// Verify the DSN constant exists and has valid format
-	assert.NotEmpty(t, sentryDSN, "sentryDSN should not be empty")
+	// The DSN is injected at build time via ldflags, or at runtime via
+	// BIRDNET_GO_SENTRY_DSN, so plain `go test` builds resolve to an empty DSN.
+	// Only assert the format when a DSN is actually configured.
+	dsn := resolveSentryDSN()
+	if dsn == "" {
+		t.Skip("no Sentry DSN configured for this build (expected for from-source/test builds)")
+	}
 
 	// Verify it's a valid Sentry DSN format (https://<key>@<host>/<project>)
-	assert.True(t, strings.HasPrefix(sentryDSN, "https://"), "sentryDSN should start with https://, got %s", sentryDSN)
-	assert.Contains(t, sentryDSN, "@", "sentryDSN should contain @ symbol")
+	assert.True(t, strings.HasPrefix(dsn, "https://"), "DSN should start with https://, got %s", dsn)
+	assert.Contains(t, dsn, "@", "DSN should contain @ symbol")
 
 	// Note: .sentry.io check assumes cloud Sentry; self-hosted endpoints
 	// would not have this domain. Log a warning instead of failing.
-	if !strings.Contains(sentryDSN, ".sentry.io") {
-		t.Log("Warning: sentryDSN does not contain .sentry.io - may be self-hosted")
+	if !strings.Contains(dsn, ".sentry.io") {
+		t.Log("Warning: DSN does not contain .sentry.io - may be self-hosted")
 	}
+}
+
+// TestResolveSentryDSN_Precedence verifies the resolver precedence:
+// BIRDNET_GO_SENTRY_DSN env var > ldflags-baked sentryDSN > empty.
+func TestResolveSentryDSN_Precedence(t *testing.T) {
+	// Not parallel: mutates the package-level sentryDSN var and the process env.
+	original := sentryDSN
+	t.Cleanup(func() { sentryDSN = original })
+
+	const (
+		baked    = "https://baked@example.ingest.sentry.io/1"
+		override = "https://override@example.ingest.sentry.io/2"
+	)
+
+	t.Run("env overrides baked-in value", func(t *testing.T) {
+		sentryDSN = baked
+		t.Setenv(sentryDSNEnvVar, override)
+		assert.Equal(t, override, resolveSentryDSN())
+	})
+
+	t.Run("falls back to baked-in value when env unset", func(t *testing.T) {
+		sentryDSN = baked
+		t.Setenv(sentryDSNEnvVar, "")
+		assert.Equal(t, baked, resolveSentryDSN())
+	})
+
+	t.Run("whitespace-only env value is ignored", func(t *testing.T) {
+		sentryDSN = baked
+		t.Setenv(sentryDSNEnvVar, "   ")
+		assert.Equal(t, baked, resolveSentryDSN())
+	})
+
+	t.Run("empty when neither is configured", func(t *testing.T) {
+		sentryDSN = ""
+		t.Setenv(sentryDSNEnvVar, "")
+		assert.Empty(t, resolveSentryDSN())
+	})
+
+	t.Run("env value is trimmed", func(t *testing.T) {
+		sentryDSN = ""
+		t.Setenv(sentryDSNEnvVar, "  "+override+"  ")
+		assert.Equal(t, override, resolveSentryDSN())
+	})
+
+	t.Run("baked value is trimmed", func(t *testing.T) {
+		sentryDSN = "  " + baked + "  "
+		t.Setenv(sentryDSNEnvVar, "")
+		assert.Equal(t, baked, resolveSentryDSN())
+	})
 }
 
 func TestIsTelemetryEnabled_InTestMode(t *testing.T) {

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -185,7 +185,8 @@ var (
 )
 
 // shouldSkipTelemetry returns true if telemetry should be skipped.
-// It checks test mode and whether Sentry is enabled in settings.
+// It checks test mode, whether Sentry is enabled in settings, and whether the
+// Sentry SDK is actually initialized for this build.
 // This helper reduces code duplication across telemetry functions.
 func shouldSkipTelemetry() bool {
 	// In test mode, never skip (telemetry is always "enabled" for testing)
@@ -193,7 +194,13 @@ func shouldSkipTelemetry() bool {
 		return false
 	}
 	settings := conf.GetSettings()
-	return settings == nil || !settings.Sentry.Enabled
+	if settings == nil || !settings.Sentry.Enabled {
+		return true
+	}
+	// Even when opted in, skip when the SDK was never initialized for this build
+	// (no DSN configured). Otherwise the capture paths would run and log
+	// "event sent" while sentry-go silently no-ops because no client is bound.
+	return sentry.CurrentHub().Client() == nil
 }
 
 // PlatformInfo holds privacy-safe platform information for telemetry
@@ -1092,8 +1099,13 @@ func InitMinimalSentryForSupport(systemID, version string) error {
 	deferredMutex.Lock()
 	defer deferredMutex.Unlock()
 
-	// If already initialized (either minimal or full), return
-	if sentryInitialized {
+	// If the Sentry SDK is already initialized (minimal or full), reuse it.
+	// NOTE: check the actual bound client, not sentryInitialized. When telemetry
+	// is opted out at startup, InitSentry sets sentryInitialized=true purely to
+	// drain deferred messages without initializing the SDK; relying on that flag
+	// here would make support-dump upload a silent no-op for users who keep
+	// telemetry disabled but request an upload.
+	if sentry.CurrentHub().Client() != nil {
 		return nil
 	}
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -3,6 +3,7 @@ package telemetry
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -63,7 +64,7 @@ const (
 // Process start time, captured once via sync.Once so repeated InitSentry
 // calls (e.g. from tests) do not reset the effective uptime seen by BeforeSend.
 // Initialized from the package `init()` below so the baseline reflects
-// actual process start, not the moment telemetry is configured — any delay
+// actual process start, not the moment telemetry is configured; any delay
 // between binary start and InitSentry would otherwise under-report uptime
 // and misbucket early failures as `startup` (CodeRabbit review on #2762).
 var (
@@ -116,7 +117,7 @@ func enrichEventWithUptime(event *sentry.Event) {
 		event.Contexts = make(map[string]sentry.Context)
 	}
 	// Merge into any existing context under the same key rather than
-	// overwriting — another part of the system may already have added
+	// overwriting; another part of the system may already have added
 	// fields here. Truncate to integer seconds: fractional precision is
 	// not useful and would needlessly inflate cardinality.
 	if event.Contexts[uptimeContextKey] == nil {
@@ -125,18 +126,40 @@ func enrichEventWithUptime(event *sentry.Event) {
 	event.Contexts[uptimeContextKey][uptimeContextField] = int(uptime.Seconds())
 }
 
-// sentryDSN is the Sentry DSN for the BirdNET-Go project
-// Defined at package level to avoid duplication across initialization functions
-const sentryDSN = "https://b9269b6c0f8fae154df65be5a97e0435@o4509553065525248.ingest.de.sentry.io/4509553112186960"
+// sentryDSN is the Sentry DSN for the BirdNET-Go project. It is intentionally a
+// var (not a const) and empty by default, so plain `go build` / `task` builds
+// and forks do NOT inherit the upstream project's DSN. Official release and
+// nightly builds bake the real DSN in at link time via
+//
+//	-ldflags "-X 'github.com/tphakala/birdnet-go/internal/telemetry.sentryDSN=<dsn>'"
+//
+// fed from the SENTRY_DSN build secret. At runtime the BIRDNET_GO_SENTRY_DSN
+// environment variable takes precedence over the baked-in value (see
+// resolveSentryDSN), letting self-hosters and local builds point telemetry at
+// their own Sentry project without recompiling. When the resolved DSN is empty
+// telemetry stays off even if the user opts in.
+var sentryDSN string
 
-// sentryFrontendDSN is the Sentry DSN for the BirdNET-Go frontend.
-// Currently points to the same project as the backend. To separate,
-// create a new Sentry project and update this constant.
-const sentryFrontendDSN = sentryDSN
+// sentryDSNEnvVar is the runtime environment variable that overrides the
+// build-time Sentry DSN. An empty or unset value leaves the baked-in value
+// (if any) in effect.
+const sentryDSNEnvVar = "BIRDNET_GO_SENTRY_DSN"
 
-// GetFrontendDSN returns the Sentry DSN for frontend error tracking.
+// resolveSentryDSN returns the effective Sentry DSN using the precedence
+// BIRDNET_GO_SENTRY_DSN env var > ldflags-baked sentryDSN > empty (telemetry
+// off). Values are trimmed so a whitespace-only entry counts as unset.
+func resolveSentryDSN() string {
+	if v := strings.TrimSpace(os.Getenv(sentryDSNEnvVar)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(sentryDSN)
+}
+
+// GetFrontendDSN returns the Sentry DSN for frontend error tracking. The
+// frontend shares the backend Sentry project, so it follows the same resolver
+// and therefore the same build-time/runtime precedence.
 func GetFrontendDSN() string {
-	return sentryFrontendDSN
+	return resolveSentryDSN()
 }
 
 // DeferredMessage represents a message that was captured before Sentry initialization
@@ -210,7 +233,7 @@ func InitSentry(settings *conf.Settings) error {
 	// Check if Sentry is explicitly enabled (opt-in)
 	if !settings.Sentry.Enabled {
 		GetLogger().Info("Sentry telemetry is disabled (opt-in required)")
-		// Drain deferred messages — Sentry will never initialize
+		// Drain deferred messages; Sentry will never initialize
 		deferredMutex.Lock()
 		deferredMessages = nil
 		sentryInitialized = true
@@ -221,6 +244,21 @@ func InitSentry(settings *conf.Settings) error {
 	// Enable debug logging if configured
 	if settings.Sentry.Debug {
 		enableDebugLogging()
+	}
+
+	// Resolve the DSN. From-source builds (and forks) ship without one unless
+	// BIRDNET_GO_SENTRY_DSN is set or a DSN was baked in via ldflags. With no
+	// DSN there is nowhere to send events, so skip initialization cleanly even
+	// though the user opted in, and tell them how to enable it.
+	if resolveSentryDSN() == "" {
+		GetLogger().Info("Sentry telemetry enabled but no DSN is configured for this build; skipping initialization",
+			logger.String("hint", "set "+sentryDSNEnvVar+" to point telemetry at a Sentry project"))
+		// Drain deferred messages; Sentry will never initialize for this build.
+		deferredMutex.Lock()
+		deferredMessages = nil
+		sentryInitialized = true
+		deferredMutex.Unlock()
+		return nil
 	}
 
 	// Initialize Sentry SDK
@@ -258,7 +296,7 @@ func enableDebugLogging() {
 func initializeSentrySDK(settings *conf.Settings) error {
 	// Initialize Sentry with privacy-compliant options
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:        sentryDSN,
+		Dsn:        resolveSentryDSN(),
 		SampleRate: 1.0,   // Capture all errors by default
 		Debug:      false, // Keep debug off for production
 
@@ -518,7 +556,7 @@ func removePrivacyExtraFields(extra map[string]any) int {
 		"source_id": true, // opaque source identifier (uuid-based)
 		"source":    true, // alias used by capture buffer
 		"device_id": true, // ALSA/WASAPI device identifier
-		// NOTE: device_name excluded — can contain user PII (e.g. "Jane's AirPods").
+		// NOTE: device_name excluded; can contain user PII (e.g. "Jane's AirPods").
 		// device_id (opaque ALSA/WASAPI identifier) provides sufficient diagnostic value.
 		"consumer_id":          true, // route consumer identifier
 		"active_streams":       true, // count of active streams
@@ -919,7 +957,7 @@ func CaptureMessage(message string, level sentry.Level, component string) {
 		return
 	}
 
-	// Filter out info/debug-level messages — these are operational signals,
+	// Filter out info/debug-level messages; these are operational signals,
 	// not errors. They create noise issues in Sentry's issue list.
 	if level == sentry.LevelInfo || level == sentry.LevelDebug {
 		return
@@ -1059,9 +1097,17 @@ func InitMinimalSentryForSupport(systemID, version string) error {
 		return nil
 	}
 
-	// Initialize with minimal configuration (uses package-level sentryDSN)
+	// Without a DSN there is no Sentry project to upload to. From-source builds
+	// hit this by design; the caller falls back to a local download.
+	dsn := resolveSentryDSN()
+	if dsn == "" {
+		GetLogger().Info("telemetry DSN not configured for this build; support dump upload unavailable")
+		return fmt.Errorf("telemetry DSN not configured for this build")
+	}
+
+	// Initialize with minimal configuration (uses the resolved DSN)
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              sentryDSN,
+		Dsn:              dsn,
 		SampleRate:       0, // Don't capture any errors automatically
 		TracesSampleRate: 0, // No performance monitoring
 		Debug:            false,


### PR DESCRIPTION
## Summary

The Sentry DSN was a hardcoded `const` compiled into every binary, so any clone or fork inherited the upstream project's DSN and opted-in users sent telemetry and support dumps to it. This makes the DSN a build-time default plus runtime override instead.

`sentryDSN` is now an empty package `var` injected at link time via `-ldflags -X`, with a `BIRDNET_GO_SENTRY_DSN` environment variable that takes precedence at runtime. Resolution order:

```
BIRDNET_GO_SENTRY_DSN env var  >  ldflags-baked sentryDSN  >  empty (telemetry off)
```

The DSN is a write-only client ingest key, not a secret; the goal is not secrecy but that the value leaves the source tree, forks stop silently inheriting ours, and self-hosters can point at their own Sentry project.

### Behavior

- **Official release/nightly/docker builds:** bake the DSN in from a CI secret, so existing opted-in users keep reporting exactly as before.
- **Plain `go build` / `task` builds and forks:** ship with telemetry off unless a DSN is provided. Set `BIRDNET_GO_SENTRY_DSN=<dsn>` at runtime (no rebuild) or pass `SENTRY_DSN=<dsn>` to `task` to bake it in. The opt-in toggle (`sentry.enabled`) is unchanged; a DSN sets the destination, the toggle controls whether anything is sent.

## Changes

- `internal/telemetry/sentry.go`: `const sentryDSN` -> empty `var`; new `resolveSentryDSN()` resolver and `BIRDNET_GO_SENTRY_DSN` override; empty-DSN guards in `InitSentry`, `initializeSentrySDK`, and `InitMinimalSentryForSupport`; `GetFrontendDSN()` follows the resolver so the frontend inherits the same precedence.
- `internal/api/v2/app.go`: emit the frontend Sentry config only when a DSN is actually configured (never hand the browser SDK an empty DSN).
- `internal/api/v2/support.go`: fall back to local download when an upload fails, so a generated support dump is never stranded (covers DSN-less builds and transient upload failures).
- Build wiring: `Taskfile.yml` reads `SENTRY_DSN` (same pattern as `BUILD_VERSION`) into the ldflags; `Dockerfile` threads it through an `ARG`/`ENV` in the build stage (never reaches the runtime image); release, nightly, and docker workflows inject it from the `SENTRY_DSN` repo secret.
- Tests: resolver precedence and skip-when-empty coverage; the app-config test injects a DSN to mirror an official build.

## Test Plan

- [x] `golangci-lint run` (full project): 0 issues
- [x] `go test -race ./internal/telemetry/ ./internal/api/v2/`: pass
- [x] Verified ldflags `-X` targets `...telemetry.sentryDSN` (test runs format checks when injected, skips when empty)
- [x] Verified the Taskfile substitutes `SENTRY_DSN` into LDFLAGS (populated when set, empty otherwise)
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build and release pipelines now support a configurable Sentry DSN so telemetry can be enabled when provided and baked into builds.

* **Bug Fixes**
  * Support dump generation now falls back to a local download if remote upload fails, ensuring diagnostic data is always retrievable.

* **Behavior**
  * Frontend Sentry configuration is omitted when no DSN is set; telemetry is skipped unless a valid DSN/client is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->