### PR TITLE
fix(threshold): dynamic-threshold v2only lifecycle race, event ModelName, read telemetry

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -458,8 +458,7 @@ func (p *Processor) initDynamicThresholds(settings *conf.Settings) {
 			logger.String("operation", "load_dynamic_thresholds"))
 	}
 
-	p.startThresholdPersistence()
-	p.startThresholdCleanup()
+	p.startThresholdGoroutines()
 }
 
 // New creates a new Processor with the given dependencies.
@@ -2425,9 +2424,14 @@ func (p *Processor) ShutdownWithContext(ctx context.Context) error {
 	}
 	p.discoveryDebounceMu.Unlock()
 
-	// Stop threshold persistence and cleanup goroutines first
-	if p.thresholdsCancel != nil {
-		p.thresholdsCancel()
+	// Stop threshold persistence and cleanup goroutines first. Snapshot the cancel func
+	// under thresholdsMutex so this never races with StopDynamicThresholds rewriting the
+	// field when the feature is toggled off at runtime (see #1025). cancel() is idempotent.
+	p.thresholdsMutex.RLock()
+	thresholdsCancel := p.thresholdsCancel
+	p.thresholdsMutex.RUnlock()
+	if thresholdsCancel != nil {
+		thresholdsCancel()
 	}
 
 	// Cancel flusher goroutine

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -177,7 +177,13 @@ func (p *Processor) cleanupExpiredThresholds(expiredSpecies []string) {
 }
 
 // saveThresholdsWithRetry attempts to save thresholds with exponential backoff.
-func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThreshold) error {
+// The caller passes the threshold-lifecycle context so the retry loop aborts on
+// cancellation without reading the shared p.thresholdsCtx field (which would race
+// with StartDynamicThresholds/StopDynamicThresholds toggling the feature at runtime).
+func (p *Processor) saveThresholdsWithRetry(ctx context.Context, dbThresholds []datastore.DynamicThreshold) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	const maxRetries = 3
 	baseDelay := 100 * time.Millisecond
 
@@ -205,20 +211,26 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 			logger.Int64("backoff_ms", backoffDuration.Milliseconds()),
 			logger.String("operation", "persist_dynamic_thresholds"))
 
+		// Use an explicit timer (not time.After) so the timer is released promptly
+		// when ctx is cancelled mid-backoff, instead of lingering until it fires.
+		timer := time.NewTimer(backoffDuration)
 		select {
-		case <-time.After(backoffDuration):
-		case <-p.thresholdsCtx.Done():
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
 			GetLogger().Info("Retry aborted due to shutdown",
 				logger.String("operation", "persist_dynamic_thresholds"))
-			return p.thresholdsCtx.Err()
+			return ctx.Err()
 		}
 	}
 	return err
 }
 
 // persistDynamicThresholds saves all current dynamic thresholds to the database
