### PR TITLE
Localized multi-model species in /species/all and multi-word advanced search

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -59,6 +59,7 @@
   import {
     buildSpeciesNameMaps,
     isSpeciesInList,
+    normalizeForLookup,
     type SpeciesNameMaps,
   } from '$lib/utils/speciesNames';
   import {
@@ -653,10 +654,11 @@
         commonName: string,
         scientificName: string
       ): boolean =>
-        nameSet.has(commonName.toLowerCase()) || nameSet.has(scientificName.toLowerCase());
+        nameSet.has(normalizeForLookup(commonName)) ||
+        nameSet.has(normalizeForLookup(scientificName));
 
-      const includeSet = new Set((currentInclude ?? []).map(s => s.toLowerCase()));
-      const configKeys = new Set(Object.keys(currentConfig ?? {}).map(s => s.toLowerCase()));
+      const includeSet = new Set((currentInclude ?? []).map(s => normalizeForLookup(s)));
+      const configKeys = new Set(Object.keys(currentConfig ?? {}).map(s => normalizeForLookup(s)));
 
       // Filter species that pass the threshold OR are manually included
       const mappedSpecies: ActiveSpecies[] = response.species

--- a/frontend/src/lib/utils/searchParser.test.ts
+++ b/frontend/src/lib/utils/searchParser.test.ts
@@ -243,3 +243,66 @@ describe('getFilterSuggestions', () => {
     expect(result).toContain('source:');
   });
 });
+
+describe('parseSearchQuery multi-word species filter', () => {
+  it('captures an unquoted multi-word species value', () => {
+    const result = parseSearchQuery('species:Great Tit');
+    expect(result.errors).toHaveLength(0);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters[0].type).toBe('species');
+    expect(result.filters[0].value).toBe('Great Tit');
+  });
+
+  it('captures a quoted multi-word species value and strips the quotes', () => {
+    const result = parseSearchQuery('species:"Great Tit"');
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters[0].value).toBe('Great Tit');
+  });
+
+  it('stops a multi-word value at the next recognized filter key', () => {
+    const result = parseSearchQuery('species:Great Tit confidence:>90');
+    expect(result.errors).toHaveLength(0);
+    const species = result.filters.find(f => f.type === 'species');
+    const confidence = result.filters.find(f => f.type === 'confidence');
+    expect(species?.value).toBe('Great Tit');
+    expect(confidence?.value).toBe(90);
+    expect(confidence?.operator).toBe('>');
+  });
+
+  it('preserves free text before a multi-word filter', () => {
+    const result = parseSearchQuery('flying species:Great Tit');
+    expect(result.textQuery).toBe('flying');
+    expect(result.filters.find(f => f.type === 'species')?.value).toBe('Great Tit');
+  });
+
+  it('captures trailing free text after a quoted value', () => {
+    const result = parseSearchQuery('species:"Great Tit" flying');
+    expect(result.filters.find(f => f.type === 'species')?.value).toBe('Great Tit');
+    expect(result.textQuery).toBe('flying');
+  });
+
+  it('greedily swallows trailing free text after an unquoted multi-word value (documented limitation)', () => {
+    const result = parseSearchQuery('species:Great Tit flying');
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters[0].value).toBe('Great Tit flying');
+    expect(result.textQuery).toBe('');
+  });
+
+  it('handles an unmatched trailing quote without throwing', () => {
+    const result = parseSearchQuery('species:"Great Tit');
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters[0].value).toBe('Great Tit');
+  });
+
+  it('captures a multi-word location value', () => {
+    const result = parseSearchQuery('location:Back Yard');
+    expect(result.filters.find(f => f.type === 'location')?.value).toBe('Back Yard');
+  });
+
+  it('pushes an error for a single-token filter with no value', () => {
+    const result = parseSearchQuery('confidence:');
+    expect(result.filters).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.textQuery).toBe('');
+  });
+});

