### PR TITLE
feat(analytics): add Species Manage view for curation

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -1,3 +1,10 @@
+<script module lang="ts">
+  // Range-filter scores require a full geo evaluation, so cache them for the
+  // browser session. Module-scoped so the cache survives navigating away from
+  // and back to the Species page within the same SPA session.
+  let cachedRangeScores: Map<string, number> | null = null;
+</script>
+
 <script lang="ts">
   import { t, getLocale, type TranslationKey } from '$lib/i18n';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
@@ -7,8 +14,15 @@
   import { getStoredValue, setStoredValue } from '$lib/utils/storage';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { isAuthenticated } from '$lib/utils/auth';
+  import { settingsActions } from '$lib/stores/settings';
+  import { api } from '$lib/utils/api';
   import { onMount, onDestroy } from 'svelte';
+  import { SvelteSet, SvelteMap } from 'svelte/reactivity';
+  import { Trash2, SlidersHorizontal } from '@lucide/svelte';
   import SortableHeader from '$lib/desktop/components/ui/SortableHeader.svelte';
+  import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
+  import Modal from '$lib/desktop/components/ui/Modal.svelte';
   import SpeciesFilterForm from '../components/forms/SpeciesFilterForm.svelte';
   import SpeciesDetailModal from '../components/modals/SpeciesDetailModal.svelte';
   import SpeciesCard from '../components/ui/SpeciesCard.svelte';
@@ -51,7 +65,19 @@
     thumbnail_url?: string;
   }
 
-  type ViewMode = 'grid' | 'list';
+  type ViewMode = 'grid' | 'list' | 'manage';
+
+  // Per-species review counts used by the Manage view.
+  interface ReviewStat {
+    scientificName: string;
+    total: number;
+    verified: number;
+    rejected: number;
+  }
+
+  // Manage-only sort keys. Kept separate from SortOrder (and never persisted to
+  // localStorage) so a Manage-only column never leaks into grid/list sorting.
+  type ManageSortKey = 'name' | 'count' | 'max_confidence' | 'last_seen' | 'review' | 'range';
 
   // A species row paired with the visitor-localized common name, used inside
   // filteredSpecies for search + name-sort so they match what the user sees.
@@ -544,6 +570,260 @@
     showDetailModal = false;
     selectedSpecies = null;
   }
+
+  // ---- Manage view (authenticated, desktop-only species curation) ----
+
+  // Membership sets keyed by the species' server common name, matching the
+  // existing exclude endpoint contract. Reactive collections re-render toggles.
+  let excludedSet = new SvelteSet<string>();
+  let includedSet = new SvelteSet<string>();
+  let confirmedSet = new SvelteSet<string>();
+
+  // Per-list in-flight species (keyed by common name) to block double-click races.
+  let togglingExcluded = new SvelteSet<string>();
+  let togglingIncluded = new SvelteSet<string>();
+  let togglingConfirmed = new SvelteSet<string>();
+
+  // Per-species review stats and range scores (keyed by scientific name).
+  let reviewStats = new SvelteMap<string, ReviewStat>();
+  let rangeScores = new SvelteMap<string, number>();
+  let rangeLoading = $state(false);
+  let manageDataLoaded = $state(false);
+
+  // Manage-only sort state, never persisted to localStorage.
+  let manageSortKey = $state<ManageSortKey>('count');
+  let manageSortDirection = $state<'asc' | 'desc'>('desc');
+
+  // Delete confirmation modal state.
+  let deleteTarget = $state<SpeciesData | null>(null);
+  let showDeleteModal = $state(false);
+  let deleteInFlight = $state(false);
+  let deleteError = $state<string | null>(null);
+
+  // Default sort direction per Manage-only column (only the name column starts ascending).
+  const MANAGE_SORT_COLUMNS: { field: ManageSortKey; defaultAsc: boolean }[] = [
+    { field: 'name', defaultAsc: true },
+    { field: 'count', defaultAsc: false },
+    { field: 'max_confidence', defaultAsc: false },
+    { field: 'last_seen', defaultAsc: false },
+    { field: 'review', defaultAsc: false },
+    { field: 'range', defaultAsc: false },
+  ];
+
+  function showManageView() {
+    viewMode = 'manage';
+    void fetchManageData();
+  }
+
+  async function fetchManageData() {
+    if (manageDataLoaded) {
+      void loadRangeScores();
+      return;
+    }
+    try {
+      const [stats, included, confirmed, excluded] = await Promise.all([
+        api.get<ReviewStat[]>('/api/v2/analytics/species/review-stats'),
+        api.get<{ species: string[] }>('/api/v2/detections/included'),
+        api.get<{ species: string[] }>('/api/v2/detections/confirmed'),
+        api.get<{ species: string[] }>('/api/v2/detections/ignored'),
+      ]);
+      reviewStats.clear();
+      for (const s of stats) reviewStats.set(s.scientificName, s);
+      includedSet.clear();
+      for (const n of included.species ?? []) includedSet.add(n);
+      confirmedSet.clear();
+      for (const n of confirmed.species ?? []) confirmedSet.add(n);
+      excludedSet.clear();
+      for (const n of excluded.species ?? []) excludedSet.add(n);
+      manageDataLoaded = true;
+    } catch (error) {
+      logger.error('Error fetching manage data:', error);
+    }
+    // Render the table immediately; range scores stream in asynchronously.
+    void loadRangeScores();
+  }
+
+  async function loadRangeScores() {
+    if (cachedRangeScores) {
+      if (rangeScores.size === 0) {
+        for (const [name, score] of cachedRangeScores) rangeScores.set(name, score);
+      }
+      return;
+    }
+    rangeLoading = true;
+    try {
+      const result = await settingsActions.loadRangeFilterSpecies();
+      const map = new Map<string, number>();
+      for (const s of result.species) {
+        if (s.scientificName && typeof s.score === 'number') {
+          map.set(s.scientificName, s.score);
+        }
+      }
+      cachedRangeScores = map;
+      for (const [name, score] of map) rangeScores.set(name, score);
+    } catch (error) {
+      logger.error('Error loading range scores:', error);
+    } finally {
+      rangeLoading = false;
+    }
+  }
+
+  function handleManageSort(field: string) {
+    const column = MANAGE_SORT_COLUMNS.find(c => c.field === field);
+    if (!column) return;
+    if (manageSortKey === column.field) {
+      manageSortDirection = manageSortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      manageSortKey = column.field;
+      manageSortDirection = column.defaultAsc ? 'asc' : 'desc';
+    }
+  }
+
+  // Review activity total used for the "review" sort (most-reviewed first).
+  function reviewActivity(species: SpeciesData): number {
+    const stat = reviewStats.get(species.scientific_name);
+    return stat ? stat.verified + stat.rejected : 0;
+  }
+
+  // Search-filtered rows (reuses filteredSpecies) re-sorted by the Manage-only key.
+  let manageRows = $derived.by<SpeciesData[]>(() => {
+    if (viewMode !== 'manage') return filteredSpecies;
+    const locale = getLocale();
+    const dir = manageSortDirection === 'asc' ? 1 : -1;
+    const rows = [...filteredSpecies];
+    rows.sort((a, b) => {
+      switch (manageSortKey) {
+        case 'name':
+          return (
+            dir *
+            localizeSpeciesName(a.scientific_name, a.common_name).localeCompare(
+              localizeSpeciesName(b.scientific_name, b.common_name),
+              locale
+            )
+          );
+        case 'count':
+          return dir * (a.count - b.count);
+        case 'max_confidence':
+          return dir * (a.max_confidence - b.max_confidence);
+        case 'last_seen': {
+          const da = parseLocalDateString(a.last_heard);
+          const db = parseLocalDateString(b.last_heard);
+          if (!da && !db) return 0;
+          if (!da) return 1;
+          if (!db) return -1;
+          return dir * (da.getTime() - db.getTime());
+        }
+        case 'review':
+          return dir * (reviewActivity(a) - reviewActivity(b));
+        case 'range':
+          return (
+            dir *
+            ((rangeScores.get(a.scientific_name) ?? -1) -
+              (rangeScores.get(b.scientific_name) ?? -1))
+          );
+        default: {
+          const _exhaustive: never = manageSortKey;
+          void _exhaustive;
+          return 0;
+        }
+      }
+    });
+    return rows;
+  });
+
+  function formatDateOnly(value: string): string {
+    if (!value) return '—';
+    const parsed = parseLocalDateString(value);
+    return parsed ? getLocalDateString(parsed) : '—';
+  }
+
+  function reviewRatioText(species: SpeciesData): string {
+    const stat = reviewStats.get(species.scientific_name);
+    if (!stat || (stat.verified === 0 && stat.rejected === 0)) return '—';
+    return `${stat.verified} / ${stat.rejected}`;
+  }
+
+  async function toggleMembership(
+    list: 'excluded' | 'included' | 'confirmed',
+    species: SpeciesData
+  ) {
+    const name = species.common_name;
+    const inflight =
+      list === 'excluded'
+        ? togglingExcluded
+        : list === 'included'
+          ? togglingIncluded
+          : togglingConfirmed;
+    if (inflight.has(name)) return;
+    const set =
+      list === 'excluded' ? excludedSet : list === 'included' ? includedSet : confirmedSet;
+    const path =
+      list === 'excluded'
+        ? '/api/v2/detections/ignore'
+        : list === 'included'
+          ? '/api/v2/detections/include'
+          : '/api/v2/detections/confirm';
+
+    inflight.add(name);
+    try {
+      const resp = await api.post<{ action: string }>(path, { common_name: name });
+      if (resp.action === 'removed') {
+        set.delete(name);
+      } else {
+        set.add(name);
+      }
+    } catch (error) {
+      logger.error(`Error toggling ${list} membership:`, error);
+    } finally {
+      inflight.delete(name);
+    }
+  }
+
+  function requestDelete(species: SpeciesData) {
+    deleteTarget = species;
+    deleteError = null;
+    showDeleteModal = true;
+  }
+
+  // All-time detection count for the confirmation modal (not the filtered count).
+  let deleteAllTimeCount = $derived(
+    deleteTarget ? (reviewStats.get(deleteTarget.scientific_name)?.total ?? deleteTarget.count) : 0
+  );
+
+  async function confirmDelete() {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    deleteInFlight = true;
+    deleteError = null;
+    try {
+      const resp = await api.post<{ deleted: number; skipped: number }>(
+        '/api/v2/detections/species/delete',
+        { scientific_name: target.scientific_name }
+      );
+      if (resp.skipped === 0) {
+        // Full deletion: drop the row locally.
+        speciesData = speciesData.filter(s => s.scientific_name !== target.scientific_name);
+      } else {
+        // Partial deletion (locked detections remain): refresh summary + review data.
+        manageDataLoaded = false;
+        await fetchData();
+        await fetchManageData();
+      }
+      showDeleteModal = false;
+      deleteTarget = null;
+    } catch (error) {
+      logger.error('Error deleting species detections:', error);
+      deleteError = t('analytics.species.manage.deleteFailed');
+    } finally {
+      deleteInFlight = false;
+    }
+  }
+
+  function cancelDelete() {
+    showDeleteModal = false;
+    deleteTarget = null;
+    deleteError = null;
+  }
 </script>
 
 <div class="col-span-12 space-y-4" role="region" aria-label={t('analytics.species.title')}>
@@ -658,6 +938,17 @@
               />
             </svg>
           </button>
