### PR TITLE
fix(analytics): insights timeout status codes, timezone hour bucketing, zero-epoch timestamps

### DIFF
--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -429,7 +429,7 @@ func (c *Controller) getExpectedTodayImpl(ctx echo.Context) error {
 
 	results, err := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, nil)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query expected species", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "Expected species", "Failed to query expected species")
 	}
 
 	nameMap := c.loadCommonNameMap()
@@ -494,7 +494,7 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 
 	observations, err := c.EBirdClient.GetRecentObservations(reqCtx, lat, lng, 14)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query eBird observations", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "eBird observations", "Failed to query eBird observations")
 	}
 
 	// Get local species to deduplicate against (best-effort; if this fails, show all eBird results)
@@ -550,7 +550,7 @@ func (c *Controller) getPhantomSpeciesImpl(ctx echo.Context) error {
 
 	results, err := c.insightsRepo.GetPhantomSpecies(reqCtx, since, phantomMinDetections, phantomMaxAvgConfidence, nil)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query phantom species", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "Phantom species", "Failed to query phantom species")
 	}
 
 	nameMap := c.loadCommonNameMap()
@@ -591,7 +591,7 @@ func (c *Controller) getDawnChorusImpl(ctx echo.Context) error {
 
 	rawEntries, err := c.insightsRepo.GetDawnChorusRaw(reqCtx, since, dawnChorusStartHour, dawnChorusEndHour, nil)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query dawn chorus", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "Dawn chorus", "Failed to query dawn chorus")
 	}
 
 	// Group by species, compute DST-correct time-of-day averages
@@ -671,12 +671,12 @@ func (c *Controller) getMigrationImpl(ctx echo.Context) error {
 
 	arrivals, err := c.insightsRepo.GetNewArrivals(reqCtx, recentSince, nil)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query new arrivals", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "New arrivals", "Failed to query new arrivals")
 	}
 
 	quiet, err := c.insightsRepo.GetGoneQuiet(reqCtx, recentSince, migrationMinTotalDetections, nil)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query gone quiet species", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "Gone quiet species", "Failed to query gone quiet species")
 	}
 
 	nameMap := c.loadCommonNameMap()
@@ -733,7 +733,7 @@ func (c *Controller) getDashboardKPIsImpl(ctx echo.Context) error {
 
 	kpis, err := c.insightsRepo.GetDashboardKPIs(reqCtx, todayStart.Unix(), nil)
 	if err != nil {
-		return c.HandleError(ctx, err, "Failed to query dashboard KPIs", http.StatusInternalServerError)
+		return c.handleAnalyticsQueryError(ctx, err, "Dashboard KPIs", "Failed to query dashboard KPIs")
 	}
 
 	today := todayStart.Format(time.DateOnly)

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 )
 
