### PR TITLE
feat(embedding): batch extraction path for stored clips and corpora

### DIFF
--- a/cmd/embed/embed.go
+++ b/cmd/embed/embed.go
@@ -1,0 +1,190 @@
+// Package embed implements the hidden "embed" subcommand: offline batch
+// embedding extraction for stored detection clips or arbitrary audio files.
+package embed
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/embedding"
+	"github.com/tphakala/birdnet-go/internal/embedding/batch"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// defaultBackfillLimit bounds one backfill run unless the operator overrides
+// it. Large clip libraries (100 GB+) must never be swept in a single
+// invocation; reruns continue incrementally because existing note ids skip.
+const defaultBackfillLimit = 1000
+
+// defaultPace is the sleep between inference calls so a concurrently running
+// live server keeps inference headroom.
+const defaultPace = 100 * time.Millisecond
+
+// progressEvery throttles progress lines to one per this many handled items.
+const progressEvery = 25
+
+// Command returns the hidden embed subcommand.
+func Command(settings *conf.Settings) *cobra.Command {
+	var (
+		dir       string
+		backfill  bool
+		limit     int
+		since     string
+		species   string
+		pace      time.Duration
+		overwrite bool
+		dryRun    bool
+	)
+	cmd := &cobra.Command{
+		Use:    "embed",
+		Short:  "Batch embedding extraction for stored audio (hidden)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if (dir == "") == !backfill {
+				return errors.NewStd("exactly one of --dir or --backfill is required")
+			}
+			if backfill && !cmd.Flags().Changed("limit") {
+				limit = defaultBackfillLimit
+			}
+			var sinceTime time.Time
+			if since != "" {
+				var err error
+				sinceTime, err = time.Parse(time.DateOnly, since)
+				if err != nil {
+					return fmt.Errorf("invalid --since (want YYYY-MM-DD): %w", err)
+				}
+			}
+			return run(cmd.Context(), settings, &runConfig{
+				dir: dir, backfill: backfill, limit: limit,
+				since: sinceTime, species: species, pace: pace,
+				overwrite: overwrite, dryRun: dryRun,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&dir, "dir", "", "embed every audio file under this directory")
+	cmd.Flags().BoolVar(&backfill, "backfill", false, "embed stored detections that still have a clip on disk")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max files this run (backfill default 1000; 0 = unlimited)")
+	cmd.Flags().StringVar(&since, "since", "", "backfill only detections on/after this date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&species, "species", "", "backfill only this scientific name")
+	cmd.Flags().DurationVar(&pace, "pace", defaultPace, "sleep between inference calls")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "re-embed entries that already exist in the store")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "decode and infer but write nothing")
+	return cmd
+}
+
+// runConfig carries validated flag values into run.
+type runConfig struct {
+	dir       string
+	backfill  bool
+	limit     int
+	since     time.Time
+	species   string
+	pace      time.Duration
+	overwrite bool
+	dryRun    bool
+}
+
+func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	lowerPriority() // best effort; logs nothing on failure
+
+	bn, err := classifier.NewOrchestrator(settings)
+	if err != nil {
+		return fmt.Errorf("model init: %w", err)
+	}
+	// Safe direct read: the orchestrator is single-owner here and ModelInfo
+	// only changes via ReloadModel, which this CLI never calls.
+	modelID := bn.ModelInfo.ID
+	if bn.ModelEmbeddingDim(modelID) == 0 {
+		return fmt.Errorf("model %s cannot extract embeddings; needs an ONNX embeddings model", modelID)
+	}
+	spec, ok := bn.ModelSpecFor(modelID)
+	if !ok {
+		return fmt.Errorf("no model spec for %s", modelID)
+	}
+
+	ffmpegPath, err := ffmpeg.ResolveBinary()
+	if err != nil {
+		return fmt.Errorf("ffmpeg required for batch decode: %w", err)
+	}
+
+	storePath := settings.Embeddings.Storage.Path
+	if storePath == "" {
+		storePath = filepath.Join(filepath.Dir(settings.Output.SQLite.Path), "embeddings.db")
+	}
+	maxRows := settings.Embeddings.Storage.MaxRows
+	if maxRows <= 0 {
+		maxRows = int(embedding.DefaultMaxRows)
+	}
+	store, err := embedding.NewStore(storePath, embedding.WithMaxRows(maxRows))
+	if err != nil {
+		return fmt.Errorf("open embedding store %s: %w", storePath, err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var items []batch.Item
+	if cfg.backfill {
+		ds := datastore.New(settings)
+		if err := ds.Open(); err != nil {
+			return fmt.Errorf("open datastore: %w", err)
+		}
+		defer func() { _ = ds.Close() }()
+		items, err = batch.BackfillItems(ds, settings.Realtime.Audio.Export.Path, batch.BackfillFilter{
+			Species: cfg.species, Since: cfg.since, Limit: cfg.limit,
+		})
+	} else {
+		items, err = batch.DirectoryItems(cfg.dir)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("embed: %d candidate files, model %s (dim %d), store %s\n",
+		len(items), modelID, bn.ModelEmbeddingDim(modelID), storePath)
+
+	predict := func(ctx context.Context, window []float32) ([]datastore.Results, []float32, error) {
+		return bn.PredictModelWithEmbeddings(ctx, modelID, [][]float32{window})
+	}
+	ex := batch.New(predict, store,
+		batch.Tags{Model: modelID, Version: bn.ModelInfo.DetectionVersion,
+			Format: embedding.Format(settings.Embeddings.Storage.Format)},
+		batch.Spec{SampleRate: spec.SampleRate,
+			WindowSamples: spec.SampleRate * int(spec.ClipLength.Seconds())},
+		batch.Options{
+			Limit: cfg.limit, Pace: cfg.pace,
+			Overwrite: cfg.overwrite, DryRun: cfg.dryRun,
+			Progress: func(s batch.Stats, _ batch.Item) {
+				if (s.Files+s.Skipped+s.Errors)%progressEvery == 0 {
+					fmt.Printf("  %d done, %d skipped, %d errors, %d windows\n",
+						s.Files, s.Skipped, s.Errors, s.Windows)
+				}
+			},
+			OnError: func(item batch.Item, err error) {
+				fmt.Printf("  failed: %s: %v\n", item.Key, err)
+			},
+		})
+	ex.SetFFmpegPath(ffmpegPath)
+
+	stats, err := ex.Run(ctx, items)
+	fmt.Printf("embed: files=%d records=%d skipped=%d errors=%d windows=%d\n",
+		stats.Files, stats.Records, stats.Skipped, stats.Errors, stats.Windows)
+	if err != nil {
+		return err
+	}
+	if _, err := store.Prune(ctx); err != nil {
+		return fmt.Errorf("prune: %w", err)
+	}
+	return nil
+}

--- a/cmd/embed/embed.go
+++ b/cmd/embed/embed.go
@@ -51,6 +51,7 @@ func Command(settings *conf.Settings) *cobra.Command {
 		Short:  "Batch embedding extraction for stored audio (hidden)",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// true when both flags are missing or both are set; exactly one mode is required.
 			if (dir == "") == !backfill {
 				return errors.NewStd("exactly one of --dir or --backfill is required")
 			}
@@ -116,9 +117,13 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 		return fmt.Errorf("no model spec for %s", modelID)
 	}
 
-	ffmpegPath, err := ffmpeg.ResolveBinary()
-	if err != nil {
-		return fmt.Errorf("ffmpeg required for batch decode: %w", err)
+	ffmpegPath := settings.Realtime.Audio.FfmpegPath
+	if ffmpegPath == "" {
+		var resolveErr error
+		ffmpegPath, resolveErr = ffmpeg.ResolveBinary()
+		if resolveErr != nil {
+			return fmt.Errorf("ffmpeg required for batch decode: %w", resolveErr)
+		}
 	}
 
 	storePath := settings.Embeddings.Storage.Path
@@ -142,7 +147,7 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 			return fmt.Errorf("open datastore: %w", err)
 		}
 		defer func() { _ = ds.Close() }()
-		items, err = batch.BackfillItems(ds, settings.Realtime.Audio.Export.Path, batch.BackfillFilter{
+		items, err = batch.BackfillItems(ctx, ds, settings.Realtime.Audio.Export.Path, batch.BackfillFilter{
 			Species: cfg.species, Since: cfg.since, Limit: cfg.limit,
 		})
 	} else {
@@ -161,7 +166,7 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 		batch.Tags{Model: modelID, Version: bn.ModelInfo.DetectionVersion,
 			Format: embedding.Format(settings.Embeddings.Storage.Format)},
 		batch.Spec{SampleRate: spec.SampleRate,
-			WindowSamples: spec.SampleRate * int(spec.ClipLength.Seconds())},
+			WindowSamples: int(int64(spec.SampleRate) * int64(spec.ClipLength) / int64(time.Second))},
 		batch.Options{
 			Limit: cfg.limit, Pace: cfg.pace,
 			Overwrite: cfg.overwrite, DryRun: cfg.dryRun,

--- a/cmd/embed/embed.go
+++ b/cmd/embed/embed.go
@@ -130,6 +130,9 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 			return fmt.Errorf("ffmpeg required for batch decode: %w", resolveErr)
 		}
 	}
+	if err := ffmpeg.ValidateFFmpegPath(ffmpegPath); err != nil {
+		return fmt.Errorf("invalid ffmpeg path: %w", err)
+	}
 
 	// --store overrides the settings-derived path entirely, letting large
 	// corpus runs write to a separate file instead of the live rolling store.

--- a/cmd/embed/embed.go
+++ b/cmd/embed/embed.go
@@ -24,7 +24,9 @@ import (
 
 // defaultBackfillLimit bounds one backfill run unless the operator overrides
 // it. Large clip libraries (100 GB+) must never be swept in a single
-// invocation; reruns continue incrementally because existing note ids skip.
+// invocation; reruns continue incrementally because already-embedded
+// detections are excluded from enumeration (unless --overwrite) and do not
+// count toward the limit.
 const defaultBackfillLimit = 1000
 
 // defaultPace is the sleep between inference calls so a concurrently running
@@ -45,6 +47,7 @@ func Command(settings *conf.Settings) *cobra.Command {
 		pace      time.Duration
 		overwrite bool
 		dryRun    bool
+		storePath string
 	)
 	cmd := &cobra.Command{
 		Use:    "embed",
@@ -69,18 +72,19 @@ func Command(settings *conf.Settings) *cobra.Command {
 			return run(cmd.Context(), settings, &runConfig{
 				dir: dir, backfill: backfill, limit: limit,
 				since: sinceTime, species: species, pace: pace,
-				overwrite: overwrite, dryRun: dryRun,
+				overwrite: overwrite, dryRun: dryRun, storePath: storePath,
 			})
 		},
 	}
-	cmd.Flags().StringVar(&dir, "dir", "", "embed every audio file under this directory")
+	cmd.Flags().StringVar(&dir, "dir", "", "embed every audio file under this directory; large corpora share the live embedding store and can evict live history via the rolling cap; use --store to write to a separate file")
 	cmd.Flags().BoolVar(&backfill, "backfill", false, "embed stored detections that still have a clip on disk")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max files this run (backfill default 1000; 0 = unlimited)")
 	cmd.Flags().StringVar(&since, "since", "", "backfill only detections on/after this date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&species, "species", "", "backfill only this scientific name")
 	cmd.Flags().DurationVar(&pace, "pace", defaultPace, "sleep between inference calls")
-	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "re-embed entries that already exist in the store")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "re-embed entries that already exist in the store; replaces live-captured records, including their Source provenance")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "decode and infer but write nothing")
+	cmd.Flags().StringVar(&storePath, "store", "", "embedding store path; overrides the settings-derived path")
 	return cmd
 }
 
@@ -94,6 +98,7 @@ type runConfig struct {
 	pace      time.Duration
 	overwrite bool
 	dryRun    bool
+	storePath string
 }
 
 func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
@@ -126,7 +131,12 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 		}
 	}
 
