### PR TITLE
fix(analytics): key daily species summary on scientific name

### DIFF
--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -348,11 +348,17 @@ func (c *Controller) aggregateDailySpeciesData(notes []datastore.Note, selectedD
 		return aggregatedData, nil
 	}
 
-	// Collect all unique species names that meet confidence threshold
+	// Collect all unique species that meet the confidence threshold, keyed by
+	// scientific name. Keying on scientific name (not the localized common name)
+	// keeps the hourly aggregation robust across models and locales: a localized
+	// common name has no reliable reverse mapping back to a scientific name for
+	// non-primary-model species (e.g. bats), which silently dropped them from the
+	// summary. Scientific names resolve directly to label IDs for
+	// every model, so no lossy round-trip is needed.
 	uniqueSpecies := make(map[string]struct{})
 	for i := range notes {
 		if notes[i].Confidence >= minConfidence {
-			uniqueSpecies[notes[i].CommonName] = struct{}{}
+			uniqueSpecies[notes[i].ScientificName] = struct{}{}
 		}
 	}
 
@@ -371,7 +377,7 @@ func (c *Controller) aggregateDailySpeciesData(notes []datastore.Note, selectedD
 			continue
 		}
 
-		counts, ok := hourlyCounts[note.CommonName]
+		counts, ok := hourlyCounts[note.ScientificName]
 		if !ok {
 			// Species not in batch result, skip
 			continue

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -25,6 +26,15 @@ import (
 
 // Test date constant used across multiple test cases
 const testDate = "2023-01-01"
+
+// Scientific names reused as hourly-batch map keys across the daily-summary tests.
+// The daily summary keys hourly aggregation on scientific name.
+const (
+	sciAmericanCrow         = "Corvus brachyrhynchos"
+	sciRedBelliedWoodpecker = "Melanerpes carolinus"
+	sciBarbastelleBat       = "Barbastella barbastellus"
+	sciEurasianBlackbird    = "Turdus merula"
+)
 
 // assertAnalyticsErrorResponse validates analytics error responses.
 func assertAnalyticsErrorResponse(t *testing.T, rec *httptest.ResponseRecorder, expectedStatus int, expectedBody string) {
@@ -632,11 +642,11 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 	// Now using batch query instead of individual calls
 	mockDS.On("GetBatchHourlyOccurrences", testDate, mock.MatchedBy(func(species []string) bool {
 		return len(species) == 2 &&
-			((species[0] == "American Crow" && species[1] == "Red-bellied Woodpecker") ||
-				(species[0] == "Red-bellied Woodpecker" && species[1] == "American Crow"))
+			((species[0] == sciAmericanCrow && species[1] == sciRedBelliedWoodpecker) ||
+				(species[0] == sciRedBelliedWoodpecker && species[1] == sciAmericanCrow))
 	}), minConfidence).Return(map[string][24]int{
-		"American Crow":          expectedAmcroHourlyCounts,
-		"Red-bellied Woodpecker": expectedRbwoHourlyCounts,
+		sciAmericanCrow:         expectedAmcroHourlyCounts,
+		sciRedBelliedWoodpecker: expectedRbwoHourlyCounts,
 	}, nil)
 
 	// Mock for image cache initialization
@@ -766,6 +776,103 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 	mockDS.AssertExpectations(t)
 }
 
+// TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies is a regression test:
+// a non-primary-model species (a bat from BattyBirdNET) whose common
+// name is localized by OpenFauna to a value different from its scientific name
+// must still appear in the daily summary. The pre-fix pipeline keyed the hourly
+// aggregation on the localized common name and reverse-mapped it through a
+// label-only map that has no bat entry, so the hourly counts came back zero and
+// the species was dropped. The fix keys the aggregation on scientific name end to
+// end.
+func TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("type", "regression")
+	t.Attr("feature", "species-summary")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+
+	const testDate = "2025-03-07"
+	const minConfidence = 0.0
+
+	// A bat localized by OpenFauna to a Finnish common name that differs from its
+	// scientific name, plus a regular bird as a control.
+	mockNotes := []datastore.Note{
+		{
+			ID:             1,
+			ScientificName: sciBarbastelleBat,
+			CommonName:     "mopsilepakko",
+			Confidence:     0.9,
+			Date:           testDate,
+			Time:           "23:15:00",
+		},
+		{
+			ID:             2,
+			ScientificName: sciEurasianBlackbird,
+			CommonName:     "Common Blackbird",
+			Confidence:     0.8,
+			Date:           testDate,
+			Time:           "08:20:00",
+		},
+	}
+
+	var batHourly [24]int
+	batHourly[23] = 5
+	var blackbirdHourly [24]int
+	blackbirdHourly[8] = 2
+
+	mockDS.On("GetTopBirdsData", testDate, minConfidence, 0).Return(mockNotes, nil)
+
+	// Post-fix contract: the controller keys the hourly aggregation on scientific
+	// name end to end, so GetBatchHourlyOccurrences receives scientific names and
+	// returns a map keyed by scientific name.
+	var passedSpecies []string
+	mockDS.On("GetBatchHourlyOccurrences", testDate, mock.Anything, minConfidence).
+		Run(func(args mock.Arguments) {
+			arg, ok := args.Get(1).([]string)
+			require.True(t, ok, "species argument should be []string")
+			passedSpecies = slices.Clone(arg)
+		}).
+		Return(map[string][24]int{
+			sciBarbastelleBat:    batHourly,
+			sciEurasianBlackbird: blackbirdHourly,
+		}, nil)
+
+	controller := &Controller{DS: mockDS}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date="+testDate, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetDailySpeciesSummary(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response []SpeciesDailySummary
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+
+	// The controller must pass scientific names (not localized common names) to
+	// the hourly batch fetch.
+	assert.ElementsMatch(t, []string{sciBarbastelleBat, sciEurasianBlackbird}, passedSpecies,
+		"hourly batch should be keyed on scientific name, not localized common name")
+
+	bySci := make(map[string]SpeciesDailySummary, len(response))
+	for i := range response {
+		bySci[response[i].ScientificName] = response[i]
+	}
+
+	bat, ok := bySci[sciBarbastelleBat]
+	require.True(t, ok, "bat species must appear in the daily summary (regression)")
+	assert.Equal(t, 5, bat.Count, "bat hourly counts must be aggregated by scientific name")
+	assert.Equal(t, "mopsilepakko", bat.CommonName, "bat keeps its localized common name for display")
+
+	blackbird, ok := bySci[sciEurasianBlackbird]
+	require.True(t, ok, "control bird must appear in the daily summary")
+	assert.Equal(t, 2, blackbird.Count)
+
+	mockDS.AssertExpectations(t)
+}
+
 // TestGetDailySpeciesSummary_SingleDetection tests that the GetDailySpeciesSummary function
 // correctly handles the case where each species has only one detection
 func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
@@ -809,8 +916,8 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 	// Setup mock expectations using m.On()
 	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return(mockNotesSingle, nil)
 	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
-		"American Crow":          expectedAmcroSingleHourly,
-		"Red-bellied Woodpecker": expectedRbwoSingleHourly,
+		sciAmericanCrow:         expectedAmcroSingleHourly,
+		sciRedBelliedWoodpecker: expectedRbwoSingleHourly,
 	}, nil)
 
 	// Mock for image cache initialization
