### PR TITLE
fix(openfauna): log unresolvable species at WARN for support-dump diagnostics

### DIFF
--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -1,6 +1,7 @@
 package openfauna
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -9,6 +10,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"golang.org/x/sync/singleflight"
 )
+
+// maxLoggedUnresolvedSpecies caps how many unresolved scientific names are listed in
+// the rebuild WARN log, so the line stays bounded when a model pairs a broad working
+// set with a locale whose species are largely absent from OpenFauna.
+const maxLoggedUnresolvedSpecies = 50
 
 // localeFallback is the ultimate locale used when a requested birdnet-go locale
 // maps to no available openfauna locale. English has the widest coverage.
@@ -106,42 +112,36 @@ func (r *Resolver) Rebuild(scientificNames []string, bngLocale string) error {
 		return err
 	}
 
-	// Pre-seed the English fallback for working-set species that have no
-	// translation in the active locale. Sparse locales ship translations for as
-	// little as ~2% of species, so without this every untranslated working-set
-	// species would hit the O(dataset) on-demand Lookup on its first resolve.
-	// Resolving them once here keeps the slow path for out-of-working-set
-	// (historic) species only.
+	// Build an English index for the working-set species missing from the active
+	// locale, so the partition below can tell an English fallback apart from a
+	// species OpenFauna cannot localize at all. Skipped when English is already the
+	// active locale (there is nothing wider to fall back to).
+	missing := missingFromIndex(scientificNames, idx)
+	var enIdx *Index
+	if eff != localeFallback && len(missing) > 0 {
+		built, enErr := BuildIndex(missing, localeFallback)
+		if enErr != nil {
+			return enErr
+		}
+		enIdx = built
+	}
+
+	// Partition the missing species: enFallback species display in English; unresolved
+	// species have no OpenFauna name in either locale and fall through to the model
+	// labels or the scientific name downstream.
+	enFallback, unresolved := classifyMissing(missing, enIdx)
+
+	// Pre-seed both groups into the lookup cache so untranslated working-set species
+	// never hit the O(dataset) on-demand Lookup: an English name when one exists, or a
+	// "" known-miss otherwise. Sparse locales ship translations for as little as ~2%
+	// of species, so this keeps the slow path for out-of-working-set (historic)
+	// species only.
 	cache := &sync.Map{}
