### PR TITLE
feat(embedding): embedding persistence store substrate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/tphakala/go-audio-resampler v1.4.0
 	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
 	github.com/tphakala/simd v1.1.0
+	github.com/x448/float16 v0.8.4
 	github.com/yalue/onnxruntime_go v1.30.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yalue/onnxruntime_go v1.30.1 h1:NaEng5lWbsHZ/8X1dtaw1mIj7eV1ozyjbFo//g0ktl4=
 github.com/yalue/onnxruntime_go v1.30.1/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/internal/embedding/codec.go
+++ b/internal/embedding/codec.go
@@ -78,7 +78,9 @@ func encodeVector(vec []float32, format Format) ([]byte, error) {
 func decodeVector(blob []byte, format Format, dim int) ([]float32, error) {
 	switch format {
 	case FormatFP16:
-		if len(blob) != dim*fp16Bytes {
+		// Validate via division rather than dim*fp16Bytes to avoid integer
+		// overflow when dim comes from a corrupt stored row.
+		if dim < 0 || len(blob)%fp16Bytes != 0 || len(blob)/fp16Bytes != dim {
 			return nil, ErrCorruptBlob
 		}
 		vec := make([]float32, dim)

--- a/internal/embedding/codec.go
+++ b/internal/embedding/codec.go
@@ -1,0 +1,95 @@
+// Package embedding provides generic persistence and read access for model
+// embedding vectors. Raw vector blobs are the source of truth; a format
+// discriminator records the on-disk encoding so additional encodings can be
+// added later without migrating existing rows.
+package embedding
+
+import (
+	"encoding/binary"
+
+	"github.com/x448/float16"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// Format identifies the on-disk encoding of a stored vector blob. It is
+// persisted alongside every row so the decoder can dispatch correctly and new
+// encodings can be added additively without a schema migration.
+type Format string
+
+const (
+	// FormatFP16 stores each component as an IEEE-754 half-precision value
+	// (little-endian uint16). It is near-lossless for cosine similarity and
+	// half the size of float32, so it is the default encoding.
+	FormatFP16 Format = "fp16"
+
+	// FormatInt8 is reserved for an optional quantized encoding. It is gated
+	// behind the discriminator and not yet implemented; it only becomes
+	// available once the offline separability probe validates that int8
+	// preserves enough signal for downstream consumers.
+	FormatInt8 Format = "int8"
+)
+
+// fp16Bytes is the on-disk size in bytes of a single fp16-encoded component.
+const fp16Bytes = 2
+
+// Sentinel errors returned by the codec. They are prefixed with Err per the
+// project's error-naming convention and are safe to test with errors.Is.
+var (
+	// ErrUnsupportedFormat is returned when a vector is encoded or decoded
+	// using a Format that is recognised by the discriminator but not yet
+	// implemented (currently FormatInt8).
+	ErrUnsupportedFormat = errors.Newf("embedding: unsupported vector format").
+				Component("embedding").
+				Category(errors.CategoryValidation).
+				Build()
+
+	// ErrCorruptBlob is returned when a stored blob cannot be decoded into the
+	// declared dimension, for example because its length is inconsistent with
+	// the encoding.
+	ErrCorruptBlob = errors.Newf("embedding: corrupt vector blob").
+			Component("embedding").
+			Category(errors.CategoryValidation).
+			Build()
+)
+
+// encodeVector encodes a float32 vector into a byte blob using the given
+// format. The returned blob is the raw source-of-truth representation written
+// to storage.
+func encodeVector(vec []float32, format Format) ([]byte, error) {
+	switch format {
+	case FormatFP16:
+		blob := make([]byte, len(vec)*fp16Bytes)
+		for i, v := range vec {
+			bits := float16.Fromfloat32(v).Bits()
+			binary.LittleEndian.PutUint16(blob[i*fp16Bytes:], bits)
+		}
+		return blob, nil
+	case FormatInt8:
+		return nil, ErrUnsupportedFormat
+	default:
+		return nil, ErrUnsupportedFormat
+	}
+}
+
+// decodeVector decodes a byte blob of the given format back into a float32
+// vector of the declared dimension. It returns ErrCorruptBlob when the blob
+// length is inconsistent with the format and dimension.
+func decodeVector(blob []byte, format Format, dim int) ([]float32, error) {
+	switch format {
+	case FormatFP16:
+		if len(blob) != dim*fp16Bytes {
+			return nil, ErrCorruptBlob
+		}
+		vec := make([]float32, dim)
+		for i := range dim {
+			bits := binary.LittleEndian.Uint16(blob[i*fp16Bytes:])
+			vec[i] = float16.Frombits(bits).Float32()
+		}
+		return vec, nil
+	case FormatInt8:
+		return nil, ErrUnsupportedFormat
+	default:
+		return nil, ErrUnsupportedFormat
+	}
+}

--- a/internal/embedding/codec_test.go
+++ b/internal/embedding/codec_test.go
@@ -1,0 +1,88 @@
+package embedding
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncodeDecodeFP16ExactValues verifies that values which are exactly
+// representable in IEEE-754 half precision survive an encode/decode round-trip
+// bit-for-bit. This isolates codec correctness from rounding error.
+func TestEncodeDecodeFP16ExactValues(t *testing.T) {
+	t.Parallel()
+
+	// All of these are exactly representable in fp16.
+	vec := []float32{0, 1, -1, 0.5, -0.5, 0.25, 2, -4, 1024, -2048}
+
+	blob, err := encodeVector(vec, FormatFP16)
+	require.NoError(t, err)
+	assert.Len(t, blob, len(vec)*fp16Bytes, "fp16 blob must be 2 bytes per element")
+
+	got, err := decodeVector(blob, FormatFP16, len(vec))
+	require.NoError(t, err)
+	require.Len(t, got, len(vec))
+
+	for i := range vec {
+		assert.InDelta(t, vec[i], got[i], 0, "exactly representable value must round-trip bit-for-bit at index %d", i)
+	}
+}
+
+// TestEncodeDecodeFP16Precision verifies that a vector of arbitrary values
+// survives the round-trip with cosine similarity high enough to be
+// near-lossless for similarity search, which is the reason fp16 is the default.
+func TestEncodeDecodeFP16Precision(t *testing.T) {
+	t.Parallel()
+
+	vec := []float32{3.14159, -2.71828, 0.001, 42.5, -0.333333, 1280.7, 9.81, -100.25}
+
+	blob, err := encodeVector(vec, FormatFP16)
+	require.NoError(t, err)
+
+	got, err := decodeVector(blob, FormatFP16, len(vec))
+	require.NoError(t, err)
+	require.Len(t, got, len(vec))
+
+	assert.Greater(t, cosineSimilarity(vec, got), 0.9999,
+		"fp16 round-trip must preserve cosine similarity for similarity search")
+}
+
+// cosineSimilarity is a test helper computing the cosine similarity between two
+// equal-length float32 vectors.
+func cosineSimilarity(a, b []float32) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// TestEncodeVectorInt8Unsupported verifies that int8 encoding is gated behind
+// the discriminator and rejected until the M0 separability probe validates it.
+func TestEncodeVectorInt8Unsupported(t *testing.T) {
+	t.Parallel()
+
+	_, err := encodeVector([]float32{1, 2, 3}, FormatInt8)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedFormat)
+}
+
+// TestDecodeVectorDimMismatch verifies that a blob whose length does not match
+// the declared dimension is rejected rather than silently truncated.
+func TestDecodeVectorDimMismatch(t *testing.T) {
+	t.Parallel()
+
+	blob, err := encodeVector([]float32{1, 2, 3}, FormatFP16)
+	require.NoError(t, err)
+
+	_, err = decodeVector(blob, FormatFP16, 4)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCorruptBlob)
+}

--- a/internal/embedding/store.go
+++ b/internal/embedding/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	stdlog "log"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -318,6 +319,12 @@ func (s *Store) Prune(ctx context.Context) (int, error) {
 	}
 
 	toDelete := count - s.maxRows
+	// Limit takes an int; clamp so the int64->int conversion cannot truncate
+	// to a wrong value on 32-bit builds (unreachable on our 64-bit targets,
+	// but defensive).
+	if toDelete > math.MaxInt32 {
+		toDelete = math.MaxInt32
+	}
 	// Delete the oldest rows via a subquery so the candidate IDs never
 	// round-trip through the application. An explicit "id IN (?, ?, ...)"
 	// list would allocate an unbounded slice and can exceed SQLite's
@@ -366,7 +373,7 @@ func rowToRecord(row *embeddingRow) (Record, error) {
 		DetectionID: row.DetectionID,
 		Model:       row.Model,
 		Source:      row.Source,
-		CapturedAt:  row.CapturedAt,
+		CapturedAt:  row.CapturedAt.UTC(),
 		Format:      format,
 		Dim:         row.Dim,
 		Version:     row.Version,

--- a/internal/embedding/store.go
+++ b/internal/embedding/store.go
@@ -1,0 +1,353 @@
+package embedding
+
+import (
+	"context"
+	"database/sql"
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	gormlogger "gorm.io/gorm/logger"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// defaultMaxRows bounds the rolling window of retained embeddings when the
+// caller does not specify a cap. Sizing math: a 1536-dim fp16 vector is ~3 KB,
+// so 50k rows is on the order of 150 MB of vector data plus row overhead.
+const defaultMaxRows int64 = 50_000
+
+// sqlitePragmas are applied to every pooled connection via the DSN so they are
+// not lost on connections opened after the first. WAL plus a generous
+// busy_timeout keeps the separate embeddings database from blocking under
+// concurrent capture, and isolates it from the main birdnet.db journal.
+const sqlitePragmas = "_journal_mode=WAL&_busy_timeout=30000&_synchronous=NORMAL&_foreign_keys=ON&_cache_size=-2000"
+
+// Sentinel errors returned by the Store.
+var (
+	// ErrNotFound is returned by Get when no embedding exists for the
+	// requested detection id.
+	ErrNotFound = errors.Newf("embedding: not found").
+			Component("embedding").
+			Category(errors.CategoryValidation).
+			Build()
+
+	// ErrInvalidRecord is returned by Put when a record fails validation, for
+	// example an empty detection id or a declared dimension that disagrees with
+	// the vector length.
+	ErrInvalidRecord = errors.Newf("embedding: invalid record").
+				Component("embedding").
+				Category(errors.CategoryValidation).
+				Build()
+)
+
+// Record is a single stored embedding and its provenance. Vector holds the
+// decoded components; the Store encodes them to the raw blob on write and
+// decodes them on read according to Format.
+type Record struct {
+	DetectionID string    // logical reference to the saved detection (note) this embedding belongs to
+	Model       string    // model identifier that produced the embedding
+	Source      string    // capture source (e.g. audio stream) for provenance and filtering
+	CapturedAt  time.Time // when the detection was captured; drives ordering and the rolling cap
+	Format      Format    // on-disk encoding of the vector blob
+	Dim         int       // declared dimension; must equal len(Vector)
+	Version     string    // model version for provenance (part of the discriminator)
+	Vector      []float32 // decoded embedding components
+}
+
+// embeddingRow is the GORM model persisted in the embeddings table. It is kept
+// separate from the public Record so the storage layout (the raw blob and the
+// format discriminator) is not part of the API surface.
+type embeddingRow struct {
+	ID          int64     `gorm:"primaryKey;autoIncrement"`
+	DetectionID string    `gorm:"column:detection_id;uniqueIndex;not null"`
+	Model       string    `gorm:"column:model;index:idx_model_captured;not null"`
+	Source      string    `gorm:"column:source;not null"`
+	CapturedAt  time.Time `gorm:"column:captured_at;index:idx_model_captured;not null"`
+	Format      string    `gorm:"column:format;not null"`
+	Dim         int       `gorm:"column:dim;not null"`
+	Version     string    `gorm:"column:version;not null"`
+	Vector      []byte    `gorm:"column:vector;not null"` // raw encoded blob; source of truth
+}
+
+// TableName sets the physical table name for embeddingRow.
+func (embeddingRow) TableName() string { return "embeddings" }
+
+// newGormLogger builds the GORM logger for the store. It logs at warn level and
+// suppresses the expected "record not found" noise, which Get translates into a
+// typed ErrNotFound rather than a logged warning.
+func newGormLogger() gormlogger.Interface {
+	return gormlogger.New(
+		stdlog.New(os.Stderr, "", stdlog.LstdFlags),
+		gormlogger.Config{
+			SlowThreshold:             500 * time.Millisecond,
+			LogLevel:                  gormlogger.Warn,
+			IgnoreRecordNotFoundError: true,
+		},
+	)
+}
+
+// Option configures a Store at construction time.
+type Option func(*storeConfig)
+
+type storeConfig struct {
+	maxRows int64
+}
+
+// WithMaxRows sets the rolling-window cap (maximum retained rows) enforced by
+// Prune. Non-positive values are ignored and the default cap is used.
+func WithMaxRows(n int) Option {
+	return func(c *storeConfig) {
+		if n > 0 {
+			c.maxRows = int64(n)
+		}
+	}
+}
+
+// Store persists embeddings in a dedicated SQLite database, separate from the
+// main application database, so embedding capture never contends on the main
+// database journal. It is safe for concurrent use.
+type Store struct {
+	db      *gorm.DB
+	sqlDB   *sql.DB
+	path    string
+	maxRows int64
+	log     logger.Logger
+}
+
+// NewStore opens (creating if necessary) the embeddings database at path and
+// migrates its schema. The parent directory is created if it does not exist.
+func NewStore(path string, opts ...Option) (*Store, error) {
+	cfg := storeConfig{maxRows: defaultMaxRows}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, errors.New(err).
+			Component("embedding").
+			Category(errors.CategorySystem).
+			Context("operation", "create_embedding_db_directory").
+			Context("directory", filepath.Dir(path)).
+			Build()
+	}
+
+	dsn := path + "?" + sqlitePragmas
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: newGormLogger(),
+	})
+	if err != nil {
+		return nil, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "open_embedding_db").
+			Context("db_path", path).
+			Build()
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_underlying_sqldb").
+			Build()
+	}
+	// SQLite permits a single writer; serialise all access through one
+	// connection so concurrent capture cannot trigger "database is locked".
+	sqlDB.SetMaxOpenConns(1)
+
+	if err := db.AutoMigrate(&embeddingRow{}); err != nil {
+		_ = sqlDB.Close()
+		return nil, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "migrate_embedding_db").
+			Context("db_path", path).
+			Build()
+	}
+
+	s := &Store{
+		db:      db,
+		sqlDB:   sqlDB,
+		path:    path,
+		maxRows: cfg.maxRows,
+		log:     logger.Global().Module("embedding"),
+	}
+	s.log.Info("Opened embedding store",
+		logger.String("path", path),
+		logger.Int64("max_rows", cfg.maxRows))
+	return s, nil
+}
+
+// Put stores or replaces the embedding for a detection. Storing twice under the
+// same detection id replaces the existing row (upsert) so a re-emitted
+// detection cannot double-store.
+func (s *Store) Put(ctx context.Context, rec *Record) error {
+	if rec.DetectionID == "" {
+		return ErrInvalidRecord
+	}
+	if rec.Dim != len(rec.Vector) {
+		return ErrInvalidRecord
+	}
+	format := rec.Format
+	if format == "" {
+		format = FormatFP16
+	}
+
+	blob, err := encodeVector(rec.Vector, format)
+	if err != nil {
+		return err
+	}
+
+	row := embeddingRow{
+		DetectionID: rec.DetectionID,
+		Model:       rec.Model,
+		Source:      rec.Source,
+		CapturedAt:  rec.CapturedAt,
+		Format:      string(format),
+		Dim:         rec.Dim,
+		Version:     rec.Version,
+		Vector:      blob,
+	}
+
+	if err := s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "detection_id"}},
+		UpdateAll: true,
+	}).Create(&row).Error; err != nil {
+		return errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "put_embedding").
+			Context("detection_id", rec.DetectionID).
+			Build()
+	}
+	return nil
+}
+
+// Get returns the embedding stored for the given detection id, decoding its
+// vector. It returns ErrNotFound when no such embedding exists.
+func (s *Store) Get(ctx context.Context, detectionID string) (Record, error) {
+	var row embeddingRow
+	if err := s.db.WithContext(ctx).
+		Where("detection_id = ?", detectionID).
+		First(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return Record{}, ErrNotFound
+		}
+		return Record{}, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_embedding").
+			Context("detection_id", detectionID).
+			Build()
+	}
+	return rowToRecord(&row)
+}
+
+// Query returns embeddings for a model whose capture time falls within
+// [from, to], ordered by capture time ascending.
+func (s *Store) Query(ctx context.Context, model string, from, to time.Time) ([]Record, error) {
+	var rows []embeddingRow
+	if err := s.db.WithContext(ctx).
+		Where("model = ? AND captured_at BETWEEN ? AND ?", model, from, to).
+		Order("captured_at ASC, id ASC").
+		Find(&rows).Error; err != nil {
+		return nil, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "query_embeddings").
+			Context("model", model).
+			Build()
+	}
+
+	records := make([]Record, 0, len(rows))
+	for i := range rows {
+		rec, err := rowToRecord(&rows[i])
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// Prune enforces the rolling-window cap by deleting the oldest rows so at most
+// maxRows remain. It returns the number of rows deleted.
+func (s *Store) Prune(ctx context.Context) (int, error) {
+	db := s.db.WithContext(ctx)
+
+	var count int64
+	if err := db.Model(&embeddingRow{}).Count(&count).Error; err != nil {
+		return 0, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "count_embeddings").
+			Build()
+	}
+	if count <= s.maxRows {
+		return 0, nil
+	}
+
+	toDelete := count - s.maxRows
+	var ids []int64
+	if err := db.Model(&embeddingRow{}).
+		Order("captured_at ASC, id ASC").
+		Limit(int(toDelete)).
+		Pluck("id", &ids).Error; err != nil {
+		return 0, errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "select_prune_candidates").
+			Build()
+	}
+
+	res := db.Where("id IN ?", ids).Delete(&embeddingRow{})
+	if res.Error != nil {
+		return 0, errors.New(res.Error).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "prune_embeddings").
+			Build()
+	}
+	return int(res.RowsAffected), nil
+}
+
+// Close releases the underlying database connection.
+func (s *Store) Close() error {
+	if s.sqlDB == nil {
+		return nil
+	}
+	if err := s.sqlDB.Close(); err != nil {
+		return errors.New(err).
+			Component("embedding").
+			Category(errors.CategoryDatabase).
+			Context("operation", "close_embedding_db").
+			Build()
+	}
+	return nil
+}
+
+// rowToRecord decodes a stored row into a public Record.
+func rowToRecord(row *embeddingRow) (Record, error) {
+	format := Format(row.Format)
+	vec, err := decodeVector(row.Vector, format, row.Dim)
+	if err != nil {
+		return Record{}, err
+	}
+	return Record{
+		DetectionID: row.DetectionID,
+		Model:       row.Model,
+		Source:      row.Source,
+		CapturedAt:  row.CapturedAt,
+		Format:      format,
+		Dim:         row.Dim,
+		Version:     row.Version,
+		Vector:      vec,
+	}, nil
+}