-// This is called periodically by the persistence goroutine
-func (p *Processor) persistDynamicThresholds() error {
+// This is called periodically by the persistence goroutine. The ctx governs the
+// retry-backoff abort and is supplied by the caller (the persistence goroutine's
+// lifecycle context, or a snapshot taken under thresholdsMutex by Stop/Flush).
+func (p *Processor) persistDynamicThresholds(ctx context.Context) error {
 	settings := p.currentSettings()
 	dbThresholds, expiredSpecies := p.convertThresholdsForPersistence(settings)
 
@@ -231,7 +243,7 @@ func (p *Processor) persistDynamicThresholds() error {
 		return nil
 	}
 
-	if err := p.saveThresholdsWithRetry(dbThresholds); err != nil {
+	if err := p.saveThresholdsWithRetry(ctx, dbThresholds); err != nil {
 		return err
 	}
 
@@ -343,10 +355,10 @@ func (p *Processor) drainPendingResets() {
 // startThresholdPersistence starts a goroutine that periodically persists dynamic thresholds
 // This ensures that learned thresholds are saved to the database and survive application restarts
 // The goroutine uses a dedicated context for clean cancellation on shutdown
-func (p *Processor) startThresholdPersistence() {
-	// Create dedicated context for threshold goroutines
-	// Both persistence and cleanup will share this context
-	p.thresholdsCtx, p.thresholdsCancel = context.WithCancel(context.Background())
+func (p *Processor) startThresholdPersistence(ctx context.Context) {
+	// The lifecycle context is created and stored by StartDynamicThresholds under
+	// thresholdsMutex; the goroutine captures the local ctx and never reads the
+	// shared p.thresholdsCtx field, so a concurrent Stop/Start cannot race it.
 
 	// Start periodic persistence
 	go func() {
@@ -360,12 +372,12 @@ func (p *Processor) startThresholdPersistence() {
 		for {
 			select {
 			case <-ticker.C:
-				if err := p.persistDynamicThresholds(); err != nil {
+				if err := p.persistDynamicThresholds(ctx); err != nil {
 					GetLogger().Error("Failed to persist dynamic thresholds",
 						logger.Error(err),
 						logger.String("operation", "persist_dynamic_thresholds"))
 				}
-			case <-p.thresholdsCtx.Done():
+			case <-ctx.Done():
 				// Shutdown signal received via context cancellation
 				GetLogger().Info("Dynamic threshold persistence stopped",
 					logger.String("operation", "threshold_persistence_shutdown"))
@@ -378,9 +390,9 @@ func (p *Processor) startThresholdPersistence() {
 // startThresholdCleanup starts a goroutine that periodically cleans up expired thresholds
 // This prevents the database from accumulating stale threshold data
 // The goroutine uses the same context as persistence for clean cancellation on shutdown
-func (p *Processor) startThresholdCleanup() {
-	// Use the same context created in startThresholdPersistence
-	// This ensures both goroutines stop together when thresholdsCancel() is called
+func (p *Processor) startThresholdCleanup(ctx context.Context) {
+	// Shares the same lifecycle context as persistence (passed by StartDynamicThresholds),
+	// so both goroutines stop together when thresholdsCancel() is called.
 	go func() {
 		ticker := time.NewTicker(DefaultCleanupInterval)
 		defer ticker.Stop()
@@ -402,7 +414,7 @@ func (p *Processor) startThresholdCleanup() {
 						logger.Int64("count", deleted),
 						logger.String("operation", "cleanup_dynamic_thresholds"))
 				}
-			case <-p.thresholdsCtx.Done():
+			case <-ctx.Done():
 				// Shutdown signal received via context cancellation
 				GetLogger().Info("Dynamic threshold cleanup stopped",
 					logger.String("operation", "threshold_cleanup_shutdown"))
@@ -412,18 +424,44 @@ func (p *Processor) startThresholdCleanup() {
 	}()
 }
 
-// StartDynamicThresholds loads thresholds from the database and starts the persistence
-// and cleanup goroutines. This is called when dynamic thresholds are enabled at runtime
-// via the settings UI. It is safe to call multiple times; if goroutines are already
-// running (thresholdsCancel is non-nil), the call is a no-op.
-func (p *Processor) StartDynamicThresholds() {
-	// Guard against double-start under lock to prevent race between concurrent callers.
+// snapshotThresholdsCtx returns the current threshold-lifecycle context, read under
+// thresholdsMutex so it never races with StartDynamicThresholds/StopDynamicThresholds
+// rewriting the field. The returned context may be nil if the goroutines are not running.
+func (p *Processor) snapshotThresholdsCtx() context.Context {
+	p.thresholdsMutex.RLock()
+	defer p.thresholdsMutex.RUnlock()
+	return p.thresholdsCtx
+}
+
+// startThresholdGoroutines creates the shared lifecycle context and launches the
+// persistence and cleanup goroutines. It is a no-op if they are already running. The
+// "already running" check and the context creation happen atomically under
+// thresholdsMutex so concurrent callers cannot double-start or leak a context.
+func (p *Processor) startThresholdGoroutines() {
 	p.thresholdsMutex.Lock()
 	if p.thresholdsCancel != nil {
 		p.thresholdsMutex.Unlock()
 		return
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	p.thresholdsCtx = ctx
+	p.thresholdsCancel = cancel
 	p.thresholdsMutex.Unlock()
+
+	p.startThresholdPersistence(ctx)
+	p.startThresholdCleanup(ctx)
+}
+
+// StartDynamicThresholds loads thresholds from the database and starts the persistence
+// and cleanup goroutines. This is called when dynamic thresholds are enabled at runtime
+// via the settings UI. It is safe to call multiple times; if goroutines are already
+// running (thresholdsCancel is non-nil), the call is a no-op.
+func (p *Processor) StartDynamicThresholds() {
+	// Fast-path skip if already running, to avoid a redundant DB reload on repeated
+	// enable toggles. startThresholdGoroutines re-checks atomically under the lock.
+	if p.snapshotThresholdsCtx() != nil {
+		return
+	}
 
 	if err := p.loadDynamicThresholdsFromDB(); err != nil {
 		GetLogger().Debug("Starting with fresh dynamic thresholds",
@@ -431,8 +469,7 @@ func (p *Processor) StartDynamicThresholds() {
 			logger.String("operation", "start_dynamic_thresholds"))
 	}
 
-	p.startThresholdPersistence()
-	p.startThresholdCleanup()
+	p.startThresholdGoroutines()
 
 	GetLogger().Info("Dynamic threshold goroutines started",
 		logger.String("operation", "start_dynamic_thresholds"))
@@ -443,13 +480,15 @@ func (p *Processor) StartDynamicThresholds() {
 // This is called when dynamic thresholds are disabled at runtime via the settings UI.
 // It is safe to call when goroutines are not running.
 func (p *Processor) StopDynamicThresholds() {
-	// Flush thresholds to DB BEFORE cancelling the context, because
-	// persistDynamicThresholds → saveThresholdsWithRetry reads p.thresholdsCtx.
-	// Guard against nil thresholdsCtx: if goroutines were never started (e.g.,
-	// feature toggled off before it was ever on), thresholdsCtx is nil and
-	// saveThresholdsWithRetry would panic on thresholdsCtx.Done().
-	if p.Ds != nil && p.thresholdsCtx != nil {
-		if err := p.persistDynamicThresholds(); err != nil {
+	// Snapshot the lifecycle context under the lock (never read the field unlocked).
+	// If goroutines were never started, ctx is nil and we skip the flush; the retry
+	// path inside saveThresholdsWithRetry also defends against a nil ctx.
+	ctx := p.snapshotThresholdsCtx()
+
+	// Flush thresholds to DB BEFORE cancelling the context, using the snapshotted ctx
+	// so the retry-backoff abort tracks the session we are stopping.
+	if p.Ds != nil && ctx != nil {
+		if err := p.persistDynamicThresholds(ctx); err != nil {
 			GetLogger().Warn("Failed to flush dynamic thresholds during disable",
 				logger.Error(err),
 				logger.String("operation", "stop_dynamic_thresholds"))
@@ -459,13 +498,19 @@ func (p *Processor) StopDynamicThresholds() {
 	// Cancel persistence and cleanup goroutines after flush completes.
 	// Protected by thresholdsMutex to prevent races with StartDynamicThresholds.
 	p.thresholdsMutex.Lock()
-	if p.thresholdsCancel != nil {
-		p.thresholdsCancel()
-		p.thresholdsCancel = nil
+	// Only tear down if the session is still the one we snapshotted. The flush above
+	// runs without the lock and can block on DB-retry backoff; if the feature was
+	// toggled back on in the meantime, StartDynamicThresholds installed a fresh ctx
+	// and goroutines, and we must not cancel/clear those (see #1025).
+	if p.thresholdsCtx == ctx {
+		if p.thresholdsCancel != nil {
+			p.thresholdsCancel()
+			p.thresholdsCancel = nil
+		}
 		p.thresholdsCtx = nil
+		// Clear in-memory thresholds while still holding the lock.
+		p.DynamicThresholds = make(map[string]*DynamicThreshold)
 	}
-	// Clear in-memory thresholds while still holding the lock
-	p.DynamicThresholds = make(map[string]*DynamicThreshold)
 	p.thresholdsMutex.Unlock()
 
 	GetLogger().Info("Dynamic threshold goroutines stopped and thresholds cleared",
@@ -478,7 +523,13 @@ func (p *Processor) FlushDynamicThresholds() error {
 	GetLogger().Info("Flushing dynamic thresholds to database",
 		logger.String("operation", "flush_dynamic_thresholds"))
 
-	if err := p.persistDynamicThresholds(); err != nil {
+	// Use the lifecycle context if running; otherwise fall back to Background so a
+	// flush during shutdown (or before Start) still completes. Read under the lock.
+	ctx := p.snapshotThresholdsCtx()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := p.persistDynamicThresholds(ctx); err != nil {
 		GetLogger().Error("Failed to flush dynamic thresholds",
 			logger.Error(err),
 			logger.String("operation", "flush_dynamic_thresholds"))

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -479,6 +479,15 @@ func (p *Processor) StartDynamicThresholds() {
 // in-memory thresholds to the database, and clears the in-memory threshold map.
 // This is called when dynamic thresholds are disabled at runtime via the settings UI.
 // It is safe to call when goroutines are not running.
+//
+// Concurrency contract: StartDynamicThresholds and StopDynamicThresholds are driven
+// exclusively by ControlMonitor's single-goroutine control loop (one settings signal
+// processed at a time), so a re-enable cannot interleave with an in-progress stop
+// flush; the queued enable signal is handled only after this call returns and tears
+// the session down, so the last toggle wins. The TOCTOU guard below (thresholdsCtx ==
+// ctx) and snapshotThresholdsCtx keep the shared fields race-free against the
+// concurrent persistence goroutine and ShutdownWithContext; they are NOT a license to
+// call these lifecycle methods concurrently from multiple goroutines.
 func (p *Processor) StopDynamicThresholds() {
 	// Snapshot the lifecycle context under the lock (never read the field unlocked).
 	// If goroutines were never started, ctx is nil and we skip the flush; the retry

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -3,6 +3,7 @@ package processor
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -555,7 +556,7 @@ func TestPersistDynamicThresholds(t *testing.T) {
 			ValidHours:    48,
 		}
 
-		err := p.persistDynamicThresholds()
+		err := p.persistDynamicThresholds(t.Context())
 
 		require.NoError(t, err)
 		assert.True(t, mockDs.batchSaveCalled)
@@ -574,7 +575,7 @@ func TestPersistDynamicThresholds(t *testing.T) {
 		p := createTestProcessor()
 		mockDs := p.Ds.(*MockDatastore)
 
-		err := p.persistDynamicThresholds()
+		err := p.persistDynamicThresholds(t.Context())
 
 		require.NoError(t, err)
 		assert.False(t, mockDs.batchSaveCalled, "Should not call batch save with no thresholds")
@@ -598,7 +599,7 @@ func TestPersistDynamicThresholds(t *testing.T) {
 			Timer:        now.Add(-1 * time.Hour), // Expired
 		}
 
-		err := p.persistDynamicThresholds()
+		err := p.persistDynamicThresholds(t.Context())
 
 		require.NoError(t, err)
 		assert.Len(t, p.DynamicThresholds, 1, "Expired threshold should be removed from memory")
@@ -646,31 +647,55 @@ func TestThresholdGoroutineLifecycle(t *testing.T) {
 	t.Run("StartAndStopGoroutines", func(t *testing.T) {
 		p := createTestProcessor()
 
-		// Start goroutines
-		p.startThresholdPersistence()
-		p.startThresholdCleanup()
+		// Start goroutines (creates the lifecycle context under the lock)
+		p.startThresholdGoroutines()
 
-		// Verify context was created
-		assert.NotNil(t, p.thresholdsCtx)
-		assert.NotNil(t, p.thresholdsCancel)
+		// Capture the context before stopping (snapshot under the lock). A non-nil
+		// snapshot proves the goroutines (and their cancel func) were installed.
+		ctx := p.snapshotThresholdsCtx()
+		require.NotNil(t, ctx)
 
 		// Wait a bit to ensure goroutines are running
 		time.Sleep(100 * time.Millisecond)
 
-		// Cancel the goroutines
-		p.thresholdsCancel()
+		// Stop tears the goroutines down and cancels the context.
+		p.StopDynamicThresholds()
 
 		// Wait for goroutines to stop
 		time.Sleep(100 * time.Millisecond)
 
-		// Verify context is done
+		// Verify the captured context is done
 		select {
-		case <-p.thresholdsCtx.Done():
+		case <-ctx.Done():
 			// Context is properly cancelled
 		default:
 			assert.Fail(t, "Context should be cancelled")
 		}
 	})
+}
+
+// TestStopDynamicThresholds_ConcurrentNoRace verifies that p.thresholdsCtx is never
+// accessed without synchronization. The feature can be toggled off at runtime via the
+// settings UI, so StopDynamicThresholds can be invoked concurrently; the nil-check read
+// must not race with the locked nil-assignment. Run with -race to catch regressions.
+func TestStopDynamicThresholds_ConcurrentNoRace(t *testing.T) {
+	p := createTestProcessor()
+	// Start launches the persistence/cleanup goroutines and sets thresholdsCtx. No
+	// in-memory thresholds, so the concurrent Stop flush path performs no datastore
+	// calls (keeping the unsynchronized MockDatastore fields out of the race window).
+	p.StartDynamicThresholds()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			p.StopDynamicThresholds()
+		})
+	}
+	close(start) // release all goroutines simultaneously
+	wg.Wait()
 }
 
 // TestLoadWithDatabaseErrors tests error handling during load
@@ -718,7 +743,7 @@ func TestBatchSaveWithBaseThreshold(t *testing.T) {
 			Timer:        now.Add(24 * time.Hour),
 		}
 
-		err := p.persistDynamicThresholds()
+		err := p.persistDynamicThresholds(t.Context())
 
 		require.NoError(t, err)
 

--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -316,6 +316,7 @@ func (r *dynamicThresholdRepository) GetThresholdEvents(ctx context.Context, spe
 
 	var events []entities.ThresholdEvent
 	query := r.db.WithContext(ctx).Table(r.eventTable()).
+		Preload("Label.Model").
 		Preload("Label").
 		Where("label_id IN ?", labelIDs).
 		Order("created_at DESC")
@@ -330,6 +331,7 @@ func (r *dynamicThresholdRepository) GetThresholdEvents(ctx context.Context, spe
 func (r *dynamicThresholdRepository) GetRecentThresholdEvents(ctx context.Context, limit int) ([]entities.ThresholdEvent, error) {
 	var events []entities.ThresholdEvent
 	query := r.db.WithContext(ctx).Table(r.eventTable()).
+		Preload("Label.Model").
 		Preload("Label").
 		Order("created_at DESC")
 	if limit > 0 {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2852,10 +2852,13 @@ func thresholdScientificName(t *entities.DynamicThreshold) string {
 	return ""
 }
 
-// thresholdModelName constructs the classifier-style model ID from a threshold's label.
-func thresholdModelName(t *entities.DynamicThreshold) string {
-	if t.Label != nil && t.Label.Model != nil && t.Label.Model.Name != "" {
-		return t.Label.Model.Name + "_V" + t.Label.Model.Version
+// labelModelName constructs the classifier-style model ID ("Name_VVersion") from a
+// label's associated AIModel, used for both threshold records and threshold events.
+// Requires the caller's query to preload Label.Model; falls back to the default
+// BirdNET model identifier when the label or model is absent.
+func labelModelName(l *entities.Label) string {
+	if l != nil && l.Model != nil && l.Model.Name != "" {
+		return l.Model.Name + "_V" + l.Model.Version
 	}
 	return detection.DefaultModelName + "_V" + detection.DefaultModelVersion
 }
@@ -2957,14 +2960,24 @@ func (ds *Datastore) GetDynamicThreshold(speciesName, _ string) (*datastore.Dyna
 	// Resolve to scientific name in case caller passes a common name
 	t, err := ds.threshold.GetDynamicThreshold(ctx, ds.resolveToScientificName(speciesName))
 	if err != nil {
-		return nil, err
+		// Pass not-found through unwrapped: it is a benign result, not a DB fault, and
+		// wrapping it with the datastore builder would surface it to Sentry as a
+		// database error (#1019). Only genuine failures get the telemetry tags.
+		if errors.Is(err, repository.ErrDynamicThresholdNotFound) {
+			return nil, err
+		}
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_dynamic_threshold").
+			Build()
 	}
 	scientificName := thresholdScientificName(t)
 	return &datastore.DynamicThreshold{
 		ID:             t.ID,
 		SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
 		ScientificName: scientificName,
-		ModelName:      thresholdModelName(t),
+		ModelName:      labelModelName(t.Label),
 		Level:          t.Level,
 		CurrentValue:   t.CurrentValue,
 		BaseThreshold:  t.BaseThreshold,
@@ -2986,7 +2999,11 @@ func (ds *Datastore) GetAllDynamicThresholds(limit ...int) ([]datastore.DynamicT
 	ctx := context.Background()
 	v2Thresholds, err := ds.threshold.GetAllDynamicThresholds(ctx, limit...)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_all_dynamic_thresholds").
+			Build()
 	}
 	result := make([]datastore.DynamicThreshold, 0, len(v2Thresholds))
 	for i := range v2Thresholds {
@@ -2996,7 +3013,7 @@ func (ds *Datastore) GetAllDynamicThresholds(limit ...int) ([]datastore.DynamicT
 			ID:             t.ID,
 			SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
 			ScientificName: scientificName,
-			ModelName:      thresholdModelName(t),
+			ModelName:      labelModelName(t.Label),
 			Level:          t.Level,
 			CurrentValue:   t.CurrentValue,
 			BaseThreshold:  t.BaseThreshold,
@@ -3104,7 +3121,15 @@ func (ds *Datastore) GetDynamicThresholdStats() (totalCount, activeCount, atMini
 		return 0, 0, 0, make(map[int]int64), nil
 	}
 	ctx := context.Background()
-	return ds.threshold.GetDynamicThresholdStats(ctx)
+	totalCount, activeCount, atMinimumCount, levelDistribution, err = ds.threshold.GetDynamicThresholdStats(ctx)
+	if err != nil {
+		return 0, 0, 0, nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_dynamic_threshold_stats").
+			Build()
+	}
+	return totalCount, activeCount, atMinimumCount, levelDistribution, nil
 }
 
 // ============================================================
@@ -3223,6 +3248,7 @@ func (ds *Datastore) GetThresholdEvents(speciesName string, limit int) ([]datast
 		result = append(result, datastore.ThresholdEvent{
 			ID:            e.ID,
 			SpeciesName:   eventSpeciesName(e),
+			ModelName:     labelModelName(e.Label),
 			PreviousLevel: e.PreviousLevel,
 			NewLevel:      e.NewLevel,
 			PreviousValue: e.PreviousValue,
@@ -3243,7 +3269,11 @@ func (ds *Datastore) GetRecentThresholdEvents(limit int) ([]datastore.ThresholdE
 	ctx := context.Background()
 	v2Events, err := ds.threshold.GetRecentThresholdEvents(ctx, limit)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_recent_threshold_events").
+			Build()
 	}
 	result := make([]datastore.ThresholdEvent, 0, len(v2Events))
 	for i := range v2Events {
@@ -3251,6 +3281,7 @@ func (ds *Datastore) GetRecentThresholdEvents(limit int) ([]datastore.ThresholdE
 		result = append(result, datastore.ThresholdEvent{
 			ID:            e.ID,
 			SpeciesName:   eventSpeciesName(e),
+			ModelName:     labelModelName(e.Label),
 			PreviousLevel: e.PreviousLevel,
 			NewLevel:      e.NewLevel,
 			PreviousValue: e.PreviousValue,

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -13,6 +13,7 @@ import (
 	v2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -770,6 +771,90 @@ func TestV2OnlyDatastore_ThresholdEvent(t *testing.T) {
 	recent, err := ds.GetRecentThresholdEvents(10)
 	require.NoError(t, err)
 	assert.Len(t, recent, 1)
+}
+
+// TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry pins #1019: the v2only threshold
+// read methods must wrap genuine DB errors with datastore Component/Category telemetry,
+// while a benign not-found (ErrDynamicThresholdNotFound) must propagate UNWRAPPED so it
+// does not reach Sentry as a database error.
+func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
+	t.Run("NotFoundPassesThroughUnwrapped", func(t *testing.T) {
+		ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+		defer cleanup()
+
+		// Label exists but no threshold was saved, so the repository returns the
+		// ErrDynamicThresholdNotFound sentinel. This is a benign not-found, not a DB fault.
+		_, err := ds.GetDynamicThreshold("Parus major", "")
+		require.Error(t, err)
+		require.ErrorIs(t, err, repository.ErrDynamicThresholdNotFound,
+			"not-found sentinel must propagate so callers can distinguish a benign miss from a genuine DB fault")
+		var ee *errors.EnhancedError
+		assert.False(t, errors.As(err, &ee),
+			"not-found must NOT be wrapped with datastore telemetry (would be Sentry noise)")
+	})
+
+	t.Run("GenuineDBErrorIsWrapped", func(t *testing.T) {
+		ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+		defer cleanup()
+
+		// Close the underlying DB so every query on the read paths fails for real.
+		require.NoError(t, ds.Close())
+
+		assertDatastoreWrapped := func(t *testing.T, err error, op string) {
+			t.Helper()
+			require.Error(t, err, "%s should surface the DB error", op)
+			var ee *errors.EnhancedError
+			require.True(t, errors.As(err, &ee), "%s error must be an EnhancedError", op)
+			assert.Equal(t, "datastore", ee.GetComponent(), "%s must tag datastore component", op)
+			assert.Equal(t, string(errors.CategoryDatabase), ee.GetCategory(), "%s must tag database category", op)
+		}
+
+		_, errGet := ds.GetDynamicThreshold("Parus major", "")
+		assertDatastoreWrapped(t, errGet, "GetDynamicThreshold")
+
+		_, errAll := ds.GetAllDynamicThresholds()
+		assertDatastoreWrapped(t, errAll, "GetAllDynamicThresholds")
+
+		_, errRecent := ds.GetRecentThresholdEvents(10)
+		assertDatastoreWrapped(t, errRecent, "GetRecentThresholdEvents")
+
+		_, _, _, _, errStats := ds.GetDynamicThresholdStats()
+		assertDatastoreWrapped(t, errStats, "GetDynamicThresholdStats")
+	})
+}
+
+// TestV2OnlyDatastore_ThresholdEvent_ModelName verifies that GetThresholdEvents and
+// GetRecentThresholdEvents return ModelName constructed from the event Label's AIModel
+// (e.g., "BirdNET_V2.4"), the event-side parallel of the GitHub #2902 record fix.
+// Regression test for #1025: events previously returned an empty ModelName because the
+// repository only preloaded Label (not Label.Model) and the converter never set it.
+func TestV2OnlyDatastore_ThresholdEvent_ModelName(t *testing.T) {
+	ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
+	defer cleanup()
+
+	event := &datastore.ThresholdEvent{
+		SpeciesName:   "Parus major",
+		PreviousLevel: 0,
+		NewLevel:      1,
+		PreviousValue: 0.6,
+		NewValue:      0.7,
+		ChangeReason:  "high_confidence",
+		Confidence:    0.95,
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, ds.SaveThresholdEvent(event))
+
+	events, err := ds.GetThresholdEvents("Parus major", 10)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "BirdNET_V2.4", events[0].ModelName,
+		"event ModelName must be constructed from the Label's Model (Name_VVersion)")
+
+	recent, err := ds.GetRecentThresholdEvents(10)
+	require.NoError(t, err)
+	require.Len(t, recent, 1)
+	assert.Equal(t, "BirdNET_V2.4", recent[0].ModelName,
+		"recent event ModelName must be constructed from the Label's Model")
 }
 
 // TestV2OnlyDatastore_GetThresholdEvents_ResolvesScientificName covers the


### PR DESCRIPTION
## Summary

Three related fixes to the v2only dynamic-threshold code, found during a datastore tech-debt review.

**1. Data race on the threshold lifecycle context.** The persistence and cleanup goroutines, plus the retry-backoff loop in `saveThresholdsWithRetry`, read `p.thresholdsCtx` without synchronization while `StopDynamicThresholds` rewrote it under `thresholdsMutex`, and `startThresholdPersistence` wrote the field unlocked. `ShutdownWithContext` also read `thresholdsCancel` without the lock. Fixes:
- The lifecycle context is threaded as a function parameter, so the goroutines and the retry loop never touch the shared field.
- A new `startThresholdGoroutines` helper creates and assigns the context/cancel atomically under `thresholdsMutex` (also closing a pre-existing double-start window).
- `StopDynamicThresholds` and `FlushDynamicThresholds` snapshot the context under `RLock` via a new `snapshotThresholdsCtx` helper; `Stop` tears down only when the snapshot still matches the live session.
- `ShutdownWithContext` snapshots `thresholdsCancel` under `RLock` before calling it.
- The retry loop uses an explicit `time.NewTimer` so it is released promptly on cancellation.
- New `-race` test exercises concurrent teardown.

**2. Empty `modelName` on threshold-event API responses.** The event queries preloaded `Label` but not `Label.Model`, and the converter never set `ModelName`, so `modelName` was always dropped by `omitempty`. The event repository queries now `Preload("Label.Model")` and the converter populates `ModelName`, matching the record side.

**3. Bare errors from the v2only threshold read methods.** `GetDynamicThreshold`, `GetAllDynamicThresholds`, `GetRecentThresholdEvents`, and `GetDynamicThresholdStats` returned raw repository/gorm errors with no datastore `Component`/`Category` telemetry. Genuine DB errors are now wrapped; the not-found sentinel is passed through unwrapped so it does not reach Sentry as a database error.

Also dedups the model-ID string construction into a single `labelModelName` helper.

## Test Plan
- [x] `go test -race ./internal/analysis/processor/` (new concurrent-teardown test + lifecycle test pass)
- [x] `go test -race ./internal/datastore/v2only/ ./internal/datastore/v2/repository/` (new ModelName + error-telemetry tests pass)
- [x] `go test -race ./internal/api/v2/` (threshold handler consumers unaffected)
- [x] `golangci-lint run` clean on changed packages
- [x] full `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety and reliability of dynamic threshold persistence lifecycle to prevent race conditions during concurrent operations.
  * Enhanced error handling and telemetry for threshold read operations so benign not-found results are preserved while real DB errors are surfaced with context.
  * Optimized threshold event queries to reduce database round-trips by preloading related model data.

* **Tests**
  * Added and updated tests covering lifecycle concurrency and error-telemetry behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->