### PR TITLE
fix: localized common-name search returns secondary-model species (bats, Perch)

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -129,7 +129,7 @@ func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, re
 		if cm.apiController != nil {
 			api = cm.apiController
 		}
-		installNameResolver(cm.bn.OpenFaunaResolver(), cm.bn.Labels(), ds, api)
+		installNameResolver(cm.bn.OpenFaunaResolver(), cm.bn.AllLabels(), ds, api)
 	}
 
 	// Initialize the sound level manager but don't start it yet
@@ -409,7 +409,9 @@ func (cm *ControlMonitor) handleReloadBirdnet() {
 	// the new locale, and the resolver was installed on Ds/apiController at startup
 	// (NewControlMonitor), so these calls re-localize the cached maps via the
 	// now-current resolver.
-	labels := cm.bn.Labels()
+	// Use the full multi-model label set so secondary-model species (bats,
+	// Perch-unique) stay searchable after a locale/model reload, not just the primary.
+	labels := cm.bn.AllLabels()
 	if cm.proc != nil && cm.proc.Ds != nil {
 		cm.proc.Ds.UpdateNameMaps(labels)
 		GetLogger().Info("Datastore name maps updated with new labels")

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -770,8 +770,17 @@ func (c *Controller) GetHourlyAnalytics(ctx echo.Context) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx.Request().Context(), analyticsQueryTimeout)
 	defer cancel()
 
+	// Resolve a localized common name (e.g. a Finnish bat name) to its scientific
+	// name so analytics matches the detections/search path. A scientific name or an
+	// unresolved term passes through unchanged. Only the datastore query uses the
+	// resolved value; logs and the response keep the user-facing species string.
+	querySpecies := speciesParam
+	if resolved, hit := c.resolveSpeciesToScientific(speciesParam); hit {
+		querySpecies = resolved
+	}
+
 	// Get hourly analytics data from the datastore
-	hourlyData, err := c.DS.GetHourlyAnalyticsData(ctxWithTimeout, date, speciesParam)
+	hourlyData, err := c.DS.GetHourlyAnalyticsData(ctxWithTimeout, date, querySpecies)
 	if err != nil {
 		// Check if error was due to timeout
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -872,8 +881,16 @@ func (c *Controller) GetDailyAnalytics(ctx echo.Context) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx.Request().Context(), analyticsQueryTimeout)
 	defer cancel()
 
+	// Resolve a localized common name to its scientific name so analytics matches the
+	// detections/search path; a scientific name or unresolved term passes through.
+	// Only the datastore query uses the resolved value.
+	querySpecies := speciesParam
+	if resolved, hit := c.resolveSpeciesToScientific(speciesParam); hit {
+		querySpecies = resolved
+	}
+
 	// Get daily analytics data from the datastore
-	dailyData, err := c.DS.GetDailyAnalyticsData(ctxWithTimeout, startDate, endDate, speciesParam)
+	dailyData, err := c.DS.GetDailyAnalyticsData(ctxWithTimeout, startDate, endDate, querySpecies)
 	if err != nil {
 		// Check if error was due to timeout
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -1393,7 +1410,14 @@ func (c *Controller) processHourlyBatchSpecies(ctx echo.Context, speciesParams [
 		}
 		seen[speciesItem] = true
 
-		hourlyData, err := c.DS.GetHourlyAnalyticsData(ctx.Request().Context(), date, speciesItem)
+		// Resolve a localized common name for the datastore query only; results stay
+		// keyed by the user-facing species string.
+		queryItem := speciesItem
+		if resolved, hit := c.resolveSpeciesToScientific(speciesItem); hit {
+			queryItem = resolved
+		}
+
+		hourlyData, err := c.DS.GetHourlyAnalyticsData(ctx.Request().Context(), date, queryItem)
 		if err != nil {
 			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get hourly data for species %s: %v", speciesItem, err))
 			c.logErrorIfEnabled("Error getting hourly data for species in batch request",
@@ -1498,7 +1522,14 @@ func (c *Controller) processDailyBatchSpecies(ctx echo.Context, uniqueSpecies []
 	processingErrors = make([]string, 0)
 
 	for _, speciesItem := range uniqueSpecies {
-		dailyData, err := c.DS.GetDailyAnalyticsData(ctx.Request().Context(), startDate, endDate, speciesItem)
+		// Resolve a localized common name for the datastore query only; the response
+		// stays keyed by and labeled with the user-facing species string.
+		queryItem := speciesItem
+		if resolved, hit := c.resolveSpeciesToScientific(speciesItem); hit {
+			queryItem = resolved
+		}
+
+		dailyData, err := c.DS.GetDailyAnalyticsData(ctx.Request().Context(), startDate, endDate, queryItem)
 		if err != nil {
 			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get daily data for species %s: %v", speciesItem, err))
 			c.logErrorIfEnabled("Error getting daily data for species in batch request",

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -1089,8 +1089,16 @@ func (c *Controller) GetTimeOfDayDistribution(ctx echo.Context) error {
 		return err
 	}
 
+	// Resolve a localized common name to its scientific name so this endpoint matches
+	// the detections/search path; a scientific name or unresolved term passes through.
+	// Only the datastore query uses the resolved value.
+	querySpecies := speciesParam
+	if resolved, hit := c.resolveSpeciesToScientific(speciesParam); hit {
+		querySpecies = resolved
+	}
+
 	// Get hourly distribution data from the datastore
-	hourlyData, err := c.DS.GetHourlyDistribution(ctx.Request().Context(), startDate, endDate, speciesParam)
+	hourlyData, err := c.DS.GetHourlyDistribution(ctx.Request().Context(), startDate, endDate, querySpecies)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to get hourly distribution data", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1377,6 +1378,97 @@ func TestGetDailySpeciesSummary_BatchQueryError(t *testing.T) {
 	assert.Equal(t, "Failed to process daily species data", errorResponse["error"])
 
 	// Assert that all expectations were met
+	mockDS.AssertExpectations(t)
+}
+
+// analyticsBatchFakeResolver is a test resolver that satisfies SpeciesNameResolver
+// and the optional batchLocalizer interface. This is distinct from the fakeResolver
+// in insights_nameresolver_test.go, which covers the forward (sci->common) path only.
+// Here we need the batch capability so that scientific-only bat labels (no embedded
+// common name) reach the commonToSci reverse map and become resolvable.
+type analyticsBatchFakeResolver struct{ batch map[string]string }
+
+func (a *analyticsBatchFakeResolver) Resolve(string, string) string      { return "" }
+func (a *analyticsBatchFakeResolver) ResolveLocal(string) (string, bool) { return "", false }
+func (a *analyticsBatchFakeResolver) ResolveLocalizedBatch(names []string) map[string]string {
+	out := make(map[string]string, len(names))
+	for _, n := range names {
+		if v, ok := a.batch[n]; ok {
+			out[n] = v
+		}
+	}
+	return out
+}
+
+// TestAnalytics_ResolvesLocalizedCommonNameToScientific verifies that after wiring a
+// batch-capable resolver and calling UpdateCommonNameMap, the reverse lookup for a
+// localized bat name (which has no embedded common name in the label) returns the
+// correct scientific name. This guards the map-builder wiring for the analytics path.
+func TestAnalytics_ResolvesLocalizedCommonNameToScientific(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("feature", "localized-name-resolution")
+
+	e := echo.New()
+	c := &Controller{Group: e.Group("/api/v2")}
+	c.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		"Barbastella barbastellus": "mopsilepakko",
+	}})
+	// "Barbastella barbastellus" is a scientific-only label (no underscore separator),
+	// which triggers the batchLocalizer path in ResolveLabelNames.
+	c.UpdateCommonNameMap([]string{"Barbastella barbastellus"})
+
+	got, hit := c.resolveSpeciesToScientific("mopsilepakko")
+	require.True(t, hit, "expected a reverse-map hit for the Finnish bat name")
+	assert.Equal(t, "Barbastella barbastellus", got)
+}
+
+// TestAnalytics_HourlyHandlerPassesResolvedSpeciesToDatastore verifies that when
+// GetHourlyAnalytics receives a localized common name, the resolved scientific name
+// is what actually reaches the datastore. The API response keeps the user-facing
+// string; only the datastore call uses the resolved value.
+func TestAnalytics_HourlyHandlerPassesResolvedSpeciesToDatastore(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("feature", "localized-name-resolution")
+
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// Wire the resolver so "mopsilepakko" reverse-maps to the scientific name.
+	controller.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		"Barbastella barbastellus": "mopsilepakko",
+	}})
+	controller.UpdateCommonNameMap([]string{"Barbastella barbastellus"})
+
+	const (
+		localizedName  = "mopsilepakko"
+		scientificName = "Barbastella barbastellus"
+		date           = testDate
+	)
+
+	// Capture the species argument that actually reaches the datastore.
+	var capturedSpecies string
+	mockDS.EXPECT().
+		GetHourlyAnalyticsData(mock.Anything, date, mock.AnythingOfType("string")).
+		RunAndReturn(func(_ context.Context, _ string, species string) ([]datastore.HourlyAnalyticsData, error) {
+			capturedSpecies = species
+			return []datastore.HourlyAnalyticsData{}, nil
+		}).Once()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/time/hourly", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/api/v2/analytics/time/hourly")
+	ctx.QueryParams().Set("date", date)
+	ctx.QueryParams().Set("species", localizedName)
+
+	err := controller.GetHourlyAnalytics(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// The resolved scientific name must reach the datastore, not the localized name.
+	assert.Equal(t, scientificName, capturedSpecies,
+		"datastore must receive the scientific name, not the localized common name")
+
 	mockDS.AssertExpectations(t)
 }
 

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -1472,6 +1472,111 @@ func TestAnalytics_HourlyHandlerPassesResolvedSpeciesToDatastore(t *testing.T) {
 	mockDS.AssertExpectations(t)
 }
 
+// TestAnalytics_TimeOfDayDistributionResolvesLocalizedSpecies verifies that
+// GetTimeOfDayDistribution passes the scientific name to the datastore when given
+// a localized common name (Finnish bat name "mopsilepakko"). Before the fix the
+// resolver was not wired and the localized string reached the datastore unchanged.
+func TestAnalytics_TimeOfDayDistributionResolvesLocalizedSpecies(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("feature", "localized-name-resolution")
+
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	controller.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		"Barbastella barbastellus": "mopsilepakko",
+	}})
+	controller.UpdateCommonNameMap([]string{"Barbastella barbastellus"})
+
+	const (
+		startDate      = "2023-01-01"
+		endDate        = "2023-01-31"
+		localizedName  = "mopsilepakko"
+		scientificName = "Barbastella barbastellus"
+	)
+
+	var capturedSpecies string
+	mockDS.EXPECT().
+		GetHourlyDistribution(mock.Anything, startDate, endDate, mock.AnythingOfType("string")).
+		RunAndReturn(func(_ context.Context, _, _ string, species string) ([]datastore.HourlyDistributionData, error) {
+			capturedSpecies = species
+			return []datastore.HourlyDistributionData{}, nil
+		}).Once()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/time/distribution/hourly", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/api/v2/analytics/time/distribution/hourly")
+	ctx.QueryParams().Set("start_date", startDate)
+	ctx.QueryParams().Set("end_date", endDate)
+	ctx.QueryParams().Set("species", localizedName)
+
+	err := controller.GetTimeOfDayDistribution(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, scientificName, capturedSpecies,
+		"datastore must receive the scientific name, not the localized common name")
+
+	mockDS.AssertExpectations(t)
+}
+
+// TestAnalytics_BatchDailySpeciesResolvesLocalizedSpecies verifies that
+// GetBatchDailySpeciesData resolves a localized common name to its scientific name
+// before querying the datastore, while keeping the user-facing name as the response key.
+func TestAnalytics_BatchDailySpeciesResolvesLocalizedSpecies(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("feature", "localized-name-resolution")
+
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	controller.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		"Barbastella barbastellus": "mopsilepakko",
+	}})
+	controller.UpdateCommonNameMap([]string{"Barbastella barbastellus"})
+
+	const (
+		startDate      = "2023-01-01"
+		endDate        = "2023-01-31"
+		localizedName  = "mopsilepakko"
+		scientificName = "Barbastella barbastellus"
+	)
+
+	var capturedSpecies string
+	mockDS.EXPECT().
+		GetDailyAnalyticsData(mock.Anything, startDate, endDate, mock.AnythingOfType("string")).
+		RunAndReturn(func(_ context.Context, _, _, species string) ([]datastore.DailyAnalyticsData, error) {
+			capturedSpecies = species
+			return []datastore.DailyAnalyticsData{}, nil
+		}).Once()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/time/daily/batch", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/api/v2/analytics/time/daily/batch")
+	ctx.QueryParams().Set("start_date", startDate)
+	ctx.QueryParams().Set("end_date", endDate)
+	ctx.QueryParams()["species"] = []string{localizedName}
+
+	err := controller.GetBatchDailySpeciesData(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// The datastore must have received the scientific name, not the localized name.
+	assert.Equal(t, scientificName, capturedSpecies,
+		"datastore must receive the scientific name, not the localized common name")
+
+	// The response is a map[string]SpeciesDailyData keyed by user-facing species name.
+	// The localized name must be the key, not the scientific name.
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasLocalizedKey := resp[localizedName]
+	assert.True(t, hasLocalizedKey,
+		"response must be keyed by the user-facing localized name %q, not the scientific name", localizedName)
+
+	mockDS.AssertExpectations(t)
+}
+
 func TestApplySpeciesStatusToSummary_FlagPassThrough(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -1332,7 +1332,7 @@ func TestGetDailySpeciesSummary_DatabaseError(t *testing.T) {
 	assert.Contains(t, errorResponse, "message")
 	assert.Contains(t, errorResponse, "code")
 
-	// Check the error message — in non-debug mode, Error field uses sanitized message
+	// Check the error message: in non-debug mode, Error field uses sanitized message
 	assert.Equal(t, "Failed to get daily species data", errorResponse["error"])
 	assert.Equal(t, "Failed to get daily species data", errorResponse["message"])
 	assert.InDelta(t, http.StatusInternalServerError, errorResponse["code"], 0.01)

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -497,7 +497,7 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to query eBird observations", http.StatusInternalServerError)
 	}
 
-	// Get local species to deduplicate against (best-effort — if this fails, show all eBird results)
+	// Get local species to deduplicate against (best-effort; if this fails, show all eBird results)
 	yearRanges := buildYearRanges(time.Now(), expectedTodayWindowDays)
 	localSpecies, localErr := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, nil)
 	if localErr != nil {

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -187,45 +187,19 @@ func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nam
 		commonToSci: make(map[string]string, len(labels)),
 	}
 	ambiguous := make(map[string]struct{})
