### PR TITLE
Reconcile feat/embeddings with main: adopt shared prediction-telemetry helpers

### DIFF
--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -23,26 +23,20 @@ type DetectionsMap map[string][]datastore.Results
 // Predict performs inference on a given sample using the classifier backend.
 // Implements ModelInstance.
 func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
-	span, _ := StartSpan(ctx, "birdnet.predict", "Species prediction")
+	span, _ := startPredictSpan(ctx, bn.ModelInfo.ID, sample)
 	defer span.Finish()
 
 	settings := bn.currentSettings()
 	start := time.Now()
-	span.SetTag("model", bn.ModelInfo.ID)
-	span.SetData("sample_count", len(sample))
-	if len(sample) > 0 {
-		span.SetData("sample_size", len(sample[0]))
-	}
 
-	// Guard against empty sample slice
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions.
 	if len(sample) == 0 || len(sample[0]) == 0 {
-		err := errors.Newf("empty audio sample").
+		span.markErrored(errTypeEmptySample)
+		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
-		span.SetTag("error", "true")
-		span.SetData("error_type", "empty_sample")
-		return nil, err
 	}
 
 	// Lock to prevent concurrent access to the classifier backend and shared buffers
@@ -51,13 +45,11 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 
 	// Guard against nil classifier (e.g., after Delete() is called concurrently)
 	if bn.classifier == nil {
-		err := errors.Newf("classifier backend is not initialized").
+		span.markErrored(errTypeClassifierNil)
+		return nil, errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
-		span.SetTag("error", "true")
-		span.SetData("error_type", "classifier_nil")
-		return nil, err
 	}
 
 	// Run inference via classifier backend
@@ -71,18 +63,12 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 			Timing("prediction-invoke", time.Since(start)).
 			Build()
 
-		span.SetTag("error", "true")
-		span.SetData("error_type", "invoke_failed")
-
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-
+		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeInvokeFailed, start, err)
 		return nil, err
 	}
 
 	invokeDuration := time.Since(invokeStart)
