### PR TITLE
fix(deps): roll back onnxruntime_go to v1.30.1 to match native ORT 1.25.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
     commit-message:
       prefix: "build(deps)"
     open-pull-requests-limit: 5
+    ignore:
+      # onnxruntime_go v1.31.0+ bundles the ORT API 26 header and requires a
+      # native ONNX Runtime 1.26.x library. The toolchain pins native ONNX
+      # Runtime 1.25.1 (Dockerfile, Taskfile.yml, setup-onnxruntime action),
+      # so newer bindings fail InitializeEnvironment at runtime. Keep the
+      # binding at v1.30.x until the native runtime is upgraded in lockstep.
+      - dependency-name: "github.com/yalue/onnxruntime_go"
+        versions: [">=1.31.0"]
     groups:
       go-minor-patch:
         patterns:

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/tphakala/go-audio-resampler v1.4.0
 	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
 	github.com/tphakala/simd v1.1.0
-	github.com/yalue/onnxruntime_go v1.31.0
+	github.com/yalue/onnxruntime_go v1.30.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/yalue/onnxruntime_go v1.31.0 h1:1ln4YW1SFOFfGJZXe3jNOb2JUSt+l2pEneZfV8HdtFA=
-github.com/yalue/onnxruntime_go v1.31.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.30.1 h1:NaEng5lWbsHZ/8X1dtaw1mIj7eV1ozyjbFo//g0ktl4=
+github.com/yalue/onnxruntime_go v1.30.1/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Summary

Dependabot PR #3418 bumped `github.com/yalue/onnxruntime_go` from v1.30.1 to v1.31.0. The only change in that release is the bundled ONNX Runtime C header moving from ORT API version 25 to 26; the binding's `SetAPIFromBase` calls `GetApi(26)` with no fallback. The project pins native ONNX Runtime 1.25.1 in the Dockerfile, Taskfile.yml, and the setup-onnxruntime CI action, and ORT returns NULL for API versions newer than the loaded library, so `ort.InitializeEnvironment()` fails at runtime with:

```
The requested API version [26] is not available, only API versions [1, 25] are supported in this build. Current ORT Version is: 1.25.1
```

This silently disables every ONNX-backed feature (range filter v3, custom classifiers, Perch, Bat) in any build that uses the repo-pinned runtime. The failure is graceful (ONNX is recorded unavailable) which is why CI stays green: real ORT init is only exercised by build-tag-gated integration tests.

Changes:
- Roll the binding back to v1.30.1, which matches the ORT API 25 header and works with the pinned 1.25.1 runtime.
- Add a Dependabot ignore rule for `>= 1.31.0` so the weekly go-minor-patch group does not re-bump the binding. We are not ready to update the native ONNX Runtime yet; when that upgrade happens the pin, `RequiredORTAPIMajor`, and the ignore rule move in lockstep.

## Verification

- Minimal probe: `ort.InitializeEnvironment()` against `/usr/lib/libonnxruntime.so.1.25.1` fails with binding v1.31.0 and succeeds with v1.30.1 (reports ORT version 1.25.1).
- No Go source differs between binding v1.30.1 and v1.31.0 (only headers, README, bundled test binaries), so no code changes are needed.
- `go build ./...`, `go test -race ./...`, and `golangci-lint run` all pass.

## Test Plan

- [x] Build with CGO against the pinned runtime
- [x] Full test suite with race detector
- [x] Runtime init probe against libonnxruntime 1.25.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted ONNX Runtime Go module to an earlier version and configured Dependabot to prevent automatic upgrades to incompatible releases.
  * Added explicit version constraints and ignore rules to the Dependabot configuration for ONNX Runtime Go module to ensure conservative dependency management and reduce potential risk of breaking changes from automatic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->