### PR TITLE
feat(analytics): localize species names in charts and overview

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
@@ -9,6 +9,7 @@
   import type { ZoomTransform } from 'd3-zoom';
 
   import { t } from '$lib/i18n';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import BaseChart from './BaseChart.svelte';
   import { getLocalDateString } from '$lib/utils/date';
   import { createTimeScale, createLinearScale } from './utils/scales';
@@ -78,6 +79,10 @@
       color: species.color || colors[index],
       visible: selectedSpecies.length === 0 || selectedSpecies.includes(species.species),
       id: species.id || species.species, // Use species name as fallback ID
+      // Visitor-locale display label. Computed inside the $derived so the repaint
+      // $effect (which reads processedData) re-runs on dictionary load / locale
+      // switch. Keys, colors, and legend ids below stay on species.species/id.
+      displayName: localizeSpeciesName(species.species, species.commonName),
     }));
   });
 
@@ -293,7 +298,7 @@
     // Draw lines for each species
     const linesGroup = chartArea.append('g').attr('class', 'lines');
 
-    processed.forEach((species: SpeciesTrendData) => {
+    processed.forEach(species => {
       // Add area (subtle background fill)
       linesGroup
         .append('path')
@@ -339,7 +344,7 @@
 
           // Show tooltip
           const tooltipData = {
-            title: species.commonName,
+            title: species.displayName,
             items: [
               {
                 label: t('analytics.advanced.charts.tooltips.date'),
@@ -429,9 +434,9 @@
 
     // Create legend
     const processedForLegend = processedData;
-    const legendItems = processedForLegend.map((species: SpeciesTrendData) => ({
+    const legendItems = processedForLegend.map(species => ({
       id: species.id || species.species,
-      label: species.commonName,
+      label: species.displayName,
       color: species.color ?? '#999999',
       visible: species.visible,
     }));

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.svelte
@@ -7,6 +7,7 @@
 
   import BaseChart from './BaseChart.svelte';
   import { getLocalDateString } from '$lib/utils/date';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import { createTimeScale, createBandScale } from './utils/scales';
   import {
     createAxis,
@@ -23,6 +24,9 @@
     scientificName?: string;
     firstHeard: Date;
   }
+
+  // Enriched row: a locale-stable band-scale key plus the visitor-locale label.
+  type LocalizedNewSpeciesDatum = NewSpeciesDatum & { key: string; displayName: string };
 
   interface Props {
     data: NewSpeciesDatum[];
@@ -43,6 +47,23 @@
     dateAxisLabel,
     ariaLabel,
   }: Props = $props();
+
+  // Visitor-locale display label plus a locale-stable band-scale key. Computed in
+  // a $derived so the repaint $effect (which reads localizedData) re-runs when the
+  // dictionary loads or the UI locale switches. The band scale is keyed on `key`
+  // (scientific name) so a species keeps a stable row/color across locales; only
+  // the axis tick label and the tooltip use `displayName`.
+  const localizedData = $derived(
+    data.map(
+      (d): LocalizedNewSpeciesDatum => ({
+        ...d,
+        // Logical OR (not ??) so an empty-string scientific name also falls back to
+        // the common name; an empty key would collapse distinct rows onto one band.
+        key: d.scientificName || d.commonName,
+        displayName: localizeSpeciesName(d.scientificName, d.commonName),
+      })
+    )
+  );
 
   // Styling constants
   const MAX_X_TICKS = 8;
@@ -69,12 +90,14 @@
 
     chartGroup.selectAll('*').remove();
 
-    if (!data.length || innerWidth <= 0 || innerHeight <= 0) {
+    if (!localizedData.length || innerWidth <= 0 || innerHeight <= 0) {
       return;
     }
 
     // Sort ascending by first-heard date so the earliest species sits at top.
-    const sorted = [...data].sort((a, b) => a.firstHeard.getTime() - b.firstHeard.getTime());
+    const sorted = [...localizedData].sort(
+      (a, b) => a.firstHeard.getTime() - b.firstHeard.getTime()
+    );
 
     // X domain: explicit dateRange, else data extent padded by one day on each
     // side so single-day markers are not clipped at the chart edges.
@@ -97,10 +120,14 @@
       range: [0, innerWidth],
     });
     const yScale = createBandScale({
-      domain: sorted.map(d => d.commonName),
+      domain: sorted.map(d => d.key),
       range: [0, innerHeight],
       padding: BAND_PADDING,
     });
+
+    // Map each stable band key to its visitor-locale label so the axis renders
+    // localized names while the scale stays keyed on the canonical scientific name.
+    const keyToDisplay = new Map(sorted.map(d => [d.key, d.displayName]));
 
     // Daily-granularity markers, so the bucket is never 'day' (clock times).
     const span = xScale.domain();
@@ -116,6 +143,7 @@
     const yAxis = createAxis({
       scale: yScale as unknown as AxisScale<AxisDomain>,
       orientation: 'left',
+      tickFormat: (d: AxisDomain) => keyToDisplay.get(String(d)) ?? String(d),
     });
 
     const xAxisGroup = chartGroup
@@ -159,7 +187,7 @@
       .append('rect')
       .attr('class', 'timeline-marker')
       .attr('x', d => xScale(d.firstHeard))
-      .attr('y', d => yScale(d.commonName) ?? 0)
+      .attr('y', d => yScale(d.key) ?? 0)
       .attr('width', dayWidth)
       .attr('height', yScale.bandwidth())
       .attr('rx', 2)
@@ -167,11 +195,11 @@
       .style('opacity', MARKER_OPACITY);
 
     markers
-      .on('mouseenter', function (event: MouseEvent, d: NewSpeciesDatum) {
+      .on('mouseenter', function (event: MouseEvent, d: LocalizedNewSpeciesDatum) {
         select(this).transition().duration(TRANSITION_MS).style('opacity', MARKER_HOVER_OPACITY);
         markers.filter(other => other !== d).style('opacity', MARKER_DIM_OPACITY);
         tooltip?.show({
-          title: d.commonName,
+          title: d.displayName,
           items: [{ label: firstHeardLabel, value: getLocalDateString(d.firstHeard) }],
           x: event.clientX,
           y: event.clientY,
@@ -186,9 +214,11 @@
       });
   }
 
-  // Repaint when any drawChart input changes (data or label/locale).
+  // Repaint when any drawChart input changes (data, locale-localized labels, or
+  // axis labels). Reading localizedData (rather than data) ties the repaint to the
+  // dictionary store, so a pure UI-locale switch re-renders the localized labels.
   $effect(() => {
-    void data;
+    void localizedData;
     void dateRange;
     void dateAxisLabel;
     void firstHeardLabel;

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import NewSpeciesTimelineChart from './NewSpeciesTimelineChart.svelte';
 
 // jsdom has no layout engine; assert on element counts/attributes only.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 afterEach(() => {
   cleanup();

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NewSpeciesTimelineChart.test.ts
@@ -55,4 +55,37 @@ describe('NewSpeciesTimelineChart', () => {
     const labelled = container.querySelector('[aria-label="New species timeline"]');
     expect(labelled).toBeTruthy();
   });
+
+  // Localization: the y band scale is keyed on the scientific name (stable across
+  // locales) while the axis renders the display name via tickFormat. Two species
+  // that share a common name must still get distinct rows; a naive scale keyed on
+  // the common name would dedupe the band and collapse them onto one row.
+  it('keeps two species sharing a common name on distinct rows', async () => {
+    const sameCommonName = [
+      { commonName: 'Owl', scientificName: 'Strix aluco', firstHeard: new Date(2024, 2, 1) },
+      { commonName: 'Owl', scientificName: 'Bubo bubo', firstHeard: new Date(2024, 2, 5) },
+    ];
+    const { container } = render(NewSpeciesTimelineChart, { props: { data: sameCommonName } });
+    await Promise.resolve();
+    const markers = container.querySelectorAll('rect.timeline-marker');
+    expect(markers).toHaveLength(2);
+    const ys = Array.from(markers, m => m.getAttribute('y'));
+    // Distinct band positions: a common-name-keyed scale would place both at the
+    // same y (the regression this decoupling prevents).
+    expect(ys[0]).not.toBe(ys[1]);
+  });
+
+  it('renders display names, not the scientific-name band keys, on the y axis', async () => {
+    const { container } = render(NewSpeciesTimelineChart, { props: { data: sampleData } });
+    await Promise.resolve();
+    const tickText = Array.from(
+      container.querySelectorAll('.y-axis .tick text'),
+      node => node.textContent
+    );
+    // No dictionary is loaded in the test, so localizeSpeciesName falls back to the
+    // common name. The tickFormat must map the scientific-name keys back to that
+    // display name rather than leaving the raw scientific key on the axis.
+    expect(tickText).toContain('Robin');
+    expect(tickText).not.toContain('Erithacus rubecula');
+  });
 });

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -7,6 +7,7 @@
   import type { Selection, AxisDomain } from 'd3';
 
   import { t } from '$lib/i18n';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import BaseChart from './BaseChart.svelte';
   import { createLinearScale } from './utils/scales';
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
@@ -51,6 +52,10 @@
       // eslint-disable-next-line security/detect-object-injection -- Safe: internal array access with controlled index
       color: species.color || colors[index],
       visible: selectedSpecies.length === 0 || selectedSpecies.includes(species.species),
+      // Visitor-locale display label. Computed here (inside the $derived) so the
+      // repaint $effect that reads visibleData re-runs when the dictionary loads
+      // or the UI locale switches. Keys/colors below stay on species.species.
+      displayName: localizeSpeciesName(species.species, species.commonName),
     }));
   });
 
@@ -237,7 +242,7 @@
 
           // Show tooltip
           const tooltipData = {
-            title: `${species.commonName}`,
+            title: species.displayName,
             items: [
               { label: t('analytics.advanced.charts.tooltips.time'), value: `${d.hour}:00` },
               { label: t('analytics.advanced.charts.tooltips.detections'), value: d.count },
@@ -276,7 +281,7 @@
               const hourPoint = species.data.find(d => d.hour === hour);
               return hourPoint
                 ? {
-                    species: species.commonName,
+                    species: species.displayName,
                     count: hourPoint.count,
                     color: species.color ?? '#999999',
                   }
@@ -308,7 +313,7 @@
     // Create legend
     const legendItems = visibleData.map(species => ({
       id: species.species,
-      label: species.commonName,
+      label: species.displayName,
       color: species.color ?? '#999999',
       visible: species.visible,
     }));

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -42,6 +42,9 @@
     uniqueSpecies: number;
     avgConfidence: number;
     mostCommonSpecies: string;
+    // Canonical scientific name of the most-common species, so the displayed
+    // common name can localize per visitor while the lookup stays canonical.
+    mostCommonScientific: string;
     mostCommonCount: number;
   }
 
@@ -117,6 +120,7 @@
     uniqueSpecies: 0,
     avgConfidence: 0,
     mostCommonSpecies: '',
+    mostCommonScientific: '',
     mostCommonCount: 0,
   });
 
@@ -138,7 +142,7 @@
   const speciesBars = $derived(
     [...(chartData.species ?? [])]
       .sort((a, b) => b.count - a.count)
-      .map(s => ({ label: s.common_name, value: s.count }))
+      .map(s => ({ label: localizeSpeciesName(s.scientific_name, s.common_name), value: s.count }))
   );
 
   // Time of day: hourly counts bucketed into the six fixed periods.
@@ -328,6 +332,7 @@
       let totalDetections = 0;
       let totalConfidence = 0;
       let mostCommonSpecies = '';
+      let mostCommonScientific = '';
       let mostCommonCount = 0;
 
       speciesArray.forEach(species => {
@@ -340,6 +345,7 @@
         if (count > mostCommonCount) {
           mostCommonCount = count;
           mostCommonSpecies = species.common_name || t('analytics.recentDetections.unknown');
+          mostCommonScientific = species.scientific_name || '';
         }
       });
 
@@ -348,6 +354,7 @@
         uniqueSpecies: speciesArray.length,
         avgConfidence: totalDetections > 0 ? totalConfidence / totalDetections : 0,
         mostCommonSpecies,
+        mostCommonScientific,
         mostCommonCount,
       };
     } catch (err) {
@@ -622,7 +629,9 @@
     <!-- Most Common Species Card -->
     <StatCard
       title={t('analytics.stats.mostCommon')}
-      value={summary.mostCommonSpecies || t('analytics.stats.none')}
+      value={summary.mostCommonCount > 0
+        ? localizeSpeciesName(summary.mostCommonScientific, summary.mostCommonSpecies)
+        : t('analytics.stats.none')}
       subtitle={summary.mostCommonCount > 0
         ? formatNumber(summary.mostCommonCount) + ' ' + t('analytics.stats.detections')
         : ''}


### PR DESCRIPTION
## Summary

Follow-up to the per-visitor species-name localization overlay. This threads the existing `localizeSpeciesName` display helper through the analytics surfaces that were still showing server-locale names, so each visitor sees species common names in their own UI locale.

Surfaces localized:
- The three D3 species charts: time-of-day, daily trend, and the new-species timeline (tooltips, legends, and axis labels).
- The Analytics overview page: the species-distribution bars and the "Most Common Species" stat card.

## How it works

Display labels localize while D3 join keys, colors, and legend ids stay keyed on the canonical scientific name, so a species keeps a stable row and color across locales. The localized label is computed inside each chart's data-processing `$derived`, so the existing repaint `$effect` re-runs when the dictionary loads or the UI locale switches.

The new-species timeline keys its y band scale on the scientific name and renders the localized label via the axis `tickFormat`, avoiding the band-dedup collapse a name-keyed scale would cause (two species sharing a localized common name would otherwise share one row). An empty-string scientific name falls back to the common name for the key.

This reuses the existing client dictionary overlay, so there are no new translation keys and no locale-file changes. The fallback chain (client dictionary, then server common name, then scientific name) means a user whose UI locale equals the server locale sees identical text to before.

Scope note: the Analytics Species page search/sort, the settings species pickers, and the aria-label i18n pass are intentionally left for separate follow-up PRs, since each carries distinct risk (search/sort consistency, canonical-value handling, locale-file churn).

## Test Plan
- [x] `npm run check:all` (format, lint, typecheck, ast-grep) passes
- [x] `npm test` for analytics charts/pages and localization utils passes
- [x] `npm run build` succeeds
- [x] Two regression tests added for the new-species timeline band-key decoupling
- [ ] Manual: view Analytics and Advanced Analytics in a non-server UI locale; confirm chart tooltips, legends, axes, species bars, and the Most Common stat show localized names, that switching locale live repaints them, and that colors/legend toggles stay stable across the switch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Species names are now localized throughout analytics: tooltips, legends, axis labels, summary cards, and distribution bars.
  * Charts correctly differentiate species that share a common name by using stable identifiers so each species renders in its own row.

* **Tests**
  * Added tests covering timeline row-keying and Y-axis label formatting; test setup now resets mocks between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->