### PR TITLE
feat(branding): drive frontend externalUrls consumers from projectLinks

### DIFF
--- a/frontend/src/lib/desktop/components/ui/HeaderSettingsMenu.svelte
+++ b/frontend/src/lib/desktop/components/ui/HeaderSettingsMenu.svelte
@@ -24,7 +24,7 @@
   } from '@lucide/svelte';
   import GithubIcon from '$lib/desktop/components/ui/GithubIcon.svelte';
   import { dropdown } from '$lib/utils/transitions';
-  import { GITHUB_REPO_URL, GITHUB_DISCUSSIONS_URL } from '$lib/utils/externalUrls';
+  import { appState } from '$lib/stores/appState.svelte';
   import ConfirmModal from '$lib/desktop/components/modals/ConfirmModal.svelte';
 
   const logger = getLogger('dashboard');
@@ -248,7 +248,7 @@
 
         <!-- Ask a Question -->
         <a
-          href={GITHUB_DISCUSSIONS_URL}
+          href={appState.projectLinks.discussionsUrl}
           target="_blank"
           rel="noopener noreferrer"
           class="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-normal text-[var(--color-base-content)] transition-colors duration-150 hover:bg-[var(--color-base-content)]/10"
@@ -261,7 +261,7 @@
 
         <!-- GitHub link -->
         <a
-          href={GITHUB_REPO_URL}
+          href={appState.projectLinks.repoUrl}
           target="_blank"
           rel="noopener noreferrer"
           class="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-normal text-[var(--color-base-content)] transition-colors duration-150 hover:bg-[var(--color-base-content)]/10"

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -80,8 +80,7 @@ Performance Optimizations:
   import { t } from '$lib/i18n';
   import CollapsibleNavSection from './CollapsibleNavSection.svelte';
   import type { NavItem } from './CollapsibleNavSection.svelte';
-  import { GITHUB_REPO_URL, GITHUB_DISCUSSIONS_URL } from '$lib/utils/externalUrls';
-  import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
+  import { appState, hasLiveAudioAccess } from '$lib/stores/appState.svelte';
   import { resetDateToToday } from '$lib/utils/datePersistence';
   import { getCurrentPathWithQuery } from '$lib/utils/urlHelpers';
   import LoginModal from '../components/modals/LoginModal.svelte';
@@ -307,7 +306,7 @@ Performance Optimizations:
       type: 'link',
       icon: MessageCircleQuestion,
       label: t('navigation.askQuestion'),
-      href: GITHUB_DISCUSSIONS_URL,
+      href: appState.projectLinks.discussionsUrl,
       ariaLabel: t('navigation.askQuestionAriaLabel'),
       trailingIcon: ExternalLink,
     },
@@ -724,7 +723,7 @@ Performance Optimizations:
       {#if !isCollapsed}
         <div class="mt-3 text-center">
           <a
-            href={GITHUB_REPO_URL}
+            href={appState.projectLinks.repoUrl}
             target="_blank"
             rel="noopener noreferrer"
             class="text-xs text-[var(--color-base-content)]/60 hover:text-[var(--color-base-content)]/80 transition-colors duration-150"

--- a/frontend/src/lib/desktop/views/Help.svelte
+++ b/frontend/src/lib/desktop/views/Help.svelte
@@ -11,12 +11,8 @@
   import GithubIcon from '$lib/desktop/components/ui/GithubIcon.svelte';
   import { t } from '$lib/i18n';
   import { navigation } from '$lib/stores/navigation.svelte';
-  import {
-    GITHUB_REPO_URL,
-    GITHUB_DISCUSSIONS_URL,
-    GITHUB_RELEASES_URL,
-    LICENSE_URL,
-  } from '$lib/utils/externalUrls';
+  import { appState } from '$lib/stores/appState.svelte';
+  import { LICENSE_URL } from '$lib/utils/externalUrls';
 </script>
 
 <div class="col-span-12 space-y-4">
@@ -62,7 +58,7 @@
 
     <div class="mt-4">
       <a
-        href={GITHUB_DISCUSSIONS_URL}
+        href={appState.projectLinks.discussionsUrl}
         target="_blank"
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary-hover)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2"
@@ -79,7 +75,7 @@
   <Card title={t('help.quickLinks.title')} className="bg-[var(--color-base-100)] shadow-sm">
     <div class="space-y-3">
       <a