+          {#if $isAuthenticated}
+            <button
+              type="button"
+              class="btn btn-sm join-item"
+              class:btn-active={viewMode === 'manage'}
+              onclick={showManageView}
+              aria-label={t('analytics.species.switchToManage')}
+            >
+              <SlidersHorizontal class="h-4 w-4" />
+            </button>
+          {/if}
         </div>
       </div>
 
@@ -775,6 +1066,129 @@
         </div>
       {/if}
 
+      <!-- Manage View (authenticated, desktop-only) -->
+      {#if !isLoading && viewMode === 'manage' && manageRows.length > 0}
+        <div class="overflow-x-auto hidden sm:block">
+          <table class="table w-full">
+            <thead>
+              <tr>
+                <SortableHeader
+                  label={t('analytics.species.headers.species')}
+                  field="name"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <SortableHeader
+                  label={t('analytics.species.headers.detections')}
+                  field="count"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <SortableHeader
+                  label={t('analytics.species.headers.maxConfidence')}
+                  field="max_confidence"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <SortableHeader
+                  label={t('analytics.species.headers.lastDetected')}
+                  field="last_seen"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <th>{t('analytics.species.manage.headers.excluded')}</th>
+                <th>{t('analytics.species.manage.headers.included')}</th>
+                <SortableHeader
+                  label={t('analytics.species.manage.headers.reviewRatio')}
+                  field="review"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <SortableHeader
+                  label={t('analytics.species.manage.headers.rangeProbability')}
+                  field="range"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <th>{t('analytics.species.manage.headers.confirmed')}</th>
+                <th>{t('analytics.species.manage.headers.actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each manageRows as species, index (`${species.scientific_name}_${index}`)}
+                {@const displayName = localizeSpeciesName(
+                  species.scientific_name,
+                  species.common_name
+                )}
+                <tr
+                  class={index % 2 === 0
+                    ? 'bg-[var(--color-base-100)]'
+                    : 'bg-[var(--color-base-200)]'}
+                >
+                  <td>
+                    <div class="font-bold">{displayName}</div>
+                    <div class="text-sm opacity-50 italic">{species.scientific_name}</div>
+                  </td>
+                  <td class="font-semibold">{species.count}</td>
+                  <td>{formatPercentage(species.max_confidence)}</td>
+                  <td class="text-sm">{formatDateOnly(species.last_heard)}</td>
+                  <td>
+                    <Checkbox
+                      checked={excludedSet.has(species.common_name)}
+                      disabled={togglingExcluded.has(species.common_name)}
+                      onchange={() => toggleMembership('excluded', species)}
+                    />
+                  </td>
+                  <td>
+                    <Checkbox
+                      checked={includedSet.has(species.common_name)}
+                      disabled={togglingIncluded.has(species.common_name)}
+                      onchange={() => toggleMembership('included', species)}
+                    />
+                  </td>
+                  <td class="text-sm">{reviewRatioText(species)}</td>
+                  <td class="text-sm">
+                    {#if rangeLoading && !rangeScores.has(species.scientific_name)}
+                      <span
+                        class="loading loading-spinner loading-xs"
+                        aria-label={t('common.ui.loading')}
+                      ></span>
+                    {:else if rangeScores.has(species.scientific_name)}
+                      {formatPercentage(rangeScores.get(species.scientific_name) ?? 0)}
+                    {:else}
+                      —
+                    {/if}
+                  </td>
+                  <td>
+                    <Checkbox
+                      checked={confirmedSet.has(species.common_name)}
+                      disabled={togglingConfirmed.has(species.common_name)}
+                      onchange={() => toggleMembership('confirmed', species)}
+                    />
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs text-[var(--color-error)]"
+                      onclick={() => requestDelete(species)}
+                      aria-label={t('analytics.species.manage.delete')}
+                    >
+                      <Trash2 class="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
+
       <!-- Empty State -->
       {#if !isLoading && filteredSpecies.length === 0}
         <div class="text-center py-8 text-[var(--color-base-content)] opacity-50">
@@ -803,6 +1217,31 @@
   isOpen={showDetailModal}
   onClose={handleCloseDetailModal}
 />
+
+<!-- Delete species confirmation (Manage view) -->
+<Modal
+  isOpen={showDeleteModal}
+  type="confirm"
+  title={t('analytics.species.manage.deleteTitle')}
+  confirmLabel={t('analytics.species.manage.deleteConfirm')}
+  confirmVariant="error"
+  loading={deleteInFlight}
+  onClose={cancelDelete}
+  onConfirm={confirmDelete}
+>
+  {#if deleteTarget}
+    <p>
+      {t('analytics.species.manage.deleteMessage', {
+        species: localizeSpeciesName(deleteTarget.scientific_name, deleteTarget.common_name),
+        count: formatNumber(deleteAllTimeCount),
+      })}
+    </p>
+    <p class="text-sm opacity-70 mt-2">{t('analytics.species.manage.deleteWarning')}</p>
+    {#if deleteError}
+      <p class="text-sm text-[var(--color-error)] mt-2" role="alert">{deleteError}</p>
+    {/if}
+  {/if}
+</Modal>
 
 <!-- Mobile Audio Player -->
 

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -743,18 +743,33 @@
     return `${stat.verified} / ${stat.rejected}`;
   }
 
+  // Returns the exact list entry matching this species by common OR scientific
+  // name (case-insensitive), or undefined when absent. The settings picker treats
+  // the two names as aliases, so a list may store either form.
+  function listEntryFor(set: SvelteSet<string>, species: SpeciesData): string | undefined {
+    const common = species.common_name.toLowerCase();
+    const scientific = species.scientific_name.toLowerCase();
+    for (const entry of set) {
+      const e = entry.toLowerCase();
+      if (e === common || e === scientific) return entry;
+    }
+    return undefined;
+  }
+
   async function toggleMembership(
     list: 'excluded' | 'included' | 'confirmed',
     species: SpeciesData
   ) {
-    const name = species.common_name;
     const inflight =
       list === 'excluded'
         ? togglingExcluded
         : list === 'included'
           ? togglingIncluded
           : togglingConfirmed;
-    if (inflight.has(name)) return;
+    // Track in-flight by scientific name (stable) so the guard holds regardless
+    // of which alias the list stores.
+    const inflightKey = species.scientific_name;
+    if (inflight.has(inflightKey)) return;
     const set =
       list === 'excluded' ? excludedSet : list === 'included' ? includedSet : confirmedSet;
     const path =
@@ -764,18 +779,21 @@
           ? '/api/v2/detections/include'
           : '/api/v2/detections/confirm';
 
-    inflight.add(name);
+    // Remove the alias actually stored in the list; add under the common name.
+    const payloadName = listEntryFor(set, species) ?? species.common_name;
+
+    inflight.add(inflightKey);
     try {
-      const resp = await api.post<{ action: string }>(path, { common_name: name });
+      const resp = await api.post<{ action: string }>(path, { common_name: payloadName });
       if (resp.action === 'removed') {
-        set.delete(name);
+        set.delete(payloadName);
       } else {
-        set.add(name);
+        set.add(payloadName);
       }
     } catch (error) {
       logger.error(`Error toggling ${list} membership:`, error);
     } finally {
-      inflight.delete(name);
+      inflight.delete(inflightKey);
     }
   }
 
@@ -1140,15 +1158,15 @@
                   <td class="text-sm">{formatDateOnly(species.last_heard)}</td>
                   <td>
                     <Checkbox
-                      checked={excludedSet.has(species.common_name)}
-                      disabled={togglingExcluded.has(species.common_name)}
+                      checked={listEntryFor(excludedSet, species) !== undefined}
+                      disabled={togglingExcluded.has(species.scientific_name)}
                       onchange={() => toggleMembership('excluded', species)}
                     />
                   </td>
                   <td>
                     <Checkbox
-                      checked={includedSet.has(species.common_name)}
-                      disabled={togglingIncluded.has(species.common_name)}
+                      checked={listEntryFor(includedSet, species) !== undefined}
+                      disabled={togglingIncluded.has(species.scientific_name)}
                       onchange={() => toggleMembership('included', species)}
                     />
                   </td>
@@ -1167,8 +1185,8 @@
                   </td>
                   <td>
                     <Checkbox
-                      checked={confirmedSet.has(species.common_name)}
-                      disabled={togglingConfirmed.has(species.common_name)}
+                      checked={listEntryFor(confirmedSet, species) !== undefined}
+                      disabled={togglingConfirmed.has(species.scientific_name)}
                       onchange={() => toggleMembership('confirmed', species)}
                     />
                   </td>

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -81,7 +81,16 @@
 
   // Manage-only sort keys. Kept separate from SortOrder (and never persisted to
   // localStorage) so a Manage-only column never leaks into grid/list sorting.
-  type ManageSortKey = 'name' | 'count' | 'max_confidence' | 'last_seen' | 'review' | 'range';
+  type ManageSortKey =
+    | 'name'
+    | 'count'
+    | 'max_confidence'
+    | 'last_seen'
+    | 'excluded'
+    | 'included'
+    | 'correct'
+    | 'range'
+    | 'confirmed';
 
   // A species row paired with the visitor-localized common name, used inside
   // filteredSpecies for search + name-sort so they match what the user sees.
@@ -626,8 +635,11 @@
     { field: 'count', defaultAsc: false },
     { field: 'max_confidence', defaultAsc: false },
     { field: 'last_seen', defaultAsc: false },
-    { field: 'review', defaultAsc: false },
+    { field: 'excluded', defaultAsc: false },
+    { field: 'included', defaultAsc: false },
+    { field: 'correct', defaultAsc: false },
     { field: 'range', defaultAsc: false },
+    { field: 'confirmed', defaultAsc: false },
   ];
 
   function showManageView() {
@@ -699,10 +711,21 @@
     }
   }
 
-  // Review activity total used for the "review" sort (most-reviewed first).
-  function reviewActivity(species: SpeciesData): number {
+  // Share of reviewed detections marked correct (verified), as a 0-100 percentage.
+  // Returns -1 when the species has no reviews so those rows sort to the bottom and
+  // render an em dash, matching the range column's missing-data convention.
+  function correctRate(species: SpeciesData): number {
     const stat = reviewStats.get(species.scientific_name);
-    return stat ? stat.verified + stat.rejected : 0;
+    if (!stat) return -1;
+    const reviewed = stat.verified + stat.rejected;
+    if (reviewed === 0) return -1;
+    return (stat.verified / reviewed) * 100;
+  }
+
+  // True when the species is in the given membership list (excluded / included /
+  // confirmed). Used by both the row checkboxes and the membership column sorts.
+  function isMember(set: SvelteSet<string>, species: SpeciesData): boolean {
+    return listEntryFor(set, species) !== undefined;
   }
 
   // The Manage view acts on a SUPERSET of the period summary: a species whose
@@ -766,8 +789,14 @@
           if (!db) return -1;
           return dir * (da.getTime() - db.getTime());
         }
-        case 'review':
-          return dir * (reviewActivity(a) - reviewActivity(b));
+        case 'excluded':
+          return dir * (Number(isMember(excludedSet, a)) - Number(isMember(excludedSet, b)));
+        case 'included':
+          return dir * (Number(isMember(includedSet, a)) - Number(isMember(includedSet, b)));
+        case 'confirmed':
+          return dir * (Number(isMember(confirmedSet, a)) - Number(isMember(confirmedSet, b)));
+        case 'correct':
+          return dir * (correctRate(a) - correctRate(b));
         case 'range':
           return (
             dir *
@@ -790,10 +819,10 @@
     return parsed ? getLocalDateString(parsed) : '—';
   }
 
-  function reviewRatioText(species: SpeciesData): string {
-    const stat = reviewStats.get(species.scientific_name);
-    if (!stat || (stat.verified === 0 && stat.rejected === 0)) return '—';
-    return `${stat.verified} / ${stat.rejected}`;
+  // Correctness rate as a 0-100 integer percentage; em dash when unreviewed.
+  function correctRateText(species: SpeciesData): string {
+    const rate = correctRate(species);
+    return rate < 0 ? '—' : `${Math.round(rate)}%`;
   }
 
   // Returns the exact list entry matching this species by common OR scientific
@@ -1171,11 +1200,25 @@
                   direction={manageSortDirection}
                   onSort={handleManageSort}
                 />
-                <th>{t('analytics.species.manage.headers.excluded')}</th>
-                <th>{t('analytics.species.manage.headers.included')}</th>
+                <SortableHeader
+                  label={t('analytics.species.manage.headers.excluded')}
+                  field="excluded"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <SortableHeader
+                  label={t('analytics.species.manage.headers.included')}
+                  field="included"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
+                <!-- Label key is historically named reviewRatio; the column now shows
+                     the correctness rate (verified / reviewed), sorted by `correct`. -->
                 <SortableHeader
                   label={t('analytics.species.manage.headers.reviewRatio')}
-                  field="review"
+                  field="correct"
                   activeField={manageSortKey}
                   direction={manageSortDirection}
                   onSort={handleManageSort}
@@ -1187,7 +1230,13 @@
                   direction={manageSortDirection}
                   onSort={handleManageSort}
                 />
-                <th>{t('analytics.species.manage.headers.confirmed')}</th>
+                <SortableHeader
+                  label={t('analytics.species.manage.headers.confirmed')}
+                  field="confirmed"
+                  activeField={manageSortKey}
+                  direction={manageSortDirection}
+                  onSort={handleManageSort}
+                />
                 <th>{t('analytics.species.manage.headers.actions')}</th>
               </tr>
             </thead>
@@ -1218,19 +1267,19 @@
                   <td class="text-sm">{formatDateOnly(species.last_heard)}</td>
                   <td>
                     <Checkbox
-                      checked={listEntryFor(excludedSet, species) !== undefined}
+                      checked={isMember(excludedSet, species)}
                       disabled={togglingExcluded.has(species.scientific_name)}
                       onchange={() => toggleMembership('excluded', species)}
                     />
                   </td>
                   <td>
                     <Checkbox
-                      checked={listEntryFor(includedSet, species) !== undefined}
+                      checked={isMember(includedSet, species)}
                       disabled={togglingIncluded.has(species.scientific_name)}
                       onchange={() => toggleMembership('included', species)}
                     />
                   </td>
-                  <td class="text-sm">{reviewRatioText(species)}</td>
+                  <td class="text-sm">{correctRateText(species)}</td>
                   <td class="text-sm">
                     {#if rangeLoading && !rangeScores.has(species.scientific_name)}
                       <span
@@ -1245,7 +1294,7 @@
                   </td>
                   <td>
                     <Checkbox
-                      checked={listEntryFor(confirmedSet, species) !== undefined}
+                      checked={isMember(confirmedSet, species)}
                       disabled={togglingConfirmed.has(species.scientific_name)}
                       onchange={() => toggleMembership('confirmed', species)}
                     />

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -70,6 +70,10 @@
   // Per-species review counts used by the Manage view.
   interface ReviewStat {
     scientificName: string;
+    // commonName lets the Manage view render a row for species that have NO
+    // surviving detections in the period summary (every detection was rejected),
+    // since those species are absent from speciesData and have no name otherwise.
+    commonName?: string;
     total: number;
     verified: number;
     rejected: number;
@@ -329,6 +333,23 @@
     };
   }
 
+  // Shared search predicate over a species' display, common, and scientific names.
+  // displayName (the visitor-localized name) is passed in so callers that already
+  // localized the row don't repeat the dictionary lookup. Used by both the grid/list
+  // (filteredSpecies) and Manage (manageRows) filters so the matching rules stay in
+  // one place.
+  function speciesMatchesSearch(
+    species: SpeciesData,
+    displayName: string,
+    searchLower: string
+  ): boolean {
+    return (
+      displayName.toLowerCase().includes(searchLower) ||
+      species.common_name.toLowerCase().includes(searchLower) ||
+      species.scientific_name.toLowerCase().includes(searchLower)
+    );
+  }
+
   // Filtered + sorted rows for display. Search and name-sort operate on the
   // visitor-localized common name (displayName) so they match what the user
   // sees, while scientific name and the server common name stay searchable too.
@@ -350,11 +371,8 @@
 
     const searchLower = debouncedSearchTerm.trim().toLowerCase();
     const filtered = searchLower
-      ? rows.filter(
-          ({ species, displayName }) =>
-            displayName.toLowerCase().includes(searchLower) ||
-            species.common_name.toLowerCase().includes(searchLower) ||
-            species.scientific_name.toLowerCase().includes(searchLower)
+      ? rows.filter(({ species, displayName }) =>
+          speciesMatchesSearch(species, displayName, searchLower)
         )
       : rows;
 
@@ -406,7 +424,9 @@
   });
 
   function getFilteredCount(): number {
-    return filteredSpecies.length;
+    // Manage view acts on manageRows (summary plus synthesized fully-rejected
+    // species), so the count badge should reflect that superset, not the summary.
+    return viewMode === 'manage' ? manageRows.length : filteredSpecies.length;
   }
 
   function getTotalSpeciesCount(): number {
@@ -685,12 +705,45 @@
     return stat ? stat.verified + stat.rejected : 0;
   }
 
-  // Search-filtered rows (reuses filteredSpecies) re-sorted by the Manage-only key.
+  // The Manage view acts on a SUPERSET of the period summary: a species whose
+  // detections were all rejected is absent from speciesData (the summary excludes
+  // false positives) yet still owns rows the user may want to delete. We synthesize
+  // a row for each such review-stats-only species so it surfaces in Manage. These
+  // carry the all-time detection count and no confidence/date data, since none
+  // survives in the summary; the row exists primarily so the species is reviewable
+  // and deletable.
+  let manageSpecies = $derived.by<SpeciesData[]>(() => {
+    if (viewMode !== 'manage') return speciesData;
+    const present = new Set(speciesData.map(s => s.scientific_name));
+    const extras: SpeciesData[] = [];
+    for (const [sciName, stat] of reviewStats) {
+      if (present.has(sciName)) continue;
+      extras.push({
+        common_name: stat.commonName || sciName,
+        scientific_name: sciName,
+        count: stat.total,
+        avg_confidence: 0,
+        max_confidence: 0,
+        first_heard: '',
+        last_heard: '',
+      });
+    }
+    return extras.length > 0 ? [...speciesData, ...extras] : speciesData;
+  });
+
+  // Search-filtered Manage rows, re-sorted by the Manage-only key. Reuses the shared
+  // speciesMatchesSearch predicate (same rules as filteredSpecies), but runs over
+  // manageSpecies so synthesized fully-rejected species are searchable too.
   let manageRows = $derived.by<SpeciesData[]>(() => {
     if (viewMode !== 'manage') return filteredSpecies;
     const locale = getLocale();
+    const searchLower = debouncedSearchTerm.trim().toLowerCase();
+    const rows = manageSpecies.filter(species => {
+      if (!searchLower) return true;
+      const displayName = localizeSpeciesName(species.scientific_name, species.common_name);
+      return speciesMatchesSearch(species, displayName, searchLower);
+    });
     const dir = manageSortDirection === 'asc' ? 1 : -1;
-    const rows = [...filteredSpecies];
     rows.sort((a, b) => {
       switch (manageSortKey) {
         case 'name':
@@ -1154,7 +1207,14 @@
                     <div class="text-sm opacity-50 italic">{species.scientific_name}</div>
                   </td>
                   <td class="font-semibold">{species.count}</td>
-                  <td>{formatPercentage(species.max_confidence)}</td>
+                  <!-- Synthesized fully-rejected rows carry no confidence data
+                       (max_confidence === 0); a real summary row is always > 0, so
+                       render an em dash instead of a misleading 0.0%. -->
+                  <td
+                    >{species.max_confidence > 0
+                      ? formatPercentage(species.max_confidence)
+                      : '—'}</td
+                  >
                   <td class="text-sm">{formatDateOnly(species.last_heard)}</td>
                   <td>
                     <Checkbox
@@ -1207,8 +1267,10 @@
         </div>
       {/if}
 
-      <!-- Empty State -->
-      {#if !isLoading && filteredSpecies.length === 0}
+      <!-- Empty State. In Manage view the actionable set is manageRows (summary
+           plus synthesized fully-rejected species), so the summary being empty does
+           not mean Manage is empty. -->
+      {#if !isLoading && (viewMode === 'manage' ? manageRows.length === 0 : filteredSpecies.length === 0)}
         <div class="text-center py-8 text-[var(--color-base-content)] opacity-50">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { cleanup, fireEvent, waitFor } from '@testing-library/svelte';
 import { createComponentTestFactory } from '../../../../../test/render-helpers';
 import { setBasePath, resetBasePath } from '$lib/utils/urlHelpers';
+import { settingsActions } from '$lib/stores/settings';
+import { initAuthContext } from '$lib/utils/auth';
 import Species from './Species.svelte';
 
 /** Must match SORT_STORAGE_KEY in Species.svelte. */
@@ -253,5 +255,135 @@ describe('Species (analytics page) — sortable column headers', () => {
     expect(
       container.querySelectorAll('table thead th')[COUNT_COLUMN_INDEX].getAttribute('aria-sort')
     ).toBe('ascending');
+  });
+});
+
+describe('Species (analytics page) — Manage view', () => {
+  const originalFetch = globalThis.fetch;
+
+  // View toggle order: grid(0), list(1), manage(2 — only when authenticated).
+  const MANAGE_VIEW_TOGGLE_INDEX = 2;
+  // Manage table body cell order: name(0), count(1), maxConf(2), lastSeen(3),
+  // excluded(4), included(5), reviewRatio(6), range(7), confirmed(8), delete(9).
+  const REVIEW_CELL_INDEX = 6;
+  const SORT_STORAGE_KEY = 'analytics.species.sortOrder';
+
+  const summary = [
+    {
+      common_name: 'American Robin',
+      scientific_name: 'Turdus migratorius',
+      count: 5,
+      avg_confidence: 0.8,
+      max_confidence: 0.9,
+      first_heard: '2026-04-01',
+      last_heard: '2026-04-20',
+    },
+  ];
+
+  function mockManageFetch(reviewStats: unknown) {
+    globalThis.fetch = mockFetchSequence({
+      '/api/v2/analytics/species/review-stats': () => reviewStats,
+      '/api/v2/analytics/species/summary': () => summary,
+      '/api/v2/analytics/species/thumbnails': () => ({}),
+      '/api/v2/detections/included': () => ({ species: [] }),
+      '/api/v2/detections/confirmed': () => ({ species: [] }),
+      '/api/v2/detections/ignored': () => ({ species: [] }),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    initAuthContext(false); // security disabled => authenticated
+    vi.spyOn(settingsActions, 'loadRangeFilterSpecies').mockResolvedValue({
+      count: 0,
+      species: [],
+    });
+    mockManageFetch([
+      { scientificName: 'Turdus migratorius', total: 10, verified: 7, rejected: 3 },
+    ]);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetBasePath();
+    globalThis.fetch = originalFetch;
+    window.localStorage.clear();
+    initAuthContext(false);
+    vi.restoreAllMocks();
+  });
+
+  const speciesTest = createComponentTestFactory(Species);
+
+  async function renderManageView() {
+    const { container } = speciesTest.render({});
+    await waitFor(() => {
+      if (container.querySelectorAll('.join button').length < 3)
+        throw new Error('toggle not ready');
+    });
+    await fireEvent.click(container.querySelectorAll('.join button')[MANAGE_VIEW_TOGGLE_INDEX]);
+    await waitFor(
+      () => {
+        if (!container.querySelector('table tbody tr'))
+          throw new Error('manage table not yet rendered');
+      },
+      { timeout: 2000 }
+    );
+    return { container };
+  }
+
+  it('renders the Manage toggle only when authenticated', async () => {
+    const { container } = speciesTest.render({});
+    await waitFor(() => {
+      if (container.querySelectorAll('.join button').length === 0)
+        throw new Error('toggle not ready');
+    });
+    expect(container.querySelectorAll('.join button')).toHaveLength(3);
+    cleanup();
+
+    initAuthContext(true, false); // security enabled, access denied => not authenticated
+    const { container: guest } = speciesTest.render({});
+    await waitFor(() => {
+      if (guest.querySelectorAll('.join button').length === 0) throw new Error('toggle not ready');
+    });
+    expect(guest.querySelectorAll('.join button')).toHaveLength(2);
+  });
+
+  it('hides average confidence and first detected columns', async () => {
+    const { container } = await renderManageView();
+    const headText = container.querySelector('table thead')?.textContent ?? '';
+    expect(headText).not.toContain('avgConfidence');
+    expect(headText).not.toContain('firstDetected');
+    // Sanity: the shared maxConfidence/lastDetected columns remain.
+    expect(headText).toContain('maxConfidence');
+    expect(headText).toContain('lastDetected');
+  });
+
+  it('shows the review ratio as "{verified} / {rejected}"', async () => {
+    const { container } = await renderManageView();
+    await waitFor(() => {
+      const cell = container.querySelectorAll('table tbody tr td')[REVIEW_CELL_INDEX];
+      expect(cell.textContent.trim()).toBe('7 / 3');
+    });
+  });
+
+  it('shows — in the review column when a species has no reviews', async () => {
+    mockManageFetch([{ scientificName: 'Turdus migratorius', total: 5, verified: 0, rejected: 0 }]);
+    const { container } = await renderManageView();
+    await waitFor(() => {
+      const cell = container.querySelectorAll('table tbody tr td')[REVIEW_CELL_INDEX];
+      expect(cell.textContent.trim()).toBe('—');
+    });
+  });
+
+  it('does not persist a Manage-only sort into the grid/list localStorage key', async () => {
+    const { container } = await renderManageView();
+    // fetchData persists the default grid/list sort on mount.
+    const persistedBefore = window.localStorage.getItem(SORT_STORAGE_KEY);
+    // Manage sortable header buttons: name(0), count(1), maxConf(2), lastSeen(3), review(4), range(5).
+    const reviewSortButton = container.querySelectorAll('table thead th button')[4];
+    await fireEvent.click(reviewSortButton);
+    // Sorting by a Manage-only column must not change the grid/list persisted sort.
+    expect(window.localStorage.getItem(SORT_STORAGE_KEY)).toBe(persistedBefore);
   });
 });

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -387,6 +387,35 @@ describe('Species (analytics page) — Manage view', () => {
     expect(window.localStorage.getItem(SORT_STORAGE_KEY)).toBe(persistedBefore);
   });
 
+  it('surfaces a fully-rejected species that is absent from the period summary', async () => {
+    // Corvus corax has detections but every one was rejected, so the summary
+    // (which excludes false positives) omits it. review-stats still reports it and
+    // now carries the common name, so Manage can render a deletable row for it.
+    mockManageFetch([
+      { scientificName: 'Turdus migratorius', total: 10, verified: 7, rejected: 3 },
+      {
+        scientificName: 'Corvus corax',
+        commonName: 'Common Raven',
+        total: 4,
+        verified: 0,
+        rejected: 4,
+      },
+    ]);
+    const { container } = await renderManageView();
+    await waitFor(() => {
+      if (container.querySelectorAll('table tbody tr').length < 2)
+        throw new Error('synthesized row not yet rendered');
+    });
+    const rows = Array.from(container.querySelectorAll('table tbody tr'));
+    const ravenRow = rows.find(r => r.textContent.includes('Common Raven'));
+    if (!ravenRow) throw new Error('Common Raven row not rendered');
+    const cells = ravenRow.querySelectorAll('td');
+    expect(cells[1].textContent.trim()).toBe('4'); // all-time detection count
+    expect(cells[2].textContent.trim()).toBe('—'); // no max-confidence data survives
+    expect(cells[3].textContent.trim()).toBe('—'); // no last-detected data survives
+    expect(cells[REVIEW_CELL_INDEX].textContent.trim()).toBe('0 / 4');
+  });
+
   it('checks the included toggle when the list stores the scientific-name alias', async () => {
     // The included list holds the scientific name; the row is American Robin /
     // Turdus migratorius, so the alias match must render the checkbox checked.

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -264,8 +264,8 @@ describe('Species (analytics page) — Manage view', () => {
   // View toggle order: grid(0), list(1), manage(2 — only when authenticated).
   const MANAGE_VIEW_TOGGLE_INDEX = 2;
   // Manage table body cell order: name(0), count(1), maxConf(2), lastSeen(3),
-  // excluded(4), included(5), reviewRatio(6), range(7), confirmed(8), delete(9).
-  const REVIEW_CELL_INDEX = 6;
+  // excluded(4), included(5), correct(6), range(7), confirmed(8), delete(9).
+  const CORRECT_CELL_INDEX = 6;
   const SORT_STORAGE_KEY = 'analytics.species.sortOrder';
 
   const summary = [
@@ -359,32 +359,70 @@ describe('Species (analytics page) — Manage view', () => {
     expect(headText).toContain('lastDetected');
   });
 
-  it('shows the review ratio as "{verified} / {rejected}"', async () => {
+  it('shows the correct rate as an integer percentage', async () => {
+    // verified 7 of 10 reviewed -> round(7 / (7 + 3) * 100) = 70%.
     const { container } = await renderManageView();
     await waitFor(() => {
-      const cell = container.querySelectorAll('table tbody tr td')[REVIEW_CELL_INDEX];
-      expect(cell.textContent.trim()).toBe('7 / 3');
+      const cell = container.querySelectorAll('table tbody tr td')[CORRECT_CELL_INDEX];
+      expect(cell.textContent.trim()).toBe('70%');
     });
   });
 
-  it('shows — in the review column when a species has no reviews', async () => {
+  it('shows — in the correct column when a species has no reviews', async () => {
     mockManageFetch([{ scientificName: 'Turdus migratorius', total: 5, verified: 0, rejected: 0 }]);
     const { container } = await renderManageView();
     await waitFor(() => {
-      const cell = container.querySelectorAll('table tbody tr td')[REVIEW_CELL_INDEX];
+      const cell = container.querySelectorAll('table tbody tr td')[CORRECT_CELL_INDEX];
       expect(cell.textContent.trim()).toBe('—');
     });
   });
 
-  it('does not persist a Manage-only sort into the grid/list localStorage key', async () => {
+  it('makes the membership columns sortable and does not persist a Manage-only sort', async () => {
     const { container } = await renderManageView();
+    // Manage sortable header buttons: name(0), count(1), maxConf(2), lastSeen(3),
+    // excluded(4), included(5), correct(6), range(7), confirmed(8). The excluded,
+    // included, and confirmed columns are now SortableHeaders (9 buttons total).
+    const sortButtons = container.querySelectorAll('table thead th button');
+    expect(sortButtons).toHaveLength(9);
     // fetchData persists the default grid/list sort on mount.
     const persistedBefore = window.localStorage.getItem(SORT_STORAGE_KEY);
-    // Manage sortable header buttons: name(0), count(1), maxConf(2), lastSeen(3), review(4), range(5).
-    const reviewSortButton = container.querySelectorAll('table thead th button')[4];
-    await fireEvent.click(reviewSortButton);
+    await fireEvent.click(sortButtons[4]); // excluded — a Manage-only column
     // Sorting by a Manage-only column must not change the grid/list persisted sort.
     expect(window.localStorage.getItem(SORT_STORAGE_KEY)).toBe(persistedBefore);
+  });
+
+  it('sorts by the Included column, grouping included species first', async () => {
+    // Two rows: Turdus (summary) and Corvus (review-stats only). Only Corvus is on
+    // the included list, so sorting Included (default desc) must put it first.
+    globalThis.fetch = mockFetchSequence({
+      '/api/v2/analytics/species/review-stats': () => [
+        { scientificName: 'Turdus migratorius', total: 10, verified: 7, rejected: 3 },
+        {
+          scientificName: 'Corvus corax',
+          commonName: 'Common Raven',
+          total: 4,
+          verified: 0,
+          rejected: 4,
+        },
+      ],
+      '/api/v2/analytics/species/summary': () => summary,
+      '/api/v2/analytics/species/thumbnails': () => ({}),
+      '/api/v2/detections/included': () => ({ species: ['Corvus corax'] }),
+      '/api/v2/detections/confirmed': () => ({ species: [] }),
+      '/api/v2/detections/ignored': () => ({ species: [] }),
+    });
+    const { container } = await renderManageView();
+    await waitFor(() => {
+      if (container.querySelectorAll('table tbody tr').length < 2)
+        throw new Error('both rows not yet rendered');
+    });
+    // Included is the 6th sortable header (index 5).
+    const sortButtons = container.querySelectorAll('table thead th button');
+    await fireEvent.click(sortButtons[5]);
+    await waitFor(() => {
+      const rows = container.querySelectorAll('table tbody tr');
+      expect(rows[0].textContent).toContain('Common Raven');
+    });
   });
 
   it('surfaces a fully-rejected species that is absent from the period summary', async () => {
@@ -413,7 +451,7 @@ describe('Species (analytics page) — Manage view', () => {
     expect(cells[1].textContent.trim()).toBe('4'); // all-time detection count
     expect(cells[2].textContent.trim()).toBe('—'); // no max-confidence data survives
     expect(cells[3].textContent.trim()).toBe('—'); // no last-detected data survives
-    expect(cells[REVIEW_CELL_INDEX].textContent.trim()).toBe('0 / 4');
+    expect(cells[CORRECT_CELL_INDEX].textContent.trim()).toBe('0%'); // 0 of 4 reviewed correct
   });
 
   it('checks the included toggle when the list stores the scientific-name alias', async () => {

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -386,4 +386,26 @@ describe('Species (analytics page) — Manage view', () => {
     // Sorting by a Manage-only column must not change the grid/list persisted sort.
     expect(window.localStorage.getItem(SORT_STORAGE_KEY)).toBe(persistedBefore);
   });
+
+  it('checks the included toggle when the list stores the scientific-name alias', async () => {
+    // The included list holds the scientific name; the row is American Robin /
+    // Turdus migratorius, so the alias match must render the checkbox checked.
+    globalThis.fetch = mockFetchSequence({
+      '/api/v2/analytics/species/review-stats': () => [
+        { scientificName: 'Turdus migratorius', total: 10, verified: 7, rejected: 3 },
+      ],
+      '/api/v2/analytics/species/summary': () => summary,
+      '/api/v2/analytics/species/thumbnails': () => ({}),
+      '/api/v2/detections/included': () => ({ species: ['Turdus migratorius'] }),
+      '/api/v2/detections/confirmed': () => ({ species: [] }),
+      '/api/v2/detections/ignored': () => ({ species: [] }),
+    });
+    const INCLUDED_CELL_INDEX = 5;
+    const { container } = await renderManageView();
+    await waitFor(() => {
+      const cell = container.querySelectorAll('table tbody tr td')[INCLUDED_CELL_INDEX];
+      const checkbox = cell.querySelector<HTMLInputElement>('input[type="checkbox"]');
+      expect(checkbox?.checked).toBe(true);
+    });
+  });
 });

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1275,6 +1275,7 @@ export type TranslationKey =
   | 'analytics.species.speciesList'
   | 'analytics.species.switchToGrid'
   | 'analytics.species.switchToList'
+  | 'analytics.species.switchToManage'
   | 'analytics.species.noSpeciesFound'
   | 'analytics.species.headers.species'
   | 'analytics.species.headers.detections'
@@ -1285,6 +1286,18 @@ export type TranslationKey =
   | 'analytics.species.card.detections'
   | 'analytics.species.card.confidence'
   | 'analytics.species.card.first'
+  | 'analytics.species.manage.headers.excluded'
+  | 'analytics.species.manage.headers.included'
+  | 'analytics.species.manage.headers.reviewRatio'
+  | 'analytics.species.manage.headers.rangeProbability'
+  | 'analytics.species.manage.headers.confirmed'
+  | 'analytics.species.manage.headers.actions'
+  | 'analytics.species.manage.delete'
+  | 'analytics.species.manage.deleteTitle'
+  | 'analytics.species.manage.deleteConfirm'
+  | 'analytics.species.manage.deleteMessage' // params: count, species
+  | 'analytics.species.manage.deleteWarning'
+  | 'analytics.species.manage.deleteFailed'
   | 'analytics.advanced.title'
   | 'analytics.advanced.chartControls'
   | 'analytics.advanced.dateRange'
@@ -3813,6 +3826,7 @@ export type TranslationParams = {
   };
   'system.database.migration.prerequisites.criticalCount': { count: string | number };
   'system.database.migration.prerequisites.warningCount': { count: string | number };
+  'analytics.species.manage.deleteMessage': { count: string | number; species: string | number };
   'analytics.advanced.speciesSelection': { count: string | number; max: string | number };
   'analytics.advanced.detections': { count: string | number };
   'settings.notFound.message': { section: string | number };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Vyloučeno",
           "included": "Zahrnuto",
-          "reviewRatio": "Kontrola",
+          "reviewRatio": "Správně",
           "rangeProbability": "Výskyt",
           "confirmed": "Potvrzeno",
           "actions": "Akce"

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Seznam druhů",
       "switchToGrid": "Přepnout na mřížku",
       "switchToList": "Přepnout na seznam",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Nebyly nalezeny žádné druhy odpovídající vašim filtrům.",
       "headers": {
         "species": "Druh",
@@ -1667,6 +1668,22 @@
         "detections": "Detekce:",
         "confidence": "Spolehlivost:",
         "first": "Poprvé:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Seznam druhů",
       "switchToGrid": "Přepnout na mřížku",
       "switchToList": "Přepnout na seznam",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Přepnout na správu",
       "noSpeciesFound": "Nebyly nalezeny žádné druhy odpovídající vašim filtrům.",
       "headers": {
         "species": "Druh",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Vyloučeno",
+          "included": "Zahrnuto",
+          "reviewRatio": "Kontrola",
+          "rangeProbability": "Výskyt",
+          "confirmed": "Potvrzeno",
+          "actions": "Akce"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Smazat všechny detekce tohoto druhu",
+        "deleteTitle": "Smazat detekce druhu",
+        "deleteConfirm": "Smazat",
+        "deleteMessage": "Smazat všech {count} detekcí druhu {species}? Uzamčené detekce zůstanou zachovány.",
+        "deleteWarning": "Tímto trvale odstraníte detekce i jejich zvukové nahrávky a tuto akci nelze vrátit zpět.",
+        "deleteFailed": "Smazání detekcí se nezdařilo. Zkuste to prosím znovu."
       }
     },
     "advanced": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Artsliste",
       "switchToGrid": "Skift til gittervisning",
       "switchToList": "Skift til listevisning",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Skift til administrationsvisning",
       "noSpeciesFound": "Ingen arter fundet der matcher dine filtre.",
       "headers": {
         "species": "Art",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Ekskluderet",
+          "included": "Inkluderet",
+          "reviewRatio": "Gennemgang",
+          "rangeProbability": "Område",
+          "confirmed": "Bekræftet",
+          "actions": "Handlinger"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Slet alle registreringer for denne art",
+        "deleteTitle": "Slet artsregistreringer",
+        "deleteConfirm": "Slet",
+        "deleteMessage": "Slet alle {count} registreringer for {species}? Låste registreringer bevares.",
+        "deleteWarning": "Dette fjerner permanent registreringerne og deres lydklip og kan ikke fortrydes.",
+        "deleteFailed": "Kunne ikke slette registreringer. Prøv igen."
       }
     },
     "advanced": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Ekskluderet",
           "included": "Inkluderet",
-          "reviewRatio": "Gennemgang",
+          "reviewRatio": "Korrekt",
           "rangeProbability": "Område",
           "confirmed": "Bekræftet",
           "actions": "Handlinger"

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Artsliste",
       "switchToGrid": "Skift til gittervisning",
       "switchToList": "Skift til listevisning",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Ingen arter fundet der matcher dine filtre.",
       "headers": {
         "species": "Art",
@@ -1667,6 +1668,22 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhed:",
         "first": "Første:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Ausgeschlossen",
           "included": "Eingeschlossen",
-          "reviewRatio": "Prüfung",
+          "reviewRatio": "Korrekt",
           "rangeProbability": "Reichweite",
           "confirmed": "Bestätigt",
           "actions": "Aktionen"

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Artenliste",
       "switchToGrid": "Zur Gitteransicht wechseln",
       "switchToList": "Zur Listenansicht wechseln",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Zur Verwaltungsansicht wechseln",
       "noSpeciesFound": "Keine Arten gefunden, die Ihren Filtern entsprechen.",
       "headers": {
         "species": "Art",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Ausgeschlossen",
+          "included": "Eingeschlossen",
+          "reviewRatio": "Prüfung",
+          "rangeProbability": "Reichweite",
+          "confirmed": "Bestätigt",
+          "actions": "Aktionen"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Alle Erkennungen dieser Art löschen",
+        "deleteTitle": "Arterkennungen löschen",
+        "deleteConfirm": "Löschen",
+        "deleteMessage": "Alle {count} Erkennungen für {species} löschen? Gesperrte Erkennungen bleiben erhalten.",
+        "deleteWarning": "Dadurch werden die Erkennungen und ihre Audioclips dauerhaft entfernt und können nicht rückgängig gemacht werden.",
+        "deleteFailed": "Erkennungen konnten nicht gelöscht werden. Bitte versuchen Sie es erneut."
       }
     },
     "advanced": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Artenliste",
       "switchToGrid": "Zur Gitteransicht wechseln",
       "switchToList": "Zur Listenansicht wechseln",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Keine Arten gefunden, die Ihren Filtern entsprechen.",
       "headers": {
         "species": "Art",
@@ -1667,6 +1668,22 @@
         "detections": "Erkennungen:",
         "confidence": "Konfidenz:",
         "first": "Erste:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Excluded",
           "included": "Included",
-          "reviewRatio": "Review",
+          "reviewRatio": "Correct",
           "rangeProbability": "Range",
           "confirmed": "Confirmed",
           "actions": "Actions"

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Species List",
       "switchToGrid": "Switch to grid view",
       "switchToList": "Switch to list view",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "No species found matching your filters.",
       "headers": {
         "species": "Species",
@@ -1667,6 +1668,22 @@
         "detections": "Detections:",
         "confidence": "Confidence:",
         "first": "First:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Excluida",
           "included": "Incluida",
-          "reviewRatio": "Revisión",
+          "reviewRatio": "Correctas",
           "rangeProbability": "Rango",
           "confirmed": "Confirmada",
           "actions": "Acciones"

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Lista de especies",
       "switchToGrid": "Cambiar a vista de cuadrícula",
       "switchToList": "Cambiar a vista de lista",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "No se encontraron especies que coincidan con tus filtros.",
       "headers": {
         "species": "Especie",
@@ -1667,6 +1668,22 @@
         "detections": "Detecciones:",
         "confidence": "Confianza:",
         "first": "Primera:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Lista de especies",
       "switchToGrid": "Cambiar a vista de cuadrícula",
       "switchToList": "Cambiar a vista de lista",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Cambiar a vista de gestión",
       "noSpeciesFound": "No se encontraron especies que coincidan con tus filtros.",
       "headers": {
         "species": "Especie",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Excluida",
+          "included": "Incluida",
+          "reviewRatio": "Revisión",
+          "rangeProbability": "Rango",
+          "confirmed": "Confirmada",
+          "actions": "Acciones"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Eliminar todas las detecciones de esta especie",
+        "deleteTitle": "Eliminar detecciones de especie",
+        "deleteConfirm": "Eliminar",
+        "deleteMessage": "¿Eliminar las {count} detecciones de {species}? Las detecciones bloqueadas se conservan.",
+        "deleteWarning": "Esto elimina permanentemente las detecciones y sus clips de audio y no se puede deshacer.",
+        "deleteFailed": "No se pudieron eliminar las detecciones. Inténtalo de nuevo."
       }
     },
     "advanced": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Lajiluettelo",
       "switchToGrid": "Vaihda ruudukkonäkymään",
       "switchToList": "Vaihda listanäkymään",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Vaihda hallintanäkymään",
       "noSpeciesFound": "Suodattimia vastaavia lajeja ei löytynyt.",
       "headers": {
         "species": "Laji",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Poissuljettu",
+          "included": "Sisällytetty",
+          "reviewRatio": "Tarkistus",
+          "rangeProbability": "Alue",
+          "confirmed": "Vahvistettu",
+          "actions": "Toiminnot"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Poista kaikki tämän lajin havainnot",
+        "deleteTitle": "Poista lajin havainnot",
+        "deleteConfirm": "Poista",
+        "deleteMessage": "Poistetaanko kaikki {count} havaintoa lajille {species}? Lukitut havainnot säilytetään.",
+        "deleteWarning": "Tämä poistaa havainnot ja niiden äänileikkeet pysyvästi, eikä toimintoa voi kumota.",
+        "deleteFailed": "Havaintojen poistaminen epäonnistui. Yritä uudelleen."
       }
     },
     "advanced": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Lajiluettelo",
       "switchToGrid": "Vaihda ruudukkonäkymään",
       "switchToList": "Vaihda listanäkymään",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Suodattimia vastaavia lajeja ei löytynyt.",
       "headers": {
         "species": "Laji",
@@ -1667,6 +1668,22 @@
         "detections": "Havainnot:",
         "confidence": "Luottamus:",
         "first": "Ensimmäinen:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Poissuljettu",
           "included": "Sisällytetty",
-          "reviewRatio": "Tarkistus",
+          "reviewRatio": "Oikein",
           "rangeProbability": "Alue",
           "confirmed": "Vahvistettu",
           "actions": "Toiminnot"

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Exclue",
           "included": "Incluse",
-          "reviewRatio": "Révision",
+          "reviewRatio": "Correctes",
           "rangeProbability": "Portée",
           "confirmed": "Confirmée",
           "actions": "Actions"

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Liste des espèces",
       "switchToGrid": "Passer à la vue en grille",
       "switchToList": "Passer à la vue en liste",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Passer à la vue de gestion",
       "noSpeciesFound": "Aucune espèce trouvée correspondant à vos filtres.",
       "headers": {
         "species": "Espèce",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
+          "excluded": "Exclue",
+          "included": "Incluse",
+          "reviewRatio": "Révision",
+          "rangeProbability": "Portée",
+          "confirmed": "Confirmée",
           "actions": "Actions"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Supprimer toutes les détections de cette espèce",
+        "deleteTitle": "Supprimer les détections de l'espèce",
+        "deleteConfirm": "Supprimer",
+        "deleteMessage": "Supprimer les {count} détections de {species} ? Les détections verrouillées sont conservées.",
+        "deleteWarning": "Cette action supprime définitivement les détections et leurs extraits audio et ne peut pas être annulée.",
+        "deleteFailed": "Échec de la suppression des détections. Veuillez réessayer."
       }
     },
     "advanced": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Liste des espèces",
       "switchToGrid": "Passer à la vue en grille",
       "switchToList": "Passer à la vue en liste",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Aucune espèce trouvée correspondant à vos filtres.",
       "headers": {
         "species": "Espèce",
@@ -1667,6 +1668,22 @@
         "detections": "Détections :",
         "confidence": "Confiance :",
         "first": "Première :"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -598,6 +598,18 @@
       "empty": "Csend van — most nincs észlelhető madárhang"
     },
     "rejected": "Elutasítva",
+    "newSpeciesHighlights": {
+      "title": "Új és visszatérő fajok",
+      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
+      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
+      "categoryLifetime": "Új fajok",
+      "categoryYear": "Idén új",
+      "categorySeason": "Ebben az évszakban új",
+      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
+      "maxConfidenceShort": "Max {confidence}%",
+      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
+      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
+    },
     "dailySummary": {
       "title": "Napi aktivitás",
       "subtitle": "Faj detektálások óránként",
@@ -761,26 +773,14 @@
       "resetConfirm": "Visszaállítja az irányítópultot az alapértelmezett elrendezésre? Ez eltávolítja az összes testreszabást.",
       "resetting": "Visszaállítás..."
     },
-    "newSpeciesHighlights": {
-      "title": "Új és visszatérő fajok",
-      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
-      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
-      "categoryLifetime": "Új fajok",
-      "categoryYear": "Idén új",
-      "categorySeason": "Ebben az évszakban új",
-      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
-      "maxConfidenceShort": "Max {confidence}%",
-      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
-      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
-    },
     "elements": {
       "banner": "Irányítópult banner",
       "dailySummary": "Napi összefoglaló",
+      "newSpeciesHighlights": "Új fajok kiemelése",
       "currentlyHearing": "Jelenleg hallható",
       "detectionsGrid": "Legutóbbi észlelések",
       "liveSpectrogram": "Élő spektrogram",
-      "videoEmbed": "Videó beágyazás",
-      "newSpeciesHighlights": "Új fajok kiemelése"
+      "videoEmbed": "Videó beágyazás"
     }
   },
   "detections": {
@@ -1668,7 +1668,6 @@
         "detections": "Detektálások:",
         "confidence": "Megbízhatóság:",
         "first": "Első:"
-      }
       },
       "manage": {
         "headers": {
@@ -1685,6 +1684,7 @@
         "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
         "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
         "deleteFailed": "Failed to delete detections. Please try again."
+      }
     },
     "advanced": {
       "title": "Speciális analitika",
@@ -3395,8 +3395,6 @@
         "redirectUriNotConfigured": "Nincs konfigurálva - állítsa be a hosztcímet vagy a Base URL-t a Szerverkonfiguráció fülön",
         "noProviders": "Nincs OAuth szolgáltató konfigurálva",
         "noProvidersDescription": "Adjon hozzá egy szolgáltatót a bejelentkezés engedélyezéséhez Google, GitHub, Microsoft, LINE, Kakao vagy egyedi OIDC szolgáltatóval.",
-        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
-        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "enableProviderLabel": "Engedélyezze ezt a szolgáltatót",
         "getCredentialsLabel": "Szerezze be a hitelesítési adatait a {provider}-tól",
         "redirectUriTitle": "Átirányítási URI:",
@@ -3406,6 +3404,8 @@
         "clientSecretHelpText": "Az OAuth 2.0 Client Secret a szolgáltató fejlesztői konzoljáról",
         "userIdLabel": "Felhasználói ID (opcionális)",
         "userIdHelpText": "Korlátozza a hozzáférést egy adott felhasználói fiókhoz e-mail vagy ID szerint",
+        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
+        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Google OAuth2 bejelentkezés engedélyezése",
@@ -3489,16 +3489,16 @@
       "exceptions": {
         "title": "Kivételek"
       },
-      "privateMode": {
-        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
-        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül \u2013 bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
-      },
       "publicAccess": {
         "title": "Nyilvános hozzáférés",
         "description": "Specifikus funkciók hozzáférhetőségének engedélyezése hitelesítés nélkül.",
         "liveAudioLabel": "Élő hang lejátszás engedélyezése",
         "liveAudioHelp": "Ha engedélyezve van, bárki hallgathatja az élő hang streameket bejelentkezés nélkül. A beállítások és törlés továbbra is hitelesítést igényel.",
         "warningText": "A nyilvános hozzáférési funkciók engedélyezése kiteszi azokat bárkinek, aki elérheti ezt a szervert. Csak akkor engedélyezze, ha megbízik a hálózati környezetében."
+      },
+      "privateMode": {
+        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
+        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül – bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -598,18 +598,6 @@
       "empty": "Csend van — most nincs észlelhető madárhang"
     },
     "rejected": "Elutasítva",
-    "newSpeciesHighlights": {
-      "title": "Új és visszatérő fajok",
-      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
-      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
-      "categoryLifetime": "Új fajok",
-      "categoryYear": "Idén új",
-      "categorySeason": "Ebben az évszakban új",
-      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
-      "maxConfidenceShort": "Max {confidence}%",
-      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
-      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
-    },
     "dailySummary": {
       "title": "Napi aktivitás",
       "subtitle": "Faj detektálások óránként",
@@ -773,14 +761,26 @@
       "resetConfirm": "Visszaállítja az irányítópultot az alapértelmezett elrendezésre? Ez eltávolítja az összes testreszabást.",
       "resetting": "Visszaállítás..."
     },
+    "newSpeciesHighlights": {
+      "title": "Új és visszatérő fajok",
+      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
+      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
+      "categoryLifetime": "Új fajok",
+      "categoryYear": "Idén új",
+      "categorySeason": "Ebben az évszakban új",
+      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
+      "maxConfidenceShort": "Max {confidence}%",
+      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
+      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
+    },
     "elements": {
       "banner": "Irányítópult banner",
       "dailySummary": "Napi összefoglaló",
-      "newSpeciesHighlights": "Új fajok kiemelése",
       "currentlyHearing": "Jelenleg hallható",
       "detectionsGrid": "Legutóbbi észlelések",
       "liveSpectrogram": "Élő spektrogram",
-      "videoEmbed": "Videó beágyazás"
+      "videoEmbed": "Videó beágyazás",
+      "newSpeciesHighlights": "Új fajok kiemelése"
     }
   },
   "detections": {
@@ -1668,6 +1668,7 @@
         "detections": "Detektálások:",
         "confidence": "Megbízhatóság:",
         "first": "Első:"
+      }
       },
       "manage": {
         "headers": {
@@ -1684,7 +1685,6 @@
         "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
         "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
         "deleteFailed": "Failed to delete detections. Please try again."
-      }
     },
     "advanced": {
       "title": "Speciális analitika",
@@ -3395,6 +3395,8 @@
         "redirectUriNotConfigured": "Nincs konfigurálva - állítsa be a hosztcímet vagy a Base URL-t a Szerverkonfiguráció fülön",
         "noProviders": "Nincs OAuth szolgáltató konfigurálva",
         "noProvidersDescription": "Adjon hozzá egy szolgáltatót a bejelentkezés engedélyezéséhez Google, GitHub, Microsoft, LINE, Kakao vagy egyedi OIDC szolgáltatóval.",
+        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
+        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "enableProviderLabel": "Engedélyezze ezt a szolgáltatót",
         "getCredentialsLabel": "Szerezze be a hitelesítési adatait a {provider}-tól",
         "redirectUriTitle": "Átirányítási URI:",
@@ -3404,8 +3406,6 @@
         "clientSecretHelpText": "Az OAuth 2.0 Client Secret a szolgáltató fejlesztői konzoljáról",
         "userIdLabel": "Felhasználói ID (opcionális)",
         "userIdHelpText": "Korlátozza a hozzáférést egy adott felhasználói fiókhoz e-mail vagy ID szerint",
-        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
-        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Google OAuth2 bejelentkezés engedélyezése",
@@ -3489,16 +3489,16 @@
       "exceptions": {
         "title": "Kivételek"
       },
+      "privateMode": {
+        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
+        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül \u2013 bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
+      },
       "publicAccess": {
         "title": "Nyilvános hozzáférés",
         "description": "Specifikus funkciók hozzáférhetőségének engedélyezése hitelesítés nélkül.",
         "liveAudioLabel": "Élő hang lejátszás engedélyezése",
         "liveAudioHelp": "Ha engedélyezve van, bárki hallgathatja az élő hang streameket bejelentkezés nélkül. A beállítások és törlés továbbra is hitelesítést igényel.",
         "warningText": "A nyilvános hozzáférési funkciók engedélyezése kiteszi azokat bárkinek, aki elérheti ezt a szervert. Csak akkor engedélyezze, ha megbízik a hálózati környezetében."
-      },
-      "privateMode": {
-        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
-        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül – bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -598,6 +598,18 @@
       "empty": "Csend van — most nincs észlelhető madárhang"
     },
     "rejected": "Elutasítva",
+    "newSpeciesHighlights": {
+      "title": "Új és visszatérő fajok",
+      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
+      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
+      "categoryLifetime": "Új fajok",
+      "categoryYear": "Idén új",
+      "categorySeason": "Ebben az évszakban új",
+      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
+      "maxConfidenceShort": "Max {confidence}%",
+      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
+      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
+    },
     "dailySummary": {
       "title": "Napi aktivitás",
       "subtitle": "Faj detektálások óránként",
@@ -761,26 +773,14 @@
       "resetConfirm": "Visszaállítja az irányítópultot az alapértelmezett elrendezésre? Ez eltávolítja az összes testreszabást.",
       "resetting": "Visszaállítás..."
     },
-    "newSpeciesHighlights": {
-      "title": "Új és visszatérő fajok",
-      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
-      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
-      "categoryLifetime": "Új fajok",
-      "categoryYear": "Idén új",
-      "categorySeason": "Ebben az évszakban új",
-      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
-      "maxConfidenceShort": "Max {confidence}%",
-      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
-      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
-    },
     "elements": {
       "banner": "Irányítópult banner",
       "dailySummary": "Napi összefoglaló",
+      "newSpeciesHighlights": "Új fajok kiemelése",
       "currentlyHearing": "Jelenleg hallható",
       "detectionsGrid": "Legutóbbi észlelések",
       "liveSpectrogram": "Élő spektrogram",
-      "videoEmbed": "Videó beágyazás",
-      "newSpeciesHighlights": "Új fajok kiemelése"
+      "videoEmbed": "Videó beágyazás"
     }
   },
   "detections": {
@@ -1654,6 +1654,7 @@
       "speciesList": "Fajlista",
       "switchToGrid": "Rács nézetre váltás",
       "switchToList": "Lista nézetre váltás",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "A szűrőknek megfelelő faj nem található.",
       "headers": {
         "species": "Faj",
@@ -1667,6 +1668,22 @@
         "detections": "Detektálások:",
         "confidence": "Megbízhatóság:",
         "first": "Első:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {
@@ -3378,8 +3395,6 @@
         "redirectUriNotConfigured": "Nincs konfigurálva - állítsa be a hosztcímet vagy a Base URL-t a Szerverkonfiguráció fülön",
         "noProviders": "Nincs OAuth szolgáltató konfigurálva",
         "noProvidersDescription": "Adjon hozzá egy szolgáltatót a bejelentkezés engedélyezéséhez Google, GitHub, Microsoft, LINE, Kakao vagy egyedi OIDC szolgáltatóval.",
-        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
-        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "enableProviderLabel": "Engedélyezze ezt a szolgáltatót",
         "getCredentialsLabel": "Szerezze be a hitelesítési adatait a {provider}-tól",
         "redirectUriTitle": "Átirányítási URI:",
@@ -3389,6 +3404,8 @@
         "clientSecretHelpText": "Az OAuth 2.0 Client Secret a szolgáltató fejlesztői konzoljáról",
         "userIdLabel": "Felhasználói ID (opcionális)",
         "userIdHelpText": "Korlátozza a hozzáférést egy adott felhasználói fiókhoz e-mail vagy ID szerint",
+        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
+        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Google OAuth2 bejelentkezés engedélyezése",
@@ -3472,16 +3489,16 @@
       "exceptions": {
         "title": "Kivételek"
       },
-      "privateMode": {
-        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
-        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül \u2013 bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
-      },
       "publicAccess": {
         "title": "Nyilvános hozzáférés",
         "description": "Specifikus funkciók hozzáférhetőségének engedélyezése hitelesítés nélkül.",
         "liveAudioLabel": "Élő hang lejátszás engedélyezése",
         "liveAudioHelp": "Ha engedélyezve van, bárki hallgathatja az élő hang streameket bejelentkezés nélkül. A beállítások és törlés továbbra is hitelesítést igényel.",
         "warningText": "A nyilvános hozzáférési funkciók engedélyezése kiteszi azokat bárkinek, aki elérheti ezt a szervert. Csak akkor engedélyezze, ha megbízik a hálózati környezetében."
+      },
+      "privateMode": {
+        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
+        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül – bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Fajlista",
       "switchToGrid": "Rács nézetre váltás",
       "switchToList": "Lista nézetre váltás",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Váltás kezelő nézetre",
       "noSpeciesFound": "A szűrőknek megfelelő faj nem található.",
       "headers": {
         "species": "Faj",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Kizárva",
+          "included": "Beleértve",
+          "reviewRatio": "Ellenőrzés",
+          "rangeProbability": "Tartomány",
+          "confirmed": "Megerősítve",
+          "actions": "Műveletek"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "A faj összes detektálásának törlése",
+        "deleteTitle": "Faj detektálásainak törlése",
+        "deleteConfirm": "Törlés",
+        "deleteMessage": "Törli a(z) {species} faj mind a(z) {count} detektálását? A zárolt detektálások megmaradnak.",
+        "deleteWarning": "Ez véglegesen eltávolítja a detektálásokat és azok hangklipjeit, és nem vonható vissza.",
+        "deleteFailed": "A detektálások törlése nem sikerült. Kérjük, próbálja újra."
       }
     },
     "advanced": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -598,18 +598,6 @@
       "empty": "Csend van — most nincs észlelhető madárhang"
     },
     "rejected": "Elutasítva",
-    "newSpeciesHighlights": {
-      "title": "Új és visszatérő fajok",
-      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
-      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
-      "categoryLifetime": "Új fajok",
-      "categoryYear": "Idén új",
-      "categorySeason": "Ebben az évszakban új",
-      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
-      "maxConfidenceShort": "Max {confidence}%",
-      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
-      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
-    },
     "dailySummary": {
       "title": "Napi aktivitás",
       "subtitle": "Faj detektálások óránként",
@@ -773,14 +761,26 @@
       "resetConfirm": "Visszaállítja az irányítópultot az alapértelmezett elrendezésre? Ez eltávolítja az összes testreszabást.",
       "resetting": "Visszaállítás..."
     },
+    "newSpeciesHighlights": {
+      "title": "Új és visszatérő fajok",
+      "subtitle": "Első alkalommal és nemrég visszatért észlelések",
+      "trackingDisabled": "Kérjük, aktiválja az \"Fajkövetés engedélyezése\" funkciót ennek a funkciónak a használatához.",
+      "categoryLifetime": "Új fajok",
+      "categoryYear": "Idén új",
+      "categorySeason": "Ebben az évszakban új",
+      "categorySeasonNamed": "Ebben a(z) {season} évszakban új",
+      "maxConfidenceShort": "Max {confidence}%",
+      "detections": "{count, plural, one {# észlelés} other {# észlelés}}",
+      "lastSeen": "Utoljára: {days, plural, =0 {ma} one {# napja} other {# napja}}"
+    },
     "elements": {
       "banner": "Irányítópult banner",
       "dailySummary": "Napi összefoglaló",
-      "newSpeciesHighlights": "Új fajok kiemelése",
       "currentlyHearing": "Jelenleg hallható",
       "detectionsGrid": "Legutóbbi észlelések",
       "liveSpectrogram": "Élő spektrogram",
-      "videoEmbed": "Videó beágyazás"
+      "videoEmbed": "Videó beágyazás",
+      "newSpeciesHighlights": "Új fajok kiemelése"
     }
   },
   "detections": {
@@ -1655,6 +1655,22 @@
       "switchToGrid": "Rács nézetre váltás",
       "switchToList": "Lista nézetre váltás",
       "switchToManage": "Váltás kezelő nézetre",
+      "manage": {
+        "headers": {
+          "excluded": "Kizárva",
+          "included": "Beleértve",
+          "reviewRatio": "Helyes",
+          "rangeProbability": "Tartomány",
+          "confirmed": "Megerősítve",
+          "actions": "Műveletek"
+        },
+        "delete": "A faj összes detektálásának törlése",
+        "deleteTitle": "Faj detektálásainak törlése",
+        "deleteConfirm": "Törlés",
+        "deleteMessage": "Törli a(z) {species} faj mind a(z) {count} detektálását? A zárolt detektálások megmaradnak.",
+        "deleteWarning": "Ez véglegesen eltávolítja a detektálásokat és azok hangklipjeit, és nem vonható vissza.",
+        "deleteFailed": "A detektálások törlése nem sikerült. Kérjük, próbálja újra."
+      },
       "noSpeciesFound": "A szűrőknek megfelelő faj nem található.",
       "headers": {
         "species": "Faj",
@@ -1668,22 +1684,6 @@
         "detections": "Detektálások:",
         "confidence": "Megbízhatóság:",
         "first": "Első:"
-      },
-      "manage": {
-        "headers": {
-          "excluded": "Kizárva",
-          "included": "Beleértve",
-          "reviewRatio": "Ellenőrzés",
-          "rangeProbability": "Tartomány",
-          "confirmed": "Megerősítve",
-          "actions": "Műveletek"
-        },
-        "delete": "A faj összes detektálásának törlése",
-        "deleteTitle": "Faj detektálásainak törlése",
-        "deleteConfirm": "Törlés",
-        "deleteMessage": "Törli a(z) {species} faj mind a(z) {count} detektálását? A zárolt detektálások megmaradnak.",
-        "deleteWarning": "Ez véglegesen eltávolítja a detektálásokat és azok hangklipjeit, és nem vonható vissza.",
-        "deleteFailed": "A detektálások törlése nem sikerült. Kérjük, próbálja újra."
       }
     },
     "advanced": {
@@ -3395,6 +3395,8 @@
         "redirectUriNotConfigured": "Nincs konfigurálva - állítsa be a hosztcímet vagy a Base URL-t a Szerverkonfiguráció fülön",
         "noProviders": "Nincs OAuth szolgáltató konfigurálva",
         "noProvidersDescription": "Adjon hozzá egy szolgáltatót a bejelentkezés engedélyezéséhez Google, GitHub, Microsoft, LINE, Kakao vagy egyedi OIDC szolgáltatóval.",
+        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
+        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "enableProviderLabel": "Engedélyezze ezt a szolgáltatót",
         "getCredentialsLabel": "Szerezze be a hitelesítési adatait a {provider}-tól",
         "redirectUriTitle": "Átirányítási URI:",
@@ -3404,8 +3406,6 @@
         "clientSecretHelpText": "Az OAuth 2.0 Client Secret a szolgáltató fejlesztői konzoljáról",
         "userIdLabel": "Felhasználói ID (opcionális)",
         "userIdHelpText": "Korlátozza a hozzáférést egy adott felhasználói fiókhoz e-mail vagy ID szerint",
-        "allowedUsersEmptyWarning": "Ennek a szolgáltatónak nincsenek engedélyezett felhasználói, ezért minden bejelentkezési kísérlet el lesz utasítva. Adjon hozzá legalább egy e-mail-t vagy felhasználói azonosítót a hozzáférés engedélyezéséhez.",
-        "allowedUsersMissingBadge": "Nincs engedélyezett felhasználó beállítva – a bejelentkezés sikertelen lesz",
         "google": {
           "title": "Google OAuth",
           "enableLabel": "Google OAuth2 bejelentkezés engedélyezése",
@@ -3489,16 +3489,16 @@
       "exceptions": {
         "title": "Kivételek"
       },
+      "privateMode": {
+        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
+        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül \u2013 bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
+      },
       "publicAccess": {
         "title": "Nyilvános hozzáférés",
         "description": "Specifikus funkciók hozzáférhetőségének engedélyezése hitelesítés nélkül.",
         "liveAudioLabel": "Élő hang lejátszás engedélyezése",
         "liveAudioHelp": "Ha engedélyezve van, bárki hallgathatja az élő hang streameket bejelentkezés nélkül. A beállítások és törlés továbbra is hitelesítést igényel.",
         "warningText": "A nyilvános hozzáférési funkciók engedélyezése kiteszi azokat bárkinek, aki elérheti ezt a szervert. Csak akkor engedélyezze, ha megbízik a hálózati környezetében."
-      },
-      "privateMode": {
-        "label": "Bejelentkezés megkövetelése az összes felhasználói felület oldalhoz (privát mód)",
-        "help": "Ha engedélyezve van, az irányítópult, az észlelések, az elemzés, a keresés, a névjegy és az értesítések oldalak mind hitelesítést igényelnek. A beállítások és a rendszer oldalak ettől függetlenül mindig védve vannak. Az alábbi \"Nyilvános élő hang\" kapcsoló önállóan érvényesül – bekapcsolva hagyva továbbra is engedélyezi a nem hitelesített lejátszást. Az alapértelmezett értéke ki, hogy a vendégek böngészhessék a csak olvasható felületet."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Elenco Specie",
       "switchToGrid": "Passa alla vista griglia",
       "switchToList": "Passa alla vista elenco",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Passa alla vista di gestione",
       "noSpeciesFound": "Nessuna specie trovata corrispondente ai tuoi filtri.",
       "headers": {
         "species": "Specie",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Escluso",
+          "included": "Incluso",
+          "reviewRatio": "Revisione",
+          "rangeProbability": "Intervallo",
+          "confirmed": "Confermato",
+          "actions": "Azioni"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Elimina tutti i rilevamenti di questa specie",
+        "deleteTitle": "Elimina rilevamenti della specie",
+        "deleteConfirm": "Elimina",
+        "deleteMessage": "Eliminare tutti i {count} rilevamenti di {species}? I rilevamenti bloccati vengono mantenuti.",
+        "deleteWarning": "Questa operazione rimuove definitivamente i rilevamenti e le loro clip audio e non può essere annullata.",
+        "deleteFailed": "Eliminazione dei rilevamenti non riuscita. Riprova."
       }
     },
     "advanced": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Elenco Specie",
       "switchToGrid": "Passa alla vista griglia",
       "switchToList": "Passa alla vista elenco",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Nessuna specie trovata corrispondente ai tuoi filtri.",
       "headers": {
         "species": "Specie",
@@ -1667,6 +1668,22 @@
         "detections": "Rilevamenti:",
         "confidence": "Confidenza:",
         "first": "Primo:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Escluso",
           "included": "Incluso",
-          "reviewRatio": "Revisione",
+          "reviewRatio": "Corretti",
           "rangeProbability": "Intervallo",
           "confirmed": "Confermato",
           "actions": "Azioni"

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Sugu saraksts",
       "switchToGrid": "Pārslēgt uz režģa skatu",
       "switchToList": "Pārslēgt uz saraksta skatu",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Pārslēgties uz pārvaldības skatu",
       "noSpeciesFound": "Sugas, kas atbilst jūsu filtriem, nav atrastas.",
       "headers": {
         "species": "Suga",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Izslēgta",
+          "included": "Iekļauta",
+          "reviewRatio": "Pārbaude",
+          "rangeProbability": "Areāls",
+          "confirmed": "Apstiprināta",
+          "actions": "Darbības"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Dzēst visas šīs sugas atpazīšanas",
+        "deleteTitle": "Dzēst sugas atpazīšanas",
+        "deleteConfirm": "Dzēst",
+        "deleteMessage": "Dzēst visas {count} sugas {species} atpazīšanas? Bloķētās atpazīšanas tiek saglabātas.",
+        "deleteWarning": "Tādējādi neatgriezeniski tiek noņemtas atpazīšanas un to audioklipi, un šo darbību nevar atsaukt.",
+        "deleteFailed": "Neizdevās dzēst atpazīšanas. Lūdzu, mēģiniet vēlreiz."
       }
     },
     "advanced": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Izslēgta",
           "included": "Iekļauta",
-          "reviewRatio": "Pārbaude",
+          "reviewRatio": "Pareizi",
           "rangeProbability": "Areāls",
           "confirmed": "Apstiprināta",
           "actions": "Darbības"

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Sugu saraksts",
       "switchToGrid": "Pārslēgt uz režģa skatu",
       "switchToList": "Pārslēgt uz saraksta skatu",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Sugas, kas atbilst jūsu filtriem, nav atrastas.",
       "headers": {
         "species": "Suga",
@@ -1667,6 +1668,22 @@
         "detections": "Atpazīšanas:",
         "confidence": "Ticamība:",
         "first": "Pirmā:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -510,6 +510,9 @@
       "sunrise": "Soloppgang +/- 30 min",
       "sunset": "Solnedgang +/- 30 min"
     },
+    "sourceOptions": {
+      "any": "All Sources"
+    },
     "sortOptions": {
       "dateDesc": "Dato (nyeste først)",
       "dateAsc": "Dato (eldste først)",
@@ -521,9 +524,9 @@
       "timeOfDay": "Tidspunkt",
       "species": "Art",
       "confidence": "Sikkerhet",
+      "source": "Source",
       "status": "Status",
-      "actions": "Handlinger",
-      "source": "Source"
+      "actions": "Handlinger"
     },
     "statusBadges": {
       "verified": "Verifisert",
@@ -559,9 +562,6 @@
       "page": "Side {current} av {total}",
       "goToPrevious": "Gå til forrige side",
       "goToNext": "Gå til neste side"
-    },
-    "sourceOptions": {
-      "any": "All Sources"
     }
   },
   "error": {
@@ -598,6 +598,18 @@
       "empty": "Stille — ingen fugler registrert akkurat nå"
     },
     "rejected": "Avvist",
+    "newSpeciesHighlights": {
+      "title": "Nye og tilbakevendende arter",
+      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
+      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
+      "categoryLifetime": "Nye arter",
+      "categoryYear": "Nye i år",
+      "categorySeason": "Nye denne sesongen",
+      "categorySeasonNamed": "Nye i {season}",
+      "maxConfidenceShort": "Maks {confidence}%",
+      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
+      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
+    },
     "dailySummary": {
       "title": "Daglig aktivitet",
       "subtitle": "Artsregistreringer per time",
@@ -764,23 +776,11 @@
     "elements": {
       "banner": "Dashbordbanner",
       "dailySummary": "Daglig sammendrag",
+      "newSpeciesHighlights": "Høydepunkter for nye arter",
       "currentlyHearing": "Hører nå",
       "detectionsGrid": "Siste registreringer",
       "liveSpectrogram": "Direkte spektrogram",
-      "videoEmbed": "Videoinnbygging",
-      "newSpeciesHighlights": "Høydepunkter for nye arter"
-    },
-    "newSpeciesHighlights": {
-      "title": "Nye og tilbakevendende arter",
-      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
-      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
-      "categoryLifetime": "Nye arter",
-      "categoryYear": "Nye i år",
-      "categorySeason": "Nye denne sesongen",
-      "categorySeasonNamed": "Nye i {season}",
-      "maxConfidenceShort": "Maks {confidence}%",
-      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
-      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
+      "videoEmbed": "Videoinnbygging"
     }
   },
   "detections": {
@@ -1641,8 +1641,8 @@
         "dateTime": "Dato og tid",
         "species": "Art",
         "confidence": "Sikkerhet",
-        "timeOfDay": "Tidspunkt",
-        "source": "Source"
+        "source": "Source",
+        "timeOfDay": "Tidspunkt"
       },
       "noRecentDetections": "Ingen siste registreringer funnet",
       "unknownSpecies": "Ukjent",
@@ -1654,6 +1654,7 @@
       "speciesList": "Artsliste",
       "switchToGrid": "Bytt til rutenettvisning",
       "switchToList": "Bytt til listevisning",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Ingen arter funnet som matcher filtrene dine.",
       "headers": {
         "species": "Art",
@@ -1667,6 +1668,22 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhet:",
         "first": "Første:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {
@@ -3516,7 +3533,6 @@
         "validityHelpText": "Hvor lenge sertifikatet skal være gyldig",
         "validity365d": "1 år",
         "validity730d": "2 år",
-        "validity1825d": "5 år",
         "generateButton": "Generer sertifikat",
         "regenerateButton": "Regenerer sertifikat",
         "generating": "Genererer...",
@@ -3548,6 +3564,7 @@
         "deleteConfirm": "Er du sikker på at du vil fjerne det installerte TLS-sertifikatet? TLS-modusen vil tilbakestilles til Ingen.",
         "restartRequired": "TLS-endringer krever en serveromstart for å ta effekt.",
         "noCertificate": "Ingen sertifikat installert",
+        "validity1825d": "5 år",
         "autoTLSHostRequired": "Et vertsnavn er nødvendig for Let's Encrypt. Skriv inn ditt offentlige domenenavn i Vert-feltet ovenfor.",
         "autoTLSNoIP": "Let's Encrypt krever et domenenavn, ikke en IP-adresse. Skriv inn et offentlig domene som fugler.eksempel.no.",
         "autoTLSNeedsFQDN": "Let's Encrypt krever et fullt kvalifisert domenenavn (f.eks. fugler.eksempel.no), ikke bare et vertsnavn.",
@@ -4148,154 +4165,6 @@
     },
     "restartRequired": "Noen endringer krever en serveromstart for å ta effekt. Start BirdNET-Go på nytt."
   },
-  "analysis": {
-    "title": "Analyse",
-    "tabs": {
-      "settings": "Innstillinger",
-      "models": "Modeller"
-    },
-    "detection": {
-      "title": "Deteksjonsinnstillinger",
-      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
-      "confidenceThreshold": {
-        "label": "Sikkerhetsterskel",
-        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
-      },
-      "batThreshold": {
-        "label": "Flaggermusdeteksjonsterskel",
-        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
-      },
-      "batFilter": {
-        "label": "Høypassfilter for flaggermuslyd",
-        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
-      },
-      "batNighttimeOnly": {
-        "label": "Kun om natten",
-        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
-      },
-      "batUltrasonicFilter": {
-        "label": "Etterdeteksjonsvalidering",
-        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
-      },
-      "batFalsePositiveFilter": {
-        "label": "Falsk positiv-filter for flaggermus",
-        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
-        "levels": {
-          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
-          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
-          "strict": "Maksimal filtrering for høyest nøyaktighet."
-        },
-        "detectionCount": "{count} bekreftelser kreves. {description}",
-        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
-      },
-      "locale": {
-        "label": "Artsspråk",
-        "helpText": "Språk brukt for artsnavnene i grensesnittet."
-      }
-    },
-    "rangeFilter": {
-      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
-      "status": {
-        "title": "Utvalgsfilter-oversikt",
-        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
-        "autoSelected": "Automatisk valgt",
-        "manual": "Manuell",
-        "classifier": "Klassifikator",
-        "totalSpecies": "Totalt arter",
-        "withRangeData": "Med utvalgsdata",
-        "withoutRangeData": "Uten utvalgsdata",
-        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
-        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
-        "noFilter": "Ingen aktivt utvalgsfilter",
-        "passUnmapped": {
-          "label": "Tillat arter uten utvalgsdata",
-          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
-        }
-      }
-    },
-    "advanced": {
-      "title": "Avansert",
-      "description": "Behandling og egendefinert modellkonfigurasjon."
-    },
-    "gallery": {
-      "title": "Modellgalleri",
-      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
-      "tabs": {
-        "installed": "Installert",
-        "available": "Tilgjengelig"
-      },
-      "loading": "Laster modeller...",
-      "retry": "Prøv igjen",
-      "builtIn": "Innebygd",
-      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
-      "species": "{count} arter",
-      "install": "Installer",
-      "installing": "Installerer...",
-      "remove": "Fjern",
-      "removing": "Fjerner...",
-      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
-      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
-      "sections": {
-        "acoustic": "Akustiske klassifikatorer",
-        "geomodel": "Geomodeller"
-      },
-      "categories": {
-        "wildlife": "Viltklassifikatorer",
-        "bird": "Fugleklassifikatorer",
-        "bat": "Flaggermusklassifikatorer"
-      },
-      "progress": {
-        "downloading": "Laster ned...",
-        "verifying": "Verifiserer...",
-        "loading": "Laster...",
-        "complete": "Installert",
-        "failed": "Mislyktes"
-      },
-      "license": {
-        "title": "Lisensavtale",
-        "model": "Modell",
-        "author": "Forfatter",
-        "license": "Lisens",
-        "commercialUse": "Kommersiell bruk",
-        "downloadSize": "Nedlastingsstørrelse",
-        "allowed": "Tillatt",
-        "notAllowed": "Ikke tillatt",
-        "commercialUseAllowed": "Kommersiell bruk tillatt",
-        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
-        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
-        "acceptAndInstall": "Godta og installer"
-      },
-      "removeDialog": {
-        "title": "Fjerne {name}?",
-        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
-      },
-      "errors": {
-        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
-        "installFailed": "Oppstart av modellinstallasjon mislyktes",
-        "removeFailed": "Fjerning av modell mislyktes"
-      },
-      "regionLabel": "Region",
-      "speciesLabel": "Arter",
-      "reinstall": "Reinstaller",
-      "reinstalling": "Reinstallerer...",
-      "reinstallComplete": "Filer verifisert",
-      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
-      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
-      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
-      "unavailable": "Ikke tilgjengelig"
-    },
-    "bird": {
-      "title": "Fugledeteksjon",
-      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
-    },
-    "bat": {
-      "title": "Flaggermusdeteksjon",
-      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
-    },
-    "dynamicThreshold": {
-      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
-    }
-  },
   "auth": {
     "login": "Logg inn",
     "logout": "Logg ut",
@@ -4355,315 +4224,6 @@
       "min": "Minimum",
       "max": "Maksimum",
       "count": "Antall"
-    }
-  },
-  "connectivity": {
-    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
-  },
-  "detection": {
-    "actions": {
-      "back": "Tilbake",
-      "review": "Gjennomgå",
-      "download": "Last ned"
-    }
-  },
-  "quietHours": {
-    "indicator": {
-      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
-    }
-  },
-  "restart": {
-    "applicationRestart": "Start applikasjon på nytt",
-    "containerRestart": "Start container på nytt",
-    "confirmTitle": "Bekreft omstart",
-    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "inProgress": "Starter på nytt...",
-    "bannerTitle": "Omstart kreves",
-    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
-    "bannerAction": "Start på nytt nå",
-    "restartFailed": "Oppstart av omstart mislyktes"
-  },
-  "help": {
-    "title": "Hjelp og støtte",
-    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
-    "reportBug": {
-      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
-    },
-    "askQuestion": {
-      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
-    },
-    "diagnostics": {
-      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
-    },
-    "quickLinks": {
-      "title": "Hurtiglenker",
-      "releases": "Versjonsnyheter"
-    }
-  },
-  "reportBug": {
-    "title": "Rapporter en feil",
-    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
-    "systemInfo": {
-      "title": "Din systeminformasjon",
-      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
-      "version": "Versjon",
-      "buildDate": "Byggedato",
-      "os": "Operativsystem",
-      "copy": "Kopier til utklippstavle",
-      "copied": "Kopiert!",
-      "architecture": "Arkitektur",
-      "hardware": "Maskinvare",
-      "environment": "Miljø"
-    },
-    "whatToInclude": {
-      "title": "Hva du bør inkludere i rapporten",
-      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
-      "step1": {
-        "title": "Tydelig beskrivelse av problemet",
-        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
-      },
-      "step2": {
-        "title": "Installasjonsmetode",
-        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
-      },
-      "step3": {
-        "title": "Systeminformasjon",
-        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
-      },
-      "step4": {
-        "title": "Supportpakke",
-        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
-      }
-    },
-    "openIssue": {
-      "title": "Åpne en GitHub-sak",
-      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
-      "button": "Åpne sak på GitHub"
-    },
-    "supportDump": {
-      "title": "Generer supportpakke",
-      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
-    }
-  },
-  "weather": {
-    "moon": {
-      "newMoon": "Nymåne",
-      "waxingCrescent": "Voksende månesigd",
-      "firstQuarter": "Første kvarter",
-      "waxingGibbous": "Voksende måne",
-      "fullMoon": "Fullmåne",
-      "waningGibbous": "Minkende måne",
-      "lastQuarter": "Siste kvarter",
-      "waningCrescent": "Minkende månesigd"
-    },
-    "birding": {
-      "excellent": "Stille — utmerket for å høre fuglekall",
-      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
-      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
-    }
-  },
-  "errors": {
-    "auth": {
-      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
-      "credentialsRequired": "Brukernavn og passord er obligatorisk",
-      "invalidCredentials": "Ugyldige innloggingsdetaljer",
-      "missingCode": "Manglende autorisasjonskode",
-      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
-      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
-      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
-      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
-    },
-    "alert": {
-      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
-      "invalidID": "Ugyldig regel-ID",
-      "notFound": "Varselregel ikke funnet",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "nameRequired": "Regelnavn er obligatorisk",
-      "typesRequired": "Objekttype og utløsertype er obligatorisk",
-      "duplicateName": "En regel med dette navnet finnes allerede",
-      "invalidJSON": "Ugyldig JSON",
-      "invalidEscalation": "Eskaleringstrinn er ugyldige"
-    },
-    "detection": {
-      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
-    },
-    "backup": {
-      "invalidType": "Type må være «legacy» eller «v2»",
-      "alreadyRunning": "Sikkerhetskopi pågår allerede",
-      "dbInfoFailed": "Henting av databaseinfo mislyktes",
-      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
-      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
-      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
-      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
-      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
-      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
-      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
-      "dbNotConfigured": "Database ikke konfigurert",
-      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
-      "v2NotInitialized": "V2-database ikke initialisert"
-    },
-    "migration": {
-      "notConfigured": "Migrering er ikke konfigurert",
-      "preFlightFailed": "Forhåndssjekker mislyktes",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
-      "startFailed": "Oppstart av migrering mislyktes",
-      "initFailed": "Initialisering av migrering mislyktes",
-      "resumeFailed": "Gjenopptak av migrering mislyktes"
-    },
-    "cleanup": {
-      "noLegacyDB": "Ingen eldre database funnet",
-      "accessFailed": "Kan ikke få tilgang til eldre database",
-      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
-      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
-      "noLegacyTables": "Ingen eldre tabeller funnet",
-      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
-      "alreadyRunning": "Opprydding pågår allerede"
-    },
-    "integration": {
-      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
-      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
-      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
-      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
-      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
-      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
-      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
-      "noWeatherProvider": "Ingen værleverandør valgt",
-      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
-      "processorUnavailable": "Prosessor ikke tilgjengelig",
-      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
-    },
-    "notification": {
-      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
-      "idRequired": "Varsel-ID er obligatorisk",
-      "notFound": "Varsel ikke funnet",
-      "hostRequired": "Vert-parameter er obligatorisk",
-      "invalidHost": "Ugyldig vert-parameter",
-      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
-    },
-    "streams": {
-      "test": {
-        "invalidBody": "Ugyldig forespørselskropp",
-        "urlRequired": "Strøm-URL er obligatorisk",
-        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
-        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
-        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
-        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
-        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
-      }
-    },
-    "debug": {
-      "notEnabled": "Feilsøkingsmodus ikke aktivert"
-    },
-    "terminal": {
-      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
-    },
-    "api": {
-      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
-      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
-      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
-      "notFound": "Den forespurte ressursen ble ikke funnet.",
-      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
-      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
-      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
-      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
-      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
-      "unknownError": "En uventet feil oppstod. Prøv igjen.",
-      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
-      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
-      "requestTimeout": "Forespørselen tok for lang tid.",
-      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
-    }
-  },
-  "health": {
-    "title": "Systemhelse",
-    "running": "Kjører diagnostikk...",
-    "lastRun": "Sist kjørt",
-    "refresh": "Oppdater",
-    "exportText": "Kopier rapport",
-    "exportJSON": "Last ned JSON",
-    "copied": "Rapport kopiert til utklippstavle",
-    "duration": "Varighet",
-    "summary": {
-      "healthy": "Frisk",
-      "warnings": "Advarsler",
-      "critical": "Kritisk",
-      "skipped": "Hoppet over",
-      "total": "Totalt sjekker"
-    },
-    "metricFooter": {
-      "allPassing": "Alle godkjent",
-      "needsAttention": "Trenger oppmerksomhet",
-      "failing": "Mislykkes",
-      "allClear": "Alt klart",
-      "noData": "Ingen nylige data",
-      "none": "Ingen"
-    },
-    "diagnostics": "Diagnostikk",
-    "categories": {
-      "system": "System",
-      "audio": "Lydpipeline",
-      "analysis": "Analyse",
-      "streams": "Lydstrømmer",
-      "database": "Database",
-      "network": "Nettverk",
-      "config": "Konfigurasjon",
-      "logs": "Logger"
-    },
-    "status": {
-      "healthy": "Frisk",
-      "warning": "Advarsel",
-      "critical": "Kritisk",
-      "unknown": "Ukjent",
-      "skipped": "Hoppet over"
-    },
-    "errors": {
-      "title": "Nylige feil",
-      "noErrors": "Ingen nylige feil",
-      "fetchFailed": "Innlasting av diagnostikk mislyktes"
-    },
-    "export": {
-      "reportTitle": "BirdNET-Go systemhelserapport",
-      "statusLabel": "Status",
-      "timeLabel": "Tid",
-      "durationLabel": "Varighet",
-      "checksLabel": "Sjekker"
-    },
-    "logs": {
-      "topErrors": "Vanligste feilmønstre",
-      "errorCount": "Antall",
-      "errorComponent": "Komponent",
-      "errorLevel": "Nivå",
-      "errorMessage": "Melding"
-    },
-    "window": {
-      "label": "Evalueringsvindu",
-      "15m": "15m",
-      "30m": "30m",
-      "1h": "1t",
-      "6h": "6t",
-      "24h": "24t",
-      "7d": "7d"
-    },
-    "detail": {
-      "lastEvent": "Siste hendelse",
-      "recentEvents": "Nylige hendelser",
-      "time": "Tid",
-      "source": "Kilde",
-      "count": "Antall",
-      "lifetime": "levetid",
-      "sparklineLabel": "Aktivitetsoversikt",
-      "activeHours": "Aktive timer",
-      "windowTotal": "I vindu",
-      "velocity": "Trend",
-      "velocityStable": "Stabil",
-      "velocityIncreasing": "Stigende",
-      "velocityDecreasing": "Synkende",
-      "pattern": "Mønster",
-      "patternNone": "Ingen",
-      "patternTransient": "Forbigående",
-      "patternSustained": "Vedvarende"
     }
   },
   "forms": {
@@ -4934,6 +4494,151 @@
       "clickToView": "Click to view detections"
     }
   },
+  "connectivity": {
+    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
+  },
+  "detection": {
+    "actions": {
+      "back": "Tilbake",
+      "review": "Gjennomgå",
+      "download": "Last ned"
+    }
+  },
+  "quietHours": {
+    "indicator": {
+      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
+    }
+  },
+  "errors": {
+    "auth": {
+      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
+      "credentialsRequired": "Brukernavn og passord er obligatorisk",
+      "invalidCredentials": "Ugyldige innloggingsdetaljer",
+      "missingCode": "Manglende autorisasjonskode",
+      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
+      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
+      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
+      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
+    },
+    "alert": {
+      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
+      "invalidID": "Ugyldig regel-ID",
+      "notFound": "Varselregel ikke funnet",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "nameRequired": "Regelnavn er obligatorisk",
+      "typesRequired": "Objekttype og utløsertype er obligatorisk",
+      "duplicateName": "En regel med dette navnet finnes allerede",
+      "invalidJSON": "Ugyldig JSON",
+      "invalidEscalation": "Eskaleringstrinn er ugyldige"
+    },
+    "detection": {
+      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
+    },
+    "backup": {
+      "invalidType": "Type må være «legacy» eller «v2»",
+      "alreadyRunning": "Sikkerhetskopi pågår allerede",
+      "dbInfoFailed": "Henting av databaseinfo mislyktes",
+      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
+      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
+      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
+      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
+      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
+      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
+      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
+      "dbNotConfigured": "Database ikke konfigurert",
+      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
+      "v2NotInitialized": "V2-database ikke initialisert"
+    },
+    "migration": {
+      "notConfigured": "Migrering er ikke konfigurert",
+      "preFlightFailed": "Forhåndssjekker mislyktes",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
+      "startFailed": "Oppstart av migrering mislyktes",
+      "initFailed": "Initialisering av migrering mislyktes",
+      "resumeFailed": "Gjenopptak av migrering mislyktes"
+    },
+    "cleanup": {
+      "noLegacyDB": "Ingen eldre database funnet",
+      "accessFailed": "Kan ikke få tilgang til eldre database",
+      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
+      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
+      "noLegacyTables": "Ingen eldre tabeller funnet",
+      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
+      "alreadyRunning": "Opprydding pågår allerede"
+    },
+    "integration": {
+      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
+      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
+      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
+      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
+      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
+      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
+      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
+      "noWeatherProvider": "Ingen værleverandør valgt",
+      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
+      "processorUnavailable": "Prosessor ikke tilgjengelig",
+      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
+    },
+    "notification": {
+      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
+      "idRequired": "Varsel-ID er obligatorisk",
+      "notFound": "Varsel ikke funnet",
+      "hostRequired": "Vert-parameter er obligatorisk",
+      "invalidHost": "Ugyldig vert-parameter",
+      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
+    },
+    "streams": {
+      "test": {
+        "invalidBody": "Ugyldig forespørselskropp",
+        "urlRequired": "Strøm-URL er obligatorisk",
+        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
+        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
+        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
+        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
+        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
+      }
+    },
+    "debug": {
+      "notEnabled": "Feilsøkingsmodus ikke aktivert"
+    },
+    "terminal": {
+      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
+    },
+    "api": {
+      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
+      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
+      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
+      "notFound": "Den forespurte ressursen ble ikke funnet.",
+      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
+      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
+      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
+      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
+      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
+      "unknownError": "En uventet feil oppstod. Prøv igjen.",
+      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
+      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
+      "requestTimeout": "Forespørselen tok for lang tid.",
+      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
+    }
+  },
+  "weather": {
+    "moon": {
+      "newMoon": "Nymåne",
+      "waxingCrescent": "Voksende månesigd",
+      "firstQuarter": "Første kvarter",
+      "waxingGibbous": "Voksende måne",
+      "fullMoon": "Fullmåne",
+      "waningGibbous": "Minkende måne",
+      "lastQuarter": "Siste kvarter",
+      "waningCrescent": "Minkende månesigd"
+    },
+    "birding": {
+      "excellent": "Stille — utmerket for å høre fuglekall",
+      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
+      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
+    }
+  },
   "wizard": {
     "skip": "Hopp over",
     "back": "Tilbake",
@@ -5025,6 +4730,318 @@
         "outro": "Denne tilnærmingen sikrer datakvalitet for vitenskapelig forskning og maksimerer din glede av og lærdom om fugler.",
         "acknowledge": "Jeg forstår"
       }
+    }
+  },
+  "analysis": {
+    "title": "Analyse",
+    "tabs": {
+      "settings": "Innstillinger",
+      "models": "Modeller"
+    },
+    "detection": {
+      "title": "Deteksjonsinnstillinger",
+      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
+      "confidenceThreshold": {
+        "label": "Sikkerhetsterskel",
+        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
+      },
+      "batThreshold": {
+        "label": "Flaggermusdeteksjonsterskel",
+        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
+      },
+      "batFilter": {
+        "label": "Høypassfilter for flaggermuslyd",
+        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
+      },
+      "batNighttimeOnly": {
+        "label": "Kun om natten",
+        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
+      },
+      "batUltrasonicFilter": {
+        "label": "Etterdeteksjonsvalidering",
+        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
+      },
+      "batFalsePositiveFilter": {
+        "label": "Falsk positiv-filter for flaggermus",
+        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
+        "levels": {
+          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
+          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
+          "strict": "Maksimal filtrering for høyest nøyaktighet."
+        },
+        "detectionCount": "{count} bekreftelser kreves. {description}",
+        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
+      },
+      "locale": {
+        "label": "Artsspråk",
+        "helpText": "Språk brukt for artsnavnene i grensesnittet."
+      }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
+      "status": {
+        "title": "Utvalgsfilter-oversikt",
+        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
+        "autoSelected": "Automatisk valgt",
+        "manual": "Manuell",
+        "classifier": "Klassifikator",
+        "totalSpecies": "Totalt arter",
+        "withRangeData": "Med utvalgsdata",
+        "withoutRangeData": "Uten utvalgsdata",
+        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
+        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
+        "noFilter": "Ingen aktivt utvalgsfilter",
+        "passUnmapped": {
+          "label": "Tillat arter uten utvalgsdata",
+          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Avansert",
+      "description": "Behandling og egendefinert modellkonfigurasjon."
+    },
+    "gallery": {
+      "title": "Modellgalleri",
+      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
+      "tabs": {
+        "installed": "Installert",
+        "available": "Tilgjengelig"
+      },
+      "loading": "Laster modeller...",
+      "retry": "Prøv igjen",
+      "builtIn": "Innebygd",
+      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
+      "species": "{count} arter",
+      "install": "Installer",
+      "installing": "Installerer...",
+      "remove": "Fjern",
+      "removing": "Fjerner...",
+      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
+      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
+      "sections": {
+        "acoustic": "Akustiske klassifikatorer",
+        "geomodel": "Geomodeller"
+      },
+      "categories": {
+        "wildlife": "Viltklassifikatorer",
+        "bird": "Fugleklassifikatorer",
+        "bat": "Flaggermusklassifikatorer"
+      },
+      "progress": {
+        "downloading": "Laster ned...",
+        "verifying": "Verifiserer...",
+        "loading": "Laster...",
+        "complete": "Installert",
+        "failed": "Mislyktes"
+      },
+      "license": {
+        "title": "Lisensavtale",
+        "model": "Modell",
+        "author": "Forfatter",
+        "license": "Lisens",
+        "commercialUse": "Kommersiell bruk",
+        "downloadSize": "Nedlastingsstørrelse",
+        "allowed": "Tillatt",
+        "notAllowed": "Ikke tillatt",
+        "commercialUseAllowed": "Kommersiell bruk tillatt",
+        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
+        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
+        "acceptAndInstall": "Godta og installer"
+      },
+      "removeDialog": {
+        "title": "Fjerne {name}?",
+        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
+      },
+      "errors": {
+        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
+        "installFailed": "Oppstart av modellinstallasjon mislyktes",
+        "removeFailed": "Fjerning av modell mislyktes"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Arter",
+      "reinstall": "Reinstaller",
+      "reinstalling": "Reinstallerer...",
+      "reinstallComplete": "Filer verifisert",
+      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
+      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
+      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
+      "unavailable": "Ikke tilgjengelig"
+    },
+    "bird": {
+      "title": "Fugledeteksjon",
+      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
+    },
+    "bat": {
+      "title": "Flaggermusdeteksjon",
+      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
+    },
+    "dynamicThreshold": {
+      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
+    }
+  },
+  "restart": {
+    "applicationRestart": "Start applikasjon på nytt",
+    "containerRestart": "Start container på nytt",
+    "confirmTitle": "Bekreft omstart",
+    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "inProgress": "Starter på nytt...",
+    "bannerTitle": "Omstart kreves",
+    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
+    "bannerAction": "Start på nytt nå",
+    "restartFailed": "Oppstart av omstart mislyktes"
+  },
+  "help": {
+    "title": "Hjelp og støtte",
+    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
+    "reportBug": {
+      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
+    },
+    "askQuestion": {
+      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
+    },
+    "diagnostics": {
+      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
+    },
+    "quickLinks": {
+      "title": "Hurtiglenker",
+      "releases": "Versjonsnyheter"
+    }
+  },
+  "reportBug": {
+    "title": "Rapporter en feil",
+    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
+    "systemInfo": {
+      "title": "Din systeminformasjon",
+      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
+      "version": "Versjon",
+      "buildDate": "Byggedato",
+      "os": "Operativsystem",
+      "copy": "Kopier til utklippstavle",
+      "copied": "Kopiert!",
+      "architecture": "Arkitektur",
+      "hardware": "Maskinvare",
+      "environment": "Miljø"
+    },
+    "whatToInclude": {
+      "title": "Hva du bør inkludere i rapporten",
+      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
+      "step1": {
+        "title": "Tydelig beskrivelse av problemet",
+        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
+      },
+      "step2": {
+        "title": "Installasjonsmetode",
+        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
+      },
+      "step3": {
+        "title": "Systeminformasjon",
+        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
+      },
+      "step4": {
+        "title": "Supportpakke",
+        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
+      }
+    },
+    "openIssue": {
+      "title": "Åpne en GitHub-sak",
+      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
+      "button": "Åpne sak på GitHub"
+    },
+    "supportDump": {
+      "title": "Generer supportpakke",
+      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
+    }
+  },
+  "health": {
+    "title": "Systemhelse",
+    "running": "Kjører diagnostikk...",
+    "lastRun": "Sist kjørt",
+    "refresh": "Oppdater",
+    "exportText": "Kopier rapport",
+    "exportJSON": "Last ned JSON",
+    "copied": "Rapport kopiert til utklippstavle",
+    "duration": "Varighet",
+    "summary": {
+      "healthy": "Frisk",
+      "warnings": "Advarsler",
+      "critical": "Kritisk",
+      "skipped": "Hoppet over",
+      "total": "Totalt sjekker"
+    },
+    "metricFooter": {
+      "allPassing": "Alle godkjent",
+      "needsAttention": "Trenger oppmerksomhet",
+      "failing": "Mislykkes",
+      "allClear": "Alt klart",
+      "noData": "Ingen nylige data",
+      "none": "Ingen"
+    },
+    "diagnostics": "Diagnostikk",
+    "categories": {
+      "system": "System",
+      "audio": "Lydpipeline",
+      "analysis": "Analyse",
+      "streams": "Lydstrømmer",
+      "database": "Database",
+      "network": "Nettverk",
+      "config": "Konfigurasjon",
+      "logs": "Logger"
+    },
+    "status": {
+      "healthy": "Frisk",
+      "warning": "Advarsel",
+      "critical": "Kritisk",
+      "unknown": "Ukjent",
+      "skipped": "Hoppet over"
+    },
+    "errors": {
+      "title": "Nylige feil",
+      "noErrors": "Ingen nylige feil",
+      "fetchFailed": "Innlasting av diagnostikk mislyktes"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go systemhelserapport",
+      "statusLabel": "Status",
+      "timeLabel": "Tid",
+      "durationLabel": "Varighet",
+      "checksLabel": "Sjekker"
+    },
+    "logs": {
+      "topErrors": "Vanligste feilmønstre",
+      "errorCount": "Antall",
+      "errorComponent": "Komponent",
+      "errorLevel": "Nivå",
+      "errorMessage": "Melding"
+    },
+    "window": {
+      "label": "Evalueringsvindu",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1t",
+      "6h": "6t",
+      "24h": "24t",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Siste hendelse",
+      "recentEvents": "Nylige hendelser",
+      "time": "Tid",
+      "source": "Kilde",
+      "count": "Antall",
+      "lifetime": "levetid",
+      "sparklineLabel": "Aktivitetsoversikt",
+      "activeHours": "Aktive timer",
+      "windowTotal": "I vindu",
+      "velocity": "Trend",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Stigende",
+      "velocityDecreasing": "Synkende",
+      "pattern": "Mønster",
+      "patternNone": "Ingen",
+      "patternTransient": "Forbigående",
+      "patternSustained": "Vedvarende"
     }
   }
 }

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -510,9 +510,6 @@
       "sunrise": "Soloppgang +/- 30 min",
       "sunset": "Solnedgang +/- 30 min"
     },
-    "sourceOptions": {
-      "any": "All Sources"
-    },
     "sortOptions": {
       "dateDesc": "Dato (nyeste først)",
       "dateAsc": "Dato (eldste først)",
@@ -524,9 +521,9 @@
       "timeOfDay": "Tidspunkt",
       "species": "Art",
       "confidence": "Sikkerhet",
-      "source": "Source",
       "status": "Status",
-      "actions": "Handlinger"
+      "actions": "Handlinger",
+      "source": "Source"
     },
     "statusBadges": {
       "verified": "Verifisert",
@@ -562,6 +559,9 @@
       "page": "Side {current} av {total}",
       "goToPrevious": "Gå til forrige side",
       "goToNext": "Gå til neste side"
+    },
+    "sourceOptions": {
+      "any": "All Sources"
     }
   },
   "error": {
@@ -598,18 +598,6 @@
       "empty": "Stille — ingen fugler registrert akkurat nå"
     },
     "rejected": "Avvist",
-    "newSpeciesHighlights": {
-      "title": "Nye og tilbakevendende arter",
-      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
-      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
-      "categoryLifetime": "Nye arter",
-      "categoryYear": "Nye i år",
-      "categorySeason": "Nye denne sesongen",
-      "categorySeasonNamed": "Nye i {season}",
-      "maxConfidenceShort": "Maks {confidence}%",
-      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
-      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
-    },
     "dailySummary": {
       "title": "Daglig aktivitet",
       "subtitle": "Artsregistreringer per time",
@@ -776,11 +764,23 @@
     "elements": {
       "banner": "Dashbordbanner",
       "dailySummary": "Daglig sammendrag",
-      "newSpeciesHighlights": "Høydepunkter for nye arter",
       "currentlyHearing": "Hører nå",
       "detectionsGrid": "Siste registreringer",
       "liveSpectrogram": "Direkte spektrogram",
-      "videoEmbed": "Videoinnbygging"
+      "videoEmbed": "Videoinnbygging",
+      "newSpeciesHighlights": "Høydepunkter for nye arter"
+    },
+    "newSpeciesHighlights": {
+      "title": "Nye og tilbakevendende arter",
+      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
+      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
+      "categoryLifetime": "Nye arter",
+      "categoryYear": "Nye i år",
+      "categorySeason": "Nye denne sesongen",
+      "categorySeasonNamed": "Nye i {season}",
+      "maxConfidenceShort": "Maks {confidence}%",
+      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
+      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
     }
   },
   "detections": {
@@ -1641,8 +1641,8 @@
         "dateTime": "Dato og tid",
         "species": "Art",
         "confidence": "Sikkerhet",
-        "source": "Source",
-        "timeOfDay": "Tidspunkt"
+        "timeOfDay": "Tidspunkt",
+        "source": "Source"
       },
       "noRecentDetections": "Ingen siste registreringer funnet",
       "unknownSpecies": "Ukjent",
@@ -1655,6 +1655,22 @@
       "switchToGrid": "Bytt til rutenettvisning",
       "switchToList": "Bytt til listevisning",
       "switchToManage": "Bytt til administrasjonsvisning",
+      "manage": {
+        "headers": {
+          "excluded": "Ekskludert",
+          "included": "Inkludert",
+          "reviewRatio": "Korrekt",
+          "rangeProbability": "Utvalg",
+          "confirmed": "Bekreftet",
+          "actions": "Handlinger"
+        },
+        "delete": "Slett alle registreringer for denne arten",
+        "deleteTitle": "Slett artsregistreringer",
+        "deleteConfirm": "Slett",
+        "deleteMessage": "Slette alle {count} registreringer for {species}? Låste registreringer beholdes.",
+        "deleteWarning": "Dette fjerner registreringene og lydklippene deres permanent og kan ikke angres.",
+        "deleteFailed": "Kunne ikke slette registreringer. Prøv igjen."
+      },
       "noSpeciesFound": "Ingen arter funnet som matcher filtrene dine.",
       "headers": {
         "species": "Art",
@@ -1668,22 +1684,6 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhet:",
         "first": "Første:"
-      },
-      "manage": {
-        "headers": {
-          "excluded": "Ekskludert",
-          "included": "Inkludert",
-          "reviewRatio": "Gjennomgang",
-          "rangeProbability": "Utvalg",
-          "confirmed": "Bekreftet",
-          "actions": "Handlinger"
-        },
-        "delete": "Slett alle registreringer for denne arten",
-        "deleteTitle": "Slett artsregistreringer",
-        "deleteConfirm": "Slett",
-        "deleteMessage": "Slette alle {count} registreringer for {species}? Låste registreringer beholdes.",
-        "deleteWarning": "Dette fjerner registreringene og lydklippene deres permanent og kan ikke angres.",
-        "deleteFailed": "Kunne ikke slette registreringer. Prøv igjen."
       }
     },
     "advanced": {
@@ -3533,6 +3533,7 @@
         "validityHelpText": "Hvor lenge sertifikatet skal være gyldig",
         "validity365d": "1 år",
         "validity730d": "2 år",
+        "validity1825d": "5 år",
         "generateButton": "Generer sertifikat",
         "regenerateButton": "Regenerer sertifikat",
         "generating": "Genererer...",
@@ -3564,7 +3565,6 @@
         "deleteConfirm": "Er du sikker på at du vil fjerne det installerte TLS-sertifikatet? TLS-modusen vil tilbakestilles til Ingen.",
         "restartRequired": "TLS-endringer krever en serveromstart for å ta effekt.",
         "noCertificate": "Ingen sertifikat installert",
-        "validity1825d": "5 år",
         "autoTLSHostRequired": "Et vertsnavn er nødvendig for Let's Encrypt. Skriv inn ditt offentlige domenenavn i Vert-feltet ovenfor.",
         "autoTLSNoIP": "Let's Encrypt krever et domenenavn, ikke en IP-adresse. Skriv inn et offentlig domene som fugler.eksempel.no.",
         "autoTLSNeedsFQDN": "Let's Encrypt krever et fullt kvalifisert domenenavn (f.eks. fugler.eksempel.no), ikke bare et vertsnavn.",
@@ -4165,6 +4165,154 @@
     },
     "restartRequired": "Noen endringer krever en serveromstart for å ta effekt. Start BirdNET-Go på nytt."
   },
+  "analysis": {
+    "title": "Analyse",
+    "tabs": {
+      "settings": "Innstillinger",
+      "models": "Modeller"
+    },
+    "detection": {
+      "title": "Deteksjonsinnstillinger",
+      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
+      "confidenceThreshold": {
+        "label": "Sikkerhetsterskel",
+        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
+      },
+      "batThreshold": {
+        "label": "Flaggermusdeteksjonsterskel",
+        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
+      },
+      "batFilter": {
+        "label": "Høypassfilter for flaggermuslyd",
+        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
+      },
+      "batNighttimeOnly": {
+        "label": "Kun om natten",
+        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
+      },
+      "batUltrasonicFilter": {
+        "label": "Etterdeteksjonsvalidering",
+        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
+      },
+      "batFalsePositiveFilter": {
+        "label": "Falsk positiv-filter for flaggermus",
+        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
+        "levels": {
+          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
+          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
+          "strict": "Maksimal filtrering for høyest nøyaktighet."
+        },
+        "detectionCount": "{count} bekreftelser kreves. {description}",
+        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
+      },
+      "locale": {
+        "label": "Artsspråk",
+        "helpText": "Språk brukt for artsnavnene i grensesnittet."
+      }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
+      "status": {
+        "title": "Utvalgsfilter-oversikt",
+        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
+        "autoSelected": "Automatisk valgt",
+        "manual": "Manuell",
+        "classifier": "Klassifikator",
+        "totalSpecies": "Totalt arter",
+        "withRangeData": "Med utvalgsdata",
+        "withoutRangeData": "Uten utvalgsdata",
+        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
+        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
+        "noFilter": "Ingen aktivt utvalgsfilter",
+        "passUnmapped": {
+          "label": "Tillat arter uten utvalgsdata",
+          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Avansert",
+      "description": "Behandling og egendefinert modellkonfigurasjon."
+    },
+    "gallery": {
+      "title": "Modellgalleri",
+      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
+      "tabs": {
+        "installed": "Installert",
+        "available": "Tilgjengelig"
+      },
+      "loading": "Laster modeller...",
+      "retry": "Prøv igjen",
+      "builtIn": "Innebygd",
+      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
+      "species": "{count} arter",
+      "install": "Installer",
+      "installing": "Installerer...",
+      "remove": "Fjern",
+      "removing": "Fjerner...",
+      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
+      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
+      "sections": {
+        "acoustic": "Akustiske klassifikatorer",
+        "geomodel": "Geomodeller"
+      },
+      "categories": {
+        "wildlife": "Viltklassifikatorer",
+        "bird": "Fugleklassifikatorer",
+        "bat": "Flaggermusklassifikatorer"
+      },
+      "progress": {
+        "downloading": "Laster ned...",
+        "verifying": "Verifiserer...",
+        "loading": "Laster...",
+        "complete": "Installert",
+        "failed": "Mislyktes"
+      },
+      "license": {
+        "title": "Lisensavtale",
+        "model": "Modell",
+        "author": "Forfatter",
+        "license": "Lisens",
+        "commercialUse": "Kommersiell bruk",
+        "downloadSize": "Nedlastingsstørrelse",
+        "allowed": "Tillatt",
+        "notAllowed": "Ikke tillatt",
+        "commercialUseAllowed": "Kommersiell bruk tillatt",
+        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
+        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
+        "acceptAndInstall": "Godta og installer"
+      },
+      "removeDialog": {
+        "title": "Fjerne {name}?",
+        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
+      },
+      "errors": {
+        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
+        "installFailed": "Oppstart av modellinstallasjon mislyktes",
+        "removeFailed": "Fjerning av modell mislyktes"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Arter",
+      "reinstall": "Reinstaller",
+      "reinstalling": "Reinstallerer...",
+      "reinstallComplete": "Filer verifisert",
+      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
+      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
+      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
+      "unavailable": "Ikke tilgjengelig"
+    },
+    "bird": {
+      "title": "Fugledeteksjon",
+      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
+    },
+    "bat": {
+      "title": "Flaggermusdeteksjon",
+      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
+    },
+    "dynamicThreshold": {
+      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
+    }
+  },
   "auth": {
     "login": "Logg inn",
     "logout": "Logg ut",
@@ -4224,6 +4372,315 @@
       "min": "Minimum",
       "max": "Maksimum",
       "count": "Antall"
+    }
+  },
+  "connectivity": {
+    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
+  },
+  "detection": {
+    "actions": {
+      "back": "Tilbake",
+      "review": "Gjennomgå",
+      "download": "Last ned"
+    }
+  },
+  "quietHours": {
+    "indicator": {
+      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
+    }
+  },
+  "restart": {
+    "applicationRestart": "Start applikasjon på nytt",
+    "containerRestart": "Start container på nytt",
+    "confirmTitle": "Bekreft omstart",
+    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "inProgress": "Starter på nytt...",
+    "bannerTitle": "Omstart kreves",
+    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
+    "bannerAction": "Start på nytt nå",
+    "restartFailed": "Oppstart av omstart mislyktes"
+  },
+  "help": {
+    "title": "Hjelp og støtte",
+    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
+    "reportBug": {
+      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
+    },
+    "askQuestion": {
+      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
+    },
+    "diagnostics": {
+      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
+    },
+    "quickLinks": {
+      "title": "Hurtiglenker",
+      "releases": "Versjonsnyheter"
+    }
+  },
+  "reportBug": {
+    "title": "Rapporter en feil",
+    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
+    "systemInfo": {
+      "title": "Din systeminformasjon",
+      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
+      "version": "Versjon",
+      "buildDate": "Byggedato",
+      "os": "Operativsystem",
+      "copy": "Kopier til utklippstavle",
+      "copied": "Kopiert!",
+      "architecture": "Arkitektur",
+      "hardware": "Maskinvare",
+      "environment": "Miljø"
+    },
+    "whatToInclude": {
+      "title": "Hva du bør inkludere i rapporten",
+      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
+      "step1": {
+        "title": "Tydelig beskrivelse av problemet",
+        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
+      },
+      "step2": {
+        "title": "Installasjonsmetode",
+        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
+      },
+      "step3": {
+        "title": "Systeminformasjon",
+        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
+      },
+      "step4": {
+        "title": "Supportpakke",
+        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
+      }
+    },
+    "openIssue": {
+      "title": "Åpne en GitHub-sak",
+      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
+      "button": "Åpne sak på GitHub"
+    },
+    "supportDump": {
+      "title": "Generer supportpakke",
+      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
+    }
+  },
+  "weather": {
+    "moon": {
+      "newMoon": "Nymåne",
+      "waxingCrescent": "Voksende månesigd",
+      "firstQuarter": "Første kvarter",
+      "waxingGibbous": "Voksende måne",
+      "fullMoon": "Fullmåne",
+      "waningGibbous": "Minkende måne",
+      "lastQuarter": "Siste kvarter",
+      "waningCrescent": "Minkende månesigd"
+    },
+    "birding": {
+      "excellent": "Stille — utmerket for å høre fuglekall",
+      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
+      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
+    }
+  },
+  "errors": {
+    "auth": {
+      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
+      "credentialsRequired": "Brukernavn og passord er obligatorisk",
+      "invalidCredentials": "Ugyldige innloggingsdetaljer",
+      "missingCode": "Manglende autorisasjonskode",
+      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
+      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
+      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
+      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
+    },
+    "alert": {
+      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
+      "invalidID": "Ugyldig regel-ID",
+      "notFound": "Varselregel ikke funnet",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "nameRequired": "Regelnavn er obligatorisk",
+      "typesRequired": "Objekttype og utløsertype er obligatorisk",
+      "duplicateName": "En regel med dette navnet finnes allerede",
+      "invalidJSON": "Ugyldig JSON",
+      "invalidEscalation": "Eskaleringstrinn er ugyldige"
+    },
+    "detection": {
+      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
+    },
+    "backup": {
+      "invalidType": "Type må være «legacy» eller «v2»",
+      "alreadyRunning": "Sikkerhetskopi pågår allerede",
+      "dbInfoFailed": "Henting av databaseinfo mislyktes",
+      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
+      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
+      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
+      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
+      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
+      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
+      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
+      "dbNotConfigured": "Database ikke konfigurert",
+      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
+      "v2NotInitialized": "V2-database ikke initialisert"
+    },
+    "migration": {
+      "notConfigured": "Migrering er ikke konfigurert",
+      "preFlightFailed": "Forhåndssjekker mislyktes",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
+      "startFailed": "Oppstart av migrering mislyktes",
+      "initFailed": "Initialisering av migrering mislyktes",
+      "resumeFailed": "Gjenopptak av migrering mislyktes"
+    },
+    "cleanup": {
+      "noLegacyDB": "Ingen eldre database funnet",
+      "accessFailed": "Kan ikke få tilgang til eldre database",
+      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
+      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
+      "noLegacyTables": "Ingen eldre tabeller funnet",
+      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
+      "alreadyRunning": "Opprydding pågår allerede"
+    },
+    "integration": {
+      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
+      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
+      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
+      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
+      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
+      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
+      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
+      "noWeatherProvider": "Ingen værleverandør valgt",
+      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
+      "processorUnavailable": "Prosessor ikke tilgjengelig",
+      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
+    },
+    "notification": {
+      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
+      "idRequired": "Varsel-ID er obligatorisk",
+      "notFound": "Varsel ikke funnet",
+      "hostRequired": "Vert-parameter er obligatorisk",
+      "invalidHost": "Ugyldig vert-parameter",
+      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
+    },
+    "streams": {
+      "test": {
+        "invalidBody": "Ugyldig forespørselskropp",
+        "urlRequired": "Strøm-URL er obligatorisk",
+        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
+        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
+        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
+        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
+        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
+      }
+    },
+    "debug": {
+      "notEnabled": "Feilsøkingsmodus ikke aktivert"
+    },
+    "terminal": {
+      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
+    },
+    "api": {
+      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
+      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
+      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
+      "notFound": "Den forespurte ressursen ble ikke funnet.",
+      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
+      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
+      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
+      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
+      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
+      "unknownError": "En uventet feil oppstod. Prøv igjen.",
+      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
+      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
+      "requestTimeout": "Forespørselen tok for lang tid.",
+      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
+    }
+  },
+  "health": {
+    "title": "Systemhelse",
+    "running": "Kjører diagnostikk...",
+    "lastRun": "Sist kjørt",
+    "refresh": "Oppdater",
+    "exportText": "Kopier rapport",
+    "exportJSON": "Last ned JSON",
+    "copied": "Rapport kopiert til utklippstavle",
+    "duration": "Varighet",
+    "summary": {
+      "healthy": "Frisk",
+      "warnings": "Advarsler",
+      "critical": "Kritisk",
+      "skipped": "Hoppet over",
+      "total": "Totalt sjekker"
+    },
+    "metricFooter": {
+      "allPassing": "Alle godkjent",
+      "needsAttention": "Trenger oppmerksomhet",
+      "failing": "Mislykkes",
+      "allClear": "Alt klart",
+      "noData": "Ingen nylige data",
+      "none": "Ingen"
+    },
+    "diagnostics": "Diagnostikk",
+    "categories": {
+      "system": "System",
+      "audio": "Lydpipeline",
+      "analysis": "Analyse",
+      "streams": "Lydstrømmer",
+      "database": "Database",
+      "network": "Nettverk",
+      "config": "Konfigurasjon",
+      "logs": "Logger"
+    },
+    "status": {
+      "healthy": "Frisk",
+      "warning": "Advarsel",
+      "critical": "Kritisk",
+      "unknown": "Ukjent",
+      "skipped": "Hoppet over"
+    },
+    "errors": {
+      "title": "Nylige feil",
+      "noErrors": "Ingen nylige feil",
+      "fetchFailed": "Innlasting av diagnostikk mislyktes"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go systemhelserapport",
+      "statusLabel": "Status",
+      "timeLabel": "Tid",
+      "durationLabel": "Varighet",
+      "checksLabel": "Sjekker"
+    },
+    "logs": {
+      "topErrors": "Vanligste feilmønstre",
+      "errorCount": "Antall",
+      "errorComponent": "Komponent",
+      "errorLevel": "Nivå",
+      "errorMessage": "Melding"
+    },
+    "window": {
+      "label": "Evalueringsvindu",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1t",
+      "6h": "6t",
+      "24h": "24t",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Siste hendelse",
+      "recentEvents": "Nylige hendelser",
+      "time": "Tid",
+      "source": "Kilde",
+      "count": "Antall",
+      "lifetime": "levetid",
+      "sparklineLabel": "Aktivitetsoversikt",
+      "activeHours": "Aktive timer",
+      "windowTotal": "I vindu",
+      "velocity": "Trend",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Stigende",
+      "velocityDecreasing": "Synkende",
+      "pattern": "Mønster",
+      "patternNone": "Ingen",
+      "patternTransient": "Forbigående",
+      "patternSustained": "Vedvarende"
     }
   },
   "forms": {
@@ -4494,151 +4951,6 @@
       "clickToView": "Click to view detections"
     }
   },
-  "connectivity": {
-    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
-  },
-  "detection": {
-    "actions": {
-      "back": "Tilbake",
-      "review": "Gjennomgå",
-      "download": "Last ned"
-    }
-  },
-  "quietHours": {
-    "indicator": {
-      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
-    }
-  },
-  "errors": {
-    "auth": {
-      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
-      "credentialsRequired": "Brukernavn og passord er obligatorisk",
-      "invalidCredentials": "Ugyldige innloggingsdetaljer",
-      "missingCode": "Manglende autorisasjonskode",
-      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
-      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
-      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
-      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
-    },
-    "alert": {
-      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
-      "invalidID": "Ugyldig regel-ID",
-      "notFound": "Varselregel ikke funnet",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "nameRequired": "Regelnavn er obligatorisk",
-      "typesRequired": "Objekttype og utløsertype er obligatorisk",
-      "duplicateName": "En regel med dette navnet finnes allerede",
-      "invalidJSON": "Ugyldig JSON",
-      "invalidEscalation": "Eskaleringstrinn er ugyldige"
-    },
-    "detection": {
-      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
-    },
-    "backup": {
-      "invalidType": "Type må være «legacy» eller «v2»",
-      "alreadyRunning": "Sikkerhetskopi pågår allerede",
-      "dbInfoFailed": "Henting av databaseinfo mislyktes",
-      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
-      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
-      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
-      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
-      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
-      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
-      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
-      "dbNotConfigured": "Database ikke konfigurert",
-      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
-      "v2NotInitialized": "V2-database ikke initialisert"
-    },
-    "migration": {
-      "notConfigured": "Migrering er ikke konfigurert",
-      "preFlightFailed": "Forhåndssjekker mislyktes",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
-      "startFailed": "Oppstart av migrering mislyktes",
-      "initFailed": "Initialisering av migrering mislyktes",
-      "resumeFailed": "Gjenopptak av migrering mislyktes"
-    },
-    "cleanup": {
-      "noLegacyDB": "Ingen eldre database funnet",
-      "accessFailed": "Kan ikke få tilgang til eldre database",
-      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
-      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
-      "noLegacyTables": "Ingen eldre tabeller funnet",
-      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
-      "alreadyRunning": "Opprydding pågår allerede"
-    },
-    "integration": {
-      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
-      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
-      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
-      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
-      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
-      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
-      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
-      "noWeatherProvider": "Ingen værleverandør valgt",
-      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
-      "processorUnavailable": "Prosessor ikke tilgjengelig",
-      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
-    },
-    "notification": {
-      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
-      "idRequired": "Varsel-ID er obligatorisk",
-      "notFound": "Varsel ikke funnet",
-      "hostRequired": "Vert-parameter er obligatorisk",
-      "invalidHost": "Ugyldig vert-parameter",
-      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
-    },
-    "streams": {
-      "test": {
-        "invalidBody": "Ugyldig forespørselskropp",
-        "urlRequired": "Strøm-URL er obligatorisk",
-        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
-        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
-        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
-        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
-        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
-      }
-    },
-    "debug": {
-      "notEnabled": "Feilsøkingsmodus ikke aktivert"
-    },
-    "terminal": {
-      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
-    },
-    "api": {
-      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
-      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
-      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
-      "notFound": "Den forespurte ressursen ble ikke funnet.",
-      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
-      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
-      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
-      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
-      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
-      "unknownError": "En uventet feil oppstod. Prøv igjen.",
-      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
-      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
-      "requestTimeout": "Forespørselen tok for lang tid.",
-      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
-    }
-  },
-  "weather": {
-    "moon": {
-      "newMoon": "Nymåne",
-      "waxingCrescent": "Voksende månesigd",
-      "firstQuarter": "Første kvarter",
-      "waxingGibbous": "Voksende måne",
-      "fullMoon": "Fullmåne",
-      "waningGibbous": "Minkende måne",
-      "lastQuarter": "Siste kvarter",
-      "waningCrescent": "Minkende månesigd"
-    },
-    "birding": {
-      "excellent": "Stille — utmerket for å høre fuglekall",
-      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
-      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
-    }
-  },
   "wizard": {
     "skip": "Hopp over",
     "back": "Tilbake",
@@ -4730,318 +5042,6 @@
         "outro": "Denne tilnærmingen sikrer datakvalitet for vitenskapelig forskning og maksimerer din glede av og lærdom om fugler.",
         "acknowledge": "Jeg forstår"
       }
-    }
-  },
-  "analysis": {
-    "title": "Analyse",
-    "tabs": {
-      "settings": "Innstillinger",
-      "models": "Modeller"
-    },
-    "detection": {
-      "title": "Deteksjonsinnstillinger",
-      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
-      "confidenceThreshold": {
-        "label": "Sikkerhetsterskel",
-        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
-      },
-      "batThreshold": {
-        "label": "Flaggermusdeteksjonsterskel",
-        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
-      },
-      "batFilter": {
-        "label": "Høypassfilter for flaggermuslyd",
-        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
-      },
-      "batNighttimeOnly": {
-        "label": "Kun om natten",
-        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
-      },
-      "batUltrasonicFilter": {
-        "label": "Etterdeteksjonsvalidering",
-        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
-      },
-      "batFalsePositiveFilter": {
-        "label": "Falsk positiv-filter for flaggermus",
-        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
-        "levels": {
-          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
-          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
-          "strict": "Maksimal filtrering for høyest nøyaktighet."
-        },
-        "detectionCount": "{count} bekreftelser kreves. {description}",
-        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
-      },
-      "locale": {
-        "label": "Artsspråk",
-        "helpText": "Språk brukt for artsnavnene i grensesnittet."
-      }
-    },
-    "rangeFilter": {
-      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
-      "status": {
-        "title": "Utvalgsfilter-oversikt",
-        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
-        "autoSelected": "Automatisk valgt",
-        "manual": "Manuell",
-        "classifier": "Klassifikator",
-        "totalSpecies": "Totalt arter",
-        "withRangeData": "Med utvalgsdata",
-        "withoutRangeData": "Uten utvalgsdata",
-        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
-        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
-        "noFilter": "Ingen aktivt utvalgsfilter",
-        "passUnmapped": {
-          "label": "Tillat arter uten utvalgsdata",
-          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
-        }
-      }
-    },
-    "advanced": {
-      "title": "Avansert",
-      "description": "Behandling og egendefinert modellkonfigurasjon."
-    },
-    "gallery": {
-      "title": "Modellgalleri",
-      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
-      "tabs": {
-        "installed": "Installert",
-        "available": "Tilgjengelig"
-      },
-      "loading": "Laster modeller...",
-      "retry": "Prøv igjen",
-      "builtIn": "Innebygd",
-      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
-      "species": "{count} arter",
-      "install": "Installer",
-      "installing": "Installerer...",
-      "remove": "Fjern",
-      "removing": "Fjerner...",
-      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
-      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
-      "sections": {
-        "acoustic": "Akustiske klassifikatorer",
-        "geomodel": "Geomodeller"
-      },
-      "categories": {
-        "wildlife": "Viltklassifikatorer",
-        "bird": "Fugleklassifikatorer",
-        "bat": "Flaggermusklassifikatorer"
-      },
-      "progress": {
-        "downloading": "Laster ned...",
-        "verifying": "Verifiserer...",
-        "loading": "Laster...",
-        "complete": "Installert",
-        "failed": "Mislyktes"
-      },
-      "license": {
-        "title": "Lisensavtale",
-        "model": "Modell",
-        "author": "Forfatter",
-        "license": "Lisens",
-        "commercialUse": "Kommersiell bruk",
-        "downloadSize": "Nedlastingsstørrelse",
-        "allowed": "Tillatt",
-        "notAllowed": "Ikke tillatt",
-        "commercialUseAllowed": "Kommersiell bruk tillatt",
-        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
-        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
-        "acceptAndInstall": "Godta og installer"
-      },
-      "removeDialog": {
-        "title": "Fjerne {name}?",
-        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
-      },
-      "errors": {
-        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
-        "installFailed": "Oppstart av modellinstallasjon mislyktes",
-        "removeFailed": "Fjerning av modell mislyktes"
-      },
-      "regionLabel": "Region",
-      "speciesLabel": "Arter",
-      "reinstall": "Reinstaller",
-      "reinstalling": "Reinstallerer...",
-      "reinstallComplete": "Filer verifisert",
-      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
-      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
-      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
-      "unavailable": "Ikke tilgjengelig"
-    },
-    "bird": {
-      "title": "Fugledeteksjon",
-      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
-    },
-    "bat": {
-      "title": "Flaggermusdeteksjon",
-      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
-    },
-    "dynamicThreshold": {
-      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
-    }
-  },
-  "restart": {
-    "applicationRestart": "Start applikasjon på nytt",
-    "containerRestart": "Start container på nytt",
-    "confirmTitle": "Bekreft omstart",
-    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "inProgress": "Starter på nytt...",
-    "bannerTitle": "Omstart kreves",
-    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
-    "bannerAction": "Start på nytt nå",
-    "restartFailed": "Oppstart av omstart mislyktes"
-  },
-  "help": {
-    "title": "Hjelp og støtte",
-    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
-    "reportBug": {
-      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
-    },
-    "askQuestion": {
-      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
-    },
-    "diagnostics": {
-      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
-    },
-    "quickLinks": {
-      "title": "Hurtiglenker",
-      "releases": "Versjonsnyheter"
-    }
-  },
-  "reportBug": {
-    "title": "Rapporter en feil",
-    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
-    "systemInfo": {
-      "title": "Din systeminformasjon",
-      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
-      "version": "Versjon",
-      "buildDate": "Byggedato",
-      "os": "Operativsystem",
-      "copy": "Kopier til utklippstavle",
-      "copied": "Kopiert!",
-      "architecture": "Arkitektur",
-      "hardware": "Maskinvare",
-      "environment": "Miljø"
-    },
-    "whatToInclude": {
-      "title": "Hva du bør inkludere i rapporten",
-      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
-      "step1": {
-        "title": "Tydelig beskrivelse av problemet",
-        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
-      },
-      "step2": {
-        "title": "Installasjonsmetode",
-        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
-      },
-      "step3": {
-        "title": "Systeminformasjon",
-        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
-      },
-      "step4": {
-        "title": "Supportpakke",
-        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
-      }
-    },
-    "openIssue": {
-      "title": "Åpne en GitHub-sak",
-      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
-      "button": "Åpne sak på GitHub"
-    },
-    "supportDump": {
-      "title": "Generer supportpakke",
-      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
-    }
-  },
-  "health": {
-    "title": "Systemhelse",
-    "running": "Kjører diagnostikk...",
-    "lastRun": "Sist kjørt",
-    "refresh": "Oppdater",
-    "exportText": "Kopier rapport",
-    "exportJSON": "Last ned JSON",
-    "copied": "Rapport kopiert til utklippstavle",
-    "duration": "Varighet",
-    "summary": {
-      "healthy": "Frisk",
-      "warnings": "Advarsler",
-      "critical": "Kritisk",
-      "skipped": "Hoppet over",
-      "total": "Totalt sjekker"
-    },
-    "metricFooter": {
-      "allPassing": "Alle godkjent",
-      "needsAttention": "Trenger oppmerksomhet",
-      "failing": "Mislykkes",
-      "allClear": "Alt klart",
-      "noData": "Ingen nylige data",
-      "none": "Ingen"
-    },
-    "diagnostics": "Diagnostikk",
-    "categories": {
-      "system": "System",
-      "audio": "Lydpipeline",
-      "analysis": "Analyse",
-      "streams": "Lydstrømmer",
-      "database": "Database",
-      "network": "Nettverk",
-      "config": "Konfigurasjon",
-      "logs": "Logger"
-    },
-    "status": {
-      "healthy": "Frisk",
-      "warning": "Advarsel",
-      "critical": "Kritisk",
-      "unknown": "Ukjent",
-      "skipped": "Hoppet over"
-    },
-    "errors": {
-      "title": "Nylige feil",
-      "noErrors": "Ingen nylige feil",
-      "fetchFailed": "Innlasting av diagnostikk mislyktes"
-    },
-    "export": {
-      "reportTitle": "BirdNET-Go systemhelserapport",
-      "statusLabel": "Status",
-      "timeLabel": "Tid",
-      "durationLabel": "Varighet",
-      "checksLabel": "Sjekker"
-    },
-    "logs": {
-      "topErrors": "Vanligste feilmønstre",
-      "errorCount": "Antall",
-      "errorComponent": "Komponent",
-      "errorLevel": "Nivå",
-      "errorMessage": "Melding"
-    },
-    "window": {
-      "label": "Evalueringsvindu",
-      "15m": "15m",
-      "30m": "30m",
-      "1h": "1t",
-      "6h": "6t",
-      "24h": "24t",
-      "7d": "7d"
-    },
-    "detail": {
-      "lastEvent": "Siste hendelse",
-      "recentEvents": "Nylige hendelser",
-      "time": "Tid",
-      "source": "Kilde",
-      "count": "Antall",
-      "lifetime": "levetid",
-      "sparklineLabel": "Aktivitetsoversikt",
-      "activeHours": "Aktive timer",
-      "windowTotal": "I vindu",
-      "velocity": "Trend",
-      "velocityStable": "Stabil",
-      "velocityIncreasing": "Stigende",
-      "velocityDecreasing": "Synkende",
-      "pattern": "Mønster",
-      "patternNone": "Ingen",
-      "patternTransient": "Forbigående",
-      "patternSustained": "Vedvarende"
     }
   }
 }

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -510,9 +510,6 @@
       "sunrise": "Soloppgang +/- 30 min",
       "sunset": "Solnedgang +/- 30 min"
     },
-    "sourceOptions": {
-      "any": "All Sources"
-    },
     "sortOptions": {
       "dateDesc": "Dato (nyeste først)",
       "dateAsc": "Dato (eldste først)",
@@ -524,9 +521,9 @@
       "timeOfDay": "Tidspunkt",
       "species": "Art",
       "confidence": "Sikkerhet",
-      "source": "Source",
       "status": "Status",
-      "actions": "Handlinger"
+      "actions": "Handlinger",
+      "source": "Source"
     },
     "statusBadges": {
       "verified": "Verifisert",
@@ -562,6 +559,9 @@
       "page": "Side {current} av {total}",
       "goToPrevious": "Gå til forrige side",
       "goToNext": "Gå til neste side"
+    },
+    "sourceOptions": {
+      "any": "All Sources"
     }
   },
   "error": {
@@ -598,18 +598,6 @@
       "empty": "Stille — ingen fugler registrert akkurat nå"
     },
     "rejected": "Avvist",
-    "newSpeciesHighlights": {
-      "title": "Nye og tilbakevendende arter",
-      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
-      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
-      "categoryLifetime": "Nye arter",
-      "categoryYear": "Nye i år",
-      "categorySeason": "Nye denne sesongen",
-      "categorySeasonNamed": "Nye i {season}",
-      "maxConfidenceShort": "Maks {confidence}%",
-      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
-      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
-    },
     "dailySummary": {
       "title": "Daglig aktivitet",
       "subtitle": "Artsregistreringer per time",
@@ -776,11 +764,23 @@
     "elements": {
       "banner": "Dashbordbanner",
       "dailySummary": "Daglig sammendrag",
-      "newSpeciesHighlights": "Høydepunkter for nye arter",
       "currentlyHearing": "Hører nå",
       "detectionsGrid": "Siste registreringer",
       "liveSpectrogram": "Direkte spektrogram",
-      "videoEmbed": "Videoinnbygging"
+      "videoEmbed": "Videoinnbygging",
+      "newSpeciesHighlights": "Høydepunkter for nye arter"
+    },
+    "newSpeciesHighlights": {
+      "title": "Nye og tilbakevendende arter",
+      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
+      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
+      "categoryLifetime": "Nye arter",
+      "categoryYear": "Nye i år",
+      "categorySeason": "Nye denne sesongen",
+      "categorySeasonNamed": "Nye i {season}",
+      "maxConfidenceShort": "Maks {confidence}%",
+      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
+      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
     }
   },
   "detections": {
@@ -1641,8 +1641,8 @@
         "dateTime": "Dato og tid",
         "species": "Art",
         "confidence": "Sikkerhet",
-        "source": "Source",
-        "timeOfDay": "Tidspunkt"
+        "timeOfDay": "Tidspunkt",
+        "source": "Source"
       },
       "noRecentDetections": "Ingen siste registreringer funnet",
       "unknownSpecies": "Ukjent",
@@ -1668,6 +1668,7 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhet:",
         "first": "Første:"
+      }
       },
       "manage": {
         "headers": {
@@ -1684,7 +1685,6 @@
         "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
         "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
         "deleteFailed": "Failed to delete detections. Please try again."
-      }
     },
     "advanced": {
       "title": "Avansert analyse",
@@ -3533,6 +3533,7 @@
         "validityHelpText": "Hvor lenge sertifikatet skal være gyldig",
         "validity365d": "1 år",
         "validity730d": "2 år",
+        "validity1825d": "5 år",
         "generateButton": "Generer sertifikat",
         "regenerateButton": "Regenerer sertifikat",
         "generating": "Genererer...",
@@ -3564,7 +3565,6 @@
         "deleteConfirm": "Er du sikker på at du vil fjerne det installerte TLS-sertifikatet? TLS-modusen vil tilbakestilles til Ingen.",
         "restartRequired": "TLS-endringer krever en serveromstart for å ta effekt.",
         "noCertificate": "Ingen sertifikat installert",
-        "validity1825d": "5 år",
         "autoTLSHostRequired": "Et vertsnavn er nødvendig for Let's Encrypt. Skriv inn ditt offentlige domenenavn i Vert-feltet ovenfor.",
         "autoTLSNoIP": "Let's Encrypt krever et domenenavn, ikke en IP-adresse. Skriv inn et offentlig domene som fugler.eksempel.no.",
         "autoTLSNeedsFQDN": "Let's Encrypt krever et fullt kvalifisert domenenavn (f.eks. fugler.eksempel.no), ikke bare et vertsnavn.",
@@ -4165,6 +4165,154 @@
     },
     "restartRequired": "Noen endringer krever en serveromstart for å ta effekt. Start BirdNET-Go på nytt."
   },
+  "analysis": {
+    "title": "Analyse",
+    "tabs": {
+      "settings": "Innstillinger",
+      "models": "Modeller"
+    },
+    "detection": {
+      "title": "Deteksjonsinnstillinger",
+      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
+      "confidenceThreshold": {
+        "label": "Sikkerhetsterskel",
+        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
+      },
+      "batThreshold": {
+        "label": "Flaggermusdeteksjonsterskel",
+        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
+      },
+      "batFilter": {
+        "label": "Høypassfilter for flaggermuslyd",
+        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
+      },
+      "batNighttimeOnly": {
+        "label": "Kun om natten",
+        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
+      },
+      "batUltrasonicFilter": {
+        "label": "Etterdeteksjonsvalidering",
+        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
+      },
+      "batFalsePositiveFilter": {
+        "label": "Falsk positiv-filter for flaggermus",
+        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
+        "levels": {
+          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
+          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
+          "strict": "Maksimal filtrering for høyest nøyaktighet."
+        },
+        "detectionCount": "{count} bekreftelser kreves. {description}",
+        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
+      },
+      "locale": {
+        "label": "Artsspråk",
+        "helpText": "Språk brukt for artsnavnene i grensesnittet."
+      }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
+      "status": {
+        "title": "Utvalgsfilter-oversikt",
+        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
+        "autoSelected": "Automatisk valgt",
+        "manual": "Manuell",
+        "classifier": "Klassifikator",
+        "totalSpecies": "Totalt arter",
+        "withRangeData": "Med utvalgsdata",
+        "withoutRangeData": "Uten utvalgsdata",
+        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
+        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
+        "noFilter": "Ingen aktivt utvalgsfilter",
+        "passUnmapped": {
+          "label": "Tillat arter uten utvalgsdata",
+          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Avansert",
+      "description": "Behandling og egendefinert modellkonfigurasjon."
+    },
+    "gallery": {
+      "title": "Modellgalleri",
+      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
+      "tabs": {
+        "installed": "Installert",
+        "available": "Tilgjengelig"
+      },
+      "loading": "Laster modeller...",
+      "retry": "Prøv igjen",
+      "builtIn": "Innebygd",
+      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
+      "species": "{count} arter",
+      "install": "Installer",
+      "installing": "Installerer...",
+      "remove": "Fjern",
+      "removing": "Fjerner...",
+      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
+      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
+      "sections": {
+        "acoustic": "Akustiske klassifikatorer",
+        "geomodel": "Geomodeller"
+      },
+      "categories": {
+        "wildlife": "Viltklassifikatorer",
+        "bird": "Fugleklassifikatorer",
+        "bat": "Flaggermusklassifikatorer"
+      },
+      "progress": {
+        "downloading": "Laster ned...",
+        "verifying": "Verifiserer...",
+        "loading": "Laster...",
+        "complete": "Installert",
+        "failed": "Mislyktes"
+      },
+      "license": {
+        "title": "Lisensavtale",
+        "model": "Modell",
+        "author": "Forfatter",
+        "license": "Lisens",
+        "commercialUse": "Kommersiell bruk",
+        "downloadSize": "Nedlastingsstørrelse",
+        "allowed": "Tillatt",
+        "notAllowed": "Ikke tillatt",
+        "commercialUseAllowed": "Kommersiell bruk tillatt",
+        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
+        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
+        "acceptAndInstall": "Godta og installer"
+      },
+      "removeDialog": {
+        "title": "Fjerne {name}?",
+        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
+      },
+      "errors": {
+        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
+        "installFailed": "Oppstart av modellinstallasjon mislyktes",
+        "removeFailed": "Fjerning av modell mislyktes"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Arter",
+      "reinstall": "Reinstaller",
+      "reinstalling": "Reinstallerer...",
+      "reinstallComplete": "Filer verifisert",
+      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
+      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
+      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
+      "unavailable": "Ikke tilgjengelig"
+    },
+    "bird": {
+      "title": "Fugledeteksjon",
+      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
+    },
+    "bat": {
+      "title": "Flaggermusdeteksjon",
+      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
+    },
+    "dynamicThreshold": {
+      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
+    }
+  },
   "auth": {
     "login": "Logg inn",
     "logout": "Logg ut",
@@ -4224,6 +4372,315 @@
       "min": "Minimum",
       "max": "Maksimum",
       "count": "Antall"
+    }
+  },
+  "connectivity": {
+    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
+  },
+  "detection": {
+    "actions": {
+      "back": "Tilbake",
+      "review": "Gjennomgå",
+      "download": "Last ned"
+    }
+  },
+  "quietHours": {
+    "indicator": {
+      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
+    }
+  },
+  "restart": {
+    "applicationRestart": "Start applikasjon på nytt",
+    "containerRestart": "Start container på nytt",
+    "confirmTitle": "Bekreft omstart",
+    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "inProgress": "Starter på nytt...",
+    "bannerTitle": "Omstart kreves",
+    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
+    "bannerAction": "Start på nytt nå",
+    "restartFailed": "Oppstart av omstart mislyktes"
+  },
+  "help": {
+    "title": "Hjelp og støtte",
+    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
+    "reportBug": {
+      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
+    },
+    "askQuestion": {
+      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
+    },
+    "diagnostics": {
+      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
+    },
+    "quickLinks": {
+      "title": "Hurtiglenker",
+      "releases": "Versjonsnyheter"
+    }
+  },
+  "reportBug": {
+    "title": "Rapporter en feil",
+    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
+    "systemInfo": {
+      "title": "Din systeminformasjon",
+      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
+      "version": "Versjon",
+      "buildDate": "Byggedato",
+      "os": "Operativsystem",
+      "copy": "Kopier til utklippstavle",
+      "copied": "Kopiert!",
+      "architecture": "Arkitektur",
+      "hardware": "Maskinvare",
+      "environment": "Miljø"
+    },
+    "whatToInclude": {
+      "title": "Hva du bør inkludere i rapporten",
+      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
+      "step1": {
+        "title": "Tydelig beskrivelse av problemet",
+        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
+      },
+      "step2": {
+        "title": "Installasjonsmetode",
+        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
+      },
+      "step3": {
+        "title": "Systeminformasjon",
+        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
+      },
+      "step4": {
+        "title": "Supportpakke",
+        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
+      }
+    },
+    "openIssue": {
+      "title": "Åpne en GitHub-sak",
+      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
+      "button": "Åpne sak på GitHub"
+    },
+    "supportDump": {
+      "title": "Generer supportpakke",
+      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
+    }
+  },
+  "weather": {
+    "moon": {
+      "newMoon": "Nymåne",
+      "waxingCrescent": "Voksende månesigd",
+      "firstQuarter": "Første kvarter",
+      "waxingGibbous": "Voksende måne",
+      "fullMoon": "Fullmåne",
+      "waningGibbous": "Minkende måne",
+      "lastQuarter": "Siste kvarter",
+      "waningCrescent": "Minkende månesigd"
+    },
+    "birding": {
+      "excellent": "Stille — utmerket for å høre fuglekall",
+      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
+      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
+    }
+  },
+  "errors": {
+    "auth": {
+      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
+      "credentialsRequired": "Brukernavn og passord er obligatorisk",
+      "invalidCredentials": "Ugyldige innloggingsdetaljer",
+      "missingCode": "Manglende autorisasjonskode",
+      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
+      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
+      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
+      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
+    },
+    "alert": {
+      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
+      "invalidID": "Ugyldig regel-ID",
+      "notFound": "Varselregel ikke funnet",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "nameRequired": "Regelnavn er obligatorisk",
+      "typesRequired": "Objekttype og utløsertype er obligatorisk",
+      "duplicateName": "En regel med dette navnet finnes allerede",
+      "invalidJSON": "Ugyldig JSON",
+      "invalidEscalation": "Eskaleringstrinn er ugyldige"
+    },
+    "detection": {
+      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
+    },
+    "backup": {
+      "invalidType": "Type må være «legacy» eller «v2»",
+      "alreadyRunning": "Sikkerhetskopi pågår allerede",
+      "dbInfoFailed": "Henting av databaseinfo mislyktes",
+      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
+      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
+      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
+      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
+      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
+      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
+      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
+      "dbNotConfigured": "Database ikke konfigurert",
+      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
+      "v2NotInitialized": "V2-database ikke initialisert"
+    },
+    "migration": {
+      "notConfigured": "Migrering er ikke konfigurert",
+      "preFlightFailed": "Forhåndssjekker mislyktes",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
+      "startFailed": "Oppstart av migrering mislyktes",
+      "initFailed": "Initialisering av migrering mislyktes",
+      "resumeFailed": "Gjenopptak av migrering mislyktes"
+    },
+    "cleanup": {
+      "noLegacyDB": "Ingen eldre database funnet",
+      "accessFailed": "Kan ikke få tilgang til eldre database",
+      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
+      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
+      "noLegacyTables": "Ingen eldre tabeller funnet",
+      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
+      "alreadyRunning": "Opprydding pågår allerede"
+    },
+    "integration": {
+      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
+      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
+      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
+      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
+      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
+      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
+      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
+      "noWeatherProvider": "Ingen værleverandør valgt",
+      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
+      "processorUnavailable": "Prosessor ikke tilgjengelig",
+      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
+    },
+    "notification": {
+      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
+      "idRequired": "Varsel-ID er obligatorisk",
+      "notFound": "Varsel ikke funnet",
+      "hostRequired": "Vert-parameter er obligatorisk",
+      "invalidHost": "Ugyldig vert-parameter",
+      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
+    },
+    "streams": {
+      "test": {
+        "invalidBody": "Ugyldig forespørselskropp",
+        "urlRequired": "Strøm-URL er obligatorisk",
+        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
+        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
+        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
+        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
+        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
+      }
+    },
+    "debug": {
+      "notEnabled": "Feilsøkingsmodus ikke aktivert"
+    },
+    "terminal": {
+      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
+    },
+    "api": {
+      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
+      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
+      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
+      "notFound": "Den forespurte ressursen ble ikke funnet.",
+      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
+      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
+      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
+      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
+      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
+      "unknownError": "En uventet feil oppstod. Prøv igjen.",
+      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
+      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
+      "requestTimeout": "Forespørselen tok for lang tid.",
+      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
+    }
+  },
+  "health": {
+    "title": "Systemhelse",
+    "running": "Kjører diagnostikk...",
+    "lastRun": "Sist kjørt",
+    "refresh": "Oppdater",
+    "exportText": "Kopier rapport",
+    "exportJSON": "Last ned JSON",
+    "copied": "Rapport kopiert til utklippstavle",
+    "duration": "Varighet",
+    "summary": {
+      "healthy": "Frisk",
+      "warnings": "Advarsler",
+      "critical": "Kritisk",
+      "skipped": "Hoppet over",
+      "total": "Totalt sjekker"
+    },
+    "metricFooter": {
+      "allPassing": "Alle godkjent",
+      "needsAttention": "Trenger oppmerksomhet",
+      "failing": "Mislykkes",
+      "allClear": "Alt klart",
+      "noData": "Ingen nylige data",
+      "none": "Ingen"
+    },
+    "diagnostics": "Diagnostikk",
+    "categories": {
+      "system": "System",
+      "audio": "Lydpipeline",
+      "analysis": "Analyse",
+      "streams": "Lydstrømmer",
+      "database": "Database",
+      "network": "Nettverk",
+      "config": "Konfigurasjon",
+      "logs": "Logger"
+    },
+    "status": {
+      "healthy": "Frisk",
+      "warning": "Advarsel",
+      "critical": "Kritisk",
+      "unknown": "Ukjent",
+      "skipped": "Hoppet over"
+    },
+    "errors": {
+      "title": "Nylige feil",
+      "noErrors": "Ingen nylige feil",
+      "fetchFailed": "Innlasting av diagnostikk mislyktes"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go systemhelserapport",
+      "statusLabel": "Status",
+      "timeLabel": "Tid",
+      "durationLabel": "Varighet",
+      "checksLabel": "Sjekker"
+    },
+    "logs": {
+      "topErrors": "Vanligste feilmønstre",
+      "errorCount": "Antall",
+      "errorComponent": "Komponent",
+      "errorLevel": "Nivå",
+      "errorMessage": "Melding"
+    },
+    "window": {
+      "label": "Evalueringsvindu",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1t",
+      "6h": "6t",
+      "24h": "24t",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Siste hendelse",
+      "recentEvents": "Nylige hendelser",
+      "time": "Tid",
+      "source": "Kilde",
+      "count": "Antall",
+      "lifetime": "levetid",
+      "sparklineLabel": "Aktivitetsoversikt",
+      "activeHours": "Aktive timer",
+      "windowTotal": "I vindu",
+      "velocity": "Trend",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Stigende",
+      "velocityDecreasing": "Synkende",
+      "pattern": "Mønster",
+      "patternNone": "Ingen",
+      "patternTransient": "Forbigående",
+      "patternSustained": "Vedvarende"
     }
   },
   "forms": {
@@ -4494,151 +4951,6 @@
       "clickToView": "Click to view detections"
     }
   },
-  "connectivity": {
-    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
-  },
-  "detection": {
-    "actions": {
-      "back": "Tilbake",
-      "review": "Gjennomgå",
-      "download": "Last ned"
-    }
-  },
-  "quietHours": {
-    "indicator": {
-      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
-    }
-  },
-  "errors": {
-    "auth": {
-      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
-      "credentialsRequired": "Brukernavn og passord er obligatorisk",
-      "invalidCredentials": "Ugyldige innloggingsdetaljer",
-      "missingCode": "Manglende autorisasjonskode",
-      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
-      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
-      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
-      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
-    },
-    "alert": {
-      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
-      "invalidID": "Ugyldig regel-ID",
-      "notFound": "Varselregel ikke funnet",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "nameRequired": "Regelnavn er obligatorisk",
-      "typesRequired": "Objekttype og utløsertype er obligatorisk",
-      "duplicateName": "En regel med dette navnet finnes allerede",
-      "invalidJSON": "Ugyldig JSON",
-      "invalidEscalation": "Eskaleringstrinn er ugyldige"
-    },
-    "detection": {
-      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
-    },
-    "backup": {
-      "invalidType": "Type må være «legacy» eller «v2»",
-      "alreadyRunning": "Sikkerhetskopi pågår allerede",
-      "dbInfoFailed": "Henting av databaseinfo mislyktes",
-      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
-      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
-      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
-      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
-      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
-      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
-      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
-      "dbNotConfigured": "Database ikke konfigurert",
-      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
-      "v2NotInitialized": "V2-database ikke initialisert"
-    },
-    "migration": {
-      "notConfigured": "Migrering er ikke konfigurert",
-      "preFlightFailed": "Forhåndssjekker mislyktes",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
-      "startFailed": "Oppstart av migrering mislyktes",
-      "initFailed": "Initialisering av migrering mislyktes",
-      "resumeFailed": "Gjenopptak av migrering mislyktes"
-    },
-    "cleanup": {
-      "noLegacyDB": "Ingen eldre database funnet",
-      "accessFailed": "Kan ikke få tilgang til eldre database",
-      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
-      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
-      "noLegacyTables": "Ingen eldre tabeller funnet",
-      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
-      "alreadyRunning": "Opprydding pågår allerede"
-    },
-    "integration": {
-      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
-      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
-      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
-      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
-      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
-      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
-      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
-      "noWeatherProvider": "Ingen værleverandør valgt",
-      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
-      "processorUnavailable": "Prosessor ikke tilgjengelig",
-      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
-    },
-    "notification": {
-      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
-      "idRequired": "Varsel-ID er obligatorisk",
-      "notFound": "Varsel ikke funnet",
-      "hostRequired": "Vert-parameter er obligatorisk",
-      "invalidHost": "Ugyldig vert-parameter",
-      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
-    },
-    "streams": {
-      "test": {
-        "invalidBody": "Ugyldig forespørselskropp",
-        "urlRequired": "Strøm-URL er obligatorisk",
-        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
-        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
-        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
-        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
-        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
-      }
-    },
-    "debug": {
-      "notEnabled": "Feilsøkingsmodus ikke aktivert"
-    },
-    "terminal": {
-      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
-    },
-    "api": {
-      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
-      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
-      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
-      "notFound": "Den forespurte ressursen ble ikke funnet.",
-      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
-      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
-      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
-      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
-      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
-      "unknownError": "En uventet feil oppstod. Prøv igjen.",
-      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
-      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
-      "requestTimeout": "Forespørselen tok for lang tid.",
-      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
-    }
-  },
-  "weather": {
-    "moon": {
-      "newMoon": "Nymåne",
-      "waxingCrescent": "Voksende månesigd",
-      "firstQuarter": "Første kvarter",
-      "waxingGibbous": "Voksende måne",
-      "fullMoon": "Fullmåne",
-      "waningGibbous": "Minkende måne",
-      "lastQuarter": "Siste kvarter",
-      "waningCrescent": "Minkende månesigd"
-    },
-    "birding": {
-      "excellent": "Stille — utmerket for å høre fuglekall",
-      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
-      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
-    }
-  },
   "wizard": {
     "skip": "Hopp over",
     "back": "Tilbake",
@@ -4730,318 +5042,6 @@
         "outro": "Denne tilnærmingen sikrer datakvalitet for vitenskapelig forskning og maksimerer din glede av og lærdom om fugler.",
         "acknowledge": "Jeg forstår"
       }
-    }
-  },
-  "analysis": {
-    "title": "Analyse",
-    "tabs": {
-      "settings": "Innstillinger",
-      "models": "Modeller"
-    },
-    "detection": {
-      "title": "Deteksjonsinnstillinger",
-      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
-      "confidenceThreshold": {
-        "label": "Sikkerhetsterskel",
-        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
-      },
-      "batThreshold": {
-        "label": "Flaggermusdeteksjonsterskel",
-        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
-      },
-      "batFilter": {
-        "label": "Høypassfilter for flaggermuslyd",
-        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
-      },
-      "batNighttimeOnly": {
-        "label": "Kun om natten",
-        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
-      },
-      "batUltrasonicFilter": {
-        "label": "Etterdeteksjonsvalidering",
-        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
-      },
-      "batFalsePositiveFilter": {
-        "label": "Falsk positiv-filter for flaggermus",
-        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
-        "levels": {
-          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
-          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
-          "strict": "Maksimal filtrering for høyest nøyaktighet."
-        },
-        "detectionCount": "{count} bekreftelser kreves. {description}",
-        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
-      },
-      "locale": {
-        "label": "Artsspråk",
-        "helpText": "Språk brukt for artsnavnene i grensesnittet."
-      }
-    },
-    "rangeFilter": {
-      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
-      "status": {
-        "title": "Utvalgsfilter-oversikt",
-        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
-        "autoSelected": "Automatisk valgt",
-        "manual": "Manuell",
-        "classifier": "Klassifikator",
-        "totalSpecies": "Totalt arter",
-        "withRangeData": "Med utvalgsdata",
-        "withoutRangeData": "Uten utvalgsdata",
-        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
-        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
-        "noFilter": "Ingen aktivt utvalgsfilter",
-        "passUnmapped": {
-          "label": "Tillat arter uten utvalgsdata",
-          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
-        }
-      }
-    },
-    "advanced": {
-      "title": "Avansert",
-      "description": "Behandling og egendefinert modellkonfigurasjon."
-    },
-    "gallery": {
-      "title": "Modellgalleri",
-      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
-      "tabs": {
-        "installed": "Installert",
-        "available": "Tilgjengelig"
-      },
-      "loading": "Laster modeller...",
-      "retry": "Prøv igjen",
-      "builtIn": "Innebygd",
-      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
-      "species": "{count} arter",
-      "install": "Installer",
-      "installing": "Installerer...",
-      "remove": "Fjern",
-      "removing": "Fjerner...",
-      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
-      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
-      "sections": {
-        "acoustic": "Akustiske klassifikatorer",
-        "geomodel": "Geomodeller"
-      },
-      "categories": {
-        "wildlife": "Viltklassifikatorer",
-        "bird": "Fugleklassifikatorer",
-        "bat": "Flaggermusklassifikatorer"
-      },
-      "progress": {
-        "downloading": "Laster ned...",
-        "verifying": "Verifiserer...",
-        "loading": "Laster...",
-        "complete": "Installert",
-        "failed": "Mislyktes"
-      },
-      "license": {
-        "title": "Lisensavtale",
-        "model": "Modell",
-        "author": "Forfatter",
-        "license": "Lisens",
-        "commercialUse": "Kommersiell bruk",
-        "downloadSize": "Nedlastingsstørrelse",
-        "allowed": "Tillatt",
-        "notAllowed": "Ikke tillatt",
-        "commercialUseAllowed": "Kommersiell bruk tillatt",
-        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
-        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
-        "acceptAndInstall": "Godta og installer"
-      },
-      "removeDialog": {
-        "title": "Fjerne {name}?",
-        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
-      },
-      "errors": {
-        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
-        "installFailed": "Oppstart av modellinstallasjon mislyktes",
-        "removeFailed": "Fjerning av modell mislyktes"
-      },
-      "regionLabel": "Region",
-      "speciesLabel": "Arter",
-      "reinstall": "Reinstaller",
-      "reinstalling": "Reinstallerer...",
-      "reinstallComplete": "Filer verifisert",
-      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
-      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
-      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
-      "unavailable": "Ikke tilgjengelig"
-    },
-    "bird": {
-      "title": "Fugledeteksjon",
-      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
-    },
-    "bat": {
-      "title": "Flaggermusdeteksjon",
-      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
-    },
-    "dynamicThreshold": {
-      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
-    }
-  },
-  "restart": {
-    "applicationRestart": "Start applikasjon på nytt",
-    "containerRestart": "Start container på nytt",
-    "confirmTitle": "Bekreft omstart",
-    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "inProgress": "Starter på nytt...",
-    "bannerTitle": "Omstart kreves",
-    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
-    "bannerAction": "Start på nytt nå",
-    "restartFailed": "Oppstart av omstart mislyktes"
-  },
-  "help": {
-    "title": "Hjelp og støtte",
-    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
-    "reportBug": {
-      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
-    },
-    "askQuestion": {
-      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
-    },
-    "diagnostics": {
-      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
-    },
-    "quickLinks": {
-      "title": "Hurtiglenker",
-      "releases": "Versjonsnyheter"
-    }
-  },
-  "reportBug": {
-    "title": "Rapporter en feil",
-    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
-    "systemInfo": {
-      "title": "Din systeminformasjon",
-      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
-      "version": "Versjon",
-      "buildDate": "Byggedato",
-      "os": "Operativsystem",
-      "copy": "Kopier til utklippstavle",
-      "copied": "Kopiert!",
-      "architecture": "Arkitektur",
-      "hardware": "Maskinvare",
-      "environment": "Miljø"
-    },
-    "whatToInclude": {
-      "title": "Hva du bør inkludere i rapporten",
-      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
-      "step1": {
-        "title": "Tydelig beskrivelse av problemet",
-        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
-      },
-      "step2": {
-        "title": "Installasjonsmetode",
-        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
-      },
-      "step3": {
-        "title": "Systeminformasjon",
-        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
-      },
-      "step4": {
-        "title": "Supportpakke",
-        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
-      }
-    },
-    "openIssue": {
-      "title": "Åpne en GitHub-sak",
-      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
-      "button": "Åpne sak på GitHub"
-    },
-    "supportDump": {
-      "title": "Generer supportpakke",
-      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
-    }
-  },
-  "health": {
-    "title": "Systemhelse",
-    "running": "Kjører diagnostikk...",
-    "lastRun": "Sist kjørt",
-    "refresh": "Oppdater",
-    "exportText": "Kopier rapport",
-    "exportJSON": "Last ned JSON",
-    "copied": "Rapport kopiert til utklippstavle",
-    "duration": "Varighet",
-    "summary": {
-      "healthy": "Frisk",
-      "warnings": "Advarsler",
-      "critical": "Kritisk",
-      "skipped": "Hoppet over",
-      "total": "Totalt sjekker"
-    },
-    "metricFooter": {
-      "allPassing": "Alle godkjent",
-      "needsAttention": "Trenger oppmerksomhet",
-      "failing": "Mislykkes",
-      "allClear": "Alt klart",
-      "noData": "Ingen nylige data",
-      "none": "Ingen"
-    },
-    "diagnostics": "Diagnostikk",
-    "categories": {
-      "system": "System",
-      "audio": "Lydpipeline",
-      "analysis": "Analyse",
-      "streams": "Lydstrømmer",
-      "database": "Database",
-      "network": "Nettverk",
-      "config": "Konfigurasjon",
-      "logs": "Logger"
-    },
-    "status": {
-      "healthy": "Frisk",
-      "warning": "Advarsel",
-      "critical": "Kritisk",
-      "unknown": "Ukjent",
-      "skipped": "Hoppet over"
-    },
-    "errors": {
-      "title": "Nylige feil",
-      "noErrors": "Ingen nylige feil",
-      "fetchFailed": "Innlasting av diagnostikk mislyktes"
-    },
-    "export": {
-      "reportTitle": "BirdNET-Go systemhelserapport",
-      "statusLabel": "Status",
-      "timeLabel": "Tid",
-      "durationLabel": "Varighet",
-      "checksLabel": "Sjekker"
-    },
-    "logs": {
-      "topErrors": "Vanligste feilmønstre",
-      "errorCount": "Antall",
-      "errorComponent": "Komponent",
-      "errorLevel": "Nivå",
-      "errorMessage": "Melding"
-    },
-    "window": {
-      "label": "Evalueringsvindu",
-      "15m": "15m",
-      "30m": "30m",
-      "1h": "1t",
-      "6h": "6t",
-      "24h": "24t",
-      "7d": "7d"
-    },
-    "detail": {
-      "lastEvent": "Siste hendelse",
-      "recentEvents": "Nylige hendelser",
-      "time": "Tid",
-      "source": "Kilde",
-      "count": "Antall",
-      "lifetime": "levetid",
-      "sparklineLabel": "Aktivitetsoversikt",
-      "activeHours": "Aktive timer",
-      "windowTotal": "I vindu",
-      "velocity": "Trend",
-      "velocityStable": "Stabil",
-      "velocityIncreasing": "Stigende",
-      "velocityDecreasing": "Synkende",
-      "pattern": "Mønster",
-      "patternNone": "Ingen",
-      "patternTransient": "Forbigående",
-      "patternSustained": "Vedvarende"
     }
   }
 }

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -510,6 +510,9 @@
       "sunrise": "Soloppgang +/- 30 min",
       "sunset": "Solnedgang +/- 30 min"
     },
+    "sourceOptions": {
+      "any": "All Sources"
+    },
     "sortOptions": {
       "dateDesc": "Dato (nyeste først)",
       "dateAsc": "Dato (eldste først)",
@@ -521,9 +524,9 @@
       "timeOfDay": "Tidspunkt",
       "species": "Art",
       "confidence": "Sikkerhet",
+      "source": "Source",
       "status": "Status",
-      "actions": "Handlinger",
-      "source": "Source"
+      "actions": "Handlinger"
     },
     "statusBadges": {
       "verified": "Verifisert",
@@ -559,9 +562,6 @@
       "page": "Side {current} av {total}",
       "goToPrevious": "Gå til forrige side",
       "goToNext": "Gå til neste side"
-    },
-    "sourceOptions": {
-      "any": "All Sources"
     }
   },
   "error": {
@@ -598,6 +598,18 @@
       "empty": "Stille — ingen fugler registrert akkurat nå"
     },
     "rejected": "Avvist",
+    "newSpeciesHighlights": {
+      "title": "Nye og tilbakevendende arter",
+      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
+      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
+      "categoryLifetime": "Nye arter",
+      "categoryYear": "Nye i år",
+      "categorySeason": "Nye denne sesongen",
+      "categorySeasonNamed": "Nye i {season}",
+      "maxConfidenceShort": "Maks {confidence}%",
+      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
+      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
+    },
     "dailySummary": {
       "title": "Daglig aktivitet",
       "subtitle": "Artsregistreringer per time",
@@ -764,23 +776,11 @@
     "elements": {
       "banner": "Dashbordbanner",
       "dailySummary": "Daglig sammendrag",
+      "newSpeciesHighlights": "Høydepunkter for nye arter",
       "currentlyHearing": "Hører nå",
       "detectionsGrid": "Siste registreringer",
       "liveSpectrogram": "Direkte spektrogram",
-      "videoEmbed": "Videoinnbygging",
-      "newSpeciesHighlights": "Høydepunkter for nye arter"
-    },
-    "newSpeciesHighlights": {
-      "title": "Nye og tilbakevendende arter",
-      "subtitle": "Førstegangsdeteksjoner og nylig gjenfunne arter",
-      "trackingDisabled": "Aktiver \"Aktiver artssporing\" for å bruke denne funksjonen.",
-      "categoryLifetime": "Nye arter",
-      "categoryYear": "Nye i år",
-      "categorySeason": "Nye denne sesongen",
-      "categorySeasonNamed": "Nye i {season}",
-      "maxConfidenceShort": "Maks {confidence}%",
-      "detections": "{count, plural, one {# deteksjon} other {# deteksjoner}}",
-      "lastSeen": "Sist: {days, plural, =0 {i dag} one {# dag siden} other {# dager siden}}"
+      "videoEmbed": "Videoinnbygging"
     }
   },
   "detections": {
@@ -1641,8 +1641,8 @@
         "dateTime": "Dato og tid",
         "species": "Art",
         "confidence": "Sikkerhet",
-        "timeOfDay": "Tidspunkt",
-        "source": "Source"
+        "source": "Source",
+        "timeOfDay": "Tidspunkt"
       },
       "noRecentDetections": "Ingen siste registreringer funnet",
       "unknownSpecies": "Ukjent",
@@ -1668,7 +1668,6 @@
         "detections": "Registreringer:",
         "confidence": "Sikkerhet:",
         "first": "Første:"
-      }
       },
       "manage": {
         "headers": {
@@ -1685,6 +1684,7 @@
         "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
         "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
         "deleteFailed": "Failed to delete detections. Please try again."
+      }
     },
     "advanced": {
       "title": "Avansert analyse",
@@ -3533,7 +3533,6 @@
         "validityHelpText": "Hvor lenge sertifikatet skal være gyldig",
         "validity365d": "1 år",
         "validity730d": "2 år",
-        "validity1825d": "5 år",
         "generateButton": "Generer sertifikat",
         "regenerateButton": "Regenerer sertifikat",
         "generating": "Genererer...",
@@ -3565,6 +3564,7 @@
         "deleteConfirm": "Er du sikker på at du vil fjerne det installerte TLS-sertifikatet? TLS-modusen vil tilbakestilles til Ingen.",
         "restartRequired": "TLS-endringer krever en serveromstart for å ta effekt.",
         "noCertificate": "Ingen sertifikat installert",
+        "validity1825d": "5 år",
         "autoTLSHostRequired": "Et vertsnavn er nødvendig for Let's Encrypt. Skriv inn ditt offentlige domenenavn i Vert-feltet ovenfor.",
         "autoTLSNoIP": "Let's Encrypt krever et domenenavn, ikke en IP-adresse. Skriv inn et offentlig domene som fugler.eksempel.no.",
         "autoTLSNeedsFQDN": "Let's Encrypt krever et fullt kvalifisert domenenavn (f.eks. fugler.eksempel.no), ikke bare et vertsnavn.",
@@ -4165,154 +4165,6 @@
     },
     "restartRequired": "Noen endringer krever en serveromstart for å ta effekt. Start BirdNET-Go på nytt."
   },
-  "analysis": {
-    "title": "Analyse",
-    "tabs": {
-      "settings": "Innstillinger",
-      "models": "Modeller"
-    },
-    "detection": {
-      "title": "Deteksjonsinnstillinger",
-      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
-      "confidenceThreshold": {
-        "label": "Sikkerhetsterskel",
-        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
-      },
-      "batThreshold": {
-        "label": "Flaggermusdeteksjonsterskel",
-        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
-      },
-      "batFilter": {
-        "label": "Høypassfilter for flaggermuslyd",
-        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
-      },
-      "batNighttimeOnly": {
-        "label": "Kun om natten",
-        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
-      },
-      "batUltrasonicFilter": {
-        "label": "Etterdeteksjonsvalidering",
-        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
-      },
-      "batFalsePositiveFilter": {
-        "label": "Falsk positiv-filter for flaggermus",
-        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
-        "levels": {
-          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
-          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
-          "strict": "Maksimal filtrering for høyest nøyaktighet."
-        },
-        "detectionCount": "{count} bekreftelser kreves. {description}",
-        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
-      },
-      "locale": {
-        "label": "Artsspråk",
-        "helpText": "Språk brukt for artsnavnene i grensesnittet."
-      }
-    },
-    "rangeFilter": {
-      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
-      "status": {
-        "title": "Utvalgsfilter-oversikt",
-        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
-        "autoSelected": "Automatisk valgt",
-        "manual": "Manuell",
-        "classifier": "Klassifikator",
-        "totalSpecies": "Totalt arter",
-        "withRangeData": "Med utvalgsdata",
-        "withoutRangeData": "Uten utvalgsdata",
-        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
-        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
-        "noFilter": "Ingen aktivt utvalgsfilter",
-        "passUnmapped": {
-          "label": "Tillat arter uten utvalgsdata",
-          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
-        }
-      }
-    },
-    "advanced": {
-      "title": "Avansert",
-      "description": "Behandling og egendefinert modellkonfigurasjon."
-    },
-    "gallery": {
-      "title": "Modellgalleri",
-      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
-      "tabs": {
-        "installed": "Installert",
-        "available": "Tilgjengelig"
-      },
-      "loading": "Laster modeller...",
-      "retry": "Prøv igjen",
-      "builtIn": "Innebygd",
-      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
-      "species": "{count} arter",
-      "install": "Installer",
-      "installing": "Installerer...",
-      "remove": "Fjern",
-      "removing": "Fjerner...",
-      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
-      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
-      "sections": {
-        "acoustic": "Akustiske klassifikatorer",
-        "geomodel": "Geomodeller"
-      },
-      "categories": {
-        "wildlife": "Viltklassifikatorer",
-        "bird": "Fugleklassifikatorer",
-        "bat": "Flaggermusklassifikatorer"
-      },
-      "progress": {
-        "downloading": "Laster ned...",
-        "verifying": "Verifiserer...",
-        "loading": "Laster...",
-        "complete": "Installert",
-        "failed": "Mislyktes"
-      },
-      "license": {
-        "title": "Lisensavtale",
-        "model": "Modell",
-        "author": "Forfatter",
-        "license": "Lisens",
-        "commercialUse": "Kommersiell bruk",
-        "downloadSize": "Nedlastingsstørrelse",
-        "allowed": "Tillatt",
-        "notAllowed": "Ikke tillatt",
-        "commercialUseAllowed": "Kommersiell bruk tillatt",
-        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
-        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
-        "acceptAndInstall": "Godta og installer"
-      },
-      "removeDialog": {
-        "title": "Fjerne {name}?",
-        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
-      },
-      "errors": {
-        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
-        "installFailed": "Oppstart av modellinstallasjon mislyktes",
-        "removeFailed": "Fjerning av modell mislyktes"
-      },
-      "regionLabel": "Region",
-      "speciesLabel": "Arter",
-      "reinstall": "Reinstaller",
-      "reinstalling": "Reinstallerer...",
-      "reinstallComplete": "Filer verifisert",
-      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
-      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
-      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
-      "unavailable": "Ikke tilgjengelig"
-    },
-    "bird": {
-      "title": "Fugledeteksjon",
-      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
-    },
-    "bat": {
-      "title": "Flaggermusdeteksjon",
-      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
-    },
-    "dynamicThreshold": {
-      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
-    }
-  },
   "auth": {
     "login": "Logg inn",
     "logout": "Logg ut",
@@ -4372,315 +4224,6 @@
       "min": "Minimum",
       "max": "Maksimum",
       "count": "Antall"
-    }
-  },
-  "connectivity": {
-    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
-  },
-  "detection": {
-    "actions": {
-      "back": "Tilbake",
-      "review": "Gjennomgå",
-      "download": "Last ned"
-    }
-  },
-  "quietHours": {
-    "indicator": {
-      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
-    }
-  },
-  "restart": {
-    "applicationRestart": "Start applikasjon på nytt",
-    "containerRestart": "Start container på nytt",
-    "confirmTitle": "Bekreft omstart",
-    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
-    "inProgress": "Starter på nytt...",
-    "bannerTitle": "Omstart kreves",
-    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
-    "bannerAction": "Start på nytt nå",
-    "restartFailed": "Oppstart av omstart mislyktes"
-  },
-  "help": {
-    "title": "Hjelp og støtte",
-    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
-    "reportBug": {
-      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
-    },
-    "askQuestion": {
-      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
-    },
-    "diagnostics": {
-      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
-    },
-    "quickLinks": {
-      "title": "Hurtiglenker",
-      "releases": "Versjonsnyheter"
-    }
-  },
-  "reportBug": {
-    "title": "Rapporter en feil",
-    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
-    "systemInfo": {
-      "title": "Din systeminformasjon",
-      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
-      "version": "Versjon",
-      "buildDate": "Byggedato",
-      "os": "Operativsystem",
-      "copy": "Kopier til utklippstavle",
-      "copied": "Kopiert!",
-      "architecture": "Arkitektur",
-      "hardware": "Maskinvare",
-      "environment": "Miljø"
-    },
-    "whatToInclude": {
-      "title": "Hva du bør inkludere i rapporten",
-      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
-      "step1": {
-        "title": "Tydelig beskrivelse av problemet",
-        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
-      },
-      "step2": {
-        "title": "Installasjonsmetode",
-        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
-      },
-      "step3": {
-        "title": "Systeminformasjon",
-        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
-      },
-      "step4": {
-        "title": "Supportpakke",
-        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
-      }
-    },
-    "openIssue": {
-      "title": "Åpne en GitHub-sak",
-      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
-      "button": "Åpne sak på GitHub"
-    },
-    "supportDump": {
-      "title": "Generer supportpakke",
-      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
-    }
-  },
-  "weather": {
-    "moon": {
-      "newMoon": "Nymåne",
-      "waxingCrescent": "Voksende månesigd",
-      "firstQuarter": "Første kvarter",
-      "waxingGibbous": "Voksende måne",
-      "fullMoon": "Fullmåne",
-      "waningGibbous": "Minkende måne",
-      "lastQuarter": "Siste kvarter",
-      "waningCrescent": "Minkende månesigd"
-    },
-    "birding": {
-      "excellent": "Stille — utmerket for å høre fuglekall",
-      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
-      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
-    }
-  },
-  "errors": {
-    "auth": {
-      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
-      "credentialsRequired": "Brukernavn og passord er obligatorisk",
-      "invalidCredentials": "Ugyldige innloggingsdetaljer",
-      "missingCode": "Manglende autorisasjonskode",
-      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
-      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
-      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
-      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
-    },
-    "alert": {
-      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
-      "invalidID": "Ugyldig regel-ID",
-      "notFound": "Varselregel ikke funnet",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "nameRequired": "Regelnavn er obligatorisk",
-      "typesRequired": "Objekttype og utløsertype er obligatorisk",
-      "duplicateName": "En regel med dette navnet finnes allerede",
-      "invalidJSON": "Ugyldig JSON",
-      "invalidEscalation": "Eskaleringstrinn er ugyldige"
-    },
-    "detection": {
-      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
-    },
-    "backup": {
-      "invalidType": "Type må være «legacy» eller «v2»",
-      "alreadyRunning": "Sikkerhetskopi pågår allerede",
-      "dbInfoFailed": "Henting av databaseinfo mislyktes",
-      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
-      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
-      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
-      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
-      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
-      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
-      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
-      "dbNotConfigured": "Database ikke konfigurert",
-      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
-      "v2NotInitialized": "V2-database ikke initialisert"
-    },
-    "migration": {
-      "notConfigured": "Migrering er ikke konfigurert",
-      "preFlightFailed": "Forhåndssjekker mislyktes",
-      "invalidBody": "Ugyldig forespørselskropp",
-      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
-      "startFailed": "Oppstart av migrering mislyktes",
-      "initFailed": "Initialisering av migrering mislyktes",
-      "resumeFailed": "Gjenopptak av migrering mislyktes"
-    },
-    "cleanup": {
-      "noLegacyDB": "Ingen eldre database funnet",
-      "accessFailed": "Kan ikke få tilgang til eldre database",
-      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
-      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
-      "noLegacyTables": "Ingen eldre tabeller funnet",
-      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
-      "alreadyRunning": "Opprydding pågår allerede"
-    },
-    "integration": {
-      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
-      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
-      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
-      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
-      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
-      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
-      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
-      "noWeatherProvider": "Ingen værleverandør valgt",
-      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
-      "processorUnavailable": "Prosessor ikke tilgjengelig",
-      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
-    },
-    "notification": {
-      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
-      "idRequired": "Varsel-ID er obligatorisk",
-      "notFound": "Varsel ikke funnet",
-      "hostRequired": "Vert-parameter er obligatorisk",
-      "invalidHost": "Ugyldig vert-parameter",
-      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
-    },
-    "streams": {
-      "test": {
-        "invalidBody": "Ugyldig forespørselskropp",
-        "urlRequired": "Strøm-URL er obligatorisk",
-        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
-        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
-        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
-        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
-        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
-      }
-    },
-    "debug": {
-      "notEnabled": "Feilsøkingsmodus ikke aktivert"
-    },
-    "terminal": {
-      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
-    },
-    "api": {
-      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
-      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
-      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
-      "notFound": "Den forespurte ressursen ble ikke funnet.",
-      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
-      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
-      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
-      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
-      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
-      "unknownError": "En uventet feil oppstod. Prøv igjen.",
-      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
-      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
-      "requestTimeout": "Forespørselen tok for lang tid.",
-      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
-    }
-  },
-  "health": {
-    "title": "Systemhelse",
-    "running": "Kjører diagnostikk...",
-    "lastRun": "Sist kjørt",
-    "refresh": "Oppdater",
-    "exportText": "Kopier rapport",
-    "exportJSON": "Last ned JSON",
-    "copied": "Rapport kopiert til utklippstavle",
-    "duration": "Varighet",
-    "summary": {
-      "healthy": "Frisk",
-      "warnings": "Advarsler",
-      "critical": "Kritisk",
-      "skipped": "Hoppet over",
-      "total": "Totalt sjekker"
-    },
-    "metricFooter": {
-      "allPassing": "Alle godkjent",
-      "needsAttention": "Trenger oppmerksomhet",
-      "failing": "Mislykkes",
-      "allClear": "Alt klart",
-      "noData": "Ingen nylige data",
-      "none": "Ingen"
-    },
-    "diagnostics": "Diagnostikk",
-    "categories": {
-      "system": "System",
-      "audio": "Lydpipeline",
-      "analysis": "Analyse",
-      "streams": "Lydstrømmer",
-      "database": "Database",
-      "network": "Nettverk",
-      "config": "Konfigurasjon",
-      "logs": "Logger"
-    },
-    "status": {
-      "healthy": "Frisk",
-      "warning": "Advarsel",
-      "critical": "Kritisk",
-      "unknown": "Ukjent",
-      "skipped": "Hoppet over"
-    },
-    "errors": {
-      "title": "Nylige feil",
-      "noErrors": "Ingen nylige feil",
-      "fetchFailed": "Innlasting av diagnostikk mislyktes"
-    },
-    "export": {
-      "reportTitle": "BirdNET-Go systemhelserapport",
-      "statusLabel": "Status",
-      "timeLabel": "Tid",
-      "durationLabel": "Varighet",
-      "checksLabel": "Sjekker"
-    },
-    "logs": {
-      "topErrors": "Vanligste feilmønstre",
-      "errorCount": "Antall",
-      "errorComponent": "Komponent",
-      "errorLevel": "Nivå",
-      "errorMessage": "Melding"
-    },
-    "window": {
-      "label": "Evalueringsvindu",
-      "15m": "15m",
-      "30m": "30m",
-      "1h": "1t",
-      "6h": "6t",
-      "24h": "24t",
-      "7d": "7d"
-    },
-    "detail": {
-      "lastEvent": "Siste hendelse",
-      "recentEvents": "Nylige hendelser",
-      "time": "Tid",
-      "source": "Kilde",
-      "count": "Antall",
-      "lifetime": "levetid",
-      "sparklineLabel": "Aktivitetsoversikt",
-      "activeHours": "Aktive timer",
-      "windowTotal": "I vindu",
-      "velocity": "Trend",
-      "velocityStable": "Stabil",
-      "velocityIncreasing": "Stigende",
-      "velocityDecreasing": "Synkende",
-      "pattern": "Mønster",
-      "patternNone": "Ingen",
-      "patternTransient": "Forbigående",
-      "patternSustained": "Vedvarende"
     }
   },
   "forms": {
@@ -4951,6 +4494,151 @@
       "clickToView": "Click to view detections"
     }
   },
