### PR TITLE
fix(frontend): dropdown, fetch-race, search-filter, and audio playback edge cases

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
@@ -527,6 +527,9 @@
               updatePortalPosition();
             } else {
               createPortalDropdown();
+              // createPortalDropdown only appends an empty container; populate it
+              // now since the portal $effect won't re-run (no dependency changed).
+              updatePortalDropdown();
             }
           }
         }}

--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
@@ -103,6 +103,10 @@
   let touched = $state(false);
   let inputElement: HTMLInputElement;
   let portalDropdown: HTMLDivElement | null = null;
+  // Tracks an explicit dismissal (click/touch outside). The portal $effect reads
+  // this so a dismissed dropdown stays closed while the input still holds text,
+  // instead of lingering on document.body until the next input change.
+  let manuallyDismissed = $state(false);
 
   // Generate unique ID for this instance using timestamp and counter
   // This ensures no collisions even with multiple instances created simultaneously
@@ -158,19 +162,27 @@
 
   // Update predictions visibility and manage portal dropdown
   $effect(() => {
-    const shouldShow = filteredPredictions.length > 0;
+    const hasPredictions = filteredPredictions.length > 0;
 
-    if (shouldShow && !portalDropdown && inputElement) {
-      createPortalDropdown();
-    } else if (!shouldShow && portalDropdown) {
-      destroyPortalDropdown();
+    if (!hasPredictions) {
+      // No predictions — always close and reset the dismissed flag.
+      if (portalDropdown) destroyPortalDropdown();
+      showPredictions = false;
+      manuallyDismissed = false;
+      return;
     }
 
-    if (shouldShow && portalDropdown) {
+    // Has predictions but the user dismissed the dropdown by clicking outside —
+    // stay closed until the next input change (which resets manuallyDismissed).
+    if (manuallyDismissed) return;
+
+    if (!portalDropdown && inputElement) {
+      createPortalDropdown();
+    }
+    if (portalDropdown) {
       updatePortalDropdown();
     }
-
-    showPredictions = shouldShow;
+    showPredictions = true;
   });
 
   // Event delegation handlers
@@ -337,6 +349,7 @@
     const target = event.target as HTMLInputElement;
     value = target.value;
     touched = false; // Reset touched state on input
+    manuallyDismissed = false; // Re-show suggestions on new input
     onInput?.(target.value);
   }
 
@@ -355,6 +368,7 @@
     } else if (event.key === 'Escape') {
       event.preventDefault();
       showPredictions = false;
+      manuallyDismissed = true;
       // Immediately destroy portal dropdown for testing consistency
       destroyPortalDropdown();
       inputElement?.blur();
@@ -420,6 +434,7 @@
     } else if (event.key === 'Escape') {
       event.preventDefault();
       showPredictions = false;
+      manuallyDismissed = true;
       // Immediately destroy portal dropdown for testing consistency
       destroyPortalDropdown();
       inputElement?.focus();
@@ -431,6 +446,8 @@
     const target = event.target as globalThis.Element;
     if (!target.closest('.form-control') && !target.closest(`#${instanceId}`)) {
       showPredictions = false;
+      manuallyDismissed = true;
+      destroyPortalDropdown();
     }
   }
 
