### PR TITLE
test(processor): fix data race in TestIntegrationWithJobQueue

### DIFF
--- a/internal/analysis/processor/test_helpers_test.go
+++ b/internal/analysis/processor/test_helpers_test.go
@@ -247,6 +247,14 @@ func (m *MockAction) Execute(ctx context.Context, data any) error {
 	return nil
 }
 
+// GetExecuteCount returns the execution count under the mock's lock so tests
+// can read it without racing the job-queue worker goroutine that calls Execute.
+func (m *MockAction) GetExecuteCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ExecuteCount
+}
+
 // GetDescription implements the Action interface.
 func (m *MockAction) GetDescription() string {
 	return "Mock Action for testing"

--- a/internal/analysis/processor/workers_test.go
+++ b/internal/analysis/processor/workers_test.go
@@ -695,8 +695,10 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 		},
 	}
 
-	// Create a channel to track action execution
-	executionChan := make(chan struct{})
+	// Create a channel to track action execution. Buffered so the worker
+	// goroutine never blocks on the send if the test has already moved on
+	// (e.g. after a timeout), which would otherwise leak the goroutine.
+	executionChan := make(chan struct{}, 1)
 
 	// Create a mock action that signals when executed
 	mockAction := &MockAction{
@@ -740,15 +742,15 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 		require.Fail(t, "Timeout waiting for action to be executed")
 	}
 
-	// Verify that the action was executed exactly once
-	assert.Equal(t, 1, mockAction.ExecuteCount, "Expected action to be executed once")
+	// Verify that the action was executed exactly once. Read the count
+	// through the lock-protected getter to avoid racing the worker goroutine.
+	assert.Equal(t, 1, mockAction.GetExecuteCount(), "Expected action to be executed once")
 
-	// Wait a bit for the job queue to update its statistics
-	waitCtx, waitCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer waitCancel()
-	<-waitCtx.Done()
-
-	// Verify that the job queue statistics reflect the completed job
+	// Poll the job queue statistics until the completed job is recorded
+	// instead of racing a fixed timeout.
+	require.Eventually(t, func() bool {
+		return realQueue.GetStats().SuccessfulJobs == 1
+	}, 2*time.Second, 10*time.Millisecond, "Expected 1 successful job")
 	stats := realQueue.GetStats()
 	assert.Equal(t, 1, stats.SuccessfulJobs, "Expected 1 successful job")
 
@@ -782,17 +784,18 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 	err = processor.EnqueueTask(failingTask)
 	require.NoError(t, err, "Failed to enqueue failing task")
 
-	// Wait for the job queue to process the failing job
-	processCtx, processCancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
-	defer processCancel()
-	<-processCtx.Done()
+	// The failing action signals no completion channel, so poll the
+	// lock-protected execution count instead of racing a fixed timeout
+	// (reading the field directly here is a data race with the worker).
+	require.Eventually(t, func() bool {
+		return failingAction.GetExecuteCount() == 1
+	}, 2*time.Second, 10*time.Millisecond, "Expected failing action to be executed once")
 
-	// Verify that the failing action was executed
-	assert.Equal(t, 1, failingAction.ExecuteCount, "Expected failing action to be executed once")
-
-	// Verify that the job queue statistics reflect the failed job
+	// Poll until the job queue records the failed job.
+	require.Eventually(t, func() bool {
+		return realQueue.GetStats().FailedJobs >= 1
+	}, 2*time.Second, 10*time.Millisecond, "Expected at least 1 failed job")
 	stats = realQueue.GetStats()
-	assert.GreaterOrEqual(t, stats.FailedJobs, 1, "Expected at least 1 failed job")
 
 	// Log final statistics
 	t.Logf("Job queue stats: Total=%d, Successful=%d, Failed=%d",

--- a/internal/analysis/processor/workers_test.go
+++ b/internal/analysis/processor/workers_test.go
@@ -672,6 +672,14 @@ func TestEnqueueMultipleTasks(t *testing.T) {
 
 // TestIntegrationWithJobQueue tests the integration between Processor.EnqueueTask and a real job queue
 func TestIntegrationWithJobQueue(t *testing.T) {
+	// Bounds for the polling assertions below: wait up to eventuallyTimeout,
+	// re-checking every eventuallyPollInterval, for the worker goroutine to
+	// reach the expected state.
+	const (
+		eventuallyTimeout      = 2 * time.Second
+		eventuallyPollInterval = 10 * time.Millisecond
+	)
+
 	// Remove t.Parallel() to avoid race conditions with testRetryConfigOverride
 	// Set up the test retry config override to ensure consistent behavior
 	testRetryConfigOverride = nil
@@ -750,9 +758,7 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 	// instead of racing a fixed timeout.
 	require.Eventually(t, func() bool {
 		return realQueue.GetStats().SuccessfulJobs == 1
-	}, 2*time.Second, 10*time.Millisecond, "Expected 1 successful job")
-	stats := realQueue.GetStats()
-	assert.Equal(t, 1, stats.SuccessfulJobs, "Expected 1 successful job")
+	}, eventuallyTimeout, eventuallyPollInterval, "Expected 1 successful job")
 
 	// Test with a failing action
 	failingAction := &MockAction{
@@ -789,13 +795,13 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 	// (reading the field directly here is a data race with the worker).
 	require.Eventually(t, func() bool {
 		return failingAction.GetExecuteCount() == 1
-	}, 2*time.Second, 10*time.Millisecond, "Expected failing action to be executed once")
+	}, eventuallyTimeout, eventuallyPollInterval, "Expected failing action to be executed once")
 
 	// Poll until the job queue records the failed job.
 	require.Eventually(t, func() bool {
 		return realQueue.GetStats().FailedJobs >= 1
-	}, 2*time.Second, 10*time.Millisecond, "Expected at least 1 failed job")
-	stats = realQueue.GetStats()
+	}, eventuallyTimeout, eventuallyPollInterval, "Expected at least 1 failed job")
+	stats := realQueue.GetStats()
 
 	// Log final statistics
 	t.Logf("Job queue stats: Total=%d, Successful=%d, Failed=%d",


### PR DESCRIPTION
## Summary

`TestIntegrationWithJobQueue` was flaky under `-race` in CI. `MockAction.Execute` increments `ExecuteCount` under its mutex, but the test read the field directly without taking that lock after a fixed timeout, racing the job-queue worker goroutine that runs the action. The race detector flagged the unsynchronized read against the locked write.

## Changes

- Add a lock-protected `GetExecuteCount()` getter to `MockAction` and route the test reads through it (no more direct field access).
- Replace the fixed-timeout `<-ctx.Done()` waits with `require.Eventually` polls, so the assertions wait until the worker has actually finished rather than racing an arbitrary sleep window. The failing action runs with retries disabled (max attempts 1), so the polled count is exactly 1 and cannot overshoot.
- Buffer `executionChan` (size 1) so the worker never blocks on the send if the test already moved on after a timeout, which would otherwise leak the goroutine and trip goleak.

Test-only change; no production code touched.

## Test Plan

- [x] `go test -race -count=30 -run '^TestIntegrationWithJobQueue$' ./internal/analysis/processor/` (previously failed intermittently, now passes)
- [x] `go test -race ./internal/analysis/processor/` (full package, incl. goleak TestMain)
- [x] `go vet ./internal/analysis/processor/` (copylocks clean)
- [x] `golangci-lint run` (full project): 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved concurrency test utilities with a new thread-safe accessor to read mock execution counts without racing.
  * Updated integration tests to be more reliable by replacing fixed timeout waits with polling for execution and job success/failure stats.
  * Adjusted action notification handling to avoid goroutine blocking during test progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->