### PR TITLE
feat(analytics): add opt-in eBird species-page links

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
@@ -2,7 +2,6 @@
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/utils/formatters';
-  import { Binoculars } from '@lucide/svelte';
 
   interface SpeciesData {
     common_name: string;
@@ -56,11 +55,11 @@
           href={ebirdUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-[var(--color-base-content)] opacity-50 transition-colors hover:bg-[var(--color-base-300)] hover:text-[var(--color-primary)] hover:opacity-100"
+          class="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-xs font-bold tracking-wide text-[var(--color-primary)] opacity-60 transition-opacity hover:opacity-100"
           title={t('analytics.species.viewOnEbird')}
           aria-label={t('analytics.species.viewOnEbirdAria', { species: species.common_name })}
         >
-          <Binoculars class="h-4 w-4" />
+          eBird&nbsp;↗
         </a>
       {/if}
     </div>

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCard.svelte
@@ -2,6 +2,7 @@
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/utils/formatters';
+  import { Binoculars } from '@lucide/svelte';
 
   interface SpeciesData {
     common_name: string;
@@ -17,9 +18,11 @@
   interface Props {
     species: SpeciesData;
     className?: string;
+    /** eBird species-page URL; when set, a link icon is shown next to the name. */
+    ebirdUrl?: string | null;
   }
 
-  let { species, className = '' }: Props = $props();
+  let { species, className = '', ebirdUrl = null }: Props = $props();
 
   function formatPercentage(value: number): string {
     return (value * 100).toFixed(1) + '%';
@@ -46,7 +49,21 @@
     </div>
   </figure>
   <div class="card-body p-4">
-    <h3 class="card-title text-base">{species.common_name}</h3>
+    <div class="flex items-center gap-1.5">
+      <h3 class="card-title text-base">{species.common_name}</h3>
+      {#if ebirdUrl}
+        <a
+          href={ebirdUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-[var(--color-base-content)] opacity-50 transition-colors hover:bg-[var(--color-base-300)] hover:text-[var(--color-primary)] hover:opacity-100"
+          title={t('analytics.species.viewOnEbird')}
+          aria-label={t('analytics.species.viewOnEbirdAria', { species: species.common_name })}
+        >
+          <Binoculars class="h-4 w-4" />
+        </a>
+      {/if}
+    </div>
     <p class="text-sm text-[var(--color-base-content)] opacity-60 italic">
       {species.scientific_name}
     </p>

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
@@ -2,7 +2,7 @@
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/utils/formatters';
-  import { ChevronRight } from '@lucide/svelte';
+  import { ChevronRight, Binoculars } from '@lucide/svelte';
 
   interface SpeciesData {
     common_name: string;
@@ -20,9 +20,11 @@
     onClick?: (_species: SpeciesData) => void;
     variant?: 'card' | 'compact' | 'list';
     className?: string;
+    /** eBird species-page URL; when set, a link icon overlays the card corner. */
+    ebirdUrl?: string | null;
   }
 
-  let { species, onClick, variant = 'card', className = '' }: Props = $props();
+  let { species, onClick, variant = 'card', className = '', ebirdUrl = null }: Props = $props();
 
   function formatPercentage(value: number): string {
     return (value * 100).toFixed(1) + '%';
@@ -41,68 +43,140 @@
   }
 </script>
 
+<!-- Sibling overlay link: the whole card is a <button>, so the eBird <a> cannot
+     be nested inside it. It is rendered as a positioned sibling instead. -->
+{#snippet ebirdLink()}
+  {#if ebirdUrl}
+    <a
+      href={ebirdUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="absolute right-2 top-2 z-10 inline-flex items-center justify-center rounded-md bg-[var(--color-base-100)] p-1 text-[var(--color-base-content)] opacity-70 shadow-sm transition-colors hover:text-[var(--color-primary)] hover:opacity-100"
+      title={t('analytics.species.viewOnEbird')}
+      aria-label={t('analytics.species.viewOnEbirdAria', { species: species.common_name })}
+    >
+      <Binoculars class="h-4 w-4" />
+    </a>
+  {/if}
+{/snippet}
+
 {#if variant === 'card'}
   <!-- Full Card Variant - Desktop/Tablet -->
-  <button
-    onclick={handleClick}
-    class={cn(
-      'card bg-[var(--color-base-200)] hover:shadow-lg transition-shadow cursor-pointer text-left',
-      className
-    )}
-  >
-    <figure class="px-4 pt-4">
-      <div class="rounded-xl w-full aspect-[4/3] overflow-hidden bg-[var(--color-base-300)]">
-        {#if species.thumbnail_url && !imageLoadFailed}
-          <img
-            src={species.thumbnail_url}
-            alt={species.common_name}
-            class="h-full w-full object-cover"
-            onerror={handleImageError}
-          />
-        {/if}
-      </div>
-    </figure>
-    <div class="card-body p-4">
-      <h3 class="card-title text-base">{species.common_name}</h3>
-      <p class="text-sm text-[var(--color-base-content)] opacity-60 italic">
-        {species.scientific_name}
-      </p>
-      <div class="text-sm space-y-1 mt-2">
-        <div class="flex justify-between">
-          <span class="text-[var(--color-base-content)] opacity-60"
-            >{t('analytics.species.card.detections')}</span
-          >
-          <span class="font-semibold">{species.count}</span>
+  <div class="relative">
+    {@render ebirdLink()}
+    <button
+      onclick={handleClick}
+      class={cn(
+        'card bg-[var(--color-base-200)] hover:shadow-lg transition-shadow cursor-pointer text-left w-full',
+        className
+      )}
+    >
+      <figure class="px-4 pt-4">
+        <div class="rounded-xl w-full aspect-[4/3] overflow-hidden bg-[var(--color-base-300)]">
+          {#if species.thumbnail_url && !imageLoadFailed}
+            <img
+              src={species.thumbnail_url}
+              alt={species.common_name}
+              class="h-full w-full object-cover"
+              onerror={handleImageError}
+            />
+          {/if}
         </div>
-        <div class="flex justify-between">
-          <span class="text-[var(--color-base-content)] opacity-60"
-            >{t('analytics.species.card.confidence')}</span
-          >
-          <span class="font-semibold">{formatPercentage(species.avg_confidence)}</span>
-        </div>
-        {#if species.first_heard}
+      </figure>
+      <div class="card-body p-4">
+        <h3 class="card-title text-base">{species.common_name}</h3>
+        <p class="text-sm text-[var(--color-base-content)] opacity-60 italic">
+          {species.scientific_name}
+        </p>
+        <div class="text-sm space-y-1 mt-2">
           <div class="flex justify-between">
             <span class="text-[var(--color-base-content)] opacity-60"
-              >{t('analytics.species.card.first')}</span
+              >{t('analytics.species.card.detections')}</span
             >
-            <span class="text-xs">{formatDate(species.first_heard)}</span>
+            <span class="font-semibold">{species.count}</span>
           </div>
-        {/if}
+          <div class="flex justify-between">
+            <span class="text-[var(--color-base-content)] opacity-60"
+              >{t('analytics.species.card.confidence')}</span
+            >
+            <span class="font-semibold">{formatPercentage(species.avg_confidence)}</span>
+          </div>
+          {#if species.first_heard}
+            <div class="flex justify-between">
+              <span class="text-[var(--color-base-content)] opacity-60"
+                >{t('analytics.species.card.first')}</span
+              >
+              <span class="text-xs">{formatDate(species.first_heard)}</span>
+            </div>
+          {/if}
+        </div>
       </div>
-    </div>
-  </button>
+    </button>
+  </div>
 {:else if variant === 'compact'}
   <!-- Compact Mobile Variant -->
-  <button
-    onclick={handleClick}
-    class={cn(
-      'flex gap-3 p-3 bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] rounded-lg transition-colors cursor-pointer w-full text-left',
-      className
-    )}
-  >
-    <div class="flex-shrink-0">
-      <div class="avatar w-16 h-16">
-        <div class="mask mask-squircle bg-[var(--color-base-300)]">
+  <div class="relative">
+    {@render ebirdLink()}
+    <button
+      onclick={handleClick}
+      class={cn(
+        'flex gap-3 p-3 bg-[var(--color-base-200)] hover:bg-[var(--color-base-300)] rounded-lg transition-colors cursor-pointer w-full text-left',
+        className
+      )}
+    >
+      <div class="flex-shrink-0">
+        <div class="avatar w-16 h-16">
+          <div class="mask mask-squircle bg-[var(--color-base-300)]">
+            {#if species.thumbnail_url}
+              <img
+                src={species.thumbnail_url}
+                alt={species.common_name}
+                class="object-cover"
+                onerror={handleImageError}
+              />
+            {/if}
+          </div>
+        </div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-bold text-sm truncate">{species.common_name}</h3>
+        <p class="text-xs text-[var(--color-base-content)] opacity-60 italic truncate">
+          {species.scientific_name}
+        </p>
+        <div class="flex gap-2 mt-1 text-xs">
+          <div class="flex items-center gap-1 bg-[var(--color-base-100)] rounded px-2 py-1">
+            <span class="font-semibold">{species.count}</span>
+            <span class="opacity-60">{t('analytics.species.card.detections')}</span>
+          </div>
+          <div
+            class="flex items-center gap-1 rounded px-2 py-1 {species.avg_confidence >= 0.8
+              ? 'bg-[var(--color-success)]/20'
+              : species.avg_confidence >= 0.4
+                ? 'bg-[var(--color-warning)]/20'
+                : 'bg-[var(--color-error)]/20'}"
+          >
+            <span class="font-semibold">{formatPercentage(species.avg_confidence)}</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex-shrink-0 flex items-center">
+        <ChevronRight class="size-5 text-[var(--color-base-content)] opacity-50" />
+      </div>
+    </button>
+  </div>
+{:else if variant === 'list'}
+  <!-- List Row Variant -->
+  <div class="relative">
+    {@render ebirdLink()}
+    <button
+      onclick={handleClick}
+      class={cn(
+        'flex items-center gap-3 w-full p-3 hover:bg-[var(--color-base-200)] transition-colors cursor-pointer text-left border-b border-[var(--color-base-300)] last:border-b-0',
+        className
+      )}
+    >
+      <div class="avatar flex-shrink-0">
+        <div class="mask mask-squircle w-12 h-12 bg-[var(--color-base-300)]">
           {#if species.thumbnail_url}
             <img
               src={species.thumbnail_url}
@@ -113,64 +187,18 @@
           {/if}
         </div>
       </div>
-    </div>
-    <div class="flex-1 min-w-0">
-      <h3 class="font-bold text-sm truncate">{species.common_name}</h3>
-      <p class="text-xs text-[var(--color-base-content)] opacity-60 italic truncate">
-        {species.scientific_name}
-      </p>
-      <div class="flex gap-2 mt-1 text-xs">
-        <div class="flex items-center gap-1 bg-[var(--color-base-100)] rounded px-2 py-1">
-          <span class="font-semibold">{species.count}</span>
-          <span class="opacity-60">{t('analytics.species.card.detections')}</span>
-        </div>
-        <div
-          class="flex items-center gap-1 rounded px-2 py-1 {species.avg_confidence >= 0.8
-            ? 'bg-[var(--color-success)]/20'
-            : species.avg_confidence >= 0.4
-              ? 'bg-[var(--color-warning)]/20'
-              : 'bg-[var(--color-error)]/20'}"
-        >
-          <span class="font-semibold">{formatPercentage(species.avg_confidence)}</span>
-        </div>
+      <div class="flex-1 min-w-0">
+        <h4 class="font-bold text-sm truncate">{species.common_name}</h4>
+        <p class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
+          {species.scientific_name}
+        </p>
       </div>
-    </div>
-    <div class="flex-shrink-0 flex items-center">
-      <ChevronRight class="size-5 text-[var(--color-base-content)] opacity-50" />
-    </div>
-  </button>
-{:else if variant === 'list'}
-  <!-- List Row Variant -->
-  <button
-    onclick={handleClick}
-    class={cn(
-      'flex items-center gap-3 w-full p-3 hover:bg-[var(--color-base-200)] transition-colors cursor-pointer text-left border-b border-[var(--color-base-300)] last:border-b-0',
-      className
-    )}
-  >
-    <div class="avatar flex-shrink-0">
-      <div class="mask mask-squircle w-12 h-12 bg-[var(--color-base-300)]">
-        {#if species.thumbnail_url}
-          <img
-            src={species.thumbnail_url}
-            alt={species.common_name}
-            class="object-cover"
-            onerror={handleImageError}
-          />
-        {/if}
+      <div class="text-right flex-shrink-0">
+        <p class="text-sm font-semibold">{species.count}</p>
+        <p class="text-xs text-[var(--color-base-content)] opacity-60">
+          {formatPercentage(species.avg_confidence)}
+        </p>
       </div>
-    </div>
-    <div class="flex-1 min-w-0">
-      <h4 class="font-bold text-sm truncate">{species.common_name}</h4>
-      <p class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
-        {species.scientific_name}
-      </p>
-    </div>
-    <div class="text-right flex-shrink-0">
-      <p class="text-sm font-semibold">{species.count}</p>
-      <p class="text-xs text-[var(--color-base-content)] opacity-60">
-        {formatPercentage(species.avg_confidence)}
-      </p>
-    </div>
-  </button>
+    </button>
+  </div>
 {/if}

--- a/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ui/SpeciesCardMobile.svelte
@@ -2,7 +2,7 @@
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/utils/formatters';
-  import { ChevronRight, Binoculars } from '@lucide/svelte';
+  import { ChevronRight, ExternalLink } from '@lucide/svelte';
 
   interface SpeciesData {
     common_name: string;
@@ -55,7 +55,7 @@
       title={t('analytics.species.viewOnEbird')}
       aria-label={t('analytics.species.viewOnEbirdAria', { species: species.common_name })}
     >
-      <Binoculars class="h-4 w-4" />
+      <ExternalLink class="h-4 w-4" />
     </a>
   {/if}
 {/snippet}

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -2,7 +2,6 @@
   import { t, getLocale, type TranslationKey } from '$lib/i18n';
   import { settingsStore } from '$lib/stores/settings';
   import { buildEbirdSpeciesUrl } from '$lib/utils/ebird';
-  import { Binoculars } from '@lucide/svelte';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
   import { downloadBlob } from '$lib/utils/fileHelpers';
   import { formatNumber, formatDateTime } from '$lib/utils/formatters';
@@ -125,7 +124,7 @@
   // Optional eBird species-page links, built client-side from each species' code.
   let ebirdSettings = $derived($settingsStore.formData.realtime?.ebird);
   let ebirdLinksEnabled = $derived(
-    Boolean(ebirdSettings?.enabled) && Boolean(ebirdSettings?.showSpeciesPageLinks)
+    !!(ebirdSettings?.enabled && ebirdSettings?.showSpeciesPageLinks)
   );
   function ebirdUrlFor(species: SpeciesData): string | null {
     if (!ebirdLinksEnabled) return null;
@@ -722,13 +721,13 @@
                               href={ebirdUrl}
                               target="_blank"
                               rel="noopener noreferrer"
-                              class="ebird-link inline-flex shrink-0 items-center justify-center rounded-md p-1 text-[var(--color-base-content)] opacity-50 transition-colors hover:bg-[var(--color-base-300)] hover:text-[var(--color-primary)] hover:opacity-100"
+                              class="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-xs font-bold tracking-wide text-[var(--color-primary)] opacity-60 transition-opacity hover:opacity-100"
                               title={t('analytics.species.viewOnEbird')}
                               aria-label={t('analytics.species.viewOnEbirdAria', {
                                 species: species.common_name,
                               })}
                             >
-                              <Binoculars class="h-4 w-4" />
+                              eBird&nbsp;↗
                             </a>
                           {/if}
                         </div>

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { t, type TranslationKey } from '$lib/i18n';
+  import { t, getLocale, type TranslationKey } from '$lib/i18n';
+  import { settingsStore } from '$lib/stores/settings';
+  import { buildEbirdSpeciesUrl } from '$lib/utils/ebird';
+  import { Binoculars } from '@lucide/svelte';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
   import { downloadBlob } from '$lib/utils/fileHelpers';
   import { formatNumber, formatDateTime } from '$lib/utils/formatters';
@@ -42,6 +45,7 @@
   interface SpeciesData {
     common_name: string;
     scientific_name: string;
+    species_code?: string;
     count: number;
     avg_confidence: number;
     max_confidence: number;
@@ -117,6 +121,20 @@
   let viewMode = $state<ViewMode>('grid');
   let selectedSpecies = $state<SpeciesData | null>(null);
   let showDetailModal = $state(false);
+
+  // Optional eBird species-page links, built client-side from each species' code.
+  let ebirdSettings = $derived($settingsStore.formData.realtime?.ebird);
+  let ebirdLinksEnabled = $derived(
+    Boolean(ebirdSettings?.enabled) && Boolean(ebirdSettings?.showSpeciesPageLinks)
+  );
+  function ebirdUrlFor(species: SpeciesData): string | null {
+    if (!ebirdLinksEnabled) return null;
+    return buildEbirdSpeciesUrl({
+      speciesCode: species.species_code,
+      region: ebirdSettings?.speciesPageRegion,
+      locale: getLocale(),
+    });
+  }
 
   // Read once so both filters and the applied-sort indicator start at the same persisted value.
   const restoredSortOrder = getStoredValue<SortOrder>(
@@ -639,7 +657,7 @@
       {#if !isLoading && viewMode === 'grid' && filteredSpecies.length > 0}
         <div class="species-grid hidden sm:grid">
           {#each filteredSpecies as species, index (`${species.scientific_name}_${index}`)}
-            <SpeciesCard {species} />
+            <SpeciesCard {species} ebirdUrl={ebirdUrlFor(species)} />
           {/each}
         </div>
       {/if}
@@ -663,6 +681,7 @@
             </thead>
             <tbody>
               {#each filteredSpecies as species, index (`${species.scientific_name}_${index}`)}
+                {@const ebirdUrl = ebirdUrlFor(species)}
                 <tr
                   class={index % 2 === 0
                     ? 'bg-[var(--color-base-100)]'
@@ -691,7 +710,23 @@
                         </div>
                       </div>
                       <div>
-                        <div class="font-bold">{species.common_name}</div>
+                        <div class="flex items-center gap-1.5">
+                          <span class="font-bold">{species.common_name}</span>
+                          {#if ebirdUrl}
+                            <a
+                              href={ebirdUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              class="ebird-link inline-flex shrink-0 items-center justify-center rounded-md p-1 text-[var(--color-base-content)] opacity-50 transition-colors hover:bg-[var(--color-base-300)] hover:text-[var(--color-primary)] hover:opacity-100"
+                              title={t('analytics.species.viewOnEbird')}
+                              aria-label={t('analytics.species.viewOnEbirdAria', {
+                                species: species.common_name,
+                              })}
+                            >
+                              <Binoculars class="h-4 w-4" />
+                            </a>
+                          {/if}
+                        </div>
                         <div class="text-sm opacity-50 italic">{species.scientific_name}</div>
                       </div>
                     </div>

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -648,7 +648,12 @@
       {#if !isLoading && viewMode === 'grid' && filteredSpecies.length > 0}
         <div class="sm:hidden space-y-2">
           {#each filteredSpecies as species, index (`${species.scientific_name}_${index}`)}
-            <SpeciesCardMobile {species} variant="compact" onClick={handleSpeciesClick} />
+            <SpeciesCardMobile
+              {species}
+              variant="compact"
+              ebirdUrl={ebirdUrlFor(species)}
+              onClick={handleSpeciesClick}
+            />
           {/each}
         </div>
       {/if}
@@ -756,7 +761,12 @@
           <!-- Mobile list view -->
           <div class="sm:hidden space-y-2">
             {#each filteredSpecies as species, index (`${species.scientific_name}_${index}`)}
-              <SpeciesCardMobile {species} variant="list" onClick={handleSpeciesClick} />
+              <SpeciesCardMobile
+                {species}
+                variant="list"
+                ebirdUrl={ebirdUrlFor(species)}
+                onClick={handleSpeciesClick}
+              />
             {/each}
           </div>
         </div>

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -31,12 +31,13 @@
   import WeatherMetrics from '$lib/desktop/components/data/WeatherMetrics.svelte';
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
   import Button from '$lib/desktop/components/ui/Button.svelte';
-  import { Volume2 } from '@lucide/svelte';
+  import { Volume2, ExternalLink } from '@lucide/svelte';
   import SpectrogramPlayer from '$lib/desktop/components/media/SpectrogramPlayer.svelte';
   import ConfirmModal from '$lib/desktop/components/modals/ConfirmModal.svelte';
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
-  import { t } from '$lib/i18n';
+  import { t, getLocale } from '$lib/i18n';
+  import { buildEbirdSpeciesUrl } from '$lib/utils/ebird';
   import type { Detection } from '$lib/types/detection.types';
   import { settingsStore } from '$lib/stores/settings';
   import { toastActions } from '$lib/stores/toast';
@@ -90,6 +91,20 @@
   // resolved from settings and the server did not send a distinct displayName).
   let sourceIsRawId = $derived(
     sourceLabel !== null && sourceLabel === (detection.source?.id ?? '')
+  );
+
+  // eBird species page link, built client-side from the detection's species code.
+  // Only present when the integration and the species-link option are both enabled
+  // and the detection carries a valid (non-placeholder) eBird species code.
+  let ebirdSettings = $derived($settingsStore.formData.realtime?.ebird);
+  let ebirdSpeciesUrl = $derived(
+    ebirdSettings?.enabled && ebirdSettings?.showSpeciesPageLinks
+      ? buildEbirdSpeciesUrl({
+          speciesCode: detection.speciesCode,
+          region: ebirdSettings.speciesPageRegion,
+          locale: getLocale(),
+        })
+      : null
   );
 
   // Modal states
@@ -398,12 +413,27 @@
     <!-- Species Names -->
     <div class="sp-species-info-wrapper">
       <div class="sp-species-names">
-        <button
-          onclick={handleDetailsClick}
-          class="sp-species-common-name hover:text-primary transition-colors cursor-pointer text-left"
-        >
-          {detection.commonName}
-        </button>
+        <div class="flex items-center gap-1">
+          <button
+            onclick={handleDetailsClick}
+            class="sp-species-common-name hover:text-primary transition-colors cursor-pointer text-left"
+          >
+            {detection.commonName}
+          </button>
+          {#if ebirdSpeciesUrl}
+            <a
+              href={ebirdSpeciesUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="shrink-0 text-[var(--color-base-content)]/50 hover:text-[var(--color-primary)] transition-colors"
+              title={t('detections.row.viewOnEbird')}
+              aria-label={t('detections.row.viewOnEbirdAria', { species: detection.commonName })}
+              onclick={e => e.stopPropagation()}
+            >
+              <ExternalLink class="h-3.5 w-3.5" />
+            </a>
+          {/if}
+        </div>
         <div class="sp-species-scientific-name">{detection.scientificName}</div>
       </div>
       <!-- Mobile-only quick play button -->

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -31,13 +31,12 @@
   import WeatherMetrics from '$lib/desktop/components/data/WeatherMetrics.svelte';
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
   import Button from '$lib/desktop/components/ui/Button.svelte';
-  import { Volume2, ExternalLink } from '@lucide/svelte';
+  import { Volume2 } from '@lucide/svelte';
   import SpectrogramPlayer from '$lib/desktop/components/media/SpectrogramPlayer.svelte';
   import ConfirmModal from '$lib/desktop/components/modals/ConfirmModal.svelte';
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
-  import { t, getLocale } from '$lib/i18n';
-  import { buildEbirdSpeciesUrl } from '$lib/utils/ebird';
+  import { t } from '$lib/i18n';
   import type { Detection } from '$lib/types/detection.types';
   import { settingsStore } from '$lib/stores/settings';
   import { toastActions } from '$lib/stores/toast';
@@ -91,20 +90,6 @@
   // resolved from settings and the server did not send a distinct displayName).
   let sourceIsRawId = $derived(
     sourceLabel !== null && sourceLabel === (detection.source?.id ?? '')
-  );
-
-  // eBird species page link, built client-side from the detection's species code.
-  // Only present when the integration and the species-link option are both enabled
-  // and the detection carries a valid (non-placeholder) eBird species code.
-  let ebirdSettings = $derived($settingsStore.formData.realtime?.ebird);
-  let ebirdSpeciesUrl = $derived(
-    ebirdSettings?.enabled && ebirdSettings?.showSpeciesPageLinks
-      ? buildEbirdSpeciesUrl({
-          speciesCode: detection.speciesCode,
-          region: ebirdSettings.speciesPageRegion,
-          locale: getLocale(),
-        })
-      : null
   );
 
   // Modal states
@@ -413,27 +398,12 @@
     <!-- Species Names -->
     <div class="sp-species-info-wrapper">
       <div class="sp-species-names">
-        <div class="flex items-center gap-1">
-          <button
-            onclick={handleDetailsClick}
-            class="sp-species-common-name hover:text-primary transition-colors cursor-pointer text-left"
-          >
-            {detection.commonName}
-          </button>
-          {#if ebirdSpeciesUrl}
-            <a
-              href={ebirdSpeciesUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="shrink-0 text-[var(--color-base-content)]/50 hover:text-[var(--color-primary)] transition-colors"
-              title={t('detections.row.viewOnEbird')}
-              aria-label={t('detections.row.viewOnEbirdAria', { species: detection.commonName })}
-              onclick={e => e.stopPropagation()}
-            >
-              <ExternalLink class="h-3.5 w-3.5" />
-            </a>
-          {/if}
-        </div>
+        <button
+          onclick={handleDetailsClick}
+          class="sp-species-common-name hover:text-primary transition-colors cursor-pointer text-left"
+        >
+          {detection.commonName}
+        </button>
         <div class="sp-species-scientific-name">{detection.scientificName}</div>
       </div>
       <!-- Mobile-only quick play button -->

--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -57,6 +57,7 @@
   import { hasSettingsChanged } from '$lib/utils/settingsChanges';
   import { getCsrfToken } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { isValidEbirdRegionCode } from '$lib/utils/ebird';
   import CertificateField from '$lib/desktop/components/forms/CertificateField.svelte';
   import CertificateInfoCard from '$lib/desktop/components/ui/CertificateInfoCard.svelte';
   import { settingsAPI, type MQTTTLSCertificateInfo } from '$lib/utils/settingsApi';
@@ -125,6 +126,8 @@
         apiKey: '',
         cacheTTL: 24,
         locale: 'en',
+        showSpeciesPageLinks: false,
+        speciesPageRegion: '',
       },
     }
   );
@@ -503,6 +506,22 @@
       ebird: { ...settings.ebird!, cacheTTL },
     });
   }
+
+  function updateEBirdShowSpeciesPageLinks(showSpeciesPageLinks: boolean) {
+    settingsActions.updateSection('realtime', {
+      ebird: { ...settings.ebird!, showSpeciesPageLinks },
+    });
+  }
+
+  function updateEBirdSpeciesPageRegion(speciesPageRegion: string) {
+    settingsActions.updateSection('realtime', {
+      ebird: { ...settings.ebird!, speciesPageRegion: speciesPageRegion.trim() },
+    });
+  }
+
+  // eBird species page links only require an enabled integration, not an API key,
+  // since the link is built client-side from the detection's species code.
+  let ebirdRegionInvalid = $derived(!isValidEbirdRegionCode(settings.ebird?.speciesPageRegion));
 
   // eBird locale options
   const ebirdLocaleOptions = [
@@ -1691,6 +1710,34 @@
                 helpText={t('settings.integration.ebird.cacheTTL.helpText')}
                 disabled={!settings.ebird?.enabled || store.isLoading || store.isSaving}
               />
+            </div>
+
+            <!-- Species page links -->
+            <div class="mt-4 space-y-4">
+              <Checkbox
+                checked={settings.ebird!.showSpeciesPageLinks}
+                label={t('settings.integration.ebird.speciesLinks.enable')}
+                helpText={t('settings.integration.ebird.speciesLinks.helpText')}
+                disabled={!settings.ebird?.enabled || store.isLoading || store.isSaving}
+                onchange={updateEBirdShowSpeciesPageLinks}
+              />
+
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <TextInput
+                  label={t('settings.integration.ebird.speciesLinks.region.label')}
+                  value={settings.ebird!.speciesPageRegion}
+                  onchange={updateEBirdSpeciesPageRegion}
+                  placeholder={t('settings.integration.ebird.speciesLinks.region.placeholder')}
+                  helpText={t('settings.integration.ebird.speciesLinks.region.helpText')}
+                  validationMessage={ebirdRegionInvalid
+                    ? t('settings.integration.ebird.speciesLinks.region.invalid')
+                    : ''}
+                  disabled={!settings.ebird?.enabled ||
+                    !settings.ebird?.showSpeciesPageLinks ||
+                    store.isLoading ||
+                    store.isSaving}
+                />
+              </div>
             </div>
 
             <!-- Test Connection -->

--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -1723,20 +1723,26 @@
               />
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <TextInput
-                  label={t('settings.integration.ebird.speciesLinks.region.label')}
-                  value={settings.ebird!.speciesPageRegion}
-                  onchange={updateEBirdSpeciesPageRegion}
-                  placeholder={t('settings.integration.ebird.speciesLinks.region.placeholder')}
-                  helpText={t('settings.integration.ebird.speciesLinks.region.helpText')}
-                  validationMessage={ebirdRegionInvalid
-                    ? t('settings.integration.ebird.speciesLinks.region.invalid')
-                    : ''}
-                  disabled={!settings.ebird?.enabled ||
-                    !settings.ebird?.showSpeciesPageLinks ||
-                    store.isLoading ||
-                    store.isSaving}
-                />
+                <div>
+                  <TextInput
+                    label={t('settings.integration.ebird.speciesLinks.region.label')}
+                    value={settings.ebird!.speciesPageRegion}
+                    onchange={updateEBirdSpeciesPageRegion}
+                    placeholder={t('settings.integration.ebird.speciesLinks.region.placeholder')}
+                    helpText={t('settings.integration.ebird.speciesLinks.region.helpText')}
+                    validationMessage={ebirdRegionInvalid
+                      ? t('settings.integration.ebird.speciesLinks.region.invalid')
+                      : ''}
+                    disabled={!settings.ebird?.enabled ||
+                      !settings.ebird?.showSpeciesPageLinks ||
+                      store.isLoading ||
+                      store.isSaving}
+                  />
+                  <!-- Region codes come from eBird; link out so users can look theirs up. -->
+                  <p class="mt-1 text-xs text-[var(--color-base-content)] opacity-60">
+                    {@html t('settings.integration.ebird.speciesLinks.region.hint')}
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -343,6 +343,8 @@ export interface EBirdSettings {
   apiKey: string;
   cacheTTL: number; // cache time-to-live in hours (default: 24)
   locale: string; // locale for eBird data (e.g., "en", "es")
+  showSpeciesPageLinks: boolean; // show direct links to eBird species pages in the UI
+  speciesPageRegion: string; // optional eBird region code for species links (e.g., "BE-WAL"); empty = global
 }
 
 export interface IntegrationSettings {
@@ -985,6 +987,8 @@ function createEmptySettings(): SettingsFormData {
         apiKey: '',
         cacheTTL: 24,
         locale: 'en',
+        showSpeciesPageLinks: false,
+        speciesPageRegion: '',
       },
       species: {
         include: [],
@@ -1184,6 +1188,8 @@ export const integrationSettings = derived(settingsStore, $store => ({
     apiKey: '',
     cacheTTL: 24,
     locale: 'en',
+    showSpeciesPageLinks: false,
+    speciesPageRegion: '',
   },
 }));
 

--- a/frontend/src/lib/utils/ebird.test.ts
+++ b/frontend/src/lib/utils/ebird.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildEbirdSpeciesUrl,
+  isValidEbirdRegionCode,
+  isValidEbirdSpeciesCode,
+  toEbirdSiteLanguage,
+} from './ebird';
+
+describe('isValidEbirdSpeciesCode', () => {
+  it('accepts real lowercase eBird codes', () => {
+    expect(isValidEbirdSpeciesCode('euptit1')).toBe(true);
+    expect(isValidEbirdSpeciesCode('amerob')).toBe(true);
+  });
+
+  it('rejects placeholder codes with uppercase prefix', () => {
+    // BirdNET-Go placeholder codes start with an uppercase prefix.
+    expect(isValidEbirdSpeciesCode('TM1a2b3c')).toBe(false);
+    expect(isValidEbirdSpeciesCode('XXabc123')).toBe(false);
+  });
+
+  it('rejects empty/nullish values', () => {
+    expect(isValidEbirdSpeciesCode('')).toBe(false);
+    expect(isValidEbirdSpeciesCode('   ')).toBe(false);
+    expect(isValidEbirdSpeciesCode(null)).toBe(false);
+    expect(isValidEbirdSpeciesCode(undefined)).toBe(false);
+  });
+});
+
+describe('isValidEbirdRegionCode', () => {
+  it('treats empty as valid (global)', () => {
+    expect(isValidEbirdRegionCode('')).toBe(true);
+    expect(isValidEbirdRegionCode('   ')).toBe(true);
+    expect(isValidEbirdRegionCode(null)).toBe(true);
+    expect(isValidEbirdRegionCode(undefined)).toBe(true);
+  });
+
+  it('accepts country, subnational1 and subnational2 codes', () => {
+    expect(isValidEbirdRegionCode('BE')).toBe(true);
+    expect(isValidEbirdRegionCode('BE-WAL')).toBe(true);
+    expect(isValidEbirdRegionCode('US-NY-109')).toBe(true);
+  });
+
+  it('rejects malformed codes', () => {
+    expect(isValidEbirdRegionCode('BEWAL')).toBe(false);
+    expect(isValidEbirdRegionCode('B')).toBe(false);
+    expect(isValidEbirdRegionCode('BE_WAL')).toBe(false);
+    expect(isValidEbirdRegionCode('BE-WAL-NY-XX')).toBe(false);
+  });
+});
+
+describe('toEbirdSiteLanguage', () => {
+  it('passes through a base language code', () => {
+    expect(toEbirdSiteLanguage('fr')).toBe('fr');
+    expect(toEbirdSiteLanguage('en')).toBe('en');
+  });
+
+  it('reduces locale variants to their base language', () => {
+    expect(toEbirdSiteLanguage('fr-BE')).toBe('fr');
+    expect(toEbirdSiteLanguage('pt_BR')).toBe('pt');
+    expect(toEbirdSiteLanguage('en-US')).toBe('en');
+  });
+
+  it('returns empty string for nullish input', () => {
+    expect(toEbirdSiteLanguage('')).toBe('');
+    expect(toEbirdSiteLanguage(null)).toBe('');
+    expect(toEbirdSiteLanguage(undefined)).toBe('');
+  });
+});
+
+describe('buildEbirdSpeciesUrl', () => {
+  it('builds a global URL with species code and language', () => {
+    expect(buildEbirdSpeciesUrl({ speciesCode: 'euptit1', locale: 'en' })).toBe(
+      'https://ebird.org/species/euptit1?siteLanguage=en'
+    );
+  });
+
+  it('builds a regional URL when a region is provided', () => {
+    expect(buildEbirdSpeciesUrl({ speciesCode: 'euptit1', region: 'BE-WAL', locale: 'fr' })).toBe(
+      'https://ebird.org/species/euptit1/BE-WAL?siteLanguage=fr'
+    );
+  });
+
+  it('reduces locale variants for siteLanguage', () => {
+    expect(buildEbirdSpeciesUrl({ speciesCode: 'euptit1', locale: 'fr-BE' })).toBe(
+      'https://ebird.org/species/euptit1?siteLanguage=fr'
+    );
+  });
+
+  it('omits siteLanguage when locale is missing', () => {
+    expect(buildEbirdSpeciesUrl({ speciesCode: 'euptit1' })).toBe(
+      'https://ebird.org/species/euptit1'
+    );
+  });
+
+  it('falls back to the global page when the region is empty or invalid', () => {
+    expect(buildEbirdSpeciesUrl({ speciesCode: 'euptit1', region: '', locale: 'en' })).toBe(
+      'https://ebird.org/species/euptit1?siteLanguage=en'
+    );
+    expect(
+      buildEbirdSpeciesUrl({ speciesCode: 'euptit1', region: 'not a region', locale: 'en' })
+    ).toBe('https://ebird.org/species/euptit1?siteLanguage=en');
+  });
+
+  it('returns null when the species code is missing or a placeholder', () => {
+    expect(buildEbirdSpeciesUrl({ speciesCode: '', locale: 'en' })).toBeNull();
+    expect(buildEbirdSpeciesUrl({ speciesCode: null, locale: 'en' })).toBeNull();
+    expect(buildEbirdSpeciesUrl({ speciesCode: 'TM1a2b3c', locale: 'en' })).toBeNull();
+  });
+});

--- a/frontend/src/lib/utils/ebird.ts
+++ b/frontend/src/lib/utils/ebird.ts
@@ -1,0 +1,92 @@
+/**
+ * Helpers for building links to eBird species pages.
+ *
+ * eBird species URLs follow the shape:
+ *   https://ebird.org/species/{speciesCode}/{optionalRegion}?siteLanguage={lang}
+ *
+ * The species code comes from detection data, the optional region from user
+ * settings, and the site language from the current BirdNET-Go UI locale.
+ */
+
+/** Base URL for an eBird species page (no trailing slash). */
+export const EBIRD_SPECIES_BASE_URL = 'https://ebird.org/species';
+
+/** Query parameter eBird uses to select the page language. */
+export const EBIRD_SITE_LANGUAGE_PARAM = 'siteLanguage';
+
+/**
+ * Matches valid eBird species codes (lowercase letters/digits, e.g. "euptit1",
+ * "amerob"). BirdNET-Go generates placeholder codes with an uppercase prefix for
+ * species missing from the taxonomy; those are intentionally excluded so the
+ * link only appears for real eBird codes.
+ */
+const EBIRD_SPECIES_CODE_PATTERN = /^[a-z][a-z0-9]*$/;
+
+/**
+ * Matches eBird region codes: a two-letter country (e.g. "BE", "US"),
+ * optionally followed by one or two subdivision segments
+ * (e.g. "BE-WAL", "US-NY-109"). Matched case-insensitively.
+ */
+// Bounded on every quantifier and each segment is anchored by a literal "-",
+// so there is no ambiguous overlap and no catastrophic backtracking risk.
+// eslint-disable-next-line security/detect-unsafe-regex -- fully bounded, linear-time pattern
+const EBIRD_REGION_CODE_PATTERN = /^[a-z]{2}(?:-[a-z0-9]{1,12}){0,2}$/i;
+
+/** Returns true when the code looks like a real (non-placeholder) eBird species code. */
+export function isValidEbirdSpeciesCode(code: string | null | undefined): boolean {
+  if (!code) return false;
+  return EBIRD_SPECIES_CODE_PATTERN.test(code.trim());
+}
+
+/** Returns true when the region is empty (global) or a valid eBird region code. */
+export function isValidEbirdRegionCode(region: string | null | undefined): boolean {
+  const trimmed = region?.trim() ?? '';
+  if (trimmed === '') return true;
+  return EBIRD_REGION_CODE_PATTERN.test(trimmed);
+}
+
+/**
+ * Reduces a BirdNET-Go UI locale to the base language code eBird expects for
+ * its siteLanguage parameter (e.g. "fr-BE" -> "fr", "pt_BR" -> "pt").
+ */
+export function toEbirdSiteLanguage(locale: string | null | undefined): string {
+  if (!locale) return '';
+  const base = locale.trim().split(/[-_]/)[0] ?? '';
+  return base.toLowerCase();
+}
+
+interface EbirdSpeciesUrlParams {
+  speciesCode: string | null | undefined;
+  /** Optional eBird region code; empty/invalid falls back to the global page. */
+  region?: string | null;
+  /** Current UI locale, reduced to an eBird site language. */
+  locale?: string | null;
+}
+
+/**
+ * Builds the eBird species page URL for the given species code, region and
+ * locale. Returns null when no valid eBird species code is available, so callers
+ * can hide the link entirely.
+ */
+export function buildEbirdSpeciesUrl({
+  speciesCode,
+  region,
+  locale,
+}: EbirdSpeciesUrlParams): string | null {
+  const code = speciesCode?.trim() ?? '';
+  if (!isValidEbirdSpeciesCode(code)) return null;
+
+  const trimmedRegion = region?.trim() ?? '';
+  const useRegion = trimmedRegion !== '' && isValidEbirdRegionCode(trimmedRegion);
+
+  const path = useRegion
+    ? `${EBIRD_SPECIES_BASE_URL}/${encodeURIComponent(code)}/${encodeURIComponent(trimmedRegion)}`
+    : `${EBIRD_SPECIES_BASE_URL}/${encodeURIComponent(code)}`;
+
+  const url = new URL(path);
+  const siteLanguage = toEbirdSiteLanguage(locale);
+  if (siteLanguage) {
+    url.searchParams.set(EBIRD_SITE_LANGUAGE_PARAM, siteLanguage);
+  }
+  return url.toString();
+}

--- a/frontend/src/lib/utils/ebird.ts
+++ b/frontend/src/lib/utils/ebird.ts
@@ -45,13 +45,16 @@ export function isValidEbirdRegionCode(region: string | null | undefined): boole
   return EBIRD_REGION_CODE_PATTERN.test(trimmed);
 }
 
+/** Separates a locale into language and region parts (e.g. "fr-BE", "pt_BR"). */
+const LOCALE_SEPARATOR_PATTERN = /[-_]/;
+
 /**
  * Reduces a BirdNET-Go UI locale to the base language code eBird expects for
  * its siteLanguage parameter (e.g. "fr-BE" -> "fr", "pt_BR" -> "pt").
  */
 export function toEbirdSiteLanguage(locale: string | null | undefined): string {
   if (!locale) return '';
-  const base = locale.trim().split(/[-_]/)[0] ?? '';
+  const base = locale.trim().split(LOCALE_SEPARATOR_PATTERN)[0] ?? '';
   return base.toLowerCase();
 }
 
@@ -83,10 +86,10 @@ export function buildEbirdSpeciesUrl({
     ? `${EBIRD_SPECIES_BASE_URL}/${encodeURIComponent(code)}/${encodeURIComponent(trimmedRegion)}`
     : `${EBIRD_SPECIES_BASE_URL}/${encodeURIComponent(code)}`;
 
-  const url = new URL(path);
+  // Plain string concatenation rather than the URL API: this runs once per
+  // detection row, and the only query parameter is a short language code.
   const siteLanguage = toEbirdSiteLanguage(locale);
-  if (siteLanguage) {
-    url.searchParams.set(EBIRD_SITE_LANGUAGE_PARAM, siteLanguage);
-  }
-  return url.toString();
+  return siteLanguage
+    ? `${path}?${EBIRD_SITE_LANGUAGE_PARAM}=${encodeURIComponent(siteLanguage)}`
+    : path;
 }

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Zobrazit podrobnosti pro {species}",
       "play": "Přehrát",
-      "playAudio": "Přehrát zvuk"
+      "playAudio": "Přehrát zvuk",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird poskytuje taxonomická data používaná pro klasifikaci druhů a analýzy. API klíč je zdarma a dostupný z Cornell Lab of Ornithology.",
         "apiKeyInfo": "Pro použití této integrace je potřeba osobní API klíč eBird. Bezplatný klíč si můžete vyžádat na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Otestovat připojení k eBird",
           "loading": "Testuje se...",

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Zobrazit podrobnosti pro {species}",
       "play": "Přehrát",
-      "playAudio": "Přehrát zvuk",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Přehrát zvuk"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Detekce:",
         "confidence": "Spolehlivost:",
         "first": "Poprvé:"
-      }
+      },
+      "viewOnEbird": "Zobrazit stránku druhu na eBird",
+      "viewOnEbirdAria": "Zobrazit stránku druhu {species} na eBird (otevře se v nové kartě)"
     },
     "advanced": {
       "title": "Pokročilá analytika",
@@ -2845,13 +2845,14 @@
         "note": "eBird poskytuje taxonomická data používaná pro klasifikaci druhů a analýzy. API klíč je zdarma a dostupný z Cornell Lab of Ornithology.",
         "apiKeyInfo": "Pro použití této integrace je potřeba osobní API klíč eBird. Bezplatný klíč si můžete vyžádat na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Zobrazit odkazy na stránky druhů eBird",
+          "helpText": "Přidá k detekcím ikonu, která otevře stránku druhu na eBird.org v nové kartě. Nevyžaduje klíč API.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Region eBird (volitelné)",
+            "placeholder": "např. BE-WAL",
+            "helpText": "Volitelné. Ponechte prázdné pro globální stránku druhu.",
+            "hint": "Kód regionu zjistíte tak, že otevřete <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, vyberete region a zkopírujete kód zobrazený v adrese URL stránky (např. BE-WAL).",
+            "invalid": "Zadejte platný kód regionu eBird, například BE nebo BE-WAL, nebo ponechte prázdné."
           }
         },
         "test": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Vis detaljer for {species}",
       "play": "Afspil",
-      "playAudio": "Afspil lyd",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Afspil lyd"
     },
     "media": {
       "title": "Optagelse og spektrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhed:",
         "first": "Første:"
-      }
+      },
+      "viewOnEbird": "Se artssiden på eBird",
+      "viewOnEbirdAria": "Se artssiden for {species} på eBird (åbnes i en ny fane)"
     },
     "advanced": {
       "title": "Avancerede analyser",
@@ -2845,13 +2845,14 @@
         "note": "eBird leverer taksonomiske data, der bruges til artsklassifikation og indsigt. API-nøglen er gratis at hente fra Cornell Lab of Ornithology.",
         "apiKeyInfo": "En personlig eBird API-nøgle er påkrævet for at bruge denne integration. Du kan anmode om en gratis nøgle fra <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Vis links til eBird-artssider",
+          "helpText": "Tilføjer et ikon ved registreringer, der åbner artssiden på eBird.org i en ny fane. Kræver ingen API-nøgle.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird-region (valgfrit)",
+            "placeholder": "f.eks. BE-WAL",
+            "helpText": "Valgfrit. Lad feltet stå tomt for den globale artsside.",
+            "hint": "For at finde en regionskode skal du åbne <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, vælge en region og kopiere koden, der vises i sidens URL (f.eks. BE-WAL).",
+            "invalid": "Indtast en gyldig eBird-regionskode som BE eller BE-WAL, eller lad feltet stå tomt."
           }
         },
         "test": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Vis detaljer for {species}",
       "play": "Afspil",
-      "playAudio": "Afspil lyd"
+      "playAudio": "Afspil lyd",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Optagelse og spektrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird leverer taksonomiske data, der bruges til artsklassifikation og indsigt. API-nøglen er gratis at hente fra Cornell Lab of Ornithology.",
         "apiKeyInfo": "En personlig eBird API-nøgle er påkrævet for at bruge denne integration. Du kan anmode om en gratis nøgle fra <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Test eBird-forbindelse",
           "loading": "Tester...",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Details für {species} anzeigen",
       "play": "Abspielen",
-      "playAudio": "Audio abspielen",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Audio abspielen"
     },
     "media": {
       "title": "Aufnahme & Spektrogramm",
@@ -1646,7 +1644,9 @@
         "detections": "Erkennungen:",
         "confidence": "Konfidenz:",
         "first": "Erste:"
-      }
+      },
+      "viewOnEbird": "Artenseite auf eBird ansehen",
+      "viewOnEbirdAria": "Artenseite für {species} auf eBird ansehen (wird in einem neuen Tab geöffnet)"
     },
     "advanced": {
       "title": "Erweiterte Analytik",
@@ -2845,13 +2845,14 @@
         "note": "eBird stellt taxonomische Daten zur Artklassifizierung und für Einblicke bereit. Der API-Schlüssel ist kostenlos beim Cornell Lab of Ornithology erhältlich.",
         "apiKeyInfo": "Ein persönlicher eBird-API-Schlüssel ist erforderlich, um diese Integration zu nutzen. Sie können einen kostenlosen Schlüssel unter <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a> anfordern.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Links zu eBird-Artenseiten anzeigen",
+          "helpText": "Fügt neben Erkennungen ein Symbol hinzu, das die Artenseite auf eBird.org in einem neuen Tab öffnet. Es ist kein API-Schlüssel erforderlich.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird-Region (optional)",
+            "placeholder": "z. B. BE-WAL",
+            "helpText": "Optional. Leer lassen für die globale Artenseite.",
+            "hint": "Um einen Regionscode zu finden, öffnen Sie <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, wählen Sie eine Region und kopieren Sie den in der Seiten-URL angezeigten Code (z. B. BE-WAL).",
+            "invalid": "Geben Sie einen gültigen eBird-Regionscode wie BE oder BE-WAL ein oder lassen Sie das Feld leer."
           }
         },
         "test": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Details für {species} anzeigen",
       "play": "Abspielen",
-      "playAudio": "Audio abspielen"
+      "playAudio": "Audio abspielen",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Aufnahme & Spektrogramm",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird stellt taxonomische Daten zur Artklassifizierung und für Einblicke bereit. Der API-Schlüssel ist kostenlos beim Cornell Lab of Ornithology erhältlich.",
         "apiKeyInfo": "Ein persönlicher eBird-API-Schlüssel ist erforderlich, um diese Integration zu nutzen. Sie können einen kostenlosen Schlüssel unter <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a> anfordern.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "eBird-Verbindung testen",
           "loading": "Wird getestet...",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "View details for {species}",
       "play": "Play",
-      "playAudio": "Play audio",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Play audio"
     },
     "media": {
       "title": "Recording & Spectrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Detections:",
         "confidence": "Confidence:",
         "first": "First:"
-      }
+      },
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "advanced": {
       "title": "Advanced Analytics",
@@ -2850,7 +2850,8 @@
           "region": {
             "label": "eBird Region (optional)",
             "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "helpText": "Optional. Leave empty for the global species page.",
+            "hint": "To find a region code, open <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
             "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
           }
         },

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "View details for {species}",
       "play": "Play",
-      "playAudio": "Play audio"
+      "playAudio": "Play audio",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Recording & Spectrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird provides taxonomic data used for species classification and insights. The API key is free to obtain from the Cornell Lab of Ornithology.",
         "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Test eBird Connection",
           "loading": "Testing...",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Ver detalles para {species}",
       "play": "Reproducir",
-      "playAudio": "Reproducir audio",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Reproducir audio"
     },
     "media": {
       "title": "Grabación y espectrograma",
@@ -1646,7 +1644,9 @@
         "detections": "Detecciones:",
         "confidence": "Confianza:",
         "first": "Primera:"
-      }
+      },
+      "viewOnEbird": "Ver la página de la especie en eBird",
+      "viewOnEbirdAria": "Ver la página de la especie {species} en eBird (se abre en una pestaña nueva)"
     },
     "advanced": {
       "title": "Análisis avanzado",
@@ -2845,13 +2845,14 @@
         "note": "eBird proporciona datos taxonómicos utilizados para la clasificación de especies y análisis. La clave API se obtiene gratuitamente del Laboratorio de Ornitología de Cornell.",
         "apiKeyInfo": "Se requiere una clave personal de la API de eBird para usar esta integración. Puedes solicitar una clave gratuita en <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Mostrar enlaces a las páginas de especies de eBird",
+          "helpText": "Añade un icono junto a las detecciones que abre la página de la especie en eBird.org en una pestaña nueva. No requiere clave de API.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Región de eBird (opcional)",
+            "placeholder": "p. ej. BE-WAL",
+            "helpText": "Opcional. Déjalo vacío para la página global de la especie.",
+            "hint": "Para encontrar un código de región, abre <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, selecciona una región y copia el código que aparece en la URL de la página (p. ej. BE-WAL).",
+            "invalid": "Introduce un código de región de eBird válido como BE o BE-WAL, o déjalo vacío."
           }
         },
         "test": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Ver detalles para {species}",
       "play": "Reproducir",
-      "playAudio": "Reproducir audio"
+      "playAudio": "Reproducir audio",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Grabación y espectrograma",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird proporciona datos taxonómicos utilizados para la clasificación de especies y análisis. La clave API se obtiene gratuitamente del Laboratorio de Ornitología de Cornell.",
         "apiKeyInfo": "Se requiere una clave personal de la API de eBird para usar esta integración. Puedes solicitar una clave gratuita en <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Probar conexión con eBird",
           "loading": "Probando...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Näytä {species} tiedot",
       "play": "Toista",
-      "playAudio": "Toista ääni"
+      "playAudio": "Toista ääni",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Tallenne ja spektrogrammi",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird tarjoaa taksonomiatietoja lajien luokitteluun ja analyyseihin. API-avain on saatavilla ilmaiseksi Cornellin ornitologian laboratoriosta.",
         "apiKeyInfo": "Henkilökohtainen eBird API -avain vaaditaan tämän integraation käyttöön. Voit pyytää ilmaisen avaimen osoitteesta <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Testaa eBird-yhteys",
           "loading": "Testataan...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Näytä {species} tiedot",
       "play": "Toista",
-      "playAudio": "Toista ääni",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Toista ääni"
     },
     "media": {
       "title": "Tallenne ja spektrogrammi",
@@ -1646,7 +1644,9 @@
         "detections": "Havainnot:",
         "confidence": "Luottamus:",
         "first": "Ensimmäinen:"
-      }
+      },
+      "viewOnEbird": "Näytä lajin sivu eBirdissä",
+      "viewOnEbirdAria": "Näytä lajin {species} sivu eBirdissä (avautuu uuteen välilehteen)"
     },
     "advanced": {
       "title": "Edistynyt analytiikka",
@@ -2845,13 +2845,14 @@
         "note": "eBird tarjoaa taksonomiatietoja lajien luokitteluun ja analyyseihin. API-avain on saatavilla ilmaiseksi Cornellin ornitologian laboratoriosta.",
         "apiKeyInfo": "Henkilökohtainen eBird API -avain vaaditaan tämän integraation käyttöön. Voit pyytää ilmaisen avaimen osoitteesta <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Näytä linkit eBird-lajisivuille",
+          "helpText": "Lisää havaintojen viereen kuvakkeen, joka avaa lajin sivun eBird.org-palvelussa uuteen välilehteen. Ei vaadi API-avainta.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird-alue (valinnainen)",
+            "placeholder": "esim. BE-WAL",
+            "helpText": "Valinnainen. Jätä tyhjäksi, niin käytetään lajin maailmanlaajuista sivua.",
+            "hint": "Löydät aluekoodin avaamalla sivun <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, valitsemalla alueen ja kopioimalla sivun URL-osoitteessa näkyvän koodin (esim. BE-WAL).",
+            "invalid": "Anna kelvollinen eBird-aluekoodi, kuten BE tai BE-WAL, tai jätä tyhjäksi."
           }
         },
         "test": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Voir les détails pour {species}",
       "play": "Lire",
-      "playAudio": "Lire l'audio"
+      "playAudio": "Lire l'audio",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Enregistrement et spectrogramme",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird fournit des données taxonomiques utilisées pour la classification des espèces et les analyses. La clé API est gratuite et disponible auprès du Cornell Lab of Ornithology.",
         "apiKeyInfo": "Une clé API eBird personnelle est requise pour utiliser cette intégration. Vous pouvez demander une clé gratuite sur <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Tester la connexion eBird",
           "loading": "Test en cours...",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Voir les détails pour {species}",
       "play": "Lire",
-      "playAudio": "Lire l'audio",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Lire l'audio"
     },
     "media": {
       "title": "Enregistrement et spectrogramme",
@@ -1646,7 +1644,9 @@
         "detections": "Détections :",
         "confidence": "Confiance :",
         "first": "Première :"
-      }
+      },
+      "viewOnEbird": "Voir la page de l’espèce sur eBird",
+      "viewOnEbirdAria": "Voir la page de l’espèce {species} sur eBird (ouvre un nouvel onglet)"
     },
     "advanced": {
       "title": "Analyses avancées",
@@ -2845,13 +2845,14 @@
         "note": "eBird fournit des données taxonomiques utilisées pour la classification des espèces et les analyses. La clé API est gratuite et disponible auprès du Cornell Lab of Ornithology.",
         "apiKeyInfo": "Une clé API eBird personnelle est requise pour utiliser cette intégration. Vous pouvez demander une clé gratuite sur <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Afficher les liens vers les pages d’espèces eBird",
+          "helpText": "Ajoute une icône à côté des détections qui ouvre la page de l’espèce sur eBird.org dans un nouvel onglet. Aucune clé API n’est requise.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Région eBird (facultatif)",
+            "placeholder": "ex. BE-WAL",
+            "helpText": "Facultatif. Laissez vide pour la page mondiale de l’espèce.",
+            "hint": "Pour trouver un code de région, ouvrez <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, sélectionnez une région et copiez le code affiché dans l’URL de la page (ex. BE-WAL).",
+            "invalid": "Saisissez un code de région eBird valide comme BE ou BE-WAL, ou laissez vide."
           }
         },
         "test": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "{species} részleteinek megtekintése",
       "play": "Lejátszás",
-      "playAudio": "Hang lejátszása"
+      "playAudio": "Hang lejátszása",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Felvétel és spektrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "Az eBird taxonómiai adatokat biztosít a faj osztályozáshoz és betekintésekhez. Az API kulcs ingyenesen beszerezhető a Cornell Lab of Ornithology-tól.",
         "apiKeyInfo": "Személyes eBird API kulcs szükséges ehhez az integrációhoz. Ingyenes kulcsot kérhet a <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a> oldalon.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "eBird kapcsolat tesztelése",
           "loading": "Tesztelés...",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "{species} részleteinek megtekintése",
       "play": "Lejátszás",
-      "playAudio": "Hang lejátszása",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Hang lejátszása"
     },
     "media": {
       "title": "Felvétel és spektrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Detektálások:",
         "confidence": "Megbízhatóság:",
         "first": "Első:"
-      }
+      },
+      "viewOnEbird": "Faj oldalának megtekintése az eBirden",
+      "viewOnEbirdAria": "{species} faj oldalának megtekintése az eBirden (új lapon nyílik meg)"
     },
     "advanced": {
       "title": "Speciális analitika",
@@ -2845,13 +2845,14 @@
         "note": "Az eBird taxonómiai adatokat biztosít a faj osztályozáshoz és betekintésekhez. Az API kulcs ingyenesen beszerezhető a Cornell Lab of Ornithology-tól.",
         "apiKeyInfo": "Személyes eBird API kulcs szükséges ehhez az integrációhoz. Ingyenes kulcsot kérhet a <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a> oldalon.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "eBird fajoldal-hivatkozások megjelenítése",
+          "helpText": "Ikont helyez el az észlelések mellé, amely új lapon megnyitja a faj oldalát az eBird.org webhelyen. Nem igényel API-kulcsot.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird régió (nem kötelező)",
+            "placeholder": "pl. BE-WAL",
+            "helpText": "Nem kötelező. Hagyja üresen a globális fajoldalhoz.",
+            "hint": "A régiókód megkereséséhez nyissa meg az <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a> oldalt, válasszon ki egy régiót, és másolja ki az oldal URL-címében megjelenő kódot (pl. BE-WAL).",
+            "invalid": "Adjon meg egy érvényes eBird régiókódot, például BE vagy BE-WAL, vagy hagyja üresen."
           }
         },
         "test": {
@@ -3455,7 +3456,7 @@
       },
       "privateMode": {
         "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
-        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül \u2013 bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
+        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül – bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
       },
       "publicAccess": {
         "title": "Nyilvános hozzáférés",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Vedi dettagli per {species}",
       "play": "Riproduci",
-      "playAudio": "Riproduci audio",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Riproduci audio"
     },
     "media": {
       "title": "Registrazione e Spettrogramma",
@@ -1646,7 +1644,9 @@
         "detections": "Rilevamenti:",
         "confidence": "Confidenza:",
         "first": "Primo:"
-      }
+      },
+      "viewOnEbird": "Vedi la pagina della specie su eBird",
+      "viewOnEbirdAria": "Vedi la pagina della specie {species} su eBird (si apre in una nuova scheda)"
     },
     "advanced": {
       "title": "Analisi Avanzate",
@@ -2845,13 +2845,14 @@
         "note": "eBird fornisce dati tassonomici utilizzati per la classificazione delle specie e le analisi. La chiave API è gratuita e disponibile presso il Cornell Lab of Ornithology.",
         "apiKeyInfo": "È necessaria una chiave API personale di eBird per utilizzare questa integrazione. Puoi richiedere una chiave gratuita su <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Mostra i collegamenti alle pagine delle specie di eBird",
+          "helpText": "Aggiunge accanto alle rilevazioni un’icona che apre la pagina della specie su eBird.org in una nuova scheda. Non è richiesta alcuna chiave API.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Regione eBird (facoltativo)",
+            "placeholder": "es. BE-WAL",
+            "helpText": "Facoltativo. Lascia vuoto per la pagina globale della specie.",
+            "hint": "Per trovare un codice regione, apri <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, seleziona una regione e copia il codice mostrato nell’URL della pagina (es. BE-WAL).",
+            "invalid": "Inserisci un codice regione eBird valido come BE o BE-WAL, oppure lascia vuoto."
           }
         },
         "test": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Vedi dettagli per {species}",
       "play": "Riproduci",
