### PR TITLE
refactor(suncalc): structured logging, docstrings, defer singleflight

### DIFF
--- a/internal/suncalc/logger.go
+++ b/internal/suncalc/logger.go
@@ -1,0 +1,13 @@
+// Package suncalc provides structured logging for the suncalc package.
+package suncalc
+
+import (
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// GetLogger returns the logger for the suncalc package.
+// The logger is fetched from the global logger each time so it uses the
+// current centralized logger (which may be set after package init).
+func GetLogger() logger.Logger {
+	return logger.Global().Module("suncalc")
+}

--- a/internal/suncalc/moon.go
+++ b/internal/suncalc/moon.go
@@ -42,10 +42,10 @@ type MoonData struct {
 
 // phaseInfo maps a phase range to its name, icon, and emoji.
 type phaseInfo struct {
-	maxPhase  float64
-	phaseName string
-	iconName  string
-	emoji     string
+	maxPhase  float64 // Exclusive upper bound of the phase value for this sub-phase
+	phaseName string  // Human-readable phase name (one of the Phase* constants)
+	iconName  string  // Basmilius weather-icons icon name (one of the IconName* constants)
+	emoji     string  // Unicode emoji representing this phase
 }
 
 // phases defines the 8 standard lunar phases with their upper bounds.

--- a/internal/suncalc/timezone.go
+++ b/internal/suncalc/timezone.go
@@ -2,11 +2,12 @@ package suncalc
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
 	tzf "github.com/ringsaturn/tzf"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // tzCache maps a rounded "lat,lon" key to the resolved *time.Location.
@@ -18,6 +19,14 @@ import (
 // hits; writers acquire the write lock across the (expensive) cache
 // miss path, which also serialises concurrent startup callers so the
 // 32 MB tzf polygon dataset is loaded at most once per unique key.
+//
+// Per-key singleflight (golang.org/x/sync/singleflight) was evaluated and
+// intentionally not adopted: every caller resolves the single configured
+// home coordinate at startup or reconfigure, so there is never more than
+// one distinct key in flight and a write lock held across an unrelated
+// key's miss cannot occur. Revisit only if a call site begins resolving
+// non-home or per-request coordinates, or if tzMu shows up in contention
+// profiles.
 var (
 	tzMu    sync.RWMutex
 	tzCache = make(map[string]*time.Location)
@@ -88,21 +97,28 @@ func resolveTimezone(latitude, longitude float64) *time.Location {
 // the call returns, no goroutine holds a pointer to it, so its
 // polygon backing store becomes eligible for collection.
 func lookupLocationLocked(latitude, longitude float64) (*time.Location, bool) {
+	log := GetLogger()
 	finder, err := tzf.NewDefaultFinder()
 	if err != nil {
-		log.Printf("suncalc: timezone finder init failed, falling back to system timezone: %v", err)
+		log.Warn("timezone finder init failed, falling back to system timezone",
+			logger.Error(err))
 		return time.Local, false
 	}
 	// tzf API takes (longitude, latitude) -- longitude first.
 	tzName := finder.GetTimezoneName(longitude, latitude)
 	if tzName == "" {
-		log.Printf("suncalc: no timezone found for coordinates (%.4f, %.4f), falling back to system timezone", latitude, longitude)
+		// Coordinates are PII (see internal/weather/weather.go), so the
+		// configured home location is intentionally not logged here.
+		log.Warn("no timezone found for coordinates, falling back to system timezone")
 		return time.Local, false
 	}
 	loc, err := time.LoadLocation(tzName)
 	if err != nil {
-		log.Printf("suncalc: failed to load timezone %q for coordinates (%.4f, %.4f), falling back to system timezone: %v",
-			tzName, latitude, longitude, err)
+		// The resolved IANA name is enough to debug a load failure without
+		// logging the PII coordinates that produced it.
+		log.Warn("failed to load timezone, falling back to system timezone",
+			logger.String("timezone", tzName),
+			logger.Error(err))
 		return time.Local, false
 	}
 	return loc, true


### PR DESCRIPTION
## Summary

Tech-debt cleanup for the `internal/suncalc` package, consolidating three small follow-ups:

- **Structured logging:** the three stdlib `log.Printf` fallback warnings in `timezone.go` now go through the project structured logger (`internal/logger`) via a new package `GetLogger()` helper, matching the canonical per-package logger pattern used across the repo. Log level stays `Warn` (these are recoverable fallbacks to the system timezone); the human-readable wording is preserved (the old `suncalc:` message prefix becomes the `Module("suncalc")` tag).
- **PII:** home coordinates are PII (matching the existing stance in `internal/weather`), so they are no longer included in the fallback warnings. The resolved IANA timezone name is retained on the load-failure warning, which is enough to debug it without exposing the location.
- **Singleflight:** evaluated per-key singleflight in `resolveTimezone` and intentionally deferred. Every caller resolves the single configured home coordinate at startup or reconfigure, so only one cache key is ever in flight and the existing double-checked `RWMutex` is sufficient. Documented the rationale and the revisit trigger inline.
- **Docstrings:** added field documentation to the `moon.go` `phaseInfo` struct.

No behavior change to timezone resolution or the fallback control flow.

## Test Plan

- [x] `golangci-lint run` (full project): 0 issues
- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/suncalc/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive inline documentation to internal module structures and their fields.
  * Documented architectural decisions and design patterns for internal coordination.

* **Improvements**
  * Upgraded logging infrastructure to utilize structured logging patterns throughout.
  * Enhanced user privacy protections by removing sensitive location data from system warning and error messages.
  * Strengthened timezone resolution error handling with improved reporting mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->