### PR TITLE
fix(audiocore): tag ffmpeg.ExportAudio failures with error telemetry

### DIFF
--- a/internal/audiocore/ffmpeg/export.go
+++ b/internal/audiocore/ffmpeg/export.go
@@ -82,19 +82,34 @@ type ExportNormalization struct {
 // renamed on success.
 func ExportAudio(ctx context.Context, opts *ExportOptions) error {
 	if opts == nil {
-		return fmt.Errorf("export options cannot be nil")
+		return errors.Newf("export options cannot be nil").
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryValidation).
+			Context("operation", "export_validate").
+			Build()
 	}
 	// Validate inputs.
 	if err := ValidateFFmpegPath(opts.FFmpegPath); err != nil {
-		return fmt.Errorf("invalid FFmpeg path: %w", err)
+		// ValidateFFmpegPath already returns a fully enhanced, telemetry-tagged
+		// error; return it directly. Re-wrapping it with another enhanced builder
+		// would report the same failure to Sentry twice.
+		return err
 	}
 
 	if opts.OutputPath == "" {
-		return fmt.Errorf("empty output path provided")
+		return errors.Newf("empty output path provided").
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryValidation).
+			Context("operation", "export_validate").
+			Build()
 	}
 
 	if len(opts.PCMData) == 0 {
-		return fmt.Errorf("empty PCM data provided for export")
+		return errors.Newf("empty PCM data provided for export").
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryValidation).
+			Context("operation", "export_validate").
+			Build()
 	}
 
 	phaseTimeout := exportPhaseTimeout(opts)
