### PR TITLE
fix(dashboard): localize species names on SSE-fed currently-hearing and live spectrogram

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -18,6 +18,7 @@ Props:
   import { t } from '$lib/i18n';
   import type { PendingDetection } from '$lib/types/pending.types';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import { settingsStore } from '$lib/stores/settings';
 
   interface Props {
@@ -164,6 +165,10 @@ Props:
       {#each displayDetections as detection (`${detection.source}_${detection.scientificName}`)}
         {@const key = detection.source + detection.scientificName}
         {@const elapsedText = getElapsedForKey(key)}
+        <!-- Localized common name in the visitor's UI locale; falls back to the
+             server-provided common name, then the scientific name. Keeps the
+             "currently hearing" card consistent with the rest of the dashboard. -->
+        {@const displayName = localizeSpeciesName(detection.scientificName, detection.species)}
         <div
           class="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors duration-300
             {detection.status === 'approved'
@@ -177,21 +182,21 @@ Props:
           {#if detection.thumbnail}
             <img
               src={buildAppUrl(detection.thumbnail)}
-              alt={detection.species}
+              alt={displayName}
               class="h-8 aspect-[4/3] rounded-md object-cover"
             />
           {:else}
             <div
               class="flex h-8 aspect-[4/3] items-center justify-center rounded-md bg-[var(--color-base-content)]/10 text-xs font-bold text-[var(--color-base-content)]/50"
             >
-              {detection.species.slice(0, 2).toUpperCase()}
+              {displayName.slice(0, 2).toUpperCase()}
             </div>
           {/if}
 
           <!-- Species info -->
           <div class="flex flex-col">
             <span class="text-sm font-medium leading-tight text-[var(--color-base-content)]">
-              {detection.species}
+              {displayName}
             </span>
             <span class="text-xs text-[var(--color-base-content)]/60">
               {elapsedText}

--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for CurrentlyHearingCard species-name localization.
+ *
+ * The "currently hearing" card is fed by the SSE `pending` event, which carries
+ * both the server-locale common name (`species`) and the `scientificName`. The
+ * card MUST display the name through localizeSpeciesName so it matches the rest
+ * of the dashboard. These tests pin that wiring: the card no longer references
+ * `detection.species` for display, it routes through localizeSpeciesName.
+ *
+ * Case 1 mocks the dictionary to a populated state (the visitor-localization
+ * feature enabled) and asserts the localized name reaches the DOM, which would
+ * fail against the old raw-`species` render. Case 2 leaves the dictionary empty
+ * (the current gated-off default, PER_VISITOR_SPECIES_LOCALE_ENABLED=false) and
+ * asserts the server common name still renders, so this fix is a no-op while the
+ * feature stays off.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../../../test/render-helpers';
+import type { PendingDetection } from '$lib/types/pending.types';
+
+// Stub the visitor dictionary store. localizeScientific feeds localizeSpeciesName.
+// Returns a Finnish label only for the mapped scientific name; undefined elsewhere
+// exercises the server-common-name fallback path.
+const FI = new Map<string, string>([['Turdus migratorius', 'Punarinta']]);
+vi.mock('$lib/stores/speciesDictionary.svelte', () => ({
+  localizeScientific: vi.fn((scientificName: string) => FI.get(scientificName)),
+}));
+
+import CurrentlyHearingCard from './CurrentlyHearingCard.svelte';
+
+function pending(overrides: Partial<PendingDetection> = {}): PendingDetection {
+  return {
+    species: 'American Robin',
+    scientificName: 'Turdus migratorius',
+    thumbnail: '',
+    status: 'active',
+    // Fixed timestamp for determinism; the card's elapsed-time text is not asserted.
+    firstDetected: 1_700_000_000,
+    source: 'mic-1',
+    sourceID: 'mic-1',
+    ...overrides,
+  };
+}
+
+const card = createComponentTestFactory(CurrentlyHearingCard);
+
+describe('CurrentlyHearingCard species-name localization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the visitor-locale name from the dictionary, not the raw server name', () => {
+    const { getByText, queryByText } = card.render({ props: { detections: [pending()] } });
+
+    expect(getByText('Punarinta')).toBeInTheDocument();
+    // The raw server-locale common name must not leak through.
+    expect(queryByText('American Robin')).toBeNull();
+  });
+
+  it('falls back to the server-provided common name when the dictionary has no entry', () => {
+    const { getByText } = card.render({
+      props: {
+        detections: [
+          pending({
+            species: 'Eurasian Wren',
+            scientificName: 'Troglodytes troglodytes',
+            source: 'mic-2',
+            sourceID: 'mic-2',
+          }),
+        ],
+      },
+    });
+
+    expect(getByText('Eurasian Wren')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -25,6 +25,7 @@
   import SpectrogramCanvas from '$lib/desktop/components/media/SpectrogramCanvas.svelte';
   import { fetchWithCSRF } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import { generateSessionId } from '$lib/utils/session';
   import { loggers } from '$lib/utils/logger';
   import type { ColorMapName } from '$lib/utils/spectrogramColorMaps';
@@ -393,12 +394,16 @@
       const newDetections = diffPendingSnapshot(prevSnapshot, pendingDetections, activeSourceId);
       const nowUnix = Date.now() / 1000;
       for (const det of newDetections) {
+        // Dedup on the server-locale common name: a stable identity key that does
+        // not shift when the visitor switches UI locale.
         if (shouldDedup(det.species, nowUnix, lastSeenSpecies)) continue;
         lastSeenSpecies.set(det.species, nowUnix);
         const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
         slotCounter = next;
         labelQueue.push({
-          text: det.species,
+          // Display the visitor-locale name so overlay labels match the rest of
+          // the dashboard; falls back to the server common name, then scientific.
+          text: localizeSpeciesName(det.scientificName, det.species),
           firstDetected: (det.audioCapturedAt ?? det.firstDetected) - LABEL_LEAD_IN_SECONDS,
           ySlot: slot,
         });

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -22,6 +22,7 @@
   import type { SelectOption } from '$lib/desktop/components/forms/SelectDropdown.types';
   import { fetchWithCSRF } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
   import { generateSessionId } from '$lib/utils/session';
   import { loggers } from '$lib/utils/logger';
   import type { ColorMapName } from '$lib/utils/spectrogramColorMaps';
@@ -471,12 +472,16 @@
         const nowUnix = Date.now() / 1000;
 
         for (const det of newDetections) {
+          // Dedup on the server-locale common name: a stable identity key that
+          // does not shift when the visitor switches UI locale.
           if (shouldDedup(det.species, nowUnix, lastSeenSpecies)) continue;
           lastSeenSpecies.set(det.species, nowUnix);
           const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
           slotCounter = next;
           labelQueue.push({
-            text: det.species,
+            // Display the visitor-locale name so overlay labels match the rest of
+            // the dashboard; falls back to the server common name, then scientific.
+            text: localizeSpeciesName(det.scientificName, det.species),
             firstDetected: (det.audioCapturedAt ?? det.firstDetected) - LABEL_LEAD_IN_SECONDS,
             ySlot: slot,
           });

--- a/frontend/src/lib/utils/detectionOverlay.ts
+++ b/frontend/src/lib/utils/detectionOverlay.ts
@@ -23,10 +23,6 @@ export interface OverlayLabel {
 /** Minimal pending detection shape for diffing. */
 interface PendingEntry {
   species: string;
-  // Scientific name carried through so label builders can localize the display
-  // name via localizeSpeciesName. Optional here because the diffing logic itself
-  // never reads it; the real SSE PendingDetection always provides it.
-  scientificName?: string;
   sourceID: string;
   firstDetected: number;
   audioCapturedAt?: number;
@@ -50,12 +46,17 @@ export const LABEL_LEAD_IN_SECONDS = 1.5;
  * Diff two pending snapshots, returning species with new activity for a given source.
  * Returns species that are newly appeared OR have an increased hitCount (new inference hit).
  * Filters by sourceID and ignores rejected status.
+ *
+ * Generic over the element type so the concrete input type is preserved on the way
+ * out: callers passing PendingDetection[] get PendingDetection[] back, keeping fields
+ * like scientificName strictly typed (string, not string | undefined) for the label
+ * builders that localize the display name.
  */
-export function diffPendingSnapshot(
-  prev: PendingEntry[],
-  curr: PendingEntry[],
+export function diffPendingSnapshot<T extends PendingEntry>(
+  prev: T[],
+  curr: T[],
   activeSourceID: string
-): PendingEntry[] {
+): T[] {
   const prevBySpecies = new Map(
     prev.filter(d => d.sourceID === activeSourceID).map(d => [d.species, d])
   );

--- a/frontend/src/lib/utils/detectionOverlay.ts
+++ b/frontend/src/lib/utils/detectionOverlay.ts
@@ -23,6 +23,10 @@ export interface OverlayLabel {
 /** Minimal pending detection shape for diffing. */
 interface PendingEntry {
   species: string;
+  // Scientific name carried through so label builders can localize the display
+  // name via localizeSpeciesName. Optional here because the diffing logic itself
+  // never reads it; the real SSE PendingDetection always provides it.
+  scientificName?: string;
   sourceID: string;
   firstDetected: number;
   audioCapturedAt?: number;


### PR DESCRIPTION
## Summary

The "currently hearing" card and the live/mini spectrogram overlay labels rendered species names straight from the SSE `pending` payload at the server-configured locale, while the rest of the dashboard routes names through `localizeSpeciesName` for per-visitor localization. That left these SSE-fed widgets inconsistent with every other species display (detection cards/rows, analytics, settings, search, daily summary, etc.).

This routes the displayed name through `localizeSpeciesName(scientificName, species)` at all three SSE-fed sites:

- `CurrentlyHearingCard.svelte` (currently-hearing card: name, image alt, initials placeholder)
- `MiniSpectrogram.svelte` (dashboard live spectrogram overlay labels)
- `LiveStreamPage.svelte` (full live stream page overlay labels)

The SSE `pending` payload already carries the scientific name (`SSEPendingDetection.ScientificName` -> `PendingDetection.scientificName`), so no backend change is needed. The overlay dedup key stays on the server-locale common name so detection identity is stable across UI-locale switches; only the displayed text is localized.

## Behavior while the feature is gated off

Per-visitor species localization is currently gated off by default (the client dictionary is not loaded). In that state `localizeSpeciesName` falls back to the server-provided common name, so display is byte-identical to today. This change closes the behavior drift so that when the feature is re-enabled, the SSE-fed widgets stay consistent with the rest of the dashboard instead of silently staying on the server locale.

## Notes

- Added a `scientificName?` field to the internal `PendingEntry` shape in `detectionOverlay.ts` so the overlay label builders can read it; `PendingDetection` (required `scientificName`) remains assignable.
- Added a regression test for `CurrentlyHearingCard` covering both the localized path (dictionary populated) and the server-locale fallback path (dictionary empty / feature off).

## Test plan

- `npm run typecheck` clean
- `npm run check:all` (format, eslint, stylelint, typecheck, ast) clean for the changed files
- New + existing Vitest suites pass (`CurrentlyHearingCard`, `SpeciesInfoBar`, `detectionOverlay`, `speciesDisplay`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Species names are now localized to the visitor's locale across the dashboard, detection overlays, and live stream, with fallback to the server-provided common name or abbreviation when localization is missing.

* **Tests**
  * Added unit tests covering species-name localization and fallback behavior.

* **Refactor**
  * Improved detection overlay diffing to preserve extra typed fields through the snapshot/diff process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->