### PR TITLE
feat(health,analysis): surface results-queue detection drops on System Health

### DIFF
--- a/internal/analysis/api_service.go
+++ b/internal/analysis/api_service.go
@@ -214,6 +214,15 @@ func (s *APIServerService) Start(ctx context.Context) error {
 		s.server.APIController().SetShutdownRequester(appInstance)
 	}
 
+	// Surface results-queue detection drops on the System Health page by
+	// bridging them from the analysis pipeline into the diagnostics health
+	// store owned by the API controller. The store is the bridge because
+	// internal/api/v2 must not import internal/analysis (import cycle):
+	// analysis pushes drops into the store, ResultsQueueDropCheck reads them.
+	if ctrl := s.server.APIController(); ctrl != nil {
+		SetResultsQueueDropHealthSink(ctrl.HealthMetricsStore(), ctrl.HealthEventBuffer())
+	}
+
 	startSucceeded = true
 	return nil
 }
@@ -269,6 +278,10 @@ func (s *APIServerService) Stop(ctx context.Context) error {
 		}
 		s.proc = nil
 	}
+
+	// Detach the results-queue drop health sink so it does not retain the
+	// controller's metrics store after shutdown. A subsequent Start re-wires it.
+	SetResultsQueueDropHealthSink(nil, nil)
 
 	// Stop notification service (after processor, which may send final notifications).
 	if notification.IsInitialized() {

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
@@ -121,6 +122,57 @@ var lastQueueOverflowReport atomic.Int64
 // telemetry extras so users can tell whether they are losing detections and by
 // how much.
 var droppedDetectionsTotal atomic.Int64
+
+// resultsQueueDropSink bridges results-queue detection drops into the
+// observability health metrics store and event buffer so the loss surfaces on
+// the System Health page. The diagnostics subsystem (owned by the API
+// controller) creates the store; the ResultsQueueDropCheck reads from it. Using
+// the store as the bridge keeps the dependency direction clean: internal/api/v2
+// must not import internal/analysis (import cycle), so drops are pushed here
+// rather than pulled by a provider closure.
+type resultsQueueDropSink struct {
+	store  *observability.HealthMetricsStore
+	events *observability.HealthEventBuffer
+}
+
+// resultsQueueDropHealthSink holds the active health sink, or nil before the
+// diagnostics subsystem is wired (or after it is cleared). Read on the drop
+// path; set at startup.
+var resultsQueueDropHealthSink atomic.Pointer[resultsQueueDropSink]
+
+// SetResultsQueueDropHealthSink wires the diagnostics health store and event
+// buffer so results-queue detection drops surface on the System Health page.
+// A nil store clears the sink, in which case drops are still logged and
+// reported to telemetry. Safe to call from startup wiring; the latest call
+// wins, so a restarted API server repoints drops at its new store.
+func SetResultsQueueDropHealthSink(store *observability.HealthMetricsStore, events *observability.HealthEventBuffer) {
+	if store == nil {
+		resultsQueueDropHealthSink.Store(nil)
+		return
+	}
+	resultsQueueDropHealthSink.Store(&resultsQueueDropSink{store: store, events: events})
+}
+
+// recordResultsQueueDropHealth records a single dropped detection into the
+// diagnostics health store and event buffer when the sink is wired. The
+// "queue_drops" metric label must match the trailing segment of
+// observability.MetricPrefixResultsQueueDrops so ResultsQueueDropCheck's
+// event-buffer filter matches, mirroring how the collector tags audio drops.
+func recordResultsQueueDropHealth(source string) {
+	sink := resultsQueueDropHealthSink.Load()
+	if sink == nil {
+		return
+	}
+	sink.store.Record(observability.MetricPrefixResultsQueueDrops+source, 1)
+	if sink.events != nil {
+		sink.events.Add(observability.HealthEvent{
+			Time:   time.Now(),
+			Source: source,
+			Delta:  1,
+			Metric: "queue_drops",
+		})
+	}
+}
 
 // recordBufferOverrun records a buffer overrun event and reports to Sentry
 // when the tumbling window expires with enough accumulated overruns.
@@ -387,6 +439,9 @@ func recordResultsQueueDrop(source, modelID string, pm *metrics.MyAudioMetrics) 
 	if pm != nil {
 		pm.RecordAudioQueueOperation(source, "enqueue", "dropped")
 	}
+	// Surface the drop on the System Health page (when diagnostics are wired)
+	// so users on constrained hardware can see they are losing detections.
+	recordResultsQueueDropHealth(source)
 	// Rate-limit queue overflow telemetry to prevent Sentry floods under sustained backpressure.
 	now := time.Now().Unix()
 	last := lastQueueOverflowReport.Load()

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -154,10 +154,10 @@ func SetResultsQueueDropHealthSink(store *observability.HealthMetricsStore, even
 }
 
 // recordResultsQueueDropHealth records a single dropped detection into the
-// diagnostics health store and event buffer when the sink is wired. The
-// "queue_drops" metric label must match the trailing segment of
-// observability.MetricPrefixResultsQueueDrops so ResultsQueueDropCheck's
-// event-buffer filter matches, mirroring how the collector tags audio drops.
+// diagnostics health store and event buffer when the sink is wired. The event
+// Metric label and the store key prefix share observability.MetricTypeResultsQueueDrops
+// so ResultsQueueDropCheck's event-buffer filter matches, mirroring how the
+// collector tags audio drops.
 func recordResultsQueueDropHealth(source string) {
 	sink := resultsQueueDropHealthSink.Load()
 	if sink == nil {
@@ -169,7 +169,7 @@ func recordResultsQueueDropHealth(source string) {
 			Time:   time.Now(),
 			Source: source,
 			Delta:  1,
-			Metric: "queue_drops",
+			Metric: observability.MetricTypeResultsQueueDrops,
 		})
 	}
 }