--- a/internal/embedding/store.go
+++ b/internal/embedding/store.go
@@ -6,6 +6,7 @@ import (
 	stdlog "log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gorm.io/driver/sqlite"
@@ -25,7 +26,8 @@ const defaultMaxRows int64 = 50_000
 // sqlitePragmas are applied to every pooled connection via the DSN so they are
 // not lost on connections opened after the first. WAL plus a generous
 // busy_timeout keeps the separate embeddings database from blocking under
-// concurrent capture, and isolates it from the main birdnet.db journal.
+// concurrent capture, and isolates it from the main birdnet.db journal. The
+// cache is intentionally small (-2000 = ~2 MB) for this auxiliary store.
 const sqlitePragmas = "_journal_mode=WAL&_busy_timeout=30000&_synchronous=NORMAL&_foreign_keys=ON&_cache_size=-2000"
 
 // Sentinel errors returned by the Store.
@@ -126,6 +128,16 @@ func NewStore(path string, opts ...Option) (*Store, error) {
 	cfg := storeConfig{maxRows: defaultMaxRows}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	// The DSN appends pragmas after "?"; a path containing a DSN delimiter
+	// would corrupt the query string and silently drop the pragmas (WAL,
+	// busy_timeout), so reject such paths before touching the filesystem.
+	if strings.ContainsAny(path, "?#") {
+		return nil, errors.Newf("embedding: database path must not contain '?' or '#': %q", path).
+			Component("embedding").
+			Category(errors.CategoryValidation).
+			Build()
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
@@ -270,7 +282,12 @@ func (s *Store) Query(ctx context.Context, model string, from, to time.Time) ([]
 	for i := range rows {
 		rec, err := rowToRecord(&rows[i])
 		if err != nil {
-			return nil, err
+			// A single undecodable blob must not hide the rest of the
+			// timeline from consumers; log and skip it.
+			s.log.Warn("Skipping undecodable embedding row",
+				logger.String("detection_id", rows[i].DetectionID),
+				logger.Error(err))
+			continue
 		}
 		records = append(records, rec)
 	}
@@ -295,19 +312,18 @@ func (s *Store) Prune(ctx context.Context) (int, error) {
 	}
 
 	toDelete := count - s.maxRows
-	var ids []int64
-	if err := db.Model(&embeddingRow{}).
+	// Delete the oldest rows via a subquery so the candidate IDs never
+	// round-trip through the application. An explicit "id IN (?, ?, ...)"
+	// list would allocate an unbounded slice and can exceed SQLite's
+	// bound-variable limit when the overflow is large.
+	oldest := s.db.WithContext(ctx).
+		Model(&embeddingRow{}).
+		Select("id").
 		Order("captured_at ASC, id ASC").
-		Limit(int(toDelete)).
-		Pluck("id", &ids).Error; err != nil {
-		return 0, errors.New(err).
-			Component("embedding").
-			Category(errors.CategoryDatabase).
-			Context("operation", "select_prune_candidates").
-			Build()
-	}
-
-	res := db.Where("id IN ?", ids).Delete(&embeddingRow{})
+		Limit(int(toDelete))
+	res := s.db.WithContext(ctx).
+		Where("id IN (?)", oldest).
+		Delete(&embeddingRow{})
 	if res.Error != nil {
 		return 0, errors.New(res.Error).
 			Component("embedding").

--- a/internal/embedding/store.go
+++ b/internal/embedding/store.go
@@ -70,7 +70,7 @@ type embeddingRow struct {
 	DetectionID string    `gorm:"column:detection_id;uniqueIndex;not null"`
 	Model       string    `gorm:"column:model;index:idx_model_captured;not null"`
 	Source      string    `gorm:"column:source;not null"`
-	CapturedAt  time.Time `gorm:"column:captured_at;index:idx_model_captured;not null"`
+	CapturedAt  time.Time `gorm:"column:captured_at;index:idx_captured_at;index:idx_model_captured;not null"`
 	Format      string    `gorm:"column:format;not null"`
 	Dim         int       `gorm:"column:dim;not null"`
 	Version     string    `gorm:"column:version;not null"`
@@ -133,6 +133,12 @@ func NewStore(path string, opts ...Option) (*Store, error) {
 	// The DSN appends pragmas after "?"; a path containing a DSN delimiter
 	// would corrupt the query string and silently drop the pragmas (WAL,
 	// busy_timeout), so reject such paths before touching the filesystem.
+	if path == "" {
+		return nil, errors.Newf("embedding: database path must not be empty").
+			Component("embedding").
+			Category(errors.CategoryValidation).
+			Build()
+	}
 	if strings.ContainsAny(path, "?#") {
 		return nil, errors.Newf("embedding: database path must not contain '?' or '#': %q", path).
 			Component("embedding").
@@ -201,10 +207,10 @@ func NewStore(path string, opts ...Option) (*Store, error) {
 // same detection id replaces the existing row (upsert) so a re-emitted
 // detection cannot double-store.
 func (s *Store) Put(ctx context.Context, rec *Record) error {
-	if rec.DetectionID == "" {
+	if rec == nil || rec.DetectionID == "" {
 		return ErrInvalidRecord
 	}
-	if rec.Dim != len(rec.Vector) {
+	if rec.Dim <= 0 || rec.Dim != len(rec.Vector) {
 		return ErrInvalidRecord
 	}
 	format := rec.Format
@@ -221,7 +227,7 @@ func (s *Store) Put(ctx context.Context, rec *Record) error {
 		DetectionID: rec.DetectionID,
 		Model:       rec.Model,
 		Source:      rec.Source,
-		CapturedAt:  rec.CapturedAt,
+		CapturedAt:  rec.CapturedAt.UTC(),
 		Format:      string(format),
 		Dim:         rec.Dim,
 		Version:     rec.Version,
@@ -262,12 +268,12 @@ func (s *Store) Get(ctx context.Context, detectionID string) (Record, error) {
 	return rowToRecord(&row)
 }
 
-// Query returns embeddings for a model whose capture time falls within
-// [from, to], ordered by capture time ascending.
+// Query returns embeddings for a model whose capture time falls within the
+// half-open interval [from, to), ordered by capture time ascending.
 func (s *Store) Query(ctx context.Context, model string, from, to time.Time) ([]Record, error) {
 	var rows []embeddingRow
 	if err := s.db.WithContext(ctx).
-		Where("model = ? AND captured_at BETWEEN ? AND ?", model, from, to).
+		Where("model = ? AND captured_at >= ? AND captured_at < ?", model, from.UTC(), to.UTC()).
 		Order("captured_at ASC, id ASC").
 		Find(&rows).Error; err != nil {
 		return nil, errors.New(err).

--- a/internal/embedding/store_lifecycle_test.go
+++ b/internal/embedding/store_lifecycle_test.go
@@ -1,0 +1,99 @@
+package embedding
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStorePersistsAcrossReopen verifies that data written to the database
+// survives closing and reopening the store at the same path, and that
+// reopening migrates cleanly against an existing schema.
+func TestStorePersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "embeddings.db")
+	rec := makeRecord(t)
+
+	s1, err := NewStore(path)
+	require.NoError(t, err)
+	require.NoError(t, s1.Put(t.Context(), rec))
+	require.NoError(t, s1.Close())
+
+	s2, err := NewStore(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s2.Close()) })
+
+	got, err := s2.Get(t.Context(), rec.DetectionID)
+	require.NoError(t, err)
+	assert.Equal(t, rec.Vector, got.Vector, "data must survive reopen")
+}
+
+// TestStoreUsesSeparateFile verifies that the store writes to its own database
+// file and creates the parent directory if needed, keeping it isolated from the
+// main application database.
+func TestStoreUsesSeparateFile(t *testing.T) {
+	t.Parallel()
+
+	// Nested directory that does not exist yet exercises parent-dir creation.
+	path := filepath.Join(t.TempDir(), "nested", "embeddings.db")
+	s, err := NewStore(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	require.NoError(t, s.Put(t.Context(), makeRecord(t)))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err, "store must persist to its own file")
+	assert.Positive(t, info.Size(), "database file must contain data")
+}
+
+// TestStorePutInt8Rejected verifies that the store surfaces the unsupported
+// format error when asked to store an int8-encoded vector, which is gated until
+// the offline separability probe validates it.
+func TestStorePutInt8Rejected(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	rec := makeRecord(t, func(r *Record) { r.Format = FormatInt8 })
+
+	err := s.Put(t.Context(), rec)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedFormat)
+}
+
+// TestStoreConcurrentPut verifies that concurrent writers do not race or trip
+// "database is locked"; every distinct detection is stored exactly once.
+func TestStoreConcurrentPut(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	const writers = 16
+
+	errCh := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Go(func() {
+			rec := makeRecord(t, func(r *Record) {
+				r.DetectionID = fmt.Sprintf("det-%02d", i)
+			})
+			errCh <- s.Put(t.Context(), rec)
+		})
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err, "concurrent Put must not fail")
+	}
+
+	all, err := s.Query(t.Context(), "birdnet_v3", time.Time{}, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Len(t, all, writers, "every concurrent writer stored exactly one row")
+}

--- a/internal/embedding/store_test.go
+++ b/internal/embedding/store_test.go
@@ -82,6 +82,19 @@ func TestStorePutValidatesDimension(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidRecord)
 }
 
+// TestStorePutValidatesDetectionID verifies that a record with an empty
+// detection id is rejected; an empty key must never be stored.
+func TestStorePutValidatesDetectionID(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	rec := makeRecord(t, func(r *Record) { r.DetectionID = "" })
+
+	err := s.Put(t.Context(), rec)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRecord)
+}
+
 // TestStoreQueryFiltersByModelAndTime verifies that Query returns only rows for
 // the requested model within the requested time window, ordered by capture
 // time.
@@ -109,6 +122,38 @@ func TestStoreQueryFiltersByModelAndTime(t *testing.T) {
 	assert.Equal(t, "b2", got[1].DetectionID)
 }
 
+// TestStoreQuerySkipsCorruptRow verifies that a single undecodable row does not
+// abort the whole query; the remaining rows are still returned. The corrupt row
+// is inserted directly, bypassing Put's validation, to simulate on-disk
+// corruption.
+func TestStoreQuerySkipsCorruptRow(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+		r.DetectionID, r.CapturedAt = "good", base
+	})))
+
+	// Blob length (2 bytes) is inconsistent with the declared dim (4).
+	require.NoError(t, s.db.Create(&embeddingRow{
+		DetectionID: "corrupt",
+		Model:       "birdnet_v3",
+		Source:      "rtsp://camera",
+		CapturedAt:  base.Add(time.Minute),
+		Format:      string(FormatFP16),
+		Dim:         4,
+		Version:     "3.0",
+		Vector:      []byte{0x00, 0x00},
+	}).Error)
+
+	got, err := s.Query(t.Context(), "birdnet_v3", base, base.Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, got, 1, "corrupt row skipped, good row returned")
+	assert.Equal(t, "good", got[0].DetectionID)
+}
+
 // TestStorePruneEnforcesRowCap verifies that Prune deletes the oldest rows so
 // at most maxRows remain, and reports how many it removed.
 func TestStorePruneEnforcesRowCap(t *testing.T) {
@@ -129,8 +174,10 @@ func TestStorePruneEnforcesRowCap(t *testing.T) {
 	assert.Equal(t, 2, deleted, "two oldest rows pruned")
 
 	// The two oldest (det-a, det-b) must be gone; the three newest remain.
-	_, err = s.Get(t.Context(), "det-a")
-	require.ErrorIs(t, err, ErrNotFound)
+	for _, id := range []string{"det-a", "det-b"} {
+		_, err := s.Get(t.Context(), id)
+		require.ErrorIs(t, err, ErrNotFound, "oldest row pruned: %s", id)
+	}
 	for _, id := range []string{"det-c", "det-d", "det-e"} {
 		_, err := s.Get(t.Context(), id)
 		assert.NoError(t, err, "newest rows retained: %s", id)

--- a/internal/embedding/store_test.go
+++ b/internal/embedding/store_test.go
@@ -1,0 +1,138 @@
+package embedding
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStorePutGetRoundTrip verifies that a stored record can be read back with
+// every field intact, including the decoded vector.
+func TestStorePutGetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	rec := makeRecord(t)
+
+	require.NoError(t, s.Put(t.Context(), rec))
+
+	got, err := s.Get(t.Context(), rec.DetectionID)
+	require.NoError(t, err)
+
+	assert.Equal(t, rec.DetectionID, got.DetectionID)
+	assert.Equal(t, rec.Model, got.Model)
+	assert.Equal(t, rec.Source, got.Source)
+	assert.True(t, rec.CapturedAt.Equal(got.CapturedAt), "captured_at must round-trip")
+	assert.Equal(t, rec.Format, got.Format)
+	assert.Equal(t, rec.Dim, got.Dim)
+	assert.Equal(t, rec.Version, got.Version)
+	assert.Equal(t, rec.Vector, got.Vector, "exactly representable vector must round-trip")
+}
+
+// TestStoreGetNotFound verifies that querying an unknown detection id returns a
+// typed not-found error rather than a zero record with no error.
+func TestStoreGetNotFound(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	_, err := s.Get(t.Context(), "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestStorePutUpsert verifies that storing twice under the same detection id
+// keeps a single row and the latest value wins. A re-emitted detection must
+// not double-store.
+func TestStorePutUpsert(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	rec := makeRecord(t)
+	require.NoError(t, s.Put(t.Context(), rec))
+
+	updated := makeRecord(t, func(r *Record) {
+		r.Vector = []float32{1, 1, 1, 1}
+		r.Source = "rtsp://other"
+	})
+	require.NoError(t, s.Put(t.Context(), updated))
+
+	got, err := s.Get(t.Context(), rec.DetectionID)
+	require.NoError(t, err)
+	assert.Equal(t, updated.Vector, got.Vector, "latest value must win")
+	assert.Equal(t, "rtsp://other", got.Source)
+
+	all, err := s.Query(t.Context(), rec.Model, time.Time{}, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Len(t, all, 1, "upsert must not create a second row")
+}
+
+// TestStorePutValidatesDimension verifies that a record whose declared
+// dimension disagrees with its vector length is rejected.
+func TestStorePutValidatesDimension(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	rec := makeRecord(t, func(r *Record) { r.Dim = 99 })
+
+	err := s.Put(t.Context(), rec)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRecord)
+}
+
+// TestStoreQueryFiltersByModelAndTime verifies that Query returns only rows for
+// the requested model within the requested time window, ordered by capture
+// time.
+func TestStoreQueryFiltersByModelAndTime(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	// Two birdnet rows an hour apart, plus one perch row in between.
+	require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+		r.DetectionID, r.Model, r.CapturedAt = "b1", "birdnet_v3", base
+	})))
+	require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+		r.DetectionID, r.Model, r.CapturedAt = "p1", "perch_v2", base.Add(30*time.Minute)
+	})))
+	require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+		r.DetectionID, r.Model, r.CapturedAt = "b2", "birdnet_v3", base.Add(time.Hour)
+	})))
+
+	got, err := s.Query(t.Context(), "birdnet_v3", base, base.Add(90*time.Minute))
+	require.NoError(t, err)
+	require.Len(t, got, 2, "only birdnet rows in window")
+	assert.Equal(t, "b1", got[0].DetectionID, "results ordered by capture time")
+	assert.Equal(t, "b2", got[1].DetectionID)
+}
+
+// TestStorePruneEnforcesRowCap verifies that Prune deletes the oldest rows so
+// at most maxRows remain, and reports how many it removed.
+func TestStorePruneEnforcesRowCap(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t, WithMaxRows(3))
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	for i := range 5 {
+		require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+			r.DetectionID = "det-" + string(rune('a'+i))
+			r.CapturedAt = base.Add(time.Duration(i) * time.Minute)
+		})))
+	}
+
+	deleted, err := s.Prune(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted, "two oldest rows pruned")
+
+	// The two oldest (det-a, det-b) must be gone; the three newest remain.
+	_, err = s.Get(t.Context(), "det-a")
+	require.ErrorIs(t, err, ErrNotFound)
+	for _, id := range []string{"det-c", "det-d", "det-e"} {
+		_, err := s.Get(t.Context(), id)
+		assert.NoError(t, err, "newest rows retained: %s", id)
+	}
+}

