### PR TITLE
fix(i18n): gate per-visitor client-side species localization off by default

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,7 +10,10 @@
   import { createSafeMap } from './lib/utils/security';
   import { sseNotifications } from './lib/stores/sseNotifications'; // Initialize SSE toast handler
   import { t, getLocale } from './lib/i18n';
-  import { loadDictionary } from './lib/stores/speciesDictionary.svelte';
+  import {
+    loadDictionary,
+    PER_VISITOR_SPECIES_LOCALE_ENABLED,
+  } from './lib/stores/speciesDictionary.svelte';
   import {
     appState,
     initApp,
@@ -570,7 +573,12 @@
   // refetch whenever the UI locale changes. getLocale() reads reactive state, so
   // reading it here re-runs the effect on locale switch. Fire-and-forget: the
   // dashboard falls back to server-provided common names until this resolves.
+  //
+  // PARKED behind PER_VISITOR_SPECIES_LOCALE_ENABLED: while off, we never fetch
+  // the dictionary, so species names follow the server-side species language
+  // (settings.BirdNET.Locale) instead of the visitor's UI locale.
   $effect(() => {
+    if (!PER_VISITOR_SPECIES_LOCALE_ENABLED) return;
     const locale = getLocale();
     // Read the version so the effect re-runs once app config populates it, fetching
     // the content-addressed URL instead of staying on the unversioned (short-cache) one.

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -31,7 +31,11 @@
   import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
   import { loggers } from '$lib/utils/logger';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
-  import { loadDictionary, searchScientificByCommon } from '$lib/stores/speciesDictionary.svelte';
+  import {
+    loadDictionary,
+    searchScientificByCommon,
+    PER_VISITOR_SPECIES_LOCALE_ENABLED,
+  } from '$lib/stores/speciesDictionary.svelte';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
@@ -278,8 +282,15 @@
       // silently fall back to the raw term (which the backend cannot resolve for a
       // foreign-locale name). loadDictionary is cached, so awaiting it when already
       // loaded is effectively instant.
-      await loadDictionary();
-      const resolvedScientific = searchScientificByCommon(speciesSearchTerm);
+      //
+      // PARKED behind PER_VISITOR_SPECIES_LOCALE_ENABLED: while off, we skip the
+      // per-visitor dictionary entirely and send only the raw term, so search
+      // resolves in the server-side species language (settings.BirdNET.Locale).
+      let resolvedScientific: string[] = [];
+      if (PER_VISITOR_SPECIES_LOCALE_ENABLED) {
+        await loadDictionary();
+        resolvedScientific = searchScientificByCommon(speciesSearchTerm);
+      }
 
       // Build request body
       const requestBody = {

--- a/frontend/src/lib/stores/speciesDictionary.svelte.ts
+++ b/frontend/src/lib/stores/speciesDictionary.svelte.ts
@@ -31,6 +31,34 @@ import type { Locale } from '$lib/i18n/config';
 const logger = getLogger('speciesDictionary');
 
 // ---------------------------------------------------------------------------
+// Feature gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Master switch for per-visitor, client-side species-name localization.
+ *
+ * PARKED (false) on purpose. The shipped overlay localized species names to the
+ * visitor's UI locale (getLocale()), which silently overrode the admin's explicit
+ * server-side species language (settings.BirdNET.Locale). For a user who runs the
+ * UI in English but sets the species language to Finnish, that turned species names
+ * back into English: a behavioral regression that conflates two independent axes
+ * (UI chrome language vs species-name language).
+ *
+ * While this is false, the two loadDictionary() call sites (App.svelte and
+ * Search.svelte) skip the fetch, so the store's maps stay empty and every consumer
+ * falls back to the server-locale behavior:
+ *   - display  (localizeSpeciesName) -> server-provided common name -> scientific
+ *   - search   (searchScientificByCommon) -> [] -> raw term resolved server-side
+ *   - settings (resolveCommonToScientificUnique) -> undefined -> prediction match
+ *
+ * The store, endpoint, generator and CI drift gate all stay in place, dormant.
+ * Re-enable ONLY together with a proper per-visitor species-language preference
+ * that is SEPARATE from the UI locale and DEFAULTS to settings.BirdNET.Locale
+ * (never the browser).
+ */
+export const PER_VISITOR_SPECIES_LOCALE_ENABLED = false;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/lib/stores/speciesDictionary.test.ts
+++ b/frontend/src/lib/stores/speciesDictionary.test.ts
@@ -39,6 +39,7 @@ import {
   resolveCommonToScientific,
   searchScientificByCommon,
   resetDictionaryForTest,
+  PER_VISITOR_SPECIES_LOCALE_ENABLED,
 } from './speciesDictionary.svelte';
 import { api } from '$lib/utils/api';
 import { getLocale } from '$lib/i18n/store.svelte';
@@ -77,6 +78,16 @@ const MOCK_FI_BAT_DICT: Record<string, string> = {
 function mockApiGet(dict: Record<string, string>): void {
   vi.mocked(api.get).mockResolvedValue(dict as unknown);
 }
+
+describe('per-visitor species locale gate', () => {
+  // The per-visitor client-side localization overlay is PARKED: it overrode the
+  // admin's server-side species language (settings.BirdNET.Locale) with the
+  // visitor's UI locale. This pins the release-blocking default so the gate is not
+  // flipped back on without the proper per-visitor species-language preference.
+  it('stays disabled until a species-language preference separate from the UI locale exists', () => {
+    expect(PER_VISITOR_SPECIES_LOCALE_ENABLED).toBe(false);
+  });
+});
 
 describe('speciesDictionary store', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

The per-visitor client-side species-name dictionary overlay localized species common names to the visitor's browser/UI locale, which silently overrode the server-side species language setting (`BirdNET.Locale`). A user running the dashboard UI in English but with the species language set to Finnish saw species names render in English instead of Finnish. That conflates two independent axes: UI chrome language and species-name language.

This adds a `PER_VISITOR_SPECIES_LOCALE_ENABLED` kill switch (default `false`) and gates the two `loadDictionary()` call sites (`App.svelte` and `Search.svelte`) behind it. With the dictionary never loaded, the store maps stay empty and every consumer falls back to server-locale behavior:

- display (`localizeSpeciesName`) falls back to the server-provided common name, then scientific
- search (`searchScientificByCommon`) sends the raw term, resolved server-side
- settings picker (`resolveCommonToScientificUnique`) falls back to prediction matching

The dictionary store, the public dictionary endpoint, the build-time generator, and the CI drift gate all stay in place but dormant, ready to re-enable behind a proper per-visitor species-language preference that is separate from the UI locale and defaults to `BirdNET.Locale`.

## Test Plan

- [x] `npm run check:all` (typecheck, lint, ast-grep, build) clean
- [x] Full frontend test suite passes
- [x] Added a test pinning `PER_VISITOR_SPECIES_LOCALE_ENABLED` to `false` so it cannot be flipped back on without the redesign
- [ ] Manual: dashboard UI in English with species language set to Finnish shows Finnish species names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added infrastructure for per-visitor species localization support (feature currently disabled pending additional configuration).

* **Tests**
  * Added test coverage for species localization feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->