### PR TITLE
feat(openfauna): NameResolver adapter (sparse index, locale mapping, hot-reload)

### DIFF
--- a/internal/classifier/openfauna_resolver_test.go
+++ b/internal/classifier/openfauna_resolver_test.go
@@ -1,0 +1,9 @@
+package classifier
+
+import "github.com/tphakala/birdnet-go/internal/openfauna"
+
+// Compile-time check that openfauna.Resolver implements NameResolver. The adapter
+// lives in internal/openfauna (alongside the data it wraps); this assertion keeps
+// it conformant without classifier importing it in non-test code (wiring is a
+// later step). If the interface drifts, the classifier test build fails here.
+var _ NameResolver = (*openfauna.Resolver)(nil)

--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -1,0 +1,192 @@
+package openfauna
+
+import (
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// localeFallback is the ultimate locale used when a requested birdnet-go locale
+// maps to no available openfauna locale. English has the widest coverage.
+const localeFallback = "en"
+
+// mapLocale translates a birdnet-go locale code (e.g. "en-uk", "pt-br", "zh") to
+// an available openfauna locale code (e.g. "en_uk", "pt", "zh_cn"). The result is
+// always either localeFallback or a code present in Locales(); no hardcoded
+// override table is used, so the mapping self-corrects as upstream locales change.
+//
+// Resolution order: exact (after "-" -> "_"), then the base language, then the
+// first available regional variant of that base, then English.
+func mapLocale(bngLocale string) string {
+	in := strings.ToLower(strings.TrimSpace(bngLocale))
+	if in == "" {
+		return localeFallback
+	}
+
+	// mapLocale runs only on Rebuild (rare), so a few linear scans of the small,
+	// sorted locale slice are cheaper than building a throwaway set.
+	available := Locales()
+
+	// 1. Exact match after normalizing the separator (en-uk -> en_uk).
+	cand := strings.ReplaceAll(in, "-", "_")
+	if slices.Contains(available, cand) {
+		return cand
+	}
+
+	// 2. Base language (pt_br -> pt).
+	base := cand
+	if b, _, found := strings.Cut(cand, "_"); found {
+		base = b
+		if slices.Contains(available, base) {
+			return base
+		}
+	}
+
+	// 3. First available regional variant of the base (zh -> zh_cn, lv -> lv_lv).
+	// Locales() is sorted, so the choice is deterministic.
+	prefix := base + "_"
+	for _, l := range available {
+		if strings.HasPrefix(l, prefix) {
+			return l
+		}
+	}
+
+	// 4. English.
+	return localeFallback
+}
+
+// resolverState is a snapshot swapped atomically on Rebuild. The index and locale
+// are immutable once published; the cache is a concurrency-safe (sync.Map) memo for
+// the on-demand lookup fallback. Bundling all three behind a single pointer
+// guarantees a locale change replaces them together (and discards the stale cache).
+type resolverState struct {
+	index  *Index
+	locale string    // effective openfauna locale code
+	cache  *sync.Map // normalized scientific name -> resolved common name ("" = known miss)
+}
+
+// Resolver resolves scientific names to localized common names from the embedded
+// OpenFauna dataset. It serves a sparse per-locale index for a working set and
+// falls back to an on-demand (memoized) single-species Lookup for species outside
+// that set. The zero value and a nil *Resolver are safe to use and resolve nothing
+// until Rebuild is called. Resolve is safe to call concurrently with Rebuild.
+//
+// It implements the classifier NameResolver interface: the per-call locale
+// argument is ignored because the resolver is built for the active BirdNET.Locale,
+// matching the existing BirdNETLabelResolver/TaxonomyResolver convention.
+type Resolver struct {
+	cur atomic.Pointer[resolverState]
+}
+
+// NewResolver returns an empty Resolver. Resolve returns "" until the first
+// successful Rebuild populates the index and effective locale.
+func NewResolver() *Resolver {
+	return &Resolver{}
+}
+
+// Rebuild builds a fresh sparse index for the given working set at the locale
+// mapped from bngLocale, then atomically swaps it in (and resets the lookup
+// cache). A failed build leaves the previous snapshot in place. Safe to call
+// concurrently with Resolve; intended to be invoked on range-filter rebuilds and
+// locale changes for hot-reload.
+func (r *Resolver) Rebuild(scientificNames []string, bngLocale string) error {
+	if r == nil {
+		return nil
+	}
+	eff := mapLocale(bngLocale)
+	idx, err := BuildIndex(scientificNames, eff)
+	if err != nil {
+		return err
+	}
+
+	// Pre-seed the English fallback for working-set species that have no
+	// translation in the active locale. Sparse locales ship translations for as
+	// little as ~2% of species, so without this every untranslated working-set
+	// species would hit the O(dataset) on-demand Lookup on its first resolve.
+	// Resolving them once here keeps the slow path for out-of-working-set
+	// (historic) species only.
+	cache := &sync.Map{}
+	preseeded := 0
+	if eff != localeFallback {
+		var missing []string
+		for _, sci := range scientificNames {
+			if _, ok := idx.CommonName(sci); !ok {
+				missing = append(missing, sci)
+			}
+		}
+		if len(missing) > 0 {
+			enIdx, enErr := BuildIndex(missing, localeFallback)
+			if enErr != nil {
+				return enErr
+			}
+			for _, sci := range missing {
+				name, _ := enIdx.CommonName(sci) // "" when absent in English too
+				cache.Store(normalizeName(sci), name)
+				preseeded++
+			}
+		}
+	}
+
+	r.cur.Store(&resolverState{index: idx, locale: eff, cache: cache})
+	GetLogger().Info("openfauna name resolver rebuilt",
+		logger.String("bng_locale", bngLocale),
+		logger.String("effective_locale", eff),
+		logger.Int("working_set", len(scientificNames)),
+		logger.Int("english_fallbacks", preseeded),
+	)
+	return nil
+}
+
+// Resolve returns the localized common name for scientificName, or "" if it is not
+// found in the active or English locale. The per-call locale argument is ignored
+// (see Resolver). Matching is case-insensitive.
+func (r *Resolver) Resolve(scientificName, _ string) string {
+	if r == nil {
+		return ""
+	}
+	st := r.cur.Load()
+	if st == nil {
+		return ""
+	}
+
+	// Fast path: the sparse working-set index.
+	if st.index != nil {
+		if name, ok := st.index.CommonName(scientificName); ok && name != "" {
+			return name
+		}
+	}
+
+	// Slow path: on-demand single-species lookup, memoized (including misses).
+	key := normalizeName(scientificName)
+	if v, ok := st.cache.Load(key); ok {
+		if name, ok := v.(string); ok {
+			return name
+		}
+	}
+
+	name, ok := Lookup(scientificName, st.locale)
+	if !ok && st.locale != localeFallback {
+		// Per-species fallback to English for species untranslated in the active locale.
+		name, ok = Lookup(scientificName, localeFallback)
+	}
+	if !ok {
+		name = ""
+	}
+	st.cache.Store(key, name)
+	return name
+}
+
+// Locale reports the effective openfauna locale code of the current index, or ""
+// before the first Rebuild. Intended for introspection and logging.
+func (r *Resolver) Locale() string {
+	if r == nil {
+		return ""
+	}
+	if st := r.cur.Load(); st != nil {
+		return st.locale
+	}
+	return ""
+}

--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -128,6 +128,16 @@ func (r *Resolver) Rebuild(scientificNames []string, bngLocale string) error {
 				preseeded++
 			}
 		}
