### PR TITLE
refactor(dashboard): extract testable overlay-label helper; document notification locale limitation

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -37,8 +37,8 @@
     promoteFromQueue,
     nextYSlot,
     computeWallClockAtPlayhead,
+    buildQueuedLabel,
     STALE_DEDUP_PRUNE_SECONDS,
-    LABEL_LEAD_IN_SECONDS,
   } from '$lib/utils/detectionOverlay';
 
   const logger = loggers.audio;
@@ -400,13 +400,10 @@
         lastSeenSpecies.set(det.species, nowUnix);
         const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
         slotCounter = next;
-        labelQueue.push({
-          // Display the visitor-locale name so overlay labels match the rest of
-          // the dashboard; falls back to the server common name, then scientific.
-          text: localizeSpeciesName(det.scientificName, det.species),
-          firstDetected: (det.audioCapturedAt ?? det.firstDetected) - LABEL_LEAD_IN_SECONDS,
-          ySlot: slot,
-        });
+        // Label text follows per-visitor localization (server-locale fallback),
+        // matching the rest of the dashboard. See buildQueuedLabel for why it is
+        // fixed at queue time rather than reactive to later locale switches.
+        labelQueue.push(buildQueuedLabel(det, slot, localizeSpeciesName));
       }
     }
     prevSnapshot = [...pendingDetections];

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -35,8 +35,8 @@
     promoteFromQueue,
     nextYSlot,
     computeWallClockAtPlayhead,
+    buildQueuedLabel,
     STALE_DEDUP_PRUNE_SECONDS,
-    LABEL_LEAD_IN_SECONDS,
   } from '$lib/utils/detectionOverlay';
 
   const logger = loggers.audio;
@@ -478,13 +478,10 @@
           lastSeenSpecies.set(det.species, nowUnix);
           const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
           slotCounter = next;
