### PR TITLE
feat(settings): localize species names in settings pickers (value/display split)

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
@@ -27,6 +27,12 @@
   import { safeGet } from '$lib/utils/security';
   import { Z_INDEX } from '$lib/utils/z-index';
   import { t } from '$lib/i18n';
+  import {
+    toLocalizedPredictions,
+    filterLocalizedPredictions,
+    matchTypedToCanonical,
+    type SpeciesPrediction,
+  } from '$lib/utils/speciesPredictions';
 
   interface Props {
     value?: string;
@@ -53,6 +59,13 @@
      * the synonym BirdNET name field, which is submitted via a separate button).
      */
     addOnSelect?: boolean;
+    /**
+     * Resolve a canonical prediction value to its visitor-locale label. When
+     * omitted, the label is the canonical value itself. The dropdown shows the
+     * label; selecting a prediction or adding free text always emits the canonical
+     * value, so server-wide config never stores a localized name.
+     */
+    localizeLabel?: (_value: string) => string;
     onInput?: (_value: string) => void;
     onAdd?: (_value: string) => void;
     onPredictionSelect?: (_prediction: string) => void;
@@ -77,6 +90,7 @@
     minCharsForPredictions = 2,
     className = '',
     addOnSelect = true,
+    localizeLabel,
     onInput,
     onAdd,
     onPredictionSelect,
@@ -127,15 +141,18 @@
     lg: 'btn-lg',
   };
 
