### PR TITLE
refactor(weather): tidy provider package and backfill regression tests

### DIFF
--- a/internal/weather/icon_codes.go
+++ b/internal/weather/icon_codes.go
@@ -226,14 +226,16 @@ var IconDescription = map[IconCode]string{
 	IconUnknown:      "Unknown", // Added description for unknown
 }
 
-// GetStandardIconCode converts provider-specific weather codes to our standard icon codes
+// GetStandardIconCode converts provider-specific weather codes to our standard icon codes.
+// Wunderground is intentionally absent: it has no provider symbol table and derives its
+// icon from measurements via InferWundergroundIcon, so it never calls this function.
 func GetStandardIconCode(code, provider string) IconCode {
 	switch provider {
-	case "yrno":
+	case yrNoProviderName:
 		if iconCode, ok := YrNoSymbolToIcon[code]; ok {
 			return iconCode
 		}
-	case "openweather":
+	case openWeatherProviderName:
 		if iconCode, ok := OpenWeatherToIcon[code]; ok {
 			return iconCode
 		}

--- a/internal/weather/icons_test.go
+++ b/internal/weather/icons_test.go
@@ -92,6 +92,42 @@ func TestGetWeatherIcon_Fallback(t *testing.T) {
 	})
 }
 
+// TestGetWeatherIcon_Identity guards against a mapping error where a weather code
+// points at the wrong SVG asset (e.g. a rain<->snow swap). TestGetWeatherIcon only
+// checks the <svg>...</svg> wrapper, so such a swap would still pass there because
+// both values are valid SVG markup. Each marker below is a stable fragment unique
+// to that condition's icon; the test asserts the marker appears in its own icon and
+// in none of the others, so a swapped or mis-keyed entry trips an assertion.
+func TestGetWeatherIcon_Identity(t *testing.T) {
+	tests := []struct {
+		name   string
+		code   IconCode
+		marker string // SVG fragment unique to this condition's icon
+	}{
+		{"clear_sky_sun_disc", IconClearSky, `cx="12" cy="12" r="5"`},
+		{"rain_drops", IconRain, `x1="12" y1="15" x2="12" y2="23"`},
+		{"snow_flakes", IconSnow, `x2="8.01"`},
+		{"thunderstorm_bolt", IconThunderstorm, `points="13 11 9 17 15 17 11 23"`},
+		{"fog_lines", IconFog, `x1="3" y1="7" x2="21" y2="7"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			own := string(GetWeatherIcon(tt.code, Day))
+			assert.Contains(t, own, tt.marker,
+				"icon for %s must contain its identifying marker", tt.code)
+			for _, other := range tests {
+				if other.code == tt.code {
+					continue
+				}
+				otherSVG := string(GetWeatherIcon(other.code, Day))
+				assert.NotContains(t, otherSVG, tt.marker,
+					"marker for %s leaked into the %s icon (mapping swap?)", tt.code, other.code)
+			}
+		})
+	}
+}
+
 func TestGetIconDescription(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/weather/icons_test.go
+++ b/internal/weather/icons_test.go
@@ -113,6 +113,7 @@ func TestGetWeatherIcon_Identity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			own := string(GetWeatherIcon(tt.code, Day))
 			assert.Contains(t, own, tt.marker,
 				"icon for %s must contain its identifying marker", tt.code)

--- a/internal/weather/provider_wunderground.go
+++ b/internal/weather/provider_wunderground.go
@@ -34,9 +34,9 @@ const (
 	NightSolarRadiationThreshold = 5.0
 	// Daytime solar radiation above this indicates clear sky.
 	DayClearSRThreshold = 600.0
-	// Daytime solar radiation range for partly cloudy (inclusive).
+	// Daytime solar radiation at or above this (up to DayClearSRThreshold)
+	// indicates partly cloudy; below it is treated as cloudy.
 	DayPartlyCloudyLowerSR = 200.0
-	DayPartlyCloudyUpperSR = 600.0
 
 	// Temperature thresholds for weather conditions
 	FreezingPointC     = 0.0  // Celsius freezing point for snow/rain determination
@@ -420,7 +420,9 @@ func mapWundergroundResponse(wuResp *wundergroundResponse, log logger.Logger) *W
 
 	measurements := extractMeasurements(&obs)
 	feelsLike := calculateFeelsLike(measurements)
-	precipMMH := getPrecipitationRate(&obs)
+	// PrecipRate is the metric precipitation rate in mm/h; clamp a negative
+	// value to zero (the JSON decoder never yields NaN here).
+	precipMMH := max(0, obs.Metric.PrecipRate)
 
 	iconCode := InferWundergroundIcon(
 		measurements.temp, precipMMH, float64(obs.Humidity), obs.SolarRadiation, measurements.windGust,
@@ -447,17 +449,9 @@ func mapWundergroundResponse(wuResp *wundergroundResponse, log logger.Logger) *W
 		},
 		Pressure:    int(math.Round(measurements.pressure)),
 		Humidity:    int(math.Round(obs.Humidity)),
-		Description: IconDescription[iconCode],
+		Description: GetIconDescription(iconCode),
 		Icon:        string(iconCode),
 	}
-}
-
-// getPrecipitationRate extracts precipitation rate in mm/h from metric data.
-func getPrecipitationRate(obs *wundergroundObservation) float64 {
-	if obs.Metric.PrecipRate > 0 {
-		return obs.Metric.PrecipRate
-	}
-	return 0.0
 }
 
 // isInvalid checks if a float64 value is NaN (invalid for HeatIndex/WindChill logic)

--- a/internal/weather/provider_yrno.go
+++ b/internal/weather/provider_yrno.go
@@ -104,15 +104,20 @@ func readYrNoResponseBody(resp *http.Response, log logger.Logger) ([]byte, error
 	return body, nil
 }
 
-// handleYrNoResponse processes a single HTTP response and returns the result
+// handleYrNoResponse processes a single HTTP response and returns the result.
+// It owns closing resp.Body (per the executeWeatherRequest handler contract); a
+// single deferred close covers every return path instead of one per branch.
 func handleYrNoResponse(resp *http.Response, log logger.Logger, isLastAttempt bool) (*yrNoRequestResult, error) {
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Debug("Failed to close response body", logger.Error(closeErr))
+		}
+	}()
+
 	result := &yrNoRequestResult{}
 
 	// Handle Not Modified
 	if resp.StatusCode == http.StatusNotModified {
-		if err := resp.Body.Close(); err != nil {
-			log.Debug("Failed to close response body", logger.Error(err))
-		}
 		result.notModified = true
 		return result, nil
 	}
@@ -120,9 +125,6 @@ func handleYrNoResponse(resp *http.Response, log logger.Logger, isLastAttempt bo
 	// Handle non-OK status
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		if err := resp.Body.Close(); err != nil {
-			log.Debug("Failed to close response body", logger.Error(err))
-		}
 		responseBodyStr := truncateBodyPreview(string(bodyBytes))
 		log.Warn("Received non-OK status code",
 			logger.Int("status_code", resp.StatusCode),
@@ -145,9 +147,6 @@ func handleYrNoResponse(resp *http.Response, log logger.Logger, isLastAttempt bo
 	// Status is OK - read body
 	result.lastMod = resp.Header.Get("Last-Modified")
 	body, err := readYrNoResponseBody(resp, log)
-	if closeErr := resp.Body.Close(); closeErr != nil {
-		log.Debug("Failed to close response body", logger.Error(closeErr))
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -294,21 +294,21 @@ func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics 
 	weatherClient := newDefaultHTTPClient()
 
 	// Select weather provider based on configuration
-	switch settings.Realtime.Weather.Provider {
-	case "yrno":
+	switch conf.WeatherProvider(settings.Realtime.Weather.Provider) {
+	case conf.WeatherYrNo:
 		provider = NewYrNoProvider(weatherClient)
 		providerName = yrNoProviderName
-	case "openweather":
+	case conf.WeatherOpenWeather:
 		provider = NewOpenWeatherProvider(weatherClient)
 		providerName = openWeatherProviderName
-	case "wunderground":
+	case conf.WeatherWunderground:
 		provider = NewWundergroundProvider(weatherClient)
 		providerName = wundergroundProviderName
 	case "":
 		// Not configured - default to yr.no
 		provider = NewYrNoProvider(weatherClient)
 		providerName = yrNoProviderName
-	case "none":
+	case conf.WeatherNone:
 		// Explicitly disabled
 		getLogger().Info("Weather provider set to none, weather service disabled")
 		return nil, ErrWeatherDisabled

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -851,153 +851,92 @@ func TestService_StartPolling(t *testing.T) {
 // STARTUP DELAY TESTS
 // =============================================================================
 
-// TestService_StartPolling_StartupDelay tests the startup delay behavior.
+// TestService_StartPolling_StartupDelay tests the startup delay behavior using
+// testing/synctest so the delay advances deterministically instead of relying on
+// real wall-clock sleeps with timing-sensitive bounds (issue #991 flaky-test guard).
 func TestService_StartPolling_StartupDelay(t *testing.T) {
-	t.Run("delay_postpones_initial_fetch", func(t *testing.T) {
-		setupHTTPMock(t)
-		mockDB := mocks.NewMockInterface(t)
-
-		registerYrNoResponder(t, http.StatusOK, yrNoSuccessResponse(), nil)
-
+	// newDelayService builds a service whose provider returns the 204 "no data"
+	// sentinel (so no DB is needed) and records, in virtual time, how long after
+	// start the first fetch ran. It closes stopChan after the first fetch so
+	// StartPolling returns without spinning through the ticker loop.
+	newDelayService := func(startupDelay time.Duration, start time.Time, fetchElapsed *time.Duration, fetched *bool, stopChan chan struct{}) *Service {
+		t.Helper()
 		settings := createTestSettings(t, "yrno", func(s *conf.Settings) {
 			s.Realtime.Weather.PollInterval = 60
 		})
-
-		delay := 200 * time.Millisecond
-		service := &Service{
-			provider:     NewYrNoProvider(nil),
-			db:           mockDB,
-			settings:     settings,
-			metrics:      nil,
-			startupDelay: delay,
+		var stopOnce sync.Once
+		provider := &mockProvider{
+			fetchFunc: func(_ *conf.Settings) (*WeatherData, error) {
+				*fetched = true
+				*fetchElapsed = time.Since(start)
+				stopOnce.Do(func() { close(stopChan) })
+				return nil, ErrWeatherNoData
+			},
 		}
-
-		fetchCalled := make(chan struct{})
-		mockDB.On("SaveDailyEvents", mock.Anything).Run(func(args mock.Arguments) {
-			de := args.Get(0).(*datastore.DailyEvents)
-			de.ID = 1
-			close(fetchCalled)
-		}).Return(nil).Once()
-		mockDB.On("SaveHourlyWeather", mock.Anything).Return(nil).Once()
-
-		stopChan := make(chan struct{})
-		done := make(chan struct{})
-		startTime := time.Now()
-
-		go func() {
-			service.StartPolling(stopChan)
-			close(done)
-		}()
-
-		// Wait for initial fetch to complete
-		select {
-		case <-fetchCalled:
-			elapsed := time.Since(startTime)
-			assert.GreaterOrEqual(t, elapsed, delay,
-				"Initial fetch should be delayed by at least the startup delay")
-		case <-time.After(5 * time.Second):
-			t.Fatal("Initial fetch did not complete within timeout")
-		}
-
-		close(stopChan)
-		select {
-		case <-done:
-		case <-time.After(2 * time.Second):
-			t.Fatal("StartPolling did not stop within timeout")
-		}
-
-		mockDB.AssertExpectations(t)
-	})
-
-	t.Run("zero_delay_fetches_immediately", func(t *testing.T) {
-		setupHTTPMock(t)
-		mockDB := mocks.NewMockInterface(t)
-
-		registerYrNoResponder(t, http.StatusOK, yrNoSuccessResponse(), nil)
-
-		settings := createTestSettings(t, "yrno", func(s *conf.Settings) {
-			s.Realtime.Weather.PollInterval = 60
-		})
-
-		service := &Service{
-			provider:     NewYrNoProvider(nil),
-			db:           mockDB,
-			settings:     settings,
-			metrics:      nil,
-			startupDelay: 0,
-		}
-
-		fetchCalled := make(chan struct{})
-		mockDB.On("SaveDailyEvents", mock.Anything).Run(func(args mock.Arguments) {
-			de := args.Get(0).(*datastore.DailyEvents)
-			de.ID = 1
-			close(fetchCalled)
-		}).Return(nil).Once()
-		mockDB.On("SaveHourlyWeather", mock.Anything).Return(nil).Once()
-
-		stopChan := make(chan struct{})
-		done := make(chan struct{})
-		startTime := time.Now()
-
-		go func() {
-			service.StartPolling(stopChan)
-			close(done)
-		}()
-
-		// Fetch should happen almost immediately
-		select {
-		case <-fetchCalled:
-			elapsed := time.Since(startTime)
-			assert.Less(t, elapsed, 500*time.Millisecond,
-				"With zero delay, fetch should happen almost immediately")
-		case <-time.After(2 * time.Second):
-			t.Fatal("Initial fetch did not complete within timeout")
-		}
-
-		close(stopChan)
-		select {
-		case <-done:
-		case <-time.After(2 * time.Second):
-			t.Fatal("StartPolling did not stop within timeout")
-		}
-
-		mockDB.AssertExpectations(t)
-	})
-
-	t.Run("delay_interruptible_via_stop_chan", func(t *testing.T) {
-		settings := createTestSettings(t, "yrno", func(s *conf.Settings) {
-			s.Realtime.Weather.PollInterval = 60
-		})
-
-		// Use a long delay that we will interrupt
-		service := &Service{
-			provider:     NewYrNoProvider(nil),
+		return &Service{
+			provider:     provider,
+			providerName: yrNoProviderName,
 			db:           nil,
 			settings:     settings,
 			metrics:      nil,
-			startupDelay: 10 * time.Second,
+			startupDelay: startupDelay,
 		}
+	}
 
-		stopChan := make(chan struct{})
-		done := make(chan struct{})
+	t.Run("delay_postpones_initial_fetch", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			const delay = 30 * time.Second
+			stopChan := make(chan struct{})
+			var fetchElapsed time.Duration
+			var fetched bool
+			service := newDelayService(delay, time.Now(), &fetchElapsed, &fetched, stopChan)
 
-		go func() {
 			service.StartPolling(stopChan)
-			close(done)
-		}()
 
-		// Close stop channel after a short time to interrupt the delay
-		time.AfterFunc(50*time.Millisecond, func() {
-			close(stopChan)
+			assert.True(t, fetched, "the initial fetch should run after the startup delay")
+			assert.Equal(t, delay, fetchElapsed,
+				"initial fetch must be postponed by exactly the startup delay")
 		})
+	})
 
-		// StartPolling should return quickly after stopChan is closed
-		select {
-		case <-done:
-			// Success - StartPolling was interrupted during delay
-		case <-time.After(2 * time.Second):
-			t.Fatal("StartPolling was not interrupted by stopChan during startup delay")
-		}
+	t.Run("zero_delay_fetches_immediately", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			stopChan := make(chan struct{})
+			var fetchElapsed time.Duration
+			var fetched bool
+			service := newDelayService(0, time.Now(), &fetchElapsed, &fetched, stopChan)
+
+			service.StartPolling(stopChan)
+
+			assert.True(t, fetched, "the initial fetch should run immediately")
+			assert.Zero(t, fetchElapsed,
+				"with zero startup delay the initial fetch must run at t=0")
+		})
+	})
+
+	t.Run("delay_interruptible_via_stop_chan", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			const delay = 10 * time.Minute
+			stopChan := make(chan struct{})
+			var fetchElapsed time.Duration
+			var fetched bool
+			service := newDelayService(delay, time.Now(), &fetchElapsed, &fetched, stopChan)
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				service.StartPolling(stopChan)
+			}()
+
+			// Advance virtual time partway into the startup delay, then interrupt:
+			// StartPolling must return without ever running a fetch.
+			time.Sleep(50 * time.Millisecond)
+			close(stopChan)
+			<-done
+
+			assert.False(t, fetched,
+				"fetch must not run if the service is stopped during the startup delay")
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary

A low-risk cleanup pass over `internal/weather` plus a test backfill. No change to weather collection or persistence behavior; the provider-selection, response-handling, and icon-mapping outputs are all preserved.

**Cleanup**
- Replace stringly-typed provider switches with typed constants: `conf.WeatherProvider` in `NewService`, and the package-local `*ProviderName` constants in `GetStandardIconCode`.
- Inline the no-op `getPrecipitationRate` wrapper as `max(0, obs.Metric.PrecipRate)`.
- Use the `GetIconDescription` accessor for the Wunderground description instead of indexing `IconDescription` directly, so an unmapped icon code falls back to `"Unknown"` rather than an empty string (unreachable for the current Wunderground icon set, but safer).
- Remove the dead `DayPartlyCloudyUpperSR` constant and correct the partly-cloudy solar-radiation threshold comment.
- Consolidate the three branch-site `resp.Body.Close()` calls in the yr.no response handler into a single deferred close, matching the OpenWeather and Wunderground providers.

**Tests**
- Add `TestGetWeatherIcon_Identity`, which pins each weather condition to a unique SVG marker so an icon-map swap (e.g. rain/snow) is caught. The existing test only checked the `<svg>` wrapper.
- Convert the flaky real-sleep `TestService_StartPolling_StartupDelay` to `testing/synctest` for deterministic virtual-clock timing, matching `TestStartPolling_RecurringTick`.

## Test Plan
- [x] `go build ./internal/...`
- [x] `go vet ./internal/weather/`
- [x] `golangci-lint run ./internal/weather/...` (0 issues)
- [x] `go test -race ./internal/weather/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable weather icon selection and handling of unknown icons.
  * Improved precipitation rate handling to avoid negative values.

* **Refactor**
  * Consolidated provider selection and internal weather service logic for clearer behavior.

* **Tests**
  * Added icon identity validation.
  * Rewrote startup-delay tests for deterministic, faster verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->