### PR TITLE
fix(analytics): bucket date and year SQL by configured timezone

### DIFF
--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -273,6 +273,15 @@ func buildThumbnailURL(scientificName string) string {
 	return imageprovider.ProxyImageURL(scientificName)
 }
 
+// analyticsTZOffset returns the server local timezone's UTC offset (seconds) in effect at ref.
+// Insights date/hour/year SQL adds this offset to detected_at so rows bucket by wall-clock value
+// in the same zone the handlers use (time.Now()/time.Local), independent of the DB session /
+// OS-local zone. This mirrors the datastore's ds.timezone (time.Local in production) and reuses
+// repository.GetTimezoneOffsetAt, the same helper the hourly charts use.
+func analyticsTZOffset(ref time.Time) int {
+	return repository.GetTimezoneOffsetAt(time.Local, ref)
+}
+
 // buildYearRanges computes index-friendly Unix timestamp ranges for the
 // +/- windowDays around today's day-of-year in each previous year.
 func buildYearRanges(now time.Time, windowDays int) []repository.TimeRange {
@@ -427,7 +436,7 @@ func (c *Controller) getExpectedTodayImpl(ctx echo.Context) error {
 	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), insightsQueryTimeout)
 	defer cancel()
 
-	results, err := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, nil)
+	results, err := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, analyticsTZOffset(now), nil)
 	if err != nil {
 		return c.handleAnalyticsQueryError(ctx, err, "Expected species", "Failed to query expected species")
 	}
@@ -498,8 +507,9 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 	}
 
 	// Get local species to deduplicate against (best-effort; if this fails, show all eBird results)
-	yearRanges := buildYearRanges(time.Now(), expectedTodayWindowDays)
-	localSpecies, localErr := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, nil)
+	now := time.Now()
+	yearRanges := buildYearRanges(now, expectedTodayWindowDays)
+	localSpecies, localErr := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, analyticsTZOffset(now), nil)
 	if localErr != nil {
 		c.logAPIRequest(ctx, logger.LogLevelWarn, "Failed to query local species for deduplication",
 			logger.Error(localErr))
@@ -589,7 +599,7 @@ func (c *Controller) getDawnChorusImpl(ctx echo.Context) error {
 	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), insightsQueryTimeout)
 	defer cancel()
 
-	rawEntries, err := c.insightsRepo.GetDawnChorusRaw(reqCtx, since, dawnChorusStartHour, dawnChorusEndHour, nil)
+	rawEntries, err := c.insightsRepo.GetDawnChorusRaw(reqCtx, since, dawnChorusStartHour, dawnChorusEndHour, analyticsTZOffset(time.Unix(since, 0)), nil)
 	if err != nil {
 		return c.handleAnalyticsQueryError(ctx, err, "Dawn chorus", "Failed to query dawn chorus")
 	}
@@ -731,7 +741,7 @@ func (c *Controller) getDashboardKPIsImpl(ctx echo.Context) error {
 	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), insightsQueryTimeout)
 	defer cancel()
 
