### PR TITLE
fix(audiocore): tag ffmpeg.ExportAudioToBuffer failures with error telemetry

### DIFF
--- a/internal/audiocore/ffmpeg/export.go
+++ b/internal/audiocore/ffmpeg/export.go
@@ -478,15 +478,25 @@ func getMaxBitrate(format, requestedBitrate string) string {
 // the result as an in-memory buffer. Useful for streaming responses.
 func ExportAudioToBuffer(ctx context.Context, pcmData []byte, ffmpegPath string, sampleRate, channels, bitDepth int, customArgs []string) (*bytes.Buffer, error) {
 	if err := ValidateFFmpegPath(ffmpegPath); err != nil {
-		return nil, fmt.Errorf("invalid FFmpeg path: %w", err)
+		// ValidateFFmpegPath already returns a fully enhanced, telemetry-tagged
+		// error; return it directly to avoid double-reporting to Sentry.
+		return nil, err
 	}
 
 	if len(pcmData) == 0 {
-		return nil, fmt.Errorf("empty PCM data provided")
+		return nil, errors.Newf("empty PCM data provided").
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryValidation).
+			Context("operation", "export_buffer_validate").
+			Build()
 	}
 
 	if len(customArgs) == 0 {
-		return nil, fmt.Errorf("empty custom FFmpeg arguments")
+		return nil, errors.Newf("empty custom FFmpeg arguments").
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryValidation).
+			Context("operation", "export_buffer_validate").
+			Build()
 	}
 
 	sampleRateStr, channelsStr, formatStr := GetFFmpegFormat(sampleRate, channels, bitDepth)
@@ -506,19 +516,35 @@ func ExportAudioToBuffer(ctx context.Context, pcmData []byte, ffmpegPath string,
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create stdin pipe: %w", err)
+		return nil, errors.Newf("failed to create stdin pipe: %w", err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_buffer_stdin_pipe").
+			Build()
 	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		return nil, errors.Newf("failed to create stdout pipe: %w", err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_buffer_stdout_pipe").
+			Build()
 	}
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to start FFmpeg: %w, stderr: %s", err, stderr.String())
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("export to buffer cancelled: %w", ctx.Err())
+		}
+		return nil, errors.Newf("failed to start FFmpeg: %w", err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_buffer_start").
+			Context("error_detail", stderr.String()).
+			Build()
 	}
 
 	// Write PCM data in a goroutine.
@@ -563,17 +589,54 @@ func ExportAudioToBuffer(ctx context.Context, pcmData []byte, ffmpegPath string,
 	}
 
 	if writeErr != nil {
-		return nil, fmt.Errorf("failed to write PCM data: %w", writeErr)
+		// Reap the process so a failed write does not leave a zombie; Kill is a
+		// no-op if FFmpeg already exited (which is what caused the broken pipe).
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		// A write failure caused by context cancellation/timeout is operational;
+		// return it untagged, mirroring the cmd.Wait() guard below.
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("export to buffer cancelled: %w", ctx.Err())
+		}
+		return nil, errors.Newf("failed to write PCM data: %w", writeErr).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_buffer_write").
+			Context("error_detail", stderr.String()).
+			Build()
 	}
 	if readErr != nil {
-		return nil, fmt.Errorf("failed to read FFmpeg output: %w", readErr)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("export to buffer cancelled: %w", ctx.Err())
+		}
+		return nil, errors.Newf("failed to read FFmpeg output: %w", readErr).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_buffer_read").
+			Context("error_detail", stderr.String()).
+			Build()
 	}
 
 	if err := cmd.Wait(); err != nil {
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("export to buffer cancelled: %w", ctx.Err())
 		}
-		return nil, fmt.Errorf("FFmpeg failed: %w, stderr: %s", err, stderr.String())
+
+		exitCode := -1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+
+		return nil, errors.Newf("FFmpeg failed (exit_code=%d): %w", exitCode, err).
+			Component("audiocore/ffmpeg").
+			Category(errors.CategoryAudio).
+			Context("operation", "export_buffer_wait").
+			Context("exit_code", exitCode).
+			Context("error_detail", stderr.String()).
+			Build()
 	}
 
 	return &outputBuf, nil

--- a/internal/audiocore/ffmpeg/export_test.go
+++ b/internal/audiocore/ffmpeg/export_test.go
@@ -349,6 +349,102 @@ func TestExportAudio_RuntimeFailuresAreEnhanced(t *testing.T) {
 	}
 }
 
