### PR TITLE
fix(weather): scrub yr.no transport errors and validate endpoint schemes

### DIFF
--- a/internal/weather/provider_apikey_leak_test.go
+++ b/internal/weather/provider_apikey_leak_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -99,6 +100,52 @@ func TestWundergroundProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 	assert.Nil(t, data)
 	assert.NotContains(t, err.Error(), sentinelAPIKey, "returned error must not embed the API key")
 	assert.NotContains(t, logs.String(), sentinelAPIKey, "logs must not embed the API key")
+}
+
+// TestYrNoProvider_TransportError_DoesNotLeakCoordinates is a regression guard
+// for the coordinate-leak / scrub-pattern divergence in the yr.no provider. The
+// request URL embeds the user's lat/lon (formatted with %.3f), and net/http
+// wraps a transport failure in a *url.Error whose Error() embeds that URL. The
+// provider must scrub the error before returning it, or the coordinates ride the
+// wrapped error up to weather.go where a plain logger.Error writes them to logs
+// and uploaded support dumps. yr.no (api.met.no) is keyless, so the sensitive
+// payload here is the coordinates rather than an API key.
+func TestYrNoProvider_TransportError_DoesNotLeakCoordinates(t *testing.T) {
+	setupHTTPMock(t)
+	logs := captureWeatherLogs(t)
+
+	// Force every attempt's client.Do to fail at the transport layer so the
+	// provider exercises its failure-log and error-wrap paths.
+	httpmock.RegisterResponder("GET", `=~^https://api\.met\.no/weatherapi/locationforecast/2\.0/complete`,
+		httpmock.NewErrorResponder(errors.NewStd("simulated transport failure")))
+
+	provider := NewYrNoProvider()
+	settings := createTestSettings(t, "yrno") // Helsinki: 60.1699, 24.9384
+
+	data, err := provider.FetchWeather(settings)
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+	// The %.3f-formatted coordinates from createTestSettings must not survive in
+	// the error that propagates to weather.go's plain logger.Error.
+	assert.NotContains(t, err.Error(), "60.170", "returned error must not embed latitude")
+	assert.NotContains(t, err.Error(), "24.938", "returned error must not embed longitude")
+
+	// The transport-failure WARN log must be scrubbed too. The Info "Fetching
+	// weather data" log intentionally shows the request URL (with coordinates),
+	// consistent across all providers, so assert specifically on the
+	// "HTTP request failed" lines rather than the whole captured buffer. Track
+	// that at least one such line was seen so a future log-message rename fails
+	// loudly here instead of silently skipping the assertion.
+	var sawTransportLog bool
+	for line := range strings.Lines(logs.String()) {
+		if strings.Contains(line, "HTTP request failed") {
+			sawTransportLog = true
+			assert.NotContains(t, line, "60.170", "transport-failure log must not embed latitude")
+			assert.NotContains(t, line, "24.938", "transport-failure log must not embed longitude")
+		}
+	}
+	assert.True(t, sawTransportLog, "expected at least one transport-failure log line to assert against")
 }
 
 // TestMaskAPIKey_FailsClosedOnParseError verifies that maskAPIKey never returns

--- a/internal/weather/provider_common.go
+++ b/internal/weather/provider_common.go
@@ -2,6 +2,7 @@ package weather
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/branding"
@@ -80,6 +81,28 @@ func newWeatherErrorWithRetries(err error, category errors.ErrorCategory, operat
 		Context("provider", provider).
 		Context("max_retries", fmt.Sprintf("%d", MaxRetries)).
 		Build()
+}
+
+// validateEndpointScheme ensures a user-configured custom weather endpoint is an
+// absolute http(s) URL. url.Parse accepts a scheme-less value such as
+// "api.example.com" as a relative path (empty Scheme and Host); the request
+// would then fail later with an opaque "unsupported protocol scheme", so reject
+// it here with a clear configuration error instead. The endpoint value is left
+// out of the message so a misconfigured URL is not echoed into logs.
+func validateEndpointScheme(u *url.URL, provider string) error {
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return newWeatherError(
+			fmt.Errorf("weather endpoint must be an absolute http(s) URL with a scheme (e.g. https://...)"),
+			errors.CategoryConfiguration, "validate_endpoint_scheme", provider,
+		)
+	}
+	if u.Host == "" {
+		return newWeatherError(
+			fmt.Errorf("weather endpoint must include a host"),
+			errors.CategoryConfiguration, "validate_endpoint_host", provider,
+		)
+	}
+	return nil
 }
 
 // Temperature conversion constants

--- a/internal/weather/provider_openweather.go
+++ b/internal/weather/provider_openweather.go
@@ -90,6 +90,9 @@ func buildOpenWeatherURL(settings *conf.Settings, apiKey string) (string, error)
 			errors.CategoryConfiguration, "parse_endpoint", openWeatherProviderName,
 		)
 	}