-	span.SetData("invoke_duration_ms", invokeDuration.Milliseconds())
+	span.SetData(dataKeyInvokeDurationMs, invokeDuration.Milliseconds())
 
 	// Record model invoke timing separately
 	if m := getMetrics(); m != nil {
@@ -102,30 +88,19 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 			Timing("prediction-total", time.Since(start)).
 			Build()
 
-		span.SetTag("error", "true")
-		span.SetData("error_type", "label_mismatch")
-
-		// Record error in metrics
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-
+		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 
 	// Use optimized top-k algorithm instead of full sort + trim
-	topResults := getTopKResults(results, 10)
+	topResults := getTopKResults(results, defaultTopKResults)
 
 	// Log prediction timing for performance monitoring
 	duration := time.Since(start)
 	bn.Debug("Prediction completed in %v with %d results", duration, len(topResults))
 
-	// Record metrics
-	span.SetData("total_duration_ms", duration.Milliseconds())
-	span.SetData("result_count", len(topResults))
-	span.SetTag("error", "false")
-
-	// The span.Finish() will automatically record the prediction metrics
+	// Record metrics. Finish() records the single success because the span is not errored.
+	recordPredictionSuccess(span, len(topResults), start)
 
 	// Return the top 10 results
 	return topResults, nil

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -879,6 +879,11 @@ func TestPredict_RecordsExactlyOnePredictionPerOutcome(t *testing.T) {
 	globalMetrics.Store(m)
 	t.Cleanup(func() { globalMetrics.Store(nil) })
 
+	// Clear global settings so BirdNET.Predict's currentSettings falls back to the
+	// per-instance settings (with this test's labels), independent of test order.
+	conf.StoreSettings(nil)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
 	countFor := func(status string) float64 {
 		return testutil.ToFloat64(m.PredictionTotal.WithLabelValues("test-model", status))
 	}

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -98,7 +98,15 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
 	log := GetLogger()
 
+	span, _ := startPredictSpan(ctx, RegistryIDBat, samples)
+	defer span.Finish()
+
+	start := time.Now()
+
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions, mirroring BirdNET.Predict.
 	if len(samples) == 0 || len(samples[0]) == 0 {
+		span.markErrored(errTypeEmptySample)
 		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			Build()
@@ -108,6 +116,7 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 	defer b.mu.Unlock()
 
 	if b.embeddingExtractor == nil || b.batClassifier == nil {
+		span.markErrored(errTypeClassifierNil)
 		return nil, errors.Newf("bat classifier is not initialized").
 			Category(errors.CategoryModelInit).
 			Build()
@@ -124,19 +133,23 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		log.Error("bat embedding extraction failed",
 			logger.Error(err),
 			logger.Duration("duration", embDuration))
-		return nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Context("stage", "embedding_extraction").
 			Build()
+		recordPredictionFailure(span, RegistryIDBat, errTypeEmbeddingExtraction, start, err)
+		return nil, err
 	}
 
 	if embeddings == nil {
 		log.Error("bat embedding model produced nil embeddings")
-		return nil, errors.Newf("embedding model did not produce embeddings").
+		err = errors.Newf("embedding model did not produce embeddings").
 			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Build()
+		recordPredictionFailure(span, RegistryIDBat, errTypeNilEmbeddings, start, err)
+		return nil, err
 	}
 
 	log.Debug("bat embeddings extracted",
@@ -150,11 +163,13 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		log.Error("bat classification failed",
 			logger.Error(err),
 			logger.Duration("duration", classDuration))
-		return nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Context("stage", "bat_classification").
 			Build()
+		recordPredictionFailure(span, RegistryIDBat, errTypeBatClassification, start, err)
+		return nil, err
 	}
 
 	log.Debug("bat classification complete",
@@ -163,6 +178,7 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 
 	results, err := pairLabelsAndConfidence(b.batClassifier.Labels(), scores)
 	if err != nil {
+		recordPredictionFailure(span, RegistryIDBat, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 
@@ -178,13 +194,17 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 		results = filtered
 	}
 
-	if len(results) > 0 {
+	// Sort and trim before logging so top_species reflects the highest-confidence
+	// detection rather than the first label that cleared the threshold (results is
+	// in label order, not confidence order).
+	topResults := getTopKResults(results, defaultTopKResults)
+	if len(topResults) > 0 {
 		log.Debug("bat detections after threshold",
 			logger.Int("pre_filter", preFilterCount),
 			logger.Int("post_filter", len(results)),
 			logger.Float64("threshold", threshold),
-			logger.String("top_species", results[0].Species),
-			logger.Float64("top_confidence", float64(results[0].Confidence)),
+			logger.String("top_species", topResults[0].Species),
+			logger.Float64("top_confidence", float64(topResults[0].Confidence)),
 			logger.Duration("total_duration", embDuration+classDuration))
 	} else {
 		log.Debug("bat no detections above threshold",
@@ -193,7 +213,10 @@ func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Res
 			logger.Duration("total_duration", embDuration+classDuration))
 	}
 
-	return getTopKResults(results, 10), nil
+	// Success: Finish records the single prediction because the span is not errored.
+	recordPredictionSuccess(span, len(topResults), start)
+
+	return topResults, nil
 }
 
 // Spec returns the audio requirements for the bat model.

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1466,6 +1466,9 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 		Name:         bn.ModelInfo.Name,
 		TotalSpecies: len(bn.Settings.BirdNET.Labels),
 	}
+	// Snapshot modelsDir under bn.mu; the auto-select check below runs after the
+	// unlock and would otherwise race a concurrent SetModelsDir write.
+	modelsDir := bn.modelsDir
 
 	mrf, isMapped := bn.rangeFilter.(*mappedRangeFilter)
 	if isMapped {
@@ -1486,8 +1489,8 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 	// No geomodel active: leave WithRangeData and WithoutRangeData at zero.
 	bn.mu.Unlock()
 
-	if rf.Model == "v3" && bn.modelsDir != "" {
-		sharedDir := filepath.Join(bn.modelsDir, "shared")
+	if rf.Model == "v3" && modelsDir != "" {
+		sharedDir := filepath.Join(modelsDir, "shared")
 		expectedONNX := filepath.Join(sharedDir, conf.GeomodelONNXLocalName)
 		expectedLabels := filepath.Join(sharedDir, conf.GeomodelLabelsLocalName)
 		autoSelected = rf.ModelPath == expectedONNX && rf.LabelsPath == expectedLabels
@@ -1513,6 +1516,12 @@ func (bn *BirdNET) rangeFilterRuntimeState() (active, fellBack bool) {
 // Called by the Orchestrator after creation so auto-selection can
 // resolve geomodel paths from the installed models directory.
 func (bn *BirdNET) SetModelsDir(dir string) {
+	// Guard the write under bn.mu: bn.modelsDir is read under bn.mu by
+	// initializeMetaModel (via NewBirdNET / ReloadRangeFilter / reloadModelInternal)
+	// and snapshotted under bn.mu by PrimaryRangeFilterCoverage. No caller of this
+	// method holds bn.mu, so locking here cannot self-deadlock.
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
 	bn.modelsDir = dir
 }
 

--- a/internal/classifier/embeddings.go
+++ b/internal/classifier/embeddings.go
@@ -77,36 +77,30 @@ func (bn *BirdNET) EmbeddingDim() int {
 // ee.EmbeddingDim()) is performed on the ee interface value, never via
 // bn.EmbeddingDim(), to avoid a self-deadlock on bn.mu.
 //
-// Telemetry mirrors BirdNET.Predict exactly: same span data keys, same
-// RecordModelInvoke/RecordPrediction call sites. The success-path
-// RecordPrediction fires via span.Finish() (tracing.go switch case
-// "birdnet.predict_embeddings"); error-path RecordPrediction is explicit.
+// Telemetry mirrors BirdNET.Predict via the shared helpers: pre-inference
+// guards use markErrored (tagged but not counted as a prediction),
+// post-inference failures use recordPredictionFailure (exactly one error), and
+// the success path uses recordPredictionSuccess. The single success metric is
+// recorded by span.Finish() because the birdnet.predict_embeddings operation
+// shares the prediction metric with the plain predict path. RecordModelInvoke
+// records the separate invoke timing, matching BirdNET.Predict.
 //
 // Implements EmbeddingCapable.
 func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32) ([]datastore.Results, []float32, error) {
-	span, _ := StartSpan(ctx, "birdnet.predict_embeddings", "Species prediction with embeddings")
+	span, _ := startPredictEmbeddingsSpan(ctx, bn.ModelInfo.ID, sample)
 	defer span.Finish()
-	span.SetTag("model", bn.ModelInfo.ID)
 
 	settings := bn.currentSettings()
 	start := time.Now()
-	span.SetData("sample_count", len(sample))
-	if len(sample) > 0 {
-		span.SetData("sample_size", len(sample[0]))
-	}
 
-	// Guard against empty sample slice
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions, mirroring BirdNET.Predict.
 	if len(sample) == 0 || len(sample[0]) == 0 {
-		err := errors.Newf("empty audio sample").
+		span.markErrored(errTypeEmptySample)
+		return nil, nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
-		span.SetTag("error", "true")
-		span.SetData("error_type", "empty_sample")
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-		return nil, nil, err
 	}
 
 	// Lock to prevent concurrent access to the classifier backend and shared buffers
@@ -115,16 +109,11 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 
 	// Guard against nil classifier (e.g., after Delete() is called concurrently)
 	if bn.classifier == nil {
-		err := errors.Newf("classifier backend is not initialized").
+		span.markErrored(errTypeClassifierNil)
+		return nil, nil, errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
-		span.SetTag("error", "true")
-		span.SetData("error_type", "classifier_nil")
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-		return nil, nil, err
 	}
 
 	// Run the capability-gated forward pass under bn.mu. extractRawWithEmbeddings
@@ -135,7 +124,6 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 	invokeStart := time.Now()
 	predictions, embedding, invokeErr := extractRawWithEmbeddings(bn.classifier, sample[0])
 	invokeDuration := time.Since(invokeStart)
-
 	if invokeErr != nil {
 		err := errors.New(invokeErr).
 			Category(errors.CategoryAudio).
@@ -143,18 +131,11 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 			Context("sample_length", len(sample[0])).
 			Timing("prediction-invoke", time.Since(start)).
 			Build()
-
-		span.SetTag("error", "true")
-		span.SetData("error_type", "invoke_failed")
-
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-
+		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeInvokeFailed, start, err)
 		return nil, nil, err
 	}
 
-	span.SetData("invoke_duration_ms", invokeDuration.Milliseconds())
+	span.SetData(dataKeyInvokeDurationMs, invokeDuration.Milliseconds())
 
 	// Record model invoke timing separately
 	if m := getMetrics(); m != nil {
@@ -169,15 +150,7 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 			Context("confidence_count", len(predictions)).
 			Timing("prediction-total", time.Since(start)).
 			Build()
-
-		span.SetTag("error", "true")
-		span.SetData("error_type", "label_mismatch")
-
-		// Record error in metrics
-		if m := getMetrics(); m != nil {
-			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
-		}
-
+		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeLabelMismatch, start, err)
 		return nil, nil, err
 	}
 
@@ -185,13 +158,9 @@ func (bn *BirdNET) PredictWithEmbeddings(ctx context.Context, sample [][]float32
 	duration := time.Since(start)
 	bn.Debug("Prediction with embeddings completed in %v with %d results", duration, len(results))
 
-	// Record metrics
-	span.SetData("total_duration_ms", duration.Milliseconds())
-	span.SetData("result_count", len(results))
-	span.SetTag("error", "false")
-
-	// The span.Finish() will automatically record the prediction metrics via the
-	// "birdnet.predict_embeddings" case in tracing.go Finish().
+	// Record metrics. Finish() records the single success because the span is not
+	// errored (birdnet.predict_embeddings shares the predict success metric).
+	recordPredictionSuccess(span, len(results), start)
 
 	return results, embedding, nil
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -30,6 +30,13 @@ type modelEntry struct {
 	mu       sync.Mutex // per-model lock; prevents inference on one model from blocking another
 }
 
+// entryRef pairs a registry ID with its model entry for the snapshot-then-iterate
+// pattern used when walking o.models outside the o.mu critical section.
+type entryRef struct {
+	id    string
+	entry *modelEntry
+}
+
 // Orchestrator manages classifier model instances and provides the primary
 // inference API. It replaces direct *BirdNET usage at all call sites.
 // Supports multiple models with per-model locking and name resolution.
@@ -156,9 +163,19 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 // geomodel auto-selection, and registers the taxonomy resolver if
 // taxonomy.csv is available on disk.
 func (o *Orchestrator) SetModelsDir(dir string) {
+	// Guard the o.modelsDir write and the o.primary read under o.mu: o.modelsDir
+	// is read by resolveInstalledPaths (always under o.mu via the model loaders),
+	// and o.primary is cleared by Delete() under o.mu.Lock(). Release before the
+	// downstream calls, which take their own locks. registerTaxonomyResolver in
+	// particular acquires o.mu.RLock() internally, so holding o.mu here would
+	// self-deadlock (the RWMutex is not reentrant).
+	o.mu.Lock()
 	o.modelsDir = dir
-	if o.primary != nil {
-		o.primary.SetModelsDir(dir)
+	primary := o.primary
+	o.mu.Unlock()
+
+	if primary != nil {
+		primary.SetModelsDir(dir)
 	}
 	o.registerTaxonomyResolver(dir)
 }
@@ -476,14 +493,26 @@ func scientificNamesFromLabels(labels []string) []string {
 
 // GetProbableSpecies returns species scores from the range filter.
 func (o *Orchestrator) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
-	return o.primary.GetProbableSpecies(date, week)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil, nil
+	}
+	return primary.GetProbableSpecies(date, week)
 }
 
 // GetProbableSpeciesWithSettings filters species using the supplied settings
 // snapshot, allowing callers to test arbitrary coordinates and thresholds
 // without modifying global state.
 func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
-	return o.primary.GetProbableSpeciesWithSettings(date, week, settings)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil, nil
+	}
+	return primary.GetProbableSpeciesWithSettings(date, week, settings)
 }
 
 // GetAllProbableSpeciesWithSettings returns species from all active classifiers.
@@ -542,11 +571,6 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	geoCovered := make(map[string]bool, len(geoLabels))
 	for _, label := range geoLabels {
 		geoCovered[strings.ToLower(detection.ExtractScientificName(label))] = true
-	}
-
-	type entryRef struct {
-		id    string
-		entry *modelEntry
 	}
 
 	o.mu.RLock()
@@ -622,27 +646,57 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 
 // GetSpeciesOccurrence returns the occurrence probability for a species at the current time.
 func (o *Orchestrator) GetSpeciesOccurrence(species string) float64 {
-	return o.primary.GetSpeciesOccurrence(species)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return 0
+	}
+	return primary.GetSpeciesOccurrence(species)
 }
 
 // GetSpeciesOccurrenceAtTime returns the occurrence probability for a species at a specific time.
 func (o *Orchestrator) GetSpeciesOccurrenceAtTime(species string, detectionTime time.Time) float64 {
-	return o.primary.GetSpeciesOccurrenceAtTime(species, detectionTime)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return 0
+	}
+	return primary.GetSpeciesOccurrenceAtTime(species, detectionTime)
 }
 
 // NumSpecies returns the number of species labels of the primary model.
 func (o *Orchestrator) NumSpecies() int {
-	return o.primary.NumSpecies()
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return 0
+	}
+	return primary.NumSpecies()
 }
 
 // Labels returns a copy of the species labels of the primary model.
 func (o *Orchestrator) Labels() []string {
-	return o.primary.Labels()
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil
+	}
+	return primary.Labels()
 }
 
 // GetSpeciesCode returns the eBird species code for a given label.
 func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
-	return o.primary.GetSpeciesCode(label)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return "", false
+	}
+	return primary.GetSpeciesCode(label)
 }
 
 // GetSpeciesNameFromCode returns the species name for a given eBird species code.
