### PR TITLE
fix(classifier): canonicalize localized common-name species overrides (+2 adjacent fixes)

### DIFF
--- a/internal/analysis/processor/privacy_filter_test.go
+++ b/internal/analysis/processor/privacy_filter_test.go
@@ -27,52 +27,64 @@ func newPrivacyFilterDetection(source string, firstDetected time.Time) *PendingD
 	}
 }
 
-// TestShouldDiscardDetection_PrivacyFilter_SameChunkHumanVoice covers the
-// equal-timestamp edge: when a human voice and a bird are detected in the exact
-// same audio chunk, both carry the same StartTime, so the privacy filter's strict
-// "human after bird" comparison let the bird through. A simultaneous human voice
-// must still discard the detection.
-func TestShouldDiscardDetection_PrivacyFilter_SameChunkHumanVoice(t *testing.T) {
+// TestShouldDiscardDetection_PrivacyFilterBoundary exercises the privacy filter
+// across the human-voice-vs-bird timestamp boundary. The key case is equal
+// timestamps: a human voice and a bird detected in the exact same audio chunk
+// share the same back-dated start time, and that must still discard the bird
+// (the prior strict "human after bird" comparison leaked it). A human voice from
+// an earlier chunk (strictly before) must not discard a later bird.
+func TestShouldDiscardDetection_PrivacyFilterBoundary(t *testing.T) {
 	t.Parallel()
 
 	const source = "src1"
-	chunkTime := time.Date(2026, 6, 11, 8, 0, 0, 0, time.UTC)
+	base := time.Date(2026, 6, 11, 8, 0, 0, 0, time.UTC)
 
-	settings := &conf.Settings{}
-	settings.Realtime.PrivacyFilter.Enabled = true
-
-	p := &Processor{
-		LastHumanDetection: map[string]time.Time{source: chunkTime},
+	tests := []struct {
+		name        string
+		humanTime   time.Time
+		birdTime    time.Time
+		wantDiscard bool
+		wantReason  string
+	}{
+		{
+			name:        "same chunk: human and bird share the timestamp",
+			humanTime:   base,
+			birdTime:    base,
+			wantDiscard: true,
+			wantReason:  "privacy filter",
+		},
+		{
+			name:        "human voice after the bird started",
+			humanTime:   base.Add(time.Second),
+			birdTime:    base,
+			wantDiscard: true,
+			wantReason:  "privacy filter",
+		},
+		{
+			name:        "human voice from an earlier chunk is kept",
+			humanTime:   base,
+			birdTime:    base.Add(time.Second),
+			wantDiscard: false,
+			wantReason:  "",
+		},
 	}
-	item := newPrivacyFilterDetection(source, chunkTime)
 
-	discard, reason := p.shouldDiscardDetection(item, settings, 1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.True(t, discard,
-		"a bird sharing an audio chunk with a human voice must be discarded by the privacy filter")
-	assert.Equal(t, "privacy filter", reason)
-}
+			settings := &conf.Settings{}
+			settings.Realtime.PrivacyFilter.Enabled = true
 
-// TestShouldDiscardDetection_PrivacyFilter_EarlierHumanVoiceKept locks the
-// non-regression boundary: a human voice heard strictly before the bird detection
-// started belongs to an earlier capture window and must not discard the bird.
-func TestShouldDiscardDetection_PrivacyFilter_EarlierHumanVoiceKept(t *testing.T) {
-	t.Parallel()
+			p := &Processor{
+				LastHumanDetection: map[string]time.Time{source: tt.humanTime},
+			}
+			item := newPrivacyFilterDetection(source, tt.birdTime)
 
-	const source = "src1"
-	humanTime := time.Date(2026, 6, 11, 8, 0, 0, 0, time.UTC)
-	birdTime := humanTime.Add(time.Second) // bird started after the human voice
+			discard, reason := p.shouldDiscardDetection(item, settings, 1)
 
-	settings := &conf.Settings{}
-	settings.Realtime.PrivacyFilter.Enabled = true
-
-	p := &Processor{
-		LastHumanDetection: map[string]time.Time{source: humanTime},
+			assert.Equal(t, tt.wantDiscard, discard)
+			assert.Equal(t, tt.wantReason, reason)
+		})
 	}
-	item := newPrivacyFilterDetection(source, birdTime)
-
-	discard, _ := p.shouldDiscardDetection(item, settings, 1)
-
-	assert.False(t, discard,
-		"a human voice from an earlier chunk must not discard a later bird detection")
 }

--- a/internal/analysis/processor/privacy_filter_test.go
+++ b/internal/analysis/processor/privacy_filter_test.go
@@ -1,0 +1,78 @@
+package processor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/detection"
+)
+
+// newPrivacyFilterDetection builds a minimal pending bird detection for a single
+// audio source, back-dated to firstDetected.
+func newPrivacyFilterDetection(source string, firstDetected time.Time) *PendingDetection {
+	return &PendingDetection{
+		Detection: Detections{
+			Result: detection.Result{
+				Species: detection.Species{
+					CommonName:     "Talitiainen",
+					ScientificName: "Parus major",
+				},
+			},
+		},
+		Source:        source,
+		FirstDetected: firstDetected,
+		Count:         5,
+	}
+}
+
+// TestShouldDiscardDetection_PrivacyFilter_SameChunkHumanVoice covers the
+// equal-timestamp edge: when a human voice and a bird are detected in the exact
+// same audio chunk, both carry the same StartTime, so the privacy filter's strict
+// "human after bird" comparison let the bird through. A simultaneous human voice
+// must still discard the detection.
+func TestShouldDiscardDetection_PrivacyFilter_SameChunkHumanVoice(t *testing.T) {
+	t.Parallel()
+
+	const source = "src1"
+	chunkTime := time.Date(2026, 6, 11, 8, 0, 0, 0, time.UTC)
+
+	settings := &conf.Settings{}
+	settings.Realtime.PrivacyFilter.Enabled = true
+
+	p := &Processor{
+		LastHumanDetection: map[string]time.Time{source: chunkTime},
+	}
+	item := newPrivacyFilterDetection(source, chunkTime)
+
+	discard, reason := p.shouldDiscardDetection(item, settings, 1)
+
+	assert.True(t, discard,
+		"a bird sharing an audio chunk with a human voice must be discarded by the privacy filter")
+	assert.Equal(t, "privacy filter", reason)
+}
+
+// TestShouldDiscardDetection_PrivacyFilter_EarlierHumanVoiceKept locks the
+// non-regression boundary: a human voice heard strictly before the bird detection
+// started belongs to an earlier capture window and must not discard the bird.
+func TestShouldDiscardDetection_PrivacyFilter_EarlierHumanVoiceKept(t *testing.T) {
+	t.Parallel()
+
+	const source = "src1"
+	humanTime := time.Date(2026, 6, 11, 8, 0, 0, 0, time.UTC)
+	birdTime := humanTime.Add(time.Second) // bird started after the human voice
+
+	settings := &conf.Settings{}
+	settings.Realtime.PrivacyFilter.Enabled = true
+
+	p := &Processor{
+		LastHumanDetection: map[string]time.Time{source: humanTime},
+	}
+	item := newPrivacyFilterDetection(source, birdTime)
+
+	discard, _ := p.shouldDiscardDetection(item, settings, 1)
+
+	assert.False(t, discard,
+		"a human voice from an earlier chunk must not discard a later bird detection")
+}

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1381,7 +1381,11 @@ func (p *Processor) shouldDiscardDetection(item *PendingDetection, settings *con
 		p.detectionMutex.RLock()
 		lastHumanDetection, exists := p.LastHumanDetection[item.Source]
 		p.detectionMutex.RUnlock()
-		if exists && lastHumanDetection.After(item.FirstDetected) {
+		// Discard when a human voice was detected at or after the bird detection
+		// started. Using !Before (>=) rather than After (>) so a human and a bird
+		// sharing the exact same audio chunk (equal timestamps) still trips the
+		// privacy filter instead of leaking the detection.
+		if exists && !lastHumanDetection.Before(item.FirstDetected) {
 			// Add structured logging for privacy filter
 			GetLogger().Debug("Detection discarded by privacy filter",
 				logger.String("species", item.Detection.Result.Species.CommonName),

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -240,30 +240,63 @@ func BuildRangeFilter(o *Orchestrator) error {
 	return nil
 }
 
+// matchingLabels returns every label that matches speciesName by its common or
+// scientific name, in canonical "Scientific_Common" form so callers can append
+// the label instead of the user's bare entry.
+func matchingLabels(labels []string, speciesName string) []string {
+	var matched []string
+	for _, label := range labels {
+		if matchesSpecies(label, speciesName) {
+			matched = append(matched, label)
+		}
+	}
+	return matched
+}
+
+// canonicalOverrideLabels resolves a user override entry to canonical labels,
+// preferring the geomodel's own labels and falling back to the active
+// classifier's localized labels. The geomodel labels are "Scientific_English",
+// so a localized common name (e.g. the Finnish "sinitiainen") matches none of
+// them; the active classifier's labels carry "Scientific_LocalizedCommon"
+// (e.g. "Cyanistes caeruleus_sinitiainen") and do match. Resolving against both
+// keeps a localized override from being appended verbatim and then mis-keyed as
+// a scientific name by the inclusion gate and the OpenFauna name resolver
+// (issue #982). Returns nil when the entry matches no biological label (e.g.
+// non-bird classes like "drone"/"heatpump"), so callers append the raw entry
+// and the name resolver legitimately reports it as unresolved.
+func canonicalOverrideLabels(speciesName string, geoLabels, classifierLabels []string) []string {
+	if matched := matchingLabels(geoLabels, speciesName); len(matched) > 0 {
+		return matched
+	}
+	return matchingLabels(classifierLabels, speciesName)
+}
+
 // addUserOverrideSpeciesScores appends species from the explicit include list
 // and species with configured actions to a SpeciesScore slice with score 1.0.
-// Used by the universal geomodel path in getProbableSpecies.
-func addUserOverrideSpeciesScores(bn *BirdNET, speciesScores *[]SpeciesScore, settings *conf.Settings, availableLabels []string) {
+// Used by the universal geomodel path in getProbableSpecies. Each entry is
+// canonicalized via canonicalOverrideLabels so localized common names enter the
+// set as "Scientific_Common" labels rather than the raw user string.
+func addUserOverrideSpeciesScores(bn *BirdNET, speciesScores *[]SpeciesScore, settings *conf.Settings, geoLabels []string) {
 	seen := make(map[string]bool, len(*speciesScores))
 	for _, ss := range *speciesScores {
 		seen[ss.Label] = true
 	}
 
 	addOverride := func(speciesName string) {
-		matched := false
-		for _, label := range availableLabels {
-			if matchesSpecies(label, speciesName) {
-				matched = true
-				if !seen[label] {
-					bn.Debug("Adding override species with max score: %s (matched with: %s)", label, speciesName)
-					*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
-					seen[label] = true
-				}
+		labels := canonicalOverrideLabels(speciesName, geoLabels, settings.BirdNET.Labels)
+		if len(labels) == 0 {
+			if !seen[speciesName] {
+				*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: speciesName})
+				seen[speciesName] = true
 			}
+			return
 		}
-		if !matched && !seen[speciesName] {
-			*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: speciesName})
-			seen[speciesName] = true
+		for _, label := range labels {
+			if !seen[label] {
+				bn.Debug("Adding override species with max score: %s (matched with: %s)", label, speciesName)
+				*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
+				seen[label] = true
+			}
 		}
 	}
 
@@ -275,30 +308,32 @@ func addUserOverrideSpeciesScores(bn *BirdNET, speciesScores *[]SpeciesScore, se
 	}
 }
 
-// addUserOverrideSpecies appends species from the explicit include list
-// and species with configured actions to the inclusion set. Each entry is
-// matched against availableLabels by common or scientific name; if no match
-// is found the raw entry is appended so the scientific name map picks it up.
-func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, availableLabels []string) {
+// addUserOverrideSpecies appends species from the explicit include list and
+// species with configured actions to the inclusion set. Each entry is
+// canonicalized via canonicalOverrideLabels (geomodel labels first, then the
+// active classifier's localized labels). A matched entry is appended in its
+// canonical "Scientific_Common" form so the scientific name map keys it
+// correctly; an unmatched entry (e.g. a non-bird class) is appended verbatim.
+func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, geoLabels []string) {
 	seen := make(map[string]bool, len(*includedSpecies))
 	for _, s := range *includedSpecies {
 		seen[s] = true
 	}
 
 	addOverride := func(speciesName string) {
-		matched := false
-		for _, label := range availableLabels {
-			if matchesSpecies(label, speciesName) {
-				matched = true
-				if !seen[label] {
-					*includedSpecies = append(*includedSpecies, label)
-					seen[label] = true
-				}
+		labels := canonicalOverrideLabels(speciesName, geoLabels, settings.BirdNET.Labels)
+		if len(labels) == 0 {
+			if !seen[speciesName] {
+				*includedSpecies = append(*includedSpecies, speciesName)
+				seen[speciesName] = true
 			}
+			return
 		}
-		if !matched && !seen[speciesName] {
-			*includedSpecies = append(*includedSpecies, speciesName)
-			seen[speciesName] = true
+		for _, label := range labels {
+			if !seen[label] {
+				*includedSpecies = append(*includedSpecies, label)
+				seen[label] = true
+			}
 		}
 	}
 

--- a/internal/classifier/range_filter_override_test.go
+++ b/internal/classifier/range_filter_override_test.go
@@ -1,0 +1,135 @@
+package classifier
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
+)
+
+// overrideTestSettings builds a v3-geomodel settings snapshot where the geomodel
+// labels are English ("Scientific_English") and the active classifier labels are
+// localized ("Scientific_LocalizedCommon"), mirroring a Finnish-locale install.
+// Parus major is deliberately kept OUT of the geomodel scores, so the only way it
+// reaches the inclusion set is the user override listed by its Finnish common name.
+func overrideTestSettings(t *testing.T, locale string) (*conf.Settings, *fakeUniversalRangeFilter) {
+	t.Helper()
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.Locale = locale
+	// Active classifier labels carry the localized (Finnish) common names.
+	settings.BirdNET.Labels = []string{
+		"Turdus merula_Mustarastas",
+		"Parus major_Talitiainen",
+	}
+	// User force-includes Parus major by its bare Finnish common name.
+	settings.Realtime.Species.Include = []string{"Talitiainen"}
+
+	rf := &fakeUniversalRangeFilter{
+		// Geomodel labels are English and independent of the classifier locale.
+		geoLabels: []string{"Turdus merula_Common Blackbird", "Parus major_Great Tit"},
+		// Only Turdus merula scores above threshold; Parus major is out of range.
+		scores:    []SpeciesScore{{Score: 0.9, Label: "Turdus merula_Common Blackbird"}},
+		rawScores: []float32{0.9},
+	}
+	return settings, rf
+}
+
+// TestBuildRangeFilter_BareLocalizedCommonNameOverride_ForceIncludesViaGate proves
+// the core of issue #982: a bare localized common name in realtime.species.include
+// must canonicalize to its "Scientific_Common" label so the inclusion gate keys on
+// the scientific name. Before the fix, the bare "Talitiainen" is appended verbatim,
+// IncludedScientificNames stores the useless key "talitiainen", and a real
+// Parus major detection is silently dropped at the gate.
+func TestBuildRangeFilter_BareLocalizedCommonNameOverride_ForceIncludesViaGate(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := buildTestOrchestrator(t, settings, rf)
+	require.NoError(t, BuildRangeFilter(o))
+
+	included := conf.GetSettings().GetIncludedSpecies()
+	assert.Contains(t, included, "Parus major_Talitiainen",
+		"override must be canonicalized to the classifier's Scientific_Common label")
+	assert.NotContains(t, included, "Talitiainen",
+		"the bare common name must not survive in the inclusion working set")
+
+	// The force-include gate must accept a real detection of the overridden species,
+	// regardless of whether the detection label carries the localized or English common.
+	assert.True(t, conf.GetSettings().IsSpeciesIncluded("Parus major_Talitiainen"),
+		"force-included species must pass the inclusion gate (localized label)")
+	assert.True(t, conf.GetSettings().IsSpeciesIncluded("Parus major_Great Tit"),
+		"force-included species must pass the inclusion gate (geomodel label)")
+}
+
+// TestBuildRangeFilter_BareLocalizedCommonNameOverride_DoesNotPolluteNameResolver
+// proves the cosmetic half of issue #982: once the override is canonicalized, the
+// OpenFauna resolver receives the scientific name "Parus major" (resolvable in fi)
+// instead of the bare "Talitiainen", so the "could not localize" WARN no longer
+// names a fully localizable species. Not parallel: mutates the global logger.
+func TestBuildRangeFilter_BareLocalizedCommonNameOverride_DoesNotPolluteNameResolver(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "debug",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cl.Close() })
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(prev) })
+
+	o := buildTestOrchestrator(t, settings, rf)
+	o.openfauna = openfauna.NewResolver()
+	require.NoError(t, BuildRangeFilter(o))
+
+	out := buf.String()
+	assert.NotContains(t, out, "Talitiainen",
+		"a canonicalized override must not appear in the openfauna unresolved WARN")
+}
+
+// TestGetProbableSpecies_BareLocalizedCommonNameOverride_CanonicalizesLabel covers
+// the sibling appender addUserOverrideSpeciesScores on the getProbableSpecies path
+// (the daily UpdateRangeFilterAction and the UI/test species-list endpoints). It must
+// receive the same canonicalization so those surfaces never show a bare common name.
+func TestGetProbableSpecies_BareLocalizedCommonNameOverride_CanonicalizesLabel(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+
+	bn := &BirdNET{
+		Settings:     settings,
+		rangeFilter:  rf,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+
+	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	labels := make([]string, 0, len(scores))
+	for _, ss := range scores {
+		labels = append(labels, ss.Label)
+	}
+	assert.Contains(t, labels, "Parus major_Talitiainen",
+		"override must be canonicalized to the classifier's Scientific_Common label")
+	assert.NotContains(t, labels, "Talitiainen",
+		"the bare common name must not survive as a species score label")
+}

--- a/internal/classifier/taxonomy.go
+++ b/internal/classifier/taxonomy.go
@@ -101,12 +101,20 @@ func GeneratePlaceholderCode(speciesName string) string {
 		scientific := parts[0]
 		words := strings.Fields(scientific)
 		if len(words) >= 2 {
-			// Get first letter of genus and species (typically first two words)
-			prefix = strings.ToUpper(string(words[0][0]) + string(words[1][0]))
+			// First rune of the genus and species (typically the first two
+			// words). Decode runes (not bytes) so a multibyte name is not
+			// mangled into the wrong characters.
+			genus, _ := utf8.DecodeRuneInString(words[0])
+			species, _ := utf8.DecodeRuneInString(words[1])
+			prefix = strings.ToUpper(string(genus) + string(species))
 		} else if len(words) == 1 {
-			// Just use first two letters of the single word
-			if len(words[0]) >= 2 {
-				prefix = strings.ToUpper(words[0][:2])
+			// Use the first two runes of the single word. Slicing by runes (not
+			// bytes) keeps multibyte names intact; a byte slice can cut a rune
+			// mid-sequence and corrupt the prefix into U+FFFD replacement
+			// characters.
+			runes := []rune(words[0])
+			if len(runes) >= 2 {
+				prefix = strings.ToUpper(string(runes[:2]))
 			} else {
 				prefix = strings.ToUpper(words[0])
 			}

--- a/internal/classifier/taxonomy_test.go
+++ b/internal/classifier/taxonomy_test.go
@@ -1,11 +1,46 @@
 package classifier
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestGeneratePlaceholderCode_MultibyteSingleWordScientificName guards against
+// slicing a single-word scientific name by bytes. A genus whose first rune spans
+// 3+ bytes (e.g. CJK) was cut mid-rune by words[0][:2], so strings.ToUpper
+// sanitized the partial bytes into U+FFFD replacement characters and the prefix
+// became garbage. The prefix must instead be the first two runes, uppercased.
+func TestGeneratePlaceholderCode_MultibyteSingleWordScientificName(t *testing.T) {
+	t.Parallel()
+
+	// "中a" is a single Fields() word whose first rune is 3 bytes; the second
+	// element forces the underscore branch that builds a prefix.
+	code := GeneratePlaceholderCode("中a_Common")
+
+	assert.True(t, utf8.ValidString(code), "placeholder code must be valid UTF-8")
+	assert.False(t, strings.ContainsRune(code, utf8.RuneError),
+		"placeholder code must not contain a U+FFFD replacement character")
+	assert.True(t, strings.HasPrefix(code, "中A"),
+		"prefix must be the first two runes uppercased, got %q", code)
+}
+
+// TestGeneratePlaceholderCode_MultibyteBinomialScientificName guards the two-word
+// branch: it must use the first rune of each word, not the first byte. Reading
+// the first byte of a multibyte genus/species produces the wrong characters.
+func TestGeneratePlaceholderCode_MultibyteBinomialScientificName(t *testing.T) {
+	t.Parallel()
+
+	// Two Fields() words, each starting with a 3-byte rune.
+	code := GeneratePlaceholderCode("中文 鸟类_Common")
+
+	assert.True(t, utf8.ValidString(code), "placeholder code must be valid UTF-8")
+	assert.True(t, strings.HasPrefix(code, "中鸟"),
+		"prefix must be the first rune of each word uppercased, got %q", code)
+}
 
 // TestRemapLegacyCode verifies that retired eBird species codes are
 // remapped to their current replacements.


### PR DESCRIPTION
## Summary

Fixes a bug on the v3 geomodel range-filter path where user species overrides written as **bare localized common names** (for example the Finnish `sinitiainen`) never resolved. Overrides were matched only against the geomodel's English labels, so a localized name matched nothing and the raw string was appended verbatim to the inclusion working set. That caused two problems:

1. **Silent force-include failure (functional).** The inclusion gate keys on the scientific name (the substring before `_`). A bare common name produced a useless key, so a species the user explicitly added to `realtime.species.include` was dropped at the detection gate whenever it was out of range.
2. **Spurious log noise (cosmetic).** The OpenFauna name resolver received the bare word as a scientific name, could not localize it, and logged a `could not localize some working-set species` WARN. That WARN exists to surface genuine upstream taxonomy gaps in support dumps, so the false positives diluted the diagnostic.

`addUserOverrideSpecies` and `addUserOverrideSpeciesScores` now resolve each override via a shared `canonicalOverrideLabels` helper: it matches the geomodel labels first (so English and scientific overrides behave exactly as before) and falls back to the active classifier's localized labels, appending the canonical `Scientific_Common` label. Entries that match neither label set (non-bird classes such as `drone`/`heatpump`) are still appended verbatim and legitimately reported as unresolved.

Two adjacent latent bugs found while reviewing this code path are fixed in separate commits:

- **Rune-safe placeholder code.** `GeneratePlaceholderCode` built its prefix from raw bytes of the scientific name, which cut multibyte runes mid-sequence (corrupting the prefix into U+FFFD) or read the wrong byte. It now decodes runes. ASCII names are unchanged.
- **Privacy filter same-chunk edge.** The privacy filter discarded a bird detection only when a human voice was detected *strictly after* it started. When a human and a bird landed in the exact same audio chunk (equal timestamps), the detection leaked. The comparison now uses `>=` so an equal timestamp still trips the filter; an earlier human voice still keeps the later bird (no over-discard).

## Commits

- `fix(classifier): resolve localized common-name overrides against classifier labels`
- `fix(classifier): use rune-safe prefix in placeholder species code`
- `fix(processor): discard same-chunk human-and-bird detections in privacy filter`

## Test Plan

- [x] New failing-first tests for each fix:
  - `TestBuildRangeFilter_BareLocalizedCommonNameOverride_ForceIncludesViaGate`
  - `TestBuildRangeFilter_BareLocalizedCommonNameOverride_DoesNotPolluteNameResolver`
  - `TestGetProbableSpecies_BareLocalizedCommonNameOverride_CanonicalizesLabel`
  - `TestGeneratePlaceholderCode_MultibyteSingleWordScientificName` / `_MultibyteBinomialScientificName`
  - `TestShouldDiscardDetection_PrivacyFilter_SameChunkHumanVoice` / `_EarlierHumanVoiceKept`
- [x] `go test -race` green for `internal/classifier`, `internal/conf`, `internal/openfauna`, `internal/analysis/processor`
- [x] `golangci-lint run` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed placeholder-code generation for scientific names containing non-ASCII characters.
  * Privacy filter now discards bird detections when a human detection has the same or later timestamp.

* **Enhancements**
  * Canonicalization of user-provided species names so localized/common overrides resolve to canonical labels where possible.

* **Tests**
  * Added tests for privacy-filter boundary cases, localized-name override canonicalization, and multibyte scientific-name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->