+  "connectivity": {
+    "offline": "Tilkobling til server mistet. Prøver å koble til igjen..."
+  },
+  "detection": {
+    "actions": {
+      "back": "Tilbake",
+      "review": "Gjennomgå",
+      "download": "Last ned"
+    }
+  },
+  "quietHours": {
+    "indicator": {
+      "tooltip": "Stille timer aktive — {count} kilde(r) satt på pause"
+    }
+  },
+  "errors": {
+    "auth": {
+      "tooManyAttempts": "For mange innloggingsforsøk. Prøv igjen om 15 minutter.",
+      "credentialsRequired": "Brukernavn og passord er obligatorisk",
+      "invalidCredentials": "Ugyldige innloggingsdetaljer",
+      "missingCode": "Manglende autorisasjonskode",
+      "serviceUnavailable": "Autentiseringstjeneste utilgjengelig. Prøv igjen senere.",
+      "timeout": "Innlogging tok for lang tid. Prøv igjen.",
+      "exchangeFailed": "Kan ikke fullføre innlogging akkurat nå. Prøv igjen.",
+      "sessionError": "Sesjonsfeil under innlogging. Prøv igjen."
+    },
+    "alert": {
+      "v2Required": "Varselregler krever den forbedrede (v2) databasen",
+      "invalidID": "Ugyldig regel-ID",
+      "notFound": "Varselregel ikke funnet",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "nameRequired": "Regelnavn er obligatorisk",
+      "typesRequired": "Objekttype og utløsertype er obligatorisk",
+      "duplicateName": "En regel med dette navnet finnes allerede",
+      "invalidJSON": "Ugyldig JSON",
+      "invalidEscalation": "Eskaleringstrinn er ugyldige"
+    },
+    "detection": {
+      "invalidDate": "Ugyldig {paramName}-format, bruk ÅÅÅÅ-MM-DD"
+    },
+    "backup": {
+      "invalidType": "Type må være «legacy» eller «v2»",
+      "alreadyRunning": "Sikkerhetskopi pågår allerede",
+      "dbInfoFailed": "Henting av databaseinfo mislyktes",
+      "diskSpaceCheck": "Sjekking av diskplass mislyktes",
+      "insufficientSpace": "Ikke nok diskplass. Trenger {needed}, har {available}",
+      "createFailed": "Opprettelse av sikkerhetskopijobb mislyktes",
+      "notFound": "Sikkerhetskopijobb ikke funnet eller utløpt",
+      "notReady": "Sikkerhetskopi ikke klar for nedlasting",
+      "fileNotFound": "Sikkerhetskopifil ikke funnet — jobben kan ha utløpt",
+      "sqliteOnly": "Sikkerhetskopi er kun tilgjengelig for SQLite-databaser",
+      "dbNotConfigured": "Database ikke konfigurert",
+      "unsupportedType": "Kan ikke utføre sikkerhetskopi på denne databasetypen",
+      "v2NotInitialized": "V2-database ikke initialisert"
+    },
+    "migration": {
+      "notConfigured": "Migrering er ikke konfigurert",
+      "preFlightFailed": "Forhåndssjekker mislyktes",
+      "invalidBody": "Ugyldig forespørselskropp",
+      "recordCountFailed": "Bestemmelse av totalt posterantall mislyktes",
+      "startFailed": "Oppstart av migrering mislyktes",
+      "initFailed": "Initialisering av migrering mislyktes",
+      "resumeFailed": "Gjenopptak av migrering mislyktes"
+    },
+    "cleanup": {
+      "noLegacyDB": "Ingen eldre database funnet",
+      "accessFailed": "Kan ikke få tilgang til eldre database",
+      "restartRequired": "Applikasjonen må startes på nytt etter migrering før opprydding er tilgjengelig",
+      "safetyCheck": "Målfilen ser ut til å være en V2-database — opprydding ikke tillatt av sikkerhetshensyn",
+      "noLegacyTables": "Ingen eldre tabeller funnet",
+      "restartNeeded": "Kan ikke rydde opp: applikasjonen må startes på nytt etter migrering",
+      "alreadyRunning": "Opprydding pågår allerede"
+    },
+    "integration": {
+      "mqttDisabled": "MQTT er ikke aktivert i innstillinger",
+      "mqttNotConfigured": "MQTT-megler ikke konfigurert",
+      "mqttMetricsUnavailable": "Målingsinstans ikke tilgjengelig for MQTT-test",
+      "mqttClientFailed": "Opprettelse av MQTT-klient mislyktes",
+      "birdweatherDisabled": "BirdWeather-integrasjon er ikke aktivert",
+      "birdweatherNotConfigured": "BirdWeather-stasjon-ID ikke konfigurert",
+      "birdweatherClientFailed": "Opprettelse av BirdWeather-klient mislyktes",
+      "noWeatherProvider": "Ingen værleverandør valgt",
+      "openWeatherKeyRequired": "OpenWeather API-nøkkel er obligatorisk",
+      "processorUnavailable": "Prosessor ikke tilgjengelig",
+      "discoveryFailed": "Utløsing av Home Assistant-oppdagelse mislyktes"
+    },
+    "notification": {
+      "serviceUnavailable": "Varseltjeneste ikke tilgjengelig",
+      "idRequired": "Varsel-ID er obligatorisk",
+      "notFound": "Varsel ikke funnet",
+      "hostRequired": "Vert-parameter er obligatorisk",
+      "invalidHost": "Ugyldig vert-parameter",
+      "rateLimit": "For mange forsøk på å koble til varselstrøm, vent litt før du prøver igjen"
+    },
+    "streams": {
+      "test": {
+        "invalidBody": "Ugyldig forespørselskropp",
+        "urlRequired": "Strøm-URL er obligatorisk",
+        "invalidUrl": "Ugyldig URL-format. Skriv inn en full URL som rtsp://vert:port/sti",
+        "unsupportedScheme": "Ikke-støttet URL-skjema «{scheme}». Bruk rtsp, rtsps, http, https, rtmp eller udp",
+        "blockedDestination": "Dette målet er blokkert av sikkerhetsgrunner",
+        "connectionFailed": "Kan ikke koble til strømmen. Sjekk at URL-en er korrekt og at strømmen er tilgjengelig",
+        "noAudioTrack": "Strømmen har ikke noe lydspor. Bare strømmer som inneholder lyd, kan brukes"
+      }
+    },
+    "debug": {
+      "notEnabled": "Feilsøkingsmodus ikke aktivert"
+    },
+    "terminal": {
+      "disabled": "Terminal er deaktivert. Aktiver den i innstillinger."
+    },
+    "api": {
+      "badRequest": "Ugyldig forespørsel. Sjekk inndataene dine og prøv igjen.",
+      "unauthorized": "Autentisering kreves. Logg inn og prøv igjen.",
+      "forbidden": "Du har ikke tillatelse til å utføre denne handlingen.",
+      "notFound": "Den forespurte ressursen ble ikke funnet.",
+      "conflict": "Denne handlingen er i konflikt med gjeldende tilstand. Oppdater og prøv igjen.",
+      "validationFailed": "Ugyldig inndata oppgitt. Sjekk dataene dine og prøv igjen.",
+      "tooManyRequests": "For mange forespørsler. Vent litt før du prøver igjen.",
+      "serverError": "En serverfeil oppstod. Prøv igjen senere.",
+      "clientError": "Klientfeil oppstod. Sjekk forespørselen din og prøv igjen.",
+      "unknownError": "En uventet feil oppstod. Prøv igjen.",
+      "validationCheck": "Validering mislyktes. Sjekk inndataene dine.",
+      "conflictData": "Denne handlingen er i konflikt med eksisterende data.",
+      "requestTimeout": "Forespørselen tok for lang tid.",
+      "networkError": "Nettverksfeil oppstod. Sjekk tilkoblingen din."
+    }
+  },
+  "weather": {
+    "moon": {
+      "newMoon": "Nymåne",
+      "waxingCrescent": "Voksende månesigd",
+      "firstQuarter": "Første kvarter",
+      "waxingGibbous": "Voksende måne",
+      "fullMoon": "Fullmåne",
+      "waningGibbous": "Minkende måne",
+      "lastQuarter": "Siste kvarter",
+      "waningCrescent": "Minkende månesigd"
+    },
+    "birding": {
+      "excellent": "Stille — utmerket for å høre fuglekall",
+      "moderate": "Moderat vind — noen fuglekall kan være vanskeligere å høre",
+      "poor": "Sterk vind — fuglekall vil trolig ikke høres"
+    }
+  },
   "wizard": {
     "skip": "Hopp over",
     "back": "Tilbake",
@@ -5042,6 +4730,318 @@
         "outro": "Denne tilnærmingen sikrer datakvalitet for vitenskapelig forskning og maksimerer din glede av og lærdom om fugler.",
         "acknowledge": "Jeg forstår"
       }
