### PR TITLE
fix(notification,api): deep-copy notifications on store read; propagate shutdown context to MySQL legacy cleanup

### DIFF
--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -459,7 +459,11 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 	if !ok {
 		return legacyTables, fmt.Errorf("cannot access database connection")
 	}
-	db := dbProvider.GetDB()
+	// Bind the cleanup context to the GORM session so both the per-table
+	// existence check (tableExistsMySQL's Raw) and the DROP TABLE Exec below
+	// observe cancellation. Without this, an in-flight DROP cannot abort on
+	// shutdown, stalling graceful shutdown and leaking the cleanup goroutine.
+	db := dbProvider.GetDB().WithContext(ctx)
 
 	var remaining []string
 	var droppedCount int

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -1,6 +1,8 @@
 package notification
 
 import (
+	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -315,4 +317,130 @@ func TestInMemoryStore_MarkAllRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 0, changed2, "second call should change nothing")
 	})
+}
+
+// TestInMemoryStore_GetReturnsIndependentMetadata verifies that mutating the
+// Metadata map of a notification returned by Get does not leak back into the
+// stored notification. A shallow copy (*notif) aliases the map; the store must
+// hand out a deep copy so REST callers cannot corrupt stored state and so
+// concurrent JSON marshaling cannot race an in-place map write. Regression test
+// for the GetNotification/GetNotifications shared-pointer hazard.
+func TestInMemoryStore_GetReturnsIndependentMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+	n := NewNotification(TypeInfo, PriorityMedium, "Test", "msg").
+		WithMetadata("seed", "value")
+	mustStoreSave(t, store, n)
+
+	got1 := mustStoreGet(t, store, n.ID)
+	require.Contains(t, got1.Metadata, "seed")
+	got1.Metadata["injected"] = "leaked"
+
+	got2 := mustStoreGet(t, store, n.ID)
+	assert.NotContains(t, got2.Metadata, "injected",
+		"mutating a returned notification's Metadata must not affect the stored copy")
+}
+
+// TestInMemoryStore_ListReturnsIndependentMetadata is the List counterpart of
+// TestInMemoryStore_GetReturnsIndependentMetadata.
+func TestInMemoryStore_ListReturnsIndependentMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+	n := NewNotification(TypeInfo, PriorityMedium, "Test", "msg").
+		WithMetadata("seed", "value")
+	mustStoreSave(t, store, n)
+
+	first, err := store.List(&FilterOptions{})
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	first[0].Metadata["injected"] = "leaked"
+
+	second, err := store.List(&FilterOptions{})
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.NotContains(t, second[0].Metadata, "injected",
+		"mutating a listed notification's Metadata must not affect the stored copy")
+}
+
+// TestInMemoryStore_ConcurrentGetMetadataIsRaceFree exercises the real hazard
+// from GetNotification/GetNotifications: many readers JSON-marshal notifications
+// fetched from the store while other callers mutate the Metadata of their own
+// fetched copies. If Get returned a shallow copy aliasing the stored map, the
+// readers' marshal would race the writers' map writes and the runtime's
+// concurrent-map detector (and go test -race) would abort. A deep copy makes
+// every returned notification independent.
+func TestInMemoryStore_ConcurrentGetMetadataIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+	n := NewNotification(TypeInfo, PriorityMedium, "Concurrent", "msg").
+		WithMetadata("seed", "value")
+	mustStoreSave(t, store, n)
+	id := n.ID
+
+	const workers = 8
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Go(func() {
+			for range iterations {
+				got, err := store.Get(id)
+				if err != nil {
+					continue
+				}
+				_, _ = json.Marshal(got)
+			}
+		})
+	}
+	for w := range workers {
+		wg.Go(func() {
+			for i := range iterations {
+				got, err := store.Get(id)
+				if err != nil {
+					continue
+				}
+				got.Metadata["w"] = w*iterations + i
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// TestInMemoryStore_GetReturnsIndependentParamsAndExpiry extends the
+// independence guarantee to the other reference-typed fields that Clone copies
+// and REST handlers serialize: the TitleParams/MessageParams maps and the
+// ExpiresAt pointer. A future regression that deep-copied only Metadata would
+// slip past the Metadata-only tests but be caught here.
+func TestInMemoryStore_GetReturnsIndependentParamsAndExpiry(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+	n := NewNotification(TypeInfo, PriorityMedium, "Test", "msg").
+		WithTitleKey("title.key", map[string]any{"a": "1"}).
+		WithMessageKey("message.key", map[string]any{"b": "2"}).
+		WithExpiry(time.Hour)
+	require.NotNil(t, n.ExpiresAt)
+	originalExpiry := *n.ExpiresAt
+	mustStoreSave(t, store, n)
+
+	got1 := mustStoreGet(t, store, n.ID)
+	require.Contains(t, got1.TitleParams, "a")
+	require.Contains(t, got1.MessageParams, "b")
+	require.NotNil(t, got1.ExpiresAt)
+
+	got1.TitleParams["injected"] = "x"
+	got1.MessageParams["injected"] = "y"
+	*got1.ExpiresAt = got1.ExpiresAt.Add(24 * time.Hour)
+
+	got2 := mustStoreGet(t, store, n.ID)
+	assert.NotContains(t, got2.TitleParams, "injected",
+		"mutating a returned notification's TitleParams must not affect the stored copy")
+	assert.NotContains(t, got2.MessageParams, "injected",
+		"mutating a returned notification's MessageParams must not affect the stored copy")
+	require.NotNil(t, got2.ExpiresAt)
+	assert.True(t, got2.ExpiresAt.Equal(originalExpiry),
+		"mutating a returned notification's ExpiresAt must not affect the stored copy")
 }

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -229,7 +229,10 @@ func (n *Notification) MarkAsAcknowledged() {
 
 // Clone creates a deep copy of the notification, including the Metadata map.
 // This is used to safely broadcast notifications to multiple subscribers
-// without risk of concurrent map access if the original is modified.
+// without risk of concurrent map access if the original is modified, and it
+// backs the InMemoryStore read path (Get/List) and write path (Save/Update).
+// NOTE: every field of Notification must be copied here; a newly added field
+// will be silently dropped from stored and returned copies if omitted.
 func (n *Notification) Clone() *Notification {
 	if n == nil {
 		return nil
@@ -341,9 +344,14 @@ func deepCopyValue(v any) any {
 type NotificationStore interface {
 	// Save persists a notification
 	Save(notification *Notification) error
-	// Get retrieves a notification by ID
+	// Get retrieves a notification by ID. The returned notification is an
+	// independent deep copy; callers may read or mutate it (including its
+	// Metadata/params maps) without affecting stored state or racing other
+	// readers. Implementations MUST honor this so REST/SSE callers can marshal
+	// results concurrently with store mutations.
 	Get(id string) (*Notification, error)
-	// List returns notifications with optional filtering
+	// List returns notifications with optional filtering. Each returned
+	// notification is an independent deep copy (see Get).
 	List(filter *FilterOptions) ([]*Notification, error)
 	// Count returns the number of notifications matching filter. filter.Limit
 	// and filter.Offset are ignored — pagination does not apply to a count.
@@ -432,9 +440,12 @@ func (s *InMemoryStore) Get(id string) (*Notification, error) {
 	defer s.mu.RUnlock()
 
 	if notif, exists := s.notifications[id]; exists {
-		// Return a copy to prevent external modifications from affecting the stored notification
-		notifCopy := *notif
-		return &notifCopy, nil
+		// Return a deep copy so external mutations (including in-place writes to
+		// the Metadata/params maps by callers or concurrent JSON marshaling in
+		// REST handlers) cannot affect the stored notification or race other
+		// readers. A shallow copy (*notif) would alias those maps; Clone copies
+		// them. The clone runs under RLock so the source is stable.
+		return notif.Clone(), nil
 	}
 	return nil, ErrNotificationNotFound
 }
@@ -444,12 +455,15 @@ func (s *InMemoryStore) List(filter *FilterOptions) ([]*Notification, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var results []*Notification
+	// len(s.notifications) is an upper bound on matches; preallocate to avoid
+	// repeated slice growth during the filter loop.
+	results := make([]*Notification, 0, len(s.notifications))
 	for _, notif := range s.notifications {
 		if s.matchesFilter(notif, filter) {
-			// Return copies to prevent external modifications
-			notifCopy := *notif
-			results = append(results, &notifCopy)
+			// Return deep copies so callers (and concurrent JSON marshaling in
+			// REST handlers) never touch the stored Metadata/params maps. A
+			// shallow copy would alias them; see Get for rationale.
+			results = append(results, notif.Clone())
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two backend correctness/lifecycle fixes surfaced during a notification DI refactor gate review, both verified still-present against current `main`.

### 1. Notification store now returns deep copies (concurrent-map-marshal hazard)

`InMemoryStore.Get`/`List` returned a shallow struct copy (`notifCopy := *notif`). Value fields were independent, but the `Metadata`, `TitleParams` and `MessageParams` maps and the `ExpiresAt` pointer stayed aliased to the stored notification. The REST read handlers (`GetNotification`/`GetNotifications`) hand those straight to `ctx.JSON`, so a concurrent map mutation could race the marshal and panic with `concurrent map read and map write`. The SSE path already cloned; the REST read path did not.

Fix: return `notif.Clone()` (a true deep copy) from `Get` and `List`. This centralizes the guarantee for every store consumer rather than cloning in each handler, and makes the store's documented "returns a copy" contract actually true. Write paths (`Save`/`Update`) already store `Clone()` and never mutate stored objects in place, so no caller relied on the old aliasing.

Also: documented the deep-copy contract on the `NotificationStore` interface, preallocated the `List` result slice, and noted that `Clone` must enumerate every field (it now backs the store read+write paths).

### 2. MySQL legacy cleanup propagates the shutdown context

`cleanupMySQLLegacy` runs in the controller's async cleanup goroutine, which receives the shutdown context and checks `ctx.Done()` between tables, but ran its per-table existence check (`tableExistsMySQL`'s `Raw`) and the `DROP TABLE` `Exec` without that context. An in-flight `DROP` could not abort on shutdown, stalling graceful shutdown and leaking the goroutine.

Fix: bind the context to the GORM session once (`db := dbProvider.GetDB().WithContext(ctx)`), so both the existence check and the `DROP` observe cancellation. Scoped to the async path only; the synchronous request-handler queries are bounded by the request lifecycle.

## Test Plan
- [x] New regression tests: `Get`/`List` return notifications whose `Metadata`/`TitleParams`/`MessageParams`/`ExpiresAt` are independent of stored state; plus a concurrent marshal-vs-mutate race test (fails the runtime map detector on the old shallow copy, clean on the deep copy).
- [x] `go test -race ./internal/notification/ ./internal/api/v2/` passes.
- [x] `golangci-lint run ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification storage to prevent data mutations and concurrent access issues by ensuring independent copies are returned.
  * Enhanced graceful shutdown robustness during cleanup operations with proper context cancellation handling.

* **Tests**
  * Added regression tests for concurrent notification access and mutation independence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->