### PR TITLE
feat(embeddings): live-path embedding extraction substrate (M1)

### DIFF
--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -48,7 +48,11 @@ func shouldLogEmbeddingUnavailable(modelID string, dim int) bool {
 // embeddings logs the unavailable warning once more if the model still cannot extract.
 func resetEmbeddingUnavailableLog(modelID string) {
 	if v, ok := embUnavailableLogged.Load(modelID); ok {
-		v.(*atomic.Bool).Store(false)
+		// Load before Store so the disabled path avoids a cache-line invalidation
+		// on every window once the flag is already cleared (the common case).
+		if flag := v.(*atomic.Bool); flag.Load() {
+			flag.Store(false)
+		}
 	}
 }
 

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -26,20 +26,30 @@ import (
 var processMetrics atomic.Pointer[metrics.MyAudioMetrics]
 
 // embUnavailableLogged throttles the "embeddings enabled but model can't extract"
-// warning to once per enable-session. Assumes a single active model (M1 scope): a
-// capable window resets the guard globally, so with multiple models active at once a
-// capable model would suppress the warning for a concurrent incapable one. It is also
-// reset on the disabled path so toggling enabled->disabled->enabled logs once more.
-var embUnavailableLogged atomic.Bool
+// warning to once per enable-session, PER MODEL. Keyed by model ID so a capable
+// model does not suppress the warning for a concurrent incapable model. The flag
+// for a model is cleared when that model produces an embedding or runs with
+// embeddings disabled, so re-enabling logs once more.
+var embUnavailableLogged sync.Map // modelID(string) -> *atomic.Bool
 
 // shouldLogEmbeddingUnavailable reports whether to emit the unavailable warning
-// now. dim == 0 means the active model cannot extract embeddings.
-func shouldLogEmbeddingUnavailable(dim int) bool {
+// now for the given model. dim == 0 means the active model cannot extract embeddings.
+func shouldLogEmbeddingUnavailable(modelID string, dim int) bool {
+	v, _ := embUnavailableLogged.LoadOrStore(modelID, &atomic.Bool{})
+	flag := v.(*atomic.Bool)
 	if dim == 0 {
-		return embUnavailableLogged.CompareAndSwap(false, true)
+		return flag.CompareAndSwap(false, true)
 	}
-	embUnavailableLogged.Store(false)
+	flag.Store(false)
 	return false
+}
+
+// resetEmbeddingUnavailableLog clears the per-model throttle so re-enabling
+// embeddings logs the unavailable warning once more if the model still cannot extract.
+func resetEmbeddingUnavailableLog(modelID string) {
+	if v, ok := embUnavailableLogged.Load(modelID); ok {
+		v.(*atomic.Bool).Store(false)
+	}
 }
 
 const (
@@ -262,8 +272,8 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		results, embedding, err = bn.PredictModelWithEmbeddings(ctx, modelID, sampleData)
 	} else {
 		results, err = bn.PredictModel(ctx, modelID, sampleData)
-		// Reset the throttle so re-enabling logs once more if the model is still incapable.
-		embUnavailableLogged.Store(false)
+		// Reset the per-model throttle so re-enabling logs once more if the model is still incapable.
+		resetEmbeddingUnavailableLog(modelID)
 	}
 	inferenceDuration := time.Since(inferenceStart)
 
@@ -289,7 +299,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		logger.Int("sample_bytes", len(data)))
 
 	if embEnabled {
-		if shouldLogEmbeddingUnavailable(len(embedding)) {
+		if shouldLogEmbeddingUnavailable(modelID, len(embedding)) {
 			log.Warn("embeddings enabled but active model cannot extract them; needs an ONNX embeddings model",
 				logger.String("model_id", modelID))
 		} else if len(embedding) > 0 && settings.BirdNET.Debug {

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -26,8 +26,10 @@ import (
 var processMetrics atomic.Pointer[metrics.MyAudioMetrics]
 
 // embUnavailableLogged throttles the "embeddings enabled but model can't extract"
-// warning to once per enable-session (reset when extraction is disabled or a
-// capable model is seen).
+// warning to once per enable-session. Assumes a single active model (M1 scope): a
+// capable window resets the guard globally, so with multiple models active at once a
+// capable model would suppress the warning for a concurrent incapable one. It is also
+// reset on the disabled path so toggling enabled->disabled->enabled logs once more.
 var embUnavailableLogged atomic.Bool
 
 // shouldLogEmbeddingUnavailable reports whether to emit the unavailable warning
@@ -246,8 +248,10 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	}
 
 	// Run inference on the specified model via the Orchestrator.
-	// Read the flag live on every call so hot-reload takes effect immediately.
-	embEnabled := conf.Setting().Embeddings.Enabled
+	// Snapshot settings once per call (read live every window for hot-reload,
+	// but consistently within the window) and reuse the snapshot below.
+	settings := conf.Setting()
+	embEnabled := settings.Embeddings.Enabled
 
 	var (
 		results   []datastore.Results
@@ -288,7 +292,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		if shouldLogEmbeddingUnavailable(len(embedding)) {
 			log.Warn("embeddings enabled but active model cannot extract them; needs an ONNX embeddings model",
 				logger.String("model_id", modelID))
-		} else if len(embedding) > 0 && conf.Setting().BirdNET.Debug {
+		} else if len(embedding) > 0 && settings.BirdNET.Debug {
 			log.Debug("embedding extracted",
 				logger.String("model_id", modelID),
 				logger.Int("dim", len(embedding)))
@@ -304,7 +308,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	}
 
 	// DEBUG print all BirdNET results
-	if conf.Setting().BirdNET.Debug {
+	if settings.BirdNET.Debug {
 		debugThreshold := float32(0) // set to 0 for now, maybe add a config option later
 		hasHighConfidenceResults := false
 		for _, result := range results {

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -25,6 +25,21 @@ import (
 
 var processMetrics atomic.Pointer[metrics.MyAudioMetrics]
 
+// embUnavailableLogged throttles the "embeddings enabled but model can't extract"
+// warning to once per enable-session (reset when extraction is disabled or a
+// capable model is seen).
+var embUnavailableLogged atomic.Bool
+
+// shouldLogEmbeddingUnavailable reports whether to emit the unavailable warning
+// now. dim == 0 means the active model cannot extract embeddings.
+func shouldLogEmbeddingUnavailable(dim int) bool {
+	if dim == 0 {
+		return embUnavailableLogged.CompareAndSwap(false, true)
+	}
+	embUnavailableLogged.Store(false)
+	return false
+}
+
 const (
 	// Float32BufferSize is the number of float32 samples in a standard buffer.
 	// For 16-bit audio: conf.BufferSize / 2 (bytes per sample) = 144384 samples.
@@ -231,8 +246,21 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	}
 
 	// Run inference on the specified model via the Orchestrator.
+	// Read the flag live on every call so hot-reload takes effect immediately.
+	embEnabled := conf.Setting().Embeddings.Enabled
+
+	var (
+		results   []datastore.Results
+		embedding []float32
+	)
 	inferenceStart := time.Now()
-	results, err := bn.PredictModel(ctx, modelID, sampleData)
+	if embEnabled {
+		results, embedding, err = bn.PredictModelWithEmbeddings(ctx, modelID, sampleData)
+	} else {
+		results, err = bn.PredictModel(ctx, modelID, sampleData)
+		// Reset the throttle so re-enabling logs once more if the model is still incapable.
+		embUnavailableLogged.Store(false)
+	}
 	inferenceDuration := time.Since(inferenceStart)
 
 	// Record inference duration metric (always, even on error)
@@ -255,6 +283,17 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		logger.Int("result_count", len(results)),
 		logger.Duration("inference_duration", inferenceDuration),
 		logger.Int("sample_bytes", len(data)))
+
+	if embEnabled {
+		if shouldLogEmbeddingUnavailable(len(embedding)) {
+			log.Warn("embeddings enabled but active model cannot extract them; needs an ONNX embeddings model",
+				logger.String("model_id", modelID))
+		} else if len(embedding) > 0 && conf.Setting().BirdNET.Debug {
+			log.Debug("embedding extracted",
+				logger.String("model_id", modelID),
+				logger.Int("dim", len(embedding)))
+		}
+	}
 
 	// get elapsed time (includes conversion + inference for overrun check)
 	elapsedTime := time.Since(predictStart)
@@ -337,6 +376,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		Results:         results,
 		Source:          audioSource,
 		ModelID:         modelID,
+		Embeddings:      embedding, // nil when disabled or unavailable
 	}
 
 	// Send the results to the queue. PCMdata is the independently owned copy

--- a/internal/analysis/process_test.go
+++ b/internal/analysis/process_test.go
@@ -8,21 +8,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestShouldLogEmbeddingUnavailable_ThrottleAndReset verifies the throttle
-// semantics of the embUnavailableLogged guard:
+// TestShouldLogEmbeddingUnavailable_ThrottleAndReset verifies the per-model
+// throttle semantics of shouldLogEmbeddingUnavailable:
 //   - first call with dim==0 logs (CAS false->true succeeds)
-//   - second call with dim==0 is throttled (CAS false->true fails)
-//   - call with dim>0 resets the guard to false (no log returned)
+//   - second call with dim==0 is throttled (CAS fails)
+//   - call with dim>0 resets the per-model flag (no log returned)
 //   - after reset, next call with dim==0 logs again
+//   - a different model ID is unaffected by the first model's throttle state
 //
 // This test MUST NOT use t.Parallel() because it mutates the package-level
-// embUnavailableLogged atomic.
+// embUnavailableLogged sync.Map.
 func TestShouldLogEmbeddingUnavailable_ThrottleAndReset(t *testing.T) {
-	embUnavailableLogged.Store(false)
-	t.Cleanup(func() { embUnavailableLogged.Store(false) })
+	const m = "test-model"
+	const m2 = "test-model-2"
+	embUnavailableLogged.Delete(m)
+	embUnavailableLogged.Delete(m2)
+	t.Cleanup(func() {
+		embUnavailableLogged.Delete(m)
+		embUnavailableLogged.Delete(m2)
+	})
 
-	assert.True(t, shouldLogEmbeddingUnavailable(0), "first unavailable should log")
-	assert.False(t, shouldLogEmbeddingUnavailable(0), "subsequent unavailable throttled")
-	assert.False(t, shouldLogEmbeddingUnavailable(1024), "capable resets without logging")
-	assert.True(t, shouldLogEmbeddingUnavailable(0), "logs again after reset")
+	assert.True(t, shouldLogEmbeddingUnavailable(m, 0), "first unavailable should log")
+	assert.False(t, shouldLogEmbeddingUnavailable(m, 0), "subsequent unavailable throttled")
+	assert.False(t, shouldLogEmbeddingUnavailable(m, 1024), "capable resets without logging")
+	assert.True(t, shouldLogEmbeddingUnavailable(m, 0), "logs again after reset")
+
+	// Per-model isolation: m is now throttled (flag true after the previous call).
+	// m2 has never been seen, so its first unavailable call must still log even
+	// though m is throttled. This proves the flags are keyed independently.
+	assert.False(t, shouldLogEmbeddingUnavailable(m, 0), "m is throttled for isolation test")
+	assert.True(t, shouldLogEmbeddingUnavailable(m2, 0), "different model ID logs independently")
 }

--- a/internal/analysis/process_test.go
+++ b/internal/analysis/process_test.go
@@ -1,0 +1,28 @@
+// process_test.go tests the per-call inference gating and throttled logging
+// helpers added to ProcessData for embedding extraction.
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestShouldLogEmbeddingUnavailable_ThrottleAndReset verifies the throttle
+// semantics of the embUnavailableLogged guard:
+//   - first call with dim==0 logs (CAS false->true succeeds)
+//   - second call with dim==0 is throttled (CAS false->true fails)
+//   - call with dim>0 resets the guard to false (no log returned)
+//   - after reset, next call with dim==0 logs again
+//
+// This test MUST NOT use t.Parallel() because it mutates the package-level
+// embUnavailableLogged atomic.
+func TestShouldLogEmbeddingUnavailable_ThrottleAndReset(t *testing.T) {
+	embUnavailableLogged.Store(false)
+	t.Cleanup(func() { embUnavailableLogged.Store(false) })
+
+	assert.True(t, shouldLogEmbeddingUnavailable(0), "first unavailable should log")
+	assert.False(t, shouldLogEmbeddingUnavailable(0), "subsequent unavailable throttled")
+	assert.False(t, shouldLogEmbeddingUnavailable(1024), "capable resets without logging")
+	assert.True(t, shouldLogEmbeddingUnavailable(0), "logs again after reset")
+}

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -74,6 +74,9 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// --- BSG ---
 	"BSG": {categories: []hotReloadCategory{hotReloadRestart}},
 
+	// --- Embeddings ---
+	"Embeddings": {categories: []hotReloadCategory{hotReloadFresh}},
+
 	// --- Models ---
 	"Models": {categories: []hotReloadCategory{hotReloadRestart}},
 

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -7,9 +7,13 @@ import (
 	"sort"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
+
+// defaultTopKResults is the number of top predictions returned per inference window.
+const defaultTopKResults = 10
 
 // Filter structure is used for filtering predictions based on certain criteria.
 type Filter struct {
@@ -89,16 +93,12 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		m.RecordModelInvoke(bn.ModelInfo.ID, invokeDuration.Seconds())
 	}
 
-	// Use optimized sigmoid function with buffer reuse
-	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
-
-	// Use the pre-allocated buffer to reduce memory allocations
-	results, err := pairLabelsAndConfidenceReuse(settings.BirdNET.Labels, confidence, bn.resultsBuffer)
+	// Use shared post-processing: sigmoid -> labels -> top-K -> caller-owned copy.
+	results, err := bn.finalizeResults(predictions, settings)
 	if err != nil {
 		err = errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("label_count", len(settings.BirdNET.Labels)).
-			Context("confidence_count", len(confidence)).
 			Timing("prediction-total", time.Since(start)).
 			Build()
 
@@ -113,22 +113,33 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		return nil, err
 	}
 
-	// Use optimized top-k algorithm instead of full sort + trim
-	topResults := getTopKResults(results, 10)
-
 	// Log prediction timing for performance monitoring
 	duration := time.Since(start)
-	bn.Debug("Prediction completed in %v with %d results", duration, len(topResults))
+	bn.Debug("Prediction completed in %v with %d results", duration, len(results))
 
 	// Record metrics
 	span.SetData("total_duration_ms", duration.Milliseconds())
-	span.SetData("result_count", len(topResults))
+	span.SetData("result_count", len(results))
 	span.SetTag("error", "false")
 
 	// The span.Finish() will automatically record the prediction metrics
 
-	// Return the top 10 results
-	return topResults, nil
+	return results, nil
+}
+
+// finalizeResults applies sigmoid to raw predictions, pairs them with labels,
+// selects the top-K, and returns a caller-owned copy. The returned slice never
+// aliases bn.resultsBuffer, so it is safe to hand to the ResultsQueue (issue #949).
+func (bn *BirdNET) finalizeResults(predictions []float32, settings *conf.Settings) ([]datastore.Results, error) {
+	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
+	results, err := pairLabelsAndConfidenceReuse(settings.BirdNET.Labels, confidence, bn.resultsBuffer)
+	if err != nil {
+		return nil, err
+	}
+	topResults := getTopKResults(results, defaultTopKResults)
+	out := make([]datastore.Results, len(topResults))
+	copy(out, topResults)
+	return out, nil
 }
 
 // customSigmoid applies a sigmoid function with sensitivity adjustment to a value.

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -99,6 +99,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		err = errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("label_count", len(settings.BirdNET.Labels)).
+			Context("confidence_count", len(predictions)).
 			Timing("prediction-total", time.Since(start)).
 			Build()
 
@@ -132,20 +133,17 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 // aliases bn.resultsBuffer, so it is safe to hand to the ResultsQueue (fixes a
 // results-buffer aliasing data race across the queue boundary).
 //
+// On label/confidence length mismatch the raw error from pairLabelsAndConfidenceReuse
+// is returned unwrapped so callers (Predict, PredictWithEmbeddings) can wrap it
+// once with BOTH confidence_count and label_count in a single top-level error.
+//
 // The caller must hold bn.mu: finalizeResults reads and writes the shared
 // bn.confidenceBuffer and bn.resultsBuffer without locking itself.
 func (bn *BirdNET) finalizeResults(predictions []float32, settings *conf.Settings) ([]datastore.Results, error) {
 	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
 	results, err := pairLabelsAndConfidenceReuse(settings.BirdNET.Labels, confidence, bn.resultsBuffer)
 	if err != nil {
-		// confidence_count is the other side of a label/confidence length
-		// mismatch (len(confidence) == len(predictions) since sigmoid
-		// preserves length); the outer Predict wrapper adds label_count, so
-		// the final error carries both counts for diagnosis.
-		return nil, errors.New(err).
-			Category(errors.CategoryValidation).
-			Context("confidence_count", len(predictions)).
-			Build()
+		return nil, err
 	}
 	topResults := getTopKResults(results, defaultTopKResults)
 	out := make([]datastore.Results, len(topResults))

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -129,7 +129,8 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 
 // finalizeResults applies sigmoid to raw predictions, pairs them with labels,
 // selects the top-K, and returns a caller-owned copy. The returned slice never
-// aliases bn.resultsBuffer, so it is safe to hand to the ResultsQueue (issue #949).
+// aliases bn.resultsBuffer, so it is safe to hand to the ResultsQueue (fixes a
+// results-buffer aliasing data race across the queue boundary).
 //
 // The caller must hold bn.mu: finalizeResults reads and writes the shared
 // bn.confidenceBuffer and bn.resultsBuffer without locking itself.

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -130,11 +130,21 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 // finalizeResults applies sigmoid to raw predictions, pairs them with labels,
 // selects the top-K, and returns a caller-owned copy. The returned slice never
 // aliases bn.resultsBuffer, so it is safe to hand to the ResultsQueue (issue #949).
+//
+// The caller must hold bn.mu: finalizeResults reads and writes the shared
+// bn.confidenceBuffer and bn.resultsBuffer without locking itself.
 func (bn *BirdNET) finalizeResults(predictions []float32, settings *conf.Settings) ([]datastore.Results, error) {
 	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
 	results, err := pairLabelsAndConfidenceReuse(settings.BirdNET.Labels, confidence, bn.resultsBuffer)
 	if err != nil {
-		return nil, err
+		// confidence_count is the other side of a label/confidence length
+		// mismatch (len(confidence) == len(predictions) since sigmoid
+		// preserves length); the outer Predict wrapper adds label_count, so
+		// the final error carries both counts for diagnosis.
+		return nil, errors.New(err).
+			Category(errors.CategoryValidation).
+			Context("confidence_count", len(predictions)).
+			Build()
 	}
 	topResults := getTopKResults(results, defaultTopKResults)
 	out := make([]datastore.Results, len(topResults))

--- a/internal/classifier/analyze_bench_test.go
+++ b/internal/classifier/analyze_bench_test.go
@@ -345,8 +345,8 @@ func BenchmarkTopKResultsOptimized(b *testing.B) {
 
 			topResults := getTopKResults(testResults, defaultTopKResults)
 
-			if len(topResults) != 10 {
-				b.Errorf("Expected 10 results, got %d", len(topResults))
+			if len(topResults) != defaultTopKResults {
+				b.Errorf("Expected %d results, got %d", defaultTopKResults, len(topResults))
 			}
 		}
 	})
@@ -405,12 +405,12 @@ func BenchmarkFullPipelineOptimized(b *testing.B) {
 				b.Errorf("pairLabelsAndConfidenceReuse failed: %v", err)
 			}
 
-			// Step 3: Get top 10 using optimized algorithm
+			// Step 3: Get top k using optimized algorithm
 			finalResults := getTopKResults(results, defaultTopKResults)
 
 			// Prevent compiler optimization
-			if len(finalResults) != 10 {
-				b.Errorf("Expected 10 final results, got %d", len(finalResults))
+			if len(finalResults) != defaultTopKResults {
+				b.Errorf("Expected %d final results, got %d", defaultTopKResults, len(finalResults))
 			}
 		}
 	})

--- a/internal/classifier/analyze_bench_test.go
+++ b/internal/classifier/analyze_bench_test.go
@@ -343,7 +343,7 @@ func BenchmarkTopKResultsOptimized(b *testing.B) {
 			testResults := make([]datastore.Results, len(results))
 			copy(testResults, results)
 
-			topResults := getTopKResults(testResults, 10)
+			topResults := getTopKResults(testResults, defaultTopKResults)
 
 			if len(topResults) != 10 {
 				b.Errorf("Expected 10 results, got %d", len(topResults))
@@ -406,7 +406,7 @@ func BenchmarkFullPipelineOptimized(b *testing.B) {
 			}
 
 			// Step 3: Get top 10 using optimized algorithm
-			finalResults := getTopKResults(results, 10)
+			finalResults := getTopKResults(results, defaultTopKResults)
 
 			// Prevent compiler optimization
 			if len(finalResults) != 10 {
@@ -451,7 +451,7 @@ func BenchmarkMemoryUsageComparison(b *testing.B) {
 			// This simulates the optimized pipeline with buffer reuse
 			confidence := applySigmoidToPredictionsReuse(predictions, sensitivity, confidenceBuffer)
 			results, _ := pairLabelsAndConfidenceReuse(labels, confidence, resultsBuffer)
-			getTopKResults(results, 10)
+			getTopKResults(results, defaultTopKResults)
 		}
 	})
 }

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -790,4 +791,28 @@ func generateLargeTestResults(count int) []datastore.Results {
 		}
 	}
 	return results
+}
+
+func TestFinalizeResults_ReturnsCallerOwnedCopy(t *testing.T) {
+	labels := []string{"a_A", "b_B", "c_C"}
+	bn := &BirdNET{
+		confidenceBuffer: make([]float32, len(labels)),
+		resultsBuffer:    make([]datastore.Results, len(labels)),
+	}
+	settings := &conf.Settings{}
+	settings.BirdNET.Labels = labels
+	settings.BirdNET.Sensitivity = 1.0
+
+	out, err := bn.finalizeResults([]float32{0.1, 0.9, 0.5}, settings)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+
+	// Snapshot, then clobber the shared buffer (as the next inference window would).
+	snapshot := make([]datastore.Results, len(out))
+	copy(snapshot, out)
+	for i := range bn.resultsBuffer {
+		bn.resultsBuffer[i] = datastore.Results{Species: "MUT", Confidence: -1}
+	}
+
+	assert.Equal(t, snapshot, out, "returned slice must not alias bn.resultsBuffer")
 }

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -794,25 +794,68 @@ func generateLargeTestResults(count int) []datastore.Results {
 }
 
 func TestFinalizeResults_ReturnsCallerOwnedCopy(t *testing.T) {
-	labels := []string{"a_A", "b_B", "c_C"}
-	bn := &BirdNET{
-		confidenceBuffer: make([]float32, len(labels)),
-		resultsBuffer:    make([]datastore.Results, len(labels)),
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		labelN    int
+		wantLen   int
+		topBranch string
+	}{
+		{
+			// Fewer labels than defaultTopKResults: getTopKResults takes the
+			// k>=len branch and returns the whole (sorted) buffer.
+			name:      "fewer labels than top-K (whole-buffer branch)",
+			labelN:    3,
+			wantLen:   3,
+			topBranch: "k>=len",
+		},
+		{
+			// More labels than defaultTopKResults: getTopKResults takes the
+			// partial-sort results[:k] sub-slice branch, mirroring the real
+			// production path with ~6000 labels. The make+copy must still sever
+			// the alias on this sub-slice.
+			name:      "more labels than top-K (sub-slice branch)",
+			labelN:    15,
+			wantLen:   defaultTopKResults,
+			topBranch: "results[:k]",
+		},
 	}
-	settings := &conf.Settings{}
-	settings.BirdNET.Labels = labels
-	settings.BirdNET.Sensitivity = 1.0
 
-	out, err := bn.finalizeResults([]float32{0.1, 0.9, 0.5}, settings)
-	require.NoError(t, err)
-	require.NotEmpty(t, out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Snapshot, then clobber the shared buffer (as the next inference window would).
-	snapshot := make([]datastore.Results, len(out))
-	copy(snapshot, out)
-	for i := range bn.resultsBuffer {
-		bn.resultsBuffer[i] = datastore.Results{Species: "MUT", Confidence: -1}
+			require.Greater(t, tt.labelN, 0, "label count must be positive")
+
+			labels := make([]string, tt.labelN)
+			predictions := make([]float32, tt.labelN)
+			for i := range labels {
+				labels[i] = fmt.Sprintf("species_%02d_Species %02d", i, i)
+				// Decreasing raw predictions so the top-K ordering is deterministic.
+				predictions[i] = float32(tt.labelN-i) / float32(tt.labelN)
+			}
+
+			bn := &BirdNET{
+				confidenceBuffer: make([]float32, tt.labelN),
+				resultsBuffer:    make([]datastore.Results, tt.labelN),
+			}
+			settings := &conf.Settings{}
+			settings.BirdNET.Labels = labels
+			settings.BirdNET.Sensitivity = 1.0
+
+			out, err := bn.finalizeResults(predictions, settings)
+			require.NoError(t, err)
+			require.Len(t, out, tt.wantLen, "unexpected top-K length for %s branch", tt.topBranch)
+
+			// Snapshot, then clobber the shared buffer (as the next inference window would).
+			snapshot := make([]datastore.Results, len(out))
+			copy(snapshot, out)
+			for i := range bn.resultsBuffer {
+				bn.resultsBuffer[i] = datastore.Results{Species: "MUT", Confidence: -1}
+			}
+
+			assert.Equal(t, snapshot, out, "returned slice must not alias bn.resultsBuffer (%s branch)", tt.topBranch)
+		})
 	}
-
-	assert.Equal(t, snapshot, out, "returned slice must not alias bn.resultsBuffer")
 }

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -826,7 +826,7 @@ func TestFinalizeResults_ReturnsCallerOwnedCopy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			require.Greater(t, tt.labelN, 0, "label count must be positive")
+			require.Positive(t, tt.labelN, "label count must be positive")
 
 			labels := make([]string, tt.labelN)
 			predictions := make([]float32, tt.labelN)

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -193,7 +193,7 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 			logger.Duration("total_duration", embDuration+classDuration))
 	}
 
-	return getTopKResults(results, 10), nil
+	return getTopKResults(results, defaultTopKResults), nil
 }
 
 // Spec returns the audio requirements for the bat model.

--- a/internal/classifier/embeddings.go
+++ b/internal/classifier/embeddings.go
@@ -61,6 +61,7 @@ func (bn *BirdNET) EmbeddingDim() int {
 func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32) ([]datastore.Results, []float32, error) {
 	span, _ := StartSpan(ctx, "birdnet.predict_embeddings", "Species prediction with embeddings")
 	defer span.Finish()
+	span.SetTag("model", bn.ModelInfo.ID)
 
 	settings := bn.currentSettings()
 
@@ -81,8 +82,8 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 			Build()
 	}
 
-	ee, capable := bn.classifier.(inference.EmbeddingExtractor)
-	if !capable || ee.EmbeddingDim() == 0 {
+	ee, ok := bn.classifier.(inference.EmbeddingExtractor)
+	if !ok || ee.EmbeddingDim() == 0 {
 		// Model cannot extract embeddings: fall back to plain prediction.
 		predictions, err := bn.classifier.Predict(sample[0])
 		if err != nil {
@@ -92,7 +93,15 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 				Build()
 		}
 		results, err := bn.finalizeResults(predictions, settings)
-		return results, nil, err
+		if err != nil {
+			// finalizeResults already adds confidence_count; wrap with label_count
+			// to carry both counts, matching BirdNET.Predict's diagnostic.
+			return nil, nil, errors.New(err).
+				Category(errors.CategoryValidation).
+				Context("label_count", len(settings.BirdNET.Labels)).
+				Build()
+		}
+		return results, nil, nil
 	}
 
 	// Model supports embedding extraction: run the combined forward pass.
@@ -108,7 +117,12 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 
 	results, err := bn.finalizeResults(predictions, settings)
 	if err != nil {
-		return nil, nil, err
+		// finalizeResults already adds confidence_count; wrap with label_count
+		// to carry both counts, matching BirdNET.Predict's diagnostic.
+		return nil, nil, errors.New(err).
+			Category(errors.CategoryValidation).
+			Context("label_count", len(settings.BirdNET.Labels)).
+			Build()
 	}
 	return results, embedding, nil
 }

--- a/internal/classifier/embeddings.go
+++ b/internal/classifier/embeddings.go
@@ -154,6 +154,7 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 		err = errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("label_count", len(settings.BirdNET.Labels)).
+			Context("confidence_count", len(predictions)).
 			Timing("prediction-total", time.Since(start)).
 			Build()
 

--- a/internal/classifier/embeddings.go
+++ b/internal/classifier/embeddings.go
@@ -3,6 +3,7 @@ package classifier
 
 import (
 	"context"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -54,8 +55,10 @@ func (bn *BirdNET) EmbeddingDim() int {
 // ee.EmbeddingDim()) is performed on the ee interface value, never via
 // bn.EmbeddingDim(), to avoid a self-deadlock on bn.mu.
 //
-// Metric recording is intentionally absent here; it is wired at the
-// orchestrator chokepoint in a later task (Task 8).
+// Telemetry mirrors BirdNET.Predict exactly: same span data keys, same
+// RecordModelInvoke/RecordPrediction call sites. The success-path
+// RecordPrediction fires via span.Finish() (tracing.go switch case
+// "birdnet.predict_embeddings"); error-path RecordPrediction is explicit.
 //
 // Implements EmbeddingCapable.
 func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32) ([]datastore.Results, []float32, error) {
@@ -64,65 +67,118 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 	span.SetTag("model", bn.ModelInfo.ID)
 
 	settings := bn.currentSettings()
+	start := time.Now()
+	span.SetData("sample_count", len(sample))
+	if len(sample) > 0 {
+		span.SetData("sample_size", len(sample[0]))
+	}
 
+	// Guard against empty sample slice
 	if len(sample) == 0 || len(sample[0]) == 0 {
-		return nil, nil, errors.Newf("empty audio sample").
+		err := errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
+		span.SetTag("error", "true")
+		span.SetData("error_type", "empty_sample")
+		return nil, nil, err
 	}
 
+	// Lock to prevent concurrent access to the classifier backend and shared buffers
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
 
+	// Guard against nil classifier (e.g., after Delete() is called concurrently)
 	if bn.classifier == nil {
-		return nil, nil, errors.Newf("classifier backend is not initialized").
+		err := errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
+		span.SetTag("error", "true")
+		span.SetData("error_type", "classifier_nil")
+		return nil, nil, err
 	}
 
-	ee, ok := bn.classifier.(inference.EmbeddingExtractor)
-	if !ok || ee.EmbeddingDim() == 0 {
+	// Capability check: type-assert once here (under bn.mu) so both branches
+	// share a single invokeStart/invokeDuration timing block below.
+	ee, capable := bn.classifier.(inference.EmbeddingExtractor)
+	capable = capable && ee.EmbeddingDim() > 0
+
+	// Run inference via the appropriate branch. Both branches produce
+	// (predictions, embedding, err); the incapable branch always yields nil embedding.
+	var (
+		predictions []float32
+		embedding   []float32
+		invokeErr   error
+	)
+	invokeStart := time.Now()
+	if capable {
+		// Model supports embedding extraction: run the combined forward pass.
+		// ee.EmbeddingDim() was called above while bn.mu is held; that reads a plain
+		// int field on the ONNX backend, not bn.EmbeddingDim() (which would deadlock).
+		predictions, embedding, invokeErr = ee.PredictWithEmbeddings(sample[0])
+	} else {
 		// Model cannot extract embeddings: fall back to plain prediction.
-		predictions, err := bn.classifier.Predict(sample[0])
-		if err != nil {
-			return nil, nil, errors.New(err).
-				Category(errors.CategoryAudio).
-				ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
-				Build()
-		}
-		results, err := bn.finalizeResults(predictions, settings)
-		if err != nil {
-			// finalizeResults already adds confidence_count; wrap with label_count
-			// to carry both counts, matching BirdNET.Predict's diagnostic.
-			return nil, nil, errors.New(err).
-				Category(errors.CategoryValidation).
-				Context("label_count", len(settings.BirdNET.Labels)).
-				Build()
-		}
-		return results, nil, nil
+		predictions, invokeErr = bn.classifier.Predict(sample[0])
+		// embedding stays nil
 	}
+	invokeDuration := time.Since(invokeStart)
 
-	// Model supports embedding extraction: run the combined forward pass.
-	// ee.EmbeddingDim() was called above while bn.mu is held; that reads a plain
-	// int field on the ONNX backend, not bn.EmbeddingDim() (which would deadlock).
-	predictions, embedding, err := ee.PredictWithEmbeddings(sample[0])
-	if err != nil {
-		return nil, nil, errors.New(err).
+	if invokeErr != nil {
+		err := errors.New(invokeErr).
 			Category(errors.CategoryAudio).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			Context("sample_length", len(sample[0])).
+			Timing("prediction-invoke", time.Since(start)).
 			Build()
+
+		span.SetTag("error", "true")
+		span.SetData("error_type", "invoke_failed")
+
+		if m := getMetrics(); m != nil {
+			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
+		}
+
+		return nil, nil, err
+	}
+
+	span.SetData("invoke_duration_ms", invokeDuration.Milliseconds())
+
+	// Record model invoke timing separately
+	if m := getMetrics(); m != nil {
+		m.RecordModelInvoke(bn.ModelInfo.ID, invokeDuration.Seconds())
 	}
 
 	results, err := bn.finalizeResults(predictions, settings)
 	if err != nil {
-		// finalizeResults already adds confidence_count; wrap with label_count
-		// to carry both counts, matching BirdNET.Predict's diagnostic.
-		return nil, nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("label_count", len(settings.BirdNET.Labels)).
+			Timing("prediction-total", time.Since(start)).
 			Build()
+
+		span.SetTag("error", "true")
+		span.SetData("error_type", "label_mismatch")
+
+		// Record error in metrics
+		if m := getMetrics(); m != nil {
+			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
+		}
+
+		return nil, nil, err
 	}
+
+	// Log prediction timing for performance monitoring
+	duration := time.Since(start)
+	bn.Debug("Prediction with embeddings completed in %v with %d results", duration, len(results))
+
+	// Record metrics
+	span.SetData("total_duration_ms", duration.Milliseconds())
+	span.SetData("result_count", len(results))
+	span.SetTag("error", "false")
+
+	// The span.Finish() will automatically record the prediction metrics via the
+	// "birdnet.predict_embeddings" case in tracing.go Finish().
+
 	return results, embedding, nil
 }

--- a/internal/classifier/embeddings.go
+++ b/internal/classifier/embeddings.go
@@ -1,0 +1,114 @@
+// Package classifier embedding-extraction capability (substrate M1, issue #948).
+package classifier
+
+import (
+	"context"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
+)
+
+// EmbeddingCapable is an optional capability a ModelInstance may implement to
+// return the primary embedding vector alongside detection results, produced by
+// the same forward pass. EmbeddingDim reports 0 when the active model cannot
+// produce embeddings.
+type EmbeddingCapable interface {
+	// PredictWithEmbeddings runs inference and returns both detection results
+	// and the model's embedding vector for the given audio window. The embedding
+	// is nil when the underlying classifier cannot produce one; callers treat
+	// nil as "unavailable".
+	PredictWithEmbeddings(ctx context.Context, sample [][]float32) (results []datastore.Results, embedding []float32, err error)
+
+	// EmbeddingDim returns the embedding vector length, or 0 when the active
+	// model cannot produce embeddings.
+	EmbeddingDim() int
+}
+
+// Verify that *BirdNET satisfies EmbeddingCapable at compile time.
+var _ EmbeddingCapable = (*BirdNET)(nil)
+
+// EmbeddingDim returns the embedding vector length of the underlying classifier,
+// or 0 when the active model cannot produce embeddings.
+// The result is read under bn.mu to avoid a race with concurrent model reloads.
+func (bn *BirdNET) EmbeddingDim() int {
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+	if ee, ok := bn.classifier.(inference.EmbeddingExtractor); ok {
+		return ee.EmbeddingDim()
+	}
+	return 0
+}
+
+// PredictWithEmbeddings runs inference and returns detection results plus the
+// model's embedding vector for the given audio window. The embedding is nil
+// when the underlying classifier cannot produce one; callers treat nil as
+// "unavailable".
+//
+// The method holds bn.mu for the full duration of the native inference call,
+// matching the lock discipline of BirdNET.Predict (issue #3336 use-after-free
+// contract: the native ONNX/TFLite buffers must not be freed by a concurrent
+// model reload or Delete while inference is running).
+//
+// The capability check (inference.EmbeddingExtractor type assertion and
+// ee.EmbeddingDim()) is performed on the ee interface value, never via
+// bn.EmbeddingDim(), to avoid a self-deadlock on bn.mu.
+//
+// Metric recording is intentionally absent here; it is wired at the
+// orchestrator chokepoint in a later task (Task 8).
+//
+// Implements EmbeddingCapable.
+func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32) ([]datastore.Results, []float32, error) {
+	span, _ := StartSpan(ctx, "birdnet.predict_embeddings", "Species prediction with embeddings")
+	defer span.Finish()
+
+	settings := bn.currentSettings()
+
+	if len(sample) == 0 || len(sample[0]) == 0 {
+		return nil, nil, errors.Newf("empty audio sample").
+			Category(errors.CategoryValidation).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			Build()
+	}
+
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+
+	if bn.classifier == nil {
+		return nil, nil, errors.Newf("classifier backend is not initialized").
+			Category(errors.CategoryModelInit).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			Build()
+	}
+
+	ee, capable := bn.classifier.(inference.EmbeddingExtractor)
+	if !capable || ee.EmbeddingDim() == 0 {
+		// Model cannot extract embeddings: fall back to plain prediction.
+		predictions, err := bn.classifier.Predict(sample[0])
+		if err != nil {
+			return nil, nil, errors.New(err).
+				Category(errors.CategoryAudio).
+				ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+				Build()
+		}
+		results, err := bn.finalizeResults(predictions, settings)
+		return results, nil, err
+	}
+
+	// Model supports embedding extraction: run the combined forward pass.
+	// ee.EmbeddingDim() was called above while bn.mu is held; that reads a plain
+	// int field on the ONNX backend, not bn.EmbeddingDim() (which would deadlock).
+	predictions, embedding, err := ee.PredictWithEmbeddings(sample[0])
+	if err != nil {
+		return nil, nil, errors.New(err).
+			Category(errors.CategoryAudio).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			Build()
+	}
+
+	results, err := bn.finalizeResults(predictions, settings)
+	if err != nil {
+		return nil, nil, err
+	}
+	return results, embedding, nil
+}

--- a/internal/classifier/embeddings.go
+++ b/internal/classifier/embeddings.go
@@ -1,4 +1,4 @@
-// Package classifier embedding-extraction capability (substrate M1, issue #948).
+// Package classifier embedding-extraction capability (substrate M1).
 package classifier
 
 import (

--- a/internal/classifier/embeddings_test.go
+++ b/internal/classifier/embeddings_test.go
@@ -86,7 +86,8 @@ func TestBirdNET_PredictWithEmbeddings_Capable(t *testing.T) {
 	results, emb, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
 	require.NoError(t, err)
 	require.Len(t, emb, 4)
-	assert.NotEmpty(t, results)
+	assert.Equal(t, []float32{1, 2, 3, 4}, emb)
+	require.Len(t, results, 3)
 }
 
 func TestBirdNET_PredictWithEmbeddings_Incapable(t *testing.T) {
@@ -98,7 +99,7 @@ func TestBirdNET_PredictWithEmbeddings_Incapable(t *testing.T) {
 	results, emb, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
 	require.NoError(t, err)
 	assert.Nil(t, emb)
-	assert.NotEmpty(t, results)
+	require.Len(t, results, 3)
 }
 
 func TestBirdNET_EmbeddingDim(t *testing.T) {

--- a/internal/classifier/embeddings_test.go
+++ b/internal/classifier/embeddings_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // fakeEmbExtractor implements inference.EmbeddingExtractor (and thus inference.Classifier).
@@ -23,6 +24,23 @@ func (f *fakeEmbExtractor) PredictWithEmbeddings(_ []float32) (logits, embedding
 	return f.logits, f.emb, nil
 }
 func (f *fakeEmbExtractor) EmbeddingDim() int { return f.dim }
+
+// fakeErrEmbExtractor implements inference.EmbeddingExtractor but returns an
+// error from PredictWithEmbeddings, with a positive EmbeddingDim so it takes
+// the capable branch of BirdNET.PredictWithEmbeddings.
+type fakeErrEmbExtractor struct {
+	logits []float32
+	dim    int
+	err    error
+}
+
+func (f *fakeErrEmbExtractor) Predict(_ []float32) ([]float32, error) { return f.logits, nil }
+func (f *fakeErrEmbExtractor) NumSpecies() int                        { return len(f.logits) }
+func (f *fakeErrEmbExtractor) Close()                                 {}
+func (f *fakeErrEmbExtractor) PredictWithEmbeddings(_ []float32) (logits, embeddings []float32, err error) {
+	return nil, nil, f.err
+}
+func (f *fakeErrEmbExtractor) EmbeddingDim() int { return f.dim }
 
 // fakePlainClassifier implements only inference.Classifier (no embedding capability).
 type fakePlainClassifier struct{ logits []float32 }
@@ -91,6 +109,25 @@ func TestBirdNET_EmbeddingDim(t *testing.T) {
 
 	bn2 := newEmbTestBirdNET(&fakePlainClassifier{logits: []float32{0}}, []string{"a_A"})
 	assert.Equal(t, 0, bn2.EmbeddingDim())
+}
+
+func TestBirdNET_PredictWithEmbeddings_ExtractorError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.Newf("extractor inference failed").
+		Category(errors.CategoryAudio).
+		Build()
+	f := &fakeErrEmbExtractor{
+		logits: []float32{0.1, 0.2, 0.3},
+		dim:    4,
+		err:    sentinel,
+	}
+	bn := newEmbTestBirdNET(f, []string{"a_A", "b_B", "c_C"})
+
+	results, emb, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
+	require.Error(t, err)
+	assert.Nil(t, emb)
+	assert.Nil(t, results)
 }
 
 func TestBirdNET_PredictWithEmbeddings_EmptySample(t *testing.T) {

--- a/internal/classifier/embeddings_test.go
+++ b/internal/classifier/embeddings_test.go
@@ -1,0 +1,107 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// fakeEmbExtractor implements inference.EmbeddingExtractor (and thus inference.Classifier).
+type fakeEmbExtractor struct {
+	logits []float32
+	emb    []float32
+	dim    int
+}
+
+func (f *fakeEmbExtractor) Predict(_ []float32) ([]float32, error) { return f.logits, nil }
+func (f *fakeEmbExtractor) NumSpecies() int                        { return len(f.logits) }
+func (f *fakeEmbExtractor) Close()                                 {}
+func (f *fakeEmbExtractor) PredictWithEmbeddings(_ []float32) (logits, embeddings []float32, err error) {
+	return f.logits, f.emb, nil
+}
+func (f *fakeEmbExtractor) EmbeddingDim() int { return f.dim }
+
+// fakePlainClassifier implements only inference.Classifier (no embedding capability).
+type fakePlainClassifier struct{ logits []float32 }
+
+func (f *fakePlainClassifier) Predict(_ []float32) ([]float32, error) { return f.logits, nil }
+func (f *fakePlainClassifier) NumSpecies() int                        { return len(f.logits) }
+func (f *fakePlainClassifier) Close()                                 {}
+
+// newEmbTestBirdNET builds a minimal *BirdNET backed by the given classifier,
+// with pre-allocated buffers and settings matching the provided labels.
+// The classifier parameter uses the structural interface that both fakes satisfy.
+func newEmbTestBirdNET(c interface {
+	Predict([]float32) ([]float32, error)
+	NumSpecies() int
+	Close()
+}, labels []string,
+) *BirdNET {
+	n := len(labels)
+	bn := &BirdNET{
+		classifier:       c,
+		confidenceBuffer: make([]float32, n),
+		resultsBuffer:    make([]datastore.Results, n),
+		ModelInfo:        ModelInfo{ID: "test-model"},
+		speciesCache:     make(map[string]*speciesCacheEntry),
+	}
+	s := &conf.Settings{}
+	s.BirdNET.Labels = labels
+	s.BirdNET.Sensitivity = 1.0
+	bn.settingsAtomic.Store(s)
+	return bn
+}
+
+func TestBirdNET_PredictWithEmbeddings_Capable(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeEmbExtractor{
+		logits: []float32{0.1, 0.9, 0.5},
+		emb:    []float32{1, 2, 3, 4},
+		dim:    4,
+	}
+	bn := newEmbTestBirdNET(f, []string{"a_A", "b_B", "c_C"})
+
+	results, emb, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
+	require.NoError(t, err)
+	require.Len(t, emb, 4)
+	assert.NotEmpty(t, results)
+}
+
+func TestBirdNET_PredictWithEmbeddings_Incapable(t *testing.T) {
+	t.Parallel()
+
+	f := &fakePlainClassifier{logits: []float32{0.1, 0.9, 0.5}}
+	bn := newEmbTestBirdNET(f, []string{"a_A", "b_B", "c_C"})
+
+	results, emb, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
+	require.NoError(t, err)
+	assert.Nil(t, emb)
+	assert.NotEmpty(t, results)
+}
+
+func TestBirdNET_EmbeddingDim(t *testing.T) {
+	t.Parallel()
+
+	bn := newEmbTestBirdNET(&fakeEmbExtractor{logits: []float32{0}, dim: 1024}, []string{"a_A"})
+	assert.Equal(t, 1024, bn.EmbeddingDim())
+
+	bn2 := newEmbTestBirdNET(&fakePlainClassifier{logits: []float32{0}}, []string{"a_A"})
+	assert.Equal(t, 0, bn2.EmbeddingDim())
+}
+
+func TestBirdNET_PredictWithEmbeddings_EmptySample(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeEmbExtractor{logits: []float32{0.5}, emb: []float32{1.0}, dim: 1}
+	bn := newEmbTestBirdNET(f, []string{"a_A"})
+
+	_, _, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{})
+	require.Error(t, err)
+
+	_, _, err = bn.PredictWithEmbeddings(t.Context(), [][]float32{{}})
+	require.Error(t, err)
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -474,6 +474,8 @@ func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID s
 	duration := time.Since(start)
 
 	if err != nil {
+		// NOTE: embedding_extraction_total{status="error"} is intentionally not
+		// incremented here in M1; the error status is reserved for a later milestone.
 		log.Error("PredictModelWithEmbeddings inference failed",
 			logger.String("model_id", modelID),
 			logger.Error(err),

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -410,6 +410,68 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 	return results, err
 }
 
+// PredictModelWithEmbeddings mirrors PredictModel but also returns the model's
+// embedding vector when the resolved model implements EmbeddingCapable. The
+// embedding is nil when the model cannot produce one; that is not an error.
+// It does not pre-check EmbeddingDim() (which would double-lock); capability is
+// routed once inside the instance's PredictWithEmbeddings.
+//
+// Locking sequence is identical to PredictModel: o.mu.RLock (map lookup),
+// o.inferenceMu.Lock (inference serialization), entry.mu.Lock (instance lifecycle).
+func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID string, sample [][]float32) ([]datastore.Results, []float32, error) {
+	o.mu.RLock()
+	entry, ok := o.models[modelID]
+	o.mu.RUnlock()
+
+	if !ok {
+		return nil, nil, errors.Newf("unknown model: %s", modelID).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Context("model_id", modelID).
+			Build()
+	}
+
+	o.inferenceMu.Lock()
+	defer o.inferenceMu.Unlock()
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.instance == nil {
+		return nil, nil, errors.Newf("model %s has been closed", modelID).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Context("model_id", modelID).
+			Build()
+	}
+
+	if ec, ok := entry.instance.(EmbeddingCapable); ok {
+		return ec.PredictWithEmbeddings(ctx, sample)
+	}
+	results, err := entry.instance.Predict(ctx, sample)
+	return results, nil, err
+}
+
+// ModelEmbeddingDim returns the embedding dimension for a model (0 = not
+// capable, unknown, or closed), for cheap out-of-band capability checks
+// without running inference.
+func (o *Orchestrator) ModelEmbeddingDim(modelID string) int {
+	o.mu.RLock()
+	entry, ok := o.models[modelID]
+	o.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.instance == nil {
+		return 0
+	}
+	if ec, ok := entry.instance.(EmbeddingCapable); ok {
+		return ec.EmbeddingDim()
+	}
+	return 0
+}
+
 // ResolveName walks the resolver chain and returns the first non-empty
 // common name for the given scientific name and locale.
 func (o *Orchestrator) ResolveName(scientificName, locale string) string {

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -419,11 +419,15 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 // Locking sequence is identical to PredictModel: o.mu.RLock (map lookup),
 // o.inferenceMu.Lock (inference serialization), entry.mu.Lock (instance lifecycle).
 func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID string, sample [][]float32) ([]datastore.Results, []float32, error) {
+	log := GetLogger()
+
 	o.mu.RLock()
 	entry, ok := o.models[modelID]
 	o.mu.RUnlock()
 
 	if !ok {
+		log.Error("PredictModelWithEmbeddings unknown model",
+			logger.String("model_id", modelID))
 		return nil, nil, errors.Newf("unknown model: %s", modelID).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
@@ -444,11 +448,44 @@ func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID s
 			Build()
 	}
 
-	if ec, ok := entry.instance.(EmbeddingCapable); ok {
-		return ec.PredictWithEmbeddings(ctx, sample)
+	chunkLen := 0
+	if len(sample) > 0 {
+		chunkLen = len(sample[0])
 	}
-	results, err := entry.instance.Predict(ctx, sample)
-	return results, nil, err
+	log.Debug("PredictModelWithEmbeddings dispatching",
+		logger.String("model_id", modelID),
+		logger.Int("sample_chunks", len(sample)),
+		logger.Int("chunk_len", chunkLen))
+
+	// Capture the dispatch result into locals so the same complete/error
+	// logging PredictModel emits runs before returning. The embedding is nil
+	// when the instance is not EmbeddingCapable; that is not an error.
+	var (
+		results []datastore.Results
+		emb     []float32
+		err     error
+	)
+	start := time.Now()
+	if ec, ok := entry.instance.(EmbeddingCapable); ok {
+		results, emb, err = ec.PredictWithEmbeddings(ctx, sample)
+	} else {
+		results, err = entry.instance.Predict(ctx, sample)
+	}
+	duration := time.Since(start)
+
+	if err != nil {
+		log.Error("PredictModelWithEmbeddings inference failed",
+			logger.String("model_id", modelID),
+			logger.Error(err),
+			logger.Duration("duration", duration))
+	} else {
+		log.Debug("PredictModelWithEmbeddings complete",
+			logger.String("model_id", modelID),
+			logger.Int("result_count", len(results)),
+			logger.Duration("duration", duration))
+	}
+
+	return results, emb, err
 }
 
 // ModelEmbeddingDim returns the embedding dimension for a model (0 = not

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -479,6 +479,7 @@ func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID s
 			logger.Error(err),
 			logger.Duration("duration", duration))
 	} else {
+		recordEmbeddingStatus(modelID, len(emb))
 		log.Debug("PredictModelWithEmbeddings complete",
 			logger.String("model_id", modelID),
 			logger.Int("result_count", len(results)),
@@ -486,6 +487,21 @@ func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID s
 	}
 
 	return results, emb, err
+}
+
+// recordEmbeddingStatus records the embedding extraction outcome for a window.
+// dim > 0 means an embedding was produced; dim == 0 means the active model
+// could not extract one. Safe no-op when getMetrics() returns nil (test paths).
+func recordEmbeddingStatus(modelID string, dim int) {
+	m := getMetrics()
+	if m == nil {
+		return
+	}
+	if dim > 0 {
+		m.RecordEmbeddingExtraction(modelID, "success")
+	} else {
+		m.RecordEmbeddingExtraction(modelID, "unavailable")
+	}
 }
 
 // ModelEmbeddingDim returns the embedding dimension for a model (0 = not

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -481,6 +481,7 @@ func (o *Orchestrator) PredictModelWithEmbeddings(ctx context.Context, modelID s
 			logger.Error(err),
 			logger.Duration("duration", duration))
 	} else {
+		globalInferenceCounters.RecordInvoke(modelID, duration.Microseconds())
 		recordEmbeddingStatus(modelID, len(emb))
 		log.Debug("PredictModelWithEmbeddings complete",
 			logger.String("model_id", modelID),

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -365,3 +365,13 @@ func TestOrchestrator_PredictModelWithEmbeddings_UnknownModel(t *testing.T) {
 	_, _, err := o.PredictModelWithEmbeddings(t.Context(), "nope", [][]float32{{0.1}})
 	require.Error(t, err)
 }
+
+func TestOrchestrator_PredictModelWithEmbeddings_ClosedInstance(t *testing.T) {
+	t.Parallel()
+	// A model entry whose instance was niled out by Delete/UnloadModel.
+	o := &Orchestrator{models: map[string]*modelEntry{"m1": {instance: nil}}}
+	results, emb, err := o.PredictModelWithEmbeddings(t.Context(), "m1", [][]float32{{0.1}})
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Nil(t, emb)
+}

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -312,3 +312,56 @@ func TestOrchestrator_ModelInfos_SkipsNilInstances(t *testing.T) {
 	assert.Len(t, infos, 1)
 	assert.Equal(t, "BirdNET_V2.4", infos[0].ID)
 }
+
+// embCapableMock embeds mockModelInstance and adds EmbeddingCapable.
+type embCapableMock struct {
+	*mockModelInstance
+	emb []float32
+	dim int
+}
+
+func (m *embCapableMock) PredictWithEmbeddings(ctx context.Context, samples [][]float32) ([]datastore.Results, []float32, error) {
+	r, err := m.Predict(ctx, samples)
+	return r, m.emb, err
+}
+
+func (m *embCapableMock) EmbeddingDim() int { return m.dim }
+
+func TestOrchestrator_PredictModelWithEmbeddings_Capable(t *testing.T) {
+	t.Parallel()
+	inner := &mockModelInstance{
+		id: "m1",
+		predict: func(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+			return []datastore.Results{{Species: "Parus major", Confidence: 0.9}}, nil
+		},
+	}
+	ec := &embCapableMock{mockModelInstance: inner, emb: []float32{1, 2, 3}, dim: 3}
+	o := &Orchestrator{models: map[string]*modelEntry{"m1": {instance: ec}}}
+
+	results, emb, err := o.PredictModelWithEmbeddings(t.Context(), "m1", [][]float32{{0.1}})
+	require.NoError(t, err)
+	assert.Len(t, emb, 3)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Parus major", results[0].Species)
+	assert.Equal(t, 3, o.ModelEmbeddingDim("m1"))
+}
+
+func TestOrchestrator_PredictModelWithEmbeddings_Incapable(t *testing.T) {
+	t.Parallel()
+	mock := &mockModelInstance{id: "m2"}
+	o := newTestOrchestrator(t, mock)
+
+	// Default mock returns 1 result: {Species: "Turdus merula", Confidence: 0.95}
+	results, emb, err := o.PredictModelWithEmbeddings(t.Context(), "m2", [][]float32{{0.1}})
+	require.NoError(t, err)
+	assert.Nil(t, emb)
+	assert.Len(t, results, 1)
+	assert.Equal(t, 0, o.ModelEmbeddingDim("m2"))
+}
+
+func TestOrchestrator_PredictModelWithEmbeddings_UnknownModel(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{models: map[string]*modelEntry{}}
+	_, _, err := o.PredictModelWithEmbeddings(t.Context(), "nope", [][]float32{{0.1}})
+	require.Error(t, err)
+}

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -136,8 +136,8 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 		return nil, err
 	}
 
-	// Return top 10 results
-	return getTopKResults(results, 10), nil
+	// Return top results
+	return getTopKResults(results, defaultTopKResults), nil
 }
 
 // Spec returns the audio requirements for Perch v2.

--- a/internal/classifier/queue.go
+++ b/internal/classifier/queue.go
@@ -16,6 +16,7 @@ type Results struct {
 	ClipName        string                // Name of the audio clip
 	Source          datastore.AudioSource // Audio source with ID, SafeString, and DisplayName
 	ModelID         string                // identifies which model produced these results
+	Embeddings      []float32             // primary model embedding for this window; nil when extraction disabled or unavailable
 }
 
 // Default buffer size for the results queue
@@ -54,6 +55,12 @@ func (r Results) Copy() Results { //nolint:gocritic // This is a copy function, 
 		for i, result := range r.Results {
 			newCopy.Results[i] = result.Copy()
 		}
+	}
+
+	// Deep copy Embeddings
+	if r.Embeddings != nil {
+		newCopy.Embeddings = make([]float32, len(r.Embeddings))
+		copy(newCopy.Embeddings, r.Embeddings)
 	}
 
 	return newCopy

--- a/internal/classifier/queue_test.go
+++ b/internal/classifier/queue_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestResults_CopyDeepCopiesEmbeddings(t *testing.T) {
+	t.Parallel()
 	orig := Results{Embeddings: []float32{1, 2, 3}}
 	cp := orig.Copy()
 	require.Equal(t, []float32{1, 2, 3}, cp.Embeddings)

--- a/internal/classifier/queue_test.go
+++ b/internal/classifier/queue_test.go
@@ -1,0 +1,17 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResults_CopyDeepCopiesEmbeddings(t *testing.T) {
+	orig := Results{Embeddings: []float32{1, 2, 3}}
+	cp := orig.Copy()
+	require.Equal(t, []float32{1, 2, 3}, cp.Embeddings)
+
+	cp.Embeddings[0] = 99
+	assert.InDelta(t, float32(1), orig.Embeddings[0], 0.0001, "Copy must deep-copy Embeddings")
+}

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -149,6 +149,8 @@ func (s *TracingSpan) Finish() {
 			switch s.operation {
 			case "birdnet.predict":
 				m.RecordPrediction(model, durationSeconds, nil)
+			case "birdnet.predict_embeddings":
+				m.RecordPrediction(model, durationSeconds, nil)
 			case "birdnet.process_chunk":
 				m.RecordChunkProcess(model, durationSeconds)
 			case "birdnet.model_invoke":

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1276,6 +1276,13 @@ type ModelsConfig struct {
 	Installed []string `yaml:"installed,omitempty" json:"installed,omitempty"` // list of installed model IDs managed by the model gallery
 }
 
+// EmbeddingsConfig gates generic embedding extraction.
+// Capability-gated: extraction only happens when the active model is an ONNX
+// model that exposes embeddings (issue #948).
+type EmbeddingsConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"` // extract embeddings on the live path (hot-reloadable)
+}
+
 // BasicAuth holds settings for the password authentication
 type BasicAuth struct {
 	Enabled        bool          `yaml:"enabled" json:"enabled"`               // true to enable password authentication
@@ -1615,11 +1622,12 @@ type Settings struct {
 		TimeAs24h bool   `yaml:"timeas24h" json:"timeAs24h"` // true 24-hour time format, false 12-hour time format
 	} `yaml:"main" json:"main"`
 
-	BirdNET BirdNETConfig `yaml:"birdnet" json:"birdnet"` // BirdNET configuration
-	Perch   PerchConfig   `yaml:"perch" json:"perch"`     // Perch v2 model configuration
-	Bat     BatConfig     `yaml:"bat" json:"bat"`         // Bat detection configuration
-	BSG     BSGConfig     `yaml:"bsg" json:"bsg"`         // BSG regional bird model configuration
-	Models  ModelsConfig  `yaml:"models" json:"models"`   // Global model enablement and management
+	BirdNET    BirdNETConfig    `yaml:"birdnet" json:"birdnet"`       // BirdNET configuration
+	Perch      PerchConfig      `yaml:"perch" json:"perch"`           // Perch v2 model configuration
+	Bat        BatConfig        `yaml:"bat" json:"bat"`               // Bat detection configuration
+	BSG        BSGConfig        `yaml:"bsg" json:"bsg"`               // BSG regional bird model configuration
+	Models     ModelsConfig     `yaml:"models" json:"models"`         // Global model enablement and management
+	Embeddings EmbeddingsConfig `yaml:"embeddings" json:"embeddings"` // Embedding extraction configuration
 
 	TaxonomySynonyms map[string]string `yaml:"taxonomySynonyms" json:"taxonomySynonyms" mapstructure:"taxonomySynonyms"` // Optional scientific-name synonym overrides merged with built-ins
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1278,7 +1278,7 @@ type ModelsConfig struct {
 
 // EmbeddingsConfig gates generic embedding extraction.
 // Capability-gated: extraction only happens when the active model is an ONNX
-// model that exposes embeddings (issue #948).
+// model that exposes embeddings.
 type EmbeddingsConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"` // extract embeddings on the live path (hot-reloadable)
 }

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -96,6 +96,9 @@ func setDefaultConfig() {
 	// Global model enablement (BirdNET only by default)
 	viper.SetDefault("models.enabled", []string{"birdnet"})
 
+	// Embedding extraction (default off, hot-reloadable)
+	viper.SetDefault("embeddings.enabled", false)
+
 	// Realtime configuration
 	viper.SetDefault("realtime.interval", 15)
 	viper.SetDefault("realtime.processingtime", false)

--- a/internal/conf/embeddings_config_test.go
+++ b/internal/conf/embeddings_config_test.go
@@ -3,14 +3,40 @@ package conf
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
-func TestEmbeddingsConfig_DefaultDisabled(t *testing.T) {
+// TestEmbeddingsConfig_ZeroValueDisabled verifies that the Go zero value of
+// Settings has Embeddings.Enabled == false. This tests the struct default,
+// not the viper default.
+func TestEmbeddingsConfig_ZeroValueDisabled(t *testing.T) {
 	t.Parallel()
 	var s Settings
+	assert.False(t, s.Embeddings.Enabled)
+}
+
+// TestEmbeddingsConfig_ViperDefaultDisabled verifies that the configured viper
+// default for "embeddings.enabled" is false. This exercises the actual default
+// set by setDefaultConfig(), not just the Go zero value.
+// Not parallel: reads/writes global viper defaults set by setDefaultConfig.
+func TestEmbeddingsConfig_ViperDefaultDisabled(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	setDefaultConfig()
+	assert.False(t, viper.GetBool("embeddings.enabled"),
+		"embeddings.enabled viper default must be false")
+}
+
+// TestEmbeddingsConfig_YAMLExplicitFalseRoundTrip verifies that an explicit
+// false in YAML unmarshals correctly, covering the case where a config file
+// explicitly sets the feature off.
+func TestEmbeddingsConfig_YAMLExplicitFalseRoundTrip(t *testing.T) {
+	t.Parallel()
+	var s Settings
+	require.NoError(t, yaml.Unmarshal([]byte("embeddings:\n  enabled: false\n"), &s))
 	assert.False(t, s.Embeddings.Enabled)
 }
 

--- a/internal/conf/embeddings_config_test.go
+++ b/internal/conf/embeddings_config_test.go
@@ -1,0 +1,22 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestEmbeddingsConfig_DefaultDisabled(t *testing.T) {
+	t.Parallel()
+	var s Settings
+	assert.False(t, s.Embeddings.Enabled)
+}
+
+func TestEmbeddingsConfig_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	var s Settings
+	require.NoError(t, yaml.Unmarshal([]byte("embeddings:\n  enabled: true\n"), &s))
+	assert.True(t, s.Embeddings.Enabled)
+}

--- a/internal/inference/backend.go
+++ b/internal/inference/backend.go
@@ -26,6 +26,10 @@ type EmbeddingExtractor interface {
 	// and the embedding vector. Returns nil embeddings if the model does not
 	// produce embeddings.
 	PredictWithEmbeddings(samples []float32) (logits []float32, embeddings []float32, err error)
+
+	// EmbeddingDim returns the embedding vector length, or 0 if the model does
+	// not produce embeddings (capability gate).
+	EmbeddingDim() int
 }
 
 // CustomClassifier runs secondary classification on embedding vectors.

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -41,6 +41,9 @@ type onnxClassifier struct {
 	numSpecies int
 }
 
+// onnxClassifier must satisfy EmbeddingExtractor.
+var _ EmbeddingExtractor = (*onnxClassifier)(nil)
+
 // NewONNXClassifier creates a Classifier backed by an ONNX Runtime model.
 // The ONNX Runtime must be initialized via InitONNXRuntime before calling this.
 func NewONNXClassifier(modelPath string, opts ONNXClassifierOptions) (Classifier, error) {
@@ -98,6 +101,15 @@ func (c *onnxClassifier) PredictWithEmbeddings(samples []float32) (logits, embed
 		return nil, nil, ort.ErrSessionClosed
 	}
 	return c.classifier.PredictRawWithEmbeddings(samples)
+}
+
+// EmbeddingDim returns the embedding dimension of the underlying ONNX model,
+// or 0 if the model does not expose embeddings.
+func (c *onnxClassifier) EmbeddingDim() int {
+	if c.classifier == nil {
+		return 0
+	}
+	return c.classifier.EmbeddingDim()
 }
 
 // NumSpecies returns the number of species in the model output.

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -310,7 +310,10 @@ func (c *Classifier) predict(audio []float32, extractEmbeddings bool) (logits, e
 	logits = make([]float32, logitsSize)
 	copy(logits, allLogits[:logitsSize])
 
-	if extractEmbeddings && c.config.EmbeddingIndex >= 0 {
+	// Gate on both signals: EmbeddingSize>0 matches the EmbeddingDim() capability
+	// signal used downstream, while EmbeddingIndex>=0 guards the tensor index access
+	// below so outputs[EmbeddingIndex] can never index with a negative value.
+	if extractEmbeddings && c.config.EmbeddingSize > 0 && c.config.EmbeddingIndex >= 0 {
 		embTensor, ok := outputs[c.config.EmbeddingIndex].(*ort.Tensor[float32])
 		if !ok {
 			return nil, nil, fmt.Errorf("birdnet: embedding tensor has unexpected type")

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -248,16 +248,31 @@ func (c *Classifier) Labels() []string {
 	return cp
 }
 
+// EmbeddingDim returns the model's embedding vector length, or 0 if the model
+// does not produce embeddings.
+func (c *Classifier) EmbeddingDim() int {
+	return c.config.EmbeddingSize
+}
+
 // PredictRaw runs inference and returns raw logits (pre-activation) for a single segment.
 // This is used by adapters that handle their own post-processing (e.g., sensitivity-adjusted sigmoid).
+// PredictRaw runs inference and returns raw logits (pre-activation) for a single segment.
 func (c *Classifier) PredictRaw(audio []float32) ([]float32, error) {
-	logits, _, err := c.PredictRawWithEmbeddings(audio)
+	logits, _, err := c.predict(audio, false)
 	return logits, err
 }
 
 // PredictRawWithEmbeddings runs inference and returns both raw logits and embedding vector.
 // Returns nil embeddings if the model does not produce embeddings.
+// PredictRawWithEmbeddings runs inference and returns both raw logits and the
+// embedding vector. Returns nil embeddings if the model does not produce embeddings.
 func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddings []float32, err error) {
+	return c.predict(audio, true)
+}
+
+// predict runs inference. When extractEmbeddings is false the embedding tensor
+// is not materialized, avoiding a per-window allocation for capable models.
+func (c *Classifier) predict(audio []float32, extractEmbeddings bool) (logits, embeddings []float32, err error) {
 	if c.session == nil {
 		return nil, nil, ErrSessionClosed
 	}
@@ -298,7 +313,7 @@ func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddin
 	logits = make([]float32, logitsSize)
 	copy(logits, allLogits[:logitsSize])
 
-	if c.config.EmbeddingIndex >= 0 {
+	if extractEmbeddings && c.config.EmbeddingIndex >= 0 {
 		embTensor, ok := outputs[c.config.EmbeddingIndex].(*ort.Tensor[float32])
 		if !ok {
 			return nil, nil, fmt.Errorf("birdnet: embedding tensor has unexpected type")

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -256,14 +256,11 @@ func (c *Classifier) EmbeddingDim() int {
 
 // PredictRaw runs inference and returns raw logits (pre-activation) for a single segment.
 // This is used by adapters that handle their own post-processing (e.g., sensitivity-adjusted sigmoid).
-// PredictRaw runs inference and returns raw logits (pre-activation) for a single segment.
 func (c *Classifier) PredictRaw(audio []float32) ([]float32, error) {
 	logits, _, err := c.predict(audio, false)
 	return logits, err
 }
 
-// PredictRawWithEmbeddings runs inference and returns both raw logits and embedding vector.
-// Returns nil embeddings if the model does not produce embeddings.
 // PredictRawWithEmbeddings runs inference and returns both raw logits and the
 // embedding vector. Returns nil embeddings if the model does not produce embeddings.
 func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddings []float32, err error) {

--- a/internal/inference/onnx/classifier_test.go
+++ b/internal/inference/onnx/classifier_test.go
@@ -7,18 +7,21 @@ import (
 )
 
 func TestBuildModelConfig_V24WithEmbeddings(t *testing.T) {
+	t.Parallel()
 	cfg := buildModelConfig(BirdNETv24, []int64{1, 144000}, [][]int64{{1, 6522}, {1, 1024}})
 	assert.Equal(t, 1, cfg.EmbeddingIndex)
 	assert.Equal(t, 1024, cfg.EmbeddingSize)
 }
 
 func TestBuildModelConfig_V24NoEmbeddings(t *testing.T) {
+	t.Parallel()
 	cfg := buildModelConfig(BirdNETv24, []int64{1, 144000}, [][]int64{{1, 6522}})
 	assert.Equal(t, -1, cfg.EmbeddingIndex)
 	assert.Equal(t, 0, cfg.EmbeddingSize)
 }
 
 func TestClassifier_EmbeddingDim(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, 1024, (&Classifier{config: ModelConfig{EmbeddingSize: 1024}}).EmbeddingDim())
 	assert.Equal(t, 0, (&Classifier{config: ModelConfig{EmbeddingSize: 0}}).EmbeddingDim())
 }

--- a/internal/inference/onnx/classifier_test.go
+++ b/internal/inference/onnx/classifier_test.go
@@ -1,0 +1,24 @@
+package onnx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildModelConfig_V24WithEmbeddings(t *testing.T) {
+	cfg := buildModelConfig(BirdNETv24, []int64{1, 144000}, [][]int64{{1, 6522}, {1, 1024}})
+	assert.Equal(t, 1, cfg.EmbeddingIndex)
+	assert.Equal(t, 1024, cfg.EmbeddingSize)
+}
+
+func TestBuildModelConfig_V24NoEmbeddings(t *testing.T) {
+	cfg := buildModelConfig(BirdNETv24, []int64{1, 144000}, [][]int64{{1, 6522}})
+	assert.Equal(t, -1, cfg.EmbeddingIndex)
+	assert.Equal(t, 0, cfg.EmbeddingSize)
+}
+
+func TestClassifier_EmbeddingDim(t *testing.T) {
+	assert.Equal(t, 1024, (&Classifier{config: ModelConfig{EmbeddingSize: 1024}}).EmbeddingDim())
+	assert.Equal(t, 0, (&Classifier{config: ModelConfig{EmbeddingSize: 0}}).EmbeddingDim())
+}

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -30,6 +30,10 @@ type BirdNETMetrics struct {
 	ActiveProcessingGauge prometheus.Gauge
 	ModelLoadedGauge      prometheus.Gauge
 
+	// Embedding extraction (substrate M1)
+	EmbeddingExtractionTotal *prometheus.CounterVec
+	EmbeddingDimGauge        *prometheus.GaugeVec
+
 	registry *prometheus.Registry
 }
 
@@ -149,6 +153,22 @@ func (m *BirdNETMetrics) initMetrics() error {
 		},
 	)
 
+	// Embedding extraction metrics (substrate M1)
+	m.EmbeddingExtractionTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "birdnet_embedding_extraction_total",
+			Help: "Total embedding extraction attempts partitioned by model and status (success, unavailable, error).",
+		},
+		[]string{"model", "status"},
+	)
+	m.EmbeddingDimGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "birdnet_embedding_dim",
+			Help: "Embedding vector length for the active model (0 when the model cannot produce embeddings).",
+		},
+		[]string{"model"},
+	)
+
 	return nil
 }
 
@@ -172,6 +192,17 @@ func (m *BirdNETMetrics) RecordPrediction(model string, durationSeconds float64,
 		m.PredictionTotal.WithLabelValues(model, "success").Inc()
 		m.PredictionDuration.WithLabelValues(model).Observe(durationSeconds)
 	}
+}
+
+// RecordEmbeddingExtraction records an embedding extraction attempt by status
+// (success, unavailable, error).
+func (m *BirdNETMetrics) RecordEmbeddingExtraction(model, status string) {
+	m.EmbeddingExtractionTotal.WithLabelValues(model, status).Inc()
+}
+
+// SetEmbeddingDim records the embedding dimension exposed by a model.
+func (m *BirdNETMetrics) SetEmbeddingDim(model string, dim int) {
+	m.EmbeddingDimGauge.WithLabelValues(model).Set(float64(dim))
 }
 
 // RecordChunkProcess records metrics for chunk processing
@@ -267,6 +298,10 @@ func (m *BirdNETMetrics) Describe(ch chan<- *prometheus.Desc) {
 	// State gauges
 	m.ActiveProcessingGauge.Describe(ch)
 	m.ModelLoadedGauge.Describe(ch)
+
+	// Embedding extraction
+	m.EmbeddingExtractionTotal.Describe(ch)
+	m.EmbeddingDimGauge.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -289,6 +324,10 @@ func (m *BirdNETMetrics) Collect(ch chan<- prometheus.Metric) {
 	// State gauges
 	m.ActiveProcessingGauge.Collect(ch)
 	m.ModelLoadedGauge.Collect(ch)
+
+	// Embedding extraction
+	m.EmbeddingExtractionTotal.Collect(ch)
+	m.EmbeddingDimGauge.Collect(ch)
 }
 
 // RecordOperation implements the Recorder interface.

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -157,14 +157,14 @@ func (m *BirdNETMetrics) initMetrics() error {
 	m.EmbeddingExtractionTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "birdnet_embedding_extraction_total",
-			Help: "Total embedding extraction attempts partitioned by model and status (success, unavailable, error).",
+			Help: "Total embedding extraction attempts partitioned by model and status (success, unavailable, error)",
 		},
 		[]string{"model", "status"},
 	)
 	m.EmbeddingDimGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "birdnet_embedding_dim",
-			Help: "Embedding vector length for the active model (0 when the model cannot produce embeddings).",
+			Help: "Embedding vector length for the active model (0 when the model cannot produce embeddings)",
 		},
 		[]string{"model"},
 	)
@@ -201,6 +201,8 @@ func (m *BirdNETMetrics) RecordEmbeddingExtraction(model, status string) {
 }
 
 // SetEmbeddingDim records the embedding dimension exposed by a model.
+// Wired from the analysis path in a later task; defined here so the gauge is
+// registered now.
 func (m *BirdNETMetrics) SetEmbeddingDim(model string, dim int) {
 	m.EmbeddingDimGauge.WithLabelValues(model).Set(float64(dim))
 }

--- a/internal/observability/metrics/birdnet_test.go
+++ b/internal/observability/metrics/birdnet_test.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBirdNETMetrics_RecordEmbeddingExtraction(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	m, err := NewBirdNETMetrics(reg)
+	require.NoError(t, err)
+
+	m.RecordEmbeddingExtraction("test-model", "success")
+	m.RecordEmbeddingExtraction("test-model", "success")
+	m.RecordEmbeddingExtraction("test-model", "unavailable")
+
+	assert.InDelta(t, float64(2), testutil.ToFloat64(m.EmbeddingExtractionTotal.WithLabelValues("test-model", "success")), 0.0001)
+	assert.InDelta(t, float64(1), testutil.ToFloat64(m.EmbeddingExtractionTotal.WithLabelValues("test-model", "unavailable")), 0.0001)
+
+	m.SetEmbeddingDim("test-model", 1024)
+	assert.InDelta(t, float64(1024), testutil.ToFloat64(m.EmbeddingDimGauge.WithLabelValues("test-model")), 0.0001)
+}


### PR DESCRIPTION
## Summary

Milestone 1 of the generic embedding-extraction substrate. It makes the live analysis path extract the primary ONNX model's embedding vector for every detection window, carry it on the result that flows to the processor, and make it observable, all behind a default-off, hot-reloadable `embeddings.enabled` flag with provably zero embedding cost when disabled. M1 stores nothing (persistence is a later milestone) and adds no consumers yet: it produces, carries, and exposes the embedding, nothing more.

It also fixes a pre-existing data race in the prediction result path (the top-K slice aliased the reused results buffer across the queue boundary).

> This PR intentionally targets the `feat/embeddings` integration branch, not `main`. M2 (persistence) and downstream consumers will stack on the same integration branch; the substrate merges to `main` once the whole thing is coherent. This keeps `main` clean and avoids stale-base churn between dependent milestones.

## Architecture

A capability is threaded through the existing layers without changing any hot-path signature:

1. **Inference (`internal/inference/onnx`)**: `Classifier.EmbeddingDim()` exposes the model's embedding length (0 when the model has none) as a cheap load-time accessor. `PredictRaw` / `PredictRawWithEmbeddings` are now thin wrappers over a private `predict(audio, extractEmbeddings bool)`, so the embedding tensor is materialized only when requested.
2. **Inference interface (`backend.go` / `onnx.go`)**: `EmbeddingExtractor` gains `EmbeddingDim() int`; `onnxClassifier` implements it by delegation.
3. **Classifier (`embeddings.go`, new)**: a new `EmbeddingCapable` interface; `BirdNET.PredictWithEmbeddings` runs the combined forward pass under `bn.mu` (the same lock contract as `Predict`) and routes by capability, returning a nil embedding when the active model cannot produce one (not an error).
4. **Orchestrator**: `PredictModelWithEmbeddings` mirrors `PredictModel`'s locking and structured logging and dispatches via the `EmbeddingCapable` capability; `ModelEmbeddingDim` is a cheap out-of-band capability check.
5. **Carrier (`queue.go`)**: `Results.Embeddings []float32`, deep-copied in `Copy()` (same ownership contract as `PCMdata`). `len()` carries both presence and dimension, so there is no redundant dim field.
6. **Call site (`process.go`)**: reads `conf.Setting().Embeddings.Enabled` live per window; enabled routes to `PredictModelWithEmbeddings`, disabled keeps the existing `PredictModel` path; the embedding is attached to the queued result; an unavailable warning is throttled to once per enable-session via a resettable atomic guard.
7. **Config (`internal/conf`)**: a top-level `embeddings.enabled` node, default false, hot-reloadable. Existing configs parse byte-identically.
8. **Observability (`internal/observability/metrics`)**: a `birdnet_embedding_extraction_total{model,status}` counter recorded at the single orchestrator chokepoint, plus a `birdnet_embedding_dim{model}` gauge.

## Key design points

- **Zero cost when disabled**: the off path runs the exact `PredictModel` flow current users run. The `extractEmbeddings=false` gate means even an embedding-capable model (v3.0 / Perch) allocates no embedding per window. Previously such models materialized and discarded an embedding on every window.
- **Lock and ownership**: `PredictWithEmbeddings` holds `bn.mu` across the full native call (the model-reload use-after-free contract), the capability check inside the lock uses the inference-layer accessor (no self-deadlock), and the shared post-processing returns a caller-owned copy so nothing aliases reused buffers across the queue boundary. The embedding slice is a fresh allocation from the backend, deep-copied again in `Results.Copy()`.
- **Pre-existing race fix**: a new `finalizeResults` helper deep-copies the top-K, fixing a latent data race where `Predict` returned a slice aliasing `bn.resultsBuffer` that the next inference window overwrote while the queue consumer still read it. The fix covers both `Predict` and the new embedding path, and is covered by a regression test that mutates the shared buffer and asserts the returned slice is unchanged.
- **Telemetry parity**: the embedding path records the same inference metrics as the normal path (the per-model invoke counter, model-invoke duration, and prediction metrics), so enabling embeddings does not blind existing dashboards or the diagnostics endpoint.

## Testing and verification

- TDD throughout: capability routing (capable / incapable / extractor-error / unknown / closed), deep-copy ownership, the aliasing-race regression, the allocation-gate config, the config default and YAML round-trip, the metrics counter and gauge, and the unavailable-log throttle/reset.
- `go test -race` green across `internal/classifier/...`, `internal/inference/...`, `internal/conf/...`, `internal/observability/metrics/...`, `internal/analysis/...`.
- `golangci-lint` clean on all touched packages.
- Each task went through a two-stage review (spec compliance, then code quality), then a whole-branch review, then a multi-agent quality gate. The gate caught and fixed an inference-telemetry parity gap (the embedding path had been dropping the pre-existing inference metrics).

## Out of scope (later milestones)

- Persistence / vector store / SQLite (M2).
- Capture policy (all vs confidence vs species vs sampled) and model+version partitioning (M2).
- Consumers: kNN review, retraining, similar-clips, novelty, retention (separate issues, depend on M1 + M2).
- The `birdnet_embedding_dim` gauge has no setter yet (pre-staged for a UI/health consumer); the embedding `status=error` counter value is reserved for a later milestone.

## Test plan

- [ ] CI green on the branch.
- [ ] `embeddings.enabled=false` (default): detection behavior byte-identical, no extra hot-path allocation, existing YAML parses unchanged.
- [ ] `embeddings.enabled=true` + embedding-capable ONNX model: `Results.Embeddings` populated with the model's dimension; `birdnet_embedding_extraction_total{status="success"}` increments; existing inference metrics still recorded.
- [ ] `embeddings.enabled=true` + non-embedding model (TFLite or 1-output ONNX): nil embedding, `status="unavailable"`, one warning, detection unaffected.
- [ ] Toggling `embeddings.enabled` at runtime takes effect on the next analysis window with no restart.

## Stats

20 commits, 23 files, +920/-35. No new dependencies. No schema or API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio predictions can now extract embedding vectors when enabled in configuration
  * Embedding dimensions are automatically detected based on the active model

* **Configuration**
  * New `embeddings.enabled` setting (disabled by default)
  * Configure via YAML/JSON under `embeddings.enabled`

* **Improvements**
  * Enhanced prediction logging and metrics for embedding operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->