+	if err := validateEndpointScheme(u, openWeatherProviderName); err != nil {
+		return "", err
+	}
 	q := u.Query()
 	q.Set("lat", strconv.FormatFloat(settings.BirdNET.Latitude, 'f', openWeatherCoordPrecision, 64))
 	q.Set("lon", strconv.FormatFloat(settings.BirdNET.Longitude, 'f', openWeatherCoordPrecision, 64))
@@ -122,7 +125,9 @@ func (p *OpenWeatherProvider) FetchWeather(settings *conf.Settings) (*WeatherDat
 
 	req, err := http.NewRequest("GET", apiURL, http.NoBody)
 	if err != nil {
-		return nil, newWeatherError(err, errors.CategoryNetwork, "create_http_request", openWeatherProviderName)
+		// Scrub before wrapping: http.NewRequest can return a *url.Error that
+		// embeds apiURL, which carries the appid API key query parameter.
+		return nil, newWeatherError(privacy.WrapError(err), errors.CategoryNetwork, "create_http_request", openWeatherProviderName)
 	}
 	req.Header.Set("User-Agent", UserAgent())
 

--- a/internal/weather/provider_openweather_test.go
+++ b/internal/weather/provider_openweather_test.go
@@ -9,7 +9,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
+
+// TestBuildOpenWeatherURL_RejectsSchemelessEndpoint guards against a
+// misconfigured custom endpoint that omits the scheme (e.g. "api.custom.org").
+// url.Parse accepts such a value as a relative path (empty Scheme and Host), so
+// without an explicit check the builder returns a relative URL and the request
+// later fails with an opaque "unsupported protocol scheme". The builder must
+// reject it up front with a configuration error instead.
+func TestBuildOpenWeatherURL_RejectsSchemelessEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{"no_scheme", "api.custom-openweather.org"},
+		{"no_scheme_with_path", "api.custom-openweather.org/data/2.5/weather"},
+		{"scheme_without_host", "https://"},
+		{"non_http_scheme", "ftp://api.custom-openweather.org"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := createTestSettings(t, "openweather", func(s *conf.Settings) {
+				s.Realtime.Weather.OpenWeather.Endpoint = tt.endpoint
+			})
+
+			_, err := buildOpenWeatherURL(settings, "test-key")
+
+			require.Error(t, err)
+			var ee *errors.EnhancedError
+			require.ErrorAs(t, err, &ee)
+			assert.Equal(t, string(errors.CategoryConfiguration), ee.GetCategory(),
+				"a malformed endpoint must classify as a configuration error")
+		})
+	}
+}
 
 func TestOpenWeatherProvider_FetchWeather_Success(t *testing.T) {
 	setupHTTPMock(t)

--- a/internal/weather/provider_wunderground.go
+++ b/internal/weather/provider_wunderground.go
@@ -271,6 +271,9 @@ func buildWundergroundURL(cfg *wundergroundConfig) (string, error) {
 			errors.CategoryConfiguration, "parse_endpoint", wundergroundProviderName,
 		)
 	}
+	if err := validateEndpointScheme(u, wundergroundProviderName); err != nil {
+		return "", err
+	}
 	q := u.Query()
 	q.Set("stationId", cfg.stationID)
 	q.Set("format", "json")
@@ -318,7 +321,9 @@ func (p *WundergroundProvider) executeRequest(apiURL string, cfg *wundergroundCo
 
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, http.NoBody)
 	if err != nil {
-		return nil, newWeatherError(err, errors.CategoryNetwork, "create_http_request", wundergroundProviderName)
+		// Scrub before wrapping: http.NewRequest can return a *url.Error that
+		// embeds apiURL, which carries the apiKey query parameter.
+		return nil, newWeatherError(privacy.WrapError(err), errors.CategoryNetwork, "create_http_request", wundergroundProviderName)
 	}
 	req.Header.Set("User-Agent", UserAgent())
 	req.Header.Set("Accept", "application/json")

