### PR TITLE
fix(classifier): resolve localized common-name overrides for non-primary models

### DIFF
--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -4,8 +4,10 @@ package classifier
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/openfauna"
 )
 
 // SpeciesScore holds a species label and its associated score.
@@ -271,77 +274,87 @@ func canonicalOverrideLabels(speciesName string, geoLabels, classifierLabels []s
 	return matchingLabels(classifierLabels, speciesName)
 }
 
+// overrideSpeciesNames returns the user's force-include overrides: the
+// realtime.species.include entries followed by the realtime.species.config keys.
+func overrideSpeciesNames(settings *conf.Settings) []string {
+	names := make([]string, 0, len(settings.Realtime.Species.Include)+len(settings.Realtime.Species.Config))
+	names = append(names, settings.Realtime.Species.Include...)
+	names = slices.AppendSeq(names, maps.Keys(settings.Realtime.Species.Config))
+	return names
+}
+
+// resolveOverrideLabels canonicalizes the user's force-include overrides (the
+// realtime.species.include entries and .config keys) into concrete model labels,
+// shared by both inclusion-set appenders. Each entry resolves, in order, to its
+// matching geomodel labels, the active classifier's localized labels, or - for a
+// species a non-primary model emits as a scientific-only label, named by its
+// localized common name (e.g. the Finnish bat/mammal "kettu"/"ilves") - the
+// scientific name(s) reverse-resolved from OpenFauna. The forward,
+// scientific-keyed label matching cannot reverse those, since the localized name
+// lives only in OpenFauna. Entries that resolve to nothing are kept verbatim, so the
+// name resolver legitimately reports a genuinely unresolvable entry. Reverse
+// resolution for every otherwise-unresolved entry is batched into one dataset scan,
+// keeping the cost off the per-entry path on the (cold) range-filter rebuild.
+func resolveOverrideLabels(settings *conf.Settings, geoLabels []string) []string {
+	names := overrideSpeciesNames(settings)
+	out := make([]string, 0, len(names))
+	var unresolved []string
+	for _, name := range names {
+		if labels := canonicalOverrideLabels(name, geoLabels, settings.BirdNET.Labels); len(labels) > 0 {
+			out = append(out, labels...)
+		} else {
+			unresolved = append(unresolved, name)
+		}
+	}
+	if len(unresolved) > 0 {
+		reverse := openfauna.LookupScientificNames(unresolved, settings.BirdNET.Locale)
+		for _, name := range unresolved {
+			if sci := reverse[name]; len(sci) > 0 {
+				out = append(out, sci...)
+			} else {
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
 // addUserOverrideSpeciesScores appends species from the explicit include list
 // and species with configured actions to a SpeciesScore slice with score 1.0.
 // Used by the universal geomodel path in getProbableSpecies. Each entry is
-// canonicalized via canonicalOverrideLabels so localized common names enter the
-// set as "Scientific_Common" labels rather than the raw user string.
+// canonicalized via resolveOverrideLabels so localized common names enter the
+// set as their canonical model labels rather than the raw user string.
 func addUserOverrideSpeciesScores(bn *BirdNET, speciesScores *[]SpeciesScore, settings *conf.Settings, geoLabels []string) {
 	seen := make(map[string]bool, len(*speciesScores))
 	for _, ss := range *speciesScores {
 		seen[ss.Label] = true
 	}
-
-	addOverride := func(speciesName string) {
-		labels := canonicalOverrideLabels(speciesName, geoLabels, settings.BirdNET.Labels)
-		if len(labels) == 0 {
-			if !seen[speciesName] {
-				*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: speciesName})
-				seen[speciesName] = true
-			}
-			return
+	for _, label := range resolveOverrideLabels(settings, geoLabels) {
+		if !seen[label] {
+			bn.Debug("Adding override species with max score: %s", label)
+			*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
+			seen[label] = true
 		}
-		for _, label := range labels {
-			if !seen[label] {
-				bn.Debug("Adding override species with max score: %s (matched with: %s)", label, speciesName)
-				*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
-				seen[label] = true
-			}
-		}
-	}
-
-	for _, species := range settings.Realtime.Species.Include {
-		addOverride(species)
-	}
-	for species := range settings.Realtime.Species.Config {
-		addOverride(species)
 	}
 }
 
 // addUserOverrideSpecies appends species from the explicit include list and
 // species with configured actions to the inclusion set. Each entry is
-// canonicalized via canonicalOverrideLabels (geomodel labels first, then the
-// active classifier's localized labels). A matched entry is appended in its
-// canonical "Scientific_Common" form so the scientific name map keys it
-// correctly; an unmatched entry (e.g. a non-bird class) is appended verbatim.
+// canonicalized via resolveOverrideLabels (geomodel labels, then the active
+// classifier's localized labels, then an OpenFauna reverse lookup for
+// scientific-only non-primary-model species). A resolved entry is appended in its
+// canonical label form so the scientific name map keys it correctly; an entry that
+// resolves to nothing (e.g. a non-fauna class) is appended verbatim.
 func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, geoLabels []string) {
 	seen := make(map[string]bool, len(*includedSpecies))
 	for _, s := range *includedSpecies {
 		seen[s] = true
 	}
-
-	addOverride := func(speciesName string) {
-		labels := canonicalOverrideLabels(speciesName, geoLabels, settings.BirdNET.Labels)
-		if len(labels) == 0 {
-			if !seen[speciesName] {
-				*includedSpecies = append(*includedSpecies, speciesName)
-				seen[speciesName] = true
-			}
-			return
+	for _, label := range resolveOverrideLabels(settings, geoLabels) {
+		if !seen[label] {
+			*includedSpecies = append(*includedSpecies, label)
+			seen[label] = true
 		}
-		for _, label := range labels {
-			if !seen[label] {
-				*includedSpecies = append(*includedSpecies, label)
-				seen[label] = true
-			}
-		}
-	}
-
-	for _, species := range settings.Realtime.Species.Include {
-		addOverride(species)
-	}
-	for species := range settings.Realtime.Species.Config {
-		addOverride(species)
 	}
 }
 

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -279,7 +279,11 @@ func canonicalOverrideLabels(speciesName string, geoLabels, classifierLabels []s
 func overrideSpeciesNames(settings *conf.Settings) []string {
 	names := make([]string, 0, len(settings.Realtime.Species.Include)+len(settings.Realtime.Species.Config))
 	names = append(names, settings.Realtime.Species.Include...)
-	names = slices.AppendSeq(names, maps.Keys(settings.Realtime.Species.Config))
+	// Sort the config keys: Go map iteration is non-deterministic, and the override
+	// order flows into the inclusion working set, debug logs, and the species-list API.
+	configKeys := slices.Collect(maps.Keys(settings.Realtime.Species.Config))
+	slices.Sort(configKeys)
+	names = append(names, configKeys...)
 	return names
 }
 
@@ -503,19 +507,12 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 	}
 
-	seen := make(map[string]bool, len(speciesScores))
-	for _, ss := range speciesScores {
-		seen[ss.Label] = true
-	}
-
-	processedSpecies := make(map[string]bool)
-	labels := settings.BirdNET.Labels
-	for _, includedSpecies := range settings.Realtime.Species.Include {
-		addSpeciesWithMaxScore(bn, &speciesScores, includedSpecies, processedSpecies, labels, seen)
-	}
-	for species := range settings.Realtime.Species.Config {
-		addSpeciesWithMaxScore(bn, &speciesScores, species, processedSpecies, labels, seen)
-	}
+	// Apply user overrides through the shared resolver so the legacy path canonicalizes
+	// localized common names (including the OpenFauna reverse lookup for scientific-only
+	// non-primary-model species) identically to the universal path. The legacy path has
+	// no geomodel label set, so resolution falls to the classifier labels and the
+	// reverse lookup.
+	addUserOverrideSpeciesScores(bn, &speciesScores, settings, nil)
 
 	sort.Sort(ByScore(speciesScores))
 	return speciesScores, nil, nil
@@ -532,29 +529,6 @@ func zeroScoresForAllLabels(labels, excludeList []string) []SpeciesScore {
 		}
 	}
 	return speciesScores
-}
-
-// addSpeciesWithMaxScore adds all matching species to the scores list with maximum score.
-func addSpeciesWithMaxScore(bn *BirdNET, speciesScores *[]SpeciesScore, speciesName string, processedSpecies map[string]bool, labels []string, seen map[string]bool) {
-	if processedSpecies[speciesName] {
-		return
-	}
-
-	matchFound := false
-	for _, label := range labels {
-		if matchesSpecies(label, speciesName) {
-			if !seen[label] {
-				bn.Debug("Adding species with max score: %s (matched with: %s)", label, speciesName)
-				*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
-				seen[label] = true
-			}
-			matchFound = true
-		}
-	}
-
-	if matchFound {
-		processedSpecies[speciesName] = true
-	}
 }
 
 // isSpeciesExcluded checks if a species should be excluded based on its label

--- a/internal/classifier/range_filter_override_test.go
+++ b/internal/classifier/range_filter_override_test.go
@@ -133,3 +133,107 @@ func TestGetProbableSpecies_BareLocalizedCommonNameOverride_CanonicalizesLabel(t
 	assert.NotContains(t, labels, "Talitiainen",
 		"the bare common name must not survive as a species score label")
 }
+
+// TestBuildRangeFilter_NonPrimaryLocalizedCommonOverride_ReverseResolvesToScientific
+// covers the non-primary-model case: a species detected only by a non-primary model
+// emits a scientific-only label, so its localized common name matches no primary
+// geomodel or classifier label. The override must reverse-resolve through OpenFauna to
+// the scientific name so the inclusion gate keys on it (force-include works) and the
+// name resolver can localize it. The Finnish fox "Kettu" -> "Vulpes vulpes" is the
+// reverse mapping; none of the (bird) labels carry it, so only OpenFauna can.
+func TestBuildRangeFilter_NonPrimaryLocalizedCommonOverride_ReverseResolvesToScientific(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+	settings.Realtime.Species.Include = []string{"Kettu"}
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := buildTestOrchestrator(t, settings, rf)
+	require.NoError(t, BuildRangeFilter(o))
+
+	included := conf.GetSettings().GetIncludedSpecies()
+	assert.Contains(t, included, "Vulpes vulpes",
+		"a non-primary localized common-name override must reverse-resolve to the scientific name")
+	assert.NotContains(t, included, "Kettu",
+		"the bare localized common name must not survive in the inclusion working set")
+	assert.True(t, conf.GetSettings().IsSpeciesIncluded("Vulpes vulpes"),
+		"force-include must work: a real Vulpes vulpes detection passes the inclusion gate")
+}
+
+// TestGetProbableSpecies_NonPrimaryLocalizedCommonOverride_ReverseResolvesToScientific
+// proves the sibling appender addUserOverrideSpeciesScores (the daily
+// UpdateRangeFilterAction / species-list endpoints) gets the same reverse
+// resolution, so the daily refresh does not revert the canonicalization a day later.
+func TestGetProbableSpecies_NonPrimaryLocalizedCommonOverride_ReverseResolvesToScientific(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+	settings.Realtime.Species.Include = []string{"Kettu"}
+
+	bn := &BirdNET{
+		Settings:     settings,
+		rangeFilter:  rf,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+
+	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	labels := make([]string, 0, len(scores))
+	for _, ss := range scores {
+		labels = append(labels, ss.Label)
+	}
+	assert.Contains(t, labels, "Vulpes vulpes",
+		"the daily path must also reverse-resolve a non-primary localized common name")
+	assert.NotContains(t, labels, "Kettu",
+		"the bare localized common name must not survive as a species score label")
+}
+
+// TestBuildRangeFilter_NonPrimaryLocalizedCommonOverride_DoesNotPolluteNameResolver
+// proves the cosmetic half: once "Kettu" is canonicalized to "Vulpes vulpes"
+// (resolvable in fi), the working set no longer feeds a bare common name to the
+// resolver, so the "could not localize" WARN does not fire. Not parallel: global logger.
+func TestBuildRangeFilter_NonPrimaryLocalizedCommonOverride_DoesNotPolluteNameResolver(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+	settings.Realtime.Species.Include = []string{"Kettu"}
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "debug",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cl.Close() })
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(prev) })
+
+	o := buildTestOrchestrator(t, settings, rf)
+	o.openfauna = openfauna.NewResolver()
+	require.NoError(t, BuildRangeFilter(o))
+
+	assert.NotContains(t, buf.String(), "could not localize",
+		"a reverse-resolved override must not leave an unresolvable working-set entry")
+}
+
+// TestBuildRangeFilter_UnresolvableOverride_StaysVerbatim guards against the reverse
+// lookup over-matching: a string that is neither a label match nor a real localized
+// fauna name must still be appended verbatim, so the fix does not start force-mapping
+// arbitrary user strings.
+func TestBuildRangeFilter_UnresolvableOverride_StaysVerbatim(t *testing.T) {
+	settings, rf := overrideTestSettings(t, "fi")
+	settings.Realtime.Species.Include = []string{"drone"}
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := buildTestOrchestrator(t, settings, rf)
+	require.NoError(t, BuildRangeFilter(o))
+
+	included := conf.GetSettings().GetIncludedSpecies()
+	assert.Contains(t, included, "drone",
+		"a non-fauna override must still be appended verbatim (no spurious reverse match)")
+}