--- a/internal/embedding/store_test.go
+++ b/internal/embedding/store_test.go
@@ -154,6 +154,27 @@ func TestStoreQuerySkipsCorruptRow(t *testing.T) {
 	assert.Equal(t, "good", got[0].DetectionID)
 }
 
+// TestStoreQueryHalfOpenInterval verifies the [from, to) contract: a row exactly
+// at `from` is included and a row exactly at `to` is excluded.
+func TestStoreQueryHalfOpenInterval(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	base := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+		r.DetectionID, r.CapturedAt = "at-from", base
+	})))
+	require.NoError(t, s.Put(t.Context(), makeRecord(t, func(r *Record) {
+		r.DetectionID, r.CapturedAt = "at-to", base.Add(time.Hour)
+	})))
+
+	got, err := s.Query(t.Context(), "birdnet_v3", base, base.Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, got, 1, "from inclusive, to exclusive")
+	assert.Equal(t, "at-from", got[0].DetectionID)
+}
+
 // TestStorePruneEnforcesRowCap verifies that Prune deletes the oldest rows so
 // at most maxRows remain, and reports how many it removed.
 func TestStorePruneEnforcesRowCap(t *testing.T) {

--- a/internal/embedding/store_test_helpers_test.go
+++ b/internal/embedding/store_test_helpers_test.go
@@ -1,0 +1,45 @@
+package embedding
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStore opens a Store backed by a fresh SQLite file in the test's
+// temporary directory and registers cleanup. Each test gets an isolated
+// database file so tests can run in parallel without contention.
+func newTestStore(t *testing.T, opts ...Option) *Store {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "embeddings.db")
+	s, err := NewStore(path, opts...)
+	require.NoError(t, err, "store must open")
+	t.Cleanup(func() {
+		require.NoError(t, s.Close(), "store must close cleanly")
+	})
+	return s
+}
+
+// makeRecord builds a Record with sensible defaults, applying any overrides.
+// CapturedAt defaults to a fixed UTC instant so time comparisons are stable.
+func makeRecord(t *testing.T, opts ...func(*Record)) *Record {
+	t.Helper()
+
+	rec := &Record{
+		DetectionID: "det-1",
+		Model:       "birdnet_v3",
+		Source:      "rtsp://camera",
+		CapturedAt:  time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC),
+		Format:      FormatFP16,
+		Dim:         4,
+		Version:     "3.0",
+		Vector:      []float32{0.5, -0.25, 2, -4}, // exactly representable in fp16
+	}
+	for _, opt := range opts {
+		opt(rec)
+	}
+	return rec
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -397,7 +397,9 @@ func init() {
 	RegisterComponent("ffmpeg-manager", "ffmpeg-manager")
 	RegisterComponent("ffmpeg-stream", "ffmpeg-stream")
 	RegisterComponent("datastore", "datastore")
-	RegisterComponent("embedding", "embedding")
+	// Path-qualified so it does not also match substrings like
+	// classifier.embeddingDimOf, which must stay component "birdnet".
+	RegisterComponent("/embedding", "embedding")
 	RegisterComponent("imageprovider", "imageprovider")
 	RegisterComponent("diskmanager", "diskmanager")
 	RegisterComponent("ebird", "ebird")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -397,6 +397,7 @@ func init() {
 	RegisterComponent("ffmpeg-manager", "ffmpeg-manager")
 	RegisterComponent("ffmpeg-stream", "ffmpeg-stream")
 	RegisterComponent("datastore", "datastore")
+	RegisterComponent("embedding", "embedding")
 	RegisterComponent("imageprovider", "imageprovider")
 	RegisterComponent("diskmanager", "diskmanager")
 	RegisterComponent("ebird", "ebird")


### PR DESCRIPTION
## Summary

Adds `internal/embedding`, a generic store for model embedding vectors persisted in a dedicated SQLite database separate from the main application database so embedding capture never contends on the main journal. This is the storage substrate only; live-path capture wiring lands in a follow-up.

- Raw vector blobs are the source of truth. A `(format, dim, model, version)` discriminator records the on-disk encoding, so future encodings can be added without migrating existing rows.
- fp16 is the default encoding (near-lossless for cosine similarity, half the size of float32). int8 is reserved behind the discriminator and rejected until validated.
- `Store` provides `Put` (upsert per detection), `Get`, time-range `Query`, and a row-count rolling-window cap via `Prune`. Access is serialised through a single connection so concurrent capture cannot trip "database is locked".
- Registers the `embedding` error component (path-qualified so it does not shadow existing components) and adds the `github.com/x448/float16` dependency.

This PR targets the `feat/embeddings` integration branch, not `main`.

## Test Plan

- [x] `go test -race ./internal/embedding/`: fp16 round-trip precision, discriminator dispatch + int8 rejection, Put/Get round-trip, upsert idempotency, query filtering, rolling-cap prunes the oldest set, durability across reopen, separate-file isolation, 16-way concurrent Put, corrupt-row skip
- [x] `golangci-lint run ./...` clean
- [x] `go build ./...` clean