### PR TITLE
fix(classifier): reverse-resolve localized species excludes and guard unmapped-species indexing

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -594,7 +594,10 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	slices.SortFunc(refs, func(a, b entryRef) int { return strings.Compare(a.id, b.id) })
 
 	passUnmapped := settings.BirdNET.RangeFilter.PassUnmappedSpecies
-	excludeList := settings.Realtime.Species.Exclude
+	// Build the exclude matcher once for this pass: it reverse-resolves localized
+	// common-name exclude entries through OpenFauna a single time so the per-label
+	// matches() below stays off the dataset scan.
+	excluder := newExcludeMatcher(settings.Realtime.Species.Exclude, settings.BirdNET.Locale)
 
 	for _, ref := range refs {
 		ref.entry.mu.Lock()
@@ -627,13 +630,13 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 					// Legacy path: no geomodel to consult. Preserve prior
 					// behavior and include the species, deduped by scientific
 					// name, without gating on PassUnmappedSpecies.
-					if !isSpeciesExcluded(label, excludeList) {
+					if !excluder.matches(label) {
 						scores = append(scores, SpeciesScore{Label: label, Score: 1.0})
 						seenSci[sci] = true
 					}
 					continue
 				}
-				if passUnmapped && !isSpeciesExcluded(label, excludeList) {
+				if passUnmapped && !excluder.matches(label) {
 					scores = append(scores, SpeciesScore{Label: label, Score: 1.0})
 					seenSci[sci] = true
 				}

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -165,9 +165,14 @@ func BuildRangeFilter(o *Orchestrator) error {
 		}
 		primary.mu.Unlock()
 
+		// Build the exclude matcher once per rebuild: it reverse-resolves localized
+		// common-name exclude entries through OpenFauna a single time so the per-score
+		// matches() below stays off the dataset scan.
+		excluder := newExcludeMatcher(settings.Realtime.Species.Exclude, settings.BirdNET.Locale)
+
 		includedSpecies = make([]string, 0, len(scores))
 		for _, ss := range scores {
-			if !isSpeciesExcluded(ss.Label, settings.Realtime.Species.Exclude) {
+			if !excluder.matches(ss.Label) {
 				includedSpecies = append(includedSpecies, ss.Label)
 			}
 		}
@@ -187,10 +192,14 @@ func BuildRangeFilter(o *Orchestrator) error {
 			if mapping == nil {
 				mapping = buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
 			}
+			// cachedMapping (mappedRangeFilter.classifierToGeo) is sized from the
+			// model's labels at load time and can be longer than the live settings
+			// snapshot during a concurrent model/settings reload, so bounds-check the
+			// snapshot index before reading it.
 			for i, geoIdx := range mapping {
-				if geoIdx == -1 {
+				if geoIdx == -1 && i < len(settings.BirdNET.Labels) {
 					label := settings.BirdNET.Labels[i]
-					if !seen[label] && !isSpeciesExcluded(label, settings.Realtime.Species.Exclude) {
+					if !seen[label] && !excluder.matches(label) {
 						includedSpecies = append(includedSpecies, label)
 						seen[label] = true
 						unmappedCount++
@@ -398,6 +407,11 @@ func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, 
 func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, []string, error) {
 	bn.Debug("Applying range filter")
 
+	// Build the exclude matcher once: it reverse-resolves localized common-name exclude
+	// entries through OpenFauna a single time so the per-score matches() below (and
+	// zeroScoresForAllLabels) stay off the dataset scan.
+	excluder := newExcludeMatcher(settings.Realtime.Species.Exclude, settings.BirdNET.Locale)
+
 	// Skip filtering if range filter backend is not initialized.
 	// Read under lock to avoid data race with Delete().
 	bn.mu.Lock()
@@ -405,13 +419,13 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	bn.mu.Unlock()
 	if !hasRangeFilter {
 		bn.Debug("Range filter model not loaded, returning zero scores for all labels")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil, nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, nil
 	}
 
 	// Skip filtering if location is not configured
 	if !settings.BirdNET.LocationConfigured {
 		bn.Debug("Location not configured, not using location based prediction filter")
-		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil, nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, excluder), nil, nil
 	}
 
 	threshold := settings.BirdNET.RangeFilter.Threshold
@@ -455,7 +469,7 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 
 		speciesScores := make([]SpeciesScore, 0, len(scores))
 		for _, ss := range scores {
-			if !isSpeciesExcluded(ss.Label, settings.Realtime.Species.Exclude) {
+			if !excluder.matches(ss.Label) {
 				speciesScores = append(speciesScores, ss)
 			}
 		}
@@ -471,10 +485,14 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 			if mapping == nil {
 				mapping = buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
 			}
+			// cachedMapping (mappedRangeFilter.classifierToGeo) is sized from the
+			// model's labels at load time and can be longer than the live settings
+			// snapshot during a concurrent model/settings reload, so bounds-check the
+			// snapshot index before reading it.
 			for i, geoIdx := range mapping {
-				if geoIdx == -1 {
+				if geoIdx == -1 && i < len(settings.BirdNET.Labels) {
 					label := settings.BirdNET.Labels[i]
-					if !seen[label] && !isSpeciesExcluded(label, settings.Realtime.Species.Exclude) {
+					if !seen[label] && !excluder.matches(label) {
 						speciesScores = append(speciesScores, SpeciesScore{Score: 0.0, Label: label})
 						seen[label] = true
 					}
@@ -500,7 +518,7 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 
 	var speciesScores []SpeciesScore
 	for _, filter := range filters {
-		if !isSpeciesExcluded(filter.Label, settings.Realtime.Species.Exclude) {
+		if !excluder.matches(filter.Label) {
 			speciesScores = append(speciesScores, SpeciesScore{Score: float64(filter.Score), Label: filter.Label})
 		} else {
 			bn.Debug("Excluding species from range filter: %s", filter.Label)
@@ -519,22 +537,65 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 }
 
 // zeroScoresForAllLabels creates a slice of SpeciesScore with zero scores for all provided labels,
-// excluding any species that appear in the exclude list. This ensures that excluded species are
+// excluding any species the matcher rejects. This ensures that excluded species are
 // filtered even when the range filter model is not active or location is not configured.
-func zeroScoresForAllLabels(labels, excludeList []string) []SpeciesScore {
+func zeroScoresForAllLabels(labels []string, excl excludeMatcher) []SpeciesScore {
 	speciesScores := make([]SpeciesScore, 0, len(labels))
 	for _, label := range labels {
-		if !isSpeciesExcluded(label, excludeList) {
+		if !excl.matches(label) {
 			speciesScores = append(speciesScores, SpeciesScore{Score: 0.0, Label: label})
 		}
 	}
 	return speciesScores
 }
 
-// isSpeciesExcluded checks if a species should be excluded based on its label
-func isSpeciesExcluded(label string, excludeList []string) bool {
-	for _, excludedSpecies := range excludeList {
-		if matchesSpecies(label, excludedSpecies) {
+// excludeMatcher matches model labels against the user's realtime.species.exclude
+// list for one rebuild/prediction pass. It forward-matches each label's scientific and
+// common name against the raw entries (like the include side), plus carries a set of
+// scientific names reverse-resolved from localized common-name entries via OpenFauna. A
+// non-primary model emits scientific-only labels (e.g. "Vulpes vulpes"), whose parsed
+// common name falls back to the scientific name, so a localized exclude entry (the
+// Finnish "Kettu") would never forward-match; that localized name lives only in
+// OpenFauna. The reverse resolution is batched once at construction (one dataset scan),
+// keeping the per-label match off OpenFauna so it stays safe on the hot paths the
+// matcher runs on (per geomodel score during rebuild, zeroScoresForAllLabels). This
+// mirrors the include-side reverse lookup in resolveOverrideLabels.
+type excludeMatcher struct {
+	entries    []string            // raw exclude entries, forward-matched per label
+	reverseSci map[string]struct{} // lower-cased scientific names of localized entries
+}
+
+// newExcludeMatcher precomputes the reverse-resolution set for excludeList at the
+// BirdNET locale. An empty exclude list yields a zero-value matcher whose matches() is
+// a cheap no-op and skips the OpenFauna scan entirely.
+func newExcludeMatcher(excludeList []string, locale string) excludeMatcher {
+	m := excludeMatcher{entries: excludeList}
+	if len(excludeList) == 0 {
+		return m
+	}
+	for _, sciNames := range openfauna.LookupScientificNames(excludeList, locale) {
+		for _, sci := range sciNames {
+			if m.reverseSci == nil {
+				m.reverseSci = make(map[string]struct{}, len(excludeList))
+			}
+			m.reverseSci[strings.ToLower(sci)] = struct{}{}
+		}
+	}
+	return m
+}
+
+// matches reports whether label is excluded: a forward scientific/common-name match
+// against an entry, or a reverse match of the label's scientific name to a localized
+// common-name entry resolved through OpenFauna.
+func (m excludeMatcher) matches(label string) bool {
+	sp := detection.ParseSpeciesString(label)
+	for _, entry := range m.entries {
+		if strings.EqualFold(sp.ScientificName, entry) || strings.EqualFold(sp.CommonName, entry) {
+			return true
+		}
+	}
+	if m.reverseSci != nil {
+		if _, ok := m.reverseSci[strings.ToLower(sp.ScientificName)]; ok {
 			return true
 		}
 	}

--- a/internal/classifier/range_filter_exclude_test.go
+++ b/internal/classifier/range_filter_exclude_test.go
@@ -1,0 +1,147 @@
+package classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestExcludeMatcher_ForwardMatch characterizes the forward matching (scientific or
+// common name equality) that the matcher preserves from the old
+// isSpeciesExcluded/matchesSpecies path.
+func TestExcludeMatcher_ForwardMatch(t *testing.T) {
+	t.Parallel()
+	m := newExcludeMatcher([]string{"Turdus merula", "Great Tit"}, "en")
+	assert.True(t, m.matches("Turdus merula_Common Blackbird"), "scientific-name forward match")
+	assert.True(t, m.matches("Parus major_Great Tit"), "common-name forward match")
+	assert.False(t, m.matches("Corvus corax_Northern Raven"), "unrelated species not excluded")
+}
+
+// TestExcludeMatcher_LocalizedCommonName_ReverseResolves is the core gap this fixes:
+// a non-primary model emits a scientific-only label ("Vulpes vulpes"), whose parsed
+// common name falls back to the scientific name, so a localized exclude entry (the
+// Finnish "Kettu") cannot forward-match. The localized name lives only in OpenFauna, so
+// the matcher must reverse-resolve "Kettu" -> "Vulpes vulpes" to exclude the label.
+func TestExcludeMatcher_LocalizedCommonName_ReverseResolves(t *testing.T) {
+	t.Parallel()
+	m := newExcludeMatcher([]string{"Kettu"}, "fi")
+	assert.True(t, m.matches("Vulpes vulpes"),
+		"a localized common-name exclude must reverse-resolve to the scientific-only label")
+	assert.False(t, m.matches("Turdus merula_Common Blackbird"),
+		"reverse resolution must not over-exclude an unrelated species")
+}
+
+// TestExcludeMatcher_Empty verifies a zero/empty exclude list yields a cheap no-op
+// matcher (no matches).
+func TestExcludeMatcher_Empty(t *testing.T) {
+	t.Parallel()
+	m := newExcludeMatcher(nil, "fi")
+	assert.False(t, m.matches("Turdus merula_Common Blackbird"))
+	assert.False(t, m.matches("Vulpes vulpes"))
+}
+
+// TestExcludeMatcher_CaseInsensitive proves matching normalizes case on both paths:
+// EqualFold on the forward (scientific/common) match, and a lower-cased scientific-name
+// set on the reverse match (where the entry is also case-folded by OpenFauna's lookup).
+func TestExcludeMatcher_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	// Lower-cased localized entry still reverse-resolves; upper-cased label still matches.
+	m := newExcludeMatcher([]string{"kettu"}, "fi")
+	assert.True(t, m.matches("VULPES VULPES"),
+		"reverse match must be case-insensitive on both the entry and the label")
+
+	// Forward scientific-name match stays case-insensitive, matching the old behavior.
+	mf := newExcludeMatcher([]string{"TURDUS MERULA"}, "fi")
+	assert.True(t, mf.matches("Turdus merula_Mustarastas"),
+		"forward scientific-name match must be case-insensitive")
+}
+
+// TestExcludeMatcher_ForwardAndReverseEntry proves a single exclude entry that both
+// forward-matches a localized label and reverse-resolves to a scientific name drops both
+// label forms: the localized "Scientific_Common" label (forward) and a scientific-only
+// label a non-primary model would emit (reverse). The two paths coexist without
+// interfering.
+func TestExcludeMatcher_ForwardAndReverseEntry(t *testing.T) {
+	t.Parallel()
+	m := newExcludeMatcher([]string{"Great Tit"}, "fi")
+	assert.True(t, m.matches("Parus major_Great Tit"),
+		"forward common-name match")
+	assert.True(t, m.matches("Parus major"),
+		"the same entry must also drop the scientific-only label via reverse resolution")
+}
+
+// excludeTestSettings builds a v3-geomodel snapshot like overrideTestSettings but
+// configured for the exclude side: the geomodel surfaces a scientific-only non-primary
+// label ("Vulpes vulpes", the fox) that a localized Finnish exclude entry ("Kettu")
+// must drop via OpenFauna reverse resolution.
+func excludeTestSettings(t *testing.T) (*conf.Settings, *fakeUniversalRangeFilter) {
+	t.Helper()
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.Locale = "fi"
+	settings.BirdNET.Labels = []string{
+		"Turdus merula_Mustarastas",
+		"Parus major_Talitiainen",
+	}
+	settings.Realtime.Species.Exclude = []string{"Kettu"}
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird", "Vulpes vulpes"},
+		scores: []SpeciesScore{
+			{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+			{Score: 0.8, Label: "Vulpes vulpes"},
+		},
+		rawScores: []float32{0.9, 0.8},
+	}
+	return settings, rf
+}
+
+// TestBuildRangeFilter_LocalizedExclude_DropsScientificOnlyNonPrimaryLabel proves the
+// wiring of the exclude reverse-resolution on the BuildRangeFilter path: a localized
+// exclude entry must reverse-resolve and remove the scientific-only label from the
+// inclusion working set.
+func TestBuildRangeFilter_LocalizedExclude_DropsScientificOnlyNonPrimaryLabel(t *testing.T) {
+	settings, rf := excludeTestSettings(t)
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := buildTestOrchestrator(t, settings, rf)
+	require.NoError(t, BuildRangeFilter(o))
+
+	included := conf.GetSettings().GetIncludedSpecies()
+	assert.NotContains(t, included, "Vulpes vulpes",
+		"a localized exclude entry must reverse-resolve and drop the scientific-only non-primary label")
+	assert.Contains(t, included, "Turdus merula_Common Blackbird",
+		"an unrelated in-range species must stay included")
+}
+
+// TestGetProbableSpecies_LocalizedExclude_DropsScientificOnlyNonPrimaryLabel proves the
+// same on the getProbableSpecies path (daily UpdateRangeFilterAction / species-list API).
+func TestGetProbableSpecies_LocalizedExclude_DropsScientificOnlyNonPrimaryLabel(t *testing.T) {
+	settings, rf := excludeTestSettings(t)
+
+	bn := &BirdNET{
+		Settings:     settings,
+		rangeFilter:  rf,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+
+	scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+	require.NoError(t, err)
+
+	labels := make([]string, 0, len(scores))
+	for _, ss := range scores {
+		labels = append(labels, ss.Label)
+	}
+	assert.NotContains(t, labels, "Vulpes vulpes",
+		"the daily path must also reverse-resolve a localized exclude entry")
+	assert.Contains(t, labels, "Turdus merula_Common Blackbird",
+		"an unrelated in-range species must stay included")
+}

--- a/internal/classifier/range_filter_unmapped_bounds_test.go
+++ b/internal/classifier/range_filter_unmapped_bounds_test.go
@@ -1,0 +1,92 @@
+package classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// unmappedBoundsFixture builds a settings snapshot whose label set is SHORTER than
+// the classifier->geomodel mapping a mappedRangeFilter captures at model-load time.
+// The mapping is built from a 3-label classifier set whose index 2 has no geomodel
+// match (geoIdx == -1) and is therefore beyond the 2-label snapshot. With
+// PassUnmappedSpecies enabled, the unmapped loop indexes the snapshot labels by the
+// mapping index, so index 2 is out of range - the panic this guards against. The divergence
+// models a concurrent model/settings reload window (or a custom settings struct passed
+// to GetProbableSpeciesWithSettings).
+func unmappedBoundsFixture(t *testing.T) (*conf.Settings, *mappedRangeFilter) {
+	t.Helper()
+	settings := conftest.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+	// Snapshot carries only 2 labels - shorter than the mapping built below.
+	settings.BirdNET.Labels = []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+	}
+
+	geomodelLabels := []string{"Turdus merula_Common Blackbird"}
+	modelClassifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Ficedula hypoleuca_Pied Flycatcher", // unmapped, at index 2 (beyond the snapshot)
+	}
+	mrf := newMappedRangeFilter(
+		&fakeRangeFilter{scores: []float32{0.9}},
+		modelClassifierLabels,
+		geomodelLabels,
+		1.0,
+	)
+	return settings, mrf
+}
+
+// TestGetProbableSpecies_PassUnmapped_MappingLongerThanSnapshotLabels_NoPanic covers
+// the getProbableSpecies universal path: the unmapped loop must bounds-check the
+// mapping index against the live settings snapshot before indexing it.
+func TestGetProbableSpecies_PassUnmapped_MappingLongerThanSnapshotLabels_NoPanic(t *testing.T) {
+	settings, mrf := unmappedBoundsFixture(t)
+
+	bn := &BirdNET{
+		Settings:     settings,
+		rangeFilter:  mrf,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+
+	require.NotPanics(t, func() {
+		scores, _, err := bn.getProbableSpecies(time.Now(), 0, settings)
+		require.NoError(t, err)
+		labels := make([]string, 0, len(scores))
+		for _, ss := range scores {
+			labels = append(labels, ss.Label)
+		}
+		// The in-range unmapped label (index 1) is still added; the out-of-range
+		// index (2) is safely skipped rather than panicking.
+		assert.Contains(t, labels, "Parus major_Great Tit",
+			"an in-range unmapped classifier species must still be added")
+	})
+}
+
+// TestBuildRangeFilter_PassUnmapped_MappingLongerThanSnapshotLabels_NoPanic covers the
+// sibling unmapped loop on the BuildRangeFilter path.
+func TestBuildRangeFilter_PassUnmapped_MappingLongerThanSnapshotLabels_NoPanic(t *testing.T) {
+	settings, mrf := unmappedBoundsFixture(t)
+	conftest.SetTestSettings(settings)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+
+	o := buildTestOrchestrator(t, settings, mrf)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, BuildRangeFilter(o))
+	})
+
+	included := conf.GetSettings().GetIncludedSpecies()
+	assert.Contains(t, included, "Parus major_Great Tit",
+		"an in-range unmapped classifier species must still be added")
+}


### PR DESCRIPTION
## Summary

Two fixes in the classifier range-filter species-inclusion path.

### Localized species excludes for non-primary models

`realtime.species.exclude` now matches localized common names for the scientific-only labels a non-primary model (Perch, BattyBirdNET) emits. Such a model emits a label like `Vulpes vulpes` whose parsed common name falls back to the scientific name, so a localized exclude entry like the Finnish `Kettu` never matched and the species was silently kept in the working set.

A new `excludeMatcher` forward-matches each label's scientific/common name against the raw exclude entries (unchanged behavior) and additionally carries a set of scientific names reverse-resolved once per rebuild via OpenFauna, so `Kettu` drops `Vulpes vulpes`. The reverse lookup is batched into a single dataset scan and kept off the per-score hot path, mirroring the existing include-side reverse resolution.

Note: this broadens exclusion for scientific-only secondary-model labels (localized and English exclude entries now also drop those). Primary bird labels already carry localized common names and are matched by the unchanged forward path, so no previously-included bird species is affected.

### Bounds guard on PassUnmappedSpecies

The `PassUnmappedSpecies` loops indexed `settings.BirdNET.Labels[i]` where `i` ranged over the classifier-to-geomodel mapping captured at model-load time. That mapping can outlength the live settings snapshot during a concurrent model/settings reload (or when a caller passes a custom settings struct), which panicked with an index-out-of-range. Both loops now bounds-check `i < len(settings.BirdNET.Labels)`, matching the guard `predictFilter` already uses.

## Test Plan

- [x] New unit coverage for `excludeMatcher`: forward, reverse, empty, case-insensitivity, combined forward+reverse entry
- [x] Exclude wiring tests on both the `BuildRangeFilter` and `getProbableSpecies` paths
- [x] Bounds-guard regression tests on both paths (reproduce the panic without the fix)
- [x] `go test -race ./internal/classifier/...` green
- [x] `golangci-lint run` clean (full project)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when species exclusion lists contain localized names across different locales.
  * Added bounds-checking to prevent crashes during concurrent configuration updates.

* **Tests**
  * Added comprehensive test coverage for species exclusion and range-filter behavior, including edge cases with localized species names and concurrent mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->