-// mockInsightsRepo is a simple mock for handler tests.
+// mockInsightsRepo is a simple mock for handler tests. When err is non-nil every
+// query method returns it, which exercises the handlers' error-mapping path.
 type mockInsightsRepo struct {
 	phantomSpecies  []repository.PhantomSpecies
 	expectedSpecies []repository.ExpectedSpecies
@@ -23,30 +24,31 @@ type mockInsightsRepo struct {
 	newArrivals     []repository.NewArrival
 	goneQuiet       []repository.GoneQuietSpecies
 	dashboardKPIs   *repository.DashboardKPIs
+	err             error
 }
 
 func (m *mockInsightsRepo) GetExpectedSpeciesToday(_ context.Context, _ []repository.TimeRange, _ *uint) ([]repository.ExpectedSpecies, error) {
-	return m.expectedSpecies, nil
+	return m.expectedSpecies, m.err
 }
 
 func (m *mockInsightsRepo) GetPhantomSpecies(_ context.Context, _ int64, _ int, _ float64, _ *uint) ([]repository.PhantomSpecies, error) {
-	return m.phantomSpecies, nil
+	return m.phantomSpecies, m.err
 }
 
 func (m *mockInsightsRepo) GetDawnChorusRaw(_ context.Context, _ int64, _, _ int, _ *uint) ([]repository.DawnChorusRawEntry, error) {
-	return m.dawnChorusRaw, nil
+	return m.dawnChorusRaw, m.err
 }
 
 func (m *mockInsightsRepo) GetNewArrivals(_ context.Context, _ int64, _ *uint) ([]repository.NewArrival, error) {
-	return m.newArrivals, nil
+	return m.newArrivals, m.err
 }
 
 func (m *mockInsightsRepo) GetGoneQuiet(_ context.Context, _ int64, _ int, _ *uint) ([]repository.GoneQuietSpecies, error) {
-	return m.goneQuiet, nil
+	return m.goneQuiet, m.err
 }
 
 func (m *mockInsightsRepo) GetDashboardKPIs(_ context.Context, _ int64, _ *uint) (*repository.DashboardKPIs, error) {
-	return m.dashboardKPIs, nil
+	return m.dashboardKPIs, m.err
 }
 
 // setupInsightsTestController creates a minimal controller with a mock insights repo.
@@ -153,6 +155,82 @@ func TestGetMigration_Handler(t *testing.T) {
 	require.Len(t, resp.GoneQuiet, 1)
 	assert.Equal(t, "Great Tit", resp.NewArrivals[0].CommonName)
 	assert.Equal(t, "Eurasian Blackbird", resp.GoneQuiet[0].CommonName)
+}
+
+// TestInsightsEndpointContextErrors verifies that insights endpoints map a query
+// context error to the right HTTP status: a deadline to 408 (not 500) and a client
+// cancellation to 499 (client closed request). Regression guard for the insights
+// query-timeout consistency fix; mirrors TestAnalyticsEndpointContextErrors for the
+// insights handlers. The eBird regional endpoint is excluded because its failure
+// path is an external HTTP client, not the insights repository.
+func TestInsightsEndpointContextErrors(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "insights")
+	t.Attr("type", "error-handling")
+	t.Attr("feature", "query-timeout")
+
+	errorCases := []struct {
+		name       string
+		queryErr   error
+		wantStatus int
+		wantMsg    string
+	}{
+		{"deadline exceeded", context.DeadlineExceeded, http.StatusRequestTimeout, "Query timeout"},
+		{"client canceled", context.Canceled, StatusClientClosedRequest, "Request canceled by client"},
+	}
+
+	endpoints := []struct {
+		name   string
+		path   string
+		invoke func(*Controller, echo.Context) error
+	}{
+		{
+			name:   "expected today",
+			path:   "/api/v2/insights/expected-today",
+			invoke: func(c *Controller, ctx echo.Context) error { return c.getExpectedTodayImpl(ctx) },
+		},
+		{
+			name:   "phantom species",
+			path:   "/api/v2/insights/phantom-species",
+			invoke: func(c *Controller, ctx echo.Context) error { return c.getPhantomSpeciesImpl(ctx) },
+		},
+		{
+			name:   "dawn chorus",
+			path:   "/api/v2/insights/dawn-chorus",
+			invoke: func(c *Controller, ctx echo.Context) error { return c.getDawnChorusImpl(ctx) },
+		},
+		{
+			name:   "migration",
+			path:   "/api/v2/insights/migration",
+			invoke: func(c *Controller, ctx echo.Context) error { return c.getMigrationImpl(ctx) },
+		},
+		{
+			name:   "dashboard kpis",
+			path:   "/api/v2/dashboard/kpis",
+			invoke: func(c *Controller, ctx echo.Context) error { return c.getDashboardKPIsImpl(ctx) },
+		},
+	}
+
+	for _, ep := range endpoints {
+		for _, ec := range errorCases {
+			t.Run(ep.name+"/"+ec.name, func(t *testing.T) {
+				t.Parallel()
+				e, controller := setupInsightsTestController(t, &mockInsightsRepo{err: ec.queryErr})
+
+				req := httptest.NewRequest(http.MethodGet, ep.path, http.NoBody)
+				rec := httptest.NewRecorder()
+				ctx := e.NewContext(req, rec)
+				ctx.SetPath(ep.path)
+
+				require.NoError(t, ep.invoke(controller, ctx))
+				assert.Equal(t, ec.wantStatus, rec.Code)
+
+				var errorResponse map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &errorResponse))
+				assert.Contains(t, errorResponse["message"], ec.wantMsg)
+			})
+		}
+	}
 }
 
 func TestCalculateStreak(t *testing.T) {

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -110,8 +110,10 @@ type DetectionRepository interface {
 	// for the given label IDs in a single grouped query (per chunk). The result maps
 	// each label ID to its [24]int hourly counts; callers that span one species across
 	// multiple model label IDs sum the per-label arrays themselves. False positives are
-	// excluded and minConfidence filters by minimum confidence threshold.
-	GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) (map[uint][24]int, error)
+	// excluded and minConfidence filters by minimum confidence threshold. tzOffsetSeconds is
+	// the configured timezone's UTC offset, applied so detections bucket by wall-clock hour in
+	// that zone rather than the database/OS-local zone.
+	GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, tzOffsetSeconds int, minConfidence float64) (map[uint][24]int, error)
 
 	// GetDailyOccurrences returns daily detection counts for a label.
 	GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64) ([]DailyCount, error)