-      "playAudio": "Riproduci audio"
+      "playAudio": "Riproduci audio",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Registrazione e Spettrogramma",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird fornisce dati tassonomici utilizzati per la classificazione delle specie e le analisi. La chiave API è gratuita e disponibile presso il Cornell Lab of Ornithology.",
         "apiKeyInfo": "È necessaria una chiave API personale di eBird per utilizzare questa integrazione. Puoi richiedere una chiave gratuita su <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Test connessione eBird",
           "loading": "Test in corso...",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Skatīt informāciju par sugu {species}",
       "play": "Atskaņot",
-      "playAudio": "Atskaņot audio"
+      "playAudio": "Atskaņot audio",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Ieraksts un spektrogramma",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird nodrošina taksonomijas datus, ko izmanto sugu klasifikācijai un ieskatu iegūšanai. API atslēga ir bezmaksas, un to var iegūt no Cornell Lab of Ornithology.",
         "apiKeyInfo": "Šīs integrācijas izmantošanai nepieciešama personīga eBird API atslēga. Bezmaksas atslēgu var pieprasīt no <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Pārbaudīt eBird savienojumu",
           "loading": "Pārbauda...",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Skatīt informāciju par sugu {species}",
       "play": "Atskaņot",
-      "playAudio": "Atskaņot audio",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Atskaņot audio"
     },
     "media": {
       "title": "Ieraksts un spektrogramma",
@@ -1646,7 +1644,9 @@
         "detections": "Atpazīšanas:",
         "confidence": "Ticamība:",
         "first": "Pirmā:"
-      }
+      },
+      "viewOnEbird": "Skatīt sugas lapu vietnē eBird",
+      "viewOnEbirdAria": "Skatīt sugas {species} lapu vietnē eBird (atveras jaunā cilnē)"
     },
     "advanced": {
       "title": "Paplašinātā analītika",
@@ -2845,13 +2845,14 @@
         "note": "eBird nodrošina taksonomijas datus, ko izmanto sugu klasifikācijai un ieskatu iegūšanai. API atslēga ir bezmaksas, un to var iegūt no Cornell Lab of Ornithology.",
         "apiKeyInfo": "Šīs integrācijas izmantošanai nepieciešama personīga eBird API atslēga. Bezmaksas atslēgu var pieprasīt no <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Rādīt saites uz eBird sugu lapām",
+          "helpText": "Pievieno blakus konstatējumiem ikonu, kas atver sugas lapu vietnē eBird.org jaunā cilnē. API atslēga nav nepieciešama.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird reģions (neobligāti)",
+            "placeholder": "piem., BE-WAL",
+            "helpText": "Neobligāti. Atstājiet tukšu, lai izmantotu globālo sugas lapu.",
+            "hint": "Lai atrastu reģiona kodu, atveriet <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, atlasiet reģionu un nokopējiet kodu, kas redzams lapas URL adresē (piem., BE-WAL).",
+            "invalid": "Ievadiet derīgu eBird reģiona kodu, piemēram, BE vai BE-WAL, vai atstājiet tukšu."
           }
         },
         "test": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -903,9 +903,7 @@
     "row": {
       "viewDetails": "Vis detaljer for {species}",
       "play": "Spill av",
-      "playAudio": "Spill av lyd",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Spill av lyd"
     },
     "media": {
       "title": "Opptak og spektrogram",
@@ -1633,7 +1631,9 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhet:",
         "first": "Første:"
-      }
+      },
+      "viewOnEbird": "Se artssiden på eBird",
+      "viewOnEbirdAria": "Se artssiden for {species} på eBird (åpnes i en ny fane)"
     },
     "advanced": {
       "title": "Avansert analyse",
@@ -2832,13 +2832,14 @@
         "note": "eBird leverer taksonomiske data brukt for artsklassifisering og innsikt. API-nøkkelen er gratis å hente fra Cornell Lab of Ornithology.",
         "apiKeyInfo": "En personlig eBird API-nøkkel er nødvendig for å bruke denne integrasjonen. Du kan be om en gratis nøkkel fra <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Vis lenker til eBird-artssider",
+          "helpText": "Legger til et ikon ved siden av registreringer som åpner artssiden på eBird.org i en ny fane. Krever ingen API-nøkkel.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird-region (valgfritt)",
+            "placeholder": "f.eks. BE-WAL",
+            "helpText": "Valgfritt. La feltet stå tomt for den globale artssiden.",
+            "hint": "For å finne en regionkode, åpne <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, velg en region og kopier koden som vises i sidens URL (f.eks. BE-WAL).",
+            "invalid": "Skriv inn en gyldig eBird-regionkode som BE eller BE-WAL, eller la feltet stå tomt."
           }
         },
         "test": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -903,7 +903,9 @@
     "row": {
       "viewDetails": "Vis detaljer for {species}",
       "play": "Spill av",
-      "playAudio": "Spill av lyd"
+      "playAudio": "Spill av lyd",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Opptak og spektrogram",
@@ -2829,6 +2831,16 @@
         },
         "note": "eBird leverer taksonomiske data brukt for artsklassifisering og innsikt. API-nøkkelen er gratis å hente fra Cornell Lab of Ornithology.",
         "apiKeyInfo": "En personlig eBird API-nøkkel er nødvendig for å bruke denne integrasjonen. Du kan be om en gratis nøkkel fra <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Test eBird-tilkobling",
           "loading": "Tester...",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Bekijk details voor {species}",
       "play": "Afspelen",