--- a/internal/analysis/process_queue_drop_test.go
+++ b/internal/analysis/process_queue_drop_test.go
@@ -81,11 +81,11 @@ func TestRecordResultsQueueDrop_SurfacesOnHealthStore(t *testing.T) {
 	key := observability.MetricPrefixResultsQueueDrops + source
 	assert.Equal(t, int64(1), store.Sum(key, time.Hour), "drop must be recorded into the health store")
 
-	events := buf.Recent("queue_drops", 10)
+	events := buf.Recent(observability.MetricTypeResultsQueueDrops, 10)
 	require.Len(t, events, 1, "drop must be recorded as a single health event")
 	assert.Equal(t, source, events[0].Source)
 	assert.Equal(t, int64(1), events[0].Delta)
-	assert.Equal(t, "queue_drops", events[0].Metric)
+	assert.Equal(t, observability.MetricTypeResultsQueueDrops, events[0].Metric)
 
 	// Clearing the sink must stop further recording without panicking.
 	SetResultsQueueDropHealthSink(nil, nil)

--- a/internal/analysis/process_queue_drop_test.go
+++ b/internal/analysis/process_queue_drop_test.go
@@ -6,8 +6,11 @@ package analysis
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
 // TestRecordResultsQueueDrop_CountsDrops confirms that each drop increments the
@@ -53,4 +56,61 @@ func TestDroppedDetectionsTotal_MonotonicUnderConcurrency(t *testing.T) {
 
 	assert.Equal(t, before+int64(goroutines*dropsEach), droppedDetectionsTotal.Load(),
 		"every concurrent drop must be counted with no lost updates")
+}
+
+// TestRecordResultsQueueDrop_SurfacesOnHealthStore verifies that, once the
+// diagnostics health sink is wired, each drop is recorded into the health
+// metrics store and event buffer with the "queue_drops" metric label that
+// ResultsQueueDropCheck filters on. Clearing the sink stops further recording.
+func TestRecordResultsQueueDrop_SurfacesOnHealthStore(t *testing.T) {
+	// Not parallel: mutates package-global drop counter and health sink.
+	beforeCount := droppedDetectionsTotal.Load()
+	prevSink := resultsQueueDropHealthSink.Load()
+	t.Cleanup(func() {
+		droppedDetectionsTotal.Store(beforeCount)
+		resultsQueueDropHealthSink.Store(prevSink)
+	})
+
+	store := observability.NewHealthMetricsStore()
+	buf := observability.NewHealthEventBuffer(observability.DefaultEventBufferCapacity)
+	SetResultsQueueDropHealthSink(store, buf)
+
+	const source = "sink-source"
+	recordResultsQueueDrop(source, "sink-model", nil)
+
+	key := observability.MetricPrefixResultsQueueDrops + source
+	assert.Equal(t, int64(1), store.Sum(key, time.Hour), "drop must be recorded into the health store")
+
+	events := buf.Recent("queue_drops", 10)
+	require.Len(t, events, 1, "drop must be recorded as a single health event")
+	assert.Equal(t, source, events[0].Source)
+	assert.Equal(t, int64(1), events[0].Delta)
+	assert.Equal(t, "queue_drops", events[0].Metric)
+
+	// Clearing the sink must stop further recording without panicking.
+	SetResultsQueueDropHealthSink(nil, nil)
+	recordResultsQueueDrop(source, "sink-model", nil)
+	assert.Equal(t, int64(1), store.Sum(key, time.Hour), "no further drops should be recorded after the sink is cleared")
+}
+
+// TestRecordResultsQueueDrop_NilEventsBufferTolerated verifies that a sink wired
+// with a store but no event buffer still records windowed counts and does not
+// panic on the drop path.
+func TestRecordResultsQueueDrop_NilEventsBufferTolerated(t *testing.T) {
+	// Not parallel: mutates package-global drop counter and health sink.
+	beforeCount := droppedDetectionsTotal.Load()
+	prevSink := resultsQueueDropHealthSink.Load()
+	t.Cleanup(func() {
+		droppedDetectionsTotal.Store(beforeCount)
+		resultsQueueDropHealthSink.Store(prevSink)
+	})
+
+	store := observability.NewHealthMetricsStore()
+	SetResultsQueueDropHealthSink(store, nil)
+
+	const source = "nil-buf-source"
+	require.NotPanics(t, func() {
+		recordResultsQueueDrop(source, "sink-model", nil)
+	})
+	assert.Equal(t, int64(1), store.Sum(observability.MetricPrefixResultsQueueDrops+source, time.Hour))
 }

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -54,6 +54,21 @@ func (c *Controller) initDiagnosticsRoutes() {
 	diagnosticsGroup.GET("/errors", c.GetRecentErrors)
 }
 
+// HealthMetricsStore returns the diagnostics health metrics store, or nil if
+// the diagnostics subsystem has not been initialized. It lets other subsystems
+// (e.g. the analysis pipeline) record health counters into the same store the
+// health checks read, avoiding an import cycle on internal/api/v2.
+func (c *Controller) HealthMetricsStore() *observability.HealthMetricsStore {
+	return c.healthMetricsStore
+}
+
+// HealthEventBuffer returns the diagnostics health event buffer, or nil if the
+// diagnostics subsystem has not been initialized. Paired with HealthMetricsStore
+// so recorded counters can also surface as recent events on the System Health page.
+func (c *Controller) HealthEventBuffer() *observability.HealthEventBuffer {
+	return c.healthEvents
+}
+
 // registerHealthChecks registers all health checks with dependency injection closures.
 func (c *Controller) registerHealthChecks() {
 	snapshotProvider := func() []audiocore.SourceHealthSnapshot {
@@ -114,6 +129,7 @@ func (c *Controller) registerHealthChecks() {
 			q := classifier.ResultsQueue
 			return len(q), cap(q)
 		}),
+		checks.NewResultsQueueDropCheck(c.healthMetricsStore, c.healthEvents.Recent),
 		checks.NewORTAvailabilityCheck(func() (available, initialized bool, version, libraryPath, errMsg string) {
 			status := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
 			return status.Available, status.Initialized, status.Version, status.LibraryPath, status.Error

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
 const (
@@ -410,4 +411,67 @@ func (c *ORTAvailabilityCheck) Run(_ context.Context) health.Result {
 		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 		Timestamp:  time.Now(),
 	}
+}
+
+// Threshold constants for the results-queue detection-drop check. Each dropped
+// detection is a species that was heard but never recorded, so even a single
+// drop within the window is worth a warning; a high or sustained rate (the
+// detection consumer falling persistently behind) is critical.
+const (
+	resultsQueueDropBaseWarnThreshold = 1
+	resultsQueueDropBaseCritThreshold = 50
+)
+
+// ResultsQueueDropCheck monitors detections dropped because the classifier
+// results queue was full, using time-windowed evaluation over the health
+// metrics store. The analysis pipeline records each drop into the same store
+// this check reads (analysis -> observability store -> health check), so no
+// import cycle is introduced and windowed counts, sparkline, and recent events
+// come for free, exactly like the audio buffer-drops path.
+type ResultsQueueDropCheck struct {
+	store     *observability.HealthMetricsStore
+	getEvents func(metric string, n int) []observability.HealthEvent
+	window    time.Duration
+}
+
+// NewResultsQueueDropCheck creates a ResultsQueueDropCheck using the health
+// metrics store and event getter.
+func NewResultsQueueDropCheck(store *observability.HealthMetricsStore, getEvents func(metric string, n int) []observability.HealthEvent) *ResultsQueueDropCheck {
+	return &ResultsQueueDropCheck{
+		store:     store,
+		getEvents: getEvents,
+		window:    DefaultWindow,
+	}
+}
+
+// Name returns the check identifier.
+func (c *ResultsQueueDropCheck) Name() string { return "results_queue_drops" }
+
+// Category returns the analysis category.
+func (c *ResultsQueueDropCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// WithWindow returns a copy of this check configured with the given evaluation
+// window. Returns the receiver unchanged when d equals the current window to
+// avoid an allocation.
+func (c *ResultsQueueDropCheck) WithWindow(d time.Duration) health.Check {
+	if d == c.window {
+		return c
+	}
+	cp := *c
+	cp.window = d
+	return &cp
+}
+
+// Run evaluates results-queue detection-drop statistics within the configured
+// time window.
+func (c *ResultsQueueDropCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	return evalWindowedStats(c.Name(), c.Category(), c.store, c.getEvents, &windowedStatsConfig{
+		baseWarnThreshold: resultsQueueDropBaseWarnThreshold,
+		baseCritThreshold: resultsQueueDropBaseCritThreshold,
+		sustainedHours:    defaultSustainedHours,
+		metricPrefix:      observability.MetricPrefixResultsQueueDrops,
+		window:            c.window,
+	}, start)
 }

--- a/internal/health/checks/analysis_test.go
+++ b/internal/health/checks/analysis_test.go
@@ -297,7 +297,7 @@ func TestResultsQueueDropCheck_HealthyWithHistory(t *testing.T) {
 
 	now := time.Now()
 	store.RecordAt(resultsQueueDropKey, 50, now.Add(-3*time.Hour))
-	buf.Add(observability.HealthEvent{Time: now.Add(-3 * time.Hour), Source: "src1", Delta: 50, Metric: "queue_drops"})
+	buf.Add(observability.HealthEvent{Time: now.Add(-3 * time.Hour), Source: "src1", Delta: 50, Metric: observability.MetricTypeResultsQueueDrops})
 	store.RecordAt(resultsQueueDropKey, 0, now)
 
 	check := NewResultsQueueDropCheck(store, eventGetter(buf))
@@ -361,9 +361,9 @@ func TestResultsQueueDropCheck_SparklineInDetails(t *testing.T) {
 
 	now := time.Now()
 	store.RecordAt(resultsQueueDropKey, 10, now.Add(-2*time.Hour))
-	buf.Add(observability.HealthEvent{Time: now.Add(-2 * time.Hour), Source: "src1", Delta: 10, Metric: "queue_drops"})
+	buf.Add(observability.HealthEvent{Time: now.Add(-2 * time.Hour), Source: "src1", Delta: 10, Metric: observability.MetricTypeResultsQueueDrops})
 	store.RecordAt(resultsQueueDropKey, 5, now)
-	buf.Add(observability.HealthEvent{Time: now, Source: "src1", Delta: 5, Metric: "queue_drops"})
+	buf.Add(observability.HealthEvent{Time: now, Source: "src1", Delta: 5, Metric: observability.MetricTypeResultsQueueDrops})
 
 	check := NewResultsQueueDropCheck(store, eventGetter(buf))
 	result := check.Run(t.Context())

--- a/internal/health/checks/analysis_test.go
+++ b/internal/health/checks/analysis_test.go
@@ -2,10 +2,12 @@ package checks
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
 // --- ModelsLoadedCheck tests ---
@@ -265,4 +267,111 @@ func TestSanitizeID(t *testing.T) {
 	for _, tt := range tests {
 		assert.Equal(t, tt.expected, sanitizeID(tt.input), "sanitizeID(%q)", tt.input)
 	}
+}
+
+// --- ResultsQueueDropCheck tests ---
+
+const resultsQueueDropKey = observability.MetricPrefixResultsQueueDrops + "src1"
+
+func TestResultsQueueDropCheck_NilStore(t *testing.T) {
+	t.Parallel()
+	check := NewResultsQueueDropCheck(nil, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+	assert.Equal(t, "results_queue_drops", result.Name)
+	assert.Equal(t, health.CategoryAnalysis, result.Category)
+}
+
+func TestResultsQueueDropCheck_NoData(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	check := NewResultsQueueDropCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestResultsQueueDropCheck_HealthyWithHistory(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	buf := newTestEventBuffer(t)
+
+	now := time.Now()
+	store.RecordAt(resultsQueueDropKey, 50, now.Add(-3*time.Hour))
+	buf.Add(observability.HealthEvent{Time: now.Add(-3 * time.Hour), Source: "src1", Delta: 50, Metric: "queue_drops"})
+	store.RecordAt(resultsQueueDropKey, 0, now)
+
+	check := NewResultsQueueDropCheck(store, eventGetter(buf))
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "No detections dropped in last 1h")
+	assert.Contains(t, result.Message, "50 lifetime")
+}
+
+func TestResultsQueueDropCheck_WarningOnAnyDrop(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+
+	// A single dropped detection within the window must surface as a warning:
+	// every drop is a species that was heard and never recorded.
+	store.RecordAt(resultsQueueDropKey, 1, time.Now())
+
+	check := NewResultsQueueDropCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+	assert.Contains(t, result.Message, "1 detections dropped in 1h")
+}
+
+func TestResultsQueueDropCheck_Critical(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+
+	store.RecordAt(resultsQueueDropKey, 50, time.Now())
+
+	check := NewResultsQueueDropCheck(store, nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusCritical, result.Status)
+	assert.Contains(t, result.Message, "50", "critical message should report the drop count")
+}
+
+func TestResultsQueueDropCheck_WithWindow(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	now := time.Now()
+
+	store.RecordAt(resultsQueueDropKey, 20, now.Add(-3*time.Hour))
+	store.RecordAt(resultsQueueDropKey, 0, now)
+
+	check := NewResultsQueueDropCheck(store, nil)
+
+	// The historical spike is outside a 1h window, so the check is healthy.
+	narrowed := check.WithWindow(1 * time.Hour)
+	result := narrowed.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+
+	// Widening the window to 6h pulls the spike back into view.
+	wide := check.WithWindow(6 * time.Hour)
+	result = wide.Run(t.Context())
+	assert.Equal(t, health.StatusWarning, result.Status)
+}
+
+func TestResultsQueueDropCheck_SparklineInDetails(t *testing.T) {
+	t.Parallel()
+	store := newTestHealthStore(t)
+	buf := newTestEventBuffer(t)
+
+	now := time.Now()
+	store.RecordAt(resultsQueueDropKey, 10, now.Add(-2*time.Hour))
+	buf.Add(observability.HealthEvent{Time: now.Add(-2 * time.Hour), Source: "src1", Delta: 10, Metric: "queue_drops"})
+	store.RecordAt(resultsQueueDropKey, 5, now)
+	buf.Add(observability.HealthEvent{Time: now, Source: "src1", Delta: 5, Metric: "queue_drops"})
+
+	check := NewResultsQueueDropCheck(store, eventGetter(buf))
+	result := check.Run(t.Context())
+
+	require.NotNil(t, result.Details)
+	assert.NotNil(t, result.Details["sparkline"])
+	assert.Equal(t, "1h", result.Details["window"])
+	// Recent events are filtered by the "queue_drops" metric type and must
+	// surface so the System Health page can show a trend view.
+	assert.NotNil(t, result.Details["recent_events"])
 }

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -339,6 +339,8 @@ func checkNameLabel(name string) string {
 		return "drops"
 	case "buffer_overrun":
 		return "overruns"
+	case "results_queue_drops":
+		return "detections dropped"
 	case "stream_error_rate":
 		return "restarts"
 	default:

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -433,6 +433,11 @@ func (c *Collector) collectAudioHealthCounters(now time.Time) {
 			// show "Healthy" instead of "Skipped" even with zero drops.
 			c.healthStore.RecordAt(MetricPrefixAudioDrops+id, 0, now)
 			c.healthStore.RecordAt(MetricPrefixAudioOverruns+id, 0, now)
+			// Results-queue detection drops are recorded by the analysis pipeline
+			// (push), not by this collector, but they are keyed by the same source
+			// IDs. Seed a zero here so ResultsQueueDropCheck reads "Healthy" from
+			// startup instead of "Skipped", consistent with the audio drop checks.
+			c.healthStore.RecordAt(MetricPrefixResultsQueueDrops+id, 0, now)
 			continue
 		}
 		c.recordHealthDelta(MetricPrefixAudioDrops+id, cur.Drops, prev.Drops, id, "drops", now)

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -178,11 +178,14 @@ func TestCollector_SeedsKeysOnFirstTick(t *testing.T) {
 		MetricPrefixAudioDrops+"src1")
 	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixAudioOverruns),
 		MetricPrefixAudioOverruns+"src1")
+	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixResultsQueueDrops),
+		MetricPrefixResultsQueueDrops+"src1")
 	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixStreamRestarts),
 		MetricPrefixStreamRestarts+"stream1")
 
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixAudioDrops+"src1"))
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixAudioOverruns+"src1"))
+	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixResultsQueueDrops+"src1"))
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal(MetricPrefixStreamRestarts+"stream1"))
 }
 