--- a/frontend/src/lib/utils/searchParser.ts
+++ b/frontend/src/lib/utils/searchParser.ts
@@ -9,17 +9,24 @@
 
 export type FilterOperator = '>' | '<' | '>=' | '<=' | '=' | ':';
 
-export type FilterType =
-  | 'confidence'
-  | 'time'
-  | 'date'
-  | 'hour'
-  | 'daterange'
-  | 'verified'
-  | 'species'
-  | 'location'
-  | 'source'
-  | 'locked';
+// Single source of truth for recognized filter keys: both the FilterType union
+// and the runtime FILTER_KEY_SET derive from this array, so they cannot drift
+// apart. Adding a key here updates the type and the parser's recognition set
+// together, preventing a new key that type-checks but is silently never parsed.
+const FILTER_KEYS = [
+  'confidence',
+  'time',
+  'date',
+  'hour',
+  'daterange',
+  'verified',
+  'species',
+  'location',
+  'source',
+  'locked',
+] as const;
+
+export type FilterType = (typeof FILTER_KEYS)[number];
 
 export interface SearchFilter {
   type: FilterType;
@@ -41,8 +48,64 @@ const TIME_OF_DAY_VALUES = ['dawn', 'day', 'dusk', 'night'];
 // Date shortcuts
 const DATE_SHORTCUTS = ['today', 'yesterday', 'week', 'month'];
 
+// Recognized filter keys (derived from FILTER_KEYS); bounds greedy multi-word value capture.
+const FILTER_KEY_SET = new Set<string>(FILTER_KEYS);
+
+// Free-text filters accept quoted or multi-word values; all others are single-token.
+const FREE_TEXT_FILTERS = new Set<string>(['species', 'location', 'source']);
+
+interface KeyToken {
+  key: string;
+  keyStart: number;
+  valueStart: number;
+}
+
+// Find recognized "key:" tokens at word boundaries, in order of appearance.
+function findFilterKeyTokens(query: string): KeyToken[] {
+  const tokens: KeyToken[] = [];
+  const re = /(?:^|\s)([A-Za-z]+):/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(query)) !== null) {
+    const key = m[1].toLowerCase();
+    if (!FILTER_KEY_SET.has(key)) continue;
+    // Skip any leading whitespace the boundary group captured.
+    const keyStart = m.index + m[0].length - (m[1].length + 1);
+    tokens.push({ key, keyStart, valueStart: keyStart + m[1].length + 1 });
+  }
+  return tokens;
+}
+
+// Capture the value for a filter token: quoted or greedy for free-text filters,
+// single whitespace-delimited token otherwise. `boundary` is the start index of
+// the next recognized key token (or query.length) and bounds the greedy case.
+function captureValue(
+  query: string,
+  tok: KeyToken,
+  boundary: number
+): { value: string; nextCursor: number } {
+  const isFreeText = FREE_TEXT_FILTERS.has(tok.key);
+
+  if (isFreeText && query[tok.valueStart] === '"') {
+    const closing = query.indexOf('"', tok.valueStart + 1);
+    if (closing >= 0) {
+      return { value: query.slice(tok.valueStart + 1, closing), nextCursor: closing + 1 };
+    }
+    // Unmatched quote: consume to end of string.
+    return { value: query.slice(tok.valueStart + 1).trim(), nextCursor: query.length };
+  }
+
+  if (isFreeText) {
+    return { value: query.slice(tok.valueStart, boundary).trim(), nextCursor: boundary };
+  }
+
+  // Single-token filters: value is the next whitespace-delimited token.
+  const wsMatch = /^\S+/.exec(query.slice(tok.valueStart));
+  const token = wsMatch ? wsMatch[0] : '';
+  return { value: token, nextCursor: tok.valueStart + token.length };
+}
+
 /**
- * Parse a search query string into text and filters
+ * Parse a search query string into text and filters.
  */
 export function parseSearchQuery(query: string): ParsedSearch {
   const result: ParsedSearch = {
@@ -55,42 +118,56 @@ export function parseSearchQuery(query: string): ParsedSearch {
     return result;
   }
 
-  // Regular expression to match filter patterns like "filter:value" or "filter:>value"
-  // Made safer by limiting operator repetition to prevent ReDoS
-  const filterRegex = /(\w+):([><=]{0,3}[^\s]+)/g;
+  const tokens = findFilterKeyTokens(query);
+  if (tokens.length === 0) {
+    result.textQuery = query.trim();
+    return result;
+  }
+
   const textParts: string[] = [];
-  let lastIndex = 0;
+  let cursor = 0;
 
-  let match;
-  while ((match = filterRegex.exec(query)) !== null) {
-    // Add text before this filter
-    const beforeFilter = query.slice(lastIndex, match.index).trim();
-    if (beforeFilter) {
-      textParts.push(beforeFilter);
+  for (let idx = 0; idx < tokens.length; idx++) {
+    // eslint-disable-next-line security/detect-object-injection -- idx is a bounded loop counter over KeyToken[]
+    const tok = tokens[idx];
+    // A key token swallowed by an earlier quoted/greedy value is skipped.
+    if (tok.keyStart < cursor) continue;
+
+    const before = query.slice(cursor, tok.keyStart).trim();
+    if (before) textParts.push(before);
+
+    // Boundary = the next recognized key token at or after this value start.
+    let boundary = query.length;
+    for (let j = idx + 1; j < tokens.length; j++) {
+      // Safety guard: regex anchoring means a later token cannot start inside a
+      // prior token's key span, so this is effectively the first j past idx.
+      // eslint-disable-next-line security/detect-object-injection -- j is a bounded loop counter over KeyToken[]
+      if (tokens[j].keyStart >= tok.valueStart) {
+        // eslint-disable-next-line security/detect-object-injection -- j is a bounded loop counter over KeyToken[]
+        boundary = tokens[j].keyStart;
+        break;
+      }
     }
 
-    const [fullMatch, filterType, filterValue] = match;
+    const { value, nextCursor } = captureValue(query, tok, boundary);
+    const raw = query.slice(tok.keyStart, nextCursor).trim();
 
-    // Parse the filter
-    const parsedFilter = parseFilter(filterType as FilterType, filterValue, fullMatch);
-    if (parsedFilter.error) {
-      result.errors.push(parsedFilter.error);
-    } else if (parsedFilter.filter) {
-      result.filters.push(parsedFilter.filter);
+    const parsed = parseFilter(tok.key as FilterType, value, raw);
+    if (parsed.error) {
+      result.errors.push(parsed.error);
+    } else if (parsed.filter) {
+      result.filters.push(parsed.filter);
     }
 
-    lastIndex = match.index + fullMatch.length;
+    cursor = nextCursor;
   }
 
-  // Add any remaining text after the last filter
-  const remainingText = query.slice(lastIndex).trim();
-  if (remainingText) {
-    textParts.push(remainingText);
+  const tail = query.slice(cursor).trim();
+  if (tail) {
+    textParts.push(tail);
   }
 
-  // Join all text parts
   result.textQuery = textParts.join(' ').trim();
-
   return result;
 }
 

--- a/frontend/src/lib/utils/speciesNames.test.ts
+++ b/frontend/src/lib/utils/speciesNames.test.ts
@@ -136,3 +136,64 @@ describe('isSpeciesInList', () => {
     expect(isSpeciesInList('Great Tit', list, maps)).toBe(false);
   });
 });
+
+describe('NFC normalization', () => {
+  // "Lehtopöllö" is the Finnish common name for Tawny Owl.
+  // nfcCommon uses composed code points (U+00F6 = o-with-umlaut).
+  // nfdInput is written in decomposed form (NFD): base letter 'o' followed by
+  // the combining diaeresis (U+0308). The two constants look identical visually
+  // but differ at the byte level so the test exercises real NFC-vs-NFD input.
+  const nfcCommon = 'Lehtopöllö'; // composed (NFC)
+  const nfdInput = 'Lehtopöllö'; // decomposed (NFD): o + combining diaeresis
+
+  const species: SpeciesApiEntry[] = [
+    { commonName: nfcCommon, scientificName: 'Strix aluco', label: `Strix aluco_${nfcCommon}` },
+  ];
+
+  it('resolves an NFD-form common name against the NFC-stored map', () => {
+    const maps = buildSpeciesNameMaps(species);
+    const resolved = resolveSpeciesDisplayNames(nfdInput, maps);
+    expect(resolved.displayScientificName).toBe('Strix aluco');
+    // The common-name branch returns storedValue verbatim, so the display name
+    // keeps its NFD bytes; assert it preserves casing and folds to the canonical
+    // NFC form. This catches a regression that returned the lowercased lookup key.
+    expect(resolved.displayCommonName.normalize('NFC')).toBe(nfcCommon);
+  });
+
+  it('matches an NFD candidate against an NFC list entry in isSpeciesInList', () => {
+    const maps = buildSpeciesNameMaps(species);
+    expect(isSpeciesInList(nfdInput, [nfcCommon], maps)).toBe(true);
+  });
+});
+
+describe('ambiguous common-name delete-on-conflict', () => {
+  const species: SpeciesApiEntry[] = [
+    { commonName: 'Owl', scientificName: 'Strix aluco', label: 'Strix aluco_Owl' },
+    { commonName: 'Owl', scientificName: 'Bubo bubo', label: 'Bubo bubo_Owl' },
+    { commonName: 'Great Tit', scientificName: 'Parus major', label: 'Parus major_Great Tit' },
+  ];
+
+  it('removes an ambiguous common-name key from commonToScientific', () => {
+    const maps = buildSpeciesNameMaps(species);
+    expect(maps.commonToScientific.has('owl')).toBe(false);
+    // Non-ambiguous names still resolve.
+    expect(maps.commonToScientific.get('great tit')).toBe('Parus major');
+  });
+
+  it('keeps every species in scientificToCommon despite common-name ambiguity', () => {
+    const maps = buildSpeciesNameMaps(species);
+    expect(maps.scientificToCommon.get('strix aluco')).toBe('Owl');
+    expect(maps.scientificToCommon.get('bubo bubo')).toBe('Owl');
+  });
+
+  it('removes a common-name key shared by three distinct scientific names', () => {
+    const threeWay: SpeciesApiEntry[] = [
+      { commonName: 'Owl', scientificName: 'Strix aluco', label: 'Strix aluco_Owl' },
+      { commonName: 'Owl', scientificName: 'Bubo bubo', label: 'Bubo bubo_Owl' },
+      { commonName: 'Owl', scientificName: 'Asio otus', label: 'Asio otus_Owl' },
+    ];
+    const maps = buildSpeciesNameMaps(threeWay);
+    expect(maps.commonToScientific.has('owl')).toBe(false);
+    expect(maps.scientificToCommon.get('asio otus')).toBe('Owl');
+  });
+});

--- a/frontend/src/lib/utils/speciesNames.ts
+++ b/frontend/src/lib/utils/speciesNames.ts
@@ -15,9 +15,9 @@ export interface SpeciesApiEntry {
 
 /** Bidirectional species name lookup maps */
 export interface SpeciesNameMaps {
-  /** commonName (lowercase) → scientificName */
+  /** commonName (lowercase) -> scientificName */
   commonToScientific: Map<string, string>;
-  /** scientificName (lowercase) → commonName */
+  /** scientificName (lowercase) -> commonName */
   scientificToCommon: Map<string, string>;
   /** All searchable names (both common and scientific, deduplicated) */
   allNames: string[];
@@ -30,13 +30,28 @@ export interface ResolvedDisplayNames {
 }
 
 /**
+ * Normalize a name for case- and Unicode-form-insensitive lookup. Mirrors the
+ * backend normalizeForLookup (strings.ToLower(norm.NFC.String(s))): labels ship
+ * as NFC, but composing keyboards (macOS) submit NFD bytes for diacritics, so both
+ * sides are normalized to NFC before lowercasing to prevent silent misses.
+ */
+export function normalizeForLookup(s: string): string {
+  return s.normalize('NFC').toLowerCase();
+}
+
+/**
  * Build bidirectional species name lookup maps from API response.
  * Skips entries missing a scientific name.
+ * Mirrors the backend delete-on-conflict: when two distinct scientific names
+ * share a normalized common name, that key is removed from commonToScientific
+ * so an ambiguous common name passes through unresolved instead of resolving
+ * to an arbitrary species.
  */
 export function buildSpeciesNameMaps(species: SpeciesApiEntry[]): SpeciesNameMaps {
   const commonToScientific = new Map<string, string>();
   const scientificToCommon = new Map<string, string>();
   const namesSet = new Set<string>();
+  const ambiguousCommon = new Set<string>();
 
   for (const s of species) {
     const commonName = s.commonName ?? s.label;
@@ -50,8 +65,22 @@ export function buildSpeciesNameMaps(species: SpeciesApiEntry[]): SpeciesNameMap
     // Only build bidirectional maps when both names are present
     if (!scientificName || !commonName) continue;
 
-    commonToScientific.set(commonName.toLowerCase(), scientificName);
-    scientificToCommon.set(scientificName.toLowerCase(), commonName);
+    const commonKey = normalizeForLookup(commonName);
+    // Mirror the backend delete-on-conflict: when two distinct scientific names
+    // share a normalized common name, drop that key so an ambiguous common name
+    // passes through unresolved instead of resolving to an arbitrary species.
+    if (!ambiguousCommon.has(commonKey)) {
+      const existing = commonToScientific.get(commonKey);
+      if (existing !== undefined && existing !== scientificName) {
+        ambiguousCommon.add(commonKey);
+        commonToScientific.delete(commonKey);
+      } else {
+        commonToScientific.set(commonKey, scientificName);
+      }
+    }
+
+    // scientificToCommon keeps every species (scientific names are unique).
+    scientificToCommon.set(normalizeForLookup(scientificName), commonName);
     namesSet.add(scientificName);
   }
 
@@ -79,7 +108,7 @@ export function resolveSpeciesDisplayNames(
     return { displayCommonName: '', displayScientificName: '' };
   }
 
-  const lower = storedValue.toLowerCase();
+  const lower = normalizeForLookup(storedValue);
 
   // Check if it's a scientific name
   const resolvedCommon = maps.scientificToCommon.get(lower);
@@ -99,7 +128,7 @@ export function resolveSpeciesDisplayNames(
     };
   }
 
-  // Unknown — show as common name with empty scientific
+  // Unknown: show as common name with empty scientific
   return {
     displayCommonName: storedValue,
     displayScientificName: '',
@@ -111,19 +140,23 @@ export function resolveSpeciesDisplayNames(
  * Prevents adding "Strix aluco" when "Tawny Owl" is already present (and vice versa).
  */
 export function isSpeciesInList(candidate: string, list: string[], maps: SpeciesNameMaps): boolean {
-  const candidateLower = candidate.toLowerCase();
-  const listLowerSet = new Set(list.map(s => s.toLowerCase()));
+  const candidateLower = normalizeForLookup(candidate);
+  const listLowerSet = new Set(list.map(s => normalizeForLookup(s)));
 
   // Direct match
   if (listLowerSet.has(candidateLower)) return true;
 
   // Check if candidate's alias is in the list
   const aliasFromScientific = maps.scientificToCommon.get(candidateLower);
-  if (aliasFromScientific !== undefined && listLowerSet.has(aliasFromScientific.toLowerCase()))
+  if (
+    aliasFromScientific !== undefined &&
+    listLowerSet.has(normalizeForLookup(aliasFromScientific))
+  )
     return true;
 
   const aliasFromCommon = maps.commonToScientific.get(candidateLower);
-  if (aliasFromCommon !== undefined && listLowerSet.has(aliasFromCommon.toLowerCase())) return true;
+  if (aliasFromCommon !== undefined && listLowerSet.has(normalizeForLookup(aliasFromCommon)))
+    return true;
 
   return false;
 }

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -4,11 +4,13 @@ package api
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -127,20 +129,7 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
-	var labels []string
-	if settings := c.controllerSettings(); settings != nil {
-		labels = settings.BirdNET.Labels
-	}
-	speciesList := make([]RangeFilterSpecies, 0, len(labels))
-
-	for _, label := range labels {
-		sp := detection.ParseSpeciesString(label)
-		speciesList = append(speciesList, RangeFilterSpecies{
-			Label:          label,
-			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
-		})
-	}
+	speciesList := buildAllSpeciesList(c.loadCommonNameMap(), c.controllerSettings())
 
 	c.logInfoIfEnabled("All species labels retrieved successfully",
 		logger.Int("count", len(speciesList)),
@@ -152,6 +141,50 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 		Species: speciesList,
 		Count:   len(speciesList),
 	})
+}
+
+// buildAllSpeciesList builds the /api/v2/species/all payload from the cached,
+// resolver-localized scientific-to-common map (sciToCommon), which control_monitor
+// populates from the orchestrator's multi-model AllLabels union at startup and on
+// hot-reload. Serving from that map yields every loaded model's species (including
+// secondary-model bats/Perch), localized to the configured BirdNET.Locale and
+// deduplicated (scientific keys are unique). Output is sorted by scientific name for
+// a deterministic response.
+//
+// When sciToCommon is empty (the brief startup window before control_monitor seeds
+// the maps), it falls back to parsing the primary BirdNET.Labels so the endpoint
+// never returns an empty list mid-startup. The fallback reproduces the legacy
+// behavior exactly (original label string, input order preserved).
+func buildAllSpeciesList(sciToCommon map[string]string, settings *conf.Settings) []RangeFilterSpecies {
+	if len(sciToCommon) > 0 {
+		speciesList := make([]RangeFilterSpecies, 0, len(sciToCommon))
+		for sci, common := range sciToCommon {
+			speciesList = append(speciesList, RangeFilterSpecies{
+				Label:          sci + "_" + common,
+				ScientificName: sci,
+				CommonName:     common,
+			})
+		}
+		sort.Slice(speciesList, func(i, j int) bool {
+			return speciesList[i].ScientificName < speciesList[j].ScientificName
+		})
+		return speciesList
+	}
+
+	var labels []string
+	if settings != nil {
+		labels = settings.BirdNET.Labels
+	}
+	speciesList := make([]RangeFilterSpecies, 0, len(labels))
+	for _, label := range labels {
+		sp := detection.ParseSpeciesString(label)
+		speciesList = append(speciesList, RangeFilterSpecies{
+			Label:          label,
+			ScientificName: sp.ScientificName,
+			CommonName:     sp.CommonName,
+		})
+	}
+	return speciesList
 }
 
 // GetSpeciesInfo retrieves extended information about a bird species

--- a/internal/api/v2/species_test.go
+++ b/internal/api/v2/species_test.go
@@ -413,6 +413,64 @@ func TestTaxonomyInfoJSONSerialization(t *testing.T) {
 	assert.Len(t, subspecies, 1)
 }
 
+// TestGetAllSpecies_LocalizedSecondaryModel verifies that GetAllSpecies serves
+// secondary-model species (a scientific-only bat label resolved via the batch
+// localizer) with their localized common name, sourced from the controller's
+// cached resolver-built maps rather than the raw primary BirdNET.Labels.
+func TestGetAllSpecies_LocalizedSecondaryModel(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "species")
+	t.Attr("feature", "localized-name-resolution")
+
+	e := echo.New()
+	controller := &Controller{
+		Echo:  e,
+		Group: e.Group("/api/v2"),
+	}
+	controller.Settings.Store(&conf.Settings{})
+
+	// Wire a batch-capable resolver so the scientific-only bat label gets a
+	// Finnish localized name, then populate the cached maps the way production
+	// does (control_monitor -> UpdateCommonNameMap with the AllLabels union).
+	controller.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		"Barbastella barbastellus": "mopsilepakko",
+	}})
+	controller.UpdateCommonNameMap([]string{
+		"Parus major_Great Tit",
+		"Barbastella barbastellus",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/species/all", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetAllSpecies(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response AllSpeciesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+
+	byScientific := make(map[string]RangeFilterSpecies, len(response.Species))
+	for _, s := range response.Species {
+		byScientific[s.ScientificName] = s
+	}
+
+	bat, ok := byScientific["Barbastella barbastellus"]
+	require.True(t, ok, "secondary-model bat species must be present in /species/all")
+	assert.Equal(t, "mopsilepakko", bat.CommonName, "bat must carry its localized common name")
+
+	tit, ok := byScientific["Parus major"]
+	require.True(t, ok, "primary species must still be present")
+	assert.Equal(t, "Great Tit", tit.CommonName)
+
+	// Response must be deterministically sorted by scientific name.
+	require.Len(t, response.Species, 2)
+	assert.Equal(t, "Barbastella barbastellus", response.Species[0].ScientificName, "response must be sorted by scientific name")
+	assert.Equal(t, "Parus major", response.Species[1].ScientificName)
+
+	assert.Equal(t, len(response.Species), response.Count)
+}
+
 // TestGetAllSpecies tests the GetAllSpecies endpoint returns all BirdNET labels.
 func TestGetAllSpecies(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Completes the localized common-name work so the species list endpoint and the frontend reverse name map cover secondary-model species (bats, Perch) at the server's configured locale, and the advanced-search species filter accepts multi-word values.

## Changes

- **Backend `GetAllSpecies` (`/api/v2/species/all`)**: now builds its response from the controller's cached, resolver-localized scientific-to-common map instead of the raw primary BirdNET labels. Secondary-model species appear with their localized common names, the list is deduplicated and sorted by scientific name, and it falls back to the legacy primary-label parse during the brief startup window before the map is seeded. The JSON response shape is unchanged.
- **Frontend `speciesNames.ts`**: lookup keys are NFC-normalized before lowercasing, so an NFD-form input (composing keyboards) matches an NFC-stored name. The reverse common-to-scientific map mirrors the backend delete-on-conflict, so an ambiguous common name passes through unresolved instead of resolving to an arbitrary species.
- **Frontend species settings**: the range-filter include/config cross-reference routes both sides through the same NFC normalization for consistent matching.
- **Frontend advanced search**: free-text filters (species, location, source) now accept a quoted value or consume greedily up to the next recognized filter key, so multi-word species names survive the parse. Single-token filters (confidence, time, date, hour, verified, locked) are unchanged. The recognized filter keys are now derived from a single source so the type and the parser's key set cannot drift apart.

## Notes

- For non-English locales, the `label` field of `/api/v2/species/all` now carries the localized common name (reconstructed as `Scientific_Common`). All in-repo consumers read `commonName`/`scientificName` directly and treat `label` only as a fallback, so this is transparent in the UI. External clients should read `commonName` rather than splitting `label`.
- Per-visitor (request-locale) localization is intentionally out of scope; this is server-locale only.

## Testing

- `golangci-lint run`: clean (0 issues)
- `go test -race ./internal/api/v2/... ./internal/datastore/...`: pass
- `npm run check:all`: pass (0 type errors)
- `npm test`: pass (2069 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Species name filtering and lookups now operate consistently across the application.
  * Species API endpoint now returns localized common names when available.
  * Improved species name variation handling in active species filtering.

* **New Features**
  * Enhanced search parser to better handle multi-word values in species and location filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->