### PR TITLE
test(openfauna): cover range-filter rebuild trigger and control-monitor wiring

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/birdweather"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -120,21 +121,50 @@ func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, re
 	// depend on this re-localize. Locale changes later re-localize via
 	// handleReloadBirdnet (BuildRangeFilter runs before UpdateNameMaps there).
 	if cm.bn != nil {
-		resolver := cm.bn.OpenFaunaResolver()
-		labels := cm.bn.Labels()
+		var ds datastore.Interface
 		if cm.proc != nil && cm.proc.Ds != nil {
-			cm.proc.Ds.SetNameResolver(resolver)
-			cm.proc.Ds.UpdateNameMaps(labels)
+			ds = cm.proc.Ds
 		}
+		var api commonNameController
 		if cm.apiController != nil {
-			cm.apiController.SetNameResolver(resolver)
-			cm.apiController.UpdateCommonNameMap(labels)
+			api = cm.apiController
 		}
+		installNameResolver(cm.bn.OpenFaunaResolver(), cm.bn.Labels(), ds, api)
 	}
 
 	// Initialize the sound level manager but don't start it yet
 	// It will be started by handleReconfigureSoundLevel based on settings
 	return cm
+}
+
+// commonNameController is the minimal api-controller surface installNameResolver
+// needs to share the resolver and refresh the cached name maps. *apiv2.Controller
+// satisfies it; tests substitute a spy.
+type commonNameController interface {
+	SetNameResolver(resolver datastore.SpeciesNameResolver)
+	UpdateCommonNameMap(labels []string)
+}
+
+// installNameResolver shares the orchestrator's authoritative OpenFauna resolver
+// with the display surfaces, then re-localizes their cached name maps. Order is
+// load-bearing: SetNameResolver must precede the map rebuild so the reverse
+// (search) maps pick up localized names; forward display reads the live resolver
+// regardless.
+//
+// There is intentionally no nil-resolver short-circuit: the maps must be rebuilt
+// from labels even when no resolver is available, otherwise search and insights
+// would start with empty maps. SetNameResolver already no-ops on a nil/typed-nil
+// resolver (datastore.IsNilResolver guard inside it), so a missing resolver simply
+// leaves the live forward path on the label maps.
+func installNameResolver(resolver datastore.SpeciesNameResolver, labels []string, ds datastore.Interface, api commonNameController) {
+	if ds != nil {
+		ds.SetNameResolver(resolver)
+		ds.UpdateNameMaps(labels)
+	}
+	if api != nil {
+		api.SetNameResolver(resolver)
+		api.UpdateCommonNameMap(labels)
+	}
 }
 
 // Start begins monitoring control signals.