@@ -735,11 +789,6 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 		id     string
 		name   string
 		labels []string
-	}
-
-	type entryRef struct {
-		id    string
-		entry *modelEntry
 	}
 
 	var refs []entryRef
@@ -843,7 +892,13 @@ func (o *Orchestrator) notifyRangeFilterReload() {
 
 // RunFilterProcess executes the filter process on demand and prints results.
 func (o *Orchestrator) RunFilterProcess(dateStr string, week float32) {
-	o.primary.RunFilterProcess(dateStr, week)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return
+	}
+	primary.RunFilterProcess(dateStr, week)
 }
 
 // ReloadModel reloads the primary model and re-syncs shared state.
@@ -921,10 +976,25 @@ func (o *Orchestrator) ReloadModel() error {
 // Delete releases all resources held by the Orchestrator and its models.
 // After calling Delete, the Orchestrator must not be used.
 func (o *Orchestrator) Delete() {
+	// Snapshot the models, stop the scheduler, and clear o.primary/o.models under
+	// o.mu so the accessors (which snapshot o.primary under o.mu) observe the
+	// deleted state immediately and fail fast. Then release o.mu before the
+	// per-model Close() calls: Close does native teardown that can be slow, and
+	// holding o.mu across it would block every accessor for the duration of
+	// teardown. UnloadModel uses the same drop-lock-before-close shape.
 	o.mu.Lock()
-	defer o.mu.Unlock()
+	models := o.models
+	// Swap(nil) both retrieves the scheduler to stop and clears the pointer, so a
+	// re-used orchestrator does not see a stale stopped scheduler (SetSunCalc skips
+	// creating a new one when o.scheduler is already non-nil).
+	if s := o.scheduler.Swap(nil); s != nil {
+		s.stop()
+	}
+	o.primary = nil
+	o.models = nil
+	o.mu.Unlock()
 
-	for _, entry := range o.models {
+	for id, entry := range models {
 		entry.mu.Lock()
 		if entry.instance != nil {
 			if err := entry.instance.Close(); err != nil {
@@ -934,17 +1004,15 @@ func (o *Orchestrator) Delete() {
 			}
 			entry.instance = nil // nil out to signal closed state to PredictModel
 		}
+		// Drop the model's global inference counters while still holding entry.mu,
+		// mirroring UnloadModel: this prevents an in-flight RecordInvoke from
+		// re-creating the entry after deletion, and stops a teardown-then-recreate
+		// cycle from leaking counter entries.
+		globalInferenceCounters.Delete(id)
 		entry.mu.Unlock()
-	}
-	if s := o.scheduler.Load(); s != nil {
-		s.stop()
 	}
 
 	CloseHeatmapService()
-
-	// Nil out references to fail fast on use-after-delete.
-	o.primary = nil
-	o.models = nil
 }
 
 // IsModelLoaded returns true if a model with the given registry ID is
@@ -1178,7 +1246,14 @@ func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int
 			Category(errors.CategoryValidation).
 			Build()
 	}
-	if len(inputs) != batchSize*inputWidth {
+	// Check batchSize against len(inputs)/inputWidth before computing
+	// batchSize*inputWidth: a near-math.MaxInt batchSize would otherwise overflow
+	// the multiplication to a small positive value that could spuriously equal
+	// len(inputs), bypass validation, and push an oversized batch into the ONNX
+	// backend (out-of-bounds read). inputWidth is a positive constant, so the
+	// division is safe; batchSize > 0 is guaranteed above, so len(inputs)==0 is
+	// rejected cleanly.
+	if batchSize > len(inputs)/inputWidth || len(inputs) != batchSize*inputWidth {
 		return nil, errors.Newf("inputs length %d does not match batchSize %d * %d", len(inputs), batchSize, inputWidth).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
@@ -1223,17 +1298,18 @@ func (o *Orchestrator) GeomodelSpeciesInfo(label string) (speciesIdx, numGeoSpec
 
 // Debug prints debug messages if debug mode is enabled.
 func (o *Orchestrator) Debug(format string, v ...any) {
-	o.primary.Debug(format, v...)
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return
+	}
+	primary.Debug(format, v...)
 }
 
 // ModelInfos returns ModelInfo for all registered models. Thread-safe.
 // Used by the pipeline to build ModelTarget lists for buffer fan-out.
 func (o *Orchestrator) ModelInfos() []ModelInfo {
-	type entryRef struct {
-		id    string
-		entry *modelEntry
-	}
-
 	o.mu.RLock()
 	if o.models == nil {
 		o.mu.RUnlock()

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -30,11 +30,11 @@ func (o *Orchestrator) loadBat(threads int) error {
 		return errors.Newf("bat model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Build()
 	}
 
-	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", "Bat", "classifier.orchestrator"); err != nil {
+	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
 		return err
 	}
 
@@ -52,7 +52,7 @@ func (o *Orchestrator) loadBat(threads int) error {
 		return errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Bat").
+			Context("model", RegistryIDBat).
 			Build()
 	}
 

--- a/internal/classifier/orchestrator_concurrency_test.go
+++ b/internal/classifier/orchestrator_concurrency_test.go
@@ -1,0 +1,237 @@
+package classifier
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestOrchestrator_AccessorsNilPrimary_NoPanic verifies the teardown contract:
+// after Delete() clears o.primary, every primary-delegating accessor must return
+// its zero value instead of dereferencing a nil o.primary and panicking. A
+// minimal Orchestrator with no primary reproduces the post-Delete state exactly.
+func TestOrchestrator_AccessorsNilPrimary_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	settings := conftest.GetTestSettings()
+	o := &Orchestrator{Settings: settings}
+
+	assert.Equal(t, 0, o.NumSpecies())
+	assert.Nil(t, o.Labels())
+
+	code, ok := o.GetSpeciesCode("Turdus merula_Common Blackbird")
+	assert.Empty(t, code)
+	assert.False(t, ok)
+
+	scores, err := o.GetProbableSpecies(time.Now(), 0)
+	require.NoError(t, err)
+	assert.Nil(t, scores)
+
+	scores2, err := o.GetProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+	assert.Nil(t, scores2)
+
+	assert.Zero(t, o.GetSpeciesOccurrence("Turdus merula_Common Blackbird"))
+	assert.Zero(t, o.GetSpeciesOccurrenceAtTime("Turdus merula_Common Blackbird", time.Now()))
+
+	// Must not panic with a nil primary.
+	assert.NotPanics(t, func() { o.RunFilterProcess(time.Now().Format(time.DateOnly), 0) })
+	assert.NotPanics(t, func() { o.Debug("noop %d", 1) })
+
+	// BuildRangeFilter snapshots the primary and returns a typed error rather than
+	// panicking when there is no primary.
+	err = BuildRangeFilter(o)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no primary model")
+}
+
+// TestOrchestrator_AccessorsConcurrentWithPrimaryClear_NoRace is the regression
+// guard for the accessor-vs-Delete() data race: Delete() sets o.primary = nil
+// under o.mu.Lock(), while the accessors used to read o.primary with no lock.
+// A writer toggles o.primary under o.mu.Lock() (mirroring Delete's write) while
+// readers hammer the accessors; the snapshot-under-RLock fix must make this
+// race-free and panic-free. Must be run with -race.
+func TestOrchestrator_AccessorsConcurrentWithPrimaryClear_NoRace(t *testing.T) {
+	t.Parallel()
+
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Labels = []string{"Turdus merula_Common Blackbird", "Parus major_Great Tit"}
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
+
+	o := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo,
+		primary:   bn,
+		models:    map[string]*modelEntry{"BirdNET_V3": {instance: bn}},
+	}
+
+	const readsPerGoroutine = 300
+	const readerCount = 4
+
+	var readerWg sync.WaitGroup
+	var readersDone atomic.Bool
+	start := make(chan struct{})
+
+	// Writer: flip o.primary between bn and nil under o.mu.Lock(), the exact write
+	// Delete() performs. Spins until the readers finish so the write window always
+	// overlaps the reads.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		<-start
+		cleared := false
+		for !readersDone.Load() {
+			o.mu.Lock()
+			if cleared {
+				o.primary = nil
+			} else {
+				o.primary = bn
+			}
+			cleared = !cleared
+			o.mu.Unlock()
+			runtime.Gosched() // yield so the spin does not starve readers on a busy CI core
+		}
+		// Leave the primary restored so any trailing read sees a valid instance.
+		o.mu.Lock()
+		o.primary = bn
+		o.mu.Unlock()
+	}()
+
+	for range readerCount {
+		readerWg.Go(func() {
+			<-start
+			for range readsPerGoroutine {
+				_ = o.NumSpecies()
+				_ = o.Labels()
+			}
+		})
+	}
+
+	close(start)
+	readerWg.Wait()
+	readersDone.Store(true)
+	<-writerDone
+}
+
+// TestBirdNET_SetModelsDirConcurrentWithCoverage_NoRace is the regression guard
+// for the bn.modelsDir data race: SetModelsDir wrote bn.modelsDir with no lock
+// while PrimaryRangeFilterCoverage read it after releasing bn.mu. The write is
+// now guarded and the read is snapshotted under bn.mu. Must be run with -race.
+//
+// Not parallel: PrimaryRangeFilterCoverage resolves its settings through
+// conf.CurrentOrFallback, which prefers the global settings instance, so the
+// test sets a global v3 range-filter config (the branch that reads modelsDir)
+// and restores a clean default on cleanup.
+func TestBirdNET_SetModelsDirConcurrentWithCoverage_NoRace(t *testing.T) {
+	v3 := conftest.GetTestSettings()
+	v3.BirdNET.RangeFilter.Model = "v3"
+	v3.BirdNET.Labels = []string{"Turdus merula_Common Blackbird"}
+	conftest.SetTestSettings(v3)
+	t.Cleanup(func() { conftest.SetTestSettings(conftest.GetTestSettings()) })
+
+	bn := &BirdNET{
+		Settings:     v3,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V3", Name: "BirdNET v3.0"}
+
+	const iterations = 300
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		<-start
+		for i := range iterations {
+			bn.SetModelsDir(fmt.Sprintf("/models/%d", i))
+		}
+	})
+	wg.Go(func() {
+		<-start
+		for range iterations {
+			_, _, _, _ = bn.PrimaryRangeFilterCoverage()
+		}
+	})
+	close(start)
+	wg.Wait()
+}
+
+// TestBatchRangeFilterInference_SizeValidation covers the input-size guards,
+// including the integer-overflow-safe form: a near-math.MaxInt batchSize whose
+// batchSize*inputWidth would overflow must be rejected by the divisor check
+// before the multiplication is trusted, instead of slipping an oversized batch
+// into the backend.
+func TestBatchRangeFilterInference_SizeValidation(t *testing.T) {
+	t.Parallel()
+
+	o := &Orchestrator{}
+
+	tests := []struct {
+		name      string
+		inputs    []float32
+		batchSize int
+		wantMsg   string
+	}{
+		{
+			name:      "non-positive batchSize",
+			inputs:    make([]float32, 3),
+			batchSize: 0,
+			wantMsg:   "must be positive",
+		},
+		{
+			name:      "plain length mismatch",
+			inputs:    make([]float32, 4),
+			batchSize: 1,
+			wantMsg:   "does not match batchSize",
+		},
+		{
+			name:      "oversized batchSize",
+			inputs:    make([]float32, 9),
+			batchSize: math.MaxInt,
+			wantMsg:   "does not match batchSize",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := o.BatchRangeFilterInference(tt.inputs, tt.batchSize)
+			require.Error(t, err)
+			assert.Nil(t, out)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+		})
+	}
+
+	// The decisive overflow case: a batchSize whose batchSize*inputWidth wraps
+	// (two's complement) to EXACTLY len(inputs). The old check
+	// `len(inputs) != batchSize*inputWidth` computes 2 != 2 (false) and would
+	// ACCEPT this oversized batch, passing it to the backend; only the divisor
+	// guard rejects it. This is the regression this fix exists for: it fails on
+	// the pre-fix code (which returns a different downstream error) and passes
+	// only with the guard. 3 * 6148914691236517206 == 2^64 + 2, which wraps to 2
+	// as int64. The construction only fits a 64-bit int; build it through uint64
+	// so the literal never overflows a 32-bit int at compile time, and skip where
+	// int is not 64-bit (overflow boundary differs there).
+	t.Run("overflow wraps to len(inputs)", func(t *testing.T) {
+		t.Parallel()
+		if math.MaxInt != math.MaxInt64 {
+			t.Skip("overflow construction requires a 64-bit int")
+		}
+		wrapBatch := int(uint64(6148914691236517206)) // 3*this == 2^64+2 -> wraps to 2
+		out, err := o.BatchRangeFilterInference(make([]float32, 2), wrapBatch)
+		require.Error(t, err)
+		assert.Nil(t, out)
+		assert.Contains(t, err.Error(), "does not match batchSize")
+	})
+}

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -26,11 +26,11 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		return errors.Newf("Perch v2 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Perch_V2").
+			Context("model", RegistryIDPerchV2).
 			Build()
 	}
 