@@ -499,10 +516,17 @@
         onblur={handleBlur}
         oninvalid={handleInvalid}
         onfocus={() => {
-          if (filteredPredictions.length > 0) {
+          // Don't auto-reopen a dropdown the user explicitly dismissed (Escape or
+          // click-outside); typing resets manuallyDismissed. Recreate the portal
+          // directly rather than relying on the $effect, which won't re-run when
+          // neither filteredPredictions nor manuallyDismissed changed (otherwise
+          // showPredictions/aria-expanded would be true with no visible listbox).
+          if (filteredPredictions.length > 0 && !manuallyDismissed) {
             showPredictions = true;
             if (portalDropdown) {
               updatePortalPosition();
+            } else {
+              createPortalDropdown();
             }
           }
         }}

--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
@@ -388,6 +388,67 @@ describe('SpeciesInput', () => {
       expect(portal?.parentElement).toBe(document.body);
     });
 
+    // Regression for #1030: clicking outside must remove the portal node from
+    // document.body even while the input still holds text. Previously the portal
+    // lingered because handleDocumentClick only set showPredictions = false and
+    // the $effect never observed it.
+    it('destroys the portal dropdown when clicking outside while text remains', async () => {
+      render(SpeciesInput, {
+        props: {
+          value: 'rob',
+          predictions: defaultPredictions,
+          onAdd: vi.fn(),
+        },
+      });
+
+      const input = screen.getByRole('combobox');
+      await fireEvent.focus(input);
+
+      // Portal exists after focus.
+      await waitFor(() => {
+        expect(document.body.querySelector('[id^="species-predictions-"]')).toBeTruthy();
+      });
+
+      // Click outside the input and the portal.
+      await fireEvent.click(document.body);
+
+      // Portal is removed even though the input value ('rob') is unchanged.
+      await waitFor(() => {
+        expect(document.body.querySelector('[id^="species-predictions-"]')).toBeNull();
+      });
+    });
+
+    // After an explicit dismissal (click-outside), typing must reopen the dropdown
+    // (handleInput resets manuallyDismissed). This proves the dismiss -> type ->
+    // reopen cycle works and the dropdown isn't stuck closed.
+    it('reopens the portal dropdown on typing after a click-outside dismissal', async () => {
+      render(SpeciesInput, {
+        props: {
+          value: 'rob',
+          predictions: defaultPredictions,
+          onAdd: vi.fn(),
+        },
+      });
+
+      const input = screen.getByRole('combobox');
+      await fireEvent.focus(input);
+      await waitFor(() => {
+        expect(document.body.querySelector('[id^="species-predictions-"]')).toBeTruthy();
+      });
+
+      // Dismiss by clicking outside.
+      await fireEvent.click(document.body);
+      await waitFor(() => {
+        expect(document.body.querySelector('[id^="species-predictions-"]')).toBeNull();
+      });
+
+      // Typing clears the dismissal and recreates the dropdown.
+      await fireEvent.input(input, { target: { value: 'robi' } });
+      await waitFor(() => {
+        expect(document.body.querySelector('[id^="species-predictions-"]')).toBeTruthy();
+      });
+    });
+
     it('positions dropdown below input when space is available', async () => {
       // Mock getBoundingClientRect for input element
       const mockRect = {

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -136,6 +136,12 @@
     newSpecies: [],
   });
 
+  // Monotonic token guarding against stale-response races. Each fetchData() run
+  // captures the latest value; a fetcher only commits its result when its captured
+  // token still matches, so a slower earlier request can no longer overwrite the
+  // data from a newer one after rapid filter changes. Non-reactive on purpose.
+  let analyticsFetchSeq = 0;
+
   // Derived chart inputs built from the reactive chartData via pure transforms.
   // Species distribution: sorted desc by count, mapped to labelled bars with
   // per-species colors from the D3 theme palette (applied inside BarChart).
@@ -238,6 +244,7 @@
 
   // Fetch all data
   async function fetchData() {
+    const seq = ++analyticsFetchSeq;
     isLoading = true;
     error = null;
 
@@ -293,13 +300,16 @@
 
       // Run all API calls in parallel
       const results = await Promise.allSettled([
-        fetchSummaryData(startDate || '', endDate || ''),
-        fetchSpeciesSummary(startDate || '', endDate || ''),
-        fetchRecentDetections(),
-        fetchTimeOfDayData(startDate || '', endDate || ''),
-        fetchTrendData(startDate || '', endDate || ''),
-        fetchNewSpeciesData(startDate || '', endDate || ''),
+        fetchSummaryData(seq, startDate || '', endDate || ''),
+        fetchSpeciesSummary(seq, startDate || '', endDate || ''),
+        fetchRecentDetections(seq),
+        fetchTimeOfDayData(seq, startDate || '', endDate || ''),
+        fetchTrendData(seq, startDate || '', endDate || ''),
+        fetchNewSpeciesData(seq, startDate || '', endDate || ''),
       ]);
+
+      // A newer fetchData() superseded this run; leave its state and loading flag alone.
+      if (seq !== analyticsFetchSeq) return;
 
       // Log any failed API calls (these show up in both dev and prod)
       const apiNames = ['Summary', 'Species', 'Recent', 'TimeOfDay', 'Trend', 'NewSpecies'];
@@ -318,17 +328,21 @@
         });
       }
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return;
       logger.error('General error fetching analytics data:', err);
       error = t('analytics.loadingError');
     }
 
     // The D3 chart components render reactively from the derived chart inputs,
-    // so there is nothing to imperatively create here.
-    isLoading = false;
+    // so there is nothing to imperatively create here. Only the most recent run
+    // clears the loading flag; a superseded run leaves it for the active fetch.
+    if (seq === analyticsFetchSeq) {
+      isLoading = false;
+    }
   }
 
   // Fetch summary metrics