+    }
+  },
+  "analysis": {
+    "title": "Analyse",
+    "tabs": {
+      "settings": "Innstillinger",
+      "models": "Modeller"
+    },
+    "detection": {
+      "title": "Deteksjonsinnstillinger",
+      "description": "Konfigurer sikkerhetsterskler og språk for artsklassifisering.",
+      "confidenceThreshold": {
+        "label": "Sikkerhetsterskel",
+        "helpText": "Minimum sikkerhetscore (0,0–1,0) kreves for at en registrering skal lagres."
+      },
+      "batThreshold": {
+        "label": "Flaggermusdeteksjonsterskel",
+        "helpText": "Minimum sikkerhetscore for flaggermusartsregistreringer. Gjelder kun for flaggermusklassifikatormodeller."
+      },
+      "batFilter": {
+        "label": "Høypassfilter for flaggermuslyd",
+        "helpText": "Filtrerer ut menneskehørbare frekvenser før flaggermusanalyse for å redusere falske positive fra fuglesang og bakgrunnsstøy."
+      },
+      "batNighttimeOnly": {
+        "label": "Kun om natten",
+        "helpText": "Når aktivert, kjøres flaggermusdeteksjon kun mellom sivil skumring og sivil grytid. Krever at posisjon er konfigurert. Deaktiver for å kjøre flaggermusdeteksjon hele døgnet."
+      },
+      "batUltrasonicFilter": {
+        "label": "Etterdeteksjonsvalidering",
+        "helpText": "Når aktivert, valideres flaggermusregistreringer ved å analysere ultrasoniske energimønstre i kildelyden. Registreringer som mangler flaggermus-ekkololokasjonskjennetegn merkes som usannsynlige."
+      },
+      "batFalsePositiveFilter": {
+        "label": "Falsk positiv-filter for flaggermus",
+        "helpText": "Krever flere bekreftelser av en flaggermusregistrering innenfor et glidende vindu før den godtas. Høyere nivåer krever flere bekreftelser og reduserer falske positive. Flaggermusmodellen bruker fast 50% overlapping, så ingen overlappjustering er nødvendig.",
+        "levels": {
+          "off": "Ingen filtrering; godtar enhver flaggermusregistrering umiddelbart.",
+          "moderate": "God balanse for de fleste oppsett. Reduserer falske positive betydelig.",
+          "strict": "Maksimal filtrering for høyest nøyaktighet."
+        },
+        "detectionCount": "{count} bekreftelser kreves. {description}",
+        "warningOff": "Uten filtrering er det høy sannsynlighet for falske positive. Aktivering av filtrering forbedrer nøyaktigheten betydelig."
+      },
+      "locale": {
+        "label": "Artsspråk",
+        "helpText": "Språk brukt for artsnavnene i grensesnittet."
+      }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Utvalgsfilter gjelder kun for fugleklassifikatorer. Flaggermusmodeller bruker egne artslister.",
+      "status": {
+        "title": "Utvalgsfilter-oversikt",
+        "geomodelInfo": "BirdNET Geomodell {version} – {species} kjente arter",
+        "autoSelected": "Automatisk valgt",
+        "manual": "Manuell",
+        "classifier": "Klassifikator",
+        "totalSpecies": "Totalt arter",
+        "withRangeData": "Med utvalgsdata",
+        "withoutRangeData": "Uten utvalgsdata",
+        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sannsynlighet ved din posisjon",
+        "withoutRangeDataTooltip": "Arter uten geografiske data i geomodellen, håndtert av innstillingen for umappede arter nedenfor",
+        "noFilter": "Ingen aktivt utvalgsfilter",
+        "passUnmapped": {
+          "label": "Tillat arter uten utvalgsdata",
+          "helpText": "Tillat registreringer av arter geomodellen ikke har geografiske data for. Når deaktivert, filtreres disse artene alltid ut."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Avansert",
+      "description": "Behandling og egendefinert modellkonfigurasjon."
+    },
+    "gallery": {
+      "title": "Modellgalleri",
+      "description": "Administrer klassifikatormodeller for fugle- og flaggermusdeteksjon.",
+      "tabs": {
+        "installed": "Installert",
+        "available": "Tilgjengelig"
+      },
+      "loading": "Laster modeller...",
+      "retry": "Prøv igjen",
+      "builtIn": "Innebygd",
+      "builtInDescription": "Innebygd fuglearts-klassifikator fra BirdNET-teamet.",
+      "species": "{count} arter",
+      "install": "Installer",
+      "installing": "Installerer...",
+      "remove": "Fjern",
+      "removing": "Fjerner...",
+      "noInstalledModels": "Ingen ekstra modeller installert. Bla gjennom Tilgjengelig-fanen for å legge til flere klassifikatorer.",
+      "noAvailableModels": "Ingen ekstra modeller tilgjengelig for din plattform.",
+      "sections": {
+        "acoustic": "Akustiske klassifikatorer",
+        "geomodel": "Geomodeller"
+      },
+      "categories": {
+        "wildlife": "Viltklassifikatorer",
+        "bird": "Fugleklassifikatorer",
+        "bat": "Flaggermusklassifikatorer"
+      },
+      "progress": {
+        "downloading": "Laster ned...",
+        "verifying": "Verifiserer...",
+        "loading": "Laster...",
+        "complete": "Installert",
+        "failed": "Mislyktes"
+      },
+      "license": {
+        "title": "Lisensavtale",
+        "model": "Modell",
+        "author": "Forfatter",
+        "license": "Lisens",
+        "commercialUse": "Kommersiell bruk",
+        "downloadSize": "Nedlastingsstørrelse",
+        "allowed": "Tillatt",
+        "notAllowed": "Ikke tillatt",
+        "commercialUseAllowed": "Kommersiell bruk tillatt",
+        "nonCommercialOnly": "Kun ikke-kommersiell bruk",
+        "nonCommercialWarning": "Denne modellen er lisensiert kun for ikke-kommersiell bruk. Ved installasjon godtar du å overholde lisensvilkårene.",
+        "acceptAndInstall": "Godta og installer"
+      },
+      "removeDialog": {
+        "title": "Fjerne {name}?",
+        "confirmation": "Dette vil fjerne modellfilene fra disk. Etikettdata beholdes for eksisterende registreringer."
+      },
+      "errors": {
+        "catalogLoadFailed": "Innlasting av modellkatalog mislyktes",
+        "installFailed": "Oppstart av modellinstallasjon mislyktes",
+        "removeFailed": "Fjerning av modell mislyktes"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Arter",
+      "reinstall": "Reinstaller",
+      "reinstalling": "Reinstallerer...",
+      "reinstallComplete": "Filer verifisert",
+      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodell",
+      "onnxRuntimeRequired": "Krever ONNX Runtime som ikke er tilgjengelig på dette systemet.",
+      "onnxRuntimeMissing": "ONNX Runtime er ikke tilgjengelig. Denne modellen kan ikke kjøres.",
+      "unavailable": "Ikke tilgjengelig"
+    },
+    "bird": {
+      "title": "Fugledeteksjon",
+      "description": "Konfigurer sikkerhetsterskel, artsspråk og falsk positiv-filtrering for fugleklassifikatorer."
+    },
+    "bat": {
+      "title": "Flaggermusdeteksjon",
+      "description": "Konfigurer terskel, planlegging og falsk positiv-filtrering for flaggermusklassifikatorer."
+    },
+    "dynamicThreshold": {
+      "birdOnlyNote": "Dynamisk terskel gjelder kun for fugleklassifikatorer."
+    }
+  },
+  "restart": {
+    "applicationRestart": "Start applikasjon på nytt",
+    "containerRestart": "Start container på nytt",
+    "confirmTitle": "Bekreft omstart",
+    "confirmApplicationMessage": "Serveren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "confirmContainerMessage": "Containeren vil starte på nytt. Du vil være midlertidig frakoblet.",
+    "inProgress": "Starter på nytt...",
+    "bannerTitle": "Omstart kreves",
+    "bannerMessage": "Konfigurasjonsendringer krever omstart for å tre i kraft:",
+    "bannerAction": "Start på nytt nå",
+    "restartFailed": "Oppstart av omstart mislyktes"
+  },
+  "help": {
+    "title": "Hjelp og støtte",
+    "subtitle": "Få hjelp, rapporter problemer og koble deg til fellesskapet",
+    "reportBug": {
+      "description": "Hvis du opplever et problem, åpne en feilrapport på GitHub for å beskrive problemet, og generer deretter en supportpakke med saksnummeret for å hjelpe med feilsøking."
+    },
+    "askQuestion": {
+      "description": "Har du spørsmål om oppsett, funksjoner eller bruk? GitHub Discussions er det beste stedet for å få hjelp fra fellesskapet."
+    },
+    "diagnostics": {
+      "description": "Generer en supportpakke for å hjelpe med å diagnostisere problemer. Dette fanger opp systemkonfigurasjonen og nylige logger."
+    },
+    "quickLinks": {
+      "title": "Hurtiglenker",
+      "releases": "Versjonsnyheter"
+    }
+  },
+  "reportBug": {
+    "title": "Rapporter en feil",
+    "subtitle": "Hjelp oss med å fikse problemer ved å gi oss informasjonen vi trenger",
+    "systemInfo": {
+      "title": "Din systeminformasjon",
+      "description": "Denne informasjonen hjelper med å identifisere oppsettet ditt. Kopier det inn i feilrapporten din.",
+      "version": "Versjon",
+      "buildDate": "Byggedato",
+      "os": "Operativsystem",
+      "copy": "Kopier til utklippstavle",
+      "copied": "Kopiert!",
+      "architecture": "Arkitektur",
+      "hardware": "Maskinvare",
+      "environment": "Miljø"
+    },
+    "whatToInclude": {
+      "title": "Hva du bør inkludere i rapporten",
+      "description": "En god feilrapport hjelper oss med å fikse problemet raskt. Inkluder følgende:",
+      "step1": {
+        "title": "Tydelig beskrivelse av problemet",
+        "description": "Hva som skjedde, hva du forventet skulle skje, og hvordan problemet kan reproduseres."
+      },
+      "step2": {
+        "title": "Installasjonsmetode",
+        "description": "Hvordan du installerte BirdNET-Go: install.sh-skript, Docker Compose, manuell bygging eller annet."
+      },
+      "step3": {
+        "title": "Systeminformasjon",
+        "description": "Kopier systemdetaljene vist ovenfor, inkludert versjon, OS og byggedato."
+      },
+      "step4": {
+        "title": "Supportpakke",
+        "description": "Generer og last opp en supportpakke nedenfor. Dette fanger opp logger og konfigurasjon som fremskynder feilsøking betraktelig."
+      }
+    },
+    "openIssue": {
+      "title": "Åpne en GitHub-sak",
+      "description": "Åpne en sak på GitHub for å beskrive problemet. Du trenger saksnummeret til neste steg.",
+      "button": "Åpne sak på GitHub"
+    },
+    "supportDump": {
+      "title": "Generer supportpakke",
+      "description": "Etter at du har registrert saken din, generer en supportpakke og skriv inn GitHub-saksnummeret. Dette kobler diagnostikken til feilrapporten og hjelper med feilsøking."
+    }
+  },
+  "health": {
+    "title": "Systemhelse",
+    "running": "Kjører diagnostikk...",
+    "lastRun": "Sist kjørt",
+    "refresh": "Oppdater",
+    "exportText": "Kopier rapport",
+    "exportJSON": "Last ned JSON",
+    "copied": "Rapport kopiert til utklippstavle",
+    "duration": "Varighet",
+    "summary": {
+      "healthy": "Frisk",
+      "warnings": "Advarsler",
+      "critical": "Kritisk",
+      "skipped": "Hoppet over",
+      "total": "Totalt sjekker"
+    },
+    "metricFooter": {
+      "allPassing": "Alle godkjent",
+      "needsAttention": "Trenger oppmerksomhet",
+      "failing": "Mislykkes",
+      "allClear": "Alt klart",
+      "noData": "Ingen nylige data",
+      "none": "Ingen"
+    },
+    "diagnostics": "Diagnostikk",
+    "categories": {
+      "system": "System",
+      "audio": "Lydpipeline",
+      "analysis": "Analyse",
+      "streams": "Lydstrømmer",
+      "database": "Database",
+      "network": "Nettverk",
+      "config": "Konfigurasjon",
+      "logs": "Logger"
+    },
+    "status": {
+      "healthy": "Frisk",
+      "warning": "Advarsel",
+      "critical": "Kritisk",
+      "unknown": "Ukjent",
+      "skipped": "Hoppet over"
+    },
+    "errors": {
+      "title": "Nylige feil",
+      "noErrors": "Ingen nylige feil",
+      "fetchFailed": "Innlasting av diagnostikk mislyktes"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go systemhelserapport",
+      "statusLabel": "Status",
+      "timeLabel": "Tid",
+      "durationLabel": "Varighet",
+      "checksLabel": "Sjekker"
+    },
+    "logs": {
+      "topErrors": "Vanligste feilmønstre",
+      "errorCount": "Antall",
+      "errorComponent": "Komponent",
+      "errorLevel": "Nivå",
+      "errorMessage": "Melding"
+    },
+    "window": {
+      "label": "Evalueringsvindu",
+      "15m": "15m",
+      "30m": "30m",
+      "1h": "1t",
+      "6h": "6t",
+      "24h": "24t",
+      "7d": "7d"
+    },
+    "detail": {
+      "lastEvent": "Siste hendelse",
+      "recentEvents": "Nylige hendelser",
+      "time": "Tid",
+      "source": "Kilde",
+      "count": "Antall",
+      "lifetime": "levetid",
+      "sparklineLabel": "Aktivitetsoversikt",
+      "activeHours": "Aktive timer",
+      "windowTotal": "I vindu",
+      "velocity": "Trend",
+      "velocityStable": "Stabil",
+      "velocityIncreasing": "Stigende",
+      "velocityDecreasing": "Synkende",
+      "pattern": "Mønster",
+      "patternNone": "Ingen",
+      "patternTransient": "Forbigående",
+      "patternSustained": "Vedvarende"
     }
   }
 }

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Artsliste",
       "switchToGrid": "Bytt til rutenettvisning",
       "switchToList": "Bytt til listevisning",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Bytt til administrasjonsvisning",
       "noSpeciesFound": "Ingen arter funnet som matcher filtrene dine.",
       "headers": {
         "species": "Art",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Ekskludert",
+          "included": "Inkludert",
+          "reviewRatio": "Gjennomgang",
+          "rangeProbability": "Utvalg",
+          "confirmed": "Bekreftet",
+          "actions": "Handlinger"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Slett alle registreringer for denne arten",
+        "deleteTitle": "Slett artsregistreringer",
+        "deleteConfirm": "Slett",
+        "deleteMessage": "Slette alle {count} registreringer for {species}? Låste registreringer beholdes.",
+        "deleteWarning": "Dette fjerner registreringene og lydklippene deres permanent og kan ikke angres.",
+        "deleteFailed": "Kunne ikke slette registreringer. Prøv igjen."
       }
     },
     "advanced": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Soorten lijst",
       "switchToGrid": "Wissel naar tegel overzicht",
       "switchToList": "Wissel naar lijst overzicht",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Naar beheerweergave schakelen",
       "noSpeciesFound": "Geen soorten gevonden voor jouw filters.",
       "headers": {
         "species": "Soort",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Uitgesloten",
+          "included": "Opgenomen",
+          "reviewRatio": "Beoordeling",
+          "rangeProbability": "Bereik",
+          "confirmed": "Bevestigd",
+          "actions": "Acties"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Alle detecties van deze soort verwijderen",
+        "deleteTitle": "Soortdetecties verwijderen",
+        "deleteConfirm": "Verwijderen",
+        "deleteMessage": "Alle {count} detecties van {species} verwijderen? Vergrendelde detecties blijven behouden.",
+        "deleteWarning": "Hiermee worden de detecties en hun audiofragmenten permanent verwijderd en dit kan niet ongedaan worden gemaakt.",
+        "deleteFailed": "Kan detecties niet verwijderen. Probeer het opnieuw."
       }
     },
     "advanced": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Uitgesloten",
           "included": "Opgenomen",