--- a/internal/observability/health_metrics_store.go
+++ b/internal/observability/health_metrics_store.go
@@ -17,11 +17,16 @@ const (
 	MetricPrefixAudioDrops     = "audio.drops."
 	MetricPrefixAudioOverruns  = "audio.overruns."
 	MetricPrefixStreamRestarts = "stream.restarts."
+	// MetricTypeResultsQueueDrops is the metric-type token shared by the producer
+	// (the analysis pipeline tags each drop HealthEvent with this label) and the
+	// consumer (ResultsQueueDropCheck filters recent events by this type). It is
+	// the trailing segment of MetricPrefixResultsQueueDrops; building the prefix
+	// from it guarantees the producer and consumer cannot drift apart. It must
+	// stay distinct from the other prefixes' segments so events do not cross-match.
+	MetricTypeResultsQueueDrops = "queue_drops"
 	// MetricPrefixResultsQueueDrops counts detection results dropped because the
-	// classifier results queue was full. The trailing segment ("queue_drops")
-	// is the metric type used for event-buffer filtering; it must stay distinct
-	// from the other prefixes so events do not cross-match.
-	MetricPrefixResultsQueueDrops = "results.queue_drops."
+	// classifier results queue was full.
+	MetricPrefixResultsQueueDrops = "results." + MetricTypeResultsQueueDrops + "."
 )
 
 // HourlyBucket holds the aggregated event count for a single hour.