@@ -120,16 +135,34 @@ func ExportAudio(ctx context.Context, opts *ExportOptions) error {
 
 	filterCtx, filterCancel := context.WithTimeout(ctx, phaseTimeout)
 	audioFilter, err := buildExportAudioFilter(filterCtx, opts)
+	// Capture whether the phase deadline/cancellation fired before filterCancel()
+	// is called; otherwise filterCtx.Err() would always read as cancelled below.
+	filterTimedOut := filterCtx.Err() != nil
 	filterCancel()
 	if err != nil {
-		return fmt.Errorf("failed to prepare audio export filter: %w", err)
+		// Today the filter pipeline only fails when loudnorm analysis is cancelled
+		// or times out; that context error is operational, so return it untagged
+		// (mirroring the native FLAC encoder). A future non-context filter failure
+		// is tagged at the source here instead.
+		if filterTimedOut {
+			return err
+		}
+		return errors.Newf("failed to prepare audio export filter: %w", err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_prepare_filter").
+			Build()
 	}
 
 	exportCtx, exportCancel := context.WithTimeout(ctx, phaseTimeout)
 	err = runExportFFmpeg(exportCtx, opts, tempPath, audioFilter)
 	exportCancel()
 	if err != nil {
-		return fmt.Errorf("FFmpeg export failed: %w", err)
+		// runExportFFmpeg tags its genuine FFmpeg failures at the source and
+		// returns context cancellation/timeout untagged. Return its error directly
+		// so it is reported exactly once; re-wrapping with another enhanced error
+		// would double-report the already-tagged failures.
+		return err
 	}
 
 	// Atomic rename to final path.
@@ -178,7 +211,11 @@ func runExportFFmpeg(ctx context.Context, opts *ExportOptions, tempPath, audioFi
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdin pipe: %w", err)
+		return errors.Newf("failed to create stdin pipe: %w", err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_ffmpeg_stdin_pipe").
+			Build()
 	}
 
 	var stderr bytes.Buffer
@@ -188,7 +225,12 @@ func runExportFFmpeg(ctx context.Context, opts *ExportOptions, tempPath, audioFi
 		if ctx.Err() != nil {
 			return fmt.Errorf("failed to start FFmpeg (context error): %w", ctx.Err())
 		}
-		return fmt.Errorf("failed to start FFmpeg: %w, stderr: %s", err, stderr.String())
+		return errors.Newf("failed to start FFmpeg: %w", err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_ffmpeg_start").
+			Context("error_detail", stderr.String()).
+			Build()
 	}
 
 	// Write PCM data in a goroutine to avoid blocking the main goroutine.
@@ -213,6 +255,13 @@ func runExportFFmpeg(ctx context.Context, opts *ExportOptions, tempPath, audioFi
 		if writeErr != nil {
 			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
+			// A write failure caused by context cancellation/timeout (either the
+			// goroutine forwarding ctx.Err(), or a broken pipe after the killed
+			// process closed stdin) is operational; return it untagged, mirroring
+			// the cmd.Wait() timeout guard below.
+			if ctx.Err() != nil {
+				return fmt.Errorf("export cancelled: %w", ctx.Err())
+			}
 			return errors.Newf("failed to write PCM data to FFmpeg: %w", writeErr).
 				Component("audiocore/ffmpeg").
 				Category(errors.CategoryAudio).

--- a/internal/audiocore/ffmpeg/export_test.go
+++ b/internal/audiocore/ffmpeg/export_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // makePCMSilence returns a slice of silence PCM bytes (16-bit LE, mono, 48 kHz).
@@ -161,6 +163,186 @@ func TestExportAudio_InvalidInputs(t *testing.T) {
 			t.Parallel()
 			err := ffmpeg.ExportAudio(t.Context(), tt.opts)
 			assert.Error(t, err)
+		})
+	}
+}
+
+// TestExportAudio_ErrorsAreEnhanced verifies that every error ExportAudio
+// returns carries internal/errors telemetry metadata (component + category) so
+// FFmpeg export failures reach Sentry tagged, matching the native WAV and FLAC
+// export paths. None of these cases require a real FFmpeg binary: the validation
+// cases return before exec, and the process-start case uses a bogus path.
+func TestExportAudio_ErrorsAreEnhanced(t *testing.T) {
+	t.Parallel()
+
+	outDir := t.TempDir()
+	pcm := makePCMSilence(t, 1)
+	const validPath = "/usr/bin/ffmpeg" // absolute + uncontaminated; never executed in validation cases
+
+	// A plain file used as an output parent directory so os.MkdirAll fails.
+	parentIsFile := filepath.Join(outDir, "not-a-dir")
+	require.NoError(t, os.WriteFile(parentIsFile, []byte("x"), 0o600))
+
+	tests := []struct {
+		name          string
+		opts          *ffmpeg.ExportOptions
+		wantComponent string
+		wantCategory  errors.ErrorCategory
+		wantOperation string
+	}{
+		{
+			name:          "nil options",
+			opts:          nil,
+			wantComponent: "audiocore/ffmpeg",
+			wantCategory:  errors.CategoryValidation,
+			wantOperation: "export_validate",
+		},
+		{
+			name: "empty output path",
+			opts: &ffmpeg.ExportOptions{
+				PCMData: pcm, OutputPath: "", Format: ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16, FFmpegPath: validPath,
+			},
+			wantComponent: "audiocore/ffmpeg",
+			wantCategory:  errors.CategoryValidation,
+			wantOperation: "export_validate",
+		},
+		{
+			name: "empty PCM data",
+			opts: &ffmpeg.ExportOptions{
+				PCMData: nil, OutputPath: filepath.Join(outDir, "out.mp3"), Format: ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16, FFmpegPath: validPath,
+			},
+			wantComponent: "audiocore/ffmpeg",
+			wantCategory:  errors.CategoryValidation,
+			wantOperation: "export_validate",
+		},
+		{
+			// ValidateFFmpegPath is a shared audiocore helper that already returns a
+			// fully enhanced error, so this case (and the relative-path one below)
+			// passed before the fix too; they are regression-locks on ExportAudio
+			// returning that error directly rather than re-wrapping (double-report).
+			name: "empty FFmpeg path",
+			opts: &ffmpeg.ExportOptions{
+				PCMData: pcm, OutputPath: filepath.Join(outDir, "out.mp3"), Format: ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16, FFmpegPath: "",
+			},
+			wantComponent: "audiocore",
+			wantCategory:  errors.CategoryValidation,
+			wantOperation: "validate_ffmpeg_path",
+		},
+		{
+			name: "relative FFmpeg path",
+			opts: &ffmpeg.ExportOptions{
+				PCMData: pcm, OutputPath: filepath.Join(outDir, "out.mp3"), Format: ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16, FFmpegPath: "ffmpeg",
+			},
+			wantComponent: "audiocore",
+			wantCategory:  errors.CategoryValidation,
+			wantOperation: "validate_ffmpeg_path",
+		},
+		{
+			name: "output directory cannot be created",
+			opts: &ffmpeg.ExportOptions{
+				PCMData: pcm, OutputPath: filepath.Join(parentIsFile, "out.mp3"), Format: ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16, FFmpegPath: validPath,
+			},
+			wantComponent: "audiocore/ffmpeg",
+			wantCategory:  errors.CategoryFileIO,
+			wantOperation: "export_create_directory",
+		},
+		{
+			name: "nonexistent FFmpeg binary fails process start",
+			opts: &ffmpeg.ExportOptions{
+				PCMData: pcm, OutputPath: filepath.Join(outDir, "out.mp3"), Format: ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16,
+				FFmpegPath: filepath.Join(outDir, "ffmpeg-does-not-exist"),
+			},
+			wantComponent: "audiocore/ffmpeg",
+			wantCategory:  errors.CategoryAudio,
+			wantOperation: "export_ffmpeg_start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ffmpeg.ExportAudio(t.Context(), tt.opts)
+			require.Error(t, err)
+
+			var enhanced *errors.EnhancedError
+			require.ErrorAs(t, err, &enhanced, "error must carry internal/errors telemetry metadata")
+			assert.Equal(t, tt.wantComponent, enhanced.GetComponent(), "component tag")
+			assert.Equal(t, tt.wantCategory, enhanced.Category, "category tag")
+			// Pin each error to its origin so a future refactor that returns the
+			// right component/category from the wrong site is caught.
+			assert.Equal(t, tt.wantOperation, enhanced.GetContext()["operation"], "operation context")
+		})
+	}
+}
+
+// TestExportAudio_RuntimeFailuresAreEnhanced covers the FFmpeg-execution and
+// finalization error paths using fake POSIX-shell "FFmpeg" binaries, so the
+// cmd.Wait() non-zero-exit and os.Rename finalize branches are exercised
+// deterministically without a real FFmpeg. POSIX-only; skipped on Windows.
+func TestExportAudio_RuntimeFailuresAreEnhanced(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell-script FFmpeg binaries are POSIX-only")
+	}
+
+	outDir := t.TempDir()
+	pcm := makePCMSilence(t, 1)
+
+	writeFakeBin := func(t *testing.T, name, script string) string {
+		t.Helper()
+		p := filepath.Join(outDir, name)
+		require.NoError(t, os.WriteFile(p, []byte(script), 0o755)) //nolint:gosec // test-only fake binary must be executable
+		return p
+	}
+
+	// Drains stdin then exits non-zero -> cmd.Wait() reports a non-zero exit.
+	waitFailBin := writeFakeBin(t, "wait-fail.sh", "#!/bin/sh\ncat > /dev/null\nexit 1\n")
+	// Exits zero but never writes the temp output file -> os.Rename finalize fails.
+	renameFailBin := writeFakeBin(t, "rename-fail.sh", "#!/bin/sh\ncat > /dev/null\nexit 0\n")
+
+	tests := []struct {
+		name          string
+		ffmpegPath    string
+		wantCategory  errors.ErrorCategory
+		wantOperation string
+	}{
+		{
+			name:          "FFmpeg exits non-zero",
+			ffmpegPath:    waitFailBin,
+			wantCategory:  errors.CategoryAudio,
+			wantOperation: "export_ffmpeg_wait",
+		},
+		{
+			name:          "missing temp output fails finalize rename",
+			ffmpegPath:    renameFailBin,
+			wantCategory:  errors.CategoryFileIO,
+			wantOperation: "export_finalize_rename",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ffmpeg.ExportAudio(t.Context(), &ffmpeg.ExportOptions{
+				PCMData:    pcm,
+				OutputPath: filepath.Join(outDir, strings.ReplaceAll(tt.name, " ", "_")+".mp3"),
+				Format:     ffmpeg.FormatMP3,
+				SampleRate: 48000, Channels: 1, BitDepth: 16,
+				FFmpegPath: tt.ffmpegPath,
+			})
+			require.Error(t, err)
+
+			var enhanced *errors.EnhancedError
+			require.ErrorAs(t, err, &enhanced, "runtime failure must carry telemetry metadata")
+			assert.Equal(t, "audiocore/ffmpeg", enhanced.GetComponent(), "component tag")
+			assert.Equal(t, tt.wantCategory, enhanced.Category, "category tag")
+			assert.Equal(t, tt.wantOperation, enhanced.GetContext()["operation"], "operation context")
 		})
 	}
 }