-      "playAudio": "Geluid afspelen"
+      "playAudio": "Geluid afspelen",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Geluid opname & Spectrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird levert taxonomische gegevens voor soortclassificatie en inzichten. De API-sleutel is gratis verkrijgbaar bij het Cornell Lab of Ornithology.",
         "apiKeyInfo": "Een persoonlijke eBird API-sleutel is vereist voor deze integratie. Je kunt een gratis sleutel aanvragen op <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "eBird-verbinding testen",
           "loading": "Testen...",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Bekijk details voor {species}",
       "play": "Afspelen",
-      "playAudio": "Geluid afspelen",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Geluid afspelen"
     },
     "media": {
       "title": "Geluid opname & Spectrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Aantal herkend:",
         "confidence": "Betrouwbaarheid:",
         "first": "Eerst:"
-      }
+      },
+      "viewOnEbird": "Soortpagina op eBird bekijken",
+      "viewOnEbirdAria": "Soortpagina van {species} op eBird bekijken (opent in een nieuw tabblad)"
     },
     "advanced": {
       "title": "Geavanceerde analyse",
@@ -2845,13 +2845,14 @@
         "note": "eBird levert taxonomische gegevens voor soortclassificatie en inzichten. De API-sleutel is gratis verkrijgbaar bij het Cornell Lab of Ornithology.",
         "apiKeyInfo": "Een persoonlijke eBird API-sleutel is vereist voor deze integratie. Je kunt een gratis sleutel aanvragen op <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Links naar eBird-soortpagina’s tonen",
+          "helpText": "Voegt naast detecties een pictogram toe dat de soortpagina op eBird.org in een nieuw tabblad opent. Er is geen API-sleutel nodig.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird-regio (optioneel)",
+            "placeholder": "bijv. BE-WAL",
+            "helpText": "Optioneel. Laat leeg voor de wereldwijde soortpagina.",
+            "hint": "Open <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a> om een regiocode te vinden, selecteer een regio en kopieer de code die in de URL van de pagina wordt weergegeven (bijv. BE-WAL).",
+            "invalid": "Voer een geldige eBird-regiocode in, zoals BE of BE-WAL, of laat leeg."
           }
         },
         "test": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Wyświetl szczegóły dla {species}",
       "play": "Odtwórz",
