### PR TITLE
Surface no-audio stream probe failures in the stream test

### DIFF
--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -169,7 +169,7 @@ describe('API utilities', () => {
       await expect(fetchWithCSRF('/api/test')).rejects.toThrow('errors.api.serverError');
     });
 
-    it('shows the backend message for stream probe failures with a specific root cause', async () => {
+    it('localizes no-audio stream probe failures via error_key without leaking the backend message', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 422,
@@ -177,14 +177,34 @@ describe('API utilities', () => {
         headers: new Headers(),
         json: () =>
           Promise.resolve({
-            error_key: 'errors.streams.test.connectionFailed',
+            error_key: 'errors.streams.test.noAudioTrack',
             message: 'stream has no audio track',
           }),
       });
 
       await expect(fetchWithCSRF('/api/test')).rejects.toMatchObject({
-        message: 'stream has no audio track',
+        message: 'The stream has no audio track. Only streams that contain audio can be used',
         status: 422,
+      });
+    });
+
+    it('keeps the localized translation for generic stream connection failures', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            error_key: 'errors.streams.test.connectionFailed',
+            message: 'stream connection failed',
+          }),
+      });
+
+      await expect(fetchWithCSRF('/api/test')).rejects.toMatchObject({
+        message:
+          'Could not connect to the stream. Check that the URL is correct and the stream is accessible',
+        status: 502,
       });
     });
 

--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -169,6 +169,25 @@ describe('API utilities', () => {
       await expect(fetchWithCSRF('/api/test')).rejects.toThrow('errors.api.serverError');
     });
 
