### PR TITLE
fix(datastore): propagate scientific-name query error in GetThresholdEvents

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3094,7 +3094,12 @@ func (ds *Datastore) GetThresholdEvents(speciesName string, limit int) ([]datast
 	// Query 1: Try with the provided name (common name) - finds legacy/incorrectly saved events
 	v2Events, err := ds.threshold.GetThresholdEvents(ctx, speciesName, limit)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_threshold_events").
+			Context("query_type", "common_name").
+			Build()
 	}
 
 	// Query 2: If we can resolve to scientific name, also query with that
@@ -3103,17 +3108,27 @@ func (ds *Datastore) GetThresholdEvents(speciesName string, limit int) ([]datast
 	// normalization; a decomposed (NFD) localized name must match the NFC-folded keys.
 	if scientificName := ds.resolveToScientificName(speciesName); scientificName != speciesName {
 		sciEvents, err := ds.threshold.GetThresholdEvents(ctx, scientificName, limit)
-		if err == nil && len(sciEvents) > 0 {
-			v2Events = append(v2Events, sciEvents...)
+		if err != nil {
+			return nil, errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "get_threshold_events").
+				Context("query_type", "scientific_name").
+				Build()
 		}
+		v2Events = append(v2Events, sciEvents...)
 	}
 
 	// Note: Deduplication not needed - each event has exactly one LabelID,
 	// so queries for different labels return disjoint result sets.
 	uniqueEvents := v2Events
 
-	// Sort by CreatedAt DESC (most recent first)
+	// Sort by CreatedAt DESC (most recent first). Tie-break on ID so events sharing a
+	// timestamp truncate deterministically when the limit is applied below.
 	sort.Slice(uniqueEvents, func(i, j int) bool {
+		if uniqueEvents[i].CreatedAt.Equal(uniqueEvents[j].CreatedAt) {
+			return uniqueEvents[i].ID > uniqueEvents[j].ID
+		}
 		return uniqueEvents[i].CreatedAt.After(uniqueEvents[j].CreatedAt)
 	})
 

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -776,6 +776,46 @@ func TestV2OnlyDatastore_GetThresholdEvents_SecondQueryError(t *testing.T) {
 	assert.ErrorContains(t, err, "injected DB failure")
 }
 
+// TestV2OnlyDatastore_GetThresholdEvents_SameTimestampTieBreak pins the
+// CreatedAt/ID sort tie-break. The per-query LIMIT is applied in SQL, so a
+// single query cannot exercise the Go-side sort; the tie-break only governs how
+// the MERGED result of the two queries (common-name + scientific-name) is
+// truncated. We store one event found by Query 1 (a legacy common-name label)
+// and one found by Query 2 (the resolved scientific name) sharing a timestamp,
+// then assert the higher-ID event wins truncation to one row.
+func TestV2OnlyDatastore_GetThresholdEvents_SameTimestampTieBreak(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+	defer cleanup()
+
+	ts := time.Now()
+	// Query 1 finds this event (label scientific_name == the common-name input).
+	require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
+		SpeciesName: "Great Tit", NewLevel: 1, NewValue: 0.7, ChangeReason: "legacy", Confidence: 0.95, CreatedAt: ts,
+	}))
+	// Query 2 finds this event (label scientific_name == resolved scientific name).
+	require.NoError(t, ds.SaveThresholdEvent(&datastore.ThresholdEvent{
+		SpeciesName: "Parus major", NewLevel: 1, NewValue: 0.7, ChangeReason: "correct", Confidence: 0.95, CreatedAt: ts,
+	}))
+
+	// Both events come back from the merge; learn the higher ID (saved second).
+	all, err := ds.GetThresholdEvents("Great Tit", 10)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	maxID := all[0].ID
+	for _, e := range all[1:] {
+		if e.ID > maxID {
+			maxID = e.ID
+		}
+	}
+
+	// Truncating the same-timestamp merge to one row must deterministically keep
+	// the higher ID via the tie-break.
+	top, err := ds.GetThresholdEvents("Great Tit", 1)
+	require.NoError(t, err)
+	require.Len(t, top, 1)
+	assert.Equal(t, maxID, top[0].ID)
+}
+
 func TestV2OnlyDatastore_SearchNotes(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -125,6 +125,21 @@ func (r nilInjectingLabelRepository) GetByIDs(ctx context.Context, ids []uint) (
 	return labels, nil
 }
 
+// errInjectingThresholdRepository wraps a DynamicThresholdRepository and forces
+// GetThresholdEvents to fail for one species, used to prove the second
+// (scientific-name) query error is propagated rather than swallowed.
+type errInjectingThresholdRepository struct {
+	repository.DynamicThresholdRepository
+	failOnSpecies string
+}
+
+func (r errInjectingThresholdRepository) GetThresholdEvents(ctx context.Context, speciesName string, limit int) ([]entities.ThresholdEvent, error) {
+	if speciesName == r.failOnSpecies {
+		return nil, fmt.Errorf("injected DB failure for %q", speciesName)
+	}
+	return r.DynamicThresholdRepository.GetThresholdEvents(ctx, speciesName, limit)
+}
+
 func TestV2OnlyDatastore_Open(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()
@@ -695,7 +710,7 @@ func TestV2OnlyDatastore_ThresholdEvent(t *testing.T) {
 	// Get events
 	events, err := ds.GetThresholdEvents("house sparrow", 10)
 	require.NoError(t, err)
-	assert.Len(t, events, 1)
+	require.Len(t, events, 1)
 	assert.Equal(t, "house sparrow", events[0].SpeciesName)
 	assert.Equal(t, "high_confidence", events[0].ChangeReason)
 
@@ -703,6 +718,62 @@ func TestV2OnlyDatastore_ThresholdEvent(t *testing.T) {
 	recent, err := ds.GetRecentThresholdEvents(10)
 	require.NoError(t, err)
 	assert.Len(t, recent, 1)
+}
+
+// TestV2OnlyDatastore_GetThresholdEvents_ResolvesScientificName covers the
+// second (scientific-name) query path: a common-name input resolves to a
+// different scientific name, so the merge query runs and finds events stored
+// under the scientific name.
+func TestV2OnlyDatastore_GetThresholdEvents_ResolvesScientificName(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+	defer cleanup()
+
+	// Save an event under the scientific name (the correctly-saved, post-#1907 shape).
+	event := &datastore.ThresholdEvent{
+		SpeciesName:   "Parus major",
+		PreviousLevel: 0,
+		NewLevel:      1,
+		PreviousValue: 0.6,
+		NewValue:      0.7,
+		ChangeReason:  "high_confidence",
+		Confidence:    0.95,
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, ds.SaveThresholdEvent(event))
+
+	// Query by the common name. resolveToScientificName("Great Tit") -> "Parus major",
+	// so the second query runs and finds the event stored under the scientific name.
+	events, err := ds.GetThresholdEvents("Great Tit", 10)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "Parus major", events[0].SpeciesName)
+}
+
+// TestV2OnlyDatastore_GetThresholdEvents_SecondQueryError pins the #1010 fix:
+// a DB failure on the second (scientific-name) query must surface, not be
+// swallowed and returned as an empty/partial success.
+func TestV2OnlyDatastore_GetThresholdEvents_SecondQueryError(t *testing.T) {
+	cfg, cfgCleanup := buildTestConfig(t, []string{"Parus major_Great Tit"})
+	defer cfgCleanup()
+
+	// Fail only the scientific-name (second) query; the common-name (first)
+	// query still succeeds, isolating the previously-swallowed error path.
+	cfg.Threshold = errInjectingThresholdRepository{
+		DynamicThresholdRepository: cfg.Threshold,
+		failOnSpecies:              "Parus major",
+	}
+
+	ds, err := New(cfg)
+	require.NoError(t, err)
+	defer func() { _ = ds.Close() }()
+
+	// resolveToScientificName("Great Tit") -> "Parus major", so the second query
+	// runs and the injected error must propagate. Assert on the injected message so
+	// the test pins the second (scientific-name) query as the failing one, not just
+	// any error.
+	_, err = ds.GetThresholdEvents("Great Tit", 10)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "injected DB failure")
 }
 
 func TestV2OnlyDatastore_SearchNotes(t *testing.T) {


### PR DESCRIPTION
## Summary

`GetThresholdEvents` in the v2only datastore runs two queries and merges them: one by the provided name and one by the resolved scientific name. The second query discarded its error (`if err == nil && len(sciEvents) > 0`), so a real database failure on that query was indistinguishable from "no events": `GET /api/v2/dynamic-thresholds/:species/events` returned HTTP 200 with partial or empty data instead of surfacing a 500.

This propagates the second query's error using the `internal/errors` builder (Component/Category/Context), consistent with the first query and the rest of the file. The redundant `len() > 0` guard is dropped (appending an empty slice is a no-op). The result sort gains an `ID` tie-break so events sharing a timestamp truncate deterministically when the limit is applied.

## Changes

- Propagate the scientific-name query error instead of swallowing it.
- Build the common-name query error with the same Component/Category/Context for symmetry and telemetry.
- Deterministic sort tie-break on event ID.
- Tests: positive coverage of the scientific-name query path (driven via common-name resolution) and an error-injection regression test that fails the second query and asserts the error now surfaces.

## Test Plan

- [x] `go test -race ./internal/datastore/v2only/` (incl. two new tests)
- [x] `golangci-lint run` (full project, 0 issues)
- [x] Regression test verified to fail against the pre-fix code, pass after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for threshold-event lookups, returning structured context for both primary and secondary queries.
  * Made threshold-event result ordering deterministic: sort by creation time descending, tie-broken by ID descending.

* **Tests**
  * Added regression tests covering scientific-name resolution, propagation of secondary-query errors, and deterministic tie-break behavior for identical timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->