### PR TITLE
fix(datastore,telemetry): v2only threshold not-found returns 404 not 500

### DIFF
--- a/internal/api/v2/dynamic_thresholds_test.go
+++ b/internal/api/v2/dynamic_thresholds_test.go
@@ -1,15 +1,19 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
@@ -166,4 +170,58 @@ func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
 	assert.Equal(t, "Common Blackbird", entry.SpeciesName)
 	assert.Equal(t, "Turdus merula", entry.ScientificName)
 	assert.Equal(t, 1, entry.Level)
+}
+
+// TestGetDynamicThreshold_NotFoundStatus pins both sides of the handler's not-found
+// classification boundary that #1068 turned on. handleErrorWithNotFound maps
+// a CategoryNotFound EnhancedError to 404 but an unclassified error (a bare sentinel)
+// to 500. The v2only datastore used to return the bare ErrDynamicThresholdNotFound
+// sentinel, so a missing threshold fell through to 500 while the legacy backend
+// returned 404; the datastore fix wraps the sentinel as CategoryNotFound. The first
+// subtest pins the fixed behavior; the second pins the bare-sentinel regression so a
+// future unwrapped return is caught here too.
+func TestGetDynamicThreshold_NotFoundStatus(t *testing.T) {
+	const species = "Nonexistent species"
+
+	t.Run("CategoryNotFoundMapsTo404", func(t *testing.T) {
+		e, mockDS, controller := setupTestEnvironment(t)
+		// What the fixed v2only datastore (and the legacy backend) returns.
+		notFound := errors.New(errors.NewStd("dynamic threshold not found")).
+			Component("datastore").
+			Category(errors.CategoryNotFound).
+			Build()
+		mockDS.EXPECT().GetDynamicThreshold(species, "").Return(nil, notFound)
+
+		rec := serveGetDynamicThreshold(t, e, controller, species)
+		assert.Equal(t, http.StatusNotFound, rec.Code,
+			"a CategoryNotFound threshold miss must map to 404, not 500")
+	})
+
+	t.Run("BareSentinelMapsTo500", func(t *testing.T) {
+		e, mockDS, controller := setupTestEnvironment(t)
+		// The pre-fix v2only behavior: a bare, unclassified sentinel. The handler
+		// cannot tell it is a benign not-found, so it falls through to 500. This is
+		// the #1068 bug, pinned so a future unwrapped return is caught at the handler.
+		mockDS.EXPECT().GetDynamicThreshold(species, "").
+			Return(nil, errors.NewStd("dynamic threshold not found"))
+
+		rec := serveGetDynamicThreshold(t, e, controller, species)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code,
+			"an unclassified (bare sentinel) threshold miss falls through to 500")
+	})
+}
+
+// serveGetDynamicThreshold issues GET /api/v2/dynamic-thresholds/:species against the
+// controller with the given species path param and returns the response recorder. The
+// handler writes the response via HandleError and returns nil (ctx.JSON success), so
+// the observable contract is the recorded status code.
+func serveGetDynamicThreshold(t *testing.T, e *echo.Echo, controller *Controller, species string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/dynamic-thresholds/test", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("species")
+	ctx.SetParamValues(species)
+	require.NoError(t, controller.GetDynamicThreshold(ctx))
+	return rec
 }

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2960,11 +2960,20 @@ func (ds *Datastore) GetDynamicThreshold(speciesName, _ string) (*datastore.Dyna
 	// Resolve to scientific name in case caller passes a common name
 	t, err := ds.threshold.GetDynamicThreshold(ctx, ds.resolveToScientificName(speciesName))
 	if err != nil {
-		// Pass not-found through unwrapped: it is a benign result, not a DB fault, and
-		// wrapping it with the datastore builder would surface it to Sentry as a
-		// database error (#1019). Only genuine failures get the telemetry tags.
+		// Not-found is a benign result, not a DB fault. Wrap it as a CategoryNotFound
+		// EnhancedError (never CategoryDatabase, so it is not surfaced to Sentry as a
+		// database error, see #1019) so the API layer's handleErrorWithNotFound maps it
+		// to HTTP 404 instead of 500, matching the legacy backend (#1068). errors.Is
+		// against the sentinel still matches because EnhancedError.Unwrap exposes it, and
+		// shouldReportToSentry suppresses the benign "dynamic threshold not found" message
+		// so building this error produces no Sentry noise. Genuine failures fall through
+		// to the CategoryDatabase telemetry tags below.
 		if errors.Is(err, repository.ErrDynamicThresholdNotFound) {
-			return nil, err
+			return nil, errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryNotFound).
+				Context("operation", "get_dynamic_threshold").
+				Build()
 		}
 		return nil, errors.New(err).
 			Component("datastore").

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -778,19 +778,26 @@ func TestV2OnlyDatastore_ThresholdEvent(t *testing.T) {
 // while a benign not-found (ErrDynamicThresholdNotFound) must propagate UNWRAPPED so it
 // does not reach Sentry as a database error.
 func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
-	t.Run("NotFoundPassesThroughUnwrapped", func(t *testing.T) {
+	t.Run("NotFoundWrappedAsNotFoundCategory", func(t *testing.T) {
 		ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})
 		defer cleanup()
 
 		// Label exists but no threshold was saved, so the repository returns the
 		// ErrDynamicThresholdNotFound sentinel. This is a benign not-found, not a DB fault.
+		// It is wrapped as a CategoryNotFound EnhancedError so the API layer's
+		// handleErrorWithNotFound maps it to HTTP 404 (#1068), while the sentinel stays
+		// reachable via errors.Is (EnhancedError.Unwrap) and the CategoryNotFound
+		// "dynamic threshold not found" message is suppressed from Sentry, so it is never
+		// surfaced as a database error (#1019).
 		_, err := ds.GetDynamicThreshold("Parus major", "")
 		require.Error(t, err)
 		require.ErrorIs(t, err, repository.ErrDynamicThresholdNotFound,
 			"not-found sentinel must propagate so callers can distinguish a benign miss from a genuine DB fault")
 		var ee *errors.EnhancedError
-		assert.False(t, errors.As(err, &ee),
-			"not-found must NOT be wrapped with datastore telemetry (would be Sentry noise)")
+		require.True(t, errors.As(err, &ee),
+			"not-found must be a CategoryNotFound EnhancedError so the API maps it to 404")
+		assert.Equal(t, string(errors.CategoryNotFound), ee.GetCategory(),
+			"not-found must be CategoryNotFound, never CategoryDatabase (which would be Sentry noise)")
 	})
 
 	t.Run("GenuineDBErrorIsWrapped", func(t *testing.T) {

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -773,10 +773,11 @@ func TestV2OnlyDatastore_ThresholdEvent(t *testing.T) {
 	assert.Len(t, recent, 1)
 }
 
-// TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry pins #1019: the v2only threshold
-// read methods must wrap genuine DB errors with datastore Component/Category telemetry,
-// while a benign not-found (ErrDynamicThresholdNotFound) must propagate UNWRAPPED so it
-// does not reach Sentry as a database error.
+// TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry pins #1019 and #1068: the v2only
+// threshold read methods must wrap genuine DB errors with datastore Component/Category
+// telemetry, while a benign not-found (ErrDynamicThresholdNotFound) must be wrapped as a
+// CategoryNotFound EnhancedError (never CategoryDatabase) so the API maps it to 404 and it
+// never reaches Sentry as a database error, all while staying reachable via errors.Is.
 func TestV2OnlyDatastore_ThresholdReads_ErrorTelemetry(t *testing.T) {
 	t.Run("NotFoundWrappedAsNotFoundCategory", func(t *testing.T) {
 		ds, cleanup := setupTestDatastoreWithLabels(t, []string{"Parus major_Great Tit"})

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -253,9 +253,13 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 	// Filter out expected not-found conditions that are not code bugs:
 	// - "note not found": transient race between write commit and read, or retention cleanup
 	// - "not found in ebird taxonomy": non-bird species (e.g., Canis latrans) detected by BirdNET
+	// - "dynamic threshold not found": a user queried the dynamic threshold for a species
+	//   that has none; both the v2only and legacy datastore backends produce this benign
+	//   404 (#1068), so it must not reach Sentry
 	if ee.Category == CategoryNotFound {
 		if strings.Contains(errorMsg, "note not found") ||
-			strings.Contains(errorMsg, "not found in ebird taxonomy") {
+			strings.Contains(errorMsg, "not found in ebird taxonomy") ||
+			strings.Contains(errorMsg, "dynamic threshold not found") {
 			return false
 		}
 	}

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -116,6 +116,18 @@ func TestShouldReportToSentry_FiltersEBirdTaxonomyNotFound(t *testing.T) {
 	assert.False(t, shouldReportToSentry(ee))
 }
 
+func TestShouldReportToSentry_FiltersDynamicThresholdNotFound(t *testing.T) {
+	t.Parallel()
+	// A user querying the dynamic threshold for a species that has none is a
+	// benign 404, not a code bug. Both the v2only and legacy datastore backends
+	// produce this CategoryNotFound error, so it must not reach Sentry (#1068).
+	ee := New(fmt.Errorf("dynamic threshold not found")).
+		Component("datastore").
+		Category(CategoryNotFound).
+		Build()
+	assert.False(t, shouldReportToSentry(ee))
+}
+
 func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 	t.Parallel()
 	// Network category error that is NOT environmental noise should still report


### PR DESCRIPTION
## Summary

In v2only mode, `(*Datastore).GetDynamicThreshold` returned the bare `ErrDynamicThresholdNotFound` sentinel for a missing threshold. The API handler classifies errors through `handleErrorWithNotFound`, which only maps an `*errors.EnhancedError` with `CategoryNotFound` to 404, so the raw sentinel fell through to 500. The legacy datastore returns a `CategoryNotFound` `EnhancedError` for the same condition and correctly yields 404, so the two backends diverged on the HTTP status for an identical "threshold not found" case.

## Changes

- **`internal/datastore/v2only/datastore.go`**: wrap the not-found sentinel in a `CategoryNotFound` `EnhancedError` (never `CategoryDatabase`, so it is not surfaced to Sentry as a database error). The sentinel stays reachable via `errors.Is` (`EnhancedError.Unwrap`), so existing callers that check the sentinel keep working, and the API layer now maps it to 404, matching the legacy backend.
- **`internal/errors/telemetry_integration.go`**: suppress the benign `"dynamic threshold not found"` message in `shouldReportToSentry`. Building the `CategoryNotFound` error triggers telemetry at construction time; without this it would be reported at `LevelInfo` when telemetry is active. This also covers the legacy backend, which produces the same message.

This is a pre-existing backend-divergence bug (observable only on the v2only backend when querying a species with no stored dynamic threshold): a backend-divergent status code, not data loss.

## Test Plan

- [x] `go test -race ./internal/datastore/v2only/ ./internal/errors/ ./internal/api/v2/`
- [x] v2only not-found path now produces a `CategoryNotFound` `EnhancedError` that still matches the sentinel via `errors.Is`
- [x] `shouldReportToSentry` suppresses the `"dynamic threshold not found"` message
- [x] Handler boundary pinned both ways: `CategoryNotFound` -> 404, bare sentinel -> 500
- [x] `golangci-lint run ./...` clean, `gofmt` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing dynamic thresholds now produce a 404 response instead of a 500.

* **Tests**
  * Added tests covering mapping of missing-threshold errors to HTTP status and Sentry-suppression behavior.

* **Chores**
  * Adjusted error classification and monitoring to avoid noisy alerts for expected “dynamic threshold not found” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->