-          labelQueue.push({
-            // Display the visitor-locale name so overlay labels match the rest of
-            // the dashboard; falls back to the server common name, then scientific.
-            text: localizeSpeciesName(det.scientificName, det.species),
-            firstDetected: (det.audioCapturedAt ?? det.firstDetected) - LABEL_LEAD_IN_SECONDS,
-            ySlot: slot,
-          });
+          // Label text follows per-visitor localization (server-locale fallback),
+          // matching the rest of the dashboard. See buildQueuedLabel for why it is
+          // fixed at queue time rather than reactive to later locale switches.
+          labelQueue.push(buildQueuedLabel(det, slot, localizeSpeciesName));
         }
         prevSnapshot = curr;
       } catch {

--- a/frontend/src/lib/utils/detectionOverlay.test.ts
+++ b/frontend/src/lib/utils/detectionOverlay.test.ts
@@ -168,9 +168,7 @@ describe('buildQueuedLabel', () => {
   const det = {
     species: 'American Robin',
     scientificName: 'Turdus migratorius',
-    sourceID: 'src1',
     firstDetected: 1000,
-    status: 'active' as const,
   };
 
   // Stand-in for localizeSpeciesName: returns a localized name only for the

--- a/frontend/src/lib/utils/detectionOverlay.test.ts
+++ b/frontend/src/lib/utils/detectionOverlay.test.ts
@@ -4,6 +4,8 @@ import {
   shouldDedup,
   promoteFromQueue,
   nextYSlot,
+  buildQueuedLabel,
+  LABEL_LEAD_IN_SECONDS,
   type QueuedLabel,
 } from './detectionOverlay';
 
@@ -159,5 +161,45 @@ describe('nextYSlot', () => {
     expect(nextYSlot(0, 4)).toEqual({ slot: 0, next: 1 });
     expect(nextYSlot(1, 4)).toEqual({ slot: 1, next: 2 });
     expect(nextYSlot(4, 4)).toEqual({ slot: 0, next: 5 });
+  });
+});
+
+describe('buildQueuedLabel', () => {
+  const det = {
+    species: 'American Robin',
+    scientificName: 'Turdus migratorius',
+    sourceID: 'src1',
+    firstDetected: 1000,
+    status: 'active' as const,
+  };
+
+  // Stand-in for localizeSpeciesName: returns a localized name only for the
+  // mapped scientific name, otherwise the server-locale fallback.
+  const localize = (scientificName: string | undefined, fallback: string): string =>
+    scientificName === 'Turdus migratorius' ? 'Punarinta' : fallback;
+
+  it('localizes the label text via the injected localizer', () => {
+    const label = buildQueuedLabel(det, 2, localize);
+    expect(label.text).toBe('Punarinta');
+    expect(label.ySlot).toBe(2);
+  });
+
+  it('falls back to the server-locale common name when no localized name exists', () => {
+    const label = buildQueuedLabel(
+      { ...det, scientificName: 'Troglodytes troglodytes' },
+      0,
+      localize
+    );
+    expect(label.text).toBe('American Robin');
+  });
+
+  it('back-dates firstDetected by the lead-in to align the label with the sound', () => {
+    const label = buildQueuedLabel(det, 0, localize);
+    expect(label.firstDetected).toBe(1000 - LABEL_LEAD_IN_SECONDS);
+  });
+
+  it('prefers audioCapturedAt over firstDetected for back-dating when present', () => {
+    const label = buildQueuedLabel({ ...det, audioCapturedAt: 950 }, 0, localize);
+    expect(label.firstDetected).toBe(950 - LABEL_LEAD_IN_SECONDS);
   });
 });

--- a/frontend/src/lib/utils/detectionOverlay.ts
+++ b/frontend/src/lib/utils/detectionOverlay.ts
@@ -164,7 +164,12 @@ export function nextYSlot(counter: number, maxSlots: number): { slot: number; ne
  * stale by a mid-session locale change clears on its own.
  */
 export function buildQueuedLabel(
-  det: PendingEntry & { scientificName?: string },
+  det: {
+    species: string;
+    firstDetected: number;
+    audioCapturedAt?: number;
+    scientificName?: string;
+  },
   ySlot: number,
   localize: (scientificName: string | undefined, fallbackCommonName: string) => string
 ): QueuedLabel {

--- a/frontend/src/lib/utils/detectionOverlay.ts
+++ b/frontend/src/lib/utils/detectionOverlay.ts
@@ -147,3 +147,30 @@ export function nextYSlot(counter: number, maxSlots: number): { slot: number; ne
   const slot = counter % maxSlots;
   return { slot, next: counter + 1 };
 }
+
+/**
+ * Build a queued overlay label for one pending detection.
+ *
+ * Centralizes the lead-in back-dating and the display-text choice so the
+ * dashboard MiniSpectrogram and the full-page LiveStreamPage stay in lockstep.
+ * The localizer (localizeSpeciesName) is injected so this module stays pure (no
+ * dependency on the visitor-dictionary store) and the text choice is unit
+ * testable. The label follows the same per-visitor localization as the rest of
+ * the dashboard; with that feature gated off, localize falls back to the
+ * server-locale common name.
+ *
+ * Note: text is fixed at queue time and does not react to a later UI-locale
+ * switch. Overlay labels are ephemeral (pruned within ~60s), so a label left
+ * stale by a mid-session locale change clears on its own.
+ */
+export function buildQueuedLabel(
+  det: PendingEntry & { scientificName?: string },
+  ySlot: number,
+  localize: (scientificName: string | undefined, fallbackCommonName: string) => string
+): QueuedLabel {
+  return {
+    text: localize(det.scientificName, det.species),
+    firstDetected: (det.audioCapturedAt ?? det.firstDetected) - LABEL_LEAD_IN_SECONDS,
+    ySlot,
+  };
+}

--- a/internal/notification/detection_consumer.go
+++ b/internal/notification/detection_consumer.go
@@ -229,6 +229,16 @@ func (c *DetectionNotificationConsumer) getDefaultValue(field string, event even
 }
 
 // buildDetectionNotification creates a notification with all metadata.
+//
+// Localization note: title and message are rendered server-side from the
+// (user-configurable) templates with the species common name resolved at the
+// configured BirdNET.Locale. They are free text, not substitutable i18n params,
+// so the frontend's per-visitor species localization (localizeSpeciesName) does
+// not apply to detection notifications; they stay on the server locale. The
+// scientific_name metadata below is the hook a future per-visitor notification
+// localizer would use. Doing this resolution server-side per request was
+// rejected for the dashboard (DoS risk on resource-constrained hosts), so any
+// future fix should localize client-side from this metadata.
 func (c *DetectionNotificationConsumer) buildDetectionNotification(event events.DetectionEvent, title, message string, templateData *TemplateData) *Notification {
 	notification := NewNotification(TypeDetection, PriorityHigh, title, message).
 		WithComponent("detection").


### PR DESCRIPTION
## Summary

Two small follow-ups to #3479 (which routed SSE-fed species displays through `localizeSpeciesName`), done now to avoid leaving them as backlog.

### 1. Extract a pure, testable overlay-label helper
The spectrogram overlay-label construction was duplicated in `MiniSpectrogram.svelte` and `LiveStreamPage.svelte`. Extracted it into `buildQueuedLabel(det, ySlot, localize)` in `detectionOverlay.ts`:

- The localizer (`localizeSpeciesName`) is **injected**, so `detectionOverlay.ts` stays a pure utility module with no dependency on the visitor-dictionary store, and the display-text choice becomes unit-testable.
- Both components now call `buildQueuedLabel(det, slot, localizeSpeciesName)` and dropped their now-unused `LABEL_LEAD_IN_SECONDS` import.
- Added unit tests for the localized path, the server-locale fallback, the lead-in back-dating, and `audioCapturedAt` precedence.
- The known-limitation note (label text is fixed at queue time, so it does not re-localize on a mid-session UI-locale switch; ephemeral labels clear within ~60s) now lives on the helper.

Behavior is byte-equivalent to the inline code it replaces.

### 2. Document the notification species-locale limitation
Added a code comment in `internal/notification/detection_consumer.go` (`buildDetectionNotification`): new-species notification title/message are rendered server-side from user-configurable templates with the species name at the configured `BirdNET.Locale`. They are free text, not substitutable i18n params, so per-visitor client-side species localization does not apply to them. The `scientific_name` metadata is the hook a future client-side localizer would use; server-side per-request resolution was rejected for the dashboard on DoS grounds.

## Test plan
- `npm run typecheck` / `npm run check:all` clean
- `detectionOverlay` suite: 18 tests pass (4 new for `buildQueuedLabel`)
- `golangci-lint` clean (Go change is a comment only)
- Reviewed by Gemini and a parallel review agent: byte-equivalent behavior, sound typing, meaningful tests, accurate comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized detection label construction used by multiple UI pages to improve consistency and maintainability.
* **Tests**
  * Added unit tests covering queued detection label text, fallback behavior, and timestamp adjustments.
* **Documentation**
  * Clarified server-side notification rendering and localization behavior in notification templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->