### PR TITLE
fix(classifier): record prediction telemetry exactly once

### DIFF
--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -1,0 +1,99 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/observability/metrics"
+)
+
+// predTelemetryModel is an arbitrary model label used by the span-level tests.
+const predTelemetryModel = "BirdNET_GLOBAL_6K_V2.4"
+
+// predictionCount returns the current value of birdnet_predictions_total for the
+// given model/status combination. WithLabelValues lazily creates the child at 0,
+// so an untouched combination reports 0.0 rather than panicking.
+func predictionCount(t *testing.T, m *metrics.BirdNETMetrics, model, status string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(m.PredictionTotal.WithLabelValues(model, status))
+}
+
+// newPredictSpan starts a birdnet.predict span for the exactly-once tests.
+func newPredictSpan(t *testing.T) *TracingSpan {
+	t.Helper()
+	span, _ := StartSpan(t.Context(), "birdnet.predict", "telemetry test")
+	require.NotNil(t, span)
+	return span
+}
+
+// TestTracingSpan_ErrorPathRecordsExactlyOnce mirrors a Predict error path: the
+// caller records the error explicitly and tags the span errored. Finish must NOT
+// add a second (success) record.
+func TestTracingSpan_ErrorPathRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+
+	// The caller records the error outcome explicitly, then tags the span errored.
+	predErr := errors.Newf("inference failed").Category(errors.CategoryAudio).Build()
+	m.RecordPrediction(predTelemetryModel, 0.01, predErr)
+	span.SetTag(tagKeyError, tagValueTrue)
+
+	span.Finish()
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
+		"errored prediction must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"Finish must not record a spurious success on an errored span")
+}
+
+// TestTracingSpan_SuccessPathRecordsExactlyOnce verifies the happy path records
+// exactly one success and that tagging error=false does not flip the errored flag.
+func TestTracingSpan_SuccessPathRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+	span.SetTag(tagKeyError, tagValueFalse) // success path tags error=false
+
+	span.Finish()
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"successful prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
+		"error=false must not record an error outcome")
+}
+
+// TestTracingSpan_ErroredEarlyGuardRecordsNothing documents the contract for the
+// Predict early-guard error paths (empty_sample, classifier_nil): they tag the
+// span errored but do not record explicitly, so the prediction is not counted at
+// all. This is intentional: the success record is suppressed and these
+// pre-inference rejections do not inflate the success or error series.
+func TestTracingSpan_ErroredEarlyGuardRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+	span.SetTag(tagKeyError, tagValueTrue) // tagged errored, but no explicit record
+
+	span.Finish()
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"an errored span must not record a success")
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
+		"an early-guard error without an explicit record must not be counted")
+}

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -97,3 +97,22 @@ func TestTracingSpan_ErroredEarlyGuardRecordsNothing(t *testing.T) {
 	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
 		"an early-guard error without an explicit record must not be counted")
 }
