### PR TITLE
feat(i18n): localize detection-detail aria labels and analytics species alt text

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -826,7 +826,8 @@
                           src={buildAppUrl(
                             `/api/v2/media/species-image?name=${encodeURIComponent(detection.scientificName ?? '')}`
                           )}
-                          alt={detection.commonName || 'Unknown species'}
+                          alt={detection.commonName ||
+                            t('analytics.recentDetections.unknownSpecies')}
                           class="w-full h-full object-cover"
                           onerror={handleBirdImageError}
                           loading="lazy"
@@ -892,7 +893,7 @@
                     src={buildAppUrl(
                       `/api/v2/media/species-image?name=${encodeURIComponent(detection.scientificName ?? '')}`
                     )}
-                    alt={detection.commonName || 'Unknown species'}
+                    alt={detection.commonName || t('analytics.recentDetections.unknownSpecies')}
                     class="w-full h-full object-cover"
                     onerror={handleBirdImageError}
                     loading="lazy"

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -480,11 +480,10 @@
             {displayName}
             <span class="sr-only">{t('detections.detail.aria.speciesHeadingSuffix')}</span>
           </h1>
-          <p
-            class="species-scientific-name"
-            aria-label={t('detections.detail.aria.scientificName')}
-          >
-            {det.scientificName}
+          <p class="species-scientific-name">
+            <span class="sr-only"
+              >{t('detections.detail.aria.scientificName')}:
+            </span>{det.scientificName}
           </p>
           <div class="mt-3" aria-label={t('detections.detail.aria.classificationBadges')}>
             <VerificationBadges detection={det} size="sm" />
@@ -495,7 +494,7 @@
         <div
           class="hero-confidence"
           aria-label={t('detections.detail.aria.confidence', {
-            confidence: Math.round(det.confidence * 100),
+            confidence: Math.round((det.confidence ?? 0) * 100),
           })}
         >
           <ConfidenceCircle confidence={det.confidence} size="xl" />
