### PR TITLE
feat(classifier): unify prediction telemetry across ONNX models

### DIFF
--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -23,26 +23,20 @@ type DetectionsMap map[string][]datastore.Results
 // Predict performs inference on a given sample using the classifier backend.
 // Implements ModelInstance.
 func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
-	span, _ := StartSpan(ctx, "birdnet.predict", "Species prediction")
+	span, _ := startPredictSpan(ctx, bn.ModelInfo.ID, sample)
 	defer span.Finish()
 
 	settings := bn.currentSettings()
 	start := time.Now()
-	span.SetTag("model", bn.ModelInfo.ID)
-	span.SetData("sample_count", len(sample))
-	if len(sample) > 0 {
-		span.SetData("sample_size", len(sample[0]))
-	}
 
-	// Guard against empty sample slice
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions.
 	if len(sample) == 0 || len(sample[0]) == 0 {
-		err := errors.Newf("empty audio sample").
+		span.markErrored(errTypeEmptySample)
+		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
-		span.SetTag("error", "true")
-		span.SetData("error_type", "empty_sample")
-		return nil, err
 	}
 
 	// Lock to prevent concurrent access to the classifier backend and shared buffers
@@ -51,13 +45,11 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 
 	// Guard against nil classifier (e.g., after Delete() is called concurrently)
 	if bn.classifier == nil {
-		err := errors.Newf("classifier backend is not initialized").
+		span.markErrored(errTypeClassifierNil)
+		return nil, errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
-		span.SetTag("error", "true")
-		span.SetData("error_type", "classifier_nil")
-		return nil, err
 	}
 
 	// Run inference via classifier backend
@@ -71,18 +63,12 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 			Timing("prediction-invoke", time.Since(start)).
 			Build()
 
-		span.SetTag("error", "true")
-		span.SetData("error_type", "invoke_failed")
-
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-
+		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeInvokeFailed, start, err)
 		return nil, err
 	}
 
 	invokeDuration := time.Since(invokeStart)
