### PR TITLE
fix(classifier): harden orchestrator concurrency and batch-size validation

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1466,6 +1466,9 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 		Name:         bn.ModelInfo.Name,
 		TotalSpecies: len(bn.Settings.BirdNET.Labels),
 	}
+	// Snapshot modelsDir under bn.mu; the auto-select check below runs after the
+	// unlock and would otherwise race a concurrent SetModelsDir write.
+	modelsDir := bn.modelsDir
 
 	mrf, isMapped := bn.rangeFilter.(*mappedRangeFilter)
 	if isMapped {
@@ -1486,8 +1489,8 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 	// No geomodel active: leave WithRangeData and WithoutRangeData at zero.
 	bn.mu.Unlock()
 
-	if rf.Model == "v3" && bn.modelsDir != "" {
-		sharedDir := filepath.Join(bn.modelsDir, "shared")
+	if rf.Model == "v3" && modelsDir != "" {
+		sharedDir := filepath.Join(modelsDir, "shared")
 		expectedONNX := filepath.Join(sharedDir, conf.GeomodelONNXLocalName)
 		expectedLabels := filepath.Join(sharedDir, conf.GeomodelLabelsLocalName)
 		autoSelected = rf.ModelPath == expectedONNX && rf.LabelsPath == expectedLabels
@@ -1513,6 +1516,12 @@ func (bn *BirdNET) rangeFilterRuntimeState() (active, fellBack bool) {
 // Called by the Orchestrator after creation so auto-selection can
 // resolve geomodel paths from the installed models directory.
 func (bn *BirdNET) SetModelsDir(dir string) {
+	// Guard the write under bn.mu: bn.modelsDir is read under bn.mu by
+	// initializeMetaModel (via NewBirdNET / ReloadRangeFilter / reloadModelInternal)
+	// and snapshotted under bn.mu by PrimaryRangeFilterCoverage. No caller of this
+	// method holds bn.mu, so locking here cannot self-deadlock.
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
 	bn.modelsDir = dir
 }
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -30,6 +30,13 @@ type modelEntry struct {
 	mu       sync.Mutex // per-model lock; prevents inference on one model from blocking another
 }
 
+// entryRef pairs a registry ID with its model entry for the snapshot-then-iterate
+// pattern used when walking o.models outside the o.mu critical section.
+type entryRef struct {
+	id    string
+	entry *modelEntry
+}
+
 // Orchestrator manages classifier model instances and provides the primary
 // inference API. It replaces direct *BirdNET usage at all call sites.
 // Supports multiple models with per-model locking and name resolution.
@@ -156,9 +163,19 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 // geomodel auto-selection, and registers the taxonomy resolver if
 // taxonomy.csv is available on disk.
 func (o *Orchestrator) SetModelsDir(dir string) {
+	// Guard the o.modelsDir write and the o.primary read under o.mu: o.modelsDir
+	// is read by resolveInstalledPaths (always under o.mu via the model loaders),
+	// and o.primary is cleared by Delete() under o.mu.Lock(). Release before the
+	// downstream calls, which take their own locks. registerTaxonomyResolver in
+	// particular acquires o.mu.RLock() internally, so holding o.mu here would
+	// self-deadlock (the RWMutex is not reentrant).
+	o.mu.Lock()
 	o.modelsDir = dir
-	if o.primary != nil {
-		o.primary.SetModelsDir(dir)
+	primary := o.primary
+	o.mu.Unlock()
+
+	if primary != nil {
+		primary.SetModelsDir(dir)
 	}
 	o.registerTaxonomyResolver(dir)
 }
@@ -476,14 +493,26 @@ func scientificNamesFromLabels(labels []string) []string {
 
 // GetProbableSpecies returns species scores from the range filter.
 func (o *Orchestrator) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
-	return o.primary.GetProbableSpecies(date, week)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil, nil
+	}
+	return primary.GetProbableSpecies(date, week)
 }
 
 // GetProbableSpeciesWithSettings filters species using the supplied settings
 // snapshot, allowing callers to test arbitrary coordinates and thresholds
 // without modifying global state.
 func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
-	return o.primary.GetProbableSpeciesWithSettings(date, week, settings)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil, nil
+	}
+	return primary.GetProbableSpeciesWithSettings(date, week, settings)
 }
 
 // GetAllProbableSpeciesWithSettings returns species from all active classifiers.
@@ -542,11 +571,6 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	geoCovered := make(map[string]bool, len(geoLabels))
 	for _, label := range geoLabels {
 		geoCovered[strings.ToLower(detection.ExtractScientificName(label))] = true
-	}
-
-	type entryRef struct {
-		id    string
-		entry *modelEntry
 	}
 
 	o.mu.RLock()
@@ -622,27 +646,57 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 
 // GetSpeciesOccurrence returns the occurrence probability for a species at the current time.
 func (o *Orchestrator) GetSpeciesOccurrence(species string) float64 {
-	return o.primary.GetSpeciesOccurrence(species)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return 0
+	}
+	return primary.GetSpeciesOccurrence(species)
 }
 
 // GetSpeciesOccurrenceAtTime returns the occurrence probability for a species at a specific time.
 func (o *Orchestrator) GetSpeciesOccurrenceAtTime(species string, detectionTime time.Time) float64 {
-	return o.primary.GetSpeciesOccurrenceAtTime(species, detectionTime)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return 0
+	}
+	return primary.GetSpeciesOccurrenceAtTime(species, detectionTime)
 }
 
 // NumSpecies returns the number of species labels of the primary model.
 func (o *Orchestrator) NumSpecies() int {
-	return o.primary.NumSpecies()
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return 0
+	}
+	return primary.NumSpecies()
 }
 
 // Labels returns a copy of the species labels of the primary model.
 func (o *Orchestrator) Labels() []string {
-	return o.primary.Labels()
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil
+	}
+	return primary.Labels()
 }
 
 // GetSpeciesCode returns the eBird species code for a given label.
 func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
