### PR TITLE
fix(conf): classify validation severity structurally, not by substring

### DIFF
--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -126,36 +126,12 @@ func Load() (*Settings, error) {
 		return nil, err
 	}
 
-	// Validate settings
-	if err := ValidateSettings(settings); err != nil {
-		// Check if it's just a validation warning (contains fallback info)
-		var validationErr ValidationError
-		if errors.As(err, &validationErr) {
-			// Report configuration issues to telemetry for debugging
-			for _, errMsg := range validationErr.Errors {
-				if strings.Contains(errMsg, "fallback") || strings.Contains(errMsg, "not supported") ||
-					strings.Contains(errMsg, "OAuth authentication warning") {
-					// This is a warning - report to telemetry but don't fail
-					GetLogger().Warn("Configuration warning", logger.String("message", errMsg))
-					// Store the warning for later telemetry reporting
-					settings.ValidationWarnings = append(settings.ValidationWarnings, errMsg)
-					// Note: Telemetry reporting will happen later in birdnet package when Sentry is initialized
-				} else {
-					// This is a real validation error - fail the config load
-					return nil, errors.New(err).
-						Category(errors.CategoryValidation).
-						Context("component", "settings").
-						Context("error_msg", errMsg).
-						Build()
-				}
-			}
-		} else {
-			// Other validation errors should fail the config load
-			return nil, errors.New(err).
-				Category(errors.CategoryValidation).
-				Context("component", "settings").
-				Build()
-		}
+	// Validate settings. Any error ValidateSettings returns is a fatal
+	// misconfiguration that must block startup; non-fatal findings live on the
+	// separate settings.ValidationWarnings channel (recorded during config
+	// migration), never demoted from a fatal error by matching its message text.
+	if err := finalizeValidation(ValidateSettings(settings)); err != nil {
+		return nil, err
 	}
 
 	// Adjust seasonal tracking for the user's hemisphere so the settings
@@ -174,6 +150,28 @@ func Load() (*Settings, error) {
 	// immediately after this point see this snapshot.
 	settingsInstance.Store(settings)
 	return settings, nil
+}
+
+// finalizeValidation converts the outcome of ValidateSettings into a fatal
+// configuration error, or nil when the settings are acceptable.
+//
+// Severity is structural: every error a validator returns (collected into
+// ValidationError.Errors) is fatal and blocks startup. Non-fatal configuration
+// findings use a separate channel, Settings.ValidationWarnings, recorded during
+// config migration (see applyModelValidation), not by the ValidateSettings
+// validators. Severity is never inferred from the error message text;
+// an earlier heuristic that demoted errors whose message contained substrings
+// like "fallback" or "not supported" to warnings could silently start the app
+// with invalid config, so it was removed.
+func finalizeValidation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return errors.New(err).
+		Component("conf").
+		Category(errors.CategoryValidation).
+		Context("component", "settings").
+		Build()
 }
 
 // initViper initializes viper with default values and reads the configuration file.

--- a/internal/conf/storage_test.go
+++ b/internal/conf/storage_test.go
@@ -1,0 +1,46 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// finalizeValidation classifies the outcome of ValidateSettings. Severity must
+// be decided structurally: any error a validator returns is fatal. A finding
+// must never be demoted to a non-fatal warning just because its human-readable
+// message happens to contain a particular substring. These tests pin that
+// contract so the old substring heuristic cannot creep back in.
+func TestFinalizeValidation_FindingsStayFatalRegardlessOfMessage(t *testing.T) {
+	t.Parallel()
+	// Each message contains a substring the removed heuristic treated as a
+	// non-fatal warning ("fallback", "not supported", "OAuth authentication
+	// warning"). A validator returning any of these as an error means a real,
+	// fatal misconfiguration and must block startup.
+	markerMessages := []string{
+		`embeddings.storage.format "int8" is not supported`,
+		"spectrogram mode invalid, no fallback available",
+		"OAuth authentication warning: redirect host missing",
+	}
+	for _, msg := range markerMessages {
+		t.Run(msg, func(t *testing.T) {
+			t.Parallel()
+			err := finalizeValidation(ValidationError{Errors: []string{msg}})
+			require.Error(t, err, "validation finding must stay fatal regardless of message text")
+		})
+	}
+}
+
+func TestFinalizeValidation_NilWhenValid(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, finalizeValidation(nil))
+}
+
+func TestFinalizeValidation_NonValidationErrorIsFatal(t *testing.T) {
+	t.Parallel()
+	err := finalizeValidation(errors.Newf("some unrelated error").Build())
+	require.Error(t, err)
+}

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -73,7 +73,12 @@ var ValidAudioModels = map[string]bool{
 	ModelIDBSG:     true,
 }
 
-// ValidationError represents a collection of validation errors
+// ValidationError is the set of fatal validation findings produced by
+// ValidateSettings. Every entry in Errors blocks startup: severity is decided
+// structurally by whether a validator returned an error, never by inspecting
+// the message text. Non-fatal configuration findings use a separate channel,
+// Settings.ValidationWarnings, recorded during config migration (see
+// applyModelValidation), not derived from the text of a fatal error.
 type ValidationError struct {
 	Errors []string
 }


### PR DESCRIPTION
## Summary

`Load()` decided whether a `ValidationError` was fatal or a non-fatal warning by substring-matching each message against `"fallback"`, `"not supported"`, and `"OAuth authentication warning"`. Any validator whose genuinely fatal error happened to contain one of those substrings was silently demoted to a warning, so the app could start with invalid config.

Severity is now structural: every error a validator returns (collected into `ValidationError.Errors`) is fatal and blocks startup, while non-fatal findings stay on the separate `Settings.ValidationWarnings` channel (recorded during config migration). The classification is extracted into a small `finalizeValidation` helper and the substring heuristic is removed.

No current validator emits a warning-as-error containing those markers, so this removes a latent footgun without changing behavior for any valid configuration. It also means future validators no longer have to carefully word fatal errors to dodge the magic substrings.

## Test Plan

- [x] New unit tests (`TestFinalizeValidation_*`) pin the contract: marker-containing findings stay fatal, `nil` stays `nil`, a non-`ValidationError` stays fatal. The headline test fails against the old heuristic and passes against the fix.
- [x] `go test -race ./internal/conf/` passes
- [x] `golangci-lint run ./internal/conf/...` clean (0 issues)
- [x] Project-wide `go build ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified configuration validation so validation outcomes are handled consistently and reliably.

* **Documentation**
  * Clarified validation behavior in configuration docs to state that fatal findings are determined structurally, not by message text.

* **Tests**
  * Added unit tests to ensure validation results remain consistently fatal when appropriate and that valid configurations are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->