-	span.SetData("invoke_duration_ms", invokeDuration.Milliseconds())
+	span.SetData(dataKeyInvokeDurationMs, invokeDuration.Milliseconds())
 
 	// Record model invoke timing separately
 	if m := getMetrics(); m != nil {
@@ -102,30 +88,19 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 			Timing("prediction-total", time.Since(start)).
 			Build()
 
-		span.SetTag("error", "true")
-		span.SetData("error_type", "label_mismatch")
-
-		// Record error in metrics
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-
+		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 
 	// Use optimized top-k algorithm instead of full sort + trim
-	topResults := getTopKResults(results, 10)
+	topResults := getTopKResults(results, defaultTopKResults)
 
 	// Log prediction timing for performance monitoring
 	duration := time.Since(start)
 	bn.Debug("Prediction completed in %v with %d results", duration, len(topResults))
 
-	// Record metrics
-	span.SetData("total_duration_ms", duration.Milliseconds())
-	span.SetData("result_count", len(topResults))
-	span.SetTag("error", "false")
-
-	// The span.Finish() will automatically record the prediction metrics
+	// Record metrics. Finish() records the single success because the span is not errored.
+	recordPredictionSuccess(span, len(topResults), start)
 
 	// Return the top 10 results
 	return topResults, nil

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -98,7 +98,15 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
 	log := GetLogger()
 
+	span, _ := startPredictSpan(ctx, RegistryIDBat, samples)
+	defer span.Finish()
+
+	start := time.Now()
+
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions, mirroring BirdNET.Predict.
 	if len(samples) == 0 || len(samples[0]) == 0 {
+		span.markErrored(errTypeEmptySample)
 		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			Build()
@@ -108,6 +116,7 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 	defer b.mu.Unlock()
 
 	if b.embeddingExtractor == nil || b.batClassifier == nil {
+		span.markErrored(errTypeClassifierNil)
 		return nil, errors.Newf("bat classifier is not initialized").
 			Category(errors.CategoryModelInit).
 			Build()
@@ -124,19 +133,23 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		log.Error("bat embedding extraction failed",
 			logger.Error(err),
 			logger.Duration("duration", embDuration))
-		return nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Context("stage", "embedding_extraction").
 			Build()
+		recordPredictionFailure(span, RegistryIDBat, errTypeEmbeddingExtraction, start, err)
+		return nil, err
 	}
 
 	if embeddings == nil {
 		log.Error("bat embedding model produced nil embeddings")
-		return nil, errors.Newf("embedding model did not produce embeddings").
+		err = errors.Newf("embedding model did not produce embeddings").
 			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Build()
+		recordPredictionFailure(span, RegistryIDBat, errTypeNilEmbeddings, start, err)
+		return nil, err
 	}
 
 	log.Debug("bat embeddings extracted",
@@ -150,11 +163,13 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		log.Error("bat classification failed",
 			logger.Error(err),
 			logger.Duration("duration", classDuration))
-		return nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Context("stage", "bat_classification").
 			Build()
+		recordPredictionFailure(span, RegistryIDBat, errTypeBatClassification, start, err)
+		return nil, err
 	}
 
 	log.Debug("bat classification complete",
@@ -163,6 +178,7 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 
 	results, err := pairLabelsAndConfidence(b.batClassifier.Labels(), scores)
 	if err != nil {
+		recordPredictionFailure(span, RegistryIDBat, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 
@@ -178,13 +194,17 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		results = filtered
 	}
 
-	if len(results) > 0 {
+	// Sort and trim before logging so top_species reflects the highest-confidence
+	// detection rather than the first label that cleared the threshold (results is
+	// in label order, not confidence order).
+	topResults := getTopKResults(results, defaultTopKResults)
+	if len(topResults) > 0 {
 		log.Debug("bat detections after threshold",
 			logger.Int("pre_filter", preFilterCount),
 			logger.Int("post_filter", len(results)),
 			logger.Float64("threshold", threshold),
-			logger.String("top_species", results[0].Species),
-			logger.Float64("top_confidence", float64(results[0].Confidence)),
+			logger.String("top_species", topResults[0].Species),
+			logger.Float64("top_confidence", float64(topResults[0].Confidence)),
 			logger.Duration("total_duration", embDuration+classDuration))
 	} else {
 		log.Debug("bat no detections above threshold",
@@ -193,7 +213,10 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 			logger.Duration("total_duration", embDuration+classDuration))
 	}
 
-	return getTopKResults(results, 10), nil
+	// Success: Finish records the single prediction because the span is not errored.
+	recordPredictionSuccess(span, len(topResults), start)
+
+	return topResults, nil
 }
 
 // Spec returns the audio requirements for the bat model.

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -30,11 +30,11 @@ func (o *Orchestrator) loadBat(threads int) error {
 		return errors.Newf("bat model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Build()
 	}
 
-	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", "Bat", "classifier.orchestrator"); err != nil {
+	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
 		return err
 	}
 
@@ -52,7 +52,7 @@ func (o *Orchestrator) loadBat(threads int) error {
 		return errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Build()
 	}
 

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -26,11 +26,11 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		return errors.Newf("Perch v2 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Perch_V2").
+			Context("model", RegistryIDPerchV2).
 			Build()
 	}
 
-	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", "Perch_V2", "classifier.orchestrator"); err != nil {
+	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", RegistryIDPerchV2, "classifier.orchestrator"); err != nil {
 		return err
 	}
 
@@ -46,7 +46,7 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		return errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Perch_V2").
+			Context("model", RegistryIDPerchV2).
 			Build()
 	}
 

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -102,7 +102,15 @@ func NewPerch(cfg PerchConfig) (*Perch, error) {
 // Predict runs inference on the given audio samples.
 // Implements ModelInstance.
 func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
+	span, _ := startPredictSpan(ctx, RegistryIDPerchV2, samples)
+	defer span.Finish()
+
+	start := time.Now()
+
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions, mirroring BirdNET.Predict.
 	if len(samples) == 0 || len(samples[0]) == 0 {
+		span.markErrored(errTypeEmptySample)
 		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			Build()
@@ -111,7 +119,9 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	// Guard against nil classifier (e.g., after Close() is called concurrently)
 	if p.classifier == nil {
+		span.markErrored(errTypeClassifierNil)
 		return nil, errors.Newf("Perch classifier is not initialized").
 			Category(errors.CategoryModelInit).
 			Build()
@@ -119,10 +129,12 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 
 	rawLogits, err := p.classifier.Predict(samples[0])
 	if err != nil {
-		return nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			Context("model", "Perch_V2").
+			Context("model", RegistryIDPerchV2).
 			Build()
+		recordPredictionFailure(span, RegistryIDPerchV2, errTypeInvokeFailed, start, err)
+		return nil, err
 	}
 
 	// Apply softmax to normalize raw logits into probabilities (0.0-1.0).
@@ -133,11 +145,15 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 	// Pair labels with predictions
 	results, err := pairLabelsAndConfidence(p.labels, predictions)
 	if err != nil {
+		recordPredictionFailure(span, RegistryIDPerchV2, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 
-	// Return top 10 results
-	return getTopKResults(results, 10), nil
+	// Success: Finish records the single prediction because the span is not errored.
+	topResults := getTopKResults(results, defaultTopKResults)
+	recordPredictionSuccess(span, len(topResults), start)
+
+	return topResults, nil
 }
 
 // Spec returns the audio requirements for Perch v2.

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -330,3 +330,23 @@ func TestBatPredict_EmptySampleRecordsNothing(t *testing.T) {
 	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
 		"an empty-sample rejection must not record a success")
 }
+
+// TestBatPredict_NilClassifierRecordsNothing verifies the nil-classifier guard
+// (e.g. after Close()) tags the span errored but records no prediction, mirroring
+// the Perch and BirdNET early-guard contract.
+func TestBatPredict_NilClassifierRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	b := &Bat{} // embeddingExtractor and batClassifier are nil interfaces
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"a nil-classifier rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"a nil-classifier rejection must not record a success")
+}

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 )
@@ -30,9 +31,9 @@ func newPredictSpan(t *testing.T) *TracingSpan {
 	return span
 }
 
-// TestTracingSpan_ErrorPathRecordsExactlyOnce mirrors a Predict error path: the
-// caller records the error explicitly and tags the span errored. Finish must NOT
-// add a second (success) record.
+// TestTracingSpan_ErrorPathRecordsExactlyOnce mirrors BirdNET.Predict's
+// invoke_failed / label_mismatch paths: the caller records the error explicitly
+// and tags the span errored. Finish must NOT add a second (success) record.
 func TestTracingSpan_ErrorPathRecordsExactlyOnce(t *testing.T) {
 	resetGlobalMetrics(t)
 	t.Cleanup(func() { resetGlobalMetrics(t) })
@@ -75,10 +76,10 @@ func TestTracingSpan_SuccessPathRecordsExactlyOnce(t *testing.T) {
 		"error=false must not record an error outcome")
 }
 
-// TestTracingSpan_ErroredEarlyGuardRecordsNothing documents the contract for the
-// Predict early-guard error paths (empty_sample, classifier_nil): they tag the
-// span errored but do not record explicitly, so the prediction is not counted at
-// all. This is intentional: the success record is suppressed and these
+// TestTracingSpan_ErroredEarlyGuardRecordsNothing documents the contract for
+// BirdNET.Predict's early-guard error paths (empty_sample, classifier_nil): they
+// tag the span errored but do not record explicitly, so the prediction is not
+// counted at all. This is intentional: the success record is suppressed and these
 // pre-inference rejections do not inflate the success or error series.
 func TestTracingSpan_ErroredEarlyGuardRecordsNothing(t *testing.T) {
 	resetGlobalMetrics(t)
@@ -115,4 +116,217 @@ func TestTracingSpan_FinishIsIdempotent(t *testing.T) {
 
 	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
 		"a span finished twice must record exactly one success")
+}
+
+// predTelemetryClassifier is a fake inference.Classifier for the Perch tests.
+type predTelemetryClassifier struct {
+	logits []float32
+	err    error
+}
+
+func (f *predTelemetryClassifier) Predict(_ []float32) ([]float32, error) {
+	return f.logits, f.err
+}
+func (f *predTelemetryClassifier) NumSpecies() int { return len(f.logits) }
+func (f *predTelemetryClassifier) Close()          {}
+
+// TestPerchPredict_SuccessRecordsExactlyOnce verifies a happy-path Perch.Predict
+// records exactly one success under the RegistryIDPerchV2 model label, making
+// Perch visible in birdnet_predictions_total separately from BirdNET.
+func TestPerchPredict_SuccessRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	labels := []string{"Species A", "Species B"}
+	p := &Perch{classifier: &predTelemetryClassifier{logits: []float32{0.2, 0.8}}, labels: labels}
+
+	results, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2, 0.3}})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a successful Perch prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a successful Perch prediction must not record an error")
+}
+
+// TestPerchPredict_InferenceErrorRecordsExactlyOnce verifies an inference failure
+// records exactly one error (and no success) under the Perch model label.
+func TestPerchPredict_InferenceErrorRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	boom := errors.Newf("backend inference failed").Category(errors.CategoryAudio).Build()
+	p := &Perch{classifier: &predTelemetryClassifier{err: boom}, labels: []string{"A", "B"}}
+
+	_, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a failed Perch inference must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a failed Perch inference must not record a spurious success")
+}
+
+// TestPerchPredict_EmptySampleRecordsNothing verifies the empty-sample guard
+// tags the span errored but records no prediction, mirroring BirdNET.Predict:
+// pre-inference rejections are not counted in either series.
+func TestPerchPredict_EmptySampleRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	p := &Perch{classifier: &predTelemetryClassifier{}, labels: []string{"A"}}
+
+	_, err := p.Predict(t.Context(), nil)
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"an empty-sample rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"an empty-sample rejection must not record a success")
+}
+
+// TestPerchPredict_NilClassifierRecordsNothing verifies the nil-classifier guard
+// (e.g. after Close()) tags the span errored but records no prediction, mirroring
+// BirdNET.Predict. The Perch is built with a true nil classifier interface (zero
+// value) so the p.classifier == nil guard fires.
+func TestPerchPredict_NilClassifierRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	p := &Perch{labels: []string{"A"}} // classifier is a nil interface
+
+	_, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a nil-classifier rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a nil-classifier rejection must not record a success")
+}
+
+// TestPerchPredict_LabelMismatchRecordsErrorOnce verifies a label/score count
+// mismatch (a failure after inference begins) records exactly one error.
+func TestPerchPredict_LabelMismatchRecordsErrorOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Two labels but only one logit: pairLabelsAndConfidence returns an error.
+	p := &Perch{classifier: &predTelemetryClassifier{logits: []float32{0.5}}, labels: []string{"A", "B"}}
+
+	_, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a label/score mismatch must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a label/score mismatch must not record a success")
+}
+
+// batEmbeddingExtractor is a fake inference.EmbeddingExtractor for the Bat tests.
+type batEmbeddingExtractor struct {
+	embeddings []float32
+	err        error
+}
+
+func (f *batEmbeddingExtractor) Predict(_ []float32) ([]float32, error) { return nil, nil }
+func (f *batEmbeddingExtractor) NumSpecies() int                        { return 0 }
+func (f *batEmbeddingExtractor) Close()                                 {}
+func (f *batEmbeddingExtractor) PredictWithEmbeddings(_ []float32) (logits, embeddings []float32, err error) {
+	return nil, f.embeddings, f.err
+}
+
+// batCustomClassifier is a fake inference.CustomClassifier for the Bat tests.
+type batCustomClassifier struct {
+	scores []float32
+	labels []string
+	err    error
+}
+
+func (f *batCustomClassifier) PredictEmbedding(_ []float32) ([]float32, error) {
+	return f.scores, f.err
+}
+func (f *batCustomClassifier) NumClasses() int  { return len(f.labels) }
+func (f *batCustomClassifier) Labels() []string { return f.labels }
+func (f *batCustomClassifier) Close()           {}
+
+// TestBatPredict_SuccessRecordsExactlyOnce verifies a happy-path Bat.Predict
+// records exactly one success under the RegistryIDBat model label, so Bat is
+// visible in birdnet_predictions_total alongside BirdNET and Perch.
+func TestBatPredict_SuccessRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Bat.Predict reads conf.Setting().Bat.Threshold; publish default test settings
+	// so the lookup returns a non-nil snapshot (threshold 0 disables filtering).
+	conftest.SetTestSettings(conftest.GetTestSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	b := &Bat{
+		embeddingExtractor: &batEmbeddingExtractor{embeddings: []float32{0.1, 0.2, 0.3}},
+		batClassifier:      &batCustomClassifier{scores: []float32{0.6, 0.4}, labels: []string{"BatA", "BatB"}},
+	}
+
+	results, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"a successful Bat prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"a successful Bat prediction must not record an error")
+}
+
+// TestBatPredict_EmbeddingErrorRecordsExactlyOnce verifies an embedding-extraction
+// failure records exactly one error under the Bat model label.
+func TestBatPredict_EmbeddingErrorRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	boom := errors.Newf("embedding extraction failed").Category(errors.CategoryAudio).Build()
+	b := &Bat{
+		embeddingExtractor: &batEmbeddingExtractor{err: boom},
+		batClassifier:      &batCustomClassifier{labels: []string{"BatA"}},
+	}
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"a failed Bat embedding extraction must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"a failed Bat embedding extraction must not record a spurious success")
+}
+
+// TestBatPredict_EmptySampleRecordsNothing verifies the empty-sample guard tags
+// the span errored but records no prediction, mirroring BirdNET.Predict.
+func TestBatPredict_EmptySampleRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	b := &Bat{} // extractors nil; empty sample returns before they are touched
+
+	_, err := b.Predict(t.Context(), nil)
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"an empty-sample rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"an empty-sample rejection must not record a success")
 }

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -27,6 +27,39 @@ const (
 	tagValueFalse = "false"
 )
 