+    it('shows the backend message for stream probe failures with a specific root cause', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            error_key: 'errors.streams.test.connectionFailed',
+            message: 'stream has no audio track',
+          }),
+      });
+
+      await expect(fetchWithCSRF('/api/test')).rejects.toMatchObject({
+        message: 'stream has no audio track',
+        status: 422,
+      });
+    });
+
     it('returns null for empty responses', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -230,9 +230,7 @@ async function handleResponse<T = unknown>(response: Response): Promise<T> {
 
       // SECURITY: Only extract safe error fields - never expose raw server errors
       if (errorData && typeof errorData === 'object') {
-        // Try i18n translation via error_key first.
-        // For stream probe failures, the backend message is already sanitized
-        // and more specific than the generic connection-failed translation.
+        // Try i18n translation via error_key first
         if (errorData.error_key && typeof errorData.error_key === 'string') {
           const params =
             errorData.error_params &&
@@ -240,17 +238,9 @@ async function handleResponse<T = unknown>(response: Response): Promise<T> {
             !Array.isArray(errorData.error_params)
               ? (errorData.error_params as Record<string, unknown>)
               : {};
-          if (
-            errorData.error_key === 'errors.streams.test.connectionFailed' &&
-            typeof errorData.message === 'string' &&
-            errorData.message.trim().length > 0
-          ) {
-            serverMessage = errorData.message;
-          } else {
-            const translated = t(errorData.error_key, params);
-            if (translated !== errorData.error_key) {
-              serverMessage = translated;
-            }
+          const translated = t(errorData.error_key, params);
+          if (translated !== errorData.error_key) {
+            serverMessage = translated;
           }
         }
 

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -230,7 +230,9 @@ async function handleResponse<T = unknown>(response: Response): Promise<T> {
 
       // SECURITY: Only extract safe error fields - never expose raw server errors
       if (errorData && typeof errorData === 'object') {
-        // Try i18n translation via error_key first
+        // Try i18n translation via error_key first.
+        // For stream probe failures, the backend message is already sanitized
+        // and more specific than the generic connection-failed translation.
         if (errorData.error_key && typeof errorData.error_key === 'string') {
           const params =
             errorData.error_params &&
@@ -238,9 +240,17 @@ async function handleResponse<T = unknown>(response: Response): Promise<T> {
             !Array.isArray(errorData.error_params)
               ? (errorData.error_params as Record<string, unknown>)
               : {};
-          const translated = t(errorData.error_key, params);
-          if (translated !== errorData.error_key) {
-            serverMessage = translated;
+          if (
+            errorData.error_key === 'errors.streams.test.connectionFailed' &&
+            typeof errorData.message === 'string' &&
+            errorData.message.trim().length > 0
+          ) {
+            serverMessage = errorData.message;
+          } else {
+            const translated = t(errorData.error_key, params);
+            if (translated !== errorData.error_key) {
+              serverMessage = translated;
+            }
           }
         }
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -119,6 +119,11 @@ vi.mock('$lib/stores/toast', () => ({
 
 // Mock internationalization - map common keys to actual text for tests
 const translations: Record<string, string> = {
+  // Stream test error keys (used by api.test.ts error handling)
+  'errors.streams.test.connectionFailed':
+    'Could not connect to the stream. Check that the URL is correct and the stream is accessible',
+  'errors.streams.test.noAudioTrack':
+    'The stream has no audio track. Only streams that contain audio can be used',
   // SelectDropdown and SpeciesInput form components
   'common.ui.search': 'Search...',
   'components.forms.select.searchOptions': 'Search options',

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Neplatný formát URL. Zadejte úplnou URL, např. rtsp://host:port/cesta",
         "unsupportedScheme": "Nepodporované schéma URL \"{scheme}\". Použijte rtsp, rtsps, http, https, rtmp nebo udp",
         "blockedDestination": "Tento cíl je z bezpečnostních důvodů blokován",
-        "connectionFailed": "Nelze se připojit ke streamu. Zkontrolujte, zda je URL správná a stream je dostupný"
+        "connectionFailed": "Nelze se připojit ke streamu. Zkontrolujte, zda je URL správná a stream je dostupný",
+        "noAudioTrack": "Stream neobsahuje žádnou zvukovou stopu. Lze použít pouze streamy obsahující zvuk"
       }
     },
     "debug": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Ugyldigt URL-format. Indtast en fuld URL som rtsp://host:port/sti",
         "unsupportedScheme": "Ikke-understøttet URL-skema \"{scheme}\". Brug rtsp, rtsps, http, https, rtmp eller udp",
         "blockedDestination": "Denne destination er blokeret af sikkerhedsmæssige årsager",
-        "connectionFailed": "Kunne ikke oprette forbindelse til streamen. Kontrollér, at URL'en er korrekt, og at streamen er tilgængelig"
+        "connectionFailed": "Kunne ikke oprette forbindelse til streamen. Kontrollér, at URL'en er korrekt, og at streamen er tilgængelig",
+        "noAudioTrack": "Streamen har ikke noget lydspor. Kun streams, der indeholder lyd, kan bruges"
       }
     },
     "debug": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Ungültiges URL-Format. Geben Sie eine vollständige URL ein, z. B. rtsp://host:port/pfad",
         "unsupportedScheme": "Nicht unterstütztes URL-Schema \"{scheme}\". Verwenden Sie rtsp, rtsps, http, https, rtmp oder udp",
         "blockedDestination": "Dieses Ziel ist aus Sicherheitsgründen gesperrt",
-        "connectionFailed": "Verbindung zum Stream konnte nicht hergestellt werden. Überprüfen Sie, ob die URL korrekt ist und der Stream erreichbar ist"
+        "connectionFailed": "Verbindung zum Stream konnte nicht hergestellt werden. Überprüfen Sie, ob die URL korrekt ist und der Stream erreichbar ist",
+        "noAudioTrack": "Der Stream enthält keine Audiospur. Es können nur Streams mit Audio verwendet werden"
       }
     },
     "debug": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Invalid URL format. Enter a full URL like rtsp://host:port/path",
         "unsupportedScheme": "Unsupported URL scheme \"{scheme}\". Use rtsp, rtsps, http, https, rtmp, or udp",
         "blockedDestination": "This destination is blocked for security reasons",
-        "connectionFailed": "Could not connect to the stream. Check that the URL is correct and the stream is accessible"
+        "connectionFailed": "Could not connect to the stream. Check that the URL is correct and the stream is accessible",
+        "noAudioTrack": "The stream has no audio track. Only streams that contain audio can be used"
       }
     },
     "debug": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Formato de URL no válido. Introduzca una URL completa como rtsp://host:puerto/ruta",
         "unsupportedScheme": "Esquema de URL no compatible \"{scheme}\". Use rtsp, rtsps, http, https, rtmp o udp",
         "blockedDestination": "Este destino está bloqueado por razones de seguridad",
-        "connectionFailed": "No se pudo conectar al stream. Compruebe que la URL es correcta y que el stream es accesible"
+        "connectionFailed": "No se pudo conectar al stream. Compruebe que la URL es correcta y que el stream es accesible",
+        "noAudioTrack": "El stream no tiene pista de audio. Solo se pueden usar streams que contengan audio"
       }
     },
     "debug": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Virheellinen URL-muoto. Syötä täydellinen URL, esim. rtsp://host:portti/polku",
         "unsupportedScheme": "URL-skeemaa \"{scheme}\" ei tueta. Käytä rtsp, rtsps, http, https, rtmp tai udp",
         "blockedDestination": "Tämä kohde on estetty turvallisuussyistä",
-        "connectionFailed": "Striimiin ei saatu yhteyttä. Tarkista, että URL on oikein ja striimi on saavutettavissa"
+        "connectionFailed": "Striimiin ei saatu yhteyttä. Tarkista, että URL on oikein ja striimi on saavutettavissa",
+        "noAudioTrack": "Striimissä ei ole ääniraitaa. Vain ääntä sisältäviä striimejä voidaan käyttää"
       }
     },
     "debug": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Format d'URL invalide. Saisissez une URL complète, par ex. rtsp://hôte:port/chemin",
         "unsupportedScheme": "Schéma d'URL non pris en charge \"{scheme}\". Utilisez rtsp, rtsps, http, https, rtmp ou udp",
         "blockedDestination": "Cette destination est bloquée pour des raisons de sécurité",
-        "connectionFailed": "Impossible de se connecter au flux. Vérifiez que l'URL est correcte et que le flux est accessible"
+        "connectionFailed": "Impossible de se connecter au flux. Vérifiez que l'URL est correcte et que le flux est accessible",
+        "noAudioTrack": "Le flux ne contient aucune piste audio. Seuls les flux contenant de l'audio peuvent être utilisés"
       }
     },
     "debug": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Érvénytelen URL-formátum. Adjon meg egy teljes URL-t, pl. rtsp://host:port/útvonal",
         "unsupportedScheme": "Nem támogatott URL-séma: \"{scheme}\". Használjon rtsp, rtsps, http, https, rtmp vagy udp sémát",
         "blockedDestination": "Ez a cél biztonsági okokból le van tiltva",
