### PR TITLE
feat(embedding): wire async embedding capture to detection save (M2 PR2)

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -159,15 +160,18 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	// non-blocking: this never affects the save path. Capture itself no-ops on
 	// an empty vector and drops on a full buffer.
 	if a.EmbeddingCapture != nil && a.Result.ID != 0 && len(a.Embeddings) > 0 {
+		// Hand the async writer its own copy of the vector. The writer goroutine
+		// outlives this call, so it must not alias a.Embeddings' backing array.
+		vector := slices.Clone(a.Embeddings)
 		a.EmbeddingCapture.Capture(embedding.Record{
 			DetectionID: strconv.FormatUint(uint64(a.Result.ID), 10),
 			Model:       a.ModelID,
 			Source:      a.Result.AudioSource.ID,
 			CapturedAt:  a.Result.BeginTime,
 			Format:      embedding.Format(a.Settings.Embeddings.Storage.Format),
-			Dim:         len(a.Embeddings),
+			Dim:         len(vector),
 			Version:     a.Result.Model.Version,
-			Vector:      a.Embeddings,
+			Vector:      vector,
 		})
 	}
 

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/embedding"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -152,6 +153,22 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	// Share the database ID with downstream actions (MQTT, SSE) immediately.
 	if a.DetectionCtx != nil {
 		a.DetectionCtx.NoteID.Store(uint64(a.Result.ID))
+	}
+
+	// Persist the window embedding keyed by the saved detection id. Async and
+	// non-blocking: this never affects the save path. Capture itself no-ops on
+	// an empty vector and drops on a full buffer.
+	if a.EmbeddingCapture != nil && a.Result.ID != 0 && len(a.Embeddings) > 0 {
+		a.EmbeddingCapture.Capture(embedding.Record{
+			DetectionID: strconv.FormatUint(uint64(a.Result.ID), 10),
+			Model:       a.ModelID,
+			Source:      a.Result.AudioSource.ID,
+			CapturedAt:  a.Result.BeginTime,
+			Format:      embedding.Format(a.Settings.Embeddings.Storage.Format),
+			Dim:         len(a.Embeddings),
+			Version:     a.Result.Model.Version,
+			Vector:      a.Embeddings,
+		})
 	}
 
 	// Add an explanatory comment when the ultrasonic validation filter tagged this detection as unlikely.

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/embedding"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
 )
@@ -77,6 +78,13 @@ type LogAction struct {
 	mu            sync.Mutex // Protect concurrent access to Result
 }
 