-  async function fetchSummaryData(startDate: string, endDate: string) {
+  async function fetchSummaryData(seq: number, startDate: string, endDate: string) {
     try {
       const params = new URLSearchParams();
       if (startDate) params.set('start_date', startDate);
@@ -338,6 +352,7 @@
       logger.debug('Fetching summary data:', { url, startDate, endDate });
 
       const speciesData = await api.get<SpeciesData[]>(url);
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       const speciesArray = Array.isArray(speciesData) ? speciesData : [];
 
       logger.debug('Summary API response:', {
@@ -377,12 +392,13 @@
         mostCommonCount,
       };
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       logger.error('Error fetching summary data:', err);
     }
   }
 
   // Fetch species summary for chart
-  async function fetchSpeciesSummary(startDate: string, endDate: string) {
+  async function fetchSpeciesSummary(seq: number, startDate: string, endDate: string) {
     try {
       const params = new URLSearchParams({ limit: '10' });
       if (startDate) params.set('start_date', startDate);
@@ -392,6 +408,7 @@
       logger.debug('Fetching species chart data:', { url, startDate, endDate });
 
       const speciesData = await api.get<SpeciesData[]>(url);
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       chartData.species = Array.isArray(speciesData) ? speciesData : [];
 
       logger.debug('Species chart API response:', {
@@ -401,15 +418,17 @@
         length: chartData.species.length,
       });
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       logger.error('Error fetching species summary:', err);
       chartData.species = [];
     }
   }
 
   // Fetch recent detections
-  async function fetchRecentDetections() {
+  async function fetchRecentDetections(seq: number) {
     try {
       const data = await api.get<ApiDetection[]>('/api/v2/detections/recent?limit=10');
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       const detections = Array.isArray(data) ? data : [];
 
       recentDetections = detections.map(detection => {
@@ -430,6 +449,7 @@
         };
       });
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       logger.error('Error fetching recent detections:', err);
       recentDetections = [];
     }
@@ -447,7 +467,7 @@
   }
 
   // Fetch time of day data
-  async function fetchTimeOfDayData(startDate: string, endDate: string) {
+  async function fetchTimeOfDayData(seq: number, startDate: string, endDate: string) {
     try {
       const params = new URLSearchParams();
       if (startDate) params.set('start_date', startDate);
@@ -457,6 +477,7 @@
       logger.debug('Fetching time of day data:', { url, startDate, endDate });
 
       const timeData = await api.get<TimeOfDayData[]>(url);
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       chartData.timeOfDay = Array.isArray(timeData) ? timeData : [];
 
       logger.debug('Time of day API response:', {
@@ -466,13 +487,14 @@
         length: Array.isArray(timeData) ? timeData.length : 0,
       });
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       logger.error('Error fetching time of day data:', err);
       chartData.timeOfDay = [];
     }
   }
 
   // Fetch trend data
-  async function fetchTrendData(startDate: string, endDate: string) {
+  async function fetchTrendData(seq: number, startDate: string, endDate: string) {
     try {
       const params = new URLSearchParams();
 
@@ -493,6 +515,7 @@
       logger.debug('Fetching trend data:', { url, startDate, endDate });
 
       const trendData = await api.get<TrendData>(url);
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       chartData.trend = trendData ?? { data: [] };
 
       logger.debug('Trend API response:', {
@@ -501,13 +524,14 @@
         dataLength: trendData?.data?.length || 0,
       });
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       logger.error('Error fetching trend data:', err);
       chartData.trend = { data: [] };
     }
   }
 
   // Fetch new species data
-  async function fetchNewSpeciesData(startDate: string, endDate: string) {
+  async function fetchNewSpeciesData(seq: number, startDate: string, endDate: string) {
     try {
       const params = new URLSearchParams();
       if (startDate) params.set('start_date', startDate);
@@ -517,6 +541,7 @@
       logger.debug('Fetching new species data:', { url, startDate, endDate });
 
       const data = await api.get<NewSpeciesData[]>(url);
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       newSpeciesData = Array.isArray(data) ? data : [];
       chartData.newSpecies = newSpeciesData;
 
@@ -527,6 +552,7 @@
         length: newSpeciesData.length,
       });
     } catch (err) {
+      if (seq !== analyticsFetchSeq) return; // superseded by a newer fetch
       logger.error('Error fetching new species data:', err);
       newSpeciesData = [];
       chartData.newSpecies = [];

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -4,7 +4,6 @@
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
   import { formatNumber, formatDateTime } from '$lib/utils/formatters';
   import { getLogger } from '$lib/utils/logger';
-  import { safeArrayAccess } from '$lib/utils/security';
   import { XCircle } from '@lucide/svelte';
   import { onMount, type Snippet } from 'svelte';
   import FilterForm from '../components/forms/FilterForm.svelte';
@@ -298,8 +297,10 @@
         calculatedRange: startDate && endDate ? `${startDate} to ${endDate}` : 'unlimited',
       });
 
-      // Run all API calls in parallel
-      const results = await Promise.allSettled([
+      // Run all API calls in parallel. Each fetcher logs and swallows its own
+      // errors and guards its own commit with the fetch-sequence token, so
+      // allSettled always fulfills and there is nothing to inspect afterwards.
+      await Promise.allSettled([
         fetchSummaryData(seq, startDate || '', endDate || ''),
         fetchSpeciesSummary(seq, startDate || '', endDate || ''),
         fetchRecentDetections(seq),
@@ -307,26 +308,6 @@
         fetchTrendData(seq, startDate || '', endDate || ''),
         fetchNewSpeciesData(seq, startDate || '', endDate || ''),
       ]);
-
-      // A newer fetchData() superseded this run; leave its state and loading flag alone.
-      if (seq !== analyticsFetchSeq) return;
-
-      // Log any failed API calls (these show up in both dev and prod)
-      const apiNames = ['Summary', 'Species', 'Recent', 'TimeOfDay', 'Trend', 'NewSpecies'];
-      const failures = results
-        .map((result, index) => ({ result, name: safeArrayAccess(apiNames, index) ?? 'Unknown' }))
-        .filter(({ result }) => result.status === 'rejected');
-
-      if (failures.length > 0) {
-        failures.forEach(({ result, name }) => {
-          const reason = result.status === 'rejected' ? result.reason : 'Unknown error';
-          logger.error(`${name} API call failed during filter operation`, reason, {
-            timePeriod: filters.timePeriod,
-            startDate,
-            endDate,
-          });
-        });
-      }
     } catch (err) {
       if (seq !== analyticsFetchSeq) return;
       logger.error('General error fetching analytics data:', err);

--- a/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
@@ -370,6 +370,9 @@
             updatePortalPosition();
           } else {
             createPortalDropdown();
+            // createPortalDropdown only appends an empty container; populate it now
+            // since the portal $effect won't re-run (no dependency changed).
+            updatePortalDropdown();
           }
         }
       }}

--- a/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
@@ -261,6 +261,7 @@
     if (event.key === 'Escape') {
       event.preventDefault();
       showPredictions = false;
+      manuallyDismissed = true;
       destroyPortalDropdown();
       inputElement?.blur();
     } else if (event.key === 'ArrowDown' && showPredictions && portalDropdown) {
@@ -308,6 +309,7 @@
     } else if (event.key === 'Escape') {
       event.preventDefault();
       showPredictions = false;
+      manuallyDismissed = true;
       destroyPortalDropdown();
       inputElement?.focus();
     }
@@ -358,10 +360,16 @@
       oninput={handleInput}
       onkeydown={handleKeydown}
       onfocus={() => {
-        if (filteredPredictions.length > 0) {
+        // Don't auto-reopen a dropdown the user explicitly dismissed (Escape or
+        // click-outside); typing resets manuallyDismissed. Recreate the portal
+        // directly rather than relying on the $effect, which won't re-run when
+        // neither filteredPredictions nor manuallyDismissed changed.
+        if (filteredPredictions.length > 0 && !manuallyDismissed) {
           showPredictions = true;
           if (portalDropdown) {
             updatePortalPosition();
+          } else {
+            createPortalDropdown();
           }
         }
       }}

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -185,21 +185,26 @@
     }
 
     detectionController?.abort();
-    detectionController = new AbortController();
+    const controller = new AbortController();
+    detectionController = controller;
+    const { signal } = controller;
 
     isLoadingDetection = true;
     detectionError = null;
 
     try {
       const response = await fetch(buildAppUrl(`/api/v2/detections/${resolvedDetectionId}`), {
-        signal: detectionController.signal,
+        signal,
       });
 
-      if (detectionController?.signal.aborted) return;
+      // Check the captured signal, not the shared controller: a newer request may
+      // have replaced detectionController with a fresh, non-aborted instance, and
+      // checking that would let this stale response overwrite newer data.
+      if (signal.aborted) return;
 
       if (response.ok) {
         const data = (await response.json()) as Detection;
-        if (detectionController?.signal.aborted) return;
+        if (signal.aborted) return;
         detection = data;
       } else {
         let errorMessage: string;
@@ -230,15 +235,19 @@
         fetchImageAttribution();
       }
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
         return;
       }
       detectionError =
         error instanceof Error ? error.message : t('detections.errors.loadFailed', { status: '' });
       logger.error('Error fetching detection:', error);
     } finally {
-      isLoadingDetection = false;
-      detectionController = null;
+      // Only the request that still owns the controller may reset shared state; a
+      // superseded request must not clear a newer request's loading flag/controller.
+      if (detectionController === controller) {
+        isLoadingDetection = false;
+        detectionController = null;
+      }
     }
   }
 
