### PR TITLE
fix(weather): harden polling lifecycle, hot-reload recovery, and backoff state machine

### DIFF
--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -195,9 +195,10 @@ type Service struct {
 	// sunCalcLat/sunCalcLon record the coordinates sunCalc was last built with.
 	sunCalcLat float64
 	sunCalcLon float64
-	// authConfigKey is the auth-relevant config fingerprint captured when auth
-	// was disabled; a change re-enables fetching (hot-reload of the API key).
-	authConfigKey string
+	// authConfigKey is the auth-relevant config fingerprint (SHA-256 digest)
+	// captured when auth was disabled; a change re-enables fetching (hot-reload
+	// of the API key).
+	authConfigKey [32]byte
 }
 
 // weatherAuthConfigKey builds a fingerprint of the auth-relevant weather config
@@ -205,16 +206,26 @@ type Service struct {
 // cycles signals the user updated credentials in the UI, which re-enables
 // fetching after an auth lockout. It returns a SHA-256 digest rather than the
 // raw values so the API keys are not retained verbatim in the Service struct
-// (s.authConfigKey); the digest is only ever compared, never logged.
-func weatherAuthConfigKey(settings *conf.Settings) string {
+// (s.authConfigKey); the digest is only ever compared, never logged. [32]byte
+// arrays are directly comparable, so no string conversion is needed.
+func weatherAuthConfigKey(settings *conf.Settings) [32]byte {
 	w := &settings.Realtime.Weather
-	joined := strings.Join([]string{
-		w.Provider,
-		w.OpenWeather.APIKey, w.OpenWeather.Endpoint,
-		w.Wunderground.APIKey, w.Wunderground.StationID, w.Wunderground.Endpoint,
-	}, "\x00")
-	sum := sha256.Sum256([]byte(joined))
-	return string(sum[:])
+	// Only the active provider's auth fields matter. Including the inactive
+	// provider's credentials would let an unrelated edit (e.g. changing the
+	// Wunderground key while OpenWeather is locked out) clear the lockout and
+	// trigger a fresh round of 401s against the still-broken active provider.
+	var fields []string
+	switch w.Provider {
+	case openWeatherProviderName:
+		fields = []string{w.Provider, w.OpenWeather.APIKey, w.OpenWeather.Endpoint}
+	case wundergroundProviderName:
+		fields = []string{w.Provider, w.Wunderground.APIKey, w.Wunderground.StationID, w.Wunderground.Endpoint}
+	default:
+		// yr.no (and "none"/unset) have no API key, so the provider name alone
+		// is the whole auth-relevant config.
+		fields = []string{w.Provider}
+	}
+	return sha256.Sum256([]byte(strings.Join(fields, "\x00")))
 }
 
 // currentSettings returns the latest settings snapshot so the service picks
@@ -519,14 +530,12 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 	if s.startupDelay > 0 {
 		getLogger().Info("Delaying initial weather fetch to reduce startup DB contention",
 			logger.String("delay", s.startupDelay.String()))
-		// time.NewTimer + Stop so the timer is released if stopChan fires first
-		// (time.After would leak the timer until startupDelay elapses).
-		timer := time.NewTimer(s.startupDelay)
+		// time.After is leak-free here: on Go 1.23+ an unreferenced timer is
+		// garbage collected even if it has not fired or been stopped.
 		select {
-		case <-timer.C:
+		case <-time.After(s.startupDelay):
 			// Delay elapsed, proceed with fetch
 		case <-stopChan:
-			timer.Stop()
 			return
 		}
 	}
@@ -557,9 +566,17 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 func (s *Service) safeFetchAndSave() {
 	defer func() {
 		if r := recover(); r != nil {
-			getLogger().Error("Weather poll cycle panicked, continuing",
+			// Record a failure so a repeatedly panicking fetch surfaces as
+			// degraded via Status()/GetStatus() and backs off, instead of being
+			// silently recovered while diagnostics keep reporting healthy.
+			// fetchAndSave's deferred unlock has already released fetchMu during
+			// the panic unwind, so recordFailure only takes backoff.mu here.
+			backoff, failures := s.backoff.recordFailure()
+			getLogger().Error("Weather poll cycle panicked, recovering and backing off",
 				logger.String("provider", s.providerName),
 				logger.Any("panic", r),
+				logger.String("backoff", backoff.String()),
+				logger.Int("consecutive_failures", failures),
 				logger.String("stack", string(debug.Stack())))
 		}
 	}()
@@ -575,10 +592,19 @@ func (s *Service) safeFetchAndSave() {
 // Unlike the StartPolling loop, Poll does not wrap the fetch in panic recovery:
 // it is a synchronous on-demand call, so a panic propagates to the caller.
 func (s *Service) Poll() error {
+	// Run a fetch cycle. fetchAndSave reconciles hot-reloaded config first, so a
+	// lockout cleared by a config change recovers even on a manual Poll; the
+	// auth check therefore happens after reconciliation, not before it. While
+	// auth is disabled and unchanged, fetchAndSave skips without a network call.
+	if err := s.fetchAndSave(); err != nil {
+		return err
+	}
+	// fetchAndSave returns nil when it skipped because auth is still disabled;
+	// surface that to the on-demand caller.
 	if s.backoff.isAuthDisabled() {
 		return ErrWeatherAuthFailed
 	}
-	return s.fetchAndSave()
+	return nil
 }
 
 // reconcileConfig applies hot-reloadable settings changes detected between poll

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -1,7 +1,10 @@
 package weather
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,8 +37,10 @@ func UnregisterService() {
 }
 
 // GetStatus returns the health status of the weather service. Returns
-// (ok, message) suitable for health check consumption. Returns (true, "not started")
-// when no service has been registered.
+// (ok, message) suitable for health check consumption. Returns
+// (false, "Weather service not started") when no service has been registered;
+// the diagnostics weather check only consults this once the provider is
+// configured (not "none"), so a missing service at that point is unhealthy.
 func GetStatus() (ok bool, msg string) {
 	globalServiceMu.RLock()
 	svc := globalService
@@ -76,12 +81,30 @@ func (b *backoffState) reset() {
 	b.consecutiveAuthFails = 0
 	b.currentBackoff = 0
 	b.nextAllowedFetchTime = time.Time{}
-	// Note: authDisabled is NOT reset here — a successful fetch from
-	// a different path (e.g., after config change) would need explicit re-enable.
+	// Note: authDisabled is NOT reset here. While auth is disabled shouldSkip()
+	// returns true and no fetch runs, so a success path can never reach this to
+	// clear it. Re-enabling is driven by a config change via clearAuthDisabled().
+}
+
+// clearAuthDisabled re-enables fetching after auth was disabled, clearing the
+// auth-failure counter. Called when the auth-relevant config (provider, API key,
+// endpoint) changes, so a user who fixes the key in the UI recovers on the next
+// cycle without a restart.
+func (b *backoffState) clearAuthDisabled() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.authDisabled = false
+	b.consecutiveAuthFails = 0
 }
 
 // recordAuthFailure increments the auth failure counter and returns true
 // if the threshold has been reached and retrying should stop.
+//
+// Auth failures intentionally do not set nextAllowedFetchTime: the first few
+// 401s retry on the normal poll cadence (no extra spacing) so a key fixed in
+// the UI recovers quickly, and only after maxConsecutiveAuthFailures does the
+// service stop retrying until the config changes. This is deliberately
+// asymmetric with recordFailure, which backs off transient errors immediately.
 func (b *backoffState) recordAuthFailure() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -111,24 +134,38 @@ func (b *backoffState) recordFailure() (backoff time.Duration, failures int) {
 	return b.currentBackoff, b.consecutiveFailures
 }
 
-// shouldSkip returns true if the current time is before the next allowed fetch time.
+// inBackoffLocked reports whether the transient-failure backoff window is still
+// open. The caller must hold b.mu. shouldSkip and snapshot share it so the
+// in-backoff predicate cannot drift between them.
+func (b *backoffState) inBackoffLocked() bool {
+	return !b.nextAllowedFetchTime.IsZero() && time.Now().Before(b.nextAllowedFetchTime)
+}
+
+// shouldSkip returns true if auth is disabled or the backoff window is still open.
 func (b *backoffState) shouldSkip() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.authDisabled {
 		return true
 	}
-	if b.nextAllowedFetchTime.IsZero() {
-		return false
-	}
-	return time.Now().Before(b.nextAllowedFetchTime)
+	return b.inBackoffLocked()
 }
 
-// isAuthDisabled returns whether auth-based retrying has been permanently stopped.
+// isAuthDisabled returns whether auth-based retrying is currently stopped.
+// This is cleared automatically by clearAuthDisabled() on a config change.
 func (b *backoffState) isAuthDisabled() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.authDisabled
+}
+
+// snapshot returns a consistent view of the backoff state under a single lock,
+// so callers do not re-derive the in-backoff predicate inline (which can drift
+// from shouldSkip).
+func (b *backoffState) snapshot() (authDisabled bool, failures int, inBackoff bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.authDisabled, b.consecutiveFailures, b.inBackoffLocked()
 }
 
 // Service handles weather data operations
@@ -144,9 +181,40 @@ type Service struct {
 	db           datastore.Interface
 	settings     *conf.Settings
 	metrics      *metrics.WeatherMetrics
-	sunCalc      *suncalc.SunCalc
 	startupDelay time.Duration
 	backoff      backoffState
+
+	// fetchMu serializes fetchAndSave so the exported Poll() and the StartPolling
+	// ticker cannot run a fetch concurrently. It also guards the hot-reload state
+	// below (sunCalc and authConfigKey), all of which is read/updated per cycle
+	// inside fetchAndSave.
+	fetchMu sync.Mutex
+	// sunCalc is rebuilt when the configured coordinates change between cycles so
+	// sunrise/sunset track the current location after a UI location change.
+	sunCalc *suncalc.SunCalc
+	// sunCalcLat/sunCalcLon record the coordinates sunCalc was last built with.
+	sunCalcLat float64
+	sunCalcLon float64
+	// authConfigKey is the auth-relevant config fingerprint captured when auth
+	// was disabled; a change re-enables fetching (hot-reload of the API key).
+	authConfigKey string
+}
+
+// weatherAuthConfigKey builds a fingerprint of the auth-relevant weather config
+// (provider plus the active provider's key/station/endpoint). A change between
+// cycles signals the user updated credentials in the UI, which re-enables
+// fetching after an auth lockout. It returns a SHA-256 digest rather than the
+// raw values so the API keys are not retained verbatim in the Service struct
+// (s.authConfigKey); the digest is only ever compared, never logged.
+func weatherAuthConfigKey(settings *conf.Settings) string {
+	w := &settings.Realtime.Weather
+	joined := strings.Join([]string{
+		w.Provider,
+		w.OpenWeather.APIKey, w.OpenWeather.Endpoint,
+		w.Wunderground.APIKey, w.Wunderground.StationID, w.Wunderground.Endpoint,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(joined))
+	return string(sum[:])
 }
 
 // currentSettings returns the latest settings snapshot so the service picks
@@ -225,7 +293,7 @@ func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics 
 		getLogger().Info("Weather provider set to none, weather service disabled")
 		return nil, ErrWeatherDisabled
 	default:
-		// Unrecognized provider — warn and treat as disabled rather than
+		// Unrecognized provider: warn and treat as disabled rather than
 		// raising an error to Sentry (this is a user configuration issue)
 		getLogger().Warn("Unrecognized weather provider, weather service disabled",
 			logger.String("provider", settings.Realtime.Weather.Provider))
@@ -239,12 +307,18 @@ func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics 
 		settings:     settings,
 		metrics:      weatherMetrics,
 		sunCalc:      suncalc.NewSunCalc(settings.BirdNET.Latitude, settings.BirdNET.Longitude),
+		sunCalcLat:   settings.BirdNET.Latitude,
+		sunCalcLon:   settings.BirdNET.Longitude,
 		startupDelay: DefaultStartupDelay,
 	}, nil
 }
 
-// SaveWeatherData saves the weather data to the database
-func (s *Service) SaveWeatherData(data *WeatherData) error {
+// saveWeatherData saves the weather data to the database.
+//
+// It reads s.sunCalc, which reconcileConfig rebuilds under s.fetchMu when the
+// configured location changes, so it must be called with s.fetchMu held. It is
+// unexported for that reason; the only caller, fetchAndSave, holds the lock.
+func (s *Service) saveWeatherData(data *WeatherData) error {
 	// Track operation duration
 	start := time.Now()
 	defer func() {
@@ -288,7 +362,7 @@ func (s *Service) SaveWeatherData(data *WeatherData) error {
 	dailyEvents.MoonIllumination = moonData.Illumination
 
 	// Save daily events data. If this fails (e.g., SQLITE_BUSY), log the error
-	// but continue — the upsert will succeed on the next hourly poll, and we
+	// but continue: the upsert will succeed on the next hourly poll, and we
 	// can still save hourly weather if a daily_events row already exists.
 	var dailyEventsFailed bool
 	if err := s.db.SaveDailyEvents(dailyEvents); err != nil {
@@ -308,14 +382,14 @@ func (s *Service) SaveWeatherData(data *WeatherData) error {
 	if dailyEventsFailed {
 		existing, lookupErr := s.db.GetDailyEvents(localDate)
 		if lookupErr != nil || existing.ID == 0 {
-			// No existing row — this is likely the first fetch of the day and the
+			// No existing row: this is likely the first fetch of the day and the
 			// initial save hit a transient error (e.g., SQLITE_BUSY). Brief pause
 			// to let the transient lock clear, then retry once.
 			getLogger().Info("No existing daily events row found, retrying save after brief delay",
 				logger.String("date", localDate))
 			time.Sleep(100 * time.Millisecond)
 			if retryErr := s.db.SaveDailyEvents(dailyEvents); retryErr != nil {
-				// Retry also failed — skip saving weather data for this cycle.
+				// Retry also failed: skip saving weather data for this cycle.
 				// The next hourly poll will try again. Log at debug level to
 				// avoid flooding Sentry with transient errors.
 				getLogger().Debug("Skipping weather save: daily events record unavailable after retry",
@@ -425,6 +499,16 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 	// Poll interval is read once at startup; the ticker cadence is not
 	// hot-reloadable without a service restart.
 	interval := time.Duration(s.settings.Realtime.Weather.PollInterval) * time.Minute
+	if interval <= 0 {
+		// PollInterval is normally validated to >= 15 minutes (conf
+		// validate_realtime), but StartPolling reads the raw setting and
+		// time.NewTicker panics on a non-positive interval, which would crash
+		// this long-lived goroutine. Fall back to the default instead.
+		getLogger().Warn("Invalid weather poll interval, using default",
+			logger.Int("configured_minutes", s.settings.Realtime.Weather.PollInterval),
+			logger.Int("default_minutes", conf.DefaultWeatherPollInterval))
+		interval = time.Duration(conf.DefaultWeatherPollInterval) * time.Minute
+	}
 
 	// Use the dedicated weather logger
 	getLogger().Info("Starting weather polling service",
@@ -435,10 +519,14 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 	if s.startupDelay > 0 {
 		getLogger().Info("Delaying initial weather fetch to reduce startup DB contention",
 			logger.String("delay", s.startupDelay.String()))
+		// time.NewTimer + Stop so the timer is released if stopChan fires first
+		// (time.After would leak the timer until startupDelay elapses).
+		timer := time.NewTimer(s.startupDelay)
 		select {
-		case <-time.After(s.startupDelay):
+		case <-timer.C:
 			// Delay elapsed, proceed with fetch
 		case <-stopChan:
+			timer.Stop()
 			return
 		}
 	}
@@ -447,14 +535,14 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 	defer ticker.Stop()
 
 	// Initial fetch (errors logged within fetchAndSave)
-	_ = s.fetchAndSave()
+	s.safeFetchAndSave()
 
 	for {
 		select {
 		case <-ticker.C:
 			getLogger().Debug("Polling weather data...")
 			// Errors logged within fetchAndSave
-			_ = s.fetchAndSave()
+			s.safeFetchAndSave()
 		case <-stopChan:
 			getLogger().Info("Stopping weather polling service")
 			return
@@ -462,11 +550,30 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 	}
 }
 
+// safeFetchAndSave runs fetchAndSave with panic recovery so a panic in a
+// provider, the response mapping, or the persistence path degrades only the
+// weather service instead of crashing the whole process. Errors are already
+// logged inside fetchAndSave, so the return value is intentionally discarded.
+func (s *Service) safeFetchAndSave() {
+	defer func() {
+		if r := recover(); r != nil {
+			getLogger().Error("Weather poll cycle panicked, continuing",
+				logger.String("provider", s.providerName),
+				logger.Any("panic", r),
+				logger.String("stack", string(debug.Stack())))
+		}
+	}()
+	_ = s.fetchAndSave()
+}
+
 // Poll fetches weather data once and saves it to the database.
 // This is useful for on-demand updates or testing the fetch-save cycle.
 // Returns nil on success or if data is not modified (304 response).
-// Returns ErrWeatherAuthFailed if the weather API key is invalid and retrying
-// has been permanently disabled.
+// Returns ErrWeatherAuthFailed when auth is currently disabled after repeated
+// 401s; that lockout clears automatically on a config change (see reconcileConfig).
+//
+// Unlike the StartPolling loop, Poll does not wrap the fetch in panic recovery:
+// it is a synchronous on-demand call, so a panic propagates to the caller.
 func (s *Service) Poll() error {
 	if s.backoff.isAuthDisabled() {
 		return ErrWeatherAuthFailed
@@ -474,28 +581,70 @@ func (s *Service) Poll() error {
 	return s.fetchAndSave()
 }
 
+// reconcileConfig applies hot-reloadable settings changes detected between poll
+// cycles so the weather service honors UI edits without a restart. It rebuilds
+// sunCalc when the configured coordinates change (so sunrise/sunset track the
+// new location) and clears an auth lockout when the auth-relevant config (API
+// key, station, endpoint, or provider) changes (so a corrected key recovers on
+// the next cycle). Must be called under s.fetchMu, which guards sunCalc and
+// authConfigKey.
+func (s *Service) reconcileConfig(settings *conf.Settings) {
+	// Rebuild sunCalc on a location change. Coordinates are PII, so the change
+	// is logged without the values themselves.
+	lat, lon := settings.BirdNET.Latitude, settings.BirdNET.Longitude
+	if lat != s.sunCalcLat || lon != s.sunCalcLon {
+		getLogger().Info("Weather location changed, rebuilding sun time calculator",
+			logger.String("provider", s.providerName))
+		s.sunCalc = suncalc.NewSunCalc(lat, lon)
+		s.sunCalcLat = lat
+		s.sunCalcLon = lon
+	}
+
+	// Re-enable fetching if auth was disabled and the auth-relevant config has
+	// changed since the lockout. While authDisabled is set, shouldSkip() returns
+	// true and no fetch runs, so a config delta is the only recovery trigger.
+	if s.backoff.isAuthDisabled() && weatherAuthConfigKey(settings) != s.authConfigKey {
+		getLogger().Info("Weather API configuration changed, re-enabling fetches after auth lockout",
+			logger.String("provider", s.providerName))
+		s.backoff.clearAuthDisabled()
+	}
+}
+
 // fetchAndSave fetches weather data and saves it to the database.
 // It tracks consecutive failures and applies exponential backoff for transient
-// errors. For persistent authentication failures (HTTP 401), it stops retrying
-// entirely after maxConsecutiveAuthFailures.
+// errors. For repeated authentication failures (HTTP 401), it pauses retrying
+// after maxConsecutiveAuthFailures until the auth-relevant config changes
+// (handled by reconcileConfig), at which point it resumes automatically.
 func (s *Service) fetchAndSave() error {
+	// Serialize fetch cycles. Both the exported Poll() and the StartPolling
+	// ticker call this; the lock keeps the skip -> fetch -> reset sequence and
+	// the SQLite writes atomic, and guards the per-cycle hot-reload state
+	// (sunCalc, authConfigKey) reconciled below.
+	s.fetchMu.Lock()
+	defer s.fetchMu.Unlock()
+
 	// Read a fresh settings snapshot so coordinate changes made via the
 	// settings UI take effect without restarting the weather service. The
 	// snapshot is captured once per cycle and passed to the provider so that
 	// coordinate/API-key reads inside the provider see a consistent view.
-	// Provider implementation stays pinned to what NewService selected —
+	// Provider implementation stays pinned to what NewService selected:
 	// switching providers still requires a service restart, and s.providerName
 	// records the actually-used one for logs and metrics.
 	currentSettings := s.currentSettings()
+
+	// Apply hot-reloadable config changes detected since the last cycle before
+	// the backoff check, so a corrected API key clears the auth lockout that
+	// shouldSkip() would otherwise honor.
+	s.reconcileConfig(currentSettings)
 
 	// Check if we should skip this cycle due to backoff
 	if s.backoff.shouldSkip() {
 		if s.backoff.isAuthDisabled() {
 			// Already logged when auth was disabled; emit periodic reminder at Debug level
-			getLogger().Debug("Skipping weather fetch — API authentication disabled due to repeated 401 errors",
+			getLogger().Debug("Skipping weather fetch, API authentication disabled due to repeated 401 errors",
 				logger.String("provider", s.providerName))
 		} else {
-			getLogger().Debug("Skipping weather fetch — backing off after previous failures",
+			getLogger().Debug("Skipping weather fetch, backing off after previous failures",
 				logger.String("provider", s.providerName))
 		}
 		return nil
@@ -508,7 +657,7 @@ func (s *Service) fetchAndSave() error {
 	data, err := s.provider.FetchWeather(currentSettings)
 
 	if err != nil {
-		// Handle "not modified" as a success case — no new data to save.
+		// Handle "not modified" as a success case: no new data to save.
 		// Check before recording metrics so these expected conditions are
 		// not counted as errors.
 		if errors.Is(err, ErrWeatherDataNotModified) {
@@ -522,7 +671,7 @@ func (s *Service) fetchAndSave() error {
 			return nil
 		}
 
-		// Handle "no data" (HTTP 204) — station exists but has no observations.
+		// Handle "no data" (HTTP 204): station exists but has no observations.
 		// This is a valid API response, not an error condition.
 		if errors.Is(err, ErrWeatherNoData) {
 			if s.metrics != nil {
@@ -531,7 +680,11 @@ func (s *Service) fetchAndSave() error {
 			}
 			getLogger().Debug("Weather station has no data available, will retry next cycle",
 				logger.String("provider", s.providerName))
-			// Don't backoff — this is a normal condition for inactive stations
+			// HTTP 204 is a successful round-trip, so clear any transient-failure
+			// backoff like the 304 and success paths do. A station that starts
+			// returning 204 should not stay stuck in "degraded" after earlier
+			// transient errors. Auth state is intentionally left untouched.
+			s.backoff.reset()
 			return nil
 		}
 	}
@@ -552,12 +705,15 @@ func (s *Service) fetchAndSave() error {
 		if errors.Is(err, ErrWeatherAuthFailed) {
 			stopped := s.backoff.recordAuthFailure()
 			if stopped {
-				getLogger().Error("Weather API authentication failed repeatedly — stopping retries. "+
-					"Please check your API key in the settings and restart the service.",
+				// Capture the auth-relevant config at lockout so reconcileConfig
+				// can re-enable fetches automatically once the user corrects it.
+				s.authConfigKey = weatherAuthConfigKey(currentSettings)
+				getLogger().Error("Weather API authentication failed repeatedly, pausing retries. "+
+					"Update your API key in the settings and fetching resumes automatically on the next cycle (no restart needed).",
 					logger.String("provider", s.providerName),
 					logger.Int("consecutive_failures", maxConsecutiveAuthFailures))
 			} else {
-				getLogger().Warn("Weather API authentication failed — will retry",
+				getLogger().Warn("Weather API authentication failed, will retry",
 					logger.String("provider", s.providerName),
 					logger.Error(err))
 			}
@@ -580,10 +736,10 @@ func (s *Service) fetchAndSave() error {
 			Build()
 	}
 
-	// Success — reset backoff state
+	// Success: reset backoff state
 	s.backoff.reset()
 
-	// Convert to local time for logging. SaveWeatherData handles its own
+	// Convert to local time for logging. saveWeatherData handles its own
 	// timezone conversion for storage.
 	localTimeForLog := data.Time.In(time.Local)
 
@@ -597,18 +753,14 @@ func (s *Service) fetchAndSave() error {
 		logger.String("description", data.Description),
 		logger.String("city", data.Location.City))
 
-	// Errors logged within SaveWeatherData
-	return s.SaveWeatherData(data)
+	// Errors logged within saveWeatherData
+	return s.saveWeatherData(data)
 }
 
 // Status reports the health of the weather service by inspecting backoff state.
 // Returns (ok, statusMessage).
 func (s *Service) Status() (ok bool, msg string) {
-	s.backoff.mu.Lock()
-	authDisabled := s.backoff.authDisabled
-	failures := s.backoff.consecutiveFailures
-	inBackoff := !s.backoff.nextAllowedFetchTime.IsZero() && time.Now().Before(s.backoff.nextAllowedFetchTime)
-	s.backoff.mu.Unlock()
+	authDisabled, failures, inBackoff := s.backoff.snapshot()
 
 	if authDisabled {
 		return false, fmt.Sprintf("Weather provider %s auth disabled", s.providerName)

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1694,3 +1694,108 @@ func TestFetchAndSave_SerializedByMutex(t *testing.T) {
 	assert.Equal(t, goroutines, unsafeCounter,
 		"every serialized fetch should have incremented the counter exactly once")
 }
+
+// TestWeatherAuthConfigKey_ScopedToActiveProvider verifies the auth fingerprint
+// only reflects the active provider's credentials, so editing the inactive
+// provider's key does not spuriously clear an active-provider auth lockout.
+func TestWeatherAuthConfigKey_ScopedToActiveProvider(t *testing.T) {
+	t.Parallel()
+
+	base := createTestSettings(t, "openweather")
+	baseKey := weatherAuthConfigKey(base)
+
+	// Editing the inactive provider's credentials must NOT change the fingerprint.
+	inactiveEdit := createTestSettings(t, "openweather", func(s *conf.Settings) {
+		s.Realtime.Weather.Wunderground.APIKey = "different-wunderground-key"
+	})
+	assert.Equal(t, baseKey, weatherAuthConfigKey(inactiveEdit),
+		"changing the inactive provider's credentials must not change the fingerprint")
+
+	// Editing the active provider's credentials MUST change the fingerprint.
+	activeEdit := createTestSettings(t, "openweather", func(s *conf.Settings) {
+		s.Realtime.Weather.OpenWeather.APIKey = "different-openweather-key"
+	})
+	assert.NotEqual(t, baseKey, weatherAuthConfigKey(activeEdit),
+		"changing the active provider's credentials must change the fingerprint")
+}
+
+// TestSafeFetchAndSave_PanicRecordsFailure verifies that a panic in the fetch
+// cycle is recovered (not propagated) and recorded as a failure, so it surfaces
+// as degraded via Status() instead of leaving the service reporting healthy.
+func TestSafeFetchAndSave_PanicRecordsFailure(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t, "wunderground")
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			panic("provider boom")
+		},
+	}
+	service := &Service{
+		provider:     provider,
+		providerName: wundergroundProviderName,
+		db:           nil,
+		settings:     settings,
+		metrics:      nil,
+	}
+
+	require.NotPanics(t, func() { service.safeFetchAndSave() },
+		"a provider panic must be recovered, not propagated")
+
+	ok, msg := service.Status()
+	assert.False(t, ok, "a panicking fetch should report unhealthy, got: %s", msg)
+	assert.Positive(t, service.backoff.consecutiveFailures,
+		"recovered panic should record a failure")
+}
+
+// TestPoll_RecoversAfterConfigChange verifies that an on-demand Poll() recovers
+// from an auth lockout once the API key is fixed, instead of returning the
+// lockout error until the background ticker reconciles.
+//
+// Intentionally NOT t.Parallel(): mutates the package-global settings snapshot.
+func TestPoll_RecoversAfterConfigChange(t *testing.T) {
+	prevSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(prevSettings) })
+
+	settings := createTestSettings(t, "wunderground", func(s *conf.Settings) {
+		s.Realtime.Weather.Wunderground.APIKey = "bad-key"
+	})
+	conf.StoreSettings(settings)
+
+	authBad := true
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			if authBad {
+				return nil, ErrWeatherAuthFailed
+			}
+			return nil, ErrWeatherNoData // recovered; no data to persist (no DB needed)
+		},
+	}
+	service := &Service{
+		provider:     provider,
+		providerName: wundergroundProviderName,
+		db:           nil,
+		settings:     settings,
+		metrics:      nil,
+	}
+
+	// Drive the lockout via Poll.
+	for range maxConsecutiveAuthFailures {
+		_ = service.Poll()
+	}
+	require.True(t, service.backoff.isAuthDisabled(), "should be locked out after threshold")
+
+	// Still locked out with unchanged config: Poll surfaces the auth failure.
+	require.ErrorIs(t, service.Poll(), ErrWeatherAuthFailed)
+
+	// Fix the key; a manual Poll must now recover without waiting for the ticker.
+	authBad = false
+	updated := createTestSettings(t, "wunderground", func(s *conf.Settings) {
+		s.Realtime.Weather.Wunderground.APIKey = "good-key"
+	})
+	conf.StoreSettings(updated)
+
+	require.NoError(t, service.Poll(), "manual Poll should recover after the key is fixed")
+	assert.False(t, service.backoff.isAuthDisabled(),
+		"auth lockout should clear on the recovering Poll")
+}

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -3,7 +3,9 @@ package weather
 import (
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/jarcoal/httpmock"
@@ -139,7 +141,7 @@ func TestAbsoluteZeroCelsiusConstant(t *testing.T) {
 // when storing weather data. This demonstrates the expected behavior and can reveal
 // timezone-related bugs.
 func TestTimezoneConversionForWeatherStorage(t *testing.T) {
-	// This test documents the timezone handling behavior in SaveWeatherData.
+	// This test documents the timezone handling behavior in saveWeatherData.
 	// The UTC time from weather providers is converted to local time for storage.
 	// This is critical for correct date-based queries.
 
@@ -363,7 +365,7 @@ func TestSettingsCreation(t *testing.T) {
 // DATABASE INTEGRATION TESTS WITH MOCK DATASTORE
 // =============================================================================
 
-// TestService_SaveWeatherData tests the SaveWeatherData method with mock datastore.
+// TestService_SaveWeatherData tests the saveWeatherData method with mock datastore.
 func TestService_SaveWeatherData(t *testing.T) {
 	t.Run("success_saves_daily_and_hourly", func(t *testing.T) {
 		mockDB := mocks.NewMockInterface(t)
@@ -398,7 +400,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 				hw.WindSpeed == testData.Wind.Speed
 		})).Return(nil).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.NoError(t, err)
 		mockDB.AssertExpectations(t)
@@ -439,7 +441,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 			capturedHW = args.Get(0).(*datastore.HourlyWeather)
 		}).Return(nil).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.NoError(t, err)
 		require.NotNil(t, capturedHW, "HourlyWeather should have been saved")
@@ -467,7 +469,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 		// First SaveDailyEvents fails (e.g., SQLITE_BUSY)
 		mockDB.On("SaveDailyEvents", mock.Anything).Return(errors.New("database is locked")).Once()
 
-		// GetDailyEvents also fails — no existing row
+		// GetDailyEvents also fails: no existing row
 		localDate := fixedTime.UTC().In(time.Local).Format(time.DateOnly)
 		mockDB.On("GetDailyEvents", localDate).Return(datastore.DailyEvents{}, errors.New("no rows")).Once()
 
@@ -483,7 +485,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 			capturedHW = args.Get(0).(*datastore.HourlyWeather)
 		}).Return(nil).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.NoError(t, err)
 		require.NotNil(t, capturedHW, "HourlyWeather should have been saved")
@@ -511,14 +513,14 @@ func TestService_SaveWeatherData(t *testing.T) {
 		// First SaveDailyEvents fails
 		mockDB.On("SaveDailyEvents", mock.Anything).Return(errors.New("database is locked")).Once()
 
-		// GetDailyEvents also fails — no existing row
+		// GetDailyEvents also fails: no existing row
 		localDate := fixedTime.UTC().In(time.Local).Format(time.DateOnly)
 		mockDB.On("GetDailyEvents", localDate).Return(datastore.DailyEvents{}, errors.New("no rows")).Once()
 
 		// Retry SaveDailyEvents also fails
 		mockDB.On("SaveDailyEvents", mock.Anything).Return(errors.New("database is locked")).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		// Graceful skip: no error returned, next poll will retry
 		require.NoError(t, err)
@@ -562,7 +564,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 			capturedHW = args.Get(0).(*datastore.HourlyWeather)
 		}).Return(nil).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.NoError(t, err)
 		require.NotNil(t, capturedHW, "HourlyWeather should have been saved")
@@ -593,7 +595,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 		// SaveHourlyWeather fails
 		mockDB.On("SaveHourlyWeather", mock.Anything).Return(errors.New("disk full")).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "disk full")
@@ -627,7 +629,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 			capturedHW = args.Get(0).(*datastore.HourlyWeather)
 		}).Return(nil).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.NoError(t, err)
 		require.NotNil(t, capturedHW, "HourlyWeather should have been captured")
@@ -666,7 +668,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 			capturedHW = args.Get(0).(*datastore.HourlyWeather)
 		}).Return(nil).Once()
 
-		err := service.SaveWeatherData(testData)
+		err := service.saveWeatherData(testData)
 
 		require.NoError(t, err)
 		require.NotNil(t, capturedDE)
@@ -1064,8 +1066,10 @@ func TestBackoffState_AuthFailureThreshold(t *testing.T) {
 	assert.True(t, b.shouldSkip(), "After auth disabled, shouldSkip should be true")
 }
 
-// TestBackoffState_AuthDisabledNotResetByReset verifies that authDisabled persists
-// through reset() calls — a restart or config change is required.
+// TestBackoffState_AuthDisabledNotResetByReset verifies that authDisabled
+// persists through reset() (so a 304/204/success path cannot silently
+// re-enable a locked-out provider) and is cleared only by clearAuthDisabled(),
+// which the service calls when the auth-relevant config changes.
 func TestBackoffState_AuthDisabledNotResetByReset(t *testing.T) {
 	b := &backoffState{}
 
@@ -1076,7 +1080,13 @@ func TestBackoffState_AuthDisabledNotResetByReset(t *testing.T) {
 
 	b.reset()
 	assert.True(t, b.isAuthDisabled(),
-		"authDisabled should persist through reset — requires service restart")
+		"authDisabled should persist through reset (cleared only on config change)")
+
+	b.clearAuthDisabled()
+	assert.False(t, b.isAuthDisabled(),
+		"clearAuthDisabled should re-enable fetching")
+	assert.Equal(t, 0, b.consecutiveAuthFails,
+		"clearAuthDisabled should reset the auth-failure counter")
 }
 
 // TestBackoffState_ShouldSkipDuringBackoff verifies skip behavior during backoff window.
@@ -1217,7 +1227,7 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 		metrics:  nil,
 	}
 
-	// First call fails — sets backoff
+	// First call fails: sets backoff
 	err := service.fetchAndSave()
 	require.Error(t, err)
 	assert.True(t, service.backoff.shouldSkip(), "Should be in backoff after failure")
@@ -1228,7 +1238,7 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 	service.backoff.nextAllowedFetchTime = time.Time{}
 	service.backoff.mu.Unlock()
 
-	// Second call succeeds — should reset backoff
+	// Second call succeeds: should reset backoff
 	err = service.fetchAndSave()
 	require.NoError(t, err)
 	assert.False(t, service.backoff.shouldSkip(), "Backoff should be cleared after success")
@@ -1248,7 +1258,7 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 // TestSettings_GetStore_NoRace in the conf package.
 func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 	// Capture the previous snapshot so any earlier test's state is restored
-	// on cleanup — blindly clearing with StoreSettings(nil) could perturb
+	// on cleanup: blindly clearing with StoreSettings(nil) could perturb
 	// siblings that depend on a previously-loaded global.
 	prevSettings := conf.GetSettings()
 	t.Cleanup(func() { conf.StoreSettings(prevSettings) })
@@ -1268,7 +1278,7 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 		},
 	}
 
-	// Service is constructed with the initial (zero-coord) snapshot — this
+	// Service is constructed with the initial (zero-coord) snapshot: this
 	// mirrors how NewService is called at startup before the user has
 	// configured their location.
 	service := &Service{
@@ -1284,7 +1294,7 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 	assert.InDelta(t, 0.0, observedLon, 1e-9, "initial fetch should use the captured coords")
 
 	// Clear backoff so the second fetch runs, then publish a new snapshot
-	// with real coords — exactly what the settings UI does.
+	// with real coords: exactly what the settings UI does.
 	service.backoff.mu.Lock()
 	service.backoff.nextAllowedFetchTime = time.Time{}
 	service.backoff.mu.Unlock()
@@ -1441,4 +1451,246 @@ func TestRegisterUnregisterService(t *testing.T) {
 	ok, msg = GetStatus()
 	assert.False(t, ok)
 	assert.Contains(t, msg, "not started")
+}
+
+// =============================================================================
+// LIFECYCLE AND STATE-MACHINE HARDENING TESTS (#987, #988, #989)
+// =============================================================================
+
+// TestFetchAndSave_NoDataResetsTransientBackoff verifies that an HTTP 204
+// (ErrWeatherNoData) clears prior transient-failure backoff, so a station that
+// starts returning 204 does not stay stuck reporting "degraded" after earlier
+// transient errors (issue #989). Auth state is left untouched.
+func TestFetchAndSave_NoDataResetsTransientBackoff(t *testing.T) {
+	settings := createTestSettings(t, "wunderground")
+
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			return nil, ErrWeatherNoData
+		},
+	}
+	service := &Service{
+		provider:     provider,
+		providerName: wundergroundProviderName,
+		db:           nil,
+		settings:     settings,
+		metrics:      nil,
+	}
+
+	// Simulate accumulated transient failures whose backoff window has already
+	// elapsed: nextAllowedFetchTime left zero so the fetch proceeds, but the
+	// failure counter still reports "degraded".
+	service.backoff.mu.Lock()
+	service.backoff.consecutiveFailures = 3
+	service.backoff.currentBackoff = initialBackoffDuration
+	service.backoff.mu.Unlock()
+
+	ok, _ := service.Status()
+	require.False(t, ok, "precondition: service should report degraded before the 204")
+
+	err := service.fetchAndSave()
+	require.NoError(t, err, "204 is a successful round-trip, not an error")
+
+	ok, msg := service.Status()
+	assert.True(t, ok, "204 should clear transient backoff, got: %s", msg)
+	assert.Equal(t, 0, service.backoff.consecutiveFailures,
+		"204 should reset the consecutive-failure counter")
+}
+
+// TestFetchAndSave_AuthRecoveryOnConfigChange verifies that after the service
+// locks out on repeated 401s, changing the auth-relevant config (the API key,
+// as the settings UI does) re-enables fetching on the next cycle without a
+// restart (issue #987).
+//
+// Intentionally NOT t.Parallel(): mutates the package-global settings snapshot.
+func TestFetchAndSave_AuthRecoveryOnConfigChange(t *testing.T) {
+	prevSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(prevSettings) })
+
+	settings := createTestSettings(t, "wunderground", func(s *conf.Settings) {
+		s.Realtime.Weather.Wunderground.APIKey = "bad-key"
+	})
+	conf.StoreSettings(settings)
+
+	authBad := true
+	callCount := 0
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			callCount++
+			if authBad {
+				return nil, ErrWeatherAuthFailed
+			}
+			return nil, ErrWeatherNoData // recovered; no data to persist (no DB needed)
+		},
+	}
+	service := &Service{
+		provider:     provider,
+		providerName: wundergroundProviderName,
+		db:           nil,
+		settings:     settings,
+		metrics:      nil,
+	}
+
+	// Drive the lockout.
+	for range maxConsecutiveAuthFailures {
+		err := service.fetchAndSave()
+		require.ErrorIs(t, err, ErrWeatherAuthFailed)
+	}
+	require.True(t, service.backoff.isAuthDisabled(), "should be locked out after threshold")
+	require.Equal(t, maxConsecutiveAuthFailures, callCount)
+
+	// A cycle with unchanged config must keep skipping (no recovery yet).
+	require.NoError(t, service.fetchAndSave())
+	require.Equal(t, maxConsecutiveAuthFailures, callCount,
+		"provider must not be called while locked out and config unchanged")
+
+	// Fix the key (as the settings UI would) and publish the new snapshot.
+	authBad = false
+	updated := createTestSettings(t, "wunderground", func(s *conf.Settings) {
+		s.Realtime.Weather.Wunderground.APIKey = "good-key"
+	})
+	conf.StoreSettings(updated)
+
+	require.NoError(t, service.fetchAndSave(), "should recover and fetch after config change")
+	assert.Equal(t, maxConsecutiveAuthFailures+1, callCount,
+		"provider should be called again after the key changed")
+	assert.False(t, service.backoff.isAuthDisabled(),
+		"auth lockout should clear automatically on config change")
+}
+
+// TestFetchAndSave_SunCalcRebuiltOnLocationChange verifies that after the
+// configured location changes, the saved sunrise/sunset reflect the new
+// location rather than the one captured at construction (issue #987). A stale
+// sunCalc would persist the old location's sun times for the new city.
+//
+// Intentionally NOT t.Parallel(): mutates the package-global settings snapshot.
+func TestFetchAndSave_SunCalcRebuiltOnLocationChange(t *testing.T) {
+	prevSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(prevSettings) })
+
+	// Fixed observation time so sunrise/sunset depend only on the location.
+	fixedTime := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			return createTestWeatherData(t, func(d *WeatherData) { d.Time = fixedTime }), nil
+		},
+	}
+
+	mockDB := mocks.NewMockInterface(t)
+	var capturedSunrise []int64
+	mockDB.On("SaveDailyEvents", mock.Anything).Run(func(args mock.Arguments) {
+		de := args.Get(0).(*datastore.DailyEvents)
+		de.ID = 1
+		capturedSunrise = append(capturedSunrise, de.Sunrise)
+	}).Return(nil)
+	mockDB.On("SaveHourlyWeather", mock.Anything).Return(nil)
+
+	// Start in Helsinki. sunCalc is left nil so reconcileConfig builds it on the
+	// first cycle from the configured coordinates.
+	helsinki := createTestSettings(t, "yrno", func(s *conf.Settings) {
+		s.BirdNET.Latitude = 60.1699
+		s.BirdNET.Longitude = 24.9384
+	})
+	conf.StoreSettings(helsinki)
+	service := &Service{
+		provider:     provider,
+		providerName: yrNoProviderName,
+		db:           mockDB,
+		settings:     helsinki,
+		metrics:      nil,
+	}
+
+	require.NoError(t, service.fetchAndSave())
+
+	// Move to Sydney: a very different latitude/longitude yields different sun
+	// times for the same instant.
+	sydney := createTestSettings(t, "yrno", func(s *conf.Settings) {
+		s.BirdNET.Latitude = -33.8688
+		s.BirdNET.Longitude = 151.2093
+	})
+	conf.StoreSettings(sydney)
+
+	require.NoError(t, service.fetchAndSave())
+
+	require.Len(t, capturedSunrise, 2)
+	assert.NotEqual(t, capturedSunrise[0], capturedSunrise[1],
+		"sunrise should differ after the location changed, proving sunCalc was rebuilt")
+	assert.InDelta(t, -33.8688, service.sunCalcLat, 1e-9, "sunCalcLat should track the new location")
+	assert.InDelta(t, 151.2093, service.sunCalcLon, 1e-9, "sunCalcLon should track the new location")
+}
+
+// TestStartPolling_RecurringTick verifies the ticker path fires fetchAndSave
+// repeatedly, not just the initial fetch (issue #991 guard). Uses
+// testing/synctest so the poll interval advances deterministically instead of
+// relying on wall-clock sleeps.
+func TestStartPolling_RecurringTick(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		settings := createTestSettings(t, "yrno", func(s *conf.Settings) {
+			s.Realtime.Weather.PollInterval = 1 // 1 minute, advanced instantly by synctest
+		})
+
+		stopChan := make(chan struct{})
+		var stopOnce sync.Once
+		fetches := 0
+		provider := &mockProvider{
+			fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+				fetches++
+				if fetches >= 3 {
+					// Stop after the initial fetch plus two ticks. sync.Once
+					// guards against a double close if the ticker and stopChan
+					// are both ready in the same select.
+					stopOnce.Do(func() { close(stopChan) })
+				}
+				return nil, ErrWeatherNoData // 204 path needs no DB
+			},
+		}
+		service := &Service{
+			provider:     provider,
+			providerName: yrNoProviderName,
+			db:           nil,
+			settings:     settings,
+			metrics:      nil,
+			startupDelay: 0,
+		}
+
+		service.StartPolling(stopChan)
+
+		assert.GreaterOrEqual(t, fetches, 3,
+			"the ticker should fire fetchAndSave beyond the initial fetch")
+	})
+}
+
+// TestFetchAndSave_SerializedByMutex verifies that concurrent fetch cycles are
+// serialized by s.fetchMu (issue #988). The provider increments a deliberately
+// non-atomic counter; serialization makes this safe, and the -race detector
+// would flag it if the mutex regressed.
+func TestFetchAndSave_SerializedByMutex(t *testing.T) {
+	settings := createTestSettings(t, "wunderground")
+
+	const goroutines = 8
+	unsafeCounter := 0 // guarded only by fetchMu serialization
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			unsafeCounter++ // racy iff fetchAndSave runs concurrently
+			return nil, ErrWeatherNoData
+		},
+	}
+	service := &Service{
+		provider:     provider,
+		providerName: wundergroundProviderName,
+		db:           nil,
+		settings:     settings,
+		metrics:      nil,
+	}
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			_ = service.fetchAndSave()
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, goroutines, unsafeCounter,
+		"every serialized fetch should have incremented the counter exactly once")
 }