@@ -233,9 +235,10 @@ type DetectionRepository interface {
 	// modelID is optional; pass nil to include all models.
 	GetSpeciesSummary(ctx context.Context, start, end int64, modelID *uint) ([]SpeciesSummaryData, error)
 
-	// GetHourlyDistribution returns detection counts by hour.
-	// labelID and modelID are optional filters.
-	GetHourlyDistribution(ctx context.Context, start, end int64, labelID, modelID *uint) ([]HourlyDistributionData, error)
+	// GetHourlyDistribution returns detection counts by hour. tzOffsetSeconds is the
+	// configured timezone's UTC offset, applied so detections bucket by wall-clock hour in
+	// that zone rather than the database/OS-local zone. labelID and modelID are optional filters.
+	GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]HourlyDistributionData, error)
 
 	// GetDailyAnalytics returns daily statistics.
 	// labelID and modelID are optional filters.

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -127,14 +127,19 @@ func (r *detectionRepository) dateFromUnixExpr(column string) string {
 	return fmt.Sprintf("DATE(datetime(%s, 'unixepoch', 'localtime'))", column)
 }
 
-// hourFromUnixExpr returns a SQL expression to extract HOUR (0-23) from a Unix timestamp in local time.
-// SQLite: CAST(strftime('%%H', datetime(column, 'unixepoch', 'localtime')) AS INTEGER)
-// MySQL:  HOUR(FROM_UNIXTIME(column))
-func (r *detectionRepository) hourFromUnixExpr(column string) string {
+// hourFromUnixExpr returns a SQL expression that extracts the wall-clock HOUR (0-23) of a
+// Unix timestamp in the configured timezone. offsetSeconds is that zone's UTC offset; it is
+// added to the epoch before bucketing, so the result is independent of the database/OS-local
+// timezone (unlike the older 'localtime'/FROM_UNIXTIME form). This mirrors the IncludedHours
+// search-filter expression. detected_at is always positive, so the integer division and
+// modulo stay non-negative even for negative (west-of-UTC) offsets.
+// SQLite: CAST((column + offset) / 3600 AS INTEGER) % 24
+// MySQL:  FLOOR((column + offset) / 3600) % 24
+func (r *detectionRepository) hourFromUnixExpr(column string, offsetSeconds int) string {
 	if r.isMySQL {
-		return fmt.Sprintf("HOUR(FROM_UNIXTIME(%s))", column)
+		return fmt.Sprintf("FLOOR((%s + %d) / 3600) %% 24", column, offsetSeconds)
 	}
-	return fmt.Sprintf("CAST(strftime('%%H', datetime(%s, 'unixepoch', 'localtime')) AS INTEGER)", column)
+	return fmt.Sprintf("CAST((%s + %d) / 3600 AS INTEGER) %% 24", column, offsetSeconds)
 }
 
 // ============================================================================
@@ -837,7 +842,7 @@ func (r *detectionRepository) GetTopSpecies(ctx context.Context, start, end int6
 // Large label sets are chunked by batchQuerySize to stay within SQL host-parameter limits;
 // per-chunk results are merged before returning. Each label ID appears in exactly one chunk,
 // so no cross-chunk aggregation is needed.
-func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) (map[uint][24]int, error) {
+func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, tzOffsetSeconds int, minConfidence float64) (map[uint][24]int, error) {
 	result := make(map[uint][24]int, len(labelIDs))
 
 	// Return empty map for empty input (no query)
@@ -851,8 +856,8 @@ func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, lab
 		Count   int
 	}
 
-	// Extract hour from Unix timestamp in local timezone; exclude false positives.
-	hourExpr := r.hourFromUnixExpr("d.detected_at")
+	// Bucket by wall-clock hour in the configured timezone (offset-adjusted); exclude false positives.
+	hourExpr := r.hourFromUnixExpr("d.detected_at", tzOffsetSeconds)
 	detTable := r.tableName()
 	revTable := r.reviewsTable()
 
@@ -1517,12 +1522,12 @@ func (r *detectionRepository) buildAnalyticsBaseQuery(ctx context.Context, start
 }
 
 // GetHourlyDistribution returns detection counts by hour.
-func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, end int64, labelID, modelID *uint) ([]HourlyDistributionData, error) {
+func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]HourlyDistributionData, error) {
 	var results []HourlyDistributionData
 
-	// Use hourFromUnixExpr for correct local timezone conversion
+	// Bucket by wall-clock hour in the configured timezone via hourFromUnixExpr.
 	// Exclude detections marked as false_positive
-	hourExpr := r.hourFromUnixExpr("d.detected_at")
+	hourExpr := r.hourFromUnixExpr("d.detected_at", tzOffsetSeconds)
 	query := r.buildAnalyticsBaseQuery(ctx, start, end, labelID, modelID).
 		Select(fmt.Sprintf("%s as hour, COUNT(*) as count", hourExpr)).
 		Group("hour").

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -259,7 +259,7 @@ func TestGetBatchHourlyOccurrences(t *testing.T) {
 		&entities.Detection{LabelID: 30, ModelID: 1, Confidence: 0.2, DetectedAt: base}).Error)
 
 	t.Run("per-label counts with confidence filter", func(t *testing.T) {
-		got, err := repo.GetBatchHourlyOccurrences(t.Context(), []uint{10, 20, 30, 99}, base-1, base+10_000, 0.5)
+		got, err := repo.GetBatchHourlyOccurrences(t.Context(), []uint{10, 20, 30, 99}, base-1, base+10_000, 0, 0.5)
 		require.NoError(t, err)
 
 		require.Contains(t, got, uint(10))
@@ -271,7 +271,7 @@ func TestGetBatchHourlyOccurrences(t *testing.T) {
 	})
 
 	t.Run("empty input returns empty map", func(t *testing.T) {
-		got, err := repo.GetBatchHourlyOccurrences(t.Context(), nil, base-1, base+10_000, 0.0)
+		got, err := repo.GetBatchHourlyOccurrences(t.Context(), nil, base-1, base+10_000, 0, 0.0)
 		require.NoError(t, err)
 		assert.Empty(t, got)
 	})
@@ -279,7 +279,7 @@ func TestGetBatchHourlyOccurrences(t *testing.T) {
 	t.Run("cancelled context surfaces an error", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
-		_, err := repo.GetBatchHourlyOccurrences(ctx, []uint{10}, base-1, base+10_000, 0.0)
+		_, err := repo.GetBatchHourlyOccurrences(ctx, []uint{10}, base-1, base+10_000, 0, 0.0)
 		require.ErrorIs(t, err, context.Canceled, "a cancelled context must abort the query with context.Canceled, not return zeros")
 	})
 }
