### PR TITLE
feat(branding): externalize project identity URLs from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,18 @@ ENV BUILD_VERSION=${BUILD_VERSION:-unknown}
 ARG SENTRY_DSN
 ENV SENTRY_DSN=${SENTRY_DSN:-}
 
+# Project identity baked into the binary at link time (consumed by the Taskfile
+# PROJECT_* vars). Empty by default so builds use the upstream defaults in
+# internal/branding; forks pass --build-arg PROJECT_NAME / PROJECT_REPO_URL /
+# PROJECT_COMMUNITY_URL to rebrand. Self-hosters can instead override at runtime
+# with the BIRDNET_GO_PROJECT_* environment variables.
+ARG PROJECT_NAME
+ENV PROJECT_NAME=${PROJECT_NAME:-}
+ARG PROJECT_REPO_URL
+ENV PROJECT_REPO_URL=${PROJECT_REPO_URL:-}
+ARG PROJECT_COMMUNITY_URL
+ENV PROJECT_COMMUNITY_URL=${PROJECT_COMMUNITY_URL:-}
+
 ARG TARGETPLATFORM
 ARG ONNXRUNTIME_VERSION
 
@@ -86,7 +98,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
     task check-tensorflow && \
     TARGET=$(echo ${TARGETPLATFORM} | tr '/' '_') && \
     echo "Building non-embedded version with BUILD_VERSION=${BUILD_VERSION}" && \
-    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET}
+    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" PROJECT_NAME="${PROJECT_NAME}" PROJECT_REPO_URL="${PROJECT_REPO_URL}" PROJECT_COMMUNITY_URL="${PROJECT_COMMUNITY_URL}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET}
 
 # Create final image using a multi-platform base image
 FROM --platform=$TARGETPLATFORM debian:trixie-slim

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,6 +32,18 @@ vars:
   # with BIRDNET_GO_SENTRY_DSN without rebuilding.
   SENTRY_DSN:
     sh: echo "${SENTRY_DSN:-}"
+  # Project identity baked into the binary at link time, for forks that want to
+  # rebrand at build time (read from PROJECT_* env vars, mirroring SENTRY_DSN).
+  # Empty by default: a plain `task` build falls back to the built-in upstream
+  # defaults in internal/branding. At runtime these can be overridden with the
+  # BIRDNET_GO_PROJECT_* environment variables without rebuilding, so most forks
+  # never need to set these at build time.
+  PROJECT_NAME:
+    sh: echo "${PROJECT_NAME:-}"
+  PROJECT_REPO_URL:
+    sh: echo "${PROJECT_REPO_URL:-}"
+  PROJECT_COMMUNITY_URL:
+    sh: echo "${PROJECT_COMMUNITY_URL:-}"
   # Common build flags
   CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I$HOME/src/tensorflow"
   EXTRA_BUILD_TAGS: '{{.EXTRA_BUILD_TAGS | default ""}}'
@@ -40,7 +52,7 @@ vars:
       if [ -n "{{.EXTRA_BUILD_TAGS}}" ]; then
         echo "-tags {{.EXTRA_BUILD_TAGS}}"
       fi
-  LDFLAGS: -ldflags "-s -w -X 'main.buildDate={{.BUILD_DATE}}' -X 'main.version={{.VERSION}}' -X 'github.com/tphakala/birdnet-go/internal/telemetry.sentryDSN={{.SENTRY_DSN}}'"
+  LDFLAGS: -ldflags "-s -w -X 'main.buildDate={{.BUILD_DATE}}' -X 'main.version={{.VERSION}}' -X 'github.com/tphakala/birdnet-go/internal/telemetry.sentryDSN={{.SENTRY_DSN}}' -X 'github.com/tphakala/birdnet-go/internal/branding.projectName={{.PROJECT_NAME}}' -X 'github.com/tphakala/birdnet-go/internal/branding.projectRepoURL={{.PROJECT_REPO_URL}}' -X 'github.com/tphakala/birdnet-go/internal/branding.projectCommunityURL={{.PROJECT_COMMUNITY_URL}}'"
   BUILD_FLAGS: '{{.BUILD_TAGS_FLAG}} {{.LDFLAGS}}'
   # System paths for native library installation (used by download/verify tasks)
   SYSTEM_LIB_DIR: /usr/lib

--- a/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
+++ b/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
@@ -6,6 +6,7 @@
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { api } from '$lib/utils/api';
+  import { appState } from '$lib/stores/appState.svelte';
 
   import type { HTMLAttributes } from 'svelte/elements';
 
@@ -26,6 +27,36 @@
   const instanceId = Math.random().toString(36).slice(2, 10);
   const githubIssueInputId = `githubIssueNumber-${instanceId}`;
   const userMessageInputId = `userMessage-${instanceId}`;
