### PR TITLE
chore(metrics): remove dead image-provider metric surface

### DIFF
--- a/internal/observability/metrics/imageprovider.go
+++ b/internal/observability/metrics/imageprovider.go
@@ -9,13 +9,11 @@ import (
 
 // ImageProviderMetrics contains all Prometheus metrics related to the image provider operations.
 type ImageProviderMetrics struct {
-	CacheSize        prometheus.Gauge
-	CacheHits        prometheus.Counter
-	CacheMisses      prometheus.Counter
-	ImageDownloads   prometheus.Counter
-	DownloadErrors   *prometheus.CounterVec
-	DownloadDuration prometheus.Histogram
-	registry         *prometheus.Registry
+	CacheHits      prometheus.Counter
+	CacheMisses    prometheus.Counter
+	ImageDownloads prometheus.Counter
+	DownloadErrors *prometheus.CounterVec
+	registry       *prometheus.Registry
 }
 
 // NewImageProviderMetrics creates a new instance of ImageProviderMetrics.
@@ -34,11 +32,6 @@ func NewImageProviderMetrics(registry *prometheus.Registry) (*ImageProviderMetri
 
 // initMetrics initializes all metrics for ImageProviderMetrics.
 func (m *ImageProviderMetrics) initMetrics() error {
-	m.CacheSize = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "image_provider_cache_size_bytes",
-		Help: "Current size of the image cache in bytes.",
-	})
-
 	m.CacheHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "image_provider_cache_hits_total",
 		Help: "Total number of cache hits.",
@@ -59,18 +52,7 @@ func (m *ImageProviderMetrics) initMetrics() error {
 		Help: "Total number of image download errors.",
 	}, []string{"error_category", "provider", "operation"})
 
-	m.DownloadDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "image_provider_download_duration_seconds",
-		Help:    "Duration of image downloads in seconds.",
-		Buckets: prometheus.ExponentialBuckets(BucketStart100ms, BucketFactor2, BucketCount10),
-	})
-
 	return nil
-}
-
-// SetCacheSize updates the current size of the image cache in bytes.
-func (m *ImageProviderMetrics) SetCacheSize(sizeBytes float64) {
-	m.CacheSize.Set(sizeBytes)
 }
 
 // IncrementCacheHits increases the cache hit counter by one.
@@ -88,38 +70,23 @@ func (m *ImageProviderMetrics) IncrementImageDownloads() {
 	m.ImageDownloads.Inc()
 }
 
-// IncrementDownloadErrors increases the download error counter by one.
-func (m *ImageProviderMetrics) IncrementDownloadErrors() {
-	m.DownloadErrors.WithLabelValues("generic", "unknown", "unknown").Inc()
-}
-
 // IncrementDownloadErrorsWithCategory increases the download error counter with categorization.
 func (m *ImageProviderMetrics) IncrementDownloadErrorsWithCategory(category, provider, operation string) {
 	m.DownloadErrors.WithLabelValues(category, provider, operation).Inc()
 }
 
-// ObserveDownloadDuration records the duration of an image download operation.
-// The duration should be provided in seconds.
-func (m *ImageProviderMetrics) ObserveDownloadDuration(durationSeconds float64) {
-	m.DownloadDuration.Observe(durationSeconds)
-}
-
 // Collect implements the prometheus.Collector interface.
 func (m *ImageProviderMetrics) Collect(ch chan<- prometheus.Metric) {
-	m.CacheSize.Collect(ch)
 	m.CacheHits.Collect(ch)
 	m.CacheMisses.Collect(ch)
 	m.ImageDownloads.Collect(ch)
 	m.DownloadErrors.Collect(ch)
-	m.DownloadDuration.Collect(ch)
 }
 
 // Describe implements the prometheus.Collector interface.
 func (m *ImageProviderMetrics) Describe(ch chan<- *prometheus.Desc) {
-	m.CacheSize.Describe(ch)
 	m.CacheHits.Describe(ch)
 	m.CacheMisses.Describe(ch)
 	m.ImageDownloads.Describe(ch)
 	m.DownloadErrors.Describe(ch)
-	m.DownloadDuration.Describe(ch)
 }


### PR DESCRIPTION
## Summary

Removes dead metric code from `ImageProviderMetrics` (`internal/observability/metrics/imageprovider.go`). Three methods had no callers anywhere in the tree:

- `SetCacheSize` (its only caller, `BirdImageCache.updateMetrics`, was removed as dead code in #3499)
- `IncrementDownloadErrors` (a no-category wrapper superseded by `IncrementDownloadErrorsWithCategory`, which is used in 7 places)
- `ObserveDownloadDuration`

Their backing metrics, the `image_provider_cache_size_bytes` gauge and the `image_provider_download_duration_seconds` histogram, were registered and exposed on `/metrics` but never populated (a constant-0 gauge and an always-empty histogram), and nothing scrapes them. Removed the dead methods plus both orphan metrics from the struct, `initMetrics`, `Collect`, and `Describe`.

The live surface is unchanged: cache hits/misses, downloads, and the categorized download-errors `CounterVec` and their methods all stay.

`SetCacheSize` was not worth wiring instead of removing: populating it means an O(n) `MemoryUsage()` scan of the whole cache on every write, for a metric no dashboard reads. If cache-size or download-latency metrics are wanted later, adding them wired-up is trivial.

## Test plan

- [x] `go build ./...`, `go vet`, and `-race` tests for the metrics and imageprovider packages pass.
- [x] Full-project `golangci-lint` clean.
- [x] `Collect`/`Describe` stay symmetric, so registry registration still succeeds (covered by metrics tests).
- [x] Grep confirms no remaining references (code, tests, dashboards, frontend, docs) to the removed methods or metric names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified image provider metrics collection by removing unused cache size and download duration tracking. Enhanced error reporting now uses only categorized download error metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->