### PR TITLE
fix(datastore,backup): half-open GetByHour boundary; drop dead backup loop var

### DIFF
--- a/internal/backup/sources/sqlite.go
+++ b/internal/backup/sources/sqlite.go
@@ -376,12 +376,12 @@ func (s *SQLiteSource) validatePageCount(total, sourcePages int) (totalPages, re
 	return total, total, nil
 }
 
-// performBackupSteps executes the backup process in chunks
-func (s *SQLiteSource) performBackupSteps(ctx context.Context, backupConn *sqlite3.SQLiteBackup, total int) error {
-	remaining := total
+// performBackupSteps executes the backup process in chunks until the backup
+// connection reports completion or an error occurs.
+func (s *SQLiteSource) performBackupSteps(ctx context.Context, backupConn *sqlite3.SQLiteBackup) error {
 	const pagesPerStep = 1000
 
-	for remaining > 0 {
+	for {
 		select {
 		case <-ctx.Done():
 			return errors.New(ctx.Err()).
@@ -604,7 +604,7 @@ func (s *SQLiteSource) streamBackupToWriter(ctx context.Context, db *sql.DB, w i
 	s.log.Debug("Validated page count for backup", logger.Int("validated_total_pages", validatedTotal))
 
 	// Perform the backup in chunks
-	if err := s.performBackupSteps(ctx, backupConn, validatedTotal); err != nil {
+	if err := s.performBackupSteps(ctx, backupConn); err != nil {
 		return err
 	}
 

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -575,10 +575,27 @@ func (r *detectionRepository) GetByDateRange(ctx context.Context, start, end int
 	return dets, total, err
 }
 
-// GetByHour retrieves detections starting at a specific Unix timestamp hour.
+// GetByHour retrieves detections in the half-open interval [hourStart, hourStart+3600).
+// The exclusive upper bound prevents the first second of the next hour from being
+// counted in both adjacent hours.
 func (r *detectionRepository) GetByHour(ctx context.Context, hourStart int64, limit, offset int) ([]*entities.Detection, int64, error) {
-	hourEnd := hourStart + 3600 // 1 hour in seconds
-	return r.GetByDateRange(ctx, hourStart, hourEnd, limit, offset)
+	return r.listByHalfOpenRange(ctx, hourStart, hourStart+3600, limit, offset)
+}
+
+// listByHalfOpenRange retrieves detections in [start, end) and returns the total count.
+func (r *detectionRepository) listByHalfOpenRange(ctx context.Context, start, end int64, limit, offset int) ([]*entities.Detection, int64, error) {
+	var dets []*entities.Detection
+	var total int64
+
+	query := r.db.WithContext(ctx).Table(r.tableName()).
+		Where("detected_at >= ? AND detected_at < ?", start, end)
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	err := query.Order("detected_at DESC").Limit(limit).Offset(offset).Find(&dets).Error
+	return dets, total, err
 }
 
 // GetByAudioSource retrieves detections for a specific audio source.
@@ -812,9 +829,20 @@ func (r *detectionRepository) CountByDateRange(ctx context.Context, start, end i
 	return count, err
 }
 
-// CountByHour returns the count of detections in a specific hour.
+// CountByHour returns the count of detections in the half-open interval
+// [hourStart, hourStart+3600). The exclusive upper bound prevents the first
+// second of the next hour from being counted in both adjacent hours.
 func (r *detectionRepository) CountByHour(ctx context.Context, hourStart int64) (int64, error) {
-	return r.CountByDateRange(ctx, hourStart, hourStart+3600)
+	return r.countByHalfOpenRange(ctx, hourStart, hourStart+3600)
+}
+
+// countByHalfOpenRange counts detections in [start, end).
+func (r *detectionRepository) countByHalfOpenRange(ctx context.Context, start, end int64) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Table(r.tableName()).
+		Where("detected_at >= ? AND detected_at < ?", start, end).
+		Count(&count).Error
+	return count, err
 }
 
 // ============================================================================

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -590,7 +590,9 @@ func (r *detectionRepository) listByHalfOpenRange(ctx context.Context, start, en
 	query := r.db.WithContext(ctx).Table(r.tableName()).
 		Where("detected_at >= ? AND detected_at < ?", start, end)
 
-	if err := query.Count(&total).Error; err != nil {
+	// Count on a cloned session so the Count finisher does not mutate the query that is
+	// reused for the paginated Find below (mirrors the Search method's pattern).
+	if err := query.Session(&gorm.Session{}).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -627,3 +627,59 @@ func TestSaveReview_ConcurrentUpsertNoDuplicates(t *testing.T) {
 	require.NoError(t, db.Table(tableDetectionReviews).Where("detection_id = ?", det.ID).Count(&count).Error)
 	assert.Equal(t, int64(1), count)
 }
+
+// ============================================================================
+// GetByHour / CountByHour boundary tests
+// ============================================================================
+
+// TestGetByHour_HalfOpenBoundary verifies that GetByHour and CountByHour use
+// a half-open interval [hourStart, hourStart+3600) so a detection whose
+// detected_at equals the next hour's start is not double-counted.
+//
+// Three detections are seeded:
+//   - t+10    (inside the hour, clearly included)
+//   - t+3599  (last second of the hour, included)
+//   - t+3600  (next hour's first second, must be EXCLUDED from the current hour)
+//
+// The current hour must return exactly 2. The next hour must return exactly 1.
+func TestGetByHour_HalfOpenBoundary(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	const hourStart = int64(1_700_000_000)
+
+	createTestDetection(t, db, hourStart+10)
+	createTestDetection(t, db, hourStart+3599)
+	createTestDetection(t, db, hourStart+3600) // boundary: next hour's first second
+
+	t.Run("GetByHour current hour excludes boundary second", func(t *testing.T) {
+		dets, total, err := repo.GetByHour(ctx, hourStart, 100, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total,
+			"GetByHour must use half-open [hourStart, hourStart+3600): expected 2, got %d", total)
+		assert.Len(t, dets, 2)
+	})
+
+	t.Run("CountByHour current hour excludes boundary second", func(t *testing.T) {
+		n, err := repo.CountByHour(ctx, hourStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), n,
+			"CountByHour must use half-open [hourStart, hourStart+3600): expected 2, got %d", n)
+	})
+
+	t.Run("GetByHour next hour includes boundary second exactly once", func(t *testing.T) {
+		dets, total, err := repo.GetByHour(ctx, hourStart+3600, 100, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total,
+			"boundary second must belong to the next hour exactly once: expected 1, got %d", total)
+		assert.Len(t, dets, 1)
+	})
+
+	t.Run("CountByHour next hour includes boundary second exactly once", func(t *testing.T) {
+		n, err := repo.CountByHour(ctx, hourStart+3600)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n,
+			"boundary second must belong to the next hour exactly once: expected 1, got %d", n)
+	})
+}

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -683,3 +683,22 @@ func TestGetByHour_HalfOpenBoundary(t *testing.T) {
 			"boundary second must belong to the next hour exactly once: expected 1, got %d", n)
 	})
 }
+
+// TestGetByHour_PaginationHonored verifies that LIMIT is applied by GetByHour even
+// though the query is used for a Count first. If the GORM query object's state leaked
+// across the Count/Find boundary, LIMIT would be ignored and all rows returned.
+func TestGetByHour_PaginationHonored(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	const hourStart = int64(1_700_000_000)
+	for i := int64(0); i < 5; i++ {
+		createTestDetection(t, db, hourStart+i*60)
+	}
+
+	dets, total, err := repo.GetByHour(ctx, hourStart, 2, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), total, "total must count all rows in the hour")
+	assert.Len(t, dets, 2, "LIMIT must be honored; query reuse after Count would return all 5")
+}


### PR DESCRIPTION
## Summary

Two small, independent correctness fixes found during datastore tech-debt review.

**1. `GetByHour` / `CountByHour` double-counted the exact hour boundary** (`internal/datastore/v2/repository/detection_impl.go`). Both delegated to `GetByDateRange`/`CountByDateRange`, which use an inclusive upper bound (`detected_at <= ?`), passing `hourStart+3600` as the end. A detection whose `detected_at` landed exactly on the next hour's start was counted in both adjacent hours. The hour methods now use dedicated half-open helpers (`detected_at >= ? AND detected_at < ?`). The shared `GetByDateRange`/`CountByDateRange` keep their inclusive semantics, which other callers (e.g. full-day ranges in `dual_write.go`, where the end is computed as `midnight + 24h - 1ns`) intentionally rely on.

**2. Dead loop variable in backup `performBackupSteps`** (`internal/backup/sources/sqlite.go`). `remaining := total` was initialized and used in `for remaining > 0`, but never decremented; the loop only exited via `backupConn.Step()` returning done/err. Replaced with `for {`, removed the now-unused `total` parameter, and updated the single caller (`validatedTotal` is still logged). Behavior-preserving: `validatePageCount` already guarantees a positive page count before the loop, and `Step()` would return done immediately on an empty backup anyway.

## Test Plan
- [x] New `TestGetByHour_HalfOpenBoundary` seeds detections at `+10`, `+3599`, and exactly `+3600`; asserts the current hour counts 2 and the next hour counts the boundary exactly once. Confirmed it fails on the old inclusive code (counts 3) and passes after the fix.
- [x] `go test -race ./internal/datastore/v2/repository/ ./internal/backup/...`
- [x] `golangci-lint run` clean on changed packages
- [x] full `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite backup reliability by switching to an open-ended chunking approach that continues until completion.
  * Fixed hourly detection retrieval and counting to correctly handle time boundary conditions.

* **Tests**
  * Added test coverage for time boundary handling in hourly detection queries.
  * Added test to verify pagination results remain accurate alongside full count reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->