### PR TITLE
fix(analysis,classifier): inference pipeline data races and queue-overflow visibility

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -744,6 +744,21 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 		}
 		if _, raced := p.soundLevelConsumers[sid]; raced {
 			p.soundLevelMu.Unlock()
+			// Deliberately do NOT RemoveRoute here, unlike the disable branch
+			// above. consumerID is deterministic ("soundlevel_"+sid) and
+			// Router.AddRoute rejects a duplicate consumer ID on a source, so at
+			// most one sound-level route can exist per source at a time. The only
+			// way to reach this branch is if THIS goroutine's freshly added route
+			// was already torn down externally (e.g. engine.RemoveSource ->
+			// Router.RemoveAllRoutes during a stream disconnect) before we could
+			// track it, which let a concurrent registration add and track a new
+			// route under the same consumerID. Calling RemoveRoute(sid,
+			// consumerID) now would delete that OTHER registration's live,
+			// tracked route, leaving soundLevelConsumers[sid] pointing at a route
+			// that no longer exists and silently stopping sound-level processing
+			// for the source until the next hot-reload. So the route this branch
+			// "skips" is never actually orphaned. A static review once flagged a
+			// leak here; it is a false positive under these semantics.
 			log.Debug("sound level consumer already registered concurrently, skipping",
 				logger.String("source_id", sid),
 				logger.String("consumer_id", consumerID),

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -65,8 +65,15 @@ type ControlMonitor struct {
 	// settings. Provided by APIServerService because it owns the monitor lifecycle.
 	reconfigureMonitoringFn func()
 
-	// Sound level manager for lifecycle management
-	soundLevelManager *SoundLevelManager
+	// Sound level manager for lifecycle management.
+	// soundLevelManagerMu guards every access to soundLevelManager. The field is
+	// written by the monitor goroutine (handleReconfigureSoundLevel) and
+	// read/written by Stop(), which runs on the pipeline shutdown goroutine while
+	// the monitor goroutine may still be processing an in-flight
+	// reconfigure_sound_level signal. Without this lock that is a -race-detectable
+	// data race.
+	soundLevelManagerMu sync.Mutex
+	soundLevelManager   *SoundLevelManager
 
 	// Track telemetry endpoint
 	telemetryEndpoint      *observability.Endpoint
@@ -198,9 +205,15 @@ func (cm *ControlMonitor) Start() {
 func (cm *ControlMonitor) Stop() {
 	GetLogger().Info("stopping control monitor")
 
-	// Stop sound level monitoring if running
-	if cm.soundLevelManager != nil {
-		cm.soundLevelManager.Stop()
+	// Stop sound level monitoring if running. Read the pointer under the lock
+	// (the monitor goroutine may still be reassigning it via
+	// handleReconfigureSoundLevel) but call Stop() outside the lock so a blocking
+	// shutdown never holds the mutex.
+	cm.soundLevelManagerMu.Lock()
+	slm := cm.soundLevelManager
+	cm.soundLevelManagerMu.Unlock()
+	if slm != nil {
+		slm.Stop()
 	}
 
 	// Stop telemetry endpoint if running
@@ -222,12 +235,15 @@ func (cm *ControlMonitor) initializeSoundLevelIfEnabled() {
 	settings := conf.Setting()
 	if settings.Realtime.Audio.SoundLevel.Enabled {
 		// Initialize the sound level manager
+		cm.soundLevelManagerMu.Lock()
 		if cm.soundLevelManager == nil {
 			cm.soundLevelManager = NewSoundLevelManager(cm.soundLevelChan, cm.proc, cm.apiController, cm.metrics)
 		}
+		slm := cm.soundLevelManager
+		cm.soundLevelManagerMu.Unlock()
 
 		// Start sound level monitoring
-		if err := cm.soundLevelManager.Start(); err != nil {
+		if err := slm.Start(); err != nil {
 			GetLogger().Warn("Failed to start sound level monitoring", logger.Error(err))
 		}
 	}
@@ -363,7 +379,14 @@ func (cm *ControlMonitor) handleReconfigureLiveStream() {
 
 // handleRebuildRangeFilter rebuilds the range filter
 func (cm *ControlMonitor) handleRebuildRangeFilter() {
-	if err := classifier.BuildRangeFilter(cm.bn); err != nil {
+	// Guard the orchestrator dereference for consistency with NewControlMonitor,
+	// which only wires bn-dependent surfaces when cm.bn != nil. In realtime
+	// analysis cm.bn is always set; the guard is defensive. Use if/else rather
+	// than an early return so the opportunistic maintenance
+	// cleanup below still runs even when the rebuild itself is skipped.
+	if cm.bn == nil {
+		GetLogger().Warn("Cannot rebuild range filter: BirdNET orchestrator not initialized")
+	} else if err := classifier.BuildRangeFilter(cm.bn); err != nil {
 		GetLogger().Error("Failed to rebuild range filter", logger.Error(err))
 		cm.notifyError("Failed to rebuild range filter", err)
 	} else {
@@ -386,6 +409,14 @@ func (cm *ControlMonitor) handleRebuildRangeFilter() {
 
 // handleReloadBirdnet reloads the BirdNET model
 func (cm *ControlMonitor) handleReloadBirdnet() {
+	// Guard the orchestrator dereference for consistency with NewControlMonitor
+	// (see handleRebuildRangeFilter). Defensive: cm.bn is always set in realtime
+	// analysis, but this avoids a panic if the handler is ever reached without an
+	// orchestrator.
+	if cm.bn == nil {
+		GetLogger().Warn("Cannot reload BirdNET model: orchestrator not initialized")
+		return
+	}
 	if err := cm.bn.ReloadModel(); err != nil {
 		GetLogger().Error("Failed to reload BirdNET model", logger.Error(err))
 		cm.notifyError("Failed to reload BirdNET model", err)
@@ -616,12 +647,15 @@ func (cm *ControlMonitor) handleReconfigureSoundLevel() {
 	}
 
 	// Initialize the sound level manager if not already created
+	cm.soundLevelManagerMu.Lock()
 	if cm.soundLevelManager == nil {
 		cm.soundLevelManager = NewSoundLevelManager(cm.soundLevelChan, cm.proc, cm.apiController, cm.metrics)
 	}
+	slm := cm.soundLevelManager
+	cm.soundLevelManagerMu.Unlock()
 
 	// Restart sound level monitoring with new settings
-	if err := cm.soundLevelManager.Restart(); err != nil {
+	if err := slm.Restart(); err != nil {
 		GetLogger().Error("Failed to reconfigure sound level monitoring", logger.Error(err))
 		cm.notifyError("Failed to reconfigure sound level monitoring", err)
 		return

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -74,6 +74,13 @@ type ControlMonitor struct {
 	// data race.
 	soundLevelManagerMu sync.Mutex
 	soundLevelManager   *SoundLevelManager
+	// soundLevelStopped is set once Stop() has run. The monitor goroutine may
+	// process a reconfigure_sound_level signal after Stop() (Stop runs before the
+	// monitor's quitChan is closed during shutdown); the flag prevents that late
+	// reconfigure from constructing and starting a fresh SoundLevelManager, which
+	// would leak its publisher goroutines past shutdown. Guarded by
+	// soundLevelManagerMu.
+	soundLevelStopped bool
 
 	// Track telemetry endpoint
 	telemetryEndpoint      *observability.Endpoint
@@ -210,6 +217,7 @@ func (cm *ControlMonitor) Stop() {
 	// handleReconfigureSoundLevel) but call Stop() outside the lock so a blocking
 	// shutdown never holds the mutex.
 	cm.soundLevelManagerMu.Lock()
+	cm.soundLevelStopped = true
 	slm := cm.soundLevelManager
 	cm.soundLevelManagerMu.Unlock()
 	if slm != nil {
@@ -646,8 +654,15 @@ func (cm *ControlMonitor) handleReconfigureSoundLevel() {
 		cm.reconfigureSoundLevelFn()
 	}
 
-	// Initialize the sound level manager if not already created
+	// Initialize the sound level manager if not already created. Bail if Stop()
+	// has already run so a reconfigure signal in flight during shutdown cannot
+	// resurrect the publisher (leaking its goroutines past teardown).
 	cm.soundLevelManagerMu.Lock()
+	if cm.soundLevelStopped {
+		cm.soundLevelManagerMu.Unlock()
+		GetLogger().Debug("Ignoring sound level reconfigure after control monitor shutdown")
+		return
+	}
 	if cm.soundLevelManager == nil {
 		cm.soundLevelManager = NewSoundLevelManager(cm.soundLevelChan, cm.proc, cm.apiController, cm.metrics)
 	}

--- a/internal/analysis/control_monitor_soundlevel_race_test.go
+++ b/internal/analysis/control_monitor_soundlevel_race_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/soundlevel"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
@@ -51,4 +52,34 @@ func TestControlMonitor_StopRacesReconfigureSoundLevel(t *testing.T) {
 		}()
 		wg.Wait()
 	}
+}
+
+// TestControlMonitor_ReconfigureAfterStopDoesNotResurrect verifies the lifecycle
+// gate: once Stop() has run, a reconfigure_sound_level signal still in flight on
+// the monitor goroutine must not construct (and start) a new SoundLevelManager,
+// which would leak its publisher goroutines past shutdown. Unlike the -race test
+// above this is deterministic: it asserts the observable effect (no manager
+// created after Stop). SoundLevel.Enabled is false so that, if the gate ever
+// regresses, the un-gated path still spawns nothing (Restart early-returns) and
+// the test fails cleanly on the nil assertion rather than leaking goroutines.
+func TestControlMonitor_ReconfigureAfterStopDoesNotResurrect(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.SoundLevel.Enabled = false
+	conftest.SetTestSettings(settings)
+
+	cm := &ControlMonitor{
+		soundLevelChan: make(chan soundlevel.SoundLevelData, 1),
+	}
+
+	cm.Stop() // marks soundLevelStopped; no manager was ever created
+
+	cm.handleReconfigureSoundLevel() // must be a no-op after shutdown
+
+	cm.soundLevelManagerMu.Lock()
+	mgr := cm.soundLevelManager
+	cm.soundLevelManagerMu.Unlock()
+	assert.Nil(t, mgr, "reconfigure after Stop must not create a sound level manager")
 }

--- a/internal/analysis/control_monitor_soundlevel_race_test.go
+++ b/internal/analysis/control_monitor_soundlevel_race_test.go
@@ -9,12 +9,37 @@ package analysis
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/soundlevel"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 )
+
+// raceStressIterations is how many concurrent Stop/reconfigure rounds the race
+// guard runs; enough rounds for the race detector to reliably observe overlap.
+const raceStressIterations = 50
+
+// raceWaitTimeout bounds each round's wait so a regression that deadlocks the
+// lifecycle fails fast in CI instead of hanging the whole job.
+const raceWaitTimeout = 5 * time.Second
+
+// waitWithTimeout waits for wg, failing the test if it does not complete within
+// d (a deadlock guard for the concurrency tests below).
+func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatal("goroutines did not finish in time; possible deadlock")
+	}
+}
 
 // TestControlMonitor_StopRacesReconfigureSoundLevel runs Stop() concurrently
 // with handleReconfigureSoundLevel (and a second reconfigure, to cover the
@@ -31,7 +56,7 @@ func TestControlMonitor_StopRacesReconfigureSoundLevel(t *testing.T) {
 	settings.Realtime.Audio.SoundLevel.Enabled = false
 	conftest.SetTestSettings(settings)
 
-	for range 50 {
+	for range raceStressIterations {
 		cm := &ControlMonitor{
 			soundLevelChan: make(chan soundlevel.SoundLevelData, 1),
 		}
@@ -50,7 +75,7 @@ func TestControlMonitor_StopRacesReconfigureSoundLevel(t *testing.T) {
 			defer wg.Done()
 			cm.Stop()
 		}()
-		wg.Wait()
+		waitWithTimeout(t, &wg, raceWaitTimeout)
 	}
 }
 

--- a/internal/analysis/control_monitor_soundlevel_race_test.go
+++ b/internal/analysis/control_monitor_soundlevel_race_test.go
@@ -1,0 +1,54 @@
+// control_monitor_soundlevel_race_test.go is a regression guard for a data race:
+// ControlMonitor.Stop() read cm.soundLevelManager without holding a lock while
+// the monitor goroutine wrote the same field in handleReconfigureSoundLevel. A
+// reconfigure_sound_level signal in flight during shutdown therefore raced the
+// shutdown read. The fix guards every access with soundLevelManagerMu; this test
+// fails under `go test -race` if that guard regresses.
+package analysis
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/soundlevel"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// TestControlMonitor_StopRacesReconfigureSoundLevel runs Stop() concurrently
+// with handleReconfigureSoundLevel (and a second reconfigure, to cover the
+// write/write window too) across many rounds. SoundLevel.Enabled is false so
+// SoundLevelManager.Start()/Stop() early-return: the test stays cheap, starts no
+// background goroutines, and isolates the race to the cm.soundLevelManager field
+// access itself.
+func TestControlMonitor_StopRacesReconfigureSoundLevel(t *testing.T) {
+	// Not parallel: conftest.SetTestSettings mutates package-global settings.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.SoundLevel.Enabled = false
+	conftest.SetTestSettings(settings)
+
+	for range 50 {
+		cm := &ControlMonitor{
+			soundLevelChan: make(chan soundlevel.SoundLevelData, 1),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			cm.handleReconfigureSoundLevel()
+		}()
+		go func() {
+			defer wg.Done()
+			cm.handleReconfigureSoundLevel()
+		}()
+		go func() {
+			defer wg.Done()
+			cm.Stop()
+		}()
+		wg.Wait()
+	}
+}

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -114,6 +114,14 @@ func RemoveOverrunTrackers(sourceID string) {
 // lastQueueOverflowReport tracks the last time a queue overflow was reported to Sentry.
 var lastQueueOverflowReport atomic.Int64
 
+// droppedDetectionsTotal counts how many detection results have been dropped
+// because the results queue was full, over the lifetime of the process. The
+// drop itself is unavoidable backpressure on a slow consumer, but the count
+// makes the otherwise-silent data loss quantifiable in the drop log line and
+// telemetry extras so users can tell whether they are losing detections and by
+// how much.
+var droppedDetectionsTotal atomic.Int64
+
 // recordBufferOverrun records a buffer overrun event and reports to Sentry
 // when the tumbling window expires with enough accumulated overruns.
 func recordBufferOverrun(tracker *bufferOverrunTracker, elapsed, bufferLen time.Duration) {
@@ -352,29 +360,53 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 			pm.RecordAudioQueueOperation(source, "enqueue", "success")
 		}
 	default:
-		log.Error("results queue is full",
-			logger.String("source", source))
-		if pm != nil {
-			pm.RecordAudioQueueOperation(source, "enqueue", "dropped")
-		}
-		// Rate-limit queue overflow telemetry to prevent Sentry floods under sustained backpressure.
-		now := time.Now().Unix()
-		last := lastQueueOverflowReport.Load()
-		if telemetry.IsTelemetryEnabled() && (now-last >= int64(bufferOverrunReportCooldown.Seconds())) {
-			if lastQueueOverflowReport.CompareAndSwap(last, now) {
-				telemetry.FastCaptureMessageWithExtras(
-					"results queue full, detections dropped",
-					sentry.LevelWarning,
-					"analysis",
-					map[string]any{
-						"source":     source,
-						"queue_size": len(classifier.ResultsQueue),
-					},
-				)
-			}
-		}
+		// The consumer is too far behind to accept this result, so it is
+		// dropped. recordResultsQueueDrop makes the loss visible (cumulative
+		// counter + log + rate-limited telemetry) instead of discarding it
+		// silently.
+		recordResultsQueueDrop(source, modelID, pm)
 	}
 	return nil
+}
+
+// recordResultsQueueDrop accounts for a single detection result that could not
+// be enqueued because the results queue was full. It increments the cumulative
+// drop counter, logs the loss with context, records the queue drop metric, and
+// emits rate-limited overflow telemetry. It returns the new cumulative total.
+//
+// Dropping is unavoidable backpressure when the detection consumer cannot keep
+// up, but the loss must not be silent: every drop is a species that was heard
+// and never recorded.
+func recordResultsQueueDrop(source, modelID string, pm *metrics.MyAudioMetrics) int64 {
+	totalDropped := droppedDetectionsTotal.Add(1)
+	GetLogger().Error("results queue is full, detection dropped",
+		logger.String("source", source),
+		logger.String("model_id", modelID),
+		logger.Int("queue_capacity", cap(classifier.ResultsQueue)),
+		logger.Int64("dropped_total", totalDropped))
+	if pm != nil {
+		pm.RecordAudioQueueOperation(source, "enqueue", "dropped")
+	}
+	// Rate-limit queue overflow telemetry to prevent Sentry floods under sustained backpressure.
+	now := time.Now().Unix()
+	last := lastQueueOverflowReport.Load()
+	if telemetry.IsTelemetryEnabled() && (now-last >= int64(bufferOverrunReportCooldown.Seconds())) {
+		if lastQueueOverflowReport.CompareAndSwap(last, now) {
+			telemetry.FastCaptureMessageWithExtras(
+				"results queue full, detections dropped",
+				sentry.LevelWarning,
+				"analysis",
+				map[string]any{
+					"source":         source,
+					"model_id":       modelID,
+					"queue_size":     len(classifier.ResultsQueue),
+					"queue_capacity": cap(classifier.ResultsQueue),
+					"dropped_total":  totalDropped,
+				},
+			)
+		}
+	}
+	return totalDropped
 }
 
 func convertToFloat32WithPool(bufMgr *buffer.Manager, sample []byte, bitDepth int) ([][]float32, error) {

--- a/internal/analysis/process_queue_drop_test.go
+++ b/internal/analysis/process_queue_drop_test.go
@@ -16,6 +16,7 @@ import (
 func TestRecordResultsQueueDrop_CountsDrops(t *testing.T) {
 	// Not parallel: mutates the package-global droppedDetectionsTotal counter.
 	before := droppedDetectionsTotal.Load()
+	t.Cleanup(func() { droppedDetectionsTotal.Store(before) })
 
 	got := recordResultsQueueDrop("test-source", "test-model", nil)
 	assert.Equal(t, before+1, got, "first drop should return previous total + 1")
@@ -32,6 +33,7 @@ func TestRecordResultsQueueDrop_CountsDrops(t *testing.T) {
 func TestDroppedDetectionsTotal_MonotonicUnderConcurrency(t *testing.T) {
 	// Not parallel: mutates the package-global counter.
 	before := droppedDetectionsTotal.Load()
+	t.Cleanup(func() { droppedDetectionsTotal.Store(before) })
 
 	const goroutines = 16
 	const dropsEach = 64

--- a/internal/analysis/process_queue_drop_test.go
+++ b/internal/analysis/process_queue_drop_test.go
@@ -1,0 +1,54 @@
+// process_queue_drop_test.go verifies that results-queue overflow drops are
+// counted rather than silently discarded. Before this accounting existed, a full
+// results queue dropped detections with no durable signal of how much data was
+// lost.
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRecordResultsQueueDrop_CountsDrops confirms that each drop increments the
+// cumulative counter and that the returned total reflects it. A nil metrics
+// pointer is passed to exercise the safe-no-op metrics path.
+func TestRecordResultsQueueDrop_CountsDrops(t *testing.T) {
+	// Not parallel: mutates the package-global droppedDetectionsTotal counter.
+	before := droppedDetectionsTotal.Load()
+
+	got := recordResultsQueueDrop("test-source", "test-model", nil)
+	assert.Equal(t, before+1, got, "first drop should return previous total + 1")
+	assert.Equal(t, before+1, droppedDetectionsTotal.Load(), "counter should reflect the increment")
+
+	got2 := recordResultsQueueDrop("test-source", "test-model", nil)
+	assert.Equal(t, before+2, got2, "second drop should return previous total + 2")
+	assert.Equal(t, before+2, droppedDetectionsTotal.Load())
+}
+
+// TestDroppedDetectionsTotal_MonotonicUnderConcurrency verifies the counter is
+// safe to increment concurrently (it is hit from per-source goroutines) and that
+// every drop is accounted for with no lost updates.
+func TestDroppedDetectionsTotal_MonotonicUnderConcurrency(t *testing.T) {
+	// Not parallel: mutates the package-global counter.
+	before := droppedDetectionsTotal.Load()
+
+	const goroutines = 16
+	const dropsEach = 64
+
+	done := make(chan struct{})
+	for range goroutines {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for range dropsEach {
+				recordResultsQueueDrop("concurrent-source", "concurrent-model", nil)
+			}
+		}()
+	}
+	for range goroutines {
+		<-done
+	}
+
+	assert.Equal(t, before+int64(goroutines*dropsEach), droppedDetectionsTotal.Load(),
+		"every concurrent drop must be counted with no lost updates")
+}

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -219,19 +219,34 @@ func getTopKResults(results []datastore.Results, k int) []datastore.Results {
 		return []datastore.Results{}
 	}
 
+	// Number of elements the caller will receive.
+	n := min(k, len(results))
+
 	if k >= len(results) {
-		// If k is greater than or equal to the number of results, sort everything
+		// If k is greater than or equal to the number of results, sort everything.
 		sortResults(results)
-		return results
+	} else {
+		// Use partial sort to move the top k elements to the front, then sort
+		// just those k in descending order.
+		partialSort(results, k)
+		sortResults(results[:k])
 	}
 
-	// Use partial sort to find top k elements
-	partialSort(results, k)
-
-	// Sort the top k elements in descending order
-	sortResults(results[:k])
-
-	return results[:k]
+	// Return a freshly-allocated copy so the result never aliases the caller's
+	// backing array. BirdNET.Predict passes a reused per-instance scratch buffer
+	// (bn.resultsBuffer) that the next inference window overwrites in place via
+	// pairLabelsAndConfidenceReuse; without this copy a top-K slice already handed
+	// to classifier.ResultsQueue would be mutated concurrently with the queue
+	// consumer reading it, an unsynchronized read/write data race that can corrupt
+	// queued detections. The Bat and Perch Predict paths pass
+	// freshly-allocated slices, so the copy is redundant-but-harmless there; doing
+	// it unconditionally keeps the ownership contract uniform for every model. n
+	// is small (defaultTopKResults = 10), so the copy is cheap and the upstream
+	// large-buffer reuse optimization stays intact: bn.resultsBuffer remains
+	// internal scratch that never escapes.
+	out := make([]datastore.Results, n)
+	copy(out, results[:n])
+	return out
 }
 
 // partialSort performs a partial sort to move the top k elements to the front.

--- a/internal/classifier/analyze_test.go
+++ b/internal/classifier/analyze_test.go
@@ -780,6 +780,66 @@ func TestGetTopKResults(t *testing.T) {
 	}
 }
 
+// TestGetTopKResults_ReturnsCopyNotAlias verifies getTopKResults returns a
+// freshly-allocated slice that does not share a backing array with the input
+// buffer. This is the guarantee that closes the data race: the
+// Predict implementations pass a reused per-instance scratch buffer
+// (bn.resultsBuffer) which the next inference window overwrites in place via
+// pairLabelsAndConfidenceReuse, while the queue consumer may still be reading a
+// previously-returned top-K slice.
+func TestGetTopKResults_ReturnsCopyNotAlias(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the reused per-instance scratch buffer.
+	buffer := []datastore.Results{
+		{Species: "A", Confidence: 0.9},
+		{Species: "B", Confidence: 0.7},
+		{Species: "C", Confidence: 0.8},
+		{Species: "D", Confidence: 0.6},
+		{Species: "E", Confidence: 0.5},
+	}
+
+	top := getTopKResults(buffer, 3)
+	require.Len(t, top, 3)
+	require.Equal(t, "A", top[0].Species)
+
+	// Overwrite the entire backing buffer the way the next inference window
+	// would (pairLabelsAndConfidenceReuse mutates buffer[i].Species/.Confidence
+	// in place). If top aliased buffer, these writes would corrupt it.
+	for i := range buffer {
+		buffer[i].Species = "OVERWRITTEN"
+		buffer[i].Confidence = -1
+	}
+
+	assert.Equal(t, "A", top[0].Species, "returned slice must not alias the input scratch buffer")
+	assert.InDelta(t, float32(0.9), top[0].Confidence, 0.0001)
+	assert.Equal(t, "C", top[1].Species)
+	assert.Equal(t, "B", top[2].Species)
+}
+
+// TestGetTopKResults_FullSortBranchReturnsCopy covers the k>=len branch: even
+// when the whole slice is returned it must be an independent copy.
+func TestGetTopKResults_FullSortBranchReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	buffer := []datastore.Results{
+		{Species: "A", Confidence: 0.5},
+		{Species: "B", Confidence: 0.9},
+	}
+
+	top := getTopKResults(buffer, 5) // k > len triggers the full-sort branch
+	require.Len(t, top, 2)
+	require.Equal(t, "B", top[0].Species)
+
+	for i := range buffer {
+		buffer[i].Species = "OVERWRITTEN"
+		buffer[i].Confidence = -1
+	}
+
+	assert.Equal(t, "B", top[0].Species, "full-sort branch must also return an independent copy")
+	assert.Equal(t, "A", top[1].Species)
+}
+
 // generateLargeTestResults creates a large dataset for testing
 func generateLargeTestResults(count int) []datastore.Results {
 	results := make([]datastore.Results, count)


### PR DESCRIPTION
## Summary

Fixes a set of concurrency and observability issues in the realtime inference pipeline. Each is independent and lands as its own commit.

### 1. Predict top-K slice aliased a reused buffer (data race)
`getTopKResults` returned `results[:k]`, a sub-slice backed by the caller's array. `BirdNET.Predict` passes its reused per-instance `bn.resultsBuffer`, which the next inference window overwrites in place via `pairLabelsAndConfidenceReuse`. The returned slice travels onto `classifier.ResultsQueue` and is read by the consumer goroutine, so the in-place overwrite was an unsynchronized read/write data race that could corrupt queued detections.

Fix: return a freshly-allocated copy of the top-K (K = 10) at the `getTopKResults` choke point, so all three Predict paths (BirdNET, Bat, Perch) share one ownership contract. The copy is cheap, the large-buffer reuse optimization stays intact, and the old sub-slice's retained multi-thousand-element backing array is no longer pinned in the queue.

### 2. ControlMonitor data race on the sound level manager
`ControlMonitor.Stop()` read `cm.soundLevelManager` without a lock while the monitor goroutine wrote the same field in `handleReconfigureSoundLevel`. A `reconfigure_sound_level` signal in flight during shutdown raced the shutdown read (`-race` detectable).

Fix: a dedicated mutex guards every access (`Stop`, `initializeSoundLevelIfEnabled`, `handleReconfigureSoundLevel`); the pointer is read or lazily created under the lock and `Start`/`Stop`/`Restart` are called outside it so a blocking shutdown never holds the lock. Also adds defensive `bn` nil-guards to `handleRebuildRangeFilter` and `handleReloadBirdnet` for consistency with the constructor (`handleRebuildRangeFilter` uses if/else so its opportunistic maintenance cleanup still runs).

### 3. Dropped detections on a full results queue were silent
When the results queue is full, `ProcessData` drops the detection. The drop is unavoidable backpressure on a slow consumer, but it was effectively silent data loss.

Fix: add a cumulative dropped-detection counter and surface it. The drop now logs `source`, `model_id`, `queue_capacity`, and the running total, records the existing drop metric, and emits the rate-limited overflow telemetry with the same added context. The drop behavior itself is unchanged.

### 4. Documented a false-positive route-leak branch
The "already registered concurrently" branch in `registerSoundLevelConsumers` was flagged by a static review as leaking a router route. It is a false positive: `consumerID` is deterministic and `Router.AddRoute` rejects duplicate consumer IDs, so the branch is only reachable after this goroutine's own route was already torn down externally, which let another registration add and track a new route under the same ID. Calling `RemoveRoute` there would delete that other registration's live route. Added a comment documenting the deliberate asymmetry; no behavior change.

## Test Plan
- [x] New unit tests prove `getTopKResults` returns an independent copy in both the partial-sort and full-sort branches (overwrite input, assert output unchanged).
- [x] New `-race` regression test runs `ControlMonitor.Stop()` concurrently with `handleReconfigureSoundLevel`; verified it fails under `-race` without the mutex and passes with it.
- [x] New tests cover the dropped-detection counter, including a concurrent monotonicity check.
- [x] `go test -race ./internal/classifier/ ./internal/analysis/` passes.
- [x] `golangci-lint run` clean on the changed packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a sound-level consumer race that could halt sound-level processing until reload
  * Prevented sound-level manager restart after shutdown during reconfigure
  * Improved hot-reload resilience by safely handling temporary absence of BirdNET controller
  * Ensured top-K detection results no longer alias reused buffers
* **Improvements (Observability)**
  * Added cumulative “results queue full” drop tracking with richer, rate-limited telemetry and metrics state updates
* **Tests**
  * Added shutdown/reconfigure race and “no resurrection after stop” regression tests
  * Added drop-counter concurrency/monotonicity tests and top-K copy-semantics tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->