-          "reviewRatio": "Beoordeling",
+          "reviewRatio": "Correct",
           "rangeProbability": "Bereik",
           "confirmed": "Bevestigd",
           "actions": "Acties"

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Soorten lijst",
       "switchToGrid": "Wissel naar tegel overzicht",
       "switchToList": "Wissel naar lijst overzicht",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Geen soorten gevonden voor jouw filters.",
       "headers": {
         "species": "Soort",
@@ -1667,6 +1668,22 @@
         "detections": "Aantal herkend:",
         "confidence": "Betrouwbaarheid:",
         "first": "Eerst:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Lista Gatunków",
       "switchToGrid": "Przełącz na widok siatki",
       "switchToList": "Przełącz na widok listy",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Nie znaleziono gatunków pasujących do twoich filtrów.",
       "headers": {
         "species": "Gatunek",
@@ -1667,6 +1668,22 @@
         "detections": "Detekcje:",
         "confidence": "Pewność:",
         "first": "Pierwsze:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Lista Gatunków",
       "switchToGrid": "Przełącz na widok siatki",
       "switchToList": "Przełącz na widok listy",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Przełącz na widok zarządzania",
       "noSpeciesFound": "Nie znaleziono gatunków pasujących do twoich filtrów.",
       "headers": {
         "species": "Gatunek",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Wykluczony",
+          "included": "Uwzględniony",
+          "reviewRatio": "Przegląd",
+          "rangeProbability": "Zasięg",
+          "confirmed": "Potwierdzony",
+          "actions": "Akcje"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Usuń wszystkie detekcje tego gatunku",
+        "deleteTitle": "Usuń detekcje gatunku",
+        "deleteConfirm": "Usuń",
+        "deleteMessage": "Usunąć wszystkie {count} detekcji gatunku {species}? Zablokowane detekcje zostaną zachowane.",
+        "deleteWarning": "Spowoduje to trwałe usunięcie detekcji oraz ich klipów audio i nie można tego cofnąć.",
+        "deleteFailed": "Nie udało się usunąć detekcji. Spróbuj ponownie."
       }
     },
     "advanced": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Wykluczony",
           "included": "Uwzględniony",
-          "reviewRatio": "Przegląd",
+          "reviewRatio": "Poprawne",
           "rangeProbability": "Zasięg",
           "confirmed": "Potwierdzony",
           "actions": "Akcje"

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Lista de espécies",
       "switchToGrid": "Mudar para visualização em grade",
       "switchToList": "Mudar para visualização em lista",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Nenhuma espécie encontrada que corresponda aos seus filtros.",
       "headers": {
         "species": "Espécie",
@@ -1667,6 +1668,22 @@
         "detections": "Detecções:",
         "confidence": "Confiança:",
         "first": "Primeira:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Lista de espécies",
       "switchToGrid": "Mudar para visualização em grade",
       "switchToList": "Mudar para visualização em lista",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Mudar para a vista de gestão",
       "noSpeciesFound": "Nenhuma espécie encontrada que corresponda aos seus filtros.",
       "headers": {
         "species": "Espécie",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Excluída",
+          "included": "Incluída",
+          "reviewRatio": "Revisão",
+          "rangeProbability": "Alcance",
+          "confirmed": "Confirmada",
+          "actions": "Ações"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Eliminar todas as detecções desta espécie",
+        "deleteTitle": "Eliminar detecções da espécie",
+        "deleteConfirm": "Eliminar",
+        "deleteMessage": "Eliminar todas as {count} detecções de {species}? As detecções bloqueadas são mantidas.",
+        "deleteWarning": "Isto remove permanentemente as detecções e os respetivos clipes de áudio e não pode ser desfeito.",
+        "deleteFailed": "Não foi possível eliminar as detecções. Tente novamente."
       }
     },
     "advanced": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Excluída",
           "included": "Incluída",
-          "reviewRatio": "Revisão",
+          "reviewRatio": "Corretas",
           "rangeProbability": "Alcance",
           "confirmed": "Confirmada",
           "actions": "Ações"

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Vylúčené",
           "included": "Zahrnuté",
-          "reviewRatio": "Kontrola",
+          "reviewRatio": "Správne",
           "rangeProbability": "Rozsah",
           "confirmed": "Potvrdené",
           "actions": "Akcie"

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Zoznam druhov",
       "switchToGrid": "Prepnúť na mriežku",
       "switchToList": "Prepnúť na zoznam",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Prepnúť na zobrazenie správy",
       "noSpeciesFound": "Nenašli sa žiadne druhy zodpovedajúce vašim filtrom.",
       "headers": {
         "species": "Druh",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Vylúčené",
+          "included": "Zahrnuté",
+          "reviewRatio": "Kontrola",
+          "rangeProbability": "Rozsah",
+          "confirmed": "Potvrdené",
+          "actions": "Akcie"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Odstrániť všetky detekcie tohto druhu",
+        "deleteTitle": "Odstrániť detekcie druhu",
+        "deleteConfirm": "Odstrániť",
+        "deleteMessage": "Odstrániť všetkých {count} detekcií druhu {species}? Uzamknuté detekcie zostanú zachované.",
+        "deleteWarning": "Týmto sa natrvalo odstránia detekcie aj ich zvukové klipy a túto akciu nie je možné vrátiť späť.",
+        "deleteFailed": "Detekcie sa nepodarilo odstrániť. Skúste to znova."
       }
     },
     "advanced": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Zoznam druhov",
       "switchToGrid": "Prepnúť na mriežku",
       "switchToList": "Prepnúť na zoznam",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Nenašli sa žiadne druhy zodpovedajúce vašim filtrom.",
       "headers": {
         "species": "Druh",
@@ -1667,6 +1668,22 @@
         "detections": "Detekcie:",
         "confidence": "Istota:",
         "first": "Prvýkrát:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1654,6 +1654,7 @@
       "speciesList": "Artlista",
       "switchToGrid": "Byt till rutnätsvy",
       "switchToList": "Byt till listvy",
+      "switchToManage": "Switch to manage view",
       "noSpeciesFound": "Inga arter hittades som matchar dina filter.",
       "headers": {
         "species": "Art",
@@ -1667,6 +1668,22 @@
         "detections": "Detektioner:",
         "confidence": "Konfidens:",
         "first": "Först:"
+      },
+      "manage": {
+        "headers": {
+          "excluded": "Excluded",
+          "included": "Included",
+          "reviewRatio": "Review",
+          "rangeProbability": "Range",
+          "confirmed": "Confirmed",
+          "actions": "Actions"
+        },
+        "delete": "Delete all detections for this species",
+        "deleteTitle": "Delete species detections",
+        "deleteConfirm": "Delete",
+        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
+        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
+        "deleteFailed": "Failed to delete detections. Please try again."
       }
     },
     "advanced": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1654,7 +1654,7 @@
       "speciesList": "Artlista",
       "switchToGrid": "Byt till rutnätsvy",
       "switchToList": "Byt till listvy",
