### PR TITLE
fix(dashboard): align species image popup to row top in the above position

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
@@ -120,6 +120,9 @@
     idCounter = ++win.__speciesInputCounter;
   }
   const instanceId = `species-predictions-${Date.now()}-${idCounter}`;
+  // Distinct prefix from instanceId so it is never matched by the portal's
+  // `[id^="species-predictions-"]` lookups.
+  const wrapperId = instanceId.replace('species-predictions-', 'species-input-wrapper-');
 
   // Auto-derive button size from input size if not specified
   let effectiveButtonSize = $derived(buttonSize ?? size);
@@ -281,12 +284,27 @@
     updatePortalPosition();
   }
 
+  // Fallback dropdown-height estimate (px), used only before the dropdown has
+  // been laid out and its real offsetHeight can be measured.
+  const DROPDOWN_MAX_HEIGHT_ESTIMATE = 240;
+  const DROPDOWN_ITEM_HEIGHT_ESTIMATE = 40;
+
   // Update portal dropdown position with smart positioning
   function updatePortalPosition() {
     if (!portalDropdown || !inputElement) return;
 
     const rect = inputElement.getBoundingClientRect();
-    const dropdownHeight = Math.min(240, filteredPredictions.length * 40); // Estimate height
+    // Use the real rendered height (the dropdown is already populated when this
+    // runs) so the 'above' flip aligns the dropdown's bottom edge to the input.
+    // Fall back to an item-count estimate only before the first layout.
+    const measuredHeight = portalDropdown.offsetHeight;
+    const dropdownHeight =
+      measuredHeight > 0
+        ? measuredHeight
+        : Math.min(
+            DROPDOWN_MAX_HEIGHT_ESTIMATE,
+            filteredPredictions.length * DROPDOWN_ITEM_HEIGHT_ESTIMATE
+          );
     const viewportHeight = window.innerHeight;
     const spaceBelow = viewportHeight - rect.bottom;
     const spaceAbove = rect.top;
@@ -441,27 +459,34 @@
     }
   }
 