@@ -718,14 +717,15 @@
       <div class="space-y-3" role="list" aria-label={t('detections.detail.aria.comments')}>
         {#each det.comments as comment (comment.id ?? comment.createdAt)}
           <article class="content-panel" role="listitem">
-            <p class="text-sm leading-relaxed" aria-label={t('detections.detail.aria.commentText')}>
-              {comment.entry}
+            <p class="text-sm leading-relaxed">
+              <span class="sr-only"
+                >{t('detections.detail.aria.commentText')}:
+              </span>{comment.entry}
             </p>
-            <p
-              class="text-xs text-[var(--color-base-content)]/40 mt-2"
-              aria-label={t('detections.detail.aria.commentTimestamp')}
-            >
-              {formatLocalDateTime(new Date(comment.createdAt))}
+            <p class="text-xs text-[var(--color-base-content)]/40 mt-2">
+              <span class="sr-only"
+                >{t('detections.detail.aria.commentTimestamp')}:
+              </span>{formatLocalDateTime(new Date(comment.createdAt))}
             </p>
           </article>
         {/each}

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -478,18 +478,26 @@
         <div class="hero-species">
           <h1 id="species-heading" class="species-display-name">
             {displayName}
-            <span class="sr-only">detection details</span>
+            <span class="sr-only">{t('detections.detail.aria.speciesHeadingSuffix')}</span>
           </h1>
-          <p class="species-scientific-name" aria-label="Scientific name">
+          <p
+            class="species-scientific-name"
+            aria-label={t('detections.detail.aria.scientificName')}
+          >
             {det.scientificName}
           </p>
-          <div class="mt-3" aria-label="Species classification badges">
+          <div class="mt-3" aria-label={t('detections.detail.aria.classificationBadges')}>
             <VerificationBadges detection={det} size="sm" />
           </div>
         </div>
 
         <!-- Confidence -->
-        <div class="hero-confidence" aria-label="Detection confidence {det.confidence}%">
+        <div
+          class="hero-confidence"
+          aria-label={t('detections.detail.aria.confidence', {
+            confidence: Math.round(det.confidence * 100),
+          })}
+        >
           <ConfidenceCircle confidence={det.confidence} size="xl" />
         </div>
       </div>
@@ -555,7 +563,11 @@
     {/if}
 
     <!-- Metadata Card -->
-    <div class="hero-card hero-metadata-card" role="region" aria-label="Detection metadata">
+    <div
+      class="hero-card hero-metadata-card"
+      role="region"
+      aria-label={t('detections.detail.aria.metadata')}
+    >
       <h3 class="section-heading">{t('detections.detail.observation')}</h3>
       <!-- Date & Time -->
       <div class="meta-section">
@@ -590,7 +602,10 @@
 
       <!-- Weather -->
       {#if det.weather}
-        <div class="meta-section hero-weather" aria-label="Weather conditions at time of detection">
+        <div
+          class="meta-section hero-weather"
+          aria-label={t('detections.detail.aria.weatherConditions')}
+        >
           <WeatherDetails
             weatherIcon={det.weather.weatherIcon}
             weatherDescription={det.weather.description}
@@ -700,13 +715,15 @@
   <section aria-labelledby="notes-heading">
     <h3 id="notes-heading" class="section-heading">{t('detections.notes.title')}</h3>
     {#if det.comments && det.comments.length > 0}
-      <div class="space-y-3" role="list" aria-label="Detection comments">
+      <div class="space-y-3" role="list" aria-label={t('detections.detail.aria.comments')}>
         {#each det.comments as comment (comment.id ?? comment.createdAt)}
           <article class="content-panel" role="listitem">
-            <p class="text-sm leading-relaxed" aria-label="Comment text">{comment.entry}</p>
+            <p class="text-sm leading-relaxed" aria-label={t('detections.detail.aria.commentText')}>
+              {comment.entry}
+            </p>
             <p
               class="text-xs text-[var(--color-base-content)]/40 mt-2"
-              aria-label="Comment timestamp"
+              aria-label={t('detections.detail.aria.commentTimestamp')}
             >
               {formatLocalDateTime(new Date(comment.createdAt))}
             </p>
@@ -725,7 +742,7 @@
 {/snippet}
 
 <!-- Main component -->
-<main class="col-span-12 detection-detail" aria-label="Detection details">
+<main class="col-span-12 detection-detail" aria-label={t('detections.detail.aria.mainRegion')}>
   <!-- Loading state with live region -->
   <div role="status" aria-live="polite" class="sr-only">
     {#if isLoadingDetection}
@@ -842,10 +859,10 @@
     <!-- Tabbed Content -->
     <section class="surface-card" aria-labelledby="tabs-heading">
       <div class="p-5 md:p-6">
-        <h2 id="tabs-heading" class="sr-only">Detection information tabs</h2>
+        <h2 id="tabs-heading" class="sr-only">{t('detections.detail.aria.tabsHeading')}</h2>
 
         <!-- Tab Navigation -->
-        <div class="tab-nav" role="tablist" aria-label="Detection details tabs">
+        <div class="tab-nav" role="tablist" aria-label={t('detections.detail.aria.tabList')}>
           {#each ['overview', 'history', 'notes'] as tab (tab)}
             <button
               id="tab-{tab}"

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -640,6 +640,18 @@ export type TranslationKey =
   | 'detections.detail.observation'
   | 'detections.detail.aria.downloadAudioClip' // params: name
   | 'detections.detail.aria.audioRecordingFor' // params: name
+  | 'detections.detail.aria.scientificName'
+  | 'detections.detail.aria.classificationBadges'
+  | 'detections.detail.aria.confidence' // params: confidence
+  | 'detections.detail.aria.metadata'
+  | 'detections.detail.aria.weatherConditions'
+  | 'detections.detail.aria.comments'
+  | 'detections.detail.aria.commentText'
+  | 'detections.detail.aria.commentTimestamp'
+  | 'detections.detail.aria.mainRegion'
+  | 'detections.detail.aria.tabsHeading'
+  | 'detections.detail.aria.tabList'
+  | 'detections.detail.aria.speciesHeadingSuffix'
   | 'detections.headers.dateTime'
   | 'detections.headers.weather'
   | 'detections.headers.source'
@@ -3729,6 +3741,7 @@ export type TranslationParams = {
   'detections.titles.allDetections': { date: string | number };
   'detections.detail.aria.downloadAudioClip': { name: string | number };
   'detections.detail.aria.audioRecordingFor': { name: string | number };
+  'detections.detail.aria.confidence': { confidence: string | number };
   'detections.pagination.showing': {
     from: string | number;
     to: string | number;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -797,7 +797,19 @@
       "observation": "Pozorování",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Vědecký název",
+        "classificationBadges": "Odznaky klasifikace druhu",
+        "confidence": "Spolehlivost detekce {confidence}%",
+        "metadata": "Metadata detekce",
+        "weatherConditions": "Povětrnostní podmínky v době detekce",
+        "comments": "Komentáře k detekci",
+        "commentText": "Text komentáře",
+        "commentTimestamp": "Časové razítko komentáře",
+        "mainRegion": "Podrobnosti detekce",
+        "tabsHeading": "Karty s informacemi o detekci",
+        "tabList": "Karty podrobností detekce",
+        "speciesHeadingSuffix": "podrobnosti detekce"
       }
     },
     "headers": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -797,7 +797,19 @@
       "observation": "Observation",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Videnskabeligt navn",
+        "classificationBadges": "Mærker for artsklassifikation",
+        "confidence": "Registreringssikkerhed {confidence}%",
+        "metadata": "Registreringsmetadata",
+        "weatherConditions": "Vejrforhold på registreringstidspunktet",
+        "comments": "Kommentarer til registreringen",
+        "commentText": "Kommentartekst",
+        "commentTimestamp": "Tidsstempel for kommentar",
+        "mainRegion": "Registreringsdetaljer",
+        "tabsHeading": "Faner med registreringsoplysninger",
+        "tabList": "Faner for registreringsdetaljer",
+        "speciesHeadingSuffix": "registreringsdetaljer"
       }
     },
     "headers": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -797,7 +797,19 @@
       "observation": "Beobachtung",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Wissenschaftlicher Name",
+        "classificationBadges": "Badges zur Artklassifizierung",
+        "confidence": "Erkennungskonfidenz {confidence}%",
+        "metadata": "Erkennungsmetadaten",
+        "weatherConditions": "Wetterbedingungen zum Zeitpunkt der Erkennung",
+        "comments": "Kommentare zur Erkennung",
+        "commentText": "Kommentartext",
+        "commentTimestamp": "Zeitstempel des Kommentars",
+        "mainRegion": "Erkennungsdetails",
+        "tabsHeading": "Registerkarten mit Erkennungsinformationen",
+        "tabList": "Registerkarten der Erkennungsdetails",
+        "speciesHeadingSuffix": "Erkennungsdetails"
       }
     },
     "headers": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -797,7 +797,19 @@
       "observation": "Observation",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Scientific name",
+        "classificationBadges": "Species classification badges",
+        "confidence": "Detection confidence {confidence}%",
+        "metadata": "Detection metadata",
+        "weatherConditions": "Weather conditions at time of detection",
+        "comments": "Detection comments",
+        "commentText": "Comment text",
+        "commentTimestamp": "Comment timestamp",
+        "mainRegion": "Detection details",
+        "tabsHeading": "Detection information tabs",
+        "tabList": "Detection details tabs",
+        "speciesHeadingSuffix": "detection details"
       }
     },
     "headers": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -797,7 +797,19 @@
       "observation": "Observación",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Nombre científico",