-      "playAudio": "Odtwórz dźwięk",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Odtwórz dźwięk"
     },
     "media": {
       "title": "Nagranie i Spektrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Detekcje:",
         "confidence": "Pewność:",
         "first": "Pierwsze:"
-      }
+      },
+      "viewOnEbird": "Zobacz stronę gatunku w eBird",
+      "viewOnEbirdAria": "Zobacz stronę gatunku {species} w eBird (otwiera się w nowej karcie)"
     },
     "advanced": {
       "title": "Zaawansowana analityka",
@@ -2845,13 +2845,14 @@
         "note": "eBird dostarcza dane taksonomiczne wykorzystywane do klasyfikacji gatunków i analiz. Klucz API jest bezpłatny i dostępny w Cornell Lab of Ornithology.",
         "apiKeyInfo": "Do korzystania z tej integracji wymagany jest osobisty klucz API eBird. Możesz bezpłatnie uzyskać klucz na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Pokaż odnośniki do stron gatunków eBird",
+          "helpText": "Dodaje przy wykryciach ikonę otwierającą stronę gatunku w serwisie eBird.org w nowej karcie. Nie wymaga klucza API.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Region eBird (opcjonalnie)",
+            "placeholder": "np. BE-WAL",
+            "helpText": "Opcjonalne. Pozostaw puste, aby użyć globalnej strony gatunku.",
+            "hint": "Aby znaleźć kod regionu, otwórz <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, wybierz region i skopiuj kod widoczny w adresie URL strony (np. BE-WAL).",
+            "invalid": "Wprowadź prawidłowy kod regionu eBird, np. BE lub BE-WAL, albo pozostaw puste."
           }
         },
         "test": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Wyświetl szczegóły dla {species}",
       "play": "Odtwórz",
