### PR TITLE
test(frontend): regression tests for detection/analytics stale-response races

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.test.ts
@@ -90,8 +90,9 @@ describe('Analytics fetch-sequence race (#978)', () => {
       },
     ]);
     // Flush the production stale-handling path: await the promise it awaits, then
-    // drain microtasks plus one macrotask so the sequence guard has run before
-    // asserting absence. More robust than a bare timer if that path grows an await.
+    // a macrotask so every microtask hop (the sequence guard, state commit) and
+    // the Svelte DOM flush complete before asserting absence. A microtask-only
+    // flush (await tick) under-drains and lets the negative assertion fire early.
     await staleRecent;
     await new Promise(resolve => setTimeout(resolve, 0));
 

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.test.ts
@@ -19,14 +19,19 @@ vi.mock('$lib/desktop/features/dashboard/components/SourceBadge.svelte');
 
 const analyticsTest = createComponentTestFactory(Analytics);
 
+// Sentinel scientific names referenced by both the mock data and the assertions,
+// so a typo cannot silently desync the two.
+const FRESH_SCIENTIFIC = 'Fresh-sci';
+const STALE_SCIENTIFIC = 'Stale-sci';
+
 describe('Analytics fetch-sequence race (#978)', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(api.get).mockReset();
   });
 
   afterEach(() => {
     cleanup();
-    vi.clearAllMocks();
   });
 
   // Regression: a slower earlier fetchData() run must not overwrite a newer run's
@@ -49,7 +54,7 @@ describe('Analytics fetch-sequence race (#978)', () => {
             id: 'fresh',
             timestamp: '2024-01-02T08:00:00',
             commonName: 'Fresh Bird',
-            scientificName: 'Fresh-sci',
+            scientificName: FRESH_SCIENTIFIC,
             confidence: 0.9,
           },
         ]);
@@ -76,7 +81,7 @@ describe('Analytics fetch-sequence race (#978)', () => {
 
     // Run 2 resolves and renders the fresh detection.
     await waitFor(() => {
-      expect(container.textContent).toContain('Fresh-sci');
+      expect(container.textContent).toContain(FRESH_SCIENTIFIC);
     });
 
     // The stale run-1 recent response now arrives; the sequence guard must drop it.
@@ -85,7 +90,7 @@ describe('Analytics fetch-sequence race (#978)', () => {
         id: 'stale',
         timestamp: '2024-01-01T08:00:00',
         commonName: 'Stale Bird',
-        scientificName: 'Stale-sci',
+        scientificName: STALE_SCIENTIFIC,
         confidence: 0.5,
       },
     ]);
@@ -96,7 +101,7 @@ describe('Analytics fetch-sequence race (#978)', () => {
     await staleRecent;
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(container.textContent).toContain('Fresh-sci');
-    expect(container.textContent).not.toContain('Stale-sci');
+    expect(container.textContent).toContain(FRESH_SCIENTIFIC);
+    expect(container.textContent).not.toContain(STALE_SCIENTIFIC);
   });
 });

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { waitFor, cleanup, fireEvent } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../../../test/render-helpers';
+import { api } from '$lib/utils/api';
+import Analytics from './Analytics.svelte';
+
+// api.get is the data source we drive for the race.
+vi.mock('$lib/utils/api', () => ({
+  api: { get: vi.fn() },
+  ApiError: class ApiError extends Error {},
+}));
+
+// D3 charts and source badge are irrelevant to the fetch-sequence logic and
+// pull in heavy/contextual dependencies, so stub them out.
+vi.mock('../components/charts/d3/BarChart.svelte');
+vi.mock('../components/charts/d3/LineChart.svelte');
+vi.mock('../components/charts/d3/NewSpeciesTimelineChart.svelte');
+vi.mock('$lib/desktop/features/dashboard/components/SourceBadge.svelte');
+
+const analyticsTest = createComponentTestFactory(Analytics);
+
+describe('Analytics fetch-sequence race (#978)', () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  // Regression: a slower earlier fetchData() run must not overwrite a newer run's
+  // data. The fix stamps each run with analyticsFetchSeq and each fetcher commits
+  // only when its captured token still matches the latest run.
+  it('does not let a stale recent-detections response overwrite a newer run', async () => {
+    let recentCalls = 0;
+    let resolveStaleRecent!: (value: unknown) => void;
+    const staleRecent = new Promise<unknown>(resolve => {
+      resolveStaleRecent = resolve;
+    });
+
+    vi.mocked(api.get).mockImplementation((url: string): Promise<unknown> => {
+      if (url.includes('/api/v2/detections/recent')) {
+        recentCalls += 1;
+        // First run's recent fetch is held in flight; the second resolves at once.
+        if (recentCalls === 1) return staleRecent;
+        return Promise.resolve([
+          {
+            id: 'fresh',
+            timestamp: '2024-01-02T08:00:00',
+            commonName: 'Fresh Bird',
+            scientificName: 'Fresh-sci',
+            confidence: 0.9,
+          },
+        ]);
+      }
+      if (url.includes('/api/v2/analytics/time/daily')) {
+        return Promise.resolve({ data: [] });
+      }
+      // summary, hourly distribution, new species all accept an empty array.
+      return Promise.resolve([]);
+    });
+
+    const { container } = analyticsTest.render({});
+
+    // The initial run (on mount) fires all six fetchers; the recent one is held.
+    await waitFor(() => {
+      expect(vi.mocked(api.get).mock.calls.length).toBeGreaterThanOrEqual(6);
+    });
+
+    // Trigger a second fetchData() via the filter form while run 1 is still in
+    // flight (submitting the form bypasses the loading-disabled button).
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    await fireEvent.submit(form as HTMLFormElement);
+
+    // Run 2 resolves and renders the fresh detection.
+    await waitFor(() => {
+      expect(container.textContent).toContain('Fresh-sci');
+    });
+
+    // The stale run-1 recent response now arrives; the sequence guard must drop it.
+    resolveStaleRecent([
+      {
+        id: 'stale',
+        timestamp: '2024-01-01T08:00:00',
+        commonName: 'Stale Bird',
+        scientificName: 'Stale-sci',
+        confidence: 0.5,
+      },
+    ]);
+    // Flush the production stale-handling path: await the promise it awaits, then
+    // drain microtasks plus one macrotask so the sequence guard has run before
+    // asserting absence. More robust than a bare timer if that path grows an await.
+    await staleRecent;
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(container.textContent).toContain('Fresh-sci');
+    expect(container.textContent).not.toContain('Stale-sci');
+  });
+});

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -32,15 +32,23 @@ function makeDetection(overrides: Partial<Detection>): Detection {
   };
 }
 