--- a/internal/observability/health_metrics_store.go
+++ b/internal/observability/health_metrics_store.go
@@ -17,6 +17,11 @@ const (
 	MetricPrefixAudioDrops     = "audio.drops."
 	MetricPrefixAudioOverruns  = "audio.overruns."
 	MetricPrefixStreamRestarts = "stream.restarts."
+	// MetricPrefixResultsQueueDrops counts detection results dropped because the
+	// classifier results queue was full. The trailing segment ("queue_drops")
+	// is the metric type used for event-buffer filtering; it must stay distinct
+	// from the other prefixes so events do not cross-match.
+	MetricPrefixResultsQueueDrops = "results.queue_drops."
 )
 
 // HourlyBucket holds the aggregated event count for a single hour.


### PR DESCRIPTION
## Summary

Detection results dropped because the classifier results queue is full were
only visible in a log line and rate-limited telemetry. A user on constrained
hardware had no in-app way to see they were losing detections, or how many.
Each drop is real data loss: a species that was heard is never recorded.

This adds a `ResultsQueueDropCheck` to the System Health page, modeled on the
existing audio `BufferDropsCheck`:

- **`internal/observability`**: new `MetricPrefixResultsQueueDrops` counter prefix.
- **`internal/analysis`**: the pipeline records each drop into the shared
  `HealthMetricsStore` and health event buffer via an atomic sink, wired from
  the API controller in `APIServerService.Start` and detached in `Stop`. The
  store is the bridge so `internal/api/v2` never imports `internal/analysis`
  (no import cycle): analysis pushes drops, the check reads them.