-	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", "Perch_V2", "classifier.orchestrator"); err != nil {
+	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", RegistryIDPerchV2, "classifier.orchestrator"); err != nil {
 		return err
 	}
 
@@ -46,7 +46,7 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		return errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
-			Context("model", "Perch_V2").
+			Context("model", RegistryIDPerchV2).
 			Build()
 	}
 

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -102,7 +102,15 @@ func NewPerch(cfg PerchConfig) (*Perch, error) {
 // Predict runs inference on the given audio samples.
 // Implements ModelInstance.
 func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
+	span, _ := startPredictSpan(ctx, RegistryIDPerchV2, samples)
+	defer span.Finish()
+
+	start := time.Now()
+
+	// Guard against empty sample slice. Pre-inference rejections are tagged but
+	// not counted as predictions, mirroring BirdNET.Predict.
 	if len(samples) == 0 || len(samples[0]) == 0 {
+		span.markErrored(errTypeEmptySample)
 		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
 			Build()
@@ -111,7 +119,9 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	// Guard against nil classifier (e.g., after Close() is called concurrently)
 	if p.classifier == nil {
+		span.markErrored(errTypeClassifierNil)
 		return nil, errors.Newf("Perch classifier is not initialized").
 			Category(errors.CategoryModelInit).
 			Build()
@@ -119,10 +129,12 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 
 	rawLogits, err := p.classifier.Predict(samples[0])
 	if err != nil {
-		return nil, errors.New(err).
+		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			Context("model", "Perch_V2").
+			Context("model", RegistryIDPerchV2).
 			Build()
+		recordPredictionFailure(span, RegistryIDPerchV2, errTypeInvokeFailed, start, err)
+		return nil, err
 	}
 
 	// Apply softmax to normalize raw logits into probabilities (0.0-1.0).
@@ -133,11 +145,15 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 	// Pair labels with predictions
 	results, err := pairLabelsAndConfidence(p.labels, predictions)
 	if err != nil {
+		recordPredictionFailure(span, RegistryIDPerchV2, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 
-	// Return top 10 results
-	return getTopKResults(results, 10), nil
+	// Success: Finish records the single prediction because the span is not errored.
+	topResults := getTopKResults(results, defaultTopKResults)
+	recordPredictionSuccess(span, len(topResults), start)
+
+	return topResults, nil
 }
 
 // Spec returns the audio requirements for Perch v2.

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -299,6 +299,111 @@ func TestPerchPredictWithEmbeddings_LabelMismatchRecordsErrorOnce(t *testing.T) 
 		"a label/score mismatch must not record a success")
 }
 
+// TestBirdNETPredictWithEmbeddings_SuccessRecordsExactlyOnce verifies the BirdNET
+// embedding predict path records exactly one success under the BirdNET model
+// label, at telemetry parity with BirdNET.Predict and Perch.PredictWithEmbeddings.
+func TestBirdNETPredictWithEmbeddings_SuccessRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Clear global settings so currentSettings falls back to the per-instance
+	// settings (with this test's labels), independent of test ordering.
+	conftest.SetTestSettings(nil)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	labels := []string{"a_A", "b_B", "c_C"}
+	bn := newEmbTestBirdNET(&fakePlainClassifier{logits: []float32{0.1, 0.9, 0.5}}, labels)
+
+	results, embedding, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	// A plain (non-embedding) backend yields a nil embedding, not an error.
+	assert.Nil(t, embedding, "a non-embedding backend must yield a nil embedding")
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, bn.ModelInfo.ID, "success"), 0,
+		"a successful BirdNET embedding prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, bn.ModelInfo.ID, "error"), 0,
+		"a successful BirdNET embedding prediction must not record an error")
+}
+
+// TestBirdNETPredictWithEmbeddings_EmptySampleRecordsNothing verifies the
+// empty-sample guard on the BirdNET embedding path is tagged but not counted,
+// matching the unified pre-inference guard semantics (this is the behaviour the
+// migration to the shared helpers introduced; the old inline path counted it).
+func TestBirdNETPredictWithEmbeddings_EmptySampleRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Clear global settings so currentSettings falls back to the per-instance
+	// settings (with this test's labels), independent of test ordering.
+	conftest.SetTestSettings(nil)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	bn := newEmbTestBirdNET(&fakePlainClassifier{logits: []float32{0.1}}, []string{"a_A"})
+
+	_, _, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{})
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, bn.ModelInfo.ID, "error"), 0,
+		"an empty-sample rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, bn.ModelInfo.ID, "success"), 0,
+		"an empty-sample rejection must not record a success")
+}
+
+// TestBirdNETPredictWithEmbeddings_InvokeErrorRecordsErrorOnce verifies a backend
+// inference failure (after inference begins) records exactly one error.
+func TestBirdNETPredictWithEmbeddings_InvokeErrorRecordsErrorOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Clear global settings so currentSettings falls back to the per-instance
+	// settings (with this test's labels), independent of test ordering.
+	conftest.SetTestSettings(nil)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	bn := newEmbTestBirdNET(&fakeErrPlainClassifier{err: assert.AnError}, []string{"a_A"})
+
+	_, _, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, bn.ModelInfo.ID, "error"), 0,
+		"a failed BirdNET embedding inference must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, bn.ModelInfo.ID, "success"), 0,
+		"a failed BirdNET embedding inference must not record a spurious success")
+}
+
+// TestBirdNETPredictWithEmbeddings_LabelMismatchRecordsErrorOnce verifies a
+// label/prediction count mismatch (a failure after inference begins) records
+// exactly one error.
+func TestBirdNETPredictWithEmbeddings_LabelMismatchRecordsErrorOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Clear global settings so currentSettings falls back to the per-instance
+	// settings (with this test's labels), independent of test ordering.
+	conftest.SetTestSettings(nil)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	// Three labels but only two logits: finalizeResults returns a mismatch error.
+	bn := newEmbTestBirdNET(&fakePlainClassifier{logits: []float32{0.1, 0.2}}, []string{"a_A", "b_B", "c_C"})
+
+	_, _, err := bn.PredictWithEmbeddings(t.Context(), [][]float32{{0.0}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, bn.ModelInfo.ID, "error"), 0,
+		"a label/prediction mismatch must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, bn.ModelInfo.ID, "success"), 0,
+		"a label/prediction mismatch must not record a success")
+}
+
 // batEmbeddingExtractor is a fake inference.EmbeddingExtractor for the Bat tests.
 type batEmbeddingExtractor struct {
 	embeddings []float32

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -1,0 +1,118 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/observability/metrics"
+)
+
+// predTelemetryModel is an arbitrary model label used by the span-level tests.
+const predTelemetryModel = "BirdNET_GLOBAL_6K_V2.4"
+
+// predictionCount returns the current value of birdnet_predictions_total for the
+// given model/status combination. WithLabelValues lazily creates the child at 0,
+// so an untouched combination reports 0.0 rather than panicking.
+func predictionCount(t *testing.T, m *metrics.BirdNETMetrics, model, status string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(m.PredictionTotal.WithLabelValues(model, status))
+}
+
+// newPredictSpan starts a birdnet.predict span for the exactly-once tests.
+func newPredictSpan(t *testing.T) *TracingSpan {
+	t.Helper()
+	span, _ := StartSpan(t.Context(), "birdnet.predict", "telemetry test")
+	require.NotNil(t, span)
+	return span
+}
+
+// TestTracingSpan_ErrorPathRecordsExactlyOnce mirrors a Predict error path: the
+// caller records the error explicitly and tags the span errored. Finish must NOT
+// add a second (success) record.
+func TestTracingSpan_ErrorPathRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+
+	// The caller records the error outcome explicitly, then tags the span errored.
+	predErr := errors.Newf("inference failed").Category(errors.CategoryAudio).Build()
+	m.RecordPrediction(predTelemetryModel, 0.01, predErr)
+	span.SetTag(tagKeyError, tagValueTrue)
+
+	span.Finish()
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
+		"errored prediction must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"Finish must not record a spurious success on an errored span")
+}
+
+// TestTracingSpan_SuccessPathRecordsExactlyOnce verifies the happy path records
+// exactly one success and that tagging error=false does not flip the errored flag.
+func TestTracingSpan_SuccessPathRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+	span.SetTag(tagKeyError, tagValueFalse) // success path tags error=false
+
+	span.Finish()
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"successful prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
+		"error=false must not record an error outcome")
+}
+
+// TestTracingSpan_ErroredEarlyGuardRecordsNothing documents the contract for the
+// Predict early-guard error paths (empty_sample, classifier_nil): they tag the
+// span errored but do not record explicitly, so the prediction is not counted at
+// all. This is intentional: the success record is suppressed and these
+// pre-inference rejections do not inflate the success or error series.
+func TestTracingSpan_ErroredEarlyGuardRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+	span.SetTag(tagKeyError, tagValueTrue) // tagged errored, but no explicit record
+
+	span.Finish()
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"an errored span must not record a success")
+	assert.InDelta(t, 0.0, predictionCount(t, m, predTelemetryModel, "error"), 0,
+		"an early-guard error without an explicit record must not be counted")
+}
+
+// TestTracingSpan_FinishIsIdempotent verifies that calling Finish more than once
+// (e.g. a manual call plus a deferred one) records the prediction only once and
+// does not decrement the active-operations counter twice.
+func TestTracingSpan_FinishIsIdempotent(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	span := newPredictSpan(t)
+	span.SetTag(tagKeyModel, predTelemetryModel)
+
+	span.Finish()
+	span.Finish() // second call must be a no-op
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
+		"a span finished twice must record exactly one success")
+}

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 )
@@ -30,9 +31,9 @@ func newPredictSpan(t *testing.T) *TracingSpan {
 	return span
 }
 