-	storePath := settings.Embeddings.Storage.Path
+	// --store overrides the settings-derived path entirely, letting large
+	// corpus runs write to a separate file instead of the live rolling store.
+	storePath := cfg.storePath
+	if storePath == "" {
+		storePath = settings.Embeddings.Storage.Path
+	}
 	if storePath == "" {
 		storePath = filepath.Join(filepath.Dir(settings.Output.SQLite.Path), "embeddings.db")
 	}
@@ -142,14 +152,28 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 
 	var items []batch.Item
 	if cfg.backfill {
-		ds := datastore.New(settings)
-		if err := ds.Open(); err != nil {
-			return fmt.Errorf("open datastore: %w", err)
-		}
-		defer func() { _ = ds.Close() }()
-		items, err = batch.BackfillItems(ctx, ds, settings.Realtime.Audio.Export.Path, batch.BackfillFilter{
-			Species: cfg.species, Since: cfg.since, Limit: cfg.limit,
-		})
+		// Scope the datastore connection to enumeration only; extraction can
+		// run for hours and must not hold the DB handle the whole time.
+		items, err = func() ([]batch.Item, error) {
+			ds := datastore.New(settings)
+			if err := ds.Open(); err != nil {
+				return nil, fmt.Errorf("open datastore: %w", err)
+			}
+			defer func() { _ = ds.Close() }()
+			filter := batch.BackfillFilter{
+				Species: cfg.species, Since: cfg.since, Limit: cfg.limit,
+			}
+			if !cfg.overwrite {
+				// Skip already-embedded detections during enumeration so reruns
+				// advance into older history instead of stalling on the newest
+				// window that live capture has already covered.
+				filter.AlreadyEmbedded = func(id string) bool {
+					_, err := store.Get(ctx, id)
+					return err == nil
+				}
+			}
+			return batch.BackfillItems(ctx, ds, settings.Realtime.Audio.Export.Path, filter)
+		}()
 	} else {
 		items, err = batch.DirectoryItems(cfg.dir)
 	}
@@ -188,8 +212,13 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 	if err != nil {
 		return err
 	}
-	if _, err := store.Prune(ctx); err != nil {
-		return fmt.Errorf("prune: %w", err)
+	// A dry run writes nothing and must not prune either: the live store
+	// legitimately sits slightly over cap between live prunes, and deleting
+	// rows here would mutate state the operator asked to leave untouched.
+	if !cfg.dryRun {
+		if _, err := store.Prune(ctx); err != nil {
+			return fmt.Errorf("prune: %w", err)
+		}
 	}
 	return nil
 }

--- a/cmd/embed/embed.go
+++ b/cmd/embed/embed.go
@@ -77,7 +77,7 @@ func Command(settings *conf.Settings) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "", "embed every audio file under this directory; large corpora share the live embedding store and can evict live history via the rolling cap; use --store to write to a separate file")
-	cmd.Flags().BoolVar(&backfill, "backfill", false, "embed stored detections that still have a clip on disk")
+	cmd.Flags().BoolVar(&backfill, "backfill", false, "embed stored detections that still have a clip on disk; opens the main database, run with the same binary version as the live server")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max files this run (backfill default 1000; 0 = unlimited)")
 	cmd.Flags().StringVar(&since, "since", "", "backfill only detections on/after this date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&species, "species", "", "backfill only this scientific name")
@@ -175,7 +175,7 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 			return batch.BackfillItems(ctx, ds, settings.Realtime.Audio.Export.Path, filter)
 		}()
 	} else {
-		items, err = batch.DirectoryItems(cfg.dir)
+		items, err = batch.DirectoryItems(ctx, cfg.dir)
 	}
 	if err != nil {
 		return err
@@ -211,6 +211,9 @@ func run(ctx context.Context, settings *conf.Settings, cfg *runConfig) error {
 		stats.Files, stats.Records, stats.Skipped, stats.Errors, stats.Windows)
 	if err != nil {
 		return err
+	}
+	if stats.Errors > 0 && stats.Files == 0 && stats.Skipped == 0 {
+		return fmt.Errorf("all %d items failed; see per-item errors above", stats.Errors)
 	}
 	// A dry run writes nothing and must not prune either: the live store
 	// legitimately sits slightly over cap between live prunes, and deleting

--- a/cmd/embed/priority_linux.go
+++ b/cmd/embed/priority_linux.go
@@ -2,10 +2,21 @@
 
 package embed
 
-import "syscall"
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// lowestNiceness is the weakest CPU scheduling priority for non-realtime
+// processes; lowering priority never requires privileges.
+const lowestNiceness = 19
 
 // lowerPriority drops this process to the lowest CPU scheduling priority so
-// a concurrently running live server always wins contention. Best effort.
+// a concurrently running live server always wins contention. Best effort:
+// a failure is reported but never blocks the run.
 func lowerPriority() {
-	_ = syscall.Setpriority(syscall.PRIO_PROCESS, 0, 19)
+	if err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, lowestNiceness); err != nil {
+		fmt.Fprintf(os.Stderr, "embed: could not lower process priority: %v\n", err)
+	}
 }

--- a/cmd/embed/priority_linux.go
+++ b/cmd/embed/priority_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package embed
+
+import "syscall"
+
+// lowerPriority drops this process to the lowest CPU scheduling priority so
+// a concurrently running live server always wins contention. Best effort.
+func lowerPriority() {
+	_ = syscall.Setpriority(syscall.PRIO_PROCESS, 0, 19)
+}

--- a/cmd/embed/priority_other.go
+++ b/cmd/embed/priority_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package embed
+
+// lowerPriority is a no-op on platforms without Unix scheduling priorities
+// wired here. Operators can use OS-level tooling instead.
+func lowerPriority() {}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tphakala/birdnet-go/cmd/authors"
 	"github.com/tphakala/birdnet-go/cmd/benchmark"
+	embedcmd "github.com/tphakala/birdnet-go/cmd/embed"
 	"github.com/tphakala/birdnet-go/cmd/license"
 	"github.com/tphakala/birdnet-go/cmd/notify"
 	"github.com/tphakala/birdnet-go/cmd/rangefilter"