-	// Hoist the (reflect-based) nil check out of the per-label loop. IsNilResolver
-	// also rejects typed-nil interfaces, consistent with SetNameResolver.
-	useResolver := !datastore.IsNilResolver(resolver)
-	for _, label := range labels {
-		// A scientific-only label (no separator, e.g. Perch v2 / bat labels) has no
-		// embedded common name; treat the whole label as the scientific name and let
-		// the resolver supply a searchable common name below.
-		scientificName, commonName, found := strings.Cut(label, "_")
-		if !found {
-			scientificName, commonName = label, ""
-		}
-		scientificName = strings.TrimSpace(scientificName)
-		commonName = strings.TrimSpace(commonName)
-		if scientificName == "" {
-			continue
-		}
-		// In-memory-only resolve: buildNameMaps runs over the full model label set,
-		// so the slow-path Resolve would scan the dataset once per out-of-working-set
-		// species on each rebuild. Those species keep their label name here.
-		if useResolver {
-			if r, ok := resolver.ResolveLocal(scientificName); ok {
-				commonName = r
-			}
-		}
-		if commonName == "" {
-			continue
-		}
-		nm.sciToCommon[scientificName] = commonName
+	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
+		nm.sciToCommon[sn.Scientific] = sn.Common
 
-		key := normalizeForLookup(commonName)
+		key := normalizeForLookup(sn.Common)
 		if _, seen := ambiguous[key]; seen {
 			continue
 		}
-		if existing, exists := nm.commonToSci[key]; exists && existing != scientificName {
+		if existing, exists := nm.commonToSci[key]; exists && existing != sn.Scientific {
 			ambiguous[key] = struct{}{}
 			delete(nm.commonToSci, key)
 			continue
 		}
-		nm.commonToSci[key] = scientificName
+		nm.commonToSci[key] = sn.Scientific
 	}
 	return nm
 }

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -78,6 +78,15 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 			logger.String("path", path),
 			logger.String("ip", ip),
 		)