@@ -982,7 +1089,7 @@ func TestGetDailySpeciesSummary_TimeHandling(t *testing.T) {
 	// Setup mock expectations using m.On()
 	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return(mockNotesTime, nil)
 	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
-		"American Crow": expectedAmcroTimeHourly,
+		sciAmericanCrow: expectedAmcroTimeHourly,
 	}, nil)
 
 	// Create a controller with our mock
@@ -1065,8 +1172,8 @@ func TestGetDailySpeciesSummary_ConfidenceFilter(t *testing.T) {
 	mockDS.On("GetTopBirdsData", "2025-03-07", expectedMinConfidence, 0).Return(mockNotesConfidence, nil)
 	// GetBatchHourlyOccurrences is called for all species returned by GetTopBirdsData
 	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, expectedMinConfidence).Return(map[string][24]int{
-		"American Crow":          expectedAmcroConfidenceHourly,
-		"Red-bellied Woodpecker": [24]int{}, // Filtered out later
+		sciAmericanCrow:         expectedAmcroConfidenceHourly,
+		sciRedBelliedWoodpecker: {}, // Filtered out later
 	}, nil)
 
 	// Create a controller with our mock
@@ -1151,8 +1258,8 @@ func TestGetDailySpeciesSummary_LimitParameter(t *testing.T) {
 	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 2).Return(mockNotesLimit, nil)
 	// Expect GetBatchHourlyOccurrences to be called for the 2 species returned
 	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