-      "playAudio": "Odtwórz dźwięk"
+      "playAudio": "Odtwórz dźwięk",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Nagranie i Spektrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird dostarcza dane taksonomiczne wykorzystywane do klasyfikacji gatunków i analiz. Klucz API jest bezpłatny i dostępny w Cornell Lab of Ornithology.",
         "apiKeyInfo": "Do korzystania z tej integracji wymagany jest osobisty klucz API eBird. Możesz bezpłatnie uzyskać klucz na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Test połączenia eBird",
           "loading": "Testowanie...",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Ver detalhes para {species}",
       "play": "Reproduzir",
-      "playAudio": "Reproduzir áudio",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Reproduzir áudio"
     },
     "media": {
       "title": "Gravação e espectrograma",
@@ -1646,7 +1644,9 @@
         "detections": "Detecções:",
         "confidence": "Confiança:",
         "first": "Primeira:"
-      }
+      },
+      "viewOnEbird": "Ver a página da espécie no eBird",
+      "viewOnEbirdAria": "Ver a página da espécie {species} no eBird (abre num novo separador)"
     },
     "advanced": {
       "title": "Análises avançadas",
@@ -2845,13 +2845,14 @@
         "note": "O eBird fornece dados taxonómicos utilizados para classificação de espécies e análises. A chave API é gratuita e pode ser obtida no Cornell Lab of Ornithology.",
         "apiKeyInfo": "É necessária uma chave API pessoal do eBird para utilizar esta integração. Pode solicitar uma chave gratuita em <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Mostrar ligações para as páginas de espécies do eBird",
+          "helpText": "Adiciona um ícone junto às deteções que abre a página da espécie no eBird.org num novo separador. Não é necessária chave de API.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Região do eBird (opcional)",
+            "placeholder": "ex. BE-WAL",
+            "helpText": "Opcional. Deixe vazio para a página global da espécie.",
+            "hint": "Para encontrar um código de região, abra <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, selecione uma região e copie o código apresentado no URL da página (ex. BE-WAL).",
+            "invalid": "Introduza um código de região do eBird válido, como BE ou BE-WAL, ou deixe vazio."
           }
         },
         "test": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Ver detalhes para {species}",
       "play": "Reproduzir",