-// TestTracingSpan_ErrorPathRecordsExactlyOnce mirrors a Predict error path: the
-// caller records the error explicitly and tags the span errored. Finish must NOT
-// add a second (success) record.
+// TestTracingSpan_ErrorPathRecordsExactlyOnce mirrors BirdNET.Predict's
+// invoke_failed / label_mismatch paths: the caller records the error explicitly
+// and tags the span errored. Finish must NOT add a second (success) record.
 func TestTracingSpan_ErrorPathRecordsExactlyOnce(t *testing.T) {
 	resetGlobalMetrics(t)
 	t.Cleanup(func() { resetGlobalMetrics(t) })
@@ -75,10 +76,10 @@ func TestTracingSpan_SuccessPathRecordsExactlyOnce(t *testing.T) {
 		"error=false must not record an error outcome")
 }
 
-// TestTracingSpan_ErroredEarlyGuardRecordsNothing documents the contract for the
-// Predict early-guard error paths (empty_sample, classifier_nil): they tag the
-// span errored but do not record explicitly, so the prediction is not counted at
-// all. This is intentional: the success record is suppressed and these
+// TestTracingSpan_ErroredEarlyGuardRecordsNothing documents the contract for
+// BirdNET.Predict's early-guard error paths (empty_sample, classifier_nil): they
+// tag the span errored but do not record explicitly, so the prediction is not
+// counted at all. This is intentional: the success record is suppressed and these
 // pre-inference rejections do not inflate the success or error series.
 func TestTracingSpan_ErroredEarlyGuardRecordsNothing(t *testing.T) {
 	resetGlobalMetrics(t)
@@ -115,4 +116,237 @@ func TestTracingSpan_FinishIsIdempotent(t *testing.T) {
 
 	assert.InDelta(t, 1.0, predictionCount(t, m, predTelemetryModel, "success"), 0,
 		"a span finished twice must record exactly one success")
+}
+
+// predTelemetryClassifier is a fake inference.Classifier for the Perch tests.
+type predTelemetryClassifier struct {
+	logits []float32
+	err    error
+}
+
+func (f *predTelemetryClassifier) Predict(_ []float32) ([]float32, error) {
+	return f.logits, f.err
+}
+func (f *predTelemetryClassifier) NumSpecies() int { return len(f.logits) }
+func (f *predTelemetryClassifier) Close()          {}
+
+// TestPerchPredict_SuccessRecordsExactlyOnce verifies a happy-path Perch.Predict
+// records exactly one success under the RegistryIDPerchV2 model label, making
+// Perch visible in birdnet_predictions_total separately from BirdNET.
+func TestPerchPredict_SuccessRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	labels := []string{"Species A", "Species B"}
+	p := &Perch{classifier: &predTelemetryClassifier{logits: []float32{0.2, 0.8}}, labels: labels}
+
+	results, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2, 0.3}})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a successful Perch prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a successful Perch prediction must not record an error")
+}
+
+// TestPerchPredict_InferenceErrorRecordsExactlyOnce verifies an inference failure
+// records exactly one error (and no success) under the Perch model label.
+func TestPerchPredict_InferenceErrorRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	boom := errors.Newf("backend inference failed").Category(errors.CategoryAudio).Build()
+	p := &Perch{classifier: &predTelemetryClassifier{err: boom}, labels: []string{"A", "B"}}
+
+	_, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a failed Perch inference must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a failed Perch inference must not record a spurious success")
+}
+
+// TestPerchPredict_EmptySampleRecordsNothing verifies the empty-sample guard
+// tags the span errored but records no prediction, mirroring BirdNET.Predict:
+// pre-inference rejections are not counted in either series.
+func TestPerchPredict_EmptySampleRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	p := &Perch{classifier: &predTelemetryClassifier{}, labels: []string{"A"}}
+
+	_, err := p.Predict(t.Context(), nil)
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"an empty-sample rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"an empty-sample rejection must not record a success")
+}
+
+// TestPerchPredict_NilClassifierRecordsNothing verifies the nil-classifier guard
+// (e.g. after Close()) tags the span errored but records no prediction, mirroring
+// BirdNET.Predict. The Perch is built with a true nil classifier interface (zero
+// value) so the p.classifier == nil guard fires.
+func TestPerchPredict_NilClassifierRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	p := &Perch{labels: []string{"A"}} // classifier is a nil interface
+
+	_, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a nil-classifier rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a nil-classifier rejection must not record a success")
+}
+
+// TestPerchPredict_LabelMismatchRecordsErrorOnce verifies a label/score count
+// mismatch (a failure after inference begins) records exactly one error.
+func TestPerchPredict_LabelMismatchRecordsErrorOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Two labels but only one logit: pairLabelsAndConfidence returns an error.
+	p := &Perch{classifier: &predTelemetryClassifier{logits: []float32{0.5}}, labels: []string{"A", "B"}}
+
+	_, err := p.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDPerchV2, "error"), 0,
+		"a label/score mismatch must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDPerchV2, "success"), 0,
+		"a label/score mismatch must not record a success")
+}
+
+// batEmbeddingExtractor is a fake inference.EmbeddingExtractor for the Bat tests.
+type batEmbeddingExtractor struct {
+	embeddings []float32
+	err        error
+}
+
+func (f *batEmbeddingExtractor) Predict(_ []float32) ([]float32, error) { return nil, nil }
+func (f *batEmbeddingExtractor) NumSpecies() int                        { return 0 }
+func (f *batEmbeddingExtractor) Close()                                 {}
+func (f *batEmbeddingExtractor) PredictWithEmbeddings(_ []float32) (logits, embeddings []float32, err error) {
+	return nil, f.embeddings, f.err
+}
+
+// batCustomClassifier is a fake inference.CustomClassifier for the Bat tests.
+type batCustomClassifier struct {
+	scores []float32
+	labels []string
+	err    error
+}
+
+func (f *batCustomClassifier) PredictEmbedding(_ []float32) ([]float32, error) {
+	return f.scores, f.err
+}
+func (f *batCustomClassifier) NumClasses() int  { return len(f.labels) }
+func (f *batCustomClassifier) Labels() []string { return f.labels }
+func (f *batCustomClassifier) Close()           {}
+
+// TestBatPredict_SuccessRecordsExactlyOnce verifies a happy-path Bat.Predict
+// records exactly one success under the RegistryIDBat model label, so Bat is
+// visible in birdnet_predictions_total alongside BirdNET and Perch.
+func TestBatPredict_SuccessRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Bat.Predict reads conf.Setting().Bat.Threshold; publish default test settings
+	// so the lookup returns a non-nil snapshot (threshold 0 disables filtering).
+	conftest.SetTestSettings(conftest.GetTestSettings())
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	b := &Bat{
+		embeddingExtractor: &batEmbeddingExtractor{embeddings: []float32{0.1, 0.2, 0.3}},
+		batClassifier:      &batCustomClassifier{scores: []float32{0.6, 0.4}, labels: []string{"BatA", "BatB"}},
+	}
+
+	results, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"a successful Bat prediction must be recorded exactly once")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"a successful Bat prediction must not record an error")
+}
+
+// TestBatPredict_EmbeddingErrorRecordsExactlyOnce verifies an embedding-extraction
+// failure records exactly one error under the Bat model label.
+func TestBatPredict_EmbeddingErrorRecordsExactlyOnce(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	boom := errors.Newf("embedding extraction failed").Category(errors.CategoryAudio).Build()
+	b := &Bat{
+		embeddingExtractor: &batEmbeddingExtractor{err: boom},
+		batClassifier:      &batCustomClassifier{labels: []string{"BatA"}},
+	}
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 1.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"a failed Bat embedding extraction must be recorded exactly once as an error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"a failed Bat embedding extraction must not record a spurious success")
+}
+
+// TestBatPredict_EmptySampleRecordsNothing verifies the empty-sample guard tags
+// the span errored but records no prediction, mirroring BirdNET.Predict.
+func TestBatPredict_EmptySampleRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	b := &Bat{} // extractors nil; empty sample returns before they are touched
+
+	_, err := b.Predict(t.Context(), nil)
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"an empty-sample rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"an empty-sample rejection must not record a success")
+}
+
+// TestBatPredict_NilClassifierRecordsNothing verifies the nil-classifier guard
+// (e.g. after Close()) tags the span errored but records no prediction, mirroring
+// the Perch and BirdNET early-guard contract.
+func TestBatPredict_NilClassifierRecordsNothing(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	b := &Bat{} // embeddingExtractor and batClassifier are nil interfaces
+
+	_, err := b.Predict(t.Context(), [][]float32{{0.1, 0.2}})
+	require.Error(t, err)
+
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "error"), 0,
+		"a nil-classifier rejection must not be counted as a prediction error")
+	assert.InDelta(t, 0.0, predictionCount(t, m, RegistryIDBat, "success"), 0,
+		"a nil-classifier rejection must not record a success")
 }

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -5,6 +5,7 @@ package classifier
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -36,6 +37,57 @@ type UniversalSpeciesPredictor interface {
 	GeomodelLabels() []string
 }
 
