### PR TITLE
fix(analytics): apply query timeout consistently and return 408 on deadline

### DIFF
--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -151,7 +151,7 @@ func (m *ActionMockDatastore) Optimize(_ context.Context) error { return nil }
 func (m *ActionMockDatastore) GetAllNotes() ([]datastore.Note, error) {
 	return nil, nil
 }
-func (m *ActionMockDatastore) GetTopBirdsData(_ string, _ float64, _ int) ([]datastore.Note, error) {
+func (m *ActionMockDatastore) GetTopBirdsData(_ context.Context, _ string, _ float64, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
 func (m *ActionMockDatastore) GetBatchHourlyOccurrences(_ context.Context, _ string, _ []string, _ float64) (map[string][24]int, error) {

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -53,7 +53,7 @@ func (m *MockDatastore) Optimize(context.Context) error                    { ret
 func (m *MockDatastore) GetAllNotes() ([]datastore.Note, error) {
 	return make([]datastore.Note, 0), nil
 }
-func (m *MockDatastore) GetTopBirdsData(string, float64, int) ([]datastore.Note, error) {
+func (m *MockDatastore) GetTopBirdsData(context.Context, string, float64, int) ([]datastore.Note, error) {
 	return make([]datastore.Note, 0), nil
 }
 func (m *MockDatastore) GetBatchHourlyOccurrences(context.Context, string, []string, float64) (map[string][24]int, error) {

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -32,6 +32,35 @@ const (
 	analyticsQueryTimeout      = 30 * time.Second // Timeout for analytics database queries
 )
 
+// msgQueryTimeout is the user-facing message returned when an analytics query
+// exceeds analyticsQueryTimeout (HTTP 408).
+const msgQueryTimeout = "Query timeout - please try a smaller date range"
+
+// withAnalyticsTimeout derives a deadline-bounded context for analytics datastore
+// queries from the incoming request, using analyticsQueryTimeout. Callers MUST
+// defer the returned cancel function (or call it before the next iteration in a
+// loop). Centralizing the wrap keeps every analytics endpoint consistent: a query
+// that exceeds the deadline surfaces as context.DeadlineExceeded, which handlers
+// map to HTTP 408 rather than leaving the query unbounded.
+func withAnalyticsTimeout(ctx echo.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx.Request().Context(), analyticsQueryTimeout)
+}
+
+// handleAnalyticsQueryError maps a single-query analytics datastore error to an
+// HTTP response: a context deadline becomes 408 (msgQueryTimeout), any other error
+// becomes 500 with genericMsg. opLabel names the operation in the structured log
+// (" query timeout" / " query failed" is appended); the query error is logged
+// alongside the supplied fields. The returned error is what the handler returns.
+func (c *Controller) handleAnalyticsQueryError(ctx echo.Context, err error, opLabel, genericMsg string, fields ...logger.Field) error {
+	fields = append(fields, logger.Error(err))
+	if errors.Is(err, context.DeadlineExceeded) {
+		c.logErrorIfEnabled(opLabel+" query timeout", fields...)
+		return c.HandleError(ctx, err, msgQueryTimeout, http.StatusRequestTimeout)
+	}
+	c.logErrorIfEnabled(opLabel+" query failed", fields...)
+	return c.HandleError(ctx, err, genericMsg, http.StatusInternalServerError)
+}
+
 // SpeciesDailySummary represents a bird in the daily species summary API response
 type SpeciesDailySummary struct {
 	ScientificName     string  `json:"scientific_name"`
@@ -154,32 +183,31 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
+	// Bound the per-request datastore work with a single deadline shared by the
+	// initial query and the hourly aggregation below.
+	queryCtx, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
 	// 2. Get Initial Data (limit applied at database level)
-	notes, err := c.DS.GetTopBirdsData(selectedDate, minConfidence, limit)
+	notes, err := c.DS.GetTopBirdsData(queryCtx, selectedDate, minConfidence, limit)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get initial daily species data",
+		return c.handleAnalyticsQueryError(ctx, err, "Daily species summary", "Failed to get daily species data",
 			logger.String("date", selectedDate),
 			logger.Float64("min_confidence", minConfidence),
-			logger.Error(err),
 			logger.String("ip", ip),
 			logger.String("path", path),
 		)
-		return c.HandleError(ctx, err, "Failed to get daily species data", http.StatusInternalServerError)
 	}
 
 	// 3. Aggregate Data (including fetching hourly counts)
-	aggregatedData, err := c.aggregateDailySpeciesData(ctx.Request().Context(), notes, selectedDate, minConfidence)
+	aggregatedData, err := c.aggregateDailySpeciesData(queryCtx, notes, selectedDate, minConfidence)
 	if err != nil {
-		// Errors during hourly fetch are logged within the helper, but we need to handle the overall failure
-		c.logErrorIfEnabled("Failed to aggregate daily species data",
+		// Errors during hourly fetch are logged within the helper; map the overall failure.
+		return c.handleAnalyticsQueryError(ctx, err, "Daily species aggregation", "Failed to process daily species data",
 			logger.String("date", selectedDate),
-			logger.Error(err),
 			logger.String("ip", ip),
 			logger.String("path", path),
 		)
-		// Decide if this is a user error (bad data?) or server error
-		// For now, assume server error if aggregation fails overall
-		return c.HandleError(ctx, err, "Failed to process daily species data", http.StatusInternalServerError)
 	}
 
 	// 4. Build Response (including fetching thumbnails)
@@ -229,7 +257,8 @@ func (c *Controller) GetBatchDailySpeciesSummary(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
-	// Process each date and collect results
+	// Process each date under a per-date query deadline (applied inside
+	// processBatchDates); the request context still aborts the batch on disconnect.
 	batchResults, processingErrors := c.processBatchDates(ctx.Request().Context(), dates, minConfidence, limit, ip, path)
 
 	// Handle results and errors
@@ -261,13 +290,16 @@ func (c *Controller) processBatchDates(ctx context.Context, dates []string, minC
 	processingErrors = make([]string, 0)
 
 	for _, selectedDate := range dates {
-		// Abort early if the request was cancelled or timed out: the remaining
-		// per-date queries would only fail fast against the cancelled context.
+		// Abort early if the request was cancelled (client disconnect / shutdown):
+		// the remaining per-date queries would only fail fast against a dead context.
 		if err := ctx.Err(); err != nil {
 			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", selectedDate, err))
 			break
 		}
-		result, err := c.processSingleDateForBatch(ctx, selectedDate, minConfidence, limit, ip, path)
+		// Bound each date's queries individually so one slow date cannot hang the batch.
+		dateCtx, cancel := context.WithTimeout(ctx, analyticsQueryTimeout)
+		result, err := c.processSingleDateForBatch(dateCtx, selectedDate, minConfidence, limit, ip, path)
+		cancel()
 		if err != nil {
 			errorMsg := fmt.Sprintf("Failed to process date %s: %v", selectedDate, err)
 			processingErrors = append(processingErrors, errorMsg)
@@ -282,7 +314,7 @@ func (c *Controller) processBatchDates(ctx context.Context, dates []string, minC
 // processSingleDateForBatch processes a single date using the same logic as the regular endpoint
 func (c *Controller) processSingleDateForBatch(ctx context.Context, selectedDate string, minConfidence float64, limit int, ip, path string) ([]SpeciesDailySummary, error) {
 	// Get data for the date (limit applied at database level)
-	notes, err := c.DS.GetTopBirdsData(selectedDate, minConfidence, limit)
+	notes, err := c.DS.GetTopBirdsData(ctx, selectedDate, minConfidence, limit)
 	if err != nil {
 		c.logErrorIfEnabled("Failed to get data for date in batch request",
 			logger.String("date", selectedDate),
@@ -601,14 +633,12 @@ func (c *Controller) GetSpeciesSummary(ctx echo.Context) error {
 	)
 
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get species summary data",
+		return c.handleAnalyticsQueryError(ctx, err, "Species summary", "Failed to get species summary data",
 			logger.String("start_date", startDate),
 			logger.String("end_date", endDate),
-			logger.Error(err),
 			logger.String("ip", ip),
 			logger.String("path", path),
 		)
-		return c.HandleError(ctx, err, "Failed to get species summary data", http.StatusInternalServerError)
 	}
 
 	// Build response with thumbnails
@@ -634,7 +664,9 @@ func (c *Controller) GetSpeciesSummary(ctx echo.Context) error {
 // fetchSpeciesSummaryData fetches species summary data with timing
 func (c *Controller) fetchSpeciesSummaryData(ctx echo.Context, startDate, endDate string) ([]datastore.SpeciesSummaryData, time.Duration, error) {
 	dbStart := time.Now()
-	summaryData, err := c.DS.GetSpeciesSummaryData(ctx.Request().Context(), startDate, endDate)
+	queryCtx, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+	summaryData, err := c.DS.GetSpeciesSummaryData(queryCtx, startDate, endDate)
 	return summaryData, time.Since(dbStart), err
 }
 
@@ -767,7 +799,7 @@ func (c *Controller) GetHourlyAnalytics(ctx echo.Context) error {
 	)
 
 	// Add timeout to prevent resource exhaustion
-	ctxWithTimeout, cancel := context.WithTimeout(ctx.Request().Context(), analyticsQueryTimeout)
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
 	defer cancel()
 
 	// Resolve a localized common name (e.g. a Finnish bat name) to its scientific
@@ -782,25 +814,12 @@ func (c *Controller) GetHourlyAnalytics(ctx echo.Context) error {
 	// Get hourly analytics data from the datastore
 	hourlyData, err := c.DS.GetHourlyAnalyticsData(ctxWithTimeout, date, querySpecies)
 	if err != nil {
-		// Check if error was due to timeout
-		if errors.Is(err, context.DeadlineExceeded) {
-			c.logErrorIfEnabled("Hourly analytics query timeout",
-				logger.String("date", date),
-				logger.String("species", speciesParam),
-				logger.Error(err),
-				logger.String("ip", ctx.RealIP()),
-			)
-			return c.HandleError(ctx, err, "Query timeout - please try a smaller date range", http.StatusRequestTimeout)
-		}
-
-		c.logErrorIfEnabled("Failed to get hourly analytics data",
+		return c.handleAnalyticsQueryError(ctx, err, "Hourly analytics", "Failed to get hourly analytics data",
 			logger.String("date", date),
 			logger.String("species", speciesParam),
-			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
-		return c.HandleError(ctx, err, "Failed to get hourly analytics data", http.StatusInternalServerError)
 	}
 
 	// Create a 24-hour array filled with zeros
@@ -878,7 +897,7 @@ func (c *Controller) GetDailyAnalytics(ctx echo.Context) error {
 	)
 
 	// Add timeout to prevent resource exhaustion
-	ctxWithTimeout, cancel := context.WithTimeout(ctx.Request().Context(), analyticsQueryTimeout)
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
 	defer cancel()
 
 	// Resolve a localized common name to its scientific name so analytics matches the
@@ -892,27 +911,13 @@ func (c *Controller) GetDailyAnalytics(ctx echo.Context) error {
 	// Get daily analytics data from the datastore
 	dailyData, err := c.DS.GetDailyAnalyticsData(ctxWithTimeout, startDate, endDate, querySpecies)
 	if err != nil {
-		// Check if error was due to timeout
-		if errors.Is(err, context.DeadlineExceeded) {
-			c.logErrorIfEnabled("Daily analytics query timeout",
-				logger.String("start_date", startDate),
-				logger.String("end_date", endDate),
-				logger.String("species", speciesParam),
-				logger.Error(err),
-				logger.String("ip", ctx.RealIP()),
-			)
-			return c.HandleError(ctx, err, "Query timeout - please try a smaller date range", http.StatusRequestTimeout)
-		}
-
-		c.logErrorIfEnabled("Failed to get daily analytics data",
+		return c.handleAnalyticsQueryError(ctx, err, "Daily analytics", "Failed to get daily analytics data",
 			logger.String("start_date", startDate),
 			logger.String("end_date", endDate),
 			logger.String("species", speciesParam),
-			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
-		return c.HandleError(ctx, err, "Failed to get daily analytics data", http.StatusInternalServerError)
 	}
 
 	// Build the response
@@ -999,30 +1004,17 @@ func (c *Controller) GetSpeciesDiversity(ctx echo.Context) error {
 	)
 
 	// Add timeout to prevent resource exhaustion
-	ctxWithTimeout, cancel := context.WithTimeout(ctx.Request().Context(), analyticsQueryTimeout)
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
 	defer cancel()
 
 	diversityData, err := c.DS.GetSpeciesDiversityData(ctxWithTimeout, startDate, endDate)
 	if err != nil {
-		// Check if error was due to timeout
-		if errors.Is(err, context.DeadlineExceeded) {
-			c.logErrorIfEnabled("Species diversity query timeout",
-				logger.String("start_date", startDate),
-				logger.String("end_date", endDate),
-				logger.Error(err),
-				logger.String("ip", ctx.RealIP()),
-			)
-			return c.HandleError(ctx, err, "Query timeout - please try a smaller date range", http.StatusRequestTimeout)
-		}
-
-		c.logErrorIfEnabled("Failed to get species diversity data",
+		return c.handleAnalyticsQueryError(ctx, err, "Species diversity", "Failed to get species diversity data",
 			logger.String("start_date", startDate),
 			logger.String("end_date", endDate),
-			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
-		return c.HandleError(ctx, err, "Failed to get species diversity data", http.StatusInternalServerError)
 	}
 
 	// Build the response
@@ -1098,9 +1090,15 @@ func (c *Controller) GetTimeOfDayDistribution(ctx echo.Context) error {
 	}
 
 	// Get hourly distribution data from the datastore
-	hourlyData, err := c.DS.GetHourlyDistribution(ctx.Request().Context(), startDate, endDate, querySpecies)
+	queryCtx, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+	hourlyData, err := c.DS.GetHourlyDistribution(queryCtx, startDate, endDate, querySpecies)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to get hourly distribution data", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "Time of day distribution", "Failed to get hourly distribution data",
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("ip", ctx.RealIP()),
+		)
 	}
 
 	// Return empty data if nothing available
@@ -1143,18 +1141,18 @@ func (c *Controller) GetNewSpeciesDetections(ctx echo.Context) error {
 	}
 
 	// Fetch data from datastore
-	newSpeciesData, err := c.DS.GetNewSpeciesDetections(ctx.Request().Context(), startDate, endDate, limit, offset)
+	queryCtx, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+	newSpeciesData, err := c.DS.GetNewSpeciesDetections(queryCtx, startDate, endDate, limit, offset)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get new species detections",
+		return c.handleAnalyticsQueryError(ctx, err, "New species detections", "Failed to get new species detections",
 			logger.String("start_date", startDate),
 			logger.String("end_date", endDate),
 			logger.Int("limit", limit),
 			logger.Int("offset", offset),
-			logger.Error(err),
 			logger.String("ip", ip),
 			logger.String("path", path),
 		)
-		return c.HandleError(ctx, err, "Failed to get new species detections", http.StatusInternalServerError)
 	}
 
 	// Build response with thumbnails
@@ -1411,7 +1409,17 @@ func (c *Controller) processHourlyBatchSpecies(ctx echo.Context, speciesParams [
 	processingErrors = make([]string, 0)
 	seen := make(map[string]bool)
 
+	// Stop the batch when the client disconnects or the server shuts down. Each
+	// per-species query is bounded individually by analyticsQueryTimeout (below) so
+	// one slow query cannot hang the batch, without capping the total time a
+	// legitimately large batch may take on slower hardware.
+	reqCtx := ctx.Request().Context()
+
 	for _, speciesItem := range speciesParams {
+		if err := reqCtx.Err(); err != nil {
+			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", speciesItem, err))
+			break
+		}
 		speciesItem = strings.TrimSpace(speciesItem)
 		if speciesItem == "" || seen[speciesItem] {
 			continue
@@ -1425,7 +1433,9 @@ func (c *Controller) processHourlyBatchSpecies(ctx echo.Context, speciesParams [
 			queryItem = resolved
 		}
 
-		hourlyData, err := c.DS.GetHourlyAnalyticsData(ctx.Request().Context(), date, queryItem)
+		queryCtx, cancel := withAnalyticsTimeout(ctx)
+		hourlyData, err := c.DS.GetHourlyAnalyticsData(queryCtx, date, queryItem)
+		cancel()
 		if err != nil {
 			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get hourly data for species %s: %v", speciesItem, err))
 			c.logErrorIfEnabled("Error getting hourly data for species in batch request",
@@ -1529,7 +1539,17 @@ func (c *Controller) processDailyBatchSpecies(ctx echo.Context, uniqueSpecies []
 	results = make(map[string]SpeciesDailyData)
 	processingErrors = make([]string, 0)
 
+	// Stop the batch when the client disconnects or the server shuts down. Each
+	// per-species query is bounded individually by analyticsQueryTimeout (below) so
+	// one slow query cannot hang the batch, without capping the total time a
+	// legitimately large batch may take on slower hardware.
+	reqCtx := ctx.Request().Context()
+
 	for _, speciesItem := range uniqueSpecies {
+		if err := reqCtx.Err(); err != nil {
+			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", speciesItem, err))
+			break
+		}
 		// Resolve a localized common name for the datastore query only; the response
 		// stays keyed by and labeled with the user-facing species string.
 		queryItem := speciesItem
@@ -1537,7 +1557,9 @@ func (c *Controller) processDailyBatchSpecies(ctx echo.Context, uniqueSpecies []
 			queryItem = resolved
 		}
 
-		dailyData, err := c.DS.GetDailyAnalyticsData(ctx.Request().Context(), startDate, endDate, queryItem)
+		queryCtx, cancel := withAnalyticsTimeout(ctx)
+		dailyData, err := c.DS.GetDailyAnalyticsData(queryCtx, startDate, endDate, queryItem)
+		cancel()
 		if err != nil {
 			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get daily data for species %s: %v", speciesItem, err))
 			c.logErrorIfEnabled("Error getting daily data for species in batch request",

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -53,12 +53,34 @@ func withAnalyticsTimeout(ctx echo.Context) (context.Context, context.CancelFunc
 // alongside the supplied fields. The returned error is what the handler returns.
 func (c *Controller) handleAnalyticsQueryError(ctx echo.Context, err error, opLabel, genericMsg string, fields ...logger.Field) error {
 	fields = append(fields, logger.Error(err))
-	if errors.Is(err, context.DeadlineExceeded) {
+	switch {
+	case errors.Is(err, context.Canceled):
+		// Client disconnected (navigated away / closed the tab). An expected lifecycle
+		// event, not a server error: log at info and return the non-standard
+		// client-closed status, matching the convention in media.go.
+		c.logInfoIfEnabled(opLabel+" query canceled by client", fields...)
+		return c.HandleError(ctx, err, "Request canceled by client", StatusClientClosedRequest)
+	case errors.Is(err, context.DeadlineExceeded):
 		c.logErrorIfEnabled(opLabel+" query timeout", fields...)
 		return c.HandleError(ctx, err, msgQueryTimeout, http.StatusRequestTimeout)
+	default:
+		c.logErrorIfEnabled(opLabel+" query failed", fields...)
+		return c.HandleError(ctx, err, genericMsg, http.StatusInternalServerError)
 	}
-	c.logErrorIfEnabled(opLabel+" query failed", fields...)
-	return c.HandleError(ctx, err, genericMsg, http.StatusInternalServerError)
+}
+
+// logBatchQueryError logs a per-item failure inside a batch analytics request at the
+// right level: a client cancellation (context.Canceled) is an expected disconnect
+// logged at debug, any other error is a real failure logged at error. It returns
+// true for a cancellation so the caller can stop the batch instead of continuing.
+func (c *Controller) logBatchQueryError(msg string, err error, fields ...logger.Field) (canceled bool) {
+	fields = append(fields, logger.Error(err))
+	if errors.Is(err, context.Canceled) {
+		c.logDebugIfEnabled(msg+": client canceled request", fields...)
+		return true
+	}
+	c.logErrorIfEnabled(msg, fields...)
+	return false
 }
 
 // SpeciesDailySummary represents a bird in the daily species summary API response
@@ -316,9 +338,8 @@ func (c *Controller) processSingleDateForBatch(ctx context.Context, selectedDate
 	// Get data for the date (limit applied at database level)
 	notes, err := c.DS.GetTopBirdsData(ctx, selectedDate, minConfidence, limit)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get data for date in batch request",
+		c.logBatchQueryError("Failed to get data for date in batch request", err,
 			logger.String("date", selectedDate),
-			logger.Error(err),
 			logger.String("ip", ip),
 			logger.String("path", path),
 		)
@@ -328,9 +349,8 @@ func (c *Controller) processSingleDateForBatch(ctx context.Context, selectedDate
 	// Aggregate data
 	aggregatedData, err := c.aggregateDailySpeciesData(ctx, notes, selectedDate, minConfidence)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to aggregate data for date in batch request",
+		c.logBatchQueryError("Failed to aggregate data for date in batch request", err,
 			logger.String("date", selectedDate),
-			logger.Error(err),
 			logger.String("ip", ip),
 			logger.String("path", path),
 		)
@@ -1437,14 +1457,15 @@ func (c *Controller) processHourlyBatchSpecies(ctx echo.Context, speciesParams [
 		hourlyData, err := c.DS.GetHourlyAnalyticsData(queryCtx, date, queryItem)
 		cancel()
 		if err != nil {
-			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get hourly data for species %s: %v", speciesItem, err))
-			c.logErrorIfEnabled("Error getting hourly data for species in batch request",
+			if c.logBatchQueryError("Error getting hourly data for species in batch request", err,
 				logger.String("species", speciesItem),
 				logger.String("date", date),
-				logger.Error(err),
 				logger.String("ip", ip),
 				logger.String("path", path),
-			)
+			) {
+				break // client disconnected; stop the batch
+			}
+			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get hourly data for species %s: %v", speciesItem, err))
 			continue
 		}
 
@@ -1561,15 +1582,16 @@ func (c *Controller) processDailyBatchSpecies(ctx echo.Context, uniqueSpecies []
 		dailyData, err := c.DS.GetDailyAnalyticsData(queryCtx, startDate, endDate, queryItem)
 		cancel()
 		if err != nil {
-			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get daily data for species %s: %v", speciesItem, err))
-			c.logErrorIfEnabled("Error getting daily data for species in batch request",
+			if c.logBatchQueryError("Error getting daily data for species in batch request", err,
 				logger.String("species", speciesItem),
 				logger.String("start_date", startDate),
 				logger.String("end_date", endDate),
-				logger.Error(err),
 				logger.String("ip", ip),
 				logger.String("path", path),
-			)
+			) {
+				break // client disconnected; stop the batch
+			}
+			processingErrors = append(processingErrors, fmt.Sprintf("Failed to get daily data for species %s: %v", speciesItem, err))
 			continue
 		}
 

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -312,10 +312,15 @@ func (c *Controller) processBatchDates(ctx context.Context, dates []string, minC
 	processingErrors = make([]string, 0)
 
 	for _, selectedDate := range dates {
-		// Abort early if the request was cancelled (client disconnect / shutdown):
-		// the remaining per-date queries would only fail fast against a dead context.
+		// Stop cleanly if the client disconnected (request canceled): an expected
+		// lifecycle event, not a processing failure worth recording.
 		if err := ctx.Err(); err != nil {
-			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", selectedDate, err))
+			c.logDebugIfEnabled("Batch daily species summary: client canceled request",
+				logger.String("date", selectedDate),
+				logger.Error(err),
+				logger.String("ip", ip),
+				logger.String("path", path),
+			)
 			break
 		}
 		// Bound each date's queries individually so one slow date cannot hang the batch.
@@ -323,6 +328,9 @@ func (c *Controller) processBatchDates(ctx context.Context, dates []string, minC
 		result, err := c.processSingleDateForBatch(dateCtx, selectedDate, minConfidence, limit, ip, path)
 		cancel()
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				break // client disconnected; stop the batch without recording a failure
+			}
 			errorMsg := fmt.Sprintf("Failed to process date %s: %v", selectedDate, err)
 			processingErrors = append(processingErrors, errorMsg)
 			continue
@@ -1437,7 +1445,12 @@ func (c *Controller) processHourlyBatchSpecies(ctx echo.Context, speciesParams [
 
 	for _, speciesItem := range speciesParams {
 		if err := reqCtx.Err(); err != nil {
-			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", speciesItem, err))
+			c.logDebugIfEnabled("Batch hourly species data: client canceled request",
+				logger.String("species", speciesItem),
+				logger.Error(err),
+				logger.String("ip", ip),
+				logger.String("path", path),
+			)
 			break
 		}
 		speciesItem = strings.TrimSpace(speciesItem)
@@ -1568,7 +1581,12 @@ func (c *Controller) processDailyBatchSpecies(ctx echo.Context, uniqueSpecies []
 
 	for _, speciesItem := range uniqueSpecies {
 		if err := reqCtx.Err(); err != nil {
-			processingErrors = append(processingErrors, fmt.Sprintf("request cancelled before processing %s: %v", speciesItem, err))
+			c.logDebugIfEnabled("Batch daily species data: client canceled request",
+				logger.String("species", speciesItem),
+				logger.Error(err),
+				logger.String("ip", ip),
+				logger.String("path", path),
+			)
 			break
 		}
 		// Resolve a localized common name for the datastore query only; the response

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -180,46 +180,57 @@ func TestGetSpeciesSummaryDatabaseError(t *testing.T) {
 	mockDS.AssertExpectations(t)
 }
 
-// TestAnalyticsEndpointQueryTimeout verifies that analytics endpoints which were
-// previously passing the raw request context now bound their datastore query with
-// analyticsQueryTimeout and map a deadline to HTTP 408 (not 500). Regression guard
-// for the query-timeout consistency fix.
-func TestAnalyticsEndpointQueryTimeout(t *testing.T) {
+// TestAnalyticsEndpointContextErrors verifies that analytics endpoints which were
+// previously passing the raw request context now bound their datastore query and map
+// context errors to the right HTTP status: a deadline to 408 (not 500), and a client
+// cancellation to 499 (client closed request). Regression guard for the query-timeout
+// consistency fix.
+func TestAnalyticsEndpointContextErrors(t *testing.T) {
 	t.Parallel()
 	t.Attr("component", "analytics")
 	t.Attr("type", "error-handling")
 	t.Attr("feature", "query-timeout")
 
-	tests := []struct {
+	errorCases := []struct {
+		name       string
+		queryErr   error
+		wantStatus int
+		wantMsg    string
+	}{
+		{"deadline exceeded", context.DeadlineExceeded, http.StatusRequestTimeout, "Query timeout"},
+		{"client canceled", context.Canceled, StatusClientClosedRequest, "Request canceled by client"},
+	}
+
+	endpoints := []struct {
 		name      string
 		path      string
-		setupMock func(*mocks.MockInterface)
+		setupMock func(*mocks.MockInterface, error)
 		invoke    func(*Controller, echo.Context) error
 	}{
 		{
 			name: "species summary",
 			path: "/api/v2/analytics/species/summary",
-			setupMock: func(m *mocks.MockInterface) {
+			setupMock: func(m *mocks.MockInterface, queryErr error) {
 				m.On("GetSpeciesSummaryData", mock.Anything, "", "").
-					Return([]datastore.SpeciesSummaryData{}, context.DeadlineExceeded)
+					Return([]datastore.SpeciesSummaryData{}, queryErr)
 			},
 			invoke: func(c *Controller, ctx echo.Context) error { return c.GetSpeciesSummary(ctx) },
 		},
 		{
 			name: "time of day distribution",
 			path: "/api/v2/analytics/time/distribution/hourly",
-			setupMock: func(m *mocks.MockInterface) {
+			setupMock: func(m *mocks.MockInterface, queryErr error) {
 				m.On("GetHourlyDistribution", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return([]datastore.HourlyDistributionData{}, context.DeadlineExceeded)
+					Return([]datastore.HourlyDistributionData{}, queryErr)
 			},
 			invoke: func(c *Controller, ctx echo.Context) error { return c.GetTimeOfDayDistribution(ctx) },
 		},
 		{
 			name: "new species detections",
 			path: "/api/v2/analytics/species/detections/new",
-			setupMock: func(m *mocks.MockInterface) {
+			setupMock: func(m *mocks.MockInterface, queryErr error) {
 				m.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return([]datastore.NewSpeciesData{}, context.DeadlineExceeded)
+					Return([]datastore.NewSpeciesData{}, queryErr)
 			},
 			invoke: func(c *Controller, ctx echo.Context) error { return c.GetNewSpeciesDetections(ctx) },
 		},
@@ -227,34 +238,36 @@ func TestAnalyticsEndpointQueryTimeout(t *testing.T) {
 			// Exercises the now-context-bounded GetTopBirdsData query.
 			name: "daily species summary",
 			path: "/api/v2/analytics/species/daily",
-			setupMock: func(m *mocks.MockInterface) {
+			setupMock: func(m *mocks.MockInterface, queryErr error) {
 				m.On("GetTopBirdsData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return([]datastore.Note{}, context.DeadlineExceeded)
+					Return([]datastore.Note{}, queryErr)
 			},
 			invoke: func(c *Controller, ctx echo.Context) error { return c.GetDailySpeciesSummary(ctx) },
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			e, mockDS, controller := setupAnalyticsTestEnvironment(t)
-			tt.setupMock(mockDS)
+	for _, ep := range endpoints {
+		for _, ec := range errorCases {
+			t.Run(ep.name+"/"+ec.name, func(t *testing.T) {
+				t.Parallel()
+				e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+				ep.setupMock(mockDS, ec.queryErr)
 
-			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
-			rec := httptest.NewRecorder()
-			c := e.NewContext(req, rec)
-			c.SetPath(tt.path)
+				req := httptest.NewRequest(http.MethodGet, ep.path, http.NoBody)
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				c.SetPath(ep.path)
 
-			require.NoError(t, tt.invoke(controller, c))
-			assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+				require.NoError(t, ep.invoke(controller, c))
+				assert.Equal(t, ec.wantStatus, rec.Code)
 
-			var errorResponse map[string]any
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errorResponse))
-			assert.Contains(t, errorResponse["message"], "Query timeout")
+				var errorResponse map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errorResponse))
+				assert.Contains(t, errorResponse["message"], ec.wantMsg)
 
-			mockDS.AssertExpectations(t)
-		})
+				mockDS.AssertExpectations(t)
+			})
+		}
 	}
 }
 

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -180,6 +180,84 @@ func TestGetSpeciesSummaryDatabaseError(t *testing.T) {
 	mockDS.AssertExpectations(t)
 }
 
+// TestAnalyticsEndpointQueryTimeout verifies that analytics endpoints which were
+// previously passing the raw request context now bound their datastore query with
+// analyticsQueryTimeout and map a deadline to HTTP 408 (not 500). Regression guard
+// for the query-timeout consistency fix.
+func TestAnalyticsEndpointQueryTimeout(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "analytics")
+	t.Attr("type", "error-handling")
+	t.Attr("feature", "query-timeout")
+
+	tests := []struct {
+		name      string
+		path      string
+		setupMock func(*mocks.MockInterface)
+		invoke    func(*Controller, echo.Context) error
+	}{
+		{
+			name: "species summary",
+			path: "/api/v2/analytics/species/summary",
+			setupMock: func(m *mocks.MockInterface) {
+				m.On("GetSpeciesSummaryData", mock.Anything, "", "").
+					Return([]datastore.SpeciesSummaryData{}, context.DeadlineExceeded)
+			},
+			invoke: func(c *Controller, ctx echo.Context) error { return c.GetSpeciesSummary(ctx) },
+		},
+		{
+			name: "time of day distribution",
+			path: "/api/v2/analytics/time/distribution/hourly",
+			setupMock: func(m *mocks.MockInterface) {
+				m.On("GetHourlyDistribution", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return([]datastore.HourlyDistributionData{}, context.DeadlineExceeded)
+			},
+			invoke: func(c *Controller, ctx echo.Context) error { return c.GetTimeOfDayDistribution(ctx) },
+		},
+		{
+			name: "new species detections",
+			path: "/api/v2/analytics/species/detections/new",
+			setupMock: func(m *mocks.MockInterface) {
+				m.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return([]datastore.NewSpeciesData{}, context.DeadlineExceeded)
+			},
+			invoke: func(c *Controller, ctx echo.Context) error { return c.GetNewSpeciesDetections(ctx) },
+		},
+		{
+			// Exercises the now-context-bounded GetTopBirdsData query.
+			name: "daily species summary",
+			path: "/api/v2/analytics/species/daily",
+			setupMock: func(m *mocks.MockInterface) {
+				m.On("GetTopBirdsData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return([]datastore.Note{}, context.DeadlineExceeded)
+			},
+			invoke: func(c *Controller, ctx echo.Context) error { return c.GetDailySpeciesSummary(ctx) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+			tt.setupMock(mockDS)
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath(tt.path)
+
+			require.NoError(t, tt.invoke(controller, c))
+			assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+
+			var errorResponse map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errorResponse))
+			assert.Contains(t, errorResponse["message"], "Query timeout")
+
+			mockDS.AssertExpectations(t)
+		})
+	}
+}
+
 // TestGetSpeciesSummaryWithDateFilters tests the species summary endpoint with date filtering
 func TestGetSpeciesSummaryWithDateFilters(t *testing.T) {
 	t.Parallel()
@@ -641,7 +719,7 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 	rbwoTotal := 2
 
 	// Setup mock expectations using m.On()
-	mockDS.On("GetTopBirdsData", testDate, minConfidence, 0).Return(mockNotes, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, testDate, minConfidence, 0).Return(mockNotes, nil)
 	// Now using batch query instead of individual calls
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, testDate, mock.MatchedBy(func(species []string) bool {
 		return len(species) == 2 &&
@@ -825,7 +903,7 @@ func TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies(t *testing.T) {
 	var blackbirdHourly [24]int
 	blackbirdHourly[8] = 2
 
-	mockDS.On("GetTopBirdsData", testDate, minConfidence, 0).Return(mockNotes, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, testDate, minConfidence, 0).Return(mockNotes, nil)
 
 	// Post-fix contract: the controller keys the hourly aggregation on scientific
 	// name end to end, so GetBatchHourlyOccurrences receives scientific names and
@@ -918,7 +996,7 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 	expectedRbwoSingleHourly[10] = 1
 
 	// Setup mock expectations using m.On()
-	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return(mockNotesSingle, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, "2025-03-07", 0.0, 0).Return(mockNotesSingle, nil)
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
 		sciAmericanCrow:         expectedAmcroSingleHourly,
 		sciRedBelliedWoodpecker: expectedRbwoSingleHourly,
@@ -1009,7 +1087,7 @@ func TestGetDailySpeciesSummary_EmptyResult(t *testing.T) {
 
 	// Setup mock expectations using m.On()
 	// Expect GetTopBirdsData to be called and return empty slice
-	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return([]datastore.Note{}, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, "2025-03-07", 0.0, 0).Return([]datastore.Note{}, nil)
 	// Expect GetBatchHourlyOccurrences not to be called since there are no birds
 
 	// Create a controller with our mock
@@ -1091,7 +1169,7 @@ func TestGetDailySpeciesSummary_TimeHandling(t *testing.T) {
 	expectedAmcroTimeHourly[21] = 1
 
 	// Setup mock expectations using m.On()
-	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 0).Return(mockNotesTime, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, "2025-03-07", 0.0, 0).Return(mockNotesTime, nil)
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
 		sciAmericanCrow: expectedAmcroTimeHourly,
 	}, nil)
@@ -1173,7 +1251,7 @@ func TestGetDailySpeciesSummary_ConfidenceFilter(t *testing.T) {
 
 	// Setup mock expectations
 	// GetTopBirdsData is called with the normalized confidence
-	mockDS.On("GetTopBirdsData", "2025-03-07", expectedMinConfidence, 0).Return(mockNotesConfidence, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, "2025-03-07", expectedMinConfidence, 0).Return(mockNotesConfidence, nil)
 	// GetBatchHourlyOccurrences is called for all species returned by GetTopBirdsData
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, expectedMinConfidence).Return(map[string][24]int{
 		sciAmericanCrow:         expectedAmcroConfidenceHourly,
@@ -1259,7 +1337,7 @@ func TestGetDailySpeciesSummary_LimitParameter(t *testing.T) {
 	expectedBcchLimitHourly[12] = 1
 
 	// Setup mock expectations
-	mockDS.On("GetTopBirdsData", "2025-03-07", 0.0, 2).Return(mockNotesLimit, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, "2025-03-07", 0.0, 2).Return(mockNotesLimit, nil)
 	// Expect GetBatchHourlyOccurrences to be called for the 2 species returned
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, "2025-03-07", mock.Anything, 0.0).Return(map[string][24]int{
 		sciAmericanCrow:         expectedAmcroLimitHourly,
@@ -1306,7 +1384,7 @@ func TestGetDailySpeciesSummary_DatabaseError(t *testing.T) {
 	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
 
 	// Override the GetTopBirdsData function to return an error
-	mockDS.On("GetTopBirdsData", mock.Anything, mock.Anything, mock.Anything).Return([]datastore.Note{}, errors.New("database connection error"))
+	mockDS.On("GetTopBirdsData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.Note{}, errors.New("database connection error"))
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07", http.NoBody)
@@ -1350,7 +1428,7 @@ func TestGetDailySpeciesSummary_BatchQueryError(t *testing.T) {
 	}
 
 	// Mock successful GetTopBirdsData call
-	mockDS.On("GetTopBirdsData", testDate, 0.0, 0).Return(mockNotes, nil)
+	mockDS.On("GetTopBirdsData", mock.Anything, testDate, 0.0, 0).Return(mockNotes, nil)
 
 	// Mock GetBatchHourlyOccurrences to return an error
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, testDate, mock.Anything, 0.0).Return(

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -83,7 +83,7 @@ func TestDailySpeciesSummary_DefaultParams(t *testing.T) {
 	notes := testNotes()
 
 	// Key assertion: GetTopBirdsData must be called with today's date and the raw limit (0 = no limit)
-	mockDS.On("GetTopBirdsData", today, 0.0, 0).Return(notes, nil).Once()
+	mockDS.On("GetTopBirdsData", mock.Anything, today, 0.0, 0).Return(notes, nil).Once()
 
 	// aggregateDailySpeciesData calls GetBatchHourlyOccurrences for hourly counts
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, today, mock.Anything, 0.0).
@@ -390,7 +390,7 @@ func TestDailySpeciesSummary_DefaultParams_AfterMigration(t *testing.T) {
 	notes := testNotes()
 
 	// After migration, the API handler still passes limit=0 (its default for "no limit param").
-	mockDS.On("GetTopBirdsData", today, 0.0, 0).Return(notes, nil).Once()
+	mockDS.On("GetTopBirdsData", mock.Anything, today, 0.0, 0).Return(notes, nil).Once()
 	mockDS.On("GetBatchHourlyOccurrences", mock.Anything, today, mock.Anything, 0.0).
 		Return(map[string][24]int{
 			sciAmericanRobin: {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -156,16 +156,14 @@ func (ds *DataStore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 			logger.Any("args", args))
 	}
 
-	// Add timeout to prevent indefinite execution
-	// Use 30 seconds as a reasonable upper bound for analytics queries
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	// Track transaction duration for performance monitoring
 	txStart := time.Now()
 
-	// Use GORM's Transaction helper for automatic commit/rollback handling
-	err := ds.DB.WithContext(ctxWithTimeout).Transaction(func(tx *gorm.DB) error {
+	// Use GORM's Transaction helper for automatic commit/rollback handling.
+	// The query is bounded by the caller's request context, which the API layer
+	// wraps with analyticsQueryTimeout (internal/api/v2/analytics.go). The v2only
+	// implementation relies on the caller's context the same way.
+	err := ds.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Execute query within transaction
 		rows, err := tx.Raw(queryStr, args...).Rows()
 		if err != nil {
@@ -189,11 +187,14 @@ func (ds *DataStore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 		}
 		rowCount := 0
 
-		// NOTE: Transaction has 30-second timeout at the top level (ctxWithTimeout)
-		// TODO(context-deadline): For very large result sets, consider adding context checks in loop
-		// Example: select { case <-ctxWithTimeout.Done(): rows.Close(); return ctxWithTimeout.Err(); default: }
-		// TODO(telemetry): Report context cancellations during row processing to internal/telemetry
+		// The query is bounded by the caller's request context (the API layer wraps
+		// it with analyticsQueryTimeout). Check cancellation inside the scan loop so a
+		// client disconnect or deadline on a large result set surfaces immediately
+		// instead of after scanning every remaining row.
 		for rows.Next() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			rowCount++
 			var summary SpeciesSummaryData
 			var firstSeenStr, lastSeenStr string

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -103,7 +103,7 @@ type Interface interface {
 	GetAllNotes() ([]Note, error)
 	// GetTopBirdsData returns daily detection summaries, ordered by detection count descending.
 	// The limit parameter (if > 0) restricts the number of unique species returned.
-	GetTopBirdsData(selectedDate string, minConfidenceNormalized float64, limit int) ([]Note, error)
+	GetTopBirdsData(ctx context.Context, selectedDate string, minConfidenceNormalized float64, limit int) ([]Note, error)
 	// GetBatchHourlyOccurrences retrieves hourly detection counts for multiple species on a given date.
 	// The species slice holds scientific names; the returned map is keyed by scientific name.
 	// Keying on scientific name keeps the result robust across models and locales.
@@ -646,7 +646,7 @@ func (ds *DataStore) GetAllNotes() ([]Note, error) {
 }
 
 // GetTopBirdsData retrieves the top bird sightings based on a selected date and minimum confidence threshold.
-func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalized float64, limit int) ([]Note, error) {
+func (ds *DataStore) GetTopBirdsData(ctx context.Context, selectedDate string, minConfidenceNormalized float64, limit int) ([]Note, error) {
 	// Define a temporary struct to hold the query results including the count
 	type SpeciesCount struct {
 		CommonName     string
@@ -668,7 +668,7 @@ func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 
 	// First, get the count and common names
 	// Exclude detections marked as false_positive
-	query := ds.DB.Table("notes").
+	query := ds.DB.WithContext(ctx).Table("notes").
 		Joins("LEFT JOIN note_reviews ON notes.id = note_reviews.note_id").
 		Select("notes.common_name, notes.scientific_name, notes.species_code, COUNT(*) as count, MAX(notes.confidence) as confidence, notes.date, MAX(notes.time) as time").
 		Where("notes.date = ? AND notes.confidence >= ?", selectedDate, minConfidenceNormalized).

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -3629,9 +3629,9 @@ func (_c *MockInterface_GetThresholdEvents_Call) RunAndReturn(run func(string, i
 	return _c
 }
 
-// GetTopBirdsData provides a mock function with given fields: selectedDate, minConfidenceNormalized, limit
-func (_m *MockInterface) GetTopBirdsData(selectedDate string, minConfidenceNormalized float64, limit int) ([]datastore.Note, error) {
-	ret := _m.Called(selectedDate, minConfidenceNormalized, limit)
+// GetTopBirdsData provides a mock function with given fields: ctx, selectedDate, minConfidenceNormalized, limit
+func (_m *MockInterface) GetTopBirdsData(ctx context.Context, selectedDate string, minConfidenceNormalized float64, limit int) ([]datastore.Note, error) {
+	ret := _m.Called(ctx, selectedDate, minConfidenceNormalized, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTopBirdsData")
@@ -3639,19 +3639,19 @@ func (_m *MockInterface) GetTopBirdsData(selectedDate string, minConfidenceNorma
 
 	var r0 []datastore.Note
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, float64, int) ([]datastore.Note, error)); ok {
-		return rf(selectedDate, minConfidenceNormalized, limit)
+	if rf, ok := ret.Get(0).(func(context.Context, string, float64, int) ([]datastore.Note, error)); ok {
+		return rf(ctx, selectedDate, minConfidenceNormalized, limit)
 	}
-	if rf, ok := ret.Get(0).(func(string, float64, int) []datastore.Note); ok {
-		r0 = rf(selectedDate, minConfidenceNormalized, limit)
+	if rf, ok := ret.Get(0).(func(context.Context, string, float64, int) []datastore.Note); ok {
+		r0 = rf(ctx, selectedDate, minConfidenceNormalized, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]datastore.Note)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, float64, int) error); ok {
-		r1 = rf(selectedDate, minConfidenceNormalized, limit)
+	if rf, ok := ret.Get(1).(func(context.Context, string, float64, int) error); ok {
+		r1 = rf(ctx, selectedDate, minConfidenceNormalized, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3665,16 +3665,17 @@ type MockInterface_GetTopBirdsData_Call struct {
 }
 
 // GetTopBirdsData is a helper method to define mock.On call
+//   - ctx context.Context
 //   - selectedDate string
 //   - minConfidenceNormalized float64
 //   - limit int
-func (_e *MockInterface_Expecter) GetTopBirdsData(selectedDate interface{}, minConfidenceNormalized interface{}, limit interface{}) *MockInterface_GetTopBirdsData_Call {
-	return &MockInterface_GetTopBirdsData_Call{Call: _e.mock.On("GetTopBirdsData", selectedDate, minConfidenceNormalized, limit)}
+func (_e *MockInterface_Expecter) GetTopBirdsData(ctx interface{}, selectedDate interface{}, minConfidenceNormalized interface{}, limit interface{}) *MockInterface_GetTopBirdsData_Call {
+	return &MockInterface_GetTopBirdsData_Call{Call: _e.mock.On("GetTopBirdsData", ctx, selectedDate, minConfidenceNormalized, limit)}
 }
 
-func (_c *MockInterface_GetTopBirdsData_Call) Run(run func(selectedDate string, minConfidenceNormalized float64, limit int)) *MockInterface_GetTopBirdsData_Call {
+func (_c *MockInterface_GetTopBirdsData_Call) Run(run func(ctx context.Context, selectedDate string, minConfidenceNormalized float64, limit int)) *MockInterface_GetTopBirdsData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(float64), args[2].(int))
+		run(args[0].(context.Context), args[1].(string), args[2].(float64), args[3].(int))
 	})
 	return _c
 }
@@ -3684,7 +3685,7 @@ func (_c *MockInterface_GetTopBirdsData_Call) Return(_a0 []datastore.Note, _a1 e
 	return _c
 }
 
-func (_c *MockInterface_GetTopBirdsData_Call) RunAndReturn(run func(string, float64, int) ([]datastore.Note, error)) *MockInterface_GetTopBirdsData_Call {
+func (_c *MockInterface_GetTopBirdsData_Call) RunAndReturn(run func(context.Context, string, float64, int) ([]datastore.Note, error)) *MockInterface_GetTopBirdsData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -670,7 +670,7 @@ func (s *testLegacyInterface) SetMetrics(_ *datastore.Metrics)                  
 func (s *testLegacyInterface) SetSunCalcMetrics(_ any)                             {}
 func (s *testLegacyInterface) Optimize(_ context.Context) error                    { return nil }
 func (s *testLegacyInterface) GetAllNotes() ([]datastore.Note, error)              { return nil, nil }
-func (s *testLegacyInterface) GetTopBirdsData(_ string, _ float64, _ int) ([]datastore.Note, error) {
+func (s *testLegacyInterface) GetTopBirdsData(_ context.Context, _ string, _ float64, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
 func (s *testLegacyInterface) GetBatchHourlyOccurrences(_ context.Context, _ string, _ []string, _ float64) (map[string][24]int, error) {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1097,7 +1097,7 @@ func (ds *Datastore) GetAllNotes() ([]datastore.Note, error) {
 }
 
 // GetTopBirdsData retrieves top birds data for a date.
-func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalized float64, limit int) ([]datastore.Note, error) {
+func (ds *Datastore) GetTopBirdsData(ctx context.Context, selectedDate string, minConfidenceNormalized float64, limit int) ([]datastore.Note, error) {
 	t, err := time.ParseInLocation("2006-01-02", selectedDate, ds.timezone)
 	if err != nil {
 		return nil, err
@@ -1128,7 +1128,7 @@ func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 	// Excludes detections marked as false_positive.
 	prefix := ds.manager.TablePrefix()
 	db := ds.manager.DB()
-	err = db.Table(prefix+"detections d").
+	err = db.WithContext(ctx).Table(prefix+"detections d").
 		Select(`
 			l.scientific_name,
 			COUNT(d.id) as count,

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1359,7 +1359,7 @@ func TestV2OnlyDatastore_ConcatenatedLabelExtraction(t *testing.T) {
 
 	t.Run("GetTopBirdsData extracts scientific name from concatenated label", func(t *testing.T) {
 		dateStr := now.Format(time.DateOnly)
-		topBirds, err := ds.GetTopBirdsData(dateStr, 0.0, 10)
+		topBirds, err := ds.GetTopBirdsData(t.Context(), dateStr, 0.0, 10)
 		require.NoError(t, err)
 		require.Len(t, topBirds, 1)
 
@@ -1463,7 +1463,7 @@ func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
 		require.NoError(t, ds.Save(note, nil))
 	}
 
-	topBirds, err := ds.GetTopBirdsData(dateStr, 0.0, 10)
+	topBirds, err := ds.GetTopBirdsData(t.Context(), dateStr, 0.0, 10)
 	require.NoError(t, err)
 	require.Len(t, topBirds, 3)
 

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -163,7 +163,7 @@ func (m *mockStore) SetMetrics(metrics *datastore.Metrics)                      
 func (m *mockStore) SetSunCalcMetrics(suncalcMetrics any)                         {}
 func (m *mockStore) Optimize(ctx context.Context) error                           { return nil }
 func (m *mockStore) GetAllNotes() ([]datastore.Note, error)                       { return []datastore.Note{}, nil }
-func (m *mockStore) GetTopBirdsData(date string, minConf float64, limit int) ([]datastore.Note, error) {
+func (m *mockStore) GetTopBirdsData(_ context.Context, date string, minConf float64, limit int) ([]datastore.Note, error) {
 	return []datastore.Note{}, nil
 }
 func (m *mockStore) GetBatchHourlyOccurrences(_ context.Context, date string, species []string, minConf float64) (map[string][24]int, error) {


### PR DESCRIPTION
## Summary

Several analytics endpoints passed the raw request context straight to the datastore, leaving the query unbounded and surfacing a timeout as HTTP 500 instead of 408. This makes the analytics layer's context/timeout handling consistent across all endpoints.

- Add a `withAnalyticsTimeout` helper and apply `analyticsQueryTimeout` (30s) to every analytics endpoint that calls a context-taking datastore method. Map `context.DeadlineExceeded` to **HTTP 408** via a shared `handleAnalyticsQueryError` helper (which also removes the previously duplicated 408 block and the repeated "Query timeout" message string).
- Thread `context.Context` into the datastore `GetTopBirdsData` method (interface + both implementations) so the daily species summary endpoint is bounded and cancellable too.
- Remove the now-redundant internal 30s timeout from the legacy `GetSpeciesSummaryData`; the API layer owns the deadline, matching the v2only implementation. Add a per-row `ctx.Err()` check inside the scan loop so cancellation on a large result set surfaces immediately instead of after scanning every remaining row.
- Bound batch endpoints **per query** (not per whole batch) with a request-context disconnect guard, so a legitimately slow batch on low-power hardware still completes while a single slow query stays bounded.

### Notes

- The Sentry-noise aspect of the original report was already resolved separately by the `context.Canceled` / `context.DeadlineExceeded` suppression in `shouldReportToSentry` (#2772). This change addresses the remaining robustness gap and the HTTP-500-on-timeout behavior.
- Pre-existing items found during review were filed separately and left out of scope: a v2only zero-epoch timestamp edge case and the insights endpoints not yet mapping deadlines to 408.

## Test Plan

- [x] `go build ./...` clean
- [x] `golangci-lint run` clean (0 issues)
- [x] `go test -race` passes for `internal/api/v2`, `internal/datastore`, `internal/datastore/v2only`, `internal/analysis/processor`, `internal/imageprovider`
- [x] New table-driven `TestAnalyticsEndpointQueryTimeout` asserts 408 + "Query timeout" for the species summary, time-of-day distribution, new species, and daily species summary endpoints (the last exercising the newly context-bounded `GetTopBirdsData`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics endpoints now enforce per-query timeouts and map timeout/cancellation to clear HTTP responses (408 for query timeout; client-closed for cancellations).

* **Bug Fixes**
  * Batch analytics processing now bounds and cancels per-item work promptly, preventing stalled or partial results.
  * Datastore queries now honor request timeouts/cancellations so cancelled requests stop database work.

* **Tests**
  * Tests expanded to verify timeout, cancellation, and batch error handling across analytics endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->