+        "classificationBadges": "Insignias de clasificación de especie",
+        "confidence": "Confianza de la detección {confidence}%",
+        "metadata": "Metadatos de detección",
+        "weatherConditions": "Condiciones meteorológicas en el momento de la detección",
+        "comments": "Comentarios de la detección",
+        "commentText": "Texto del comentario",
+        "commentTimestamp": "Marca de tiempo del comentario",
+        "mainRegion": "Detalles de detección",
+        "tabsHeading": "Pestañas de información de la detección",
+        "tabList": "Pestañas de detalles de la detección",
+        "speciesHeadingSuffix": "detalles de detección"
       }
     },
     "headers": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -797,7 +797,19 @@
       "observation": "Havainto",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Tieteellinen nimi",
+        "classificationBadges": "Lajin luokitusmerkit",
+        "confidence": "Havainnon luottamus {confidence}%",
+        "metadata": "Havainnon metatiedot",
+        "weatherConditions": "Sääolosuhteet havaintohetkellä",
+        "comments": "Havainnon kommentit",
+        "commentText": "Kommentin teksti",
+        "commentTimestamp": "Kommentin aikaleima",
+        "mainRegion": "Havainnon tiedot",
+        "tabsHeading": "Havaintotietojen välilehdet",
+        "tabList": "Havainnon tietojen välilehdet",
+        "speciesHeadingSuffix": "havainnon tiedot"
       }
     },
     "headers": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -797,7 +797,19 @@
       "observation": "Observation",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Nom scientifique",