+// writeIncludedSpeciesDebug dumps the included-species list to a debug file when
+// RangeFilter.Debug is enabled. It prefers a user-private cache directory over the
+// process CWD (pollution, read-only-root containers) and over a world-writable
+// shared temp dir, which is open to symlink clobbering (CWE-377/CWE-59) and
+// multi-user filename collisions on a fixed name; it falls back to the OS temp dir
+// only when no per-user cache dir is available.
+func writeIncludedSpeciesDebug(includedSpecies []string) {
+	var content strings.Builder
+	fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
+		time.Now().Format(time.DateTime),
+		len(includedSpecies))
+	for _, species := range includedSpecies {
+		content.WriteString(species)
+		content.WriteByte('\n')
+	}
+	data := []byte(content.String())
+
+	// A user-private cache directory (0700) is not world-writable, so a fixed
+	// filename there is not exposed to symlink clobbering.
+	var path string
+	var err error
+	if cacheDir, cdErr := os.UserCacheDir(); cdErr == nil {
+		birdnetCacheDir := filepath.Join(cacheDir, "birdnet-go")
+		if mkErr := os.MkdirAll(birdnetCacheDir, 0o700); mkErr == nil {
+			path = filepath.Join(birdnetCacheDir, "debug_included_species.txt")
+			err = os.WriteFile(path, data, 0o600)
+		}
+	}
+
+	// No per-user cache dir: fall back to the world-writable temp dir, but use
+	// os.CreateTemp so the file is created O_EXCL with a random name and cannot
+	// follow a pre-planted symlink (CWE-377/CWE-59).
+	if path == "" {
+		f, ctErr := os.CreateTemp("", "debug_included_species_*.txt")
+		if ctErr != nil {
+			GetLogger().Warn("Failed to create included species debug file", logger.Error(ctErr))
+			return
+		}
+		path = f.Name()
+		_, err = f.Write(data)
+		_ = f.Close()
+	}
+
+	if err != nil {
+		GetLogger().Warn("Failed to write included species debug file",
+			logger.Error(err),
+			logger.String("debug_file", path),
+			logger.Int("species_count", len(includedSpecies)))
+	}
+}
+
 // BuildRangeFilter updates the range filter with current probable species.
 // If the active range filter implements UniversalSpeciesPredictor, the
 // species list is derived directly from the geomodel's own labels