+
+  // Issue links rendered inside the translated helper/notice strings. The URLs
+  // come from the backend-resolved project branding (appState.projectLinks) and
+  // the link labels from i18n, so both follow configuration and locale. They are
+  // built as HTML and injected via {@html}, the same way these strings carried
+  // their anchors before the URLs were de-embedded from the locale files.
+  //
+  // The URLs are operator-controlled branding, but BirdNET-Go commonly runs over
+  // plain HTTP on home networks where the config response is not integrity
+  // protected, so harden the value before it reaches {@html}: require an http(s)
+  // scheme (blocks javascript:/data: payloads) and escape any attribute-breaking
+  // characters so a tampered value cannot break out of the href attribute.
+  function safeIssueHref(url: string): string {
+    if (!/^https?:\/\//i.test(url)) return '#';
+    return url
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  const viewIssuesLink = $derived(
+    `<a href="${safeIssueHref(appState.projectLinks.issuesUrl)}" target="_blank" rel="noopener noreferrer" class="link link-primary">${t('settings.support.supportReport.githubIssue.viewExistingIssues')}</a>`
+  );
+  const createNewIssueLink = $derived(
+    `<a href="${safeIssueHref(appState.projectLinks.newIssueUrl)}" target="_blank" rel="noopener noreferrer" class="link link-primary">${t('settings.support.supportReport.githubIssue.createNewIssue')}</a>`
+  );
+  const createGithubIssueLink = $derived(
+    `<a href="${safeIssueHref(appState.projectLinks.newIssueUrl)}" target="_blank" rel="noopener noreferrer" class="underline font-semibold">${t('settings.support.supportReport.githubRequired.createGithubIssue')}</a>`
+  );
 
   let timers: ReturnType<typeof setTimeout>[] = [];
 
@@ -243,7 +274,9 @@
                   {t('settings.support.supportReport.githubRequired.title')}
                 </span>
                 <div class="mt-1">
-                  {@html t('settings.support.supportReport.githubRequired.description')}
+                  {@html t('settings.support.supportReport.githubRequired.description', {
+                    createIssueLink: createGithubIssueLink,
+                  })}
                 </div>
               </div>
             {/snippet}
@@ -321,7 +354,10 @@
                 disabled={generating}
               />
               <span class="text-xs text-[var(--color-base-content)] opacity-60 mt-1 block">
-                {@html t('settings.support.supportReport.githubIssue.helper')}
+                {@html t('settings.support.supportReport.githubIssue.helper', {
+                  viewIssuesLink,
+                  createIssueLink: createNewIssueLink,
+                })}
               </span>
             </div>
           {/if}

--- a/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
+++ b/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
@@ -45,6 +45,7 @@
     if (!url || !/^https?:\/\//i.test(url)) return '#';
     return url
       .replace(/&/g, '&amp;')
+      .replace(/'/g, '&#39;')
       .replace(/"/g, '&quot;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');

--- a/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
+++ b/frontend/src/lib/desktop/components/ui/SupportDumpCard.svelte
@@ -39,8 +39,10 @@
   // protected, so harden the value before it reaches {@html}: require an http(s)
   // scheme (blocks javascript:/data: payloads) and escape any attribute-breaking
   // characters so a tampered value cannot break out of the href attribute.
-  function safeIssueHref(url: string): string {
-    if (!/^https?:\/\//i.test(url)) return '#';
+  function safeIssueHref(url: string | undefined | null): string {
+    // projectLinks fields are typed as strings, but they arrive from a JSON
+    // config response, so a partial object could leave one missing at runtime.
+    if (!url || !/^https?:\/\//i.test(url)) return '#';
     return url
       .replace(/&/g, '&amp;')
       .replace(/"/g, '&quot;')

--- a/frontend/src/lib/desktop/views/About.svelte
+++ b/frontend/src/lib/desktop/views/About.svelte
@@ -26,6 +26,7 @@
   import GithubIcon from '$lib/desktop/components/ui/GithubIcon.svelte';
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
+  import { appState } from '$lib/stores/appState.svelte';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   interface VersionSettings {
@@ -99,7 +100,7 @@
 
     <div class="mt-4 flex justify-center">
       <a
-        href="https://github.com/tphakala/birdnet-go"
+        href={appState.projectLinks.repoUrl}
         class="btn btn-outline-primary gap-2"
         target="_blank"
         rel="noopener noreferrer"

--- a/frontend/src/lib/desktop/views/GenericErrorPage.svelte
+++ b/frontend/src/lib/desktop/views/GenericErrorPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js';
   import { t } from '$lib/i18n';
+  import { appState } from '$lib/stores/appState.svelte';
 
   interface SecuritySettings {
     enabled: boolean;
@@ -67,7 +68,7 @@
       </a>
       {#if showDetails}
         <a
-          href="https://github.com/tphakala/birdnet-go/issues"
+          href={appState.projectLinks.issuesUrl}
           class="btn btn-accent normal-case text-base font-semibold transition duration-300"
         >
           {t('common.reportIssue')}

--- a/frontend/src/lib/desktop/views/ServerErrorPage.svelte
+++ b/frontend/src/lib/desktop/views/ServerErrorPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js';
   import { t } from '$lib/i18n';
+  import { appState } from '$lib/stores/appState.svelte';
 
   interface SecuritySettings {
     enabled: boolean;
@@ -62,7 +63,7 @@
       </a>
       {#if showDetails}
         <a
-          href="https://github.com/tphakala/birdnet-go/issues"
+          href={appState.projectLinks.issuesUrl}
           class="btn btn-accent normal-case text-base font-semibold transition duration-300"
         >
           {t('common.reportIssue')}

--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -85,6 +85,23 @@ interface AppConfigResponse {
     dsn: string;
     systemId: string;
   };
+  projectLinks?: ProjectLinks;
+}
+
+/**
+ * Project identity and routing links served by the backend (always present in
+ * a normal config response). These drive in-app links ("View on GitHub",
+ * "Report an Issue", the support-page issue links) so a fork that rebrands the
+ * backend (via BIRDNET_GO_PROJECT_* env vars or ldflags) is reflected in the UI
+ * without editing translations or component source.
+ */
+interface ProjectLinks {
+  name: string;
+  repoUrl: string;
+  issuesUrl: string;
+  newIssueUrl: string;
+  supportUrl: string;
+  communityUrl: string;
 }
 
 /**
@@ -113,6 +130,8 @@ interface AppState {
   liveSpectrogram: boolean;
   /** Dashboard layout from public config (available before auth) */
   layout: AppConfigResponse['layout'] | null;
+  /** Project identity/links for routing in-app links */
+  projectLinks: ProjectLinks;
   /** Security configuration */
   security: {
     enabled: boolean;
@@ -124,6 +143,21 @@ interface AppState {
     privateMode: boolean;
   };
 }
+
+/**
+ * Upstream project links used as a fallback before the backend config loads
+ * (and on the pre-config server-error screen). Once the app-config response
+ * arrives, these are replaced by the backend-resolved branding values, so a
+ * fork's configured links take over for the entire authenticated UI.
+ */
+const DEFAULT_PROJECT_LINKS: ProjectLinks = {
+  name: 'BirdNET-Go',
+  repoUrl: 'https://github.com/tphakala/birdnet-go',
+  issuesUrl: 'https://github.com/tphakala/birdnet-go/issues',
+  newIssueUrl: 'https://github.com/tphakala/birdnet-go/issues/new',
+  supportUrl: 'https://github.com/tphakala/birdnet-go',
+  communityUrl: 'https://discord.gg/gcSCFGUtsd',
+};
 
 /**
  * Default state values
@@ -140,6 +174,7 @@ const DEFAULT_STATE: AppState = {
   previousVersion: null,
   liveSpectrogram: false,
   layout: null,
+  projectLinks: DEFAULT_PROJECT_LINKS,
   security: {
     enabled: false,
     accessAllowed: true,
@@ -268,6 +303,7 @@ export async function initApp(): Promise<boolean> {
       appState.previousVersion = config.previousVersion ?? null;
       appState.liveSpectrogram = config.liveSpectrogram ?? false;
       appState.layout = config.layout ?? null;
+      appState.projectLinks = config.projectLinks ?? DEFAULT_PROJECT_LINKS;
 
       // Apply server-configured appearance settings
       if (config.colorScheme) {

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Vyžadováno: GitHub issue pro nahrání podpory",
-          "description": "<strong>Nahrání podpory vyžaduje číslo GitHub issue.</strong> Prosím <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">vytvořte GitHub issue</a> popisující váš problém <strong>před</strong> vygenerováním zprávy podpory. Bez propojené issue nemohou vývojáři s vašimi daty podpory pracovat."
+          "description": "<strong>Nahrání podpory vyžaduje číslo GitHub issue.</strong> Prosím {createIssueLink} popisující váš problém <strong>před</strong> vygenerováním zprávy podpory. Bez propojené issue nemohou vývojáři s vašimi daty podpory pracovat.",
+          "createGithubIssue": "vytvořte GitHub issue"
         },
         "githubIssue": {
           "label": "Číslo GitHub issue",
           "placeholder": "např. 123 nebo #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Zobrazit existující issue</a> nebo nejprve <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">vytvořte novou issue</a>"
+          "helper": "{viewIssuesLink} nebo nejprve {createIssueLink}",
+          "viewExistingIssues": "Zobrazit existující issue",
+          "createNewIssue": "vytvořte novou issue"
         },
         "whatsIncluded": {
           "title": "Co je ve zprávě zahrnuto:",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Påkrævet: GitHub-issue til supportuploads",
-          "description": "<strong>Supportuploads kræver et GitHub-issuenummer.</strong> <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">Opret venligst et GitHub-issue</a>, der beskriver dit problem, <strong>før</strong> du genererer en supportrapport. Uden et tilknyttet issue kan udviklere ikke handle på dine supportdata."
+          "description": "<strong>Supportuploads kræver et GitHub-issuenummer.</strong> {createIssueLink}, der beskriver dit problem, <strong>før</strong> du genererer en supportrapport. Uden et tilknyttet issue kan udviklere ikke handle på dine supportdata.",
+          "createGithubIssue": "Opret venligst et GitHub-issue"
         },
         "githubIssue": {
           "label": "GitHub-issuenummer",
           "placeholder": "f.eks. 123 eller #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Se eksisterende issues</a> eller <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">opret et nyt issue</a> først"
+          "helper": "{viewIssuesLink} eller {createIssueLink} først",
+          "viewExistingIssues": "Se eksisterende issues",
+          "createNewIssue": "opret et nyt issue"
         },
         "whatsIncluded": {
           "title": "Hvad er inkluderet i rapporten:",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Erforderlich: GitHub-Issue für Support-Uploads",
-          "description": "<strong>Support-Uploads erfordern eine GitHub-Issue-Nummer.</strong> Bitte <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">erstellen Sie ein GitHub-Issue</a>, das Ihr Problem beschreibt, <strong>bevor</strong> Sie einen Support-Bericht erstellen. Ohne ein verknüpftes Issue können Entwickler Ihre Support-Daten nicht bearbeiten."
+          "description": "<strong>Support-Uploads erfordern eine GitHub-Issue-Nummer.</strong> Bitte {createIssueLink}, das Ihr Problem beschreibt, <strong>bevor</strong> Sie einen Support-Bericht erstellen. Ohne ein verknüpftes Issue können Entwickler Ihre Support-Daten nicht bearbeiten.",
+          "createGithubIssue": "erstellen Sie ein GitHub-Issue"
         },
         "githubIssue": {
           "label": "GitHub-Issue-Nummer",
           "placeholder": "z.B. 123 oder #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Bestehende Issues anzeigen</a> oder <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">neues Issue erstellen</a>"
+          "helper": "{viewIssuesLink} oder {createIssueLink}",
+          "viewExistingIssues": "Bestehende Issues anzeigen",
+          "createNewIssue": "neues Issue erstellen"
         },
         "whatsIncluded": {
           "title": "Was im Bericht enthalten ist:",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Required: GitHub Issue for Support Uploads",
-          "description": "<strong>Support uploads require a GitHub issue number.</strong> Please <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">create a GitHub issue</a> describing your problem <strong>before</strong> generating a support report. Without a linked issue, developers cannot act on your support data."
+          "description": "<strong>Support uploads require a GitHub issue number.</strong> Please {createIssueLink} describing your problem <strong>before</strong> generating a support report. Without a linked issue, developers cannot act on your support data.",
+          "createGithubIssue": "create a GitHub issue"
         },
         "githubIssue": {
           "label": "GitHub Issue Number",
           "placeholder": "e.g., 123 or #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">View existing issues</a> or <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">create a new issue</a> first"
+          "helper": "{viewIssuesLink} or {createIssueLink} first",
+          "viewExistingIssues": "View existing issues",
+          "createNewIssue": "create a new issue"
         },
         "whatsIncluded": {
           "title": "What's included in the report:",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Requerido: Issue de GitHub para cargas de soporte",
-          "description": "<strong>Las cargas de soporte requieren un número de issue de GitHub.</strong> Por favor <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">crea un issue de GitHub</a> describiendo tu problema <strong>antes</strong> de generar un informe de soporte. Sin un issue vinculado, los desarrolladores no pueden actuar sobre tus datos de soporte."
+          "description": "<strong>Las cargas de soporte requieren un número de issue de GitHub.</strong> Por favor {createIssueLink} describiendo tu problema <strong>antes</strong> de generar un informe de soporte. Sin un issue vinculado, los desarrolladores no pueden actuar sobre tus datos de soporte.",
+          "createGithubIssue": "crea un issue de GitHub"
         },
         "githubIssue": {
           "label": "Número de issue de GitHub",
           "placeholder": "p.ej., 123 o #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Ver issues existentes</a> o <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">crear un nuevo issue</a> primero"
+          "helper": "{viewIssuesLink} o {createIssueLink} primero",
+          "viewExistingIssues": "Ver issues existentes",
+          "createNewIssue": "crear un nuevo issue"
         },
         "whatsIncluded": {
           "title": "Qué incluye el informe:",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Vaaditaan: GitHub-ongelmaraportti tukilähetyksille",
-          "description": "<strong>Tukilähetykset vaativat GitHub-ongelman numeron.</strong> Ole hyvä ja <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">luo GitHub-ongelma</a> kuvaten ongelmasi <strong>ennen</strong> tukiraportin luomista. Ilman linkitettyä ongelmaa kehittäjät eivät voi käsitellä tukitietojasi."
+          "description": "<strong>Tukilähetykset vaativat GitHub-ongelman numeron.</strong> Ole hyvä ja {createIssueLink} kuvaten ongelmasi <strong>ennen</strong> tukiraportin luomista. Ilman linkitettyä ongelmaa kehittäjät eivät voi käsitellä tukitietojasi.",
+          "createGithubIssue": "luo GitHub-ongelma"
         },
         "githubIssue": {
           "label": "GitHub-ongelman numero",
           "placeholder": "#123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Näytä olemassa olevat ongelmat</a> tai <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">luo uusi ongelma</a> ensin"
+          "helper": "{viewIssuesLink} tai {createIssueLink} ensin",
+          "viewExistingIssues": "Näytä olemassa olevat ongelmat",
+          "createNewIssue": "luo uusi ongelma"
         },
         "whatsIncluded": {
           "title": "Mitä raportti sisältää:",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Requis : Problème GitHub pour les envois de support",
-          "description": "<strong>Les envois de support nécessitent un numéro de problème GitHub.</strong> Veuillez <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">créer un problème GitHub</a> décrivant votre problème <strong>avant</strong> de générer un rapport de support. Sans problème lié, les développeurs ne peuvent pas traiter vos données de support."
+          "description": "<strong>Les envois de support nécessitent un numéro de problème GitHub.</strong> Veuillez {createIssueLink} décrivant votre problème <strong>avant</strong> de générer un rapport de support. Sans problème lié, les développeurs ne peuvent pas traiter vos données de support.",
+          "createGithubIssue": "créer un problème GitHub"
         },
         "githubIssue": {
           "label": "Numéro du problème GitHub",
           "placeholder": "#123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Voir les problèmes existants</a> ou <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">créer un nouveau problème</a> d'abord"
+          "helper": "{viewIssuesLink} ou {createIssueLink} d'abord",
+          "viewExistingIssues": "Voir les problèmes existants",
+          "createNewIssue": "créer un nouveau problème"
         },
         "whatsIncluded": {
           "title": "Ce qui est inclus dans le rapport :",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Szükséges: GitHub issue a támogatási feltöltésekhez",
-          "description": "<strong>A támogatási feltöltésekhez GitHub issue szám szükséges.</strong> Kérjük, <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">hozzon létre egy GitHub issue-t</a>, amely leírja a problémáját <strong>megelőzőleg</strong> a támogatási jelentés generálását. A kapcsolódó issue nélkül a fejlesztők nem tudnak reagálni a támogatási adatokra."
+          "description": "<strong>A támogatási feltöltésekhez GitHub issue szám szükséges.</strong> Kérjük, {createIssueLink}, amely leírja a problémáját <strong>megelőzőleg</strong> a támogatási jelentés generálását. A kapcsolódó issue nélkül a fejlesztők nem tudnak reagálni a támogatási adatokra.",
+          "createGithubIssue": "hozzon létre egy GitHub issue-t"
         },
         "githubIssue": {
           "label": "GitHub issue szám",
           "placeholder": "pl., 123 vagy #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Meglévő issue-k megtekintése</a> vagy <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">új issue létrehozása</a> először"
+          "helper": "{viewIssuesLink} vagy {createIssueLink} először",
+          "viewExistingIssues": "Meglévő issue-k megtekintése",
+          "createNewIssue": "új issue létrehozása"
         },
         "whatsIncluded": {
           "title": "A jelentés tartalma:",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Richiesto: GitHub Issue per Caricamenti Supporto",
-          "description": "<strong>I caricamenti di supporto richiedono un numero GitHub issue.</strong> Per favore <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">crea una GitHub issue</a> descrivendo il tuo problema <strong>prima</strong> di generare un rapporto di supporto. Senza una issue collegata, gli sviluppatori non possono agire sui tuoi dati di supporto."
+          "description": "<strong>I caricamenti di supporto richiedono un numero GitHub issue.</strong> Per favore {createIssueLink} descrivendo il tuo problema <strong>prima</strong> di generare un rapporto di supporto. Senza una issue collegata, gli sviluppatori non possono agire sui tuoi dati di supporto.",
+          "createGithubIssue": "crea una GitHub issue"
         },
         "githubIssue": {
           "label": "Numero GitHub Issue",
           "placeholder": "es. 123 o #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Vedi issue esistenti</a> o <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">crea una nuova issue</a> prima"
+          "helper": "{viewIssuesLink} o {createIssueLink} prima",
+          "viewExistingIssues": "Vedi issue esistenti",
+          "createNewIssue": "crea una nuova issue"
         },
         "whatsIncluded": {
           "title": "Cosa è incluso nel rapporto:",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Nepieciešams: GitHub problēma atbalsta augšupielādēm",
-          "description": "<strong>Atbalsta augšupielādēm nepieciešams GitHub problēmas numurs.</strong> Lūdzu, <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">izveidojiet GitHub problēmu</a>, aprakstot savu problēmu, <strong>pirms</strong> ģenerējat atbalsta ziņojumu. Bez saistītās problēmas izstrādātāji nevar rīkoties ar jūsu atbalsta datiem."
+          "description": "<strong>Atbalsta augšupielādēm nepieciešams GitHub problēmas numurs.</strong> Lūdzu, {createIssueLink}, aprakstot savu problēmu, <strong>pirms</strong> ģenerējat atbalsta ziņojumu. Bez saistītās problēmas izstrādātāji nevar rīkoties ar jūsu atbalsta datiem.",
+          "createGithubIssue": "izveidojiet GitHub problēmu"
         },
         "githubIssue": {
           "label": "GitHub problēmas numurs",
           "placeholder": "piem., 123 vai #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Skatīt esošās problēmas</a> vai <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">vispirms izveidojiet jaunu problēmu</a>"
+          "helper": "{viewIssuesLink} vai {createIssueLink}",
+          "viewExistingIssues": "Skatīt esošās problēmas",
+          "createNewIssue": "vispirms izveidojiet jaunu problēmu"
         },
         "whatsIncluded": {
           "title": "Kas ir iekļauts ziņojumā:",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Vereist: GitHub Issue voor Ondersteunings Uploads",
-          "description": "<strong>Ondersteunings uploads vereisen een GitHub issue nummer.</strong> <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">Maak een GitHub issue aan</a> waarin je jouw probleem beschrijft <strong>voordat</strong> je een ondersteunings rapport genereert. Zonder een gelinkt issue kunnen ontwikkelaars niets doen met jouw ondersteunings gegevens."
+          "description": "<strong>Ondersteunings uploads vereisen een GitHub issue nummer.</strong> {createIssueLink} waarin je jouw probleem beschrijft <strong>voordat</strong> je een ondersteunings rapport genereert. Zonder een gelinkt issue kunnen ontwikkelaars niets doen met jouw ondersteunings gegevens.",
+          "createGithubIssue": "Maak een GitHub issue aan"
         },
         "githubIssue": {
           "label": "GitHub Issue Nummer",
           "placeholder": "bijv., 123 of #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Bekijk bestaande issues</a> of <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">maak eerst een nieuw issue aan</a>"
+          "helper": "{viewIssuesLink} of {createIssueLink}",
+          "viewExistingIssues": "Bekijk bestaande issues",
+          "createNewIssue": "maak eerst een nieuw issue aan"
         },
         "whatsIncluded": {
           "title": "Wat is opgenomen in het rapport:",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Wymagane: Problem GitHub do Przesyłania Wsparcia",
-          "description": "<strong>Przesyłanie wsparcia wymaga numeru problemu GitHub.</strong> Proszę <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">utwórz problem GitHub</a> opisujący twój problem <strong>przed</strong> wygenerowaniem raportu wsparcia. Bez powiązanego problemu programiści nie mogą działać na twoich danych wsparcia."
+          "description": "<strong>Przesyłanie wsparcia wymaga numeru problemu GitHub.</strong> Proszę {createIssueLink} opisujący twój problem <strong>przed</strong> wygenerowaniem raportu wsparcia. Bez powiązanego problemu programiści nie mogą działać na twoich danych wsparcia.",
+          "createGithubIssue": "utwórz problem GitHub"
         },
         "githubIssue": {
           "label": "Numer Problemu GitHub",
           "placeholder": "np. 123 lub #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Wyświetl istniejące problemy</a> lub <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">utwórz nowy problem</a> najpierw"
+          "helper": "{viewIssuesLink} lub {createIssueLink} najpierw",
+          "viewExistingIssues": "Wyświetl istniejące problemy",
+          "createNewIssue": "utwórz nowy problem"
         },
         "whatsIncluded": {
           "title": "Co jest zawarte w raporcie:",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Obrigatório: Issue do GitHub para envios de suporte",
-          "description": "<strong>Envios de suporte requerem um número de issue do GitHub.</strong> Por favor <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">crie um issue no GitHub</a> descrevendo seu problema <strong>antes</strong> de gerar um relatório de suporte. Sem um issue vinculado, os desenvolvedores não podem agir sobre seus dados de suporte."
+          "description": "<strong>Envios de suporte requerem um número de issue do GitHub.</strong> Por favor {createIssueLink} descrevendo seu problema <strong>antes</strong> de gerar um relatório de suporte. Sem um issue vinculado, os desenvolvedores não podem agir sobre seus dados de suporte.",
+          "createGithubIssue": "crie um issue no GitHub"
         },
         "githubIssue": {
           "label": "Número do issue do GitHub",
           "placeholder": "#123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Ver issues existentes</a> ou <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">criar um novo issue</a> primeiro"
+          "helper": "{viewIssuesLink} ou {createIssueLink} primeiro",
+          "viewExistingIssues": "Ver issues existentes",
+          "createNewIssue": "criar um novo issue"
         },
         "whatsIncluded": {
           "title": "O que está incluído no relatório:",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Vyžaduje sa: GitHub Issue pre nahranie podpory",
-          "description": "<strong>Nahranie podpory vyžaduje číslo GitHub issue.</strong> Pred vygenerovaním správy o podpore prosím <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">vytvorte GitHub issue</a> popisujúce váš problém. Bez prepojenej issue nemôžu vývojári s vašimi údajmi o podpore pracovať."
+          "description": "<strong>Nahranie podpory vyžaduje číslo GitHub issue.</strong> Pred vygenerovaním správy o podpore prosím {createIssueLink} popisujúce váš problém. Bez prepojenej issue nemôžu vývojári s vašimi údajmi o podpore pracovať.",
+          "createGithubIssue": "vytvorte GitHub issue"
         },
         "githubIssue": {
           "label": "Číslo GitHub Issue",
           "placeholder": "napr. 123 alebo #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Zobraziť existujúce issue</a> alebo <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">vytvoriť novú issue</a>"
+          "helper": "{viewIssuesLink} alebo {createIssueLink}",
+          "viewExistingIssues": "Zobraziť existujúce issue",
+          "createNewIssue": "vytvoriť novú issue"
         },
         "whatsIncluded": {
           "title": "Čo je zahrnuté v správe:",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -2152,12 +2152,15 @@
         },
         "githubRequired": {
           "title": "Krav: GitHub-ärende för supportuppladdningar",
-          "description": "<strong>Supportuppladdningar kräver ett GitHub-ärendenummer.</strong> Vänligen <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">skapa ett GitHub-ärende</a> som beskriver ditt problem <strong>innan</strong> du genererar en supportrapport. Utan ett länkat ärende kan utvecklare inte agera på din supportdata."
+          "description": "<strong>Supportuppladdningar kräver ett GitHub-ärendenummer.</strong> Vänligen {createIssueLink} som beskriver ditt problem <strong>innan</strong> du genererar en supportrapport. Utan ett länkat ärende kan utvecklare inte agera på din supportdata.",
+          "createGithubIssue": "skapa ett GitHub-ärende"
         },
         "githubIssue": {
           "label": "GitHub-ärendenummer",
           "placeholder": "t.ex. 123 eller #123",
-          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Visa befintliga ärenden</a> eller <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">skapa ett nytt ärende</a> först"
+          "helper": "{viewIssuesLink} eller {createIssueLink} först",
+          "viewExistingIssues": "Visa befintliga ärenden",
+          "createNewIssue": "skapa ett nytt ärende"
         },
         "whatsIncluded": {
           "title": "Vad som ingår i rapporten:",

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/middleware"
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -42,6 +43,7 @@ type AppConfigResponse struct {
 	NewVersion      bool                  `json:"newVersion"`                // true when the app was upgraded since last dismiss
 	PreviousVersion string                `json:"previousVersion,omitempty"` // last version the user acknowledged
 	Sentry          *SentryFrontendConfig `json:"sentry,omitempty"`          // frontend telemetry config (only when enabled)
+	ProjectLinks    ProjectLinksConfig    `json:"projectLinks"`              // project identity/links served to the frontend
 }
 
 // SentryFrontendConfig exposes telemetry configuration to the frontend.
@@ -50,6 +52,18 @@ type SentryFrontendConfig struct {
 	Enabled  bool   `json:"enabled"`
 	DSN      string `json:"dsn"`
 	SystemID string `json:"systemId"`
+}
+
+// ProjectLinksConfig exposes the configurable project identity (name and links)
+// to the frontend so in-app links follow the branding package rather than
+// hardcoded upstream URLs. It is always populated (not gated on telemetry).
+type ProjectLinksConfig struct {
+	Name         string `json:"name"`
+	RepoURL      string `json:"repoUrl"`
+	IssuesURL    string `json:"issuesUrl"`
+	NewIssueURL  string `json:"newIssueUrl"`
+	SupportURL   string `json:"supportUrl"`
+	CommunityURL string `json:"communityUrl"`
 }
 
 // SecurityConfigDTO represents the security configuration for the frontend.
@@ -182,6 +196,16 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 		FreshInstall:    freshInstall,
 		NewVersion:      newVersion,
 		PreviousVersion: previousVersion,
+		// Project identity/links are always served (independent of telemetry) so
+		// in-app links follow the configured branding instead of hardcoded URLs.
+		ProjectLinks: ProjectLinksConfig{
+			Name:         branding.Name(),
+			RepoURL:      branding.RepoURL(),
+			IssuesURL:    branding.IssuesURL(),
+			NewIssueURL:  branding.NewIssueURL(),
+			SupportURL:   branding.SupportURL(),
+			CommunityURL: branding.CommunityURL(),
+		},
 	}
 
 	// Include dashboard layout for guest/pre-auth rendering if configured

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -185,6 +185,16 @@ func TestGetAppConfig_NoSecurity(t *testing.T) {
 // project identity/links (independent of telemetry), defaulting to the upstream
 // values with correctly derived issue URLs when nothing is overridden.
 func TestGetAppConfig_ProjectLinks(t *testing.T) {
+	// Branding resolution gives BIRDNET_GO_PROJECT_* env vars highest precedence;
+	// clear them so this default-links assertion is deterministic regardless of
+	// the caller's environment.
+	for _, key := range []string{
+		"BIRDNET_GO_PROJECT_NAME", "BIRDNET_GO_PROJECT_REPO_URL", "BIRDNET_GO_PROJECT_ISSUES_URL",
+		"BIRDNET_GO_PROJECT_NEW_ISSUE_URL", "BIRDNET_GO_PROJECT_SUPPORT_URL", "BIRDNET_GO_PROJECT_COMMUNITY_URL",
+	} {
+		t.Setenv(key, "")
+	}
+
 	e, controller := setupAppConfigTest(t, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
@@ -941,6 +951,9 @@ func TestGetAppConfig_NoExtraFields(t *testing.T) {
 
 	for key := range projectLinks {
 		assert.True(t, expectedProjectLinkKeys[key], "Unexpected field in projectLinks: %s", key)
+	}
+	for key := range expectedProjectLinkKeys {
+		assert.Contains(t, projectLinks, key, "Missing field in projectLinks: %s", key)
 	}
 
 	// Check security sub-object

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -181,6 +181,34 @@ func TestGetAppConfig_NoSecurity(t *testing.T) {
 	assert.Empty(t, response.Security.AuthConfig.EnabledProviders, "No OAuth providers should be enabled")
 }
 
+// TestGetAppConfig_ProjectLinks verifies the response always carries the
+// project identity/links (independent of telemetry), defaulting to the upstream
+// values with correctly derived issue URLs when nothing is overridden.
+func TestGetAppConfig_ProjectLinks(t *testing.T) {
+	e, controller := setupAppConfigTest(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/app/config")
+
+	err := controller.GetAppConfig(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response AppConfigResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	links := response.ProjectLinks
+	assert.Equal(t, "BirdNET-Go", links.Name)
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go", links.RepoURL)
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues", links.IssuesURL)
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues/new", links.NewIssueURL)
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go", links.SupportURL)
+	assert.Equal(t, "https://discord.gg/gcSCFGUtsd", links.CommunityURL)
+}
+
 // TestGetAppConfig_BasicAuthEnabled tests the endpoint with BasicAuth enabled.
 func TestGetAppConfig_BasicAuthEnabled(t *testing.T) {
 	securityConfig := conf.Security{
@@ -890,10 +918,29 @@ func TestGetAppConfig_NoExtraFields(t *testing.T) {
 		"liveSpectrogram": true,
 		"freshInstall":    true,
 		"newVersion":      true,
+		"projectLinks":    true,
 	}
 
 	for key := range rawResponse {
 		assert.True(t, expectedKeys[key], "Unexpected field in response: %s", key)
+	}
+
+	// Check projectLinks sub-object
+	projectLinksRaw, ok := rawResponse["projectLinks"]
+	require.True(t, ok, "projectLinks field should exist")
+	projectLinks, ok := projectLinksRaw.(map[string]any)
+	require.True(t, ok, "projectLinks should be a map")
+	expectedProjectLinkKeys := map[string]bool{
+		"name":         true,
+		"repoUrl":      true,
+		"issuesUrl":    true,
+		"newIssueUrl":  true,
+		"supportUrl":   true,
+		"communityUrl": true,
+	}
+
+	for key := range projectLinks {
+		assert.True(t, expectedProjectLinkKeys[key], "Unexpected field in projectLinks: %s", key)
 	}
 
 	// Check security sub-object

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -210,13 +211,18 @@ func TestGetAppConfig_ProjectLinks(t *testing.T) {
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
 	require.NoError(t, err)
 
+	// Assert the endpoint serves exactly what the branding package resolves
+	// (the exact default values are locked in branding's own TestDefaults). With
+	// the env cleared above and no ldflags baked into the test binary, these
+	// resolve to the upstream defaults; asserting against the getters also keeps
+	// the test correct for ldflags-built binaries, which t.Setenv cannot clear.
 	links := response.ProjectLinks
-	assert.Equal(t, "BirdNET-Go", links.Name)
-	assert.Equal(t, "https://github.com/tphakala/birdnet-go", links.RepoURL)
-	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues", links.IssuesURL)
-	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues/new", links.NewIssueURL)
-	assert.Equal(t, "https://github.com/tphakala/birdnet-go", links.SupportURL)
-	assert.Equal(t, "https://discord.gg/gcSCFGUtsd", links.CommunityURL)
+	assert.Equal(t, branding.Name(), links.Name)
+	assert.Equal(t, branding.RepoURL(), links.RepoURL)
+	assert.Equal(t, branding.IssuesURL(), links.IssuesURL)
+	assert.Equal(t, branding.NewIssueURL(), links.NewIssueURL)
+	assert.Equal(t, branding.SupportURL(), links.SupportURL)
+	assert.Equal(t, branding.CommunityURL(), links.CommunityURL)
 }
 
 // TestGetAppConfig_BasicAuthEnabled tests the endpoint with BasicAuth enabled.

--- a/internal/branding/branding.go
+++ b/internal/branding/branding.go
@@ -13,6 +13,7 @@
 package branding
 
 import (
+	"net/url"
 	"os"
 	"strings"
 )
@@ -85,35 +86,49 @@ func joinURL(base, suffix string) string {
 	return strings.TrimRight(base, "/") + "/" + suffix
 }
 
+// sanitizeURL strips any userinfo (the user:password@ component) from a URL so
+// that credentials an operator might accidentally embed in a configured
+// identity URL are never emitted in the public app-config response, outbound
+// User-Agent headers, or logs. URLs without userinfo (the normal case) and
+// values that do not parse as URLs are returned unchanged.
+func sanitizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
+}
+
 // Name returns the configured project name.
 func Name() string {
 	return resolve(envName, projectName, defaultName)
 }
 
-// RepoURL returns the configured source repository URL.
+// RepoURL returns the configured source repository URL (credential-free).
 func RepoURL() string {
-	return resolve(envRepoURL, projectRepoURL, defaultRepoURL)
+	return sanitizeURL(resolve(envRepoURL, projectRepoURL, defaultRepoURL))
 }
 
 // IssuesURL returns the issue-tracker listing URL, derived from RepoURL when
 // not explicitly configured.
 func IssuesURL() string {
-	return resolve(envIssuesURL, projectIssuesURL, joinURL(RepoURL(), issuesPath))
+	return sanitizeURL(resolve(envIssuesURL, projectIssuesURL, joinURL(RepoURL(), issuesPath)))
 }
 
 // NewIssueURL returns the "create a new issue" URL, derived from RepoURL when
 // not explicitly configured.
 func NewIssueURL() string {
-	return resolve(envNewIssueURL, projectNewIssueURL, joinURL(RepoURL(), newIssuePath))
+	return sanitizeURL(resolve(envNewIssueURL, projectNewIssueURL, joinURL(RepoURL(), newIssuePath)))
 }
 
 // SupportURL returns the user-facing support URL, defaulting to RepoURL when
 // not explicitly configured.
 func SupportURL() string {
-	return resolve(envSupportURL, projectSupportURL, RepoURL())
+	return sanitizeURL(resolve(envSupportURL, projectSupportURL, RepoURL()))
 }
 
 // CommunityURL returns the community chat/forum URL.
 func CommunityURL() string {
-	return resolve(envCommunityURL, projectCommunityURL, defaultCommunityURL)
+	return sanitizeURL(resolve(envCommunityURL, projectCommunityURL, defaultCommunityURL))
 }

--- a/internal/branding/branding.go
+++ b/internal/branding/branding.go
@@ -1,0 +1,119 @@
+// Package branding centralizes BirdNET-Go's project identity: the application
+// name and the canonical repository, issue-tracker, support, and community
+// URLs. Each value is resolved at call time with the precedence
+//
+//	BIRDNET_GO_PROJECT_* env var > ldflags-baked var > built-in default
+//
+// so a fork can rebrand the running binary without editing source or
+// translations: bake values in at link time via -ldflags -X, or set the
+// environment variables at runtime. The defaults intentionally stay in source
+// (these are public identity, not secrets), so from-source builds keep pointing
+// at the upstream project. This mirrors the build-time/runtime injection model
+// used for the Sentry DSN in internal/telemetry.
+package branding
+
+import (
+	"os"
+	"strings"
+)
+
+// Build-time injection targets. They are intentionally unexported (so callers
+// must go through the getters, never read a possibly-empty var directly) and
+// empty by default, so a plain `go build` falls through to the built-in const
+// defaults below, while official and fork builds can override them at link
+// time, e.g.:
+//
+//	-ldflags "-X 'github.com/tphakala/birdnet-go/internal/branding.projectRepoURL=https://github.com/acme/birdnet-fork'"
+//
+// The linker can set unexported package vars, so this mirrors the unexported
+// internal/telemetry.sentryDSN injection target exactly.
+var (
+	// projectName is the human-readable application name.
+	projectName string
+	// projectRepoURL is the canonical source repository URL.
+	projectRepoURL string
+	// projectIssuesURL is the issue-tracker listing URL; derived from the repo
+	// URL when empty.
+	projectIssuesURL string
+	// projectNewIssueURL is the "create a new issue" URL; derived from the repo
+	// URL when empty.
+	projectNewIssueURL string
+	// projectSupportURL is the user-facing support URL (shown e.g. on the Home
+	// Assistant device page); defaults to the repo URL when empty.
+	projectSupportURL string
+	// projectCommunityURL is the community chat/forum URL.
+	projectCommunityURL string
+)
+
+// Built-in defaults, used when neither an environment override nor a baked-in
+// value is present. These are the upstream project's public identity.
+const (
+	defaultName         = "BirdNET-Go"
+	defaultRepoURL      = "https://github.com/tphakala/birdnet-go"
+	defaultCommunityURL = "https://discord.gg/gcSCFGUtsd"
+
+	issuesPath   = "issues"
+	newIssuePath = "issues/new"
+)
+
+// Environment variables that override the build-time values at runtime.
+const (
+	envName         = "BIRDNET_GO_PROJECT_NAME"
+	envRepoURL      = "BIRDNET_GO_PROJECT_REPO_URL"
+	envIssuesURL    = "BIRDNET_GO_PROJECT_ISSUES_URL"
+	envNewIssueURL  = "BIRDNET_GO_PROJECT_NEW_ISSUE_URL"
+	envSupportURL   = "BIRDNET_GO_PROJECT_SUPPORT_URL"
+	envCommunityURL = "BIRDNET_GO_PROJECT_COMMUNITY_URL"
+)
+
+// resolve returns the first non-empty candidate among the environment variable
+// named by envKey, the ldflags-baked value, and the fallback. All candidates
+// are trimmed so a whitespace-only entry counts as unset.
+func resolve(envKey, ldflagsVar, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(envKey)); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(ldflagsVar); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// joinURL appends a path suffix to a base URL, collapsing any trailing slash on
+// the base so it yields the same result with or without one.
+func joinURL(base, suffix string) string {
+	return strings.TrimRight(base, "/") + "/" + suffix
+}
+
+// Name returns the configured project name.
+func Name() string {
+	return resolve(envName, projectName, defaultName)
+}
+
+// RepoURL returns the configured source repository URL.
+func RepoURL() string {
+	return resolve(envRepoURL, projectRepoURL, defaultRepoURL)
+}
+
+// IssuesURL returns the issue-tracker listing URL, derived from RepoURL when
+// not explicitly configured.
+func IssuesURL() string {
+	return resolve(envIssuesURL, projectIssuesURL, joinURL(RepoURL(), issuesPath))
+}
+
+// NewIssueURL returns the "create a new issue" URL, derived from RepoURL when
+// not explicitly configured.
+func NewIssueURL() string {
+	return resolve(envNewIssueURL, projectNewIssueURL, joinURL(RepoURL(), newIssuePath))
+}
+
+// SupportURL returns the user-facing support URL, defaulting to RepoURL when
+// not explicitly configured.
+func SupportURL() string {
+	return resolve(envSupportURL, projectSupportURL, RepoURL())
+}
+
+// CommunityURL returns the community chat/forum URL.
+func CommunityURL() string {
+	return resolve(envCommunityURL, projectCommunityURL, defaultCommunityURL)
+}

--- a/internal/branding/branding_test.go
+++ b/internal/branding/branding_test.go
@@ -1,0 +1,80 @@
+package branding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Note: these tests mutate process-global state (environment variables and the
+// ldflags-target package vars), so they intentionally do NOT call t.Parallel().
+
+func TestDefaults(t *testing.T) {
+	// With no environment overrides and empty (un-baked) ldflags vars, the
+	// getters fall back to the built-in upstream defaults.
+	assert.Equal(t, "BirdNET-Go", Name())
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go", RepoURL())
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues", IssuesURL())
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues/new", NewIssueURL())
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go", SupportURL())
+	assert.Equal(t, "https://discord.gg/gcSCFGUtsd", CommunityURL())
+}
+
+func TestEnvOverride(t *testing.T) {
+	t.Setenv(envName, "MyFork")
+	t.Setenv(envRepoURL, "https://example.com/me/fork")
+	t.Setenv(envCommunityURL, "https://chat.example.com")
+
+	assert.Equal(t, "MyFork", Name())
+	assert.Equal(t, "https://example.com/me/fork", RepoURL())
+	// Derived values follow the env-overridden repo URL.
+	assert.Equal(t, "https://example.com/me/fork/issues", IssuesURL())
+	assert.Equal(t, "https://example.com/me/fork/issues/new", NewIssueURL())
+	assert.Equal(t, "https://example.com/me/fork", SupportURL())
+	assert.Equal(t, "https://chat.example.com", CommunityURL())
+}
+
+func TestExplicitDerivedOverride(t *testing.T) {
+	// Explicit overrides win over derivation.
+	t.Setenv(envIssuesURL, "https://example.com/tracker")
+	t.Setenv(envNewIssueURL, "https://example.com/tracker/file")
+	t.Setenv(envSupportURL, "https://support.example.com")
+
+	assert.Equal(t, "https://example.com/tracker", IssuesURL())
+	assert.Equal(t, "https://example.com/tracker/file", NewIssueURL())
+	assert.Equal(t, "https://support.example.com", SupportURL())
+}
+
+func TestDerivationCollapsesTrailingSlash(t *testing.T) {
+	t.Setenv(envRepoURL, "https://example.com/fork/")
+
+	// Derived sub-paths normalize the trailing slash so there is no double slash.
+	assert.Equal(t, "https://example.com/fork/issues", IssuesURL())
+	assert.Equal(t, "https://example.com/fork/issues/new", NewIssueURL())
+	// The repo and support URLs are returned verbatim (a trailing slash on a
+	// repository URL is harmless and reflects exactly what the operator set).
+	assert.Equal(t, "https://example.com/fork/", RepoURL())
+	assert.Equal(t, "https://example.com/fork/", SupportURL())
+}
+
+func TestWhitespaceCountsAsUnset(t *testing.T) {
+	t.Setenv(envRepoURL, "   ")
+	t.Setenv(envName, "\t")
+
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go", RepoURL())
+	assert.Equal(t, "BirdNET-Go", Name())
+}
+
+func TestLdflagsVarPrecedence(t *testing.T) {
+	// Simulate a value baked in at link time via -ldflags -X.
+	orig := projectRepoURL
+	t.Cleanup(func() { projectRepoURL = orig })
+	projectRepoURL = "https://baked.example.com/repo"
+
+	assert.Equal(t, "https://baked.example.com/repo", RepoURL())
+	assert.Equal(t, "https://baked.example.com/repo/issues", IssuesURL())
+
+	// The environment variable still beats the baked-in value.
+	t.Setenv(envRepoURL, "https://env.example.com/repo")
+	assert.Equal(t, "https://env.example.com/repo", RepoURL())
+}

--- a/internal/branding/branding_test.go
+++ b/internal/branding/branding_test.go
@@ -9,7 +9,34 @@ import (
 // Note: these tests mutate process-global state (environment variables and the
 // ldflags-target package vars), so they intentionally do NOT call t.Parallel().
 
+// resetBrandingState makes a test hermetic against the caller's environment: it
+// clears every BIRDNET_GO_PROJECT_* env var and the ldflags-target package vars
+// (restoring them after the test) so the getters resolve deterministically
+// regardless of any inherited env or baked-in build values.
+func resetBrandingState(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		envName, envRepoURL, envIssuesURL, envNewIssueURL, envSupportURL, envCommunityURL,
+	} {
+		t.Setenv(key, "")
+	}
+
+	origName, origRepo := projectName, projectRepoURL
+	origIssues, origNewIssue := projectIssuesURL, projectNewIssueURL
+	origSupport, origCommunity := projectSupportURL, projectCommunityURL
+	projectName, projectRepoURL = "", ""
+	projectIssuesURL, projectNewIssueURL = "", ""
+	projectSupportURL, projectCommunityURL = "", ""
+	t.Cleanup(func() {
+		projectName, projectRepoURL = origName, origRepo
+		projectIssuesURL, projectNewIssueURL = origIssues, origNewIssue
+		projectSupportURL, projectCommunityURL = origSupport, origCommunity
+	})
+}
+
 func TestDefaults(t *testing.T) {
+	resetBrandingState(t)
 	// With no environment overrides and empty (un-baked) ldflags vars, the
 	// getters fall back to the built-in upstream defaults.
 	assert.Equal(t, "BirdNET-Go", Name())
@@ -21,6 +48,7 @@ func TestDefaults(t *testing.T) {
 }
 
 func TestEnvOverride(t *testing.T) {
+	resetBrandingState(t)
 	t.Setenv(envName, "MyFork")
 	t.Setenv(envRepoURL, "https://example.com/me/fork")
 	t.Setenv(envCommunityURL, "https://chat.example.com")
@@ -35,6 +63,7 @@ func TestEnvOverride(t *testing.T) {
 }
 
 func TestExplicitDerivedOverride(t *testing.T) {
+	resetBrandingState(t)
 	// Explicit overrides win over derivation.
 	t.Setenv(envIssuesURL, "https://example.com/tracker")
 	t.Setenv(envNewIssueURL, "https://example.com/tracker/file")
@@ -46,6 +75,7 @@ func TestExplicitDerivedOverride(t *testing.T) {
 }
 
 func TestDerivationCollapsesTrailingSlash(t *testing.T) {
+	resetBrandingState(t)
 	t.Setenv(envRepoURL, "https://example.com/fork/")
 
 	// Derived sub-paths normalize the trailing slash so there is no double slash.
@@ -58,6 +88,7 @@ func TestDerivationCollapsesTrailingSlash(t *testing.T) {
 }
 
 func TestWhitespaceCountsAsUnset(t *testing.T) {
+	resetBrandingState(t)
 	t.Setenv(envRepoURL, "   ")
 	t.Setenv(envName, "\t")
 
@@ -66,9 +97,8 @@ func TestWhitespaceCountsAsUnset(t *testing.T) {
 }
 
 func TestLdflagsVarPrecedence(t *testing.T) {
+	resetBrandingState(t)
 	// Simulate a value baked in at link time via -ldflags -X.
-	orig := projectRepoURL
-	t.Cleanup(func() { projectRepoURL = orig })
 	projectRepoURL = "https://baked.example.com/repo"
 
 	assert.Equal(t, "https://baked.example.com/repo", RepoURL())
@@ -77,4 +107,17 @@ func TestLdflagsVarPrecedence(t *testing.T) {
 	// The environment variable still beats the baked-in value.
 	t.Setenv(envRepoURL, "https://env.example.com/repo")
 	assert.Equal(t, "https://env.example.com/repo", RepoURL())
+}
+
+func TestSanitizesCredentials(t *testing.T) {
+	resetBrandingState(t)
+	// Credentials an operator accidentally embeds in a configured URL must be
+	// stripped before any getter returns it, since the values feed the public
+	// app-config endpoint, outbound User-Agent headers, and logs.
+	t.Setenv(envRepoURL, "https://user:secret@example.com/fork")
+
+	assert.Equal(t, "https://example.com/fork", RepoURL())
+	assert.Equal(t, "https://example.com/fork/issues", IssuesURL())
+	assert.Equal(t, "https://example.com/fork/issues/new", NewIssueURL())
+	assert.Equal(t, "https://example.com/fork", SupportURL())
 }

--- a/internal/imageprovider/helpers_test.go
+++ b/internal/imageprovider/helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -284,7 +285,7 @@ func TestBuildUserAgent(t *testing.T) {
 			assert.Contains(t, got, tt.wantPrefix, "user-agent should contain app name and version")
 
 			// Check it contains required components per Wikimedia policy
-			assert.Contains(t, got, userAgentContact, "user-agent should contain contact URL")
+			assert.Contains(t, got, branding.RepoURL(), "user-agent should contain contact URL")
 			assert.Contains(t, got, userAgentLibrary, "user-agent should contain library name")
 			assert.Contains(t, got, "go", "user-agent should contain Go version")
 		})

--- a/internal/imageprovider/helpers_test.go
+++ b/internal/imageprovider/helpers_test.go
@@ -285,7 +285,9 @@ func TestBuildUserAgent(t *testing.T) {
 			assert.Contains(t, got, tt.wantPrefix, "user-agent should contain app name and version")
 
 			// Check it contains required components per Wikimedia policy
-			assert.Contains(t, got, branding.RepoURL(), "user-agent should contain contact URL")
+			expectedContact := branding.RepoURL()
+			require.NotEmpty(t, expectedContact, "branding repo URL must not be empty")
+			assert.Contains(t, got, expectedContact, "user-agent should contain contact URL")
 			assert.Contains(t, got, userAgentLibrary, "user-agent should contain library name")
 			assert.Contains(t, got, "go", "user-agent should contain Go version")
 		})

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -19,6 +19,7 @@ import (
 	"github.com/antonholmquist/jason"
 	"github.com/google/uuid"
 	"github.com/k3a/html2text"
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -32,8 +33,9 @@ const (
 
 	// User-Agent constants following Wikimedia robot policy
 	// https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy
+	// The contact URL is resolved at runtime from the branding package (see
+	// buildUserAgent) so forks identify themselves rather than the upstream repo.
 	userAgentName    = "BirdNETGo"
-	userAgentContact = "https://github.com/tphakala/birdnet-go"
 	userAgentLibrary = "Go-HTTP-Client"
 
 	// Circuit breaker timeout durations
@@ -513,7 +515,7 @@ func buildUserAgent(appVersion string) string {
 
 	// Format: BirdNET-Go/1.0.0 (https://github.com/tphakala/birdnet-go) Go-HTTP-Client/go1.21.0
 	return fmt.Sprintf("%s/%s (%s) %s/%s",
-		userAgentName, appVersion, userAgentContact, userAgentLibrary, goVersion)
+		userAgentName, appVersion, branding.RepoURL(), userAgentLibrary, goVersion)
 }
 
 // logUserAgentValidation logs the constructed user-agent for debugging purposes
@@ -525,7 +527,7 @@ func logUserAgentValidation(appVersion string) {
 		logger.String("complies_with_policy", "https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy"),
 		logger.String("contains_app_name", userAgentName),
 		logger.String("contains_version", appVersion),
-		logger.String("contains_contact", userAgentContact),
+		logger.String("contains_contact", branding.RepoURL()),
 		logger.String("contains_library", userAgentLibrary),
 		logger.String("go_version", runtime.Version()))
 }

--- a/internal/mqtt/discovery.go
+++ b/internal/mqtt/discovery.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -223,7 +224,7 @@ func (p *Publisher) publishBridgeDiscovery(ctx context.Context) error {
 		Device: DiscoveryDevice{
 			Identifiers:  []string{bridgeID},
 			Name:         p.config.DeviceName,
-			Manufacturer: "BirdNET-Go",
+			Manufacturer: branding.Name(),
 			Model:        "Bridge",
 			SWVersion:    p.config.Version,
 		},
@@ -254,7 +255,7 @@ func (p *Publisher) publishSourceDiscovery(ctx context.Context, source datastore
 	device := DiscoveryDevice{
 		Identifiers:  []string{deviceID},
 		Name:         deviceName,
-		Manufacturer: "BirdNET-Go",
+		Manufacturer: branding.Name(),
 		Model:        "Audio Analyzer",
 		SWVersion:    p.config.Version,
 		ViaDevice:    bridgeID,
@@ -369,9 +370,9 @@ func (p *Publisher) getSensorTopic(nodeID, sourceID, sensorType string) string {
 // defaultOrigin returns the standard origin block for discovery payloads.
 func (p *Publisher) defaultOrigin() *DiscoveryOrigin {
 	return &DiscoveryOrigin{
-		Name:       "BirdNET-Go",
+		Name:       branding.Name(),
 		SWVersion:  p.config.Version,
-		SupportURL: "https://github.com/tphakala/birdnet-go",
+		SupportURL: branding.SupportURL(),
 	}
 }
 

--- a/internal/weather/provider_common.go
+++ b/internal/weather/provider_common.go
@@ -4,15 +4,22 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 const (
 	RequestTimeout = 10 * time.Second
-	UserAgent      = "BirdNET-Go https://github.com/tphakala/birdnet-go"
 	RetryDelay     = 2 * time.Second
 	MaxRetries     = 3
 )
+
+// UserAgent returns the HTTP User-Agent header value for outbound weather API
+// requests, built from the configured project identity so forks identify
+// themselves rather than the upstream project.
+func UserAgent() string {
+	return branding.Name() + " " + branding.RepoURL()
+}
 
 // Sentinel errors for weather API responses
 var (

--- a/internal/weather/provider_common_test.go
+++ b/internal/weather/provider_common_test.go
@@ -169,8 +169,8 @@ func TestConstants(t *testing.T) {
 	})
 
 	t.Run("user agent is set", func(t *testing.T) {
-		assert.NotEmpty(t, UserAgent)
-		assert.Contains(t, UserAgent, "BirdNET-Go")
+		assert.NotEmpty(t, UserAgent())
+		assert.Contains(t, UserAgent(), "BirdNET-Go")
 	})
 }
 

--- a/internal/weather/provider_common_test.go
+++ b/internal/weather/provider_common_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
@@ -169,8 +170,12 @@ func TestConstants(t *testing.T) {
 	})
 
 	t.Run("user agent is set", func(t *testing.T) {
-		assert.NotEmpty(t, UserAgent())
-		assert.Contains(t, UserAgent(), "BirdNET-Go")
+		ua := UserAgent()
+		assert.NotEmpty(t, ua)
+		// Assert against the resolved branding values rather than a hardcoded
+		// upstream literal, so the test holds for branded builds/overrides too.
+		assert.Contains(t, ua, branding.Name())
+		assert.Contains(t, ua, branding.RepoURL())
 	})
 }
 

--- a/internal/weather/provider_openweather.go
+++ b/internal/weather/provider_openweather.go
@@ -83,7 +83,7 @@ func (p *OpenWeatherProvider) FetchWeather(settings *conf.Settings) (*WeatherDat
 	if err != nil {
 		return nil, newWeatherError(err, errors.CategoryNetwork, "create_http_request", openWeatherProviderName)
 	}
-	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("User-Agent", UserAgent())
 
 	// Execute request with retry
 	body, err := executeOpenWeatherRequest(req, providerLogger)

--- a/internal/weather/provider_wunderground.go
+++ b/internal/weather/provider_wunderground.go
@@ -319,7 +319,7 @@ func (p *WundergroundProvider) executeRequest(apiURL string, cfg *wundergroundCo
 	if err != nil {
 		return nil, newWeatherError(err, errors.CategoryNetwork, "create_http_request", wundergroundProviderName)
 	}
-	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("User-Agent", UserAgent())
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := p.httpClient.Do(req)

--- a/internal/weather/provider_yrno.go
+++ b/internal/weather/provider_yrno.go
@@ -197,7 +197,7 @@ func (p *YrNoProvider) FetchWeather(settings *conf.Settings) (*WeatherData, erro
 	if err != nil {
 		return nil, newWeatherError(err, errors.CategoryNetwork, "create_http_request", yrNoProviderName)
 	}
-	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("User-Agent", UserAgent())
 	req.Header.Set("Accept-Encoding", "gzip")
 	p.mu.Lock()
 	if p.lastModified != "" {


### PR DESCRIPTION
## Summary

Phase 2 of externalizing hardcoded upstream identifiers (Phase 1 externalized the Sentry DSN in #3397). Adds an `internal/branding` package that resolves project identity (name and the repo, issues, new-issue, support, and community URLs) with the precedence:

```
BIRDNET_GO_PROJECT_* env var  >  ldflags-baked var  >  built-in default
```

mirroring the `internal/telemetry` `sentryDSN` injection model from Phase 1. Forks can now rebrand the running binary without editing source or translations: bake values in at link time, or set the env vars at runtime. Defaults stay in source (these are public identity, not secrets), so from-source builds keep pointing at the upstream project.

## What changed

**New package** `internal/branding`: unexported ldflags-target vars (empty by default) + const defaults + `BIRDNET_GO_PROJECT_*` env overrides, exposed through getters `Name() / RepoURL() / IssuesURL() / NewIssueURL() / SupportURL() / CommunityURL()`. The issue/new-issue/support URLs derive from the repo URL when not set explicitly.

**Backend consumers** now read branding getters instead of hardcoded `github.com/tphakala/birdnet-go` literals:
- `internal/mqtt/discovery.go`: Home Assistant Origin name + support URL, and the device `Manufacturer`.
- `internal/imageprovider/wikipedia.go`: Wikimedia User-Agent contact URL (the policy product token `BirdNETGo` is intentionally left as-is).
- `internal/weather/provider_common.go`: outbound `UserAgent` (const is now a `UserAgent()` func).

**Frontend**: a new always-present `projectLinks` object on the app-config endpoint (`internal/api/v2/app.go`) carries the resolved identity to the browser. The support page issue links, About "View on GitHub", and the two error-page issue links now follow it. The support-card help/notice strings had their embedded `<a href>` anchors de-embedded from all 15 locale files into interpolation tokens plus translated label keys; the anchors are rebuilt in `SupportDumpCard.svelte` from the config URLs, hardened against attribute breakout and non-`http(s)` schemes before reaching `{@html}` (BirdNET-Go often runs on plain HTTP).

**Build**: `Taskfile.yml` and `Dockerfile` thread optional `PROJECT_*` build-time overrides into the branding ldflags (empty by default; official builds keep the in-source upstream defaults, so this is a no-op for them).

## Backward compatibility

Behavior is unchanged for existing upstream users: the new app-config field is additive, and every resolved default is byte-identical to the previous hardcoded literal (verified for the weather/Wikipedia User-Agents, MQTT Origin support URL/name, the support-card links, the About link, and the error-page links). New frontend against an old backend falls back to upstream defaults.

## Test plan
- [x] `go test -race ./internal/branding/...` (new precedence/derivation tests)
- [x] `go test ./internal/api/v2/ -run TestGetAppConfig` (new ProjectLinks contract test + no-extra-fields guard)
- [x] `go test -race` on touched packages (mqtt, weather, imageprovider)
- [x] `golangci-lint run` full project: 0 issues
- [x] `npm run check:all` (typecheck, lint, ast-grep, prettier): pass
- [x] i18n sync + integrity validation: all 15 locales in sync, no English placeholders, tokens present
- [x] Verified ldflags injection + runtime env override end-to-end (defaults, fork override, derivation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable project branding and links can be embedded in builds and are exposed to the app and API.
  * About, error, and support pages use the configured project links instead of fixed URLs.
  * Localized support-report text now uses link placeholders for viewing/creating issues.

* **Bug Fixes**
  * Support-dump link handling rejects unsafe URLs and properly escapes special characters.

* **Tests**
  * Added tests covering branding values and app config exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->