### PR TITLE
fix(notification): guard subscriber count read against data race

### DIFF
--- a/internal/notification/race_test.go
+++ b/internal/notification/race_test.go
@@ -362,3 +362,73 @@ func TestCloneDeepCopiesNestedMetadata(t *testing.T) {
 	assert.Equal(t, "timeout", originalErrors[0],
 		"Modifying nested slice in clone should not affect original")
 }
+
+// TestCreateConcurrentSubscriberCountRace reproduces a data race on
+// Service.subscribers. broadcast() writes s.subscribers under subscribersMu, but
+// Create() and CreateWithMetadata() read len(s.subscribers) OUTSIDE the lock in
+// their post-broadcast debug log. Two goroutines creating notifications
+// concurrently race: one broadcast() writes s.subscribers while the other's debug
+// log reads len(s.subscribers).
+//
+// The unguarded read lives inside an `if s.config.Debug` branch, so the race only
+// manifests with Debug logging enabled.
+//
+// Run with: go test -race -run TestCreateConcurrentSubscriberCountRace ./internal/notification/
+func TestCreateConcurrentSubscriberCountRace(t *testing.T) {
+	config := &ServiceConfig{
+		MaxNotifications:   1000,
+		CleanupInterval:    time.Minute,
+		RateLimitWindow:    time.Minute,
+		RateLimitMaxEvents: 10_000, // well above the goroutines*iterations creates below, no rate limiting
+		Debug:              true,   // REQUIRED: the unguarded read is gated behind Debug
+	}
+	service := NewService(config)
+	defer service.Stop()
+
+	// Subscribers make broadcast() rewrite s.subscribers on every call, widening
+	// the window between the guarded write and the unguarded read.
+	const numSubscribers = 3
+	subscribers := make([]<-chan *Notification, numSubscribers)
+	for i := range numSubscribers {
+		ch, _ := service.Subscribe()
+		subscribers[i] = ch
+	}
+	defer func() {
+		for _, ch := range subscribers {
+			service.Unsubscribe(ch)
+		}
+	}()
+
+	// Continuously drain subscriber channels so broadcast never sees a full channel.
+	stop := make(chan struct{})
+	var drainWg sync.WaitGroup
+	for _, ch := range subscribers {
+		drainWg.Go(func() {
+			for {
+				select {
+				case <-ch:
+				case <-stop:
+					return
+				}
+			}
+		})
+	}
+
+	const goroutines = 50
+	const iterations = 20
+	runConcurrent(t, goroutines, func(id int) {
+		for j := range iterations {
+			// Exercise both create paths that read len(s.subscribers) outside the
+			// lock after broadcast: Create (service.go) and CreateWithMetadata.
+			if (id+j)%2 == 0 {
+				notif := NewNotification(TypeInfo, PriorityMedium, "Race", "msg")
+				_ = service.CreateWithMetadata(notif)
+			} else {
+				_, _ = service.Create(TypeInfo, PriorityMedium, "Race", "msg")
+			}
+		}
+	})
+
+	close(stop)
+	drainWg.Wait()
+}

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -151,13 +151,14 @@ func (s *Service) Create(notifType Type, priority Priority, title, message strin
 			Build()
 	}
 
-	// Broadcast to subscribers
-	s.broadcast(notification)
+	// Broadcast to subscribers. Use the count returned under the lock instead of
+	// reading len(s.subscribers) here, which would race with broadcast's write.
+	subscriberCount := s.broadcast(notification)
 
 	if s.config.Debug {
 		s.logger.Debug("notification created and broadcast",
 			logger.String("id", notification.ID),
-			logger.Int("subscriber_count", len(s.subscribers)))
+			logger.Int("subscriber_count", subscriberCount))
 	}
 
 	return notification, nil
@@ -440,7 +441,12 @@ type broadcastStats struct {
 // broadcast sends a notification to all subscribers.
 // Each subscriber receives a clone of the notification to prevent race conditions
 // if the original notification is modified after broadcast (e.g., adding metadata).
-func (s *Service) broadcast(notification *Notification) {
+//
+// It returns the number of active subscribers remaining after the broadcast. The
+// count is computed while holding subscribersMu so callers can log it without
+// re-reading s.subscribers outside the lock, which would data-race with the write
+// to s.subscribers below.
+func (s *Service) broadcast(notification *Notification) int {
 	s.subscribersMu.Lock()
 	defer s.subscribersMu.Unlock()
 
@@ -463,6 +469,8 @@ func (s *Service) broadcast(notification *Notification) {
 			logger.Int("failed_count", stats.failed),
 			logger.Int("success_count", stats.success))
 	}
+
+	return len(activeSubscribers)
 }
 
 // logBroadcastStart logs the start of a broadcast operation.

--- a/internal/notification/service_extensions.go
+++ b/internal/notification/service_extensions.go
@@ -63,13 +63,15 @@ func (s *Service) CreateWithMetadata(notification *Notification) error {
 		}
 	}
 
-	// Always broadcast so push dispatcher can receive push-targeted notifications
-	s.broadcast(notification)
+	// Always broadcast so push dispatcher can receive push-targeted notifications.
+	// Use the count returned under the lock instead of reading len(s.subscribers)
+	// here, which would race with broadcast's write.
+	subscriberCount := s.broadcast(notification)
 
 	if s.config.Debug {
 		s.logger.Debug("notification created and broadcast",
 			logger.String("id", notification.ID),
-			logger.Int("subscriber_count", len(s.subscribers)))
+			logger.Int("subscriber_count", subscriberCount))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

`broadcast()` writes `s.subscribers` while holding `subscribersMu`, but `Create()` and `CreateWithMetadata()` read `len(s.subscribers)` **outside** the lock in their post-broadcast debug log. When two goroutines create notifications concurrently with Debug logging enabled, one `broadcast()` writes `s.subscribers` while the other's debug log reads it, which the race detector flags. It is a real (if low-impact) production race: any two goroutines creating notifications concurrently with Debug logging on can trip it.

The fix returns the active subscriber count from `broadcast()` (computed while holding `subscribersMu`) and logs that returned value in both callers instead of re-reading `s.subscribers`. This removes both unguarded reads. The other `broadcast()` callers (`CreateWithComponent`, the detection consumer) never read the subscriber count after broadcast and simply ignore the new return value.

## Changes

- `broadcast()` now returns `int` (the active subscriber count, snapshotted under the lock).
- `Create()` and `CreateWithMetadata()` log that returned count instead of the unguarded `len(s.subscribers)`.
- New `TestCreateConcurrentSubscriberCountRace` reproducing the race.

## Test Plan

- [x] `go test -race -run TestCreateConcurrentSubscriberCountRace ./internal/notification/` (trips the detector on the old code, passes after the fix)
- [x] `go test -race ./internal/notification/` (full package green)
- [x] `golangci-lint run` (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrent access race condition in the notification service, improving reliability of subscriber count tracking during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->