@@ -294,6 +294,40 @@ func totalBatchHourly(byLabel map[uint][24]int, labelID uint) int {
 		total += c
 	}
 	return total
+}
+
+// TestGetBatchHourlyOccurrences_TimezoneOffset verifies that a detection buckets into the
+// hour given by the supplied timezone offset, not the database/OS-local zone. A single
+// detection at UTC midnight must land in hour 0 at UTC, hour 2 at UTC+2, and hour 23
+// (previous day) at UTC-1. Guards against bucketing in the engine's local timezone.
+func TestGetBatchHourlyOccurrences_TimezoneOffset(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	repo := &detectionRepository{db: db}
+
+	// 2024-06-15T00:00:00Z.
+	const utcMidnight = int64(1718409600)
+	createDetectionForLabel(t, db, 10, utcMidnight)
+
+	cases := []struct {
+		name       string
+		offsetSecs int
+		wantHour   int
+	}{
+		{"utc", 0, 0},
+		{"plus two hours", 2 * 3600, 2},
+		{"minus one hour wraps to previous day", -3600, 23},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := repo.GetBatchHourlyOccurrences(
+				t.Context(), []uint{10}, utcMidnight-86_400, utcMidnight+86_400, tc.offsetSecs, 0.0)
+			require.NoError(t, err)
+			require.Equal(t, 1, totalBatchHourly(got, 10), "exactly one detection regardless of offset")
+			counts := got[10]
+			assert.Equal(t, 1, counts[tc.wantHour],
+				"detection must bucket into the offset-adjusted hour %d", tc.wantHour)
+		})
+	}
 }
 
 // ============================================================================

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -196,20 +196,27 @@ func MergeHourFilters(timeOfDay []string, hour *datastore.HourFilter) []int {
 	return intersection
 }
 