-        "connectionFailed": "Nem sikerült csatlakozni a streamhez. Ellenőrizze, hogy az URL helyes-e és a stream elérhető-e"
+        "connectionFailed": "Nem sikerült csatlakozni a streamhez. Ellenőrizze, hogy az URL helyes-e és a stream elérhető-e",
+        "noAudioTrack": "A stream nem tartalmaz hangsávot. Csak hangot tartalmazó streamek használhatók"
       }
     },
     "debug": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Formato URL non valido. Inserisci un URL completo, ad es. rtsp://host:porta/percorso",
         "unsupportedScheme": "Schema URL non supportato \"{scheme}\". Usa rtsp, rtsps, http, https, rtmp o udp",
         "blockedDestination": "Questa destinazione è bloccata per motivi di sicurezza",
-        "connectionFailed": "Impossibile connettersi allo stream. Verifica che l'URL sia corretto e che lo stream sia accessibile"
+        "connectionFailed": "Impossibile connettersi allo stream. Verifica che l'URL sia corretto e che lo stream sia accessibile",
+        "noAudioTrack": "Lo stream non ha una traccia audio. È possibile utilizzare solo stream che contengono audio"
       }
     },
     "debug": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Nederīgs URL formāts. Ievadiet pilnu URL, piem., rtsp://resursdators:ports/ceļš",
         "unsupportedScheme": "Neatbalstīta URL shēma \"{scheme}\". Izmantojiet rtsp, rtsps, http, https, rtmp vai udp",
         "blockedDestination": "Šis galamērķis ir bloķēts drošības apsvērumu dēļ",
-        "connectionFailed": "Nevarēja izveidot savienojumu ar straumi. Pārbaudiet, vai URL ir pareizs un straume ir pieejama"
+        "connectionFailed": "Nevarēja izveidot savienojumu ar straumi. Pārbaudiet, vai URL ir pareizs un straume ir pieejama",
+        "noAudioTrack": "Straumē nav audio celiņa. Var izmantot tikai straumes, kas satur audio"
       }
     },
     "debug": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -761,7 +761,20 @@
       "currentlyHearing": "Hører nå",
       "detectionsGrid": "Siste registreringer",
       "liveSpectrogram": "Direkte spektrogram",