+        "classificationBadges": "Badges de classification de l'espèce",
+        "confidence": "Confiance de détection {confidence}%",
+        "metadata": "Métadonnées de détection",
+        "weatherConditions": "Conditions météo au moment de la détection",
+        "comments": "Commentaires de la détection",
+        "commentText": "Texte du commentaire",
+        "commentTimestamp": "Horodatage du commentaire",
+        "mainRegion": "Détails de détection",
+        "tabsHeading": "Onglets d'informations de détection",
+        "tabList": "Onglets des détails de détection",
+        "speciesHeadingSuffix": "détails de détection"
       }
     },
     "headers": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -797,7 +797,19 @@
       "observation": "Megfigyelés",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Tudományos név",
+        "classificationBadges": "Faj besorolási jelvények",
+        "confidence": "Detektálás megbízhatósága {confidence}%",
+        "metadata": "Detektálás metaadatok",
+        "weatherConditions": "Időjárási viszonyok a detektálás idején",
+        "comments": "Detektálás megjegyzései",
+        "commentText": "Megjegyzés szövege",
+        "commentTimestamp": "Megjegyzés időbélyege",
+        "mainRegion": "Detektálás részletei",
+        "tabsHeading": "Detektálási információk lapjai",
+        "tabList": "Detektálás részleteinek lapjai",
+        "speciesHeadingSuffix": "detektálás részletei"
       }
     },
     "headers": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -797,7 +797,19 @@
       "observation": "Osservazione",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Nome scientifico",
+        "classificationBadges": "Badge di classificazione della specie",
+        "confidence": "Confidenza del rilevamento {confidence}%",
+        "metadata": "Metadati del rilevamento",
+        "weatherConditions": "Condizioni meteo al momento del rilevamento",
+        "comments": "Commenti del rilevamento",
+        "commentText": "Testo del commento",
+        "commentTimestamp": "Data e ora del commento",
+        "mainRegion": "Dettagli del rilevamento",
+        "tabsHeading": "Schede informazioni rilevamento",
+        "tabList": "Schede dettagli rilevamento",
+        "speciesHeadingSuffix": "dettagli del rilevamento"
       }
     },
     "headers": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -797,7 +797,19 @@
       "observation": "Novērojums",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Zinātniskais nosaukums",