+// Sentinel scientific names referenced by both the fixtures and the assertions,
+// so a typo cannot silently desync the two.
+const FRESH_SCIENTIFIC = 'Fresh-sci-B';
+const STALE_SCIENTIFIC = 'Stale-sci-A';
+
 /** Minimal fetch Response stub carrying a JSON body. */
 function jsonResponse(body: unknown): Response {
+  // Pre-serialize so text() never throws synchronously (e.g. circular refs);
+  // a Promise-returning method must reject, not throw.
+  const serialized = JSON.stringify(body);
   return {
     ok: true,
     status: 200,
     statusText: 'OK',
     headers: new Headers({ 'content-type': 'application/json' }),
     json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
+    text: () => Promise.resolve(serialized),
   } as unknown as Response;
 }
 
@@ -48,13 +56,13 @@ describe('DetectionDetail stale-response race (#978)', () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     originalFetch = globalThis.fetch;
   });
 
   afterEach(() => {
     cleanup();
     globalThis.fetch = originalFetch;
-    vi.clearAllMocks();
   });
 
   // Regression: navigating from detection A to B while A's request is still in
@@ -77,7 +85,7 @@ describe('DetectionDetail stale-response race (#978)', () => {
       if (url.includes('/api/v2/detections/det-b')) {
         return Promise.resolve(
           jsonResponse(
-            makeDetection({ id: 2, scientificName: 'Fresh-sci-B', commonName: 'Fresh B' })
+            makeDetection({ id: 2, scientificName: FRESH_SCIENTIFIC, commonName: 'Fresh B' })
           )
         );
       }
@@ -90,12 +98,14 @@ describe('DetectionDetail stale-response race (#978)', () => {
     // Switch to detection B before A resolves.
     await rerender({ detectionId: 'det-b' });
     await waitFor(() => {
-      expect(container.textContent).toContain('Fresh-sci-B');
+      expect(container.textContent).toContain(FRESH_SCIENTIFIC);
     });
 
     // A's response now arrives late; the captured-signal guard must drop it.
     resolveStale(
-      jsonResponse(makeDetection({ id: 1, scientificName: 'Stale-sci-A', commonName: 'Stale A' }))
+      jsonResponse(
+        makeDetection({ id: 1, scientificName: STALE_SCIENTIFIC, commonName: 'Stale A' })
+      )
     );
     // Flush the production stale-handling path: await the promise it awaits, then
     // a macrotask so every microtask hop (response.json, the captured-signal
@@ -104,7 +114,7 @@ describe('DetectionDetail stale-response race (#978)', () => {
     await staleResponse;
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(container.textContent).toContain('Fresh-sci-B');
-    expect(container.textContent).not.toContain('Stale-sci-A');
+    expect(container.textContent).toContain(FRESH_SCIENTIFIC);
+    expect(container.textContent).not.toContain(STALE_SCIENTIFIC);
   });
 });

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -98,8 +98,9 @@ describe('DetectionDetail stale-response race (#978)', () => {
       jsonResponse(makeDetection({ id: 1, scientificName: 'Stale-sci-A', commonName: 'Stale A' }))
     );
     // Flush the production stale-handling path: await the promise it awaits, then
-    // drain microtasks plus one macrotask so the captured-signal guard has run
-    // before asserting. More robust than a bare timer if that path grows an await.
+    // a macrotask so every microtask hop (response.json, the captured-signal
+    // guard) and the Svelte DOM flush complete before asserting. A microtask-only
+    // flush (await tick) under-drains and lets the negative assertion fire early.
     await staleResponse;
     await new Promise(resolve => setTimeout(resolve, 0));
 

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -39,30 +39,32 @@ const STALE_SCIENTIFIC = 'Stale-sci-A';
 
 /** Minimal fetch Response stub carrying a JSON body. */
 function jsonResponse(body: unknown): Response {
-  // Pre-serialize so text() never throws synchronously (e.g. circular refs);
-  // a Promise-returning method must reject, not throw.
-  const serialized = JSON.stringify(body);
   return {
     ok: true,
     status: 200,
     statusText: 'OK',
     headers: new Headers({ 'content-type': 'application/json' }),
     json: () => Promise.resolve(body),
-    text: () => Promise.resolve(serialized),
+    // Serialize lazily and reject (never throw synchronously) so this
+    // Promise-returning method honors its contract even on a non-serializable body.
+    text: () => {
+      try {
+        return Promise.resolve(JSON.stringify(body));
+      } catch (error) {
+        return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    },
   } as unknown as Response;
 }
 
 describe('DetectionDetail stale-response race (#978)', () => {
-  let originalFetch: typeof globalThis.fetch;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    originalFetch = globalThis.fetch;
   });
 
   afterEach(() => {
     cleanup();
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
   });
 
   // Regression: navigating from detection A to B while A's request is still in
@@ -75,23 +77,26 @@ describe('DetectionDetail stale-response race (#978)', () => {
       resolveStale = resolve;
     });
 
-    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
-      const url = String(input);
-      // Detection A: held in flight until we resolve it manually (after switching to B).
-      if (url.includes('/api/v2/detections/det-a')) {
-        return staleResponse;
-      }
-      // Detection B: resolves immediately and becomes the current detection.
-      if (url.includes('/api/v2/detections/det-b')) {
-        return Promise.resolve(
-          jsonResponse(
-            makeDetection({ id: 2, scientificName: FRESH_SCIENTIFIC, commonName: 'Fresh B' })
-          )
-        );
-      }
-      // Secondary species/taxonomy/attribution endpoints: irrelevant here.
-      return Promise.resolve(jsonResponse({}));
-    }) as unknown as typeof fetch;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        // Detection A: held in flight until we resolve it manually (after switching to B).
+        if (url.includes('/api/v2/detections/det-a')) {
+          return staleResponse;
+        }
+        // Detection B: resolves immediately and becomes the current detection.
+        if (url.includes('/api/v2/detections/det-b')) {
+          return Promise.resolve(
+            jsonResponse(
+              makeDetection({ id: 2, scientificName: FRESH_SCIENTIFIC, commonName: 'Fresh B' })
+            )
+          );
+        }
+        // Secondary species/taxonomy/attribution endpoints: irrelevant here.
+        return Promise.resolve(jsonResponse({}));
+      })
+    );
 
     const { container, rerender } = detailTest.render({ detectionId: 'det-a' });
 

