### PR TITLE
feat(i18n): localize time-of-day chart labels and species-name aria labels

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -147,26 +147,25 @@
 
   // Time of day: hourly counts bucketed into the six fixed periods. The period
   // display labels are localized at render time so the pure transform stays
-  // i18n-free; the key order matches bucketHourlyByPeriod's fixed output order.
-  // The two Night labels (0-4 and 20-23) must remain distinct in every locale:
-  // the BarChart uses the label as its d3 band-scale domain key, so identical
-  // strings would collapse the two buckets into a single bar.
-  const TIME_OF_DAY_PERIOD_LABEL_KEYS = [
-    'analytics.timeOfDayPeriods.night0to4',
-    'analytics.timeOfDayPeriods.dawn5to8',
-    'analytics.timeOfDayPeriods.morning9to11',
-    'analytics.timeOfDayPeriods.afternoon12to16',
-    'analytics.timeOfDayPeriods.evening17to19',
-    'analytics.timeOfDayPeriods.night20to23',
-  ] as const satisfies readonly TranslationKey[];
-  const timeOfDayBars = $derived.by(() => {
-    const buckets = bucketHourlyByPeriod(chartData.timeOfDay);
-    return TIME_OF_DAY_PERIOD_LABEL_KEYS.map((key, i) => ({
-      label: t(key),
-      // eslint-disable-next-line security/detect-object-injection -- i iterates a fixed-length const array; bucketHourlyByPeriod always returns six entries in this order
-      value: buckets[i]?.value ?? 0,
-    }));
-  });
+  // i18n-free. The map is keyed on the transform's stable English labels, so the
+  // localization is robust to bucket order or length; an unmapped label falls
+  // back to its English text. The two Night labels (0-4 and 20-23) must remain
+  // distinct in every locale: the BarChart uses the label as its d3 band-scale
+  // domain key, so identical strings would collapse the two buckets into one bar.
+  const TIME_OF_DAY_PERIOD_LABEL_KEYS = new Map<string, TranslationKey>([
+    ['Night (0-4)', 'analytics.timeOfDayPeriods.night0to4'],
+    ['Dawn (5-8)', 'analytics.timeOfDayPeriods.dawn5to8'],
+    ['Morning (9-11)', 'analytics.timeOfDayPeriods.morning9to11'],
+    ['Afternoon (12-16)', 'analytics.timeOfDayPeriods.afternoon12to16'],
+    ['Evening (17-19)', 'analytics.timeOfDayPeriods.evening17to19'],
+    ['Night (20-23)', 'analytics.timeOfDayPeriods.night20to23'],
+  ]);
+  const timeOfDayBars = $derived.by(() =>
+    bucketHourlyByPeriod(chartData.timeOfDay).map(bucket => {
+      const key = TIME_OF_DAY_PERIOD_LABEL_KEYS.get(bucket.label);
+      return { label: key ? t(key) : bucket.label, value: bucket.value };
+    })
+  );
 
   // Detection trend: aggregated/sorted daily points, wrapped as a single series.
   const trendSeries = $derived([

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { t } from '$lib/i18n';
+  import { t, type TranslationKey } from '$lib/i18n';
   import { api } from '$lib/utils/api';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
   import { formatNumber, formatDateTime } from '$lib/utils/formatters';
@@ -145,8 +145,28 @@
       .map(s => ({ label: localizeSpeciesName(s.scientific_name, s.common_name), value: s.count }))
   );
 
-  // Time of day: hourly counts bucketed into the six fixed periods.
-  const timeOfDayBars = $derived(bucketHourlyByPeriod(chartData.timeOfDay));
+  // Time of day: hourly counts bucketed into the six fixed periods. The period
+  // display labels are localized at render time so the pure transform stays
+  // i18n-free; the key order matches bucketHourlyByPeriod's fixed output order.
+  // The two Night labels (0-4 and 20-23) must remain distinct in every locale:
+  // the BarChart uses the label as its d3 band-scale domain key, so identical
+  // strings would collapse the two buckets into a single bar.
+  const TIME_OF_DAY_PERIOD_LABEL_KEYS = [
+    'analytics.timeOfDayPeriods.night0to4',
+    'analytics.timeOfDayPeriods.dawn5to8',
+    'analytics.timeOfDayPeriods.morning9to11',
+    'analytics.timeOfDayPeriods.afternoon12to16',
+    'analytics.timeOfDayPeriods.evening17to19',
+    'analytics.timeOfDayPeriods.night20to23',
+  ] as const satisfies readonly TranslationKey[];
+  const timeOfDayBars = $derived.by(() => {
+    const buckets = bucketHourlyByPeriod(chartData.timeOfDay);
+    return TIME_OF_DAY_PERIOD_LABEL_KEYS.map((key, i) => ({
+      label: t(key),
+      // eslint-disable-next-line security/detect-object-injection -- i iterates a fixed-length const array; bucketHourlyByPeriod always returns six entries in this order
+      value: buckets[i]?.value ?? 0,
+    }));
+  });
 
   // Detection trend: aggregated/sorted daily points, wrapped as a single series.
   const trendSeries = $derived([

--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -29,6 +29,7 @@
   import type { ImageAttribution } from '$lib/types/detection.types';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { t } from '$lib/i18n';
   import { portal } from '$lib/utils/portal';
   import { dropdown } from '$lib/utils/transitions';
   import { Image } from '@lucide/svelte';
@@ -200,7 +201,7 @@
     onmousemove={handleMouseMove}
     onfocus={handleFocus}
     onblur={handleBlur}
-    aria-label="View {displayName} detections"
+    aria-label={t('components.birdThumbnail.viewDetections', { name: displayName })}
     aria-describedby={showPopup ? 'bird-popup' : undefined}
   >
     <!-- Thumbnail placeholder -->
@@ -262,13 +263,13 @@
               style:color="color-mix(in srgb, var(--color-base-content) 50%, transparent)"
             >
               <Image class="size-8 mb-2" />
-              <p class="text-xs text-center">Image not available</p>
+              <p class="text-xs text-center">{t('common.ui.imageNotAvailable')}</p>
             </div>
           {:else}
             <!-- Large image -->
             <img
               src={thumbnailUrl}
-              alt={`Large view of ${displayName}`}
+              alt={t('components.birdThumbnail.largeView', { name: displayName })}
               class="w-full h-full object-contain transition-opacity duration-200"
               class:opacity-0={!imageLoaded}
               class:opacity-100={imageLoaded}
@@ -279,7 +280,10 @@
 
           <!-- Photo credit overlay -->
           {#if imageAttribution?.authorName && imageLoaded}
-            <div class="thumbnail-credit" aria-label="Image credit: {imageAttribution.authorName}">
+            <div
+              class="thumbnail-credit"
+              aria-label={t('common.aria.imageCredit', { name: imageAttribution.authorName })}
+            >
               <span class="credit-text">{imageAttribution.authorName}</span>
               {#if imageAttribution.licenseName}
                 <span class="credit-separator">·</span>
@@ -304,7 +308,7 @@
             class="text-xs"
             style:color="color-mix(in srgb, var(--color-base-content) 50%, transparent)"
           >
-            Click to view detections
+            {t('components.birdThumbnail.clickToView')}
           </p>
         </div>
       </div>

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -451,7 +451,10 @@
             loading="eager"
           />
           {#if imageAttribution?.authorName}
-            <div class="thumbnail-credit" aria-label="Image credit: {imageAttribution.authorName}">
+            <div
+              class="thumbnail-credit"
+              aria-label={t('common.aria.imageCredit', { name: imageAttribution.authorName })}
+            >
               <Camera size={10} class="credit-icon" />
               <span class="credit-text">{imageAttribution.authorName}</span>
               {#if imageAttribution.licenseName}
@@ -608,7 +611,7 @@
             href={buildAppUrl(`/api/v2/media/audio/${det.clipName}`)}
             download
             class="meta-download"
-            aria-label="Download audio clip for {displayName} detection"
+            aria-label={t('detections.detail.aria.downloadAudioClip', { name: displayName })}
           >
             <Download class="w-4 h-4" />
             <span>{t('media.audio.download')}</span>
@@ -815,10 +818,9 @@
         {/if}
         <div
           role="region"
-          aria-label="Audio recording and spectrogram for {localizeSpeciesName(
-            detection.scientificName,
-            detection.commonName
-          )}"
+          aria-label={t('detections.detail.aria.audioRecordingFor', {
+            name: localizeSpeciesName(detection.scientificName, detection.commonName),
+          })}
         >
           <div class="detail-audio-container">
             <AudioPlayer

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -133,6 +133,7 @@ export type TranslationKey =
   | 'common.aria.visitEbirdLink'
   | 'common.aria.learnEbirdTaxonomyLink'
   | 'common.aria.resizeHandle'
+  | 'common.aria.imageCredit' // params: name
   | 'common.labels.confidence'
   | 'common.labels.github'
   | 'common.values.yes'
@@ -637,6 +638,8 @@ export type TranslationKey =
   | 'detections.titles.allDetections' // params: date
   | 'detections.detail.species'
   | 'detections.detail.observation'
+  | 'detections.detail.aria.downloadAudioClip' // params: name
+  | 'detections.detail.aria.audioRecordingFor' // params: name
   | 'detections.headers.dateTime'
   | 'detections.headers.weather'
   | 'detections.headers.source'
@@ -1320,6 +1323,12 @@ export type TranslationKey =
   | 'analytics.advanced.aria.loadingTrends'
   | 'analytics.advanced.aria.loadingDiversity'
   | 'analytics.errors.loadFailed'
+  | 'analytics.timeOfDayPeriods.night0to4'
+  | 'analytics.timeOfDayPeriods.dawn5to8'
+  | 'analytics.timeOfDayPeriods.morning9to11'
+  | 'analytics.timeOfDayPeriods.afternoon12to16'
+  | 'analytics.timeOfDayPeriods.evening17to19'
+  | 'analytics.timeOfDayPeriods.night20to23'
   | 'settings.title'
   | 'settings.loading'
   | 'settings.sections.analysis'
@@ -3210,6 +3219,9 @@ export type TranslationKey =
   | 'components.tls.removeCertificate'
   | 'components.tls.fileReadError'
   | 'components.tls.loading'
+  | 'components.birdThumbnail.viewDetections' // params: name
+  | 'components.birdThumbnail.largeView' // params: name
+  | 'components.birdThumbnail.clickToView'
   | 'connectivity.offline'
   | 'detection.actions.back'
   | 'detection.actions.review'
@@ -3607,6 +3619,7 @@ export type TranslationParams = {
   'common.validation.minValue': { min: string | number };
   'common.validation.maxValue': { max: string | number };
   'common.aria.dateSelected': { date: string | number };
+  'common.aria.imageCredit': { name: string | number };
   'common.review.modalTitle': { species: string | number };
   'common.review.form.commentCount': { chars: string | number };
   'notifications.timeAgo.minutesAgo': { minutes: string | number };
@@ -3714,6 +3727,8 @@ export type TranslationParams = {
   'detections.titles.species': { species: string | number; date: string | number };
   'detections.titles.search': { query: string | number };
   'detections.titles.allDetections': { date: string | number };
+  'detections.detail.aria.downloadAudioClip': { name: string | number };
+  'detections.detail.aria.audioRecordingFor': { name: string | number };
   'detections.pagination.showing': {
     from: string | number;
     to: string | number;
@@ -3892,6 +3907,8 @@ export type TranslationParams = {
     start: string | number;
     end: string | number;
   };
+  'components.birdThumbnail.viewDetections': { name: string | number };
+  'components.birdThumbnail.largeView': { name: string | number };
   'quietHours.indicator.tooltip': { count: string | number };
   'errors.detection.invalidDate': { paramName: string | number };
   'errors.backup.insufficientSpace': { needed: string | number; available: string | number };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Stáhnout seznam druhů jako CSV",
       "visitEbirdLink": "Otevřít eBird.org v nové kartě",
       "learnEbirdTaxonomyLink": "Otevřít taxonomii eBird v nové kartě",
-      "resizeHandle": "Tažením změníte velikost"
+      "resizeHandle": "Tažením změníte velikost",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Spolehlivost",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Druh",
-      "observation": "Pozorování"
+      "observation": "Pozorování",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Datum a čas",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Nepodařilo se načíst analytická data. Zkuste to prosím znovu."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Odstranit certifikát",
       "fileReadError": "Soubor se nepodařilo přečíst",
       "loading": "Načítání informací o certifikátu…"
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Download artsliste som CSV",
       "visitEbirdLink": "Åbn eBird.org i en ny fane",
       "learnEbirdTaxonomyLink": "Åbn eBird Taxonomy i en ny fane",
-      "resizeHandle": "Træk for at ændre størrelse"
+      "resizeHandle": "Træk for at ændre størrelse",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Sikkerhed",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Art",
-      "observation": "Observation"
+      "observation": "Observation",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Dato og tid",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Kunne ikke indlæse analysedata. Prøv venligst igen."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Fjern certifikat",
       "fileReadError": "Kunne ikke læse fil",
       "loading": "Indlæser certifikatoplysninger..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Artenliste als CSV herunterladen",
       "visitEbirdLink": "eBird.org in neuem Tab öffnen",
       "learnEbirdTaxonomyLink": "eBird-Taxonomie in neuem Tab öffnen",
-      "resizeHandle": "Ziehen zum Ändern der Größe"
+      "resizeHandle": "Ziehen zum Ändern der Größe",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Konfidenz",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Art",
-      "observation": "Beobachtung"
+      "observation": "Beobachtung",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Datum & Zeit",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Analysedaten konnten nicht geladen werden. Bitte versuchen Sie es erneut."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Zertifikat entfernen",
       "fileReadError": "Datei konnte nicht gelesen werden",
       "loading": "Zertifikatsinformationen werden geladen..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Download species list as CSV",
       "visitEbirdLink": "Open eBird.org in a new tab",
       "learnEbirdTaxonomyLink": "Open eBird Taxonomy in a new tab",
-      "resizeHandle": "Drag to resize"
+      "resizeHandle": "Drag to resize",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Confidence",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Species",
-      "observation": "Observation"
+      "observation": "Observation",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Date & Time",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Failed to load analytics data. Please try again."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Remove Certificate",
       "fileReadError": "Failed to read file",
       "loading": "Loading certificate information..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Descargar lista de especies en CSV",
       "visitEbirdLink": "Abrir eBird.org en una nueva pestaña",
       "learnEbirdTaxonomyLink": "Abrir Taxonomía de eBird en una nueva pestaña",
-      "resizeHandle": "Arrastrar para redimensionar"
+      "resizeHandle": "Arrastrar para redimensionar",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Confianza",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Especie",
-      "observation": "Observación"
+      "observation": "Observación",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Fecha y hora",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Error al cargar los datos de análisis. Por favor, inténtelo de nuevo."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Eliminar certificado",
       "fileReadError": "Error al leer el archivo",
       "loading": "Cargando información del certificado..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Lataa lajilista CSV-tiedostona",
       "visitEbirdLink": "Avaa eBird.org uuteen välilehteen",
       "learnEbirdTaxonomyLink": "Avaa eBird-taksonomia uuteen välilehteen",
-      "resizeHandle": "Vedä muuttaaksesi kokoa"
+      "resizeHandle": "Vedä muuttaaksesi kokoa",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Luottamus",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Laji",
-      "observation": "Havainto"
+      "observation": "Havainto",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Päivä ja aika",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Analytiikkatietojen lataaminen epäonnistui. Yritä uudelleen."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Poista sertifikaatti",
       "fileReadError": "Tiedoston lukeminen epäonnistui",
       "loading": "Ladataan sertifikaattitietoja..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Télécharger la liste des espèces au format CSV",
       "visitEbirdLink": "Ouvrir eBird.org dans un nouvel onglet",
       "learnEbirdTaxonomyLink": "Ouvrir la taxonomie eBird dans un nouvel onglet",
-      "resizeHandle": "Glisser pour redimensionner"
+      "resizeHandle": "Glisser pour redimensionner",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Confiance",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Espèce",
-      "observation": "Observation"
+      "observation": "Observation",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Date et heure",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Échec du chargement des données d'analyse. Veuillez réessayer."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Supprimer le certificat",
       "fileReadError": "Échec de la lecture du fichier",
       "loading": "Chargement des informations du certificat..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Fajlista letöltése CSV formátumban",
       "visitEbirdLink": "eBird.org megnyitása új lapon",
       "learnEbirdTaxonomyLink": "eBird taxonómia megnyitása új lapon",
-      "resizeHandle": "Húzza az átméretezéshez"
+      "resizeHandle": "Húzza az átméretezéshez",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Megbízhatóság",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Faj",
-      "observation": "Megfigyelés"
+      "observation": "Megfigyelés",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Dátum és idő",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Az analitikai adatok betöltése sikertelen. Próbálja újra."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Tanúsítvány eltávolítása",
       "fileReadError": "A fájl olvasása sikertelen",
       "loading": "Tanúsítvány információ betöltése..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Scarica elenco specie come CSV",
       "visitEbirdLink": "Apri eBird.org in una nuova scheda",
       "learnEbirdTaxonomyLink": "Apri Tassonomia eBird in una nuova scheda",
-      "resizeHandle": "Trascina per ridimensionare"
+      "resizeHandle": "Trascina per ridimensionare",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Confidenza",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Specie",
-      "observation": "Osservazione"
+      "observation": "Osservazione",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Data e Ora",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Caricamento dei dati di analisi non riuscito. Riprova."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Rimuovi certificato",
       "fileReadError": "Impossibile leggere il file",
       "loading": "Caricamento informazioni certificato..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Lejupielādēt sugu sarakstu kā CSV",
       "visitEbirdLink": "Atvērt eBird.org jaunā cilnē",
       "learnEbirdTaxonomyLink": "Atvērt eBird taksonomiju jaunā cilnē",
-      "resizeHandle": "Velciet, lai mainītu izmēru"
+      "resizeHandle": "Velciet, lai mainītu izmēru",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Ticamība",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Suga",
-      "observation": "Novērojums"
+      "observation": "Novērojums",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Datums un laiks",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Neizdevās ielādēt analītikas datus. Lūdzu, mēģiniet vēlreiz."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Noņemt sertifikātu",
       "fileReadError": "Neizdevās nolasīt failu",
       "loading": "Ielādē sertifikāta informāciju..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Last ned artsliste som CSV",
       "visitEbirdLink": "Åpne eBird.org i ny fane",
       "learnEbirdTaxonomyLink": "Åpne eBird-taksonomi i ny fane",
-      "resizeHandle": "Dra for å endre størrelse"
+      "resizeHandle": "Dra for å endre størrelse",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Sikkerhet",
@@ -486,7 +487,8 @@
       "confidenceMax": "Maksimum sikkerhetsprosentandel",
       "verifiedStatus": "Verifiseringsstatus",
       "lockedStatus": "Låsestatus",
-      "timeOfDay": "Tidspunkt på døgnet"
+      "timeOfDay": "Tidspunkt på døgnet",
+      "source": "Audio Source"
     },
     "advancedFilters": "Avanserte filtre",
     "showAdvancedFilters": "Vis avanserte filtre",
@@ -520,7 +522,8 @@
       "species": "Art",
       "confidence": "Sikkerhet",
       "status": "Status",
-      "actions": "Handlinger"
+      "actions": "Handlinger",
+      "source": "Source"
     },
     "statusBadges": {
       "verified": "Verifisert",
@@ -556,6 +559,9 @@
       "page": "Side {current} av {total}",
       "goToPrevious": "Gå til forrige side",
       "goToNext": "Gå til neste side"
+    },
+    "sourceOptions": {
+      "any": "All Sources"
     }
   },
   "error": {
@@ -788,7 +794,11 @@
     },
     "detail": {
       "species": "Art",
-      "observation": "Observasjon"
+      "observation": "Observasjon",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Dato og tid",
@@ -1619,7 +1629,8 @@
         "dateTime": "Dato og tid",
         "species": "Art",
         "confidence": "Sikkerhet",
-        "timeOfDay": "Tidspunkt"
+        "timeOfDay": "Tidspunkt",
+        "source": "Source"
       },
       "noRecentDetections": "Ingen siste registreringer funnet",
       "unknownSpecies": "Ukjent",
@@ -1719,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Innlasting av analysedata mislyktes. Prøv igjen."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4896,6 +4915,11 @@
       "removeCertificate": "Fjern sertifikat",
       "fileReadError": "Lesing av fil mislyktes",
       "loading": "Laster sertifikatinformasjon..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "wizard": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Soorten lijst als CSV ophalen",
       "visitEbirdLink": "Open eBird.org in een nieuwe tab",
       "learnEbirdTaxonomyLink": "Open eBird Taxonomy in een nieuwe tab",
-      "resizeHandle": "Sleep om te vergroten/verkleinen"
+      "resizeHandle": "Sleep om te vergroten/verkleinen",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Betrouwbaarheid",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Soort",
-      "observation": "Waarneming"
+      "observation": "Waarneming",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Datum/Tijd",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Analysegegevens konden niet worden geladen. Probeer het opnieuw."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Certificaat verwijderen",
       "fileReadError": "Kan bestand niet lezen",
       "loading": "Certificaatinformatie laden..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Pobierz listę gatunków jako CSV",
       "visitEbirdLink": "Otwórz eBird.org w nowej karcie",
       "learnEbirdTaxonomyLink": "Otwórz Taksonomię eBird w nowej karcie",
-      "resizeHandle": "Przeciągnij, aby zmienić rozmiar"
+      "resizeHandle": "Przeciągnij, aby zmienić rozmiar",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Pewność",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Gatunek",
-      "observation": "Obserwacja"
+      "observation": "Obserwacja",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Data i Czas",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Nie udało się załadować danych analitycznych. Spróbuj ponownie."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Usuń certyfikat",
       "fileReadError": "Nie udało się odczytać pliku",
       "loading": "Ładowanie informacji o certyfikacie..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Baixar lista de espécies em CSV",
       "visitEbirdLink": "Abrir eBird.org em uma nova aba",
       "learnEbirdTaxonomyLink": "Abrir Taxonomia eBird em uma nova aba",
-      "resizeHandle": "Arraste para redimensionar"
+      "resizeHandle": "Arraste para redimensionar",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Confiança",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Espécie",
-      "observation": "Observação"
+      "observation": "Observação",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Data e hora",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Falha ao carregar os dados de análise. Tente novamente."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Remover Certificado",
       "fileReadError": "Falha ao ler ficheiro",
       "loading": "A carregar informações do certificado..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Stiahnuť zoznam druhov ako CSV",
       "visitEbirdLink": "Otvoriť eBird.org v novej karte",
       "learnEbirdTaxonomyLink": "Otvoriť taxonómiu eBird v novej karte",
-      "resizeHandle": "Potiahnutím zmeníte veľkosť"
+      "resizeHandle": "Potiahnutím zmeníte veľkosť",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Istota",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Druh",
-      "observation": "Pozorovanie"
+      "observation": "Pozorovanie",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Dátum a čas",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Nepodarilo sa načítať analytické údaje. Skúste to znova."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Odstrániť certifikát",
       "fileReadError": "Nepodarilo sa prečítať súbor",
       "loading": "Načítavanie informácií o certifikáte..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -133,7 +133,8 @@
       "downloadCsv": "Ladda ner artlistan som CSV",
       "visitEbirdLink": "Öppna eBird.org i en ny flik",
       "learnEbirdTaxonomyLink": "Öppna eBird Taxonomy i en ny flik",
-      "resizeHandle": "Dra för att ändra storlek"
+      "resizeHandle": "Dra för att ändra storlek",
+      "imageCredit": "Image credit: {name}"
     },
     "labels": {
       "confidence": "Konfidens",
@@ -793,7 +794,11 @@
     },
     "detail": {
       "species": "Art",
-      "observation": "Observation"
+      "observation": "Observation",
+      "aria": {
+        "downloadAudioClip": "Download audio clip for {name} detection",
+        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+      }
     },
     "headers": {
       "dateTime": "Datum och tid",
@@ -1725,6 +1730,14 @@
     },
     "errors": {
       "loadFailed": "Kunde inte ladda analysdata. Försök igen."
+    },
+    "timeOfDayPeriods": {
+      "night0to4": "Night (0-4)",
+      "dawn5to8": "Dawn (5-8)",
+      "morning9to11": "Morning (9-11)",
+      "afternoon12to16": "Afternoon (12-16)",
+      "evening17to19": "Evening (17-19)",
+      "night20to23": "Night (20-23)"
     }
   },
   "settings": {
@@ -4445,6 +4458,11 @@
       "removeCertificate": "Ta bort certifikat",
       "fileReadError": "Kunde inte läsa fil",
       "loading": "Laddar certifikatinformation..."
+    },
+    "birdThumbnail": {
+      "viewDetections": "View {name} detections",
+      "largeView": "Large view of {name}",
+      "clickToView": "Click to view detections"
     }
   },
   "connectivity": {


### PR DESCRIPTION
## Summary

Two small, additive i18n improvements with no behavior change for existing English-locale users:

**Time-of-day chart labels.** The analytics time-of-day distribution chart rendered its six period categories (`Night (0-4)`, `Dawn (5-8)`, ...) from hardcoded English strings that reached the chart axis untranslated in every locale. They are now localized at the render boundary: the pure bucketing transform (`bucketHourlyByPeriod`) stays i18n-free and its unit test is untouched, while `Analytics.svelte` maps each fixed-order bucket to a `t()` key. The two `Night` labels keep their hour-range suffixes so the d3 band scale never collapses two buckets onto a single bar (a translator note documents this constraint).

**Species-name aria/alt labels.** Several aria/alt labels that interpolate a species name into otherwise-hardcoded English literals are converted to `t()` keys in `BirdThumbnailPopup.svelte` and `DetectionDetail.svelte` (view detections, large view, image credit, click to view, download audio clip, audio recording region). These reuse the existing `common.ui.imageNotAvailable` key and a shared new `common.aria.imageCredit`. English output is byte-identical to the prior hardcoded strings.

Adds 12 keys to `en.json`, propagated to all 16 locales (English fallback per the repo's sync workflow) with regenerated `types.generated.ts`.

## Test Plan

- [x] `npm run typecheck` (0 errors), `npm run check:all` (format, eslint, stylelint, ast all clean)
- [x] `npm run i18n:sync:check` and `generate:i18n-types:check` in sync
- [x] `analyticsTransforms` + `BarChart` unit tests green (transform unchanged)
- [ ] Manual: switch UI locale and confirm the time-of-day chart axis and the touched aria/alt labels localize, and that the chart still renders six distinct bars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added new translation keys and updated many locale files to provide localized UI text for time-of-day labels, image credit, bird-thumbnail prompts, and audio-related ARIA strings across numerous languages.

* **Accessibility**
  * Replaced hardcoded text with localized aria-labels for image credits, audio clip download/player info, and thumbnail actions to improve screen reader clarity.

* **Improvements**
  * Analytics time-of-day chart now shows consistent, localized period labels (night, dawn, morning, afternoon, evening).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->