### PR TITLE
fix(api): propagate request context to synchronous MySQL legacy-cleanup queries

### DIFF
--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -271,7 +271,8 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 	// Bind the request context so the existence checks and information_schema
 	// queries below abort if the client disconnects, rather than running
 	// unbounded on the request thread.
-	db := dbProvider.GetDB().WithContext(ctx.Request().Context())
+	reqCtx := ctx.Request().Context()
+	db := dbProvider.GetDB().WithContext(reqCtx)
 
 	// Check each legacy table and get its size
 	var totalSize int64
@@ -285,6 +286,13 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 		// Check if table exists
 		exists, err := c.tableExistsMySQL(db, tableName)
 		if err != nil {
+			// Client disconnected: the request context is cancelled and every
+			// remaining table query would fail the same way, so stop quietly
+			// instead of logging a warning per table.
+			if reqCtx.Err() != nil {
+				c.logDebugIfEnabled("Legacy status query cancelled by client", logger.Error(reqCtx.Err()))
+				break
+			}
 			c.logWarnIfEnabled("Legacy cleanup: failed to check table existence",
 				logger.String("table", tableName),
 				logger.Error(err))
@@ -548,6 +556,11 @@ func (c *Controller) getMySQLLegacySize(ctx context.Context) int64 {
 	for _, tableName := range legacyTables {
 		exists, err := c.tableExistsMySQL(db, tableName)
 		if err != nil {
+			// Client disconnected: stop quietly instead of warning per table.
+			if ctx.Err() != nil {
+				c.logDebugIfEnabled("Legacy size query cancelled by client", logger.Error(ctx.Err()))
+				break
+			}
 			c.logWarnIfEnabled("Legacy cleanup: failed to check table existence",
 				logger.String("table", tableName),
 				logger.Error(err))

--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -268,7 +268,10 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 		response.Reason = "Cannot access database connection"
 		return ctx.JSON(http.StatusOK, response)
 	}
-	db := dbProvider.GetDB()
+	// Bind the request context so the existence checks and information_schema
+	// queries below abort if the client disconnects, rather than running
+	// unbounded on the request thread.
+	db := dbProvider.GetDB().WithContext(ctx.Request().Context())
 
 	// Check each legacy table and get its size
 	var totalSize int64
@@ -364,7 +367,7 @@ func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 	// Get size before deletion for reporting
 	var sizeBytes int64
 	if c.isUsingMySQL() {
-		sizeBytes = c.getMySQLLegacySize()
+		sizeBytes = c.getMySQLLegacySize(ctx.Request().Context())
 	} else {
 		sizeBytes = c.getSQLiteLegacySize()
 	}
@@ -531,13 +534,15 @@ func (c *Controller) getSQLiteLegacySize() int64 {
 	return totalSize
 }
 
-// getMySQLLegacySize returns the total size of MySQL legacy tables.
-func (c *Controller) getMySQLLegacySize() int64 {
+// getMySQLLegacySize returns the total size of MySQL legacy tables. ctx (the
+// request context) bounds the information_schema queries so they abort if the
+// caller disconnects instead of running unbounded on the request thread.
+func (c *Controller) getMySQLLegacySize(ctx context.Context) int64 {
 	dbProvider, ok := c.Repo.(gormDBProvider)
 	if !ok {
 		return 0
 	}
-	db := dbProvider.GetDB()
+	db := dbProvider.GetDB().WithContext(ctx)
 
 	var totalSize int64
 	for _, tableName := range legacyTables {


### PR DESCRIPTION
## Summary

Follow-up to PR #3477. That PR scoped the GORM context fix to the async, shutdown-cancellable cleanup path (`cleanupMySQLLegacy`). This propagates the request context into the two **synchronous** MySQL legacy-cleanup read paths that previously ran unbounded on the request thread:

- `getLegacyStatusMySQL` (backs `GET /api/v2/system/database/legacy/status`): per-table existence checks + `COUNT(*)` + `information_schema` size queries.
- `getMySQLLegacySize` (size measured in `StartLegacyCleanup`, synchronously before the async goroutine spawns).

Both now bind the request context via `GetDB().WithContext(ctx.Request().Context())`, so the queries abort if the client disconnects mid-request instead of running to completion on the request thread. `getMySQLLegacySize` gains a `context.Context` parameter, threaded from its only caller. `getSQLiteLegacySize` is unchanged (it only calls `os.Stat`, which has no context support).

## Test Plan
- [x] `go test -race ./internal/api/v2/` (legacy cleanup tests) pass.
- [x] `golangci-lint run ./...` clean.
- Behavior: a connected client sees identical behavior; only an abandoned/disconnected request now releases the DB connection early.

Note: a deterministic unit test of the context binding would require `go-sqlmock` (not a project dependency) plus MySQL `information_schema`, so this is verified by build, lint, and review, consistent with the async-path fix in #3477.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client cancellations during legacy data cleanup: database operations and per-table processing now stop promptly when a request is cancelled, avoiding unnecessary work and noisy warnings.
  * Legacy size calculations now respect request cancellation, preventing extra queries after a client disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->