+        "classificationBadges": "Sugas klasifikācijas nozīmītes",
+        "confidence": "Atklāšanas ticamība {confidence}%",
+        "metadata": "Atklāšanas metadati",
+        "weatherConditions": "Laikapstākļi atklāšanas brīdī",
+        "comments": "Atklāšanas komentāri",
+        "commentText": "Komentāra teksts",
+        "commentTimestamp": "Komentāra laika zīmogs",
+        "mainRegion": "Atklāšanas informācija",
+        "tabsHeading": "Atklāšanas informācijas cilnes",
+        "tabList": "Atklāšanas detaļu cilnes",
+        "speciesHeadingSuffix": "atklāšanas informācija"
       }
     },
     "headers": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -797,7 +797,19 @@
       "observation": "Observasjon",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Vitenskapelig navn",
+        "classificationBadges": "Merker for artsklassifisering",
+        "confidence": "Registreringssikkerhet {confidence}%",
+        "metadata": "Registreringsmetadata",
+        "weatherConditions": "Værforhold på registreringstidspunktet",
+        "comments": "Kommentarer til registreringen",
+        "commentText": "Kommentartekst",
+        "commentTimestamp": "Tidsstempel for kommentar",
+        "mainRegion": "Registreringsdetaljer",
+        "tabsHeading": "Faner med registreringsinformasjon",
+        "tabList": "Faner for registreringsdetaljer",
+        "speciesHeadingSuffix": "registreringsdetaljer"
       }
     },
     "headers": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -797,7 +797,19 @@
       "observation": "Waarneming",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Wetenschappelijke naam",
+        "classificationBadges": "Soortclassificatie-badges",
+        "confidence": "Betrouwbaarheid herkenning {confidence}%",
+        "metadata": "Meta informatie herkenning",
+        "weatherConditions": "Weersomstandigheden op het moment van herkenning",
+        "comments": "Notities bij herkenning",
+        "commentText": "Notitietekst",
+        "commentTimestamp": "Tijdstempel van notitie",
+        "mainRegion": "Herkenningsdetails",
+        "tabsHeading": "Tabbladen met herkenningsinformatie",
+        "tabList": "Tabbladen met herkenningsdetails",
+        "speciesHeadingSuffix": "herkenningsdetails"
       }
     },
     "headers": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -797,7 +797,19 @@
       "observation": "Obserwacja",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Nazwa naukowa",
+        "classificationBadges": "Odznaki klasyfikacji gatunku",
+        "confidence": "Pewność detekcji {confidence}%",
+        "metadata": "Metadane detekcji",
+        "weatherConditions": "Warunki pogodowe w czasie detekcji",
+        "comments": "Komentarze detekcji",
+        "commentText": "Treść komentarza",
+        "commentTimestamp": "Znacznik czasu komentarza",
+        "mainRegion": "Szczegóły detekcji",
+        "tabsHeading": "Karty informacji o detekcji",
+        "tabList": "Karty szczegółów detekcji",
+        "speciesHeadingSuffix": "szczegóły detekcji"
       }
     },
     "headers": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -797,7 +797,19 @@
       "observation": "Observação",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Nome científico",
+        "classificationBadges": "Distintivos de classificação da espécie",
+        "confidence": "Confiança da detecção {confidence}%",
+        "metadata": "Metadados da detecção",
+        "weatherConditions": "Condições meteorológicas no momento da detecção",
+        "comments": "Comentários da detecção",
+        "commentText": "Texto do comentário",
+        "commentTimestamp": "Data e hora do comentário",
+        "mainRegion": "Detalhes de detecção",
+        "tabsHeading": "Abas de informação da detecção",
+        "tabList": "Abas de detalhes da detecção",
+        "speciesHeadingSuffix": "detalhes de detecção"
       }
     },
     "headers": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -797,7 +797,19 @@
       "observation": "Pozorovanie",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Vedecký názov",