-// GetTimezoneOffset returns the timezone offset in seconds for the given location.
-// Uses the current time to determine the offset (handles DST).
-//
-// LIMITATION: This applies the current DST state to all data. When filtering
-// historical data that spans DST transitions, hour boundaries may be off by
-// up to 1 hour for data recorded in a different DST state than the current one.
-// For most use cases (recent data, non-DST timezones), this is acceptable.
-// For precise historical hour filtering across DST boundaries, consider using
-// database-native timezone conversion functions.
+// GetTimezoneOffset returns the timezone offset in seconds for the given location at the
+// current time (handles DST for "now"). See GetTimezoneOffsetAt for the DST limitation.
 func GetTimezoneOffset(tz *time.Location) int {
+	return GetTimezoneOffsetAt(tz, time.Now())
+}
+
+// GetTimezoneOffsetAt returns the timezone offset in seconds for the given location at the
+// instant t (handles DST for that instant). Prefer this over GetTimezoneOffset when the
+// query has a known reference time (e.g. the start of the queried day), so the offset
+// reflects the data's DST state rather than the current one.
+//
+// LIMITATION: a single offset is applied to a whole query. When bucketing or filtering data
+// that spans a DST transition, hours may be off by up to 1 hour for rows recorded in a
+// different DST state than t. For most use cases (recent data, single-day windows, non-DST
+// timezones) this is acceptable; for precise historical conversion across DST boundaries,
+// use database-native timezone conversion functions.
+func GetTimezoneOffsetAt(tz *time.Location, t time.Time) int {
 	if tz == nil {
 		tz = time.Local
 	}
-	_, offset := time.Now().In(tz).Zone()
+	_, offset := t.In(tz).Zone()
 	return offset
 }
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1245,7 +1245,7 @@ func (ds *Datastore) GetBatchHourlyOccurrences(ctx context.Context, date string,
 	}
 
 	// Fetch per-label hourly counts in one batched query (chunked internally).