-        href={GITHUB_REPO_URL}
+        href={appState.projectLinks.repoUrl}
         target="_blank"
         rel="noopener noreferrer"
         class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors duration-150 hover:bg-[var(--color-base-200)]"
@@ -90,7 +86,7 @@
         <ExternalLink class="size-3.5 text-[var(--color-base-content)]/40" />
       </a>
       <a
-        href={GITHUB_RELEASES_URL}
+        href={appState.projectLinks.releasesUrl}
         target="_blank"
         rel="noopener noreferrer"
         class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors duration-150 hover:bg-[var(--color-base-200)]"

--- a/frontend/src/lib/desktop/views/ReportBug.svelte
+++ b/frontend/src/lib/desktop/views/ReportBug.svelte
@@ -6,7 +6,7 @@
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
   import { copyToClipboard, COPY_FEEDBACK_TIMEOUT_MS } from '$lib/utils/clipboard';
-  import { GITHUB_ISSUES_URL } from '$lib/utils/externalUrls';
+  import { appState } from '$lib/stores/appState.svelte';
 
   interface HealthResponse {
     version?: string;
@@ -244,7 +244,7 @@
     </p>
 
     <a
-      href={GITHUB_ISSUES_URL}
+      href={appState.projectLinks.newIssueUrl}
       target="_blank"
       rel="noopener noreferrer"
       class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary-hover)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2"

--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -101,6 +101,8 @@ interface ProjectLinks {
   issuesUrl: string;
   newIssueUrl: string;
   supportUrl: string;
+  discussionsUrl: string;
+  releasesUrl: string;
   communityUrl: string;
 }
 
@@ -156,6 +158,8 @@ const DEFAULT_PROJECT_LINKS: ProjectLinks = {
   issuesUrl: 'https://github.com/tphakala/birdnet-go/issues',
   newIssueUrl: 'https://github.com/tphakala/birdnet-go/issues/new',
   supportUrl: 'https://github.com/tphakala/birdnet-go',
+  discussionsUrl: 'https://github.com/tphakala/birdnet-go/discussions',
+  releasesUrl: 'https://github.com/tphakala/birdnet-go/releases',
   communityUrl: 'https://discord.gg/gcSCFGUtsd',
 };
 