### PR DESCRIPTION
## Summary

Hardens the weather polling service after a deep review of `internal/weather`. All changes are confined to `internal/weather/weather.go` plus tests; no config, API, DB schema, or CLI surface is touched.

**Hot-reload (these previously required a restart):**
- Rebuild `sunCalc` when the configured location changes between poll cycles, so saved sunrise/sunset track the new location instead of the one captured at construction.
- Auto-recover from an auth lockout when the auth-relevant config (provider, API key, station, endpoint) changes. The lockout log no longer tells the user to restart; fetching resumes on the next cycle. The config fingerprint is stored as a SHA-256 digest so raw API keys are not retained in the service struct.

**Lifecycle robustness:**
- Serialize `fetchAndSave` with a mutex so the exported `Poll()` and the polling ticker cannot run concurrently (keeps the skip/fetch/reset sequence and the SQLite writes atomic).
- Recover from panics in the poll goroutine so a provider or mapping panic degrades only weather instead of crashing the process.
- Replace `time.After` with `time.NewTimer`+`Stop` in the startup delay to avoid a timer leak when the stop signal fires first.
- Clamp a non-positive poll interval to the default to avoid a `time.NewTicker` panic in the long-lived goroutine.

**State machine:**
- HTTP 204 (no data) now clears transient-failure backoff like the 304 and success paths, so a station that recovers to 204 stops reporting "degraded". Auth state is left untouched.
- Reconcile the `GetStatus` doc comment with its actual return value.
- Add `backoffState.snapshot()`/`inBackoffLocked()` so `Status()` and `shouldSkip()` share one in-backoff predicate instead of duplicating it.

**Other:**
- Unexport `saveWeatherData` (no external callers); it reads `sunCalc` under the fetch mutex and must not be called concurrently with the polling loop.

## Test Plan
- [x] `go test -race ./internal/weather/...` (new tests: recurring-tick via `testing/synctest`, auth auto-recovery on config change, sunCalc rebuild on location change, 204 backoff reset, `fetchAndSave` mutex serialization under `-race`)
- [x] `golangci-lint run` (full project, 0 issues)
- [x] `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config changes (auth/coordinates) apply immediately without restarting; polling updates accordingly.

* **Bug Fixes**
  * Improved polling robustness: panics during fetch are recovered and no longer crash the process.
  * Protection against invalid poll intervals to prevent crashes.

* **Improvements**
  * Auth lockout automatically clears when relevant config is fixed.
  * Transient "no data" results now reset backoff so retries resume faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->