-	hourlyByLabel, err := ds.detection.GetBatchHourlyOccurrences(ctx, flatLabelIDs, startOfDay, endOfDay, minConfidence)
+	hourlyByLabel, err := ds.detection.GetBatchHourlyOccurrences(ctx, flatLabelIDs, startOfDay, endOfDay, ds.zoneOffsetSeconds(startOfDay), minConfidence)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("datastore").
@@ -2352,6 +2352,26 @@ func (ds *Datastore) parseDateRange(startDate, endDate string) (start, end int64
 	return start, end, nil
 }
 
+// unixTimeOrZero converts a Unix epoch (seconds) to a time.Time in loc, returning the
+// zero value for a non-positive epoch. A zero/negative epoch means "no detection time"
+// rather than the 1970 epoch origin, so the API layer (formatTimeIfNotZero) renders it
+// as an empty timestamp instead of 1970-01-01.
+func unixTimeOrZero(epoch int64, loc *time.Location) time.Time {
+	if epoch <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(epoch, 0).In(loc)
+}
+
+// zoneOffsetSeconds returns the configured timezone's UTC offset in seconds in effect at
+// the given epoch. SQL hour bucketing adds this offset to detected_at so detections group
+// by wall-clock hour in ds.timezone rather than the database/OS-local zone. Anchoring the
+// offset to the queried epoch (rather than "now") keeps it correct for historical days;
+// see repository.GetTimezoneOffsetAt for the single-offset DST limitation on multi-day ranges.
+func (ds *Datastore) zoneOffsetSeconds(epoch int64) int {
+	return repository.GetTimezoneOffsetAt(ds.timezone, time.Unix(epoch, 0))
+}
+
 // GetSpeciesSummaryData retrieves species summary data.
 func (ds *Datastore) GetSpeciesSummaryData(ctx context.Context, startDate, endDate string) ([]datastore.SpeciesSummaryData, error) {
 	start, end, err := ds.parseDateRange(startDate, endDate)
@@ -2378,8 +2398,8 @@ func (ds *Datastore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 			CommonName:     commonName,
 			SpeciesCode:    ds.speciesCodeMap[sciName],
 			Count:          int(d.TotalDetections),
-			FirstSeen:      time.Unix(d.FirstDetection, 0).In(ds.timezone),
-			LastSeen:       time.Unix(d.LastDetection, 0).In(ds.timezone),
+			FirstSeen:      unixTimeOrZero(d.FirstDetection, ds.timezone),
+			LastSeen:       unixTimeOrZero(d.LastDetection, ds.timezone),
 			AvgConfidence:  d.AvgConfidence,
 			MaxConfidence:  d.MaxConfidence,
 		})
@@ -2402,7 +2422,7 @@ func (ds *Datastore) GetHourlyAnalyticsData(ctx context.Context, date, species s
 		return nil, err
 	}
 