-      "videoEmbed": "Videoinnbygging"
+      "videoEmbed": "Videoinnbygging",
+      "newSpeciesHighlights": "Høydepunkter for nye arter"
+    },
+    "newSpeciesHighlights": {
+      "title": "Nye og tilbakevendende arter",
+      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
+      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
+      "categoryLifetime": "Nye arter",
+      "categoryYear": "Nye i år",
+      "categorySeason": "Nye denne sesongen",
+      "categorySeasonNamed": "Nye i {season}",
+      "maxConfidenceShort": "Maks {confidence}%",
+      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
+      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
     }
   },
   "detections": {
@@ -4505,7 +4518,8 @@
         "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
         "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
         "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
-        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig"
+        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
+        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
       }
     },
     "debug": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Ongeldig URL-formaat. Voer een volledige URL in, bijv. rtsp://host:poort/pad",
         "unsupportedScheme": "Niet-ondersteund URL-schema \"{scheme}\". Gebruik rtsp, rtsps, http, https, rtmp of udp",
         "blockedDestination": "Deze bestemming is geblokkeerd om veiligheidsredenen",
-        "connectionFailed": "Kan geen verbinding maken met de stream. Controleer of de URL correct is en de stream bereikbaar is"
+        "connectionFailed": "Kan geen verbinding maken met de stream. Controleer of de URL correct is en de stream bereikbaar is",
+        "noAudioTrack": "De stream heeft geen audiospoor. Alleen streams die audio bevatten, kunnen worden gebruikt"
       }
     },
     "debug": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Nieprawidłowy format URL. Wprowadź pełny URL, np. rtsp://host:port/ścieżka",
         "unsupportedScheme": "Nieobsługiwany schemat URL \"{scheme}\". Użyj rtsp, rtsps, http, https, rtmp lub udp",
         "blockedDestination": "Ten cel jest zablokowany ze względów bezpieczeństwa",
-        "connectionFailed": "Nie udało się połączyć ze strumieniem. Sprawdź, czy URL jest poprawny i strumień jest dostępny"
+        "connectionFailed": "Nie udało się połączyć ze strumieniem. Sprawdź, czy URL jest poprawny i strumień jest dostępny",
+        "noAudioTrack": "Strumień nie zawiera ścieżki dźwiękowej. Można używać tylko strumieni zawierających dźwięk"
       }
     },
     "debug": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Formato de URL inválido. Introduza um URL completo, por ex. rtsp://host:porta/caminho",
         "unsupportedScheme": "Esquema de URL não suportado \"{scheme}\". Use rtsp, rtsps, http, https, rtmp ou udp",
         "blockedDestination": "Este destino está bloqueado por razões de segurança",
-        "connectionFailed": "Não foi possível ligar ao stream. Verifique se o URL está correto e se o stream está acessível"
+        "connectionFailed": "Não foi possível ligar ao stream. Verifique se o URL está correto e se o stream está acessível",
+        "noAudioTrack": "O stream não tem faixa de áudio. Apenas streams que contenham áudio podem ser usados"
       }
     },
     "debug": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Neplatný formát URL. Zadajte úplnú URL, napr. rtsp://host:port/cesta",
         "unsupportedScheme": "Nepodporovaná schéma URL \"{scheme}\". Použite rtsp, rtsps, http, https, rtmp alebo udp",
         "blockedDestination": "Tento cieľ je z bezpečnostných dôvodov zablokovaný",
-        "connectionFailed": "Nepodarilo sa pripojiť k streamu. Skontrolujte, či je URL správna a stream je dostupný"
+        "connectionFailed": "Nepodarilo sa pripojiť k streamu. Skontrolujte, či je URL správna a stream je dostupný",
+        "noAudioTrack": "Stream neobsahuje žiadnu zvukovú stopu. Použiť možno iba streamy obsahujúce zvuk"
       }
     },
     "debug": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4542,7 +4542,8 @@
         "invalidUrl": "Ogiltigt URL-format. Ange en fullständig URL, t.ex. rtsp://värd:port/sökväg",
         "unsupportedScheme": "URL-schema \"{scheme}\" stöds inte. Använd rtsp, rtsps, http, https, rtmp eller udp",
         "blockedDestination": "Denna destination är blockerad av säkerhetsskäl",