+        "classificationBadges": "Odznaky klasifikácie druhu",
+        "confidence": "Istota detekcie {confidence}%",
+        "metadata": "Metadáta detekcie",
+        "weatherConditions": "Poveternostné podmienky v čase detekcie",
+        "comments": "Komentáre k detekcii",
+        "commentText": "Text komentára",
+        "commentTimestamp": "Časová značka komentára",
+        "mainRegion": "Podrobnosti detekcie",
+        "tabsHeading": "Karty s informáciami o detekcii",
+        "tabList": "Karty podrobností detekcie",
+        "speciesHeadingSuffix": "podrobnosti detekcie"
       }
     },
     "headers": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -797,7 +797,19 @@
       "observation": "Observation",
       "aria": {
         "downloadAudioClip": "Download audio clip for {name} detection",
-        "audioRecordingFor": "Audio recording and spectrogram for {name}"
+        "audioRecordingFor": "Audio recording and spectrogram for {name}",
+        "scientificName": "Vetenskapligt namn",
+        "classificationBadges": "Märken för artklassificering",
+        "confidence": "Detekteringskonfidens {confidence}%",
+        "metadata": "Detekteringsmetadata",
+        "weatherConditions": "Väderförhållanden vid detekteringstillfället",
+        "comments": "Kommentarer till detekteringen",
+        "commentText": "Kommentarstext",
+        "commentTimestamp": "Tidsstämpel för kommentar",
+        "mainRegion": "Detekteringsinformation",
+        "tabsHeading": "Flikar med detekteringsinformation",
+        "tabList": "Flikar med detekteringsdetaljer",
+        "speciesHeadingSuffix": "detekteringsinformation"
       }
     },
     "headers": {


### PR DESCRIPTION
## Summary

Converts the remaining hardcoded English assistive strings in the detection detail view to i18n `t()` keys, so screen-reader and tooltip text follows the visitor's UI locale like the rest of the page.

- **DetectionDetail.svelte**: 12 `aria-label` / `sr-only` strings now use new `detections.detail.aria.*` keys (scientific name, classification badges, detection confidence, metadata, weather conditions, comments, comment text, comment timestamp, the main landmark, the tabs heading, the tab list, and the species-heading screen-reader suffix). The confidence label keeps its percentage via a `{confidence}` interpolation token.
- **Analytics.svelte**: the two species thumbnail `alt` fallbacks now reuse the existing `analytics.recentDetections.unknownSpecies` key instead of a hardcoded `'Unknown species'` literal, keeping the alt text in lockstep with the visible display name.

Adds 12 new keys with native translations across all 15 non-English locales (cs, da, de, es, fi, fr, hu, it, lv, nb, nl, pl, pt, sk, sv) and regenerates the i18n TypeScript types.

### Bonus fix

While converting the confidence label I fixed a pre-existing scaling bug: the old `aria-label` appended `%` to the raw 0..1 confidence fraction, so screen readers announced "Detection confidence 0.85%" instead of "85%". It now multiplies by 100 to match the visible `ConfidenceCircle` and the app-wide convention.

English output is otherwise unchanged; this is purely an accessibility/i18n cleanup with no behavioral change for existing users.

## Test Plan

- [x] `npm run check:all` (format, lint, typecheck, ast-grep) passes
- [x] `npm run i18n:sync:check` and `generate:i18n-types:check` pass
- [x] `npx tsx validateTranslations.ts` reports 15/15 locales, 0 errors, all 12 new keys translated (no English placeholders)
- [x] Targeted vitest suites (views, analytics, i18n) pass: 132 tests
- [ ] Manual: detection detail page reads localized aria labels under a non-English locale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility in detection details with localized ARIA labels for screen readers—covers scientific names, confidence indicators, metadata, weather conditions, comments, and tab/region headings.
  * Localized "Unknown species" alt text for recent detections and mobile thumbnails.
  * Added missing accessibility translations across 15+ languages for consistent multilingual support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->