--- a/frontend/src/lib/desktop/views/DetectionDetail.test.ts
+++ b/frontend/src/lib/desktop/views/DetectionDetail.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { waitFor, cleanup } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../test/render-helpers';
+import DetectionDetail from './DetectionDetail.svelte';
+import type { Detection } from '$lib/types/detection.types';
+
+// Heavy / context-dependent children are not relevant to the fetch-race logic.
+vi.mock('$lib/desktop/components/media/AudioPlayer.svelte');
+vi.mock('$lib/desktop/components/data/ConfidenceCircle.svelte');
+vi.mock('$lib/desktop/components/data/WeatherDetails.svelte');
+vi.mock('$lib/desktop/features/dashboard/components/SourceBadge.svelte');
+vi.mock('$lib/desktop/components/ui/VerificationBadges.svelte');
+
+const detailTest = createComponentTestFactory(DetectionDetail);
+
+/** Build a minimal valid Detection for the detail view. */
+function makeDetection(overrides: Partial<Detection>): Detection {
+  return {
+    id: 1,
+    date: '2024-01-01',
+    time: '10:00:00',
+    timestamp: '2024-01-01T10:00:00Z',
+    beginTime: '2024-01-01T10:00:00Z',
+    endTime: '2024-01-01T10:00:03Z',
+    speciesCode: 'spc',
+    scientificName: 'Default scientific',
+    commonName: 'Default common',
+    confidence: 0.9,
+    verified: 'unverified',
+    locked: false,
+    ...overrides,
+  };
+}
+
+/** Minimal fetch Response stub carrying a JSON body. */
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('DetectionDetail stale-response race (#978)', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  // Regression: navigating from detection A to B while A's request is still in
+  // flight must not let A's late response overwrite B. The fix captures the
+  // AbortController signal locally and checks the captured signal (not the shared
+  // controller reference, which by then points at B's non-aborted controller).
+  it('does not let a stale detection response overwrite a newer one', async () => {
+    let resolveStale!: (r: Response) => void;
+    const staleResponse = new Promise<Response>(resolve => {
+      resolveStale = resolve;
+    });
+
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      // Detection A: held in flight until we resolve it manually (after switching to B).
+      if (url.includes('/api/v2/detections/det-a')) {
+        return staleResponse;
+      }
+      // Detection B: resolves immediately and becomes the current detection.
+      if (url.includes('/api/v2/detections/det-b')) {
+        return Promise.resolve(
+          jsonResponse(
+            makeDetection({ id: 2, scientificName: 'Fresh-sci-B', commonName: 'Fresh B' })
+          )
+        );
+      }
+      // Secondary species/taxonomy/attribution endpoints: irrelevant here.
+      return Promise.resolve(jsonResponse({}));
+    }) as unknown as typeof fetch;
+
+    const { container, rerender } = detailTest.render({ detectionId: 'det-a' });
+
+    // Switch to detection B before A resolves.
+    await rerender({ detectionId: 'det-b' });
+    await waitFor(() => {
+      expect(container.textContent).toContain('Fresh-sci-B');
+    });
+
+    // A's response now arrives late; the captured-signal guard must drop it.
+    resolveStale(
+      jsonResponse(makeDetection({ id: 1, scientificName: 'Stale-sci-A', commonName: 'Stale A' }))
+    );
+    // Flush the production stale-handling path: await the promise it awaits, then
+    // drain microtasks plus one macrotask so the captured-signal guard has run
+    // before asserting. More robust than a bare timer if that path grows an await.
+    await staleResponse;
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(container.textContent).toContain('Fresh-sci-B');
+    expect(container.textContent).not.toContain('Stale-sci-A');
+  });
+});