-  // Filter predictions based on current value
-  let filteredPredictions = $derived(
-    value.length >= minCharsForPredictions && predictions.length > 0
-      ? predictions
-          .filter(
-            prediction =>
-              prediction.toLowerCase().includes(value.toLowerCase()) && prediction !== value
-          )
-          .slice(0, maxPredictions)
+  // Pair canonical predictions with localized labels. Reactive to the dictionary
+  // store via localizeLabel, so the dropdown re-renders on locale switch.
+  let localizedPredictions = $derived(toLocalizedPredictions(predictions, localizeLabel));
+
+  // Filter predictions based on current value (matches the localized label or the
+  // canonical value). Each entry keeps its canonical value for emission.
+  let filteredPredictions = $derived<SpeciesPrediction[]>(
+    value.length >= minCharsForPredictions && localizedPredictions.length > 0
+      ? filterLocalizedPredictions(localizedPredictions, value, {
+          max: maxPredictions,
+          excludeValue: value,
+        })
       : []
   );
 
@@ -208,14 +225,16 @@
     const predictionsCount = filteredPredictions.length;
     const existingCount = existingButtons.length;
 
-    // Update existing buttons
+    // Update existing buttons. The visible text is the localized label; the
+    // canonical value travels in data-prediction so selection never emits a
+    // localized name.
     for (let i = 0; i < Math.min(predictionsCount, existingCount); i++) {
       // eslint-disable-next-line security/detect-object-injection
       const button = existingButtons[i] as HTMLButtonElement;
       // eslint-disable-next-line security/detect-object-injection
-      button.textContent = filteredPredictions[i];
-      // eslint-disable-next-line security/detect-object-injection
-      button.setAttribute('data-prediction', filteredPredictions[i]);
+      const prediction = filteredPredictions[i];
+      button.textContent = prediction.label;
+      button.setAttribute('data-prediction', prediction.value);
       button.setAttribute('data-index', i.toString());
       button.style.display = 'block';
     }
@@ -223,17 +242,17 @@
     // Add new buttons if needed
     if (predictionsCount > existingCount) {
       for (let i = existingCount; i < predictionsCount; i++) {
+        // eslint-disable-next-line security/detect-object-injection
+        const prediction = filteredPredictions[i];
         const button = document.createElement('button');
         button.type = 'button';
         button.className =
           'species-prediction-item w-full text-left px-4 py-2 hover:bg-[var(--color-base-200)] focus:bg-[var(--color-base-200)] focus:outline-hidden border-none bg-transparent text-sm';
-        // eslint-disable-next-line security/detect-object-injection
-        button.textContent = filteredPredictions[i];
+        button.textContent = prediction.label;
         button.setAttribute('role', 'option');
         button.setAttribute('aria-selected', 'false');
         button.setAttribute('tabindex', '-1');
-        // eslint-disable-next-line security/detect-object-injection
-        button.setAttribute('data-prediction', filteredPredictions[i]);
+        button.setAttribute('data-prediction', prediction.value);
         button.setAttribute('data-index', i.toString());
         portalDropdown.appendChild(button);
       }
@@ -352,8 +371,11 @@
   function handleAdd() {
     if (!value.trim() || disabled) return;
 
-    const trimmedValue = value.trim();
-    onAdd?.(trimmedValue);
+    // Map the typed text to a prediction's canonical value when it matches a
+    // label or value (so a typed localized name persists canonically); otherwise
+    // keep the typed text as-is (today's behavior for advanced raw entries).
+    const canonical = matchTypedToCanonical(value, localizedPredictions) ?? value.trim();
+    onAdd?.(canonical);
 
     // Clear input after successful add
     value = '';

--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
@@ -839,4 +839,81 @@ describe('SpeciesInput', () => {
 
     expect(onAdd).toHaveBeenCalledWith('test species');
   });
+
+  describe('localized predictions (value/display split)', () => {
+    // Finnish labels for canonical English predictions.
+    const FI = new Map<string, string>([
+      ['American Robin', 'Punarinta'],
+      ['Blue Jay', 'Sinitöyhtönärhi'],
+    ]);
+    const localizeLabel = (value: string): string => FI.get(value) ?? value;
+
+    it('shows the localized label but emits the canonical value on select', async () => {
+      const onAdd = vi.fn();
+      const onPredictionSelect = vi.fn();
+
+      render(SpeciesInput, {
+        props: {
+          // Typing the localized name filters by label.
+          value: 'puna',
+          predictions: ['American Robin', 'Blue Jay'],
+          localizeLabel,
+          onAdd,
+          onPredictionSelect,
+        },
+      });
+
+      // The dropdown renders the localized label, not the canonical value.
+      const option = screen.getByText('Punarinta');
+      expect(option).toBeInTheDocument();
+      expect(screen.queryByText('American Robin')).not.toBeInTheDocument();
+
+      await fireEvent.click(option);
+
+      // The persisted value is canonical, never the localized label.
+      expect(onPredictionSelect).toHaveBeenCalledWith('American Robin');
+      await waitFor(() => {
+        expect(onAdd).toHaveBeenCalledWith('American Robin');
+      });
+      expect(onAdd).not.toHaveBeenCalledWith('Punarinta');
+    });
+
+    it('maps a typed localized name to the canonical value on Add', async () => {
+      const onAdd = vi.fn();
+
+      render(SpeciesInput, {
+        props: {
+          // User typed the full localized name without picking from the dropdown.
+          value: 'Punarinta',
+          predictions: ['American Robin', 'Blue Jay'],
+          localizeLabel,
+          onAdd,
+        },
+      });
+
+      const addButton = screen.getByRole('button', { name: 'Add species' });
+      await fireEvent.click(addButton);
+
+      expect(onAdd).toHaveBeenCalledWith('American Robin');
+      expect(onAdd).not.toHaveBeenCalledWith('Punarinta');
+    });
+
+    it('keeps unmatched free text as-is (advanced raw entry)', async () => {
+      const onAdd = vi.fn();
+
+      render(SpeciesInput, {
+        props: {
+          value: 'Some Unlisted Name',
+          predictions: ['American Robin', 'Blue Jay'],
+          localizeLabel,
+          onAdd,
+        },
+      });
+
+      const addButton = screen.getByRole('button', { name: 'Add species' });
+      await fireEvent.click(addButton);
+
+      expect(onAdd).toHaveBeenCalledWith('Some Unlisted Name');
+    });
+  });
 });

--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import SpeciesInput from './SpeciesInput.svelte';
 
 const defaultPredictions = ['American Robin', 'Blue Jay', 'Northern Cardinal', 'House Sparrow'];
 
 describe('SpeciesInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders with basic props', () => {
     render(SpeciesInput, {
       props: {

--- a/frontend/src/lib/desktop/components/forms/SpeciesListEditor.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesListEditor.svelte
@@ -38,6 +38,12 @@
     addButtonText: string;
     hasChanges: boolean;
     caseInsensitive?: boolean;
+    /**
+     * Resolve a stored (canonical) species value to its visitor-locale label for
+     * display. The stored value is never localized: add/edit persist canonical
+     * strings, and the inline edit field operates on the raw stored value.
+     */
+    localizeLabel?: (_value: string) => string;
     onSpeciesChange: (_updatedSpecies: string[]) => void;
   }
 
@@ -53,6 +59,7 @@
     addButtonText,
     hasChanges,
     caseInsensitive = true,
+    localizeLabel,
     onSpeciesChange,
   }: Props = $props();
 
@@ -171,7 +178,7 @@
               <X class="size-4" />
             </button>
           {:else}
-            <span class="flex-1 text-sm">{entry}</span>
+            <span class="flex-1 text-sm">{localizeLabel?.(entry) ?? entry}</span>
             <button
               type="button"
               class="inline-flex items-center justify-center h-8 px-3 text-sm font-medium rounded-lg bg-transparent hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-base-content)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -204,6 +211,7 @@
     helpText={addHelpText}
     disabled={disabled || predictionsLoading}
     {predictions}
+    {localizeLabel}
     size="sm"
     buttonText={addButtonText}
     buttonIcon={true}

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesConfigEditor.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesConfigEditor.svelte
@@ -15,6 +15,8 @@
   import EditorSlider from './editor/EditorSlider.svelte';
   import EditorFooter from './editor/EditorFooter.svelte';
   import EditorSpeciesInput from './editor/EditorSpeciesInput.svelte';
+  import { toLocalizedPredictions, matchTypedToCanonical } from '$lib/utils/speciesPredictions';
+  import { resolveCommonToScientificUnique } from '$lib/stores/speciesDictionary.svelte';
 
   interface SavePayload {
     species: string;
@@ -29,6 +31,8 @@
     predictions: string[];
     disabled?: boolean;
     saving?: boolean;
+    /** Resolve a canonical species value to its visitor-locale display label. */
+    localizeLabel?: (_value: string) => string;
     onSave: (_payload: SavePayload) => void;
     onClose: () => void;
     onDelete?: (_species: string) => void;
@@ -42,6 +46,7 @@
     predictions,
     disabled = false,
     saving = false,
+    localizeLabel,
     onSave,
     onClose,
     onDelete,
@@ -52,8 +57,20 @@
   // Form state initialized from props — parent uses {#key} to reset on species change
   // svelte-ignore state_referenced_locally
   const existingAction = config?.actions?.[0];
+  // The field DISPLAYS the localized label, while canonicalSpecies holds the value
+  // persisted as the config-map key. On open, seed the canonical value with the raw
+  // key so saving an unchanged entry re-emits that key (no spurious rename to a
+  // localized label), and seed the display with the localized label.
   // svelte-ignore state_referenced_locally
-  let speciesName = $state(species ?? '');
+  let canonicalSpecies = $state(species ?? '');
+  // svelte-ignore state_referenced_locally
+  let speciesName = $state(species ? (localizeLabel?.(species) ?? species) : '');
+  // Tracks whether the user has typed into the species field. Until they do, the
+  // tracked canonical value is authoritative and is saved verbatim. This makes the
+  // save robust against a UI locale switch while the editor is open: the displayed
+  // label may go stale, but an unchanged save still re-emits the canonical key
+  // instead of persisting the stale label (which would corrupt/rename the config).
+  let speciesEdited = $state(false);
   // svelte-ignore state_referenced_locally
   let threshold = $state(config?.threshold ?? 0.5);
   // svelte-ignore state_referenced_locally
@@ -65,14 +82,45 @@
   );
   let actionExecuteDefaults = $state(existingAction?.executeDefaults !== false);
 
+  // Predictions paired with localized labels for save-time resolution.
+  let localizedPredictions = $derived(toLocalizedPredictions(predictions ?? [], localizeLabel));
+
   // Validation
   let isValid = $derived(speciesName.trim() !== '' && threshold >= 0 && threshold <= 1);
 
   let title = $derived(
     species
-      ? t('settings.species.customConfiguration.editing', { species })
+      ? t('settings.species.customConfiguration.editing', {
+          species: localizeLabel?.(species) ?? species,
+        })
       : t('settings.species.customConfiguration.newConfiguration')
   );
+
+  /**
+   * Resolve the canonical config-map key to persist from the current field text.
+   * Never persists a localized label: it preserves the tracked canonical when the
+   * field is unchanged/just-selected, otherwise maps a typed label/value to its
+   * prediction's canonical value, then to a unique scientific name, and only falls
+   * back to the typed text when nothing resolves (advanced raw entry).
+   */
+  function resolveCanonicalForSave(): string {
+    // 1. Unchanged or just-selected: the tracked canonical value is authoritative.
+    //    Returning it verbatim (instead of re-deriving from the displayed text)
+    //    means an unchanged save never renames the config key, even if the UI locale
+    //    changed while the editor was open and the field shows a stale-locale label.
+    if (!speciesEdited && canonicalSpecies) return canonicalSpecies;
+    const display = speciesName.trim();
+    // 2. Field text matches a prediction's label or canonical value.
+    const matched = matchTypedToCanonical(display, localizedPredictions);
+    if (matched) return matched;
+    // 3. Field text is a localized common name that resolves to a single scientific
+    //    name (a safe canonical key: the backend matches config keys by scientific
+    //    name via EqualFold fallback).
+    const scientific = resolveCommonToScientificUnique(display);
+    if (scientific) return scientific;
+    // 4. Advanced raw entry: keep what the user typed.
+    return display;
+  }
 
   function handleSave() {
     if (!isValid) return;
@@ -91,7 +139,7 @@
     }
 
     onSave({
-      species: speciesName.trim(),
+      species: resolveCanonicalForSave(),
       threshold,
       interval: Number(interval) || 0,
       actions,
@@ -110,13 +158,18 @@
     actionParameters = '';
   }
 
-  function handleSpeciesPicked(picked: string) {
-    speciesName = picked;
-    onPredictionSelect(picked);
+  // EditorSpeciesInput reports the canonical value here and sets the field text to
+  // the localized label via bind:value, so we only record the canonical value. A
+  // clean pick resets the edited flag: the picked canonical is saved verbatim.
+  function handleSpeciesPicked(canonicalValue: string) {
+    canonicalSpecies = canonicalValue;
+    speciesEdited = false;
+    onPredictionSelect(canonicalValue);
   }
 
   function handleSpeciesInput(value: string) {
     speciesName = value;
+    speciesEdited = true;
     onInput(value);
   }
 </script>
@@ -128,6 +181,7 @@
     label={t('settings.species.customConfiguration.columnHeaders.species')}
     placeholder={t('settings.species.customConfiguration.searchPlaceholder')}
     {predictions}
+    {localizeLabel}
     disabled={disabled || saving}
     onInput={handleSpeciesInput}
     onPredictionSelect={handleSpeciesPicked}

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesConfigEditor.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesConfigEditor.svelte
@@ -85,6 +85,17 @@
   // Predictions paired with localized labels for save-time resolution.
   let localizedPredictions = $derived(toLocalizedPredictions(predictions ?? [], localizeLabel));
 
+  // Keep the displayed label in sync with the active locale (and the current
+  // selection) until the user edits the field. This refreshes the field if the UI
+  // locale changes while the editor is open. It tracks canonicalSpecies (not the
+  // species prop) so that after picking a different prediction the field keeps the
+  // picked label instead of reverting to the originally-opened species.
+  $effect(() => {
+    if (!speciesEdited && canonicalSpecies) {
+      speciesName = localizeLabel?.(canonicalSpecies) ?? canonicalSpecies;
+    }
+  });
+
   // Validation
   let isValid = $derived(speciesName.trim() !== '' && threshold >= 0 && threshold <= 1);
 

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesConfigEditor.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesConfigEditor.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for SpeciesConfigEditor's field-level value/display split.
+ *
+ * The species field shows a localized label but the config-map KEY persisted on
+ * save must stay canonical. The highest-risk path is the rename trap: opening an
+ * existing entry and saving it must re-emit the original canonical key, never the
+ * displayed label, even after a UI locale switch while the editor is open.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SpeciesConfigEditor from './SpeciesConfigEditor.svelte';
+import { resolveCommonToScientificUnique } from '$lib/stores/speciesDictionary.svelte';
+
+// The dictionary store is the only dict dependency; stub the unique resolver so the
+// free-typed-name path is deterministic.
+vi.mock('$lib/stores/speciesDictionary.svelte', () => ({
+  resolveCommonToScientificUnique: vi.fn(() => undefined),
+}));
+
+// Finnish labels for canonical (config-key / prediction) values.
+const FI = new Map<string, string>([
+  ['barn owl', 'Tornipöllö'],
+  ['Barn Owl', 'Tornipöllö'],
+  ['Tawny Owl', 'Lehtopöllö'],
+]);
+const fiLocalize = (value: string): string => FI.get(value) ?? value;
+
+const SAVE_BUTTON = 'settings.species.customConfiguration.save';
+
+interface RenderOpts {
+  predictions?: string[];
+  localizeLabel?: (_value: string) => string;
+}
+
+function renderEditor(opts: RenderOpts = {}) {
+  const onSave = vi.fn();
+  const result = render(SpeciesConfigEditor, {
+    props: {
+      species: 'barn owl', // existing canonical config key (lowercased)
+      config: { threshold: 0.5, interval: 0, actions: [] },
+      predictions: opts.predictions ?? ['Barn Owl', 'Tawny Owl'],
+      localizeLabel: opts.localizeLabel ?? fiLocalize,
+      onSave,
+      onClose: vi.fn(),
+      onInput: vi.fn(),
+      onPredictionSelect: vi.fn(),
+    },
+  });
+  return { onSave, ...result };
+}
+
+function savedSpecies(onSave: ReturnType<typeof vi.fn>): string {
+  return onSave.mock.calls[0][0].species;
+}
+
+describe('SpeciesConfigEditor canonical-key persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the localized label in the field for an existing entry', () => {
+    renderEditor();
+    expect(screen.getByRole('combobox')).toHaveValue('Tornipöllö');
+  });
+
+  it('re-emits the canonical key on an unchanged save (no rename to the label)', async () => {
+    const { onSave } = renderEditor();
+
+    await fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(savedSpecies(onSave)).toBe('barn owl');
+    expect(savedSpecies(onSave)).not.toBe('Tornipöllö');
+  });
+
+  it('re-emits the canonical key after a UI locale switch while open (rename-trap guard)', async () => {
+    const { onSave, rerender } = renderEditor();
+
+    // Simulate switching the UI locale: localizeLabel now returns German labels,
+    // but the user has not touched the field.
+    const DE = new Map<string, string>([['barn owl', 'Schleiereule']]);
+    await rerender({
+      species: 'barn owl',
+      config: { threshold: 0.5, interval: 0, actions: [] },
+      predictions: ['Barn Owl', 'Tawny Owl'],
+      localizeLabel: (value: string) => DE.get(value) ?? value,
+      onSave,
+      onClose: vi.fn(),
+      onInput: vi.fn(),
+      onPredictionSelect: vi.fn(),
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON }));
+
+    // Must still be the canonical key, not the stale Finnish label nor the German one.
+    expect(savedSpecies(onSave)).toBe('barn owl');
+  });
+
+  it('emits the picked prediction canonical value, not its localized label', async () => {
+    const { onSave } = renderEditor();
+
+    // The portal dropdown renders the localized labels; pick "Tornipöllö" (Barn Owl).
+    // The portal delegates selection on click.
+    const option = await screen.findByText('Tornipöllö');
+    await fireEvent.click(option);
+
+    await fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON }));
+
+    expect(savedSpecies(onSave)).toBe('Barn Owl');
+  });
+
+  it('resolves a free-typed localized common name to a unique scientific name', async () => {
+    vi.mocked(resolveCommonToScientificUnique).mockReturnValue('Strix aluco');
+    // No predictions, so the typed text cannot match a prediction and falls through
+    // to the unique scientific-name resolution.
+    const { onSave } = renderEditor({ predictions: [] });
+
+    const input = screen.getByRole('combobox');
+    await fireEvent.input(input, { target: { value: 'Lehtopöllö' } });
+
+    await fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON }));
+
+    expect(resolveCommonToScientificUnique).toHaveBeenCalledWith('Lehtopöllö');
+    expect(savedSpecies(onSave)).toBe('Strix aluco');
+  });
+
+  it('keeps an unmatched free-typed name as-is (advanced raw entry)', async () => {
+    vi.mocked(resolveCommonToScientificUnique).mockReturnValue(undefined);
+    const { onSave } = renderEditor({ predictions: [] });
+
+    const input = screen.getByRole('combobox');
+    await fireEvent.input(input, { target: { value: 'Some Custom Name' } });
+
+    await fireEvent.click(screen.getByRole('button', { name: SAVE_BUTTON }));
+
+    expect(savedSpecies(onSave)).toBe('Some Custom Name');
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesConfigList.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesConfigList.svelte
@@ -11,9 +11,16 @@
   import { Pencil, Trash2, Clock, Settings2 } from '@lucide/svelte';
   import { t } from '$lib/i18n';
   import type { SpeciesConfig } from '$lib/stores/settings';
+  import { normalizeForLookup } from '$lib/utils/speciesNames';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
   interface Props {
     configs: Record<string, SpeciesConfig>;
+    /**
+     * Normalized common name -> scientific name map (the parent's
+     * speciesNameMaps.commonToScientific). Used to resolve the scientific name
+     * for the localized display label and the scientific-name subtitle.
+     */
     scientificNameMap: Map<string, string>;
     editingSpecies: string | null;
     disabled?: boolean;
@@ -49,7 +56,8 @@
   <div class="rounded-xl bg-[var(--color-base-100)] shadow-xs overflow-hidden">
     {#each entries as [species, config] (species)}
       {@const isEditing = editingSpecies === species}
-      {@const scientificName = scientificNameMap.get(species.toLowerCase()) ?? ''}
+      {@const scientificName = scientificNameMap.get(normalizeForLookup(species)) ?? ''}
+      {@const displayName = localizeSpeciesName(scientificName || undefined, species)}
       <div
         class="px-4 py-3 flex items-start gap-3 border-b border-[var(--color-base-200)] last:border-b-0 transition-colors {isEditing
           ? 'bg-[var(--color-primary)]/5 ring-1 ring-inset ring-[var(--color-primary)]/30'
@@ -59,7 +67,7 @@
         <div class="flex-1 min-w-0">
           <!-- Primary line: species name + action badge -->
           <div class="flex items-center gap-2 flex-wrap">
-            <span class="text-sm font-medium text-[var(--color-base-content)]">{species}</span>
+            <span class="text-sm font-medium text-[var(--color-base-content)]">{displayName}</span>
             {#if config.actions?.length > 0}
               <span
                 class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-teal-500/10 text-teal-600 dark:text-teal-400"

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.svelte
@@ -33,6 +33,7 @@
   import ResizableContainer from '$lib/desktop/components/ui/ResizableContainer.svelte';
   import { resolveSpeciesDisplayNames, type SpeciesNameMaps } from '$lib/utils/speciesNames';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { resolveCommonToScientificUnique } from '$lib/stores/speciesDictionary.svelte';
   import {
     toLocalizedPredictions,
     filterLocalizedPredictions,
@@ -215,8 +216,16 @@
 
   function handleAdd() {
     // Free-typed input: map a typed label/value to its canonical value when it
-    // matches a prediction; otherwise keep the typed text as-is (today's behavior).
-    const canonical = matchTypedToCanonical(inputValue, localizedPredictions) ?? inputValue;
+    // matches a prediction. If the parent's debounced predictions are still stale
+    // (e.g. the user typed a localized name and hit Add within the debounce window),
+    // fall back to the always-current visitor dictionary to resolve an unambiguous
+    // localized common name to its scientific name. Both include and exclude match
+    // scientific names server-side, so this stays canonical. Only when nothing
+    // resolves do we keep the typed text as-is (today's advanced-entry behavior).
+    const canonical =
+      matchTypedToCanonical(inputValue, localizedPredictions) ??
+      resolveCommonToScientificUnique(inputValue.trim()) ??
+      inputValue;
     addValue(canonical);
   }
 

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.svelte
@@ -32,6 +32,13 @@
   import { t } from '$lib/i18n';
   import ResizableContainer from '$lib/desktop/components/ui/ResizableContainer.svelte';
   import { resolveSpeciesDisplayNames, type SpeciesNameMaps } from '$lib/utils/speciesNames';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import {
+    toLocalizedPredictions,
+    filterLocalizedPredictions,
+    matchTypedToCanonical,
+    type SpeciesPrediction,
+  } from '$lib/utils/speciesPredictions';
 
   interface Props {
     title: string;
@@ -46,6 +53,12 @@
     inputPlaceholder: string;
     emptyMessage: string;
     disabled?: boolean;
+    /**
+     * Resolve a canonical prediction/list value to its visitor-locale label.
+     * When omitted, labels fall back to the canonical value. The value emitted by
+     * onAdd is always canonical regardless of the label shown.
+     */
+    localizeLabel?: (_value: string) => string;
     onAdd: (_species: string) => void;
     onRemove: (_species: string) => void;
     onInput: (_input: string) => void;
@@ -64,6 +77,7 @@
     inputPlaceholder,
     emptyMessage,
     disabled = false,
+    localizeLabel,
     onAdd,
     onRemove,
     onInput,
@@ -108,11 +122,29 @@
     allNames: [],
   });
 
+  // Resolve a stored value to its display pair, with the common name localized to
+  // the visitor's UI locale (layered on top of the server-locale resolution).
+  // Reads the dictionary store via localizeSpeciesName, so callers must invoke it
+  // inside a reactive context to re-run on locale change.
+  function localizedDisplay(storedValue: string): {
+    displayCommonName: string;
+    displayScientificName: string;
+  } {
+    const resolved = resolveSpeciesDisplayNames(storedValue, nameMaps);
+    return {
+      displayCommonName: localizeSpeciesName(
+        resolved.displayScientificName || undefined,
+        resolved.displayCommonName
+      ),
+      displayScientificName: resolved.displayScientificName,
+    };
+  }
+
   let filteredSpecies = $derived.by(() => {
     const query = searchQuery.trim().toLowerCase();
     let result = query
       ? species.filter(s => {
-          const resolved = resolveSpeciesDisplayNames(s, nameMaps);
+          const resolved = localizedDisplay(s);
           return (
             resolved.displayCommonName.toLowerCase().includes(query) ||
             resolved.displayScientificName.toLowerCase().includes(query)
@@ -122,7 +154,7 @@
     if (sortColumn) {
       const withResolved = result.map(s => ({
         raw: s,
-        resolved: resolveSpeciesDisplayNames(s, nameMaps),
+        resolved: localizedDisplay(s),
       }));
       withResolved.sort((a, b) => {
         const cmp =
@@ -149,11 +181,18 @@
   let showPredictions = $state(false);
   let selectedPredictionIndex = $state(-1);
 
-  let filteredPredictions = $derived.by(() => {
-    if (inputValue.length < 2 || predictions.length === 0) return [];
-    return predictions
-      .filter(p => p.toLowerCase().includes(inputValue.toLowerCase()) && p !== inputValue)
-      .slice(0, 8);
+  // Pair canonical predictions with localized labels. Reactive to the dictionary
+  // store, so labels refresh on locale switch.
+  let localizedPredictions = $derived(toLocalizedPredictions(predictions, localizeLabel));
+
+  let filteredPredictions = $derived.by((): SpeciesPrediction[] => {
+    if (inputValue.length < 2 || localizedPredictions.length === 0) return [];
+    // Match against the localized label or the canonical value; exclude the exact
+    // current input so it does not echo itself.
+    return filterLocalizedPredictions(localizedPredictions, inputValue, {
+      max: 8,
+      excludeValue: inputValue,
+    });
   });
 
   function handleInputChange(e: Event) {
@@ -164,20 +203,28 @@
     onInput(target.value);
   }
 
-  function handleAdd() {
-    if (!inputValue.trim() || disabled) return;
-    onAdd(inputValue.trim());
+  // Emit a canonical value (never the localized label) and reset the input.
+  function addValue(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onAdd(trimmed);
     inputValue = '';
     showPredictions = false;
     selectedPredictionIndex = -1;
   }
 
-  function selectPrediction(prediction: string) {
-    inputValue = prediction;
+  function handleAdd() {
+    // Free-typed input: map a typed label/value to its canonical value when it
+    // matches a prediction; otherwise keep the typed text as-is (today's behavior).
+    const canonical = matchTypedToCanonical(inputValue, localizedPredictions) ?? inputValue;
+    addValue(canonical);
+  }
+
+  function selectPrediction(prediction: SpeciesPrediction) {
     showPredictions = false;
     selectedPredictionIndex = -1;
-    // Auto-add after selecting
-    setTimeout(() => handleAdd(), 0);
+    // Emit the canonical value directly; the displayed label is never persisted.
+    addValue(prediction.value);
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -321,7 +368,7 @@
         </thead>
         <tbody>
           {#each filteredSpecies as item, index (`${item}_${index}`)}
-            {@const resolved = resolveSpeciesDisplayNames(item, nameMaps)}
+            {@const resolved = localizedDisplay(item)}
             <tr
               class="border-b last:border-b-0 border-[var(--border-100)]/50 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
             >
@@ -414,7 +461,7 @@
           role="listbox"
           aria-label={t('settings.species.suggestions') || 'Species suggestions'}
         >
-          {#each filteredPredictions as prediction, idx (`${prediction}_${idx}`)}
+          {#each filteredPredictions as prediction, idx (`${prediction.value}_${idx}`)}
             <button
               type="button"
               role="option"
@@ -425,7 +472,7 @@
                 : ''}"
               onmousedown={() => selectPrediction(prediction)}
             >
-              {prediction}
+              {prediction.label}
             </button>
           {/each}
         </div>

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.test.ts
@@ -10,6 +10,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { CirclePlus } from '@lucide/svelte';
 import SpeciesListCard from './SpeciesListCard.svelte';
+import { resolveCommonToScientificUnique } from '$lib/stores/speciesDictionary.svelte';
+
+// Stub the visitor dictionary store. localizeScientific feeds localizeSpeciesName
+// (list-row display); resolveCommonToScientificUnique is the stale-predictions
+// fallback exercised by the race test below.
+vi.mock('$lib/stores/speciesDictionary.svelte', () => ({
+  localizeScientific: vi.fn(() => undefined),
+  resolveCommonToScientificUnique: vi.fn(() => undefined),
+}));
 
 // Finnish labels for canonical English/scientific values.
 const FI = new Map<string, string>([
@@ -80,5 +89,20 @@ describe('SpeciesListCard value/display split', () => {
     await fireEvent.click(addButton);
 
     expect(onAdd).toHaveBeenCalledWith('Unlisted Bird');
+  });
+
+  it('resolves a typed localized name via the dictionary when predictions are stale', async () => {
+    // Simulate the debounce race: the parent has not yet populated predictions, so
+    // the typed localized name cannot match a prediction. The always-current
+    // dictionary resolves it to a canonical scientific name (safe for include/exclude).
+    vi.mocked(resolveCommonToScientificUnique).mockReturnValueOnce('Turdus migratorius');
+    const { onAdd } = renderCard({ predictions: [], inputValue: 'Punarinta' });
+
+    const addButton = screen.getByRole('button', { name: 'Add species' });
+    await fireEvent.click(addButton);
+
+    expect(resolveCommonToScientificUnique).toHaveBeenCalledWith('Punarinta');
+    expect(onAdd).toHaveBeenCalledWith('Turdus migratorius');
+    expect(onAdd).not.toHaveBeenCalledWith('Punarinta');
   });
 });

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.test.ts
@@ -6,7 +6,7 @@
  * localized label. These tests guard that invariant.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { CirclePlus } from '@lucide/svelte';
 import SpeciesListCard from './SpeciesListCard.svelte';
@@ -41,6 +41,10 @@ function renderCard(overrides: Record<string, unknown> = {}) {
 }
 
 describe('SpeciesListCard value/display split', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders the localized label in the dropdown but emits the canonical value', async () => {
     const { onAdd } = renderCard();
 

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression tests for SpeciesListCard's value/display split.
+ *
+ * The include/exclude lists this card feeds are persisted server-wide config, so
+ * selecting a localized prediction MUST emit the canonical value, never the
+ * localized label. These tests guard that invariant.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { CirclePlus } from '@lucide/svelte';
+import SpeciesListCard from './SpeciesListCard.svelte';
+
+// Finnish labels for canonical English/scientific values.
+const FI = new Map<string, string>([
+  ['American Robin', 'Punarinta'],
+  ['Blue Jay', 'Sinitöyhtönärhi'],
+]);
+const localizeLabel = (value: string): string => FI.get(value) ?? value;
+
+function renderCard(overrides: Record<string, unknown> = {}) {
+  const onAdd = vi.fn();
+  render(SpeciesListCard, {
+    props: {
+      title: 'Always Include',
+      species: [],
+      icon: CirclePlus,
+      predictions: ['American Robin', 'Blue Jay'],
+      inputValue: 'puna',
+      inputLabel: 'Add species',
+      inputPlaceholder: 'Type a species name',
+      emptyMessage: 'No species',
+      localizeLabel,
+      onAdd,
+      onRemove: vi.fn(),
+      onInput: vi.fn(),
+      ...overrides,
+    },
+  });
+  return { onAdd };
+}
+
+describe('SpeciesListCard value/display split', () => {
+  it('renders the localized label in the dropdown but emits the canonical value', async () => {
+    const { onAdd } = renderCard();
+
+    const input = screen.getByRole('combobox');
+    await fireEvent.focus(input);
+
+    // The dropdown shows the localized label, not the canonical value.
+    const option = await screen.findByText('Punarinta');
+    expect(screen.queryByText('American Robin')).not.toBeInTheDocument();
+
+    await fireEvent.mouseDown(option);
+
+    // The persisted value is canonical.
+    expect(onAdd).toHaveBeenCalledWith('American Robin');
+    expect(onAdd).not.toHaveBeenCalledWith('Punarinta');
+  });
+
+  it('maps a typed localized name to the canonical value on Add', async () => {
+    const { onAdd } = renderCard({ inputValue: 'Punarinta' });
+
+    const addButton = screen.getByRole('button', { name: 'Add species' });
+    await fireEvent.click(addButton);
+
+    // handleAdd emits synchronously (no deferred add), so assert directly.
+    expect(onAdd).toHaveBeenCalledWith('American Robin');
+    expect(onAdd).not.toHaveBeenCalledWith('Punarinta');
+  });
+
+  it('keeps unmatched free text as-is', async () => {
+    const { onAdd } = renderCard({ inputValue: 'Unlisted Bird' });
+
+    const addButton = screen.getByRole('button', { name: 'Add species' });
+    await fireEvent.click(addButton);
+
+    expect(onAdd).toHaveBeenCalledWith('Unlisted Bird');
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesTable.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesTable.svelte
@@ -19,6 +19,7 @@
   import { t } from '$lib/i18n';
   import { ChevronUp, ChevronDown, ChevronsUpDown, Search, Download, Bird } from '@lucide/svelte';
   import ResizableContainer from '$lib/desktop/components/ui/ResizableContainer.svelte';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
   interface ActiveSpeciesItem {
     commonName: string;
@@ -27,6 +28,9 @@
     isManuallyIncluded: boolean;
     hasCustomConfig: boolean;
   }
+
+  /** A species row paired with the visitor-locale display name. */
+  type LocalizedSpeciesItem = ActiveSpeciesItem & { displayName: string };
 
   interface Props {
     species: ActiveSpeciesItem[];
@@ -52,12 +56,25 @@
   let sortDirection = $state<'asc' | 'desc'>('desc');
   let searchQuery = $state('');
 
+  // Pair each row with its visitor-locale display name. localizeSpeciesName reads
+  // the dictionary store, so this re-runs on dictionary load and locale switch.
+  let localizedSpecies = $derived.by((): LocalizedSpeciesItem[] =>
+    species.map(s => ({
+      ...s,
+      displayName: localizeSpeciesName(s.scientificName, s.commonName),
+    }))
+  );
+
   let filteredSpecies = $derived.by(() => {
     const query = searchQuery.trim().toLowerCase();
-    if (!query) return species;
-    return species.filter(
+    if (!query) return localizedSpecies;
+    // Match the localized name the visitor sees, plus the server common name and
+    // scientific name so search keeps working regardless of locale.
+    return localizedSpecies.filter(
       s =>
-        s.commonName.toLowerCase().includes(query) || s.scientificName.toLowerCase().includes(query)
+        s.displayName.toLowerCase().includes(query) ||
+        s.commonName.toLowerCase().includes(query) ||
+        s.scientificName.toLowerCase().includes(query)
     );
   });
 
@@ -66,7 +83,8 @@
       let cmp = 0;
       switch (sortColumn) {
         case 'commonName':
-          cmp = a.commonName.localeCompare(b.commonName);
+          // Sort by the localized name shown in the column.
+          cmp = a.displayName.localeCompare(b.displayName);
           break;
         case 'scientificName':
           cmp = a.scientificName.localeCompare(b.scientificName);
@@ -213,7 +231,7 @@
               class="border-b last:border-b-0 border-[var(--border-100)]/50 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
             >
               <td class="py-2 px-3">
-                <span class="font-medium text-sm">{item.commonName}</span>
+                <span class="font-medium text-sm">{item.displayName}</span>
               </td>
               <td class="py-2 px-3">
                 <span class="text-xs text-muted italic">{item.scientificName}</span>

--- a/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
@@ -15,6 +15,7 @@
 <script lang="ts">
   import { Z_INDEX } from '$lib/utils/z-index';
   import { t } from '$lib/i18n';
+  import { toLocalizedPredictions, type SpeciesPrediction } from '$lib/utils/speciesPredictions';
 
   interface Props {
     value?: string;
@@ -23,6 +24,12 @@
     placeholder?: string;
     disabled?: boolean;
     id?: string;
+    /**
+     * Resolve a canonical prediction value to its visitor-locale label. The input
+     * displays the label after selection, while onPredictionSelect reports the
+     * canonical value so the parent persists a canonical config key, not a label.
+     */
+    localizeLabel?: (_value: string) => string;
     onInput?: (_value: string) => void;
     onPredictionSelect?: (_prediction: string) => void;
   }
@@ -34,6 +41,7 @@
     placeholder = '',
     disabled = false,
     id,
+    localizeLabel,
     onInput,
     onPredictionSelect,
   }: Props = $props();
@@ -66,8 +74,11 @@
       }`
   );
 
-  // All predictions are pre-filtered by the parent; show them as-is
-  let filteredPredictions = $derived(predictions ?? []);
+  // All predictions are pre-filtered by the parent; pair each with its localized
+  // label. Reactive to the dictionary store via localizeLabel.
+  let filteredPredictions = $derived<SpeciesPrediction[]>(
+    toLocalizedPredictions(predictions ?? [], localizeLabel)
+  );
 
   // Manage portal lifecycle based on prediction visibility
   $effect(() => {
@@ -98,9 +109,10 @@
   function handlePortalClick(event: MouseEvent) {
     const button = (event.target as HTMLElement).closest('.species-prediction-item');
     if (button) {
-      const prediction = button.getAttribute('data-prediction');
-      if (prediction) {
-        selectPrediction(prediction);
+      // data-prediction carries the canonical value; the visible text is the label.
+      const canonicalValue = button.getAttribute('data-prediction');
+      if (canonicalValue) {
+        selectPrediction(canonicalValue, button.textContent ?? canonicalValue);
       }
     }
   }
@@ -108,10 +120,10 @@
   function handlePortalKeydown(event: KeyboardEvent) {
     const button = (event.target as HTMLElement).closest('.species-prediction-item');
     if (button) {
-      const prediction = button.getAttribute('data-prediction');
+      const canonicalValue = button.getAttribute('data-prediction');
       const index = parseInt(button.getAttribute('data-index') ?? '0', 10);
-      if (prediction !== null) {
-        handlePredictionKeydown(event, prediction, index);
+      if (canonicalValue !== null) {
+        handlePredictionKeydown(event, canonicalValue, button.textContent ?? canonicalValue, index);
       }
     }
   }
@@ -144,14 +156,15 @@
     const predictionsCount = filteredPredictions.length;
     const existingCount = existingButtons.length;
 
-    // Update existing buttons in place to avoid DOM churn
+    // Update existing buttons in place to avoid DOM churn. Visible text is the
+    // localized label; data-prediction holds the canonical value.
     for (let i = 0; i < Math.min(predictionsCount, existingCount); i++) {
       // eslint-disable-next-line security/detect-object-injection
       const button = existingButtons[i] as HTMLButtonElement;
       // eslint-disable-next-line security/detect-object-injection
-      button.textContent = filteredPredictions[i];
-      // eslint-disable-next-line security/detect-object-injection
-      button.setAttribute('data-prediction', filteredPredictions[i]);
+      const prediction = filteredPredictions[i];
+      button.textContent = prediction.label;
+      button.setAttribute('data-prediction', prediction.value);
       button.setAttribute('data-index', i.toString());
       button.style.display = 'block';
     }
@@ -159,17 +172,17 @@
     // Append new buttons when list grows
     if (predictionsCount > existingCount) {
       for (let i = existingCount; i < predictionsCount; i++) {
+        // eslint-disable-next-line security/detect-object-injection
+        const prediction = filteredPredictions[i];
         const button = document.createElement('button');
         button.type = 'button';
         button.className =
           'species-prediction-item w-full text-left px-4 py-2 hover:bg-[var(--color-base-200)] focus:bg-[var(--color-base-200)] focus:outline-hidden border-none bg-transparent text-sm';
-        // eslint-disable-next-line security/detect-object-injection
-        button.textContent = filteredPredictions[i];
+        button.textContent = prediction.label;
         button.setAttribute('role', 'option');
         button.setAttribute('aria-selected', 'false');
         button.setAttribute('tabindex', '-1');
-        // eslint-disable-next-line security/detect-object-injection
-        button.setAttribute('data-prediction', filteredPredictions[i]);
+        button.setAttribute('data-prediction', prediction.value);
         button.setAttribute('data-index', i.toString());
         portalDropdown.appendChild(button);
       }
@@ -257,18 +270,25 @@
     }
   }
 
-  function selectPrediction(prediction: string) {
-    value = prediction;
-    onPredictionSelect?.(prediction);
+  function selectPrediction(canonicalValue: string, predictionLabel: string) {
+    // Show the localized label in the field, but report the canonical value so the
+    // parent persists a canonical config key rather than the displayed label.
+    value = predictionLabel;
+    onPredictionSelect?.(canonicalValue);
     showPredictions = false;
     destroyPortalDropdown();
     inputElement?.focus();
   }
 
-  function handlePredictionKeydown(event: KeyboardEvent, prediction: string, index: number) {
+  function handlePredictionKeydown(
+    event: KeyboardEvent,
+    canonicalValue: string,
+    predictionLabel: string,
+    index: number
+  ) {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      selectPrediction(prediction);
+      selectPrediction(canonicalValue, predictionLabel);
     } else if (event.key === 'ArrowDown') {
       event.preventDefault();
       if (portalDropdown) {

--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
@@ -69,6 +69,8 @@
     Info,
   } from '@lucide/svelte';
   import { api } from '$lib/utils/api';
+  import { normalizeForLookup } from '$lib/utils/speciesNames';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
   const logger = loggers.audio;
 
@@ -337,6 +339,16 @@
     data: [],
   });
 
+  // Normalized species value -> scientific name (species entries only; taxonomy
+  // group rows have no scientific name and display verbatim).
+  let speciesScientificMap = $state(new Map<string, string>());
+
+  // Resolve a stored extended-capture value to its visitor-locale label. Taxonomy
+  // group rows (genus/family/order) fall through to their verbatim value.
+  function localizeSpeciesLabel(value: string): string {
+    return localizeSpeciesName(speciesScientificMap.get(normalizeForLookup(value)), value);
+  }
+
   $effect(() => {
     loadSpeciesList();
   });
@@ -348,8 +360,16 @@
     try {
       const data = await api.get<SpeciesListResponse>('/api/v2/range/species/list');
       if (data?.species && Array.isArray(data.species)) {
-        // Species common names
-        const speciesNames = data.species.map(sp => sp.commonName ?? sp.label.replace('_', ' - '));
+        // Species common names, building a value -> scientific name map for display.
+        const sciMap = new Map<string, string>();
+        const speciesNames = data.species.map(sp => {
+          const value = sp.commonName ?? sp.label.replace('_', ' - ');
+          if (sp.scientificName) {
+            sciMap.set(normalizeForLookup(value), sp.scientificName);
+          }
+          return value;
+        });
+        speciesScientificMap = sciMap;
 
         // Taxonomy group entries from server (with display suffixes)
         const generaEntries = (data.genera ?? []).map(g => `${g}${GENUS_SUFFIX}`);
@@ -366,6 +386,7 @@
         ];
       } else {
         speciesListState.data = [];
+        speciesScientificMap = new Map();
       }
     } catch (error) {
       logger.warn('Failed to load species list for extended capture', error, {
@@ -374,6 +395,7 @@
       });
       speciesListState.error = t('settings.filters.errors.speciesLoadFailed');
       speciesListState.data = [];
+      speciesScientificMap = new Map();
     } finally {
       speciesListState.loading = false;
     }
@@ -1197,6 +1219,7 @@
               species={extendedCaptureSettingsLocal.species}
               disabled={!extendedCaptureSettingsLocal.enabled || store.isLoading || store.isSaving}
               predictions={speciesListState.data}
+              localizeLabel={localizeSpeciesLabel}
               predictionsLoading={speciesListState.loading}
               listLabel={t('settings.audio.extendedCapture.speciesListLabel')}
               addLabel={t('settings.audio.extendedCapture.addSpeciesLabel')}

--- a/frontend/src/lib/desktop/features/settings/pages/FilterSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/FilterSettingsPage.svelte
@@ -42,10 +42,12 @@
 
   // API response interfaces
   interface SpeciesListResponse {
-    species?: Array<{ label: string }>;
+    species?: Array<{ label: string; commonName?: string; scientificName?: string }>;
   }
   import { Filter } from '@lucide/svelte';
   import { loggers } from '$lib/utils/logger';
+  import { normalizeForLookup } from '$lib/utils/speciesNames';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
   const logger = loggers.settings;
 
@@ -145,6 +147,16 @@
     data: [],
   });
 
+  // Normalized stored value -> scientific name, used to localize the displayed
+  // labels while the stored filter values stay canonical (server-locale names).
+  let speciesScientificMap = $state(new Map<string, string>());
+
+  // Resolve a stored filter value to its visitor-locale label. Reactive to the
+  // dictionary store; the stored value itself is never localized.
+  function localizeSpeciesLabel(value: string): string {
+    return localizeSpeciesName(speciesScientificMap.get(normalizeForLookup(value)), value);
+  }
+
   // PERFORMANCE OPTIMIZATION: Load species list with proper state management
   $effect(() => {
     loadSpeciesList();
@@ -157,11 +169,18 @@
     try {
       const data = await api.get<SpeciesListResponse>('/api/v2/range/species/list');
       if (data?.species && Array.isArray(data.species)) {
-        speciesListState.data = data.species.map(
-          (species: { label: string; commonName?: string }) => species.commonName || species.label
-        );
+        const sciMap = new Map<string, string>();
+        speciesListState.data = data.species.map(species => {
+          const value = species.commonName || species.label;
+          if (species.scientificName) {
+            sciMap.set(normalizeForLookup(value), species.scientificName);
+          }
+          return value;
+        });
+        speciesScientificMap = sciMap;
       } else {
         speciesListState.data = [];
+        speciesScientificMap = new Map();
       }
     } catch (error) {
       // Species list loading failure affects form functionality but isn't critical
@@ -175,6 +194,7 @@
       speciesListState.error = t('settings.filters.errors.speciesLoadFailed');
       // Set empty array so form still works, just without suggestions
       speciesListState.data = [];
+      speciesScientificMap = new Map();
     } finally {
       speciesListState.loading = false;
     }
@@ -358,6 +378,7 @@
               disabled={!settings.dogBark.enabled || store.isLoading || store.isSaving}
               predictions={speciesListState.data}
               predictionsLoading={speciesListState.loading}
+              localizeLabel={localizeSpeciesLabel}
               listLabel={t('settings.filters.dogBarkSpeciesList')}
               addLabel={t('settings.filters.falsePositivePrevention.addDogBarkSpeciesLabel')}
               addPlaceholder={t('settings.filters.typeSpeciesName')}
@@ -423,6 +444,7 @@
               disabled={!settings.daylight.enabled || store.isLoading || store.isSaving}
               predictions={speciesListState.data}
               predictionsLoading={speciesListState.loading}
+              localizeLabel={localizeSpeciesLabel}
               listLabel={t('settings.filters.daylightFilter.speciesListLabel')}
               addLabel={t('settings.filters.daylightFilter.addSpeciesLabel')}
               addPlaceholder={t('settings.filters.typeSpeciesName')}

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -62,6 +62,7 @@
     normalizeForLookup,
     type SpeciesNameMaps,
   } from '$lib/utils/speciesNames';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import {
     ArrowLeftRight,
     ChevronRight,
@@ -814,6 +815,28 @@
     clearTimeout(debounceTimeouts.config);
   });
 
+  // Resolve a canonical species value (server-locale common name or scientific
+  // name from allNames) to its visitor-locale display label. Reads speciesNameMaps
+  // and the dictionary store, so callers must invoke it in a reactive context to
+  // re-run on locale change. Passed to the pickers as localizeLabel; the predictions
+  // and stored values stay canonical.
+  function localizeSpeciesLabel(value: string): string {
+    const lower = normalizeForLookup(value);
+    const scientific = speciesNameMaps.scientificToCommon.has(lower)
+      ? value
+      : speciesNameMaps.commonToScientific.get(lower);
+    return localizeSpeciesName(scientific, value);
+  }
+
+  // Match a candidate against the typed input by its canonical value OR its
+  // localized label, so a visitor can find a species by typing the name they see.
+  function predictionMatchesInput(species: string, needle: string): boolean {
+    return (
+      normalizeForLookup(species).includes(needle) ||
+      normalizeForLookup(localizeSpeciesLabel(species)).includes(needle)
+    );
+  }
+
   function updateIncludePredictions(input: string) {
     clearTimeout(debounceTimeouts.include);
     debounceTimeouts.include = window.setTimeout(() => {
@@ -822,11 +845,11 @@
         return;
       }
 
-      const inputLower = input.toLowerCase();
+      const needle = normalizeForLookup(input);
       includePredictions = allSpecies
         .filter(
           species =>
-            species.toLowerCase().includes(inputLower) &&
+            predictionMatchesInput(species, needle) &&
             !isSpeciesInList(species, settings.include, speciesNameMaps)
         )
         .slice(0, 10);
@@ -841,11 +864,11 @@
         return;
       }
 
-      const inputLower = input.toLowerCase();
+      const needle = normalizeForLookup(input);
       excludePredictions = allSpecies
         .filter(
           species =>
-            species.toLowerCase().includes(inputLower) &&
+            predictionMatchesInput(species, needle) &&
             !isSpeciesInList(species, settings.exclude, speciesNameMaps)
         )
         .slice(0, 10);
@@ -860,14 +883,14 @@
         return;
       }
 
-      const inputLower = input.toLowerCase();
+      const needle = normalizeForLookup(input);
       // Exclude the currently-editing species from the collision check so its
       // own alias remains selectable during rename operations.
       const existingConfigKeys = Object.keys(settings.config).filter(key => key !== editingSpecies);
       configPredictions = allSpecies
         .filter(
           species =>
-            species.toLowerCase().includes(inputLower) &&
+            predictionMatchesInput(species, needle) &&
             !isSpeciesInList(species, existingConfigKeys, speciesNameMaps)
         )
         .slice(0, 10);
@@ -1294,6 +1317,7 @@
     scientificNameMap={speciesNameMaps.commonToScientific}
     scientificToCommonMap={speciesNameMaps.scientificToCommon}
     predictions={includePredictions}
+    localizeLabel={localizeSpeciesLabel}
     bind:inputValue={includeInputValue}
     inputLabel={t('settings.species.addSpeciesToIncludeLabel')}
     inputPlaceholder={t('settings.species.addSpeciesToInclude')}
@@ -1315,6 +1339,7 @@
     scientificNameMap={speciesNameMaps.commonToScientific}
     scientificToCommonMap={speciesNameMaps.scientificToCommon}
     predictions={excludePredictions}
+    localizeLabel={localizeSpeciesLabel}
     bind:inputValue={excludeInputValue}
     inputLabel={t('settings.species.addSpeciesToExcludeLabel')}
     inputPlaceholder={t('settings.species.addSpeciesToExclude')}
@@ -1370,6 +1395,7 @@
             species={editingSpecies}
             config={editingSpecies ? (safeGet(settings.config, editingSpecies) ?? null) : null}
             predictions={configPredictions}
+            localizeLabel={localizeSpeciesLabel}
             disabled={store.isLoading}
             saving={store.isSaving}
             onSave={handleEditorSave}

--- a/frontend/src/lib/stores/speciesDictionary.svelte.ts
+++ b/frontend/src/lib/stores/speciesDictionary.svelte.ts
@@ -221,6 +221,24 @@ export function resolveCommonToScientific(text: string): string[] {
   return current.reverse.get(normalizeForLookup(text)) ?? [];
 }
 
+/**
+ * Resolve a localized common name to its scientific name ONLY when the match is
+ * unambiguous (exactly one scientific name shares that normalized common name in
+ * the current locale).
+ *
+ * The reverse map intentionally keeps every candidate for an ambiguous common
+ * name; this helper exists so a settings picker never silently writes reverse[0]
+ * (an arbitrary pick) into server-wide config. Returns undefined when there are
+ * zero matches or more than one, so the caller can fall back to the typed text.
+ *
+ * @param text - The common name to resolve. Normalized via NFC + lowercase.
+ * @returns The single matching scientific name, or undefined when not unique.
+ */
+export function resolveCommonToScientificUnique(text: string): string | undefined {
+  const matches = current.reverse.get(normalizeForLookup(text));
+  return matches?.length === 1 ? matches[0] : undefined;
+}
+
 /** Minimum query length for substring search (avoids matching everything on 1 char). */
 const MIN_SEARCH_LENGTH = 2;
 

--- a/frontend/src/lib/stores/speciesDictionary.test.ts
+++ b/frontend/src/lib/stores/speciesDictionary.test.ts
@@ -34,6 +34,7 @@ vi.mock('$lib/utils/api', () => ({
 // Import after mocks are declared
 import {
   loadDictionary,
+  resolveCommonToScientificUnique,
   localizeScientific,
   resolveCommonToScientific,
   searchScientificByCommon,
@@ -254,6 +255,39 @@ describe('speciesDictionary store', () => {
     // Lookup with NFC 'ä' (U+00E4) should still find the entry
     const result = resolveCommonToScientific('Tälltiainen');
     expect(result).toContain('Parus major');
+  });
+
+  // --- Unique reverse resolution ---
+
+  describe('resolveCommonToScientificUnique', () => {
+    it('returns the single scientific name for an unambiguous common name', async () => {
+      mockApiGet(MOCK_FI_DICT);
+      await loadDictionary('fi');
+
+      expect(resolveCommonToScientificUnique('Mustarastas')).toBe('Turdus merula');
+    });
+
+    it('returns undefined for an ambiguous common name (more than one match)', async () => {
+      mockApiGet(MOCK_AMBIGUOUS_DICT);
+      await loadDictionary('fi');
+
+      // Two scientific names share this common name; a unique resolution is impossible.
+      expect(resolveCommonToScientificUnique('Raven')).toBeUndefined();
+    });
+
+    it('returns undefined for an unknown common name (no match)', async () => {
+      mockApiGet(MOCK_FI_DICT);
+      await loadDictionary('fi');
+
+      expect(resolveCommonToScientificUnique('Tuntematon Lintu')).toBeUndefined();
+    });
+
+    it('normalizes the query (NFC + case-insensitive) before resolving', async () => {
+      mockApiGet(MOCK_FI_DICT);
+      await loadDictionary('fi');
+
+      expect(resolveCommonToScientificUnique('mustarastas')).toBe('Turdus merula');
+    });
   });
 
   // --- Version in URL ---

--- a/frontend/src/lib/utils/speciesPredictions.test.ts
+++ b/frontend/src/lib/utils/speciesPredictions.test.ts
@@ -109,6 +109,12 @@ describe('filterLocalizedPredictions', () => {
     expect(result.map(p => p.value)).not.toContain('Barn Owl');
     expect(result).toHaveLength(2);
   });
+
+  it('excludes by localized label too (no self-echo of a fully-typed name)', () => {
+    const result = filterLocalizedPredictions(predictions, '', { excludeValue: 'Tornipöllö' });
+    expect(result.map(p => p.value)).not.toContain('Barn Owl');
+    expect(result).toHaveLength(2);
+  });
 });
 
 describe('matchTypedToCanonical', () => {

--- a/frontend/src/lib/utils/speciesPredictions.test.ts
+++ b/frontend/src/lib/utils/speciesPredictions.test.ts
@@ -26,21 +26,35 @@ const localizeLabel = (value: string): string => FI_LABELS.get(value) ?? value;
 describe('toLocalizedPredictions', () => {
   it('pairs each canonical value with its localized label', () => {
     const result = toLocalizedPredictions(['Barn Owl', 'Tawny Owl'], localizeLabel);
-    expect(result).toEqual([
+    expect(result).toMatchObject([
       { value: 'Barn Owl', label: 'Tornipöllö' },
       { value: 'Tawny Owl', label: 'Lehtopöllö' },
     ]);
   });
 
+  it('pre-normalizes the value and label for fast filtering', () => {
+    const [first] = toLocalizedPredictions(['Barn Owl'], localizeLabel);
+    expect(first.normalizedValue).toBe('barn owl');
+    expect(first.normalizedLabel).toBe('tornipöllö');
+  });
+
   it('falls back to the value when no localizer is provided', () => {
     const result = toLocalizedPredictions(['Barn Owl']);
-    expect(result).toEqual([{ value: 'Barn Owl', label: 'Barn Owl' }]);
+    expect(result).toMatchObject([{ value: 'Barn Owl', label: 'Barn Owl' }]);
   });
 
   it('falls back to the value for entries the localizer leaves unchanged', () => {
     // A taxonomy group row that the dictionary cannot localize.
     const result = toLocalizedPredictions(['Owls (Family)'], localizeLabel);
-    expect(result).toEqual([{ value: 'Owls (Family)', label: 'Owls (Family)' }]);
+    expect(result).toMatchObject([{ value: 'Owls (Family)', label: 'Owls (Family)' }]);
+  });
+
+  it('falls back to the value when the localizer returns an empty string', () => {
+    const result = toLocalizedPredictions(['Barn Owl', 'Tawny Owl'], () => '');
+    expect(result).toMatchObject([
+      { value: 'Barn Owl', label: 'Barn Owl' },
+      { value: 'Tawny Owl', label: 'Tawny Owl' },
+    ]);
   });
 
   it('never lets the label leak into the value', () => {
@@ -79,6 +93,17 @@ describe('filterLocalizedPredictions', () => {
     expect(filterLocalizedPredictions(predictions, '', { max: 2 })).toHaveLength(2);
   });
 
+  it('returns nothing for a zero (or negative) max', () => {
+    expect(filterLocalizedPredictions(predictions, '', { max: 0 })).toEqual([]);
+    expect(filterLocalizedPredictions(predictions, '', { max: -3 })).toEqual([]);
+  });
+
+  it('trims the query before matching', () => {
+    expect(filterLocalizedPredictions(predictions, '  torni  ')).toEqual([
+      { value: 'Barn Owl', label: 'Tornipöllö' },
+    ]);
+  });
+
   it('excludes the given canonical value', () => {
     const result = filterLocalizedPredictions(predictions, '', { excludeValue: 'Barn Owl' });
     expect(result.map(p => p.value)).not.toContain('Barn Owl');
@@ -102,6 +127,10 @@ describe('matchTypedToCanonical', () => {
 
   it('is case- and NFC-insensitive', () => {
     expect(matchTypedToCanonical('tornipöllö', predictions)).toBe('Barn Owl');
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(matchTypedToCanonical('  Tornipöllö  ', predictions)).toBe('Barn Owl');
   });
 
   it('returns undefined when nothing matches (caller keeps the typed text)', () => {

--- a/frontend/src/lib/utils/speciesPredictions.test.ts
+++ b/frontend/src/lib/utils/speciesPredictions.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the shared species-prediction helpers.
+ *
+ * These guard the core PR invariant: a prediction's `value` (what gets persisted)
+ * is never the localized label, and label-aware filtering/matching never turns a
+ * localized label into a persisted value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  toLocalizedPredictions,
+  filterLocalizedPredictions,
+  matchTypedToCanonical,
+  type SpeciesPrediction,
+} from './speciesPredictions';
+
+/** A Finnish-locale label map for canonical (English/scientific) values. */
+const FI_LABELS = new Map<string, string>([
+  ['Barn Owl', 'Tornipöllö'],
+  ['Tawny Owl', 'Lehtopöllö'],
+  ['Tyto alba', 'Tornipöllö'],
+]);
+
+const localizeLabel = (value: string): string => FI_LABELS.get(value) ?? value;
+
+describe('toLocalizedPredictions', () => {
+  it('pairs each canonical value with its localized label', () => {
+    const result = toLocalizedPredictions(['Barn Owl', 'Tawny Owl'], localizeLabel);
+    expect(result).toEqual([
+      { value: 'Barn Owl', label: 'Tornipöllö' },
+      { value: 'Tawny Owl', label: 'Lehtopöllö' },
+    ]);
+  });
+
+  it('falls back to the value when no localizer is provided', () => {
+    const result = toLocalizedPredictions(['Barn Owl']);
+    expect(result).toEqual([{ value: 'Barn Owl', label: 'Barn Owl' }]);
+  });
+
+  it('falls back to the value for entries the localizer leaves unchanged', () => {
+    // A taxonomy group row that the dictionary cannot localize.
+    const result = toLocalizedPredictions(['Owls (Family)'], localizeLabel);
+    expect(result).toEqual([{ value: 'Owls (Family)', label: 'Owls (Family)' }]);
+  });
+
+  it('never lets the label leak into the value', () => {
+    const result = toLocalizedPredictions(['Barn Owl'], localizeLabel);
+    expect(result[0].value).toBe('Barn Owl');
+    expect(result[0].label).toBe('Tornipöllö');
+  });
+});
+
+describe('filterLocalizedPredictions', () => {
+  const predictions: SpeciesPrediction[] = [
+    { value: 'Barn Owl', label: 'Tornipöllö' },
+    { value: 'Tawny Owl', label: 'Lehtopöllö' },
+    { value: 'Common Blackbird', label: 'Mustarastas' },
+  ];
+
+  it('matches the localized label', () => {
+    const result = filterLocalizedPredictions(predictions, 'torni');
+    expect(result).toEqual([{ value: 'Barn Owl', label: 'Tornipöllö' }]);
+  });
+
+  it('matches the canonical value too', () => {
+    const result = filterLocalizedPredictions(predictions, 'blackbird');
+    expect(result).toEqual([{ value: 'Common Blackbird', label: 'Mustarastas' }]);
+  });
+
+  it('is case- and NFC-insensitive', () => {
+    expect(filterLocalizedPredictions(predictions, 'LEHTO')).toHaveLength(1);
+  });
+
+  it('returns all predictions for an empty query', () => {
+    expect(filterLocalizedPredictions(predictions, '')).toHaveLength(3);
+  });
+
+  it('honors max', () => {
+    expect(filterLocalizedPredictions(predictions, '', { max: 2 })).toHaveLength(2);
+  });
+
+  it('excludes the given canonical value', () => {
+    const result = filterLocalizedPredictions(predictions, '', { excludeValue: 'Barn Owl' });
+    expect(result.map(p => p.value)).not.toContain('Barn Owl');
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('matchTypedToCanonical', () => {
+  const predictions: SpeciesPrediction[] = [
+    { value: 'Barn Owl', label: 'Tornipöllö' },
+    { value: 'Tawny Owl', label: 'Lehtopöllö' },
+  ];
+
+  it('maps a typed localized label to the canonical value (the corruption guard)', () => {
+    expect(matchTypedToCanonical('Tornipöllö', predictions)).toBe('Barn Owl');
+  });
+
+  it('maps a typed canonical value to itself', () => {
+    expect(matchTypedToCanonical('Tawny Owl', predictions)).toBe('Tawny Owl');
+  });
+
+  it('is case- and NFC-insensitive', () => {
+    expect(matchTypedToCanonical('tornipöllö', predictions)).toBe('Barn Owl');
+  });
+
+  it('returns undefined when nothing matches (caller keeps the typed text)', () => {
+    expect(matchTypedToCanonical('Unlisted Bird', predictions)).toBeUndefined();
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(matchTypedToCanonical('', predictions)).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/utils/speciesPredictions.ts
+++ b/frontend/src/lib/utils/speciesPredictions.ts
@@ -94,8 +94,10 @@ export function filterLocalizedPredictions(
   const out: SpeciesPrediction[] = [];
   for (const prediction of predictions) {
     const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
-    if (exclude !== undefined && valueKey === exclude) continue;
     const labelKey = prediction.normalizedLabel ?? normalizeForLookup(prediction.label);
+    // Exclude the entry the input already holds, matching either the canonical
+    // value or the localized label so a fully-typed localized name does not echo.
+    if (exclude !== undefined && (valueKey === exclude || labelKey === exclude)) continue;
     if (needle.length === 0 || labelKey.includes(needle) || valueKey.includes(needle)) {
       out.push(prediction);
       if (out.length >= max) break;

--- a/frontend/src/lib/utils/speciesPredictions.ts
+++ b/frontend/src/lib/utils/speciesPredictions.ts
@@ -21,6 +21,15 @@ export interface SpeciesPrediction {
   value: string;
   /** Visitor-locale display label. Never persisted. */
   label: string;
+  /**
+   * Pre-normalized value for filtering, computed once by toLocalizedPredictions to
+   * keep NFC normalization out of the per-keystroke filter loop. Optional so
+   * hand-built predictions still work (the filter/match helpers fall back to
+   * normalizing on demand).
+   */
+  normalizedValue?: string;
+  /** Pre-normalized label for filtering. See normalizedValue. */
+  normalizedLabel?: string;
 }
 
 /**
@@ -38,7 +47,18 @@ export function toLocalizedPredictions(
   values: string[],
   localizeLabel?: (value: string) => string
 ): SpeciesPrediction[] {
-  return values.map(value => ({ value, label: localizeLabel?.(value) ?? value }));
+  return values.map(value => {
+    // Treat an empty/whitespace localized label as missing so the label always
+    // falls back to the canonical value (a blank label would render nothing).
+    const localized = localizeLabel?.(value);
+    const label = localized && localized.trim().length > 0 ? localized : value;
+    return {
+      value,
+      label,
+      normalizedValue: normalizeForLookup(value),
+      normalizedLabel: normalizeForLookup(label),
+    };
+  });
 }
 
 /** Options for {@link filterLocalizedPredictions}. */
@@ -60,20 +80,23 @@ export function filterLocalizedPredictions(
   query: string,
   options: FilterOptions = {}
 ): SpeciesPrediction[] {
-  const needle = normalizeForLookup(query);
+  const needle = normalizeForLookup(query.trim());
   const exclude =
-    options.excludeValue !== undefined ? normalizeForLookup(options.excludeValue) : undefined;
-  const max = options.max ?? Number.POSITIVE_INFINITY;
+    options.excludeValue !== undefined
+      ? normalizeForLookup(options.excludeValue.trim())
+      : undefined;
+  // Clamp max to a non-negative integer and short-circuit on 0, so a zero/invalid
+  // bound returns nothing instead of leaking one item past the post-push check.
+  const maxRaw = options.max ?? Number.POSITIVE_INFINITY;
+  const max = Number.isFinite(maxRaw) ? Math.max(0, Math.floor(maxRaw)) : Number.POSITIVE_INFINITY;
+  if (max === 0) return [];
 
   const out: SpeciesPrediction[] = [];
   for (const prediction of predictions) {
-    const valueKey = normalizeForLookup(prediction.value);
+    const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
     if (exclude !== undefined && valueKey === exclude) continue;
-    if (
-      needle.length === 0 ||
-      normalizeForLookup(prediction.label).includes(needle) ||
-      valueKey.includes(needle)
-    ) {
+    const labelKey = prediction.normalizedLabel ?? normalizeForLookup(prediction.label);
+    if (needle.length === 0 || labelKey.includes(needle) || valueKey.includes(needle)) {
       out.push(prediction);
       if (out.length >= max) break;
     }
@@ -95,13 +118,15 @@ export function matchTypedToCanonical(
   typed: string,
   predictions: SpeciesPrediction[]
 ): string | undefined {
-  const needle = normalizeForLookup(typed);
+  // Trim before normalizing so a name typed with surrounding spaces still matches
+  // a prediction; otherwise the caller's fallback would persist the trimmed label
+  // instead of the canonical value.
+  const needle = normalizeForLookup(typed.trim());
   if (needle.length === 0) return undefined;
   for (const prediction of predictions) {
-    if (
-      normalizeForLookup(prediction.label) === needle ||
-      normalizeForLookup(prediction.value) === needle
-    ) {
+    const labelKey = prediction.normalizedLabel ?? normalizeForLookup(prediction.label);
+    const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
+    if (labelKey === needle || valueKey === needle) {
       return prediction.value;
     }
   }

--- a/frontend/src/lib/utils/speciesPredictions.ts
+++ b/frontend/src/lib/utils/speciesPredictions.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared autocomplete-prediction helpers for the settings species pickers.
+ *
+ * The settings pickers persist server-wide config, so the value they emit must
+ * stay canonical (a server-locale common name or a scientific name the backend
+ * matches against). The label shown to the visitor, by contrast, is localized to
+ * the visitor's UI locale. This module is the single place that pairs a canonical
+ * value with its localized label and does label-aware filtering and matching, so
+ * the three picker components (SpeciesInput, EditorSpeciesInput, and
+ * SpeciesListCard's inline dropdown) share one implementation instead of three.
+ *
+ * Invariant: a prediction's `value` is NEVER the localized label. Selecting a
+ * prediction always emits `value`; the label is display-only.
+ */
+
+import { normalizeForLookup } from '$lib/utils/speciesNames';
+
+/** A canonical value paired with the visitor-locale label shown for it. */
+export interface SpeciesPrediction {
+  /** Canonical value emitted/persisted (server-locale common name or scientific name). */
+  value: string;
+  /** Visitor-locale display label. Never persisted. */
+  label: string;
+}
+
+/**
+ * Pair each canonical value with its localized label.
+ *
+ * `localizeLabel` should resolve a canonical value to its visitor-locale name
+ * (typically `v => localizeSpeciesName(scientificFor(v), v)`); when omitted or
+ * when it returns nothing useful, the label falls back to the value itself so
+ * non-localizable entries (e.g. taxonomy group rows) display verbatim.
+ *
+ * Call this inside a `$derived` so the labels recompute when the dictionary
+ * store loads or the visitor switches locale.
+ */
+export function toLocalizedPredictions(
+  values: string[],
+  localizeLabel?: (value: string) => string
+): SpeciesPrediction[] {
+  return values.map(value => ({ value, label: localizeLabel?.(value) ?? value }));
+}
+
+/** Options for {@link filterLocalizedPredictions}. */
+interface FilterOptions {
+  /** Maximum number of predictions to return. Defaults to unbounded. */
+  max?: number;
+  /** A canonical value to exclude (e.g. the exact current input value). */
+  excludeValue?: string;
+}
+
+/**
+ * Filter predictions by a query, matching against BOTH the localized label and
+ * the canonical value, so a visitor can type either the name they see or the
+ * stored value. Comparison is NFC + case-insensitive. An empty query returns all
+ * predictions (subject to `max`).
+ */
+export function filterLocalizedPredictions(
+  predictions: SpeciesPrediction[],
+  query: string,
+  options: FilterOptions = {}
+): SpeciesPrediction[] {
+  const needle = normalizeForLookup(query);
+  const exclude =
+    options.excludeValue !== undefined ? normalizeForLookup(options.excludeValue) : undefined;
+  const max = options.max ?? Number.POSITIVE_INFINITY;
+
+  const out: SpeciesPrediction[] = [];
+  for (const prediction of predictions) {
+    const valueKey = normalizeForLookup(prediction.value);
+    if (exclude !== undefined && valueKey === exclude) continue;
+    if (
+      needle.length === 0 ||
+      normalizeForLookup(prediction.label).includes(needle) ||
+      valueKey.includes(needle)
+    ) {
+      out.push(prediction);
+      if (out.length >= max) break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve typed free text to a canonical value by matching it (NFC +
+ * case-insensitive) against a prediction's label OR value, returning the matched
+ * prediction's canonical `value`.
+ *
+ * Returns undefined when nothing matches, so the caller keeps the typed text
+ * as-is (today's behavior for advanced raw entries). Because it only ever maps
+ * text the visitor could have selected to that prediction's canonical value, it
+ * can never turn a localized label into a persisted value.
+ */
+export function matchTypedToCanonical(
+  typed: string,
+  predictions: SpeciesPrediction[]
+): string | undefined {
+  const needle = normalizeForLookup(typed);
+  if (needle.length === 0) return undefined;
+  for (const prediction of predictions) {
+    if (
+      normalizeForLookup(prediction.label) === needle ||
+      normalizeForLookup(prediction.value) === needle
+    ) {
+      return prediction.value;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Continues the per-visitor species-name localization work into the settings species pickers. Species common names now display in the visitor's UI locale across the Active Species table, the include/exclude lists, the custom-configuration list and editor, and the dog-bark/daylight/extended-capture filter lists, while the value persisted to server-wide config stays canonical.

### The risk this addresses

In the plain-string autocomplete pickers, the prediction text was simultaneously the displayed label and the value persisted to `realtime.species` include/exclude/config and the dog-bark/daylight/extended-capture filter lists. Naively localizing the predictions would write a visitor-locale common name into server-wide config. The backend resolves those lists against server-locale name maps (config keys by lowercased common name or `EqualFold` scientific name; exclude reverse-resolution at the server `BirdNET.Locale`; dog-bark by exact lowercased server-locale common name), so a visitor-locale string would silently break matching. This was verified against the Go matchers, not assumed.

### Approach

Localize only the rendered label; the value emitted on prediction-select stays byte-identical to today's canonical value.

- A shared helper (`speciesPredictions.ts`) pairs each canonical value with a localized label and does label-aware filtering/matching, written once and reused by all three autocomplete implementations.
- Pickers render the label, carry the canonical value in `data-prediction`, and always emit the canonical value. Free-typed input is mapped to a prediction's canonical value when it matches that prediction's label or value; otherwise it is kept as-is (today's advanced-entry behavior).
- The custom-config editor shows the localized label in the field but tracks the canonical config-map key, saving the tracked canonical verbatim until the user actually edits the field. Reopening and saving an entry, even after a UI locale switch while the editor is open, never re-keys it.
- Display-only surfaces (Active Species table, custom-config list, include/exclude rows) localize the displayed name plus search and sort, while CSV export and emitted values stay canonical.
- Reuses the existing `localizeSpeciesName` runtime helper and the globally-loaded dictionary store (reactive on locale switch). Adds one helper, `resolveCommonToScientificUnique`, which returns a scientific name only when the localized common name is unambiguous.

No new i18n keys; no message-file or generated-types changes.

## Test Plan

- [x] `npm run check:all` (prettier, eslint, stylelint, svelte-check, ast-grep) clean
- [x] `npm test` green (2126 tests), including new regression tests
- [x] Regression tests assert selecting or typing a localized name persists the canonical value, not the label, across the input pickers
- [x] Config-editor tests cover the rename-trap guard: unchanged save (and unchanged save after a locale switch) re-emits the original canonical key
- [ ] Manual: switch UI locale, confirm settings pickers show localized names and that saved include/exclude/config values stay canonical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locale-aware species labels throughout settings and editors: UI shows localized names while preserving canonical values for storage and selection.
  * Shared autocomplete enhancements: localized prediction labels, locale-insensitive filtering/sorting, and mapping typed or localized input back to canonical values.
  * Resolver to map unique localized common names to scientific (canonical) names when possible.

* **Tests**
  * Expanded test coverage for localization, prediction filtering, typed-to-canonical mapping, and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->