--- a/internal/analysis/control_monitor_resolver_test.go
+++ b/internal/analysis/control_monitor_resolver_test.go
@@ -1,0 +1,149 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+const (
+	wiringSpeciesSci   = "Turdus merula"       // seeded into the resolver's working set
+	wiringSpeciesLabel = "Turdus merula_WRONG" // label whose common name the resolver must override
+	wiringLabelCommon  = "WRONG"
+	wiringLocale       = "en"
+)
+
+// nameWiringRecorder captures the externally-observable effect of the two
+// name-wiring calls on one surface: the order they ran (setAt < updateAt) and the
+// localized name the live resolver would produce at map-build time. It mirrors
+// production: SetNameResolver no-ops on a nil/typed-nil resolver
+// (datastore.IsNilResolver), and the map rebuild localizes via ResolveLocal.
+type nameWiringRecorder struct {
+	calls         int
+	resolver      datastore.SpeciesNameResolver
+	setAt         int
+	updateAt      int
+	localizedName string
+	localizedOK   bool
+}
+
+func (r *nameWiringRecorder) setResolver(res datastore.SpeciesNameResolver) {
+	r.calls++
+	r.setAt = r.calls
+	if !datastore.IsNilResolver(res) { // mirror production no-op-on-nil
+		r.resolver = res
+	}
+}
+
+func (r *nameWiringRecorder) rebuildMaps() {
+	r.calls++
+	r.updateAt = r.calls
+	if r.resolver != nil {
+		r.localizedName, r.localizedOK = r.resolver.ResolveLocal(wiringSpeciesSci)
+	}
+}
+
+// spyDatastore is a minimal datastore.Interface: only SetNameResolver and
+// UpdateNameMaps are exercised; any other call hits the nil embedded Interface and
+// panics loudly (surfacing an unexpected new dependency).
+type spyDatastore struct {
+	datastore.Interface
+	nameWiringRecorder
+}
+
+func (s *spyDatastore) SetNameResolver(r datastore.SpeciesNameResolver) { s.setResolver(r) }
+func (s *spyDatastore) UpdateNameMaps(_ []string)                       { s.rebuildMaps() }
+
+// spyController implements commonNameController (the api-controller surface).
+type spyController struct {
+	nameWiringRecorder
+}
+
+func (s *spyController) SetNameResolver(r datastore.SpeciesNameResolver) { s.setResolver(r) }
+func (s *spyController) UpdateCommonNameMap(_ []string)                  { s.rebuildMaps() }
+
+func newSeededResolver(t *testing.T) *openfauna.Resolver {
+	t.Helper()
+	of := openfauna.NewResolver()
+	require.NoError(t, of.Rebuild([]string{wiringSpeciesSci}, wiringLocale))
+	return of
+}
+
+// wiringObservation captures the externally-visible result of installNameResolver
+// on one surface so both surfaces can be asserted identically.
+type wiringObservation struct {
+	surface       string
+	setAt         int
+	updateAt      int
+	localizedName string
+	localizedOK   bool
+}
+
+// TestInstallNameResolver_InstallsBeforeRebuild proves NewControlMonitor's wiring
+// helper installs the shared resolver BEFORE rebuilding the cached name maps, on
+// both the datastore and the api-controller surface. Swapping the order or
+// dropping SetNameResolver leaves the resolver nil at map-build time, so the
+// localized capture is empty and the test fails.
+func TestInstallNameResolver_InstallsBeforeRebuild(t *testing.T) {
+	of := newSeededResolver(t)
+	ds := &spyDatastore{}
+	api := &spyController{}
+
+	installNameResolver(of, []string{wiringSpeciesLabel}, ds, api)
+
+	observations := []wiringObservation{
+		{"datastore", ds.setAt, ds.updateAt, ds.localizedName, ds.localizedOK},
+		{"controller", api.setAt, api.updateAt, api.localizedName, api.localizedOK},
+	}
+	for _, obs := range observations {
+		t.Run(obs.surface, func(t *testing.T) {
+			require.Positive(t, obs.setAt, "SetNameResolver must be called")
+			require.Positive(t, obs.updateAt, "the name-map rebuild must be called")
+			assert.Less(t, obs.setAt, obs.updateAt, "SetNameResolver must precede the map rebuild")
+			assert.True(t, obs.localizedOK, "resolver must be live at map-build time")
+			assert.NotEmpty(t, obs.localizedName)
+			assert.NotEqual(t, wiringSpeciesSci, obs.localizedName, "name must be localized, not the scientific name")
+			assert.NotEqual(t, wiringLabelCommon, obs.localizedName, "resolver must override the label common name")
+		})
+	}
+}
+
+// TestInstallNameResolver_NilResolverStillRebuildsMaps pins the behavior that the
+// map rebuild must run even without a resolver (otherwise search/insights start
+// with empty maps). A typed-nil *openfauna.Resolver is treated as absent by
+// SetNameResolver, but UpdateNameMaps/UpdateCommonNameMap still fire.
+func TestInstallNameResolver_NilResolverStillRebuildsMaps(t *testing.T) {
+	var typedNil *openfauna.Resolver // nil pointer wrapped into the interface
+	ds := &spyDatastore{}
+	api := &spyController{}
+
+	installNameResolver(typedNil, []string{wiringSpeciesLabel}, ds, api)
+
+	assert.Positive(t, ds.updateAt, "datastore maps must be rebuilt even with no resolver")
+	assert.False(t, ds.localizedOK, "no localization without a resolver")
+	assert.Positive(t, api.updateAt, "controller maps must be rebuilt even with no resolver")
+	assert.False(t, api.localizedOK, "no localization without a resolver")
+}
+
+// TestInstallNameResolver_NilSurfacesTolerated proves a missing surface is skipped
+// without panicking while the other surface is still wired.
+func TestInstallNameResolver_NilSurfacesTolerated(t *testing.T) {
+	of := newSeededResolver(t)
+
+	t.Run("nil datastore", func(t *testing.T) {
+		api := &spyController{}
+		installNameResolver(of, []string{wiringSpeciesLabel}, nil, api)
+		assert.Positive(t, api.updateAt, "controller still wired when datastore is nil")
+		assert.True(t, api.localizedOK)
+	})
+
+	t.Run("nil controller", func(t *testing.T) {
+		ds := &spyDatastore{}
+		installNameResolver(of, []string{wiringSpeciesLabel}, ds, nil)
+		assert.Positive(t, ds.updateAt, "datastore still wired when controller is nil")
+		assert.True(t, ds.localizedOK)
+	})
+}