--- a/internal/audiocore/ffmpeg/export_test.go
+++ b/internal/audiocore/ffmpeg/export_test.go
@@ -177,7 +177,9 @@ func TestExportAudio_ErrorsAreEnhanced(t *testing.T) {
 
 	outDir := t.TempDir()
 	pcm := makePCMSilence(t, 1)
-	const validPath = "/usr/bin/ffmpeg" // absolute + uncontaminated; never executed in validation cases
+	// Absolute on every platform (t.TempDir is absolute) and uncontaminated, so
+	// ValidateFFmpegPath passes; never executed in the validation cases.
+	validPath := filepath.Join(outDir, "ffmpeg-never-executed")
 
 	// A plain file used as an output parent directory so os.MkdirAll fails.
 	parentIsFile := filepath.Join(outDir, "not-a-dir")


### PR DESCRIPTION
## Summary

`ffmpeg.ExportAudio` returned a mix of plain `fmt.Errorf` errors (no telemetry metadata) and enhanced `internal/errors` builder errors. The plain paths reached Sentry without component/category tagging, unlike the native WAV (`convert.SavePCMDataToWAV`) and native-FLAC (`flac.EncodePCM`) export paths, which are fully enhanced. This converts the remaining paths so FFmpeg export failures are tagged at the source.

### What changed

- Validation errors (nil opts, empty output path, empty PCM data) now carry `Component("audiocore/ffmpeg")` and `CategoryValidation`.
- Genuine FFmpeg-exec failures (stdin pipe, process start) carry `CategoryAudio`, with stderr preserved in structured context rather than the message.
- `invalid-FFmpeg-path` and the top-level export wrap now return the already-enhanced inner error directly instead of re-wrapping. `ValidateFFmpegPath` and `runExportFFmpeg`'s write/wait paths already build enhanced (and reported) errors; re-wrapping them with another builder would report the same failure to Sentry twice.
- Context cancellation/timeout stays untagged (operational), mirroring the native FLAC encoder. This also fixes a write-phase cancellation that was mis-tagged as `CategoryAudio`, and a filter-prep guard that read the phase context after it had already been cancelled (making its enhanced branch dead).

### Why at the source

Wrapping in the processor (`SaveAudioAction.encodeClip`) would mislabel the origin component, so the fix belongs in the ffmpeg package.

## Related

Found during review of #3483 (native go-flac encoder). Pre-existing; not introduced by that PR.

## Test Plan

- [x] `go test -race ./internal/audiocore/ffmpeg/...` passes
- [x] `golangci-lint run ./internal/audiocore/ffmpeg/...` clean
- [x] New table tests assert component/category/operation for each error path (nil opts, empty output, empty PCM, empty/relative FFmpeg path, MkdirAll failure, process start, non-zero exit, finalize rename)
- [x] `go build ./...` and the `analysis/processor` caller package tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio export error reporting: errors now include richer telemetry/context and avoid duplicate tagging, preserving original failure details for easier diagnosis.

* **Tests**
  * Added tests covering audio export error scenarios, including validation failures and runtime failure modes (with POSIX-only coverage for process/runtime branches).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->