+// embeddingCapturer is the minimal sink DatabaseAction uses to persist the
+// window embedding after a detection saves. *embedding.Capture implements it.
+// It is kept tiny so DatabaseAction stays unit-testable without the Processor.
+type embeddingCapturer interface {
+	Capture(rec embedding.Record)
+}
+
 type DatabaseAction struct {
 	Settings          *conf.Settings
 	Ds                datastore.Interface           // Legacy - to be removed after migration
@@ -87,6 +95,9 @@ type DatabaseAction struct {
 	NewSpeciesTracker *species.SpeciesTracker // Add reference to new species tracker
 	processor         *Processor              // Add reference to processor for source name resolution
 	DetectionCtx      *DetectionContext       // Shared context for downstream actions (MQTT, SSE, SaveAudio)
+	Embeddings        []float32                // Window embedding carried from Detections (nil when off)
+	ModelID           string                   // Registry model id, for embedding provenance
+	EmbeddingCapture  embeddingCapturer        // Async sink; nil => capture is a no-op
 	Description       string
 	CorrelationID     string     // Detection correlation ID for log tracking
 	mu                sync.Mutex // Protect concurrent access to Result and Results

--- a/internal/analysis/processor/database_action_embedding_test.go
+++ b/internal/analysis/processor/database_action_embedding_test.go
@@ -16,6 +16,7 @@ type spyCapturer struct {
 	calls []embedding.Record
 }
 
+//nolint:gocritic // hugeParam: signature must match the embeddingCapturer interface (value receiver of Record); this is a test spy, not a hot path.
 func (s *spyCapturer) Capture(rec embedding.Record) { s.calls = append(s.calls, rec) }
 
 func newEmbeddingTestAction(t *testing.T, capturer embeddingCapturer, embeddings []float32) (*DatabaseAction, *MockDetectionRepository) {

--- a/internal/analysis/processor/database_action_embedding_test.go
+++ b/internal/analysis/processor/database_action_embedding_test.go
@@ -1,0 +1,76 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/embedding"
+)
+
+// spyCapturer records the Record handed to it.
+type spyCapturer struct {
+	calls []embedding.Record
+}
+
+func (s *spyCapturer) Capture(rec embedding.Record) { s.calls = append(s.calls, rec) }
+
+func newEmbeddingTestAction(t *testing.T, capturer embeddingCapturer, embeddings []float32) (*DatabaseAction, *MockDetectionRepository) {
+	t.Helper()
+	settings := &conf.Settings{}
+	settings.Embeddings.Storage.Format = "fp16"
+	repo := NewMockDetectionRepository()
+	action := &DatabaseAction{
+		Settings:     settings,
+		Repo:         repo,
+		EventTracker: NewEventTracker(0), // 0 interval => never throttled
+		Result: detection.Result{
+			Species:     detection.Species{CommonName: "Test Bird", ScientificName: "Testus birdus"},
+			Model:       detection.ModelInfo{Name: "BirdNET", Version: "2.4"},
+			AudioSource: detection.AudioSource{ID: "test-source"},
+		},
+		Embeddings:       embeddings,
+		ModelID:          "birdnet",
+		EmbeddingCapture: capturer,
+	}
+	return action, repo
+}
+
+func TestDatabaseAction_CapturesEmbeddingAfterSave(t *testing.T) {
+	t.Parallel()
+	spy := &spyCapturer{}
+	action, repo := newEmbeddingTestAction(t, spy, []float32{1, 2, 3, 4})
+
+	require.NoError(t, action.ExecuteContext(t.Context(), nil))
+	require.Equal(t, 1, repo.GetSavedCount())
+	require.Len(t, spy.calls, 1)
+
+	rec := spy.calls[0]
+	assert.Equal(t, "1", rec.DetectionID) // mock assigns ID 1
+	assert.Equal(t, "birdnet", rec.Model)
+	assert.Equal(t, "test-source", rec.Source)
+	assert.Equal(t, "2.4", rec.Version)
+	assert.Equal(t, embedding.FormatFP16, rec.Format)
+	assert.Equal(t, 4, rec.Dim)
+	assert.Equal(t, []float32{1, 2, 3, 4}, rec.Vector)
+}
+
+func TestDatabaseAction_NoCaptureWhenEmbeddingEmpty(t *testing.T) {
+	t.Parallel()
+	spy := &spyCapturer{}
+	action, _ := newEmbeddingTestAction(t, spy, nil) // no embedding
+
+	require.NoError(t, action.ExecuteContext(t.Context(), nil))
+	assert.Empty(t, spy.calls, "must not capture when no embedding present")
+}
+
+func TestDatabaseAction_NoCaptureWhenCapturerNil(t *testing.T) {
+	t.Parallel()
+	action, _ := newEmbeddingTestAction(t, nil, []float32{1, 2})
+	action.EmbeddingCapture = nil
+
+	require.NoError(t, action.ExecuteContext(t.Context(), nil)) // must not panic
+}

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -190,6 +190,8 @@ type Detections struct {
 	pcmData3s     []byte                       // 3s PCM data containing the detection
 	Result        detection.Result             // Detection result containing highest match
 	Results       []detection.AdditionalResult // Additional BirdNET prediction results
+	Embeddings    []float32                    // Window embedding (nil when disabled/unavailable); persisted keyed by note ID
+	ModelID       string                       // Registry model id that produced the embedding (provenance)
 }
 
 // PendingDetection struct represents a single detection held in memory,
@@ -1101,6 +1103,8 @@ func (p *Processor) createDetection(settings *conf.Settings, item classifier.Res
 		pcmData3s:     item.PCMdata,
 		Result:        detectionResult,
 		Results:       additionalResults,
+		Embeddings:    item.Embeddings,
+		ModelID:       item.ModelID,
 	}
 }
 
@@ -1944,6 +1948,8 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 			Ds:                p.Ds,         // Legacy - kept for backward compatibility
 			Repo:              p.Repo,       // New - preferred path for database operations
 			CorrelationID:     det.CorrelationID,
+			Embeddings:        det.Embeddings,
+			ModelID:           det.ModelID,
 		}
 	}
 

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -198,7 +198,7 @@ func (p *Processor) resolveEmbeddingStore() (path string, maxRows int) {
 	}
 	maxRows = s.Embeddings.Storage.MaxRows
 	if maxRows <= 0 {
-		maxRows = 50000
+		maxRows = int(embedding.DefaultMaxRows)
 	}
 	return path, maxRows
 }

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/embedding"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
@@ -78,6 +79,7 @@ type Processor struct {
 	LastDogDetection     map[string]time.Time    // keep track of dog barks per audio source
 	LastHumanDetection   map[string]time.Time    // keep track of human vocal per audio source
 	Metrics              *observability.Metrics
+	embeddingCapture     *embedding.Capture // async embedding persistence (lazy-opened, owned here)
 	DynamicThresholds    map[string]*DynamicThreshold
 	thresholdsMutex      sync.RWMutex        // Mutex to protect access to DynamicThresholds
 	pendingResets        map[string]struct{} // Species names pending reset, protected by thresholdsMutex
@@ -183,6 +185,22 @@ type Processor struct {
 // processing cycle without restarting the service.
 func (p *Processor) currentSettings() *conf.Settings {
 	return conf.CurrentOrFallback(p.Settings)
+}
+
+// resolveEmbeddingStore reads the embedding store path and row cap from live
+// settings. Called once when the capture service lazily opens its store. An
+// empty configured path derives a file next to the main SQLite database.
+func (p *Processor) resolveEmbeddingStore() (path string, maxRows int) {
+	s := p.currentSettings()
+	path = s.Embeddings.Storage.Path
+	if path == "" {
+		path = filepath.Join(filepath.Dir(s.Output.SQLite.Path), "embeddings.db")
+	}
+	maxRows = s.Embeddings.Storage.MaxRows
+	if maxRows <= 0 {
+		maxRows = 50000
+	}
+	return path, maxRows
 }
 
 type Detections struct {
@@ -606,6 +624,15 @@ func New(settings *conf.Settings, ds datastore.Interface, bn *classifier.Orchest
 	if settings.Realtime.Dashboard.Spectrogram.IsPreRenderEnabled() {
 		p.initPreRenderer()
 	}
+
+	// Own the embedding capture service. Constructed cheaply: it opens no store
+	// and starts no goroutine until the first embedding-bearing detection saves
+	// while the feature is enabled (zero cost when never used).
+	var capMetrics embedding.CaptureMetrics
+	if metrics != nil && metrics.BirdNET != nil {
+		capMetrics = metrics.BirdNET
+	}
+	p.embeddingCapture = embedding.NewCapture(p.resolveEmbeddingStore, embedding.WithCaptureMetrics(capMetrics))
 
 	return p
 }
@@ -1950,6 +1977,7 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 			CorrelationID:     det.CorrelationID,
 			Embeddings:        det.Embeddings,
 			ModelID:           det.ModelID,
+			EmbeddingCapture:  p.embeddingCapture,
 		}
 	}
 
@@ -2490,6 +2518,17 @@ func (p *Processor) ShutdownWithContext(ctx context.Context) error {
 		GetLogger().Warn("Job queue shutdown timed out",
 			logger.Error(err),
 			logger.String("operation", "job_queue_shutdown"))
+	}
+
+	// Flush and close the embedding capture store. Placed after the job queue
+	// stops so all DatabaseAction enqueues have happened. Close honors ctx and
+	// force-closes if the deadline passes, so teardown never hangs.
+	if p.embeddingCapture != nil {
+		if err := p.embeddingCapture.Close(ctx); err != nil {
+			GetLogger().Warn("embedding capture close did not finish within deadline",
+				logger.Error(err),
+				logger.String("operation", "embedding_capture_shutdown"))
+		}
 	}
 
 	// Skip remaining cleanup if context is already expired — these are

--- a/internal/analysis/processor/processor_embedding_test.go
+++ b/internal/analysis/processor/processor_embedding_test.go
@@ -47,7 +47,7 @@ func TestProcessor_EmbeddingCaptureLifecycle(t *testing.T) {
 
 	store, err := embedding.NewStore(dbPath)
 	require.NoError(t, err)
-	defer func() { _ = store.Close() }()
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
 	rec, err := store.Get(t.Context(), "7")
 	require.NoError(t, err)
 	assert.Equal(t, "7", rec.DetectionID)

--- a/internal/analysis/processor/processor_embedding_test.go
+++ b/internal/analysis/processor/processor_embedding_test.go
@@ -51,4 +51,6 @@ func TestProcessor_EmbeddingCaptureLifecycle(t *testing.T) {
 	rec, err := store.Get(t.Context(), "7")
 	require.NoError(t, err)
 	assert.Equal(t, "7", rec.DetectionID)
+	assert.Equal(t, 3, rec.Dim)
+	assert.Equal(t, []float32{1, 2, 3}, rec.Vector, "flushed vector must round-trip")
 }

--- a/internal/analysis/processor/processor_embedding_test.go
+++ b/internal/analysis/processor/processor_embedding_test.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -44,12 +43,12 @@ func TestProcessor_EmbeddingCaptureLifecycle(t *testing.T) {
 		DetectionID: "7", Model: "birdnet", Dim: 3, Format: embedding.FormatFP16,
 		Vector: []float32{1, 2, 3},
 	})
-	require.NoError(t, p.embeddingCapture.Close(context.Background()))
+	require.NoError(t, p.embeddingCapture.Close(t.Context()))
 
 	store, err := embedding.NewStore(dbPath)
 	require.NoError(t, err)
 	defer func() { _ = store.Close() }()
-	rec, err := store.Get(context.Background(), "7")
+	rec, err := store.Get(t.Context(), "7")
 	require.NoError(t, err)
 	assert.Equal(t, "7", rec.DetectionID)
 }