--- a/internal/classifier/range_filter_override_test.go
+++ b/internal/classifier/range_filter_override_test.go
@@ -237,3 +237,55 @@ func TestBuildRangeFilter_UnresolvableOverride_StaysVerbatim(t *testing.T) {
 	assert.Contains(t, included, "drone",
 		"a non-fauna override must still be appended verbatim (no spurious reverse match)")
 }
+
+// TestGetProbableSpecies_LegacyPath_NonPrimaryLocalizedCommonOverride_ReverseResolves
+// covers the legacy (non-UniversalSpeciesPredictor) range-filter path, which builds
+// the working set via getProbableSpecies' legacy branch. A non-universal range filter
+// (fakeRangeFilter implements only the base inference.RangeFilter interface) forces
+// that branch, and the localized non-primary override must reverse-resolve there too,
+// matching the universal path.
+func TestGetProbableSpecies_LegacyPath_NonPrimaryLocalizedCommonOverride_ReverseResolves(t *testing.T) {
+	settings, _ := overrideTestSettings(t, "fi")
+	settings.Realtime.Species.Include = []string{"Kettu"}
+
+	bn := &BirdNET{
+		Settings: settings,
+		// Non-universal range filter: forces the legacy getProbableSpecies branch.
+		// Two scores aligned with the two classifier labels; only the first clears
+		// the threshold, so the legacy filter contributes Turdus merula.
+		rangeFilter:  &fakeRangeFilter{scores: []float32{0.9, 0.0}},
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+
+	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	labels := make([]string, 0, len(scores))
+	for _, ss := range scores {
+		labels = append(labels, ss.Label)
+	}
+	assert.Contains(t, labels, "Vulpes vulpes",
+		"the legacy (non-universal) path must also reverse-resolve a localized non-primary override")
+	assert.NotContains(t, labels, "Kettu",
+		"the bare localized common name must not survive as a species score label")
+}
+
+// TestOverrideSpeciesNames_SortsConfigKeysDeterministically guards the deterministic
+// override order: include entries keep the user's order, and the config map keys
+// (whose Go iteration order is random) follow in sorted order, so the inclusion
+// working set, debug logs, and species-list API stay stable across runs.
+func TestOverrideSpeciesNames_SortsConfigKeysDeterministically(t *testing.T) {
+	t.Parallel()
+
+	settings := conftest.GetTestSettings()
+	settings.Realtime.Species.Include = []string{"UserOrderTwo", "UserOrderOne"}
+	settings.Realtime.Species.Config = map[string]conf.SpeciesConfig{
+		"zzz species": {}, "aaa species": {}, "mmm species": {},
+	}
+
+	got := overrideSpeciesNames(settings)
+	assert.Equal(t,
+		[]string{"UserOrderTwo", "UserOrderOne", "aaa species", "mmm species", "zzz species"},
+		got,
+		"include entries keep user order; config keys follow in sorted order")
+}

--- a/internal/openfauna/openfauna.go
+++ b/internal/openfauna/openfauna.go
@@ -6,7 +6,9 @@
 // The dataset is large (tens of thousands of species across 40+ locales), so the
 // package never materializes all of it. Build a sparse Index for just the species
 // and locale you need with BuildIndex, and use Lookup/LookupMeta for the rare
-// species that fall outside a pre-built Index.
+// species that fall outside a pre-built Index. LookupScientificNames serves the
+// reverse direction (localized common name -> scientific name) for the rare need to
+// canonicalize a user-supplied common name.
 //
 // The embedded data is a committed, gzipped snapshot; see README.md for the
 // command that regenerates it from an openfauna checkout.
@@ -17,6 +19,8 @@ import (
 	"compress/gzip"
 	"encoding/csv"
 	"io"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/tphakala/birdnet-go/internal/csvutil"
@@ -345,6 +349,100 @@ func Lookup(scientific, locale string) (string, bool) {
 		logger.Bool("found", ok),
 	)
 	return found, ok
+}
+
+// LookupScientificNames is the reverse of Lookup: for each requested localized common
+// name it returns the scientific name(s) carrying that name in the locale mapped from
+// bngLocale, resolving every request in a single pass over the embedded dataset. The
+// result is keyed by the caller's exact input strings (matching is case-insensitive
+// and whitespace-trimmed); a requested name with no match is absent from the result.
+// Each name's scientific list is de-duplicated and sorted.
+//
+// It exists for the rare cold-path need to canonicalize user-supplied localized common
+// names (for example a non-primary model's bat or mammal, whose model label is
+// scientific-only so the forward, scientific-keyed resolvers cannot reverse it). The
+// scan is O(dataset) once regardless of how many names are requested, so callers batch
+// all of a rebuild's unresolved overrides into one call rather than looping; it must
+// not be used on a hot path.
+//
+// Resolution mirrors Resolver.Resolve: bngLocale is mapped to an openfauna locale
+// (mapLocale) and matches there take precedence; the English fallback is consulted
+// only for names the active locale did not resolve, so an English common name still
+// resolves on a sparsely-translated locale.
+func LookupScientificNames(commonNames []string, bngLocale string) map[string][]string {
+	// Map each distinct normalized name to the caller's original input strings, so the
+	// result can be keyed by exactly what the caller passed.
+	inputs := make(map[string][]string) // normalized name -> original inputs
+	for _, in := range commonNames {
+		norm := normalizeName(in)
+		if norm == "" {
+			continue
+		}
+		inputs[norm] = append(inputs[norm], in)
+	}
+	if len(inputs) == 0 {
+		return map[string][]string{}
+	}
+	eff := mapLocale(bngLocale)
+
+	// One pass collects both the active locale and (when distinct) the English fallback;
+	// the active locale wins per name, English rescues only the names it missed.
+	inLocale := make(map[string]map[string]struct{})  // normalized name -> set of scientific
+	inEnglish := make(map[string]map[string]struct{}) // normalized name -> set of scientific
+	collect := func(dst map[string]map[string]struct{}, norm, sci string) {
+		set := dst[norm]
+		if set == nil {
+			set = make(map[string]struct{})
+			dst[norm] = set
+		}
+		set[sci] = struct{}{}
+	}
+	if err := streamTranslations(func(sci, loc, common string) error {
+		isLocale := loc == eff
+		isEnglish := eff != localeFallback && loc == localeFallback
+		if !isLocale && !isEnglish {
+			return nil
+		}
+		norm := normalizeName(common)
+		if _, want := inputs[norm]; !want {
+			return nil
+		}
+		if isLocale {
+			collect(inLocale, norm, sci)
+		} else {
+			collect(inEnglish, norm, sci)
+		}
+		return nil
+	}); err != nil {
+		GetLogger().Error("openfauna reverse common-name lookup failed",
+			logger.String("locale", eff),
+			logger.Int("requested", len(inputs)),
+			logger.Error(err),
+		)
+		return map[string][]string{}
+	}
+
+	out := make(map[string][]string, len(inputs))
+	for norm, origins := range inputs {
+		set := inLocale[norm]
+		if len(set) == 0 {
+			set = inEnglish[norm]
+		}
+		if len(set) == 0 {
+			continue
+		}
+		sciNames := slices.Collect(maps.Keys(set))
+		slices.Sort(sciNames)
+		for _, in := range origins {
+			out[in] = sciNames
+		}
+	}
+	GetLogger().Debug("openfauna reverse common-name lookup",
+		logger.String("locale", eff),
+		logger.Int("requested", len(inputs)),
+		logger.Int("resolved", len(out)),
+	)
+	return out
 }
 
 // LookupMeta returns taxonomy/link metadata for one scientific name by scanning

--- a/internal/openfauna/openfauna_test.go
+++ b/internal/openfauna/openfauna_test.go
@@ -273,3 +273,46 @@ func TestDecodeTranslationRows_FiltersSynthetic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"Turdus merula": "mustarastas", "Erithacus rubecula": "punarinta"}, got)
 }