-  // Close predictions when clicking/touching outside
+  // Close predictions when clicking/touching outside this input's wrapper or its
+  // portaled dropdown. Scope to the per-instance wrapper id rather than the
+  // global `.form-control` class, which matches every other form field on the
+  // page and would otherwise keep the dropdown open on unrelated clicks.
   function handleDocumentClick(event: MouseEvent | TouchEvent) {
     const target = event.target as globalThis.Element;
-    if (!target.closest('.form-control') && !target.closest(`#${instanceId}`)) {
+    if (!target.closest(`#${wrapperId}`) && !target.closest(`#${instanceId}`)) {
       showPredictions = false;
       manuallyDismissed = true;
       destroyPortalDropdown();
     }
   }
 
-  // Add document click and touch listeners for mobile support, plus scroll/resize for positioning
+  // Register outside-click/touch and scroll/resize listeners only while the
+  // dropdown is open, so closed inputs do not keep global listeners that thrash
+  // layout on every scroll. Capture phase catches scrolls in nested containers.
   $effect(() => {
+    if (!showPredictions) return;
+
     document.addEventListener('click', handleDocumentClick);
     document.addEventListener('touchstart', handleDocumentClick);
-    window.addEventListener('scroll', updatePortalPosition, { passive: true });
+    window.addEventListener('scroll', updatePortalPosition, { passive: true, capture: true });
     window.addEventListener('resize', updatePortalPosition);
 
     return () => {
       document.removeEventListener('click', handleDocumentClick);
       document.removeEventListener('touchstart', handleDocumentClick);
-      window.removeEventListener('scroll', updatePortalPosition);
+      window.removeEventListener('scroll', updatePortalPosition, { capture: true });
       window.removeEventListener('resize', updatePortalPosition);
       // Clean up any remaining portal dropdown
       destroyPortalDropdown();
@@ -469,7 +494,11 @@
   });
 </script>
 
-<div class={cn('form-control relative min-w-0 species-input-container', className)} {...rest}>
+<div
+  id={wrapperId}
+  class={cn('form-control relative min-w-0 species-input-container', className)}
+  {...rest}
+>
   {#if label}
     <label class="label justify-start" for={id}>
       <span class="label-text capitalize">

--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -29,10 +29,14 @@
   import type { ImageAttribution } from '$lib/types/detection.types';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { validateProtocolURL } from '$lib/utils/security';
   import { t } from '$lib/i18n';
   import { portal } from '$lib/utils/portal';
   import { dropdown } from '$lib/utils/transitions';
+  import { loggers } from '$lib/utils/logger';
   import { Image } from '@lucide/svelte';
+
+  const logger = loggers.ui;
 
   interface Props {
     thumbnailUrl: string;
@@ -48,10 +52,24 @@
   // the server-provided common name, then the scientific name.
   const displayName = $derived(localizeSpeciesName(scientificName, commonName));
 
+  // The popup width is fixed (also applied via style:width below), so the
+  // constant is the authoritative width. The height is content-driven, so
+  // calculatePosition() measures the mounted element and uses the height
+  // estimate only as the first-pass fallback before the popup is in the DOM.
+  const POPUP_WIDTH = 320;
+  const POPUP_HEIGHT_ESTIMATE = 320;
+
   // State for popup visibility and positioning
   let showPopup = $state(false);
   let popupX = $state(0);
-  let popupY = $state(0);
+  // Vertical anchor. When the popup sits below the trigger we pin its `top`;
+  // when it sits above we pin its `bottom` so the bottom edge aligns to the row
+  // top regardless of the popup's rendered height. Exactly one is non-null.
+  let popupTop = $state<number | null>(0);
+  let popupBottom = $state<number | null>(null);
+  // Horizontal offset (px) of the arrow within the popup, so it points at the
+  // trigger's center instead of a fixed corner.
+  let popupArrowX = $state(20);
   let popupPosition = $state<'above' | 'below'>('below');
   let triggerElement: HTMLElement | undefined = $state();
   let popupElement: HTMLElement | undefined = $state();
@@ -62,30 +80,51 @@
   let imageAttribution = $state<ImageAttribution | null>(null);
   let lastFetchedScientificName = '';
 
-  // Fetch image attribution when popup opens
+  // Only allow http(s) license links. The attribution payload comes from an
+  // external image provider, so a javascript:/data: URL must never reach href.
+  const safeLicenseURL = $derived(
+    imageAttribution?.licenseURL &&
+      validateProtocolURL(imageAttribution.licenseURL, ['http', 'https'])
+      ? imageAttribution.licenseURL
+      : undefined
+  );
+
+  // Fetch image attribution when popup opens. Attribution is non-critical: a
+  // failure only suppresses the credit overlay, it never blocks the popup.
   async function fetchImageAttribution() {
-    if (!scientificName?.trim() || lastFetchedScientificName === scientificName) return;
-    lastFetchedScientificName = scientificName;
+    const name = scientificName?.trim();
+    if (!name || lastFetchedScientificName === name) return;
+    // Mark as fetched up front so concurrent/repeat hovers do not re-request.
+    lastFetchedScientificName = name;
 
     try {
-      const url = buildAppUrl(
-        `/api/v2/media/species-image/info?name=${encodeURIComponent(scientificName)}`
-      );
+      const url = buildAppUrl(`/api/v2/media/species-image/info?name=${encodeURIComponent(name)}`);
       const response = await fetch(url);
       if (response.ok) {
         imageAttribution = (await response.json()) as ImageAttribution;
+      } else {
+        // Allow a later hover to retry a transient non-OK response.
+        lastFetchedScientificName = '';
       }
-    } catch {
-      // Attribution is non-critical — fail silently
+    } catch (error) {
+      // Clear the dedupe key so a later hover can retry after a network error.
+      lastFetchedScientificName = '';
+      logger.debug('Failed to fetch bird image attribution', { error, species: name });
     }
   }
 
   // Show popup and calculate position
-  function handleMouseEnter(event: MouseEvent) {
+  function handleMouseEnter() {
     if (!triggerElement) return;
 
     showPopup = true;
-    calculatePosition(event);
+    // First pass positions the popup with size estimates (it is not in the DOM
+    // yet). Re-measure on the next frame, once mounted, so the 'above' branch
+    // uses the real height. Mirrors ActionMenu/AudioSettingsButton.
+    calculatePosition();
+    globalThis.requestAnimationFrame(() => {
+      if (showPopup) calculatePosition();
+    });
     imageLoaded = false;
     imageError = false;
     fetchImageAttribution();
@@ -96,22 +135,39 @@
     showPopup = false;
   }
 
-  // Update position on mouse move for better UX
-  function handleMouseMove(event: MouseEvent) {
-    if (showPopup) {
-      calculatePosition(event);
-    }
-  }
+  // Keep the popup anchored to its trigger while open. It is portaled to
+  // <body> with position:fixed, so without this it would drift away from the
+  // row on scroll/resize. Placement is trigger-relative (not cursor-relative),
+  // so there is no need to recompute on mousemove.
+  $effect(() => {
+    if (!showPopup) return;
 
-  // Calculate optimal popup position
-  function calculatePosition(_event: MouseEvent) {
+    const reposition = () => calculatePosition();
+    // Capture phase so scrolls inside nested overflow containers are caught too.
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  });
+
+  // Calculate optimal popup position.
+  //
+  // Vertical placement uses the real rendered popup height once it is mounted
+  // (offsetHeight, which ignores the dropdown transition's scale transform);
+  // POPUP_HEIGHT_ESTIMATE is only the fallback for the first synchronous pass,
+  // before the popup exists in the DOM. Width is fixed via POPUP_WIDTH.
+  function calculatePosition() {
     if (!triggerElement) return;
 
     const triggerRect = triggerElement.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
-    const popupWidth = 320; // Popup width
-    const popupHeight = 280; // Popup height
+    const popupWidth = POPUP_WIDTH;
+    const popupHeight = popupElement?.offsetHeight ?? POPUP_HEIGHT_ESTIMATE;
+    const viewportMargin = 10; // Keep the popup this far from the viewport edges
     const offsetX = 10; // Horizontal offset from trigger
     const offsetY = 10; // Vertical offset from trigger when below
     const offsetYAbove = 20; // Larger vertical offset when above for better separation
@@ -133,36 +189,45 @@
     } else {
       // Center horizontally if not enough space on sides
       x = Math.max(
-        10,
-        Math.min(viewportWidth / 2 - popupWidth / 2, viewportWidth - popupWidth - 10)
+        viewportMargin,
+        Math.min(viewportWidth / 2 - popupWidth / 2, viewportWidth - popupWidth - viewportMargin)
       );
     }
+    // Ensure popup stays within viewport bounds horizontally
+    popupX = Math.max(viewportMargin, Math.min(x, viewportWidth - popupWidth - viewportMargin));
 
-    // Determine vertical position
-    // Add extra buffer to trigger earlier (200px buffer)
+    // Point the arrow at the trigger's horizontal center, clamped so it stays
+    // within the popup body.
+    const arrowSize = 12; // matches w-3/h-3
+    const triggerCenterX = triggerRect.left + triggerRect.width / 2;
+    popupArrowX = Math.max(
+      arrowSize,
+      Math.min(triggerCenterX - popupX, popupWidth - arrowSize * 2)
+    );
+
+    // Determine vertical position. Add an extra buffer so the popup flips to
+    // the 'above' placement earlier (before the trigger reaches the very edge).
     const earlyTriggerBuffer = 200;
-    let y: number;
 
     if (spaceBelow >= popupHeight + offsetY + earlyTriggerBuffer) {
-      // Position below trigger
-      y = triggerRect.bottom + offsetY;
+      // Below: anchor the popup's TOP edge just under the trigger row. Height
+      // independent, which is why the 'below' case never misaligned.
       popupPosition = 'below';
+      popupTop = triggerRect.bottom + offsetY;
+      popupBottom = null;
     } else if (spaceAbove >= popupHeight + offsetYAbove) {
-      // Position above trigger with larger offset
-      y = triggerRect.top - popupHeight - offsetYAbove;
+      // Above: anchor the popup's BOTTOM edge just above the trigger row by
+      // pinning `bottom` to the viewport. Aligning the bottom edge means the
+      // exact height is irrelevant and the popup grows upward from the row.
       popupPosition = 'above';
+      popupBottom = viewportHeight - triggerRect.top + offsetYAbove;
+      popupTop = null;
     } else {
-      // Position at the top of viewport if not enough space
-      y = 10;
+      // Not enough room either way: pin near the top of the viewport.
       popupPosition = 'below';
+      popupTop = viewportMargin;
+      popupBottom = null;
     }
-
-    // Ensure popup stays within viewport bounds
-    x = Math.max(10, Math.min(x, viewportWidth - popupWidth - 10));
-    y = Math.max(10, Math.min(y, viewportHeight - popupHeight - 10));
-
-    popupX = x;
-    popupY = y;
   }
 
   // Handle image load success
@@ -178,12 +243,9 @@
     imageError = true;
   }
 
-  // Handle focus events for keyboard users
-  function handleFocus() {
-    // Don't show popup on focus to avoid interference with screen readers
-    // Users can press Enter/Space to navigate
-  }
-
+  // Close the popup if the trigger loses focus. The popup is intentionally not
+  // opened on focus, to avoid interfering with screen readers; keyboard users
+  // press Enter/Space to navigate to the detail page instead.
   function handleBlur() {
     showPopup = false;
   }
@@ -198,8 +260,6 @@
     class="flex {className} relative"
     onmouseenter={handleMouseEnter}
     onmouseleave={handleMouseLeave}
-    onmousemove={handleMouseMove}
-    onfocus={handleFocus}
     onblur={handleBlur}
     aria-label={t('components.birdThumbnail.viewDetections', { name: displayName })}
     aria-describedby={showPopup ? 'bird-popup' : undefined}
@@ -221,12 +281,13 @@
       bind:this={popupElement}
       use:portal
       id="bird-popup"
-      in:dropdown
-      out:dropdown={{ duration: 100 }}
+      in:dropdown={{ y: popupPosition === 'above' ? 8 : -8 }}
+      out:dropdown={{ duration: 100, y: popupPosition === 'above' ? 8 : -8 }}
       class="fixed z-50 bg-[var(--color-base-100)] border border-[var(--color-base-300)] rounded-lg shadow-xl p-4"
       style:left="{popupX}px"
-      style:top="{popupY}px"
-      style:width="320px"
+      style:top={popupTop !== null ? `${popupTop}px` : undefined}
+      style:bottom={popupBottom !== null ? `${popupBottom}px` : undefined}
+      style:width="{POPUP_WIDTH}px"
       role="tooltip"
       aria-live="polite"
     >
@@ -251,7 +312,11 @@
         >
           {#if !imageLoaded && !imageError}
             <!-- Loading state -->
-            <div class="absolute inset-0 flex items-center justify-center">
+            <div
+              class="absolute inset-0 flex items-center justify-center"
+              role="status"
+              aria-label={t('common.ui.loading')}
+            >
               <div class="loading loading-spinner loading-md"></div>
             </div>
           {/if}
@@ -287,9 +352,9 @@
               <span class="credit-text">{imageAttribution.authorName}</span>
               {#if imageAttribution.licenseName}
                 <span class="credit-separator">·</span>
-                {#if imageAttribution.licenseURL}
+                {#if safeLicenseURL}
                   <a
-                    href={imageAttribution.licenseURL}
+                    href={safeLicenseURL}
                     target="_blank"
                     rel="noopener noreferrer"
                     class="credit-license">{imageAttribution.licenseName}</a
@@ -318,14 +383,14 @@
         <!-- Arrow at top of popup -->
         <div
           class="absolute w-3 h-3 bg-[var(--color-base-100)] border-l border-t border-[var(--color-base-300)] rotate-45 -z-10"
-          style:left="20px"
+          style:left="{popupArrowX}px"
           style:top="-6px"
         ></div>
       {:else}
         <!-- Arrow at bottom of popup -->
         <div
           class="absolute w-3 h-3 bg-[var(--color-base-100)] border-r border-b border-[var(--color-base-300)] rotate-45 -z-10"
-          style:left="20px"
+          style:left="{popupArrowX}px"
           style:bottom="-6px"
         ></div>
       {/if}

--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -104,23 +104,33 @@
   async function fetchImageAttribution() {
     const name = scientificName?.trim();
     if (!name || lastFetchedScientificName === name) return;
-    // Mark as fetched up front so concurrent/repeat hovers do not re-request.
+    // Mark as fetched up front so concurrent/repeat hovers do not re-request,
+    // and clear any prior attribution so a reused row cannot show it as stale.
     lastFetchedScientificName = name;
+    imageAttribution = null;
 
     try {
       const url = buildAppUrl(`/api/v2/media/species-image/info?name=${encodeURIComponent(name)}`);
       const response = await fetch(url);
       if (response.ok) {
-        imageAttribution = (await response.json()) as ImageAttribution;
-      } else if (response.status >= 500) {
+        const data = (await response.json()) as ImageAttribution;
+        // Only apply if this row still represents the requested species (it may
+        // have been reused for a different one while the request was in flight).
+        if (lastFetchedScientificName === name) {
+          imageAttribution = data;
+        }
+      } else if (response.status >= 500 && lastFetchedScientificName === name) {
         // Transient server error: allow a later hover to retry. A 4xx (e.g. a
         // 404 when a species has no attribution) is permanent, so keep the
         // dedupe key to avoid re-querying the API on every subsequent hover.
         lastFetchedScientificName = '';
       }
     } catch (error) {
-      // Clear the dedupe key so a later hover can retry after a network error.
-      lastFetchedScientificName = '';
+      // Clear the dedupe key so a later hover can retry after a network error,
+      // unless a newer request for a different species has superseded this one.
+      if (lastFetchedScientificName === name) {
+        lastFetchedScientificName = '';
+      }
       logger.debug('Failed to fetch bird image attribution', { error, species: name });
     }
   }
@@ -295,8 +305,8 @@
       bind:this={popupElement}
       use:portal
       id="bird-popup"
-      in:dropdown={{ y: popupPosition === 'above' ? 8 : -8 }}
-      out:dropdown={{ duration: 100, y: popupPosition === 'above' ? 8 : -8 }}
+      in:dropdown
+      out:dropdown={{ duration: 100 }}
       class="fixed z-50 bg-[var(--color-base-100)] border border-[var(--color-base-300)] rounded-lg shadow-xl p-4"
       style:left="{popupX}px"
       style:top={popupTop !== null ? `${popupTop}px` : undefined}

--- a/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BirdThumbnailPopup.svelte
@@ -59,6 +59,16 @@
   const POPUP_WIDTH = 320;
   const POPUP_HEIGHT_ESTIMATE = 320;
 
+  // Positioning tuning constants (px).
+  const POPUP_VIEWPORT_MARGIN = 10; // minimum gap kept from the viewport edges
+  const POPUP_OFFSET_X = 10; // horizontal gap from the trigger
+  const POPUP_OFFSET_Y = 10; // vertical gap from the trigger when below
+  const POPUP_OFFSET_Y_ABOVE = 20; // larger vertical gap when above, for separation
+  const POPUP_ARROW_SIZE = 12; // arrow square size, matches the w-3/h-3 classes
+  // Flip to the 'above' placement once free space below drops under the popup
+  // height plus this buffer, so it flips before the trigger reaches the edge.
+  const POPUP_EARLY_FLIP_BUFFER = 200;
+
   // State for popup visibility and positioning
   let showPopup = $state(false);
   let popupX = $state(0);
@@ -102,8 +112,10 @@
       const response = await fetch(url);
       if (response.ok) {
         imageAttribution = (await response.json()) as ImageAttribution;
-      } else {
-        // Allow a later hover to retry a transient non-OK response.
+      } else if (response.status >= 500) {
+        // Transient server error: allow a later hover to retry. A 4xx (e.g. a
+        // 404 when a species has no attribution) is permanent, so keep the
+        // dedupe key to avoid re-querying the API on every subsequent hover.
         lastFetchedScientificName = '';
       }
     } catch (error) {
@@ -166,11 +178,10 @@
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const popupWidth = POPUP_WIDTH;
-    const popupHeight = popupElement?.offsetHeight ?? POPUP_HEIGHT_ESTIMATE;
-    const viewportMargin = 10; // Keep the popup this far from the viewport edges
-    const offsetX = 10; // Horizontal offset from trigger
-    const offsetY = 10; // Vertical offset from trigger when below
-    const offsetYAbove = 20; // Larger vertical offset when above for better separation
+    // offsetHeight is 0 before the first layout pass (or while hidden); fall
+    // back to the estimate then instead of positioning against a 0 height.
+    const measuredHeight = popupElement?.offsetHeight ?? 0;
+    const popupHeight = measuredHeight > 0 ? measuredHeight : POPUP_HEIGHT_ESTIMATE;
 
     // Calculate available space in each direction
     const spaceAbove = triggerRect.top;
@@ -180,52 +191,55 @@
 
     // Determine horizontal position
     let x: number;
-    if (spaceRight >= popupWidth + offsetX) {
+    if (spaceRight >= popupWidth + POPUP_OFFSET_X) {
       // Position to the right of trigger
-      x = triggerRect.right + offsetX;
-    } else if (spaceLeft >= popupWidth + offsetX) {
+      x = triggerRect.right + POPUP_OFFSET_X;
+    } else if (spaceLeft >= popupWidth + POPUP_OFFSET_X) {
       // Position to the left of trigger
-      x = triggerRect.left - popupWidth - offsetX;
+      x = triggerRect.left - popupWidth - POPUP_OFFSET_X;
     } else {
       // Center horizontally if not enough space on sides
       x = Math.max(
-        viewportMargin,
-        Math.min(viewportWidth / 2 - popupWidth / 2, viewportWidth - popupWidth - viewportMargin)
+        POPUP_VIEWPORT_MARGIN,
+        Math.min(
+          viewportWidth / 2 - popupWidth / 2,
+          viewportWidth - popupWidth - POPUP_VIEWPORT_MARGIN
+        )
       );
     }
     // Ensure popup stays within viewport bounds horizontally
-    popupX = Math.max(viewportMargin, Math.min(x, viewportWidth - popupWidth - viewportMargin));
-
-    // Point the arrow at the trigger's horizontal center, clamped so it stays
-    // within the popup body.
-    const arrowSize = 12; // matches w-3/h-3
-    const triggerCenterX = triggerRect.left + triggerRect.width / 2;
-    popupArrowX = Math.max(
-      arrowSize,
-      Math.min(triggerCenterX - popupX, popupWidth - arrowSize * 2)
+    popupX = Math.max(
+      POPUP_VIEWPORT_MARGIN,
+      Math.min(x, viewportWidth - popupWidth - POPUP_VIEWPORT_MARGIN)
     );
 
-    // Determine vertical position. Add an extra buffer so the popup flips to
-    // the 'above' placement earlier (before the trigger reaches the very edge).
-    const earlyTriggerBuffer = 200;
+    // Align the arrow's midpoint (not its left edge) with the trigger center,
+    // clamped so the arrow stays within the popup body and clear of its corners.
+    const triggerCenterX = triggerRect.left + triggerRect.width / 2;
+    popupArrowX = Math.max(
+      POPUP_ARROW_SIZE,
+      Math.min(triggerCenterX - popupX - POPUP_ARROW_SIZE / 2, popupWidth - POPUP_ARROW_SIZE * 2)
+    );
 
-    if (spaceBelow >= popupHeight + offsetY + earlyTriggerBuffer) {
+    // Determine vertical position. Flip to 'above' early via the buffer (before
+    // the trigger reaches the very edge of the viewport).
+    if (spaceBelow >= popupHeight + POPUP_OFFSET_Y + POPUP_EARLY_FLIP_BUFFER) {
       // Below: anchor the popup's TOP edge just under the trigger row. Height
       // independent, which is why the 'below' case never misaligned.
       popupPosition = 'below';
-      popupTop = triggerRect.bottom + offsetY;
+      popupTop = triggerRect.bottom + POPUP_OFFSET_Y;
       popupBottom = null;
-    } else if (spaceAbove >= popupHeight + offsetYAbove) {
+    } else if (spaceAbove >= popupHeight + POPUP_OFFSET_Y_ABOVE) {
       // Above: anchor the popup's BOTTOM edge just above the trigger row by
       // pinning `bottom` to the viewport. Aligning the bottom edge means the
       // exact height is irrelevant and the popup grows upward from the row.
       popupPosition = 'above';
-      popupBottom = viewportHeight - triggerRect.top + offsetYAbove;
+      popupBottom = viewportHeight - triggerRect.top + POPUP_OFFSET_Y_ABOVE;
       popupTop = null;
     } else {
       // Not enough room either way: pin near the top of the viewport.
       popupPosition = 'below';
-      popupTop = viewportMargin;
+      popupTop = POPUP_VIEWPORT_MARGIN;
       popupBottom = null;
     }
   }

--- a/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/editor/EditorSpeciesInput.svelte
@@ -199,11 +199,26 @@
     updatePortalPosition();
   }
 
+  // Fallback dropdown-height estimate (px), used only before the dropdown has
+  // been laid out and its real offsetHeight can be measured.
+  const DROPDOWN_MAX_HEIGHT_ESTIMATE = 240;
+  const DROPDOWN_ITEM_HEIGHT_ESTIMATE = 40;
+
   function updatePortalPosition() {
     if (!portalDropdown || !inputElement) return;
 
     const rect = inputElement.getBoundingClientRect();
-    const dropdownHeight = Math.min(240, filteredPredictions.length * 40);
+    // Use the real rendered height (the dropdown is already populated when this
+    // runs) so the 'above' flip aligns the dropdown's bottom edge to the input.
+    // Fall back to an item-count estimate only before the first layout.
+    const measuredHeight = portalDropdown.offsetHeight;
+    const dropdownHeight =
+      measuredHeight > 0
+        ? measuredHeight
+        : Math.min(
+            DROPDOWN_MAX_HEIGHT_ESTIMATE,
+            filteredPredictions.length * DROPDOWN_ITEM_HEIGHT_ESTIMATE
+          );
     const viewportHeight = window.innerHeight;
     const spaceBelow = viewportHeight - rect.bottom;
     const spaceAbove = rect.top;
@@ -325,17 +340,21 @@
     }
   }
 
-  // Register document-level listeners and clean up on destroy
+  // Register outside-click/touch and scroll/resize listeners only while the
+  // dropdown is open, so closed inputs do not keep global listeners that thrash
+  // layout on every scroll. Capture phase catches scrolls in nested containers.
   $effect(() => {
+    if (!showPredictions) return;
+
     document.addEventListener('click', handleDocumentClick);
     document.addEventListener('touchstart', handleDocumentClick);
-    window.addEventListener('scroll', updatePortalPosition, { passive: true });
+    window.addEventListener('scroll', updatePortalPosition, { passive: true, capture: true });
     window.addEventListener('resize', updatePortalPosition);
 
     return () => {
       document.removeEventListener('click', handleDocumentClick);
       document.removeEventListener('touchstart', handleDocumentClick);
-      window.removeEventListener('scroll', updatePortalPosition);
+      window.removeEventListener('scroll', updatePortalPosition, { capture: true });
       window.removeEventListener('resize', updatePortalPosition);
       destroyPortalDropdown();
     };


### PR DESCRIPTION
## Summary

The dashboard species-image hover popup (`BirdThumbnailPopup`) positioned correctly when it opened **below** a detection row, but when it flipped to the **above** position it stayed pinned near the bottom of the row instead of aligning its bottom edge to the top of the row, overlapping the row.

Root cause: `calculatePosition()` used a hardcoded `popupHeight = 280` estimate. The `below` branch anchors the popup's top edge to `triggerRect.bottom` (height-independent, always correct), but the `above` branch derived the top edge as `triggerRect.top - 280 - offsetYAbove`. The real rendered popup is ~320-340px tall, so the bottom edge overshot down onto the row.

Fix (mirrors the existing `ActionMenu` / `AudioSettingsButton` positioning pattern):
- Anchor the `above` case by its **bottom** edge via `style:bottom`, so alignment no longer depends on the popup height and the popup grows upward from the row.
- Measure the real height via `offsetHeight` (which ignores the enter transition's `scale` transform, unlike `getBoundingClientRect`) with a `requestAnimationFrame` re-measure once the popup mounts.

### Additional fixes in the same components
- Reposition on scroll/resize via a `$effect` gated on the open state instead of recomputing on every `mousemove`; the popup no longer drifts away from its row on scroll.
- Point the popup arrow at the trigger's horizontal center instead of a fixed corner.
- Validate license-link URLs through the shared `validateProtocolURL` util (http/https only) so an external attribution payload cannot inject a `javascript:`/`data:` href.
- Retry image-attribution fetch after a transient failure (instead of suppressing it permanently) and debug-log the error.
- Remove a dead focus no-op handler; give the loading spinner `role="status"` + an accessible label.

`SpeciesInput` and `EditorSpeciesInput` had the same estimate-based flip-above behaviour, plus two pre-existing issues in the same code paths:
- Flip-above now measures the dropdown's real `offsetHeight` instead of an item-count estimate.
- Their window scroll/resize listeners were bound unconditionally on mount (every closed input kept global listeners that read layout on each scroll); now gated on the dropdown being open, with scroll capture phase so nested scroll containers reposition the dropdown.
- `SpeciesInput`'s click-outside was scoped to the global `.form-control` class (so clicking any other form field counted as "inside"); now scoped to a per-instance wrapper id.

## Test Plan
- [ ] On the dashboard, hover a thumbnail near the bottom of the viewport: the popup opens above the row with its bottom edge aligned just above the row, arrow pointing at the thumbnail.
- [ ] Hover a thumbnail with space below: popup opens below, unchanged.
- [ ] Scroll the detections table while a popup is open: the popup stays anchored to its row.
- [ ] Species autocomplete (settings + dashboard search) still opens, flips above near the viewport bottom with correct alignment, and closes when clicking elsewhere.
- [x] `svelte-check` 0 errors, `npm run check:all` clean, full frontend test suite passes (125 files / 2150 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown dismissal so other inputs no longer prevent dropdowns from closing.
  * Improved dropdown and hover popup positioning by using measured popup heights, with correct scroll/resize repositioning within the viewport.
  * Hardened image attribution by validating license links (http/https only) and refining deduping and retry behavior.
* **Improvements**
  * Reduced overhead by only registering outside-click/touch and scroll/resize handling while predictions/popups are open.
  * Updated hover popup interaction so keyboard focus no longer triggers hover opening (blur still closes).
* **Accessibility**
  * Added an ARIA live status indicator for image loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->