@@ -247,24 +256,28 @@
     if (!detection?.scientificName?.trim()) return;
 
     attributionController?.abort();
-    attributionController = new AbortController();
+    const controller = new AbortController();
+    attributionController = controller;
+    const { signal } = controller;
 
     try {
       const url = buildAppUrl(
         `/api/v2/media/species-image/info?name=${encodeURIComponent(detection.scientificName)}`
       );
-      const response = await fetch(url, { signal: attributionController?.signal });
-      if (attributionController?.signal.aborted) return;
+      const response = await fetch(url, { signal });
+      if (signal.aborted) return;
       if (response.ok) {
         const data = await response.json();
-        if (attributionController?.signal.aborted) return;
+        if (signal.aborted) return;
         imageAttribution = data as ImageAttribution;
       }
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') return;
+      if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) return;
       // Attribution is non-critical - fail silently
     } finally {
-      attributionController = null;
+      if (attributionController === controller) {
+        attributionController = null;
+      }
     }
   }
 
@@ -273,28 +286,32 @@
     if (!detection?.scientificName?.trim()) return;
 
     speciesController?.abort();
-    speciesController = new AbortController();
+    const controller = new AbortController();
+    speciesController = controller;
+    const { signal } = controller;
 
     try {
       const response = await fetch(
         buildAppUrl(
           `/api/v2/species?scientific_name=${encodeURIComponent(detection.scientificName)}`
         ),
-        { signal: speciesController?.signal }
+        { signal }
       );
-      if (speciesController?.signal.aborted) return;
+      if (signal.aborted) return;
       if (response.ok) {
         const data = await response.json();
-        if (speciesController?.signal.aborted) return;
+        if (signal.aborted) return;
         speciesInfo = data;
       }
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
         return;
       }
       logger.error('Error fetching species info:', error);
     } finally {
-      speciesController = null;
+      if (speciesController === controller) {
+        speciesController = null;
+      }
     }
   }
 