-	preseeded := 0
-	if eff != localeFallback {
-		var missing []string
-		for _, sci := range scientificNames {
-			if _, ok := idx.CommonName(sci); !ok {
-				missing = append(missing, sci)
-			}
-		}
-		if len(missing) > 0 {
-			enIdx, enErr := BuildIndex(missing, localeFallback)
-			if enErr != nil {
-				return enErr
-			}
-			for _, sci := range missing {
-				name, _ := enIdx.CommonName(sci) // "" when absent in English too
-				cache.Store(normalizeName(sci), name)
-				preseeded++
-			}
-		}
-	} else {
-		// Active locale is English: a working-set species missing from the index has
-		// no English name at all, so pre-seed it as a known miss to keep it off the
-		// slow path as well.
-		for _, sci := range scientificNames {
-			if _, ok := idx.CommonName(sci); !ok {
-				cache.Store(normalizeName(sci), "")
-				preseeded++
-			}
-		}
+	for sci, name := range enFallback {
+		cache.Store(normalizeName(sci), name)
+	}
+	for _, sci := range unresolved {
+		cache.Store(normalizeName(sci), "")
 	}
 
 	r.cur.Store(&resolverState{index: idx, locale: eff, cache: cache})
@@ -149,9 +149,66 @@ func (r *Resolver) Rebuild(scientificNames []string, bngLocale string) error {
 		logger.String("bng_locale", bngLocale),
 		logger.String("effective_locale", eff),
 		logger.Int("working_set", len(scientificNames)),
-		logger.Int("english_fallbacks", preseeded),
+		logger.Int("english_fallbacks", len(enFallback)),
+		logger.Int("unresolved", len(unresolved)),
 	)
+	// Name the species OpenFauna could not localize at all. This runs only on the cold
+	// rebuild path (startup, locale change, daily range-filter refresh), never on the
+	// hot Resolve path, and is logged at WARN so it lands in INFO-level support dumps:
+	// it is the diagnostic for "species X shows the wrong name" reports, which are
+	// usually upstream taxonomy reclassifications (e.g. a genus rename leaving the old
+	// label untranslated). Capped so the line stays bounded.
+	if len(unresolved) > 0 {
+		GetLogger().Warn("openfauna could not localize some working-set species; falling back to model labels or scientific name",
+			logger.String("effective_locale", eff),
+			logger.Int("count", len(unresolved)),
+			logger.String("species", capJoinSpecies(unresolved, maxLoggedUnresolvedSpecies)),
+		)
+	}
 	return nil
+}
+
+// missingFromIndex returns the working-set species absent from idx, preserving input
+// order. A species is "missing" when the active-locale index holds no common name for
+// it, so it needs an English fallback or is unresolved.
+func missingFromIndex(scientificNames []string, idx *Index) []string {
+	var missing []string
+	for _, sci := range scientificNames {
+		if _, ok := idx.CommonName(sci); !ok {
+			missing = append(missing, sci)
+		}
+	}
+	return missing
+}
+
+// classifyMissing partitions the active-locale-missing species (as returned by
+// missingFromIndex) into those an English name rescues (enFallback: scientific name ->
+// English common name) and those with no OpenFauna name in either locale (unresolved,
+// input order preserved). en may be nil when English is the active locale, in which
+// case every species is unresolved (there is nothing wider to fall back to).
+func classifyMissing(missing []string, en *Index) (enFallback map[string]string, unresolved []string) {
+	enFallback = make(map[string]string)
+	for _, sci := range missing {
+		var name string
+		if en != nil {
+			name, _ = en.CommonName(sci)
+		}
+		if name != "" {
+			enFallback[sci] = name
+		} else {
+			unresolved = append(unresolved, sci)
+		}
+	}
+	return enFallback, unresolved
+}
+
+// capJoinSpecies joins up to maxNames scientific names with ", ", appending a
+// "(+N more)" suffix when the list is longer so the rendered log line stays bounded.
+func capJoinSpecies(names []string, maxNames int) string {
+	if len(names) <= maxNames {
+		return strings.Join(names, ", ")
+	}
+	return strings.Join(names[:maxNames], ", ") + fmt.Sprintf(" (+%d more)", len(names)-maxNames)
 }
 
 // Resolve returns the localized common name for scientificName, or "" if it is not