-      "playAudio": "Reproduzir áudio"
+      "playAudio": "Reproduzir áudio",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Gravação e espectrograma",
@@ -2842,6 +2844,16 @@
         },
         "note": "O eBird fornece dados taxonómicos utilizados para classificação de espécies e análises. A chave API é gratuita e pode ser obtida no Cornell Lab of Ornithology.",
         "apiKeyInfo": "É necessária uma chave API pessoal do eBird para utilizar esta integração. Pode solicitar uma chave gratuita em <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Testar Ligação eBird",
           "loading": "A testar...",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Zobraziť podrobnosti pre {species}",
       "play": "Prehrať",
-      "playAudio": "Prehrať zvuk"
+      "playAudio": "Prehrať zvuk",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird poskytuje taxonomické údaje používané na klasifikáciu druhov a analýzy. API kľúč je bezplatný a dostupný z Cornell Lab of Ornithology.",
         "apiKeyInfo": "Na použitie tejto integrácie je potrebný osobný kľúč API eBird. Bezplatný kľúč si môžete vyžiadať na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Test pripojenia eBird",
           "loading": "Testovanie...",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Zobraziť podrobnosti pre {species}",
       "play": "Prehrať",
-      "playAudio": "Prehrať zvuk",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Prehrať zvuk"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Detekcie:",
         "confidence": "Istota:",
         "first": "Prvýkrát:"