-        "connectionFailed": "Kunde inte ansluta till strömmen. Kontrollera att URL:en är korrekt och att strömmen är tillgänglig"
+        "connectionFailed": "Kunde inte ansluta till strömmen. Kontrollera att URL:en är korrekt och att strömmen är tillgänglig",
+        "noAudioTrack": "Strömmen har inget ljudspår. Endast strömmar som innehåller ljud kan användas"
       }
     },
     "debug": {

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -149,6 +149,11 @@ type Controller struct {
 	processingCache     *processingCache
 	processingSemaphore chan struct{}
 
+	// probeStreamInfo probes a live stream's audio characteristics for the
+	// stream-test endpoint. Nil in production, where TestStream falls back to
+	// ffmpeg.ProbeStreamInfo; tests set it to stub probing without ffprobe.
+	probeStreamInfo probeStreamInfoFunc
+
 	// Legacy cleanup state tracker
 	cleanupStatus *CleanupStatus
 

--- a/internal/api/v2/streams_test_handler.go
+++ b/internal/api/v2/streams_test_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	stderrors "errors"
 	"fmt"
 	"maps"
 	"net"
@@ -54,6 +55,10 @@ var blockedHosts = map[string]bool{
 	"localhost":                true,
 }
 
+// probeStreamInfo is assigned to ffmpeg.ProbeStreamInfo by default and kept as
+// a package variable so tests can stub stream probing without invoking ffprobe.
+var probeStreamInfo = ffmpeg.ProbeStreamInfo
+
 // initStreamTestRoutes registers stream testing endpoints.
 func (c *Controller) initStreamTestRoutes() {
 	c.Group.POST("/streams/test", c.TestStream, c.authMiddleware)
@@ -75,10 +80,18 @@ func (c *Controller) TestStream(ctx echo.Context) error {
 			vErr.status, vErr.errorKey, vErr.params)
 	}
 
-	info, err := ffmpeg.ProbeStreamInfo(ctx.Request().Context(), req.URL)
+	info, err := probeStreamInfo(ctx.Request().Context(), req.URL)
 	if err != nil {
-		return c.HandleErrorWithKey(ctx, err, "stream connection failed",
-			http.StatusBadGateway, "errors.streams.test.connectionFailed", nil)
+		message := "stream connection failed"
+		errorKey := "errors.streams.test.connectionFailed"
+		status := http.StatusBadGateway
+
+		if stderrors.Is(err, ffmpeg.ErrNoAudioStreamsFound) {
+			message = "stream has no audio track"
+			status = http.StatusUnprocessableEntity
+		}
+
+		return c.HandleErrorWithKey(ctx, err, message, status, errorKey, nil)
 	}
 
 	lossy := ffmpeg.IsLossyCodec(info.Codec)

--- a/internal/api/v2/streams_test_handler.go
+++ b/internal/api/v2/streams_test_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	stderrors "errors"
 	"fmt"
 	"maps"
@@ -55,9 +56,10 @@ var blockedHosts = map[string]bool{
 	"localhost":                true,
 }
 
-// probeStreamInfo is assigned to ffmpeg.ProbeStreamInfo by default and kept as
-// a package variable so tests can stub stream probing without invoking ffprobe.
-var probeStreamInfo = ffmpeg.ProbeStreamInfo
+// probeStreamInfoFunc probes a live stream for its audio characteristics.
+// Controller.probeStreamInfo defaults to ffmpeg.ProbeStreamInfo (used when the
+// field is nil) and is overridden in tests to stub probing without ffprobe.
+type probeStreamInfoFunc func(ctx context.Context, url string) (*ffmpeg.StreamInfo, error)
 
 // initStreamTestRoutes registers stream testing endpoints.
 func (c *Controller) initStreamTestRoutes() {
@@ -80,7 +82,12 @@ func (c *Controller) TestStream(ctx echo.Context) error {
 			vErr.status, vErr.errorKey, vErr.params)
 	}
 
-	info, err := probeStreamInfo(ctx.Request().Context(), req.URL)
+	probe := c.probeStreamInfo
+	if probe == nil {
+		probe = ffmpeg.ProbeStreamInfo
+	}
+
+	info, err := probe(ctx.Request().Context(), req.URL)
 	if err != nil {
 		message := "stream connection failed"
 		errorKey := "errors.streams.test.connectionFailed"
@@ -88,6 +95,7 @@ func (c *Controller) TestStream(ctx echo.Context) error {
 
 		if stderrors.Is(err, ffmpeg.ErrNoAudioStreamsFound) {
 			message = "stream has no audio track"
+			errorKey = "errors.streams.test.noAudioTrack"
 			status = http.StatusUnprocessableEntity
 		}
 

--- a/internal/api/v2/streams_test_handler_test.go
+++ b/internal/api/v2/streams_test_handler_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -98,4 +100,34 @@ func TestTestStreamHandler_ValidationErrors(t *testing.T) {
 			assert.Equal(t, tt.errorKey, resp.ErrorKey)
 		})
 	}
+}
+
+func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
+	e := echo.New()
+
+	originalProbeStreamInfo := probeStreamInfo
+	probeStreamInfo = func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
+		return nil, ffmpeg.ErrNoAudioStreamsFound
+	}
+	t.Cleanup(func() {
+		probeStreamInfo = originalProbeStreamInfo
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/streams/test",
+		strings.NewReader(`{"url":"rtsp://example.test/stream"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	ctrl := &Controller{}
+	ctrl.Settings.Store(&conf.Settings{})
+	err := ctrl.TestStream(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "errors.streams.test.connectionFailed", resp.ErrorKey)
+	assert.Equal(t, "stream has no audio track", resp.Message)
 }

--- a/internal/api/v2/streams_test_handler_test.go
+++ b/internal/api/v2/streams_test_handler_test.go
@@ -103,15 +103,9 @@ func TestTestStreamHandler_ValidationErrors(t *testing.T) {
 }
 
 func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
-	e := echo.New()
+	t.Parallel()
 
-	originalProbeStreamInfo := probeStreamInfo
-	probeStreamInfo = func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
-		return nil, ffmpeg.ErrNoAudioStreamsFound
-	}
-	t.Cleanup(func() {
-		probeStreamInfo = originalProbeStreamInfo
-	})
+	e := echo.New()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/streams/test",
 		strings.NewReader(`{"url":"rtsp://example.test/stream"}`))
@@ -119,7 +113,11 @@ func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	ctrl := &Controller{}
+	ctrl := &Controller{
+		probeStreamInfo: func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
+			return nil, ffmpeg.ErrNoAudioStreamsFound
+		},
+	}
 	ctrl.Settings.Store(&conf.Settings{})
 	err := ctrl.TestStream(ctx)
 	require.NoError(t, err)
@@ -128,6 +126,6 @@ func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
 
 	var resp ErrorResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, "errors.streams.test.connectionFailed", resp.ErrorKey)
+	assert.Equal(t, "errors.streams.test.noAudioTrack", resp.ErrorKey)
 	assert.Equal(t, "stream has no audio track", resp.Message)
 }

--- a/internal/audiocore/ffmpeg/probe.go
+++ b/internal/audiocore/ffmpeg/probe.go
@@ -18,6 +18,9 @@ import (
 // models. Streams below this rate cannot carry ultrasonic content.
 const MinBatSampleRate = 96000
 
+// ErrNoAudioStreamsFound reports that ffprobe found no audio streams in the input.
+var ErrNoAudioStreamsFound = errors.NewStd("no audio streams found in probe output")
+
 // probeTimeout is the maximum time to wait for ffprobe stream probing.
 // This is separate from FFprobeTimeout (3s) used for local file validation;
 // live streams may need longer to connect and negotiate.
@@ -107,7 +110,7 @@ func parseProbeOutput(data []byte) (*StreamInfo, error) {
 	}
 
 	if len(output.Streams) == 0 {
-		return nil, errors.NewStd("no audio streams found in probe output")
+		return nil, ErrNoAudioStreamsFound
 	}
 
 	stream := output.Streams[0]


### PR DESCRIPTION
- Return a specific error when ffprobe finds no audio stream in the tested URL.
- Show that backend message in the stream test UI instead of the generic connection failure.
- Add regression tests for the handler and API client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream testing with better error detection and messaging—distinguishing between connection failures and streams lacking audio tracks.

* **Localization**
  * Added translations for new stream test error messages across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->