--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -170,10 +170,18 @@ func (r *Resolver) Rebuild(scientificNames []string, bngLocale string) error {
 
 // missingFromIndex returns the working-set species absent from idx, preserving input
 // order. A species is "missing" when the active-locale index holds no common name for
-// it, so it needs an English fallback or is unresolved.
+// it, so it needs an English fallback or is unresolved. Names that normalize to the
+// same key are returned at most once, so a working set with duplicates or casing
+// variants does not inflate the unresolved count or repeat names in the rebuild log.
 func missingFromIndex(scientificNames []string, idx *Index) []string {
 	var missing []string
+	seen := make(map[string]struct{}, len(scientificNames))
 	for _, sci := range scientificNames {
+		key := normalizeName(sci)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
 		if _, ok := idx.CommonName(sci); !ok {
 			missing = append(missing, sci)
 		}

--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -182,7 +182,14 @@ func missingFromIndex(scientificNames []string, idx *Index) []string {
 			continue
 		}
 		seen[key] = struct{}{}
-		if _, ok := idx.CommonName(sci); !ok {
+		// key is already normalized, so read idx.names directly rather than calling
+		// CommonName (which would re-normalize), mirroring the fast path in Resolve.
+		// A nil index resolves nothing, so every species counts as missing.
+		if idx == nil {
+			missing = append(missing, sci)
+			continue
+		}
+		if _, ok := idx.names[key]; !ok {
 			missing = append(missing, sci)
 		}
 	}

--- a/internal/openfauna/resolver_test.go
+++ b/internal/openfauna/resolver_test.go
@@ -300,12 +300,15 @@ func TestResolveLocal_NoSlowPath(t *testing.T) {
 }
 
 // TestMissingFromIndex checks that only species absent from the active-locale index
-// are reported missing, in input order.
+// are reported missing, in input order, and that names normalizing to the same key
+// (duplicates, casing variants) are returned at most once so the unresolved count and
+// rebuild WARN log are not inflated.
 func TestMissingFromIndex(t *testing.T) {
 	t.Parallel()
 	// Index keys are stored normalized (lowercased/trimmed) by BuildIndex.
 	active := &Index{locale: "fi", names: map[string]string{"parus major": "talitiainen"}}
-	missing := missingFromIndex([]string{"Parus major", "Corvus corax", "Apus apus"}, active)
+	missing := missingFromIndex(
+		[]string{"Parus major", "Corvus corax", "Apus apus", "Corvus corax", "corvus corax"}, active)
 	assert.Equal(t, []string{"Corvus corax", "Apus apus"}, missing)
 }
 

--- a/internal/openfauna/resolver_test.go
+++ b/internal/openfauna/resolver_test.go
@@ -1,12 +1,16 @@
 package openfauna
 
 import (
+	"bytes"
+	"log/slog"
 	"slices"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // TestMapLocale_Table pins the birdnet-go -> openfauna locale mapping. Results are
@@ -293,4 +297,83 @@ func TestResolveLocal_NoSlowPath(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = NewResolver().ResolveLocal("Turdus merula")
 	assert.False(t, ok)
+}
+
+// TestMissingFromIndex checks that only species absent from the active-locale index
+// are reported missing, in input order.
+func TestMissingFromIndex(t *testing.T) {
+	t.Parallel()
+	// Index keys are stored normalized (lowercased/trimmed) by BuildIndex.
+	active := &Index{locale: "fi", names: map[string]string{"parus major": "talitiainen"}}
+	missing := missingFromIndex([]string{"Parus major", "Corvus corax", "Apus apus"}, active)
+	assert.Equal(t, []string{"Corvus corax", "Apus apus"}, missing)
+}
+
+// TestClassifyMissing separates English-rescued species from species OpenFauna cannot
+// localize at all. The input is the active-locale-missing set (see missingFromIndex);
+// the unresolved group is the diagnostic the rebuild WARN log names.
+func TestClassifyMissing(t *testing.T) {
+	t.Parallel()
+	// English has Corvus corax but not Accipiter gentilis (a taxonomy-reclassified
+	// miss: OpenFauna carries fi/en only under the new name Astur gentilis).
+	en := &Index{locale: "en", names: map[string]string{"corvus corax": "Northern Raven"}}
+
+	enFallback, unresolved := classifyMissing([]string{"Corvus corax", "Accipiter gentilis"}, en)
+
+	require.Len(t, enFallback, 1)
+	assert.Equal(t, "Northern Raven", enFallback["Corvus corax"])
+	assert.Equal(t, []string{"Accipiter gentilis"}, unresolved)
+}
+
+// TestClassifyMissing_EnglishActiveLocale treats every missing species as unresolved
+// when English is already the active locale (en == nil, nothing wider to fall back to).
+func TestClassifyMissing_EnglishActiveLocale(t *testing.T) {
+	t.Parallel()
+	enFallback, unresolved := classifyMissing([]string{"Corvus corax", "Gibberish nonexistus"}, nil)
+	assert.Empty(t, enFallback)
+	assert.Equal(t, []string{"Corvus corax", "Gibberish nonexistus"}, unresolved)
+}
+
+// TestCapJoinSpecies bounds the rendered unresolved-species log line.
+func TestCapJoinSpecies(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, capJoinSpecies(nil, 3))
+	assert.Equal(t, "a, b", capJoinSpecies([]string{"a", "b"}, 5))
+	assert.Equal(t, "a, b", capJoinSpecies([]string{"a", "b"}, 2))
+	assert.Equal(t, "a, b (+1 more)", capJoinSpecies([]string{"a", "b", "c"}, 2))
+}
+
+// TestRebuild_LogsUnresolvedSpecies locks the diagnostic wiring (not just the helpers):
+// Rebuild must emit the INFO summary and a WARN naming each working-set species
+// OpenFauna cannot localize, so an INFO-level support dump can pinpoint a "wrong name"
+// report. Uses the embedded dataset: "Turdus merula" resolves in fi, while
+// "Accipiter gentilis" is carried only under its reclassified name (Astur gentilis),
+// so it misses both fi and the English fallback. Not parallel: mutates the global logger.
+func TestRebuild_LogsUnresolvedSpecies(t *testing.T) {
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "debug",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cl.Close() })
+
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(prev) })
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula", "Accipiter gentilis"}, "fi"))
+
+	out := buf.String()
+	assert.Contains(t, out, "openfauna name resolver rebuilt", "INFO rebuild summary must be logged")
+	assert.Contains(t, out, "unresolved=1", "INFO summary must count the unresolvable species")
+	assert.Contains(t, out, "openfauna could not localize", "WARN diagnostic must fire for unresolved species")
+	assert.Contains(t, out, "Accipiter gentilis", "WARN must name the unresolvable species")
+	assert.NotContains(t, out, "Turdus merula", "a species resolved in the active locale must not be flagged")
 }