-	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, labelID, nil)
+	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, ds.zoneOffsetSeconds(start), labelID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2500,7 +2520,7 @@ func (ds *Datastore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, labelID, nil)
+	v2Data, err := ds.detection.GetHourlyDistribution(ctx, start, end, ds.zoneOffsetSeconds(start), labelID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2538,7 +2558,12 @@ func (ds *Datastore) convertToNewSpeciesData(_ context.Context, data []speciesFi
 		// Look up common name from pre-built map, fallback to scientific name
 		commonName := ds.resolveCommonName(sciName)
 
-		firstSeenDate := time.Unix(d.FirstDetected, 0).In(ds.timezone).Format(time.DateOnly)
+		// A zero/negative epoch means "no detection date"; emit an empty string instead
+		// of formatting the 1970 epoch origin (mirrors the LastDetected guard below).
+		var firstSeenDate string
+		if d.FirstDetected > 0 {
+			firstSeenDate = time.Unix(d.FirstDetected, 0).In(ds.timezone).Format(time.DateOnly)
+		}
 		var lastSeenDate string
 		if d.LastDetected > 0 {
 			lastSeenDate = time.Unix(d.LastDetected, 0).In(ds.timezone).Format(time.DateOnly)

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2360,16 +2360,27 @@ func unixTimeOrZero(epoch int64, loc *time.Location) time.Time {
 	if epoch <= 0 {
 		return time.Time{}
 	}
+	if loc == nil {
+		loc = time.Local
+	}
 	return time.Unix(epoch, 0).In(loc)
 }
 
 // zoneOffsetSeconds returns the configured timezone's UTC offset in seconds in effect at
 // the given epoch. SQL hour bucketing adds this offset to detected_at so detections group
 // by wall-clock hour in ds.timezone rather than the database/OS-local zone. Anchoring the
-// offset to the queried epoch (rather than "now") keeps it correct for historical days;
-// see repository.GetTimezoneOffsetAt for the single-offset DST limitation on multi-day ranges.
+// offset to the queried epoch (rather than "now") keeps it correct for historical days.
+//
+// For an open-ended range parseDateRange yields start==0; anchoring to the 1970 epoch would
+// pick an arbitrary historical offset, so non-positive epochs fall back to the current offset
+// (the best single choice for an all-time range). The single-offset approach is still a DST
+// approximation on multi-day ranges; see repository.GetTimezoneOffsetAt for that limitation.
 func (ds *Datastore) zoneOffsetSeconds(epoch int64) int {
-	return repository.GetTimezoneOffsetAt(ds.timezone, time.Unix(epoch, 0))
+	ref := time.Unix(epoch, 0)
+	if epoch <= 0 {
+		ref = time.Now()
+	}
+	return repository.GetTimezoneOffsetAt(ds.timezone, ref)
 }
 
 // GetSpeciesSummaryData retrieves species summary data.

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1756,3 +1756,47 @@ func TestBuildNameMaps_AmbiguousCommonNameDeletedNotLastWriterWins(t *testing.T)
 	assert.Equal(t, "Owl", nm.common["Strix aluco"], "forward map must retain common name for Strix aluco")
 	assert.Equal(t, "Owl", nm.common["Bubo bubo"], "forward map must retain common name for Bubo bubo")
 }
+
+// TestUnixTimeOrZero verifies that a non-positive epoch yields the zero time (so the
+// API renders an empty timestamp) instead of the 1970 epoch origin, while a positive
+// epoch converts in the supplied location.
+func TestUnixTimeOrZero(t *testing.T) {
+	t.Parallel()
+
+	t.Run("positive epoch converts in location", func(t *testing.T) {
+		t.Parallel()
+		got := unixTimeOrZero(1718000000, time.UTC)
+		require.False(t, got.IsZero())
+		assert.Equal(t, int64(1718000000), got.Unix())
+		assert.Equal(t, time.UTC, got.Location())
+	})
+
+	t.Run("zero epoch returns zero time", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, unixTimeOrZero(0, time.UTC).IsZero())
+	})
+
+	t.Run("negative epoch returns zero time", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, unixTimeOrZero(-1, time.UTC).IsZero())
+	})
+}
+
+// TestConvertToNewSpeciesData_ZeroEpoch verifies the new-species path emits an empty
+// date for a zero/negative FirstDetected epoch rather than formatting 1970-01-01.
+func TestConvertToNewSpeciesData_ZeroEpoch(t *testing.T) {
+	t.Parallel()
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	got := ds.convertToNewSpeciesData(t.Context(), []speciesFirstSeenInfo{
+		{ScientificName: "Parus major", FirstDetected: 0, LastDetected: 0},
+		{ScientificName: "Turdus merula", FirstDetected: 1718000000, LastDetected: 1718600000},
+	})
+
+	require.Len(t, got, 2)
+	assert.Empty(t, got[0].FirstSeenDate, "zero epoch must not render the 1970 origin")
+	assert.Empty(t, got[0].LastSeenDate)
+	assert.NotEmpty(t, got[1].FirstSeenDate)
+	assert.NotEmpty(t, got[1].LastSeenDate)
+}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1780,6 +1780,13 @@ func TestUnixTimeOrZero(t *testing.T) {
 		t.Parallel()
 		assert.True(t, unixTimeOrZero(-1, time.UTC).IsZero())
 	})