-      }
+      },
+      "viewOnEbird": "Zobraziť stránku druhu na eBird",
+      "viewOnEbirdAria": "Zobraziť stránku druhu {species} na eBird (otvorí sa na novej karte)"
     },
     "advanced": {
       "title": "Rozšírená analytika",
@@ -2845,13 +2845,14 @@
         "note": "eBird poskytuje taxonomické údaje používané na klasifikáciu druhov a analýzy. API kľúč je bezplatný a dostupný z Cornell Lab of Ornithology.",
         "apiKeyInfo": "Na použitie tejto integrácie je potrebný osobný kľúč API eBird. Bezplatný kľúč si môžete vyžiadať na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Zobraziť odkazy na stránky druhov eBird",
+          "helpText": "Pridá k detekciám ikonu, ktorá otvorí stránku druhu na eBird.org na novej karte. Nevyžaduje kľúč API.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "Región eBird (voliteľné)",
+            "placeholder": "napr. BE-WAL",
+            "helpText": "Voliteľné. Ponechajte prázdne pre globálnu stránku druhu.",
+            "hint": "Kód regiónu zistíte tak, že otvoríte <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, vyberiete región a skopírujete kód zobrazený v adrese URL stránky (napr. BE-WAL).",
+            "invalid": "Zadajte platný kód regiónu eBird, napríklad BE alebo BE-WAL, alebo ponechajte prázdne."
           }
         },
         "test": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -916,7 +916,9 @@
     "row": {
       "viewDetails": "Visa detaljer för {species}",
       "play": "Spela upp",
-      "playAudio": "Spela upp ljud"
+      "playAudio": "Spela upp ljud",
+      "viewOnEbird": "View species page on eBird",
+      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
     },
     "media": {
       "title": "Inspelning och spektrogram",
@@ -2842,6 +2844,16 @@
         },
         "note": "eBird tillhandahåller taxonomidata som används för artklassificering och insikter. API-nyckeln är gratis att erhålla från Cornell Lab of Ornithology.",
         "apiKeyInfo": "En personlig eBird API-nyckel krävs för att använda denna integration. Du kan begära en gratis nyckel från <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "speciesLinks": {