-	kpis, err := c.insightsRepo.GetDashboardKPIs(reqCtx, todayStart.Unix(), nil)
+	kpis, err := c.insightsRepo.GetDashboardKPIs(reqCtx, todayStart.Unix(), analyticsTZOffset(now), nil)
 	if err != nil {
 		return c.handleAnalyticsQueryError(ctx, err, "Dashboard KPIs", "Failed to query dashboard KPIs")
 	}

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -25,6 +25,11 @@ type mockInsightsRepo struct {
 	goneQuiet       []repository.GoneQuietSpecies
 	dashboardKPIs   *repository.DashboardKPIs
 	err             error
+
+	// lastTzOffsetSeconds records the most recent timezone offset forwarded by a handler, so
+	// tests can assert the handler actually threads analyticsTZOffset into the repository rather
+	// than passing 0 or a stale reference time.
+	lastTzOffsetSeconds int
 }
 
 func (m *mockInsightsRepo) GetExpectedSpeciesToday(_ context.Context, _ []repository.TimeRange, _ int, _ *uint) ([]repository.ExpectedSpecies, error) {
@@ -47,7 +52,8 @@ func (m *mockInsightsRepo) GetGoneQuiet(_ context.Context, _ int64, _ int, _ *ui
 	return m.goneQuiet, m.err
 }
 
-func (m *mockInsightsRepo) GetDashboardKPIs(_ context.Context, _ int64, _ int, _ *uint) (*repository.DashboardKPIs, error) {
+func (m *mockInsightsRepo) GetDashboardKPIs(_ context.Context, _ int64, tzOffsetSeconds int, _ *uint) (*repository.DashboardKPIs, error) {
+	m.lastTzOffsetSeconds = tzOffsetSeconds
 	return m.dashboardKPIs, m.err
 }
 
@@ -126,6 +132,12 @@ func TestGetDashboardKPIs_Handler(t *testing.T) {
 	assert.Equal(t, int64(87), resp.LifetimeSpecies)
 	assert.Equal(t, int64(42), resp.TodayDetections)
 	assert.Equal(t, 2, resp.DetectionStreak.Days)
+
+	// The handler must forward the configured-timezone offset (not 0) so the repository buckets
+	// "today" in the same zone the handler computed the day boundary in. analyticsTZOffset uses
+	// time.Local at the request instant; recompute it here within the same DST window.
+	assert.Equal(t, repository.GetTimezoneOffsetAt(time.Local, time.Now()), mockRepo.lastTzOffsetSeconds,
+		"handler must thread analyticsTZOffset into GetDashboardKPIs")
 }
 
 func TestGetMigration_Handler(t *testing.T) {

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -27,7 +27,7 @@ type mockInsightsRepo struct {
 	err             error
 }
 
-func (m *mockInsightsRepo) GetExpectedSpeciesToday(_ context.Context, _ []repository.TimeRange, _ *uint) ([]repository.ExpectedSpecies, error) {
+func (m *mockInsightsRepo) GetExpectedSpeciesToday(_ context.Context, _ []repository.TimeRange, _ int, _ *uint) ([]repository.ExpectedSpecies, error) {
 	return m.expectedSpecies, m.err
 }
 
@@ -35,7 +35,7 @@ func (m *mockInsightsRepo) GetPhantomSpecies(_ context.Context, _ int64, _ int, 
 	return m.phantomSpecies, m.err
 }
 
-func (m *mockInsightsRepo) GetDawnChorusRaw(_ context.Context, _ int64, _, _ int, _ *uint) ([]repository.DawnChorusRawEntry, error) {
+func (m *mockInsightsRepo) GetDawnChorusRaw(_ context.Context, _ int64, _, _, _ int, _ *uint) ([]repository.DawnChorusRawEntry, error) {
 	return m.dawnChorusRaw, m.err
 }
 
@@ -47,7 +47,7 @@ func (m *mockInsightsRepo) GetGoneQuiet(_ context.Context, _ int64, _ int, _ *ui
 	return m.goneQuiet, m.err
 }
 
-func (m *mockInsightsRepo) GetDashboardKPIs(_ context.Context, _ int64, _ *uint) (*repository.DashboardKPIs, error) {
+func (m *mockInsightsRepo) GetDashboardKPIs(_ context.Context, _ int64, _ int, _ *uint) (*repository.DashboardKPIs, error) {
 	return m.dashboardKPIs, m.err
 }
 

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -123,8 +123,13 @@ func TestGetDashboardKPIs_Handler(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
+	// Bracket the handler's internal time.Now() so the offset assertion holds even if a DST
+	// transition lands mid-test: the handler's offset must equal the local offset at some instant
+	// during the call (before or after are the only possible values, even across a boundary).
+	beforeOffset := repository.GetTimezoneOffsetAt(time.Local, time.Now())
 	err := controller.getDashboardKPIsImpl(ctx)
 	require.NoError(t, err)
+	afterOffset := repository.GetTimezoneOffsetAt(time.Local, time.Now())
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var resp DashboardKPIsResponse
@@ -134,9 +139,8 @@ func TestGetDashboardKPIs_Handler(t *testing.T) {
 	assert.Equal(t, 2, resp.DetectionStreak.Days)
 
 	// The handler must forward the configured-timezone offset (not 0) so the repository buckets
-	// "today" in the same zone the handler computed the day boundary in. analyticsTZOffset uses
-	// time.Local at the request instant; recompute it here within the same DST window.
-	assert.Equal(t, repository.GetTimezoneOffsetAt(time.Local, time.Now()), mockRepo.lastTzOffsetSeconds,
+	// "today" in the same zone the handler computed the day boundary in.
+	assert.Contains(t, []int{beforeOffset, afterOffset}, mockRepo.lastTzOffsetSeconds,
 		"handler must thread analyticsTZOffset into GetDashboardKPIs")
 }
 

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -116,7 +116,9 @@ type DetectionRepository interface {
 	GetBatchHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, tzOffsetSeconds int, minConfidence float64) (map[uint][24]int, error)
 
 	// GetDailyOccurrences returns daily detection counts for a label.
-	GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64) ([]DailyCount, error)
+	// tzOffsetSeconds is the configured timezone's UTC offset, applied so detections bucket by
+	// wall-clock date in that zone rather than the database/OS-local zone.
+	GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64, tzOffsetSeconds int) ([]DailyCount, error)
 
 	// GetSpeciesFirstDetection returns the first-ever detection of a species.
 	// Returns ErrDetectionNotFound if the species has never been detected.
@@ -241,13 +243,17 @@ type DetectionRepository interface {
 	GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]HourlyDistributionData, error)
 
 	// GetDailyAnalytics returns daily statistics.
+	// tzOffsetSeconds is the configured timezone's UTC offset, applied so detections bucket by
+	// wall-clock date in that zone rather than the database/OS-local zone.
 	// labelID and modelID are optional filters.
-	GetDailyAnalytics(ctx context.Context, start, end int64, labelID, modelID *uint) ([]DailyAnalyticsData, error)
+	GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]DailyAnalyticsData, error)
 
 	// GetDetectionTrends returns detection trends over time.
 	// period is "day", "week", or "month".
+	// tzOffsetSeconds is the configured timezone's UTC offset, applied so detections bucket by
+	// wall-clock date in that zone rather than the database/OS-local zone.
 	// modelID is optional.
-	GetDetectionTrends(ctx context.Context, period string, limit int, modelID *uint) ([]DailyAnalyticsData, error)
+	GetDetectionTrends(ctx context.Context, period string, limit, tzOffsetSeconds int, modelID *uint) ([]DailyAnalyticsData, error)
 
 	// GetNewSpecies returns species detected for the first time ever within the range.
 	GetNewSpecies(ctx context.Context, start, end int64, limit, offset int) ([]NewSpeciesData, error)

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -117,14 +117,25 @@ func (r *detectionRepository) sourcesTable() string {
 	return tableAudioSources
 }
 
-// dateFromUnixExpr returns a SQL expression to extract DATE from a Unix timestamp in local time.
-// SQLite: DATE(datetime(column, 'unixepoch', 'localtime'))
-// MySQL:  DATE(FROM_UNIXTIME(column))
-func (r *detectionRepository) dateFromUnixExpr(column string) string {
+// dateFromUnixExpr returns a SQL expression for the wall-clock calendar date (YYYY-MM-DD) of a
+// Unix timestamp in the configured timezone. offsetSeconds is that zone's UTC offset; it is added
+// to the epoch before the date is taken, so the result is independent of the database session /
+// OS-local timezone (unlike the older 'localtime' / FROM_UNIXTIME form). This mirrors
+// hourFromUnixExpr. detected_at is always positive, so the integer division stays non-negative
+// even for west-of-UTC (negative) offsets.
+//
+// The MySQL form computes the civil date arithmetically (DATE_ADD on a literal date with an
+// integer day count) so it does not depend on the session time_zone; DATE(FROM_UNIXTIME(...))
+// would apply that zone on top of the offset and double-count. Integer DIV avoids floating-point
+// rounding at exact day boundaries.
+//
+// SQLite: date(column + offset, 'unixepoch')
+// MySQL:  DATE_ADD('1970-01-01', INTERVAL (column + offset) DIV 86400 DAY)
+func (r *detectionRepository) dateFromUnixExpr(column string, offsetSeconds int) string {
 	if r.isMySQL {
-		return fmt.Sprintf("DATE(FROM_UNIXTIME(%s))", column)
+		return fmt.Sprintf("DATE_ADD('1970-01-01', INTERVAL (%s + %d) DIV 86400 DAY)", column, offsetSeconds)
 	}
-	return fmt.Sprintf("DATE(datetime(%s, 'unixepoch', 'localtime'))", column)
+	return fmt.Sprintf("date(%s + %d, 'unixepoch')", column, offsetSeconds)
 }
 
 // hourFromUnixExpr returns a SQL expression that extracts the wall-clock HOUR (0-23) of a
@@ -895,11 +906,11 @@ func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, lab
 }
 
 // GetDailyOccurrences returns daily detection counts for a label.
-func (r *detectionRepository) GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64) ([]DailyCount, error) {
+func (r *detectionRepository) GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64, tzOffsetSeconds int) ([]DailyCount, error) {
 	var results []DailyCount
 
-	// Group by date using dialect-appropriate date conversion
-	dateExpr := r.dateFromUnixExpr("detected_at")
+	// Group by wall-clock date in the configured timezone (offset-adjusted).
+	dateExpr := r.dateFromUnixExpr("detected_at", tzOffsetSeconds)
 	err := r.db.WithContext(ctx).Table(r.tableName()).
 		Select(fmt.Sprintf("%s as date, COUNT(*) as count", dateExpr)).
 		Where("label_id = ? AND detected_at >= ? AND detected_at <= ?", labelID, start, end).
@@ -1538,12 +1549,12 @@ func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, 
 }
 
 // GetDailyAnalytics returns daily statistics.
-func (r *detectionRepository) GetDailyAnalytics(ctx context.Context, start, end int64, labelID, modelID *uint) ([]DailyAnalyticsData, error) {
+func (r *detectionRepository) GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]DailyAnalyticsData, error) {
 	var results []DailyAnalyticsData
 
-	// Use dialect-appropriate date conversion
+	// Group by wall-clock date in the configured timezone (offset-adjusted).
 	// Exclude detections marked as false_positive
-	dateExpr := r.dateFromUnixExpr("d.detected_at")
+	dateExpr := r.dateFromUnixExpr("d.detected_at", tzOffsetSeconds)
 	query := r.buildAnalyticsBaseQuery(ctx, start, end, labelID, modelID).
 		Select(fmt.Sprintf(`
 			%s as date,
@@ -1559,7 +1570,7 @@ func (r *detectionRepository) GetDailyAnalytics(ctx context.Context, start, end 
 }
 
 // GetDetectionTrends returns detection trends over time.
-func (r *detectionRepository) GetDetectionTrends(ctx context.Context, period string, limit int, modelID *uint) ([]DailyAnalyticsData, error) {
+func (r *detectionRepository) GetDetectionTrends(ctx context.Context, period string, limit, tzOffsetSeconds int, modelID *uint) ([]DailyAnalyticsData, error) {
 	// Calculate start time based on period
 	var startTime int64
 	now := time.Now().Unix()
@@ -1573,7 +1584,7 @@ func (r *detectionRepository) GetDetectionTrends(ctx context.Context, period str
 		startTime = now - (24 * 3600)
 	}
 
-	return r.GetDailyAnalytics(ctx, startTime, now, nil, modelID)
+	return r.GetDailyAnalytics(ctx, startTime, now, tzOffsetSeconds, nil, modelID)
 }
 
 // GetNewSpecies returns species detected for the first time ever within the range.

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -330,6 +330,41 @@ func TestGetBatchHourlyOccurrences_TimezoneOffset(t *testing.T) {
 	}
 }
 
+// TestGetDailyAnalytics_TimezoneOffset verifies that a near-midnight detection buckets into the
+// calendar date given by the supplied timezone offset, not the database/OS-local zone. A detection
+// at 2024-06-14T23:30:00Z falls on 2024-06-14 at UTC, crosses to 2024-06-15 at UTC+2, and stays on
+// 2024-06-14 at UTC-1. Guards against date bucketing in the engine's local timezone (the deferred
+// half of the hourly fix in TestGetBatchHourlyOccurrences_TimezoneOffset).
+func TestGetDailyAnalytics_TimezoneOffset(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	repo := &detectionRepository{db: db}
+
+	// 2024-06-14T23:30:00Z, 30 minutes before UTC midnight.
+	const nearMidnight = int64(1718407800)
+	createDetectionForLabel(t, db, 10, nearMidnight)
+
+	cases := []struct {
+		name       string
+		offsetSecs int
+		wantDate   string
+	}{
+		{"utc", 0, "2024-06-14"},
+		{"plus two hours crosses midnight", 2 * 3600, "2024-06-15"},
+		{"minus one hour stays previous day", -3600, "2024-06-14"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := repo.GetDailyAnalytics(
+				t.Context(), nearMidnight-86_400, nearMidnight+86_400, tc.offsetSecs, nil, nil)
+			require.NoError(t, err)
+			require.Len(t, got, 1, "exactly one date bucket regardless of offset")
+			assert.Equal(t, tc.wantDate, got[0].Date,
+				"detection must bucket into the offset-adjusted date %s", tc.wantDate)
+			assert.Equal(t, int64(1), got[0].TotalDetections)
+		})
+	}
+}
+
 // ============================================================================
 // Lock Tests
 // ============================================================================

--- a/internal/datastore/v2/repository/insights.go
+++ b/internal/datastore/v2/repository/insights.go
@@ -7,7 +7,9 @@ import "context"
 type InsightsRepository interface {
 	// GetExpectedSpeciesToday returns species detected within the given
 	// Unix timestamp ranges (one per previous year, pre-calculated for index usage).
-	GetExpectedSpeciesToday(ctx context.Context, yearRanges []TimeRange, modelID *uint) ([]ExpectedSpecies, error)
+	// tzOffsetSeconds is the configured timezone's UTC offset, applied so the date and
+	// year grouping bucket by wall-clock value in that zone rather than the DB/OS-local zone.
+	GetExpectedSpeciesToday(ctx context.Context, yearRanges []TimeRange, tzOffsetSeconds int, modelID *uint) ([]ExpectedSpecies, error)
 
 	// GetPhantomSpecies returns species with minDetections+ in the period
 	// but average confidence below maxAvgConfidence.
@@ -15,7 +17,10 @@ type InsightsRepository interface {
 
 	// GetDawnChorusRaw returns per-day earliest detection per species
 	// in the given hour range. Caller averages time-of-day in Go.
-	GetDawnChorusRaw(ctx context.Context, since int64, startHour, endHour int, modelID *uint) ([]DawnChorusRawEntry, error)
+	// tzOffsetSeconds is the configured timezone's UTC offset, applied to BOTH the hour
+	// filter and the date grouping so the query is internally consistent (a single offset
+	// for both) rather than mixing the DB/OS-local zone with the configured zone.
+	GetDawnChorusRaw(ctx context.Context, since int64, startHour, endHour, tzOffsetSeconds int, modelID *uint) ([]DawnChorusRawEntry, error)
 
 	// GetNewArrivals returns species whose first-ever detection is after recentSince.
 	GetNewArrivals(ctx context.Context, recentSince int64, modelID *uint) ([]NewArrival, error)
@@ -26,5 +31,8 @@ type InsightsRepository interface {
 
 	// GetDashboardKPIs returns lifetime species count, today's detections,
 	// best day, and recent distinct dates for streak calculation.
-	GetDashboardKPIs(ctx context.Context, todaySince int64, modelID *uint) (*DashboardKPIs, error)
+	// tzOffsetSeconds is the configured timezone's UTC offset, applied so the date grouping
+	// (best day, recent dates) buckets by wall-clock date in that zone rather than the
+	// DB/OS-local zone.
+	GetDashboardKPIs(ctx context.Context, todaySince int64, tzOffsetSeconds int, modelID *uint) (*DashboardKPIs, error)
 }

--- a/internal/datastore/v2/repository/insights_impl.go
+++ b/internal/datastore/v2/repository/insights_impl.go
@@ -45,26 +45,40 @@ func (r *insightsRepository) reviewsTable() string {
 	return tableDetectionReviews
 }
 
-// SQL expression helpers — same pattern as detectionRepository.
-func (r *insightsRepository) dateFromUnixExpr(column string) string {
+// SQL expression helpers — same offset-arithmetic pattern as detectionRepository.hourFromUnixExpr.
+// offsetSeconds is the configured timezone's UTC offset; it is added to the epoch before the
+// date/hour/year is extracted, so the result buckets by wall-clock value in that zone and is
+// independent of the database session / OS-local timezone (unlike the older 'localtime' /
+// FROM_UNIXTIME forms). detected_at is always positive and offsets are bounded, so the
+// arithmetic stays non-negative even for west-of-UTC (negative) offsets.
+
+// dateFromUnixExpr returns a SQL expression for the wall-clock calendar date (YYYY-MM-DD).
+// SQLite: date(column + offset, 'unixepoch')
+// MySQL:  DATE_ADD('1970-01-01', INTERVAL (column + offset) DIV 86400 DAY)
+//
+// The MySQL form computes the civil date arithmetically (DATE_ADD on a literal date with an
+// integer day count) so it does not depend on the session time_zone; DATE(FROM_UNIXTIME(...))
+// would apply the session zone on top of the offset and double-count. Integer DIV avoids any
+// floating-point rounding at exact day boundaries.
+func (r *insightsRepository) dateFromUnixExpr(column string, offsetSeconds int) string {
 	if r.isMySQL {
-		return fmt.Sprintf("DATE(FROM_UNIXTIME(%s))", column)
+		return fmt.Sprintf("DATE_ADD('1970-01-01', INTERVAL (%s + %d) DIV 86400 DAY)", column, offsetSeconds)
 	}
-	return fmt.Sprintf("DATE(datetime(%s, 'unixepoch', 'localtime'))", column)
+	return fmt.Sprintf("date(%s + %d, 'unixepoch')", column, offsetSeconds)
 }
 
-func (r *insightsRepository) hourFromUnixExpr(column string) string {
+func (r *insightsRepository) hourFromUnixExpr(column string, offsetSeconds int) string {
 	if r.isMySQL {
-		return fmt.Sprintf("HOUR(FROM_UNIXTIME(%s))", column)
+		return fmt.Sprintf("FLOOR((%s + %d) / 3600) %% 24", column, offsetSeconds)
 	}
-	return fmt.Sprintf("CAST(strftime('%%H', datetime(%s, 'unixepoch', 'localtime')) AS INTEGER)", column)
+	return fmt.Sprintf("CAST((%s + %d) / 3600 AS INTEGER) %% 24", column, offsetSeconds)
 }
 
-func (r *insightsRepository) yearFromUnixExpr(column string) string {
+func (r *insightsRepository) yearFromUnixExpr(column string, offsetSeconds int) string {
 	if r.isMySQL {
-		return fmt.Sprintf("YEAR(FROM_UNIXTIME(%s))", column)
+		return fmt.Sprintf("YEAR(DATE_ADD('1970-01-01', INTERVAL (%s + %d) DIV 86400 DAY))", column, offsetSeconds)
 	}
-	return fmt.Sprintf("CAST(strftime('%%Y', datetime(%s, 'unixepoch', 'localtime')) AS INTEGER)", column)
+	return fmt.Sprintf("CAST(strftime('%%Y', %s + %d, 'unixepoch') AS INTEGER)", column, offsetSeconds)
 }
 
 // falsePositiveExclusion returns the standard LEFT JOIN + WHERE clause
@@ -77,7 +91,7 @@ func (r *insightsRepository) falsePositiveExclusion(detAlias string) (joinClause
 	return joinClause, whereClause
 }
 
-func (r *insightsRepository) GetExpectedSpeciesToday(ctx context.Context, yearRanges []TimeRange, modelID *uint) ([]ExpectedSpecies, error) {
+func (r *insightsRepository) GetExpectedSpeciesToday(ctx context.Context, yearRanges []TimeRange, tzOffsetSeconds int, modelID *uint) ([]ExpectedSpecies, error) {
 	if len(yearRanges) == 0 {
 		return nil, nil
 	}
@@ -85,8 +99,8 @@ func (r *insightsRepository) GetExpectedSpeciesToday(ctx context.Context, yearRa
 	det := r.detectionsTable()
 	lab := r.labelsTable()
 	fpJoin, fpWhere := r.falsePositiveExclusion("d")
-	dateExpr := r.dateFromUnixExpr("d.detected_at")
-	yearExpr := r.yearFromUnixExpr("d.detected_at")
+	dateExpr := r.dateFromUnixExpr("d.detected_at", tzOffsetSeconds)
+	yearExpr := r.yearFromUnixExpr("d.detected_at", tzOffsetSeconds)
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
@@ -133,7 +147,7 @@ func (r *insightsRepository) GetPhantomSpecies(ctx context.Context, since int64,
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group(lab + ".scientific_name").
+	query = query.Group(lab+".scientific_name").
 		Having("COUNT(*) >= ? AND AVG(d.confidence) < ?", minDetections, maxAvgConfidence).
 		Order("avg_confidence ASC")
 
@@ -144,12 +158,15 @@ func (r *insightsRepository) GetPhantomSpecies(ctx context.Context, since int64,
 	return results, nil
 }
 
-func (r *insightsRepository) GetDawnChorusRaw(ctx context.Context, since int64, startHour, endHour int, modelID *uint) ([]DawnChorusRawEntry, error) {
+func (r *insightsRepository) GetDawnChorusRaw(ctx context.Context, since int64, startHour, endHour, tzOffsetSeconds int, modelID *uint) ([]DawnChorusRawEntry, error) {
 	det := r.detectionsTable()
 	lab := r.labelsTable()
 	fpJoin, fpWhere := r.falsePositiveExclusion("d")
-	hourExpr := r.hourFromUnixExpr("d.detected_at")
-	dateExpr := r.dateFromUnixExpr("d.detected_at")
+	// Hour filter and date grouping MUST share the same offset to keep the query internally
+	// consistent (otherwise a near-midnight detection could be hour-filtered in one zone and
+	// date-grouped in another).
+	hourExpr := r.hourFromUnixExpr("d.detected_at", tzOffsetSeconds)
+	dateExpr := r.dateFromUnixExpr("d.detected_at", tzOffsetSeconds)
 
 	query := r.db.WithContext(ctx).
 		Table(fmt.Sprintf("%s d", det)).
@@ -190,7 +207,7 @@ func (r *insightsRepository) GetNewArrivals(ctx context.Context, recentSince int
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group(lab + ".scientific_name").
+	query = query.Group(lab+".scientific_name").
 		Having("MIN(d.detected_at) >= ?", recentSince).
 		Order("first_detected DESC")
 
@@ -217,7 +234,7 @@ func (r *insightsRepository) GetGoneQuiet(ctx context.Context, recentSince int64
 		query = query.Where("d.model_id = ?", *modelID)
 	}
 
-	query = query.Group(lab + ".scientific_name").
+	query = query.Group(lab+".scientific_name").
 		Having("COUNT(*) >= ? AND MAX(d.detected_at) < ?", minTotalDetections, recentSince).
 		Order("last_detected DESC")
 
@@ -228,10 +245,10 @@ func (r *insightsRepository) GetGoneQuiet(ctx context.Context, recentSince int64
 	return results, nil
 }
 
-func (r *insightsRepository) GetDashboardKPIs(ctx context.Context, todaySince int64, modelID *uint) (*DashboardKPIs, error) {
+func (r *insightsRepository) GetDashboardKPIs(ctx context.Context, todaySince int64, tzOffsetSeconds int, modelID *uint) (*DashboardKPIs, error) {
 	det := r.detectionsTable()
 	fpJoin, fpWhere := r.falsePositiveExclusion("d")
-	dateExpr := r.dateFromUnixExpr("d.detected_at")
+	dateExpr := r.dateFromUnixExpr("d.detected_at", tzOffsetSeconds)
 
 	kpis := &DashboardKPIs{}
 

--- a/internal/datastore/v2/repository/insights_impl_test.go
+++ b/internal/datastore/v2/repository/insights_impl_test.go
@@ -77,6 +77,15 @@ func seedFalsePositiveReview(t *testing.T, db *gorm.DB, detectionID uint) {
 	require.NoError(t, db.Create(&review).Error)
 }
 
+// localOffsetAt returns time.Local's UTC offset (seconds) at ref. The tests below seed timestamps
+// in time.Local and assert local-zone bucketing, so they pass the matching offset (the same value
+// production derives via GetTimezoneOffsetAt) to the offset-aware insights queries. Dedicated
+// bucketing tests pass explicit offsets and fixed UTC instants instead, so they are independent of
+// the host's zone.
+func localOffsetAt(ref time.Time) int {
+	return GetTimezoneOffsetAt(time.Local, ref)
+}
+
 func TestGetPhantomSpecies(t *testing.T) {
 	db := setupInsightsTestDB(t)
 	repo := NewInsightsRepository(db, false, false)
@@ -155,17 +164,21 @@ func TestGetExpectedSpeciesToday(t *testing.T) {
 		},
 	}
 
-	results, err := repo.GetExpectedSpeciesToday(ctx, yearRanges, nil)
+	results, err := repo.GetExpectedSpeciesToday(ctx, yearRanges, localOffsetAt(y2Start), nil)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
 	// Species A should be first (seen in 2 years)
 	assert.Equal(t, "Turdus merula", results[0].ScientificName)
 	assert.Equal(t, 2, results[0].YearsSeen)
+	// MAX(date) asserts the date expression groups in the configured zone: the latest Turdus
+	// merula detection is 2025-03-07 (00:00 local), so LastSeenDate must be that calendar day.
+	assert.Equal(t, "2025-03-07", results[0].LastSeenDate)
 
 	// Species B seen in 1 year
 	assert.Equal(t, "Parus major", results[1].ScientificName)
 	assert.Equal(t, 1, results[1].YearsSeen)
+	assert.Equal(t, "2024-03-08", results[1].LastSeenDate)
 }
 
 func TestGetDawnChorusRaw(t *testing.T) {
@@ -193,7 +206,7 @@ func TestGetDawnChorusRaw(t *testing.T) {
 	// Detection before since (should be excluded)
 	seedDetection(t, db, labelA, now.AddDate(0, 0, -45).Add(5*time.Hour).Unix(), 0.8)
 
-	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, nil)
+	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, localOffsetAt(now), nil)
 	require.NoError(t, err)
 	require.Len(t, results, 2) // 2 days
 
@@ -296,7 +309,7 @@ func TestGetDashboardKPIs(t *testing.T) {
 		seedDetection(t, db, labelC, bestDay.Add(time.Duration(i)*time.Hour).Unix(), 0.9)
 	}
 
-	kpis, err := repo.GetDashboardKPIs(ctx, today.Unix(), nil)
+	kpis, err := repo.GetDashboardKPIs(ctx, today.Unix(), localOffsetAt(today), nil)
 	require.NoError(t, err)
 	require.NotNil(t, kpis)
 
@@ -312,7 +325,7 @@ func TestGetDashboardKPIs_Empty(t *testing.T) {
 	repo := NewInsightsRepository(db, false, false)
 	ctx := t.Context()
 
-	kpis, err := repo.GetDashboardKPIs(ctx, time.Now().Unix(), nil)
+	kpis, err := repo.GetDashboardKPIs(ctx, time.Now().Unix(), localOffsetAt(time.Now()), nil)
 	require.NoError(t, err)
 	require.NotNil(t, kpis)
 	assert.Equal(t, int64(0), kpis.LifetimeSpecies)
@@ -413,7 +426,7 @@ func TestGetDawnChorusRaw_MultiModel(t *testing.T) {
 	seedDetectionForModel(t, db, labelA1, 1, day1.Add(5*time.Hour).Unix(), 0.9)
 	seedDetectionForModel(t, db, labelA2, 2, day1.Add(6*time.Hour).Unix(), 0.85)
 
-	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, nil)
+	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, localOffsetAt(now), nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1, "same species on same day from two models should produce one result")
 	assert.Equal(t, "Turdus merula", results[0].ScientificName)
@@ -468,7 +481,7 @@ func TestGetExpectedSpeciesToday_MultiModel(t *testing.T) {
 		},
 	}
 
-	results, err := repo.GetExpectedSpeciesToday(ctx, yearRanges, nil)
+	results, err := repo.GetExpectedSpeciesToday(ctx, yearRanges, localOffsetAt(y2Start), nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1, "same species from two models should produce one result")
 	assert.Equal(t, "Turdus merula", results[0].ScientificName)
@@ -492,7 +505,7 @@ func TestGetDashboardKPIs_MultiModel(t *testing.T) {
 	labelB := seedLabelForModel(t, db, "Parus major", 1)
 	seedDetectionForModel(t, db, labelB, 1, today.Add(4*time.Hour).Unix(), 0.8)
 
-	kpis, err := repo.GetDashboardKPIs(ctx, today.Unix(), nil)
+	kpis, err := repo.GetDashboardKPIs(ctx, today.Unix(), localOffsetAt(today), nil)
 	require.NoError(t, err)
 	require.NotNil(t, kpis)
 	assert.Equal(t, int64(2), kpis.LifetimeSpecies, "same species from two models should count as one")
@@ -526,7 +539,52 @@ func TestGetExpectedSpeciesToday_EmptyRanges(t *testing.T) {
 	repo := NewInsightsRepository(db, false, false)
 	ctx := t.Context()
 
-	results, err := repo.GetExpectedSpeciesToday(ctx, nil, nil)
+	results, err := repo.GetExpectedSpeciesToday(ctx, nil, 0, nil)
 	require.NoError(t, err)
 	assert.Nil(t, results)
+}
+
+// TestGetExpectedSpeciesToday_TimezoneBucketing verifies the date (MAX) and year
+// (COUNT DISTINCT) expressions bucket by the supplied timezone offset, not the database/OS-local
+// zone. Two near-midnight detections at fixed UTC instants straddle a calendar-day and a
+// calendar-year boundary, so the offset changes both the date and the distinct-year count. Using
+// explicit UTC instants and explicit offsets keeps the test independent of the host's zone.
+func TestGetExpectedSpeciesToday_TimezoneBucketing(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewInsightsRepository(db, false, false)
+	ctx := t.Context()
+
+	label := seedLabel(t, db, "Turdus merula")
+
+	// 2023-12-31T23:30:00Z: year 2023 at UTC, but 2024-01-01 (year 2024) at UTC+5.
+	yearBoundary := time.Date(2023, 12, 31, 23, 30, 0, 0, time.UTC).Unix()
+	seedDetection(t, db, label, yearBoundary, 0.9)
+	// 2024-03-08T23:30:00Z: date 2024-03-08 at UTC, but 2024-03-09 at UTC+5.
+	nearMidnight := time.Date(2024, 3, 8, 23, 30, 0, 0, time.UTC).Unix()
+	seedDetection(t, db, label, nearMidnight, 0.9)
+
+	// A single wide range covering both detections; the range filter is on the raw detected_at
+	// epoch, so it is unaffected by the bucketing offset.
+	ranges := []TimeRange{{
+		Start: time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC).Unix(),
+		End:   time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC).Unix(),
+	}}
+
+	const offsetEast = 5 * 3600 // UTC+5
+
+	t.Run("utc buckets the two detections as distinct years", func(t *testing.T) {
+		got, err := repo.GetExpectedSpeciesToday(ctx, ranges, 0, nil)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, 2, got[0].YearsSeen, "2023-12-31 and 2024-03-08 are distinct years at UTC")
+		assert.Equal(t, "2024-03-08", got[0].LastSeenDate)
+	})
+
+	t.Run("east offset rolls both detections into 2024", func(t *testing.T) {
+		got, err := repo.GetExpectedSpeciesToday(ctx, ranges, offsetEast, nil)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, 1, got[0].YearsSeen, "at UTC+5 the year-boundary detection rolls into 2024")
+		assert.Equal(t, "2024-03-09", got[0].LastSeenDate, "23:30Z + 5h crosses to the next calendar day")
+	})
 }

--- a/internal/datastore/v2/repository/insights_impl_test.go
+++ b/internal/datastore/v2/repository/insights_impl_test.go
@@ -132,16 +132,19 @@ func TestGetExpectedSpeciesToday(t *testing.T) {
 	repo := NewInsightsRepository(db, false, false)
 	ctx := t.Context()
 
-	// Species A: detected in two previous years around same DOY
+	// Species A: detected in two previous years around same DOY.
+	// Seed at local noon (not midnight) so the single query-wide offset cannot shift a row onto
+	// the adjacent calendar day on a non-UTC host near a DST boundary; the asserted dates stay
+	// stable for any host offset.
 	labelA := seedLabel(t, db, "Turdus merula")
 
-	// Year 1 (2024): March 8-10 timestamps
-	y1Start := time.Date(2024, 3, 8, 0, 0, 0, 0, time.Local)
+	// Year 1 (2024): March 8-9 (noon)
+	y1Start := time.Date(2024, 3, 8, 12, 0, 0, 0, time.Local)
 	seedDetection(t, db, labelA, y1Start.Unix(), 0.9)
 	seedDetection(t, db, labelA, y1Start.Add(24*time.Hour).Unix(), 0.85)
 
-	// Year 2 (2025): March 7-9 timestamps
-	y2Start := time.Date(2025, 3, 7, 0, 0, 0, 0, time.Local)
+	// Year 2 (2025): March 7 (noon)
+	y2Start := time.Date(2025, 3, 7, 12, 0, 0, 0, time.Local)
 	seedDetection(t, db, labelA, y2Start.Unix(), 0.88)
 
 	// Species B: detected in only one previous year
@@ -196,9 +199,10 @@ func TestGetDawnChorusRaw(t *testing.T) {
 	seedDetection(t, db, labelA, day1.Add(5*time.Hour).Unix(), 0.9)
 	seedDetection(t, db, labelA, day1.Add(6*time.Hour+30*time.Minute).Unix(), 0.85)
 
-	// Day 2: detection at 4:15 AM
+	// Day 2: detection at 6:00 AM (kept clear of the 4 AM filter edge so a one-hour offset
+	// difference cannot drop it out of the dawn window)
 	day2 := time.Date(now.Year(), now.Month(), now.Day()-3, 0, 0, 0, 0, time.Local)
-	seedDetection(t, db, labelA, day2.Add(4*time.Hour+15*time.Minute).Unix(), 0.88)
+	seedDetection(t, db, labelA, day2.Add(6*time.Hour).Unix(), 0.88)
 
 	// Detection outside hour range (11:00 AM — should be excluded)
 	seedDetection(t, db, labelA, day1.Add(11*time.Hour).Unix(), 0.92)
@@ -206,7 +210,9 @@ func TestGetDawnChorusRaw(t *testing.T) {
 	// Detection before since (should be excluded)
 	seedDetection(t, db, labelA, now.AddDate(0, 0, -45).Add(5*time.Hour).Unix(), 0.8)
 
-	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, localOffsetAt(now), nil)
+	// Anchor the offset to the seeded day (not now, which is up to 5 days later) so the hour
+	// bucketing matches the data's DST state regardless of host zone.
+	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, localOffsetAt(day1), nil)
 	require.NoError(t, err)
 	require.Len(t, results, 2) // 2 days
 
@@ -302,11 +308,13 @@ func TestGetDashboardKPIs(t *testing.T) {
 	seedDetection(t, db, labelB, today.AddDate(0, 0, -1).Add(6*time.Hour).Unix(), 0.82)
 	seedDetection(t, db, labelB, today.AddDate(0, 0, -2).Add(7*time.Hour).Unix(), 0.80)
 
-	// Species C: 5 detections on a single day (should be best day candidate)
+	// Species C: 5 detections on a single day (should be best day candidate). Seed around midday
+	// (hours 10-14) so the single query-wide offset cannot split the day's count across a calendar
+	// boundary on a non-UTC host.
 	labelC := seedLabel(t, db, "Corvus corax")
 	bestDay := today.AddDate(0, 0, -5)
 	for i := range 5 {
-		seedDetection(t, db, labelC, bestDay.Add(time.Duration(i)*time.Hour).Unix(), 0.9)
+		seedDetection(t, db, labelC, bestDay.Add(time.Duration(i+10)*time.Hour).Unix(), 0.9)
 	}
 
 	kpis, err := repo.GetDashboardKPIs(ctx, today.Unix(), localOffsetAt(today), nil)
@@ -426,7 +434,8 @@ func TestGetDawnChorusRaw_MultiModel(t *testing.T) {
 	seedDetectionForModel(t, db, labelA1, 1, day1.Add(5*time.Hour).Unix(), 0.9)
 	seedDetectionForModel(t, db, labelA2, 2, day1.Add(6*time.Hour).Unix(), 0.85)
 
-	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, localOffsetAt(now), nil)
+	// Anchor the offset to the seeded day so the asserted earliest hour is exact regardless of host.
+	results, err := repo.GetDawnChorusRaw(ctx, since, 4, 10, localOffsetAt(day1), nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1, "same species on same day from two models should produce one result")
 	assert.Equal(t, "Turdus merula", results[0].ScientificName)
@@ -464,10 +473,12 @@ func TestGetExpectedSpeciesToday_MultiModel(t *testing.T) {
 	labelA1 := seedLabelForModel(t, db, "Turdus merula", 1)
 	labelA2 := seedLabelForModel(t, db, "Turdus merula", 2)
 
-	y1Start := time.Date(2024, 3, 8, 0, 0, 0, 0, time.Local)
+	// Seed at local noon so the single query-wide offset cannot shift a row across a day boundary
+	// on a non-UTC host (keeps the distinct-year count stable regardless of host offset).
+	y1Start := time.Date(2024, 3, 8, 12, 0, 0, 0, time.Local)
 	seedDetectionForModel(t, db, labelA1, 1, y1Start.Unix(), 0.9)
 
-	y2Start := time.Date(2025, 3, 7, 0, 0, 0, 0, time.Local)
+	y2Start := time.Date(2025, 3, 7, 12, 0, 0, 0, time.Local)
 	seedDetectionForModel(t, db, labelA2, 2, y2Start.Unix(), 0.88)
 
 	yearRanges := []TimeRange{

--- a/internal/datastore/v2/repository/types.go
+++ b/internal/datastore/v2/repository/types.go
@@ -132,7 +132,8 @@ type SpeciesCount struct {
 // because daily aggregations are timezone-dependent and the string format
 // is more natural for display and grouping purposes.
 type DailyCount struct {
-	// Date in YYYY-MM-DD format (local timezone).
+	// Date in YYYY-MM-DD format, bucketed in the configured timezone (offset-adjusted),
+	// not necessarily the database/OS-local zone.
 	Date string
 
 	// Count is the number of detections on this date.

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -62,9 +62,7 @@ const (
 	maxHour = 23
 	// saveTransactionTimeout is the maximum duration for a Save transaction.
 	// This prevents indefinite lock holding during slow I/O operations.
-	saveTransactionTimeout  = 30 * time.Second
-	sqliteDetectionDateExpr = "date(d.detected_at, 'unixepoch', 'localtime')"
-	mysqlDetectionDateExpr  = "DATE(FROM_UNIXTIME(d.detected_at))"
+	saveTransactionTimeout = 30 * time.Second
 )
 
 // parseHour validates and parses an hour string to an integer.
@@ -2383,6 +2381,23 @@ func (ds *Datastore) zoneOffsetSeconds(epoch int64) int {
 	return repository.GetTimezoneOffsetAt(ds.timezone, ref)
 }
 
+// detectionDateExpr returns a SQL expression for the wall-clock calendar date (YYYY-MM-DD) of
+// d.detected_at in the configured timezone. offsetSeconds is added to the epoch before the date
+// is taken, so the result buckets by date in ds.timezone and is independent of the database
+// session / OS-local zone (the same offset-arithmetic approach as the hour bucketing). The
+// MySQL form uses DATE_ADD on a literal date with an integer day count so it does not depend on
+// the session time_zone; DATE(FROM_UNIXTIME(...)) would apply that zone on top of the offset and
+// double-count. Integer DIV avoids floating-point rounding at exact day boundaries.
+//
+// SQLite: date(d.detected_at + offset, 'unixepoch')
+// MySQL:  DATE_ADD('1970-01-01', INTERVAL (d.detected_at + offset) DIV 86400 DAY)
+func (ds *Datastore) detectionDateExpr(offsetSeconds int) string {
+	if ds.manager.IsMySQL() {
+		return fmt.Sprintf("DATE_ADD('1970-01-01', INTERVAL (d.detected_at + %d) DIV 86400 DAY)", offsetSeconds)
+	}
+	return fmt.Sprintf("date(d.detected_at + %d, 'unixepoch')", offsetSeconds)
+}
+
 // GetSpeciesSummaryData retrieves species summary data.
 func (ds *Datastore) GetSpeciesSummaryData(ctx context.Context, startDate, endDate string) ([]datastore.SpeciesSummaryData, error) {
 	start, end, err := ds.parseDateRange(startDate, endDate)
@@ -2484,7 +2499,8 @@ func (ds *Datastore) GetDailyAnalyticsData(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	v2Data, err := ds.detection.GetDailyAnalytics(ctx, start, end, labelID, nil)
+	// Bucket dates by the configured timezone, anchored to the range start.
+	v2Data, err := ds.detection.GetDailyAnalytics(ctx, start, end, ds.zoneOffsetSeconds(start), labelID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2501,7 +2517,8 @@ func (ds *Datastore) GetDailyAnalyticsData(ctx context.Context, startDate, endDa
 
 // GetDetectionTrends retrieves detection trends.
 func (ds *Datastore) GetDetectionTrends(ctx context.Context, period string, limit int) ([]datastore.DailyAnalyticsData, error) {
-	v2Data, err := ds.detection.GetDetectionTrends(ctx, period, limit, nil)
+	// Trends cover a trailing window ending now, so anchor the offset to the current time.
+	v2Data, err := ds.detection.GetDetectionTrends(ctx, period, limit, ds.zoneOffsetSeconds(0), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2651,10 +2668,8 @@ func (ds *Datastore) GetSpeciesDetectionDatesInPeriod(ctx context.Context, start
 		limit = 10000
 	}
 
-	dateExpr := sqliteDetectionDateExpr
-	if ds.manager.IsMySQL() {
-		dateExpr = mysqlDetectionDateExpr
-	}
+	// Bucket dates by the configured timezone, anchored to the range start.
+	dateExpr := ds.detectionDateExpr(ds.zoneOffsetSeconds(start))
 
 	type result struct {
 		ScientificName string `gorm:"column:scientific_name"`
@@ -2705,10 +2720,8 @@ func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scie
 		return "", fmt.Errorf("invalid before date format: %w", err)
 	}
 
-	dateExpr := sqliteDetectionDateExpr
-	if ds.manager.IsMySQL() {
-		dateExpr = mysqlDetectionDateExpr
-	}
+	// Bucket dates by the configured timezone, anchored to the before date.
+	dateExpr := ds.detectionDateExpr(ds.zoneOffsetSeconds(before.Unix()))
 
 	var result struct {
 		LastSeenDate string `gorm:"column:last_seen_date"`
@@ -2754,13 +2767,17 @@ func (ds *Datastore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 
 	var results []datastore.DailyAnalyticsData
 
-	// Generate database-agnostic date expression
-	// MySQL: DATE(FROM_UNIXTIME(d.detected_at))
-	// SQLite: date(d.detected_at, 'unixepoch', 'localtime') - localtime for timezone-aware bucketing
-	dateExpr := sqliteDetectionDateExpr
-	if ds.manager.IsMySQL() {
-		dateExpr = mysqlDetectionDateExpr
+	// Bucket dates by the configured timezone, anchored to the start of the requested window
+	// (or the current offset for an open-ended range). The SELECT, GROUP BY, and BETWEEN filter
+	// all reuse this single expression so they stay internally consistent; the user's date
+	// strings are interpreted in the same zone the dates are bucketed in.
+	var refEpoch int64
+	if startDate != "" {
+		if t, perr := time.ParseInLocation(time.DateOnly, startDate, ds.timezone); perr == nil {
+			refEpoch = t.Unix()
+		}
 	}
+	dateExpr := ds.detectionDateExpr(ds.zoneOffsetSeconds(refEpoch))
 
 	// Build query to count distinct species per day, excluding false positives
 	prefix := ds.manager.TablePrefix()

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2381,6 +2381,23 @@ func (ds *Datastore) zoneOffsetSeconds(epoch int64) int {
 	return repository.GetTimezoneOffsetAt(ds.timezone, ref)
 }
 
+// dateRangeOffsetAnchor returns the epoch to anchor the timezone offset to for a date-bucketed
+// query over [start, end) (epochs from parseDateRange: start==0 means open-start, end==MaxInt64
+// means open-end). It prefers the start boundary, falls back to the end boundary for a left-open
+// range, and only as a last resort returns 0 (which zoneOffsetSeconds maps to the current offset)
+// for a fully open range. Anchoring to a query boundary rather than "now" keeps an end-only
+// historical query bucketing the same way regardless of when it runs.
+func dateRangeOffsetAnchor(start, end int64) int64 {
+	switch {
+	case start > 0:
+		return start
+	case end > 0 && end != math.MaxInt64:
+		return end
+	default:
+		return 0
+	}
+}
+
 // detectionDateExpr returns a SQL expression for the wall-clock calendar date (YYYY-MM-DD) of
 // d.detected_at in the configured timezone. offsetSeconds is added to the epoch before the date
 // is taken, so the result buckets by date in ds.timezone and is independent of the database
@@ -2499,8 +2516,9 @@ func (ds *Datastore) GetDailyAnalyticsData(ctx context.Context, startDate, endDa
 		return nil, err
 	}
 
-	// Bucket dates by the configured timezone, anchored to the range start.
-	v2Data, err := ds.detection.GetDailyAnalytics(ctx, start, end, ds.zoneOffsetSeconds(start), labelID, nil)
+	// Bucket dates by the configured timezone, anchored to a query boundary (start, or end for a
+	// left-open range) so an end-only historical query buckets stably regardless of run time.
+	v2Data, err := ds.detection.GetDailyAnalytics(ctx, start, end, ds.zoneOffsetSeconds(dateRangeOffsetAnchor(start, end)), labelID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2668,8 +2686,9 @@ func (ds *Datastore) GetSpeciesDetectionDatesInPeriod(ctx context.Context, start
 		limit = 10000
 	}
 
-	// Bucket dates by the configured timezone, anchored to the range start.
-	dateExpr := ds.detectionDateExpr(ds.zoneOffsetSeconds(start))
+	// Bucket dates by the configured timezone, anchored to a query boundary (start, or end for a
+	// left-open range) so an end-only historical query buckets stably regardless of run time.
+	dateExpr := ds.detectionDateExpr(ds.zoneOffsetSeconds(dateRangeOffsetAnchor(start, end)))
 
 	type result struct {
 		ScientificName string `gorm:"column:scientific_name"`
@@ -2767,13 +2786,20 @@ func (ds *Datastore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 
 	var results []datastore.DailyAnalyticsData
 
-	// Bucket dates by the configured timezone, anchored to the start of the requested window
-	// (or the current offset for an open-ended range). The SELECT, GROUP BY, and BETWEEN filter
-	// all reuse this single expression so they stay internally consistent; the user's date
-	// strings are interpreted in the same zone the dates are bucketed in.
+	// Bucket dates by the configured timezone, anchored to a query boundary: the start of the
+	// window, falling back to the end for a left-open range (and only then to the current offset
+	// for a fully open range), so an end-only historical query buckets stably regardless of run
+	// time. The SELECT, GROUP BY, and BETWEEN filter all reuse this single expression so they stay
+	// internally consistent; the user's date strings are interpreted in the same zone the dates
+	// are bucketed in.
 	var refEpoch int64
 	if startDate != "" {
 		if t, perr := time.ParseInLocation(time.DateOnly, startDate, ds.timezone); perr == nil {
+			refEpoch = t.Unix()
+		}
+	}
+	if refEpoch == 0 && endDate != "" {
+		if t, perr := time.ParseInLocation(time.DateOnly, endDate, ds.timezone); perr == nil {
 			refEpoch = t.Unix()
 		}
 	}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1807,3 +1807,41 @@ func TestConvertToNewSpeciesData_ZeroEpoch(t *testing.T) {
 	assert.NotEmpty(t, got[1].FirstSeenDate)
 	assert.NotEmpty(t, got[1].LastSeenDate)
 }
+
+// TestV2OnlyDatastore_GetSpeciesDiversityData_TimezoneBucketing verifies the date grouping in
+// GetSpeciesDiversityData buckets by the configured timezone, not UTC or the OS-local zone. A
+// detection at a fixed UTC instant 30 minutes before midnight must group on the NEXT calendar day
+// when the configured zone is UTC+5. The negative assertion (the UTC date does not match) proves
+// the bucketing is genuinely offset-aware, and exercises the BETWEEN date filter end-to-end.
+func TestV2OnlyDatastore_GetSpeciesDiversityData_TimezoneBucketing(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	// Force a deterministic non-UTC zone so the assertion does not depend on the test host.
+	ds.timezone = time.FixedZone("UTC+5", 5*3600)
+
+	label, err := ds.label.GetOrCreate(ctx, "Turdus merula", ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+
+	// 2024-06-14T23:30:00Z -> 2024-06-15 04:30 in UTC+5, so the detection belongs to 2024-06-15.
+	nearMidnight := time.Date(2024, 6, 14, 23, 30, 0, 0, time.UTC).Unix()
+	require.NoError(t, ds.detection.Save(ctx, &entities.Detection{
+		ModelID:    ds.defaultModelID,
+		LabelID:    label.ID,
+		DetectedAt: nearMidnight,
+		Confidence: 0.9,
+	}))
+
+	// The configured-zone date matches.
+	data, err := ds.GetSpeciesDiversityData(ctx, "2024-06-15", "2024-06-15")
+	require.NoError(t, err)
+	require.Len(t, data, 1, "near-midnight detection must bucket on the configured-zone date 2024-06-15")
+	assert.Equal(t, "2024-06-15", data[0].Date)
+	assert.Equal(t, 1, data[0].Count)
+
+	// The UTC date must NOT match, proving bucketing is not in UTC.
+	none, err := ds.GetSpeciesDiversityData(ctx, "2024-06-14", "2024-06-14")
+	require.NoError(t, err)
+	assert.Empty(t, none, "detection must not bucket on the UTC date when the configured zone is UTC+5")
+}


### PR DESCRIPTION
## Summary

The hourly analytics charts already bucket by the configured timezone via UTC-offset arithmetic, but the DATE and YEAR SQL expressions still resolved against the database engine / OS-local zone (SQLite `'localtime'`, MySQL `FROM_UNIXTIME`). On deployments where that zone differs from the app's configured timezone (most notably MySQL, whose session `time_zone` is usually UTC), daily and yearly grouping bucketed near-midnight detections on the wrong calendar day or year.

This threads the configured zone's UTC offset into the date/year SQL the same way the hour fix does, using session-timezone-independent expressions.

## SQL forms

| Unit | SQLite | MySQL |
|------|--------|-------|
| DATE | `date(col + off, 'unixepoch')` | `DATE_ADD('1970-01-01', INTERVAL (col + off) DIV 86400 DAY)` |
| YEAR | `CAST(strftime('%Y', col + off, 'unixepoch') AS INTEGER)` | `YEAR(DATE_ADD('1970-01-01', INTERVAL (col + off) DIV 86400 DAY))` |

The MySQL form computes the civil date arithmetically (DATE_ADD on a literal date with an integer day count) so it does not depend on the session `time_zone`; `DATE(FROM_UNIXTIME(...))` would apply that zone on top of the offset and double-count. Integer `DIV` avoids floating-point rounding at exact day boundaries.

The offset is supplied per call by the caller that owns the wall-clock reference (the API insights handlers via `time.Local`, the v2only datastore via `ds.timezone`), matching the merged hourly approach.

## Scope

- **Insights repository**: expected-today (date + year), dawn-chorus (hour filter + date grouping share one offset so the query stays internally consistent), dashboard KPIs (best day, recent dates).
- **v2only datastore date methods**: species diversity, detection-dates-in-period, last-detection-date-before.
- **Detection repository daily analytics/trends**: feeds `GET /api/v2/analytics/time/daily`, which had the identical timezone-naive date expression.

`internal/datastore/v2only/inspector.go` (raw diagnostic queries) and the legacy `internal/datastore/` (deprecated) are intentionally untouched.

## Behavior

For the common deployment where the database/OS zone already equals the configured timezone (single-process SQLite), the new arithmetic produces the same calendar dates and years as the old form, so it is a no-op. It is a genuine fix where those zones differ. The single query-wide offset remains the documented, accepted DST approximation on multi-day ranges (per-row bucketing is out of scope); this matches the merged hourly fix.

## Tests

Adds non-UTC timezone bucketing tests with near-midnight and year-boundary detections, asserting date/year grouping (not just totals) at the repository and datastore layers, plus a positive/negative date-filter assertion in v2only. Existing insights tests now pass an explicit offset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics and insight reports now bucket dates/times using the server-configured timezone so daily counts, expected-species lists, dawn-chorus/hourly summaries, and dashboard KPIs align with local wall-clock dates/times.
  * Edge cases around date/hour boundaries (including DST and offsets) are corrected so events near midnight are assigned to the proper local day.
* **Tests**
  * Added regression tests validating timezone-aware bucketing for analytics and insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->