+
+	t.Run("nil location does not panic", func(t *testing.T) {
+		t.Parallel()
+		got := unixTimeOrZero(1718000000, nil)
+		require.False(t, got.IsZero())
+		assert.Equal(t, int64(1718000000), got.Unix())
+	})
 }
 
 // TestConvertToNewSpeciesData_ZeroEpoch verifies the new-species path emits an empty


### PR DESCRIPTION
## Summary

Three correctness fixes across the analytics + insights API and the v2only analytics datastore. All are internally-filed follow-ups; no user-facing API or config contract changes.

### 1. Insights endpoints: correct HTTP status on query timeout/cancellation
The seven insights handlers (expected-today, expected-today/regional, phantom-species, dawn-chorus, migration, dashboard KPIs) wrapped their datastore queries in a `context.WithTimeout` but mapped every error to HTTP 500. A query that exceeded the deadline therefore surfaced as 500 instead of 408, and a client disconnect as 500 instead of 499. They now route through the shared `handleAnalyticsQueryError` mapper the analytics endpoints already use: `context.DeadlineExceeded` -> 408, `context.Canceled` -> 499, anything else -> 500.

### 2. Timezone-aware hour bucketing
The hourly-occurrence and hourly-distribution charts extracted the detection hour with SQLite `'localtime'` / MySQL `FROM_UNIXTIME`, which resolve against the database/OS-local zone rather than the configured `ds.timezone`. When those differ, detections near midnight landed in the wrong hour bucket while the day window (already computed in `ds.timezone`) disagreed. The hour expression now buckets arithmetically as `((detected_at + offset) / 3600) % 24`, with the zone's UTC offset anchored to the queried day, mirroring the existing `IncludedHours` search-filter expression and dropping the DB-local-zone dependency. The offset helper is consolidated as `repository.GetTimezoneOffsetAt`.

Scope note: this fixes the hourly charts (the user-visible symptom). The date/year SQL expressions and the insights `dawn-chorus` hour filter share the same latent DB-local-zone issue and are intentionally left for a separate follow-up (they involve date grouping and a different repository, so a half-applied change there would be inconsistent).

### 3. Zero-epoch timestamps no longer render 1970-01-01
`GetSpeciesSummaryData` and the new-species path formatted a zero/negative detection epoch as `1970-01-01` via `time.Unix(0, 0)`. Non-positive epochs are now guarded so the API renders an empty timestamp instead.

A fourth tracked item (species-summary returning 500) was found to be already resolved by the recent query-timeout consistency work; its behavior is now pinned by the existing `TestAnalyticsEndpointContextErrors` regression test, so no code change was needed here.

## Tests
- Insights context-error mapping across the repo-backed endpoints (408 / 499).
- Per-hour timezone bucketing (UTC, +2h, -1h wrap-to-23).
- Zero-epoch timestamp guards.

## Preflight Status

- [x] Single concern: analytics/insights query correctness
- [x] Preflight passed: 6-dimension review + Gemini cross-validation; findings (helper duplication, doc/comment staleness) fixed
- [x] Linters clean: `golangci-lint run` (full project) -> 0 issues
- [x] Tests pass: `go test -race ./internal/datastore/... ./internal/api/v2/...`
- [x] No regression/backward-compat break: no migration, config-key, or wire-contract changes; HTTP 408/499 already handled by the frontend; same-zone users with no in-range DST transition see unchanged buckets
- [x] No secrets or PII in diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hourly analytics now respect timezone offsets for accurate time-based reporting.
  * Missing detection timestamps no longer render as 1970-01-01.
  * Insights endpoints return clearer, standardized error responses on query/database failures.

* **Tests**
  * Added coverage for timezone bucketing and error-to-status mapping across insights endpoints.

* **Chores**
  * Consolidated analytics error handling to a shared helper for consistent responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->