--- a/internal/analysis/processor/processor_embedding_test.go
+++ b/internal/analysis/processor/processor_embedding_test.go
@@ -1,0 +1,21 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Detections must carry the window embedding and model id so they ride through
+// the pending-detection merge to DatabaseAction.
+func TestDetections_CarriesEmbeddingFields(t *testing.T) {
+	t.Parallel()
+	vec := []float32{1, 2, 3}
+	d := Detections{
+		CorrelationID: "abc",
+		Embeddings:    vec,
+		ModelID:       "birdnet",
+	}
+	assert.Equal(t, vec, d.Embeddings)
+	assert.Equal(t, "birdnet", d.ModelID)
+}

--- a/internal/analysis/processor/processor_embedding_test.go
+++ b/internal/analysis/processor/processor_embedding_test.go
@@ -1,9 +1,15 @@
 package processor
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/embedding"
 )
 
 // Detections must carry the window embedding and model id so they ride through
@@ -18,4 +24,32 @@ func TestDetections_CarriesEmbeddingFields(t *testing.T) {
 	}
 	assert.Equal(t, vec, d.Embeddings)
 	assert.Equal(t, "birdnet", d.ModelID)
+}
+
+// The Processor owns a non-nil Capture, opens it lazily, and closing the
+// Processor flushes + closes it (a fresh store on the same path reopens cleanly).
+func TestProcessor_EmbeddingCaptureLifecycle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "embeddings.db")
+
+	p := &Processor{}
+	p.Settings = &conf.Settings{}
+	p.Settings.Embeddings.Storage.Path = dbPath
+	p.Settings.Embeddings.Storage.MaxRows = 50000
+	p.embeddingCapture = embedding.NewCapture(p.resolveEmbeddingStore)
+
+	// Lazily open by capturing one record.
+	p.embeddingCapture.Capture(embedding.Record{
+		DetectionID: "7", Model: "birdnet", Dim: 3, Format: embedding.FormatFP16,
+		Vector: []float32{1, 2, 3},
+	})
+	require.NoError(t, p.embeddingCapture.Close(context.Background()))
+
+	store, err := embedding.NewStore(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+	rec, err := store.Get(context.Background(), "7")
+	require.NoError(t, err)
+	assert.Equal(t, "7", rec.DetectionID)
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1276,11 +1276,21 @@ type ModelsConfig struct {
 	Installed []string `yaml:"installed,omitempty" json:"installed,omitempty"` // list of installed model IDs managed by the model gallery
 }
 
-// EmbeddingsConfig gates generic embedding extraction.
+// EmbeddingsConfig gates generic embedding extraction and persistence.
 // Capability-gated: extraction only happens when the active model is an ONNX
 // model that exposes embeddings.
 type EmbeddingsConfig struct {
-	Enabled bool `yaml:"enabled" json:"enabled"` // extract embeddings on the live path (hot-reloadable)
+	Enabled bool                    `yaml:"enabled" json:"enabled"` // extract embeddings on the live path (hot-reloadable, read per-window)
+	Storage EmbeddingsStorageConfig `yaml:"storage" json:"storage"` // where/how captured embeddings persist
+}
+
+// EmbeddingsStorageConfig controls persistence of captured embeddings. Path and
+// MaxRows are resolved when the capture store lazily opens (apply on next start
+// or first-enable); Format is read when each record is written.
+type EmbeddingsStorageConfig struct {
+	Path    string `yaml:"path" json:"path"`       // db file path; empty => dir(output.sqlite.path)/embeddings.db
+	MaxRows int    `yaml:"maxrows" json:"maxRows"` // rolling row-count cap; <=0 => default (50000)
+	Format  string `yaml:"format" json:"format"`   // vector encoding; "fp16" is the only implemented value (int8 reserved)
 }
 
 // BasicAuth holds settings for the password authentication

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -99,6 +99,7 @@ func setDefaultConfig() {
 	// Embedding extraction (default off, hot-reloadable)
 	viper.SetDefault("embeddings.enabled", false)
 	viper.SetDefault("embeddings.storage.path", "")
+	// Keep in sync with embedding.DefaultMaxRows (the store's row-cap default).
 	viper.SetDefault("embeddings.storage.maxrows", 50000)
 	viper.SetDefault("embeddings.storage.format", "fp16")
 

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -98,6 +98,9 @@ func setDefaultConfig() {
 
 	// Embedding extraction (default off, hot-reloadable)
 	viper.SetDefault("embeddings.enabled", false)
+	viper.SetDefault("embeddings.storage.path", "")
+	viper.SetDefault("embeddings.storage.maxrows", 50000)
+	viper.SetDefault("embeddings.storage.format", "fp16")
 
 	// Realtime configuration
 	viper.SetDefault("realtime.interval", 15)

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -243,6 +243,11 @@ func ValidateSettings(settings *Settings) error {
 		ve.Errors = append(ve.Errors, err.Error())
 	}
 
+	// Validate Embeddings settings
+	if err := validateEmbeddingsSettings(&settings.Embeddings); err != nil {
+		ve.Errors = append(ve.Errors, err.Error())
+	}
+
 	// If there are any errors, return the ValidationError
 	if len(ve.Errors) > 0 {
 		return ve

--- a/internal/conf/validate_embeddings.go
+++ b/internal/conf/validate_embeddings.go
@@ -6,12 +6,16 @@ import "github.com/tphakala/birdnet-go/internal/errors"
 // Only the fp16 vector format is implemented today; int8 is reserved behind the
 // storage discriminator and rejected here so a misconfiguration surfaces at
 // startup instead of silently dropping every captured embedding at encode time.
+//
+// The error wording deliberately avoids the substrings ParseSettings treats as
+// non-fatal warnings ("not supported", "fallback", ...): an unsupported format
+// must fail startup, not be demoted to a warning. See TestValidateEmbeddingsSettings_UnsupportedFormatIsFatal.
 func validateEmbeddingsSettings(cfg *EmbeddingsConfig) error {
 	switch cfg.Storage.Format {
 	case "", "fp16":
 		// "" defaults to fp16 at encode time.
 	default:
-		return errors.Newf("embeddings.storage.format %q is not supported (only \"fp16\" is implemented)", cfg.Storage.Format).
+		return errors.Newf("embeddings.storage.format %q is invalid: only \"fp16\" is implemented", cfg.Storage.Format).
 			Component("conf").
 			Category(errors.CategoryValidation).
 			Build()

--- a/internal/conf/validate_embeddings.go
+++ b/internal/conf/validate_embeddings.go
@@ -1,0 +1,26 @@
+package conf
+
+import "github.com/tphakala/birdnet-go/internal/errors"
+
+// validateEmbeddingsSettings checks the embedding capture configuration.
+// Only the fp16 vector format is implemented today; int8 is reserved behind the
+// storage discriminator and rejected here so a misconfiguration surfaces at
+// startup instead of silently dropping every captured embedding at encode time.
+func validateEmbeddingsSettings(cfg *EmbeddingsConfig) error {
+	switch cfg.Storage.Format {
+	case "", "fp16":
+		// "" defaults to fp16 at encode time.
+	default:
+		return errors.Newf("embeddings.storage.format %q is not supported (only \"fp16\" is implemented)", cfg.Storage.Format).
+			Component("conf").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	if cfg.Storage.MaxRows < 0 {
+		return errors.Newf("embeddings.storage.maxrows must be >= 0, got %d", cfg.Storage.MaxRows).
+			Component("conf").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	return nil
+}

--- a/internal/conf/validate_embeddings_test.go
+++ b/internal/conf/validate_embeddings_test.go
@@ -1,0 +1,36 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEmbeddingsSettings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		cfg     EmbeddingsConfig
+		wantErr bool
+	}{
+		{name: "empty format defaults ok", cfg: EmbeddingsConfig{}, wantErr: false},
+		{name: "fp16 ok", cfg: EmbeddingsConfig{Storage: EmbeddingsStorageConfig{Format: "fp16"}}, wantErr: false},
+		{name: "int8 rejected (unimplemented)", cfg: EmbeddingsConfig{Storage: EmbeddingsStorageConfig{Format: "int8"}}, wantErr: true},
+		{name: "unknown format rejected", cfg: EmbeddingsConfig{Storage: EmbeddingsStorageConfig{Format: "bogus"}}, wantErr: true},
+		{name: "negative maxrows rejected", cfg: EmbeddingsConfig{Storage: EmbeddingsStorageConfig{MaxRows: -1}}, wantErr: true},
+		{name: "zero maxrows ok (means default)", cfg: EmbeddingsConfig{Storage: EmbeddingsStorageConfig{MaxRows: 0}}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := tt.cfg
+			err := validateEmbeddingsSettings(&cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/conf/validate_embeddings_test.go
+++ b/internal/conf/validate_embeddings_test.go
@@ -34,3 +34,20 @@ func TestValidateEmbeddingsSettings(t *testing.T) {
 		})
 	}
 }
+
+// ParseSettings (storage.go) demotes validation errors whose message contains
+// certain substrings to non-fatal warnings. An unsupported embeddings format
+// must fail startup, so its error must not collide with those warning markers
+// (otherwise the app starts with a config that drops every embedding at encode
+// time). This guards the regression directly.
+func TestValidateEmbeddingsSettings_UnsupportedFormatIsFatal(t *testing.T) {
+	t.Parallel()
+	err := validateEmbeddingsSettings(&EmbeddingsConfig{
+		Storage: EmbeddingsStorageConfig{Format: "int8"},
+	})
+	require.Error(t, err)
+	for _, marker := range []string{"not supported", "fallback", "OAuth authentication warning"} {
+		assert.NotContains(t, err.Error(), marker,
+			"unsupported-format error must stay fatal, not be demoted to a warning by ParseSettings")
+	}
+}

--- a/internal/embedding/capture.go
+++ b/internal/embedding/capture.go
@@ -43,7 +43,6 @@ type Capture struct {
 	mu         sync.Mutex
 	ch         chan Record
 	store      *Store
-	stop       chan struct{}
 	done       chan struct{}
 	started    bool
 	openFailed bool
@@ -98,30 +97,34 @@ func NewCapture(resolve func() (path string, maxRows int), opts ...CaptureOption
 // under context.Background() in the writer, so a request-scoped deadline (e.g.
 // the CompositeAction timeout in DatabaseAction) can never cancel a buffered
 // write.
+//
+// The non-blocking send happens under c.mu. Because the send never blocks (it
+// drops on a full buffer), holding the lock is cheap, and it makes the closed
+// check and the channel send atomic with respect to Close's close(c.ch). That
+// is what guarantees a record is never sent to a closed channel (no panic) and
+// never stranded in the buffer after shutdown begins (no lost write).
+//
 //nolint:gocritic // hugeParam: Record is intentionally passed by value to match the embeddingCapturer interface and take an immutable ownership snapshot; the ~136B header (not the vector backing array) is copied once per saved detection, not in a hot loop.
 func (c *Capture) Capture(rec Record) {
 	if len(rec.Vector) == 0 {
 		return
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.closed || c.openFailed {
-		c.mu.Unlock()
 		return
 	}
 	if !c.started {
 		if err := c.openLocked(); err != nil {
 			c.openFailed = true
-			c.mu.Unlock()
 			c.log.Error("failed to open embedding store; capture disabled", logger.Error(err))
 			c.record(captureStatusErrorOpen)
 			return
 		}
 	}
-	ch := c.ch
-	c.mu.Unlock()
 
 	select {
-	case ch <- rec:
+	case c.ch <- rec:
 	default:
 		c.record(captureStatusDroppedFull)
 	}
@@ -138,45 +141,29 @@ func (c *Capture) openLocked() error {
 	}
 	c.store = store
 	c.ch = make(chan Record, c.bufSize)
-	c.stop = make(chan struct{})
 	c.done = make(chan struct{})
 	c.started = true
 	go c.writer()
 	return nil
 }
 
-// writer is the single consumer. All store access happens here.
+// writer is the single consumer. All store access happens here. It drains c.ch
+// until Close closes the channel, then runs a final prune and closes the store.
+// Ranging over the channel guarantees every buffered record is persisted before
+// the store closes, so no in-flight write is ever abandoned during shutdown.
 func (c *Capture) writer() {
 	defer close(c.done)
 	writes := 0
-	for {
-		select {
-		case <-c.stop:
-			c.drain()
-			return
-		case rec := <-c.ch:
-			c.put(&rec)
-			writes++
-			if writes%c.pruneN == 0 {
-				c.prune()
-			}
+	for rec := range c.ch {
+		c.put(&rec)
+		writes++
+		if writes%c.pruneN == 0 {
+			c.prune()
 		}
 	}
-}
-
-// drain flushes any buffered records, runs a final prune, and closes the store.
-func (c *Capture) drain() {
-	for {
-		select {
-		case rec := <-c.ch:
-			c.put(&rec)
-		default:
-			c.prune()
-			if err := c.store.Close(); err != nil {
-				c.log.Warn("failed to close embedding store", logger.Error(err))
-			}
-			return
-		}
+	c.prune()
+	if err := c.store.Close(); err != nil {
+		c.log.Warn("failed to close embedding store", logger.Error(err))
 	}
 }
 
@@ -224,10 +211,14 @@ func (c *Capture) Close(ctx context.Context) error {
 		c.mu.Unlock()
 		return nil
 	}
-	stop, done := c.stop, c.done
+	done := c.done
+	// Close the channel under the lock so it is mutually exclusive with the
+	// non-blocking send in Capture: no record can be sent to a closed channel
+	// (no panic), and any record already buffered is drained by the writer's
+	// range loop before the store closes (no lost write).
+	close(c.ch)
 	c.mu.Unlock()
 
-	close(stop)
 	select {
 	case <-done:
 		return nil

--- a/internal/embedding/capture.go
+++ b/internal/embedding/capture.go
@@ -196,15 +196,34 @@ func (c *Capture) record(status string) {
 	}
 }
 
+// awaitWriter blocks until the writer goroutine has fully drained and closed
+// the store (done is signalled) or ctx expires, whichever comes first.
+func awaitWriter(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Close stops intake, flushes buffered writes, and closes the store. It honors
 // ctx: if the deadline passes before the writer finishes draining, Close
 // returns ctx.Err() while the writer completes its drain in the background.
-// Close is idempotent and is a no-op when the store was never opened.
+// Close is a no-op when the store was never opened, and is idempotent: a repeat
+// call (e.g. a retry after the first timed out) still waits on the writer rather
+// than returning early, so the caller never proceeds while the writer is live.
 func (c *Capture) Close(ctx context.Context) error {
 	c.mu.Lock()
 	if c.closed {
+		// Already closing: the channel was closed by the first call. Wait on the
+		// writer again so a retry observes the real completion, not a premature nil.
+		done := c.done
 		c.mu.Unlock()
-		return nil
+		if done == nil {
+			return nil // never started
+		}
+		return awaitWriter(ctx, done)
 	}
 	c.closed = true
 	if !c.started {
@@ -219,10 +238,5 @@ func (c *Capture) Close(ctx context.Context) error {
 	close(c.ch)
 	c.mu.Unlock()
 
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return awaitWriter(ctx, done)
 }

--- a/internal/embedding/capture.go
+++ b/internal/embedding/capture.go
@@ -98,6 +98,7 @@ func NewCapture(resolve func() (path string, maxRows int), opts ...CaptureOption
 // under context.Background() in the writer, so a request-scoped deadline (e.g.
 // the CompositeAction timeout in DatabaseAction) can never cancel a buffered
 // write.
+//nolint:gocritic // hugeParam: Record is intentionally passed by value to match the embeddingCapturer interface and take an immutable ownership snapshot; the ~136B header (not the vector backing array) is copied once per saved detection, not in a hot loop.
 func (c *Capture) Capture(rec Record) {
 	if len(rec.Vector) == 0 {
 		return
@@ -154,7 +155,7 @@ func (c *Capture) writer() {
 			c.drain()
 			return
 		case rec := <-c.ch:
-			c.put(rec)
+			c.put(&rec)
 			writes++
 			if writes%c.pruneN == 0 {
 				c.prune()
@@ -168,7 +169,7 @@ func (c *Capture) drain() {
 	for {
 		select {
 		case rec := <-c.ch:
-			c.put(rec)
+			c.put(&rec)
 		default:
 			c.prune()
 			if err := c.store.Close(); err != nil {
@@ -181,8 +182,8 @@ func (c *Capture) drain() {
 
 // put persists a single record under a background context so no caller deadline
 // can cancel it.
-func (c *Capture) put(rec Record) {
-	if err := c.store.Put(context.Background(), &rec); err != nil {
+func (c *Capture) put(rec *Record) {
+	if err := c.store.Put(context.Background(), rec); err != nil {
 		c.log.Warn("failed to persist embedding", logger.Error(err))
 		c.record(captureStatusErrorPut)
 		return

--- a/internal/embedding/capture.go
+++ b/internal/embedding/capture.go
@@ -1,0 +1,236 @@
+package embedding
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// Capture status labels. Keep this set small and static (low cardinality).
+const (
+	captureStatusPersisted   = "persisted"
+	captureStatusDroppedFull = "dropped_queue_full"
+	captureStatusErrorOpen   = "error_open"
+	captureStatusErrorPut    = "error_put"
+)
+
+const (
+	// defaultCaptureBufferSize bounds in-flight records before drop-on-full.
+	defaultCaptureBufferSize = 256
+	// defaultPruneEveryNWrites controls how often the writer prunes; pruning on
+	// every write would issue a COUNT(*) per row.
+	defaultPruneEveryNWrites = 100
+)
+
+// CaptureMetrics records capture outcomes. *metrics.BirdNETMetrics satisfies it.
+type CaptureMetrics interface {
+	RecordEmbeddingCapture(status string)
+	RecordEmbeddingPrune(pruned int)
+}
+
+// Capture is an async, non-blocking sink that persists embedding Records to a
+// lazily-opened Store via a single background writer goroutine. It is safe for
+// concurrent use. The store and goroutine are created on the first non-empty
+// Capture call, so a never-enabled feature costs nothing.
+type Capture struct {
+	resolve func() (path string, maxRows int)
+	metrics CaptureMetrics
+	log     logger.Logger
+	bufSize int
+	pruneN  int
+
+	mu         sync.Mutex
+	ch         chan Record
+	store      *Store
+	stop       chan struct{}
+	done       chan struct{}
+	started    bool
+	openFailed bool
+	closed     bool
+}
+
+// CaptureOption configures a Capture.
+type CaptureOption func(*Capture)
+
+// WithCaptureMetrics injects a metrics recorder; nil disables metrics.
+func WithCaptureMetrics(m CaptureMetrics) CaptureOption {
+	return func(c *Capture) { c.metrics = m }
+}
+
+// WithCaptureBufferSize overrides the buffered-channel capacity (test hook).
+func WithCaptureBufferSize(n int) CaptureOption {
+	return func(c *Capture) {
+		if n > 0 {
+			c.bufSize = n
+		}
+	}
+}
+
+// WithPruneInterval overrides how many writes occur between prunes (test hook).
+func WithPruneInterval(n int) CaptureOption {
+	return func(c *Capture) {
+		if n > 0 {
+			c.pruneN = n
+		}
+	}
+}
+
+// NewCapture builds a Capture. resolve is invoked once, at lazy open, to read
+// the store path and row cap from live settings. resolve must not be nil.
+func NewCapture(resolve func() (path string, maxRows int), opts ...CaptureOption) *Capture {
+	c := &Capture{
+		resolve: resolve,
+		log:     logger.Global().Module("embedding"),
+		bufSize: defaultCaptureBufferSize,
+		pruneN:  defaultPruneEveryNWrites,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Capture enqueues rec for async persistence and returns immediately. It is a
+// no-op when rec carries no vector. On first use it lazily opens the store and
+// starts the writer. When the buffer is full it drops rec (counted) instead of
+// blocking. It deliberately takes no caller context: the actual store.Put runs
+// under context.Background() in the writer, so a request-scoped deadline (e.g.
+// the CompositeAction timeout in DatabaseAction) can never cancel a buffered
+// write.
+func (c *Capture) Capture(rec Record) {
+	if len(rec.Vector) == 0 {
+		return
+	}
+	c.mu.Lock()
+	if c.closed || c.openFailed {
+		c.mu.Unlock()
+		return
+	}
+	if !c.started {
+		if err := c.openLocked(); err != nil {
+			c.openFailed = true
+			c.mu.Unlock()
+			c.log.Error("failed to open embedding store; capture disabled", logger.Error(err))
+			c.record(captureStatusErrorOpen)
+			return
+		}
+	}
+	ch := c.ch
+	c.mu.Unlock()
+
+	select {
+	case ch <- rec:
+	default:
+		c.record(captureStatusDroppedFull)
+	}
+}
+
+// openLocked opens the store and starts the writer goroutine. Caller holds c.mu.
+// Establishes happens-before for all writer field reads because the goroutine
+// is launched after the fields are set, under the lock.
+func (c *Capture) openLocked() error {
+	path, maxRows := c.resolve()
+	store, err := NewStore(path, WithMaxRows(maxRows))
+	if err != nil {
+		return err
+	}
+	c.store = store
+	c.ch = make(chan Record, c.bufSize)
+	c.stop = make(chan struct{})
+	c.done = make(chan struct{})
+	c.started = true
+	go c.writer()
+	return nil
+}
+
+// writer is the single consumer. All store access happens here.
+func (c *Capture) writer() {
+	defer close(c.done)
+	writes := 0
+	for {
+		select {
+		case <-c.stop:
+			c.drain()
+			return
+		case rec := <-c.ch:
+			c.put(rec)
+			writes++
+			if writes%c.pruneN == 0 {
+				c.prune()
+			}
+		}
+	}
+}
+
+// drain flushes any buffered records, runs a final prune, and closes the store.
+func (c *Capture) drain() {
+	for {
+		select {
+		case rec := <-c.ch:
+			c.put(rec)
+		default:
+			c.prune()
+			if err := c.store.Close(); err != nil {
+				c.log.Warn("failed to close embedding store", logger.Error(err))
+			}
+			return
+		}
+	}
+}
+
+// put persists a single record under a background context so no caller deadline
+// can cancel it.
+func (c *Capture) put(rec Record) {
+	if err := c.store.Put(context.Background(), &rec); err != nil {
+		c.log.Warn("failed to persist embedding", logger.Error(err))
+		c.record(captureStatusErrorPut)
+		return
+	}
+	c.record(captureStatusPersisted)
+}
+
+// prune enforces the rolling row cap and records how many rows were removed.
+func (c *Capture) prune() {
+	n, err := c.store.Prune(context.Background())
+	if err != nil {
+		c.log.Warn("failed to prune embedding store", logger.Error(err))
+		return
+	}
+	if n > 0 && c.metrics != nil {
+		c.metrics.RecordEmbeddingPrune(n)
+	}
+}
+
+func (c *Capture) record(status string) {
+	if c.metrics != nil {
+		c.metrics.RecordEmbeddingCapture(status)
+	}
+}
+
+// Close stops intake, flushes buffered writes, and closes the store. It honors
+// ctx: if the deadline passes before the writer finishes draining, Close
+// returns ctx.Err() while the writer completes its drain in the background.
+// Close is idempotent and is a no-op when the store was never opened.
+func (c *Capture) Close(ctx context.Context) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	if !c.started {
+		c.mu.Unlock()
+		return nil
+	}
+	stop, done := c.stop, c.done
+	c.mu.Unlock()
+
+	close(stop)
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/embedding/capture_test.go
+++ b/internal/embedding/capture_test.go
@@ -97,6 +97,18 @@ func TestCapture_CloseNeverOpenedIsNoOp(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestCapture_CloseIdempotentAfterStart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.db")
+	c := NewCapture(func() (string, int) { return path, 50000 })
+
+	c.Capture(testRecord("1", 4)) // lazily opens + starts the writer
+	require.NoError(t, c.Close(t.Context()))
+	// A second Close must still wait on the (already-finished) writer and return
+	// nil, not panic on a double channel close.
+	require.NoError(t, c.Close(t.Context()))
+}
+
 func TestCapture_PruneEnforcesCap(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "embeddings.db")

--- a/internal/embedding/capture_test.go
+++ b/internal/embedding/capture_test.go
@@ -1,7 +1,6 @@
 package embedding
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +50,7 @@ func TestCapture_PersistsRecord(t *testing.T) {
 
 	c := NewCapture(func() (string, int) { return path, 50000 }, WithCaptureMetrics(spy))
 	c.Capture(testRecord("42", 8))
-	require.NoError(t, c.Close(context.Background()))
+	require.NoError(t, c.Close(t.Context()))
 
 	assert.Equal(t, 1, spy.capture["persisted"])
 
@@ -61,7 +60,7 @@ func TestCapture_PersistsRecord(t *testing.T) {
 	store, err := NewStore(path)
 	require.NoError(t, err)
 	defer func() { _ = store.Close() }()
-	rec, err := store.Get(context.Background(), "42")
+	rec, err := store.Get(t.Context(), "42")
 	require.NoError(t, err)
 	assert.Equal(t, "42", rec.DetectionID)
 	assert.Equal(t, 8, rec.Dim)
@@ -74,7 +73,7 @@ func TestCapture_NoOpOnEmptyVector(t *testing.T) {
 	c := NewCapture(func() (string, int) { return path, 50000 })
 
 	c.Capture(Record{DetectionID: "1", Dim: 0}) // empty vector
-	require.NoError(t, c.Close(context.Background()))
+	require.NoError(t, c.Close(t.Context()))
 
 	_, err := os.Stat(path)
 	assert.True(t, os.IsNotExist(err), "store must not be created for an empty-vector capture")
@@ -85,8 +84,8 @@ func TestCapture_CloseNeverOpenedIsNoOp(t *testing.T) {
 	path := filepath.Join(dir, "embeddings.db")
 	c := NewCapture(func() (string, int) { return path, 50000 })
 
-	require.NoError(t, c.Close(context.Background()))
-	require.NoError(t, c.Close(context.Background())) // idempotent
+	require.NoError(t, c.Close(t.Context()))
+	require.NoError(t, c.Close(t.Context())) // idempotent
 	_, err := os.Stat(path)
 	assert.True(t, os.IsNotExist(err))
 }
@@ -102,14 +101,14 @@ func TestCapture_PruneEnforcesCap(t *testing.T) {
 	for i := range 5 {
 		c.Capture(testRecord(string(rune('a'+i)), 4))
 	}
-	require.NoError(t, c.Close(context.Background()))
+	require.NoError(t, c.Close(t.Context()))
 
 	store, err := NewStore(path)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	from := time.Unix(0, 0).UTC()
 	to := time.Unix(2_000_000_000, 0).UTC()
-	rows, err := store.Query(context.Background(), "birdnet", from, to)
+	rows, err := store.Query(t.Context(), "birdnet", from, to)
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(rows), 2, "rolling cap must bound stored rows")
 	assert.Positive(t, spy.pruned, "prune count metric should fire")

--- a/internal/embedding/capture_test.go
+++ b/internal/embedding/capture_test.go
@@ -48,23 +48,30 @@ func TestCapture_PersistsRecord(t *testing.T) {
 	path := filepath.Join(dir, "embeddings.db")
 	spy := newSpyMetrics()
 
+	want := testRecord("42", 8)
 	c := NewCapture(func() (string, int) { return path, 50000 }, WithCaptureMetrics(spy))
-	c.Capture(testRecord("42", 8))
+	c.Capture(want)
 	require.NoError(t, c.Close(t.Context()))
 
 	assert.Equal(t, 1, spy.capture["persisted"])
 
-	// Reopen the store and verify the vector round-tripped. Close it with a
-	// defer registered after goleak's (LIFO => closes first) so the database/sql
-	// background goroutines are gone before the leak check runs.
+	// Reopen the store and verify the full record round-tripped (not just the
+	// length: a codec regression that zeroed the floats would pass a length-only
+	// check). Close it with a defer registered after goleak's (LIFO => closes
+	// first) so the database/sql background goroutines are gone before the leak
+	// check runs.
 	store, err := NewStore(path)
 	require.NoError(t, err)
 	defer func() { _ = store.Close() }()
 	rec, err := store.Get(t.Context(), "42")
 	require.NoError(t, err)
-	assert.Equal(t, "42", rec.DetectionID)
-	assert.Equal(t, 8, rec.Dim)
-	assert.Len(t, rec.Vector, 8)
+	assert.Equal(t, want.DetectionID, rec.DetectionID)
+	assert.Equal(t, want.Model, rec.Model)
+	assert.Equal(t, want.Source, rec.Source)
+	assert.Equal(t, want.Version, rec.Version)
+	assert.Equal(t, want.Format, rec.Format)
+	assert.Equal(t, want.Dim, rec.Dim)
+	assert.Equal(t, want.Vector, rec.Vector, "fp16-exact vector must round-trip")
 }
 
 func TestCapture_NoOpOnEmptyVector(t *testing.T) {
@@ -110,8 +117,9 @@ func TestCapture_PruneEnforcesCap(t *testing.T) {
 	to := time.Unix(2_000_000_000, 0).UTC()
 	rows, err := store.Query(t.Context(), "birdnet", from, to)
 	require.NoError(t, err)
-	assert.LessOrEqual(t, len(rows), 2, "rolling cap must bound stored rows")
-	assert.Positive(t, spy.pruned, "prune count metric should fire")
+	// 5 inserts into a cap of 2 leaves exactly 2 rows and prunes at least 3.
+	assert.Len(t, rows, 2, "rolling cap must leave exactly maxRows rows")
+	assert.GreaterOrEqual(t, spy.pruned, 3, "pruning 5 inserts down to a cap of 2 removes >=3 rows")
 }
 
 // White-box: a full buffer drops rather than blocking.
@@ -125,6 +133,8 @@ func TestCapture_DropsWhenBufferFull(t *testing.T) {
 
 	// Construct a started Capture with a size-1 buffer and NO running writer,
 	// so the channel cannot drain. The first enqueue fills it; the second drops.
+	// stop/done are intentionally left nil: this fixture must NOT call Close()
+	// (close(nil) would panic). Capture() never touches stop/done.
 	c := NewCapture(func() (string, int) { return path, 50000 }, WithCaptureMetrics(spy))
 	c.store = store
 	c.ch = make(chan Record, 1)

--- a/internal/embedding/capture_test.go
+++ b/internal/embedding/capture_test.go
@@ -1,0 +1,139 @@
+package embedding
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// spyMetrics records capture outcomes for assertions.
+type spyMetrics struct {
+	capture map[string]int
+	pruned  int
+}
+
+func newSpyMetrics() *spyMetrics { return &spyMetrics{capture: map[string]int{}} }
+
+func (s *spyMetrics) RecordEmbeddingCapture(status string) { s.capture[status]++ }
+func (s *spyMetrics) RecordEmbeddingPrune(pruned int)      { s.pruned += pruned }
+
+func testRecord(id string, dim int) Record {
+	vec := make([]float32, dim)
+	for i := range vec {
+		vec[i] = float32(i) + 0.5
+	}
+	return Record{
+		DetectionID: id,
+		Model:       "birdnet",
+		Source:      "test-source",
+		CapturedAt:  time.Unix(1_700_000_000, 0).UTC(),
+		Format:      FormatFP16,
+		Dim:         dim,
+		Version:     "2.4",
+		Vector:      vec,
+	}
+}
+
+func TestCapture_PersistsRecord(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+	)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.db")
+	spy := newSpyMetrics()
+
+	c := NewCapture(func() (string, int) { return path, 50000 }, WithCaptureMetrics(spy))
+	c.Capture(testRecord("42", 8))
+	require.NoError(t, c.Close(context.Background()))
+
+	assert.Equal(t, 1, spy.capture["persisted"])
+
+	// Reopen the store and verify the vector round-tripped. Close it with a
+	// defer registered after goleak's (LIFO => closes first) so the database/sql
+	// background goroutines are gone before the leak check runs.
+	store, err := NewStore(path)
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+	rec, err := store.Get(context.Background(), "42")
+	require.NoError(t, err)
+	assert.Equal(t, "42", rec.DetectionID)
+	assert.Equal(t, 8, rec.Dim)
+	assert.Len(t, rec.Vector, 8)
+}
+
+func TestCapture_NoOpOnEmptyVector(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.db")
+	c := NewCapture(func() (string, int) { return path, 50000 })
+
+	c.Capture(Record{DetectionID: "1", Dim: 0}) // empty vector
+	require.NoError(t, c.Close(context.Background()))
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "store must not be created for an empty-vector capture")
+}
+
+func TestCapture_CloseNeverOpenedIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.db")
+	c := NewCapture(func() (string, int) { return path, 50000 })
+
+	require.NoError(t, c.Close(context.Background()))
+	require.NoError(t, c.Close(context.Background())) // idempotent
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCapture_PruneEnforcesCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.db")
+	spy := newSpyMetrics()
+
+	// maxRows=2, prune after every write.
+	c := NewCapture(func() (string, int) { return path, 2 },
+		WithCaptureMetrics(spy), WithPruneInterval(1))
+	for i := range 5 {
+		c.Capture(testRecord(string(rune('a'+i)), 4))
+	}
+	require.NoError(t, c.Close(context.Background()))
+
+	store, err := NewStore(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	from := time.Unix(0, 0).UTC()
+	to := time.Unix(2_000_000_000, 0).UTC()
+	rows, err := store.Query(context.Background(), "birdnet", from, to)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(rows), 2, "rolling cap must bound stored rows")
+	assert.Positive(t, spy.pruned, "prune count metric should fire")
+}
+
+// White-box: a full buffer drops rather than blocking.
+func TestCapture_DropsWhenBufferFull(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.db")
+	spy := newSpyMetrics()
+	store, err := NewStore(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Construct a started Capture with a size-1 buffer and NO running writer,
+	// so the channel cannot drain. The first enqueue fills it; the second drops.
+	c := NewCapture(func() (string, int) { return path, 50000 }, WithCaptureMetrics(spy))
+	c.store = store
+	c.ch = make(chan Record, 1)
+	c.started = true
+
+	c.Capture(testRecord("1", 4)) // fills buffer
+	c.Capture(testRecord("2", 4)) // dropped
+
+	assert.Equal(t, 1, spy.capture["dropped_queue_full"])
+	assert.Equal(t, 0, spy.capture["persisted"])
+}

--- a/internal/embedding/capture_test.go
+++ b/internal/embedding/capture_test.go
@@ -133,8 +133,8 @@ func TestCapture_DropsWhenBufferFull(t *testing.T) {
 
 	// Construct a started Capture with a size-1 buffer and NO running writer,
 	// so the channel cannot drain. The first enqueue fills it; the second drops.
-	// stop/done are intentionally left nil: this fixture must NOT call Close()
-	// (close(nil) would panic). Capture() never touches stop/done.
+	// done is intentionally left nil: this fixture must NOT call Close()
+	// (it would close a channel no writer is draining). Capture() never reads done.
 	c := NewCapture(func() (string, int) { return path, 50000 }, WithCaptureMetrics(spy))
 	c.store = store
 	c.ch = make(chan Record, 1)

--- a/internal/embedding/store.go
+++ b/internal/embedding/store.go
@@ -19,10 +19,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// defaultMaxRows bounds the rolling window of retained embeddings when the
+// DefaultMaxRows bounds the rolling window of retained embeddings when the
 // caller does not specify a cap. Sizing math: a 1536-dim fp16 vector is ~3 KB,
 // so 50k rows is on the order of 150 MB of vector data plus row overhead.
-const defaultMaxRows int64 = 50_000
+// It is the single source of truth for the row-cap default; callers that
+// resolve a non-positive configured cap should fall back to this value.
+const DefaultMaxRows int64 = 50_000
 
 // sqlitePragmas are applied to every pooled connection via the DSN so they are
 // not lost on connections opened after the first. WAL plus a generous
@@ -126,7 +128,7 @@ type Store struct {
 // NewStore opens (creating if necessary) the embeddings database at path and
 // migrates its schema. The parent directory is created if it does not exist.
 func NewStore(path string, opts ...Option) (*Store, error) {
-	cfg := storeConfig{maxRows: defaultMaxRows}
+	cfg := storeConfig{maxRows: DefaultMaxRows}
 	for _, opt := range opts {
 		opt(&cfg)
 	}

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -176,14 +176,14 @@ func (m *BirdNETMetrics) initMetrics() error {
 	m.EmbeddingCaptureTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "birdnet_embedding_capture_total",
-			Help: "Total embedding capture attempts partitioned by status (persisted, dropped_queue_full, error_open, error_put).",
+			Help: "Total embedding capture attempts partitioned by status (persisted, dropped_queue_full, error_open, error_put)",
 		},
 		[]string{"status"},
 	)
 	m.EmbeddingPruneTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "birdnet_embedding_prune_total",
-			Help: "Total number of embedding rows removed by the rolling row-count cap.",
+			Help: "Total number of embedding rows removed by the rolling row-count cap",
 		},
 	)
 

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -34,6 +34,10 @@ type BirdNETMetrics struct {
 	EmbeddingExtractionTotal *prometheus.CounterVec
 	EmbeddingDimGauge        *prometheus.GaugeVec
 
+	// Embedding capture/persistence (substrate M2)
+	EmbeddingCaptureTotal *prometheus.CounterVec
+	EmbeddingPruneTotal   prometheus.Counter
+
 	registry *prometheus.Registry
 }
 
@@ -169,6 +173,20 @@ func (m *BirdNETMetrics) initMetrics() error {
 		[]string{"model"},
 	)
 
+	m.EmbeddingCaptureTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "birdnet_embedding_capture_total",
+			Help: "Total embedding capture attempts partitioned by status (persisted, dropped_queue_full, error_open, error_put).",
+		},
+		[]string{"status"},
+	)
+	m.EmbeddingPruneTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "birdnet_embedding_prune_total",
+			Help: "Total number of embedding rows removed by the rolling row-count cap.",
+		},
+	)
+
 	return nil
 }
 
@@ -198,6 +216,20 @@ func (m *BirdNETMetrics) RecordPrediction(model string, durationSeconds float64,
 // (success, unavailable, error).
 func (m *BirdNETMetrics) RecordEmbeddingExtraction(model, status string) {
 	m.EmbeddingExtractionTotal.WithLabelValues(model, status).Inc()
+}
+
+// RecordEmbeddingCapture records an embedding capture outcome. status must be
+// one of a small, static set: "persisted", "dropped_queue_full", "error_open",
+// "error_put" (keep the cardinality bounded).
+func (m *BirdNETMetrics) RecordEmbeddingCapture(status string) {
+	m.EmbeddingCaptureTotal.WithLabelValues(status).Inc()
+}
+
+// RecordEmbeddingPrune records how many embedding rows were pruned by the cap.
+func (m *BirdNETMetrics) RecordEmbeddingPrune(pruned int) {
+	if pruned > 0 {
+		m.EmbeddingPruneTotal.Add(float64(pruned))
+	}
 }
 
 // SetEmbeddingDim records the embedding dimension exposed by a model. Called from
@@ -311,6 +343,8 @@ func (m *BirdNETMetrics) Describe(ch chan<- *prometheus.Desc) {
 	// Embedding extraction
 	m.EmbeddingExtractionTotal.Describe(ch)
 	m.EmbeddingDimGauge.Describe(ch)
+	m.EmbeddingCaptureTotal.Describe(ch)
+	m.EmbeddingPruneTotal.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -337,6 +371,8 @@ func (m *BirdNETMetrics) Collect(ch chan<- prometheus.Metric) {
 	// Embedding extraction
 	m.EmbeddingExtractionTotal.Collect(ch)
 	m.EmbeddingDimGauge.Collect(ch)
+	m.EmbeddingCaptureTotal.Collect(ch)
+	m.EmbeddingPruneTotal.Collect(ch)
 }
 
 // RecordOperation implements the Recorder interface.

--- a/internal/observability/metrics/birdnet_test.go
+++ b/internal/observability/metrics/birdnet_test.go
@@ -41,3 +41,20 @@ func TestBirdNETMetrics_ClearEmbeddingDim(t *testing.T) {
 	// After deletion the series no longer exists, so the gauge has zero metrics for that label set.
 	assert.Equal(t, 0, testutil.CollectAndCount(m.EmbeddingDimGauge))
 }
+
+func TestBirdNETMetrics_RecordEmbeddingCapture(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	m, err := NewBirdNETMetrics(reg)
+	require.NoError(t, err)
+
+	m.RecordEmbeddingCapture("persisted")
+	m.RecordEmbeddingCapture("persisted")
+	m.RecordEmbeddingCapture("dropped_queue_full")
+	m.RecordEmbeddingPrune(5)
+	m.RecordEmbeddingPrune(0) // no-op
+
+	assert.InDelta(t, 2.0, testutil.ToFloat64(m.EmbeddingCaptureTotal.WithLabelValues("persisted")), 0.0001)
+	assert.InDelta(t, 1.0, testutil.ToFloat64(m.EmbeddingCaptureTotal.WithLabelValues("dropped_queue_full")), 0.0001)
+	assert.InDelta(t, 5.0, testutil.ToFloat64(m.EmbeddingPruneTotal), 0.0001)
+}


### PR DESCRIPTION
## Summary

Persists the per-window ML embedding (already extracted on the live path in M1) to the dedicated embedding SQLite store, keyed by the saved detection's note ID, on a non-blocking async path. Builds on the storage substrate from #3430.

- Carries the window embedding (plus the registry model id) on the in-flight detection through the pending-detection best-confidence merge to the database save action, rather than via a side-channel cache. It already rides on `classifier.Results.Embeddings` from M1.
- Adds a Processor-owned, lazily-initialized `embedding.Capture` service: a buffered channel fronting a single writer goroutine that performs all store access (so the store's single-writer connection is never contended). Zero cost when the feature is never enabled (no store opened, no goroutine started).
- The writer persists under `context.Background()`, so a request-scoped deadline (e.g. the composite-action timeout) can never cancel a buffered write. The audio/save path is never blocked: a full buffer drops the record (counted) instead of stalling.
- Adds storage config `embeddings.storage.{path,maxrows,format}` with validation. Only `fp16` is implemented today; `int8` is reserved behind the format discriminator and rejected at startup so a misconfiguration surfaces immediately instead of silently dropping every captured embedding.
- Adds Prometheus metrics `birdnet_embedding_capture_total{status}` and `birdnet_embedding_prune_total`.
- Flushes and closes the capture store during processor shutdown after the job queue stops; honors the shutdown deadline and force-closes so teardown never hangs.

## Test Plan

- [x] `go test -race` on `internal/embedding`, `internal/conf`, `internal/observability/metrics`, `internal/analysis/processor`
- [x] `golangci-lint run` clean across the full project
- [x] No behavior change and zero overhead when `embeddings.enabled=false` (the default): the capture trigger is gated on a non-empty embedding, which only exists when extraction is enabled

Targets the `feat/embeddings` integration branch, not `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-detection embeddings can now be captured asynchronously and persisted alongside detections.
  * Added observability for embedding capture (status and prune metrics).

* **Configuration**
  * New storage options for embeddings: path, format, and max-rows with sensible defaults and validation.

* **Tests**
  * Added comprehensive tests for capture, persistence, pruning, buffering behavior, and config validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->