+	} else if originalSpecies != "" {
+		// The species term did not map to a known scientific name; the query falls
+		// back to substring/LIKE. Log it so "unresolvable name" is distinguishable
+		// from "resolved but no detections" when triaging an empty result.
+		c.logDebugIfEnabled("Species query did not resolve to a scientific name, using substring search",
+			logger.String("input", originalSpecies),
+			logger.String("path", path),
+			logger.String("ip", ip),
+		)
 	}
 
 	// Log validated request parameters

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -312,7 +312,6 @@ func TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies(t *testing.T) {
 	// Drive a POST /search request with the localized Finnish bat name.
 	body := strings.NewReader(`{"species":"mopsilepakko"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/search", body)
-	req.Header.Set(echo.MIMEApplicationJSON, "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -1,12 +1,18 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 )
 
 // testLabels contains representative BirdNET label strings used across
@@ -259,4 +265,68 @@ func TestLoadNameMaps_CalledBeforeInit(t *testing.T) {
 	assert.NotNil(t, c.loadCommonToScientificMap())
 	assert.Empty(t, c.loadCommonNameMap())
 	assert.Empty(t, c.loadCommonToScientificMap())
+}
+
+// TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies is the end-to-end
+// HTTP regression test for the localized common-name search fix. It verifies that when a search
+// request arrives with a localized common name for a secondary-model species
+// (a bat label that has no embedded common name in the label string and is
+// resolved only via the batch localizer), the name is resolved to the scientific
+// name before the datastore query runs. Pre-fix, the batch seam was absent so
+// the bat label never entered commonToSci and the search fell back to a
+// substring match on the unresolved localized string.
+func TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "search")
+	t.Attr("feature", "localized-name-resolution")
+
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+
+	controller := &Controller{
+		Group: e.Group("/api/v2"),
+		DS:    mockDS,
+	}
+	controller.Settings.Store(newValidTestSettings())
+
+	// Wire a batch-capable resolver so the scientific-only bat label
+	// "Barbastella barbastellus" (no underscore-separated common name in the
+	// label string) gets a Finnish localized name via the batch path.
+	controller.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		"Barbastella barbastellus": "mopsilepakko",
+	}})
+	// Feed the scientific-only label so UpdateCommonNameMap triggers the
+	// batchLocalizer path and populates commonToSci with
+	// "mopsilepakko" -> "Barbastella barbastellus".
+	controller.UpdateCommonNameMap([]string{"Barbastella barbastellus"})
+
+	// Capture the SearchFilters that reach the datastore.
+	var captured *datastore.SearchFilters
+	mockDS.EXPECT().
+		SearchDetections(mock.Anything).
+		RunAndReturn(func(f *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
+			captured = f
+			return nil, 0, nil
+		}).Once()
+
+	// Drive a POST /search request with the localized Finnish bat name.
+	body := strings.NewReader(`{"species":"mopsilepakko"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/search", body)
+	req.Header.Set(echo.MIMEApplicationJSON, "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/api/v2/search")
+
+	err := controller.HandleSearch(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// The localized name must have been resolved to the scientific name before
+	// the datastore call. Pre-fix this would be "mopsilepakko" (unresolved).
+	require.NotNil(t, captured, "SearchDetections must have been called")
+	assert.Equal(t, "Barbastella barbastellus", captured.Species,
+		"localized bat name must resolve to scientific name before the datastore query")
+
+	mockDS.AssertExpectations(t)
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -739,6 +739,11 @@ func (o *Orchestrator) AllLabels() []string {
 	}
 	o.mu.RUnlock()
 
+	// Sort secondary models by ID so the union (and the reverse maps built from it) is
+	// stable across rebuilds; Go's randomized map iteration would otherwise pick a
+	// different winner for duplicate scientific names, matching GetAllProbableSpeciesWithSettings.
+	slices.SortFunc(refs, func(a, b entryRef) int { return strings.Compare(a.id, b.id) })
+
 	// Include the primary explicitly. primary.Labels() is safe without entry.mu because
 	// BirdNET.Labels takes the model's own lock internally, matching Labels() and
 	// GetAllProbableSpeciesWithSettings; only secondary entries are read under entry.mu.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -691,6 +691,64 @@ func (o *Orchestrator) Labels() []string {
 	return primary.Labels()
 }
 
+// unionLabels returns the deduplicated concatenation of the given label sets,
+// preserving first-seen order and skipping empty strings.
+func unionLabels(sets ...[]string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, set := range sets {
+		for _, label := range set {
+			if label == "" {
+				continue
+			}
+			if _, dup := seen[label]; dup {
+				continue
+			}
+			seen[label] = struct{}{}
+			out = append(out, label)
+		}
+	}
+	return out
+}
+
+// AllLabels returns the deduplicated union of every loaded model's labels: the
+// primary model plus all secondary models, INCLUDING the bat model. Unlike Labels(),
+// which returns the primary model's labels only, and unlike
+// GetAllProbableSpeciesWithSettings, which range-filters and skips the bat model,
+// AllLabels is the unfiltered superset. It is the label source for the reverse
+// name-search maps so localized common names of secondary-model species (bats,
+// Perch-unique species) are searchable, matching how the forward display path
+// already resolves them.
+func (o *Orchestrator) AllLabels() []string {
+	if o == nil {
+		return nil
+	}
+	o.mu.RLock()
+	primary := o.primary
+	refs := make([]entryRef, 0, len(o.models))
+	for id, entry := range o.models {
+		refs = append(refs, entryRef{id: id, entry: entry})
+	}
+	o.mu.RUnlock()
+
+	// primary is also keyed in o.models, but include it explicitly so a future path
+	// that leaves it out of the map cannot drop the primary labels; unionLabels dedupes.
+	sets := make([][]string, 0, len(refs)+1)
+	if primary != nil {
+		sets = append(sets, primary.Labels())
+	}
+	for _, ref := range refs {
+		ref.entry.mu.Lock()
+		var labels []string
+		if ref.entry.instance != nil {
+			labels = ref.entry.instance.Labels()
+		}
+		ref.entry.mu.Unlock()
+		sets = append(sets, labels)
+	}
+	return unionLabels(sets...)
+}
+
 // GetSpeciesCode returns the eBird species code for a given label.
 func (o *Orchestrator) GetSpeciesCode(label string) (string, bool) {
 	o.mu.RLock()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -725,14 +725,23 @@ func (o *Orchestrator) AllLabels() []string {
 	}
 	o.mu.RLock()
 	primary := o.primary
+	primaryID := o.ModelInfo.ID
 	refs := make([]entryRef, 0, len(o.models))
 	for id, entry := range o.models {
+		// When a primary is set, skip its map entry: its labels are unioned explicitly
+		// below via the *BirdNET pointer, so including it here would snapshot them twice.
+		// When primary is nil, do not skip, so the primary model's labels are still
+		// covered via the map entry. unionLabels dedupes regardless.
+		if primary != nil && id == primaryID {
+			continue
+		}
 		refs = append(refs, entryRef{id: id, entry: entry})
 	}
 	o.mu.RUnlock()
 
-	// primary is also keyed in o.models, but include it explicitly so a future path
-	// that leaves it out of the map cannot drop the primary labels; unionLabels dedupes.
+	// Include the primary explicitly. primary.Labels() is safe without entry.mu because
+	// BirdNET.Labels takes the model's own lock internally, matching Labels() and
+	// GetAllProbableSpeciesWithSettings; only secondary entries are read under entry.mu.
 	sets := make([][]string, 0, len(refs)+1)
 	if primary != nil {
 		sets = append(sets, primary.Labels())

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -334,3 +334,33 @@ func TestUnionLabels_SkipsEmptyEntries(t *testing.T) {
 	got := unionLabels([]string{"", "Parus major_Great Tit", ""})
 	assert.Equal(t, []string{"Parus major_Great Tit"}, got)
 }
+
+// TestAllLabels_IncludesSecondaryModelLabels verifies that AllLabels returns the
+// union of primary and secondary model labels, including scientific-only bat labels.
+// This is the label source used by the reverse name-search maps, so a secondary
+// model label must appear for localized search to find it.
+// When o.primary is nil (as in unit tests that avoid real model files), AllLabels
+// iterates o.models only; unionLabels deduplicates, so the result is still correct.
+func TestAllLabels_IncludesSecondaryModelLabels(t *testing.T) {
+	t.Parallel()
+
+	bird := &mockModelInstance{
+		id:     "BirdNET_V2.4",
+		labels: []string{"Turdus merula_Common Blackbird", "Parus major_Great Tit"},
+	}
+	bat := &mockModelInstance{
+		id:     "BattyBirdNET_V1.0",
+		labels: []string{"Barbastella barbastellus", "Myotis daubentonii"},
+	}
+
+	// newTestOrchestrator builds o.models but leaves o.primary nil, which is fine:
+	// AllLabels handles nil primary by iterating all entries in o.models.
+	o := newTestOrchestrator(t, bird, bat)
+
+	got := o.AllLabels()
+
+	assert.Contains(t, got, "Turdus merula_Common Blackbird", "bird model label must be included")
+	assert.Contains(t, got, "Parus major_Great Tit", "bird model label must be included")
+	assert.Contains(t, got, "Barbastella barbastellus", "bat model scientific-only label must be included")
+	assert.Contains(t, got, "Myotis daubentonii", "bat model scientific-only label must be included")
+}

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -312,3 +312,25 @@ func TestOrchestrator_ModelInfos_SkipsNilInstances(t *testing.T) {
 	assert.Len(t, infos, 1)
 	assert.Equal(t, "BirdNET_V2.4", infos[0].ID)
 }
+
+func TestUnionLabels_DedupesAcrossModelsPreservingOrder(t *testing.T) {
+	t.Parallel()
+
+	primary := []string{"Turdus merula_Common Blackbird", "Parus major_Great Tit"}
+	bat := []string{"Barbastella barbastellus", "Turdus merula_Common Blackbird"}
+
+	got := unionLabels(primary, bat)
+
+	assert.Equal(t, []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Barbastella barbastellus",
+	}, got)
+}
+
+func TestUnionLabels_SkipsEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	got := unionLabels([]string{"", "Parus major_Great Tit", ""})
+	assert.Equal(t, []string{"Parus major_Great Tit"}, got)
+}

--- a/internal/datastore/species_names.go
+++ b/internal/datastore/species_names.go
@@ -1,0 +1,81 @@
+package datastore
+
+import "strings"
+
+// SpeciesName is one resolved model label: its scientific name and the localized
+// common name to display and search for it.
+type SpeciesName struct {
+	Scientific string
+	Common     string
+}
+
+// batchLocalizer is the optional cold-path capability used to localize the
+// scientific-only labels (bats, Perch-unique species) that ResolveLocal misses.
+// SpeciesNameResolver implementations may also satisfy this to make those labels
+// searchable; the production *openfauna.Resolver does. Kept separate from
+// SpeciesNameResolver so adding it does not force a change on every implementer or a
+// mock regeneration.
+type batchLocalizer interface {
+	ResolveLocalizedBatch(scientificNames []string) map[string]string
+}
+
+// ResolveLabelNames splits each "Scientific_Common" (or scientific-only) label and
+// resolves a localized common name for it. Scientific-only secondary-model labels
+// that the working-set resolver (ResolveLocal) does not cover are batched into a
+// single cold-path dataset pass via batchLocalizer, so they become searchable without
+// a per-label scan. The returned slice preserves label order; labels with no
+// resolvable common name are omitted. This is the single source the api/v2 and
+// v2only name maps build on, so their reverse search and forward display stay in
+// lockstep.
+func ResolveLabelNames(labels []string, resolver SpeciesNameResolver) []SpeciesName {
+	useResolver := !IsNilResolver(resolver)
+
+	type parsed struct {
+		sci    string
+		common string // "" means: needs the batch pass
+	}
+	items := make([]parsed, 0, len(labels))
+	var needBatch []string
+	for _, label := range labels {
+		// A scientific-only label (no separator, for example Perch v2 / bat labels)
+		// has no embedded common name; treat the whole label as the scientific name.
+		sci, common, found := strings.Cut(label, "_")
+		if !found {
+			sci, common = label, ""
+		}
+		sci = strings.TrimSpace(sci)
+		common = strings.TrimSpace(common)
+		if sci == "" {
+			continue
+		}
+		if useResolver {
+			if r, ok := resolver.ResolveLocal(sci); ok {
+				common = r
+			}
+		}
+		if common == "" && useResolver {
+			needBatch = append(needBatch, sci)
+		}
+		items = append(items, parsed{sci: sci, common: common})
+	}
+
+	var batch map[string]string
+	if len(needBatch) > 0 {
+		if bl, ok := resolver.(batchLocalizer); ok {
+			batch = bl.ResolveLocalizedBatch(needBatch)
+		}
+	}
+
+	out := make([]SpeciesName, 0, len(items))
+	for _, it := range items {
+		common := it.common
+		if common == "" {
+			common = batch[it.sci] // nil-map read is "", safe
+		}
+		if common == "" {
+			continue
+		}
+		out = append(out, SpeciesName{Scientific: it.sci, Common: common})
+	}
+	return out
+}

--- a/internal/datastore/species_names_test.go
+++ b/internal/datastore/species_names_test.go
@@ -1,0 +1,50 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeResolver misses ResolveLocal for everything (the branch that broke localized search) and
+// resolves scientific-only labels only through the batch seam, exactly like the real
+// resolver does for out-of-working-set secondary-model species.
+type fakeResolver struct {
+	batch map[string]string
+}
+
+func (f *fakeResolver) Resolve(string, string) string      { return "" }
+func (f *fakeResolver) ResolveLocal(string) (string, bool) { return "", false }
+func (f *fakeResolver) ResolveLocalizedBatch(names []string) map[string]string {
+	out := make(map[string]string, len(names))
+	for _, n := range names {
+		if v, ok := f.batch[n]; ok {
+			out[n] = v
+		}
+	}
+	return out
+}
+
+func TestResolveLabelNames_BatchResolvesScientificOnlyLabel(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeResolver{batch: map[string]string{"Barbastella barbastellus": "mopsilepakko"}}
+	got := ResolveLabelNames([]string{"Barbastella barbastellus"}, r)
+
+	assert.Equal(t, []SpeciesName{{Scientific: "Barbastella barbastellus", Common: "mopsilepakko"}}, got)
+}
+
+func TestResolveLabelNames_EmbeddedCommonNameUsedDirectly(t *testing.T) {
+	t.Parallel()
+
+	got := ResolveLabelNames([]string{"Turdus merula_Common Blackbird"}, nil)
+	assert.Equal(t, []SpeciesName{{Scientific: "Turdus merula", Common: "Common Blackbird"}}, got)
+}
+
+func TestResolveLabelNames_UnresolvableScientificOnlyLabelDropped(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeResolver{batch: map[string]string{}}
+	got := ResolveLabelNames([]string{"Genus species"}, r)
+	assert.Empty(t, got)
+}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3099,8 +3099,9 @@ func (ds *Datastore) GetThresholdEvents(speciesName string, limit int) ([]datast
 
 	// Query 2: If we can resolve to scientific name, also query with that
 	// This finds correctly saved events (after #1907 fix)
-	normalizedCommon := strings.ToLower(strings.TrimSpace(speciesName))
-	if scientificName, ok := ds.loadNameMaps().species[normalizedCommon]; ok && scientificName != speciesName {
+	// Resolve through resolveToScientificName so this shares the reverse map's NFC-folded
+	// normalization; a decomposed (NFD) localized name must match the NFC-folded keys.
+	if scientificName := ds.resolveToScientificName(speciesName); scientificName != speciesName {
 		sciEvents, err := ds.threshold.GetThresholdEvents(ctx, scientificName, limit)
 		if err == nil && len(sciEvents) > 0 {
 			v2Events = append(v2Events, sciEvents...)

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -326,40 +326,24 @@ func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nam
 	speciesMap := make(map[string]string, len(labels))
 	commonMap := make(map[string]string, len(labels))
 	commonFoldedMap := make(map[string]string, len(labels))
-	// Hoist the (reflect-based) nil check out of the per-label loop. IsNilResolver
-	// also rejects typed-nil interfaces, consistent with SetNameResolver.
-	useResolver := !datastore.IsNilResolver(resolver)
-	for _, label := range labels {
-		// "Scientific_Common" splits into both names; a scientific-only label (no
-		// separator, e.g. Perch v2 / bat labels) has no embedded common name, so
-		// treat the whole label as the scientific name and rely on the resolver to
-		// make it searchable.
-		scientificName, commonName, found := strings.Cut(label, "_")
-		if !found {
-			scientificName, commonName = label, ""
-		}
-		scientificName = strings.TrimSpace(scientificName)
-		commonName = strings.TrimSpace(commonName)
-		if scientificName == "" {
+	// Ambiguous reverse keys are deleted, not last-writer-wins: an ambiguous common
+	// name must fall through to substring search (which returns all matches) rather
+	// than route to an arbitrary species.
+	ambiguous := make(map[string]struct{})
+	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
+		commonMap[sn.Scientific] = sn.Common
+		folded := strings.ToLower(norm.NFC.String(sn.Common))
+		commonFoldedMap[sn.Scientific] = folded
+
+		if _, seen := ambiguous[folded]; seen {
 			continue
 		}
-		// Use the in-memory-only resolve here: buildNameMaps runs over the full
-		// model label set, so calling the slow-path Resolve for every
-		// out-of-working-set species would drive thousands of dataset scans on each
-		// rebuild. Out-of-working-set species keep their label name in the (reverse
-		// search) maps; live resolveCommonName still resolves them on-demand for
-		// display.
-		if useResolver {
-			if r, ok := resolver.ResolveLocal(scientificName); ok {
-				commonName = r
-			}
-		}
-		if commonName == "" {
+		if existing, exists := speciesMap[folded]; exists && existing != sn.Scientific {
+			ambiguous[folded] = struct{}{}
+			delete(speciesMap, folded)
 			continue
 		}
-		speciesMap[strings.ToLower(commonName)] = scientificName
-		commonMap[scientificName] = commonName
-		commonFoldedMap[scientificName] = strings.ToLower(norm.NFC.String(commonName))
+		speciesMap[folded] = sn.Scientific
 	}
 	return &nameMaps{common: commonMap, commonFolded: commonFoldedMap, species: speciesMap}
 }
@@ -2839,9 +2823,17 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 // Uses the pre-built species name map (lowercase common name → scientific name).
 // Falls back to the input unchanged if no mapping is found.
 func (ds *Datastore) resolveToScientificName(name string) string {
-	normalized := strings.ToLower(strings.TrimSpace(name))
-	if sci, ok := ds.loadNameMaps().species[normalized]; ok {
+	normalized := strings.ToLower(norm.NFC.String(strings.TrimSpace(name)))
+	species := ds.loadNameMaps().species
+	if sci, ok := species[normalized]; ok {
 		return sci
+	}
+	// Reverse miss: the input did not map to a known scientific name, so callers fall
+	// back to substring/LIKE. Log once so an unresolvable name is distinguishable from
+	// a name with no detections. Guard ds.log (may be nil; matches resolveCommonName).
+	if ds.log != nil && len(species) > 0 {
+		ds.log.Debug("species name did not resolve to a scientific name, using input verbatim",
+			logger.String("input", name))
 	}
 	return name
 }

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1548,3 +1548,42 @@ func TestV2OnlyDatastore_UpdateNameMaps_ConcurrentAccess(t *testing.T) {
 
 	wg.Wait()
 }
+
+// batchFakeResolver misses ResolveLocal (the cold-path branch) and resolves only via the
+// batch seam, like the real resolver does for out-of-working-set bats.
+type batchFakeResolver struct{ batch map[string]string }
+
+func (b *batchFakeResolver) Resolve(string, string) string      { return "" }
+func (b *batchFakeResolver) ResolveLocal(string) (string, bool) { return "", false }
+func (b *batchFakeResolver) ResolveLocalizedBatch(names []string) map[string]string {
+	out := make(map[string]string, len(names))
+	for _, n := range names {
+		if v, ok := b.batch[n]; ok {
+			out[n] = v
+		}
+	}
+	return out
+}
+
+func TestBuildNameMaps_SecondaryModelScientificOnlyLabelIsReverseSearchable(t *testing.T) {
+	t.Parallel()
+
+	r := &batchFakeResolver{batch: map[string]string{"Barbastella barbastellus": "mopsilepakko"}}
+	nm := buildNameMaps([]string{"Barbastella barbastellus"}, r)
+
+	// Reverse exact map is NFC-folded, lowercased.
+	assert.Equal(t, "Barbastella barbastellus", nm.species["mopsilepakko"])
+	// Forward + substring maps present too.
+	assert.Equal(t, "mopsilepakko", nm.common["Barbastella barbastellus"])
+	assert.Equal(t, "mopsilepakko", nm.commonFolded["Barbastella barbastellus"])
+}
+
+func TestBuildNameMaps_AmbiguousCommonNameDeletedNotLastWriterWins(t *testing.T) {
+	t.Parallel()
+
+	// Two scientific names sharing one common name must not silently route to an
+	// arbitrary winner; the ambiguous reverse key is dropped.
+	nm := buildNameMaps([]string{"Strix aluco_Owl", "Bubo bubo_Owl"}, nil)
+	_, ok := nm.species["owl"]
+	assert.False(t, ok, "ambiguous common name must be deleted from the exact reverse map")
+}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1415,7 +1415,7 @@ func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {
 	}
 	require.NoError(t, ds.Save(note, nil))
 
-	// Query with no date filter — this was returning empty before the fix
+	// Query with no date filter; this was returning empty before the fix
 	summaries, err := ds.GetSpeciesSummaryData(t.Context(), "", "")
 	require.NoError(t, err)
 	require.NotEmpty(t, summaries, "summary should return data when no date filter is provided")

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1586,4 +1586,10 @@ func TestBuildNameMaps_AmbiguousCommonNameDeletedNotLastWriterWins(t *testing.T)
 	nm := buildNameMaps([]string{"Strix aluco_Owl", "Bubo bubo_Owl"}, nil)
 	_, ok := nm.species["owl"]
 	assert.False(t, ok, "ambiguous common name must be deleted from the exact reverse map")
+
+	// The forward display maps must still contain both species so their common names
+	// are shown correctly in the UI. Ambiguity handling must only drop the reverse
+	// lookup key, not the forward display names.
+	assert.Equal(t, "Owl", nm.common["Strix aluco"], "forward map must retain common name for Strix aluco")
+	assert.Equal(t, "Owl", nm.common["Bubo bubo"], "forward map must retain common name for Bubo bubo")
 }

--- a/internal/openfauna/lookup_common_names_test.go
+++ b/internal/openfauna/lookup_common_names_test.go
@@ -24,14 +24,30 @@ func TestLookupCommonNames_EmptyInputReturnsEmptyMap(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestLookupCommonNames_FinnishTranslationForKnownSpecies(t *testing.T) {
+	t.Parallel()
+
+	// Turdus merula has a genuine Finnish translation; this test pins the exact value.
+	got := LookupCommonNames([]string{"Turdus merula"}, "fi")
+	require.Contains(t, got, "Turdus merula")
+	assert.Equal(t, "mustarastas", got["Turdus merula"])
+}
+
 func TestLookupCommonNames_EnglishFallbackForUntranslatedLocale(t *testing.T) {
 	t.Parallel()
 
-	// A species translated in English but not in the target locale must still
-	// resolve via the English fallback, mirroring Resolver.Resolve.
-	got := LookupCommonNames([]string{"Turdus merula"}, "fi")
-	require.Contains(t, got, "Turdus merula")
-	assert.NotEmpty(t, got["Turdus merula"])
+	// Puffinus newelli has an English common name but no Finnish translation.
+	// The function must fall back to the English name rather than returning empty.
+	// This exercises the eff != localeFallback && loc == localeFallback branch in
+	// lookupCommonNamesEffective.
+	en := LookupCommonNames([]string{"Puffinus newelli"}, "en")
+	require.Contains(t, en, "Puffinus newelli", "English name must exist for this species")
+	require.NotEmpty(t, en["Puffinus newelli"], "English name must be non-empty")
+
+	got := LookupCommonNames([]string{"Puffinus newelli"}, "fi")
+	require.Contains(t, got, "Puffinus newelli")
+	assert.Equal(t, en["Puffinus newelli"], got["Puffinus newelli"],
+		"species with no Finnish translation must resolve to its English common name")
 }
 
 func TestResolver_ResolveLocalizedBatch_UsesBuiltLocale(t *testing.T) {

--- a/internal/openfauna/lookup_common_names_test.go
+++ b/internal/openfauna/lookup_common_names_test.go
@@ -1,0 +1,55 @@
+package openfauna
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupCommonNames_ResolvesSecondaryModelScientificLabel(t *testing.T) {
+	t.Parallel()
+
+	// Barbastella barbastellus is a bat: scientific-only label, localized in Finnish.
+	got := LookupCommonNames([]string{"Barbastella barbastellus"}, "fi")
+
+	require.Contains(t, got, "Barbastella barbastellus")
+	assert.Equal(t, "mopsilepakko", got["Barbastella barbastellus"])
+}
+
+func TestLookupCommonNames_EmptyInputReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	got := LookupCommonNames(nil, "fi")
+	assert.Empty(t, got)
+}
+
+func TestLookupCommonNames_EnglishFallbackForUntranslatedLocale(t *testing.T) {
+	t.Parallel()
+
+	// A species translated in English but not in the target locale must still
+	// resolve via the English fallback, mirroring Resolver.Resolve.
+	got := LookupCommonNames([]string{"Turdus merula"}, "fi")
+	require.Contains(t, got, "Turdus merula")
+	assert.NotEmpty(t, got["Turdus merula"])
+}
+
+func TestResolver_ResolveLocalizedBatch_UsesBuiltLocale(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver()
+	require.NoError(t, r.Rebuild([]string{"Turdus merula"}, "fi"))
+
+	// A scientific-only secondary-model species NOT in the working set must still
+	// resolve through the cold-path batch (one dataset pass at the built locale).
+	got := r.ResolveLocalizedBatch([]string{"Barbastella barbastellus"})
+	require.Contains(t, got, "Barbastella barbastellus")
+	assert.Equal(t, "mopsilepakko", got["Barbastella barbastellus"])
+}
+
+func TestResolver_ResolveLocalizedBatch_NilResolverSafe(t *testing.T) {
+	t.Parallel()
+
+	var r *Resolver
+	assert.Empty(t, r.ResolveLocalizedBatch([]string{"Turdus merula"}))
+}

--- a/internal/openfauna/openfauna.go
+++ b/internal/openfauna/openfauna.go
@@ -489,6 +489,9 @@ func lookupCommonNamesEffective(scientificNames []string, eff string) map[string
 		if _, want := inputs[norm]; !want {
 			return nil
 		}
+		if common == "" {
+			return nil // an empty translation cannot satisfy a lookup; skip so it cannot block a real name
+		}
 		switch {
 		case loc == eff:
 			if _, exists := inLocale[norm]; !exists {

--- a/internal/openfauna/openfauna.go
+++ b/internal/openfauna/openfauna.go
@@ -445,6 +445,91 @@ func LookupScientificNames(commonNames []string, bngLocale string) map[string][]
 	return out
 }
 
+// LookupCommonNames is the forward, batched companion to LookupScientificNames:
+// for each requested scientific name it returns the localized common name in the
+// locale mapped from bngLocale, resolving every request in a single pass over the
+// embedded dataset. The result is keyed by the caller's exact input strings
+// (matching is case-insensitive and whitespace-trimmed); a requested name with no
+// translation in either the active locale or English is absent from the result.
+//
+// It exists for the cold-path need to give the reverse search maps a localized
+// common name for every model label, including the scientific-only labels emitted
+// by non-primary models (bats, Perch-unique species) that the forward,
+// scientific-keyed working-set resolver (ResolveLocal) does not cover. The scan is
+// O(dataset) once regardless of how many names are requested, so callers batch all
+// of a name-map rebuild's unresolved labels into one call; it must not be used on a
+// hot path.
+//
+// Resolution mirrors Resolver.Resolve: bngLocale is mapped via mapLocale and matches
+// there take precedence; the English fallback is consulted only for names the active
+// locale did not resolve.
+func LookupCommonNames(scientificNames []string, bngLocale string) map[string]string {
+	return lookupCommonNamesEffective(scientificNames, mapLocale(bngLocale))
+}
+
+// lookupCommonNamesEffective is the locale-already-mapped core of LookupCommonNames,
+// shared with (*Resolver).ResolveLocalizedBatch which holds an effective locale.
+func lookupCommonNamesEffective(scientificNames []string, eff string) map[string]string {
+	inputs := make(map[string][]string) // normalized sci -> original inputs
+	for _, in := range scientificNames {
+		norm := normalizeName(in)
+		if norm == "" {
+			continue
+		}
+		inputs[norm] = append(inputs[norm], in)
+	}
+	if len(inputs) == 0 {
+		return map[string]string{}
+	}
+
+	inLocale := make(map[string]string)  // normalized sci -> common (active locale)
+	inEnglish := make(map[string]string) // normalized sci -> common (English fallback)
+	if err := streamTranslations(func(sci, loc, common string) error {
+		norm := normalizeName(sci)
+		if _, want := inputs[norm]; !want {
+			return nil
+		}
+		switch {
+		case loc == eff:
+			if _, exists := inLocale[norm]; !exists {
+				inLocale[norm] = common
+			}
+		case eff != localeFallback && loc == localeFallback:
+			if _, exists := inEnglish[norm]; !exists {
+				inEnglish[norm] = common
+			}
+		}
+		return nil
+	}); err != nil {
+		GetLogger().Error("openfauna forward common-name batch lookup failed",
+			logger.String("locale", eff),
+			logger.Int("requested", len(inputs)),
+			logger.Error(err),
+		)
+		return map[string]string{}
+	}
+
+	out := make(map[string]string, len(inputs))
+	for norm, origins := range inputs {
+		name := inLocale[norm]
+		if name == "" {
+			name = inEnglish[norm]
+		}
+		if name == "" {
+			continue
+		}
+		for _, in := range origins {
+			out[in] = name
+		}
+	}
+	GetLogger().Debug("openfauna forward common-name batch lookup",
+		logger.String("locale", eff),
+		logger.Int("requested", len(inputs)),
+		logger.Int("resolved", len(out)),
+	)
+	return out
+}
+
 // LookupMeta returns taxonomy/link metadata for one scientific name by scanning
 // the embedded dataset. Same performance caveat as Lookup.
 func LookupMeta(scientific string) (Meta, bool) {

--- a/internal/openfauna/resolver.go
+++ b/internal/openfauna/resolver.go
@@ -312,6 +312,24 @@ func (r *Resolver) ResolveLocal(scientificName string) (name string, ok bool) {
 	return "", false
 }
 
+// ResolveLocalizedBatch resolves localized common names for many scientific names in
+// a single dataset pass at the resolver's current (already mapped) locale, with the
+// English fallback, returning sci -> common keyed by the caller's exact inputs. It is
+// the cold-path companion to ResolveLocal: scientific-only secondary-model labels
+// that ResolveLocal misses (because they are outside the working-set index) are
+// batched here when rebuilding the reverse search maps. Names with no translation are
+// absent from the result. Must not be called on a hot path.
+func (r *Resolver) ResolveLocalizedBatch(scientificNames []string) map[string]string {
+	if r == nil {
+		return map[string]string{}
+	}
+	st := r.cur.Load()
+	if st == nil {
+		return map[string]string{}
+	}
+	return lookupCommonNamesEffective(scientificNames, st.locale)
+}
+
 // Locale reports the effective openfauna locale code of the current index, or ""
 // before the first Rebuild. Intended for introspection and logging.
 func (r *Resolver) Locale() string {


### PR DESCRIPTION
## Summary

Searching by a localized common name (for example the Finnish "mopsilepakko" for the bat Barbastella barbastellus) returned no results for species emitted by secondary models (bats via BattyBirdNET, Perch-unique species), even though those same names display correctly elsewhere. This makes search and display consistent for every loaded model.

### Root cause

The reverse common-to-scientific search maps were built from the primary model's labels only, through a working-set-only resolver (`ResolveLocal`). Scientific-only secondary-model labels carry no embedded common name, so they were never localized into the reverse maps, and a localized query never resolved to a scientific name. The forward display path worked because it consults the live resolver per call.

The two `buildNameMaps` implementations (api/v2 and the v2only datastore) had also drifted: one NFC-folded reverse keys and dropped ambiguous names, the other used bare lowercase keys with last-writer-wins.

### Fix

- **openfauna:** add a batched forward dataset lookup (`LookupCommonNames` + `(*Resolver).ResolveLocalizedBatch`), the twin of the existing reverse `LookupScientificNames`, to localize scientific-only labels in one cold-path pass.
- **datastore:** add one shared `ResolveLabelNames` builder that both name-map builders call, so NFC normalization and the delete-on-conflict ambiguity policy stop drifting. Scientific-only secondary-model labels are localized through an optional extension interface, so `SpeciesNameResolver` is unchanged and no mocks need regenerating.
- **classifier:** add `Orchestrator.AllLabels()`, the deduplicated union of every loaded model's labels (including the bat model), and feed it into the reverse maps at both rebuild sites (startup and hot-reload) instead of the primary-only labels.
- **analytics:** route the `species` query param through the existing scientific-name resolver in the hourly, daily, batch, and time-of-day endpoints, so analytics filtering by a localized common name works like search and detections. Response keys and labels keep the user-facing value.
- **search:** log reverse-resolution misses so an unresolvable name is distinguishable from a name with no detections.

### Notes

- Display semantics and the resolver hot-path working set are unchanged. The only new cost is one dataset pass per name-map rebuild (startup and locale/model change), bounded to the scientific-only labels the working set misses.
- The v2only reverse map now uses NFC-folded keys (a strict improvement: NFD-form input now matches NFC-stored labels) and delete-on-conflict for ambiguous common names, matching the api/v2 builder. An ambiguous common name now falls through to substring search instead of resolving to an arbitrary species.

## Test Plan

- [x] Unit tests for the forward batch lookup, the shared builder, the label union, and both rewired `buildNameMaps` (including the ambiguity invariant and the cold-path batch seam).
- [x] HTTP-level regression test confirming a localized bat-name search resolves to the scientific name before the datastore query (verified to fail on the pre-fix code).
- [x] Handler-level tests confirming the analytics endpoints (single, batch, time-of-day) resolve localized names while keeping user-facing response keys.
- [x] `golangci-lint run` clean; full `-race` suite passes across the touched packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secondary-model species remain searchable after model reloads and locale/model refreshes.
  * Localized/common names are now reliably resolved to scientific names for datastore queries across analytics and threshold endpoints.

* **New Features**
  * Search supports localized common-name inputs (e.g., Finnish bat names) and returns accurate results keyed by original user-facing names.

* **Tests**
  * Added regression and unit tests covering localized name resolution, batch resolution, and reverse-lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->