- **`internal/health/checks`**: `ResultsQueueDropCheck` (analysis category)
  reuses the shared `evalWindowedStats` helper, so it gets windowed counts, a
  sparkline, and recent events for free. Warning on any drop within the
  window, critical on a high or sustained drop rate. Registered next to
  `QueueDepthCheck`.
- **collector**: zero-seeds the new per-source key on first sight so the check
  reads Healthy from startup, consistent with the audio drop checks.

The System Health page renders the new check generically (name, status pill,
message, and the existing sparkline / recent-events detail panel), so there is
no frontend change.

## Test Plan

- [x] `go test -race ./internal/health/... ./internal/observability/ ./internal/analysis/ ./internal/api/v2/` (all green)
- [x] `golangci-lint run` (0 issues)
- [x] Unit tests cover the check thresholds (skipped / healthy-with-history /
  warning-on-any-drop / critical / window boundary / sparkline+events) and the
  drop-to-store recording path (records key + event, clearing the sink stops
  recording, nil event buffer tolerated).
- [x] Collector seeding test asserts the new key is zero-seeded on first tick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system health monitoring for detection result queue drops, including configurable warning/critical thresholds and windowed statistics.
  * Enhanced diagnostics to surface these queue-drop metrics via health metrics and recent health events.
  * Ensured consistent startup behavior by seeding the queue-drop metric so the check reports healthy (not skipped) initially.
* **Tests**
  * Added/expanded coverage for health metric and event recording, window behavior, and nil/edge-case handling for queue-drop diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->