-		"American Crow":          expectedAmcroLimitHourly,
-		"Red-bellied Woodpecker": expectedRbwoLimitHourly,
+		sciAmericanCrow:         expectedAmcroLimitHourly,
+		sciRedBelliedWoodpecker: expectedRbwoLimitHourly,
 	}, nil)
 
 	// Create a controller with our mock

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -34,6 +34,8 @@ const (
 	sciRedBelliedWoodpecker = "Melanerpes carolinus"
 	sciBarbastelleBat       = "Barbastella barbastellus"
 	sciEurasianBlackbird    = "Turdus merula"
+	sciAmericanRobin        = "Turdus migratorius"
+	sciBlueJay              = "Cyanocitta cristata"
 )
 
 // assertAnalyticsErrorResponse validates analytics error responses.

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -32,7 +32,7 @@ func testNotes() []datastore.Note {
 		{
 			ID:             1,
 			CommonName:     "American Robin",
-			ScientificName: "Turdus migratorius",
+			ScientificName: sciAmericanRobin,
 			Confidence:     0.85,
 			Date:           today,
 			Time:           "08:30:00",
@@ -40,7 +40,7 @@ func testNotes() []datastore.Note {
 		{
 			ID:             2,
 			CommonName:     "Blue Jay",
-			ScientificName: "Cyanocitta cristata",
+			ScientificName: sciBlueJay,
 			Confidence:     0.72,
 			Date:           today,
 			Time:           "09:15:00",
@@ -88,8 +88,8 @@ func TestDailySpeciesSummary_DefaultParams(t *testing.T) {
 	// aggregateDailySpeciesData calls GetBatchHourlyOccurrences for hourly counts
 	mockDS.On("GetBatchHourlyOccurrences", today, mock.Anything, 0.0).
 		Return(map[string][24]int{
-			"Turdus migratorius":  {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			"Cyanocitta cristata": {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			sciAmericanRobin: {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			sciBlueJay:       {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}, nil).Once()
 
 	rec := executeRequest(t, e, http.MethodGet, "/api/v2/analytics/species/daily", controller.GetDailySpeciesSummary)
@@ -116,7 +116,7 @@ func TestSpeciesSummary_DefaultParams(t *testing.T) {
 
 	mockData := []datastore.SpeciesSummaryData{
 		{
-			ScientificName: "Turdus migratorius",
+			ScientificName: sciAmericanRobin,
 			CommonName:     "American Robin",
 			SpeciesCode:    "amerob",
 			Count:          42,
@@ -148,7 +148,7 @@ func TestNewSpeciesDetections_DefaultParams(t *testing.T) {
 
 	mockData := []datastore.NewSpeciesData{
 		{
-			ScientificName: "Turdus migratorius",
+			ScientificName: sciAmericanRobin,
 			CommonName:     "American Robin",
 			FirstSeenDate:  "2025-01-15",
 			CountInPeriod:  5,
@@ -393,8 +393,8 @@ func TestDailySpeciesSummary_DefaultParams_AfterMigration(t *testing.T) {
 	mockDS.On("GetTopBirdsData", today, 0.0, 0).Return(notes, nil).Once()
 	mockDS.On("GetBatchHourlyOccurrences", today, mock.Anything, 0.0).
 		Return(map[string][24]int{
-			"Turdus migratorius":  {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			"Cyanocitta cristata": {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			sciAmericanRobin: {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			sciBlueJay:       {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}, nil).Once()
 
 	rec := executeRequest(t, e, http.MethodGet, "/api/v2/analytics/species/daily", controller.GetDailySpeciesSummary)

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -88,8 +88,8 @@ func TestDailySpeciesSummary_DefaultParams(t *testing.T) {
 	// aggregateDailySpeciesData calls GetBatchHourlyOccurrences for hourly counts
 	mockDS.On("GetBatchHourlyOccurrences", today, mock.Anything, 0.0).
 		Return(map[string][24]int{
-			"American Robin": {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			"Blue Jay":       {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			"Turdus migratorius":  {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			"Cyanocitta cristata": {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}, nil).Once()
 
 	rec := executeRequest(t, e, http.MethodGet, "/api/v2/analytics/species/daily", controller.GetDailySpeciesSummary)
@@ -393,8 +393,8 @@ func TestDailySpeciesSummary_DefaultParams_AfterMigration(t *testing.T) {
 	mockDS.On("GetTopBirdsData", today, 0.0, 0).Return(notes, nil).Once()
 	mockDS.On("GetBatchHourlyOccurrences", today, mock.Anything, 0.0).
 		Return(map[string][24]int{
-			"American Robin": {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			"Blue Jay":       {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			"Turdus migratorius":  {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			"Cyanocitta cristata": {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}, nil).Once()
 
 	rec := executeRequest(t, e, http.MethodGet, "/api/v2/analytics/species/daily", controller.GetDailySpeciesSummary)

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -547,6 +547,35 @@ func TestGetNewSpeciesDetections(t *testing.T) {
 	})
 }
 
+// TestGetBatchHourlyOccurrences_ScientificNameKey is a regression test:
+// the batch hourly query keys on scientific name, not the (possibly
+// localized) common name. A note whose common name differs from its scientific
+// name must still be counted when queried by scientific name.
+func TestGetBatchHourlyOccurrences_ScientificNameKey(t *testing.T) {
+	t.Parallel()
+	ds := setupTestDB(t)
+
+	notes := []Note{
+		{Date: "2024-01-15", Time: "23:15:00", ScientificName: "Barbastella barbastellus", CommonName: "mopsilepakko", Confidence: 0.9},
+		{Date: "2024-01-15", Time: "08:20:00", ScientificName: "Turdus merula", CommonName: "Common Blackbird", Confidence: 0.8},
+	}
+	for i := range notes {
+		require.NoError(t, ds.DB.Create(&notes[i]).Error)
+	}
+
+	counts, err := ds.GetBatchHourlyOccurrences("2024-01-15",
+		[]string{"Barbastella barbastellus", "Turdus merula"}, 0.0)
+	require.NoError(t, err)
+
+	bat, ok := counts["Barbastella barbastellus"]
+	require.True(t, ok, "result must be keyed by scientific name")
+	assert.Equal(t, 1, bat[23], "bat detection at 23:00 must be counted by scientific name")
+
+	blackbird, ok := counts["Turdus merula"]
+	require.True(t, ok, "result must be keyed by scientific name")
+	assert.Equal(t, 1, blackbird[8], "blackbird detection at 08:00 must be counted by scientific name")
+}
+
 // TestGetHourlyDistribution tests the GetHourlyDistribution function
 func TestGetHourlyDistribution(t *testing.T) {
 	t.Parallel()

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -106,8 +106,10 @@ type Interface interface {
 	GetTopBirdsData(selectedDate string, minConfidenceNormalized float64, limit int) ([]Note, error)
 	GetHourlyOccurrences(date, commonName string, minConfidenceNormalized float64) ([24]int, error)
 	// GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
-	// Returns a map of species CommonName to [24]int hourly counts.
-	// This batches multiple GetHourlyOccurrences calls into a single query for performance.
+	// The species slice holds scientific names; the returned map is keyed by scientific name.
+	// Keying on scientific name keeps the result robust across models and locales.
+	// This batches the per-species hourly lookups into a single query for performance. Note it keys
+	// on scientific name, unlike the singular GetHourlyOccurrences which still accepts a common name.
 	GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error)
 	SpeciesDetections(species, date, hour string, duration int, sortAscending bool, limit int, offset int) ([]Note, error)
 	GetLastDetections(numDetections int) ([]Note, error)
@@ -849,6 +851,9 @@ func (ds *DataStore) GetHourlyOccurrences(date, commonName string, minConfidence
 }
 
 // GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
+// The species parameter holds scientific names, and the returned map is keyed by
+// scientific name. Keying on scientific name (rather than the localized common
+// name) keeps the daily summary robust across models and locales.
 func (ds *DataStore) GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error) {
 	if len(species) == 0 {
 		return make(map[string][24]int), nil
@@ -857,19 +862,19 @@ func (ds *DataStore) GetBatchHourlyOccurrences(date string, species []string, mi
 	hourFormat := ds.GetHourFormat()
 
 	var results []struct {
-		CommonName string
-		Hour       int
-		Count      int
+		ScientificName string
+		Hour           int
+		Count          int
 	}
 
 	// Exclude detections marked as false_positive
 	err := ds.DB.Model(&Note{}).
 		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
-		Select(fmt.Sprintf("notes.common_name, %s as hour, COUNT(*) as count", hourFormat)).
-		Where("notes.common_name IN ? AND notes.date = ? AND notes.confidence >= ?", species, date, minConfidence).
+		Select(fmt.Sprintf("notes.scientific_name, %s as hour, COUNT(*) as count", hourFormat)).
+		Where("notes.scientific_name IN ? AND notes.date = ? AND notes.confidence >= ?", species, date, minConfidence).
 		Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive)).
-		Group(fmt.Sprintf("notes.common_name, %s", hourFormat)).
-		Order("notes.common_name, hour").
+		Group(fmt.Sprintf("notes.scientific_name, %s", hourFormat)).
+		Order("notes.scientific_name, hour").
 		Scan(&results).Error
 
 	if err != nil {
@@ -891,9 +896,9 @@ func (ds *DataStore) GetBatchHourlyOccurrences(date string, species []string, mi
 
 	for _, r := range results {
 		if r.Hour >= 0 && r.Hour < 24 {
-			hourlyData := result[r.CommonName]
+			hourlyData := result[r.ScientificName]
 			hourlyData[r.Hour] = r.Count
-			result[r.CommonName] = hourlyData
+			result[r.ScientificName] = hourlyData
 		}
 	}
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1257,10 +1257,14 @@ func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, mi
 		// Get label IDs for this species across all models
 		labelIDs, err := ds.label.GetLabelIDsByScientificName(ctx, scientificName)
 		if err != nil {
-			// Log error with context and continue with other species
-			ds.log.Warn("failed to get label IDs for species in batch query",
-				logger.String("scientific_name", scientificName),
-				logger.Error(err))
+			// Log error with context and continue with other species. ds.log may be
+			// nil when the datastore is constructed without a logger, so guard it
+			// like the other logging sites in this file.
+			if ds.log != nil {
+				ds.log.Warn("failed to get label IDs for species in batch query",
+					logger.String("scientific_name", scientificName),
+					logger.Error(err))
+			}
 			continue
 		}
 		if len(labelIDs) > 0 {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1228,6 +1228,11 @@ func (ds *Datastore) GetHourlyOccurrences(date, commonName string, minConfidence
 }
 
 // GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
+// The species parameter holds scientific names. Scientific names map directly to
+// label IDs for every model via GetLabelIDsByScientificName, so no localized
+// common-name round-trip is performed (that round-trip dropped non-primary-model
+// species such as bats from the daily summary). The returned map
+// is keyed by the same scientific names that were passed in.
 func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error) {
 	if len(species) == 0 {
 		return make(map[string][24]int), nil
@@ -1246,46 +1251,39 @@ func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, mi
 	startOfDay := targetDate.Unix()
 	endOfDay := targetDate.AddDate(0, 0, 1).Unix()
 
-	// Convert species common names to scientific names and collect label IDs
-	allLabelIDs := make(map[string][]uint) // map[commonName][]labelID
-	for _, commonName := range species {
-		normalized := strings.ToLower(strings.TrimSpace(commonName))
-		scientificName := commonName
-		if sci, ok := ds.loadNameMaps().species[normalized]; ok {
-			scientificName = sci
-		}
-
+	// Collect label IDs per scientific name across all models
+	allLabelIDs := make(map[string][]uint) // map[scientificName][]labelID
+	for _, scientificName := range species {
 		// Get label IDs for this species across all models
 		labelIDs, err := ds.label.GetLabelIDsByScientificName(ctx, scientificName)
 		if err != nil {
 			// Log error with context and continue with other species
 			ds.log.Warn("failed to get label IDs for species in batch query",
-				logger.String("common_name", commonName),
 				logger.String("scientific_name", scientificName),
 				logger.Error(err))
 			continue
 		}
 		if len(labelIDs) > 0 {
-			allLabelIDs[commonName] = labelIDs
+			allLabelIDs[scientificName] = labelIDs
 		}
 	}
 
 	if len(allLabelIDs) == 0 {
-		// No matching species found in map
+		// No matching species found
 		result := make(map[string][24]int)
-		for _, commonName := range species {
-			result[commonName] = [24]int{}
+		for _, scientificName := range species {
+			result[scientificName] = [24]int{}
 		}
 		return result, nil
 	}
 
 	// Flatten all label IDs for batch query
 	var flatLabelIDs []uint
-	labelToCommonName := make(map[uint]string) // reverse map for results
-	for commonName, labelIDs := range allLabelIDs {
+	labelToScientificName := make(map[uint]string) // reverse map for results
+	for scientificName, labelIDs := range allLabelIDs {
 		for _, labelID := range labelIDs {
 			flatLabelIDs = append(flatLabelIDs, labelID)
-			labelToCommonName[labelID] = commonName
+			labelToScientificName[labelID] = scientificName
 		}
 	}
 
@@ -1324,21 +1322,21 @@ func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, mi
 		return nil, fmt.Errorf("failed to fetch batch hourly occurrences: %w", err)
 	}
 
-	// Build result map with common names
+	// Build result map keyed by scientific name
 	resultMap := make(map[string][24]int)
 
 	// Initialize all requested species with zero counts
-	for _, commonName := range species {
-		resultMap[commonName] = [24]int{}
+	for _, scientificName := range species {
+		resultMap[scientificName] = [24]int{}
 	}
 
-	// Fill in actual counts, aggregating by common name
+	// Fill in actual counts, aggregating by scientific name
 	for _, r := range results {
-		if commonName, ok := labelToCommonName[r.LabelID]; ok {
+		if scientificName, ok := labelToScientificName[r.LabelID]; ok {
 			if r.Hour >= 0 && r.Hour < 24 {
-				hourlyData := resultMap[commonName]
+				hourlyData := resultMap[scientificName]
 				hourlyData[r.Hour] += r.Count // Accumulate counts from multiple label IDs
-				resultMap[commonName] = hourlyData
+				resultMap[scientificName] = hourlyData
 			}
 		}
 	}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1315,6 +1315,63 @@ func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
 	assert.Empty(t, codeByScientific["Passer domesticus"], "species not in taxonomy should have empty code")
 }
 
+// TestV2OnlyDatastore_GetBatchHourlyOccurrences_ScientificName is a regression
+// test: the batch hourly query is keyed strictly on scientific
+// name. One label carries an embedded common name that differs from the
+// scientific name (Turdus merula -> "Common Blackbird"); the other is
+// scientific-only like a BattyBirdNET bat label. Before the fix, the query
+// reverse-mapped the localized common name to a scientific name and keyed the
+// result by the input string, so querying by the common name returned the count
+// and scientific-only labels were dropped. The negative assertion (querying by
+// the localized common name now returns zero) is the discriminator that fails on
+// the pre-fix code.
+func TestV2OnlyDatastore_GetBatchHourlyOccurrences_ScientificName(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{
+		"Turdus merula_Common Blackbird",
+		"Barbastella barbastellus", // scientific-only, like a BattyBirdNET label
+	})
+	defer cleanup()
+
+	const date = "2024-01-15"
+	saveTestNote(t, ds, date, "08:20:00", "Turdus merula", 0.8)
+	saveTestNote(t, ds, date, "23:15:00", "Barbastella barbastellus", 0.9)
+
+	// Querying by scientific name returns the counts keyed by scientific name,
+	// including the scientific-only bat label. Assert the daily total per species
+	// rather than a specific hour index: the query buckets hours using SQLite's
+	// OS-local timezone, which may differ from the test datastore's configured UTC.
+	counts, err := ds.GetBatchHourlyOccurrences(date,
+		[]string{"Turdus merula", "Barbastella barbastellus"}, 0.0)
+	require.NoError(t, err)
+
+	blackbird, ok := counts["Turdus merula"]
+	require.True(t, ok, "result must be keyed by scientific name")
+	assert.Equal(t, 1, hourlyTotal(&blackbird), "blackbird must be counted under its scientific name")
+
+	bat, ok := counts["Barbastella barbastellus"]
+	require.True(t, ok, "result must be keyed by scientific name")
+	assert.Equal(t, 1, hourlyTotal(&bat), "scientific-only bat label must be counted under its scientific name")
+
+	// The localized common name is no longer an accepted key. Pre-fix, the batch
+	// query reverse-mapped "Common Blackbird" -> "Turdus merula" and returned the
+	// blackbird's count under the common-name key; the fixed query returns zero.
+	byCommon, err := ds.GetBatchHourlyOccurrences(date, []string{"Common Blackbird"}, 0.0)
+	require.NoError(t, err)
+	common, ok := byCommon["Common Blackbird"]
+	require.True(t, ok)
+	assert.Equal(t, 0, hourlyTotal(&common),
+		"localized common name must not resolve to detections")
+}
+
+// hourlyTotal sums a 24-hour occurrence array.
+func hourlyTotal(hours *[24]int) int {
+	total := 0
+	for _, c := range hours {
+		total += c
+	}
+	return total
+}
+
 // TestGetSpeciesSummaryData_NoDateFilter verifies that species summary returns
 // data when no date filter is provided. Regression test for issue #2191.
 func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {


### PR DESCRIPTION
## Summary

The dashboard daily species summary (`GET /api/v2/analytics/species/daily`) silently dropped non-primary-model species such as bats (BattyBirdNET) and any Perch-unique species after the OpenFauna name-localization feature shipped. The species were still detected, stored, and returned by the search and detail endpoints; they just stopped appearing in the summary that powers the dashboard.

### Root cause

A forward/reverse name-resolution asymmetry. The summary pipeline computed a localized common name for display via the live OpenFauna resolver, then keyed the hourly aggregation on that common name and reverse-mapped it back to a scientific name through a map built only from the primary BirdNET model's labels. Species from other models (and OpenFauna-localized scientific-only labels) had no reverse entry, so their hourly counts came back zero and the zero-count species were dropped before reaching the response. Before localization the forward name was already the scientific name, so the round-trip happened to work.

### Fix

Key the hourly aggregation on scientific name end to end, removing the lossy locale-dependent common-name step:

- `aggregateDailySpeciesData` builds its species set and join key from `note.ScientificName` instead of `note.CommonName`.
- v2only `Datastore.GetBatchHourlyOccurrences` treats its input as scientific names and keys the result map by scientific name, dropping the reverse-map normalization. Scientific names resolve to label IDs for every model.
- Legacy `DataStore.GetBatchHourlyOccurrences` queries `notes.scientific_name` instead of `notes.common_name` and keys its result by scientific name, so the shared `datastore.Interface` contract holds on un-migrated installs too (this method has two live implementations).

The JSON response shape is unchanged; only the previously dropped species now appear, each keeping its localized common name for display.

## Test Plan

- [x] New regression tests at the controller and both datastore layers, each verified to fail on the pre-fix code:
  - `TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies` (controller)
  - `TestGetBatchHourlyOccurrences_ScientificNameKey` (legacy datastore)
  - `TestV2OnlyDatastore_GetBatchHourlyOccurrences_ScientificName` (v2only datastore)
- [x] Existing daily-summary tests updated to the new scientific-name contract
- [x] `golangci-lint run` clean (0 issues)
- [x] `go test ./internal/api/v2/ ./internal/datastore/ ./internal/datastore/v2only/` passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily species detection summaries now aggregate counts using scientific names, improving accuracy when species have multiple common or localized names.
  * Queries that power hourly counts now consistently match aggregated data to the correct species, reducing mismatches in reports.

* **Tests**
  * Added regression tests to ensure hourly and daily aggregation use scientific identifiers and that localized common names still display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->