### PR TITLE
refactor(api/v2): inject notification.Service into Controller for test isolation

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/securefs"
 	"github.com/tphakala/birdnet-go/internal/spectrogram"
@@ -91,6 +92,13 @@ type Controller struct {
 	// Auth related fields (injected from server via functional options)
 	authService    auth.Service        // Authentication service (injected from server)
 	authMiddleware echo.MiddlewareFunc // Authentication middleware function (injected from server)
+
+	// notificationService is the notification service this controller uses. It is
+	// nil in production, where getNotificationService() falls back to the
+	// process-global singleton (notification.GetService()). Tests inject an
+	// isolated per-test instance via WithNotificationService so each test gets its
+	// own config and store without touching the global singleton.
+	notificationService *notification.Service
 
 	// Metrics history store for sparkline data
 	metricsStore observability.MetricsStore
@@ -220,6 +228,16 @@ func WithAuthMiddleware(mw echo.MiddlewareFunc) Option {
 func WithAuthService(svc auth.Service) Option {
 	return func(c *Controller) {
 		c.authService = svc
+	}
+}
+
+// WithNotificationService injects the notification service the controller should
+// use, overriding the process-global singleton. Production leaves this unset and
+// falls back to notification.GetService(); tests use it to give each test an
+// isolated service instance.
+func WithNotificationService(svc *notification.Service) Option {
+	return func(c *Controller) {
+		c.notificationService = svc
 	}
 }
 

--- a/internal/api/v2/dashboard_public_endpoints_test.go
+++ b/internal/api/v2/dashboard_public_endpoints_test.go
@@ -76,20 +76,6 @@ func guestGet(t *testing.T, e *echo.Echo, path string) *httptest.ResponseRecorde
 
 // ---- notifications -----------------------------------------------------
 
-// ensureNotificationServiceInitialized brings up a notification service for
-// tests that need to drive the notification path end-to-end. Callers get the
-// active service back and are responsible for cleanup of any fixtures they
-// add (the service itself is process-global and persists across tests).
-func ensureNotificationServiceInitialized(t *testing.T) *notification.Service {
-	t.Helper()
-	if !notification.IsInitialized() {
-		notification.Initialize(notification.DefaultServiceConfig())
-	}
-	svc := notification.GetService()
-	require.NotNil(t, svc, "notification service must be initialized for guest-filter tests")
-	return svc
-}
-
 // TestNotifications_PublicReadsAllowed verifies that the dashboard-facing
 // read endpoints are reachable without auth. Including the SSE endpoint is
 // important: NotificationBell opens a persistent /notifications/stream
@@ -151,7 +137,7 @@ func TestNotifications_MutationsRequireAuth(t *testing.T) {
 // against the toast-metadata leak path (a TypeDetection notification with
 // MetadataKeyIsToast=true must not reach unauthenticated callers).
 func TestNotifications_GuestListFiltersNonDetectionAndToasts(t *testing.T) {
-	svc := ensureNotificationServiceInitialized(t)
+	e, svc := newSettingsAuthTestEnvWithNotifier(t)
 
 	detection, err := svc.Create(notification.TypeDetection, notification.PriorityHigh,
 		"Detection: Test Bird", "guest-visible detection body")
@@ -166,9 +152,7 @@ func TestNotifications_GuestListFiltersNonDetectionAndToasts(t *testing.T) {
 		WithMetadata(notification.MetadataKeyIsToast, true)
 	require.NoError(t, svc.CreateWithMetadata(detectionToast))
 
-	// Best-effort cleanup so repeated runs do not accumulate fixtures in
-	// the process-global service. Ignore not-found errors (Delete may
-	// already have been issued by a parallel test).
+	// Clean up the fixtures created in this test's isolated service.
 	t.Cleanup(func() {
 		for _, n := range []*notification.Notification{detection, adminErr, detectionToast} {
 			if n == nil {
@@ -177,8 +161,6 @@ func TestNotifications_GuestListFiltersNonDetectionAndToasts(t *testing.T) {
 			_ = svc.Delete(n.ID)
 		}
 	})
-
-	e := newSettingsAuthTestEnv(t)
 
 	rec := guestGet(t, e, "/api/v2/notifications?limit=50")
 	require.Equal(t, http.StatusOK, rec.Code,
@@ -213,7 +195,7 @@ func TestNotifications_GuestListFiltersNonDetectionAndToasts(t *testing.T) {
 // TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts verifies
 // that the guest /unread/count matches what the guest list actually shows.
 func TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts(t *testing.T) {
-	svc := ensureNotificationServiceInitialized(t)
+	e, svc := newSettingsAuthTestEnvWithNotifier(t)
 
 	det, err := svc.Create(notification.TypeDetection, notification.PriorityHigh,
 		"Detection A", "body")
@@ -234,8 +216,6 @@ func TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts(t *testing.T
 			_ = svc.Delete(n.ID)
 		}
 	})
-
-	e := newSettingsAuthTestEnv(t)
 
 	rec := guestGet(t, e, "/api/v2/notifications/unread/count")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
@@ -302,9 +282,7 @@ func readSSEEvent(r *bufio.Reader) (sseEvent, error) {
 // in the guard condition (notif.Type != TypeDetection || isToast) is caught
 // before it reaches the dashboard.
 func TestNotifications_GuestSSEFiltersNonDetectionAndToasts(t *testing.T) {
-	svc := ensureNotificationServiceInitialized(t)
-
-	e := newSettingsAuthTestEnv(t)
+	e, svc := newSettingsAuthTestEnvWithNotifier(t)
 	srv := httptest.NewServer(e)
 	t.Cleanup(func() {
 		// Force-close active connections before srv.Close blocks waiting

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -150,7 +150,7 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 	}
 
 	// Get notification service
-	notificationService := notification.GetService()
+	notificationService := c.getNotificationService()
 	if notificationService == nil {
 		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
@@ -202,10 +202,12 @@ func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
 		status.Telemetry = telemetryStatus
 	}
 
-	// Get notification status
-	if notificationService := notification.GetService(); notificationService != nil {
+	// Get notification status. The map is only populated when a service is
+	// available (the enclosing guard), so both fields are unconditionally true
+	// here; they report "a notification service is wired and active".
+	if notificationService := c.getNotificationService(); notificationService != nil {
 		status.Notifications = map[string]any{
-			"initialized": notification.IsInitialized(),
+			"initialized": true,
 			"enabled":     true,
 		}
 	}

--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -568,7 +568,7 @@ func (c *Controller) getMySQLLegacySize() int64 {
 
 // sendCleanupNotification sends a notification about cleanup status.
 func (c *Controller) sendCleanupNotification(success bool, spaceReclaimed int64, errMsg string) {
-	notifService := notification.GetService()
+	notifService := c.getNotificationService()
 	if notifService == nil {
 		return
 	}

--- a/internal/api/v2/migration.go
+++ b/internal/api/v2/migration.go
@@ -452,7 +452,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 	}
 
 	// Send notification that migration has started
-	if notifService := notification.GetService(); notifService != nil {
+	if notifService := c.getNotificationService(); notifService != nil {
 		// Build notification fully before broadcast to ensure SSE subscribers see translation keys
 		notif := notification.NewNotification(
 			notification.TypeSystem,
@@ -643,7 +643,7 @@ func (c *Controller) CancelMigration(ctx echo.Context) error {
 	}
 
 	// Send notification that migration was cancelled
-	if notifService := notification.GetService(); notifService != nil {
+	if notifService := c.getNotificationService(); notifService != nil {
 		// Build notification fully before broadcast to ensure SSE subscribers see translation keys
 		notif := notification.NewNotification(
 			notification.TypeSystem,
@@ -772,7 +772,7 @@ func (c *Controller) executeMigrationAction(ctx echo.Context, params *migrationA
 
 	// Send notification if configured
 	if params.notificationTitle != "" {
-		if notifService := notification.GetService(); notifService != nil {
+		if notifService := c.getNotificationService(); notifService != nil {
 			// Build notification fully before broadcast to ensure SSE subscribers see translation keys
 			notif := notification.NewNotification(
 				notification.TypeSystem,

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -107,10 +107,23 @@ type notificationAction struct {
 	successRespMsg string
 }
 
+// getNotificationService returns the notification service this controller uses:
+// the injected instance when set (tests inject via WithNotificationService),
+// otherwise the process-global singleton (notification.GetService()). Routing all
+// handlers through this accessor lets a controller be fully isolated from global
+// state while keeping production behavior unchanged (the field is nil in
+// production, so it falls back to the singleton exactly as before).
+func (c *Controller) getNotificationService() *notification.Service {
+	if c.notificationService != nil {
+		return c.notificationService
+	}
+	return notification.GetService()
+}
+
 // requireNotificationService is middleware that returns 503 if the notification service is not initialized.
 func (c *Controller) requireNotificationService(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		if !notification.IsInitialized() {
+		if c.getNotificationService() == nil {
 			return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 		}
 		return next(ctx)
@@ -126,7 +139,7 @@ func (c *Controller) executeNotificationAction(ctx echo.Context, action notifica
 		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
 	}
 
-	service := notification.GetService()
+	service := c.getNotificationService()
 	if err := action.operation(service, id); err != nil {
 		if errors.Is(err, notification.ErrNotificationNotFound) || errors.IsNotFound(err) {
 			return c.HandleErrorWithKey(ctx, err, "Notification not found", http.StatusNotFound, notification.MsgErrNotifNotFound, nil)
@@ -430,7 +443,7 @@ func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*Notification
 	clientID := uuid.New().String()
 
 	// Subscribe to notifications
-	service := notification.GetService()
+	service := c.getNotificationService()
 	notificationCh, notificationCtx := service.Subscribe()
 
 	// Create notification client. Record whether the caller is a guest so
@@ -700,7 +713,7 @@ func (c *Controller) isGuestNotificationRequest(ctx echo.Context) bool {
 
 // GetNotifications returns a list of notifications with optional filtering
 func (c *Controller) GetNotifications(ctx echo.Context) error {
-	service := notification.GetService()
+	service := c.getNotificationService()
 
 	// Build filter options from query parameters
 	filter := &notification.FilterOptions{}
@@ -805,7 +818,7 @@ func (c *Controller) GetNotification(ctx echo.Context) error {
 		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
 	}
 
-	service := notification.GetService()
+	service := c.getNotificationService()
 	notif, err := service.Get(id)
 	if err != nil {
 		if errors.Is(err, notification.ErrNotificationNotFound) || errors.IsNotFound(err) {
@@ -822,7 +835,7 @@ func (c *Controller) GetNotification(ctx echo.Context) error {
 
 // MarkAllNotificationsRead marks every unread notification as read in one call.
 func (c *Controller) MarkAllNotificationsRead(ctx echo.Context) error {
-	service := notification.GetService()
+	service := c.getNotificationService()
 
 	count, err := service.MarkAllAsRead()
 	if err != nil {
@@ -870,7 +883,7 @@ func (c *Controller) DeleteNotification(ctx echo.Context) error {
 // unauthenticated dashboard requests, only unread detection notifications are
 // counted so the NotificationBell badge matches the filtered guest list.
 func (c *Controller) GetUnreadCount(ctx echo.Context) error {
-	service := notification.GetService()
+	service := c.getNotificationService()
 
 	if c.isGuestNotificationRequest(ctx) {
 		// Count unread detection non-toast notifications only. The store's
@@ -908,7 +921,7 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
 	}
 
-	service := notification.GetService()
+	service := c.getNotificationService()
 
 	// Build base URL for links
 	baseURL := settings.Security.GetBaseURL(settings.WebServer.Port)

--- a/internal/api/v2/notifications_mark_read_test.go
+++ b/internal/api/v2/notifications_mark_read_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
-// setupNotificationTestService initializes a notification service for testing
-// and returns a cleanup function.
-func setupNotificationTestService(t *testing.T) *notification.Service {
+// newNotificationTestController builds a controller wired to an isolated, per-test
+// notification service injected through the controller's DI seam. The service is
+// stopped via t.Cleanup so its cleanupLoop goroutine does not leak (TestMain runs
+// a goleak gate). Because no process-global state is touched, tests using this
+// helper are safe to run with t.Parallel().
+func newNotificationTestController(t *testing.T) (*Controller, *notification.Service) {
 	t.Helper()
 
 	config := &notification.ServiceConfig{
@@ -28,19 +31,12 @@ func setupNotificationTestService(t *testing.T) *notification.Service {
 	}
 
 	service := notification.NewService(config)
-	if err := notification.SetServiceForTesting(service); err != nil {
-		// An instance already exists; stop the service we just created so its
-		// cleanupLoop goroutine does not leak (the gate in TestMain would flag
-		// it), then use the existing singleton. We deliberately do NOT stop the
-		// service on the success path: it becomes the global singleton, which is
-		// stopped once after the whole suite in TestMain. Stopping it here would
-		// leave later GetService() callers with a stopped instance.
-		service.Stop()
-		service = notification.GetService()
-		require.NotNil(t, service, "Expected notification service to be available")
-	}
+	t.Cleanup(service.Stop)
 
-	return service
+	controller := &Controller{notificationService: service}
+	controller.Settings.Store(&conf.Settings{})
+
+	return controller, service
 }
 
 // runMarkNotificationNotFoundTest exercises a mark-state handler against a
@@ -50,8 +46,7 @@ func setupNotificationTestService(t *testing.T) *notification.Service {
 func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage string, handler func(*Controller, echo.Context) error) {
 	t.Helper()
 
-	service := setupNotificationTestService(t)
-	require.NotNil(t, service)
+	controller, _ := newNotificationTestController(t)
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications/non-existent-id/"+pathSuffix, http.NoBody)
@@ -59,9 +54,6 @@ func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage s
 	ctx := e.NewContext(req, rec)
 	ctx.SetParamNames("id")
 	ctx.SetParamValues("non-existent-id")
-
-	controller := &Controller{}
-	controller.Settings.Store(&conf.Settings{})
 
 	err := handler(controller, ctx)
 	require.NoError(t, err, "handler should return nil")
@@ -75,13 +67,14 @@ func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage s
 }
 
 func TestMarkNotificationRead_NotFound(t *testing.T) {
+	t.Parallel()
 	runMarkNotificationNotFoundTest(t, "read", "Notification marked as read",
 		(*Controller).MarkNotificationRead)
 }
 
 func TestMarkNotificationRead_EmptyID(t *testing.T) {
-	service := setupNotificationTestService(t)
-	require.NotNil(t, service)
+	t.Parallel()
+	controller, _ := newNotificationTestController(t)
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications//read", http.NoBody)
@@ -90,9 +83,6 @@ func TestMarkNotificationRead_EmptyID(t *testing.T) {
 	ctx.SetParamNames("id")
 	ctx.SetParamValues("")
 
-	controller := &Controller{}
-	controller.Settings.Store(&conf.Settings{})
-
 	err := controller.MarkNotificationRead(ctx)
 	require.NoError(t, err)
 
@@ -100,8 +90,8 @@ func TestMarkNotificationRead_EmptyID(t *testing.T) {
 }
 
 func TestMarkNotificationRead_Success(t *testing.T) {
-	service := setupNotificationTestService(t)
-	require.NotNil(t, service)
+	t.Parallel()
+	controller, service := newNotificationTestController(t)
 
 	// Create a notification first
 	notif := notification.NewNotification(notification.TypeInfo, notification.PriorityMedium, "Test", "Test message")
@@ -115,9 +105,6 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 	ctx.SetParamNames("id")
 	ctx.SetParamValues(notif.ID)
 
-	controller := &Controller{}
-	controller.Settings.Store(&conf.Settings{})
-
 	err = controller.MarkNotificationRead(ctx)
 	require.NoError(t, err)
 
@@ -125,6 +112,7 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 }
 
 func TestMarkNotificationAcknowledged_NotFound(t *testing.T) {
+	t.Parallel()
 	runMarkNotificationNotFoundTest(t, "acknowledge", "Notification marked as acknowledged",
 		(*Controller).MarkNotificationAcknowledged)
 }

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -20,11 +20,14 @@ func parseJSONResponse(body []byte, target any) error {
 }
 
 func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
-	// Skip this test if notification service is already initialized
-	// This test specifically validates the uninitialized service error path
-	if notification.IsInitialized() {
-		t.Skip("notification service already initialized; skipping service-not-initialized path")
-	}
+	t.Parallel()
+
+	// This validates the requireNotificationService guard when no service is
+	// available. The api/v2 test suite never initializes the process-global
+	// singleton (every test injects an isolated instance), so a controller with
+	// no injected service resolves to nil and the middleware must return 503.
+	require.False(t, notification.IsInitialized(),
+		"no api/v2 test may initialize the global notification singleton; this test relies on it staying unset")
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/notifications/test/new-species", http.NoBody)
@@ -45,7 +48,11 @@ func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
 }
 
 func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
-	// Initialize notification service for testing using correct API
+	// No t.Parallel(): this test publishes to the process-global settings
+	// singleton via publishTestSettings (CreateTestNewSpeciesNotification reads
+	// the live snapshot through currentSettings(), which consults
+	// conf.GetSettings() first). The notification service is fully isolated
+	// per test via dependency injection.
 	config := &notification.ServiceConfig{
 		Debug:              true,
 		MaxNotifications:   100,
@@ -54,26 +61,15 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 		RateLimitMaxEvents: 10,
 	}
 
-	// Try to set up isolated service for testing
 	service := notification.NewService(config)
-	if err := notification.SetServiceForTesting(service); err != nil {
-		// An instance already exists; stop the service we just created so its
-		// cleanupLoop goroutine does not leak (the gate in TestMain would flag
-		// it), then use the existing singleton. We deliberately do NOT stop the
-		// service on the success path: it becomes the global singleton, which is
-		// stopped once after the whole suite in TestMain. Stopping it here would
-		// leave later GetService() callers with a stopped instance.
-		service.Stop()
-		service = notification.GetService()
-		require.NotNil(t, service, "Expected notification service to be available")
-	}
+	t.Cleanup(service.Stop)
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/notifications/test/new-species", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{}
+	controller := &Controller{notificationService: service}
 	// Build a minimal settings snapshot with only the fields this test needs,
 	// then publish it once (the empty base matches the original test).
 	settings := &conf.Settings{}

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/security/securitytest"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
@@ -37,8 +38,20 @@ import (
 // newSettingsAuthTestEnv creates a controller with fully registered routes,
 // BasicAuth enabled, and a remote-IP rewrite middleware that forces requests
 // to look like they come from a non-LAN client (so the auth middleware does
-// NOT bypass auth for the test's loopback address).
+// NOT bypass auth for the test's loopback address). Callers that do not need the
+// notification service handle use this thin wrapper.
 func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
+	t.Helper()
+	e, _ := newSettingsAuthTestEnvWithNotifier(t)
+	return e
+}
+
+// newSettingsAuthTestEnvWithNotifier is newSettingsAuthTestEnv plus the isolated
+// per-test notification service injected into the controller. Tests that need to
+// seed notifications (e.g. the guest-filter tests) use the returned service so
+// the controller's handlers and the test operate on the same instance, without
+// ever touching the process-global singleton.
+func newSettingsAuthTestEnvWithNotifier(t *testing.T) (*echo.Echo, *notification.Service) {
 	t.Helper()
 
 	securityConfig := conf.Security{
@@ -117,11 +130,18 @@ func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
 		gothic.Store = prevGothicStore
 	})
 
+	// Inject an isolated per-test notification service so the controller never
+	// depends on the process-global singleton. Stopped via t.Cleanup so its
+	// cleanupLoop goroutine does not leak (TestMain runs a goleak gate).
+	notifService := notification.NewService(notification.DefaultServiceConfig())
+	t.Cleanup(notifService.Stop)
+
 	controller, err := NewWithOptions(
 		e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics,
 		true, // initializeRoutes - register full /api/v2 route tree
 		WithAuthMiddleware(authMw.Authenticate),
 		WithAuthService(authService),
+		WithNotificationService(notifService),
 	)
 	require.NoError(t, err, "Failed to create test API controller with auth")
 
@@ -130,7 +150,7 @@ func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
 		close(controlChan)
 	})
 
-	return e
+	return e, notifService
 }
 
 // TestGetDashboardSettings_PublicWithAuthEnabled verifies that GET

--- a/internal/api/v2/settings_test_setup_test.go
+++ b/internal/api/v2/settings_test_setup_test.go
@@ -44,11 +44,12 @@ func TestMain(m *testing.M) {
 	// Run tests
 	testResult := m.Run()
 
-	// Stop the process-global notification service if any test brought it up.
-	// Tests initialize it via notification.Initialize()/SetServiceForTesting()
-	// (singleton, guarded by sync.Once), so it cannot be reset and stopped from
-	// an individual test's cleanup; its cleanupLoop goroutine would otherwise
-	// outlive the suite and trip the leak gate below. m.Run() has returned, so
+	// Defensive safety net: stop the process-global notification service if
+	// anything brought it up. After the notification DI refactor, api/v2 tests
+	// inject isolated per-test services (each stopped via t.Cleanup) and never
+	// initialize the global singleton, so this is normally a no-op. It remains to
+	// stop a stray instance (and its cleanupLoop goroutine) before the leak gate
+	// below, should future code initialize the global. m.Run() has returned, so
 	// no test is using the service at this point.
 	if svc := notification.GetService(); svc != nil {
 		svc.Stop()

--- a/internal/api/v2/toast_helpers.go
+++ b/internal/api/v2/toast_helpers.go
@@ -20,12 +20,23 @@ func mapToastType(toastType string) notification.ToastType {
 	}
 }
 
-// SendToast sends a toast notification through the notification system
+// SendToast sends a toast notification through the notification system. When a
+// service is injected (tests), it is used directly; otherwise the call falls
+// through to the package-level helper backed by the process-global singleton,
+// preserving production behavior exactly (including its not-initialized guard).
 func (c *Controller) SendToast(message, toastType string, duration int) error {
+	if svc := c.notificationService; svc != nil {
+		return svc.SendToastWithDuration(message, mapToastType(toastType), "api", duration)
+	}
 	return notification.SendToastWithDuration(message, mapToastType(toastType), "api", duration)
 }
 
-// SendToastWithKey sends a toast notification with an i18n translation key
+// SendToastWithKey sends a toast notification with an i18n translation key. It
+// uses the injected service when present and otherwise falls through to the
+// package-level helper backed by the process-global singleton.
 func (c *Controller) SendToastWithKey(message, toastType string, duration int, messageKey string, messageParams map[string]any) error {
+	if svc := c.notificationService; svc != nil {
+		return svc.SendToastWithDurationAndKey(message, mapToastType(toastType), "api", duration, messageKey, messageParams)
+	}
 	return notification.SendToastWithDurationAndKey(message, mapToastType(toastType), "api", duration, messageKey, messageParams)
 }

--- a/internal/api/v2/toast_helpers_test.go
+++ b/internal/api/v2/toast_helpers_test.go
@@ -67,30 +67,31 @@ func assertNotificationMapping(t *testing.T, toastType string, notif *notificati
 	assert.Equal(t, expectedPriority, notif.Priority, "Toast to notification priority mapping for %q mismatch", toastType)
 }
 
+// newToastTestController builds a controller wired to an isolated, per-test
+// notification service injected through the controller's DI seam. The service is
+// stopped via tb.Cleanup so its cleanupLoop goroutine does not leak (TestMain
+// runs a goleak gate). No process-global state is touched, so callers are safe to
+// run with t.Parallel().
+func newToastTestController(tb testing.TB) (*Controller, *notification.Service) {
+	tb.Helper()
+	service := notification.NewService(notification.DefaultServiceConfig())
+	tb.Cleanup(service.Stop)
+	c := mockController()
+	c.notificationService = service
+	return c, service
+}
+
 func TestController_SendToast(t *testing.T) {
-	// Remove t.Parallel() to prevent interference between tests
-	// Each test will use an isolated service instance
+	t.Parallel()
 
 	tests := getToastTestCases()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create isolated service for each test
-			config := notification.DefaultServiceConfig()
-			service := notification.NewService(config)
-			defer service.Stop()
-
-			c := mockController()
-			runSendToastTestIsolated(t, c, service, tt)
+			t.Parallel()
+			c, service := newToastTestController(t)
+			runSendToastTest(t, c, service, tt)
 		})
-	}
-}
-
-// setupTestNotificationService initializes the notification service for testing
-func setupTestNotificationService() {
-	config := notification.DefaultServiceConfig()
-	if !notification.IsInitialized() {
-		notification.Initialize(config)
 	}
 }
 
@@ -158,49 +159,30 @@ func getToastTestCases() []toastTestCase {
 	}
 }
 
-// runSendToastTestIsolated runs a single SendToast test case with an isolated service
-// This tests the notification service directly since Controller.SendToast uses global service
-func runSendToastTestIsolated(t *testing.T, c *Controller, service *notification.Service, tc toastTestCase) {
+// runSendToastTest runs a single SendToast test case against an isolated service
+// injected into the controller, exercising the real Controller.SendToast path
+// (string-to-ToastType mapping, component, duration, broadcast).
+func runSendToastTest(t *testing.T, c *Controller, service *notification.Service, tc toastTestCase) {
 	t.Helper()
-	// Subscribe to the isolated service
+	// Subscribe to the isolated service to observe the broadcast.
 	notifCh, _ := service.Subscribe()
 	defer service.Unsubscribe(notifCh)
 
-	// Map string toast type to notification.ToastType (same logic as Controller.SendToast)
-	var notifToastType notification.ToastType
-	switch tc.toastType {
-	case ToastTypeSuccess:
-		notifToastType = notification.ToastTypeSuccess
-	case ToastTypeError:
-		notifToastType = notification.ToastTypeError
-	case ToastTypeWarning:
-		notifToastType = notification.ToastTypeWarning
-	case ToastTypeInfo:
-		notifToastType = notification.ToastTypeInfo
-	default:
-		notifToastType = notification.ToastTypeInfo
-	}
-
-	// Create and send toast directly to the isolated service (bypassing global service)
-	toast := notification.NewToast(tc.message, notifToastType).
-		WithComponent("api").
-		WithDuration(tc.duration)
-
-	err := service.CreateWithMetadata(toast.ToNotification())
+	err := c.SendToast(tc.message, tc.toastType, tc.duration)
 
 	if tc.wantError {
-		assert.Error(t, err, "CreateWithMetadata() expected error but got none")
+		assert.Error(t, err, "SendToast() expected error but got none")
 		return
 	}
 
-	require.NoError(t, err, "CreateWithMetadata() unexpected error")
+	require.NoError(t, err, "SendToast() unexpected error")
 
 	// Verify notification was created and broadcast
 	select {
 	case notif := <-notifCh:
 		verifyToastNotification(t, notif, tc)
 	case <-time.After(100 * time.Millisecond):
-		require.Fail(t, "CreateWithMetadata() should have broadcast notification within timeout")
+		require.Fail(t, "SendToast() should have broadcast notification within timeout")
 	}
 }
 
@@ -300,58 +282,37 @@ func TestController_SendToast_TypeMapping(t *testing.T) {
 }
 
 func TestController_SendToast_ServiceNotInitialized(t *testing.T) {
-	// Note: Cannot use t.Parallel() because this test uses the global notification service
-	// which has a shared rate limiter. Running in parallel with other tests causes
-	// rate limit exhaustion and test failures.
+	t.Parallel()
 
-	// Create a controller without initializing the notification service
+	// The api/v2 test suite never initializes the process-global notification
+	// singleton (every test injects an isolated instance), so a controller with
+	// no injected service resolves to nil and SendToast must fail gracefully
+	// rather than panicking.
+	require.False(t, notification.IsInitialized(),
+		"no api/v2 test may initialize the global notification singleton; this test relies on it staying unset")
+
 	c := mockController()
+	require.Nil(t, c.notificationService, "controller must have no injected service for this test")
 
-	// This test is tricky because the notification service is global.
-	// In a real scenario where the service isn't initialized, SendToast should fail gracefully.
-	// However, since we've already initialized it in other tests, we can't easily test this
-	// without more complex mocking or service lifecycle management.
-
-	// For now, this test documents the expected behavior:
-	// If notification service is not initialized, SendToast should return an error
 	err := c.SendToast("test message", ToastTypeInfo, 1000)
-
-	// Since service is likely already initialized from other tests, this may pass
-	// In a real uninitialized scenario, this should return an error
-	if notification.IsInitialized() {
-		assert.NoError(t, err, "SendToast() with initialized service should not error")
-	}
+	require.Error(t, err, "SendToast() must return an error when no notification service is available")
 }
 
 func TestController_SendToast_Integration(t *testing.T) {
-	// Integration test that verifies the complete flow
-	config := notification.DefaultServiceConfig()
-
-	if !notification.IsInitialized() {
-		notification.Initialize(config)
-	}
-
-	c := mockController()
+	t.Parallel()
+	// Integration test that verifies the complete flow through an injected service.
+	c, _ := newToastTestController(t)
 
 	// Send a toast with all features
 	err := c.SendToast("Integration test message", ToastTypeWarning, 4000)
 	require.NoError(t, err, "SendToast() integration test error")
-
-	// Retrieve the notification from the service to verify it was stored
-	// Note: This requires access to the service's store, which might not be public
-	// For now, we'll just verify the method doesn't error
 }
 
 // Benchmark for SendToast performance
 func BenchmarkController_SendToast(b *testing.B) {
-	config := notification.DefaultServiceConfig()
+	c, _ := newToastTestController(b)
 
-	if !notification.IsInitialized() {
-		notification.Initialize(config)
-	}
-
-	c := mockController()
-
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	// Use b.Loop() for benchmark iteration (Go 1.25)

--- a/internal/api/v2/toast_integration_test.go
+++ b/internal/api/v2/toast_integration_test.go
@@ -62,13 +62,7 @@ func checkSSERequired(t *testing.T, eventData map[string]any) {
 // TestToastIntegrationFlow tests the complete flow:
 // SendToast -> notification creation -> SSE event data creation
 func TestToastIntegrationFlow(t *testing.T) {
-	config := notification.DefaultServiceConfig()
-	if !notification.IsInitialized() {
-		notification.Initialize(config)
-	}
-
-	service := notification.GetService()
-	c := mockController()
+	t.Parallel()
 
 	testCases := []struct {
 		name              string
@@ -101,6 +95,10 @@ func TestToastIntegrationFlow(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Each subtest gets its own isolated service so parallel subtests do
+			// not receive each other's broadcasts on a shared subscription.
+			c, service := newToastTestController(t)
 			notifCh, _ := service.Subscribe()
 			defer service.Unsubscribe(notifCh)
 
@@ -195,14 +193,7 @@ func TestToastToSSEEventConsistency(t *testing.T) {
 
 // BenchmarkCompleteToastFlow benchmarks the complete toast flow
 func BenchmarkCompleteToastFlow(b *testing.B) {
-	// Initialize notification service
-	config := notification.DefaultServiceConfig()
-	if !notification.IsInitialized() {
-		notification.Initialize(config)
-	}
-
-	service := notification.GetService()
-	c := mockController()
+	c, service := newToastTestController(b)
 
 	// Subscribe to notifications (needed for SendToast to work)
 	notifCh, _ := service.Subscribe()

--- a/internal/notification/toast.go
+++ b/internal/notification/toast.go
@@ -149,6 +149,34 @@ func (t *Toast) ToNotification() *Notification {
 	return notif
 }
 
+// SendToast builds a toast notification and persists/broadcasts it through this
+// service instance. It is the instance-bound equivalent of the package-level
+// SendToast helper, usable with an explicitly injected service (e.g. in tests
+// or via dependency injection) instead of the process-global singleton.
+func (s *Service) SendToast(message string, toastType ToastType, component string) error {
+	toast := NewToast(message, toastType).WithComponent(component)
+	return s.CreateWithMetadata(toast.ToNotification())
+}
+
+// SendToastWithDuration builds a toast with a specific display duration and
+// persists/broadcasts it through this service instance.
+func (s *Service) SendToastWithDuration(message string, toastType ToastType, component string, duration int) error {
+	toast := NewToast(message, toastType).
+		WithComponent(component).
+		WithDuration(duration)
+	return s.CreateWithMetadata(toast.ToNotification())
+}
+
+// SendToastWithDurationAndKey builds a toast with a specific display duration and
+// translation key and persists/broadcasts it through this service instance.
+func (s *Service) SendToastWithDurationAndKey(message string, toastType ToastType, component string, duration int, messageKey string, messageParams map[string]any) error {
+	toast := NewToast(message, toastType).
+		WithComponent(component).
+		WithDuration(duration).
+		WithMessageKey(messageKey, messageParams)
+	return s.CreateWithMetadata(toast.ToNotification())
+}
+
 // SendToast is a convenience function to send a toast through the notification service
 func SendToast(message string, toastType ToastType, component string) error {
 	if !IsInitialized() {
@@ -160,11 +188,7 @@ func SendToast(message string, toastType ToastType, component string) error {
 		return errors.Newf("notification service is nil").Component("notification").Category(errors.CategoryState).Build()
 	}
 
-	toast := NewToast(message, toastType).WithComponent(component)
-	notification := toast.ToNotification()
-
-	// Use CreateWithMetadata to preserve all toast metadata
-	return service.CreateWithMetadata(notification)
+	return service.SendToast(message, toastType, component)
 }
 
 // SendToastWithDuration sends a toast with a specific display duration
@@ -178,13 +202,7 @@ func SendToastWithDuration(message string, toastType ToastType, component string
 		return errors.Newf("notification service is nil").Component("notification").Category(errors.CategoryState).Build()
 	}
 
-	toast := NewToast(message, toastType).
-		WithComponent(component).
-		WithDuration(duration)
-	notification := toast.ToNotification()
-
-	// Use CreateWithMetadata to preserve all toast metadata
-	return service.CreateWithMetadata(notification)
+	return service.SendToastWithDuration(message, toastType, component, duration)
 }
 
 // SendToastWithDurationAndKey sends a toast with a specific display duration and translation key
@@ -198,12 +216,5 @@ func SendToastWithDurationAndKey(message string, toastType ToastType, component 
 		return errors.Newf("notification service is nil").Component("notification").Category(errors.CategoryState).Build()
 	}
 
-	toast := NewToast(message, toastType).
-		WithComponent(component).
-		WithDuration(duration).
-		WithMessageKey(messageKey, messageParams)
-	notification := toast.ToNotification()
-
-	// Use CreateWithMetadata to preserve all toast metadata
-	return service.CreateWithMetadata(notification)
+	return service.SendToastWithDurationAndKey(message, toastType, component, duration, messageKey, messageParams)
 }


### PR DESCRIPTION
## Summary

The api/v2 `Controller` resolved the notification service through the process-global singleton (`notification.GetService()` / `notification.IsInitialized()`). Tests configured it via `notification.SetServiceForTesting`, which refuses to overwrite an existing instance, so the first test to register won for the whole suite and every later test silently reused that instance, ignoring its own config. The notification tests became order-dependent and had to run serially.

This adds a dependency-injection seam, keeping production behavior identical:

- New unexported `notificationService` field on `Controller`, a `getNotificationService()` accessor that returns the injected instance when set and otherwise falls back to the global singleton, and a `WithNotificationService` functional option. Production never sets the field, so the accessor returns the global singleton exactly as before.
- All Controller notification call sites (`notifications.go`, `debug.go`, `migration.go`, `legacy_cleanup.go`, toast helpers) now resolve through the accessor; `requireNotificationService` gates on the same resolution the handlers use.
- Toast build logic is extracted into `*Service` methods (`SendToast`, `SendToastWithDuration`, `SendToastWithDurationAndKey`) so an injected service can send toasts; the package-level helpers keep their existing guards and delegate.

Tests now inject isolated per-test services: no test initializes the process-global notification singleton anymore, the previously degenerate "service not initialized" tests exercise the real nil path, and order-independent tests run with `t.Parallel()`.

## Test Plan

- [x] `go test -race ./internal/notification/... ./internal/api/v2/...` passes
- [x] `go test -race -shuffle=on` confirms the notification tests are now order-independent (they flaked on the base branch under shuffle)
- [x] `golangci-lint run` reports 0 issues
- [x] Production behavior unchanged: field is nil in production, so the accessor returns the global singleton

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal notification system architecture for better test isolation and reliability.
  * Enhanced notification service initialization to support per-instance configuration, replacing global service dependencies.

* **Tests**
  * Updated notification-related tests to use isolated service instances, improving test coverage and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->