+	} else {
+		// Active locale is English: a working-set species missing from the index has
+		// no English name at all, so pre-seed it as a known miss to keep it off the
+		// slow path as well.
+		for _, sci := range scientificNames {
+			if _, ok := idx.CommonName(sci); !ok {
+				cache.Store(normalizeName(sci), "")
+				preseeded++
+			}
+		}
 	}
 
 	r.cur.Store(&resolverState{index: idx, locale: eff, cache: cache})
@@ -152,15 +162,18 @@ func (r *Resolver) Resolve(scientificName, _ string) string {
 		return ""
 	}
 
-	// Fast path: the sparse working-set index.
+	// Normalize once and reuse the key for the index, cache lookup, and store.
+	key := normalizeName(scientificName)
+
+	// Fast path: the sparse working-set index. Read the (already normalized) map
+	// directly to avoid re-normalizing inside CommonName on every resolve.
 	if st.index != nil {
-		if name, ok := st.index.CommonName(scientificName); ok && name != "" {
+		if name, ok := st.index.names[key]; ok && name != "" {
 			return name
 		}
 	}
 
 	// Slow path: on-demand single-species lookup, memoized (including misses).
-	key := normalizeName(scientificName)
 	if v, ok := st.cache.Load(key); ok {
 		if name, ok := v.(string); ok {
 			return name

--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"golang.org/x/sync/singleflight"
 )
 
 // localeFallback is the ultimate locale used when a requested birdnet-go locale
@@ -60,12 +61,15 @@ func mapLocale(bngLocale string) string {
 
 // resolverState is a snapshot swapped atomically on Rebuild. The index and locale
 // are immutable once published; the cache is a concurrency-safe (sync.Map) memo for
-// the on-demand lookup fallback. Bundling all three behind a single pointer
-// guarantees a locale change replaces them together (and discards the stale cache).
+// the on-demand lookup fallback, and sf coalesces concurrent slow-path lookups for
+// the same species so only one dataset scan runs. Bundling them behind a single
+// pointer guarantees a locale change replaces them together (and discards the stale
+// cache and in-flight group).
 type resolverState struct {
 	index  *Index
-	locale string    // effective openfauna locale code
-	cache  *sync.Map // normalized scientific name -> resolved common name ("" = known miss)
+	locale string             // effective openfauna locale code
+	cache  *sync.Map          // normalized scientific name -> resolved common name ("" = known miss)
+	sf     singleflight.Group // dedupes concurrent slow-path lookups per scientific name
 }
 
 // Resolver resolves scientific names to localized common names from the embedded
@@ -165,8 +169,9 @@ func (r *Resolver) Resolve(scientificName, _ string) string {
 	// Normalize once and reuse the key for the index, cache lookup, and store.
 	key := normalizeName(scientificName)
 
-	// Fast path: the sparse working-set index. Read the (already normalized) map
-	// directly to avoid re-normalizing inside CommonName on every resolve.
+	// Fast path: the sparse working-set index. names is unexported but same-package,
+	// so read it directly with the pre-normalized key to avoid re-normalizing inside
+	// CommonName on every resolve.
 	if st.index != nil {
 		if name, ok := st.index.names[key]; ok && name != "" {
 			return name
@@ -180,15 +185,27 @@ func (r *Resolver) Resolve(scientificName, _ string) string {
 		}
 	}
 
-	name, ok := Lookup(scientificName, st.locale)
-	if !ok && st.locale != localeFallback {
-		// Per-species fallback to English for species untranslated in the active locale.
-		name, ok = Lookup(scientificName, localeFallback)
-	}
-	if !ok {
-		name = ""
-	}
-	st.cache.Store(key, name)
+	// Coalesce concurrent lookups for the same species: Lookup streams the whole
+	// dataset, so a stampede of identical misses would otherwise each scan it.
+	v, _, _ := st.sf.Do(key, func() (any, error) {
+		// Re-check the cache; a prior flight may have populated it while we waited.
+		if cached, ok := st.cache.Load(key); ok {
+			if name, ok := cached.(string); ok {
+				return name, nil
+			}
+		}
+		name, ok := Lookup(scientificName, st.locale)
+		if !ok && st.locale != localeFallback {
+			// Per-species fallback to English for species untranslated in the active locale.
+			name, ok = Lookup(scientificName, localeFallback)
+		}
+		if !ok {
+			name = ""
+		}
+		st.cache.Store(key, name)
+		return name, nil
+	})
+	name, _ := v.(string)
 	return name
 }
 

--- a/internal/openfauna/resolver_test.go
+++ b/internal/openfauna/resolver_test.go
@@ -35,16 +35,21 @@ func TestMapLocale_Table(t *testing.T) {
 		// Region expand: no bare zh/lv, but a single regional variant exists.
 		{"zh", "zh_cn"},
 		{"lv", "lv_lv"},
-		// Uncovered languages fall back to English.
-		{"af", "en"},
-		{"ar", "en"},
-		{"he", "en"},
-		{"ko", "en"},
-		{"th", "en"},
-		{"id", "en"},
-		{"ml", "en"},
-		{"hi-in", "en"},
-		{"vi-vn", "en"},
+		// Languages present in the dataset resolve to their own code (exact, or
+		// "-" -> "_"); coverage level is irrelevant to the mapping.
+		{"af", "af"},
+		{"ar", "ar"},
+		{"he", "he"},
+		{"ko", "ko"},
+		{"th", "th"},
+		{"id", "id"},
+		{"ml", "ml"},
+		{"hi-in", "hi_in"},
+		{"vi-vn", "vi_vn"},
+		// Only codes with no exact, base, or regional match fall back to English.
+		// Use reserved/unassigned codes so this stays correct as the dataset grows.
+		{"zz", "en"},
+		{"qaa-x", "en"},
 		// Trimming and casing.
 		{"  FI  ", "fi"},
 		{"EN-UK", "en_uk"},
@@ -139,6 +144,30 @@ func TestResolver_UntranslatedLocale_FallsBackToEnglish_Embedded(t *testing.T) {
 	}
 }
 
+func TestResolver_EnglishLocale_PreseedsUntranslatedAsMiss_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// A few species (some bats) exist in the dataset with no English translation.
+	// When the active locale resolves to English, such working-set species are
+	// pre-seeded as known misses at Rebuild so they skip the slow path entirely.
+	const sci = "Eptesicus nilssonii"
+	_, hasEn := Lookup(sci, "en")
+	require.False(t, hasEn,
+		"test premise: %q must have no English translation; pick another English-missing species if upstream added one", sci)
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{sci}, "en")) // active locale resolves to English
+	assert.Equal(t, "en", r.Locale())
+
+	st := r.cur.Load()
+	require.NotNil(t, st)
+	cached, ok := st.cache.Load(normalizeName(sci))
+	assert.True(t, ok, "an English-missing working-set species must be pre-seeded as a known miss")
+	assert.Empty(t, cached)
+
+	assert.Empty(t, r.Resolve(sci, ""))
+}
+
 func TestResolver_NonexistentSpecies_ReturnsEmpty_Embedded(t *testing.T) {
 	t.Parallel()
 
@@ -215,9 +244,13 @@ func TestResolver_ConcurrentResolveDuringRebuild_NoRace(t *testing.T) {
 	set := []string{"Turdus merula", "Erithacus rubecula"}
 
 	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
 	wg.Go(func() {
 		for i := range 10 {
-			_ = r.Rebuild(set, locales[i%len(locales)])
+			if err := r.Rebuild(set, locales[i%len(locales)]); err != nil {
+				errCh <- err
+				return
+			}
 		}
 	})
 	for range 4 {
@@ -229,4 +262,8 @@ func TestResolver_ConcurrentResolveDuringRebuild_NoRace(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err, "concurrent Rebuild must not fail")
+	}
 }

--- a/internal/openfauna/resolver_test.go
+++ b/internal/openfauna/resolver_test.go
@@ -1,0 +1,232 @@
+package openfauna
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMapLocale_Table pins the birdnet-go -> openfauna locale mapping. Results are
+// derived from Locales() (no hardcoded override table), so the cases cover exact
+// passthrough, region-strip (pt-br -> pt), region-expand (zh -> zh_cn, lv -> lv_lv),
+// uncovered languages (-> en), and trimming/casing.
+func TestMapLocale_Table(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Exact / underscore swap.
+		{"en-uk", "en_uk"},
+		{"en-us", "en_us"},
+		{"de", "de"},
+		{"fi", "fi"},
+		{"es", "es"},
+		{"et", "et"}, // base "et" present; must NOT expand to et_ee
+		{"ja", "ja"},
+		{"pt", "pt"},
+		{"pt-pt", "pt_pt"},
+		// Region strip: pt-br has no pt_br, falls back to base pt.
+		{"pt-br", "pt"},
+		// Region expand: no bare zh/lv, but a single regional variant exists.
+		{"zh", "zh_cn"},
+		{"lv", "lv_lv"},
+		// Uncovered languages fall back to English.
+		{"af", "en"},
+		{"ar", "en"},
+		{"he", "en"},
+		{"ko", "en"},
+		{"th", "en"},
+		{"id", "en"},
+		{"ml", "en"},
+		{"hi-in", "en"},
+		{"vi-vn", "en"},
+		// Trimming and casing.
+		{"  FI  ", "fi"},
+		{"EN-UK", "en_uk"},
+		// Degenerate input.
+		{"", "en"},
+		{"not-a-locale", "en"},
+	}
+
+	available := Locales()
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got := mapLocale(tc.in)
+			assert.Equal(t, tc.want, got)
+			// Every result must be the English fallback or a real openfauna locale.
+			if got != localeFallback {
+				assert.True(t, slices.Contains(available, got),
+					"mapLocale must return a code present in Locales(), got %q", got)
+			}
+		})
+	}
+}
+
+func TestResolver_ResolvesFromSparseIndex_Embedded(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula", "Barbastella barbastellus"}, "fi"))
+	assert.Equal(t, "fi", r.Locale())
+
+	// A bird and a bat both resolve (openfauna covers Chiroptera too; this is the
+	// #928 bat-localization preview).
+	bird := r.Resolve("Turdus merula", "")
+	assert.NotEmpty(t, bird)
+	assert.NotEqual(t, "Turdus merula", bird)
+
+	bat := r.Resolve("Barbastella barbastellus", "")
+	assert.NotEmpty(t, bat)
+
+	// Matching is case-insensitive (callers may supply any case/whitespace).
+	assert.Equal(t, bird, r.Resolve("  turdus MERULA ", ""))
+
+	// Prove the locale is actually applied: a de resolver yields a different name.
+	rDe := NewResolver()
+	require.NoError(t, rDe.Rebuild([]string{"Turdus merula"}, "de"))
+	assert.NotEqual(t, bird, rDe.Resolve("Turdus merula", ""),
+		"fi and de must resolve to different names")
+}
+
+func TestResolver_OutOfSetSpecies_OnDemandFallback_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// Erithacus rubecula is NOT in the working set, so it is absent from the sparse
+	// index. The on-demand Lookup fallback must still resolve it (historic detection).
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "fi"))
+
+	want, ok := Lookup("Erithacus rubecula", "fi")
+	require.True(t, ok)
+	assert.Equal(t, want, r.Resolve("Erithacus rubecula", ""))
+}
+
+func TestResolver_UntranslatedLocale_FallsBackToEnglish_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// "it" is a sparse locale in the dataset; Erithacus rubecula has no Italian
+	// translation but does have English, so Resolve must fall back to the English
+	// common name rather than returning empty.
+	const sci = "Erithacus rubecula"
+	enName, hasEn := Lookup(sci, "en")
+	require.True(t, hasEn)
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{sci}, "it"))
+	assert.Equal(t, "it", r.Locale())
+
+	got := r.Resolve(sci, "")
+	if itName, hasIt := Lookup(sci, "it"); hasIt {
+		// Stay correct if upstream later adds the Italian translation.
+		assert.Equal(t, itName, got)
+	} else {
+		assert.Equal(t, enName, got,
+			"a species untranslated in the active locale must fall back to the English common name")
+
+		// The English fallback for an untranslated working-set species is pre-seeded
+		// at Rebuild, so it resolves from the cache without a per-species dataset scan.
+		st := r.cur.Load()
+		require.NotNil(t, st)
+		cached, ok := st.cache.Load(normalizeName(sci))
+		assert.True(t, ok, "untranslated working-set species must be pre-seeded into the cache")
+		assert.Equal(t, enName, cached)
+	}
+}
+
+func TestResolver_NonexistentSpecies_ReturnsEmpty_Embedded(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "fi"))
+
+	const missSpecies = "Definitely notaspecies"
+	assert.Empty(t, r.Resolve(missSpecies, ""))
+
+	// The miss must be memoized (stored as "") so a second resolve serves from the
+	// cache instead of rescanning the whole dataset again.
+	st := r.cur.Load()
+	require.NotNil(t, st)
+	cached, ok := st.cache.Load(normalizeName(missSpecies))
+	assert.True(t, ok, "a true miss must be stored in the negative-result memo")
+	assert.Empty(t, cached)
+
+	assert.Empty(t, r.Resolve(missSpecies, ""))
+}
+
+func TestResolver_AtomicSwapRebuild_HotReload_Embedded(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "fi"))
+	fiName := r.Resolve("Turdus merula", "")
+	assert.NotEmpty(t, fiName)
+
+	// Locale change (hot-reload): rebuild atomically swaps the index.
+	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "de"))
+	assert.Equal(t, "de", r.Locale())
+	deName := r.Resolve("Turdus merula", "")
+	assert.NotEmpty(t, deName)
+	assert.NotEqual(t, fiName, deName, "rebuild at a new locale must change the resolved name")
+}
+
+func TestResolver_EmptyWorkingSet_OnDemandStillResolves_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// An empty working set yields an empty index, but on-demand Lookup still resolves.
+	r := NewResolver()
+	require.NoError(t, r.Rebuild(nil, "fi"))
+	assert.Equal(t, "fi", r.Locale())
+
+	want, ok := Lookup("Turdus merula", "fi")
+	require.True(t, ok)
+	assert.Equal(t, want, r.Resolve("Turdus merula", ""))
+}
+
+func TestResolver_NilAndZeroValue_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	var nilR *Resolver
+	assert.Empty(t, nilR.Resolve("Turdus merula", ""))
+	assert.Empty(t, nilR.Locale())
+
+	// A freshly constructed resolver (no Rebuild yet) resolves nothing.
+	r := NewResolver()
+	assert.Empty(t, r.Resolve("Turdus merula", ""))
+	assert.Empty(t, r.Locale())
+}
+
+func TestResolver_ConcurrentResolveDuringRebuild_NoRace(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "fi"))
+
+	// Keep iteration counts modest: every Rebuild and every on-demand Lookup
+	// (Erithacus is out of the working set) streams the whole embedded dataset,
+	// which is slow under -race. This is plenty to trip the detector if the
+	// atomic swap or the per-state cache were unsafe.
+	locales := []string{"fi", "de", "en", "fr"}
+	set := []string{"Turdus merula", "Erithacus rubecula"}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range 10 {
+			_ = r.Rebuild(set, locales[i%len(locales)])
+		}
+	})
+	for range 4 {
+		wg.Go(func() {
+			for range 50 {
+				_ = r.Resolve("Turdus merula", "")      // index hit (no scan)
+				_ = r.Resolve("Erithacus rubecula", "") // on-demand, memoized per state
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Adds `openfauna.Resolver`, a read-time species-name resolver backed by the embedded OpenFauna dataset (added in #3404). It implements the classifier `NameResolver` interface and is the building block for routing common-name resolution through OpenFauna.

- Serves a sparse per-locale index for the active working set at the configured `BirdNET.Locale`; out-of-set species (historic detections) resolve via an on-demand, memoized single-species lookup.
- `mapLocale` derives the OpenFauna locale from the birdnet-go locale using `Locales()` (exact, then base language, then regional variant, then English), so the mapping self-corrects as the dataset changes: `en-uk` to `en_uk`, `pt-br` to `pt`, `zh` to `zh_cn`, `lv` to `lv_lv`; uncovered languages fall back to English.
- `Rebuild` atomically swaps an index/locale/cache snapshot, so the resolver hot-reloads on range-filter rebuilds and locale changes without locking the `Resolve` path. The English fallback for working-set species untranslated in the active locale is pre-seeded at rebuild, so sparse locales (some ship translations for only ~2% of species) do not push the working set onto the slow path.
- Pure addition: not yet wired into the resolution path (orchestrator chain, datastore/API display, hot-reload triggers). That wiring is a follow-up; this PR has no user-visible behavior change.

## Test Plan

- [x] `go test -race ./internal/openfauna/` (sparse-index resolve incl. bird and bat, case-insensitivity, on-demand fallback, English per-species fallback, atomic-swap hot-reload, nil/zero-value safety, concurrent Resolve during Rebuild)
- [x] `go test -race ./internal/classifier/` (compile-time `NameResolver` conformance)
- [x] `golangci-lint run` clean (full project)

Follow-up to #3404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resolves scientific species names to localized common names with deterministic locale mapping, automatic English fallback, and memoized lookups.
  * Safe, atomic hot-reloads of resolver data with pre-seeding of fallback results to avoid first-use latency.

* **Tests**
  * Extensive tests covering locale normalization, fallback/pre-seed behavior, case-insensitive matching, empty/nil safety, hot-reload semantics, and concurrency/no-race resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->