@@ -39,6 +40,7 @@ func RootCommand(settings *conf.Settings) *cobra.Command {
 	supportCmd := support.Command(settings)
 	benchmarkCmd := benchmark.Command(settings)
 	notifyCmd := notify.Command(settings)
+	embedCmd := embedcmd.Command(settings)
 
 	subcommands := []*cobra.Command{
 		serveCmd,
@@ -48,6 +50,7 @@ func RootCommand(settings *conf.Settings) *cobra.Command {
 		supportCmd,
 		benchmarkCmd,
 		notifyCmd,
+		embedCmd,
 	}
 
 	rootCmd.AddCommand(subcommands...)

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -234,3 +234,11 @@ func GetAudioDuration(ctx context.Context, audioPath string) (float64, error) {
 
 	return duration, nil
 }
+
+// ResolveBinary returns the path to the ffmpeg executable, honoring the
+// configured override before falling back to PATH lookup. Exported for
+// offline consumers (batch embedding extraction) that decode files outside
+// the streaming pipeline.
+func ResolveBinary() (string, error) {
+	return resolveFFmpegBinary()
+}

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -235,10 +235,11 @@ func GetAudioDuration(ctx context.Context, audioPath string) (float64, error) {
 	return duration, nil
 }
 
-// ResolveBinary returns the path to the ffmpeg executable, honoring the
-// configured override before falling back to PATH lookup. Exported for
-// offline consumers (batch embedding extraction) that decode files outside
-// the streaming pipeline.
+// ResolveBinary returns the path to the ffmpeg executable via PATH lookup
+// only. Callers with access to settings should prefer
+// settings.Realtime.Audio.FfmpegPath and use this function only as a
+// fallback when that field is empty. Exported for offline consumers (batch
+// embedding extraction) that decode files outside the streaming pipeline.
 func ResolveBinary() (string, error) {
 	return resolveFFmpegBinary()
 }

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -140,6 +140,20 @@ func GetAudioDuration(ctx context.Context, audioPath string) (float64, error) {
 			Build()
 	}
 
+	// Resolve to an absolute path before handing it to sox: absolute paths
+	// cannot start with "-", so a crafted relative path can never be parsed
+	// as a sox option.
+	absPath, err := filepath.Abs(audioPath)
+	if err != nil {
+		return 0, errors.Newf("failed to resolve absolute path for %s: %w", audioPath, err).
+			Component("audiocore").
+			Category(errors.CategoryValidation).
+			Context("operation", "get_audio_duration").
+			Context("path", audioPath).
+			Build()
+	}
+	audioPath = absPath
+
 	// Track the actual timeout/deadline for accurate error messages.
 	var timeoutDuration time.Duration
 

--- a/internal/audiocore/ffmpeg/common_test.go
+++ b/internal/audiocore/ffmpeg/common_test.go
@@ -291,3 +291,13 @@ func TestGetAudioDuration_CanceledContext(t *testing.T) {
 	_, err := ffmpeg.GetAudioDuration(ctx, dummyPath)
 	assert.Error(t, err, "canceled context should return an error")
 }
+
+// TestResolveBinary verifies that ResolveBinary returns a non-empty path to the ffmpeg executable.
+func TestResolveBinary(t *testing.T) {
+	t.Parallel()
+	path, err := ffmpeg.ResolveBinary()
+	if err != nil {
+		t.Skip("ffmpeg not installed on this host")
+	}
+	require.NotEmpty(t, path)
+}

--- a/internal/embedding/batch/decode.go
+++ b/internal/embedding/batch/decode.go
@@ -25,6 +25,16 @@ import (
 // be emitted. A tail below this fraction is silently dropped.
 const minTailFraction = 0.25
 
+// windowOffset returns the start offset of window windowIdx without
+// overflowing int64 nanoseconds on very long recordings: whole seconds and
+// the sub-second remainder are scaled separately.
+func windowOffset(windowIdx, windowSamples, sampleRate int) time.Duration {
+	total := int64(windowIdx) * int64(windowSamples)
+	rate := int64(sampleRate)
+	return time.Duration(total/rate)*time.Second +
+		time.Duration(total%rate)*time.Second/time.Duration(rate)
+}
+
 // pcm16Divisor scales int16 PCM samples to float32 so that -32768 maps
 // exactly to -1.0. This matches the live analysis path (see
 // internal/analysis/process.go and internal/audiocore/convert/pcm.go) so
@@ -104,7 +114,7 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 	// flushWindow delivers the current full window to fn and resets the fill
 	// position for the next one.
 	flushWindow := func() error {
-		offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
+		offset := windowOffset(windowIdx, windowSamples, sampleRate)
 		if err := fn(window, offset); err != nil {
 			return err
 		}

--- a/internal/embedding/batch/decode.go
+++ b/internal/embedding/batch/decode.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -53,6 +54,12 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 	if sampleRate <= 0 || windowSamples <= 0 {
 		return fmt.Errorf("decodeWindows: sampleRate (%d) and windowSamples (%d) must be positive", sampleRate, windowSamples)
 	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("resolve absolute path for %s: %w", filePath, err)
+	}
+	filePath = absPath
 
 	var stderrBuf bytes.Buffer
 	cmd := exec.CommandContext(ctx, ffmpegPath,
@@ -127,7 +134,7 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 		// byte) with data[0] (high byte) into a little-endian int16.
 		start := 0
 		if hasCarry && len(data) > 0 {
-			sample := int16(carryByte[0]) | int16(data[0])<<8
+			sample := int16(uint16(carryByte[0]) | uint16(data[0])<<8)
 			start = 1
 			hasCarry = false
 			if err := pushSample(sample); err != nil {

--- a/internal/embedding/batch/decode.go
+++ b/internal/embedding/batch/decode.go
@@ -2,6 +2,9 @@
 // decode files to model-rate windows, run the embedding-capable model, and
 // persist tagged vectors through the embedding store. It is the offline
 // counterpart of the live capture path and shares its store contract.
+// This decoder exists alongside internal/audiocore/readfile because readfile
+// handles only WAV and FLAC, while batch processing needs arbitrary formats
+// (MP3, Opus, etc.) with on-the-fly resampling, both provided by FFmpeg.
 package batch
 
 import (

--- a/internal/embedding/batch/decode.go
+++ b/internal/embedding/batch/decode.go
@@ -9,14 +9,29 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"math"
+	"io"
 	"os/exec"
+	"strconv"
 	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // minTailFraction is the minimum fill ratio for a trailing partial window to
 // be emitted. A tail below this fraction is silently dropped.
 const minTailFraction = 0.25
+
+// pcm16Divisor scales int16 PCM samples to float32 so that -32768 maps
+// exactly to -1.0. This matches the live analysis path (see
+// internal/analysis/process.go and internal/audiocore/convert/pcm.go) so
+// batch embeddings see identically scaled input.
+const pcm16Divisor = float32(32768.0)
+
+// pcm16ToFloat32 converts a single little-endian-decoded int16 PCM sample to
+// a float32 in [-1, 1].
+func pcm16ToFloat32(s int16) float32 {
+	return float32(s) / pcm16Divisor
+}
 
 // windowFunc is called once per analysis window. window is a slice of exactly
 // windowSamples float32 values in the range [-1, 1]. The slice is owned by
@@ -32,6 +47,10 @@ type windowFunc func(window []float32, offset time.Duration) error
 // is silently dropped. The function returns the first error from fn, any ffmpeg
 // exit error (with stderr included), or a context error if ctx is cancelled.
 func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate, windowSamples int, fn windowFunc) error {
+	if sampleRate <= 0 || windowSamples <= 0 {
+		return fmt.Errorf("decodeWindows: sampleRate (%d) and windowSamples (%d) must be positive", sampleRate, windowSamples)
+	}
+
 	var stderrBuf bytes.Buffer
 	cmd := exec.CommandContext(ctx, ffmpegPath,
 		"-hide_banner", "-loglevel", "error",
@@ -39,7 +58,7 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 		"-f", "s16le",
 		"-acodec", "pcm_s16le",
 		"-ac", "1",
-		"-ar", fmt.Sprintf("%d", sampleRate),
+		"-ar", strconv.Itoa(sampleRate),
 		"-",
 	)
 	cmd.Stderr = &stderrBuf
@@ -72,7 +91,27 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 		_ = cmd.Wait()
 	}
 
-	var callbackErr error
+	// flushWindow delivers the current full window to fn and resets the fill
+	// position for the next one.
+	flushWindow := func() error {
+		offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
+		if err := fn(window, offset); err != nil {
+			return err
+		}
+		windowIdx++
+		windowPos = 0
+		return nil
+	}
+
+	// pushSample appends one sample to the current window, flushing when full.
+	pushSample := func(s int16) error {
+		window[windowPos] = pcm16ToFloat32(s)
+		windowPos++
+		if windowPos == windowSamples {
+			return flushWindow()
+		}
+		return nil
+	}
 
 	for {
 		// Read a chunk from ffmpeg stdout.
@@ -81,27 +120,16 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 		// Process whatever bytes arrived, including on a partial/final read.
 		data := buf[:n]
 
-		// If we have a leftover byte from the previous read, prepend it by
-		// handling it as the low byte of the next sample.
+		// If we have a leftover byte from the previous read, combine it (low
+		// byte) with data[0] (high byte) into a little-endian int16.
 		start := 0
 		if hasCarry && len(data) > 0 {
-			// Combine the carry byte (low byte) with data[0] (high byte) to
-			// form a little-endian int16: low byte first, then high byte.
 			sample := int16(carryByte[0]) | int16(data[0])<<8
-			window[windowPos] = float32(sample) / math.MaxInt16
-			windowPos++
 			start = 1
 			hasCarry = false
-
-			if windowPos == windowSamples {
-				offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
-				if err := fn(window, offset); err != nil {
-					callbackErr = err
-					killAndWait()
-					return callbackErr
-				}
-				windowIdx++
-				windowPos = 0
+			if err := pushSample(sample); err != nil {
+				killAndWait()
+				return err
 			}
 		}
 
@@ -111,18 +139,9 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 		for i := range pairs {
 			b := remaining[i*2 : i*2+2]
 			sample := int16(binary.LittleEndian.Uint16(b))
-			window[windowPos] = float32(sample) / math.MaxInt16
-			windowPos++
-
-			if windowPos == windowSamples {
-				offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
-				if err := fn(window, offset); err != nil {
-					callbackErr = err
-					killAndWait()
-					return callbackErr
-				}
-				windowIdx++
-				windowPos = 0
+			if err := pushSample(sample); err != nil {
+				killAndWait()
+				return err
 			}
 		}
 
@@ -133,8 +152,18 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 		}
 
 		if readErr != nil {
-			// Any error here (including io.EOF) means the stream is done.
-			break
+			if errors.Is(readErr, io.EOF) {
+				// Normal end of stream.
+				break
+			}
+			// A non-EOF read error: kill ffmpeg so it cannot block writing
+			// into a full pipe, then surface the read error (or the context
+			// error if the read failed because ctx was cancelled).
+			killAndWait()
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("ffmpeg stdout read: %w", readErr)
 		}
 	}
 
@@ -163,8 +192,7 @@ func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate,
 			for i := windowPos; i < windowSamples; i++ {
 				window[i] = 0
 			}
-			offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
-			if err := fn(window, offset); err != nil {
+			if err := flushWindow(); err != nil {
 				return err
 			}
 		}

--- a/internal/embedding/batch/decode.go
+++ b/internal/embedding/batch/decode.go
@@ -1,0 +1,174 @@
+// Package batch implements offline embedding extraction for stored audio:
+// decode files to model-rate windows, run the embedding-capable model, and
+// persist tagged vectors through the embedding store. It is the offline
+// counterpart of the live capture path and shares its store contract.
+package batch
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os/exec"
+	"time"
+)
+
+// minTailFraction is the minimum fill ratio for a trailing partial window to
+// be emitted. A tail below this fraction is silently dropped.
+const minTailFraction = 0.25
+
+// windowFunc is called once per analysis window. window is a slice of exactly
+// windowSamples float32 values in the range [-1, 1]. The slice is owned by
+// decodeWindows and is reused across calls; the callback must not retain it.
+// offset is the start time of the window relative to the beginning of the file.
+// Returning a non-nil error aborts decoding.
+type windowFunc func(window []float32, offset time.Duration) error
+
+// decodeWindows shells out to ffmpegPath to decode filePath as mono PCM at
+// sampleRate samples per second, then partitions the stream into windows of
+// exactly windowSamples float32 values, calling fn for each. A trailing partial
+// window is emitted only when it is at least minTailFraction full; otherwise it
+// is silently dropped. The function returns the first error from fn, any ffmpeg
+// exit error (with stderr included), or a context error if ctx is cancelled.
+func decodeWindows(ctx context.Context, ffmpegPath, filePath string, sampleRate, windowSamples int, fn windowFunc) error {
+	var stderrBuf bytes.Buffer
+	cmd := exec.CommandContext(ctx, ffmpegPath,
+		"-hide_banner", "-loglevel", "error",
+		"-i", filePath,
+		"-f", "s16le",
+		"-acodec", "pcm_s16le",
+		"-ac", "1",
+		"-ar", fmt.Sprintf("%d", sampleRate),
+		"-",
+	)
+	cmd.Stderr = &stderrBuf
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("ffmpeg stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("ffmpeg start: %w", err)
+	}
+
+	// readChunkBytes is the number of bytes to read per iteration. We use a
+	// multiple of 2 (each int16 sample is 2 bytes) that is large enough for
+	// efficiency.
+	const readChunkBytes = 65536 // 32768 int16 samples per read
+
+	buf := make([]byte, readChunkBytes)
+	window := make([]float32, windowSamples)
+	windowPos := 0 // number of samples filled in window
+	windowIdx := 0 // index of the current window (0-based)
+	var carryByte [1]byte
+	hasCarry := false
+
+	// killAndWait terminates ffmpeg and waits for it, discarding the wait error
+	// since we already have a more informative error to return.
+	killAndWait := func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+
+	var callbackErr error
+
+	for {
+		// Read a chunk from ffmpeg stdout.
+		n, readErr := stdout.Read(buf)
+
+		// Process whatever bytes arrived, including on a partial/final read.
+		data := buf[:n]
+
+		// If we have a leftover byte from the previous read, prepend it by
+		// handling it as the low byte of the next sample.
+		start := 0
+		if hasCarry && len(data) > 0 {
+			// Combine the carry byte (low byte) with data[0] (high byte) to
+			// form a little-endian int16: low byte first, then high byte.
+			sample := int16(carryByte[0]) | int16(data[0])<<8
+			window[windowPos] = float32(sample) / math.MaxInt16
+			windowPos++
+			start = 1
+			hasCarry = false
+
+			if windowPos == windowSamples {
+				offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
+				if err := fn(window, offset); err != nil {
+					callbackErr = err
+					killAndWait()
+					return callbackErr
+				}
+				windowIdx++
+				windowPos = 0
+			}
+		}
+
+		// Process remaining complete pairs of bytes.
+		remaining := data[start:]
+		pairs := len(remaining) / 2
+		for i := range pairs {
+			b := remaining[i*2 : i*2+2]
+			sample := int16(binary.LittleEndian.Uint16(b))
+			window[windowPos] = float32(sample) / math.MaxInt16
+			windowPos++
+
+			if windowPos == windowSamples {
+				offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
+				if err := fn(window, offset); err != nil {
+					callbackErr = err
+					killAndWait()
+					return callbackErr
+				}
+				windowIdx++
+				windowPos = 0
+			}
+		}
+
+		// Check for a leftover odd byte.
+		if len(remaining)%2 == 1 {
+			carryByte[0] = remaining[len(remaining)-1]
+			hasCarry = true
+		}
+
+		if readErr != nil {
+			// Any error here (including io.EOF) means the stream is done.
+			break
+		}
+	}
+
+	// Wait for ffmpeg to exit. This also drains any remaining stdout data.
+	waitErr := cmd.Wait()
+
+	// Check context first: if cancelled, report that.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// If ffmpeg exited with an error, surface stderr for diagnostics.
+	if waitErr != nil {
+		stderr := bytes.TrimSpace(stderrBuf.Bytes())
+		if len(stderr) > 0 {
+			return fmt.Errorf("ffmpeg: %w: %s", waitErr, stderr)
+		}
+		return fmt.Errorf("ffmpeg: %w", waitErr)
+	}
+
+	// Emit a trailing partial window if it meets the minimum fill threshold.
+	if windowPos > 0 {
+		filled := float64(windowPos) / float64(windowSamples)
+		if filled >= minTailFraction {
+			// Zero-pad the remainder.
+			for i := windowPos; i < windowSamples; i++ {
+				window[i] = 0
+			}
+			offset := time.Duration(windowIdx) * time.Duration(windowSamples) * time.Second / time.Duration(sampleRate)
+			if err := fn(window, offset); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/embedding/batch/decode_test.go
+++ b/internal/embedding/batch/decode_test.go
@@ -96,6 +96,23 @@ func TestDecodeWindowsMissingFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWindowOffsetNoOverflow(t *testing.T) {
+	t.Parallel()
+
+	// (a) parity with the old expression: window 2, 144000 samples, 48000 Hz => 6s
+	assert.Equal(t, 6*time.Second, windowOffset(2, 144000, 48000),
+		"window 2 at 3s stride must start at 6s")
+
+	// (b) overflow case: window 100000, 144000 samples, 48000 Hz => 300000s (83+ hours).
+	// Old expression: 100000 * 144000 * 1e9 = 1.44e19 > 9.22e18 (int64 max) overflows.
+	assert.Equal(t, 300000*time.Second, windowOffset(100000, 144000, 48000),
+		"large window index must not overflow")
+
+	// (c) sub-second precision: window 1, 72000 samples, 48000 Hz => 1.5s
+	assert.Equal(t, 1500*time.Millisecond, windowOffset(1, 72000, 48000),
+		"non-whole-second offset must preserve sub-second precision")
+}
+
 func TestDecodeWindowsCallbackErrorAborts(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/embedding/batch/decode_test.go
+++ b/internal/embedding/batch/decode_test.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -20,10 +21,13 @@ func genWAV(t *testing.T, dir, name string, seconds float64) string {
 		t.Skip("ffmpeg not installed")
 	}
 	out := filepath.Join(dir, name)
-	cmd := exec.Command(ffmpeg, "-f", "lavfi", "-i",
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, ffmpeg, "-f", "lavfi", "-i",
 		"sine=frequency=1000:duration="+strconv.FormatFloat(seconds, 'f', -1, 64),
 		"-ar", "48000", "-ac", "1", "-y", out)
-	require.NoError(t, cmd.Run(), "ffmpeg fixture generation failed")
+	combined, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg fixture generation failed: %s", combined)
 	return out
 }
 

--- a/internal/embedding/batch/decode_test.go
+++ b/internal/embedding/batch/decode_test.go
@@ -27,6 +27,15 @@ func genWAV(t *testing.T, dir, name string, seconds float64) string {
 	return out
 }
 
+func TestPCM16ToFloat32(t *testing.T) {
+	t.Parallel()
+	// -32768 must map exactly to -1.0 so batch scaling matches the live
+	// analysis path (divisor 32768, not 32767).
+	assert.InDelta(t, -1.0, float64(pcm16ToFloat32(-32768)), 0)
+	assert.InDelta(t, float64(32767)/32768, float64(pcm16ToFloat32(32767)), 0)
+	assert.InDelta(t, 0.0, float64(pcm16ToFloat32(0)), 0)
+}
+
 func TestDecodeWindows(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/embedding/batch/decode_test.go
+++ b/internal/embedding/batch/decode_test.go
@@ -1,0 +1,100 @@
+package batch
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// genWAV writes a mono 48 kHz sine WAV of the given duration using ffmpeg.
+func genWAV(t *testing.T, dir, name string, seconds float64) string {
+	t.Helper()
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	out := filepath.Join(dir, name)
+	cmd := exec.Command(ffmpeg, "-f", "lavfi", "-i",
+		"sine=frequency=1000:duration="+strconv.FormatFloat(seconds, 'f', -1, 64),
+		"-ar", "48000", "-ac", "1", "-y", out)
+	require.NoError(t, cmd.Run(), "ffmpeg fixture generation failed")
+	return out
+}
+
+func TestDecodeWindows(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := genWAV(t, dir, "tone.wav", 7.5) // 2 full 3s windows + 1.5s tail (padded, >=25%)
+
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+
+	const rate = 48000
+	windowSamples := rate * 3
+	var offsets []time.Duration
+	var lengths []int
+	err = decodeWindows(t.Context(), ffmpeg, path, rate, windowSamples,
+		func(window []float32, offset time.Duration) error {
+			offsets = append(offsets, offset)
+			lengths = append(lengths, len(window))
+			return nil
+		})
+	require.NoError(t, err)
+	require.Len(t, offsets, 3)
+	assert.Equal(t, []time.Duration{0, 3 * time.Second, 6 * time.Second}, offsets)
+	for _, n := range lengths {
+		assert.Equal(t, windowSamples, n, "every window must be exactly windowSamples long")
+	}
+}
+
+func TestDecodeWindowsShortTailDropped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := genWAV(t, dir, "short.wav", 3.5) // 1 full window + 0.5s tail (<25%, dropped)
+
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	const rate = 48000
+	count := 0
+	err = decodeWindows(t.Context(), ffmpeg, path, rate, rate*3,
+		func(window []float32, offset time.Duration) error { count++; return nil })
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestDecodeWindowsMissingFile(t *testing.T) {
+	t.Parallel()
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	err = decodeWindows(t.Context(), ffmpeg, "/nonexistent/clip.wav", 48000, 48000*3,
+		func([]float32, time.Duration) error { return nil })
+	require.Error(t, err)
+}
+
+func TestDecodeWindowsCallbackErrorAborts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := genWAV(t, dir, "abort.wav", 9.0)
+	ffmpeg, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	sentinel := errors.NewStd("stop now")
+	count := 0
+	err = decodeWindows(t.Context(), ffmpeg, path, 48000, 48000*3,
+		func([]float32, time.Duration) error { count++; return sentinel })
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, count, "decode must stop after the callback errors")
+}

--- a/internal/embedding/batch/extractor.go
+++ b/internal/embedding/batch/extractor.go
@@ -1,0 +1,281 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/embedding"
+	"github.com/tphakala/birdnet-go/internal/errors"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// PredictFunc runs one analysis window through the embedding-capable model.
+// The window slice is reused between calls and must not be retained.
+type PredictFunc func(ctx context.Context, window []float32) ([]datastore.Results, []float32, error)
+
+// StoreAPI is the slice of embedding.Store the extractor needs.
+type StoreAPI interface {
+	Put(ctx context.Context, rec *embedding.Record) error
+	Get(ctx context.Context, detectionID string) (embedding.Record, error)
+}
+
+// decodeFunc matches decodeWindows; swapped out in tests.
+type decodeFunc func(ctx context.Context, ffmpegPath, filePath string, sampleRate, windowSamples int, fn windowFunc) error
+
+// Item is one unit of batch work: an audio file plus optional detection
+// identity. When DetectionID is set (backfill) the extractor stores one
+// record for the whole file, keyed by DetectionID, using the window that
+// best matches Species. When DetectionID is empty (directory corpus) it
+// stores one record per window under the synthetic key "<Key>@<offsetSec>".
+type Item struct {
+	Path        string    // absolute path to the audio file
+	Key         string    // stable corpus-relative key (directory mode)
+	DetectionID string    // datastore note id (backfill mode), "" otherwise
+	Species     string    // scientific name for best-window match (backfill)
+	Source      string    // Record.Source override; defaults to "file:<Key>"
+	CapturedAt  time.Time // Record.CapturedAt override; defaults to now per run
+}
+
+// Tags carry the embedding-space partition: model id, version, vector format.
+type Tags struct {
+	Model   string
+	Version string
+	Format  embedding.Format
+}
+
+// Spec is the per-model audio geometry.
+type Spec struct {
+	SampleRate    int
+	WindowSamples int
+}
+
+// Options bound and shape a run. Zero values mean: no limit, no pacing,
+// skip existing, write records.
+type Options struct {
+	Limit     int           // max files processed this run; 0 = unlimited
+	Pace      time.Duration // sleep between inference calls
+	Overwrite bool          // re-embed even when the key already exists
+	DryRun    bool          // decode + predict but never write
+	Progress  func(stats Stats, item Item)
+}
+
+// Stats summarize a run.
+type Stats struct {
+	Files   int // files fully processed (excludes skipped)
+	Windows int // inference calls made
+	Records int // records written
+	Skipped int // items skipped because already embedded
+	Errors  int // items that failed (decode or predict); run continues
+}
+
+// Extractor drives decode -> predict -> put for a sequence of items.
+type Extractor struct {
+	predict    PredictFunc
+	store      StoreAPI
+	tags       Tags
+	spec       Spec
+	opts       Options
+	decode     decodeFunc
+	ffmpegPath string
+	now        func() time.Time
+}
+
+// New builds an Extractor. Callers must call SetFFmpegPath before Run when
+// using the real decoder.
+func New(predict PredictFunc, store StoreAPI, tags Tags, spec Spec, opts Options) *Extractor {
+	return &Extractor{
+		predict: predict,
+		store:   store,
+		tags:    tags,
+		spec:    spec,
+		opts:    opts,
+		decode:  decodeWindows,
+		now:     time.Now,
+	}
+}
+
+// SetFFmpegPath sets the resolved ffmpeg binary used for decoding.
+func (e *Extractor) SetFFmpegPath(path string) { e.ffmpegPath = path }
+
+// Run processes items in order until the list, the limit, or the context is
+// exhausted. Per-item failures are counted; they do not abort the run.
+// Context cancellation returns promptly with the context error.
+func (e *Extractor) Run(ctx context.Context, items []Item) (Stats, error) {
+	var stats Stats
+	for _, item := range items {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		if e.opts.Limit > 0 && stats.Files+stats.Errors >= e.opts.Limit {
+			break
+		}
+		skipped, err := e.processItem(ctx, &item, &stats)
+		switch {
+		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+			return stats, err
+		case err != nil:
+			stats.Errors++
+		case skipped:
+			stats.Skipped++
+		default:
+			stats.Files++
+		}
+		if e.opts.Progress != nil {
+			e.opts.Progress(stats, item)
+		}
+	}
+	return stats, nil
+}
+
+func (e *Extractor) processItem(ctx context.Context, item *Item, stats *Stats) (skipped bool, err error) {
+	backfill := item.DetectionID != ""
+
+	if backfill && !e.opts.Overwrite {
+		if _, err := e.store.Get(ctx, item.DetectionID); err == nil {
+			return true, nil
+		} else if !errors.Is(err, embedding.ErrNotFound) {
+			return false, err
+		}
+	}
+	// Directory mode skip: probe the first window key only; a partially
+	// embedded file is re-run (Put is an idempotent upsert).
+	if !backfill && !e.opts.Overwrite {
+		if _, err := e.store.Get(ctx, windowKey(item.Key, 0)); err == nil {
+			return true, nil
+		} else if !errors.Is(err, embedding.ErrNotFound) {
+			return false, err
+		}
+	}
+
+	capturedAt := item.CapturedAt
+	if capturedAt.IsZero() {
+		capturedAt = e.now()
+	}
+	source := item.Source
+	if source == "" {
+		source = "file:" + item.Key
+	}
+
+	var best struct {
+		conf   float32
+		vector []float32
+		found  bool
+	}
+
+	decodeErr := e.decode(ctx, e.ffmpegPath, item.Path, e.spec.SampleRate, e.spec.WindowSamples,
+		func(window []float32, offset time.Duration) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			results, emb, err := e.predict(ctx, window)
+			if err != nil {
+				return err
+			}
+			stats.Windows++
+			if e.opts.Pace > 0 {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(e.opts.Pace):
+				}
+			}
+			if len(emb) == 0 {
+				return errEmbeddingUnavailable
+			}
+			if backfill {
+				conf := bestConfidenceFor(results, item.Species)
+				if !best.found || conf > best.conf {
+					best.conf = conf
+					// Clone: the next predict call may reuse the backing array.
+					best.vector = slices.Clone(emb)
+					best.found = true
+				}
+				return nil
+			}
+			// Directory mode: one record per window.
+			if e.opts.DryRun {
+				return nil
+			}
+			putErr := e.store.Put(ctx, &embedding.Record{
+				DetectionID: windowKey(item.Key, int(offset.Seconds())),
+				Model:       e.tags.Model,
+				Source:      source,
+				CapturedAt:  capturedAt,
+				Format:      e.tags.Format,
+				Dim:         len(emb),
+				Version:     e.tags.Version,
+				Vector:      emb,
+			})
+			if putErr != nil {
+				return putErr
+			}
+			stats.Records++
+			return nil
+		})
+	if decodeErr != nil {
+		return false, decodeErr
+	}
+
+	if !backfill {
+		return false, nil
+	}
+
+	if !best.found {
+		return false, fmt.Errorf("no usable window in %s", item.Path)
+	}
+	if e.opts.DryRun {
+		return false, nil
+	}
+	if err := e.store.Put(ctx, &embedding.Record{
+		DetectionID: item.DetectionID,
+		Model:       e.tags.Model,
+		Source:      source,
+		CapturedAt:  capturedAt,
+		Format:      e.tags.Format,
+		Dim:         len(best.vector),
+		Version:     e.tags.Version,
+		Vector:      best.vector,
+	}); err != nil {
+		return false, err
+	}
+	stats.Records++
+	return false, nil
+}
+
+// errEmbeddingUnavailable is returned when the model produced an empty
+// embedding vector; this indicates the model lacks an embedding path.
+var errEmbeddingUnavailable = errors.NewStd("model returned no embedding; needs an ONNX embeddings model")
+
+func windowKey(key string, offsetSeconds int) string {
+	return fmt.Sprintf("%s@%d", key, offsetSeconds)
+}
+
+// bestConfidenceFor returns the highest confidence among results whose label
+// matches the scientific name (labels are "Scientific_Common"). Falls back
+// to the overall top confidence when no label matches, so clips whose
+// re-analysis disagrees with the stored detection still embed something.
+func bestConfidenceFor(results []datastore.Results, scientific string) float32 {
+	var matched, top float32
+	matchedFound := false
+	for i := range results {
+		c := results[i].Confidence
+		if c > top {
+			top = c
+		}
+		label := results[i].Species
+		if sci, _, ok := strings.Cut(label, "_"); ok && strings.EqualFold(sci, scientific) {
+			if c > matched {
+				matched = c
+			}
+			matchedFound = true
+		}
+	}
+	if matchedFound {
+		return matched
+	}
+	return top
+}

--- a/internal/embedding/batch/extractor.go
+++ b/internal/embedding/batch/extractor.go
@@ -56,7 +56,9 @@ type Spec struct {
 // Options bound and shape a run. Zero values mean: no limit, no pacing,
 // skip existing, write records.
 type Options struct {
-	Limit     int           // max files processed this run; 0 = unlimited
+	// Limit is the max files processed this run; 0 = unlimited. Errored items
+	// count toward the limit; skipped items (already embedded) do not.
+	Limit     int
 	Pace      time.Duration // sleep between inference calls
 	Overwrite bool          // re-embed even when the key already exists
 	DryRun    bool          // decode + predict but never write
@@ -67,7 +69,9 @@ type Options struct {
 
 // Stats summarize a run.
 type Stats struct {
-	Files   int // files fully processed (excludes skipped)
+	// Files counts items fully processed (excludes skipped). Dry-run items
+	// are counted here: they are processed (decoded and inferred) but not written.
+	Files   int
 	Windows int // inference calls made
 	Records int // records written
 	Skipped int // items skipped because already embedded
@@ -86,8 +90,8 @@ type Extractor struct {
 	now        func() time.Time
 }
 
-// New builds an Extractor. Callers must call SetFFmpegPath before Run when
-// using the real decoder.
+// New builds an Extractor. predict and store must be non-nil. Callers must
+// call SetFFmpegPath before Run when using the real decoder.
 func New(predict PredictFunc, store StoreAPI, tags Tags, spec Spec, opts Options) *Extractor {
 	return &Extractor{
 		predict: predict,
@@ -256,14 +260,21 @@ func (e *Extractor) processItem(ctx context.Context, item *Item, stats *Stats) (
 // embedding vector; this indicates the model lacks an embedding path.
 var errEmbeddingUnavailable = errors.NewStd("model returned no embedding; needs an ONNX embeddings model")
 
+// windowKey builds the stable per-window record key. The format "<key>@<offsetSeconds>"
+// is a stable contract: external tooling and store lookups depend on it.
 func windowKey(key string, offsetSeconds int) string {
 	return fmt.Sprintf("%s@%d", key, offsetSeconds)
 }
 
 // bestConfidenceFor returns the highest confidence among results whose label
-// matches the scientific name (labels are "Scientific_Common"). Falls back
-// to the overall top confidence when no label matches, so clips whose
-// re-analysis disagrees with the stored detection still embed something.
+// matches the scientific name. Labels may use either of two shapes:
+//   - "Scientific_Common" (BirdNET style): the part before the first "_" is
+//     compared case-insensitively against scientific.
+//   - bare scientific name (Perch style): the whole label is compared
+//     case-insensitively against scientific after trimming whitespace.
+//
+// Falls back to the overall top confidence when no label matches, so clips
+// whose re-analysis disagrees with the stored detection still embed something.
 func bestConfidenceFor(results []datastore.Results, scientific string) float32 {
 	var matched, top float32
 	matchedFound := false
@@ -273,7 +284,14 @@ func bestConfidenceFor(results []datastore.Results, scientific string) float32 {
 			top = c
 		}
 		label := results[i].Species
-		if sci, _, ok := strings.Cut(label, "_"); ok && strings.EqualFold(sci, scientific) {
+		if sci, _, ok := strings.Cut(label, "_"); ok {
+			if strings.EqualFold(strings.TrimSpace(sci), scientific) {
+				if c > matched {
+					matched = c
+				}
+				matchedFound = true
+			}
+		} else if strings.EqualFold(strings.TrimSpace(label), scientific) {
 			if c > matched {
 				matched = c
 			}

--- a/internal/embedding/batch/extractor.go
+++ b/internal/embedding/batch/extractor.go
@@ -141,8 +141,9 @@ func (e *Extractor) processItem(ctx context.Context, item *Item, stats *Stats) (
 			return false, err
 		}
 	}
-	// Directory mode skip: probe the first window key only; a partially
-	// embedded file is re-run (Put is an idempotent upsert).
+	// Directory mode skip: probe the first window key only. Window 0 is
+	// written first, so a partially embedded file already has "@0" and is
+	// skipped on re-run; use Overwrite to recover a partial file.
 	if !backfill && !e.opts.Overwrite {
 		if _, err := e.store.Get(ctx, windowKey(item.Key, 0)); err == nil {
 			return true, nil

--- a/internal/embedding/batch/extractor.go
+++ b/internal/embedding/batch/extractor.go
@@ -48,6 +48,11 @@ type Tags struct {
 }
 
 // Spec is the per-model audio geometry.
+//
+// WindowSamples must be a positive whole multiple of SampleRate (i.e. a whole
+// number of seconds). This is required because the directory-mode window key
+// format "<key>@<offsetSeconds>" has second precision: a sub-second window step
+// would produce duplicate keys and silently overwrite records.
 type Spec struct {
 	SampleRate    int
 	WindowSamples int
@@ -113,6 +118,10 @@ func (e *Extractor) SetFFmpegPath(path string) { e.ffmpegPath = path }
 func (e *Extractor) Run(ctx context.Context, items []Item) (Stats, error) {
 	if e.ffmpegPath == "" {
 		return Stats{}, errors.NewStd("batch: ffmpeg path not set; call SetFFmpegPath before Run")
+	}
+	if e.spec.SampleRate <= 0 || e.spec.WindowSamples <= 0 || e.spec.WindowSamples%e.spec.SampleRate != 0 {
+		return Stats{}, fmt.Errorf("batch: window length must be a positive whole number of seconds (WindowSamples %d, SampleRate %d): the window key format has second precision",
+			e.spec.WindowSamples, e.spec.SampleRate)
 	}
 	var stats Stats
 	for _, item := range items {

--- a/internal/embedding/batch/extractor.go
+++ b/internal/embedding/batch/extractor.go
@@ -61,6 +61,8 @@ type Options struct {
 	Overwrite bool          // re-embed even when the key already exists
 	DryRun    bool          // decode + predict but never write
 	Progress  func(stats Stats, item Item)
+	// OnError is invoked for each item that fails; the run continues.
+	OnError func(item Item, err error)
 }
 
 // Stats summarize a run.
@@ -119,6 +121,9 @@ func (e *Extractor) Run(ctx context.Context, items []Item) (Stats, error) {
 			return stats, err
 		case err != nil:
 			stats.Errors++
+			if e.opts.OnError != nil {
+				e.opts.OnError(item, err)
+			}
 		case skipped:
 			stats.Skipped++
 		default:

--- a/internal/embedding/batch/extractor.go
+++ b/internal/embedding/batch/extractor.go
@@ -111,6 +111,9 @@ func (e *Extractor) SetFFmpegPath(path string) { e.ffmpegPath = path }
 // exhausted. Per-item failures are counted; they do not abort the run.
 // Context cancellation returns promptly with the context error.
 func (e *Extractor) Run(ctx context.Context, items []Item) (Stats, error) {
+	if e.ffmpegPath == "" {
+		return Stats{}, errors.NewStd("batch: ffmpeg path not set; call SetFFmpegPath before Run")
+	}
 	var stats Stats
 	for _, item := range items {
 		if err := ctx.Err(); err != nil {

--- a/internal/embedding/batch/extractor_test.go
+++ b/internal/embedding/batch/extractor_test.go
@@ -290,3 +290,20 @@ func TestRunBackfillDryRunWritesNothing(t *testing.T) {
 	_, getErr := store.Get(t.Context(), "99")
 	assert.ErrorIs(t, getErr, embedding.ErrNotFound, "store must remain empty after dry-run")
 }
+
+func TestRunRejectsFractionalSecondWindows(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "S_C"}
+	store := newTestStore(t)
+
+	// 48000 * 2.5 = 120000 samples: not a whole multiple of 48000.
+	e := New(fp.predict, store, Tags{Model: "M", Version: "1", Format: embedding.FormatFP16},
+		Spec{SampleRate: 48000, WindowSamples: 120000}, Options{})
+	e.decode = decodeStub(1)
+	e.ffmpegPath = stubFFmpegPath
+
+	_, err := e.Run(t.Context(), []Item{{Path: "/x/a.wav", Key: "a.wav"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "whole number of seconds")
+	assert.Equal(t, 0, fp.calls, "predict must not be called when spec is invalid")
+}

--- a/internal/embedding/batch/extractor_test.go
+++ b/internal/embedding/batch/extractor_test.go
@@ -156,6 +156,48 @@ func TestRunDryRunWritesNothing(t *testing.T) {
 	assert.ErrorIs(t, err, embedding.ErrNotFound)
 }
 
+// reusePredict simulates a model whose returned embedding aliases ONE reused
+// backing slice across calls. Confidence is highest on the first window and
+// strictly decreases after, so the first window must win best-window
+// selection while the buffer keeps being overwritten by later calls.
+type reusePredict struct {
+	calls int
+	buf   []float32
+}
+
+func (f *reusePredict) predict(ctx context.Context, window []float32) ([]datastore.Results, []float32, error) {
+	f.calls++
+	for i := range f.buf {
+		f.buf[i] = float32(f.calls * 10)
+	}
+	conf := 1.0 / float32(f.calls)
+	return []datastore.Results{{Species: "S_C", Confidence: conf}}, f.buf, nil
+}
+
+func TestRunBackfillCloneSurvivesBufferReuse(t *testing.T) {
+	t.Parallel()
+	fp := &reusePredict{buf: make([]float32, 4)}
+	store := newTestStore(t)
+	e := New(fp.predict, store, Tags{Model: "BirdNET_V2.4", Version: "2.4", Format: embedding.FormatFP16},
+		Spec{SampleRate: 48000, WindowSamples: 48000 * 3}, Options{})
+	e.decode = decodeStub(3)
+	e.ffmpegPath = "unused"
+
+	_, err := e.Run(t.Context(), []Item{{
+		Path: "/x/clip.wav", Key: "clip.wav",
+		DetectionID: "9", Species: "S",
+	}})
+	require.NoError(t, err)
+
+	rec, err := store.Get(t.Context(), "9")
+	require.NoError(t, err)
+	// The first window won (confidence 1.0), so the stored vector must hold
+	// that window's values (10s), not the buffer's final contents (30s).
+	for i, v := range rec.Vector {
+		assert.InDelta(t, 10.0, float64(v), 1e-6, "component %d aliased the reused buffer", i)
+	}
+}
+
 func TestRunContextCancelStops(t *testing.T) {
 	t.Parallel()
 	fp := &fakePredict{species: "S_C"}

--- a/internal/embedding/batch/extractor_test.go
+++ b/internal/embedding/batch/extractor_test.go
@@ -73,13 +73,13 @@ func TestRunDirectoryModePutsPerWindow(t *testing.T) {
 	assert.Equal(t, 1, stats.Files)
 	assert.Equal(t, 3, stats.Records)
 
-	rec, err := store.Get(t.Context(), "a.wav@0")
+	rec, err := store.Get(t.Context(), windowKey("a.wav", 0))
 	require.NoError(t, err)
 	assert.Equal(t, "BirdNET_V2.4", rec.Model)
 	assert.Equal(t, "2.4", rec.Version)
 	assert.Equal(t, "file:a.wav", rec.Source)
 	assert.Equal(t, 4, rec.Dim)
-	_, err = store.Get(t.Context(), "a.wav@6")
+	_, err = store.Get(t.Context(), windowKey("a.wav", 6))
 	require.NoError(t, err)
 }
 
@@ -156,7 +156,7 @@ func TestRunDryRunWritesNothing(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats.Records)
 	assert.Equal(t, 1, stats.Files)
-	_, err = store.Get(t.Context(), "d.wav@0")
+	_, err = store.Get(t.Context(), windowKey("d.wav", 0))
 	assert.ErrorIs(t, err, embedding.ErrNotFound)
 }
 
@@ -253,4 +253,40 @@ func TestRunOnErrorFiresAndRunContinues(t *testing.T) {
 	require.Len(t, gotItems, 1, "OnError must fire exactly once")
 	assert.Equal(t, "bad.wav", gotItems[0].Key)
 	require.ErrorIs(t, gotErrs[0], errBoom)
+}
+
+func TestRunDirectoryModeSkipsExisting(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "S_C"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 2, Options{})
+
+	item := Item{Path: "/x/skip.wav", Key: "skip.wav"}
+	_, err := e.Run(t.Context(), []Item{item})
+	require.NoError(t, err)
+	callsAfterFirst := fp.calls
+
+	// Second run without Overwrite: window 0 already exists, should skip.
+	stats, err := e.Run(t.Context(), []Item{item})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Skipped, "second run must skip the already-embedded item")
+	assert.Equal(t, callsAfterFirst, fp.calls, "skip must not run inference")
+}
+
+func TestRunBackfillDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "Turdus merula_Eurasian Blackbird"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 2, Options{DryRun: true})
+
+	item := Item{
+		Path: "/x/dryrun.wav", Key: "dryrun.wav",
+		DetectionID: "99", Species: "Turdus merula",
+	}
+	stats, err := e.Run(t.Context(), []Item{item})
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Records, "dry-run must write zero records")
+	assert.Equal(t, 1, stats.Files, "dry-run item must still count as processed")
+	_, getErr := store.Get(t.Context(), "99")
+	assert.ErrorIs(t, getErr, embedding.ErrNotFound, "store must remain empty after dry-run")
 }

--- a/internal/embedding/batch/extractor_test.go
+++ b/internal/embedding/batch/extractor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/embedding"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // fakePredict returns a fixed embedding whose first component encodes the
@@ -36,6 +37,9 @@ func newTestStore(t *testing.T) *embedding.Store {
 	return s
 }
 
+// stubFFmpegPath is a placeholder; decodeStub never invokes ffmpeg.
+const stubFFmpegPath = "unused"
+
 // decodeStub bypasses ffmpeg: emits n windows of silence.
 func decodeStub(n int) decodeFunc {
 	return func(ctx context.Context, ffmpegPath, filePath string, sampleRate, windowSamples int, fn windowFunc) error {
@@ -54,7 +58,7 @@ func newTestExtractor(t *testing.T, fp *fakePredict, store *embedding.Store, win
 	e := New(fp.predict, store, Tags{Model: "BirdNET_V2.4", Version: "2.4", Format: embedding.FormatFP16},
 		Spec{SampleRate: 48000, WindowSamples: 48000 * 3}, opts)
 	e.decode = decodeStub(windows)
-	e.ffmpegPath = "unused"
+	e.ffmpegPath = stubFFmpegPath
 	return e
 }
 
@@ -181,7 +185,7 @@ func TestRunBackfillCloneSurvivesBufferReuse(t *testing.T) {
 	e := New(fp.predict, store, Tags{Model: "BirdNET_V2.4", Version: "2.4", Format: embedding.FormatFP16},
 		Spec{SampleRate: 48000, WindowSamples: 48000 * 3}, Options{})
 	e.decode = decodeStub(3)
-	e.ffmpegPath = "unused"
+	e.ffmpegPath = stubFFmpegPath
 
 	_, err := e.Run(t.Context(), []Item{{
 		Path: "/x/clip.wav", Key: "clip.wav",
@@ -208,4 +212,45 @@ func TestRunContextCancelStops(t *testing.T) {
 	cancel()
 	_, err := e.Run(ctx, []Item{{Path: "/x/e.wav", Key: "e.wav"}})
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRunOnErrorFiresAndRunContinues(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	errBoom := errors.NewStd("predict boom")
+
+	// Fail only the very first predict call so item one errors and item two
+	// completes, proving the run continues past a failure.
+	failed := false
+	predict := func(ctx context.Context, window []float32) ([]datastore.Results, []float32, error) {
+		if !failed {
+			failed = true
+			return nil, nil, errBoom
+		}
+		return []datastore.Results{{Species: "S_C", Confidence: 0.5}}, []float32{1, 2, 3, 4}, nil
+	}
+
+	var gotItems []Item
+	var gotErrs []error
+	e := New(predict, store, Tags{Model: "M", Version: "1", Format: embedding.FormatFP16},
+		Spec{SampleRate: 48000, WindowSamples: 48000 * 3}, Options{
+			OnError: func(item Item, err error) {
+				gotItems = append(gotItems, item)
+				gotErrs = append(gotErrs, err)
+			},
+		})
+	e.decode = decodeStub(1)
+	e.ffmpegPath = stubFFmpegPath
+
+	stats, err := e.Run(t.Context(), []Item{
+		{Path: "/x/bad.wav", Key: "bad.wav"},
+		{Path: "/x/good.wav", Key: "good.wav"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Errors)
+	assert.Equal(t, 1, stats.Files, "run must continue to the next item")
+
+	require.Len(t, gotItems, 1, "OnError must fire exactly once")
+	assert.Equal(t, "bad.wav", gotItems[0].Key)
+	require.ErrorIs(t, gotErrs[0], errBoom)
 }

--- a/internal/embedding/batch/extractor_test.go
+++ b/internal/embedding/batch/extractor_test.go
@@ -1,0 +1,169 @@
+package batch
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/embedding"
+)
+
+// fakePredict returns a fixed embedding whose first component encodes the
+// window index, and a single result with confidence rising per window so
+// best-window selection is deterministic.
+type fakePredict struct {
+	calls   int
+	species string
+}
+
+func (f *fakePredict) predict(ctx context.Context, window []float32) ([]datastore.Results, []float32, error) {
+	f.calls++
+	conf := float32(f.calls) * 0.1
+	emb := []float32{float32(f.calls), 2, 3, 4}
+	return []datastore.Results{{Species: f.species, Confidence: conf}}, emb, nil
+}
+
+func newTestStore(t *testing.T) *embedding.Store {
+	t.Helper()
+	s, err := embedding.NewStore(filepath.Join(t.TempDir(), "emb.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// decodeStub bypasses ffmpeg: emits n windows of silence.
+func decodeStub(n int) decodeFunc {
+	return func(ctx context.Context, ffmpegPath, filePath string, sampleRate, windowSamples int, fn windowFunc) error {
+		w := make([]float32, windowSamples)
+		for i := range n {
+			if err := fn(w, time.Duration(i)*3*time.Second); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func newTestExtractor(t *testing.T, fp *fakePredict, store *embedding.Store, windows int, opts Options) *Extractor {
+	t.Helper()
+	e := New(fp.predict, store, Tags{Model: "BirdNET_V2.4", Version: "2.4", Format: embedding.FormatFP16},
+		Spec{SampleRate: 48000, WindowSamples: 48000 * 3}, opts)
+	e.decode = decodeStub(windows)
+	e.ffmpegPath = "unused"
+	return e
+}
+
+func TestRunDirectoryModePutsPerWindow(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "Turdus merula_Eurasian Blackbird"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 3, Options{})
+
+	stats, err := e.Run(t.Context(), []Item{{Path: "/x/a.wav", Key: "a.wav"}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Files)
+	assert.Equal(t, 3, stats.Records)
+
+	rec, err := store.Get(t.Context(), "a.wav@0")
+	require.NoError(t, err)
+	assert.Equal(t, "BirdNET_V2.4", rec.Model)
+	assert.Equal(t, "2.4", rec.Version)
+	assert.Equal(t, "file:a.wav", rec.Source)
+	assert.Equal(t, 4, rec.Dim)
+	_, err = store.Get(t.Context(), "a.wav@6")
+	require.NoError(t, err)
+}
+
+func TestRunBackfillModePutsBestWindow(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "Turdus merula_Eurasian Blackbird"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 3, Options{})
+
+	began := time.Date(2026, 6, 1, 6, 0, 0, 0, time.UTC)
+	stats, err := e.Run(t.Context(), []Item{{
+		Path: "/x/clip.wav", Key: "clip.wav",
+		DetectionID: "42", Species: "Turdus merula",
+		Source: "rtsp-cam1", CapturedAt: began,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Records)
+
+	rec, err := store.Get(t.Context(), "42")
+	require.NoError(t, err)
+	// Confidence rises per window, so the best window is the last (3rd) call:
+	// its embedding first component is 3.
+	assert.InDelta(t, 3.0, float64(rec.Vector[0]), 1e-6)
+	assert.Equal(t, "rtsp-cam1", rec.Source)
+	assert.Equal(t, began, rec.CapturedAt.UTC())
+}
+
+func TestRunSkipsExistingUnlessOverwrite(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "S_C"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 2, Options{})
+
+	item := Item{Path: "/x/c.wav", Key: "c.wav", DetectionID: "7", Species: "S"}
+	_, err := e.Run(t.Context(), []Item{item})
+	require.NoError(t, err)
+	callsAfterFirst := fp.calls
+
+	stats, err := e.Run(t.Context(), []Item{item})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Skipped)
+	assert.Equal(t, callsAfterFirst, fp.calls, "skip must not run inference")
+
+	e.opts.Overwrite = true
+	stats, err = e.Run(t.Context(), []Item{item})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Records)
+	assert.Greater(t, fp.calls, callsAfterFirst)
+}
+
+func TestRunHonorsLimit(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "S_C"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 1, Options{Limit: 2})
+
+	items := []Item{
+		{Path: "/x/1.wav", Key: "1.wav"},
+		{Path: "/x/2.wav", Key: "2.wav"},
+		{Path: "/x/3.wav", Key: "3.wav"},
+	}
+	stats, err := e.Run(t.Context(), items)
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.Files)
+}
+
+func TestRunDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "S_C"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 2, Options{DryRun: true})
+
+	stats, err := e.Run(t.Context(), []Item{{Path: "/x/d.wav", Key: "d.wav"}})
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Records)
+	assert.Equal(t, 1, stats.Files)
+	_, err = store.Get(t.Context(), "d.wav@0")
+	assert.ErrorIs(t, err, embedding.ErrNotFound)
+}
+
+func TestRunContextCancelStops(t *testing.T) {
+	t.Parallel()
+	fp := &fakePredict{species: "S_C"}
+	store := newTestStore(t)
+	e := newTestExtractor(t, fp, store, 1, Options{})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := e.Run(ctx, []Item{{Path: "/x/e.wav", Key: "e.wav"}})
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/embedding/batch/source_backfill.go
+++ b/internal/embedding/batch/source_backfill.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // backfillPageSize bounds each datastore query. Pages keep memory flat on
@@ -18,7 +20,7 @@ const backfillPageSize = 500
 // requested. applyDateRangeFilter in the datastore applies both Start and End
 // unconditionally (date >= start AND date <= end), so an open upper bound
 // must be represented with a date far enough in the future to include all
-// realistic detections.
+// realistic detections. Treated as a constant; never reassign.
 var farFuture = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
 
 // NoteSearcher is the slice of datastore.Interface backfill needs.
@@ -42,14 +44,18 @@ type BackfillFilter struct {
 // BackfillItems enumerates detections that still have a clip on disk,
 // newest first, as batch Items keyed by note id. Notes without a clip
 // record or whose clip file was purged are skipped silently: they are
-// simply not embeddable.
-func BackfillItems(ds NoteSearcher, clipDir string, filter BackfillFilter) ([]Item, error) {
+// simply not embeddable. ctx cancellation is checked at the start of each
+// page iteration and returns promptly with the context error.
+func BackfillItems(ctx context.Context, ds NoteSearcher, clipDir string, filter BackfillFilter) ([]Item, error) {
 	var items []Item
 	offset := 0
 	// Accepted tradeoff: offset pagination over date_desc can skip or duplicate
 	// notes if detections are inserted mid-run; fine for backfill because the
 	// next run catches skips and duplicates re-embed harmlessly (Put is an upsert).
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		f := &datastore.AdvancedSearchFilters{
 			SortBy: "date_desc",
 			Limit:  backfillPageSize,
@@ -78,7 +84,10 @@ func BackfillItems(ds NoteSearcher, clipDir string, filter BackfillFilter) ([]It
 			}
 			path := filepath.Join(clipDir, n.ClipName)
 			if _, statErr := os.Stat(path); statErr != nil {
-				continue
+				if errors.Is(statErr, os.ErrNotExist) {
+					continue
+				}
+				return nil, fmt.Errorf("backfill: stat %s: %w", path, statErr)
 			}
 			items = append(items, Item{
 				Path:        path,

--- a/internal/embedding/batch/source_backfill.go
+++ b/internal/embedding/batch/source_backfill.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -45,6 +46,9 @@ type BackfillFilter struct {
 func BackfillItems(ds NoteSearcher, clipDir string, filter BackfillFilter) ([]Item, error) {
 	var items []Item
 	offset := 0
+	// Accepted tradeoff: offset pagination over date_desc can skip or duplicate
+	// notes if detections are inserted mid-run; fine for backfill because the
+	// next run catches skips and duplicates re-embed harmlessly (Put is an upsert).
 	for {
 		f := &datastore.AdvancedSearchFilters{
 			SortBy: "date_desc",
@@ -65,10 +69,7 @@ func BackfillItems(ds NoteSearcher, clipDir string, filter BackfillFilter) ([]It
 		}
 		notes, _, err := ds.SearchNotesAdvanced(f)
 		if err != nil {
-			return nil, err
-		}
-		if len(notes) == 0 {
-			return items, nil
+			return nil, fmt.Errorf("backfill: search notes page offset %d: %w", offset, err)
 		}
 		for i := range notes {
 			n := &notes[i]
@@ -89,6 +90,11 @@ func BackfillItems(ds NoteSearcher, clipDir string, filter BackfillFilter) ([]It
 			if filter.Limit > 0 && len(items) >= filter.Limit {
 				return items, nil
 			}
+		}
+		// A short page means the result set is exhausted; returning here skips
+		// the terminal zero-row query and its count/preload cost.
+		if len(notes) < backfillPageSize {
+			return items, nil
 		}
 		offset += backfillPageSize
 	}

--- a/internal/embedding/batch/source_backfill.go
+++ b/internal/embedding/batch/source_backfill.go
@@ -39,6 +39,11 @@ type BackfillFilter struct {
 	Since time.Time
 	// Limit is the max items returned; 0 means unbounded.
 	Limit int
+	// AlreadyEmbedded, when non-nil, excludes notes for which it returns true
+	// during enumeration. Excluded notes do NOT count toward Limit, so reruns
+	// advance past already-embedded history instead of re-enumerating the
+	// same newest window every time.
+	AlreadyEmbedded func(detectionID string) bool
 }
 
 // BackfillItems enumerates detections that still have a clip on disk,
@@ -89,10 +94,14 @@ func BackfillItems(ctx context.Context, ds NoteSearcher, clipDir string, filter 
 				}
 				return nil, fmt.Errorf("backfill: stat %s: %w", path, statErr)
 			}
+			id := strconv.FormatUint(uint64(n.ID), 10)
+			if filter.AlreadyEmbedded != nil && filter.AlreadyEmbedded(id) {
+				continue
+			}
 			items = append(items, Item{
 				Path:        path,
 				Key:         n.ClipName,
-				DetectionID: strconv.FormatUint(uint64(n.ID), 10),
+				DetectionID: id,
 				Species:     n.ScientificName,
 				CapturedAt:  n.BeginTime,
 			})

--- a/internal/embedding/batch/source_backfill.go
+++ b/internal/embedding/batch/source_backfill.go
@@ -1,0 +1,95 @@
+package batch
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// backfillPageSize bounds each datastore query. Pages keep memory flat on
+// installs with very large detection histories.
+const backfillPageSize = 500
+
+// farFuture is a sentinel end date used when a Since-only date range is
+// requested. applyDateRangeFilter in the datastore applies both Start and End
+// unconditionally (date >= start AND date <= end), so an open upper bound
+// must be represented with a date far enough in the future to include all
+// realistic detections.
+var farFuture = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+// NoteSearcher is the slice of datastore.Interface backfill needs.
+type NoteSearcher interface {
+	SearchNotesAdvanced(filters *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error)
+}
+
+// BackfillFilter scopes a backfill run.
+type BackfillFilter struct {
+	// Species is the scientific name to restrict to; empty means all species.
+	// SearchNotesAdvanced matches this against both species_code and
+	// scientific_name columns, so it may also match legacy species-code values
+	// that happen to equal the scientific name string.
+	Species string
+	// Since is the lower bound on detection date (inclusive); zero means no bound.
+	Since time.Time
+	// Limit is the max items returned; 0 means unbounded.
+	Limit int
+}
+
+// BackfillItems enumerates detections that still have a clip on disk,
+// newest first, as batch Items keyed by note id. Notes without a clip
+// record or whose clip file was purged are skipped silently: they are
+// simply not embeddable.
+func BackfillItems(ds NoteSearcher, clipDir string, filter BackfillFilter) ([]Item, error) {
+	var items []Item
+	offset := 0
+	for {
+		f := &datastore.AdvancedSearchFilters{
+			SortBy: "date_desc",
+			Limit:  backfillPageSize,
+			Offset: offset,
+		}
+		if filter.Species != "" {
+			f.Species = []string{filter.Species}
+		}
+		if !filter.Since.IsZero() {
+			// applyDateRangeFilter always applies both Start and End bounds, so
+			// an open-ended Since filter must carry a far-future End sentinel to
+			// avoid excluding all real records.
+			f.DateRange = &datastore.DateRange{
+				Start: filter.Since,
+				End:   farFuture,
+			}
+		}
+		notes, _, err := ds.SearchNotesAdvanced(f)
+		if err != nil {
+			return nil, err
+		}
+		if len(notes) == 0 {
+			return items, nil
+		}
+		for i := range notes {
+			n := &notes[i]
+			if n.ClipName == "" {
+				continue
+			}
+			path := filepath.Join(clipDir, n.ClipName)
+			if _, statErr := os.Stat(path); statErr != nil {
+				continue
+			}
+			items = append(items, Item{
+				Path:        path,
+				Key:         n.ClipName,
+				DetectionID: strconv.FormatUint(uint64(n.ID), 10),
+				Species:     n.ScientificName,
+				CapturedAt:  n.BeginTime,
+			})
+			if filter.Limit > 0 && len(items) >= filter.Limit {
+				return items, nil
+			}
+		}
+		offset += backfillPageSize
+	}
+}

--- a/internal/embedding/batch/source_backfill_test.go
+++ b/internal/embedding/batch/source_backfill_test.go
@@ -64,6 +64,27 @@ func TestBackfillItemsLimit(t *testing.T) {
 	assert.Equal(t, "1", items[0].DetectionID, "first note in fixture order must survive the limit cut")
 }
 
+func TestBackfillItemsSkipsAlreadyEmbedded(t *testing.T) {
+	t.Parallel()
+	clipDir := t.TempDir()
+	notes := make([]datastore.Note, 10)
+	for i := range notes {
+		name := "c" + strconv.Itoa(i) + ".wav"
+		touch(t, filepath.Join(clipDir, name))
+		notes[i] = datastore.Note{ID: uint(i + 1), ClipName: name}
+	}
+	embedded := map[string]bool{"1": true, "2": true, "3": true, "4": true}
+	items, err := BackfillItems(t.Context(), &fakeSearcher{notes: notes}, clipDir, BackfillFilter{
+		Limit:           3,
+		AlreadyEmbedded: func(id string) bool { return embedded[id] },
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 3, "already-embedded notes must not count toward Limit")
+	assert.Equal(t, "5", items[0].DetectionID)
+	assert.Equal(t, "6", items[1].DetectionID)
+	assert.Equal(t, "7", items[2].DetectionID)
+}
+
 func TestBackfillItemsSpeciesAndSinceForwarded(t *testing.T) {
 	t.Parallel()
 	clipDir := t.TempDir()

--- a/internal/embedding/batch/source_backfill_test.go
+++ b/internal/embedding/batch/source_backfill_test.go
@@ -34,7 +34,7 @@ func TestBackfillItems(t *testing.T) {
 	begin := time.Date(2026, 6, 1, 5, 0, 0, 0, time.UTC)
 	notes := []datastore.Note{
 		{ID: 1, ScientificName: "Turdus merula", ClipName: "clips/n1.wav", BeginTime: begin},
-		{ID: 2, ScientificName: "Erithacus rubecula", ClipName: ""},                // no clip recorded
+		{ID: 2, ScientificName: "Erithacus rubecula", ClipName: ""}, // no clip recorded
 		{ID: 3, ScientificName: "Parus major", ClipName: "clips/n3.wav", BeginTime: begin},
 		{ID: 4, ScientificName: "Sitta europaea", ClipName: "clips/gone.wav"}, // purged from disk
 	}
@@ -81,7 +81,9 @@ func TestBackfillItemsSpeciesAndSinceForwarded(t *testing.T) {
 	assert.Equal(t, "date_desc", rec.got.SortBy)
 }
 
-type recordingSearcher struct{ got *datastore.AdvancedSearchFilters }
+type recordingSearcher struct {
+	got *datastore.AdvancedSearchFilters
+}
 
 func (r *recordingSearcher) SearchNotesAdvanced(f *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
 	r.got = f

--- a/internal/embedding/batch/source_backfill_test.go
+++ b/internal/embedding/batch/source_backfill_test.go
@@ -1,0 +1,89 @@
+package batch
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+type fakeSearcher struct {
+	notes []datastore.Note
+}
+
+func (f *fakeSearcher) SearchNotesAdvanced(filters *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
+	start := filters.Offset
+	if start >= len(f.notes) {
+		return nil, int64(len(f.notes)), nil
+	}
+	end := min(start+filters.Limit, len(f.notes))
+	return f.notes[start:end], int64(len(f.notes)), nil
+}
+
+func TestBackfillItems(t *testing.T) {
+	t.Parallel()
+	clipDir := t.TempDir()
+	touch(t, filepath.Join(clipDir, "clips", "n1.wav"))
+	touch(t, filepath.Join(clipDir, "clips", "n3.wav"))
+
+	begin := time.Date(2026, 6, 1, 5, 0, 0, 0, time.UTC)
+	notes := []datastore.Note{
+		{ID: 1, ScientificName: "Turdus merula", ClipName: "clips/n1.wav", BeginTime: begin},
+		{ID: 2, ScientificName: "Erithacus rubecula", ClipName: ""},                // no clip recorded
+		{ID: 3, ScientificName: "Parus major", ClipName: "clips/n3.wav", BeginTime: begin},
+		{ID: 4, ScientificName: "Sitta europaea", ClipName: "clips/gone.wav"}, // purged from disk
+	}
+
+	items, err := BackfillItems(&fakeSearcher{notes: notes}, clipDir, BackfillFilter{})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "1", items[0].DetectionID)
+	assert.Equal(t, "Turdus merula", items[0].Species)
+	assert.Equal(t, filepath.Join(clipDir, "clips", "n1.wav"), items[0].Path)
+	assert.Equal(t, begin, items[0].CapturedAt)
+	assert.Equal(t, "3", items[1].DetectionID)
+}
+
+func TestBackfillItemsLimit(t *testing.T) {
+	t.Parallel()
+	clipDir := t.TempDir()
+	notes := make([]datastore.Note, 10)
+	for i := range notes {
+		name := "c" + strconv.Itoa(i) + ".wav"
+		touch(t, filepath.Join(clipDir, name))
+		notes[i] = datastore.Note{ID: uint(i + 1), ClipName: name}
+	}
+	items, err := BackfillItems(&fakeSearcher{notes: notes}, clipDir, BackfillFilter{Limit: 3})
+	require.NoError(t, err)
+	assert.Len(t, items, 3)
+}
+
+func TestBackfillItemsSpeciesAndSinceForwarded(t *testing.T) {
+	t.Parallel()
+	clipDir := t.TempDir()
+	rec := &recordingSearcher{}
+	since := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	_, err := BackfillItems(rec, clipDir, BackfillFilter{Species: "Turdus merula", Since: since})
+	require.NoError(t, err)
+	require.NotNil(t, rec.got)
+	assert.Equal(t, []string{"Turdus merula"}, rec.got.Species)
+	require.NotNil(t, rec.got.DateRange)
+	// DateRange.Start must be the Since value; End is a far-future sentinel so the
+	// date >= start AND date <= end query in applyDateRangeFilter admits all future records.
+	assert.Equal(t, since, rec.got.DateRange.Start)
+	assert.True(t, rec.got.DateRange.End.After(time.Now().AddDate(100, 0, 0)),
+		"DateRange.End should be a far-future sentinel (>100 years from now)")
+	assert.Equal(t, "date_desc", rec.got.SortBy)
+}
+
+type recordingSearcher struct{ got *datastore.AdvancedSearchFilters }
+
+func (r *recordingSearcher) SearchNotesAdvanced(f *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
+	r.got = f
+	return nil, 0, nil
+}

--- a/internal/embedding/batch/source_backfill_test.go
+++ b/internal/embedding/batch/source_backfill_test.go
@@ -39,7 +39,7 @@ func TestBackfillItems(t *testing.T) {
 		{ID: 4, ScientificName: "Sitta europaea", ClipName: "clips/gone.wav"}, // purged from disk
 	}
 
-	items, err := BackfillItems(&fakeSearcher{notes: notes}, clipDir, BackfillFilter{})
+	items, err := BackfillItems(t.Context(), &fakeSearcher{notes: notes}, clipDir, BackfillFilter{})
 	require.NoError(t, err)
 	require.Len(t, items, 2)
 	assert.Equal(t, "1", items[0].DetectionID)
@@ -58,9 +58,10 @@ func TestBackfillItemsLimit(t *testing.T) {
 		touch(t, filepath.Join(clipDir, name))
 		notes[i] = datastore.Note{ID: uint(i + 1), ClipName: name}
 	}
-	items, err := BackfillItems(&fakeSearcher{notes: notes}, clipDir, BackfillFilter{Limit: 3})
+	items, err := BackfillItems(t.Context(), &fakeSearcher{notes: notes}, clipDir, BackfillFilter{Limit: 3})
 	require.NoError(t, err)
 	assert.Len(t, items, 3)
+	assert.Equal(t, "1", items[0].DetectionID, "first note in fixture order must survive the limit cut")
 }
 
 func TestBackfillItemsSpeciesAndSinceForwarded(t *testing.T) {
@@ -68,7 +69,7 @@ func TestBackfillItemsSpeciesAndSinceForwarded(t *testing.T) {
 	clipDir := t.TempDir()
 	rec := &recordingSearcher{}
 	since := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	_, err := BackfillItems(rec, clipDir, BackfillFilter{Species: "Turdus merula", Since: since})
+	_, err := BackfillItems(t.Context(), rec, clipDir, BackfillFilter{Species: "Turdus merula", Since: since})
 	require.NoError(t, err)
 	require.NotNil(t, rec.got)
 	assert.Equal(t, []string{"Turdus merula"}, rec.got.Species)

--- a/internal/embedding/batch/source_dir.go
+++ b/internal/embedding/batch/source_dir.go
@@ -15,7 +15,9 @@ var audioExtensions = map[string]bool{
 }
 
 // DirectoryItems walks root and returns one Item per audio file, keyed by
-// the path relative to root. Hidden directories are skipped. Order is
+// the path relative to root. Hidden subdirectories (names beginning with ".")
+// are skipped, but a hidden root directory is still walked. Directory
+// symlinks are not followed (filepath.WalkDir semantics). Order is
 // deterministic (sorted by key) so limits and reruns behave predictably.
 func DirectoryItems(root string) ([]Item, error) {
 	absRoot, err := filepath.Abs(root)
@@ -28,7 +30,7 @@ func DirectoryItems(root string) ([]Item, error) {
 			return err
 		}
 		if d.IsDir() {
-			if name := d.Name(); name != "." && strings.HasPrefix(name, ".") && path != absRoot {
+			if strings.HasPrefix(d.Name(), ".") && path != absRoot {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/embedding/batch/source_dir.go
+++ b/internal/embedding/batch/source_dir.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"io/fs"
 	"path/filepath"
 	"sort"
@@ -19,13 +20,17 @@ var audioExtensions = map[string]bool{
 // are skipped, but a hidden root directory is still walked. Directory
 // symlinks are not followed (filepath.WalkDir semantics). Order is
 // deterministic (sorted by key) so limits and reruns behave predictably.
-func DirectoryItems(root string) ([]Item, error) {
+// ctx is checked on every entry so a large tree walk can be cancelled promptly.
+func DirectoryItems(ctx context.Context, root string) ([]Item, error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
 	}
 	var items []Item
 	err = filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/embedding/batch/source_dir.go
+++ b/internal/embedding/batch/source_dir.go
@@ -1,0 +1,51 @@
+package batch
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// audioExtensions are the corpus file types the batch path accepts. FFmpeg
+// handles the actual decode, so this is a walk filter, not a format gate.
+var audioExtensions = map[string]bool{
+	".wav": true, ".flac": true, ".mp3": true,
+	".m4a": true, ".aac": true, ".opus": true, ".ogg": true,
+}
+
+// DirectoryItems walks root and returns one Item per audio file, keyed by
+// the path relative to root. Hidden directories are skipped. Order is
+// deterministic (sorted by key) so limits and reruns behave predictably.
+func DirectoryItems(root string) ([]Item, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	var items []Item
+	err = filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if name := d.Name(); name != "." && strings.HasPrefix(name, ".") && path != absRoot {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !audioExtensions[strings.ToLower(filepath.Ext(path))] {
+			return nil
+		}
+		rel, err := filepath.Rel(absRoot, path)
+		if err != nil {
+			return err
+		}
+		items = append(items, Item{Path: path, Key: rel})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Key < items[j].Key })
+	return items, nil
+}

--- a/internal/embedding/batch/source_dir_test.go
+++ b/internal/embedding/batch/source_dir_test.go
@@ -1,0 +1,48 @@
+package batch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
+}
+
+func TestDirectoryItems(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	touch(t, filepath.Join(dir, "blackbird", "a.wav"))
+	touch(t, filepath.Join(dir, "blackbird", "b.flac"))
+	touch(t, filepath.Join(dir, "robin", "c.mp3"))
+	touch(t, filepath.Join(dir, "robin", "notes.txt")) // ignored
+	touch(t, filepath.Join(dir, ".hidden", "d.wav"))   // ignored (hidden dir)
+
+	items, err := DirectoryItems(dir)
+	require.NoError(t, err)
+	require.Len(t, items, 3)
+
+	keys := make([]string, 0, len(items))
+	for _, it := range items {
+		keys = append(keys, it.Key)
+		assert.Empty(t, it.DetectionID)
+		assert.True(t, filepath.IsAbs(it.Path))
+	}
+	assert.ElementsMatch(t, []string{
+		filepath.Join("blackbird", "a.wav"),
+		filepath.Join("blackbird", "b.flac"),
+		filepath.Join("robin", "c.mp3"),
+	}, keys)
+}
+
+func TestDirectoryItemsMissingDir(t *testing.T) {
+	t.Parallel()
+	_, err := DirectoryItems("/nonexistent-dir-xyz")
+	require.Error(t, err)
+}

--- a/internal/embedding/batch/source_dir_test.go
+++ b/internal/embedding/batch/source_dir_test.go
@@ -34,11 +34,11 @@ func TestDirectoryItems(t *testing.T) {
 		assert.Empty(t, it.DetectionID)
 		assert.True(t, filepath.IsAbs(it.Path))
 	}
-	assert.ElementsMatch(t, []string{
+	assert.Equal(t, []string{
 		filepath.Join("blackbird", "a.wav"),
 		filepath.Join("blackbird", "b.flac"),
 		filepath.Join("robin", "c.mp3"),
-	}, keys)
+	}, keys, "keys must be sorted lexicographically")
 }
 
 func TestDirectoryItemsMissingDir(t *testing.T) {

--- a/internal/embedding/batch/source_dir_test.go
+++ b/internal/embedding/batch/source_dir_test.go
@@ -24,7 +24,7 @@ func TestDirectoryItems(t *testing.T) {
 	touch(t, filepath.Join(dir, "robin", "notes.txt")) // ignored
 	touch(t, filepath.Join(dir, ".hidden", "d.wav"))   // ignored (hidden dir)
 
-	items, err := DirectoryItems(dir)
+	items, err := DirectoryItems(t.Context(), dir)
 	require.NoError(t, err)
 	require.Len(t, items, 3)
 
@@ -43,6 +43,6 @@ func TestDirectoryItems(t *testing.T) {
 
 func TestDirectoryItemsMissingDir(t *testing.T) {
 	t.Parallel()
-	_, err := DirectoryItems("/nonexistent-dir-xyz")
+	_, err := DirectoryItems(t.Context(), "/nonexistent-dir-xyz")
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Adds the offline batch extraction path to the embedding substrate: given stored detection clips or an arbitrary directory of audio files, produce tagged embedding vectors through the same model forward pass as live capture and persist them via the existing `internal/embedding` store with identical (model, version, dim, format) partitioning.

New package `internal/embedding/batch`:
- `decode.go`: streaming FFmpeg decoder (any input format, resampled to the model rate, mono s16le) delivering fixed-size analysis windows through a reused buffer; memory is bounded by one window regardless of corpus size.
- `extractor.go`: decode-predict-put core with pacing between inference calls, idempotent skip of already-embedded keys, per-run limits, dry-run, per-item error callbacks, and best-window selection for backfill (max confidence for the note's species, falling back to top-1).
- `source_dir.go`: directory corpus enumerator (one record per window, synthetic `<relpath>@<offsetSec>` keys; labels stay outside the consumer-agnostic store).
- `source_backfill.go`: datastore enumerator for detections that still have a clip on disk, newest first, paged, with species/date scoping and exclusion of already-embedded notes so reruns advance incrementally into history.

Hidden CLI driver `birdnet-go embed` (cobra `Hidden: true`):
- `--dir <path>` or `--backfill` (exactly one), `--limit` (backfill defaults to 1000 per run), `--since`, `--species`, `--pace` (default 100 ms), `--overwrite`, `--dry-run`, `--store` (alternate store file for large corpora).
- Bounded by design for small systems: single-threaded inference, one file decoded at a time, pacing, best-effort niceness 19 on Linux, and a hard per-run cap so a 100 GB clip library can never be swept in one invocation.
- Capability-gated: exits with a clear message on non-ONNX models. ffmpeg path honors the validated `realtime.audio.ffmpegpath` setting with PATH fallback (new exported `ffmpeg.ResolveBinary`).
- Dry runs never write and never prune; plain backfill can never replace live-captured records (upsert key skip); only `--overwrite` does, as its help text states.

## Review

Multi-agent pre-push gate run on the branch (14/14 files covered, three fix rounds applied, Gemini cross-validation on the regression pass). Notable hardening that came out of it: incremental backfill enumeration, dry-run prune guard, cancellable directory walk, fail-fast on missing ffmpeg path, non-zero exit when every item fails, and sox argument hardening in `GetAudioDuration` (bonus pre-existing fix).

## Test Plan

- [x] 22 package tests including real-FFmpeg decode fixtures, fp16 store round-trips, best-window clone semantics (mutation-verified), skip/limit/dry-run/cancellation, and enumerator paging; all pass with `-race`
- [x] `go build ./...` with CGO, `golangci-lint run` clean
- [x] CLI smoke: flag validation, hidden from help

Merge with a merge commit (substrate branch policy), not squash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `embed` CLI subcommand for offline batch embedding extraction with two modes: directory corpus scanning and backfill of stored detections
  * Supports filtering by species, date range, and item limit with optional `--dry-run` mode for testing without persisting results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->