### PR DESCRIPTION
## Why

OpenFauna is the authoritative species-name resolver. When it cannot localize a working-set species in the active locale **or** English (typically an upstream taxonomy reclassification, e.g. a genus rename that leaves the old model label untranslated), the displayed name falls through to the model label or scientific name. That fallback is correct, but the only per-species signal was a `DEBUG` log in the slow-path `Lookup`, which is **invisible in an INFO-level support dump**. So a user report like "species X shows the wrong name" could not be traced to the specific species from a dump.

Concrete example surfaced during pre-release QA: with `locale: fi`, `Accipiter gentilis` resolves to the correct Finnish name via the BirdNET label fallback, but OpenFauna itself misses it because the dataset carries fi/en only under the reclassified name `Astur gentilis`. The logs gave no way to identify which species OpenFauna could not localize.

## What

`Rebuild` (the cold path: startup, locale change, daily range-filter refresh) now partitions the active-locale-missing working set into English fallbacks vs. truly-unresolvable species, and:

- adds an `unresolved` count to the existing INFO rebuild summary, and
- emits a **capped WARN** naming the unresolvable species.

This lands at INFO/WARN so it is captured in default support dumps. The hot `Resolve` path stays completely log-free.

The `english_fallbacks` INFO field now counts only species an English name actually rescues; the unlocalizable ones moved to the new `unresolved` field. No code consumes either field (verified repo-wide).

## Tests

- New unit tests for the extracted helpers (`missingFromIndex`, `classifyMissing`, `capJoinSpecies`).
- A `Rebuild`-level test asserting the WARN diagnostic actually fires and names the unresolvable species while a resolved species is not flagged.
- Full package passes with `-race`; `golangci-lint` clean.

Behavior is otherwise unchanged: the cache pre-seeding refactor is byte-identical to the previous logic (cross-validated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolver pre-seeds lookup cache for missing items with English names when available, or marks truly unresolved; logging now reports only true English fallbacks and emits a capped WARN list of unresolved species for clearer triage.

* **Tests**
  * Added unit and integration tests for missing-item detection, English-fallback classification, capped unresolved-list formatting, and rebuild logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->