@@ -303,7 +320,9 @@
     if (!detection?.scientificName?.trim()) return;
 
     taxonomyController?.abort();
-    taxonomyController = new AbortController();
+    const controller = new AbortController();
+    taxonomyController = controller;
+    const { signal } = controller;
 
     isLoadingTaxonomy = true;
     try {
@@ -311,22 +330,24 @@
         buildAppUrl(
           `/api/v2/species/taxonomy?scientific_name=${encodeURIComponent(detection.scientificName)}`
         ),
-        { signal: taxonomyController?.signal }
+        { signal }
       );
-      if (taxonomyController?.signal.aborted) return;
+      if (signal.aborted) return;
       if (response.ok) {
         const data = await response.json();
-        if (taxonomyController?.signal.aborted) return;
+        if (signal.aborted) return;
         taxonomyInfo = data;
       }
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
         return;
       }
       logger.error('Error fetching taxonomy info:', error);
     } finally {
-      isLoadingTaxonomy = false;
-      taxonomyController = null;
+      if (taxonomyController === controller) {
+        isLoadingTaxonomy = false;
+        taxonomyController = null;
+      }
     }
   }
 

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -191,6 +191,13 @@
 
     isLoadingDetection = true;
     detectionError = null;
+    // Reset the detail and its dependent data so a newer detection never briefly
+    // shows the previously viewed one's species/taxonomy/attribution while the
+    // secondary fetches are still in flight.
+    detection = null;
+    speciesInfo = null;
+    taxonomyInfo = null;
+    imageAttribution = null;
 
     try {
       const response = await fetch(buildAppUrl(`/api/v2/detections/${resolvedDetectionId}`), {

--- a/frontend/src/lib/utils/searchParser.test.ts
+++ b/frontend/src/lib/utils/searchParser.test.ts
@@ -166,7 +166,9 @@ describe('formatFiltersForAPI', () => {
     expect(result).toEqual({ timeOfDay: 'dawn' });
   });
 
-  it('should map source filter to location API param', () => {
+  // location and source are aliases for the same backend dimension (source_node),
+  // exposed by GET /api/v2/detections as the single `location` query param.
+  it('should map source filter to the location API param (shared source_node dimension)', () => {
     const filters = [
       {
         type: 'source' as const,
@@ -178,6 +180,35 @@ describe('formatFiltersForAPI', () => {
 
     const result = formatFiltersForAPI(filters);
     expect(result).toEqual({ location: 'rtsp_87b89761' });
+  });
+
+  it('should map location filter to the location API param', () => {
+    const filters = [
+      {
+        type: 'location' as const,
+        operator: ':' as const,
+        value: 'Back Yard',
+        raw: 'location:Back Yard',
+      },
+    ];
+
+    const result = formatFiltersForAPI(filters);
+    expect(result).toEqual({ location: 'Back Yard' });
+  });
+
+  it('should map daterange filter to snake_case start_date/end_date API params', () => {
+    const filters = [
+      {
+        type: 'daterange' as const,
+        operator: ':' as const,
+        value: '2024-01-01',
+        value2: '2024-01-31',
+        raw: 'daterange:2024-01-01:2024-01-31',
+      },
+    ];
+
+    const result = formatFiltersForAPI(filters);
+    expect(result).toEqual({ start_date: '2024-01-01', end_date: '2024-01-31' });
   });
 
   it('should format multiple filters', () => {
@@ -241,6 +272,16 @@ describe('getFilterSuggestions', () => {
   it('should include source: in filter-type suggestions', () => {
     const result = getFilterSuggestions('sou');
     expect(result).toContain('source:');
+  });
+
+  it('should include daterange: in filter-type suggestions', () => {
+    const result = getFilterSuggestions('dater');
+    expect(result).toContain('daterange:');
+  });
+
+  it('should suggest both date: and daterange: for the "date" prefix', () => {
+    const result = getFilterSuggestions('date');
+    expect(result).toEqual(expect.arrayContaining(['date:', 'daterange:']));
   });
 });
 

--- a/frontend/src/lib/utils/searchParser.ts
+++ b/frontend/src/lib/utils/searchParser.ts
@@ -587,8 +587,10 @@ export function formatFiltersForAPI(filters: SearchFilter[]): Record<string, str
         break;
 
       case 'daterange':
-        params.startDate = filter.value.toString();
-        params.endDate = filter.value2 ?? '';
+        // Backend GET /api/v2/detections reads snake_case start_date/end_date
+        // (see parseDetectionQueryParams). camelCase keys were silently ignored.
+        params.start_date = filter.value.toString();
+        params.end_date = filter.value2 ?? '';
         break;
 
       case 'verified':
@@ -599,10 +601,13 @@ export function formatFiltersForAPI(filters: SearchFilter[]): Record<string, str
         params.species = filter.value.toString();
         break;
 
+      // location and source are aliases for the same backend dimension: both map
+      // to the notes.source_node column (datastore AdvancedSearchFilters.Location),
+      // which the GET /api/v2/detections endpoint reads from the `location` query
+      // param. There is no separate `source` param on that endpoint, so source:
+      // intentionally serializes to params.location too. A query that sets both
+      // keys collides on this single param (last one wins) by design.
       case 'location':
-        params.location = filter.value.toString();
-        break;
-
       case 'source':
         params.location = filter.value.toString();
         break;
@@ -653,23 +658,16 @@ export function getFilterSuggestions(partialInput: string): string[] {
         break;
     }
   } else {
-    // Suggest filter types
-    const filterTypes = [
-      'confidence:',
-      'time:',
-      'date:',
-      'hour:',
-      'verified:',
-      'species:',
-      'source:',
-      'location:',
-      'locked:',
-    ];
-    filterTypes.forEach(type => {
-      if (type.startsWith(partialInput.toLowerCase())) {
-        suggestions.push(type);
+    // Suggest filter types. Derived from FILTER_KEYS so every recognized key
+    // (including daterange:) is offered and the list can never drift from the
+    // parser's accepted keys.
+    const lowerInput = partialInput.toLowerCase();
+    for (const key of FILTER_KEYS) {
+      const suggestion = `${key}:`;
+      if (suggestion.startsWith(lowerInput)) {
+        suggestions.push(suggestion);
       }
-    });
+    }
   }
 
   return suggestions;

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -265,6 +265,10 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
       try {
         await audioElement.play();
       } catch (err) {
+        // The media 'error' handler can run before play() rejects and may have
+        // queued a transient retry. Don't clobber that with an error message: the
+        // retry can still succeed, and 'canplay' clears the error on success.
+        if (audioRetryCount > 0) return;
         logger.error('Playback failed', err as Error);
         error = t('media.audio.playError');
       }
@@ -386,7 +390,11 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
         canplayTimeoutId = undefined;
       }
 
-      // Retry on 503 (audio still encoding by FFmpeg)
+      // Retry on load failure (audio still encoding by FFmpeg, served as 503/404).
+      // A media element reports such HTTP errors as MediaError.code 4
+      // (MEDIA_ERR_SRC_NOT_SUPPORTED), indistinguishable from a genuinely
+      // unsupported format, so we cannot skip retrying on code 4 without breaking
+      // the still-encoding path. Retrying is bounded by MAX_AUDIO_LOAD_RETRIES.
       if (audioRetryCount < MAX_AUDIO_LOAD_RETRIES) {
         if (audioRetryTimer) {
           clearTimeout(audioRetryTimer);

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -431,6 +431,9 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
 
       error = t('media.audio.error');
       isLoading = false;
+      // Retries are exhausted; drop any pending play intent so a late 'canplay'
+      // can't resume a clip that has permanently failed.
+      playRequestedAfterRetry = false;
     });
 
     if (!audio.paused) {

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -139,6 +139,10 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
   let canplayTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let audioRetryCount = 0;
   let audioRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  // True when the user pressed play during an active load retry; consumed by the
+  // 'canplay' handler to resume playback once the reloaded clip is ready, so the
+  // play intent is not lost when the transient error is suppressed.
+  let playRequestedAfterRetry = false;
   let eventListeners: Array<{
     element: HTMLElement | HTMLAudioElement | Document | Window | null;
     event: string;
@@ -267,8 +271,12 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
       } catch (err) {
         // The media 'error' handler can run before play() rejects and may have
         // queued a transient retry. Don't clobber that with an error message: the
-        // retry can still succeed, and 'canplay' clears the error on success.
-        if (audioRetryCount > 0) return;
+        // retry can still succeed. Remember the play intent so 'canplay' resumes
+        // playback once the reloaded clip is ready, instead of leaving it paused.
+        if (audioRetryCount > 0) {
+          playRequestedAfterRetry = true;
+          return;
+        }
         logger.error('Playback failed', err as Error);
         error = t('media.audio.playError');
       }
@@ -304,6 +312,7 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
         duration = 0;
         error = null;
         audioRetryCount = 0;
+        playRequestedAfterRetry = false;
         if (audioRetryTimer) {
           clearTimeout(audioRetryTimer);
           audioRetryTimer = undefined;
@@ -381,6 +390,15 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
       if (audioRetryTimer) {
         clearTimeout(audioRetryTimer);
         audioRetryTimer = undefined;
+      }
+      // If the user pressed play while the clip was still loading/encoding and we
+      // suppressed the transient error, resume playback now that it can play.
+      if (playRequestedAfterRetry) {
+        playRequestedAfterRetry = false;
+        void audio.play().catch(err => {
+          logger.error('Playback failed after retry', err as Error);
+          error = t('media.audio.playError');
+        });
       }
     });
 

--- a/frontend/src/lib/utils/useAudioPlayback.test.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.test.ts
@@ -338,6 +338,31 @@ describe('useAudioPlayback', () => {
   });
 
   // ---------------------------------------------------------------
+  // 7c. A play press during a transient retry resumes once 'canplay' fires,
+  //     so the play intent is not lost (regression for #954)
+  // ---------------------------------------------------------------
+  it('resumes playback on canplay after a play press during a transient retry', async () => {
+    await renderAndWait();
+
+    // A transient load error queues a retry.
+    fireAudioEvent('error');
+
+    // User presses play during the retry; play() rejects and the intent is held.
+    mockPlay.mockRejectedValueOnce(new DOMException('not supported', 'NotSupportedError'));
+    await getState().togglePlayPause();
+    expect(getState().error).toBeNull();
+
+    const callsBefore = mockPlay.mock.calls.length;
+
+    // Once the reloaded clip can play, playback resumes automatically.
+    fireAudioEvent('canplay');
+    await waitFor(() => {
+      expect(mockPlay.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+    expect(getState().error).toBeNull();
+  });
+
+  // ---------------------------------------------------------------
   // 8. seek() clamps to [0, duration]
   // ---------------------------------------------------------------
   it('seek() clamps time to [0, duration]', async () => {

--- a/frontend/src/lib/utils/useAudioPlayback.test.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.test.ts
@@ -318,6 +318,26 @@ describe('useAudioPlayback', () => {
   });
 
   // ---------------------------------------------------------------
+  // 7b. togglePlayPause() must not clobber a queued transient retry
+  //     with a play error (regression for #954)
+  // ---------------------------------------------------------------
+  it('does not surface a play error while a transient retry is queued', async () => {
+    await renderAndWait();
+
+    // A transient load error (no permanent MediaError code) queues a retry.
+    fireAudioEvent('error');
+    expect(getState().error).toBeNull();
+
+    // play() rejects (browsers reject play() once the media has errored), but a
+    // retry is already pending, so the rejection must stay silent.
+    mockPlay.mockRejectedValueOnce(new DOMException('not supported', 'NotSupportedError'));
+
+    await getState().togglePlayPause();
+
+    expect(getState().error).toBeNull();
+  });
+
+  // ---------------------------------------------------------------
   // 8. seek() clamps to [0, duration]
   // ---------------------------------------------------------------
   it('seek() clamps time to [0, duration]', async () => {


### PR DESCRIPTION
## Summary

Fixes a batch of frontend edge cases and UX papercuts found during review:

- **Advanced search filter mapping** (`searchParser.ts`): the `daterange:` filter now emits snake_case `start_date`/`end_date` so it matches the backend `GET /api/v2/detections` query params (the camelCase keys were silently ignored). Filter-type autocomplete suggestions now derive from the `FILTER_KEYS` single source of truth, so `daterange:` is offered and the list can't drift from the parser. `location:` and `source:` are documented as aliases for the same backend `source_node` dimension.
- **Species autocomplete dropdown** (`SpeciesInput.svelte`, `EditorSpeciesInput.svelte`): clicking outside or pressing Escape now destroys the portal dropdown instead of leaving it orphaned on `document.body`, via a `manuallyDismissed` guard. Refocusing respects the dismissal (reopens on typing), and `aria-expanded` stays in sync with the visible listbox.
- **Detection detail stale-response race** (`DetectionDetail.svelte`): the four fetch functions capture the `AbortController` signal locally before awaiting and check the captured signal, so a stale in-flight response can no longer overwrite newer data when navigating quickly between detections. The `finally` block is guarded by controller identity so a superseded request can't reset a newer one's state.
- **Analytics stale-response race** (`Analytics.svelte`): a fetch-sequence token guards all six parallel chart fetches, so a slower earlier response can't overwrite a newer one after rapid filter changes.
- **Audio playback** (`useAudioPlayback.svelte.ts`): a `play()` rejection no longer surfaces an error while a transient load retry is already queued, so a freshly detected clip still being encoded plays once ready instead of flashing an error.

## Test Plan

- [x] `npm run check:all` (svelte-check, eslint, stylelint, ast-grep) clean: 0 errors
- [x] Vitest: `searchParser`, `SpeciesInput`, `useAudioPlayback` suites pass (92 tests, including new regression tests for the filter mapping/suggestions, the click-outside + refocus dropdown behavior, and the audio retry guard)
- [ ] Manual: type `daterange:` / `source:` in the search box, confirm suggestions include `daterange:`
- [ ] Manual: open species autocomplete, click outside or press Escape, confirm the dropdown disappears; refocus stays closed, typing reopens it
- [ ] Manual: rapidly switch analytics time periods, confirm the charts settle on the latest selection
- [ ] Manual: play a just-detected clip that is still encoding, confirm it plays after the retry instead of erroring

## Notes

The `searchParser` change makes the emitted param names correct, but the detections list page does not yet forward the full set of advanced filters to the backend; that pre-existing end-to-end gap is tracked separately and is out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search filter handling with consistent `daterange` serialization for backend query parameters and more reliable filter-key suggestions.

* **Bug Fixes**
  * Autocomplete/suggestions dropdown now respects manual dismissal (Escape/outside click) across both species inputs and won’t auto-reopen until the user types again.
  * Analytics and detection detail views now prevent stale async responses from overwriting newer UI state.
  * Audio playback now defers play requests during retry so transient play failures don’t incorrectly surface as errors.

* **Tests**
  * Added regression coverage for dropdown dismissal/portal behavior, audio retry edge cases, and search filter serialization/suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->