### PR DESCRIPTION
## Summary

Adds Vitest regression coverage for two stale-response race fixes that previously shipped without tests. Both are component-level tests that drive the actual race and assert the stale response is dropped.

- **DetectionDetail** (`DetectionDetail.test.ts`): navigating from one detection to another while the first request is still in flight must not let the first (now stale) response overwrite the newer detection. Exercises the captured-`AbortController`-signal guard in `fetchDetection`.
- **Analytics** (`Analytics.test.ts`): a slower earlier `fetchData()` run must not overwrite a newer run's recent-detections data. Exercises the monotonic `analyticsFetchSeq` token guard.

Each test holds the first request in flight, completes a second request, then resolves the first late and asserts the stale data is dropped. Both were verified to **fail when the respective guard is reverted** and pass with it in place, so they genuinely catch the regression.

## Test Plan

- [x] `npx vitest run` on both new files: 2 passed
- [x] Verified each test fails on the pre-fix code (guard reverted)
- [x] `npm run typecheck`: 0 errors
- [x] ESLint clean on both new files

## Notes

Tests-only change; no production code is modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale Analytics “recent detections” results from replacing the latest data when multiple fetches overlap.
  * Ensured DetectionDetail doesn’t get overwritten by an older in-flight detection response after switching views.
* **Tests**
  * Added Vitest regression coverage for concurrent request race conditions on both Analytics and DetectionDetail, confirming the UI consistently renders the most recent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->