### PR TITLE
fix(weather): consolidate provider HTTP layer, cancel in-flight fetches, redact coordinates in logs

### DIFF
--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
 	"github.com/tphakala/birdnet-go/internal/notification"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/weather"
 )
 
@@ -677,13 +678,16 @@ func (c *Controller) testWeatherAuthentication(ctx context.Context, settings *co
 		client := &http.Client{Timeout: integrationShortTimeout * time.Second}
 		req, err := http.NewRequestWithContext(ctx, "GET", testURL, http.NoBody)
 		if err != nil {
-			return "", fmt.Errorf("failed to create authentication request: %w", err)
+			// Scrub before wrapping: the *url.Error embeds testURL, which carries
+			// the appid API key, and this error is returned to the API client and logs.
+			return "", fmt.Errorf("failed to create authentication request: %w", privacy.WrapError(err))
 		}
 
 		req.Header.Set("User-Agent", "BirdNET-Go Weather Test")
 		resp, err := client.Do(req)
 		if err != nil {
-			return "", fmt.Errorf("failed to authenticate with OpenWeather API: %w", err)
+			// Scrub before wrapping: the transport *url.Error embeds the appid API key.
+			return "", fmt.Errorf("failed to authenticate with OpenWeather API: %w", privacy.WrapError(err))
 		}
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
@@ -712,16 +716,16 @@ func (c *Controller) testWeatherDataFetch(ctx context.Context, settings *conf.Se
 	var provider weather.Provider
 	switch settings.Realtime.Weather.Provider {
 	case WeatherProviderYrno:
-		provider = weather.NewYrNoProvider()
+		provider = weather.NewYrNoProvider(nil)
 	case WeatherProviderOpenWeather:
-		provider = weather.NewOpenWeatherProvider()
+		provider = weather.NewOpenWeatherProvider(nil)
 	case WeatherProviderWunderground:
 		provider = weather.NewWundergroundProvider(nil)
 	default:
 		return "", fmt.Errorf("unsupported weather provider: %s", settings.Realtime.Weather.Provider)
 	}
 
-	weatherData, err := provider.FetchWeather(settings)
+	weatherData, err := provider.FetchWeather(ctx, settings)
 	if err != nil {
 		// Extract the actual error message instead of wrapping it
 		// The provider already returns detailed error messages

--- a/internal/weather/provider_apikey_leak_test.go
+++ b/internal/weather/provider_apikey_leak_test.go
@@ -65,12 +65,12 @@ func TestOpenWeatherProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 	httpmock.RegisterResponder("GET", `=~^https://api\.openweathermap\.org/data/2\.5/weather`,
 		httpmock.NewErrorResponder(errors.NewStd("simulated transport failure")))
 
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	settings := createTestSettings(t, "openweather", func(s *conf.Settings) {
 		s.Realtime.Weather.OpenWeather.APIKey = sentinelAPIKey
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -94,7 +94,7 @@ func TestWundergroundProvider_TransportError_DoesNotLeakAPIKey(t *testing.T) {
 		s.Realtime.Weather.Wunderground.APIKey = sentinelAPIKey
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -119,10 +119,10 @@ func TestYrNoProvider_TransportError_DoesNotLeakCoordinates(t *testing.T) {
 	httpmock.RegisterResponder("GET", `=~^https://api\.met\.no/weatherapi/locationforecast/2\.0/complete`,
 		httpmock.NewErrorResponder(errors.NewStd("simulated transport failure")))
 
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	settings := createTestSettings(t, "yrno") // Helsinki: 60.1699, 24.9384
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -131,34 +131,36 @@ func TestYrNoProvider_TransportError_DoesNotLeakCoordinates(t *testing.T) {
 	assert.NotContains(t, err.Error(), "60.170", "returned error must not embed latitude")
 	assert.NotContains(t, err.Error(), "24.938", "returned error must not embed longitude")
 
-	// The transport-failure WARN log must be scrubbed too. The Info "Fetching
-	// weather data" log intentionally shows the request URL (with coordinates),
-	// consistent across all providers, so assert specifically on the
-	// "HTTP request failed" lines rather than the whole captured buffer. Track
-	// that at least one such line was seen so a future log-message rename fails
-	// loudly here instead of silently skipping the assertion.
+	// No log line may embed the coordinates. The Info "Fetching weather data" log
+	// now masks them via maskURLForLog (the URL query's lat/lon are PII), and the
+	// transport-failure WARN log is scrubbed, so the whole captured buffer must be
+	// free of the raw coordinates. Track that at least one transport-failure line
+	// was seen so a future log-message rename fails loudly here instead of
+	// silently weakening the guard.
+	assert.NotContains(t, logs.String(), "60.170", "no log line may embed latitude")
+	assert.NotContains(t, logs.String(), "24.938", "no log line may embed longitude")
+
 	var sawTransportLog bool
 	for line := range strings.Lines(logs.String()) {
 		if strings.Contains(line, "HTTP request failed") {
 			sawTransportLog = true
-			assert.NotContains(t, line, "60.170", "transport-failure log must not embed latitude")
-			assert.NotContains(t, line, "24.938", "transport-failure log must not embed longitude")
 		}
 	}
 	assert.True(t, sawTransportLog, "expected at least one transport-failure log line to assert against")
 }
 
-// TestMaskAPIKey_FailsClosedOnParseError verifies that maskAPIKey never returns
-// the raw URL when url.Parse fails. The raw URL embeds the API key, so the
-// previous behavior of returning it on a parse error leaked the key at the Info
+// TestMaskURLForLog_FailsClosedOnParseError verifies that maskURLForLog never
+// returns the raw URL when url.Parse fails. The raw URL embeds the API key and
+// the coordinates, so returning it on a parse error would leak both at the Info
 // log that masks the fetch URL.
-func TestMaskAPIKey_FailsClosedOnParseError(t *testing.T) {
+func TestMaskURLForLog_FailsClosedOnParseError(t *testing.T) {
 	// A raw DEL control character (0x7f) makes url.Parse fail.
-	rawURL := "https://api.example.com/path\x7f?appid=" + sentinelAPIKey
+	rawURL := "https://api.example.com/path\x7f?appid=" + sentinelAPIKey + "&lat=60.170&lon=24.938"
 
-	got := maskAPIKey(rawURL, "appid")
+	got := maskURLForLog(rawURL)
 
 	assert.NotContains(t, got, sentinelAPIKey, "a parse failure must not return the raw URL with the key")
+	assert.NotContains(t, got, "60.170", "a parse failure must not return the raw URL with coordinates")
 	assert.Equal(t, maskedURLOnError, got, "a parse failure must return the fail-closed placeholder")
 }
 
@@ -183,9 +185,9 @@ func TestBuildOpenWeatherURL_EscapesAPIKey(t *testing.T) {
 	// Round-trip: decoding the query yields the original key, and only one appid.
 	assert.Equal(t, keyWithSpecials, parsed.Query().Get("appid"), "appid must round-trip through escaping")
 
-	// maskAPIKey must mask the (now valid) URL rather than falling back to the
+	// maskURLForLog must mask the (now valid) URL rather than falling back to the
 	// parse-failure placeholder.
-	masked := maskAPIKey(rawURL, "appid")
+	masked := maskURLForLog(rawURL)
 	assert.NotEqual(t, maskedURLOnError, masked, "a well-formed URL must not hit the fail-closed path")
 	assert.NotContains(t, masked, "key with spaces", "the masked URL must not reveal the key")
 }
@@ -228,10 +230,10 @@ func TestOpenWeatherProvider_HTTP401_AuthFailed(t *testing.T) {
 
 	registerOpenWeatherResponder(t, http.StatusUnauthorized, `{"cod": 401, "message": "Invalid API key"}`)
 
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	settings := createTestSettings(t, "openweather")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)

--- a/internal/weather/provider_common.go
+++ b/internal/weather/provider_common.go
@@ -1,12 +1,16 @@
 package weather
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 const (
@@ -103,6 +107,125 @@ func validateEndpointScheme(u *url.URL, provider string) error {
 		)
 	}
 	return nil
+}
+
+// redactedValue replaces sensitive query-parameter values in log-safe URLs.
+const redactedValue = "***MASKED***"
+
+// maskedURLOnError is returned by maskURLForLog when the URL cannot be parsed.
+// The raw URL embeds the API key and coordinates, so it is never returned on a
+// parse failure; this fully redacted placeholder is returned instead (fail
+// closed).
+const maskedURLOnError = "[unparseable-url-redacted]"
+
+// sensitiveQueryParams lists the query parameters that must be redacted before a
+// weather API request URL is logged. The key parameters (appid for OpenWeather,
+// apiKey for Wunderground) authenticate the account, and the coordinates
+// (lat/lon, used by OpenWeather and yr.no) are PII that reveal the user's
+// location, so neither may reach a log sink in cleartext.
+var sensitiveQueryParams = []string{"appid", "apiKey", "lat", "lon"}
+
+// maskURLForLog returns a log-safe representation of a weather provider request
+// URL. It redacts the API key and the location coordinates while preserving
+// non-sensitive parameters (units, format, ...) that aid debugging. On a parse
+// failure it fails closed, returning a fully redacted placeholder rather than
+// risk echoing the raw URL, which embeds the key and coordinates.
+func maskURLForLog(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return maskedURLOnError
+	}
+	q := parsed.Query()
+	for _, p := range sensitiveQueryParams {
+		if q.Has(p) {
+			q.Set(p, redactedValue)
+		}
+	}
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+// sleepWithContext waits for d to elapse or for ctx to be cancelled, whichever
+// happens first, returning ctx.Err() on cancellation. Using it in place of
+// time.Sleep lets a shutdown abort an in-progress retry backoff instead of
+// blocking for the full delay. time.After is leak-free on Go 1.23+ (an
+// unreferenced timer is garbage collected even if it has not fired), so it is
+// preferred here over the more verbose time.NewTimer/Stop dance.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// weatherResponseHandler processes a single HTTP response inside the shared
+// retry loop. It returns the response body on success. retry==true asks the
+// executor to back off and try again (a transient failure on a non-final
+// attempt). A non-nil err is returned to the caller verbatim, so a handler can
+// surface sentinel errors (e.g. ErrWeatherAuthFailed, ErrWeatherDataNotModified)
+// that errors.Is must still match upstream. The handler owns closing resp.Body.
+type weatherResponseHandler func(resp *http.Response, attemptLog logger.Logger, isLastAttempt bool) (body []byte, retry bool, err error)
+
+// executeWeatherRequest runs req through up to MaxRetries attempts with the
+// injected client, delegating per-status handling to handle. It centralizes the
+// retry loop, the transport-error scrubbing, the context-aware backoff, and the
+// "max retries exceeded" terminal error that the yr.no and OpenWeather providers
+// previously duplicated. The same request is reused across attempts, which is
+// safe for the GET/NoBody weather requests: http.Client.Timeout is applied fresh
+// on every Do, and no request body needs replaying. A cancelled context is
+// returned verbatim (not wrapped or retried) so callers can treat shutdown as
+// benign rather than a provider failure.
+func executeWeatherRequest(ctx context.Context, client *http.Client, req *http.Request, provider string, log logger.Logger, handle weatherResponseHandler) ([]byte, error) {
+	for i := range MaxRetries {
+		isLastAttempt := i == MaxRetries-1
+		attemptLogger := log.With(
+			logger.Int("attempt", i+1),
+			logger.Int("max_attempts", MaxRetries))
+
+		resp, err := client.Do(req) //nolint:bodyclose // resp.Body is closed by the handle callback on every path; bodyclose cannot trace the close through the function pointer.
+		if err != nil {
+			// A cancelled context means shutdown (or an aborted on-demand
+			// request), not a provider failure: surface it directly so callers
+			// skip the failure/backoff bookkeeping.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			// Scrub before logging and wrapping: net/http wraps transport
+			// failures in a *url.Error whose Error() embeds the request URL,
+			// which may carry the API key or the user's coordinates.
+			attemptLogger.Warn("HTTP request failed", logger.SanitizedError(err))
+			if isLastAttempt {
+				return nil, newWeatherErrorWithRetries(privacy.WrapError(err), errors.CategoryNetwork, "weather_api_request", provider)
+			}
+			if serr := sleepWithContext(ctx, RetryDelay); serr != nil {
+				return nil, serr
+			}
+			continue
+		}
+
+		attemptLogger.Debug("Received HTTP response", logger.Int("status_code", resp.StatusCode))
+
+		body, retry, err := handle(resp, attemptLogger, isLastAttempt)
+		if err != nil {
+			return nil, err
+		}
+		if retry {
+			if serr := sleepWithContext(ctx, RetryDelay); serr != nil {
+				return nil, serr
+			}
+			continue
+		}
+		return body, nil
+	}
+
+	return nil, newWeatherErrorWithRetries(
+		fmt.Errorf("max retries exceeded"),
+		errors.CategoryNetwork,
+		"weather_api_request",
+		provider,
+	)
 }
 
 // Temperature conversion constants

--- a/internal/weather/provider_common.go
+++ b/internal/weather/provider_common.go
@@ -184,7 +184,11 @@ func executeWeatherRequest(ctx context.Context, client *http.Client, req *http.R
 			logger.Int("attempt", i+1),
 			logger.Int("max_attempts", MaxRetries))
 
-		resp, err := client.Do(req) //nolint:bodyclose // resp.Body is closed by the handle callback on every path; bodyclose cannot trace the close through the function pointer.
+		// Clone the request per attempt. A reused *http.Request can retain cancelled
+		// state from a prior attempt whose client.Timeout fired, which would fail the
+		// retry with a spurious http.ErrRequestCanceled. client.Do mutates only the
+		// clone, so the original stays pristine for the next attempt.
+		resp, err := client.Do(req.Clone(ctx)) //nolint:bodyclose // resp.Body is closed by the handle callback on every path; bodyclose cannot trace the close through the function pointer.
 		if err != nil {
 			// A cancelled context means shutdown (or an aborted on-demand
 			// request), not a provider failure: surface it directly so callers

--- a/internal/weather/provider_http_test.go
+++ b/internal/weather/provider_http_test.go
@@ -1,0 +1,125 @@
+package weather
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestMaskURLForLog verifies that the consolidated log-redaction helper masks
+// both the API key (appid/apiKey) and the location coordinates (lat/lon), while
+// preserving non-sensitive query parameters. Coordinates are PII, so they must
+// never reach a log sink in cleartext.
+func TestMaskURLForLog(t *testing.T) {
+	t.Parallel()
+
+	const secret = "secret123"
+
+	tests := []struct {
+		name           string
+		url            string
+		mustNotContain []string
+		mustContain    []string
+	}{
+		{
+			name:           "openweather masks key and coordinates, keeps units",
+			url:            "https://api.openweathermap.org/data/2.5/weather?lat=60.170&lon=24.938&appid=" + secret + "&units=metric&lang=en",
+			mustNotContain: []string{secret, "60.170", "24.938"},
+			mustContain:    []string{"api.openweathermap.org", "MASKED", "units=metric", "lang=en"},
+		},
+		{
+			name:           "wunderground masks apiKey, keeps stationId",
+			url:            "https://api.weather.com/v2/pws/observations/current?stationId=KTEST123&format=json&units=m&apiKey=" + secret + "&numericPrecision=decimal",
+			mustNotContain: []string{secret},
+			mustContain:    []string{"api.weather.com", "MASKED", "stationId=KTEST123", "format=json"},
+		},
+		{
+			name:           "yrno masks bare coordinates",
+			url:            "https://api.met.no/weatherapi/locationforecast/2.0/complete?lat=60.170&lon=24.938",
+			mustNotContain: []string{"60.170", "24.938"},
+			mustContain:    []string{"api.met.no", "MASKED"},
+		},
+		{
+			name:        "url without query is unchanged",
+			url:         "https://api.example.com/path",
+			mustContain: []string{"https://api.example.com/path"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := maskURLForLog(tt.url)
+			for _, s := range tt.mustNotContain {
+				assert.NotContains(t, got, s, "masked URL must not leak %q", s)
+			}
+			for _, s := range tt.mustContain {
+				assert.Contains(t, got, s, "masked URL should contain %q", s)
+			}
+		})
+	}
+}
+
+// TestSleepWithContext verifies the context-aware retry sleep: it waits for the
+// full delay when the context stays live, and returns promptly with the context
+// error when cancelled, so a shutdown aborts an in-progress retry backoff.
+func TestSleepWithContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil after the delay elapses", func(t *testing.T) {
+		t.Parallel()
+		err := sleepWithContext(t.Context(), 10*time.Millisecond)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns ctx error promptly when already cancelled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // cancel before sleeping
+
+		start := time.Now()
+		err := sleepWithContext(ctx, time.Hour)
+
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Less(t, time.Since(start), time.Second, "must return promptly on cancellation, not wait the full delay")
+	})
+}
+
+// TestFetchWeather_ContextCancelAbortsRequest proves the end-to-end #988
+// behavior: cancelling the context aborts an in-flight provider fetch promptly
+// instead of waiting out the per-request timeout or the retry budget. It points
+// the provider at a real server that blocks until the request is cancelled, so
+// the real transport (not httpmock) honors the cancellation and the shared
+// executor returns context.Canceled.
+func TestFetchWeather_ContextCancelAbortsRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // block until the client cancels the request
+	}))
+	defer srv.Close()
+
+	provider := NewOpenWeatherProvider(nil)
+	settings := createTestSettings(t, "openweather", func(s *conf.Settings) {
+		s.Realtime.Weather.OpenWeather.Endpoint = srv.URL
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	data, err := provider.FetchWeather(ctx, settings)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+	require.ErrorIs(t, err, context.Canceled, "a cancelled context must surface as context.Canceled")
+	assert.Less(t, elapsed, RequestTimeout, "cancel must abort the fetch promptly, not wait out the timeout or retries")
+}

--- a/internal/weather/provider_http_test.go
+++ b/internal/weather/provider_http_test.go
@@ -2,8 +2,12 @@ package weather
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -122,4 +126,49 @@ func TestFetchWeather_ContextCancelAbortsRequest(t *testing.T) {
 	assert.Nil(t, data)
 	require.ErrorIs(t, err, context.Canceled, "a cancelled context must surface as context.Canceled")
 	assert.Less(t, elapsed, RequestTimeout, "cancel must abort the fetch promptly, not wait out the timeout or retries")
+}
+
+// reqRecordingTransport records every request it receives and fails the first
+// failFirst attempts at the transport layer to force a retry.
+type reqRecordingTransport struct {
+	mu        sync.Mutex
+	seen      []*http.Request
+	failFirst int
+	body      string
+}
+
+func (rt *reqRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.seen = append(rt.seen, req)
+	n := len(rt.seen)
+	rt.mu.Unlock()
+	if n <= rt.failFirst {
+		return nil, fmt.Errorf("simulated transport failure")
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(rt.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// TestExecuteWeatherRequest_ClonesRequestPerAttempt guards against reusing a
+// single *http.Request across retries. A reused request can retain cancelled
+// state from a prior attempt whose client.Timeout fired and fail the retry with
+// a spurious http.ErrRequestCanceled, so the executor must send a fresh (cloned)
+// request each attempt. The transport fails the first attempt and then succeeds,
+// and the two recorded requests must be distinct instances.
+func TestExecuteWeatherRequest_ClonesRequestPerAttempt(t *testing.T) {
+	rt := &reqRecordingTransport{failFirst: 1, body: openWeatherSuccessResponse()}
+	client := &http.Client{Transport: rt, Timeout: RequestTimeout}
+
+	provider := NewOpenWeatherProvider(client)
+	settings := createTestSettings(t, "openweather")
+
+	data, err := provider.FetchWeather(t.Context(), settings)
+
+	require.NoError(t, err, "the retry after a transport failure must succeed")
+	require.NotNil(t, data)
+	require.Len(t, rt.seen, 2, "expected one failed attempt followed by one successful retry")
+	assert.NotSame(t, rt.seen[0], rt.seen[1], "each attempt must use a freshly cloned request, not the reused instance")
 }

--- a/internal/weather/provider_openweather.go
+++ b/internal/weather/provider_openweather.go
@@ -160,17 +160,20 @@ func (p *OpenWeatherProvider) FetchWeather(ctx context.Context, settings *conf.S
 // retry executor. A 401 maps to the auth-failed sentinel without retrying; any
 // other non-200 retries until the final attempt; a 200 returns the body.
 func (p *OpenWeatherProvider) handleResponse(resp *http.Response, attemptLog logger.Logger, isLastAttempt bool) (body []byte, retry bool, err error) {
+	// Close the body on every return path; the error-status branches still drain
+	// it first so the shared keep-alive connection can be reused. This also keeps
+	// the body closed if a read panics, matching WundergroundProvider.executeRequest.
+	defer func() { _ = resp.Body.Close() }()
+
 	// HTTP 401: authentication failed — don't retry, return sentinel.
 	if resp.StatusCode == http.StatusUnauthorized {
 		_, _ = io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
 		attemptLog.Error("Weather API authentication failed — check your API key")
 		return nil, false, ErrWeatherAuthFailed
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
 		attemptLog.Warn("Received non-OK status code", logger.Int("status_code", resp.StatusCode))
 		if isLastAttempt {
 			return nil, false, newWeatherErrorWithRetries(
@@ -184,7 +187,6 @@ func (p *OpenWeatherProvider) handleResponse(resp *http.Response, attemptLog log
 	}
 
 	body, err = io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
 	if err != nil {
 		return nil, false, newWeatherError(err, errors.CategoryNetwork, "read_response_body", openWeatherProviderName)
 	}

--- a/internal/weather/provider_openweather.go
+++ b/internal/weather/provider_openweather.go
@@ -115,7 +115,7 @@ func (p *OpenWeatherProvider) FetchWeather(ctx context.Context, settings *conf.S
 		return nil, err
 	}
 
-	providerLogger := getLogger().With(logger.String("provider", openWeatherProviderName))
+	providerLogger := getLogger().WithContext(ctx).With(logger.String("provider", openWeatherProviderName))
 	providerLogger.Info("Fetching weather data", logger.String("url", maskURLForLog(apiURL)))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, http.NoBody)

--- a/internal/weather/provider_openweather.go
+++ b/internal/weather/provider_openweather.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,12 +24,6 @@ const (
 	// openWeatherCoordPrecision is the number of decimal places used when
 	// formatting latitude/longitude into the request URL (~110 m resolution).
 	openWeatherCoordPrecision = 3
-
-	// maskedURLOnError is returned by maskAPIKey when the URL cannot be parsed.
-	// The raw URL embeds the API key as a query parameter, so it is never
-	// returned on a parse failure; this fully redacted placeholder is returned
-	// instead (fail closed).
-	maskedURLOnError = "[unparseable-url-redacted]"
 )
 
 // OpenWeatherResponse represents the structure of weather data returned by the OpenWeather API
@@ -104,7 +99,7 @@ func buildOpenWeatherURL(settings *conf.Settings, apiKey string) (string, error)
 }
 
 // FetchWeather implements the Provider interface for OpenWeatherProvider
-func (p *OpenWeatherProvider) FetchWeather(settings *conf.Settings) (*WeatherData, error) {
+func (p *OpenWeatherProvider) FetchWeather(ctx context.Context, settings *conf.Settings) (*WeatherData, error) {
 	apiKey := settings.Realtime.Weather.OpenWeather.APIKey
 	if apiKey == "" {
 		return nil, newWeatherError(
@@ -121,18 +116,19 @@ func (p *OpenWeatherProvider) FetchWeather(settings *conf.Settings) (*WeatherDat
 	}
 
 	providerLogger := getLogger().With(logger.String("provider", openWeatherProviderName))
-	providerLogger.Info("Fetching weather data", logger.String("url", maskAPIKey(apiURL, "appid")))
+	providerLogger.Info("Fetching weather data", logger.String("url", maskURLForLog(apiURL)))
 
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, http.NoBody)
 	if err != nil {
-		// Scrub before wrapping: http.NewRequest can return a *url.Error that
-		// embeds apiURL, which carries the appid API key query parameter.
+		// Scrub before wrapping: http.NewRequestWithContext can return a
+		// *url.Error that embeds apiURL, which carries the appid API key query
+		// parameter.
 		return nil, newWeatherError(privacy.WrapError(err), errors.CategoryNetwork, "create_http_request", openWeatherProviderName)
 	}
 	req.Header.Set("User-Agent", UserAgent())
 
-	// Execute request with retry
-	body, err := executeOpenWeatherRequest(req, providerLogger)
+	// Execute request with retry via the shared executor.
+	body, err := executeWeatherRequest(ctx, p.httpClient, req, openWeatherProviderName, providerLogger, p.handleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -160,69 +156,39 @@ func (p *OpenWeatherProvider) FetchWeather(settings *conf.Settings) (*WeatherDat
 	return mappedData, nil
 }
 
-// executeOpenWeatherRequest executes HTTP request with retry logic
-func executeOpenWeatherRequest(req *http.Request, log logger.Logger) ([]byte, error) {
-	client := &http.Client{Timeout: RequestTimeout}
-
-	for i := range MaxRetries {
-		isLastAttempt := i == MaxRetries-1
-		attemptLogger := log.With(
-			logger.Int("attempt", i+1),
-			logger.Int("max_attempts", MaxRetries))
-
-		resp, err := client.Do(req)
-		if err != nil {
-			// Scrub before logging and wrapping: the *url.Error embeds the
-			// request URL, including the appid API key query parameter.
-			attemptLogger.Warn("HTTP request failed", logger.SanitizedError(err))
-			if isLastAttempt {
-				return nil, newWeatherErrorWithRetries(privacy.WrapError(err), errors.CategoryNetwork, "weather_api_request", openWeatherProviderName)
-			}
-			time.Sleep(RetryDelay)
-			continue
-		}
-
-		attemptLogger.Debug("Received HTTP response", logger.Int("status_code", resp.StatusCode))
-
-		// HTTP 401: authentication failed — don't retry, return sentinel
-		if resp.StatusCode == http.StatusUnauthorized {
-			_, _ = io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
-			attemptLogger.Error("Weather API authentication failed — check your API key")
-			return nil, ErrWeatherAuthFailed
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			bodyBytes, _ := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
-			attemptLogger.Warn("Received non-OK status code", logger.Int("status_code", resp.StatusCode))
-			if isLastAttempt {
-				return nil, newWeatherErrorWithRetries(
-					fmt.Errorf("received non-200 response (%d)", resp.StatusCode),
-					errors.CategoryNetwork,
-					"weather_api_response",
-					openWeatherProviderName,
-				)
-			}
-			_ = bodyBytes // Suppress unused warning
-			time.Sleep(RetryDelay)
-			continue
-		}
-
-		body, err := io.ReadAll(resp.Body)
+// handleResponse classifies a single OpenWeather HTTP response for the shared
+// retry executor. A 401 maps to the auth-failed sentinel without retrying; any
+// other non-200 retries until the final attempt; a 200 returns the body.
+func (p *OpenWeatherProvider) handleResponse(resp *http.Response, attemptLog logger.Logger, isLastAttempt bool) (body []byte, retry bool, err error) {
+	// HTTP 401: authentication failed — don't retry, return sentinel.
+	if resp.StatusCode == http.StatusUnauthorized {
+		_, _ = io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		if err != nil {
-			return nil, newWeatherError(err, errors.CategoryNetwork, "read_response_body", openWeatherProviderName)
-		}
-		return body, nil
+		attemptLog.Error("Weather API authentication failed — check your API key")
+		return nil, false, ErrWeatherAuthFailed
 	}
 
-	return nil, newWeatherErrorWithRetries(
-		fmt.Errorf("max retries exceeded"),
-		errors.CategoryNetwork,
-		"weather_api_request",
-		openWeatherProviderName,
-	)
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		attemptLog.Warn("Received non-OK status code", logger.Int("status_code", resp.StatusCode))
+		if isLastAttempt {
+			return nil, false, newWeatherErrorWithRetries(
+				fmt.Errorf("received non-200 response (%d)", resp.StatusCode),
+				errors.CategoryNetwork,
+				"weather_api_response",
+				openWeatherProviderName,
+			)
+		}
+		return nil, true, nil
+	}
+
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, false, newWeatherError(err, errors.CategoryNetwork, "read_response_body", openWeatherProviderName)
+	}
+	return body, false, nil
 }
 
 // mapOpenWeatherResponse converts OpenWeatherResponse to WeatherData
@@ -286,19 +252,4 @@ func convertOpenWeatherTemps(temp, feelsLike, tempMin, tempMax float64, units st
 		// metric: already Celsius
 		return temp, feelsLike, tempMin, tempMax
 	}
-}
-
-func maskAPIKey(rawURL, keyParamName string) string {
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil {
-		// Fail closed: the raw URL embeds the API key, so returning it on a
-		// parse failure would leak the key into logs.
-		return maskedURLOnError
-	}
-	queryParams := parsedURL.Query()
-	if queryParams.Has(keyParamName) {
-		queryParams.Set(keyParamName, "***MASKED***")
-	}
-	parsedURL.RawQuery = queryParams.Encode()
-	return parsedURL.String()
 }

--- a/internal/weather/provider_openweather_test.go
+++ b/internal/weather/provider_openweather_test.go
@@ -50,10 +50,10 @@ func TestOpenWeatherProvider_FetchWeather_Success(t *testing.T) {
 
 	registerOpenWeatherResponder(t, http.StatusOK, openWeatherSuccessResponse())
 
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	settings := createTestSettings(t, "openweather")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.NoError(t, err)
 	assertWeatherDataBasics(t, data)
@@ -83,12 +83,12 @@ func TestOpenWeatherProvider_FetchWeather_Success(t *testing.T) {
 }
 
 func TestOpenWeatherProvider_FetchWeather_NoAPIKey(t *testing.T) {
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	settings := createTestSettings(t, "openweather", func(s *conf.Settings) {
 		s.Realtime.Weather.OpenWeather.APIKey = ""
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -115,10 +115,10 @@ func TestOpenWeatherProvider_FetchWeather_HTTPError(t *testing.T) {
 			httpmock.Reset()
 			registerOpenWeatherResponder(t, tt.statusCode, `{"cod": "401", "message": "Invalid API key"}`)
 
-			provider := NewOpenWeatherProvider()
+			provider := NewOpenWeatherProvider(nil)
 			settings := createTestSettings(t, "openweather")
 
-			data, err := provider.FetchWeather(settings)
+			data, err := provider.FetchWeather(t.Context(), settings)
 
 			require.Error(t, err)
 			assert.Nil(t, data)
@@ -126,15 +126,40 @@ func TestOpenWeatherProvider_FetchWeather_HTTPError(t *testing.T) {
 	}
 }
 
+// TestOpenWeatherProvider_FetchWeather_Unauthorized_ReturnsSentinel guards the
+// 401 classification: an HTTP 401 must map to the ErrWeatherAuthFailed sentinel
+// (so the polling service can pause retries) and must NOT be retried. This
+// protects the sentinel-classification path through the shared retry helper.
+func TestOpenWeatherProvider_FetchWeather_Unauthorized_ReturnsSentinel(t *testing.T) {
+	setupHTTPMock(t)
+
+	callCount := 0
+	httpmock.RegisterResponder("GET", `=~^https://api\.openweathermap\.org/data/2\.5/weather`,
+		func(_ *http.Request) (*http.Response, error) {
+			callCount++
+			return httpmock.NewStringResponse(http.StatusUnauthorized, `{"cod":401,"message":"Invalid API key"}`), nil
+		})
+
+	provider := NewOpenWeatherProvider(nil)
+	settings := createTestSettings(t, "openweather")
+
+	data, err := provider.FetchWeather(t.Context(), settings)
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+	require.ErrorIs(t, err, ErrWeatherAuthFailed, "401 must map to the auth-failed sentinel")
+	assert.Equal(t, 1, callCount, "a 401 must not be retried")
+}
+
 func TestOpenWeatherProvider_FetchWeather_InvalidJSON(t *testing.T) {
 	setupHTTPMock(t)
 
 	registerOpenWeatherResponder(t, http.StatusOK, `{invalid json`)
 
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	settings := createTestSettings(t, "openweather")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -158,10 +183,10 @@ func TestOpenWeatherProvider_FetchWeather_EmptyWeatherArray(t *testing.T) {
 }`
 	registerOpenWeatherResponder(t, http.StatusOK, emptyWeatherResponse)
 
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	settings := createTestSettings(t, "openweather")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -198,49 +223,8 @@ func TestConvertOpenWeatherTemps_Standard(t *testing.T) {
 	assert.InDelta(t, 25.0, tempMax, 0.001)   // 298.15K = 25°C
 }
 
-func TestMaskAPIKey(t *testing.T) {
-	tests := []struct {
-		name     string
-		url      string
-		keyParam string
-		expected string
-	}{
-		{
-			name:     "masks_appid",
-			url:      "https://api.example.com?lat=60&appid=secret123&units=metric",
-			keyParam: "appid",
-			expected: "https://api.example.com?appid=%2A%2A%2AMASKED%2A%2A%2A&lat=60&units=metric",
-		},
-		{
-			name:     "no_key_present",
-			url:      "https://api.example.com?lat=60&units=metric",
-			keyParam: "appid",
-			expected: "https://api.example.com?lat=60&units=metric",
-		},
-		{
-			name:     "url_without_query",
-			url:      "https://api.example.com/path",
-			keyParam: "appid",
-			expected: "https://api.example.com/path",
-		},
-		{
-			name:     "different_key_param",
-			url:      "https://api.example.com?apiKey=secret&lat=60",
-			keyParam: "apiKey",
-			expected: "https://api.example.com?apiKey=%2A%2A%2AMASKED%2A%2A%2A&lat=60",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := maskAPIKey(tt.url, tt.keyParam)
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}
-
 func TestNewOpenWeatherProvider(t *testing.T) {
-	provider := NewOpenWeatherProvider()
+	provider := NewOpenWeatherProvider(nil)
 	require.NotNil(t, provider)
 
 	// Verify it implements Provider interface

--- a/internal/weather/provider_wunderground.go
+++ b/internal/weather/provider_wunderground.go
@@ -284,7 +284,7 @@ func buildWundergroundURL(cfg *wundergroundConfig) (string, error) {
 	return u.String(), nil
 }
 
-func (p *WundergroundProvider) FetchWeather(settings *conf.Settings) (*WeatherData, error) {
+func (p *WundergroundProvider) FetchWeather(ctx context.Context, settings *conf.Settings) (*WeatherData, error) {
 	cfg, err := validateWundergroundConfig(settings)
 	if err != nil {
 		return nil, err
@@ -296,10 +296,10 @@ func (p *WundergroundProvider) FetchWeather(settings *conf.Settings) (*WeatherDa
 	}
 
 	providerLogger := getLogger().With(logger.String("provider", wundergroundProviderName))
-	providerLogger.Info("Fetching weather data", logger.String("url", maskAPIKey(apiURL, "apiKey")))
+	providerLogger.Info("Fetching weather data", logger.String("url", maskURLForLog(apiURL)))
 
 	// Execute request
-	body, err := p.executeRequest(apiURL, cfg, providerLogger)
+	body, err := p.executeRequest(ctx, apiURL, cfg, providerLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -314,9 +314,18 @@ func (p *WundergroundProvider) FetchWeather(settings *conf.Settings) (*WeatherDa
 	return mapWundergroundResponse(wuResp, providerLogger), nil
 }
 
-// executeRequest performs the HTTP request with context timeout
-func (p *WundergroundProvider) executeRequest(apiURL string, cfg *wundergroundConfig, log logger.Logger) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+// executeRequest performs the HTTP request with a context timeout derived from
+// the caller's context, so both the per-request timeout and a shutdown
+// cancellation abort the in-flight call.
+//
+// Wunderground deliberately keeps its own one-shot request path rather than
+// using the shared executeWeatherRequest: it does not retry, and it maps each
+// non-OK status to a provider-specific, user-facing message via
+// parseWundergroundError (including HTTP 204 -> ErrWeatherNoData). Routing that
+// through the shared retry/handler callback would add more complexity than the
+// duplication it removes.
+func (p *WundergroundProvider) executeRequest(ctx context.Context, apiURL string, cfg *wundergroundConfig, log logger.Logger) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, RequestTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, http.NoBody)
@@ -368,14 +377,16 @@ func (p *WundergroundProvider) executeRequest(apiURL string, cfg *wundergroundCo
 // apiKey query parameter, so it is scrubbed before wrapping to prevent an
 // upstream logger.Error in weather.go from leaking the key.
 func handleWundergroundRequestError(ctx context.Context, err error) error {
-	var category errors.ErrorCategory
-	switch ctx.Err() {
-	case context.Canceled:
+	// Surface a parent cancellation directly (unwrapped) so fetchAndSave treats a
+	// shutdown as benign, matching the shared executeWeatherRequest. The
+	// per-request RequestTimeout deadline is a real timeout worth a backoff, so it
+	// stays a categorized weather error.
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return ctx.Err()
+	}
+	category := errors.CategoryNetwork
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		category = errors.CategoryTimeout
-	case context.DeadlineExceeded:
-		category = errors.CategoryTimeout
-	default:
-		category = errors.CategoryNetwork
 	}
 	return newWeatherError(privacy.WrapError(err), category, "weather_api_request", wundergroundProviderName)
 }

--- a/internal/weather/provider_wunderground.go
+++ b/internal/weather/provider_wunderground.go
@@ -295,7 +295,7 @@ func (p *WundergroundProvider) FetchWeather(ctx context.Context, settings *conf.
 		return nil, err
 	}
 
-	providerLogger := getLogger().With(logger.String("provider", wundergroundProviderName))
+	providerLogger := getLogger().WithContext(ctx).With(logger.String("provider", wundergroundProviderName))
 	providerLogger.Info("Fetching weather data", logger.String("url", maskURLForLog(apiURL)))
 
 	// Execute request

--- a/internal/weather/provider_wunderground_test.go
+++ b/internal/weather/provider_wunderground_test.go
@@ -1,7 +1,10 @@
 package weather
 
 import (
+	"context"
+	"math"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -53,7 +56,7 @@ func TestWundergroundProvider_FetchWeather_Success(t *testing.T) {
 	provider := NewWundergroundProvider(nil)
 	settings := createTestSettings(t, "wunderground")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.NoError(t, err)
 	assertWeatherDataBasics(t, data)
@@ -83,7 +86,7 @@ func TestWundergroundProvider_TimeParsing(t *testing.T) {
 	provider := NewWundergroundProvider(nil)
 	settings := createTestSettings(t, "wunderground")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 	require.NoError(t, err)
 
 	// The fixture contains obsTimeUtc: "2026-01-13T12:00:00Z"
@@ -111,7 +114,7 @@ func TestWundergroundProvider_FetchWeather_ImperialConfigIgnored(t *testing.T) {
 		s.Realtime.Weather.Wunderground.Units = "e" // User configured imperial
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.NoError(t, err)
 	assertWeatherDataBasics(t, data)
@@ -129,7 +132,7 @@ func TestWundergroundProvider_FetchWeather_NoAPIKey(t *testing.T) {
 		s.Realtime.Weather.Wunderground.APIKey = ""
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -142,7 +145,7 @@ func TestWundergroundProvider_FetchWeather_NoStationID(t *testing.T) {
 		s.Realtime.Weather.Wunderground.StationID = ""
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -155,7 +158,7 @@ func TestWundergroundProvider_FetchWeather_InvalidStationID(t *testing.T) {
 		s.Realtime.Weather.Wunderground.StationID = "invalid!station@id"
 	})
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -200,7 +203,7 @@ func TestWundergroundProvider_FetchWeather_HTTPError(t *testing.T) {
 			provider := NewWundergroundProvider(nil)
 			settings := createTestSettings(t, "wunderground")
 
-			data, err := provider.FetchWeather(settings)
+			data, err := provider.FetchWeather(t.Context(), settings)
 
 			require.Error(t, err)
 			assert.Nil(t, data)
@@ -216,7 +219,7 @@ func TestWundergroundProvider_FetchWeather_InvalidJSON(t *testing.T) {
 	provider := NewWundergroundProvider(nil)
 	settings := createTestSettings(t, "wunderground")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -231,7 +234,7 @@ func TestWundergroundProvider_FetchWeather_EmptyObservations(t *testing.T) {
 	provider := NewWundergroundProvider(nil)
 	settings := createTestSettings(t, "wunderground")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -474,6 +477,112 @@ func TestValidateWundergroundConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCalculateFeelsLike guards every branch of the feels-like selection logic,
+// including the NaN guards that prevent a bogus heat-index/wind-chill reading
+// from replacing the actual temperature. All values are metric (Celsius, m/s).
+func TestCalculateFeelsLike(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    weatherMeasurements
+		want float64
+	}{
+		{
+			name: "hot uses heat index",
+			m:    weatherMeasurements{temp: 30, heatIndex: 33},
+			want: 33,
+		},
+		{
+			name: "hot but non-positive heat index falls back to temp",
+			m:    weatherMeasurements{temp: 30, heatIndex: 0},
+			want: 30,
+		},
+		{
+			name: "hot but NaN heat index falls back to temp",
+			m:    weatherMeasurements{temp: 30, heatIndex: math.NaN()},
+			want: 30,
+		},
+		{
+			name: "hot boundary at threshold uses heat index",
+			m:    weatherMeasurements{temp: MetricHotTempC, heatIndex: 29},
+			want: 29,
+		},
+		{
+			name: "cold and windy uses wind chill",
+			m:    weatherMeasurements{temp: 5, windSpeed: 2.0, windChill: 2.0},
+			want: 2.0,
+		},
+		{
+			name: "cold but calm falls back to temp",
+			m:    weatherMeasurements{temp: 5, windSpeed: 1.0, windChill: 2.0},
+			want: 5,
+		},
+		{
+			name: "cold and windy but NaN wind chill falls back to temp",
+			m:    weatherMeasurements{temp: 5, windSpeed: 2.0, windChill: math.NaN()},
+			want: 5,
+		},
+		{
+			name: "cold boundary at threshold uses wind chill",
+			m:    weatherMeasurements{temp: MetricColdTempC, windSpeed: 2.0, windChill: 8.0},
+			want: 8.0,
+		},
+		{
+			name: "moderate temperature uses raw temp",
+			m:    weatherMeasurements{temp: 20, heatIndex: 99, windChill: -99},
+			want: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := calculateFeelsLike(tt.m)
+			assert.InDelta(t, tt.want, got, 0.001)
+		})
+	}
+}
+
+// TestHandleWundergroundRequestError_CancellationIsBenign guards that a parent
+// context cancellation (shutdown) surfaces as raw context.Canceled so
+// fetchAndSave treats it as benign, while a per-request deadline stays a real
+// categorized timeout failure. Wunderground keeps its own one-shot request path,
+// so this must match the shared executeWeatherRequest cancellation behavior.
+func TestHandleWundergroundRequestError_CancellationIsBenign(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parent cancellation is benign", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		// net/http returns a *url.Error embedding the request URL on cancellation.
+		transportErr := &url.Error{Op: "Get", URL: "https://api.weather.com/v2/pws/observations/current?apiKey=secret", Err: context.Canceled}
+
+		got := handleWundergroundRequestError(ctx, transportErr)
+
+		require.ErrorIs(t, got, context.Canceled, "cancellation must surface as context.Canceled so fetchAndSave skips backoff")
+		assert.Equal(t, context.Canceled, got, "cancellation must be returned unwrapped, not as a categorized weather error")
+	})
+
+	t.Run("deadline is a real timeout failure", func(t *testing.T) {
+		t.Parallel()
+		// A context whose deadline is already in the past reports DeadlineExceeded.
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Hour))
+		defer cancel()
+		transportErr := &url.Error{Op: "Get", URL: "https://api.weather.com/v2/pws/observations/current?apiKey=secret", Err: context.DeadlineExceeded}
+
+		got := handleWundergroundRequestError(ctx, transportErr)
+
+		require.Error(t, got)
+		require.NotErrorIs(t, got, context.Canceled, "a deadline must NOT be treated as a benign cancellation")
+		var ee *errors.EnhancedError
+		require.ErrorAs(t, got, &ee)
+		assert.Equal(t, string(errors.CategoryTimeout), ee.GetCategory(), "a deadline must classify as a timeout failure")
+		assert.NotContains(t, got.Error(), "secret", "the API key must be scrubbed from the wrapped error")
+	})
 }
 
 func TestNewWundergroundProvider(t *testing.T) {

--- a/internal/weather/provider_yrno.go
+++ b/internal/weather/provider_yrno.go
@@ -205,7 +205,7 @@ func (p *YrNoProvider) FetchWeather(ctx context.Context, settings *conf.Settings
 	}
 	apiURL := YrNoBaseURL + "?" + query.Encode()
 
-	providerLogger := getLogger().With(logger.String("provider", yrNoProviderName))
+	providerLogger := getLogger().WithContext(ctx).With(logger.String("provider", yrNoProviderName))
 	// Mask the URL before logging: its query carries the user's lat/lon, which
 	// are PII (yr.no needs no API key, so coordinates are the sensitive part).
 	providerLogger.Info("Fetching weather data", logger.String("url", maskURLForLog(apiURL)))

--- a/internal/weather/provider_yrno.go
+++ b/internal/weather/provider_yrno.go
@@ -2,10 +2,13 @@ package weather
 
 import (
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -18,6 +21,11 @@ const (
 	YrNoBaseURL        = "https://api.met.no/weatherapi/locationforecast/2.0/complete"
 	yrNoProviderName   = "yrno"
 	maxBodyPreviewSize = 200 // Maximum characters to show in error logs
+
+	// yrNoCoordPrecision is the number of decimal places used when formatting
+	// latitude/longitude into the request URL (~110 m resolution), matching the
+	// OpenWeather provider.
+	yrNoCoordPrecision = 3
 )
 
 // YrResponse represents the structure of the Yr.no API response
@@ -186,18 +194,26 @@ func mapYrResponseToWeatherData(response *YrResponse, settings *conf.Settings) *
 }
 
 // FetchWeather implements the Provider interface for YrNoProvider
-func (p *YrNoProvider) FetchWeather(settings *conf.Settings) (*WeatherData, error) {
-	apiURL := fmt.Sprintf("%s?lat=%.3f&lon=%.3f", YrNoBaseURL,
-		settings.BirdNET.Latitude,
-		settings.BirdNET.Longitude)
+func (p *YrNoProvider) FetchWeather(ctx context.Context, settings *conf.Settings) (*WeatherData, error) {
+	// Build the query with url.Values so the coordinates are properly escaped,
+	// matching buildOpenWeatherURL and buildWundergroundURL. yr.no (api.met.no)
+	// needs no API key, so only the coordinates go in the query. YrNoBaseURL is a
+	// constant with no existing query, so appending "?" + encoded is safe.
+	query := url.Values{
+		"lat": {strconv.FormatFloat(settings.BirdNET.Latitude, 'f', yrNoCoordPrecision, 64)},
+		"lon": {strconv.FormatFloat(settings.BirdNET.Longitude, 'f', yrNoCoordPrecision, 64)},
+	}
+	apiURL := YrNoBaseURL + "?" + query.Encode()
 
 	providerLogger := getLogger().With(logger.String("provider", yrNoProviderName))
-	providerLogger.Info("Fetching weather data", logger.String("url", apiURL))
+	// Mask the URL before logging: its query carries the user's lat/lon, which
+	// are PII (yr.no needs no API key, so coordinates are the sensitive part).
+	providerLogger.Info("Fetching weather data", logger.String("url", maskURLForLog(apiURL)))
 
-	req, err := http.NewRequest("GET", apiURL, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, http.NoBody)
 	if err != nil {
-		// Scrub before wrapping: http.NewRequest can return a *url.Error that
-		// embeds apiURL, which carries the user's lat/lon coordinates.
+		// Scrub before wrapping: http.NewRequestWithContext can return a
+		// *url.Error that embeds apiURL, which carries the user's lat/lon coordinates.
 		return nil, newWeatherError(privacy.WrapError(err), errors.CategoryNetwork, "create_http_request", yrNoProviderName)
 	}
 	req.Header.Set("User-Agent", UserAgent())
@@ -208,8 +224,8 @@ func (p *YrNoProvider) FetchWeather(settings *conf.Settings) (*WeatherData, erro
 	}
 	p.mu.Unlock()
 
-	// Execute request with retry
-	body, err := p.executeWithRetry(req, providerLogger)
+	// Execute request with retry via the shared executor.
+	body, err := executeWeatherRequest(ctx, p.httpClient, req, yrNoProviderName, providerLogger, p.handleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -237,62 +253,34 @@ func (p *YrNoProvider) FetchWeather(settings *conf.Settings) (*WeatherData, erro
 	return mappedData, nil
 }
 
-// executeWithRetry executes the HTTP request with retry logic
-func (p *YrNoProvider) executeWithRetry(req *http.Request, log logger.Logger) ([]byte, error) {
-	client := &http.Client{Timeout: RequestTimeout}
-
-	for i := range MaxRetries {
-		isLastAttempt := i == MaxRetries-1
-		attemptLogger := log.With(
-			logger.Int("attempt", i+1),
-			logger.Int("max_attempts", MaxRetries))
-
-		resp, err := client.Do(req)
-		if err != nil {
-			// Scrub before logging and wrapping: net/http wraps transport
-			// failures in a *url.Error whose Error() embeds the request URL,
-			// which carries the user's lat/lon coordinates. The wrapped error
-			// also propagates to weather.go's plain logger.Error.
-			attemptLogger.Warn("HTTP request failed", logger.SanitizedError(err))
-			if isLastAttempt {
-				return nil, newWeatherErrorWithRetries(privacy.WrapError(err), errors.CategoryNetwork, "weather_api_request", yrNoProviderName)
-			}
-			time.Sleep(RetryDelay)
-			continue
-		}
-
-		attemptLogger.Debug("Received HTTP response", logger.Int("status_code", resp.StatusCode))
-		result, err := handleYrNoResponse(resp, attemptLogger, isLastAttempt)
-		if err != nil {
-			return nil, err
-		}
-
-		if result.notModified {
-			p.mu.Lock()
-			lm := p.lastModified
-			p.mu.Unlock()
-			log.Info("Weather data not modified since last fetch", logger.String("last_modified", lm))
-			return nil, ErrWeatherDataNotModified
-		}
-
-		if result.shouldRetry {
-			time.Sleep(RetryDelay)
-			continue
-		}
-
-		// Success
-		if result.lastMod != "" {
-			p.mu.Lock()
-			p.lastModified = result.lastMod
-			p.mu.Unlock()
-		}
-		return result.body, nil
+// handleResponse adapts the yr.no per-status handling (conditional GET, gzip
+// decode, Last-Modified tracking) to the shared retry executor. A 304 returns
+// the not-modified sentinel; a transient non-OK asks for a retry; a 200 records
+// the new Last-Modified value for the next conditional request and returns the
+// body.
+func (p *YrNoProvider) handleResponse(resp *http.Response, attemptLog logger.Logger, isLastAttempt bool) (body []byte, retry bool, err error) {
+	result, err := handleYrNoResponse(resp, attemptLog, isLastAttempt)
+	if err != nil {
+		return nil, false, err
 	}
 
-	return nil, newWeatherErrorWithRetries(
-		fmt.Errorf("max retries exceeded"),
-		errors.CategoryNetwork,
-		"weather_api_request",
-		yrNoProviderName,
-	)
+	if result.notModified {
+		p.mu.Lock()
+		lm := p.lastModified
+		p.mu.Unlock()
+		attemptLog.Info("Weather data not modified since last fetch", logger.String("last_modified", lm))
+		return nil, false, ErrWeatherDataNotModified
+	}
+
+	if result.shouldRetry {
+		return nil, true, nil
+	}
+
+	// Success: persist the Last-Modified value for the next conditional request.
+	if result.lastMod != "" {
+		p.mu.Lock()
+		p.lastModified = result.lastMod
+		p.mu.Unlock()
+	}
+	return result.body, false, nil
 }

--- a/internal/weather/provider_yrno_test.go
+++ b/internal/weather/provider_yrno_test.go
@@ -1,6 +1,8 @@
 package weather
 
 import (
+	"bytes"
+	"compress/gzip"
 	"net/http"
 	"testing"
 	"time"
@@ -15,10 +17,10 @@ func TestYrNoProvider_FetchWeather_Success(t *testing.T) {
 
 	registerYrNoResponder(t, http.StatusOK, yrNoSuccessResponse(), nil)
 
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	settings := createTestSettings(t, "yrno")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.NoError(t, err)
 	assertWeatherDataBasics(t, data)
@@ -56,16 +58,16 @@ func TestYrNoProvider_FetchWeather_NotModified(t *testing.T) {
 			return resp, nil
 		})
 
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	settings := createTestSettings(t, "yrno")
 
 	// First fetch should succeed
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 	require.NoError(t, err)
 	require.NotNil(t, data)
 
 	// Second fetch should return ErrWeatherDataNotModified
-	data2, err := provider.FetchWeather(settings)
+	data2, err := provider.FetchWeather(t.Context(), settings)
 	require.Error(t, err)
 	assert.Nil(t, data2)
 	assert.ErrorIs(t, err, ErrWeatherDataNotModified)
@@ -91,10 +93,10 @@ func TestYrNoProvider_FetchWeather_HTTPError(t *testing.T) {
 			httpmock.Reset()
 			registerYrNoResponder(t, tt.statusCode, `{"error": "test error"}`, nil)
 
-			provider := NewYrNoProvider()
+			provider := NewYrNoProvider(nil)
 			settings := createTestSettings(t, "yrno")
 
-			data, err := provider.FetchWeather(settings)
+			data, err := provider.FetchWeather(t.Context(), settings)
 
 			require.Error(t, err)
 			assert.Nil(t, data)
@@ -108,10 +110,10 @@ func TestYrNoProvider_FetchWeather_InvalidJSON(t *testing.T) {
 
 	registerYrNoResponder(t, http.StatusOK, `{invalid json`, nil)
 
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	settings := createTestSettings(t, "yrno")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -128,10 +130,10 @@ func TestYrNoProvider_FetchWeather_EmptyTimeseries(t *testing.T) {
 }`
 	registerYrNoResponder(t, http.StatusOK, emptyResponse, nil)
 
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	settings := createTestSettings(t, "yrno")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -146,13 +148,49 @@ func TestYrNoProvider_FetchWeather_GzipResponse(t *testing.T) {
 		"Content-Type": "application/json",
 	})
 
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	settings := createTestSettings(t, "yrno")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.NoError(t, err)
 	require.NotNil(t, data)
+}
+
+// TestYrNoProvider_FetchWeather_RealGzip guards the gzip decode path in
+// readYrNoResponseBody by serving an actually gzip-compressed body with
+// Content-Encoding: gzip. The provider sets Accept-Encoding: gzip itself, which
+// disables the transport's automatic decompression, so the provider must
+// decode the body by hand. The existing GzipResponse test only sends plaintext,
+// so this is the test that exercises gzip.NewReader.
+func TestYrNoProvider_FetchWeather_RealGzip(t *testing.T) {
+	setupHTTPMock(t)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(yrNoSuccessResponse()))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	gzippedBody := buf.Bytes()
+
+	httpmock.RegisterResponder("GET", `=~^https://api\.met\.no/weatherapi/locationforecast/2\.0/complete`,
+		func(_ *http.Request) (*http.Response, error) {
+			resp := httpmock.NewBytesResponse(http.StatusOK, gzippedBody)
+			resp.Header.Set("Content-Encoding", "gzip")
+			resp.Header.Set("Content-Type", "application/json")
+			return resp, nil
+		})
+
+	provider := NewYrNoProvider(nil)
+	settings := createTestSettings(t, "yrno")
+
+	data, err := provider.FetchWeather(t.Context(), settings)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	// Confirm the gzip body decoded and parsed into real values.
+	assert.InDelta(t, 15.4, data.Temperature.Current, 0.01)
+	assert.Equal(t, 62, data.Humidity)
 }
 
 func TestMapYrResponseToWeatherData(t *testing.T) {
@@ -251,7 +289,7 @@ func TestTruncateBodyPreview(t *testing.T) {
 }
 
 func TestNewYrNoProvider(t *testing.T) {
-	provider := NewYrNoProvider()
+	provider := NewYrNoProvider(nil)
 	require.NotNil(t, provider)
 
 	// Verify it implements Provider interface

--- a/internal/weather/providers.go
+++ b/internal/weather/providers.go
@@ -3,39 +3,54 @@ package weather
 import (
 	"net/http"
 	"sync"
-	"time"
 )
 
-// DefaultHTTPClientTimeout is the default timeout for HTTP clients when not specified
-const DefaultHTTPClientTimeout = 30 * time.Second
-
-// NewYrNoProvider creates a new Yr.no weather provider
-func NewYrNoProvider() Provider {
-	return &YrNoProvider{}
+// newDefaultHTTPClient builds the fallback HTTP client used when a provider is
+// constructed without an injected client (e.g. directly in tests). It leaves
+// Transport nil so it uses http.DefaultTransport, which keeps it interceptable
+// by httpmock in tests, and bounds each request with RequestTimeout.
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: RequestTimeout}
 }
 
-// NewOpenWeatherProvider creates a new OpenWeather provider
-func NewOpenWeatherProvider() Provider {
-	return &OpenWeatherProvider{}
+// NewYrNoProvider creates a new Yr.no weather provider with a shared HTTP client.
+// A nil client falls back to a default client (see newDefaultHTTPClient).
+func NewYrNoProvider(client *http.Client) Provider {
+	if client == nil {
+		client = newDefaultHTTPClient()
+	}
+	return &YrNoProvider{httpClient: client}
+}
+
+// NewOpenWeatherProvider creates a new OpenWeather provider with a shared HTTP
+// client. A nil client falls back to a default client (see newDefaultHTTPClient).
+func NewOpenWeatherProvider(client *http.Client) Provider {
+	if client == nil {
+		client = newDefaultHTTPClient()
+	}
+	return &OpenWeatherProvider{httpClient: client}
+}
+
+// NewWundergroundProvider creates a new WeatherUnderground provider with a shared
+// HTTP client. A nil client falls back to a default client (see
+// newDefaultHTTPClient).
+func NewWundergroundProvider(client *http.Client) Provider {
+	if client == nil {
+		client = newDefaultHTTPClient()
+	}
+	return &WundergroundProvider{httpClient: client}
 }
 
 // Provider implementations
 type YrNoProvider struct {
+	httpClient   *http.Client
 	mu           sync.Mutex
 	lastModified string
 }
-type OpenWeatherProvider struct{}
 
-// NewWundergroundProvider creates a new WeatherUnderground provider with shared HTTP client
-func NewWundergroundProvider(client *http.Client) Provider {
-	if client == nil {
-		client = &http.Client{
-			Timeout: DefaultHTTPClientTimeout,
-		}
-	}
-	return &WundergroundProvider{
-		httpClient: client,
-	}
+// OpenWeatherProvider implements the Provider interface for OpenWeather.
+type OpenWeatherProvider struct {
+	httpClient *http.Client
 }
 
 // WundergroundProvider implements the Provider interface for WeatherUnderground

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -713,9 +713,14 @@ func (s *Service) fetchAndSave(ctx context.Context) error {
 		// an error nor trips the failure backoff. context.DeadlineExceeded is
 		// intentionally excluded; that is a real request timeout worth a backoff.
 		if errors.Is(err, context.Canceled) {
+			// Cancellation is a shutdown or an aborted on-demand request, not a
+			// provider failure, so skip the failure/backoff bookkeeping below. Return
+			// the error rather than swallowing it so an on-demand Poll(ctx) caller
+			// still observes the cancellation; the StartPolling loop ignores
+			// fetchAndSave's return value, so a background shutdown stays benign.
 			getLogger().Debug("Weather fetch cancelled",
 				logger.String("provider", s.providerName))
-			return nil
+			return err
 		}
 
 		// Handle "not modified" as a success case: no new data to save.

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"runtime/debug"
@@ -60,7 +61,10 @@ func getLogger() logger.Logger {
 
 // Provider represents a weather data provider interface
 type Provider interface {
-	FetchWeather(settings *conf.Settings) (*WeatherData, error)
+	// FetchWeather retrieves current weather. The context lets a shutdown or an
+	// aborted on-demand request cancel an in-flight HTTP call and its retry
+	// backoff instead of blocking until the request finishes.
+	FetchWeather(ctx context.Context, settings *conf.Settings) (*WeatherData, error)
 }
 
 // backoffState tracks consecutive failures and backoff timing for the polling loop.
@@ -284,20 +288,25 @@ func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics 
 		providerName string
 	)
 
+	// One HTTP client is shared across every fetch cycle and retry attempt for
+	// the service's lifetime, replacing the per-request clients the providers
+	// used to allocate. It is injected into whichever provider is selected.
+	weatherClient := newDefaultHTTPClient()
+
 	// Select weather provider based on configuration
 	switch settings.Realtime.Weather.Provider {
 	case "yrno":
-		provider = NewYrNoProvider()
+		provider = NewYrNoProvider(weatherClient)
 		providerName = yrNoProviderName
 	case "openweather":
-		provider = NewOpenWeatherProvider()
+		provider = NewOpenWeatherProvider(weatherClient)
 		providerName = openWeatherProviderName
 	case "wunderground":
-		provider = NewWundergroundProvider(nil)
+		provider = NewWundergroundProvider(weatherClient)
 		providerName = wundergroundProviderName
 	case "":
 		// Not configured - default to yr.no
-		provider = NewYrNoProvider()
+		provider = NewYrNoProvider(weatherClient)
 		providerName = yrNoProviderName
 	case "none":
 		// Explicitly disabled
@@ -521,6 +530,22 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 		interval = time.Duration(conf.DefaultWeatherPollInterval) * time.Minute
 	}
 
+	// Derive a context that is cancelled when stopChan closes (or when this
+	// method returns), and thread it through each fetch so a shutdown cancels an
+	// in-flight provider HTTP call and its retry backoff. StartPolling keeps its
+	// channel-based signature (the sole caller has no context to pass); the
+	// bridge goroutine exits via ctx.Done() once the deferred cancel fires, so
+	// it cannot leak.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-stopChan:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	// Use the dedicated weather logger
 	getLogger().Info("Starting weather polling service",
 		logger.String("provider", s.providerName),
@@ -544,14 +569,14 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 	defer ticker.Stop()
 
 	// Initial fetch (errors logged within fetchAndSave)
-	s.safeFetchAndSave()
+	s.safeFetchAndSave(ctx)
 
 	for {
 		select {
 		case <-ticker.C:
 			getLogger().Debug("Polling weather data...")
 			// Errors logged within fetchAndSave
-			s.safeFetchAndSave()
+			s.safeFetchAndSave(ctx)
 		case <-stopChan:
 			getLogger().Info("Stopping weather polling service")
 			return
@@ -563,7 +588,7 @@ func (s *Service) StartPolling(stopChan <-chan struct{}) {
 // provider, the response mapping, or the persistence path degrades only the
 // weather service instead of crashing the whole process. Errors are already
 // logged inside fetchAndSave, so the return value is intentionally discarded.
-func (s *Service) safeFetchAndSave() {
+func (s *Service) safeFetchAndSave(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
 			// Record a failure so a repeatedly panicking fetch surfaces as
@@ -580,7 +605,7 @@ func (s *Service) safeFetchAndSave() {
 				logger.String("stack", string(debug.Stack())))
 		}
 	}()
-	_ = s.fetchAndSave()
+	_ = s.fetchAndSave(ctx)
 }
 
 // Poll fetches weather data once and saves it to the database.
@@ -591,12 +616,12 @@ func (s *Service) safeFetchAndSave() {
 //
 // Unlike the StartPolling loop, Poll does not wrap the fetch in panic recovery:
 // it is a synchronous on-demand call, so a panic propagates to the caller.
-func (s *Service) Poll() error {
+func (s *Service) Poll(ctx context.Context) error {
 	// Run a fetch cycle. fetchAndSave reconciles hot-reloaded config first, so a
 	// lockout cleared by a config change recovers even on a manual Poll; the
 	// auth check therefore happens after reconciliation, not before it. While
 	// auth is disabled and unchanged, fetchAndSave skips without a network call.
-	if err := s.fetchAndSave(); err != nil {
+	if err := s.fetchAndSave(ctx); err != nil {
 		return err
 	}
 	// fetchAndSave returns nil when it skipped because auth is still disabled;
@@ -641,7 +666,7 @@ func (s *Service) reconcileConfig(settings *conf.Settings) {
 // errors. For repeated authentication failures (HTTP 401), it pauses retrying
 // after maxConsecutiveAuthFailures until the auth-relevant config changes
 // (handled by reconcileConfig), at which point it resumes automatically.
-func (s *Service) fetchAndSave() error {
+func (s *Service) fetchAndSave(ctx context.Context) error {
 	// Serialize fetch cycles. Both the exported Poll() and the StartPolling
 	// ticker call this; the lock keeps the skip -> fetch -> reset sequence and
 	// the SQLite writes atomic, and guards the per-cycle hot-reload state
@@ -680,9 +705,19 @@ func (s *Service) fetchAndSave() error {
 	fetchStart := time.Now()
 
 	// FetchWeather should now internally log its start/end/errors
-	data, err := s.provider.FetchWeather(currentSettings)
+	data, err := s.provider.FetchWeather(ctx, currentSettings)
 
 	if err != nil {
+		// A cancelled context means the service is shutting down (or an
+		// on-demand caller aborted): treat it as benign so shutdown neither logs
+		// an error nor trips the failure backoff. context.DeadlineExceeded is
+		// intentionally excluded; that is a real request timeout worth a backoff.
+		if errors.Is(err, context.Canceled) {
+			getLogger().Debug("Weather fetch cancelled",
+				logger.String("provider", s.providerName))
+			return nil
+		}
+
 		// Handle "not modified" as a success case: no new data to save.
 		// Check before recording metrics so these expected conditions are
 		// not counted as errors.

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"sync"
@@ -22,7 +23,7 @@ type mockProvider struct {
 	fetchFunc func(settings *conf.Settings) (*WeatherData, error)
 }
 
-func (m *mockProvider) FetchWeather(settings *conf.Settings) (*WeatherData, error) {
+func (m *mockProvider) FetchWeather(_ context.Context, settings *conf.Settings) (*WeatherData, error) {
 	return m.fetchFunc(settings)
 }
 
@@ -373,7 +374,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 		// Create service with mock DB
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -411,7 +412,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -455,7 +456,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -499,7 +500,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -534,7 +535,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -578,7 +579,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -607,7 +608,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -641,7 +642,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -698,7 +699,7 @@ func TestService_Poll(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
@@ -711,7 +712,7 @@ func TestService_Poll(t *testing.T) {
 		}).Return(nil).Once()
 		mockDB.On("SaveHourlyWeather", mock.Anything).Return(nil).Once()
 
-		err := service.Poll()
+		err := service.Poll(t.Context())
 
 		require.NoError(t, err)
 		mockDB.AssertExpectations(t)
@@ -726,13 +727,13 @@ func TestService_Poll(t *testing.T) {
 
 		settings := createTestSettings(t, "yrno")
 		service := &Service{
-			provider: NewYrNoProvider(),
+			provider: NewYrNoProvider(nil),
 			db:       mockDB,
 			settings: settings,
 			metrics:  nil,
 		}
 
-		err := service.Poll()
+		err := service.Poll(t.Context())
 
 		require.Error(t, err)
 		// DB should not be called when fetch fails
@@ -756,7 +757,7 @@ func TestService_Poll(t *testing.T) {
 			})
 
 		settings := createTestSettings(t, "yrno")
-		provider := NewYrNoProvider()
+		provider := NewYrNoProvider(nil)
 		service := &Service{
 			provider: provider,
 			db:       mockDB,
@@ -771,11 +772,11 @@ func TestService_Poll(t *testing.T) {
 		}).Return(nil).Once()
 		mockDB.On("SaveHourlyWeather", mock.Anything).Return(nil).Once()
 
-		err := service.Poll()
+		err := service.Poll(t.Context())
 		require.NoError(t, err)
 
 		// Second poll should return "not modified" - no DB calls
-		err = service.Poll()
+		err = service.Poll(t.Context())
 		require.NoError(t, err, "Not modified should return nil, not error")
 
 		// Only the first poll should have called DB
@@ -797,7 +798,7 @@ func TestService_StartPolling(t *testing.T) {
 			s.Realtime.Weather.PollInterval = 60
 		})
 		service := &Service{
-			provider:     NewYrNoProvider(),
+			provider:     NewYrNoProvider(nil),
 			db:           mockDB,
 			settings:     settings,
 			metrics:      nil,
@@ -864,7 +865,7 @@ func TestService_StartPolling_StartupDelay(t *testing.T) {
 
 		delay := 200 * time.Millisecond
 		service := &Service{
-			provider:     NewYrNoProvider(),
+			provider:     NewYrNoProvider(nil),
 			db:           mockDB,
 			settings:     settings,
 			metrics:      nil,
@@ -919,7 +920,7 @@ func TestService_StartPolling_StartupDelay(t *testing.T) {
 		})
 
 		service := &Service{
-			provider:     NewYrNoProvider(),
+			provider:     NewYrNoProvider(nil),
 			db:           mockDB,
 			settings:     settings,
 			metrics:      nil,
@@ -970,7 +971,7 @@ func TestService_StartPolling_StartupDelay(t *testing.T) {
 
 		// Use a long delay that we will interrupt
 		service := &Service{
-			provider:     NewYrNoProvider(),
+			provider:     NewYrNoProvider(nil),
 			db:           nil,
 			settings:     settings,
 			metrics:      nil,
@@ -1123,7 +1124,7 @@ func TestFetchAndSave_AuthFailure(t *testing.T) {
 
 	// First few calls should attempt fetches and return auth error
 	for range maxConsecutiveAuthFailures {
-		err := service.fetchAndSave()
+		err := service.fetchAndSave(t.Context())
 		require.ErrorIs(t, err, ErrWeatherAuthFailed)
 	}
 	assert.Equal(t, maxConsecutiveAuthFailures, callCount,
@@ -1131,9 +1132,38 @@ func TestFetchAndSave_AuthFailure(t *testing.T) {
 
 	// After threshold, fetchAndSave should skip without calling provider
 	prevCount := callCount
-	err := service.fetchAndSave()
+	err := service.fetchAndSave(t.Context())
 	require.NoError(t, err, "Should return nil when skipping due to auth disabled")
 	assert.Equal(t, prevCount, callCount, "Provider should NOT be called after auth disabled")
+}
+
+// TestFetchAndSave_CancelledContextIsBenign verifies that a provider returning
+// context.Canceled (a service shutdown or an aborted on-demand request) is
+// treated as benign: fetchAndSave returns nil and does not trip the failure
+// backoff. Only genuine failures should back off; a shutdown should not log an
+// error or degrade the service state.
+func TestFetchAndSave_CancelledContextIsBenign(t *testing.T) {
+	settings := createTestSettings(t, "yrno")
+
+	provider := &mockProvider{
+		fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+			return nil, context.Canceled
+		},
+	}
+	service := &Service{
+		provider: provider,
+		db:       nil,
+		settings: settings,
+		metrics:  nil,
+	}
+
+	err := service.fetchAndSave(t.Context())
+	require.NoError(t, err, "a cancelled fetch must be treated as benign, not a failure")
+
+	authDisabled, failures, inBackoff := service.backoff.snapshot()
+	assert.False(t, authDisabled, "cancellation must not disable auth")
+	assert.Zero(t, failures, "cancellation must not increment the failure counter")
+	assert.False(t, inBackoff, "cancellation must not start a backoff window")
 }
 
 // TestFetchAndSave_NoData tests that HTTP 204 is handled gracefully without backoff.
@@ -1156,12 +1186,12 @@ func TestFetchAndSave_NoData(t *testing.T) {
 	}
 
 	// Should return nil and not trigger backoff
-	err := service.fetchAndSave()
+	err := service.fetchAndSave(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 1, callCount)
 
 	// Next call should still attempt (no backoff)
-	err = service.fetchAndSave()
+	err = service.fetchAndSave(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 2, callCount, "No backoff should be applied for no-data responses")
 }
@@ -1186,12 +1216,12 @@ func TestFetchAndSave_GeneralFailureBackoff(t *testing.T) {
 	}
 
 	// First call should fail and apply backoff
-	err := service.fetchAndSave()
+	err := service.fetchAndSave(t.Context())
 	require.Error(t, err)
 	assert.Equal(t, 1, callCount)
 
 	// Second call should be skipped due to backoff (nextAllowedFetchTime is 1 minute away)
-	err = service.fetchAndSave()
+	err = service.fetchAndSave(t.Context())
 	require.NoError(t, err, "Should return nil when skipping due to backoff")
 	assert.Equal(t, 1, callCount, "Provider should NOT be called during backoff")
 }
@@ -1228,7 +1258,7 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 	}
 
 	// First call fails: sets backoff
-	err := service.fetchAndSave()
+	err := service.fetchAndSave(t.Context())
 	require.Error(t, err)
 	assert.True(t, service.backoff.shouldSkip(), "Should be in backoff after failure")
 
@@ -1239,7 +1269,7 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 	service.backoff.mu.Unlock()
 
 	// Second call succeeds: should reset backoff
-	err = service.fetchAndSave()
+	err = service.fetchAndSave(t.Context())
 	require.NoError(t, err)
 	assert.False(t, service.backoff.shouldSkip(), "Backoff should be cleared after success")
 
@@ -1289,7 +1319,7 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 		metrics:      nil,
 	}
 
-	_ = service.fetchAndSave()
+	_ = service.fetchAndSave(t.Context())
 	assert.InDelta(t, 0.0, observedLat, 1e-9, "initial fetch should use the captured coords")
 	assert.InDelta(t, 0.0, observedLon, 1e-9, "initial fetch should use the captured coords")
 
@@ -1305,7 +1335,7 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 	})
 	conf.StoreSettings(updated)
 
-	_ = service.fetchAndSave()
+	_ = service.fetchAndSave(t.Context())
 	assert.InDelta(t, 60.1699, observedLat, 1e-9,
 		"fetch should pick up updated latitude from global settings")
 	assert.InDelta(t, 24.9384, observedLon, 1e-9,
@@ -1350,7 +1380,7 @@ func TestWundergroundProvider_HTTP204_NoContent(t *testing.T) {
 	provider := NewWundergroundProvider(nil)
 	settings := createTestSettings(t, "wunderground")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -1369,7 +1399,7 @@ func TestWundergroundProvider_HTTP401_AuthFailed(t *testing.T) {
 	provider := NewWundergroundProvider(nil)
 	settings := createTestSettings(t, "wunderground")
 
-	data, err := provider.FetchWeather(settings)
+	data, err := provider.FetchWeather(t.Context(), settings)
 
 	require.Error(t, err)
 	assert.Nil(t, data)
@@ -1488,7 +1518,7 @@ func TestFetchAndSave_NoDataResetsTransientBackoff(t *testing.T) {
 	ok, _ := service.Status()
 	require.False(t, ok, "precondition: service should report degraded before the 204")
 
-	err := service.fetchAndSave()
+	err := service.fetchAndSave(t.Context())
 	require.NoError(t, err, "204 is a successful round-trip, not an error")
 
 	ok, msg := service.Status()
@@ -1533,14 +1563,14 @@ func TestFetchAndSave_AuthRecoveryOnConfigChange(t *testing.T) {
 
 	// Drive the lockout.
 	for range maxConsecutiveAuthFailures {
-		err := service.fetchAndSave()
+		err := service.fetchAndSave(t.Context())
 		require.ErrorIs(t, err, ErrWeatherAuthFailed)
 	}
 	require.True(t, service.backoff.isAuthDisabled(), "should be locked out after threshold")
 	require.Equal(t, maxConsecutiveAuthFailures, callCount)
 
 	// A cycle with unchanged config must keep skipping (no recovery yet).
-	require.NoError(t, service.fetchAndSave())
+	require.NoError(t, service.fetchAndSave(t.Context()))
 	require.Equal(t, maxConsecutiveAuthFailures, callCount,
 		"provider must not be called while locked out and config unchanged")
 
@@ -1551,7 +1581,7 @@ func TestFetchAndSave_AuthRecoveryOnConfigChange(t *testing.T) {
 	})
 	conf.StoreSettings(updated)
 
-	require.NoError(t, service.fetchAndSave(), "should recover and fetch after config change")
+	require.NoError(t, service.fetchAndSave(t.Context()), "should recover and fetch after config change")
 	assert.Equal(t, maxConsecutiveAuthFailures+1, callCount,
 		"provider should be called again after the key changed")
 	assert.False(t, service.backoff.isAuthDisabled(),
@@ -1600,7 +1630,7 @@ func TestFetchAndSave_SunCalcRebuiltOnLocationChange(t *testing.T) {
 		metrics:      nil,
 	}
 
-	require.NoError(t, service.fetchAndSave())
+	require.NoError(t, service.fetchAndSave(t.Context()))
 
 	// Move to Sydney: a very different latitude/longitude yields different sun
 	// times for the same instant.
@@ -1610,7 +1640,7 @@ func TestFetchAndSave_SunCalcRebuiltOnLocationChange(t *testing.T) {
 	})
 	conf.StoreSettings(sydney)
 
-	require.NoError(t, service.fetchAndSave())
+	require.NoError(t, service.fetchAndSave(t.Context()))
 
 	require.Len(t, capturedSunrise, 2)
 	assert.NotEqual(t, capturedSunrise[0], capturedSunrise[1],
@@ -1686,7 +1716,7 @@ func TestFetchAndSave_SerializedByMutex(t *testing.T) {
 	var wg sync.WaitGroup
 	for range goroutines {
 		wg.Go(func() {
-			_ = service.fetchAndSave()
+			_ = service.fetchAndSave(t.Context())
 		})
 	}
 	wg.Wait()
@@ -1739,7 +1769,7 @@ func TestSafeFetchAndSave_PanicRecordsFailure(t *testing.T) {
 		metrics:      nil,
 	}
 
-	require.NotPanics(t, func() { service.safeFetchAndSave() },
+	require.NotPanics(t, func() { service.safeFetchAndSave(t.Context()) },
 		"a provider panic must be recovered, not propagated")
 
 	ok, msg := service.Status()
@@ -1781,12 +1811,12 @@ func TestPoll_RecoversAfterConfigChange(t *testing.T) {
 
 	// Drive the lockout via Poll.
 	for range maxConsecutiveAuthFailures {
-		_ = service.Poll()
+		_ = service.Poll(t.Context())
 	}
 	require.True(t, service.backoff.isAuthDisabled(), "should be locked out after threshold")
 
 	// Still locked out with unchanged config: Poll surfaces the auth failure.
-	require.ErrorIs(t, service.Poll(), ErrWeatherAuthFailed)
+	require.ErrorIs(t, service.Poll(t.Context()), ErrWeatherAuthFailed)
 
 	// Fix the key; a manual Poll must now recover without waiting for the ticker.
 	authBad = false
@@ -1795,7 +1825,7 @@ func TestPoll_RecoversAfterConfigChange(t *testing.T) {
 	})
 	conf.StoreSettings(updated)
 
-	require.NoError(t, service.Poll(), "manual Poll should recover after the key is fixed")
+	require.NoError(t, service.Poll(t.Context()), "manual Poll should recover after the key is fixed")
 	assert.False(t, service.backoff.isAuthDisabled(),
 		"auth lockout should clear on the recovering Poll")
 }

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1137,12 +1137,13 @@ func TestFetchAndSave_AuthFailure(t *testing.T) {
 	assert.Equal(t, prevCount, callCount, "Provider should NOT be called after auth disabled")
 }
 
-// TestFetchAndSave_CancelledContextIsBenign verifies that a provider returning
-// context.Canceled (a service shutdown or an aborted on-demand request) is
-// treated as benign: fetchAndSave returns nil and does not trip the failure
-// backoff. Only genuine failures should back off; a shutdown should not log an
-// error or degrade the service state.
-func TestFetchAndSave_CancelledContextIsBenign(t *testing.T) {
+// TestFetchAndSave_CancelledContextPropagatesWithoutBackoff verifies that a
+// provider returning context.Canceled (a service shutdown or an aborted
+// on-demand request) propagates the cancellation to the caller so an on-demand
+// Poll(ctx) observes it, while still skipping the failure backoff. The
+// StartPolling loop ignores fetchAndSave's return value, so a background
+// shutdown stays benign; only the on-demand path sees the error.
+func TestFetchAndSave_CancelledContextPropagatesWithoutBackoff(t *testing.T) {
 	settings := createTestSettings(t, "yrno")
 
 	provider := &mockProvider{
@@ -1158,7 +1159,7 @@ func TestFetchAndSave_CancelledContextIsBenign(t *testing.T) {
 	}
 
 	err := service.fetchAndSave(t.Context())
-	require.NoError(t, err, "a cancelled fetch must be treated as benign, not a failure")
+	require.ErrorIs(t, err, context.Canceled, "cancellation must propagate so on-demand Poll(ctx) callers observe it")
 
 	authDisabled, failures, inBackoff := service.backoff.snapshot()
 	assert.False(t, authDisabled, "cancellation must not disable auth")


### PR DESCRIPTION
## Summary

Rework the weather provider HTTP layer into a single shared path and make fetches cancellable and privacy-safe.

- **Shared retry/HTTP layer.** Extract one shared retry/execute helper that the yr.no and OpenWeather providers call via a per-provider response handler, removing their duplicated retry loops. Wunderground keeps its own one-shot path (it does not retry and returns provider-specific, user-facing error messages); a comment now records why.
- **One injected HTTP client.** Build a single HTTP client in `NewService` and inject it into whichever provider is selected, replacing the per-request clients yr.no and OpenWeather allocated on every fetch. The yr.no and OpenWeather constructors now take a client, matching Wunderground.
- **Cancellable fetches.** Thread a `context.Context` through the `Provider` interface and the polling loop (`StartPolling` derives a context from its stop channel) so shutdown cancels an in-flight HTTP call and its retry backoff. The uncancellable retry sleep is replaced with a context-aware wait, and a cancellation is treated as a benign shutdown signal rather than a fetch failure, consistently across the shared executor and the Wunderground one-shot path.
- **No coordinates in logs.** Stop printing the full latitude/longitude in cleartext on the success-path "Fetching weather data" line. API-key and coordinate redaction are now one log-safe URL masker that fails closed on a parse error (coordinates are PII).
- **API-key scrub in the connection test.** Scrub the API key from transport errors in the OpenWeather connection-test endpoint, which previously echoed the key-bearing request URL into the API response and logs.
- **Consistent URL building.** Build the yr.no request URL with `url.Values`, matching the other providers.

## Test Plan

- [x] `golangci-lint run ./...` (zero issues)
- [x] `go test -race ./internal/weather/... ./internal/api/v2/...`
- New tests cover: the feels-like branches and NaN guards, real gzip decode, the OpenWeather 401 sentinel classification (and no-retry), context cancellation at the provider and service levels, the Wunderground cancellation vs timeout split, and the new helpers (`maskURLForLog`, `sleepWithContext`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather fetches now support cancellable requests and use a shared HTTP client for provider calls.

* **Bug Fixes**
  * API keys and location coordinates are redacted from logs and errors to prevent leaks.
  * Retry behavior improved to respect cancellation and better classify authentication and timeout failures.

* **Tests**
  * Expanded coverage for URL masking, retries/request cloning, context cancellation, gzip responses, and provider calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->