+// TestExportAudioToBuffer_ErrorsAreEnhanced verifies that every error
+// ExportAudioToBuffer returns carries internal/errors telemetry metadata, the
+// same parity ExportAudio has. None of these cases require a real FFmpeg binary.
+func TestExportAudioToBuffer_ErrorsAreEnhanced(t *testing.T) {
+	t.Parallel()
+
+	outDir := t.TempDir()
+	pcm := makePCMSilence(t, 1)
+	// Absolute on every platform and uncontaminated, so ValidateFFmpegPath passes;
+	// never executed in the validation cases.
+	validPath := filepath.Join(outDir, "ffmpeg-never-executed")
+	customArgs := []string{"-c:a", "flac", "-f", "flac"}
+
+	tests := []struct {
+		name          string
+		pcm           []byte
+		ffmpegPath    string
+		customArgs    []string
+		wantComponent string
+		wantCategory  errors.ErrorCategory
+		wantOperation string
+	}{
+		{
+			name: "empty PCM data", pcm: nil, ffmpegPath: validPath, customArgs: customArgs,
+			wantComponent: "audiocore/ffmpeg", wantCategory: errors.CategoryValidation,
+			wantOperation: "export_buffer_validate",
+		},
+		{
+			name: "empty custom args", pcm: pcm, ffmpegPath: validPath, customArgs: nil,
+			wantComponent: "audiocore/ffmpeg", wantCategory: errors.CategoryValidation,
+			wantOperation: "export_buffer_validate",
+		},
+		{
+			// ValidateFFmpegPath already returns a fully enhanced error; returned
+			// directly rather than re-wrapped, to avoid double-reporting.
+			name: "empty FFmpeg path", pcm: pcm, ffmpegPath: "", customArgs: customArgs,
+			wantComponent: "audiocore", wantCategory: errors.CategoryValidation,
+			wantOperation: "validate_ffmpeg_path",
+		},
+		{
+			name: "relative FFmpeg path", pcm: pcm, ffmpegPath: "ffmpeg", customArgs: customArgs,
+			wantComponent: "audiocore", wantCategory: errors.CategoryValidation,
+			wantOperation: "validate_ffmpeg_path",
+		},
+		{
+			name: "nonexistent FFmpeg binary fails process start",
+			pcm:  pcm, ffmpegPath: filepath.Join(outDir, "ffmpeg-does-not-exist"), customArgs: customArgs,
+			wantComponent: "audiocore/ffmpeg", wantCategory: errors.CategoryAudio,
+			wantOperation: "export_buffer_start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			buf, err := ffmpeg.ExportAudioToBuffer(t.Context(), tt.pcm, tt.ffmpegPath, 48000, 1, 16, tt.customArgs)
+			require.Error(t, err)
+			assert.Nil(t, buf, "no buffer on error")
+
+			var enhanced *errors.EnhancedError
+			require.ErrorAs(t, err, &enhanced, "error must carry internal/errors telemetry metadata")
+			assert.Equal(t, tt.wantComponent, enhanced.GetComponent(), "component tag")
+			assert.Equal(t, tt.wantCategory, enhanced.Category, "category tag")
+			assert.Equal(t, tt.wantOperation, enhanced.GetContext()["operation"], "operation context")
+		})
+	}
+}
+
+// TestExportAudioToBuffer_RuntimeFailuresAreEnhanced covers the FFmpeg-execution
+// error paths using a fake POSIX-shell "FFmpeg" binary so the cmd.Wait()
+// non-zero-exit branch is exercised deterministically. POSIX-only.
+func TestExportAudioToBuffer_RuntimeFailuresAreEnhanced(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell-script FFmpeg binaries are POSIX-only")
+	}
+
+	outDir := t.TempDir()
+	pcm := makePCMSilence(t, 1)
+
+	// Drains stdin, writes nothing to stdout, exits non-zero -> cmd.Wait() error.
+	waitFailBin := filepath.Join(outDir, "wait-fail.sh")
+	require.NoError(t, os.WriteFile(waitFailBin, []byte("#!/bin/sh\ncat > /dev/null\nexit 1\n"), 0o755)) //nolint:gosec // test-only fake binary must be executable
+
+	buf, err := ffmpeg.ExportAudioToBuffer(t.Context(), pcm, waitFailBin, 48000, 1, 16, []string{"-c:a", "flac", "-f", "flac"})
+	require.Error(t, err)
+	assert.Nil(t, buf, "no buffer on error")
+
+	var enhanced *errors.EnhancedError
+	require.ErrorAs(t, err, &enhanced, "runtime failure must carry telemetry metadata")
+	assert.Equal(t, "audiocore/ffmpeg", enhanced.GetComponent(), "component tag")
+	assert.Equal(t, errors.CategoryAudio, enhanced.Category, "category tag")
+	assert.Equal(t, "export_buffer_wait", enhanced.GetContext()["operation"], "operation context")
+	assert.Equal(t, 1, enhanced.GetContext()["exit_code"], "exit code captured from the failed FFmpeg process")
+}
+
 // TestExportAudio_CreatesDirectory verifies that the output directory is created
 // if it does not already exist.
 func TestExportAudio_CreatesDirectory(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #3487. `ffmpeg.ExportAudio` was converted to enhanced `internal/errors`, but its sibling `ExportAudioToBuffer` (the in-memory FLAC encoder used by BirdWeather streaming uploads) still returned plain `fmt.Errorf`, so its failures reached Sentry without component/category tagging. This brings it to parity.

### What changed

- Validation errors (empty PCM, empty custom args) carry `Component("audiocore/ffmpeg")` + `CategoryValidation`.
- Genuine FFmpeg-exec failures (stdin/stdout pipe, process start, write, read, non-zero exit) carry `CategoryAudio`, with stderr and exit code in structured context rather than the message.
- `invalid-FFmpeg-path` returns `ValidateFFmpegPath`'s already-enhanced error directly instead of re-wrapping it (re-wrapping would report the same failure to Sentry twice).
- Context cancellation/timeout stays untagged (operational), consistent with `ExportAudio` and the native FLAC encoder.
- Bonus correctness fix: the write/read error branches now `Kill()`+`Wait()` the FFmpeg process before returning, so a failed export no longer leaks a zombie process (pre-existing; the branches returned without reaping).

The two BirdWeather callers only plain-wrap and log the error, so tagging at the ffmpeg source is correct (origin component) and does not double-report.

## Test Plan

- [x] `go test -race ./internal/audiocore/ffmpeg/...` passes
- [x] `golangci-lint run ./internal/audiocore/ffmpeg/...` clean
- [x] New table tests assert component/category/operation per error path (empty PCM, empty args, empty/relative FFmpeg path, process start, non-zero exit with exit_code)
- [x] `go build ./...` and `internal/birdweather` caller tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio export error handling with better error context and messages.
  * Prevented potential zombie processes during audio export failures.

* **Tests**
  * Added comprehensive test coverage for all audio export error scenarios.
  * New runtime tests validate error reporting and recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->