### PR TITLE
fix(datastore): delete legacy common-name threshold events in v2only

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3185,16 +3185,42 @@ func (ds *Datastore) GetRecentThresholdEvents(limit int) ([]datastore.ThresholdE
 }
 
 // DeleteThresholdEvents deletes threshold events for a species.
-// NOTE: This only deletes events by the resolved scientific name. GetThresholdEvents
-// queries both common-name and scientific-name labels (WORKAROUND #1907). Legacy events
-// saved with common-name labels may survive this delete. Full dual-delete cleanup
-// should be added when the #1907 workaround is removed.
+// WORKAROUND(#1907): mirrors GetThresholdEvents' dual lookup. It deletes events saved
+// under BOTH the provided name (legacy common-name labels) AND the resolved scientific
+// name (post-#1907 labels). Without the common-name pass, legacy events survive the
+// delete and GetThresholdEvents resurfaces them on the next read.
+// TODO: Collapse to a single scientific-name delete when the #1907 workaround is removed
+// (after legacy common-name labels have been migrated).
 func (ds *Datastore) DeleteThresholdEvents(speciesName string) error {
 	if ds.threshold == nil {
 		return nil
 	}
 	ctx := context.Background()
-	return ds.threshold.DeleteThresholdEvents(ctx, ds.resolveToScientificName(speciesName))
+
+	// Delete by the provided name first - matches legacy/incorrectly saved events
+	// whose label scientific_name actually holds the common name.
+	if err := ds.threshold.DeleteThresholdEvents(ctx, speciesName); err != nil {
+		return errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "delete_threshold_events").
+			Context("query_type", "common_name").
+			Build()
+	}
+
+	// Also delete by the resolved scientific name when it differs - matches
+	// correctly saved events (after the #1907 fix).
+	if scientificName := ds.resolveToScientificName(speciesName); scientificName != speciesName {
+		if err := ds.threshold.DeleteThresholdEvents(ctx, scientificName); err != nil {
+			return errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "delete_threshold_events").
+				Context("query_type", "scientific_name").
+				Build()
+		}
+	}
+	return nil
 }
 
 // DeleteAllThresholdEvents deletes all threshold events.

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -601,6 +601,58 @@ func TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName(t *testing.T)
 	assert.Empty(t, events, "events should be deleted when using common name")
 }
 
+// TestV2OnlyDatastore_DeleteThresholdEvents_LegacyCommonNameLabel pins the read/delete
+// symmetry: an event saved under a legacy common-name-shaped label (its scientific_name
+// column actually holds the common name, mimicking pre-#1907 mis-saved data) must
+// be deleted, not just the post-#1907 scientific-name-shaped event. On the pre-fix
+// code DeleteThresholdEvents resolved only to the scientific name, so the legacy
+// event survived and GetThresholdEvents resurfaced it on the next read.
+func TestV2OnlyDatastore_DeleteThresholdEvents_LegacyCommonNameLabel(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+	defer cleanup()
+
+	// Legacy mis-saved event: an empty ScientificName forces SaveThresholdEvent's
+	// fallback to use the common name, creating a label whose scientific_name = "great tit".
+	legacy := &datastore.ThresholdEvent{
+		SpeciesName:   "great tit",
+		PreviousLevel: 0,
+		NewLevel:      1,
+		PreviousValue: 0.8,
+		NewValue:      0.6,
+		ChangeReason:  "high_confidence",
+		Confidence:    0.95,
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, ds.SaveThresholdEvent(legacy))
+
+	// Correctly-shaped event (post-#1907): label scientific_name = "Parus major".
+	correct := &datastore.ThresholdEvent{
+		SpeciesName:    "great tit",
+		ScientificName: "Parus major",
+		PreviousLevel:  1,
+		NewLevel:       2,
+		PreviousValue:  0.6,
+		NewValue:       0.5,
+		ChangeReason:   "high_confidence",
+		Confidence:     0.97,
+		CreatedAt:      time.Now().Add(time.Second),
+	}
+	require.NoError(t, ds.SaveThresholdEvent(correct))
+
+	// The dual-read by common name surfaces both label shapes before delete.
+	events, err := ds.GetThresholdEvents("great tit", 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2, "both legacy and correct events should be visible before delete")
+
+	// Delete by common name must remove BOTH shapes (the read/delete symmetry fix).
+	require.NoError(t, ds.DeleteThresholdEvents("great tit"))
+
+	// Nothing should reappear on the next read.
+	events, err = ds.GetThresholdEvents("great tit", 10)
+	require.NoError(t, err)
+	assert.Empty(t, events, "legacy common-name event must not survive the delete")
+}
+
 func TestV2OnlyDatastore_ImageCache(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

In the v2only datastore, `DeleteThresholdEvents` deleted threshold events only by the resolved scientific name, while `GetThresholdEvents` queries by BOTH the common-name and scientific-name labels (the #1907 transition workaround). As a result, threshold events saved under a legacy common-name label survived a per-species reset and reappeared on the next read, so a cleared species' events looked like they came back.

This mirrors the dual lookup in `DeleteThresholdEvents`:

- delete by the provided name first (matches legacy common-name labels)
- then delete by the resolved scientific name when it differs (matches post-#1907 labels)

The two passes target disjoint label sets, and the repository delete is a no-op on an empty label set, so the change is idempotent and cannot touch another species' events (label resolution is an exact `scientific_name` match). Read and delete are now symmetric.

## Test Plan

- [x] Added `TestV2OnlyDatastore_DeleteThresholdEvents_LegacyCommonNameLabel`: stores a legacy common-name-shaped event and a correct scientific-name-shaped event, then asserts a delete-by-common-name removes both. Fails on the pre-fix single-name delete, passes on the fix.
- [x] `go test -race ./internal/datastore/v2only/`
- [x] `golangci-lint run` (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Threshold event deletion now correctly handles legacy species name data alongside current formats, ensuring all related records are properly removed.
  * Enhanced error handling with improved diagnostic information for threshold events.

* **Tests**
  * Added regression test for legacy threshold event data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->