+
+// TestTracingSpan_FinishIsIdempotent verifies that calling Finish more than once
+// (e.g. a manual call plus a deferred one) records the prediction only once and
+// does not decrement the active-operations counter twice.
+func TestTracingSpan_FinishIsIdempotent(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+
+	span.Finish()
+	span.Finish() // second call must be a no-op
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"a span finished twice must record exactly one success")
+}

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -3,7 +3,6 @@ package classifier
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,6 +17,16 @@ import (
 // tagKeyModel is the tracing tag key used to identify the model in spans.
 const tagKeyModel = "model"
 
+// Tracing tag key and values that record the error outcome of a span.
+// Finish() consults these via the errored flag set in SetTag to avoid recording
+// a spurious success metric on error paths, so the producers that call SetTag and
+// the consumer in Finish must agree on these exact strings.
+const (
+	tagKeyError   = "error"
+	tagValueTrue  = "true"
+	tagValueFalse = "false"
+)
+
 // TracingSpan represents a traced operation with minimal overhead.
 // A TracingSpan must not be used from multiple goroutines concurrently.
 type TracingSpan struct {
@@ -29,6 +38,7 @@ type TracingSpan struct {
 	sentrySpan     *sentry.Span
 	metricsEnabled bool
 	model          string // For metrics labeling
+	errored        bool   // True once an error tag is set; gates the success metric in Finish
 }
 
 // Global metrics instance (set by observability package)
@@ -102,6 +112,13 @@ func (s *TracingSpan) SetTag(key, value string) {
 		s.model = value
 	}
 
+	// Track the error outcome so Finish does not record a spurious success metric
+	// on error paths. Callers record the error outcome explicitly, so once an error
+	// tag is set the flag stays set for the lifetime of the span.
+	if key == tagKeyError && value == tagValueTrue {
+		s.errored = true
+	}
+
 	// Only allocate tags map if Sentry is enabled
 	if s.sentrySpan != nil {
 		if s.tags == nil {
@@ -139,16 +156,28 @@ func (s *TracingSpan) Finish() {
 
 	// Record metrics if enabled
 	if s.metricsEnabled {
-		model := s.model
-		if model == "" {
-			model = "unknown"
-		}
+		// Balance the activeOperations increment from StartSpan. Decrement under
+		// the same metricsEnabled guard as the increment so the counter stays
+		// balanced even if the metrics instance is reset between StartSpan and
+		// Finish.
+		count := atomic.AddInt64(&activeOperations, -1)
 
 		if m := getMetrics(); m != nil {
+			model := s.model
+			if model == "" {
+				model = "unknown"
+			}
+
 			// Record appropriate metric based on operation
 			switch s.operation {
 			case "birdnet.predict":
-				m.RecordPrediction(model, durationSeconds, nil)
+				// Skip the success record on error spans. Callers record the
+				// error outcome explicitly, so recording here would either
+				// double-count (when the caller already recorded an error) or
+				// log a spurious success (on early-guard error paths).
+				if !s.errored {
+					m.RecordPrediction(model, durationSeconds, nil)
+				}
 			case "birdnet.process_chunk":
 				m.RecordChunkProcess(model, durationSeconds)
 			case "birdnet.model_invoke":
@@ -157,8 +186,6 @@ func (s *TracingSpan) Finish() {
 				m.RecordRangeFilter(model, durationSeconds)
 			}
 
-			// Update active operations count
-			count := atomic.AddInt64(&activeOperations, -1)
 			m.SetActiveProcessing(float64(count))
 		}
 	}
@@ -168,50 +195,6 @@ func (s *TracingSpan) Finish() {
 		s.SetData("duration_ms", duration.Milliseconds())
 		s.sentrySpan.Finish()
 	}
-}
-
-// TraceAnalysis traces audio analysis operations
-func TraceAnalysis(ctx context.Context, operation string, fn func() error) error {
-	span, _ := StartSpan(ctx, "birdnet."+operation, operation)
-	defer span.Finish()
-
-	err := fn()
-	if err != nil {
-		span.SetTag("error", "true")
-		span.SetData("error_message", err.Error())
-	}
-
-	return err
-}
-
-// TracePrediction traces prediction operations with additional metrics
-func TracePrediction(ctx context.Context, sampleSize int, fn func() (any, error)) (any, error) {
-	span, _ := StartSpan(ctx, "birdnet.predict", "Audio prediction")
-	defer span.Finish()
-
-	span.SetData("sample_size", sampleSize)
-
-	start := time.Now()
-	result, err := fn()
-	duration := time.Since(start)
-
-	span.SetData("prediction_duration_ms", duration.Milliseconds())
-
-	if err != nil {
-		span.SetTag("error", "true")
-		span.SetData("error_message", err.Error())
-	} else {
-		span.SetTag("error", "false")
-		// Add result metrics if available using reflection
-		if result != nil {
-			resultValue := reflect.ValueOf(result)
-			if resultValue.Kind() == reflect.Slice {
-				span.SetData("result_count", resultValue.Len())
-			}
-		}
-	}
-
-	return result, err
 }
 
 // RecordMetric records a performance metric

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -39,6 +39,7 @@ type TracingSpan struct {
 	metricsEnabled bool
 	model          string // For metrics labeling
 	errored        bool   // True once an error tag is set; gates the success metric in Finish
+	finished       bool   // True once Finish has run; makes Finish idempotent
 }
 
 // Global metrics instance (set by observability package)
@@ -147,9 +148,13 @@ func (s *TracingSpan) SetData(key string, value any) {
 
 // Finish completes the span and records timing
 func (s *TracingSpan) Finish() {
-	if s == nil {
+	if s == nil || s.finished {
 		return
 	}
+	// Make Finish idempotent: a span represents one operation, so a second call
+	// (e.g. a manual Finish plus a deferred one) must not decrement
+	// activeOperations again or record the prediction twice.
+	s.finished = true
 
 	duration := time.Since(s.startTime)
 	durationSeconds := duration.Seconds()


### PR DESCRIPTION
## Summary

`TracingSpan.Finish()` recorded a success prediction unconditionally for the `birdnet.predict` operation, but `BirdNET.Predict`'s error paths already record the error explicitly. Every failed prediction was therefore counted twice: once as the real error and once as a spurious success, inflating `birdnet_predictions_total{status="success"}` on exactly the paths an operator watches.

This adds an `errored` flag to `TracingSpan`, sets it when an error tag is recorded, and gates the success record in `Finish` on it. Failed predictions now record exactly once, and the early-guard rejections (empty sample, uninitialised classifier) no longer log a spurious success.

It also balances the `activeOperations` counter: the decrement in `Finish` was gated on the metrics instance being non-nil, while the `StartSpan` increment was gated only on `metricsEnabled`, so a metrics reset between the two could leak the counter. The decrement now sits under the same `metricsEnabled` guard.

Finally it removes the dead `TraceAnalysis` and `TracePrediction` helpers (no callers) and the `reflect` import that only `TracePrediction` used.

## Notes

This is a focused correctness fix. A follow-up PR adds prediction-metric coverage for the Perch and Bat classifiers on top of this `errored` flag.

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/classifier/...`
- [x] `golangci-lint run` (0 issues)
- [x] New span-level tests assert exactly-once on the error path, the success path, and the errored early-guard path; they fail on the old double-counting code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added telemetry span tests covering error path, success path, early-guard behavior, and idempotent finish semantics.

* **Bug Fixes**
  * Fixed span metrics so error outcomes no longer produce success counts and active-operation accounting is correct.

* **Refactoring**
  * Simplified internal tracing behavior and removed higher-level tracing helpers; added safer span lifecycle handling and a default model label for metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->