-      "switchToManage": "Switch to manage view",
+      "switchToManage": "Växla till hanteringsvy",
       "noSpeciesFound": "Inga arter hittades som matchar dina filter.",
       "headers": {
         "species": "Art",
@@ -1671,19 +1671,19 @@
       },
       "manage": {
         "headers": {
-          "excluded": "Excluded",
-          "included": "Included",
-          "reviewRatio": "Review",
-          "rangeProbability": "Range",
-          "confirmed": "Confirmed",
-          "actions": "Actions"
+          "excluded": "Exkluderad",
+          "included": "Inkluderad",
+          "reviewRatio": "Granskning",
+          "rangeProbability": "Område",
+          "confirmed": "Bekräftad",
+          "actions": "Åtgärder"
         },
-        "delete": "Delete all detections for this species",
-        "deleteTitle": "Delete species detections",
-        "deleteConfirm": "Delete",
-        "deleteMessage": "Delete all {count} detections for {species}? Locked detections are kept.",
-        "deleteWarning": "This permanently removes the detections and their audio clips and cannot be undone.",
-        "deleteFailed": "Failed to delete detections. Please try again."
+        "delete": "Radera alla detektioner för denna art",
+        "deleteTitle": "Radera artdetektioner",
+        "deleteConfirm": "Radera",
+        "deleteMessage": "Radera alla {count} detektioner för {species}? Låsta detektioner behålls.",
+        "deleteWarning": "Detta tar bort detektionerna och deras ljudklipp permanent och kan inte ångras.",
+        "deleteFailed": "Det gick inte att radera detektionerna. Försök igen."
       }
     },
     "advanced": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1673,7 +1673,7 @@
         "headers": {
           "excluded": "Exkluderad",
           "included": "Inkluderad",
-          "reviewRatio": "Granskning",
+          "reviewRatio": "Korrekt",
           "rangeProbability": "Område",
           "confirmed": "Bekräftad",
           "actions": "Åtgärder"

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -86,6 +86,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | ------ | ------------------------------------- | -------------------------- | ---- | ---------------------------------- |
 | GET    | `/analytics/species/daily`            | `GetDailySpeciesSummary`   | ❌   | Daily species detection summary    |
 | GET    | `/analytics/species/summary`          | `GetSpeciesSummary`        | ❌   | Overall species statistics         |
+| GET    | `/analytics/species/review-stats`     | `GetSpeciesReviewStats`    | ✅   | Per-species total/verified/rejected review counts (Manage view; 501 if datastore unsupported) |
 | GET    | `/analytics/species/detections/new`   | `GetNewSpeciesDetections`  | ❌   | Recently detected new species      |
 | GET    | `/analytics/species/thumbnails`       | `GetSpeciesThumbnails`     | ❌   | Species thumbnail images           |
 | GET    | `/analytics/time/hourly`              | `GetHourlyAnalytics`       | ❌   | Hourly detection patterns          |
@@ -125,6 +126,11 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | POST   | `/detections/:id/lock`        | `LockDetection`         | ✅   | Lock detection from changes                |
 | POST   | `/detections/ignore`          | `IgnoreSpecies`         | ✅   | Toggle species in ignore list (add/remove) |
 | GET    | `/detections/ignored`         | `GetExcludedSpecies`    | ✅   | Get list of excluded species               |
+| POST   | `/detections/include`         | `IncludeSpecies`        | ✅   | Toggle species in always-include list (add/remove) |
+| GET    | `/detections/included`        | `GetIncludedSpecies`    | ✅   | Get always-include species list            |
+| POST   | `/detections/confirm`         | `ConfirmSpecies`        | ✅   | Toggle species in confirmed list (analytics-only) |
+| GET    | `/detections/confirmed`       | `GetConfirmedSpecies`   | ✅   | Get confirmed species list                 |
+| POST   | `/detections/species/delete`  | `DeleteSpeciesDetections` | ✅ | Delete all detections for a species (skips locked; 501 if datastore unsupported) |
 | POST   | `/detections/batch/delete`    | `BatchDeleteDetections` | ✅   | Bulk delete detections by ID               |
 | POST   | `/detections/batch/review`    | `BatchReviewDetections` | ✅   | Bulk set verification status               |
 | POST   | `/detections/batch/lock`      | `BatchLockDetections`   | ✅   | Bulk lock or unlock detections             |

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -172,6 +172,7 @@ func (c *Controller) initAnalyticsRoutes() {
 	speciesGroup.GET("/daily", c.GetDailySpeciesSummary)
 	speciesGroup.GET("/daily/batch", c.GetBatchDailySpeciesSummary) // Batch daily summaries endpoint
 	speciesGroup.GET("/summary", c.GetSpeciesSummary)
+	speciesGroup.GET("/review-stats", c.GetSpeciesReviewStats, c.authMiddleware) // Protected: analytics "Manage" view
 	speciesGroup.GET("/detections/new", c.GetNewSpeciesDetections) // Renamed endpoint
 	speciesGroup.GET("/thumbnails", c.GetSpeciesThumbnails)        // Batch thumbnail endpoint
 	speciesGroup.GET("/diversity", c.GetSpeciesDiversity)          // Species diversity over time
@@ -631,6 +632,46 @@ func applySpeciesStatusToSummary(summary *SpeciesDailySummary, status *species.S
 	}
 
 	summary.CurrentSeason = status.CurrentSeason
+}
+
+// speciesReviewStatsDatastore is the optional datastore capability required to
+// compute per-species review statistics. Datastores that do not implement it
+// cause GetSpeciesReviewStats to return HTTP 501.
+type speciesReviewStatsDatastore interface {
+	GetSpeciesReviewStats(ctx context.Context) ([]datastore.SpeciesReviewStat, error)
+}
+
+// GetSpeciesReviewStats handles GET /api/v2/analytics/species/review-stats.
+// It returns per-species total/verified/rejected counts across all time for the
+// analytics "Manage" view. Returns HTTP 501 when the active datastore cannot
+// provide review statistics.
+func (c *Controller) GetSpeciesReviewStats(ctx echo.Context) error {
+	ip, path := ctx.RealIP(), ctx.Request().URL.Path
+
+	ds, ok := c.DS.(speciesReviewStatsDatastore)
+	if !ok {
+		return c.HandleError(ctx, fmt.Errorf("datastore does not support review stats"),
+			"Review statistics are not supported by the active datastore", http.StatusNotImplemented)
+	}
+
+	queryCtx, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
+	stats, err := ds.GetSpeciesReviewStats(queryCtx)
+	if err != nil {
+		return c.handleAnalyticsQueryError(ctx, err, "Species review stats", "Failed to get species review stats",
+			logger.String("ip", ip),
+			logger.String("path", path),
+		)
+	}
+
+	c.logInfoIfEnabled("Species review stats retrieved",
+		logger.Int("count", len(stats)),
+		logger.String("ip", ip),
+		logger.String("path", path),
+	)
+
+	return ctx.JSON(http.StatusOK, stats)
 }
 
 // GetSpeciesSummary handles GET /api/v2/analytics/species/summary

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -66,7 +66,7 @@ func TestGetSpeciesReviewStats(t *testing.T) {
 		controller.DS = &managedSpeciesStubDS{
 			MockInterface: mockDS,
 			reviewStats: []datastore.SpeciesReviewStat{
-				{ScientificName: "Turdus migratorius", Total: 3, Verified: 2, Rejected: 1},
+				{ScientificName: "Turdus migratorius", CommonName: "American Robin", Total: 3, Verified: 2, Rejected: 1},
 			},
 		}
 
@@ -81,6 +81,9 @@ func TestGetSpeciesReviewStats(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 		require.Len(t, response, 1)
 		assert.Equal(t, "Turdus migratorius", response[0]["scientificName"])
+		// commonName is surfaced so the Manage view can render a row for species
+		// whose detections were all rejected (absent from the period summary).
+		assert.Equal(t, "American Robin", response[0]["commonName"])
 		assert.InDelta(t, 3, response[0]["total"], 0.01)
 		assert.InDelta(t, 2, response[0]["verified"], 0.01)
 		assert.InDelta(t, 1, response[0]["rejected"], 0.01)

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -55,6 +55,68 @@ func assertAnalyticsErrorResponse(t *testing.T, rec *httptest.ResponseRecorder, 
 }
 
 // TestGetSpeciesSummary tests the species summary endpoint
+// TestGetSpeciesReviewStats covers the analytics review-stats endpoint: success,
+// empty result, and the HTTP 501 fallback when the datastore lacks support.
+func TestGetSpeciesReviewStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+		controller.DS = &managedSpeciesStubDS{
+			MockInterface: mockDS,
+			reviewStats: []datastore.SpeciesReviewStat{
+				{ScientificName: "Turdus migratorius", Total: 3, Verified: 2, Rejected: 1},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/review-stats", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		require.NoError(t, controller.GetSpeciesReviewStats(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response []map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+		require.Len(t, response, 1)
+		assert.Equal(t, "Turdus migratorius", response[0]["scientificName"])
+		assert.InDelta(t, 3, response[0]["total"], 0.01)
+		assert.InDelta(t, 2, response[0]["verified"], 0.01)
+		assert.InDelta(t, 1, response[0]["rejected"], 0.01)
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		t.Parallel()
+		e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+		controller.DS = &managedSpeciesStubDS{MockInterface: mockDS, reviewStats: []datastore.SpeciesReviewStat{}}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/review-stats", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		require.NoError(t, controller.GetSpeciesReviewStats(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response []map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+		assert.Empty(t, response)
+	})
+
+	t.Run("unsupported datastore returns 501", func(t *testing.T) {
+		t.Parallel()
+		// The plain mock does not implement speciesReviewStatsDatastore.
+		e, _, controller := setupAnalyticsTestEnvironment(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/review-stats", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		require.NoError(t, controller.GetSpeciesReviewStats(c))
+		assert.Equal(t, http.StatusNotImplemented, rec.Code)
+	})
+}
+
 func TestGetSpeciesSummary(t *testing.T) {
 	t.Parallel()
 	// Go 1.25: Add test metadata for better organization and reporting

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -158,6 +158,11 @@ func (c *Controller) initDetectionRoutes() {
 	detectionGroup.POST("/:id/lock", c.LockDetection)
 	detectionGroup.POST("/ignore", c.IgnoreSpecies)
 	detectionGroup.GET("/ignored", c.GetExcludedSpecies)
+	detectionGroup.POST("/include", c.IncludeSpecies)
+	detectionGroup.GET("/included", c.GetIncludedSpecies)
+	detectionGroup.POST("/confirm", c.ConfirmSpecies)
+	detectionGroup.GET("/confirmed", c.GetConfirmedSpecies)
+	detectionGroup.POST("/species/delete", c.DeleteSpeciesDetections)
 
 	// Batch operation endpoints
 	batchGroup := detectionGroup.Group("/batch")
@@ -1537,6 +1542,31 @@ type ExcludedSpeciesResponse struct {
 	Count   int      `json:"count"`
 }
 
+// Species-list toggle actions returned to clients.
+const (
+	speciesActionAdded   = "added"
+	speciesActionRemoved = "removed"
+)
+
+// SpeciesListRequest represents the request body for toggling a species in a
+// managed species list (always-include or confirmed).
+type SpeciesListRequest struct {
+	CommonName string `json:"common_name"`
+}
+
+// SpeciesListToggleResponse is returned by the include/confirm toggle endpoints.
+type SpeciesListToggleResponse struct {
+	CommonName string `json:"common_name"`
+	Action     string `json:"action"` // "added" or "removed"
+	Present    bool   `json:"present"`
+}
+
+// SpeciesListResponse is returned by the included/confirmed list endpoints.
+type SpeciesListResponse struct {
+	Species []string `json:"species"`
+	Count   int      `json:"count"`
+}
+
 // IgnoreSpecies toggles a species in the ignored list (adds if not present, removes if present)
 func (c *Controller) IgnoreSpecies(ctx echo.Context) error {
 	// Parse request body
@@ -1667,6 +1697,121 @@ func (c *Controller) addSpeciesToIgnoredList(species string) error {
 	}
 
 	return nil
+}
+
+// IncludeSpecies toggles a species in the always-include list (adds if absent, removes if present).
+func (c *Controller) IncludeSpecies(ctx echo.Context) error {
+	return c.toggleManagedSpecies(ctx,
+		func(s *conf.Settings) []string { return s.Realtime.Species.Include },
+		func(s *conf.Settings, list []string) { s.Realtime.Species.Include = list },
+		true, "include")
+}
+
+// GetIncludedSpecies returns the always-include species list.
+func (c *Controller) GetIncludedSpecies(ctx echo.Context) error {
+	species := slices.Clone(c.getSettingsOrFallback().Realtime.Species.Include)
+
+	return ctx.JSON(http.StatusOK, SpeciesListResponse{
+		Species: species,
+		Count:   len(species),
+	})
+}
+
+// ConfirmSpecies toggles a species in the confirmed list (adds if absent, removes if present).
+// The confirmed list is analytics-only and does not affect detection processing, so no
+// settings side-effects are triggered.
+func (c *Controller) ConfirmSpecies(ctx echo.Context) error {
+	return c.toggleManagedSpecies(ctx,
+		func(s *conf.Settings) []string { return s.Realtime.Species.Confirmed },
+		func(s *conf.Settings, list []string) { s.Realtime.Species.Confirmed = list },
+		false, "confirm")
+}
+
+// GetConfirmedSpecies returns the confirmed species list.
+func (c *Controller) GetConfirmedSpecies(ctx echo.Context) error {
+	species := slices.Clone(c.getSettingsOrFallback().Realtime.Species.Confirmed)
+
+	return ctx.JSON(http.StatusOK, SpeciesListResponse{
+		Species: species,
+		Count:   len(species),
+	})
+}
+
+// toggleManagedSpecies binds and validates the request, toggles the species in
+// the list selected by listOf/setList, and returns the standard toggle response.
+func (c *Controller) toggleManagedSpecies(ctx echo.Context, listOf func(*conf.Settings) []string, setList func(*conf.Settings, []string), triggerSideEffects bool, opLabel string) error {
+	req := &SpeciesListRequest{}
+	if err := ctx.Bind(req); err != nil {
+		return c.HandleError(ctx, err, "Invalid request format", http.StatusBadRequest)
+	}
+	if req.CommonName == "" {
+		return c.HandleError(ctx, nil, "Missing species name", http.StatusBadRequest)
+	}
+
+	action, present, err := c.toggleSpeciesInList(req.CommonName, listOf, setList, triggerSideEffects)
+	if err != nil {
+		return c.HandleError(ctx, err, "Failed to update species list", http.StatusInternalServerError)
+	}
+
+	c.logInfoIfEnabled("Species "+opLabel+" toggled",
+		logger.String("species", req.CommonName),
+		logger.String("action", action),
+		logger.Bool("present", present),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	return ctx.JSON(http.StatusOK, SpeciesListToggleResponse{
+		CommonName: req.CommonName,
+		Action:     action,
+		Present:    present,
+	})
+}
+
+// toggleSpeciesInList toggles a species in one of the realtime species lists
+// (e.g. include or confirmed) under the settings mutex, persisting the change
+// through the standard publish/save path. listOf reads the current slice and
+// setList writes the updated slice back onto a cloned Settings. When
+// triggerSideEffects is true, settings change side-effects (e.g. range filter
+// rebuild) are triggered after saving. Returns the action ("added"/"removed")
+// and the resulting membership state.
+func (c *Controller) toggleSpeciesInList(species string, listOf func(*conf.Settings) []string, setList func(*conf.Settings, []string), triggerSideEffects bool) (action string, present bool, err error) {
+	if species == "" {
+		return "", false, nil
+	}
+
+	// Serialise this read-modify-write against concurrent settings saves so an
+	// out-of-band StoreSettings cannot interleave between read and publish.
+	c.settingsMutex.Lock()
+	defer c.settingsMutex.Unlock()
+
+	current := c.getSettingsOrFallback()
+	wasPresent := slices.Contains(listOf(current), species)
+
+	updated := conf.CloneSettings(current)
+	if wasPresent {
+		setList(updated, slices.DeleteFunc(listOf(updated), func(s string) bool { return s == species }))
+		action = speciesActionRemoved
+		present = false
+	} else {
+		setList(updated, append(listOf(updated), species))
+		action = speciesActionAdded
+		present = true
+	}
+
+	if err := c.publishAndSaveSettings(current, updated); err != nil {
+		return "", wasPresent, err
+	}
+
+	if triggerSideEffects {
+		if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
+			GetLogger().Warn("Failed to trigger settings side-effects after species list change",
+				logger.Error(handleErr),
+				logger.String("species", species),
+				logger.String("action", action))
+		}
+	}
+
+	return action, present, nil
 }
 
 // AddComment creates a comment for a note

--- a/internal/api/v2/detections_batch.go
+++ b/internal/api/v2/detections_batch.go
@@ -79,12 +79,25 @@ func (c *Controller) BatchDeleteDetections(ctx echo.Context) error {
 			"Batch size exceeds maximum", http.StatusBadRequest)
 	}
 
-	ids := deduplicateIDs(req.IDs)
-	var processed, skipped int
+	processed, skipped := c.deleteNotesByIDs(deduplicateIDs(req.IDs))
+
+	c.invalidateDetectionCache()
+
+	return ctx.JSON(http.StatusOK, BatchResult{
+		Processed: processed,
+		Skipped:   skipped,
+	})
+}
+
+// deleteNotesByIDs deletes the given detections, skipping locked ones, and removes
+// any associated audio/spectrogram files. It returns the number of deletions
+// performed and the number skipped (missing or locked). Callers are responsible
+// for deduplicating IDs and invalidating the detection cache.
+func (c *Controller) deleteNotesByIDs(ids []string) (deleted, skipped int) {
 	for _, idStr := range ids {
 		note, err := c.DS.Get(idStr)
 		if err != nil {
-			c.logWarnIfEnabled("Batch delete: failed to get detection",
+			c.logWarnIfEnabled("Delete: failed to get detection",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
@@ -97,25 +110,19 @@ func (c *Controller) BatchDeleteDetections(ctx echo.Context) error {
 
 		clipName := note.ClipName
 		if err := c.DS.Delete(idStr); err != nil {
-			c.logWarnIfEnabled("Batch delete: failed to delete detection",
+			c.logWarnIfEnabled("Delete: failed to delete detection",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
 			continue
 		}
 
-		processed++
+		deleted++
 		if clipName != "" {
 			c.removeDetectionFiles(clipName)
 		}
 	}
-
-	c.invalidateDetectionCache()
-
-	return ctx.JSON(http.StatusOK, BatchResult{
-		Processed: processed,
-		Skipped:   skipped,
-	})
+	return deleted, skipped
 }
 
 // BatchReviewDetections sets the verification status on multiple detections, skipping locked ones.
@@ -270,5 +277,63 @@ func (c *Controller) BatchResolveDetections(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, BatchResolveResult{
 		IDs:   ids,
 		Count: len(ids),
+	})
+}
+
+// SpeciesDeleteRequest is the request body for deleting all detections of a species.
+type SpeciesDeleteRequest struct {
+	ScientificName string `json:"scientific_name"`
+}
+
+// SpeciesDeleteResult reports the outcome of a species-wide delete.
+type SpeciesDeleteResult struct {
+	Deleted int `json:"deleted"`
+	Skipped int `json:"skipped"`
+}
+
+// speciesNoteIDsDatastore is the optional datastore capability required to resolve
+// every detection ID for a scientific name. Datastores that do not implement it
+// cause DeleteSpeciesDetections to return HTTP 501.
+type speciesNoteIDsDatastore interface {
+	GetSpeciesNoteIDs(scientificName string) ([]string, error)
+}
+
+// DeleteSpeciesDetections deletes every detection for a scientific name, skipping
+// locked detections. The species is supplied in the JSON body. Returns the number
+// of detections deleted and skipped.
+func (c *Controller) DeleteSpeciesDetections(ctx echo.Context) error {
+	var req SpeciesDeleteRequest
+	if err := ctx.Bind(&req); err != nil {
+		return c.HandleError(ctx, err, "Invalid request format", http.StatusBadRequest)
+	}
+	if req.ScientificName == "" {
+		return c.HandleError(ctx, fmt.Errorf("no scientific name provided"),
+			"Scientific name is required", http.StatusBadRequest)
+	}
+
+	ds, ok := c.DS.(speciesNoteIDsDatastore)
+	if !ok {
+		return c.HandleError(ctx, fmt.Errorf("datastore does not support species note lookup"),
+			"Species deletion is not supported by the active datastore", http.StatusNotImplemented)
+	}
+
+	ids, err := ds.GetSpeciesNoteIDs(req.ScientificName)
+	if err != nil {
+		return c.HandleError(ctx, err, "Failed to look up detections for species", http.StatusInternalServerError)
+	}
+
+	deleted, skipped := c.deleteNotesByIDs(deduplicateIDs(ids))
+
+	c.invalidateDetectionCache()
+
+	c.logInfoIfEnabled("Species detections deleted",
+		logger.String("scientific_name", req.ScientificName),
+		logger.Int("deleted", deleted),
+		logger.Int("skipped", skipped),
+		logger.String("ip", ctx.RealIP()))
+
+	return ctx.JSON(http.StatusOK, SpeciesDeleteResult{
+		Deleted: deleted,
+		Skipped: skipped,
 	})
 }

--- a/internal/api/v2/detections_batch_test.go
+++ b/internal/api/v2/detections_batch_test.go
@@ -100,6 +100,123 @@ func TestBatchDeleteDetections(t *testing.T) {
 	}
 }
 
+// TestDeleteSpeciesDetections tests the species-wide delete endpoint, including
+// skip-locked behavior, no-match handling, and the HTTP 501 fallback.
+func TestDeleteSpeciesDetections(t *testing.T) {
+	e, mockDS, controller := setupTestEnvironment(t)
+
+	testCases := []struct {
+		name           string
+		body           any
+		noteIDs        map[string][]string
+		useStub        bool
+		mockSetup      func(*mock.Mock)
+		expectedStatus int
+		checkResult    func(t *testing.T, rec *httptest.ResponseRecorder)
+	}{
+		{
+			name:    "deletes detections for scientific name",
+			body:    SpeciesDeleteRequest{ScientificName: "Turdus migratorius"},
+			noteIDs: map[string][]string{"Turdus migratorius": {"1", "2"}},
+			useStub: true,
+			mockSetup: func(m *mock.Mock) {
+				m.On("Get", "1").Return(datastore.Note{ID: 1, Locked: false, ClipName: ""}, nil)
+				m.On("Delete", "1").Return(nil)
+				m.On("Get", "2").Return(datastore.Note{ID: 2, Locked: false, ClipName: ""}, nil)
+				m.On("Delete", "2").Return(nil)
+			},
+			expectedStatus: http.StatusOK,
+			checkResult: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
+				var result SpeciesDeleteResult
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+				assert.Equal(t, 2, result.Deleted)
+				assert.Equal(t, 0, result.Skipped)
+			},
+		},
+		{
+			name:           "no matching detections",
+			body:           SpeciesDeleteRequest{ScientificName: "Unknown species"},
+			noteIDs:        map[string][]string{},
+			useStub:        true,
+			mockSetup:      func(_ *mock.Mock) {},
+			expectedStatus: http.StatusOK,
+			checkResult: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
+				var result SpeciesDeleteResult
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+				assert.Equal(t, 0, result.Deleted)
+				assert.Equal(t, 0, result.Skipped)
+			},
+		},
+		{
+			name:    "skips locked detections",
+			body:    SpeciesDeleteRequest{ScientificName: "Turdus migratorius"},
+			noteIDs: map[string][]string{"Turdus migratorius": {"1", "2"}},
+			useStub: true,
+			mockSetup: func(m *mock.Mock) {
+				m.On("Get", "1").Return(datastore.Note{ID: 1, Locked: false, ClipName: ""}, nil)
+				m.On("Delete", "1").Return(nil)
+				m.On("Get", "2").Return(datastore.Note{ID: 2, Locked: true}, nil)
+			},
+			expectedStatus: http.StatusOK,
+			checkResult: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
+				var result SpeciesDeleteResult
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+				assert.Equal(t, 1, result.Deleted)
+				assert.Equal(t, 1, result.Skipped)
+			},
+		},
+		{
+			name:           "missing scientific name returns 400",
+			body:           SpeciesDeleteRequest{ScientificName: ""},
+			useStub:        true,
+			mockSetup:      func(_ *mock.Mock) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "unsupported datastore returns 501",
+			body:           SpeciesDeleteRequest{ScientificName: "Turdus migratorius"},
+			useStub:        false,
+			mockSetup:      func(_ *mock.Mock) {},
+			expectedStatus: http.StatusNotImplemented,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDS.ExpectedCalls = nil
+			mockDS.Calls = nil
+			tc.mockSetup(&mockDS.Mock)
+
+			if tc.useStub {
+				controller.DS = &managedSpeciesStubDS{MockInterface: mockDS, noteIDs: tc.noteIDs}
+			} else {
+				controller.DS = mockDS
+			}
+
+			bodyBytes, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/species/delete", bytes.NewReader(bodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err = controller.DeleteSpeciesDetections(c)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedStatus, rec.Code)
+
+			if tc.checkResult != nil {
+				tc.checkResult(t, rec)
+			}
+
+			mockDS.AssertExpectations(t)
+		})
+	}
+}
+
 // TestBatchReviewDetections tests the BatchReviewDetections endpoint.
 func TestBatchReviewDetections(t *testing.T) {
 	e, mockDS, controller := setupTestEnvironment(t)

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -1367,6 +1367,69 @@ func clearExcludedSpeciesList(t *testing.T, settings *conf.Settings) {
 	settings.Realtime.Species.Exclude = []string{}
 }
 
+// postSpeciesListToggle posts a common_name body to a species-list toggle handler
+// and returns the response recorder.
+func postSpeciesListToggle(t *testing.T, e *echo.Echo, handler func(echo.Context) error, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/toggle", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	require.NoError(t, handler(e.NewContext(req, rec)))
+	return rec
+}
+
+// getSpeciesList calls a species-list GET handler and returns the species slice.
+func getSpeciesList(t *testing.T, e *echo.Echo, handler func(echo.Context) error) []string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	require.NoError(t, handler(e.NewContext(httptest.NewRequest(http.MethodGet, "/api/v2/detections/list", http.NoBody), rec)))
+	var listed SpeciesListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &listed))
+	return listed.Species
+}
+
+// assertSpeciesListToggleRoundTrip exercises add -> verify -> remove -> verify plus
+// the empty-name error path for a managed species list (include or confirmed).
+func assertSpeciesListToggleRoundTrip(t *testing.T, e *echo.Echo, toggle, get func(echo.Context) error) {
+	t.Helper()
+	const speciesName = "American Crow"
+	const body = `{"common_name": "American Crow"}`
+
+	added := postSpeciesListToggle(t, e, toggle, body)
+	assert.Equal(t, http.StatusOK, added.Code)
+	var addResp SpeciesListToggleResponse
+	require.NoError(t, json.Unmarshal(added.Body.Bytes(), &addResp))
+	assert.Equal(t, "added", addResp.Action)
+	assert.True(t, addResp.Present)
+	assert.Contains(t, getSpeciesList(t, e, get), speciesName, "species should be saved after add")
+
+	removed := postSpeciesListToggle(t, e, toggle, body)
+	var removeResp SpeciesListToggleResponse
+	require.NoError(t, json.Unmarshal(removed.Body.Bytes(), &removeResp))
+	assert.Equal(t, "removed", removeResp.Action)
+	assert.False(t, removeResp.Present)
+	assert.NotContains(t, getSpeciesList(t, e, get), speciesName, "species should be removed after second toggle")
+
+	errRec := postSpeciesListToggle(t, e, toggle, `{"common_name": ""}`)
+	assert.Equal(t, http.StatusBadRequest, errRec.Code)
+}
+
+// TestIncludeSpecies tests the always-include toggle endpoint and its read endpoint.
+func TestIncludeSpecies(t *testing.T) {
+	e, _, controller := setupTestEnvironment(t)
+	controller.DisableSaveSettings = true // exercise the publish path without disk I/O
+	controller.Settings.Load().Realtime.Species.Include = []string{}
+	assertSpeciesListToggleRoundTrip(t, e, controller.IncludeSpecies, controller.GetIncludedSpecies)
+}
+
+// TestConfirmSpecies tests the confirmed-list toggle endpoint and its read endpoint.
+func TestConfirmSpecies(t *testing.T) {
+	e, _, controller := setupTestEnvironment(t)
+	controller.DisableSaveSettings = true // exercise the publish path without disk I/O
+	controller.Settings.Load().Realtime.Species.Confirmed = []string{}
+	assertSpeciesListToggleRoundTrip(t, e, controller.ConfirmSpecies, controller.GetConfirmedSpecies)
+}
+
 // TestIgnoreSpecies tests the IgnoreSpecies endpoint with toggle behavior
 func TestIgnoreSpecies(t *testing.T) {
 	// Test cases for error scenarios

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2106,6 +2106,12 @@ func getBlockedFieldMap() map[string]any {
 		// Realtime section - block runtime fields
 		"Realtime": map[string]any{
 			"Audio": getAudioBlockedFields(),
+			// Species.Confirmed is analytics-only and managed exclusively via
+			// /api/v2/detections/confirm. Block it so a Settings save (which omits
+			// it) cannot clobber the confirmed list.
+			"Species": map[string]any{
+				"Confirmed": true,
+			},
 		},
 
 		// All other fields are allowed by default

--- a/internal/api/v2/settings_update_test.go
+++ b/internal/api/v2/settings_update_test.go
@@ -526,6 +526,29 @@ func TestEmptyUpdatePreservesEverything(t *testing.T) {
 	assert.JSONEq(t, string(initialJSON), string(updatedJSON))
 }
 
+// TestUpdateAllowedSettings_PreservesConfirmedSpecies verifies that a full-settings
+// update (PUT /api/v2/settings) which omits Realtime.Species.Confirmed — as the
+// frontend does, since it is analytics-only and absent from the settings form —
+// preserves the confirmed list while still applying the other species fields.
+func TestUpdateAllowedSettings_PreservesConfirmedSpecies(t *testing.T) {
+	dest := getTestSettings(t)
+	dest.Realtime.Species.Confirmed = []string{"American Robin"}
+	dest.Realtime.Species.Include = []string{"Blue Jay"}
+
+	// Simulate the frontend payload: include changes, confirmed omitted (nil).
+	src := conf.CloneSettings(dest)
+	src.Realtime.Species.Confirmed = nil
+	src.Realtime.Species.Include = []string{"Northern Cardinal"}
+
+	_, err := updateAllowedSettingsWithTracking(dest, src)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"American Robin"}, dest.Realtime.Species.Confirmed,
+		"confirmed list must be preserved across a settings save")
+	assert.Equal(t, []string{"Northern Cardinal"}, dest.Realtime.Species.Include,
+		"include list must still update normally")
+}
+
 // TestValidationErrors verifies validation rules are enforced
 func TestValidationErrors(t *testing.T) {
 	t.Parallel()

--- a/internal/api/v2/test_utils_test.go
+++ b/internal/api/v2/test_utils_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,6 +18,26 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
+
+// managedSpeciesStubDS wraps the generated datastore mock and additionally
+// implements the optional speciesReviewStatsDatastore and speciesNoteIDsDatastore
+// interfaces, so tests can exercise the success paths of the analytics
+// "Manage" view endpoints. The embedded mock still drives Get/Delete behavior.
+type managedSpeciesStubDS struct {
+	*mocks.MockInterface
+	reviewStats []datastore.SpeciesReviewStat
+	noteIDs     map[string][]string
+}
+
+// GetSpeciesReviewStats returns the canned review stats configured on the stub.
+func (d *managedSpeciesStubDS) GetSpeciesReviewStats(_ context.Context) ([]datastore.SpeciesReviewStat, error) {
+	return d.reviewStats, nil
+}
+
+// GetSpeciesNoteIDs returns the canned note IDs for the given scientific name.
+func (d *managedSpeciesStubDS) GetSpeciesNoteIDs(scientificName string) ([]string, error) {
+	return d.noteIDs[scientificName], nil
+}
 
 // Test environment constants
 const (

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -88,6 +88,7 @@ func CloneSettings(src *Settings) *Settings {
 	// Realtime.Species.
 	dst.Realtime.Species.Include = slices.Clone(src.Realtime.Species.Include)
 	dst.Realtime.Species.Exclude = slices.Clone(src.Realtime.Species.Exclude)
+	dst.Realtime.Species.Confirmed = slices.Clone(src.Realtime.Species.Confirmed)
 	dst.Realtime.Species.Config = cloneSpeciesConfigMap(src.Realtime.Species.Config)
 
 	// Realtime.SpeciesTracking.SeasonalTracking.Seasons: values are plain value

--- a/internal/conf/clone_test.go
+++ b/internal/conf/clone_test.go
@@ -118,6 +118,7 @@ func newPopulatedSettings() *Settings {
 
 	s.Realtime.Species.Include = []string{"Corvus corax"}
 	s.Realtime.Species.Exclude = []string{"Passer domesticus"}
+	s.Realtime.Species.Confirmed = []string{"Turdus merula"}
 	s.Realtime.Species.Config = map[string]SpeciesConfig{
 		"Turdus merula": {
 			Threshold: 0.5,
@@ -241,6 +242,7 @@ func mutateCloneEverywhere(dst *Settings) {
 
 	dst.Realtime.Species.Include[0] = mutated
 	dst.Realtime.Species.Exclude[0] = mutated
+	dst.Realtime.Species.Confirmed[0] = mutated
 	sc := dst.Realtime.Species.Config["Turdus merula"]
 	sc.Threshold = 0.99
 	sc.Actions[0].Parameters[0] = mutated
@@ -374,6 +376,7 @@ func assertSourceUnchanged(t *testing.T, src *Settings) {
 
 	assert.Equal(t, []string{"Corvus corax"}, src.Realtime.Species.Include)
 	assert.Equal(t, []string{"Passer domesticus"}, src.Realtime.Species.Exclude)
+	assert.Equal(t, []string{"Turdus merula"}, src.Realtime.Species.Confirmed)
 	sc, ok := src.Realtime.Species.Config["Turdus merula"]
 	require.True(t, ok)
 	assert.InDelta(t, 0.5, sc.Threshold, 0.0001)

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -860,10 +860,10 @@ type SpeciesConfig struct {
 // species names in any case (e.g., "American Robin", "american robin")
 // and they will all resolve to the same lowercase key.
 type SpeciesSettings struct {
-	Include []string                 `yaml:"include" json:"include"` // Always include these species
-	Exclude []string                 `yaml:"exclude" json:"exclude"` // Always exclude these species
+	Include   []string                 `yaml:"include" json:"include"`     // Always include these species
+	Exclude   []string                 `yaml:"exclude" json:"exclude"`     // Always exclude these species
 	Confirmed []string                 `yaml:"confirmed" json:"confirmed"` // Species marked as confirmed (analytics-only; does not affect detection processing)
-	Config  map[string]SpeciesConfig `yaml:"config" json:"config"`   // Per-species configuration (keys normalized to lowercase)
+	Config    map[string]SpeciesConfig `yaml:"config" json:"config"`       // Per-species configuration (keys normalized to lowercase)
 }
 
 // LogDeduplicationSettings contains settings for log deduplication

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -860,9 +860,10 @@ type SpeciesConfig struct {
 // species names in any case (e.g., "American Robin", "american robin")
 // and they will all resolve to the same lowercase key.
 type SpeciesSettings struct {
-	Include []string                 `yaml:"include" json:"include"` // Always include these species
-	Exclude []string                 `yaml:"exclude" json:"exclude"` // Always exclude these species
-	Config  map[string]SpeciesConfig `yaml:"config" json:"config"`   // Per-species configuration (keys normalized to lowercase)
+	Include   []string                 `yaml:"include" json:"include"`     // Always include these species
+	Exclude   []string                 `yaml:"exclude" json:"exclude"`     // Always exclude these species
+	Confirmed []string                 `yaml:"confirmed" json:"confirmed"` // Species marked as confirmed (analytics-only; does not affect detection processing)
+	Config    map[string]SpeciesConfig `yaml:"config" json:"config"`       // Per-species configuration (keys normalized to lowercase)
 }
 
 // LogDeduplicationSettings contains settings for log deduplication

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -860,10 +860,10 @@ type SpeciesConfig struct {
 // species names in any case (e.g., "American Robin", "american robin")
 // and they will all resolve to the same lowercase key.
 type SpeciesSettings struct {
-	Include   []string                 `yaml:"include" json:"include"`     // Always include these species
-	Exclude   []string                 `yaml:"exclude" json:"exclude"`     // Always exclude these species
+	Include []string                 `yaml:"include" json:"include"` // Always include these species
+	Exclude []string                 `yaml:"exclude" json:"exclude"` // Always exclude these species
 	Confirmed []string                 `yaml:"confirmed" json:"confirmed"` // Species marked as confirmed (analytics-only; does not affect detection processing)
-	Config    map[string]SpeciesConfig `yaml:"config" json:"config"`       // Per-species configuration (keys normalized to lowercase)
+	Config  map[string]SpeciesConfig `yaml:"config" json:"config"`   // Per-species configuration (keys normalized to lowercase)
 }
 
 // LogDeduplicationSettings contains settings for log deduplication

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -4,6 +4,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,6 +31,16 @@ type SpeciesSummaryData struct {
 	LastSeen       time.Time
 	AvgConfidence  float64
 	MaxConfidence  float64
+}
+
+// SpeciesReviewStat holds per-species detection and review counts used by the
+// analytics "Manage" view. Total counts every detection (including false
+// positives) so the verified/rejected ratio reflects all reviews.
+type SpeciesReviewStat struct {
+	ScientificName string `json:"scientificName"`
+	Total          int    `json:"total"`
+	Verified       int    `json:"verified"`
+	Rejected       int    `json:"rejected"`
 }
 
 // HourlyAnalyticsData represents detection counts by hour
@@ -271,6 +282,57 @@ func (ds *DataStore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 	}
 
 	return summaries, nil
+}
+
+// GetSpeciesReviewStats returns per-species detection and review counts across
+// all time. Unlike GetSpeciesSummaryData it intentionally does not exclude false
+// positives, so the rejected count reflects every detection marked as such.
+func (ds *DataStore) GetSpeciesReviewStats(ctx context.Context) ([]SpeciesReviewStat, error) {
+	stats := make([]SpeciesReviewStat, 0, 100)
+
+	query := fmt.Sprintf(`
+		SELECT
+			notes.scientific_name AS scientific_name,
+			COUNT(DISTINCT notes.id) AS total,
+			COUNT(DISTINCT CASE WHEN note_reviews.verified = '%s' THEN notes.id END) AS verified,
+			COUNT(DISTINCT CASE WHEN note_reviews.verified = '%s' THEN notes.id END) AS rejected
+		FROM notes
+		LEFT JOIN note_reviews ON notes.id = note_reviews.note_id
+		GROUP BY notes.scientific_name
+	`, entities.VerificationCorrect, entities.VerificationFalsePositive)
+
+	if err := ds.DB.WithContext(ctx).Raw(query).Scan(&stats).Error; err != nil {
+		return nil, dbError(err, "get_species_review_stats", errors.PriorityMedium,
+			"action", "generate_species_review_stats")
+	}
+
+	return stats, nil
+}
+
+// GetSpeciesNoteIDs returns the string IDs of every note for the given scientific
+// name. Legacy callers may pass a raw BirdNET label ("ScientificName_CommonName");
+// only the scientific-name portion before the first underscore is used.
+func (ds *DataStore) GetSpeciesNoteIDs(scientificName string) ([]string, error) {
+	name := scientificName
+	if idx := strings.IndexByte(name, '_'); idx >= 0 {
+		name = name[:idx]
+	}
+	if name == "" {
+		return []string{}, nil
+	}
+
+	var ids []uint
+	if err := ds.DB.Model(&Note{}).Where("scientific_name = ?", name).Pluck("id", &ids).Error; err != nil {
+		return nil, dbError(err, "get_species_note_ids", errors.PriorityMedium,
+			"action", "lookup_species_note_ids")
+	}
+
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, strconv.FormatUint(uint64(id), 10))
+	}
+
+	return result, nil
 }
 
 // GetHourlyAnalyticsData retrieves detection counts grouped by hour

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -38,6 +38,7 @@ type SpeciesSummaryData struct {
 // positives) so the verified/rejected ratio reflects all reviews.
 type SpeciesReviewStat struct {
 	ScientificName string `json:"scientificName"`
+	CommonName     string `json:"commonName"`
 	Total          int    `json:"total"`
 	Verified       int    `json:"verified"`
 	Rejected       int    `json:"rejected"`
@@ -293,6 +294,7 @@ func (ds *DataStore) GetSpeciesReviewStats(ctx context.Context) ([]SpeciesReview
 	query := fmt.Sprintf(`
 		SELECT
 			notes.scientific_name AS scientific_name,
+			COALESCE(MAX(notes.common_name), '') AS common_name,
 			COUNT(DISTINCT notes.id) AS total,
 			COUNT(DISTINCT CASE WHEN note_reviews.verified = '%s' THEN notes.id END) AS verified,
 			COUNT(DISTINCT CASE WHEN note_reviews.verified = '%s' THEN notes.id END) AS rejected

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -312,11 +312,13 @@ func TestGetSpeciesReviewStats(t *testing.T) {
 	}
 
 	robin := byName["Turdus migratorius"]
+	assert.Equal(t, "American Robin", robin.CommonName)
 	assert.Equal(t, 2, robin.Total)
 	assert.Equal(t, 1, robin.Verified)
 	assert.Equal(t, 0, robin.Rejected)
 
 	jay := byName["Cyanocitta cristata"]
+	assert.Equal(t, "Blue Jay", jay.CommonName)
 	assert.Equal(t, 2, jay.Total)
 	assert.Equal(t, 0, jay.Verified)
 	assert.Equal(t, 1, jay.Rejected) // false positive remains counted in review stats

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+
+	"github.com/tphakala/birdnet-go/internal/datastore/entities"
 )
 
 // setupTestDB creates an in-memory SQLite database for testing
@@ -289,6 +291,78 @@ func TestGetSpeciesSummaryData(t *testing.T) {
 }
 
 // TestGetSpeciesSummaryDataTimeFormat tests that the time parsing works correctly
+// TestGetSpeciesReviewStats verifies per-species total/verified/rejected counts,
+// including that false positives are counted (unlike GetSpeciesSummaryData).
+func TestGetSpeciesReviewStats(t *testing.T) {
+	t.Parallel()
+	ds := setupTestDB(t)
+	seedTestData(t, ds)
+
+	// Review note 1 (Turdus migratorius) as correct and note 3 (Cyanocitta
+	// cristata) as a false positive; note 5 (Northern Cardinal) stays unreviewed.
+	require.NoError(t, ds.DB.Create(&NoteReview{NoteID: 1, Verified: string(entities.VerificationCorrect)}).Error)
+	require.NoError(t, ds.DB.Create(&NoteReview{NoteID: 3, Verified: string(entities.VerificationFalsePositive)}).Error)
+
+	stats, err := ds.GetSpeciesReviewStats(t.Context())
+	require.NoError(t, err)
+
+	byName := make(map[string]SpeciesReviewStat, len(stats))
+	for _, s := range stats {
+		byName[s.ScientificName] = s
+	}
+
+	robin := byName["Turdus migratorius"]
+	assert.Equal(t, 2, robin.Total)
+	assert.Equal(t, 1, robin.Verified)
+	assert.Equal(t, 0, robin.Rejected)
+
+	jay := byName["Cyanocitta cristata"]
+	assert.Equal(t, 2, jay.Total)
+	assert.Equal(t, 0, jay.Verified)
+	assert.Equal(t, 1, jay.Rejected) // false positive remains counted in review stats
+
+	cardinal := byName["Cardinalis cardinalis"] //nolint:misspell // correct scientific name
+	assert.Equal(t, 1, cardinal.Total)
+	assert.Equal(t, 0, cardinal.Verified)
+	assert.Equal(t, 0, cardinal.Rejected)
+}
+
+// TestGetSpeciesReviewStats_Empty verifies an empty database yields no stats.
+func TestGetSpeciesReviewStats_Empty(t *testing.T) {
+	t.Parallel()
+	ds := setupTestDB(t)
+
+	stats, err := ds.GetSpeciesReviewStats(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, stats)
+}
+
+// TestGetSpeciesNoteIDs verifies note-ID lookup by scientific name, including the
+// legacy "ScientificName_CommonName" label format.
+func TestGetSpeciesNoteIDs(t *testing.T) {
+	t.Parallel()
+	ds := setupTestDB(t)
+	seedTestData(t, ds)
+
+	t.Run("returns all note IDs for a scientific name", func(t *testing.T) {
+		ids, err := ds.GetSpeciesNoteIDs("Turdus migratorius")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"1", "2"}, ids)
+	})
+
+	t.Run("handles legacy ScientificName_CommonName label", func(t *testing.T) {
+		ids, err := ds.GetSpeciesNoteIDs("Turdus migratorius_American Robin")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"1", "2"}, ids)
+	})
+
+	t.Run("returns empty for unknown species", func(t *testing.T) {
+		ids, err := ds.GetSpeciesNoteIDs("Nonexistent species")
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}
+
 func TestGetSpeciesSummaryDataTimeFormat(t *testing.T) {
 	t.Parallel()
 	ds := setupTestDB(t)

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -233,6 +233,15 @@ type DetectionRepository interface {
 	// modelID is optional; pass nil to include all models.
 	GetSpeciesSummary(ctx context.Context, start, end int64, modelID *uint) ([]SpeciesSummaryData, error)
 
+	// GetSpeciesReviewStats returns per-species detection and review counts
+	// across all time, including false positives.
+	GetSpeciesReviewStats(ctx context.Context) ([]SpeciesReviewStat, error)
+
+	// GetDetectionIDsByScientificName returns the IDs of all detections whose
+	// label resolves to the given scientific name. Legacy labels stored as
+	// "ScientificName_CommonName" are matched on the scientific-name portion.
+	GetDetectionIDsByScientificName(ctx context.Context, scientificName string) ([]uint, error)
+
 	// GetHourlyDistribution returns detection counts by hour.
 	// labelID and modelID are optional filters.
 	GetHourlyDistribution(ctx context.Context, start, end int64, labelID, modelID *uint) ([]HourlyDistributionData, error)

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1543,10 +1543,17 @@ func (r *detectionRepository) GetDetectionIDsByScientificName(ctx context.Contex
 	detTable := r.tableName()
 	labTable := r.labelsTable()
 
+	// Match the clean scientific name exactly, or a legacy concatenated
+	// "ScientificName_CommonName" label. The separator underscore is a LIKE
+	// wildcard, so escape it (and any metacharacters in name) with '/' — chosen
+	// for SQLite/MySQL portability — so e.g. "Motacilla alba" does not also match
+	// "Motacilla alba alba".
+	escaped := strings.NewReplacer("/", "//", "%", "/%", "_", "/_").Replace(name)
+
 	var ids []uint
 	err := r.db.WithContext(ctx).Table(detTable).
 		Joins(fmt.Sprintf("JOIN %s ON %s.id = %s.label_id", labTable, labTable, detTable)).
-		Where(fmt.Sprintf("%s.scientific_name = ? OR %s.scientific_name LIKE ?", labTable, labTable), name, name+"_%").
+		Where(fmt.Sprintf("%s.scientific_name = ? OR %s.scientific_name LIKE ? ESCAPE '/'", labTable, labTable), name, escaped+"/_%").
 		Pluck(fmt.Sprintf("%s.id", detTable), &ids).Error
 	return ids, err
 }

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -1494,6 +1495,55 @@ func (r *detectionRepository) GetSpeciesSummary(ctx context.Context, start, end 
 		Scan(&results).Error
 
 	return results, err
+}
+
+// GetSpeciesReviewStats returns per-species detection and review counts across
+// all time. Unlike GetSpeciesSummary it does not exclude false positives, so the
+// rejected count reflects every detection marked as such.
+func (r *detectionRepository) GetSpeciesReviewStats(ctx context.Context) ([]SpeciesReviewStat, error) {
+	var results []SpeciesReviewStat
+
+	detTable := r.tableName()
+	labTable := r.labelsTable()
+	revTable := r.reviewsTable()
+
+	query := r.db.WithContext(ctx).Table(detTable).
+		Select(fmt.Sprintf(`
+			%s.scientific_name,
+			COUNT(DISTINCT %s.id) as total,
+			COUNT(DISTINCT CASE WHEN %s.verified = ? THEN %s.id END) as verified,
+			COUNT(DISTINCT CASE WHEN %s.verified = ? THEN %s.id END) as rejected
+		`, labTable, detTable, revTable, detTable, revTable, detTable),
+			string(entities.VerificationCorrect), string(entities.VerificationFalsePositive)).
+		Joins(fmt.Sprintf("JOIN %s ON %s.id = %s.label_id", labTable, labTable, detTable)).
+		Joins(fmt.Sprintf("LEFT JOIN %s ON %s.id = %s.detection_id", revTable, detTable, revTable)).
+		Group(fmt.Sprintf("%s.scientific_name", labTable))
+
+	err := query.Scan(&results).Error
+	return results, err
+}
+
+// GetDetectionIDsByScientificName returns the IDs of all detections whose label
+// resolves to the given scientific name. Legacy labels stored as
+// "ScientificName_CommonName" are matched on the scientific-name portion.
+func (r *detectionRepository) GetDetectionIDsByScientificName(ctx context.Context, scientificName string) ([]uint, error) {
+	name := scientificName
+	if idx := strings.IndexByte(name, '_'); idx >= 0 {
+		name = name[:idx]
+	}
+	if name == "" {
+		return []uint{}, nil
+	}
+
+	detTable := r.tableName()
+	labTable := r.labelsTable()
+
+	var ids []uint
+	err := r.db.WithContext(ctx).Table(detTable).
+		Joins(fmt.Sprintf("JOIN %s ON %s.id = %s.label_id", labTable, labTable, detTable)).
+		Where(fmt.Sprintf("%s.scientific_name = ? OR %s.scientific_name LIKE ?", labTable, labTable), name, name+"_%").
+		Pluck(fmt.Sprintf("%s.id", detTable), &ids).Error
+	return ids, err
 }
 
 // buildAnalyticsBaseQuery creates a base query with JOIN and WHERE clauses for analytics.

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -219,6 +219,20 @@ func TestGetDetectionIDsByScientificName(t *testing.T) {
 		assert.Contains(t, ids, d.ID)
 	})
 
+	t.Run("does not match a longer name sharing the prefix", func(t *testing.T) {
+		// The legacy "_" separator is a LIKE wildcard; "Motacilla alba" must not
+		// match the distinct species "Motacilla alba alba".
+		alba := createTestLabel(t, db, "Motacilla alba", 1)
+		albaAlba := createTestLabel(t, db, "Motacilla alba alba", 1)
+		dAlba := createDetectionForLabel(t, db, alba.ID, 3000)
+		dAlbaAlba := createDetectionForLabel(t, db, albaAlba.ID, 3001)
+
+		ids, err := repo.GetDetectionIDsByScientificName(ctx, "Motacilla alba")
+		require.NoError(t, err)
+		assert.Contains(t, ids, dAlba.ID)
+		assert.NotContains(t, ids, dAlbaAlba.ID, "must not delete a different species sharing the prefix")
+	})
+
 	t.Run("no match", func(t *testing.T) {
 		ids, err := repo.GetDetectionIDsByScientificName(ctx, "Nonexistent species")
 		require.NoError(t, err)

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -150,6 +150,82 @@ func TestSearch_ScientificLikeNotTruncated(t *testing.T) {
 	assert.Equal(t, int64(n), total, "scientific LIKE must not be capped at 100 labels")
 }
 
+// TestGetSpeciesReviewStats verifies per-species total/verified/rejected counts,
+// counting false positives in the totals (unlike GetSpeciesSummary).
+func TestGetSpeciesReviewStats(t *testing.T) {
+	db := setupDetectionTestDBWithLabels(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	robin := createTestLabel(t, db, "Turdus migratorius", 1)
+	jay := createTestLabel(t, db, "Cyanocitta cristata", 1)
+
+	r1 := createDetectionForLabel(t, db, robin.ID, 1000)
+	_ = createDetectionForLabel(t, db, robin.ID, 1001)
+	j1 := createDetectionForLabel(t, db, jay.ID, 1002)
+
+	require.NoError(t, db.Table(repo.reviewsTable()).
+		Create(&entities.DetectionReview{DetectionID: r1.ID, Verified: entities.VerificationCorrect}).Error)
+	require.NoError(t, db.Table(repo.reviewsTable()).
+		Create(&entities.DetectionReview{DetectionID: j1.ID, Verified: entities.VerificationFalsePositive}).Error)
+
+	stats, err := repo.GetSpeciesReviewStats(ctx)
+	require.NoError(t, err)
+
+	byName := make(map[string]SpeciesReviewStat, len(stats))
+	for _, s := range stats {
+		byName[s.ScientificName] = s
+	}
+
+	assert.Equal(t, int64(2), byName["Turdus migratorius"].Total)
+	assert.Equal(t, int64(1), byName["Turdus migratorius"].Verified)
+	assert.Equal(t, int64(0), byName["Turdus migratorius"].Rejected)
+
+	assert.Equal(t, int64(1), byName["Cyanocitta cristata"].Total)
+	assert.Equal(t, int64(0), byName["Cyanocitta cristata"].Verified)
+	assert.Equal(t, int64(1), byName["Cyanocitta cristata"].Rejected) // false positive counted
+}
+
+// TestGetDetectionIDsByScientificName verifies detection-ID lookup by scientific
+// name, including the legacy "ScientificName_CommonName" label format.
+func TestGetDetectionIDsByScientificName(t *testing.T) {
+	db := setupDetectionTestDBWithLabels(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	robin := createTestLabel(t, db, "Turdus migratorius", 1)
+	jay := createTestLabel(t, db, "Cyanocitta cristata", 1)
+	d1 := createDetectionForLabel(t, db, robin.ID, 1000)
+	d2 := createDetectionForLabel(t, db, robin.ID, 1001)
+	_ = createDetectionForLabel(t, db, jay.ID, 1002)
+
+	t.Run("exact scientific name", func(t *testing.T) {
+		ids, err := repo.GetDetectionIDsByScientificName(ctx, "Turdus migratorius")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{d1.ID, d2.ID}, ids)
+	})
+
+	t.Run("input label in underscore form is normalized", func(t *testing.T) {
+		ids, err := repo.GetDetectionIDsByScientificName(ctx, "Turdus migratorius_American Robin")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{d1.ID, d2.ID}, ids)
+	})
+
+	t.Run("matches label stored in underscore form", func(t *testing.T) {
+		owl := createTestLabel(t, db, "Tyto alba_Barn Owl", 1)
+		d := createDetectionForLabel(t, db, owl.ID, 2000)
+		ids, err := repo.GetDetectionIDsByScientificName(ctx, "Tyto alba")
+		require.NoError(t, err)
+		assert.Contains(t, ids, d.ID)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		ids, err := repo.GetDetectionIDsByScientificName(ctx, "Nonexistent species")
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}
+
 func TestDeleteBatch_SkipsLockedDetections(t *testing.T) {
 	db := setupDetectionTestDB(t)
 	ctx := t.Context()

--- a/internal/datastore/v2/repository/types.go
+++ b/internal/datastore/v2/repository/types.go
@@ -178,6 +178,22 @@ type SpeciesSummaryData struct {
 	MaxConfidence float64
 }
 
+// SpeciesReviewStat contains per-species detection and review counts. Total
+// includes false positives so the verified/rejected ratio is accurate.
+type SpeciesReviewStat struct {
+	// ScientificName is the species scientific name.
+	ScientificName string
+
+	// Total is the count of all detections (including false positives).
+	Total int64
+
+	// Verified is the count of detections reviewed as correct.
+	Verified int64
+
+	// Rejected is the count of detections reviewed as false positive.
+	Rejected int64
+}
+
 // HourlyDistributionData contains detection counts by hour.
 type HourlyDistributionData struct {
 	// Hour is 0-23.

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2433,6 +2433,7 @@ func (ds *Datastore) GetSpeciesReviewStats(ctx context.Context) ([]datastore.Spe
 		sciName := detection.ExtractScientificName(d.ScientificName)
 		result = append(result, datastore.SpeciesReviewStat{
 			ScientificName: sciName,
+			CommonName:     ds.resolveCommonName(sciName),
 			Total:          int(d.Total),
 			Verified:       int(d.Verified),
 			Rejected:       int(d.Rejected),

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2387,6 +2387,45 @@ func (ds *Datastore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 	return result, nil
 }
 
+// GetSpeciesReviewStats retrieves per-species detection and review counts across
+// all time, including false positives.
+func (ds *Datastore) GetSpeciesReviewStats(ctx context.Context) ([]datastore.SpeciesReviewStat, error) {
+	v2Data, err := ds.detection.GetSpeciesReviewStats(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]datastore.SpeciesReviewStat, 0, len(v2Data))
+	for _, d := range v2Data {
+		// Labels may contain legacy concatenated "ScientificName_CommonName" format,
+		// so extract only the scientific name portion.
+		sciName := detection.ExtractScientificName(d.ScientificName)
+		result = append(result, datastore.SpeciesReviewStat{
+			ScientificName: sciName,
+			Total:          int(d.Total),
+			Verified:       int(d.Verified),
+			Rejected:       int(d.Rejected),
+		})
+	}
+	return result, nil
+}
+
+// GetSpeciesNoteIDs returns the string IDs of all detections for the given
+// scientific name, matching legacy "ScientificName_CommonName" labels on the
+// scientific-name portion.
+func (ds *Datastore) GetSpeciesNoteIDs(scientificName string) ([]string, error) {
+	ids, err := ds.detection.GetDetectionIDsByScientificName(context.Background(), scientificName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, strconv.FormatUint(uint64(id), 10))
+	}
+	return result, nil
+}
+
 // GetHourlyAnalyticsData retrieves hourly analytics data for a specific date and species.
 func (ds *Datastore) GetHourlyAnalyticsData(ctx context.Context, date, species string) ([]datastore.HourlyAnalyticsData, error) {
 	start, end, err := ds.parseDateRange(date, date)

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1086,10 +1086,15 @@ func TestV2OnlyDatastore_GetSpeciesReviewStats(t *testing.T) {
 	assert.Equal(t, 2, byName["Passer domesticus"].Total)
 	assert.Equal(t, 1, byName["Passer domesticus"].Verified)
 	assert.Equal(t, 0, byName["Passer domesticus"].Rejected)
+	// CommonName is resolved via resolveCommonName; with no name maps loaded in the
+	// test it falls back to the scientific name. The fully-rejected-species UI relies
+	// on this field being populated so it can render a row for the deleted species.
+	assert.Equal(t, "Passer domesticus", byName["Passer domesticus"].CommonName)
 
 	assert.Equal(t, 1, byName["Turdus merula"].Total)
 	assert.Equal(t, 0, byName["Turdus merula"].Verified)
 	assert.Equal(t, 1, byName["Turdus merula"].Rejected) // false positive counted
+	assert.Equal(t, "Turdus merula", byName["Turdus merula"].CommonName)
 }
 
 // TestV2OnlyDatastore_GetSpeciesNoteIDs verifies note-ID lookup by scientific name.

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1062,6 +1062,87 @@ func TestV2OnlyDatastore_ReviewOperations(t *testing.T) {
 	assert.Equal(t, "correct", retrieved.Verified)
 }
 
+// TestV2OnlyDatastore_GetSpeciesReviewStats verifies per-species total/verified/
+// rejected counts bridged from the v2 repository, including false positives.
+func TestV2OnlyDatastore_GetSpeciesReviewStats(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	saveTestNote(t, ds, "2024-01-15", "08:00:00", "Passer domesticus", 0.85) // ID 1
+	saveTestNote(t, ds, "2024-01-15", "09:00:00", "Passer domesticus", 0.90) // ID 2
+	saveTestNote(t, ds, "2024-01-16", "10:00:00", "Turdus merula", 0.80)     // ID 3
+
+	require.NoError(t, ds.SaveNoteReview(&datastore.NoteReview{NoteID: 1, Verified: "correct"}))
+	require.NoError(t, ds.SaveNoteReview(&datastore.NoteReview{NoteID: 3, Verified: "false_positive"}))
+
+	stats, err := ds.GetSpeciesReviewStats(t.Context())
+	require.NoError(t, err)
+
+	byName := make(map[string]datastore.SpeciesReviewStat, len(stats))
+	for _, s := range stats {
+		byName[s.ScientificName] = s
+	}
+
+	assert.Equal(t, 2, byName["Passer domesticus"].Total)
+	assert.Equal(t, 1, byName["Passer domesticus"].Verified)
+	assert.Equal(t, 0, byName["Passer domesticus"].Rejected)
+
+	assert.Equal(t, 1, byName["Turdus merula"].Total)
+	assert.Equal(t, 0, byName["Turdus merula"].Verified)
+	assert.Equal(t, 1, byName["Turdus merula"].Rejected) // false positive counted
+}
+
+// TestV2OnlyDatastore_GetSpeciesNoteIDs verifies note-ID lookup by scientific name.
+func TestV2OnlyDatastore_GetSpeciesNoteIDs(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	saveTestNote(t, ds, "2024-01-15", "08:00:00", "Passer domesticus", 0.85) // ID 1
+	saveTestNote(t, ds, "2024-01-15", "09:00:00", "Passer domesticus", 0.90) // ID 2
+	saveTestNote(t, ds, "2024-01-16", "10:00:00", "Turdus merula", 0.80)     // ID 3
+
+	ids, err := ds.GetSpeciesNoteIDs("Passer domesticus")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"1", "2"}, ids)
+
+	none, err := ds.GetSpeciesNoteIDs("Nonexistent species")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+// TestV2OnlyDatastore_GetSpeciesNoteIDs_LegacyLabelFormat is a regression test for
+// labels stored in the legacy "ScientificName_CommonName" form: a lookup by the
+// clean scientific name must still resolve the detection, and review stats must
+// report the extracted scientific name.
+func TestV2OnlyDatastore_GetSpeciesNoteIDs_LegacyLabelFormat(t *testing.T) {
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+
+	ctx := t.Context()
+	// Create a legacy concatenated label and a detection referencing it directly,
+	// bypassing Save's ExtractScientificName normalization so the underscore form
+	// is actually persisted.
+	label, err := ds.label.GetOrCreate(ctx, "Tyto alba_Barn Owl", ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err)
+	det := &entities.Detection{ModelID: ds.defaultModelID, LabelID: label.ID, DetectedAt: time.Now().Unix(), Confidence: 0.9}
+	require.NoError(t, ds.detection.Save(ctx, det))
+
+	ids, err := ds.GetSpeciesNoteIDs("Tyto alba")
+	require.NoError(t, err)
+	assert.Equal(t, []string{fmt.Sprintf("%d", det.ID)}, ids)
+
+	stats, err := ds.GetSpeciesReviewStats(ctx)
+	require.NoError(t, err)
+	found := false
+	for _, s := range stats {
+		if s.ScientificName == "Tyto alba" {
+			found = true
+			assert.Equal(t, 1, s.Total)
+		}
+	}
+	assert.True(t, found, "review stats should report the extracted scientific name")
+}
+
 func TestV2OnlyDatastore_CommentOperations(t *testing.T) {
 	ds, cleanup := setupTestDatastore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Adds an authenticated, desktop-only **Manage** view mode to the Species analytics page for species curation: excluded / included (whitelisted) / confirmed toggles, review ratio, range probability, and per-species deletion. The Manage view also surfaces **fully-rejected species** — species whose every detection was marked a false positive, so they no longer appear in the period summary — so they remain reviewable and deletable (#693). Grid and list views are unchanged.

Addresses https://github.com/tphakala/birdnet-go/issues/3405

## Backend

- **Config:** `Realtime.Species.Confirmed []string` (analytics-only; deep-copied in `CloneSettings`). It is persisted but never read by detection processing.
- **Datastore:** `GetSpeciesReviewStats` (per-species total / verified / rejected — false positives are counted, now also returning the resolved **common name** so a row can be rendered for species absent from the summary) and `GetSpeciesNoteIDs` (handles the legacy `"ScientificName_CommonName"` label format), implemented for the legacy GORM v1 store, the v2 repository, and the v2only datastore. The legacy store resolves the common name via `MAX(notes.common_name)` within the existing `GROUP BY`; v2only resolves it via `resolveCommonName` (the v2 repository layer stays name-free, as its labels table has no common-name column).
- **API v2** (all authenticated; handlers type-assert optional datastore capability and return **501** when unsupported):

  | Method | Path | Purpose |
  | ------ | ---- | ------- |
  | GET  | `/analytics/species/review-stats` | Per-species total/verified/rejected (+ common name) |
  | POST | `/detections/include` | Toggle always-include list |
  | GET  | `/detections/included` | Fetch always-include list |
  | POST | `/detections/confirm` | Toggle confirmed list |
  | GET  | `/detections/confirmed` | Fetch confirmed list |
  | POST | `/detections/species/delete` | Delete all detections for a species (skips locked) |

  The batch-delete loop was extracted into a shared `deleteNotesByIDs` helper (behavior-preserving) and reused by the species-delete handler. `README.md` updated.

## Frontend

- `Species.svelte`: third `manage` view mode with an auth-gated toggle (`$isAuthenticated`); parallel fetch of review-stats / included / confirmed / excluded plus async, session-cached range scores (`settingsActions.loadRangeFilterSpecies()`); the table renders before range scores arrive (per-cell spinner). Manage hides average confidence and first-seen. Review ratio shows `{verified} / {rejected}` (`—` when no reviews); range probability shows the score / `—` / spinner. Membership uses reactive `SvelteSet`/`SvelteMap` with per-(list, species) in-flight guards. Delete opens a confirmation modal showing the **all-time** detection count; a full delete removes the row locally, a partial delete refetches. Manage-only column sorts live in separate state and never persist to `localStorage`. Search reuses the existing debounced behavior.
- **Fully-rejected species (#693):** the Manage view acts on a superset of the period summary. A `manageSpecies` derived merges summary species with synthesized rows for any review-stats-only species (carrying the all-time count; an em dash for max-confidence and last-seen, which do not survive in the summary), so species with no remaining non-false-positive detections can still be reviewed/deleted. The empty-state condition and the filtered-count badge are Manage-aware, and the grid/list and Manage search filters share a single `speciesMatchesSearch` predicate. `commonName` is optional on the client, so a newer frontend talking to an older backend degrades gracefully to the scientific name.
- i18n: the `analytics.species.manage.*` keys and `analytics.species.switchToManage` are now **translated in all 15 non-English locales** (cs, da, de, es, fi, fr, hu, it, lv, nb, nl, pl, pt, sk, sv) — they had previously been English fallback only. The `{count}`/`{species}` placeholders are preserved; key structure is unchanged, so the generated types and `i18n:sync:check` stay valid.

## Testing

- Go (`-race`): config clone, datastore review-stats / note-IDs (incl. legacy-label regression) across all three store paths, and API v2 endpoints (success / empty / 501; include & confirm add-remove-action-saved; species-delete deletes / no-match / skips-locked / counts / 501). Review-stats tests now also assert the resolved common name.
- Frontend: `npm run check:all` clean (0 errors); `Species.test.ts` extended with Manage-view tests (auth-gating, hidden columns, review-ratio rendering, `—`, sort non-persistence) plus a test asserting a fully-rejected species surfaces with its all-time count, em dashes, and review ratio. `i18n:validate:full` passes (sync-check, type-check, coverage).

## Preflight

The #693 surfacing change was run through the preflight gate (6 review passes: reuse, correctness, quality, i18n, integration wiring, regression/back-compat). No Critical/High/Medium findings; the one reuse finding (duplicated search predicate) was fixed by extracting `speciesMatchesSearch`. The change is additive on the API wire and read-only on the DB; reviewers classified the new Manage rows as a restorative, backward-compatible improvement (no maintainer-confirm items).

## Notes

- `nb.json` and `hu.json` show large churn because those locale files had **pre-existing drift** (missing keys / non-canonical order from earlier PRs). The repo's `i18n:sync:check` gate requires canonical locale files, so running the documented `npm run i18n:sync` workflow normalizes them; reverting them fails the gate. The other 14 locales are a clean additive change. Happy to split those two files into a separate cleanup commit if preferred.
- Excluded/included/confirmed toggles key by common name (matching the existing `/detections/ignore` contract); review-stats, range scores, and delete key by scientific name.

https://claude.ai/code/session_01CnkYpgci2ayc2JZvsdVEBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnkYpgci2ayc2JZvsdVEBT)_