--- a/internal/weather/provider_wunderground_test.go
+++ b/internal/weather/provider_wunderground_test.go
@@ -9,7 +9,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
+
+// TestBuildWundergroundURL_RejectsSchemelessEndpoint mirrors the OpenWeather
+// guard: a custom endpoint without a scheme parses as a relative path and would
+// produce a request http.NewRequest rejects with "unsupported protocol scheme".
+// buildWundergroundURL must reject it with a configuration error instead.
+func TestBuildWundergroundURL_RejectsSchemelessEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{"no_scheme", "api.custom-wunderground.com"},
+		{"no_scheme_with_path", "api.custom-wunderground.com/v2/pws/observations/current"},
+		{"scheme_without_host", "https://"},
+		{"non_http_scheme", "ftp://api.custom-wunderground.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &wundergroundConfig{
+				apiKey:    "test-api-key",
+				stationID: "KTEST123",
+				endpoint:  tt.endpoint,
+			}
+
+			_, err := buildWundergroundURL(cfg)
+
+			require.Error(t, err)
+			var ee *errors.EnhancedError
+			require.ErrorAs(t, err, &ee)
+			assert.Equal(t, string(errors.CategoryConfiguration), ee.GetCategory(),
+				"a malformed endpoint must classify as a configuration error")
+		})
+	}
+}
 
 func TestWundergroundProvider_FetchWeather_Success(t *testing.T) {
 	setupHTTPMock(t)

--- a/internal/weather/provider_yrno.go
+++ b/internal/weather/provider_yrno.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 const (
@@ -195,7 +196,9 @@ func (p *YrNoProvider) FetchWeather(settings *conf.Settings) (*WeatherData, erro
 
 	req, err := http.NewRequest("GET", apiURL, http.NoBody)
 	if err != nil {
-		return nil, newWeatherError(err, errors.CategoryNetwork, "create_http_request", yrNoProviderName)
+		// Scrub before wrapping: http.NewRequest can return a *url.Error that
+		// embeds apiURL, which carries the user's lat/lon coordinates.
+		return nil, newWeatherError(privacy.WrapError(err), errors.CategoryNetwork, "create_http_request", yrNoProviderName)
 	}
 	req.Header.Set("User-Agent", UserAgent())
 	req.Header.Set("Accept-Encoding", "gzip")
@@ -246,9 +249,13 @@ func (p *YrNoProvider) executeWithRetry(req *http.Request, log logger.Logger) ([
 
 		resp, err := client.Do(req)
 		if err != nil {
-			attemptLogger.Warn("HTTP request failed", logger.Error(err))
+			// Scrub before logging and wrapping: net/http wraps transport
+			// failures in a *url.Error whose Error() embeds the request URL,
+			// which carries the user's lat/lon coordinates. The wrapped error
+			// also propagates to weather.go's plain logger.Error.
+			attemptLogger.Warn("HTTP request failed", logger.SanitizedError(err))
 			if isLastAttempt {
-				return nil, newWeatherErrorWithRetries(err, errors.CategoryNetwork, "weather_api_request", yrNoProviderName)
+				return nil, newWeatherErrorWithRetries(privacy.WrapError(err), errors.CategoryNetwork, "weather_api_request", yrNoProviderName)
 			}
 			time.Sleep(RetryDelay)
 			continue


### PR DESCRIPTION
## Summary

Two follow-ups to the provider API-key scrubbing work, hardening how the weather providers handle request URLs and error logging.

**yr.no error-path PII scrubbing.** The yr.no provider still logged and wrapped raw transport errors. `net/http` wraps a transport failure in a `*url.Error` whose message embeds the request URL, which carries the user's lat/lon coordinates, and that wrapped error propagated to a plain `logger.Error` in the polling service. It now applies `logger.SanitizedError` to the transport-failure log and `privacy.WrapError` to the wrapped errors, in line with the OpenWeather and Wunderground providers. The `create_http_request` error path is also scrubbed in all three providers (the OpenWeather and Wunderground ones still embedded the API key on that path).

**Endpoint scheme validation.** `buildOpenWeatherURL` and `buildWundergroundURL` parsed a user-configured custom endpoint with `url.Parse`, which accepts a scheme-less value like `api.example.com` as a relative path (empty scheme and host). The builder then returned a relative URL and the request later failed with an opaque "unsupported protocol scheme". A shared `validateEndpointScheme` helper now rejects a custom endpoint unless it is an absolute http(s) URL with a host, returning a clear configuration error. The default endpoints are absolute https URLs, so only misconfigured custom endpoints are affected; plain `http://` (local proxies), ports, and IPv6 hosts are still accepted.

## Preflight Status

Ran the full pre-push gate (reuse, correctness/safety, quality/patterns, integration wiring, regression/back-compat, test quality) plus Gemini cross-validation over all changed files. Coverage: 7/7 reviewable files.

- No blocking defects in changed code. Scrub pattern verified consistent across all three providers; endpoint validation correctly placed and classified as a configuration error; `errors.Is` sentinel semantics preserved through the new wrappers; no previously-working endpoint config is rejected (regression check + Gemini both confirm).
- Fixed during gate: hardened the yr.no leak-guard test so its transport-failure-log assertions cannot vacuously pass if the log message is later renamed.
- Filed as a separate follow-up (out of this PR's error-path scope): the Info-level "Fetching weather data" log prints coordinates in cleartext on every successful fetch across all three providers; closing that consistently is a logging-policy decision tracked separately.

## Test Plan

- [x] `go test -race ./internal/weather/...` (full package green)
- [x] `golangci-lint run ./internal/weather/...` (0 issues)
- [x] New regression tests fail on pre-fix code and pass with the fix: yr.no transport-error coordinate-leak guard (asserts both the returned error and the WARN log are coordinate-free), and per-provider scheme-validation tests asserting a scheme-less / hostless / non-http(s) endpoint yields a configuration error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for weather service endpoints to ensure only valid HTTP/HTTPS configurations are accepted.
  * Improved error handling to prevent sensitive information (coordinates, API keys) from appearing in error messages and logs.

* **Tests**
  * Added regression and unit tests for endpoint validation and error privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->