+
+// TestLookupScientificNames_ReverseResolvesLocalizedCommon_Embedded covers the reverse
+// direction (localized common name -> scientific name) the openfauna package gained
+// for the non-primary-model case: a user adding a species (a bat or mammal whose
+// model label is scientific-only) by its localized common name must resolve back to
+// the scientific name. All three entries are unique in the embedded fi data, and all
+// three resolve from a single batched call.
+func TestLookupScientificNames_ReverseResolvesLocalizedCommon_Embedded(t *testing.T) {
+	t.Parallel()
+
+	got := LookupScientificNames([]string{"Kettu", "Ilves", "mopsilepakko"}, "fi")
+	assert.Contains(t, got["Kettu"], "Vulpes vulpes", "fox")
+	assert.Contains(t, got["Ilves"], "Lynx lynx", "lynx")
+	assert.Contains(t, got["mopsilepakko"], "Barbastella barbastellus", "bat")
+}
+
+func TestLookupScientificNames_CaseInsensitiveAndTrimmed_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// Users supply varying case/whitespace; matching mirrors the forward Lookup. The
+	// result is keyed by the caller's exact input string.
+	got := LookupScientificNames([]string{"  kETTu  "}, "fi")
+	assert.Contains(t, got["  kETTu  "], "Vulpes vulpes", "reverse lookup must trim and match case-insensitively")
+}
+
+func TestLookupScientificNames_Miss_OmitsName_Embedded(t *testing.T) {
+	t.Parallel()
+
+	got := LookupScientificNames([]string{"drone", "", "   "}, "fi")
+	assert.Empty(t, got["drone"], "a non-fauna string must not reverse-resolve")
+	assert.Empty(t, got[""], "empty input must not resolve")
+	assert.NotContains(t, got, "drone", "an unmatched name must be absent from the result, not an empty entry")
+}
+
+func TestLookupScientificNames_HonorsLocale_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// "Kettu" is the Finnish word for fox; it is meaningless as a German common name,
+	// so a de lookup (with English fallback) must not resolve it to Vulpes vulpes.
+	assert.Contains(t, LookupScientificNames([]string{"Kettu"}, "fi")["Kettu"], "Vulpes vulpes")
+	assert.NotContains(t, LookupScientificNames([]string{"Kettu"}, "de")["Kettu"], "Vulpes vulpes",
+		"the reverse lookup must honor the active locale")
+}