+// opPredict is the span operation name for a model prediction. It is the only
+// operation currently instrumented via StartSpan; the constant keeps the
+// producers (BirdNET/Perch/Bat Predict) and the Finish consumer in sync.
+const opPredict = "birdnet.predict"
+
+// Span data keys recorded on prediction spans. Centralised so the telemetry
+// schema is documented in one place and stays consistent across models.
+const (
+	dataKeyErrorType        = "error_type"
+	dataKeySampleCount      = "sample_count"
+	dataKeySampleSize       = "sample_size"
+	dataKeyResultCount      = "result_count"
+	dataKeyTotalDurationMs  = "total_duration_ms"
+	dataKeyInvokeDurationMs = "invoke_duration_ms"
+	dataKeyDurationMs       = "duration_ms"
+)
+
+// error_type values recorded on failed predictions. Shared by every
+// ModelInstance.Predict implementation so the telemetry vocabulary stays
+// consistent across models.
+const (
+	errTypeEmptySample         = "empty_sample"
+	errTypeClassifierNil       = "classifier_nil"
+	errTypeInvokeFailed        = "invoke_failed"
+	errTypeLabelMismatch       = "label_mismatch"
+	errTypeEmbeddingExtraction = "embedding_extraction"
+	errTypeNilEmbeddings       = "nil_embeddings"
+	errTypeBatClassification   = "bat_classification"
+)
+
+// defaultTopKResults is the number of top predictions every model returns.
+const defaultTopKResults = 10
+
 // TracingSpan represents a traced operation with minimal overhead.
 // A TracingSpan must not be used from multiple goroutines concurrently.
 type TracingSpan struct {
@@ -173,22 +206,13 @@ func (s *TracingSpan) Finish() {
 				model = "unknown"
 			}
 
-			// Record appropriate metric based on operation
-			switch s.operation {
-			case "birdnet.predict":
-				// Skip the success record on error spans. Callers record the
-				// error outcome explicitly, so recording here would either
-				// double-count (when the caller already recorded an error) or
-				// log a spurious success (on early-guard error paths).
-				if !s.errored {
-					m.RecordPrediction(model, durationSeconds, nil)
-				}
-			case "birdnet.process_chunk":
-				m.RecordChunkProcess(model, durationSeconds)
-			case "birdnet.model_invoke":
-				m.RecordModelInvoke(model, durationSeconds)
-			case "birdnet.range_filter":
-				m.RecordRangeFilter(model, durationSeconds)
+			// Only predict spans are recorded here. Skip the success record on
+			// error spans: callers record the error outcome explicitly, so
+			// recording here would either double-count (when the caller already
+			// recorded an error) or log a spurious success (on early-guard error
+			// paths).
+			if s.operation == opPredict && !s.errored {
+				m.RecordPrediction(model, durationSeconds, nil)
 			}
 
 			m.SetActiveProcessing(float64(count))
@@ -197,9 +221,51 @@ func (s *TracingSpan) Finish() {
 
 	// Record in Sentry if enabled
 	if s.sentrySpan != nil {
-		s.SetData("duration_ms", duration.Milliseconds())
+		s.SetData(dataKeyDurationMs, duration.Milliseconds())
 		s.sentrySpan.Finish()
 	}
+}
+
+// startPredictSpan opens a birdnet.predict span and records the standard
+// prediction preamble (model tag and sample dimensions). It is the shared entry
+// point for every ModelInstance.Predict implementation so the operation name,
+// description, and data keys stay consistent across models.
+func startPredictSpan(ctx context.Context, model string, samples [][]float32) (*TracingSpan, context.Context) {
+	span, ctx := StartSpan(ctx, opPredict, "Species prediction")
+	span.SetTag(tagKeyModel, model)
+	span.SetData(dataKeySampleCount, len(samples))
+	if len(samples) > 0 {
+		span.SetData(dataKeySampleSize, len(samples[0]))
+	}
+	return span, ctx
+}
+
+// markErrored tags the span as failed with the given error_type. SetTag latches
+// the errored flag so Finish skips the success metric. Pre-inference guard
+// rejections (empty sample, uninitialised classifier) use this directly because
+// they are not counted as predictions; failures after inference begins use
+// recordPredictionFailure, which also records the error outcome.
+func (s *TracingSpan) markErrored(errorType string) {
+	s.SetTag(tagKeyError, tagValueTrue)
+	s.SetData(dataKeyErrorType, errorType)
+}
+
+// recordPredictionFailure marks the span errored and records the failed
+// prediction exactly once for the given model. Finish then skips its success
+// record because the span is errored.
+func recordPredictionFailure(span *TracingSpan, model, errorType string, start time.Time, err error) {
+	span.markErrored(errorType)
+	if m := getMetrics(); m != nil {
+		m.RecordPrediction(model, time.Since(start).Seconds(), err)
+	}
+}
+
+// recordPredictionSuccess records span data for a successful prediction and tags
+// it not-errored. The single success metric is recorded by Finish.
+func recordPredictionSuccess(span *TracingSpan, resultCount int, start time.Time) {
+	span.SetData(dataKeyResultCount, resultCount)
+	span.SetData(dataKeyTotalDurationMs, time.Since(start).Milliseconds())
+	span.SetTag(tagKeyError, tagValueFalse)
 }
 
 // RecordMetric records a performance metric


### PR DESCRIPTION
## Summary

Only `BirdNET.Predict` opened a prediction span, so Perch and Bat predictions never appeared in `birdnet_predictions_total` or `birdnet_prediction_duration_seconds`. This wraps `Perch.Predict` and `Bat.Predict` so every ONNX classifier reports its predictions, tagged by model (`Perch_V2`, `Bat`), and consolidates the telemetry onto a shared, exactly-once helper set:

- `startPredictSpan` opens the `birdnet.predict` span and records the model tag and sample dimensions.
- `markErrored` tags a pre-inference rejection (empty sample, uninitialised classifier) without recording a prediction (matching BirdNET, so these are not counted in either series).
- `recordPredictionFailure` records a post-inference failure exactly once.
- `recordPredictionSuccess` records span data; `Finish` records the single success.

`BirdNET.Predict` is refactored onto these helpers (behavior-preserving). The telemetry vocabulary (operation name, `error_type` values, span data keys, top-K count) moves to named constants. The dead `process_chunk`/`model_invoke`/`range_filter` cases in `Finish` are removed (no span ever produced those operations), and the bare `Perch_V2`/`Bat` id literals in the orchestrator loaders move to the `RegistryID*` constants.

Also fixes a pre-existing bug in `Bat.Predict`'s debug log, which reported the first above-threshold detection as the top species rather than the highest-confidence one.

## Notes

- Builds on #3426 (the exactly-once recording fix); this PR depends on the `errored` flag introduced there.
- `Perch.PredictWithEmbeddings` is on a separate feature branch and is not wrapped here.
- Operator-facing: new `model="Perch_V2"` and `model="Bat"` series appear in the prediction metrics, and `birdnet_active_processing` now aggregates Perch and Bat alongside BirdNET. No migration required.

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/classifier/...`
- [x] `golangci-lint run` (0 issues)
- [x] New tests assert exactly-once recording for Perch (success, inference error, label mismatch) and Bat (success, embedding error), plus the early-guard "records nothing" contract for both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved and standardized prediction telemetry and error handling across models for more consistent observability and diagnostics.
  * Unified top-K result selection to use a consistent default instead of model-specific fixed values.

* **Tests**
  * Added end-to-end telemetry tests to verify exactly-once recording of prediction success/error and coverage for various early-guard and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->