--- a/internal/classifier/range_filter_resolver_test.go
+++ b/internal/classifier/range_filter_resolver_test.go
@@ -1,0 +1,71 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+// TestBuildRangeFilter_TriggersNameResolverRebuild proves that BuildRangeFilter
+// fires the o.RebuildNameResolver(includedSpecies) call at the end of
+// range_filter.go. That seam is otherwise only verified by inspection: deleting
+// the call would still pass every other test because the daily action and startup
+// paths rebuild the resolver elsewhere and on-demand Resolve masks a stale index.
+//
+// The assertion targets the in-memory fast-path index via ResolveLocal, which is
+// empty until Rebuild runs and only ever holds the working set. So a removed
+// trigger leaves the index empty and this test fails.
+func TestBuildRangeFilter_TriggersNameResolverRebuild(t *testing.T) {
+	const workingSetSci = "Turdus merula" // scores in the geomodel -> enters the working set
+	const outOfSetSci = "Parus major"     // real OpenFauna species, kept OUT of the working set
+	const localeEN = "en"
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.Locale = localeEN
+	settings.BirdNET.Labels = []string{
+		workingSetSci + "_Common Blackbird",
+		outOfSetSci + "_Great Tit",
+	}
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	// Only Turdus merula scores in the geomodel, so the range-filter working set
+	// (includedSpecies) is exactly {Turdus merula}. Parus major is deliberately
+	// absent from the scores so it never enters the resolver's sparse index.
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{workingSetSci + "_Common Blackbird", outOfSetSci + "_Great Tit"},
+		scores:    []SpeciesScore{{Score: 0.9, Label: workingSetSci + "_Common Blackbird"}},
+		rawScores: []float32{0.9},
+	}
+
+	o := buildTestOrchestrator(t, settings, rf)
+	o.openfauna = openfauna.NewResolver()
+
+	// Precondition: the fast-path index is empty before BuildRangeFilter runs.
+	_, ok := o.openfauna.ResolveLocal(workingSetSci)
+	require.False(t, ok, "fast-path index should be empty before BuildRangeFilter")
+
+	require.NoError(t, BuildRangeFilter(o))
+
+	// The trigger rebuilt the sparse index for the working set, so the in-memory
+	// fast path now resolves the working-set species without a dataset scan.
+	name, ok := o.openfauna.ResolveLocal(workingSetSci)
+	assert.True(t, ok,
+		"BuildRangeFilter must rebuild the OpenFauna name resolver for the working set (is the RebuildNameResolver trigger missing?)")
+	assert.NotEmpty(t, name)
+	assert.NotEqual(t, workingSetSci, name,
+		"resolved value should be the localized common name, not the scientific name echoed back")
+
+	// Negative control: a real dataset species outside the working set stays off the
+	// fast-path index, proving the rebuilt index is working-set-scoped (sparse) and
+	// not the whole dataset. Its on-demand Resolve would still find it.
+	_, ok = o.openfauna.ResolveLocal(outOfSetSci)
+	assert.False(t, ok, "out-of-working-set species must not be in the fast-path index")
+}


### PR DESCRIPTION
## Summary

Two OpenFauna name-resolver wiring seams were only verified by inspection and could be broken silently. This adds integration coverage for both, plus a small behavior-preserving extraction that makes one of them testable.

- **`BuildRangeFilter` -> `RebuildNameResolver`:** no test exercised the call site, so deleting the trigger still passed. Added a test that, after `BuildRangeFilter`, the OpenFauna fast-path index resolves a working-set species (`ResolveLocal` ok), with a negative control proving the rebuilt index is working-set-scoped (sparse), not the whole dataset.
- **`ControlMonitor` startup wiring:** `SetNameResolver` must run before the name maps are rebuilt, but swapping the order or dropping the call still passed. Extracted the resolver-install + map-rebuild block out of `NewControlMonitor` into a small `installNameResolver` helper (behavior-preserving; `NewControlMonitor` delegates) and added tests asserting install-before-rebuild on both the datastore and the api-controller surfaces, plus nil-resolver and nil-surface cases.

No runtime behavior changes: the only production edit is the helper extraction, which the diff confirms is call-for-call equivalent to the previous inline block.

## Test Plan

- [x] `go test -race ./internal/analysis/... ./internal/classifier/...` (green)
- [x] `golangci-lint run` (full project) clean
- [x] Mutation-verified: removing the `RebuildNameResolver` trigger fails the range-filter test; swapping the install/rebuild order fails the wiring test on both surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal resolver installation logic to eliminate code duplication and improve maintainability.

* **Tests**
  * Added comprehensive test coverage for resolver installation behavior across multiple system surfaces and range filter integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->