### PR TITLE
fix(analytics): batch label lookups and thread context in hourly summary

### DIFF
--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -154,10 +154,7 @@ func (m *ActionMockDatastore) GetAllNotes() ([]datastore.Note, error) {
 func (m *ActionMockDatastore) GetTopBirdsData(_ string, _ float64, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
-func (m *ActionMockDatastore) GetHourlyOccurrences(_, _ string, _ float64) ([24]int, error) {
-	return [24]int{}, nil
-}
-func (m *ActionMockDatastore) GetBatchHourlyOccurrences(_ string, _ []string, _ float64) (map[string][24]int, error) {
+func (m *ActionMockDatastore) GetBatchHourlyOccurrences(_ context.Context, _ string, _ []string, _ float64) (map[string][24]int, error) {
 	return make(map[string][24]int), nil
 }
 func (m *ActionMockDatastore) SpeciesDetections(_, _, _ string, _ int, _ bool, _, _ int) ([]datastore.Note, error) {

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -56,10 +56,7 @@ func (m *MockDatastore) GetAllNotes() ([]datastore.Note, error) {
 func (m *MockDatastore) GetTopBirdsData(string, float64, int) ([]datastore.Note, error) {
 	return make([]datastore.Note, 0), nil
 }
-func (m *MockDatastore) GetHourlyOccurrences(string, string, float64) ([24]int, error) {
-	return [24]int{}, nil
-}
-func (m *MockDatastore) GetBatchHourlyOccurrences(string, []string, float64) (map[string][24]int, error) {
+func (m *MockDatastore) GetBatchHourlyOccurrences(context.Context, string, []string, float64) (map[string][24]int, error) {
 	return make(map[string][24]int), nil
 }
 func (m *MockDatastore) SpeciesDetections(string, string, string, int, bool, int, int) ([]datastore.Note, error) {

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -261,6 +261,12 @@ func (c *Controller) processBatchDates(ctx context.Context, dates []string, minC
 	processingErrors = make([]string, 0)
 
 	for _, selectedDate := range dates {
+		// Abort early if the request was cancelled or timed out: the remaining
+		// per-date queries would only fail fast against the cancelled context.
+		if err := ctx.Err(); err != nil {
+			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", selectedDate, err))
+			break
+		}
 		result, err := c.processSingleDateForBatch(ctx, selectedDate, minConfidence, limit, ip, path)
 		if err != nil {
 			errorMsg := fmt.Sprintf("Failed to process date %s: %v", selectedDate, err)

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -168,7 +168,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 	}
 
 	// 3. Aggregate Data (including fetching hourly counts)
-	aggregatedData, err := c.aggregateDailySpeciesData(notes, selectedDate, minConfidence)
+	aggregatedData, err := c.aggregateDailySpeciesData(ctx.Request().Context(), notes, selectedDate, minConfidence)
 	if err != nil {
 		// Errors during hourly fetch are logged within the helper, but we need to handle the overall failure
 		c.logErrorIfEnabled("Failed to aggregate daily species data",
@@ -230,7 +230,7 @@ func (c *Controller) GetBatchDailySpeciesSummary(ctx echo.Context) error {
 	)
 
 	// Process each date and collect results
-	batchResults, processingErrors := c.processBatchDates(dates, minConfidence, limit, ip, path)
+	batchResults, processingErrors := c.processBatchDates(ctx.Request().Context(), dates, minConfidence, limit, ip, path)
 
 	// Handle results and errors
 	return c.handleBatchResults(ctx, batchResults, processingErrors, len(dates), ip, path)
@@ -256,12 +256,12 @@ func (c *Controller) parseBatchDailySummaryParams(ctx echo.Context) (dates []str
 }
 
 // processBatchDates processes multiple dates and returns results and errors
-func (c *Controller) processBatchDates(dates []string, minConfidence float64, limit int, ip, path string) (batchResults map[string][]SpeciesDailySummary, processingErrors []string) {
+func (c *Controller) processBatchDates(ctx context.Context, dates []string, minConfidence float64, limit int, ip, path string) (batchResults map[string][]SpeciesDailySummary, processingErrors []string) {
 	batchResults = make(map[string][]SpeciesDailySummary)
 	processingErrors = make([]string, 0)
 
 	for _, selectedDate := range dates {
-		result, err := c.processSingleDateForBatch(selectedDate, minConfidence, limit, ip, path)
+		result, err := c.processSingleDateForBatch(ctx, selectedDate, minConfidence, limit, ip, path)
 		if err != nil {
 			errorMsg := fmt.Sprintf("Failed to process date %s: %v", selectedDate, err)
 			processingErrors = append(processingErrors, errorMsg)
@@ -274,7 +274,7 @@ func (c *Controller) processBatchDates(dates []string, minConfidence float64, li
 }
 
 // processSingleDateForBatch processes a single date using the same logic as the regular endpoint
-func (c *Controller) processSingleDateForBatch(selectedDate string, minConfidence float64, limit int, ip, path string) ([]SpeciesDailySummary, error) {
+func (c *Controller) processSingleDateForBatch(ctx context.Context, selectedDate string, minConfidence float64, limit int, ip, path string) ([]SpeciesDailySummary, error) {
 	// Get data for the date (limit applied at database level)
 	notes, err := c.DS.GetTopBirdsData(selectedDate, minConfidence, limit)
 	if err != nil {
@@ -288,7 +288,7 @@ func (c *Controller) processSingleDateForBatch(selectedDate string, minConfidenc
 	}
 
 	// Aggregate data
-	aggregatedData, err := c.aggregateDailySpeciesData(notes, selectedDate, minConfidence)
+	aggregatedData, err := c.aggregateDailySpeciesData(ctx, notes, selectedDate, minConfidence)
 	if err != nil {
 		c.logErrorIfEnabled("Failed to aggregate data for date in batch request",
 			logger.String("date", selectedDate),
@@ -341,7 +341,7 @@ func (c *Controller) parseDailySpeciesSummaryParams(ctx echo.Context) (selectedD
 }
 
 // aggregateDailySpeciesData processes raw notes, fetches hourly counts, and aggregates results.
-func (c *Controller) aggregateDailySpeciesData(notes []datastore.Note, selectedDate string, minConfidence float64) (map[string]aggregatedBirdInfo, error) {
+func (c *Controller) aggregateDailySpeciesData(ctx context.Context, notes []datastore.Note, selectedDate string, minConfidence float64) (map[string]aggregatedBirdInfo, error) {
 	aggregatedData := make(map[string]aggregatedBirdInfo)
 
 	if len(notes) == 0 {
@@ -365,7 +365,7 @@ func (c *Controller) aggregateDailySpeciesData(notes []datastore.Note, selectedD
 	// Batch fetch hourly counts for all species in single query
 	speciesList := slices.Collect(maps.Keys(uniqueSpecies))
 
-	hourlyCounts, err := c.DS.GetBatchHourlyOccurrences(selectedDate, speciesList, minConfidence)
+	hourlyCounts, err := c.DS.GetBatchHourlyOccurrences(ctx, selectedDate, speciesList, minConfidence)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get batch hourly occurrences: %w", err)
 	}

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -642,7 +642,7 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 	// Setup mock expectations using m.On()
 	mockDS.On("GetTopBirdsData", testDate, minConfidence, 0).Return(mockNotes, nil)
 	// Now using batch query instead of individual calls
-	mockDS.On("GetBatchHourlyOccurrences", testDate, mock.MatchedBy(func(species []string) bool {
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, testDate, mock.MatchedBy(func(species []string) bool {
 		return len(species) == 2 &&
 			((species[0] == sciAmericanCrow && species[1] == sciRedBelliedWoodpecker) ||
 				(species[0] == sciRedBelliedWoodpecker && species[1] == sciAmericanCrow))
@@ -830,9 +830,10 @@ func TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies(t *testing.T) {
 	// name end to end, so GetBatchHourlyOccurrences receives scientific names and
 	// returns a map keyed by scientific name.
 	var passedSpecies []string
-	mockDS.On("GetBatchHourlyOccurrences", testDate, mock.Anything, minConfidence).
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, testDate, mock.Anything, minConfidence).
 		Run(func(args mock.Arguments) {
-			arg, ok := args.Get(1).([]string)
+			// Args are (ctx, date, species, minConfidence); species is index 2.
+			arg, ok := args.Get(2).([]string)
 			require.True(t, ok, "species argument should be []string")
 			passedSpecies = slices.Clone(arg)
 		}).
@@ -917,7 +918,7 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 
 	// Setup mock expectations using m.On()
 	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return(mockNotesSingle, nil)
-	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
 		sciAmericanCrow:         expectedAmcroSingleHourly,
 		sciRedBelliedWoodpecker: expectedRbwoSingleHourly,
 	}, nil)
@@ -1090,7 +1091,7 @@ func TestGetDailySpeciesSummary_TimeHandling(t *testing.T) {
 
 	// Setup mock expectations using m.On()
 	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return(mockNotesTime, nil)
-	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
 		sciAmericanCrow: expectedAmcroTimeHourly,
 	}, nil)
 
@@ -1173,7 +1174,7 @@ func TestGetDailySpeciesSummary_ConfidenceFilter(t *testing.T) {
 	// GetTopBirdsData is called with the normalized confidence
 	mockDS.On("GetTopBirdsData", "2025-03-07", expectedMinConfidence, 0).Return(mockNotesConfidence, nil)
 	// GetBatchHourlyOccurrences is called for all species returned by GetTopBirdsData
-	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, expectedMinConfidence).Return(map[string][24]int{
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, expectedMinConfidence).Return(map[string][24]int{
 		sciAmericanCrow:         expectedAmcroConfidenceHourly,
 		sciRedBelliedWoodpecker: {}, // Filtered out later
 	}, nil)
@@ -1259,7 +1260,7 @@ func TestGetDailySpeciesSummary_LimitParameter(t *testing.T) {
 	// Setup mock expectations
 	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 2).Return(mockNotesLimit, nil)
 	// Expect GetBatchHourlyOccurrences to be called for the 2 species returned
-	mockDS.On("GetBatchHourlyOccurrences", "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
 		sciAmericanCrow:         expectedAmcroLimitHourly,
 		sciRedBelliedWoodpecker: expectedRbwoLimitHourly,
 	}, nil)
@@ -1351,7 +1352,7 @@ func TestGetDailySpeciesSummary_BatchQueryError(t *testing.T) {
 	mockDS.On("GetTopBirdsData", testDate, 0.0, 0).Return(mockNotes, nil)
 
 	// Mock GetBatchHourlyOccurrences to return an error
-	mockDS.On("GetBatchHourlyOccurrences", testDate, mock.Anything, 0.0).Return(
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, testDate, mock.Anything, 0.0).Return(
 		map[string][24]int{}, errors.New("batch query failed: connection timeout"))
 
 	// Create a request

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -86,7 +86,7 @@ func TestDailySpeciesSummary_DefaultParams(t *testing.T) {
 	mockDS.On("GetTopBirdsData", today, 0.0, 0).Return(notes, nil).Once()
 
 	// aggregateDailySpeciesData calls GetBatchHourlyOccurrences for hourly counts
-	mockDS.On("GetBatchHourlyOccurrences", today, mock.Anything, 0.0).
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, today, mock.Anything, 0.0).
 		Return(map[string][24]int{
 			sciAmericanRobin: {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			sciBlueJay:       {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -391,7 +391,7 @@ func TestDailySpeciesSummary_DefaultParams_AfterMigration(t *testing.T) {
 
 	// After migration, the API handler still passes limit=0 (its default for "no limit param").
 	mockDS.On("GetTopBirdsData", today, 0.0, 0).Return(notes, nil).Once()
-	mockDS.On("GetBatchHourlyOccurrences", today, mock.Anything, 0.0).
+	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, today, mock.Anything, 0.0).
 		Return(map[string][24]int{
 			sciAmericanRobin: {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			sciBlueJay:       {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -563,7 +563,7 @@ func TestGetBatchHourlyOccurrences_ScientificNameKey(t *testing.T) {
 		require.NoError(t, ds.DB.Create(&notes[i]).Error)
 	}
 
-	counts, err := ds.GetBatchHourlyOccurrences("2024-01-15",
+	counts, err := ds.GetBatchHourlyOccurrences(t.Context(), "2024-01-15",
 		[]string{"Barbastella barbastellus", "Turdus merula"}, 0.0)
 	require.NoError(t, err)
 

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -104,13 +104,11 @@ type Interface interface {
 	// GetTopBirdsData returns daily detection summaries, ordered by detection count descending.
 	// The limit parameter (if > 0) restricts the number of unique species returned.
 	GetTopBirdsData(selectedDate string, minConfidenceNormalized float64, limit int) ([]Note, error)
-	GetHourlyOccurrences(date, commonName string, minConfidenceNormalized float64) ([24]int, error)
 	// GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
 	// The species slice holds scientific names; the returned map is keyed by scientific name.
 	// Keying on scientific name keeps the result robust across models and locales.
-	// This batches the per-species hourly lookups into a single query for performance. Note it keys
-	// on scientific name, unlike the singular GetHourlyOccurrences which still accepts a common name.
-	GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error)
+	// This batches the per-species hourly lookups into a single query for performance.
+	GetBatchHourlyOccurrences(ctx context.Context, date string, species []string, minConfidence float64) (map[string][24]int, error)
 	SpeciesDetections(species, date, hour string, duration int, sortAscending bool, limit int, offset int) ([]Note, error)
 	GetLastDetections(numDetections int) ([]Note, error)
 	GetAllDetectedSpecies() ([]Note, error)
@@ -706,7 +704,7 @@ func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 		notes = append(notes, note)
 
 		// For the web UI, we only need one note per species
-		// The hourly counts will be retrieved separately via GetHourlyOccurrences
+		// The hourly counts will be retrieved separately via GetBatchHourlyOccurrences
 	}
 
 	return notes, nil
@@ -812,49 +810,11 @@ func (ds *DataStore) GetDateFormat(columnName string) string {
 	}
 }
 
-// GetHourlyOccurrences retrieves hourly occurrences of a specified bird species.
-func (ds *DataStore) GetHourlyOccurrences(date, commonName string, minConfidenceNormalized float64) ([24]int, error) {
-	var hourlyCounts [24]int
-	var results []struct {
-		Hour  int
-		Count int
-	}
-
-	hourFormat := ds.GetHourFormat()
-
-	// Exclude detections marked as false_positive
-	err := ds.DB.Model(&Note{}).
-		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
-		Select(fmt.Sprintf("%s as hour, COUNT(*) as count", hourFormat)).
-		Where("notes.date = ? AND notes.common_name = ? AND notes.confidence >= ?", date, commonName, minConfidenceNormalized).
-		Where("(note_reviews.verified IS NULL OR note_reviews.verified != ?)", string(entities.VerificationFalsePositive)).
-		Group(hourFormat).
-		Scan(&results).Error
-
-	if err != nil {
-		return hourlyCounts, errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "get_hourly_occurrences").
-			Context("date", date).
-			Context("species", commonName).
-			Build()
-	}
-
-	for _, result := range results {
-		if result.Hour >= 0 && result.Hour < 24 {
-			hourlyCounts[result.Hour] = result.Count
-		}
-	}
-
-	return hourlyCounts, nil
-}
-
 // GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
 // The species parameter holds scientific names, and the returned map is keyed by
 // scientific name. Keying on scientific name (rather than the localized common
 // name) keeps the daily summary robust across models and locales.
-func (ds *DataStore) GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error) {
+func (ds *DataStore) GetBatchHourlyOccurrences(ctx context.Context, date string, species []string, minConfidence float64) (map[string][24]int, error) {
 	if len(species) == 0 {
 		return make(map[string][24]int), nil
 	}
@@ -868,7 +828,7 @@ func (ds *DataStore) GetBatchHourlyOccurrences(date string, species []string, mi
 	}
 
 	// Exclude detections marked as false_positive
-	err := ds.DB.Model(&Note{}).
+	err := ds.DB.WithContext(ctx).Model(&Note{}).
 		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
 		Select(fmt.Sprintf("notes.scientific_name, %s as hour, COUNT(*) as count", hourFormat)).
 		Where("notes.scientific_name IN ? AND notes.date = ? AND notes.confidence >= ?", species, date, minConfidence).

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -1663,9 +1663,9 @@ func (_c *MockInterface_GetAppEventsSince_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
-// GetBatchHourlyOccurrences provides a mock function with given fields: date, species, minConfidence
-func (_m *MockInterface) GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error) {
-	ret := _m.Called(date, species, minConfidence)
+// GetBatchHourlyOccurrences provides a mock function with given fields: ctx, date, species, minConfidence
+func (_m *MockInterface) GetBatchHourlyOccurrences(ctx context.Context, date string, species []string, minConfidence float64) (map[string][24]int, error) {
+	ret := _m.Called(ctx, date, species, minConfidence)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBatchHourlyOccurrences")
@@ -1673,19 +1673,19 @@ func (_m *MockInterface) GetBatchHourlyOccurrences(date string, species []string
 
 	var r0 map[string][24]int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, []string, float64) (map[string][24]int, error)); ok {
-		return rf(date, species, minConfidence)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, float64) (map[string][24]int, error)); ok {
+		return rf(ctx, date, species, minConfidence)
 	}
-	if rf, ok := ret.Get(0).(func(string, []string, float64) map[string][24]int); ok {
-		r0 = rf(date, species, minConfidence)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, float64) map[string][24]int); ok {
+		r0 = rf(ctx, date, species, minConfidence)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string][24]int)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, []string, float64) error); ok {
-		r1 = rf(date, species, minConfidence)
+	if rf, ok := ret.Get(1).(func(context.Context, string, []string, float64) error); ok {
+		r1 = rf(ctx, date, species, minConfidence)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1699,16 +1699,17 @@ type MockInterface_GetBatchHourlyOccurrences_Call struct {
 }
 
 // GetBatchHourlyOccurrences is a helper method to define mock.On call
+//   - ctx context.Context
 //   - date string
 //   - species []string
 //   - minConfidence float64
-func (_e *MockInterface_Expecter) GetBatchHourlyOccurrences(date interface{}, species interface{}, minConfidence interface{}) *MockInterface_GetBatchHourlyOccurrences_Call {
-	return &MockInterface_GetBatchHourlyOccurrences_Call{Call: _e.mock.On("GetBatchHourlyOccurrences", date, species, minConfidence)}
+func (_e *MockInterface_Expecter) GetBatchHourlyOccurrences(ctx interface{}, date interface{}, species interface{}, minConfidence interface{}) *MockInterface_GetBatchHourlyOccurrences_Call {
+	return &MockInterface_GetBatchHourlyOccurrences_Call{Call: _e.mock.On("GetBatchHourlyOccurrences", ctx, date, species, minConfidence)}
 }
 
-func (_c *MockInterface_GetBatchHourlyOccurrences_Call) Run(run func(date string, species []string, minConfidence float64)) *MockInterface_GetBatchHourlyOccurrences_Call {
+func (_c *MockInterface_GetBatchHourlyOccurrences_Call) Run(run func(ctx context.Context, date string, species []string, minConfidence float64)) *MockInterface_GetBatchHourlyOccurrences_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].([]string), args[2].(float64))
+		run(args[0].(context.Context), args[1].(string), args[2].([]string), args[3].(float64))
 	})
 	return _c
 }
@@ -1718,7 +1719,7 @@ func (_c *MockInterface_GetBatchHourlyOccurrences_Call) Return(_a0 map[string][2
 	return _c
 }
 
-func (_c *MockInterface_GetBatchHourlyOccurrences_Call) RunAndReturn(run func(string, []string, float64) (map[string][24]int, error)) *MockInterface_GetBatchHourlyOccurrences_Call {
+func (_c *MockInterface_GetBatchHourlyOccurrences_Call) RunAndReturn(run func(context.Context, string, []string, float64) (map[string][24]int, error)) *MockInterface_GetBatchHourlyOccurrences_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2333,66 +2334,6 @@ func (_c *MockInterface_GetHourlyDistribution_Call) Return(_a0 []datastore.Hourl
 }
 
 func (_c *MockInterface_GetHourlyDistribution_Call) RunAndReturn(run func(context.Context, string, string, string) ([]datastore.HourlyDistributionData, error)) *MockInterface_GetHourlyDistribution_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetHourlyOccurrences provides a mock function with given fields: date, commonName, minConfidenceNormalized
-func (_m *MockInterface) GetHourlyOccurrences(date string, commonName string, minConfidenceNormalized float64) ([24]int, error) {
-	ret := _m.Called(date, commonName, minConfidenceNormalized)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetHourlyOccurrences")
-	}
-
-	var r0 [24]int
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, float64) ([24]int, error)); ok {
-		return rf(date, commonName, minConfidenceNormalized)
-	}
-	if rf, ok := ret.Get(0).(func(string, string, float64) [24]int); ok {
-		r0 = rf(date, commonName, minConfidenceNormalized)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([24]int)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string, string, float64) error); ok {
-		r1 = rf(date, commonName, minConfidenceNormalized)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockInterface_GetHourlyOccurrences_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetHourlyOccurrences'
-type MockInterface_GetHourlyOccurrences_Call struct {
-	*mock.Call
-}
-
-// GetHourlyOccurrences is a helper method to define mock.On call
-//   - date string
-//   - commonName string
-//   - minConfidenceNormalized float64
-func (_e *MockInterface_Expecter) GetHourlyOccurrences(date interface{}, commonName interface{}, minConfidenceNormalized interface{}) *MockInterface_GetHourlyOccurrences_Call {
-	return &MockInterface_GetHourlyOccurrences_Call{Call: _e.mock.On("GetHourlyOccurrences", date, commonName, minConfidenceNormalized)}
-}
-
-func (_c *MockInterface_GetHourlyOccurrences_Call) Run(run func(date string, commonName string, minConfidenceNormalized float64)) *MockInterface_GetHourlyOccurrences_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(float64))
-	})
-	return _c
-}
-
-func (_c *MockInterface_GetHourlyOccurrences_Call) Return(_a0 [24]int, _a1 error) *MockInterface_GetHourlyOccurrences_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockInterface_GetHourlyOccurrences_Call) RunAndReturn(run func(string, string, float64) ([24]int, error)) *MockInterface_GetHourlyOccurrences_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -673,10 +673,7 @@ func (s *testLegacyInterface) GetAllNotes() ([]datastore.Note, error)           
 func (s *testLegacyInterface) GetTopBirdsData(_ string, _ float64, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
-func (s *testLegacyInterface) GetHourlyOccurrences(_, _ string, _ float64) ([24]int, error) {
-	return [24]int{}, nil
-}
-func (s *testLegacyInterface) GetBatchHourlyOccurrences(_ string, _ []string, _ float64) (map[string][24]int, error) {
+func (s *testLegacyInterface) GetBatchHourlyOccurrences(_ context.Context, _ string, _ []string, _ float64) (map[string][24]int, error) {
 	return make(map[string][24]int), nil
 }
 func (s *testLegacyInterface) SpeciesDetections(_, _, _ string, _ int, _ bool, _, _ int) ([]datastore.Note, error) {

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -106,10 +106,12 @@ type DetectionRepository interface {
 	// modelID is optional; pass nil to include all models.
 	GetTopSpecies(ctx context.Context, start, end int64, minConfidence float64, modelID *uint, limit int) ([]SpeciesCount, error)
 
-	// GetHourlyOccurrences returns detection counts by hour (0-23) for the given labels.
-	// Aggregates across all provided label IDs (multi-model support).
-	// minConfidence filters detections by minimum confidence threshold.
-	GetHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) ([24]int, error)
+	// GetBatchHourlyOccurrences returns per-label-ID hourly detection counts (0-23)
+	// for the given label IDs in a single grouped query (per chunk). The result maps
+	// each label ID to its [24]int hourly counts; callers that span one species across
+	// multiple model label IDs sum the per-label arrays themselves. False positives are
+	// excluded and minConfidence filters by minimum confidence threshold.
+	GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) (map[uint][24]int, error)
 
 	// GetDailyOccurrences returns daily detection counts for a label.
 	GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64) ([]DailyCount, error)

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -858,6 +858,10 @@ func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, lab
 
 	// Chunk label IDs to avoid exceeding SQL host-parameter limits on the IN clause.
 	for i := 0; i < len(labelIDs); i += batchQuerySize {
+		// Fail fast between chunks if the caller's context was cancelled.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		chunkEnd := min(i+batchQuerySize, len(labelIDs))
 		chunk := labelIDs[i:chunkEnd]
 

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -829,47 +829,60 @@ func (r *detectionRepository) GetTopSpecies(ctx context.Context, start, end int6
 	return results, err
 }
 
-// GetHourlyOccurrences returns detection counts by hour (0-23) for the given labels.
-// Aggregates across all provided label IDs in a single query (multi-model support).
-// minConfidence filters detections by minimum confidence threshold.
-func (r *detectionRepository) GetHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) ([24]int, error) {
-	var counts [24]int
+// GetBatchHourlyOccurrences returns per-label-ID hourly detection counts (0-23) for the
+// given label IDs. It groups by (label_id, hour) so a single query (per chunk) covers many
+// labels at once; callers that map one species to multiple model label IDs sum the per-label
+// arrays themselves. False positives are excluded and minConfidence filters by confidence.
+//
+// Large label sets are chunked by batchQuerySize to stay within SQL host-parameter limits;
+// per-chunk results are merged before returning. Each label ID appears in exactly one chunk,
+// so no cross-chunk aggregation is needed.
+func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) (map[uint][24]int, error) {
+	result := make(map[uint][24]int, len(labelIDs))
 
-	// Return zero array for empty input
+	// Return empty map for empty input (no query)
 	if len(labelIDs) == 0 {
-		return counts, nil
+		return result, nil
 	}
 
-	type hourCount struct {
-		Hour  int
-		Count int
+	type labelHourCount struct {
+		LabelID uint
+		Hour    int
+		Count   int
 	}
-	var results []hourCount
 
-	// Extract hour from Unix timestamp in local timezone
-	// Exclude detections marked as false_positive
+	// Extract hour from Unix timestamp in local timezone; exclude false positives.
 	hourExpr := r.hourFromUnixExpr("d.detected_at")
 	detTable := r.tableName()
 	revTable := r.reviewsTable()
-	err := r.db.WithContext(ctx).Table(fmt.Sprintf("%s d", detTable)).
-		Joins(fmt.Sprintf("LEFT JOIN %s dr ON d.id = dr.detection_id", revTable)).
-		Select(fmt.Sprintf("%s as hour, COUNT(*) as count", hourExpr)).
-		Where("d.label_id IN ? AND d.detected_at >= ? AND d.detected_at < ? AND d.confidence >= ?", labelIDs, start, end, minConfidence).
-		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
-		Group("hour").
-		Scan(&results).Error
 
-	if err != nil {
-		return counts, err
-	}
+	// Chunk label IDs to avoid exceeding SQL host-parameter limits on the IN clause.
+	for i := 0; i < len(labelIDs); i += batchQuerySize {
+		chunkEnd := min(i+batchQuerySize, len(labelIDs))
+		chunk := labelIDs[i:chunkEnd]
 
-	for _, r := range results {
-		if r.Hour >= 0 && r.Hour < 24 {
-			counts[r.Hour] = r.Count
+		var rows []labelHourCount
+		err := r.db.WithContext(ctx).Table(fmt.Sprintf("%s d", detTable)).
+			Joins(fmt.Sprintf("LEFT JOIN %s dr ON d.id = dr.detection_id", revTable)).
+			Select(fmt.Sprintf("d.label_id as label_id, %s as hour, COUNT(*) as count", hourExpr)).
+			Where("d.label_id IN ? AND d.detected_at >= ? AND d.detected_at < ? AND d.confidence >= ?", chunk, start, end, minConfidence).
+			Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
+			Group(fmt.Sprintf("d.label_id, %s", hourExpr)).
+			Scan(&rows).Error
+		if err != nil {
+			return nil, fmt.Errorf("batch hourly occurrences: %w", err)
+		}
+
+		for _, row := range rows {
+			if row.Hour >= 0 && row.Hour < 24 {
+				counts := result[row.LabelID]
+				counts[row.Hour] = row.Count
+				result[row.LabelID] = counts
+			}
 		}
 	}
 
-	return counts, nil
+	return result, nil
 }
 
 // GetDailyOccurrences returns daily detection counts for a label.

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -234,6 +235,65 @@ func TestDeleteBatch_ChunksRemainderCorrectly(t *testing.T) {
 	require.NoError(t, db.Table(tableDetections).Find(&remaining).Error)
 	require.Len(t, remaining, 1)
 	assert.Equal(t, dets[len(dets)-1].ID, remaining[0].ID)
+}
+
+// ============================================================================
+// Batch Hourly Occurrence Tests
+// ============================================================================
+
+// TestGetBatchHourlyOccurrences verifies the batch hourly query returns per-label-ID
+// counts, omits labels with no detections, honors the confidence filter, handles empty
+// input, and propagates context cancellation (rather than silently returning zeros).
+func TestGetBatchHourlyOccurrences(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	repo := &detectionRepository{db: db}
+
+	// Fixed epoch so the test does not depend on the wall clock. Per-label daily totals
+	// (sum across hours) are asserted to stay independent of the OS-local hour bucketing.
+	const base = int64(1_700_000_000)
+	createDetectionForLabel(t, db, 10, base)
+	createDetectionForLabel(t, db, 10, base+3600)
+	createDetectionForLabel(t, db, 20, base+7200)
+	// Low-confidence detection on label 30 must be filtered out by minConfidence below.
+	require.NoError(t, db.Table(tableDetections).Create(
+		&entities.Detection{LabelID: 30, ModelID: 1, Confidence: 0.2, DetectedAt: base}).Error)
+
+	t.Run("per-label counts with confidence filter", func(t *testing.T) {
+		got, err := repo.GetBatchHourlyOccurrences(t.Context(), []uint{10, 20, 30, 99}, base-1, base+10_000, 0.5)
+		require.NoError(t, err)
+
+		require.Contains(t, got, uint(10))
+		require.Contains(t, got, uint(20))
+		assert.NotContains(t, got, uint(30), "below-confidence detection must be filtered out")
+		assert.NotContains(t, got, uint(99), "label with no detections must be absent from the map")
+		assert.Equal(t, 2, totalBatchHourly(got, 10), "label 10 has two qualifying detections")
+		assert.Equal(t, 1, totalBatchHourly(got, 20), "label 20 has one qualifying detection")
+	})
+
+	t.Run("empty input returns empty map", func(t *testing.T) {
+		got, err := repo.GetBatchHourlyOccurrences(t.Context(), nil, base-1, base+10_000, 0.0)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("cancelled context surfaces an error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := repo.GetBatchHourlyOccurrences(ctx, []uint{10}, base-1, base+10_000, 0.0)
+		require.Error(t, err, "a cancelled context must abort the query, not return zeros")
+	})
+}
+
+// totalBatchHourly returns the total detections for a label across its 24-hour occurrence
+// array. It takes the map and key (rather than the [24]int by value) to avoid copying the
+// 192-byte array, and returns 0 for a label that is absent from the map.
+func totalBatchHourly(byLabel map[uint][24]int, labelID uint) int {
+	total := 0
+	hours := byLabel[labelID]
+	for _, c := range hours {
+		total += c
+	}
+	return total
 }
 
 // ============================================================================

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -280,7 +280,7 @@ func TestGetBatchHourlyOccurrences(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 		_, err := repo.GetBatchHourlyOccurrences(ctx, []uint{10}, base-1, base+10_000, 0.0)
-		require.Error(t, err, "a cancelled context must abort the query, not return zeros")
+		require.ErrorIs(t, err, context.Canceled, "a cancelled context must abort the query with context.Canceled, not return zeros")
 	})
 }
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1192,58 +1192,31 @@ func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 	return notes, nil
 }
 
-// GetHourlyOccurrences retrieves hourly occurrences for a species on a date.
-// The parameter is named commonName for interface compatibility with legacy datastore,
-// but we need to normalize it to scientific name for the V2 label lookup.
-func (ds *Datastore) GetHourlyOccurrences(date, commonName string, minConfidenceNormalized float64) ([24]int, error) {
-	ctx := context.Background()
-	var hourly [24]int
-
-	// Normalize common name to scientific name using speciesMap
-	speciesName := commonName
-	normalized := strings.ToLower(strings.TrimSpace(commonName))
-	if sci, ok := ds.loadNameMaps().species[normalized]; ok {
-		speciesName = sci
-	}
-
-	// Get label IDs for this species across all models
-	labelIDs, err := ds.label.GetLabelIDsByScientificName(ctx, speciesName)
-	if err != nil {
-		return hourly, err
-	}
-	if len(labelIDs) == 0 {
-		return hourly, nil
-	}
-
-	t, err := time.ParseInLocation("2006-01-02", date, ds.timezone)
-	if err != nil {
-		return hourly, fmt.Errorf("invalid date format: %w", err)
-	}
-
-	startTime := t.Unix()
-	endTime := t.AddDate(0, 0, 1).Unix()
-
-	// Single query with IN clause for all label IDs (multi-model support)
-	return ds.detection.GetHourlyOccurrences(ctx, labelIDs, startTime, endTime, minConfidenceNormalized)
-}
-
 // GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
 // The species parameter holds scientific names. Scientific names map directly to
-// label IDs for every model via GetLabelIDsByScientificName, so no localized
-// common-name round-trip is performed (that round-trip dropped non-primary-model
-// species such as bats from the daily summary). The returned map
-// is keyed by the same scientific names that were passed in.
-func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, minConfidence float64) (map[string][24]int, error) {
+// label IDs for every model, so no localized common-name round-trip is performed
+// (that round-trip dropped non-primary-model species such as bats from the daily
+// summary). The returned map is keyed by the same scientific names that were passed in.
+//
+// Label IDs are resolved in a single batched query (no per-species N+1) and the hourly
+// counts are fetched in a single batched query, so this is two queries total regardless
+// of the number of species. A failure in either query is returned to the caller rather
+// than silently zeroing a species, so a cancelled context aborts the request instead of
+// producing partial counts.
+func (ds *Datastore) GetBatchHourlyOccurrences(ctx context.Context, date string, species []string, minConfidence float64) (map[string][24]int, error) {
 	if len(species) == 0 {
 		return make(map[string][24]int), nil
 	}
 
-	ctx := context.Background()
-
 	// Parse date
 	targetDate, err := time.ParseInLocation(time.DateOnly, date, ds.timezone)
 	if err != nil {
-		return nil, fmt.Errorf("invalid date format: %w", err)
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "get_batch_hourly_occurrences").
+			Context("date", date).
+			Build()
 	}
 
 	// Calculate Unix timestamp range for the date
@@ -1251,98 +1224,66 @@ func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, mi
 	startOfDay := targetDate.Unix()
 	endOfDay := targetDate.AddDate(0, 0, 1).Unix()
 
-	// Collect label IDs per scientific name across all models
-	allLabelIDs := make(map[string][]uint) // map[scientificName][]labelID
-	for _, scientificName := range species {
-		// Get label IDs for this species across all models
-		labelIDs, err := ds.label.GetLabelIDsByScientificName(ctx, scientificName)
-		if err != nil {
-			// Log error with context and continue with other species. ds.log may be
-			// nil when the datastore is constructed without a logger, so guard it
-			// like the other logging sites in this file.
-			if ds.log != nil {
-				ds.log.Warn("failed to get label IDs for species in batch query",
-					logger.String("scientific_name", scientificName),
-					logger.Error(err))
-			}
-			continue
-		}
-		if len(labelIDs) > 0 {
-			allLabelIDs[scientificName] = labelIDs
-		}
-	}
-
-	if len(allLabelIDs) == 0 {
-		// No matching species found
-		result := make(map[string][24]int)
-		for _, scientificName := range species {
-			result[scientificName] = [24]int{}
-		}
-		return result, nil
-	}
-
-	// Flatten all label IDs for batch query
-	var flatLabelIDs []uint
-	labelToScientificName := make(map[uint]string) // reverse map for results
-	for scientificName, labelIDs := range allLabelIDs {
-		for _, labelID := range labelIDs {
-			flatLabelIDs = append(flatLabelIDs, labelID)
-			labelToScientificName[labelID] = scientificName
-		}
-	}
-
-	// Query detections grouped by label_id and hour
-	type result struct {
-		LabelID uint
-		Hour    int
-		Count   int
-	}
-
-	// Generate database-agnostic hour expression
-	// MySQL: HOUR(FROM_UNIXTIME(d.detected_at))
-	// SQLite: CAST(strftime('%H', datetime(d.detected_at, 'unixepoch', 'localtime')) AS INTEGER)
-	var hourExpr string
-	if ds.manager.IsMySQL() {
-		hourExpr = "HOUR(FROM_UNIXTIME(d.detected_at))"
-	} else {
-		hourExpr = "CAST(strftime('%H', datetime(d.detected_at, 'unixepoch', 'localtime')) AS INTEGER)"
-	}
-
-	var results []result
-	// Exclude detections marked as false_positive
-	prefix := ds.manager.TablePrefix()
-	err = ds.manager.DB().WithContext(ctx).
-		Table(prefix+"detections d").
-		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
-		Select(fmt.Sprintf("d.label_id as label_id, %s as hour, COUNT(*) as count", hourExpr)).
-		Where("d.label_id IN ?", flatLabelIDs).
-		Where("d.detected_at >= ? AND d.detected_at < ?", startOfDay, endOfDay).
-		Where("d.confidence >= ?", minConfidence).
-		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
-		Group(fmt.Sprintf("d.label_id, %s", hourExpr)).
-		Scan(&results).Error
-
+	// Resolve all scientific names to label IDs in one batched query (avoids the
+	// per-species N+1 round-trip). The returned map is keyed by the stored scientific
+	// name; results are re-keyed by the caller's input names below.
+	labelsByName, err := ds.label.GetByScientificNames(ctx, species)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch batch hourly occurrences: %w", err)
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_batch_hourly_occurrences_labels").
+			Build()
 	}
 
-	// Build result map keyed by scientific name
-	resultMap := make(map[string][24]int)
+	// Flatten label IDs across all requested species and build a reverse map from label
+	// ID back to the caller's input scientific name. Keying by the input name (not the
+	// stored label.ScientificName) preserves the exact map contract the caller relies on
+	// (it looks up results by note.ScientificName).
+	flatLabelIDs := make([]uint, 0, len(species))
+	labelToScientificName := make(map[uint]string) // labelID -> input scientific name
+	for _, scientificName := range species {
+		for _, label := range labelsByName[scientificName] {
+			flatLabelIDs = append(flatLabelIDs, label.ID)
+			labelToScientificName[label.ID] = scientificName
+		}
+	}
 
-	// Initialize all requested species with zero counts
+	// Initialize all requested species with zero counts so callers always get an entry.
+	resultMap := make(map[string][24]int, len(species))
 	for _, scientificName := range species {
 		resultMap[scientificName] = [24]int{}
 	}
 
-	// Fill in actual counts, aggregating by scientific name
-	for _, r := range results {
-		if scientificName, ok := labelToScientificName[r.LabelID]; ok {
-			if r.Hour >= 0 && r.Hour < 24 {
-				hourlyData := resultMap[scientificName]
-				hourlyData[r.Hour] += r.Count // Accumulate counts from multiple label IDs
-				resultMap[scientificName] = hourlyData
-			}
+	// No matching labels: every requested species has zero detections.
+	if len(flatLabelIDs) == 0 {
+		return resultMap, nil
+	}
+
+	// Fetch per-label hourly counts in one batched query (chunked internally).
+	hourlyByLabel, err := ds.detection.GetBatchHourlyOccurrences(ctx, flatLabelIDs, startOfDay, endOfDay, minConfidence)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_batch_hourly_occurrences").
+			Build()
+	}
+
+	// Aggregate per-label counts into per-species counts, keyed by the input scientific
+	// name. Multiple label IDs (one per model) can map to the same species. Range over
+	// keys only to avoid copying the 192-byte [24]int value on every iteration.
+	for labelID := range hourlyByLabel {
+		scientificName, ok := labelToScientificName[labelID]
+		if !ok {
+			continue
 		}
+		hours := hourlyByLabel[labelID]
+		hourlyData := resultMap[scientificName]
+		for h := range 24 {
+			hourlyData[h] += hours[h]
+		}
+		resultMap[scientificName] = hourlyData
 	}
 
 	return resultMap, nil
@@ -2880,7 +2821,10 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 	// Logged at info because the fallback to the scientific name is the intended
 	// behavior; surfacing as a warning made it surface on the diagnostics health
 	// check as an "elevated error count" for benign missing translations.
-	if len(nm.common) > 0 {
+	// Guard ds.log: it may be nil when the datastore is constructed without a logger,
+	// matching the other logging sites in this file. Skipping the LoadOrStore when there
+	// is no logger is harmless: the dedup set only exists to rate-limit this log line.
+	if ds.log != nil && len(nm.common) > 0 {
 		if _, alreadyLogged := ds.loggedMissingNames.LoadOrStore(sciName, struct{}{}); !alreadyLogged {
 			ds.log.Info("common name not found in name maps, falling back to scientific name",
 				logger.String("scientific_name", sciName),
@@ -2894,7 +2838,6 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 // or scientific name) to a scientific name for v2 label lookups.
 // Uses the pre-built species name map (lowercase common name → scientific name).
 // Falls back to the input unchanged if no mapping is found.
-// This follows the same pattern used in GetHourlyOccurrences.
 func (ds *Datastore) resolveToScientificName(name string) string {
 	normalized := strings.ToLower(strings.TrimSpace(name))
 	if sci, ok := ds.loadNameMaps().species[normalized]; ok {

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1340,7 +1340,7 @@ func TestV2OnlyDatastore_GetBatchHourlyOccurrences_ScientificName(t *testing.T) 
 	// including the scientific-only bat label. Assert the daily total per species
 	// rather than a specific hour index: the query buckets hours using SQLite's
 	// OS-local timezone, which may differ from the test datastore's configured UTC.
-	counts, err := ds.GetBatchHourlyOccurrences(date,
+	counts, err := ds.GetBatchHourlyOccurrences(t.Context(), date,
 		[]string{"Turdus merula", "Barbastella barbastellus"}, 0.0)
 	require.NoError(t, err)
 
@@ -1355,12 +1355,28 @@ func TestV2OnlyDatastore_GetBatchHourlyOccurrences_ScientificName(t *testing.T) 
 	// The localized common name is no longer an accepted key. Pre-fix, the batch
 	// query reverse-mapped "Common Blackbird" -> "Turdus merula" and returned the
 	// blackbird's count under the common-name key; the fixed query returns zero.
-	byCommon, err := ds.GetBatchHourlyOccurrences(date, []string{"Common Blackbird"}, 0.0)
+	byCommon, err := ds.GetBatchHourlyOccurrences(t.Context(), date, []string{"Common Blackbird"}, 0.0)
 	require.NoError(t, err)
 	common, ok := byCommon["Common Blackbird"]
 	require.True(t, ok)
 	assert.Equal(t, 0, hourlyTotal(&common),
 		"localized common name must not resolve to detections")
+}
+
+// TestV2OnlyDatastore_GetBatchHourlyOccurrences_CancelledContext verifies that a cancelled
+// request context surfaces as an error rather than silently returning zeroed counts. Before
+// the #984 fix the per-species label lookup logged a warning and continued on error, so a
+// cancelled context produced an all-zero result with a nil error (HTTP 200 with wrong data).
+func TestV2OnlyDatastore_GetBatchHourlyOccurrences_CancelledContext(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Turdus merula_Common Blackbird"})
+	defer cleanup()
+	saveTestNote(t, ds, "2024-01-15", "08:20:00", "Turdus merula", 0.8)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := ds.GetBatchHourlyOccurrences(ctx, "2024-01-15", []string{"Turdus merula"}, 0.0)
+	require.Error(t, err, "cancelled context must surface as an error, not silently zeroed counts")
 }
 
 // hourlyTotal sums a 24-hour occurrence array.

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1376,7 +1376,7 @@ func TestV2OnlyDatastore_GetBatchHourlyOccurrences_CancelledContext(t *testing.T
 	cancel()
 
 	_, err := ds.GetBatchHourlyOccurrences(ctx, "2024-01-15", []string{"Turdus merula"}, 0.0)
-	require.Error(t, err, "cancelled context must surface as an error, not silently zeroed counts")
+	require.ErrorIs(t, err, context.Canceled, "cancelled context must surface as context.Canceled, not silently zeroed counts")
 }
 
 // hourlyTotal sums a 24-hour occurrence array.

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -166,10 +166,7 @@ func (m *mockStore) GetAllNotes() ([]datastore.Note, error)                     
 func (m *mockStore) GetTopBirdsData(date string, minConf float64, limit int) ([]datastore.Note, error) {
 	return []datastore.Note{}, nil
 }
-func (m *mockStore) GetHourlyOccurrences(date, name string, minConf float64) ([24]int, error) {
-	return [24]int{}, nil
-}
-func (m *mockStore) GetBatchHourlyOccurrences(date string, species []string, minConf float64) (map[string][24]int, error) {
+func (m *mockStore) GetBatchHourlyOccurrences(_ context.Context, date string, species []string, minConf float64) (map[string][24]int, error) {
 	return make(map[string][24]int), nil
 }
 func (m *mockStore) SpeciesDetections(species, date, hour string, duration int, asc bool, limit, offset int) ([]datastore.Note, error) {


### PR DESCRIPTION
## Summary

The daily species summary resolved label IDs one species at a time inside `GetBatchHourlyOccurrences`, an N+1 query on a frequently polled dashboard endpoint. This resolves all species in a single `GetByScientificNames` lookup and fetches per-label hourly counts through a new `DetectionRepository.GetBatchHourlyOccurrences` (one chunked, grouped query), so the path runs two queries regardless of species count instead of N+1.

It also threads `context.Context` through `datastore.Interface.GetBatchHourlyOccurrences` and the api/v2 caller chain (`GetDailySpeciesSummary` / `GetBatchDailySpeciesSummary` -> `processBatchDates` -> `processSingleDateForBatch` -> `aggregateDailySpeciesData`), so request cancellation and tracing reach the database. A label-lookup error is now propagated instead of logged and skipped; previously a transient failure or a cancelled request produced an all-zero hourly histogram with HTTP 200.

## Changes
- New `DetectionRepository.GetBatchHourlyOccurrences(ctx, labelIDs, start, end, minConfidence) -> map[uint][24]int`, chunked by `batchQuerySize`, reusing the existing hour-expression and false-positive-exclusion helpers.
- `v2only` and legacy `DataStore` batch implementations rewired/updated for context and the batch repository method.
- Context threaded through the api/v2 daily-summary handlers.
- Removed the dead singular `GetHourlyOccurrences` (interface + both impls + repository + regenerated mock + test doubles); no production callers, superseded by the batch method.

## Test Plan
- [x] `go test -race ./internal/datastore/... ./internal/api/v2/... ./internal/analysis/processor/... ./internal/imageprovider/...`
- [x] `golangci-lint run` (0 issues)
- [x] New tests: repository `TestGetBatchHourlyOccurrences` (per-label counts, confidence filter, empty input, context cancellation) and `TestV2OnlyDatastore_GetBatchHourlyOccurrences_CancelledContext`
- [x] Existing scientific-name keying regression tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated hourly counts into a single batch-based query and improved cancellation/context handling across analytics and datastore paths.
* **Bug Fixes**
  * Endpoints now stop promptly on cancelled or timed-out requests and surface errors for remaining items.
* **Tests**
  * Updated and added tests to verify batch hourly aggregation and cancelled-context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->