+          "enable": "Show eBird species page links",
+          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "region": {
+            "label": "eBird Region (optional)",
+            "placeholder": "e.g. BE-WAL",
+            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
+            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+          }
+        },
         "test": {
           "button": "Testa eBird-anslutning",
           "loading": "Testar...",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -916,9 +916,7 @@
     "row": {
       "viewDetails": "Visa detaljer för {species}",
       "play": "Spela upp",
-      "playAudio": "Spela upp ljud",
-      "viewOnEbird": "View species page on eBird",
-      "viewOnEbirdAria": "View {species} species page on eBird (opens in a new tab)"
+      "playAudio": "Spela upp ljud"
     },
     "media": {
       "title": "Inspelning och spektrogram",
@@ -1646,7 +1644,9 @@
         "detections": "Detektioner:",
         "confidence": "Konfidens:",
         "first": "Först:"
-      }
+      },
+      "viewOnEbird": "Visa artsidan på eBird",
+      "viewOnEbirdAria": "Visa artsidan för {species} på eBird (öppnas i en ny flik)"
     },
     "advanced": {
       "title": "Avancerad analys",
@@ -2845,13 +2845,14 @@
         "note": "eBird tillhandahåller taxonomidata som används för artklassificering och insikter. API-nyckeln är gratis att erhålla från Cornell Lab of Ornithology.",
         "apiKeyInfo": "En personlig eBird API-nyckel krävs för att använda denna integration. Du kan begära en gratis nyckel från <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "speciesLinks": {
-          "enable": "Show eBird species page links",
-          "helpText": "Add an icon next to detections that opens the species page on eBird.org in a new tab. No API key is required.",
+          "enable": "Visa länkar till eBird-artsidor",
+          "helpText": "Lägger till en ikon bredvid detekteringar som öppnar artsidan på eBird.org i en ny flik. Ingen API-nyckel krävs.",
           "region": {
-            "label": "eBird Region (optional)",
-            "placeholder": "e.g. BE-WAL",
-            "helpText": "Optional. Leave empty for the global species page. To find a region code, open ebird.org/explore, select a region, and copy the code shown in the page URL (e.g. BE-WAL).",
-            "invalid": "Enter a valid eBird region code such as BE or BE-WAL, or leave empty."
+            "label": "eBird-region (valfritt)",
+            "placeholder": "t.ex. BE-WAL",
+            "helpText": "Valfritt. Lämna tomt för den globala artsidan.",
+            "hint": "För att hitta en regionkod, öppna <a href=\"https://ebird.org/explore\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"link link-primary\">ebird.org/explore</a>, välj en region och kopiera koden som visas i sidans URL (t.ex. BE-WAL).",
+            "invalid": "Ange en giltig eBird-regionkod som BE eller BE-WAL, eller lämna tomt."
           }
         },
         "test": {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -343,10 +343,12 @@ type BirdweatherSettings struct {
 
 // EBirdSettings contains settings for eBird API integration.
 type EBirdSettings struct {
-	Enabled  bool   `yaml:"enabled" json:"enabled"`   // true to enable eBird integration
-	APIKey   string `yaml:"apikey" json:"apiKey"`     // eBird API key
-	CacheTTL int    `yaml:"cachettl" json:"cacheTTL"` // cache time-to-live in hours (default: 24)
-	Locale   string `yaml:"locale" json:"locale"`     // locale for eBird data (e.g., "en", "es")
+	Enabled              bool   `yaml:"enabled" json:"enabled"`                           // true to enable eBird integration
+	APIKey               string `yaml:"apikey" json:"apiKey"`                             // eBird API key
+	CacheTTL             int    `yaml:"cachettl" json:"cacheTTL"`                         // cache time-to-live in hours (default: 24)
+	Locale               string `yaml:"locale" json:"locale"`                             // locale for eBird data (e.g., "en", "es")
+	ShowSpeciesPageLinks bool   `yaml:"showspeciespagelinks" json:"showSpeciesPageLinks"` // true to show direct links to eBird species pages in the UI
+	SpeciesPageRegion    string `yaml:"speciespageregion" json:"speciesPageRegion"`       // optional eBird region code for species links (e.g., "BE-WAL"); empty = global page
 }
 
 // WeatherSettings contains all weather-related settings

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -280,6 +280,8 @@ realtime:
     apikey: ""            # eBird API key (get from https://ebird.org/api/keygen)
     cachettl: 24          # cache time-to-live in hours (default: 24)
     locale: "en"          # locale for eBird data (e.g., "en", "es", "fr")
+    showspeciespagelinks: false  # true to show eBird species-page links in the analytics UI (no API key required)
+    speciespageregion: ""        # optional eBird region code for species links (e.g., "BE-WAL"); empty = global page
 
   weather:
     provider: yrno

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -222,6 +222,8 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.ebird.apikey", "")
 	viper.SetDefault("realtime.ebird.cachettl", 24) // 24 hours default
 	viper.SetDefault("realtime.ebird.locale", "en")
+	viper.SetDefault("realtime.ebird.showspeciespagelinks", false)
+	viper.SetDefault("realtime.ebird.speciespageregion", "")
 
 	// OpenWeather configuration
 	/*


### PR DESCRIPTION
## Summary

Adds an optional, client-side eBird species-page link to every species view in the Analytics section. When enabled, each species shows a link that opens its eBird page in a new tab. The URL is built entirely client-side from the detection's existing species code plus an optional user-configured region and the current UI language — **no eBird API key required**.

**Surfaces:**
- **Desktop grid cards** — compact `eBird ↗` text pill next to the species name
- **Desktop table** — same `eBird ↗` text pill (consistent with grid)
- **Mobile cards** (card / compact / list variants) — `ExternalLink` icon as a positioned corner overlay (rendered as a sibling of the card `<button>` to keep valid HTML)

**Settings** (Integrations → eBird):
- `Show eBird species page links` toggle (independent of the API-key-based eBird features)
- Optional `eBird Region` field (e.g. `BE-WAL`) with client-side validation; empty = global page

## Implementation notes

- New `frontend/src/lib/utils/ebird.ts` helper: `buildEbirdSpeciesUrl`, `isValidEbirdSpeciesCode`, `isValidEbirdRegionCode`, `toEbirdSiteLanguage` — fully unit-tested (`ebird.test.ts`)
- Placeholder species codes (uppercase-prefixed, generated for species missing from the eBird taxonomy) are intentionally excluded, so the link only appears for real eBird codes
- Backend adds two purely-additive config fields: `realtime.ebird.showspeciespagelinks` (default `false`) and `realtime.ebird.speciespageregion` (default `""`), with viper defaults and documentation in the example `config.yaml`
- Settings hot-reload: the link reactively appears/updates as soon as the toggle/region change, no restart needed

## Backward compatibility

Purely additive. Existing `config.yaml` files without the new keys fall back to viper defaults (feature off). Existing eBird-integration users see no change until they explicitly enable the toggle. The two new JSON fields in the settings API response are additive and ignored by existing clients.

## Test plan

- [ ] Enable eBird integration, toggle "Show species page links" → links appear in grid, table, and mobile views
- [ ] Set a region (e.g. `BE-WAL`) → links resolve to the region-scoped eBird URL; clear it → links resolve to the global page
- [ ] Enter an invalid region (e.g. `BEWAL`) → inline validation message shown
- [ ] Toggle off → all links disappear without a page reload
- [ ] Species with placeholder/missing eBird code → no link shown
- [ ] `npm run check:all` and `npm test` pass

## Preflight Status

Ran the 6-pass preflight quality gate. All in-scope findings resolved:

- ✅ Aligned desktop-table link to the `eBird ↗` text pill (was a leftover `Binoculars` icon)
- ✅ Removed unused `ebird-link` CSS class and stale `Binoculars` import
- ✅ Simplified redundant `Boolean()` wraps
- ✅ Documented new fields in the embedded `config.yaml`

Verified clean: `{@html}` usage (static i18n content, established pattern), URL encoding (regex-guarded + `encodeURIComponent`), settings reactivity, i18n integrity (all 9 new keys translated across all 16 locales, `{species}` placeholder preserved), HTML validity of the overlay link.

Certification:
- [x] Single concern · [x] Linters clean · [x] Tests pass · [x] No regression / backward-compat break · [x] i18n complete · [x] No secrets or PII

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f8dd105b-2d22-426f-8112-6e07107b30a5" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/5a972eaf-58a2-485e-a73d-2fe4ff764cfc" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/68e8d9af-e1fb-47f1-ac39-4ed770f79297" />