-	return o.primary.GetSpeciesCode(label)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return "", false
+	}
+	return primary.GetSpeciesCode(label)
 }
 
 // GetSpeciesNameFromCode returns the species name for a given eBird species code.
@@ -735,11 +789,6 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 		id     string
 		name   string
 		labels []string
-	}
-
-	type entryRef struct {
-		id    string
-		entry *modelEntry
 	}
 
 	var refs []entryRef
@@ -843,7 +892,13 @@ func (o *Orchestrator) notifyRangeFilterReload() {
 
 // RunFilterProcess executes the filter process on demand and prints results.
 func (o *Orchestrator) RunFilterProcess(dateStr string, week float32) {
-	o.primary.RunFilterProcess(dateStr, week)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return
+	}
+	primary.RunFilterProcess(dateStr, week)
 }
 
 // ReloadModel reloads the primary model and re-syncs shared state.
@@ -921,10 +976,22 @@ func (o *Orchestrator) ReloadModel() error {
 // Delete releases all resources held by the Orchestrator and its models.
 // After calling Delete, the Orchestrator must not be used.
 func (o *Orchestrator) Delete() {
+	// Snapshot the models, stop the scheduler, and clear o.primary/o.models under
+	// o.mu so the accessors (which snapshot o.primary under o.mu) observe the
+	// deleted state immediately and fail fast. Then release o.mu before the
+	// per-model Close() calls: Close does native teardown that can be slow, and
+	// holding o.mu across it would block every accessor for the duration of
+	// teardown. UnloadModel uses the same drop-lock-before-close shape.
 	o.mu.Lock()
-	defer o.mu.Unlock()
+	models := o.models
+	if s := o.scheduler.Load(); s != nil {
+		s.stop()
+	}
+	o.primary = nil
+	o.models = nil
+	o.mu.Unlock()
 
-	for _, entry := range o.models {
+	for id, entry := range models {
 		entry.mu.Lock()
 		if entry.instance != nil {
 			if err := entry.instance.Close(); err != nil {
@@ -934,17 +1001,15 @@ func (o *Orchestrator) Delete() {
 			}
 			entry.instance = nil // nil out to signal closed state to PredictModel
 		}
+		// Drop the model's global inference counters while still holding entry.mu,
+		// mirroring UnloadModel: this prevents an in-flight RecordInvoke from
+		// re-creating the entry after deletion, and stops a teardown-then-recreate
+		// cycle from leaking counter entries.
+		globalInferenceCounters.Delete(id)
 		entry.mu.Unlock()
-	}
-	if s := o.scheduler.Load(); s != nil {
-		s.stop()
 	}
 
 	CloseHeatmapService()
-
-	// Nil out references to fail fast on use-after-delete.
-	o.primary = nil
-	o.models = nil
 }
 
 // IsModelLoaded returns true if a model with the given registry ID is
@@ -1178,7 +1243,14 @@ func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int
 			Category(errors.CategoryValidation).
 			Build()
 	}
-	if len(inputs) != batchSize*inputWidth {
+	// Check batchSize against len(inputs)/inputWidth before computing
+	// batchSize*inputWidth: a near-math.MaxInt batchSize would otherwise overflow
+	// the multiplication to a small positive value that could spuriously equal
+	// len(inputs), bypass validation, and push an oversized batch into the ONNX
+	// backend (out-of-bounds read). inputWidth is a positive constant, so the
+	// division is safe; batchSize > 0 is guaranteed above, so len(inputs)==0 is
+	// rejected cleanly.
+	if batchSize > len(inputs)/inputWidth || len(inputs) != batchSize*inputWidth {
 		return nil, errors.Newf("inputs length %d does not match batchSize %d * %d", len(inputs), batchSize, inputWidth).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
@@ -1223,17 +1295,18 @@ func (o *Orchestrator) GeomodelSpeciesInfo(label string) (speciesIdx, numGeoSpec
 
 // Debug prints debug messages if debug mode is enabled.
 func (o *Orchestrator) Debug(format string, v ...any) {
-	o.primary.Debug(format, v...)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return
+	}
+	primary.Debug(format, v...)
 }
 
 // ModelInfos returns ModelInfo for all registered models. Thread-safe.
 // Used by the pipeline to build ModelTarget lists for buffer fan-out.
 func (o *Orchestrator) ModelInfos() []ModelInfo {
-	type entryRef struct {
-		id    string
-		entry *modelEntry
-	}
-
 	o.mu.RLock()
 	if o.models == nil {
 		o.mu.RUnlock()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -984,7 +984,10 @@ func (o *Orchestrator) Delete() {
 	// teardown. UnloadModel uses the same drop-lock-before-close shape.
 	o.mu.Lock()
 	models := o.models
-	if s := o.scheduler.Load(); s != nil {
+	// Swap(nil) both retrieves the scheduler to stop and clears the pointer, so a
+	// re-used orchestrator does not see a stale stopped scheduler (SetSunCalc skips
+	// creating a new one when o.scheduler is already non-nil).
+	if s := o.scheduler.Swap(nil); s != nil {
 		s.stop()
 	}
 	o.primary = nil

--- a/internal/classifier/orchestrator_concurrency_test.go
+++ b/internal/classifier/orchestrator_concurrency_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"fmt"
 	"math"
 	"runtime"
 	"sync"
@@ -123,6 +124,47 @@ func TestOrchestrator_AccessorsConcurrentWithPrimaryClear_NoRace(t *testing.T) {
 	readerWg.Wait()
 	readersDone.Store(true)
 	<-writerDone
+}
+
+// TestBirdNET_SetModelsDirConcurrentWithCoverage_NoRace is the regression guard
+// for the bn.modelsDir data race: SetModelsDir wrote bn.modelsDir with no lock
+// while PrimaryRangeFilterCoverage read it after releasing bn.mu. The write is
+// now guarded and the read is snapshotted under bn.mu. Must be run with -race.
+//
+// Not parallel: PrimaryRangeFilterCoverage resolves its settings through
+// conf.CurrentOrFallback, which prefers the global settings instance, so the
+// test sets a global v3 range-filter config (the branch that reads modelsDir)
+// and restores a clean default on cleanup.
+func TestBirdNET_SetModelsDirConcurrentWithCoverage_NoRace(t *testing.T) {
+	v3 := conftest.GetTestSettings()
+	v3.BirdNET.RangeFilter.Model = "v3"
+	v3.BirdNET.Labels = []string{"Turdus merula_Common Blackbird"}
+	conftest.SetTestSettings(v3)
+	t.Cleanup(func() { conftest.SetTestSettings(conftest.GetTestSettings()) })
+
+	bn := &BirdNET{
+		Settings:     v3,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
+
+	const iterations = 300
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		<-start
+		for i := range iterations {
+			bn.SetModelsDir(fmt.Sprintf("/models/%d", i))
+		}
+	})
+	wg.Go(func() {
+		<-start
+		for range iterations {
+			_, _, _, _ = bn.PrimaryRangeFilterCoverage()
+		}
+	})
+	close(start)
+	wg.Wait()
 }
 
 // TestBatchRangeFilterInference_SizeValidation covers the input-size guards,

--- a/internal/classifier/orchestrator_concurrency_test.go
+++ b/internal/classifier/orchestrator_concurrency_test.go
@@ -1,0 +1,195 @@
+package classifier
+
+import (
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestOrchestrator_AccessorsNilPrimary_NoPanic verifies the teardown contract:
+// after Delete() clears o.primary, every primary-delegating accessor must return
+// its zero value instead of dereferencing a nil o.primary and panicking. A
+// minimal Orchestrator with no primary reproduces the post-Delete state exactly.
+func TestOrchestrator_AccessorsNilPrimary_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	settings := conftest.GetTestSettings()
+	o := &Orchestrator{Settings: settings}
+
+	assert.Equal(t, 0, o.NumSpecies())
+	assert.Nil(t, o.Labels())
+
+	code, ok := o.GetSpeciesCode("Turdus merula_Common Blackbird")
+	assert.Empty(t, code)
+	assert.False(t, ok)
+
+	scores, err := o.GetProbableSpecies(time.Now(), 0)
+	require.NoError(t, err)
+	assert.Nil(t, scores)
+
+	scores2, err := o.GetProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+	assert.Nil(t, scores2)
+
+	assert.Zero(t, o.GetSpeciesOccurrence("Turdus merula_Common Blackbird"))
+	assert.Zero(t, o.GetSpeciesOccurrenceAtTime("Turdus merula_Common Blackbird", time.Now()))
+
+	// Must not panic with a nil primary.
+	assert.NotPanics(t, func() { o.RunFilterProcess(time.Now().Format(time.DateOnly), 0) })
+	assert.NotPanics(t, func() { o.Debug("noop %d", 1) })
+
+	// BuildRangeFilter snapshots the primary and returns a typed error rather than
+	// panicking when there is no primary.
+	err = BuildRangeFilter(o)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no primary model")
+}
+
+// TestOrchestrator_AccessorsConcurrentWithPrimaryClear_NoRace is the regression
+// guard for the accessor-vs-Delete() data race: Delete() sets o.primary = nil
+// under o.mu.Lock(), while the accessors used to read o.primary with no lock.
+// A writer toggles o.primary under o.mu.Lock() (mirroring Delete's write) while
+// readers hammer the accessors; the snapshot-under-RLock fix must make this
+// race-free and panic-free. Must be run with -race.
+func TestOrchestrator_AccessorsConcurrentWithPrimaryClear_NoRace(t *testing.T) {
+	t.Parallel()
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Labels = []string{"Turdus merula_Common Blackbird", "Parus major_Great Tit"}
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
+
+	o := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo,
+		primary:   bn,
+		models:    map[string]*modelEntry{"BirdNET_V3": {instance: bn}},
+	}
+
+	const readsPerGoroutine = 300
+	const readerCount = 4
+
+	var readerWg sync.WaitGroup
+	var readersDone atomic.Bool
+	start := make(chan struct{})
+
+	// Writer: flip o.primary between bn and nil under o.mu.Lock(), the exact write
+	// Delete() performs. Spins until the readers finish so the write window always
+	// overlaps the reads.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		<-start
+		cleared := false
+		for !readersDone.Load() {
+			o.mu.Lock()
+			if cleared {
+				o.primary = nil
+			} else {
+				o.primary = bn
+			}
+			cleared = !cleared
+			o.mu.Unlock()
+			runtime.Gosched() // yield so the spin does not starve readers on a busy CI core
+		}
+		// Leave the primary restored so any trailing read sees a valid instance.
+		o.mu.Lock()
+		o.primary = bn
+		o.mu.Unlock()
+	}()
+
+	for range readerCount {
+		readerWg.Go(func() {
+			<-start
+			for range readsPerGoroutine {
+				_ = o.NumSpecies()
+				_ = o.Labels()
+			}
+		})
+	}
+
+	close(start)
+	readerWg.Wait()
+	readersDone.Store(true)
+	<-writerDone
+}
+
+// TestBatchRangeFilterInference_SizeValidation covers the input-size guards,
+// including the integer-overflow-safe form: a near-math.MaxInt batchSize whose
+// batchSize*inputWidth would overflow must be rejected by the divisor check
+// before the multiplication is trusted, instead of slipping an oversized batch
+// into the backend.
+func TestBatchRangeFilterInference_SizeValidation(t *testing.T) {
+	t.Parallel()
+
+	o := &Orchestrator{}
+
+	tests := []struct {
+		name      string
+		inputs    []float32
+		batchSize int
+		wantMsg   string
+	}{
+		{
+			name:      "non-positive batchSize",
+			inputs:    make([]float32, 3),
+			batchSize: 0,
+			wantMsg:   "must be positive",
+		},
+		{
+			name:      "plain length mismatch",
+			inputs:    make([]float32, 4),
+			batchSize: 1,
+			wantMsg:   "does not match batchSize",
+		},
+		{
+			name:      "oversized batchSize",
+			inputs:    make([]float32, 9),
+			batchSize: math.MaxInt,
+			wantMsg:   "does not match batchSize",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := o.BatchRangeFilterInference(tt.inputs, tt.batchSize)
+			require.Error(t, err)
+			assert.Nil(t, out)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+		})
+	}
+
+	// The decisive overflow case: a batchSize whose batchSize*inputWidth wraps
+	// (two's complement) to EXACTLY len(inputs). The old check
+	// `len(inputs) != batchSize*inputWidth` computes 2 != 2 (false) and would
+	// ACCEPT this oversized batch, passing it to the backend; only the divisor
+	// guard rejects it. This is the regression this fix exists for: it fails on
+	// the pre-fix code (which returns a different downstream error) and passes
+	// only with the guard. 3 * 6148914691236517206 == 2^64 + 2, which wraps to 2
+	// as int64. The construction only fits a 64-bit int; build it through uint64
+	// so the literal never overflows a 32-bit int at compile time, and skip where
+	// int is not 64-bit (overflow boundary differs there).
+	t.Run("overflow wraps to len(inputs)", func(t *testing.T) {
+		t.Parallel()
+		if math.MaxInt != math.MaxInt64 {
+			t.Skip("overflow construction requires a 64-bit int")
+		}
+		wrapBatch := int(uint64(6148914691236517206)) // 3*this == 2^64+2 -> wraps to 2
+		out, err := o.BatchRangeFilterInference(make([]float32, 2), wrapBatch)
+		require.Error(t, err)
+		assert.Nil(t, out)
+		assert.Contains(t, err.Error(), "does not match batchSize")
+	})
+}

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -5,6 +5,7 @@ package classifier
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -51,8 +52,21 @@ func BuildRangeFilter(o *Orchestrator) error {
 
 	var includedSpecies []string
 
-	o.primary.mu.Lock()
-	rf := o.primary.rangeFilter
+	// Snapshot primary under read lock to avoid racing with Delete(), which sets
+	// o.primary = nil under o.mu.Lock(). All callers reach BuildRangeFilter
+	// without holding o.mu, so taking RLock here cannot self-deadlock.
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return errors.Newf("orchestrator has no primary model").
+			Component("classifier.orchestrator").
+			Category(errors.CategorySystem).
+			Build()
+	}
+
+	primary.mu.Lock()
+	rf := primary.rangeFilter
 	up, isUniversal := rf.(UniversalSpeciesPredictor)
 
 	if isUniversal && settings.BirdNET.LocationConfigured {
@@ -69,7 +83,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			threshold,
 		)
 		if err != nil {
-			o.primary.mu.Unlock()
+			primary.mu.Unlock()
 			return errors.New(err).
 				Category(errors.CategoryValidation).
 				Context("date", today.Format(time.DateOnly)).
@@ -95,7 +109,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			mrf.unmappedScore = score
 			cachedMapping = mrf.classifierToGeo
 		}
-		o.primary.mu.Unlock()
+		primary.mu.Unlock()
 
 		includedSpecies = make([]string, 0, len(scores))
 		for _, ss := range scores {
@@ -138,7 +152,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			logger.Float64("threshold", float64(threshold)),
 			logger.String("duration", time.Since(start).String()))
 	} else {
-		o.primary.mu.Unlock()
+		primary.mu.Unlock()
 		speciesScores, err := o.GetProbableSpecies(today, 0.0)
 		if err != nil {
 			return errors.New(err).
@@ -160,7 +174,9 @@ func BuildRangeFilter(o *Orchestrator) error {
 	}
 
 	if settings.BirdNET.RangeFilter.Debug {
-		debugFile := "debug_included_species.txt"
+		// Write under the OS temp dir rather than the process CWD so the debug dump
+		// does not pollute the working directory and works in read-only-root containers.
+		debugFile := filepath.Join(os.TempDir(), "debug_included_species.txt")
 		var content strings.Builder
 		fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
 			time.Now().Format(time.DateTime),

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -37,6 +37,37 @@ type UniversalSpeciesPredictor interface {
 	GeomodelLabels() []string
 }
 
+// writeIncludedSpeciesDebug dumps the included-species list to a debug file when
+// RangeFilter.Debug is enabled. It prefers a user-private cache directory over the
+// process CWD (pollution, read-only-root containers) and over a world-writable
+// shared temp dir, which is open to symlink clobbering (CWE-377/CWE-59) and
+// multi-user filename collisions on a fixed name; it falls back to the OS temp dir
+// only when no per-user cache dir is available.
+func writeIncludedSpeciesDebug(includedSpecies []string) {
+	debugFile := filepath.Join(os.TempDir(), "debug_included_species.txt")
+	if cacheDir, err := os.UserCacheDir(); err == nil {
+		birdnetCacheDir := filepath.Join(cacheDir, "birdnet-go")
+		if mkErr := os.MkdirAll(birdnetCacheDir, 0o700); mkErr == nil {
+			debugFile = filepath.Join(birdnetCacheDir, "debug_included_species.txt")
+		}
+	}
+
+	var content strings.Builder
+	fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
+		time.Now().Format(time.DateTime),
+		len(includedSpecies))
+	for _, species := range includedSpecies {
+		content.WriteString(species)
+		content.WriteByte('\n')
+	}
+	if err := os.WriteFile(debugFile, []byte(content.String()), 0o600); err != nil {
+		GetLogger().Warn("Failed to write included species debug file",
+			logger.Error(err),
+			logger.String("debug_file", debugFile),
+			logger.Int("species_count", len(includedSpecies)))
+	}
+}
+
 // BuildRangeFilter updates the range filter with current probable species.
 // If the active range filter implements UniversalSpeciesPredictor, the
 // species list is derived directly from the geomodel's own labels
@@ -174,23 +205,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 	}
 
 	if settings.BirdNET.RangeFilter.Debug {
-		// Write under the OS temp dir rather than the process CWD so the debug dump
-		// does not pollute the working directory and works in read-only-root containers.
-		debugFile := filepath.Join(os.TempDir(), "debug_included_species.txt")
-		var content strings.Builder
-		fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
-			time.Now().Format(time.DateTime),
-			len(includedSpecies))
-		for _, species := range includedSpecies {
-			content.WriteString(species)
-			content.WriteByte('\n')
-		}
-		if err := os.WriteFile(debugFile, []byte(content.String()), 0o600); err != nil {
-			GetLogger().Warn("Failed to write included species debug file",
-				logger.Error(err),
-				logger.String("debug_file", debugFile),
-				logger.Int("species_count", len(includedSpecies)))
-		}
+		writeIncludedSpeciesDebug(includedSpecies)
 	}
 
 	conf.UpdateIncludedSpecies(includedSpecies)

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -44,14 +44,6 @@ type UniversalSpeciesPredictor interface {
 // multi-user filename collisions on a fixed name; it falls back to the OS temp dir
 // only when no per-user cache dir is available.
 func writeIncludedSpeciesDebug(includedSpecies []string) {
-	debugFile := filepath.Join(os.TempDir(), "debug_included_species.txt")
-	if cacheDir, err := os.UserCacheDir(); err == nil {
-		birdnetCacheDir := filepath.Join(cacheDir, "birdnet-go")
-		if mkErr := os.MkdirAll(birdnetCacheDir, 0o700); mkErr == nil {
-			debugFile = filepath.Join(birdnetCacheDir, "debug_included_species.txt")
-		}
-	}
-
 	var content strings.Builder
 	fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
 		time.Now().Format(time.DateTime),
@@ -60,10 +52,38 @@ func writeIncludedSpeciesDebug(includedSpecies []string) {
 		content.WriteString(species)
 		content.WriteByte('\n')
 	}
-	if err := os.WriteFile(debugFile, []byte(content.String()), 0o600); err != nil {
+	data := []byte(content.String())
+
+	// A user-private cache directory (0700) is not world-writable, so a fixed
+	// filename there is not exposed to symlink clobbering.
+	var path string
+	var err error
+	if cacheDir, cdErr := os.UserCacheDir(); cdErr == nil {
+		birdnetCacheDir := filepath.Join(cacheDir, "birdnet-go")
+		if mkErr := os.MkdirAll(birdnetCacheDir, 0o700); mkErr == nil {
+			path = filepath.Join(birdnetCacheDir, "debug_included_species.txt")
+			err = os.WriteFile(path, data, 0o600)
+		}
+	}
+
+	// No per-user cache dir: fall back to the world-writable temp dir, but use
+	// os.CreateTemp so the file is created O_EXCL with a random name and cannot
+	// follow a pre-planted symlink (CWE-377/CWE-59).
+	if path == "" {
+		f, ctErr := os.CreateTemp("", "debug_included_species_*.txt")
+		if ctErr != nil {
+			GetLogger().Warn("Failed to create included species debug file", logger.Error(ctErr))
+			return
+		}
+		path = f.Name()
+		_, err = f.Write(data)
+		_ = f.Close()
+	}
+
+	if err != nil {
 		GetLogger().Warn("Failed to write included species debug file",
 			logger.Error(err),
-			logger.String("debug_file", debugFile),
+			logger.String("debug_file", path),
 			logger.Int("species_count", len(includedSpecies)))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes several pre-existing concurrency and input-validation bugs in the classifier orchestrator that were surfaced during a code review. All changes are confined to `internal/classifier/` and are purely defensive: behavior is unchanged for an existing running setup; the fixed paths were reachable only during teardown, concurrent reconfiguration, or with maliciously oversized input.

### Accessor races with `Delete()`
`Delete()` sets `o.primary = nil` under `o.mu.Lock()`, but several accessors dereferenced `o.primary` with no lock and no nil guard, so a concurrent delete could panic. The following now snapshot `o.primary` under `o.mu.RLock()` and nil-check, matching the already-guarded siblings (`GetAllProbableSpeciesWithSettings`, `GetSpeciesWithScientificAndCommonName`, `EnrichResultWithTaxonomy`): `NumSpecies`, `Labels`, `GetSpeciesCode`, `GetProbableSpecies`, `GetProbableSpeciesWithSettings`, `GetSpeciesOccurrence`, `GetSpeciesOccurrenceAtTime`, `RunFilterProcess`, `Debug`, and `BuildRangeFilter`.

### `SetModelsDir` unlocked write
`SetModelsDir` wrote `o.modelsDir` and read `o.primary` with no lock, racing with `resolveInstalledPaths` (which reads `o.modelsDir` under `o.mu` via the model loaders). The write is now guarded, and the lock is released before the downstream calls so `registerTaxonomyResolver` (which takes `o.mu.RLock()` internally) cannot self-deadlock on the non-reentrant `RWMutex`.

### Integer overflow in `BatchRangeFilterInference`
The size check `len(inputs) != batchSize*inputWidth` could overflow for a near-`math.MaxInt` `batchSize`, wrapping to a value equal to `len(inputs)`, bypassing validation and pushing an oversized batch into the ONNX backend. The check now divides first (`batchSize > len(inputs)/inputWidth`) so the multiplication is never trusted on an overflowing `batchSize`.

### `Delete()` teardown under lock + counter leak
`Delete()` held `o.mu` for the whole teardown, including the per-model native `Close()` calls, blocking every accessor for the duration. It now snapshots the models, stops the scheduler, and nils `o.primary`/`o.models` under `o.mu`, then closes the models outside the lock (mirroring `UnloadModel`) and drops each model's global inference counters (inside `entry.mu`, also mirroring `UnloadModel`) so a teardown-then-recreate cycle does not leak counter entries.

### Minor cleanups (same files)
- Hoist the duplicated `entryRef` struct to one file-scope type.
- Write the opt-in range-filter debug dump under the OS temp dir instead of the process working directory (avoids CWD pollution / read-only-root container failures).

## Test Plan
- [x] New `orchestrator_concurrency_test.go`: nil-primary teardown contract, accessor-vs-`Delete()` race under `-race`, and `BatchRangeFilterInference` size validation including a deterministic integer-overflow case that fails on the pre-fix code
- [x] `go test -race ./internal/classifier/...`
- [x] `golangci-lint run` clean, `go vet`, `gofmt`, full `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided crashes, races, and deadlocks when the primary model is absent or toggled; made teardown and lifecycle operations safe under concurrent access.
  * Improved input validation to reject mismatched or overflowed batch sizes.
  * Safer debug output handling: writes to per-user cache or temp with restrictive permissions and clearer failure logging.

* **Tests**
  * Added concurrency tests for accessor/race scenarios and concurrent model-dir updates.
  * Added table-driven tests for batch-size and overflow edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->