@@ -51,8 +103,21 @@ func BuildRangeFilter(o *Orchestrator) error {
 
 	var includedSpecies []string
 
-	o.primary.mu.Lock()
-	rf := o.primary.rangeFilter
+	// Snapshot primary under read lock to avoid racing with Delete(), which sets
+	// o.primary = nil under o.mu.Lock(). All callers reach BuildRangeFilter
+	// without holding o.mu, so taking RLock here cannot self-deadlock.
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return errors.Newf("orchestrator has no primary model").
+			Component("classifier.orchestrator").
+			Category(errors.CategorySystem).
+			Build()
+	}
+
+	primary.mu.Lock()
+	rf := primary.rangeFilter
 	up, isUniversal := rf.(UniversalSpeciesPredictor)
 
 	if isUniversal && settings.BirdNET.LocationConfigured {
@@ -69,7 +134,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			threshold,
 		)
 		if err != nil {
-			o.primary.mu.Unlock()
+			primary.mu.Unlock()
 			return errors.New(err).
 				Category(errors.CategoryValidation).
 				Context("date", today.Format(time.DateOnly)).
@@ -95,7 +160,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			mrf.unmappedScore = score
 			cachedMapping = mrf.classifierToGeo
 		}
-		o.primary.mu.Unlock()
+		primary.mu.Unlock()
 
 		includedSpecies = make([]string, 0, len(scores))
 		for _, ss := range scores {
@@ -138,7 +203,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			logger.Float64("threshold", float64(threshold)),
 			logger.String("duration", time.Since(start).String()))
 	} else {
-		o.primary.mu.Unlock()
+		primary.mu.Unlock()
 		speciesScores, err := o.GetProbableSpecies(today, 0.0)
 		if err != nil {
 			return errors.New(err).
@@ -160,21 +225,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 	}
 
 	if settings.BirdNET.RangeFilter.Debug {
-		debugFile := "debug_included_species.txt"
-		var content strings.Builder
-		fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
-			time.Now().Format(time.DateTime),
-			len(includedSpecies))
-		for _, species := range includedSpecies {
-			content.WriteString(species)
-			content.WriteByte('\n')
-		}
-		if err := os.WriteFile(debugFile, []byte(content.String()), 0o600); err != nil {
-			GetLogger().Warn("Failed to write included species debug file",
-				logger.Error(err),
-				logger.String("debug_file", debugFile),
-				logger.Int("species_count", len(includedSpecies)))
-		}
+		writeIncludedSpeciesDebug(includedSpecies)
 	}
 
 	conf.UpdateIncludedSpecies(includedSpecies)

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -3,7 +3,6 @@ package classifier
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,6 +17,16 @@ import (
 // tagKeyModel is the tracing tag key used to identify the model in spans.
 const tagKeyModel = "model"
 
+// Tracing tag key and values that record the error outcome of a span.
+// Finish() consults these via the errored flag set in SetTag to avoid recording
+// a spurious success metric on error paths, so the producers that call SetTag and
+// the consumer in Finish must agree on these exact strings.
+const (
+	tagKeyError   = "error"
+	tagValueTrue  = "true"
+	tagValueFalse = "false"
+)
+
 // TracingSpan represents a traced operation with minimal overhead.
 // A TracingSpan must not be used from multiple goroutines concurrently.
 type TracingSpan struct {
@@ -29,6 +38,8 @@ type TracingSpan struct {
 	sentrySpan     *sentry.Span
 	metricsEnabled bool
 	model          string // For metrics labeling
+	errored        bool   // True once an error tag is set; gates the success metric in Finish
+	finished       bool   // True once Finish has run; makes Finish idempotent
 }
 
 // Global metrics instance (set by observability package)
@@ -102,6 +113,13 @@ func (s *TracingSpan) SetTag(key, value string) {
 		s.model = value
 	}
 
+	// Track the error outcome so Finish does not record a spurious success metric
+	// on error paths. Callers record the error outcome explicitly, so once an error
+	// tag is set the flag stays set for the lifetime of the span.
+	if key == tagKeyError && value == tagValueTrue {
+		s.errored = true
+	}
+
 	// Only allocate tags map if Sentry is enabled
 	if s.sentrySpan != nil {
 		if s.tags == nil {
@@ -130,25 +148,41 @@ func (s *TracingSpan) SetData(key string, value any) {
 
 // Finish completes the span and records timing
 func (s *TracingSpan) Finish() {
-	if s == nil {
+	if s == nil || s.finished {
 		return
 	}
+	// Make Finish idempotent: a span represents one operation, so a second call
+	// (e.g. a manual Finish plus a deferred one) must not decrement
+	// activeOperations again or record the prediction twice.
+	s.finished = true
 
 	duration := time.Since(s.startTime)
 	durationSeconds := duration.Seconds()
 
 	// Record metrics if enabled
 	if s.metricsEnabled {
-		model := s.model
-		if model == "" {
-			model = "unknown"
-		}
+		// Balance the activeOperations increment from StartSpan. Decrement under
+		// the same metricsEnabled guard as the increment so the counter stays
+		// balanced even if the metrics instance is reset between StartSpan and
+		// Finish.
+		count := atomic.AddInt64(&activeOperations, -1)
 
 		if m := getMetrics(); m != nil {
+			model := s.model
+			if model == "" {
+				model = "unknown"
+			}
+
 			// Record appropriate metric based on operation
 			switch s.operation {
 			case "birdnet.predict":
-				m.RecordPrediction(model, durationSeconds, nil)
+				// Skip the success record on error spans. Callers record the
+				// error outcome explicitly, so recording here would either
+				// double-count (when the caller already recorded an error) or
+				// log a spurious success (on early-guard error paths).
+				if !s.errored {
+					m.RecordPrediction(model, durationSeconds, nil)
+				}
 			case "birdnet.process_chunk":
 				m.RecordChunkProcess(model, durationSeconds)
 			case "birdnet.model_invoke":
@@ -157,8 +191,6 @@ func (s *TracingSpan) Finish() {
 				m.RecordRangeFilter(model, durationSeconds)
 			}
 
-			// Update active operations count
-			count := atomic.AddInt64(&activeOperations, -1)
 			m.SetActiveProcessing(float64(count))
 		}
 	}
@@ -168,50 +200,6 @@ func (s *TracingSpan) Finish() {
 		s.SetData("duration_ms", duration.Milliseconds())
 		s.sentrySpan.Finish()
 	}
-}
-
-// TraceAnalysis traces audio analysis operations
-func TraceAnalysis(ctx context.Context, operation string, fn func() error) error {
-	span, _ := StartSpan(ctx, "birdnet."+operation, operation)
-	defer span.Finish()
-
-	err := fn()
-	if err != nil {
-		span.SetTag("error", "true")
-		span.SetData("error_message", err.Error())
-	}
-
-	return err
-}
-
-// TracePrediction traces prediction operations with additional metrics
-func TracePrediction(ctx context.Context, sampleSize int, fn func() (any, error)) (any, error) {
-	span, _ := StartSpan(ctx, "birdnet.predict", "Audio prediction")
-	defer span.Finish()
-
-	span.SetData("sample_size", sampleSize)
-
-	start := time.Now()
-	result, err := fn()
-	duration := time.Since(start)
-
-	span.SetData("prediction_duration_ms", duration.Milliseconds())
-
-	if err != nil {
-		span.SetTag("error", "true")
-		span.SetData("error_message", err.Error())
-	} else {
-		span.SetTag("error", "false")
-		// Add result metrics if available using reflection
-		if result != nil {
-			resultValue := reflect.ValueOf(result)
-			if resultValue.Kind() == reflect.Slice {
-				span.SetData("result_count", resultValue.Len())
-			}
-		}
-	}
-
-	return result, err
 }
 
 // RecordMetric records a performance metric

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -27,6 +27,39 @@ const (
 	tagValueFalse = "false"
 )
 
+// opPredict is the span operation name for a model prediction. It is the only
+// operation currently instrumented via StartSpan; the constant keeps the
+// producers (BirdNET/Perch/Bat Predict) and the Finish consumer in sync.
+const opPredict = "birdnet.predict"
+
+// Span data keys recorded on prediction spans. Centralised so the telemetry
+// schema is documented in one place and stays consistent across models.
+const (
+	dataKeyErrorType        = "error_type"
+	dataKeySampleCount      = "sample_count"
+	dataKeySampleSize       = "sample_size"
+	dataKeyResultCount      = "result_count"
+	dataKeyTotalDurationMs  = "total_duration_ms"
+	dataKeyInvokeDurationMs = "invoke_duration_ms"
+	dataKeyDurationMs       = "duration_ms"
+)
+
+// error_type values recorded on failed predictions. Shared by every
+// ModelInstance.Predict implementation so the telemetry vocabulary stays
+// consistent across models.
+const (
+	errTypeEmptySample         = "empty_sample"
+	errTypeClassifierNil       = "classifier_nil"
+	errTypeInvokeFailed        = "invoke_failed"
+	errTypeLabelMismatch       = "label_mismatch"
+	errTypeEmbeddingExtraction = "embedding_extraction"
+	errTypeNilEmbeddings       = "nil_embeddings"
+	errTypeBatClassification   = "bat_classification"
+)
+
+// defaultTopKResults is the number of top predictions every model returns.
+const defaultTopKResults = 10
+
 // TracingSpan represents a traced operation with minimal overhead.
 // A TracingSpan must not be used from multiple goroutines concurrently.
 type TracingSpan struct {
@@ -173,22 +206,13 @@ func (s *TracingSpan) Finish() {
 				model = "unknown"
 			}
 
-			// Record appropriate metric based on operation
-			switch s.operation {
-			case "birdnet.predict":
-				// Skip the success record on error spans. Callers record the
-				// error outcome explicitly, so recording here would either
-				// double-count (when the caller already recorded an error) or
-				// log a spurious success (on early-guard error paths).
-				if !s.errored {
-					m.RecordPrediction(model, durationSeconds, nil)
-				}
-			case "birdnet.process_chunk":
-				m.RecordChunkProcess(model, durationSeconds)
-			case "birdnet.model_invoke":
-				m.RecordModelInvoke(model, durationSeconds)
-			case "birdnet.range_filter":
-				m.RecordRangeFilter(model, durationSeconds)
+			// Only predict spans are recorded here. Skip the success record on
+			// error spans: callers record the error outcome explicitly, so
+			// recording here would either double-count (when the caller already
+			// recorded an error) or log a spurious success (on early-guard error
+			// paths).
+			if s.operation == opPredict && !s.errored {
+				m.RecordPrediction(model, durationSeconds, nil)
 			}
 
 			m.SetActiveProcessing(float64(count))
@@ -197,9 +221,51 @@ func (s *TracingSpan) Finish() {
 
 	// Record in Sentry if enabled
 	if s.sentrySpan != nil {
-		s.SetData("duration_ms", duration.Milliseconds())
+		s.SetData(dataKeyDurationMs, duration.Milliseconds())
 		s.sentrySpan.Finish()
 	}
+}
+
+// startPredictSpan opens a birdnet.predict span and records the standard
+// prediction preamble (model tag and sample dimensions). It is the shared entry
+// point for every ModelInstance.Predict implementation so the operation name,
+// description, and data keys stay consistent across models.
+func startPredictSpan(ctx context.Context, model string, samples [][]float32) (*TracingSpan, context.Context) {
+	span, ctx := StartSpan(ctx, opPredict, "Species prediction")
+	span.SetTag(tagKeyModel, model)
+	span.SetData(dataKeySampleCount, len(samples))
+	if len(samples) > 0 {
+		span.SetData(dataKeySampleSize, len(samples[0]))
+	}
+	return span, ctx
+}
+
+// markErrored tags the span as failed with the given error_type. SetTag latches
+// the errored flag so Finish skips the success metric. Pre-inference guard
+// rejections (empty sample, uninitialised classifier) use this directly because
+// they are not counted as predictions; failures after inference begins use
+// recordPredictionFailure, which also records the error outcome.
+func (s *TracingSpan) markErrored(errorType string) {
+	s.SetTag(tagKeyError, tagValueTrue)
+	s.SetData(dataKeyErrorType, errorType)
+}
+
+// recordPredictionFailure marks the span errored and records the failed
+// prediction exactly once for the given model. Finish then skips its success
+// record because the span is errored.
+func recordPredictionFailure(span *TracingSpan, model, errorType string, start time.Time, err error) {
+	span.markErrored(errorType)
+	if m := getMetrics(); m != nil {
+		m.RecordPrediction(model, time.Since(start).Seconds(), err)
+	}
+}
+
+// recordPredictionSuccess records span data for a successful prediction and tags
+// it not-errored. The single success metric is recorded by Finish.
+func recordPredictionSuccess(span *TracingSpan, resultCount int, start time.Time) {
+	span.SetData(dataKeyResultCount, resultCount)
+	span.SetData(dataKeyTotalDurationMs, time.Since(start).Milliseconds())
+	span.SetTag(tagKeyError, tagValueFalse)
 }
 
 // RecordMetric records a performance metric


### PR DESCRIPTION
## Summary

Reconciles the long-lived `feat/embeddings` integration branch with `main` after main's prediction-telemetry refactor (#3425, #3426, #3427). Merges `main` into `feat/embeddings` and resolves the conflicts so feat adopts main's shared telemetry helpers (`startPredictSpan`, `markErrored`, `recordPredictionFailure`, `recordPredictionSuccess`, idempotent `Finish`) while preserving feat's embedding work.

Conflict resolutions (`internal/classifier/`):
- `tracing.go`: keep main's shared helpers and idempotent `Finish`; add an `opPredictEmbeddings` operation and `startPredictEmbeddingsSpan`; the `Finish` success record covers both `predict` and `predict_embeddings`.
- `analyze.go`: `BirdNET.Predict` adopts the shared helpers while keeping feat's `finalizeResults` (the caller-owned copy that fixes a results-buffer aliasing race). `defaultTopKResults` is centralised in `tracing.go`.
- `perch_onnx.go`: `Perch.Predict` adopts the shared helpers with a pure `finalizeResults`; `Perch.PredictWithEmbeddings` is now instrumented with its own `birdnet.predict_embeddings` span.
- `bat_onnx.go`: take main's instrumented `Bat.Predict`.

Telemetry parity (same change):
- Migrate `BirdNET.PredictWithEmbeddings` (`embeddings.go`) off the old inline span pattern onto the shared helpers, matching every other prediction path. The separate `RecordModelInvoke` invoke timing and the `ModelContext` error enrichment are preserved.
- Behaviour change: `BirdNET.PredictWithEmbeddings` pre-inference guard rejections (empty sample, nil classifier) are now tagged-but-not-counted, consistent with all other prediction entry points (previously they recorded a spurious error prediction).

## Test Plan
- [x] `golangci-lint run` clean (full project, 0 issues)
- [x] `go test -race ./internal/classifier/...` green, including `-shuffle=on`
- [x] `go test -race` green for affected packages (inference, observability, analysis, conf)
- [x] New telemetry tests for `BirdNET.PredictWithEmbeddings` and `Perch.PredictWithEmbeddings` (success / pre-inference-guard-not-counted / post-inference-error exactly-once)
- [x] Existing `BirdNET.PredictWithEmbeddings` behavioural tests still pass (embedding extraction unchanged)