--- a/frontend/src/lib/utils/externalUrls.ts
+++ b/frontend/src/lib/utils/externalUrls.ts
@@ -1,5 +1,8 @@
-export const GITHUB_REPO_URL = 'https://github.com/tphakala/birdnet-go';
-export const GITHUB_ISSUES_URL = 'https://github.com/tphakala/birdnet-go/issues/new/choose';
-export const GITHUB_DISCUSSIONS_URL = 'https://github.com/tphakala/birdnet-go/discussions';
-export const GITHUB_RELEASES_URL = 'https://github.com/tphakala/birdnet-go/releases';
+// Project identity/routing URLs (repo, issues, discussions, releases) now come
+// from the backend-resolved branding config via appState.projectLinks, so a fork
+// that rebrands the backend is reflected in the UI. See internal/branding and
+// AppConfigResponse.projectLinks. Only non-identity links remain hardcoded here.
+
+// License is fixed project metadata (CC BY-NC-SA 4.0), not project identity, so
+// it stays a constant rather than a configurable branding value.
 export const LICENSE_URL = 'https://creativecommons.org/licenses/by-nc-sa/4.0/';

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -58,12 +58,14 @@ type SentryFrontendConfig struct {
 // to the frontend so in-app links follow the branding package rather than
 // hardcoded upstream URLs. It is always populated (not gated on telemetry).
 type ProjectLinksConfig struct {
-	Name         string `json:"name"`
-	RepoURL      string `json:"repoUrl"`
-	IssuesURL    string `json:"issuesUrl"`
-	NewIssueURL  string `json:"newIssueUrl"`
-	SupportURL   string `json:"supportUrl"`
-	CommunityURL string `json:"communityUrl"`
+	Name           string `json:"name"`
+	RepoURL        string `json:"repoUrl"`
+	IssuesURL      string `json:"issuesUrl"`
+	NewIssueURL    string `json:"newIssueUrl"`
+	SupportURL     string `json:"supportUrl"`
+	DiscussionsURL string `json:"discussionsUrl"`
+	ReleasesURL    string `json:"releasesUrl"`
+	CommunityURL   string `json:"communityUrl"`
 }
 
 // SecurityConfigDTO represents the security configuration for the frontend.
@@ -199,12 +201,14 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 		// Project identity/links are always served (independent of telemetry) so
 		// in-app links follow the configured branding instead of hardcoded URLs.
 		ProjectLinks: ProjectLinksConfig{
-			Name:         branding.Name(),
-			RepoURL:      branding.RepoURL(),
-			IssuesURL:    branding.IssuesURL(),
-			NewIssueURL:  branding.NewIssueURL(),
-			SupportURL:   branding.SupportURL(),
-			CommunityURL: branding.CommunityURL(),
+			Name:           branding.Name(),
+			RepoURL:        branding.RepoURL(),
+			IssuesURL:      branding.IssuesURL(),
+			NewIssueURL:    branding.NewIssueURL(),
+			SupportURL:     branding.SupportURL(),
+			DiscussionsURL: branding.DiscussionsURL(),
+			ReleasesURL:    branding.ReleasesURL(),
+			CommunityURL:   branding.CommunityURL(),
 		},
 	}
 

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -191,7 +191,9 @@ func TestGetAppConfig_ProjectLinks(t *testing.T) {
 	// the caller's environment.
 	for _, key := range []string{
 		"BIRDNET_GO_PROJECT_NAME", "BIRDNET_GO_PROJECT_REPO_URL", "BIRDNET_GO_PROJECT_ISSUES_URL",
-		"BIRDNET_GO_PROJECT_NEW_ISSUE_URL", "BIRDNET_GO_PROJECT_SUPPORT_URL", "BIRDNET_GO_PROJECT_COMMUNITY_URL",
+		"BIRDNET_GO_PROJECT_NEW_ISSUE_URL", "BIRDNET_GO_PROJECT_SUPPORT_URL",
+		"BIRDNET_GO_PROJECT_DISCUSSIONS_URL", "BIRDNET_GO_PROJECT_RELEASES_URL",
+		"BIRDNET_GO_PROJECT_COMMUNITY_URL",
 	} {
 		t.Setenv(key, "")
 	}
@@ -222,6 +224,8 @@ func TestGetAppConfig_ProjectLinks(t *testing.T) {
 	assert.Equal(t, branding.IssuesURL(), links.IssuesURL)
 	assert.Equal(t, branding.NewIssueURL(), links.NewIssueURL)
 	assert.Equal(t, branding.SupportURL(), links.SupportURL)
+	assert.Equal(t, branding.DiscussionsURL(), links.DiscussionsURL)
+	assert.Equal(t, branding.ReleasesURL(), links.ReleasesURL)
 	assert.Equal(t, branding.CommunityURL(), links.CommunityURL)
 }
 
@@ -947,12 +951,14 @@ func TestGetAppConfig_NoExtraFields(t *testing.T) {
 	projectLinks, ok := projectLinksRaw.(map[string]any)
 	require.True(t, ok, "projectLinks should be a map")
 	expectedProjectLinkKeys := map[string]bool{
-		"name":         true,
-		"repoUrl":      true,
-		"issuesUrl":    true,
-		"newIssueUrl":  true,
-		"supportUrl":   true,
-		"communityUrl": true,
+		"name":           true,
+		"repoUrl":        true,
+		"issuesUrl":      true,
+		"newIssueUrl":    true,
+		"supportUrl":     true,
+		"discussionsUrl": true,
+		"releasesUrl":    true,
+		"communityUrl":   true,
 	}
 
 	for key := range projectLinks {

--- a/internal/branding/branding.go
+++ b/internal/branding/branding.go
@@ -42,6 +42,12 @@ var (
 	// projectSupportURL is the user-facing support URL (shown e.g. on the Home
 	// Assistant device page); defaults to the repo URL when empty.
 	projectSupportURL string
+	// projectDiscussionsURL is the community discussions/forum URL; derived from
+	// the repo URL when empty.
+	projectDiscussionsURL string
+	// projectReleasesURL is the release-notes/downloads URL; derived from the
+	// repo URL when empty.
+	projectReleasesURL string
 	// projectCommunityURL is the community chat/forum URL.
 	projectCommunityURL string
 )
@@ -53,18 +59,22 @@ const (
 	defaultRepoURL      = "https://github.com/tphakala/birdnet-go"
 	defaultCommunityURL = "https://discord.gg/gcSCFGUtsd"
 
-	issuesPath   = "issues"
-	newIssuePath = "issues/new"
+	issuesPath      = "issues"
+	newIssuePath    = "issues/new"
+	discussionsPath = "discussions"
+	releasesPath    = "releases"
 )
 
 // Environment variables that override the build-time values at runtime.
 const (
-	envName         = "BIRDNET_GO_PROJECT_NAME"
-	envRepoURL      = "BIRDNET_GO_PROJECT_REPO_URL"
-	envIssuesURL    = "BIRDNET_GO_PROJECT_ISSUES_URL"
-	envNewIssueURL  = "BIRDNET_GO_PROJECT_NEW_ISSUE_URL"
-	envSupportURL   = "BIRDNET_GO_PROJECT_SUPPORT_URL"
-	envCommunityURL = "BIRDNET_GO_PROJECT_COMMUNITY_URL"
+	envName           = "BIRDNET_GO_PROJECT_NAME"
+	envRepoURL        = "BIRDNET_GO_PROJECT_REPO_URL"
+	envIssuesURL      = "BIRDNET_GO_PROJECT_ISSUES_URL"
+	envNewIssueURL    = "BIRDNET_GO_PROJECT_NEW_ISSUE_URL"
+	envSupportURL     = "BIRDNET_GO_PROJECT_SUPPORT_URL"
+	envDiscussionsURL = "BIRDNET_GO_PROJECT_DISCUSSIONS_URL"
+	envReleasesURL    = "BIRDNET_GO_PROJECT_RELEASES_URL"
+	envCommunityURL   = "BIRDNET_GO_PROJECT_COMMUNITY_URL"
 )
 
 // resolve returns the first non-empty candidate among the environment variable
@@ -126,6 +136,18 @@ func NewIssueURL() string {
 // not explicitly configured.
 func SupportURL() string {
 	return sanitizeURL(resolve(envSupportURL, projectSupportURL, RepoURL()))
+}
+
+// DiscussionsURL returns the community discussions URL, derived from RepoURL
+// when not explicitly configured.
+func DiscussionsURL() string {
+	return sanitizeURL(resolve(envDiscussionsURL, projectDiscussionsURL, joinURL(RepoURL(), discussionsPath)))
+}
+
+// ReleasesURL returns the release-notes/downloads URL, derived from RepoURL
+// when not explicitly configured.
+func ReleasesURL() string {
+	return sanitizeURL(resolve(envReleasesURL, projectReleasesURL, joinURL(RepoURL(), releasesPath)))
 }
 
 // CommunityURL returns the community chat/forum URL.

--- a/internal/branding/branding_test.go
+++ b/internal/branding/branding_test.go
@@ -17,7 +17,8 @@ func resetBrandingState(t *testing.T) {
 	t.Helper()
 
 	for _, key := range []string{
-		envName, envRepoURL, envIssuesURL, envNewIssueURL, envSupportURL, envCommunityURL,
+		envName, envRepoURL, envIssuesURL, envNewIssueURL, envSupportURL,
+		envDiscussionsURL, envReleasesURL, envCommunityURL,
 	} {
 		t.Setenv(key, "")
 	}
@@ -25,13 +26,16 @@ func resetBrandingState(t *testing.T) {
 	origName, origRepo := projectName, projectRepoURL
 	origIssues, origNewIssue := projectIssuesURL, projectNewIssueURL
 	origSupport, origCommunity := projectSupportURL, projectCommunityURL
+	origDiscussions, origReleases := projectDiscussionsURL, projectReleasesURL
 	projectName, projectRepoURL = "", ""
 	projectIssuesURL, projectNewIssueURL = "", ""
 	projectSupportURL, projectCommunityURL = "", ""
+	projectDiscussionsURL, projectReleasesURL = "", ""
 	t.Cleanup(func() {
 		projectName, projectRepoURL = origName, origRepo
 		projectIssuesURL, projectNewIssueURL = origIssues, origNewIssue
 		projectSupportURL, projectCommunityURL = origSupport, origCommunity
+		projectDiscussionsURL, projectReleasesURL = origDiscussions, origReleases
 	})
 }
 
@@ -44,6 +48,8 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues", IssuesURL())
 	assert.Equal(t, "https://github.com/tphakala/birdnet-go/issues/new", NewIssueURL())
 	assert.Equal(t, "https://github.com/tphakala/birdnet-go", SupportURL())
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go/discussions", DiscussionsURL())
+	assert.Equal(t, "https://github.com/tphakala/birdnet-go/releases", ReleasesURL())
 	assert.Equal(t, "https://discord.gg/gcSCFGUtsd", CommunityURL())
 }
 
@@ -59,6 +65,8 @@ func TestEnvOverride(t *testing.T) {
 	assert.Equal(t, "https://example.com/me/fork/issues", IssuesURL())
 	assert.Equal(t, "https://example.com/me/fork/issues/new", NewIssueURL())
 	assert.Equal(t, "https://example.com/me/fork", SupportURL())
+	assert.Equal(t, "https://example.com/me/fork/discussions", DiscussionsURL())
+	assert.Equal(t, "https://example.com/me/fork/releases", ReleasesURL())
 	assert.Equal(t, "https://chat.example.com", CommunityURL())
 }
 
@@ -68,10 +76,14 @@ func TestExplicitDerivedOverride(t *testing.T) {
 	t.Setenv(envIssuesURL, "https://example.com/tracker")
 	t.Setenv(envNewIssueURL, "https://example.com/tracker/file")
 	t.Setenv(envSupportURL, "https://support.example.com")
+	t.Setenv(envDiscussionsURL, "https://forum.example.com")
+	t.Setenv(envReleasesURL, "https://example.com/downloads")
 
 	assert.Equal(t, "https://example.com/tracker", IssuesURL())
 	assert.Equal(t, "https://example.com/tracker/file", NewIssueURL())
 	assert.Equal(t, "https://support.example.com", SupportURL())
+	assert.Equal(t, "https://forum.example.com", DiscussionsURL())
+	assert.Equal(t, "https://example.com/downloads", ReleasesURL())
 }
 
 func TestDerivationCollapsesTrailingSlash(t *testing.T) {
@@ -81,6 +93,8 @@ func TestDerivationCollapsesTrailingSlash(t *testing.T) {
 	// Derived sub-paths normalize the trailing slash so there is no double slash.
 	assert.Equal(t, "https://example.com/fork/issues", IssuesURL())
 	assert.Equal(t, "https://example.com/fork/issues/new", NewIssueURL())
+	assert.Equal(t, "https://example.com/fork/discussions", DiscussionsURL())
+	assert.Equal(t, "https://example.com/fork/releases", ReleasesURL())
 	// The repo and support URLs are returned verbatim (a trailing slash on a
 	// repository URL is harmless and reflects exactly what the operator set).
 	assert.Equal(t, "https://example.com/fork/", RepoURL())
@@ -104,6 +118,13 @@ func TestLdflagsVarPrecedence(t *testing.T) {
 	assert.Equal(t, "https://baked.example.com/repo", RepoURL())
 	assert.Equal(t, "https://baked.example.com/repo/issues", IssuesURL())
 
+	// A value baked directly into a derived getter's own var wins over the
+	// repo-derived default (covers the same tier-2 plumbing for the newer vars).
+	projectReleasesURL = "https://baked.example.com/downloads"
+	assert.Equal(t, "https://baked.example.com/downloads", ReleasesURL())
+	// Discussions has no baked value, so it still derives from the baked repo.
+	assert.Equal(t, "https://baked.example.com/repo/discussions", DiscussionsURL())
+
 	// The environment variable still beats the baked-in value.
 	t.Setenv(envRepoURL, "https://env.example.com/repo")
 	assert.Equal(t, "https://env.example.com/repo", RepoURL())
@@ -120,4 +141,6 @@ func TestSanitizesCredentials(t *testing.T) {
 	assert.Equal(t, "https://example.com/fork/issues", IssuesURL())
 	assert.Equal(t, "https://example.com/fork/issues/new", NewIssueURL())
 	assert.Equal(t, "https://example.com/fork", SupportURL())
+	assert.Equal(t, "https://example.com/fork/discussions", DiscussionsURL())
+	assert.Equal(t, "https://example.com/fork/releases", ReleasesURL())
 }


### PR DESCRIPTION
## Summary

Completes the fork-rebranding work from PR #3398 (dynamic project identity URLs). PR #3398 routed the support page, About header, error pages, MQTT discovery, and outbound User-Agents through the configurable `internal/branding` package, but the Help & Support feature (added after that work) introduced `frontend/src/lib/utils/externalUrls.ts` with hardcoded upstream URLs that were not driven by `projectLinks`. A fork that set `BIRDNET_GO_PROJECT_REPO_URL` rebranded most of the UI but those Help-feature links still pointed upstream.

This change closes that gap:

- **Branding package**: add `DiscussionsURL()` and `ReleasesURL()` getters, derived from `RepoURL()` (`repo + /discussions`, `repo + /releases`) with the same `BIRDNET_GO_PROJECT_* env > ldflags > derived` precedence and credential sanitization as the existing getters.
- **App config**: expose `discussionsUrl` and `releasesUrl` on the `/api/v2/app/config` `projectLinks` object (always populated, not gated on telemetry), and on the frontend `ProjectLinks` interface + `DEFAULT_PROJECT_LINKS` fallback.
- **Consumers**: migrate `Help.svelte`, `ReportBug.svelte`, `HeaderSettingsMenu.svelte`, and `DesktopSidebar.svelte` to read `appState.projectLinks.*`, and drop the four `GITHUB_*` constants from `externalUrls.ts`. `LICENSE_URL` stays (fixed CC license metadata, not project identity).
- **New-issue link**: `ReportBug`'s "Open Issue" link now uses the generic `newIssueUrl` (`/issues/new`) instead of the GitHub-only `/issues/new/choose` chooser, keeping branding platform-agnostic for non-GitHub forks.

## Behavior

Additive and byte-identical for existing upstream users: the derived defaults resolve to the exact same URLs the old constants used. The only user-visible change for upstream is that the Report Bug button now opens the standard new-issue form instead of GitHub's template chooser. Setting `BIRDNET_GO_PROJECT_REPO_URL` (or the ldflags vars) now also rebrands the Help-page repo/discussions/releases links and the Report Bug link, with zero source or translation edits.

## Test Plan

- [x] `go test -race ./internal/branding/... ./internal/api/v2/...`
- [x] `golangci-lint run` (changed packages, 0 issues)
- [x] `npm run check:all` (0 errors; svelte-check clean)
- [x] Frontend component test (`DesktopSidebar.test.ts`) passes
- [ ] Manual: set `BIRDNET_GO_PROJECT_REPO_URL` and confirm Help/Sidebar/HeaderMenu/ReportBug links follow it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project identity links (GitHub discussions, releases, repository, and issue tracking) can now be dynamically configured and customized via backend settings rather than being hardcoded in the application code. This enables seamless, flexible customization of all external URLs throughout the user interface without requiring any code changes, redeployment, or frontend modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->