### PR DESCRIPTION
## Summary

On a multi-model setup (BirdNET primary + a non-primary model such as BattyBirdNET bats or Perch), a force-include override added by its **localized common name** was silently mishandled. Non-primary models emit **scientific-only** labels (e.g. `Barbastella barbastellus`, no `_LocalizedCommon` suffix), so a localized name like the Finnish `kettu` (fox) or `ilves` (lynx) matched no geomodel or classifier label. The raw string was appended verbatim to the inclusion working set, which meant:

- it was **not** force-included (the inclusion gate keys on the scientific name, not the localized string), and
- it surfaced in the OpenFauna "could not localize some working-set species" WARN.

Adding the species by scientific name worked; adding it by localized common name did not. The localized name for those scientific-only species lives only in OpenFauna, which until now resolved one way (scientific -> common).

## What changed

- **`openfauna.LookupScientificNames(commonNames, bngLocale)`** - a reverse lookup (localized common name -> scientific name) over the embedded dataset. One pass resolves every requested name (O(dataset) once, not per name), with the same locale mapping + English fallback the forward resolver uses. Results are keyed by the caller's exact input, de-duplicated and sorted.
- **`resolveOverrideLabels`** - a shared helper that canonicalizes the user's `realtime.species.include`/`.config` overrides: geomodel labels, then classifier labels, then the OpenFauna reverse lookup for scientific-only non-primary-model species. Entries that still resolve to nothing are kept verbatim (a genuinely unresolvable entry). The reverse lookup is batched into a single dataset scan per range-filter rebuild (a cold path: startup, settings save, daily refresh, locale change).
- The two override appenders (`addUserOverrideSpecies`, `addUserOverrideSpeciesScores`) now share `resolveOverrideLabels`, removing the duplicated per-entry closures.

Net effect: a localized common-name override now canonicalizes to the model's scientific label, so the inclusion gate force-includes it and the resolver localizes it (no spurious WARN). `canonicalOverrideLabels` is unchanged; the `Resolver` stays forward-only (the reverse is a stateless package function).

## Test Plan

- [x] `go test -race ./internal/openfauna/ ./internal/classifier/`
- [x] `golangci-lint run` (0 issues)
- New unit tests: reverse lookup (`kettu`->`Vulpes vulpes`, `ilves`->`Lynx lynx`, `mopsilepakko`->`Barbastella barbastellus`), case/trim, miss-omits-name, locale-honoring.
- New override tests: both producers (event + daily paths) canonicalize a localized non-primary override to its scientific name and pass the inclusion gate; WARN-absence; a non-fauna string still stays verbatim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Species overrides now accept localized common names and reverse-resolve them to scientific names for consistent inclusion across locales.
  * Deterministic ordering of override entries and verbatim retention when a name cannot be resolved.

* **Tests**
  * Added tests covering localized-name reverse resolution, legacy-path behavior, non-pollution of the name resolver, unresolvable overrides, and deterministic ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->