### PR TITLE
feat(birdweather): native FFmpeg-free FLAC upload encoding behind the encoder gate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/tphakala/go-audio-resampler v1.4.0
 	github.com/tphakala/go-flac v0.3.0
 	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
-	github.com/tphakala/simd v1.3.0
+	github.com/tphakala/simd v1.4.0-rc.2
 	github.com/yalue/onnxruntime_go v1.30.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a h1:BBvsu7Mes8McH6iky
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a/go.mod h1:fht+y3WzLavlVj4eN6u+/lmoQ4lOcsL6blDhBckFLPE=
 github.com/tphakala/malgo v0.11.25-birdnet.1 h1:QwqenAMHWxLPcWDVEfRyqbYHPvMpr0IoNLHFcTG9YO0=
 github.com/tphakala/malgo v0.11.25-birdnet.1/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
-github.com/tphakala/simd v1.3.0 h1:6DBkVfF/DEf/dnkfajbtu13+EZVReIIgIoUm2GNRs/k=
-github.com/tphakala/simd v1.3.0/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
+github.com/tphakala/simd v1.4.0-rc.2 h1:CGak7ycje3HPVF/3Nxyaj4D91tukZnrmr2PXjGeg9X4=
+github.com/tphakala/simd v1.4.0-rc.2/go.mod h1:RDX4bQNU8wV5JAYHEkic0l1CcQpBUwV7odEISuOvpUY=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=

--- a/internal/audiocore/audionorm/alloc_test.go
+++ b/internal/audiocore/audionorm/alloc_test.go
@@ -1,0 +1,66 @@
+//go:build !race
+
+// The race detector adds allocations to instrumented code, which makes
+// testing.AllocsPerRun report non-zero counts. These zero-allocation assertions
+// are therefore only meaningful without -race.
+
+package audionorm
+
+import "testing"
+
+// A reused meter (Reset between clips) must not allocate in steady state.
+func TestMeterReuseZeroAlloc(t *testing.T) {
+	m := NewMeter(48000, 1)
+	pcm := sineInterleaved(-12, 1000, 1, 48000, 1)
+	allocs := testing.AllocsPerRun(20, func() {
+		m.Reset()
+		m.AddFloat64(pcm)
+		_ = m.IntegratedLoudness()
+		_ = m.TruePeakDBTP()
+	})
+	if allocs != 0 {
+		t.Errorf("reused meter: %.1f allocs/op, want 0", allocs)
+	}
+}
+
+// The int16 reuse path (Reset + AddInt16) must also be zero-alloc.
+func TestMeterReuseInt16ZeroAlloc(t *testing.T) {
+	m := NewMeter(48000, 1)
+	pcm := sineInt16(-12, 1000, 1, 48000)
+	allocs := testing.AllocsPerRun(20, func() {
+		m.Reset()
+		m.AddInt16(pcm)
+		_ = m.IntegratedLoudness()
+		_ = m.TruePeakDBTP()
+	})
+	if allocs != 0 {
+		t.Errorf("reused meter (int16): %.1f allocs/op, want 0", allocs)
+	}
+}
+
+// The convenience MeasureInt16 must reach zero allocations in steady state via
+// the internal meter pool (same config reused).
+func TestMeasureInt16SteadyStateZeroAlloc(t *testing.T) {
+	pcm := sineInt16(-12, 1000, 1, 48000)
+	allocs := testing.AllocsPerRun(20, func() {
+		_, _ = MeasureInt16(pcm, 48000, 1)
+	})
+	if allocs != 0 {
+		t.Errorf("pooled MeasureInt16: %.1f allocs/op, want 0", allocs)
+	}
+}
+
+// NormalizeInt16 in steady state must also be zero-alloc (gain applied in place
+// with a stack scratch buffer; meter pooled).
+func TestNormalizeInt16SteadyStateZeroAlloc(t *testing.T) {
+	src := sineInt16(-12, 1000, 1, 48000)
+	pcm := make([]int16, len(src))
+	opts := DefaultOptions()
+	allocs := testing.AllocsPerRun(20, func() {
+		copy(pcm, src)
+		_, _ = NormalizeInt16(pcm, opts)
+	})
+	if allocs != 0 {
+		t.Errorf("pooled NormalizeInt16: %.1f allocs/op, want 0", allocs)
+	}
+}

--- a/internal/audiocore/audionorm/audionorm.go
+++ b/internal/audiocore/audionorm/audionorm.go
@@ -203,8 +203,12 @@ func (o Options) validate(n int) error {
 		return err
 	}
 	switch {
+	case math.IsNaN(o.TargetLUFS) || math.IsInf(o.TargetLUFS, 0):
+		return fmt.Errorf("audionorm: target loudness must be finite, got %v", o.TargetLUFS)
 	case o.TargetLUFS >= 0 || o.TargetLUFS <= absoluteGateLUFS:
 		return fmt.Errorf("audionorm: target loudness %.2f LUFS out of range (%.0f, 0)", o.TargetLUFS, absoluteGateLUFS)
+	case math.IsNaN(o.TruePeakDBTP) || math.IsInf(o.TruePeakDBTP, 0):
+		return fmt.Errorf("audionorm: true-peak ceiling must be finite, got %v", o.TruePeakDBTP)
 	case o.TruePeakDBTP > 0:
 		return fmt.Errorf("audionorm: true-peak ceiling %.2f dBTP must be <= 0", o.TruePeakDBTP)
 	}

--- a/internal/audiocore/audionorm/audionorm.go
+++ b/internal/audiocore/audionorm/audionorm.go
@@ -1,0 +1,212 @@
+// Package audionorm performs two-pass loudness normalization of in-memory PCM
+// audio to the EBU R 128 / ITU-R BS.1770-4 standard.
+//
+// Pass one measures the gated integrated loudness and the true peak; pass two
+// applies a single linear gain so the signal reaches the target loudness without
+// its true peak exceeding the configured ceiling. Linear gain preserves the
+// clip's dynamics and cannot pump, which suits field and nature recordings.
+//
+// The implementation is pure Go (no cgo) so it cross-compiles cleanly, and uses
+// github.com/tphakala/simd for the hot paths. It works at any standard audio
+// sample rate (>= 8000 Hz) and channel count; the primary, most-tested path is
+// 48 kHz, 16-bit, mono. Loudness is accurate at every supported rate; the
+// true-peak estimate uses BS.1770-4 4x oversampling, which is specified for
+// rates up to 48 kHz and is less precise above that.
+//
+//	opts := audionorm.DefaultOptions() // -23 LUFS, -1.0 dBTP, 48 kHz mono
+//	res, err := audionorm.NormalizeInt16(pcm, opts)
+package audionorm
+
+import (
+	"fmt"
+	"math"
+	"sync"
+)
+
+// meterPool reuses Meters across the convenience functions so repeated calls at
+// a fixed sample rate and channel count are allocation-free in steady state.
+var meterPool sync.Pool
+
+// acquireMeter returns a reset meter for the given config, reusing a pooled one
+// when its config matches. A pooled meter with a different config is discarded
+// (left for GC) and a fresh one is built.
+func acquireMeter(sampleRate, channels int) *Meter {
+	if v := meterPool.Get(); v != nil {
+		m := v.(*Meter)
+		if m.sampleRate == sampleRate && m.channels == channels {
+			m.Reset()
+			return m
+		}
+	}
+	return NewMeter(sampleRate, channels)
+}
+
+func releaseMeter(m *Meter) { meterPool.Put(m) }
+
+// Default normalization parameters. The target and ceiling are the EBU R 128
+// reference values (-23 LUFS programme loudness, -1 dBTP maximum true peak).
+const (
+	DefaultTargetLUFS   = -23.0
+	DefaultTruePeakDBTP = -1.0
+	defaultSampleRate   = 48000
+	defaultChannels     = 1
+)
+
+// Options configures normalization. Use DefaultOptions and override as needed.
+type Options struct {
+	SampleRate int // samples per second, must be >= 8000
+	// Channels is the interleaved channel count, must be > 0. Layouts of 5 or 6
+	// channels are assumed to be SMPTE-ordered (L, R, C, [LFE,] Ls, Rs) for the
+	// BS.1770 channel weighting; other orderings will mis-weight surround/LFE.
+	Channels     int
+	TargetLUFS   float64 // target integrated loudness, in (-70, 0); the zero value is rejected
+	TruePeakDBTP float64 // maximum allowed true peak in dBTP, must be <= 0
+}
+
+// DefaultOptions returns the EBU R 128 defaults for the BirdNET-Go signal:
+// 48 kHz mono, target -23 LUFS, ceiling -1.0 dBTP.
+func DefaultOptions() Options {
+	return Options{
+		SampleRate:   defaultSampleRate,
+		Channels:     defaultChannels,
+		TargetLUFS:   DefaultTargetLUFS,
+		TruePeakDBTP: DefaultTruePeakDBTP,
+	}
+}
+
+// Measurement holds the pass-one analysis of a buffer. Silent or sub-400 ms
+// input yields IntegratedLUFS = -Inf; silent input yields TruePeakDBTP = -Inf.
+type Measurement struct {
+	IntegratedLUFS float64 // gated integrated loudness (LUFS)
+	TruePeakDBTP   float64 // maximum true peak (dBTP)
+}
+
+// Result describes the outcome of a normalization.
+type Result struct {
+	Input        Measurement // pass-one measurement of the original buffer
+	TargetGainDB float64     // gain needed to reach TargetLUFS, before peak limiting
+	GainDB       float64     // gain actually applied
+	PeakLimited  bool        // true if the true-peak ceiling reduced the gain
+	OutputLUFS   float64     // estimated loudness after normalization (-Inf for silence)
+}
+
+// MeasureFloat32 measures interleaved float32 PCM (nominal range [-1, 1]).
+func MeasureFloat32(pcm []float32, sampleRate, channels int) (Measurement, error) {
+	if err := validateDims(sampleRate, channels, len(pcm)); err != nil {
+		return Measurement{}, err
+	}
+	m := acquireMeter(sampleRate, channels)
+	defer releaseMeter(m)
+	m.AddFloat32(pcm)
+	return result(m), nil
+}
+
+// MeasureInt16 measures interleaved 16-bit PCM.
+func MeasureInt16(pcm []int16, sampleRate, channels int) (Measurement, error) {
+	if err := validateDims(sampleRate, channels, len(pcm)); err != nil {
+		return Measurement{}, err
+	}
+	m := acquireMeter(sampleRate, channels)
+	defer releaseMeter(m)
+	m.AddInt16(pcm)
+	return result(m), nil
+}
+
+// NormalizeFloat32 normalizes interleaved float32 PCM in place and returns the
+// outcome. Silent input is left untouched (GainDB = 0).
+func NormalizeFloat32(pcm []float32, opts Options) (Result, error) {
+	if err := opts.validate(len(pcm)); err != nil {
+		return Result{}, err
+	}
+	m := acquireMeter(opts.SampleRate, opts.Channels)
+	defer releaseMeter(m)
+	m.AddFloat32(pcm)
+	res := PlanGain(result(m), opts)
+	if res.GainDB != 0 {
+		applyGainFloat32(pcm, math.Pow(10, res.GainDB/20))
+	}
+	return res, nil
+}
+
+// NormalizeInt16 normalizes interleaved 16-bit PCM in place and returns the
+// outcome. Gain is applied with rounding and saturation so a boost never wraps.
+// Silent input is left untouched (GainDB = 0).
+func NormalizeInt16(pcm []int16, opts Options) (Result, error) {
+	if err := opts.validate(len(pcm)); err != nil {
+		return Result{}, err
+	}
+	m := acquireMeter(opts.SampleRate, opts.Channels)
+	defer releaseMeter(m)
+	m.AddInt16(pcm)
+	res := PlanGain(result(m), opts)
+	if res.GainDB != 0 {
+		applyGainInt16(pcm, math.Pow(10, res.GainDB/20))
+	}
+	return res, nil
+}
+
+// result reads the final measurement from a fully-fed meter.
+func result(m *Meter) Measurement {
+	return Measurement{
+		IntegratedLUFS: m.IntegratedLoudness(),
+		TruePeakDBTP:   m.TruePeakDBTP(),
+	}
+}
+
+// PlanGain decides the linear gain for pass two from a pass-one Measurement and
+// the target/ceiling in opts, without touching any audio buffer. It returns the
+// full Result: the target gain (target minus measured loudness), the gain
+// actually applied after true-peak limiting, and the projected output loudness.
+//
+// The Normalize* helpers call this internally. Callers that want to apply the
+// gain themselves (for example while encoding, to avoid a second buffer pass)
+// can measure with Measure* and plan here. opts is not validated against a
+// buffer length, so callers that bypass Normalize* should ensure SampleRate,
+// Channels, TargetLUFS and TruePeakDBTP are sane.
+func PlanGain(meas Measurement, opts Options) Result {
+	res := Result{Input: meas, OutputLUFS: math.Inf(-1)}
+	if math.IsInf(meas.IntegratedLUFS, -1) {
+		return res // silence: nothing to normalize
+	}
+
+	res.TargetGainDB = opts.TargetLUFS - meas.IntegratedLUFS
+	gain := res.TargetGainDB
+
+	// Never let the gained true peak exceed the ceiling.
+	if !math.IsInf(meas.TruePeakDBTP, -1) {
+		headroom := opts.TruePeakDBTP - meas.TruePeakDBTP
+		if gain > headroom {
+			gain = headroom
+			res.PeakLimited = true
+		}
+	}
+
+	res.GainDB = gain
+	res.OutputLUFS = meas.IntegratedLUFS + gain
+	return res
+}
+
+func validateDims(sampleRate, channels, n int) error {
+	switch {
+	case sampleRate < minSampleRate:
+		return fmt.Errorf("audionorm: sample rate %d Hz too low; minimum is %d Hz (K-weighting is undefined below it)", sampleRate, minSampleRate)
+	case channels <= 0:
+		return fmt.Errorf("audionorm: channels must be positive, got %d", channels)
+	case n%channels != 0:
+		return fmt.Errorf("audionorm: sample count %d is not a multiple of channels %d", n, channels)
+	}
+	return nil
+}
+
+func (o Options) validate(n int) error {
+	if err := validateDims(o.SampleRate, o.Channels, n); err != nil {
+		return err
+	}
+	switch {
+	case o.TargetLUFS >= 0 || o.TargetLUFS <= absoluteGateLUFS:
+		return fmt.Errorf("audionorm: target loudness %.2f LUFS out of range (%.0f, 0)", o.TargetLUFS, absoluteGateLUFS)
+	case o.TruePeakDBTP > 0:
+		return fmt.Errorf("audionorm: true-peak ceiling %.2f dBTP must be <= 0", o.TruePeakDBTP)
+	}
+	return nil
+}

--- a/internal/audiocore/audionorm/audionorm_test.go
+++ b/internal/audiocore/audionorm/audionorm_test.go
@@ -1,0 +1,182 @@
+package audionorm
+
+import (
+	"math"
+	"testing"
+)
+
+// sineInt16 synthesizes mono int16 PCM of a sine at the given peak dBFS.
+func sineInt16(dbfs, freq, seconds, fs float64) []int16 {
+	amp := math.Pow(10, dbfs/20) * 32767
+	n := int(seconds * fs)
+	out := make([]int16, n)
+	w := 2 * math.Pi * freq / fs
+	for i := range n {
+		out[i] = int16(math.Round(amp * math.Sin(w*float64(i))))
+	}
+	return out
+}
+
+func sineFloat32(dbfs, freq, seconds, fs float64, channels int) []float32 {
+	f64 := sineInterleaved(dbfs, freq, seconds, fs, channels)
+	out := make([]float32, len(f64))
+	for i, v := range f64 {
+		out[i] = float32(v)
+	}
+	return out
+}
+
+// Normalizing a float32 buffer to a target must bring the re-measured loudness
+// to that target (the round-trip test).
+func TestNormalizeFloat32RoundTrip(t *testing.T) {
+	pcm := sineFloat32(-10, 1000, 3, 48000, 2)
+	opts := DefaultOptions()
+	opts.SampleRate, opts.Channels = 48000, 2
+	opts.TargetLUFS = -23
+
+	res, err := NormalizeFloat32(pcm, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.PeakLimited {
+		t.Errorf("did not expect peak limiting for a quiet sine")
+	}
+	got, err := MeasureFloat32(pcm, 48000, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(got.IntegratedLUFS-(-23)) > 0.1 {
+		t.Errorf("after normalize, loudness = %.3f LUFS, want -23 +/-0.1", got.IntegratedLUFS)
+	}
+}
+
+// The BirdNET-Go path: 48 kHz, 16-bit, mono.
+func TestNormalizeInt16MonoRoundTrip(t *testing.T) {
+	pcm := sineInt16(-10, 1000, 3, 48000)
+	opts := DefaultOptions() // 48 kHz mono by default
+	opts.TargetLUFS = -23
+
+	res, err := NormalizeInt16(pcm, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// -10 dBFS mono is ~-13 LUFS; reaching -23 needs ~-10 dB of attenuation.
+	if res.GainDB >= 0 {
+		t.Errorf("expected attenuation (negative gain), got %.3f dB", res.GainDB)
+	}
+	got, err := MeasureInt16(pcm, 48000, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(got.IntegratedLUFS-(-23)) > 0.3 {
+		t.Errorf("after normalize, loudness = %.3f LUFS, want -23 +/-0.3", got.IntegratedLUFS)
+	}
+}
+
+// When reaching the target would exceed the true-peak ceiling, the gain is
+// reduced so the output peak sits at the ceiling, and PeakLimited is reported.
+func TestNormalizePeakLimited(t *testing.T) {
+	pcm := sineFloat32(-10, 1000, 3, 48000, 2) // loudness ~-10 LUFS, TP ~-10 dBTP
+	opts := DefaultOptions()
+	opts.SampleRate, opts.Channels = 48000, 2
+	opts.TargetLUFS = -3     // would need +7 dB -> projected TP ~-3 dBTP
+	opts.TruePeakDBTP = -6.0 // ceiling forces limiting
+
+	res, err := NormalizeFloat32(pcm, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.PeakLimited {
+		t.Fatalf("expected PeakLimited=true (ceiling -6 dBTP)")
+	}
+	got, _ := MeasureFloat32(pcm, 48000, 2)
+	if got.TruePeakDBTP > -6.0+0.3 {
+		t.Errorf("output true peak = %.3f dBTP, must not exceed ceiling -6 (+0.3 tol)", got.TruePeakDBTP)
+	}
+}
+
+func TestNormalizeSilenceIsNoOp(t *testing.T) {
+	pcm := make([]float32, 48000*2)
+	opts := DefaultOptions()
+	opts.SampleRate, opts.Channels = 48000, 2
+	res, err := NormalizeFloat32(pcm, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.GainDB != 0 {
+		t.Errorf("silence gain = %.3f, want 0 (no-op)", res.GainDB)
+	}
+	if !math.IsInf(res.OutputLUFS, -1) {
+		t.Errorf("silence output loudness = %.3f, want -Inf", res.OutputLUFS)
+	}
+}
+
+// Sample rates below the supported minimum must be rejected with an error, not
+// panic and not produce garbage. 4000 Hz is in the danger zone where the
+// K-weighting high-shelf center (1681.97 Hz) approaches/exceeds Nyquist.
+func TestMeasureRejectsTooLowSampleRate(t *testing.T) {
+	pcm := []int16{1, 2, 3, 4, 5, 6, 7, 8}
+	for _, fs := range []int{4, 4000, 7999} {
+		if _, err := MeasureInt16(pcm, fs, 1); err == nil {
+			t.Errorf("expected error for %d Hz sample rate, got nil", fs)
+		}
+	}
+	// The 8000 Hz minimum and a normal rate must be accepted.
+	for _, fs := range []int{8000, 48000} {
+		if _, err := MeasureInt16(pcm, fs, 1); err != nil {
+			t.Errorf("%d Hz unexpectedly rejected: %v", fs, err)
+		}
+	}
+}
+
+func TestNormalizeValidation(t *testing.T) {
+	opts := DefaultOptions()
+	opts.SampleRate, opts.Channels = 48000, 2
+	cases := map[string]func() error{
+		"length not multiple of channels": func() error {
+			_, err := NormalizeFloat32([]float32{0, 0, 0}, opts)
+			return err
+		},
+		"zero sample rate": func() error {
+			o := opts
+			o.SampleRate = 0
+			_, err := NormalizeFloat32([]float32{0, 0}, o)
+			return err
+		},
+		"positive target": func() error {
+			o := opts
+			o.TargetLUFS = 5
+			_, err := NormalizeFloat32([]float32{0, 0}, o)
+			return err
+		},
+		"zero target (full-scale loudness footgun)": func() error {
+			o := opts
+			o.TargetLUFS = 0
+			_, err := NormalizeFloat32([]float32{0, 0}, o)
+			return err
+		},
+		"target below absolute gate": func() error {
+			o := opts
+			o.TargetLUFS = -80
+			_, err := NormalizeFloat32([]float32{0, 0}, o)
+			return err
+		},
+		"positive true-peak ceiling": func() error {
+			o := opts
+			o.TruePeakDBTP = 1
+			_, err := NormalizeFloat32([]float32{0, 0}, o)
+			return err
+		},
+		"sample rate too low": func() error {
+			o := opts
+			o.SampleRate = 4
+			_, err := NormalizeFloat32([]float32{0, 0}, o)
+			return err
+		},
+	}
+	for name, fn := range cases {
+		if err := fn(); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}

--- a/internal/audiocore/audionorm/bench_test.go
+++ b/internal/audiocore/audionorm/bench_test.go
@@ -1,0 +1,43 @@
+package audionorm
+
+import "testing"
+
+// A 3-second 48 kHz mono clip, the typical BirdNET-Go export size.
+func benchClipInt16() []int16 { return sineInt16(-12, 1000, 3, 48000) }
+
+func BenchmarkMeasureInt16Mono48k(b *testing.B) {
+	pcm := benchClipInt16()
+	b.SetBytes(int64(len(pcm) * 2))
+	for b.Loop() {
+		if _, err := MeasureInt16(pcm, 48000, 1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMeterReuseMono48k measures the explicit zero-allocation reuse path: a
+// single meter reset and reused across clips.
+func BenchmarkMeterReuseMono48k(b *testing.B) {
+	pcm := benchClipInt16()
+	m := NewMeter(48000, 1)
+	b.SetBytes(int64(len(pcm) * 2))
+	for b.Loop() {
+		m.Reset()
+		m.AddInt16(pcm)
+		_ = m.IntegratedLoudness()
+		_ = m.TruePeakDBTP()
+	}
+}
+
+func BenchmarkNormalizeInt16Mono48k(b *testing.B) {
+	src := benchClipInt16()
+	pcm := make([]int16, len(src))
+	opts := DefaultOptions()
+	b.SetBytes(int64(len(pcm) * 2))
+	for b.Loop() {
+		copy(pcm, src) // fresh buffer each iteration (normalize mutates in place)
+		if _, err := NormalizeInt16(pcm, opts); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/audiocore/audionorm/example_test.go
+++ b/internal/audiocore/audionorm/example_test.go
@@ -1,0 +1,50 @@
+package audionorm_test
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+)
+
+// toneInt16 builds a mono 1 kHz sine at the given peak dBFS, 48 kHz.
+func toneInt16(dbfs float64, seconds int) []int16 {
+	amp := math.Pow(10, dbfs/20) * 32767
+	n := 48000 * seconds
+	pcm := make([]int16, n)
+	for i := range pcm {
+		pcm[i] = int16(math.Round(amp * math.Sin(2*math.Pi*1000*float64(i)/48000)))
+	}
+	return pcm
+}
+
+// Normalize a 48 kHz mono 16-bit clip to the EBU R 128 defaults, in place.
+func ExampleNormalizeInt16() {
+	pcm := toneInt16(-10, 2) // ~-13 LUFS, needs attenuation to reach -23
+
+	opts := audionorm.DefaultOptions() // 48 kHz mono, -23 LUFS, -1.0 dBTP
+	res, err := audionorm.NormalizeInt16(pcm, opts)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("input:  %.1f LUFS, %.1f dBTP\n", res.Input.IntegratedLUFS, res.Input.TruePeakDBTP)
+	fmt.Printf("gain:   %.1f dB (peak limited: %t)\n", res.GainDB, res.PeakLimited)
+	fmt.Printf("output: %.1f LUFS\n", res.OutputLUFS)
+	// Output:
+	// input:  -13.0 LUFS, -10.0 dBTP
+	// gain:   -10.0 dB (peak limited: false)
+	// output: -23.0 LUFS
+}
+
+// Measure loudness and true peak without modifying the buffer.
+func ExampleMeasureInt16() {
+	pcm := toneInt16(-23, 2)
+
+	m, err := audionorm.MeasureInt16(pcm, 48000, 1)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%.1f LUFS, %.1f dBTP\n", m.IntegratedLUFS, m.TruePeakDBTP)
+	// Output: -26.0 LUFS, -23.0 dBTP
+}

--- a/internal/audiocore/audionorm/ffmpeg_test.go
+++ b/internal/audiocore/audionorm/ffmpeg_test.go
@@ -91,8 +91,11 @@ func ffmpegEBUR128(t *testing.T, samples []float64, sampleRate, channels int) (i
 
 func parseFloatOrInf(t *testing.T, s string) float64 {
 	t.Helper()
-	if s == "-inf" || s == "inf" {
+	switch s {
+	case "-inf":
 		return math.Inf(-1)
+	case "inf":
+		return math.Inf(1)
 	}
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil {

--- a/internal/audiocore/audionorm/ffmpeg_test.go
+++ b/internal/audiocore/audionorm/ffmpeg_test.go
@@ -1,0 +1,200 @@
+package audionorm
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// These tests use FFmpeg's ebur128 filter as an independent reference oracle:
+// the same PCM is measured by our pure-Go meter and by FFmpeg, and the results
+// must agree. They are skipped automatically when ffmpeg is not installed.
+
+func ffmpegPath(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not found in PATH; skipping reference cross-validation")
+	}
+	return p
+}
+
+// float32ToFloat64 widens interleaved float32 PCM to float64 (test helper).
+func float32ToFloat64(dst []float64, src []float32) {
+	for i, s := range src {
+		dst[i] = float64(s)
+	}
+}
+
+// f32leBytes encodes interleaved float64 samples as little-endian float32 PCM.
+func f32leBytes(samples []float64) []byte {
+	buf := make([]byte, len(samples)*4)
+	for i := range len(samples) {
+		s := samples[i]
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(s)))
+	}
+	return buf
+}
+
+var (
+	reEbuI    = regexp.MustCompile(`(?m)^\s*I:\s*(-?[\d.]+|-?inf)\s*LUFS`)
+	reEbuPeak = regexp.MustCompile(`(?m)^\s*Peak:\s*(-?[\d.]+|-?inf)\s*dBFS`)
+)
+
+// ffmpegEBUR128 runs ffmpeg's ebur128 scanner over the given interleaved PCM and
+// returns the reported integrated loudness (LUFS) and true peak (dBTP).
+func ffmpegEBUR128(t *testing.T, samples []float64, sampleRate, channels int) (integrated, truePeak float64) {
+	t.Helper()
+	bin := ffmpegPath(t)
+
+	tmp, err := os.CreateTemp(t.TempDir(), "audionorm-*.f32le")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmp.Write(f32leBytes(samples)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin,
+		"-hide_banner", "-nostats",
+		"-f", "f32le", "-ar", strconv.Itoa(sampleRate), "-ac", strconv.Itoa(channels),
+		"-i", tmp.Name(),
+		"-af", "ebur128=peak=true", "-f", "null", "-",
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ffmpeg failed: %v\n%s", err, stderr.String())
+	}
+
+	out := stderr.String()
+	mI := reEbuI.FindStringSubmatch(out)
+	mP := reEbuPeak.FindStringSubmatch(out)
+	if mI == nil || mP == nil {
+		t.Fatalf("could not parse ffmpeg ebur128 summary:\n%s", out)
+	}
+	return parseFloatOrInf(t, mI[1]), parseFloatOrInf(t, mP[1])
+}
+
+func parseFloatOrInf(t *testing.T, s string) float64 {
+	t.Helper()
+	if s == "-inf" || s == "inf" {
+		return math.Inf(-1)
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+// compareToFFmpeg measures `samples` both ways and asserts agreement.
+func compareToFFmpeg(t *testing.T, name string, samples []float64, sampleRate, channels int) {
+	t.Helper()
+	refI, refTP := ffmpegEBUR128(t, samples, sampleRate, channels)
+
+	m := NewMeter(sampleRate, channels)
+	m.AddFloat64(samples)
+	gotI := m.IntegratedLoudness()
+	gotTP := m.TruePeakDBTP()
+
+	if math.Abs(gotI-refI) > 0.3 {
+		t.Errorf("%s: integrated loudness %.3f LUFS vs ffmpeg %.3f (diff %.3f > 0.3)", name, gotI, refI, math.Abs(gotI-refI))
+	}
+	if math.Abs(gotTP-refTP) > 0.5 {
+		t.Errorf("%s: true peak %.3f dBTP vs ffmpeg %.3f (diff %.3f > 0.5)", name, gotTP, refTP, math.Abs(gotTP-refTP))
+	}
+}
+
+func TestFFmpegSineStereoLevels(t *testing.T) {
+	for _, dbfs := range []float64{-6, -14, -23, -33} {
+		compareToFFmpeg(t, "stereo sine "+strconv.Itoa(int(dbfs)),
+			sineInterleaved(dbfs, 997, 4, 48000, 2), 48000, 2)
+	}
+}
+
+func TestFFmpegSineMono(t *testing.T) {
+	compareToFFmpeg(t, "mono sine -16",
+		sineInterleaved(-16, 997, 4, 48000, 1), 48000, 1)
+}
+
+// Relative-gate behavior: two segments at different levels (EBU TC4/TC5 shape).
+func TestFFmpegTwoSegmentGating(t *testing.T) {
+	fs := 48000
+	seg1 := sineInterleaved(-20, 997, 5, float64(fs), 2)
+	seg2 := sineInterleaved(-30, 997, 5, float64(fs), 2)
+	compareToFFmpeg(t, "gating -20/-30", append(seg1, seg2...), fs, 2)
+
+	seg3 := sineInterleaved(-15, 997, 5, float64(fs), 2)
+	compareToFFmpeg(t, "gating -20/-15", append(sineInterleaved(-20, 997, 5, float64(fs), 2), seg3...), fs, 2)
+}
+
+// White noise exercises the K-weighting filter across the spectrum, not just at
+// one tone. Deterministic seed for reproducibility.
+func TestFFmpegWhiteNoise(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	n := 48000 * 4 * 2
+	samples := make([]float64, n)
+	for i := range samples {
+		samples[i] = (rng.Float64()*2 - 1) * 0.2 // ~-14 dBFS peak noise
+	}
+	compareToFFmpeg(t, "white noise", samples, 48000, 2)
+}
+
+// End-to-end: our library normalizes, then FFmpeg independently confirms the
+// output loudness is on target and the true peak respects the ceiling. This is
+// the full two-pass result validated against the reference.
+func TestFFmpegNormalizeRoundTrip(t *testing.T) {
+	ffmpegPath(t) // skip early if ffmpeg is missing
+
+	// A quiet tone-plus-noise mix that needs a boost to reach target.
+	rng := rand.New(rand.NewSource(7))
+	n := 48000 * 4
+	pcm := make([]float32, n)
+	w := 2 * math.Pi * 1000 / 48000
+	for i := range n {
+		tone := 0.05 * math.Sin(w*float64(i))
+		noise := (rng.Float64()*2 - 1) * 0.02
+		pcm[i] = float32(tone + noise)
+	}
+
+	opts := DefaultOptions() // 48 kHz mono, -23 LUFS, -1.0 dBTP
+	res, err := NormalizeFloat32(pcm, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.PeakLimited {
+		t.Fatalf("unexpected peak limiting (gain %.2f dB)", res.GainDB)
+	}
+
+	out := make([]float64, len(pcm))
+	float32ToFloat64(out, pcm)
+	refI, refTP := ffmpegEBUR128(t, out, 48000, 1)
+
+	if math.Abs(refI-opts.TargetLUFS) > 0.5 {
+		t.Errorf("ffmpeg reports normalized loudness %.2f LUFS, want %.1f +/-0.5", refI, opts.TargetLUFS)
+	}
+	if refTP > opts.TruePeakDBTP+0.5 {
+		t.Errorf("ffmpeg reports true peak %.2f dBTP, exceeds ceiling %.1f", refTP, opts.TruePeakDBTP)
+	}
+}
+
+// A signal at 44.1 kHz checks that bilinear-transform coefficients are correct
+// at a non-48k rate (FFmpeg recomputes the K-weighting too).
+func TestFFmpegNon48kRate(t *testing.T) {
+	compareToFFmpeg(t, "44.1k sine -18",
+		sineInterleaved(-18, 1000, 4, 44100, 2), 44100, 2)
+}

--- a/internal/audiocore/audionorm/kweight.go
+++ b/internal/audiocore/audionorm/kweight.go
@@ -1,0 +1,68 @@
+package audionorm
+
+import "math"
+
+// biquad is a second-order IIR section in transposed-direct-form-II-ready
+// normalized coefficients. The difference equation is:
+//
+//	y[n] = b0*x[n] + b1*x[n-1] + b2*x[n-2] - a1*y[n-1] - a2*y[n-2]
+//
+// (a0 is normalized to 1).
+type biquad struct {
+	b0, b1, b2, a1, a2 float64
+}
+
+// K-weighting analog prototype parameters from ITU-R BS.1770-4. At 48 kHz the
+// bilinear transform of these reproduces the published digital coefficients.
+const (
+	// Stage 1: high-shelf "head" pre-filter.
+	kStage1F0   = 1681.974450955533
+	kStage1Q    = 0.7071752369554196
+	kStage1GdB  = 3.999843853973347
+	kStage1VbEx = 0.4996667741545416 // exponent relating Vb to Vh
+
+	// Stage 2: RLB high-pass filter.
+	kStage2F0 = 38.13547087602444
+	kStage2Q  = 0.5003270373238773
+)
+
+// kWeightingStages returns the two cascaded biquad sections of the BS.1770-4
+// K-weighting filter for an arbitrary sample rate (Hz), derived via the
+// bilinear transform of the analog prototypes.
+func kWeightingStages(sampleRate float64) (stage1, stage2 biquad) {
+	stage1 = kHighShelf(sampleRate)
+	stage2 = kHighPass(sampleRate)
+	return stage1, stage2
+}
+
+// kHighShelf builds stage 1, the high-frequency shelving filter.
+func kHighShelf(fs float64) biquad {
+	K := math.Tan(math.Pi * kStage1F0 / fs)
+	Vh := math.Pow(10.0, kStage1GdB/20.0)
+	Vb := math.Pow(Vh, kStage1VbEx)
+	K2 := K * K
+	a0 := 1.0 + K/kStage1Q + K2
+	return biquad{
+		b0: (Vh + Vb*K/kStage1Q + K2) / a0,
+		b1: 2.0 * (K2 - Vh) / a0,
+		b2: (Vh - Vb*K/kStage1Q + K2) / a0,
+		a1: 2.0 * (K2 - 1.0) / a0,
+		a2: (1.0 - K/kStage1Q + K2) / a0,
+	}
+}
+
+// kHighPass builds stage 2, the RLB high-pass filter. Its numerator is fixed at
+// (1 - z^-1)^2, i.e. b = {1, -2, 1}, per BS.1770-4; only the denominator depends
+// on the sample rate.
+func kHighPass(fs float64) biquad {
+	K := math.Tan(math.Pi * kStage2F0 / fs)
+	K2 := K * K
+	a0 := 1.0 + K/kStage2Q + K2
+	return biquad{
+		b0: 1.0,
+		b1: -2.0,
+		b2: 1.0,
+		a1: 2.0 * (K2 - 1.0) / a0,
+		a2: (1.0 - K/kStage2Q + K2) / a0,
+	}
+}

--- a/internal/audiocore/audionorm/kweight_test.go
+++ b/internal/audiocore/audionorm/kweight_test.go
@@ -1,0 +1,80 @@
+package audionorm
+
+import (
+	"math"
+	"testing"
+)
+
+// Published ITU-R BS.1770-4 digital coefficients at 48 kHz. Our bilinear
+// transform must reproduce these from the analog prototype parameters.
+func TestKWeightingStages48kMatchesPublished(t *testing.T) {
+	s1, s2 := kWeightingStages(48000)
+
+	const tol = 1e-6
+
+	wantS1 := biquad{
+		b0: 1.53512485958697,
+		b1: -2.69169618940638,
+		b2: 1.19839281085285,
+		a1: -1.69065929318241,
+		a2: 0.73248077421585,
+	}
+	wantS2 := biquad{
+		b0: 1.0,
+		b1: -2.0,
+		b2: 1.0,
+		a1: -1.99004745483398,
+		a2: 0.99007225036621,
+	}
+
+	checkBiquad(t, "stage1", s1, wantS1, tol)
+	checkBiquad(t, "stage2", s2, wantS2, tol)
+}
+
+func checkBiquad(t *testing.T, name string, got, want biquad, tol float64) {
+	t.Helper()
+	for _, c := range []struct {
+		field    string
+		got, exp float64
+	}{
+		{"b0", got.b0, want.b0},
+		{"b1", got.b1, want.b1},
+		{"b2", got.b2, want.b2},
+		{"a1", got.a1, want.a1},
+		{"a2", got.a2, want.a2},
+	} {
+		if math.Abs(c.got-c.exp) > tol {
+			t.Errorf("%s.%s = %.14f, want %.14f (diff %.2e)", name, c.field, c.got, c.exp, math.Abs(c.got-c.exp))
+		}
+	}
+}
+
+// A 1 kHz tone should pass the K-weighting filter with ~+0.69 dB gain, which is
+// the property that cancels the -0.691 LUFS calibration offset for a 1 kHz
+// reference. This is the single most important filter property.
+func TestKWeightingGainAt1kHz(t *testing.T) {
+	const fs = 48000.0
+	s1, s2 := kWeightingStages(fs)
+
+	gainDB := biquadGainDB(s1, 1000, fs) + biquadGainDB(s2, 1000, fs)
+	const want = 0.691
+	if math.Abs(gainDB-want) > 0.05 {
+		t.Errorf("K-weighting gain at 1 kHz = %.4f dB, want ~%.3f dB", gainDB, want)
+	}
+}
+
+// biquadGainDB returns the magnitude response of a biquad at frequency f (Hz)
+// for sample rate fs (Hz), in dB. Used only by tests.
+func biquadGainDB(b biquad, f, fs float64) float64 {
+	w := 2 * math.Pi * f / fs
+	// H(e^jw) = (b0 + b1 e^-jw + b2 e^-2jw) / (1 + a1 e^-jw + a2 e^-2jw)
+	cw, c2w := math.Cos(w), math.Cos(2*w)
+	sw, s2w := math.Sin(w), math.Sin(2*w)
+	numRe := b.b0 + b.b1*cw + b.b2*c2w
+	numIm := -(b.b1*sw + b.b2*s2w)
+	denRe := 1 + b.a1*cw + b.a2*c2w
+	denIm := -(b.a1*sw + b.a2*s2w)
+	numMag := math.Hypot(numRe, numIm)
+	denMag := math.Hypot(denRe, denIm)
+	return 20 * math.Log10(numMag/denMag)
+}

--- a/internal/audiocore/audionorm/meter.go
+++ b/internal/audiocore/audionorm/meter.go
@@ -1,0 +1,341 @@
+package audionorm
+
+import (
+	"math"
+
+	simdf32 "github.com/tphakala/simd/f32"
+)
+
+// Calibration and gating constants from ITU-R BS.1770-4 / EBU R 128.
+const (
+	loudnessOffset   = -0.691 // LUFS calibration offset
+	absoluteGateLUFS = -70.0  // absolute gate
+	relativeGateLU   = -10.0  // relative gate, below the absolute-gated mean
+	subBlockSeconds  = 0.1    // sub-block length (100 ms hop, 75% overlap); 4 per 400 ms block
+	subBlocksPerGate = 4      // 400 ms / 100 ms
+
+	// minSampleRate is the lowest supported rate. Below ~3364 Hz the K-weighting
+	// high-shelf center (1681.97 Hz) exceeds Nyquist and the bilinear transform
+	// produces unstable coefficients; 8000 Hz (the lowest standard audio rate)
+	// keeps the filter well-conditioned and the 100 ms sub-block non-empty.
+	minSampleRate = 8000
+)
+
+// Gating is performed in the energy domain (float32 comparisons) to avoid a
+// per-block log; only the final integrated value is converted to dB.
+var (
+	// absGateEnergy is the absolute -70 LUFS gate as a weighted-energy threshold:
+	// a block passes when z > absGateEnergy, equivalent to
+	// loudnessOffset + 10*log10(z) > absoluteGateLUFS.
+	absGateEnergy = float32(math.Pow(10, (absoluteGateLUFS-loudnessOffset)/10))
+	// relGateEnergyFactor is the energy ratio for the -10 LU relative gate.
+	relGateEnergyFactor = float32(math.Pow(10, relativeGateLU/10))
+)
+
+// biquadState is a stateful second-order section in float32. Coefficients are
+// computed in float64 (see kWeightingStages) and stored here as float32; the
+// per-sample recurrence runs in float32, which stays within ~0.001 LU of the
+// float64 result even for low-frequency, long-duration signals.
+type biquadState struct {
+	b0, b1, b2, a1, a2 float32
+	x1, x2, y1, y2     float32
+}
+
+func newBiquadState(c biquad) biquadState {
+	return biquadState{
+		b0: float32(c.b0), b1: float32(c.b1), b2: float32(c.b2),
+		a1: float32(c.a1), a2: float32(c.a2),
+	}
+}
+
+func (s *biquadState) process(x float32) float32 {
+	y := s.b0*x + s.b1*s.x1 + s.b2*s.x2 - s.a1*s.y1 - s.a2*s.y2
+	s.x2, s.x1 = s.x1, x
+	s.y2, s.y1 = s.y1, y
+	return y
+}
+
+func (s *biquadState) resetState() { s.x1, s.x2, s.y1, s.y2 = 0, 0, 0, 0 }
+
+// Meter accumulates K-weighted energy from interleaved PCM and computes the
+// BS.1770-4 gated integrated loudness. Feed all samples with AddFloat64/Float32/
+// Int16 (one or many calls), then read IntegratedLoudness. A Meter is not safe
+// for concurrent use. The numeric path is float32; the returned loudness and
+// true-peak values are float64.
+type Meter struct {
+	sampleRate   int
+	channels     int
+	weights      []float32
+	subBlockSize int // samples per channel in a 100 ms sub-block
+
+	stage1 []biquadState // per channel
+	stage2 []biquadState // per channel
+
+	accum    [][]float32 // per-channel K-weighted samples for the current sub-block
+	accumLen int         // frames filled in the current sub-block
+
+	// subEnergy[c] holds the sum of squares of each completed 100 ms sub-block
+	// for channel c.
+	subEnergy [][]float32
+
+	tp []truePeakChannel // per-channel true-peak estimator (raw, not K-weighted)
+
+	zBuf  []float32 // reusable per-block weighted-energy scratch for gating
+	tpSig []float32 // reusable [history | chunk] signal buffer for true-peak convolution
+}
+
+// subBlockSamples returns the number of samples per channel in a 100 ms gating
+// sub-block at the given sample rate. It is < 1 only for absurdly low rates,
+// which the public API rejects.
+func subBlockSamples(sampleRate int) int {
+	return int(math.Round(subBlockSeconds * float64(sampleRate)))
+}
+
+// NewMeter creates a meter for the given sample rate (Hz) and interleaved
+// channel count. It panics if channels is not positive or sampleRate is below
+// minSampleRate (8000 Hz); callers using the validated top-level API never hit
+// that.
+func NewMeter(sampleRate, channels int) *Meter {
+	if channels <= 0 {
+		panic("audionorm: NewMeter requires positive channels")
+	}
+	if sampleRate < minSampleRate {
+		panic("audionorm: NewMeter requires sample rate >= 8000 Hz")
+	}
+	s1, s2 := kWeightingStages(float64(sampleRate))
+	m := &Meter{
+		sampleRate:   sampleRate,
+		channels:     channels,
+		weights:      channelWeights(channels),
+		subBlockSize: subBlockSamples(sampleRate),
+		stage1:       make([]biquadState, channels),
+		stage2:       make([]biquadState, channels),
+		accum:        make([][]float32, channels),
+		subEnergy:    make([][]float32, channels),
+		tp:           make([]truePeakChannel, channels),
+		tpSig:        make([]float32, tapsPerPhase-1+tpChunk),
+	}
+	for c := range channels {
+		m.stage1[c] = newBiquadState(s1)
+		m.stage2[c] = newBiquadState(s2)
+		m.accum[c] = make([]float32, m.subBlockSize)
+	}
+	return m
+}
+
+// Reset returns the meter to its just-constructed state so it can be reused for
+// another clip without reallocating. Filter state, sub-block accumulation, true
+// peak, and gating buffers are cleared while their backing arrays are retained,
+// so a reused meter is allocation-free in steady state. Sample rate and channel
+// count are unchanged.
+func (m *Meter) Reset() {
+	for c := range m.channels {
+		m.stage1[c].resetState()
+		m.stage2[c].resetState()
+		m.subEnergy[c] = m.subEnergy[c][:0]
+		m.tp[c] = truePeakChannel{}
+	}
+	m.accumLen = 0
+}
+
+// AddFloat64 feeds interleaved float64 samples (range nominally [-1, 1]). The
+// length must be a multiple of the channel count; any trailing partial frame is
+// ignored. Samples are narrowed to float32 internally (lossless for audio in
+// [-1, 1]).
+func (m *Meter) AddFloat64(interleaved []float64) {
+	frames := len(interleaved) / m.channels
+	if frames == 0 {
+		return
+	}
+	for i := range frames {
+		base := i * m.channels
+		for c := range m.channels {
+			m.kweight(c, float32(interleaved[base+c]))
+		}
+		m.advanceFrame()
+	}
+	for c := range m.channels {
+		for pos := 0; pos < frames; pos += tpChunk {
+			n := min(tpChunk, frames-pos)
+			dst := m.tpChunkStart(c, n)
+			for i := range n {
+				dst[i] = float32(interleaved[(pos+i)*m.channels+c])
+			}
+			m.tpChunkEnd(c, n)
+		}
+	}
+}
+
+// AddFloat32 feeds interleaved float32 samples, the native BirdNET-Go format.
+func (m *Meter) AddFloat32(interleaved []float32) {
+	frames := len(interleaved) / m.channels
+	if frames == 0 {
+		return
+	}
+	for i := range frames {
+		base := i * m.channels
+		for c := range m.channels {
+			m.kweight(c, interleaved[base+c])
+		}
+		m.advanceFrame()
+	}
+	for c := range m.channels {
+		for pos := 0; pos < frames; pos += tpChunk {
+			n := min(tpChunk, frames-pos)
+			dst := m.tpChunkStart(c, n)
+			for i := range n {
+				dst[i] = interleaved[(pos+i)*m.channels+c]
+			}
+			m.tpChunkEnd(c, n)
+		}
+	}
+}
+
+// AddInt16 feeds interleaved 16-bit PCM, converting inline with the 1/32768
+// convention (exact in float32, a power of two).
+func (m *Meter) AddInt16(interleaved []int16) {
+	const scale = float32(1.0 / 32768.0)
+	frames := len(interleaved) / m.channels
+	if frames == 0 {
+		return
+	}
+	for i := range frames {
+		base := i * m.channels
+		for c := range m.channels {
+			m.kweight(c, float32(interleaved[base+c])*scale)
+		}
+		m.advanceFrame()
+	}
+	for c := range m.channels {
+		for pos := 0; pos < frames; pos += tpChunk {
+			n := min(tpChunk, frames-pos)
+			dst := m.tpChunkStart(c, n)
+			for i := range n {
+				dst[i] = float32(interleaved[(pos+i)*m.channels+c]) * scale
+			}
+			m.tpChunkEnd(c, n)
+		}
+	}
+}
+
+// kweight runs one sample of channel c through the K-weighting cascade, storing
+// the weighted result in the current sub-block accumulator.
+func (m *Meter) kweight(c int, x float32) {
+	m.accum[c][m.accumLen] = m.stage2[c].process(m.stage1[c].process(x))
+}
+
+// tpChunkStart copies channel c's carried-over history into the shared true-peak
+// signal buffer and returns the slice to fill with the next n raw samples.
+func (m *Meter) tpChunkStart(c, n int) []float32 {
+	copy(m.tpSig[:tapsPerPhase-1], m.tp[c].hist[:])
+	return m.tpSig[tapsPerPhase-1 : tapsPerPhase-1+n]
+}
+
+// tpChunkEnd runs the fused oversampling peak detection over the filled buffer.
+func (m *Meter) tpChunkEnd(c, n int) {
+	m.tp[c].batch(m.tpSig[:tapsPerPhase-1+n])
+}
+
+// advanceFrame closes the current sub-block when it fills, recording its energy.
+func (m *Meter) advanceFrame() {
+	m.accumLen++
+	if m.accumLen == m.subBlockSize {
+		for c := range m.channels {
+			m.subEnergy[c] = append(m.subEnergy[c], simdf32.SumOfSquares(m.accum[c]))
+		}
+		m.accumLen = 0
+	}
+}
+
+// blockEnergies returns the per-gating-block weighted mean-square energy z_j
+// (sum_i G_i * meanSquare_i) over all overlapping 400 ms blocks.
+func (m *Meter) blockEnergies() []float32 {
+	numSub := len(m.subEnergy[0])
+	numBlocks := numSub - (subBlocksPerGate - 1)
+	if numBlocks <= 0 {
+		return nil
+	}
+	blockSamples := float32(subBlocksPerGate * m.subBlockSize)
+	if cap(m.zBuf) < numBlocks {
+		m.zBuf = make([]float32, numBlocks)
+	}
+	z := m.zBuf[:numBlocks]
+	for j := range numBlocks {
+		var sum float32
+		for c := range m.channels {
+			e := m.subEnergy[c][j] + m.subEnergy[c][j+1] + m.subEnergy[c][j+2] + m.subEnergy[c][j+3]
+			sum += m.weights[c] * (e / blockSamples)
+		}
+		z[j] = sum
+	}
+	return z
+}
+
+// IntegratedLoudness returns the BS.1770-4 gated integrated loudness in LUFS.
+// It returns negative infinity when the input is shorter than one 400 ms block
+// or entirely below the absolute gate (silence). Gating runs in the energy
+// domain (float32); only the final dB conversion uses float64.
+func (m *Meter) IntegratedLoudness() float64 {
+	z := m.blockEnergies()
+	if len(z) == 0 {
+		return math.Inf(-1)
+	}
+
+	// Absolute gate at -70 LUFS (z > absGateEnergy).
+	var sumAbs float32
+	var cntAbs int
+	for _, zj := range z {
+		if zj > absGateEnergy {
+			sumAbs += zj
+			cntAbs++
+		}
+	}
+	if cntAbs == 0 {
+		return math.Inf(-1)
+	}
+
+	// Relative gate: 10 LU below the absolute-gated mean (z > 0.1 * meanAbs).
+	relGate := (sumAbs / float32(cntAbs)) * relGateEnergyFactor
+	var sumRel float32
+	var cntRel int
+	for _, zj := range z {
+		if zj > absGateEnergy && zj > relGate {
+			sumRel += zj
+			cntRel++
+		}
+	}
+	if cntRel == 0 {
+		return math.Inf(-1)
+	}
+	return loudnessOffset + 10*math.Log10(float64(sumRel)/float64(cntRel))
+}
+
+// TruePeakDBTP returns the maximum true peak across all channels in dBTP (full
+// scale = 0 dBTP). It returns negative infinity for digital silence.
+func (m *Meter) TruePeakDBTP() float64 {
+	maxDB := math.Inf(-1)
+	for c := range m.tp {
+		if d := m.tp[c].dbtp(); d > maxDB {
+			maxDB = d
+		}
+	}
+	return maxDB
+}
+
+// channelWeights returns the BS.1770-4 channel weighting coefficients G_i for a
+// standard interleaved layout. Mono, stereo, 3.0 and 4.0 use unity weights; 5.0
+// and 5.1 apply the +1.5 dB surround weighting and exclude LFE.
+func channelWeights(channels int) []float32 {
+	w := make([]float32, channels)
+	for i := range w {
+		w[i] = 1.0
+	}
+	switch channels {
+	case 5: // L R C Ls Rs
+		w[3], w[4] = 1.41, 1.41
+	case 6: // 5.1: L R C LFE Ls Rs
+		w[3] = 0.0
+		w[4], w[5] = 1.41, 1.41
+	}
+	return w
+}

--- a/internal/audiocore/audionorm/meter_test.go
+++ b/internal/audiocore/audionorm/meter_test.go
@@ -1,0 +1,147 @@
+package audionorm
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+// sineInterleaved synthesizes `seconds` of a `freq` Hz sine at `dbfs` peak
+// level, replicated in-phase across `channels` interleaved channels.
+func sineInterleaved(dbfs, freq, seconds, fs float64, channels int) []float64 {
+	amp := math.Pow(10, dbfs/20)
+	n := int(seconds * fs)
+	out := make([]float64, n*channels)
+	w := 2 * math.Pi * freq / fs
+	for i := range n {
+		s := amp * math.Sin(w*float64(i))
+		for c := range channels {
+			out[i*channels+c] = s
+		}
+	}
+	return out
+}
+
+func measure(t *testing.T, pcm []float64, fs, channels int) float64 {
+	t.Helper()
+	m := NewMeter(fs, channels)
+	m.AddFloat64(pcm)
+	return m.IntegratedLoudness()
+}
+
+// EBU Tech 3341 Test Case 1: stereo 1 kHz sine at -23 dBFS reads -23.0 LUFS.
+// This is the calibration anchor of the whole standard.
+func TestMeterStereo1kHzMinus23(t *testing.T) {
+	got := measure(t, sineInterleaved(-23, 1000, 4, 48000, 2), 48000, 2)
+	if math.Abs(got-(-23.0)) > 0.1 {
+		t.Errorf("integrated loudness = %.3f LUFS, want -23.0 +/-0.1", got)
+	}
+}
+
+// EBU Tech 3341 Test Case 2: stereo 1 kHz sine at -33 dBFS reads -33.0 LUFS.
+func TestMeterStereo1kHzMinus33(t *testing.T) {
+	got := measure(t, sineInterleaved(-33, 1000, 4, 48000, 2), 48000, 2)
+	if math.Abs(got-(-33.0)) > 0.1 {
+		t.Errorf("integrated loudness = %.3f LUFS, want -33.0 +/-0.1", got)
+	}
+}
+
+// EBU Tech 3341 Test Case 3: -23 dBFS tone for 10 s then silence for 10 s still
+// reads -23.0 LUFS, because the absolute -70 LUFS gate discards the silence.
+func TestMeterAbsoluteGateDiscardsSilence(t *testing.T) {
+	fs := 48000
+	tone := sineInterleaved(-23, 1000, 10, float64(fs), 2)
+	silence := make([]float64, 10*fs*2)
+	pcm := slices.Concat(tone, silence)
+	got := measure(t, pcm, fs, 2)
+	if math.Abs(got-(-23.0)) > 0.1 {
+		t.Errorf("integrated loudness = %.3f LUFS, want -23.0 +/-0.1 (silence must be gated)", got)
+	}
+}
+
+// Mono is the BirdNET-Go signal. A mono 1 kHz sine at -23 dBFS reads
+// 10*log10(2) ~= 3.01 dB lower than the stereo case, i.e. -26.01 LUFS.
+func TestMeterMono1kHzMinus23(t *testing.T) {
+	got := measure(t, sineInterleaved(-23, 1000, 4, 48000, 1), 48000, 1)
+	want := -23.0 - 10*math.Log10(2)
+	if math.Abs(got-want) > 0.1 {
+		t.Errorf("mono integrated loudness = %.3f LUFS, want %.3f +/-0.1", got, want)
+	}
+}
+
+// AddInt16 must produce the same loudness as feeding the equivalent float64
+// samples, since it just converts inline.
+func TestMeterAddInt16MatchesFloat64(t *testing.T) {
+	i16 := sineInt16(-14, 1000, 2, 48000)
+	f64 := make([]float64, len(i16))
+	for i, s := range i16 {
+		f64[i] = float64(s) / 32768
+	}
+
+	mi := NewMeter(48000, 1)
+	mi.AddInt16(i16)
+	mf := NewMeter(48000, 1)
+	mf.AddFloat64(f64)
+
+	if mi.IntegratedLoudness() != mf.IntegratedLoudness() {
+		t.Errorf("AddInt16 loudness %.6f != AddFloat64 %.6f", mi.IntegratedLoudness(), mf.IntegratedLoudness())
+	}
+}
+
+// AddFloat32 must match AddFloat64 of the widened samples exactly.
+func TestMeterAddFloat32MatchesFloat64(t *testing.T) {
+	f32 := sineFloat32(-14, 1000, 2, 48000, 1)
+	f64 := make([]float64, len(f32))
+	for i, s := range f32 {
+		f64[i] = float64(s)
+	}
+
+	ma := NewMeter(48000, 1)
+	ma.AddFloat32(f32)
+	mb := NewMeter(48000, 1)
+	mb.AddFloat64(f64)
+
+	if ma.IntegratedLoudness() != mb.IntegratedLoudness() {
+		t.Errorf("AddFloat32 loudness %.6f != AddFloat64 %.6f", ma.IntegratedLoudness(), mb.IntegratedLoudness())
+	}
+}
+
+// The LFE channel (index 3 in a 5.1 layout) has weight 0, so energy there must
+// not contribute to loudness. A 5.1 signal with a loud tone only in LFE reads as
+// silence.
+func TestMeterLFEExcluded(t *testing.T) {
+	const fs, channels = 48000, 6
+	n := fs * 2
+	pcm := make([]float64, n*channels)
+	amp := 0.5 // a loud tone, but only in LFE
+	w := 2 * math.Pi * 1000 / float64(fs)
+	for i := range n {
+		pcm[i*channels+3] = amp * math.Sin(w*float64(i)) // LFE only
+	}
+	got := measure(t, pcm, fs, channels)
+	if !math.IsInf(got, -1) {
+		t.Errorf("LFE-only 5.1 signal measured %.3f LUFS, want -Inf (LFE excluded)", got)
+	}
+}
+
+// Pure-Go relative-gate check (independent of ffmpeg): a loud segment followed by
+// a much quieter one. The quiet segment passes the absolute gate but falls below
+// the relative gate (-10 LU under the mean), so it is excluded and the result
+// equals the loud segment's loudness.
+func TestMeterRelativeGateExcludesQuietSegment(t *testing.T) {
+	fs := 48000
+	loud := sineInterleaved(-20, 1000, 5, float64(fs), 2)  // -20 LUFS
+	quiet := sineInterleaved(-50, 1000, 5, float64(fs), 2) // -50 LUFS, gated out
+	got := measure(t, append(loud, quiet...), fs, 2)
+	if math.Abs(got-(-20.0)) > 0.2 {
+		t.Errorf("integrated loudness = %.3f LUFS, want -20.0 +/-0.2 (quiet part relative-gated)", got)
+	}
+}
+
+// A signal shorter than one 400 ms gating block has no measurable loudness.
+func TestMeterTooShortIsSilent(t *testing.T) {
+	got := measure(t, sineInterleaved(-23, 1000, 0.2, 48000, 1), 48000, 1)
+	if !math.IsInf(got, -1) {
+		t.Errorf("integrated loudness = %.3f, want -Inf for sub-400ms input", got)
+	}
+}

--- a/internal/audiocore/audionorm/pcm.go
+++ b/internal/audiocore/audionorm/pcm.go
@@ -1,0 +1,38 @@
+package audionorm
+
+import simdf32 "github.com/tphakala/simd/f32"
+
+// gainChunk bounds the scratch buffer used to apply int16 gain so memory stays
+// O(1) regardless of clip length.
+const gainChunk = 8192
+
+// applyGainFloat32 multiplies every sample by a linear gain in place. Float
+// samples are not clamped: the caller's true-peak ceiling is what bounds them.
+func applyGainFloat32(pcm []float32, gain float64) {
+	if gain == 1.0 || len(pcm) == 0 {
+		return
+	}
+	simdf32.Scale(pcm, pcm, float32(gain))
+}
+
+// applyGainInt16 multiplies every sample by a linear gain in place, rounding to
+// the nearest integer (ties to even) and saturating to the int16 range so a
+// boost can never wrap around. Both the multiply and the saturating round are
+// SIMD-accelerated. Work proceeds in fixed-size chunks to avoid allocating a
+// full-length scratch buffer for large clips.
+func applyGainInt16(pcm []int16, gain float64) {
+	if gain == 1.0 || len(pcm) == 0 {
+		return
+	}
+	g := float32(gain)
+	var scratch [gainChunk]float32
+	for start := 0; start < len(pcm); start += gainChunk {
+		end := min(start+gainChunk, len(pcm))
+		seg := pcm[start:end]
+		buf := scratch[:len(seg)]
+		// buf = seg * gain in int16 magnitude units, then round-to-even and
+		// saturate back into seg. Float32ToInt16Scale clamps to [-32768, 32767].
+		simdf32.Int16ToFloat32Scale(buf, seg, g)
+		simdf32.Float32ToInt16Scale(seg, buf, 1.0)
+	}
+}

--- a/internal/audiocore/audionorm/pcm_test.go
+++ b/internal/audiocore/audionorm/pcm_test.go
@@ -1,0 +1,65 @@
+package audionorm
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+func TestApplyGainFloat32(t *testing.T) {
+	pcm := []float32{0.1, -0.2, 0.3, -0.05}
+	applyGainFloat32(pcm, 2.0)
+	want := []float32{0.2, -0.4, 0.6, -0.1}
+	for i := range pcm {
+		if math.Abs(float64(pcm[i]-want[i])) > 1e-6 {
+			t.Errorf("pcm[%d] = %g, want %g", i, pcm[i], want[i])
+		}
+	}
+}
+
+func TestApplyGainInt16ScalesAndRounds(t *testing.T) {
+	pcm := []int16{100, -100, 10000, -10000}
+	applyGainInt16(pcm, 2.0)
+	want := []int16{200, -200, 20000, -20000}
+	for i := range pcm {
+		if pcm[i] != want[i] {
+			t.Errorf("pcm[%d] = %d, want %d", i, pcm[i], want[i])
+		}
+	}
+}
+
+// Boosting past full scale must saturate, never wrap around.
+func TestApplyGainInt16Saturates(t *testing.T) {
+	pcm := []int16{20000, -20000, 32767, -32768}
+	applyGainInt16(pcm, 4.0)
+	want := []int16{32767, -32768, 32767, -32768}
+	for i := range pcm {
+		if pcm[i] != want[i] {
+			t.Errorf("pcm[%d] = %d, want %d (must saturate, not wrap)", i, pcm[i], want[i])
+		}
+	}
+}
+
+// Half-integer results must round to even (matching the documented behavior),
+// not truncate or round half-up.
+func TestApplyGainInt16RoundsHalfToEven(t *testing.T) {
+	pcm := []int16{1, 3, 5, 7}
+	applyGainInt16(pcm, 2.5) // -> 2.5, 7.5, 12.5, 17.5
+	want := []int16{2, 8, 12, 18}
+	for i := range pcm {
+		if pcm[i] != want[i] {
+			t.Errorf("pcm[%d] = %d, want %d (round half to even)", i, pcm[i], want[i])
+		}
+	}
+}
+
+func TestApplyGainInt16Unity(t *testing.T) {
+	pcm := []int16{1, -1, 12345, -12345, 32767, -32768}
+	orig := slices.Clone(pcm)
+	applyGainInt16(pcm, 1.0)
+	for i := range pcm {
+		if pcm[i] != orig[i] {
+			t.Errorf("unity gain changed pcm[%d]: %d -> %d", i, orig[i], pcm[i])
+		}
+	}
+}

--- a/internal/audiocore/audionorm/truepeak.go
+++ b/internal/audiocore/audionorm/truepeak.go
@@ -1,0 +1,172 @@
+package audionorm
+
+import (
+	"math"
+
+	simdf32 "github.com/tphakala/simd/f32"
+)
+
+// True-peak estimation per ITU-R BS.1770-4 Annex 2: oversample by 4x with a
+// low-pass interpolation FIR and take the maximum absolute value of the
+// reconstructed signal.
+const (
+	oversample   = 4  // 4x oversampling (sufficient for fs <= 48 kHz per BS.1770-4)
+	tapsPerPhase = 32 // taps per polyphase branch
+	protoLen     = oversample * tapsPerPhase
+	kaiserBeta   = 9.0  // window beta: sharp passband to Nyquist, matches swresample defaults
+	tpChunk      = 8192 // samples per SIMD convolution batch (bounds true-peak scratch)
+)
+
+// tpCoef[p][t] is the polyphase interpolation kernel: phase p (fractional
+// position p/oversample), tap t weighting input sample x[k-t]. Built once from a
+// Kaiser-windowed sinc with cutoff at the original Nyquist and normalized so
+// each phase is a partition of unity (a constant input is reproduced exactly).
+// A sharp Kaiser window keeps the passband flat up to Nyquist, so it captures
+// the inter-sample overshoot of high-frequency content rather than rolling it
+// off (which would under-report the true peak).
+var tpCoef = buildTruePeakKernel()
+
+// tpKernelRev holds each phase's coefficients reversed. simd ConvolveValid
+// computes a correlation (dst[i] = sum(signal[i+j]*kernel[j])), so feeding it
+// the reversed kernel yields the true convolution sum_t coef[t]*signal[k-t],
+// which is exactly the per-sample polyphase output. This lets the whole
+// oversampling pass run as batched SIMD convolutions instead of a scalar dot
+// product per input sample.
+var tpKernelRev = func() [oversample][tapsPerPhase]float32 {
+	var r [oversample][tapsPerPhase]float32
+	for p := range oversample {
+		for t := range tapsPerPhase {
+			r[p][t] = float32(tpCoef[p][tapsPerPhase-1-t])
+		}
+	}
+	return r
+}()
+
+// tpKernelsRev is a slice-of-slices view of the reversed phase kernels, the form
+// ConvolveValidMaxAbsMulti takes (one fused pass over all polyphase branches).
+var tpKernelsRev = func() [][]float32 {
+	ks := make([][]float32, oversample)
+	for p := range oversample {
+		ks[p] = tpKernelRev[p][:]
+	}
+	return ks
+}()
+
+func buildTruePeakKernel() [oversample][tapsPerPhase]float64 {
+	proto := make([]float64, protoLen)
+	center := float64(protoLen-1) / 2.0
+	for n := range protoLen {
+		x := (float64(n) - center) / float64(oversample)
+		proto[n] = sinc(x) * kaiser(n, protoLen, kaiserBeta)
+	}
+
+	var k [oversample][tapsPerPhase]float64
+	for p := range oversample {
+		var sum float64
+		for t := range tapsPerPhase {
+			c := proto[p+oversample*t]
+			k[p][t] = c
+			sum += c
+		}
+		if sum != 0 {
+			for t := range tapsPerPhase {
+				k[p][t] /= sum
+			}
+		}
+	}
+	return k
+}
+
+func sinc(x float64) float64 {
+	if x == 0 {
+		return 1
+	}
+	px := math.Pi * x
+	return math.Sin(px) / px
+}
+
+// kaiser returns the n-th sample of a length-`length` Kaiser window with shape
+// parameter beta.
+func kaiser(n, length int, beta float64) float64 {
+	N := float64(length - 1)
+	r := 2*float64(n)/N - 1 // -1 .. 1
+	return besselI0(beta*math.Sqrt(1-r*r)) / besselI0(beta)
+}
+
+// besselI0 is the zeroth-order modified Bessel function of the first kind,
+// evaluated by its rapidly converging power series.
+func besselI0(x float64) float64 {
+	sum := 1.0
+	term := 1.0
+	half := x / 2
+	for k := 1; k < 40; k++ {
+		term *= (half / float64(k)) * (half / float64(k))
+		sum += term
+		if term < 1e-15*sum {
+			break
+		}
+	}
+	return sum
+}
+
+// truePeakChannel estimates the true peak of one channel. Samples are processed
+// in batches: hist carries the last tapsPerPhase-1 samples across batches so the
+// oversampling filter spans batch boundaries seamlessly.
+type truePeakChannel struct {
+	hist   [tapsPerPhase - 1]float32
+	maxAbs float32
+}
+
+// absF32 returns the absolute value of a float32 (math.Abs is float64-only).
+func absF32(x float32) float32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// batch processes one sub-chunk of raw samples. sig is [history | new samples]
+// with len(sig) == tapsPerPhase-1+n. It updates maxAbs with both the raw sample
+// peak and the 4x-oversampled peak (the max across all polyphase branches,
+// computed in one fused SIMD pass with no output materialization), then stores
+// the last tapsPerPhase-1 samples as history for the next batch.
+func (t *truePeakChannel) batch(sig []float32) {
+	// Raw sample peak (vectorized), so the estimate never under-reports the input.
+	if pk := simdf32.MaxAbs(sig[tapsPerPhase-1:]); pk > t.maxAbs {
+		t.maxAbs = pk
+	}
+	// Oversampled peak: the max across all 4 polyphase branches in one fused pass
+	// (dedicated SIMD kernel, no output materialization, signal read once).
+	if pk := simdf32.ConvolveValidMaxAbsMulti(sig, tpKernelsRev); pk > t.maxAbs {
+		t.maxAbs = pk
+	}
+	copy(t.hist[:], sig[len(sig)-(tapsPerPhase-1):])
+}
+
+// dbtp converts the linear maximum to dBTP (full scale = 1.0). It first drains
+// the interpolator's group delay (about tapsPerPhase/2 samples) by sliding
+// trailing zeros through the history, so inter-sample peaks in the final samples
+// are captured. The drain runs on a stack-local copy and only reads state, so it
+// allocates nothing and repeated calls are idempotent.
+func (t *truePeakChannel) dbtp() float64 {
+	maxAbs := t.maxAbs
+	const drainLen = tapsPerPhase / 2
+	var sig [tapsPerPhase - 1 + drainLen]float32 // history followed by zeros
+	copy(sig[:tapsPerPhase-1], t.hist[:])
+	for i := range drainLen {
+		for p := range oversample {
+			rev := &tpKernelRev[p]
+			var y float32
+			for j := range tapsPerPhase {
+				y += sig[i+j] * rev[j]
+			}
+			if a := absF32(y); a > maxAbs {
+				maxAbs = a
+			}
+		}
+	}
+	if maxAbs <= 0 {
+		return math.Inf(-1)
+	}
+	return 20 * math.Log10(float64(maxAbs))
+}

--- a/internal/audiocore/audionorm/truepeak_test.go
+++ b/internal/audiocore/audionorm/truepeak_test.go
@@ -1,0 +1,57 @@
+package audionorm
+
+import (
+	"math"
+	"testing"
+)
+
+// The true peak of a pure sine equals its amplitude. A -6 dBFS, 1 kHz sine must
+// therefore measure about -6.0 dBTP after oversampling.
+func TestTruePeakSineAmplitude(t *testing.T) {
+	m := NewMeter(48000, 1)
+	m.AddFloat64(sineInterleaved(-6, 1000, 1, 48000, 1))
+	got := m.TruePeakDBTP()
+	if math.Abs(got-(-6.0)) > 0.2 {
+		t.Errorf("true peak = %.3f dBTP, want -6.0 +/-0.2", got)
+	}
+}
+
+// Silence has no peak.
+func TestTruePeakSilence(t *testing.T) {
+	m := NewMeter(48000, 1)
+	m.AddFloat64(make([]float64, 48000))
+	got := m.TruePeakDBTP()
+	if !math.IsInf(got, -1) {
+		t.Errorf("true peak = %.3f dBTP, want -Inf for silence", got)
+	}
+}
+
+// TruePeakDBTP must be non-destructive: the group-delay drain runs on a copy of
+// the filter state, so repeated calls return the same value.
+func TestTruePeakIdempotent(t *testing.T) {
+	m := NewMeter(48000, 1)
+	m.AddFloat64(sineInterleaved(-6, 4000, 0.5, 48000, 1))
+	first := m.TruePeakDBTP()
+	second := m.TruePeakDBTP()
+	if first != second {
+		t.Errorf("TruePeakDBTP not idempotent: %.6f then %.6f", first, second)
+	}
+}
+
+// Oversampled true peak must never under-report the raw sample peak.
+func TestTruePeakAtLeastSamplePeak(t *testing.T) {
+	pcm := sineInterleaved(-3, 5000, 0.5, 48000, 1)
+	var samplePeak float64
+	for _, s := range pcm {
+		// The meter processes float32, so compare against the float32 sample peak.
+		if a := math.Abs(float64(float32(s))); a > samplePeak {
+			samplePeak = a
+		}
+	}
+	m := NewMeter(48000, 1)
+	m.AddFloat64(pcm)
+	tp := math.Pow(10, m.TruePeakDBTP()/20)
+	if tp < samplePeak-1e-9 {
+		t.Errorf("true peak %.6f below sample peak %.6f", tp, samplePeak)
+	}
+}

--- a/internal/audiocore/flac/doc.go
+++ b/internal/audiocore/flac/doc.go
@@ -1,6 +1,7 @@
-// Package flac provides native, FFmpeg-free FLAC encoding of detection audio
-// clips using github.com/tphakala/go-flac. The native path is selected at
-// runtime by the BIRDNET_FLAC_ENCODER environment variable; when it is not
-// selected the caller keeps using the FFmpeg-based exporter. This package is
-// scoped to the detection save path (raw PCM to FLAC) only.
+// Package flac provides native, FFmpeg-free FLAC encoding of audio clips using
+// github.com/tphakala/go-flac. The native path is selected at runtime by the
+// BIRDNET_FLAC_ENCODER environment variable; when it is not selected the caller
+// keeps using the FFmpeg-based exporter. EncodePCM writes a FLAC file (the
+// detection save path); EncodePCMToBuffer returns FLAC bytes in memory (the
+// BirdWeather soundscape upload path).
 package flac

--- a/internal/audiocore/flac/encode.go
+++ b/internal/audiocore/flac/encode.go
@@ -84,7 +84,7 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 			Context("operation", "flac_encode_validate").
 			Build()
 	}
-	if err := validateEncodeInput(opts.PCMData, opts.BitDepth); err != nil {
+	if err := validateEncodeInput(opts.PCMData, opts.BitDepth, opts.Channels); err != nil {
 		return err
 	}
 	if opts.OutputPath == "" {
@@ -176,7 +176,7 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 
 // validateEncodeInput checks the PCM data and bit depth shared by the file and
 // buffer encode entry points. It returns an enhanced validation error or nil.
-func validateEncodeInput(pcmData []byte, bitDepth int) error {
+func validateEncodeInput(pcmData []byte, bitDepth, channels int) error {
 	if len(pcmData) == 0 {
 		return errors.Newf("flac encode: empty PCM data").
 			Component("audiocore/flac").
@@ -192,15 +192,24 @@ func validateEncodeInput(pcmData []byte, bitDepth int) error {
 			Context("bit_depth", bitDepth).
 			Build()
 	}
-	// Reject a partial trailing sample early with a clear error rather than
-	// letting it surface as an opaque flush failure deep inside go-flac.
-	if bytesPerSample := bitDepth / 8; len(pcmData)%bytesPerSample != 0 {
-		return errors.Newf("flac encode: PCM length %d is not a multiple of the %d-byte sample size", len(pcmData), bytesPerSample).
+	if channels <= 0 {
+		return errors.Newf("flac encode: channels must be positive, got %d", channels).
+			Component("audiocore/flac").
+			Category(errors.CategoryValidation).
+			Context("operation", "flac_encode_validate").
+			Context("channels", channels).
+			Build()
+	}
+	// Reject a partial trailing frame early with a clear error rather than
+	// letting it surface as an opaque flush failure deep inside go-flac. A full
+	// inter-channel sample (frame) is bytesPerSample*channels.
+	if bytesPerFrame := (bitDepth / 8) * channels; len(pcmData)%bytesPerFrame != 0 {
+		return errors.Newf("flac encode: PCM length %d is not a multiple of the %d-byte frame size (%d-bit x %d ch)", len(pcmData), bytesPerFrame, bitDepth, channels).
 			Component("audiocore/flac").
 			Category(errors.CategoryValidation).
 			Context("operation", "flac_encode_validate").
 			Context("pcm_len", len(pcmData)).
-			Context("bytes_per_sample", bytesPerSample).
+			Context("bytes_per_frame", bytesPerFrame).
 			Build()
 	}
 	return nil
@@ -323,7 +332,7 @@ func EncodePCMToBuffer(ctx context.Context, opts *BufferOptions) (*bytes.Buffer,
 			Context("operation", "flac_encode_validate").
 			Build()
 	}
-	if err := validateEncodeInput(opts.PCMData, opts.BitDepth); err != nil {
+	if err := validateEncodeInput(opts.PCMData, opts.BitDepth, opts.Channels); err != nil {
 		return nil, err
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {

--- a/internal/audiocore/flac/encode.go
+++ b/internal/audiocore/flac/encode.go
@@ -1,7 +1,9 @@
 package flac
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -82,20 +84,8 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 			Context("operation", "flac_encode_validate").
 			Build()
 	}
-	if len(opts.PCMData) == 0 {
-		return errors.Newf("flac encode: empty PCM data").
-			Component("audiocore/flac").
-			Category(errors.CategoryValidation).
-			Context("operation", "flac_encode_validate").
-			Build()
-	}
-	if !SupportedBitDepth(opts.BitDepth) {
-		return errors.Newf("flac encode: unsupported bit depth %d", opts.BitDepth).
-			Component("audiocore/flac").
-			Category(errors.CategoryValidation).
-			Context("operation", "flac_encode_validate").
-			Context("bit_depth", opts.BitDepth).
-			Build()
+	if err := validateEncodeInput(opts.PCMData, opts.BitDepth); err != nil {
+		return err
 	}
 	if opts.OutputPath == "" {
 		return errors.Newf("flac encode: empty output path").
@@ -154,31 +144,8 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 		SeekTableInterval: opts.SampleRate,
 	}
 
-	enc := encoderPool.Get().(*goflac.Encoder)
-	if resetErr := enc.Reset(f, cfg); resetErr != nil {
-		// A failed Reset may leave the encoder half-initialized; go-flac's
-		// contract says it must not be reused, so drop it (do not Put it back)
-		// and let the pool allocate a fresh one next time.
-		return errors.New(resetErr).
-			Component("audiocore/flac").
-			Category(errors.CategoryAudio).
-			Context("operation", "flac_encode_reset").
-			Build()
-	}
-	// Reset succeeded: safe to return to the pool even if a later Write/Close
-	// errors, since the next Get/Reset fully reinitializes it.
-	defer encoderPool.Put(enc)
-
-	if writeErr := encodeSamples(ctx, enc, opts); writeErr != nil {
-		return writeErr
-	}
-
-	if closeErr := enc.Close(); closeErr != nil {
-		return errors.New(closeErr).
-			Component("audiocore/flac").
-			Category(errors.CategoryAudio).
-			Context("operation", "flac_encode_close").
-			Build()
+	if encErr := encodeToWriter(ctx, f, cfg, opts.PCMData, opts.GainDB); encErr != nil {
+		return encErr
 	}
 
 	if syncErr := f.Sync(); syncErr != nil {
@@ -207,32 +174,107 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 	return nil
 }
 
-// encodeSamples writes opts.PCMData to enc, applying gain when requested. With no
-// gain it is a single zero-copy Write; with gain it streams fixed-size chunks
-// through a pooled scratch buffer so the source is never copied wholesale or
-// mutated.
-func encodeSamples(ctx context.Context, enc *goflac.Encoder, opts *Options) error {
-	if opts.GainDB == 0 {
-		if _, err := enc.Write(opts.PCMData); err != nil {
+// validateEncodeInput checks the PCM data and bit depth shared by the file and
+// buffer encode entry points. It returns an enhanced validation error or nil.
+func validateEncodeInput(pcmData []byte, bitDepth int) error {
+	if len(pcmData) == 0 {
+		return errors.Newf("flac encode: empty PCM data").
+			Component("audiocore/flac").
+			Category(errors.CategoryValidation).
+			Context("operation", "flac_encode_validate").
+			Build()
+	}
+	if !SupportedBitDepth(bitDepth) {
+		return errors.Newf("flac encode: unsupported bit depth %d", bitDepth).
+			Component("audiocore/flac").
+			Category(errors.CategoryValidation).
+			Context("operation", "flac_encode_validate").
+			Context("bit_depth", bitDepth).
+			Build()
+	}
+	// Reject a partial trailing sample early with a clear error rather than
+	// letting it surface as an opaque flush failure deep inside go-flac.
+	if bytesPerSample := bitDepth / 8; len(pcmData)%bytesPerSample != 0 {
+		return errors.Newf("flac encode: PCM length %d is not a multiple of the %d-byte sample size", len(pcmData), bytesPerSample).
+			Component("audiocore/flac").
+			Category(errors.CategoryValidation).
+			Context("operation", "flac_encode_validate").
+			Context("pcm_len", len(pcmData)).
+			Context("bytes_per_sample", bytesPerSample).
+			Build()
+	}
+	return nil
+}
+
+// encodeToWriter encodes pcmData (applying gainDB when non-zero) to w using a
+// pooled go-flac encoder configured by cfg. It resets the encoder, writes the
+// samples, and closes the encoder (which patches STREAMINFO/SEEKTABLE when w is
+// an io.WriteSeeker), but does not close w itself. Used by both the file and
+// in-memory buffer entry points.
+func encodeToWriter(ctx context.Context, w io.Writer, cfg goflac.Config, pcmData []byte, gainDB float64) error {
+	enc := encoderPool.Get().(*goflac.Encoder)
+	if resetErr := enc.Reset(w, cfg); resetErr != nil {
+		// A failed Reset may leave the encoder half-initialized; go-flac's
+		// contract says it must not be reused, so drop it (do not Put it back)
+		// and let the pool allocate a fresh one next time.
+		return errors.New(resetErr).
+			Component("audiocore/flac").
+			Category(errors.CategoryAudio).
+			Context("operation", "flac_encode_reset").
+			Build()
+	}
+	// Reset succeeded, so the encoder may be pooled even if a later Write/Close
+	// errors. Before pooling, re-Reset onto io.Discard to drop the reference to
+	// w: for the buffer path w is the *bytes.Buffer holding the entire encoded
+	// clip, and a pooled encoder would otherwise pin that memory until its next
+	// use. go-flac exposes no writer setter, so re-Reset is the only way to
+	// release it; SeekTableInterval is zeroed so a non-seekable sink is accepted.
+	// This also re-primes the encoder, so it is pooled only if the re-Reset
+	// succeeds (a failed one drops the encoder, matching the failed-Reset path).
+	defer func() {
+		depinCfg := cfg
+		depinCfg.SeekTableInterval = 0
+		if enc.Reset(io.Discard, depinCfg) == nil {
+			encoderPool.Put(enc)
+		}
+	}()
+
+	if writeErr := encodeSamples(ctx, enc, pcmData, gainDB); writeErr != nil {
+		return writeErr
+	}
+
+	if closeErr := enc.Close(); closeErr != nil {
+		return errors.New(closeErr).
+			Component("audiocore/flac").
+			Category(errors.CategoryAudio).
+			Context("operation", "flac_encode_close").
+			Build()
+	}
+	return nil
+}
+
+// encodeSamples writes pcmData to enc, applying gain when requested. With no gain
+// it is a single zero-copy Write; with gain it streams fixed-size chunks through
+// a pooled scratch buffer so the source is never copied wholesale or mutated.
+func encodeSamples(ctx context.Context, enc *goflac.Encoder, pcmData []byte, gainDB float64) error {
+	if gainDB == 0 {
+		if _, err := enc.Write(pcmData); err != nil {
 			return wrapWriteErr(err)
 		}
 		return nil
 	}
 
-	factor := math.Pow(10, opts.GainDB/20)
+	factor := math.Pow(10, gainDB/20)
 	scratchPtr := gainScratchPool.Get().(*[]byte)
 	scratch := *scratchPtr
 	defer gainScratchPool.Put(scratchPtr)
 
-	src := opts.PCMData
+	src := pcmData
 	for off := 0; off < len(src); {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
-		end := off + len(scratch)
-		if end > len(src) {
-			end = len(src)
-		}
+		end := min(off+len(scratch), len(src))
 		chunk := scratch[:end-off]
 		applyGainInt16(chunk, src[off:end], factor)
 		if _, err := enc.Write(chunk); err != nil {
@@ -249,4 +291,58 @@ func wrapWriteErr(err error) error {
 		Category(errors.CategoryAudio).
 		Context("operation", "flac_encode_write").
 		Build()
+}
+
+// BufferOptions configures a native FLAC export of an in-memory PCM buffer to an
+// in-memory FLAC buffer. It mirrors Options without OutputPath.
+type BufferOptions struct {
+	// PCMData is interleaved little-endian PCM (the capture buffer format).
+	PCMData []byte
+	// SampleRate is the PCM sample rate in Hz.
+	SampleRate int
+	// Channels is the number of interleaved channels.
+	Channels int
+	// BitDepth is the PCM bit depth; only 16 is supported.
+	BitDepth int
+	// GainDB is the volume adjustment in dB (0 = no change).
+	GainDB float64
+}
+
+// EncodePCMToBuffer encodes opts.PCMData to a FLAC stream and returns it as an
+// in-memory buffer. Unlike EncodePCM it writes to a non-seekable bytes.Buffer,
+// so no SEEKTABLE is emitted and the STREAMINFO total-samples/MD5 fields are
+// left at their spec-legal "unknown" sentinels (the same result as FFmpeg
+// encoding to a pipe). A non-zero GainDB is applied in Go before encoding;
+// opts.PCMData itself is never modified. Intended for upload paths (e.g.
+// BirdWeather) that need FLAC bytes in memory rather than a file.
+func EncodePCMToBuffer(ctx context.Context, opts *BufferOptions) (*bytes.Buffer, error) {
+	if opts == nil {
+		return nil, errors.Newf("flac encode: nil options").
+			Component("audiocore/flac").
+			Category(errors.CategoryValidation).
+			Context("operation", "flac_encode_validate").
+			Build()
+	}
+	if err := validateEncodeInput(opts.PCMData, opts.BitDepth); err != nil {
+		return nil, err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+
+	cfg := goflac.Config{
+		SampleRate:       opts.SampleRate,
+		BitDepth:         opts.BitDepth,
+		Channels:         opts.Channels,
+		CompressionLevel: defaultCompressionLevel,
+		// No SeekTableInterval: a bytes.Buffer is not an io.WriteSeeker, and
+		// go-flac rejects a seektable on a non-seekable sink. Short upload clips
+		// do not need one.
+	}
+
+	buf := new(bytes.Buffer)
+	if encErr := encodeToWriter(ctx, buf, cfg, opts.PCMData, opts.GainDB); encErr != nil {
+		return nil, encErr
+	}
+	return buf, nil
 }

--- a/internal/audiocore/flac/encode_test.go
+++ b/internal/audiocore/flac/encode_test.go
@@ -1,6 +1,7 @@
 package flac
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -325,4 +326,112 @@ func TestSupportedBitDepth(t *testing.T) {
 	assert.True(t, SupportedBitDepth(16))
 	assert.False(t, SupportedBitDepth(24))
 	assert.False(t, SupportedBitDepth(0))
+}
+
+// decodeFLACBytes reads a FLAC byte stream back to interleaved little-endian PCM.
+func decodeFLACBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	dec, err := goflac.NewDecoder(bytes.NewReader(data))
+	require.NoError(t, err)
+	out, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	return out
+}
+
+func bufferBaseOpts(pcm []byte) *BufferOptions {
+	return &BufferOptions{
+		PCMData:    pcm,
+		SampleRate: testSampleRate,
+		Channels:   testChannels,
+		BitDepth:   testBitDepth,
+	}
+}
+
+func TestEncodePCMToBuffer_RoundTripLossless(t *testing.T) {
+	t.Parallel()
+	pcm := makeTestPCM(10000)
+	buf, err := EncodePCMToBuffer(t.Context(), bufferBaseOpts(pcm))
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+	assert.Equal(t, pcm, decodeFLACBytes(t, buf.Bytes()), "decoded PCM must equal input (lossless)")
+}
+
+// TestEncodePCMToBuffer_GainRoundTrip uses PCM larger than two gain scratch
+// chunks (with a non-aligned tail) so the shared chunked gain loop is exercised
+// through the buffer path too.
+func TestEncodePCMToBuffer_GainRoundTrip(t *testing.T) {
+	t.Parallel()
+	pcm := makeTestPCM(2*gainScratchBytes + 777)
+	opts := bufferBaseOpts(pcm)
+	opts.GainDB = 6.0 // roughly 2x
+	buf, err := EncodePCMToBuffer(t.Context(), opts)
+	require.NoError(t, err)
+
+	want := make([]byte, len(pcm))
+	applyGainInt16(want, pcm, math.Pow(10, opts.GainDB/20))
+	assert.Equal(t, want, decodeFLACBytes(t, buf.Bytes()),
+		"decoded PCM must equal the gained input (gain applied, stored losslessly)")
+}
+
+func TestEncodePCMToBuffer_StereoRoundTrip(t *testing.T) {
+	t.Parallel()
+	pcm := makeTestPCMStereo(10000)
+	opts := bufferBaseOpts(pcm)
+	opts.Channels = 2
+	buf, err := EncodePCMToBuffer(t.Context(), opts)
+	require.NoError(t, err)
+	assert.Equal(t, pcm, decodeFLACBytes(t, buf.Bytes()), "stereo decode must be lossless")
+}
+
+// TestEncodePCMToBuffer_NoSeekTable documents the intentional difference from the
+// file path: a bytes.Buffer is not seekable, so no SEEKTABLE is emitted, yet the
+// stream stays valid and decodable.
+func TestEncodePCMToBuffer_NoSeekTable(t *testing.T) {
+	t.Parallel()
+	pcm := makeTestPCM(60000)
+	buf, err := EncodePCMToBuffer(t.Context(), bufferBaseOpts(pcm))
+	require.NoError(t, err)
+	assert.False(t, hasSeekTable(buf.Bytes()), "buffer path must not emit a SEEKTABLE (non-seekable sink)")
+	assert.Equal(t, pcm, decodeFLACBytes(t, buf.Bytes()), "stream must still decode losslessly")
+}
+
+func TestEncodePCMToBuffer_Validation(t *testing.T) {
+	t.Parallel()
+	t.Run("nil options", func(t *testing.T) {
+		t.Parallel()
+		_, err := EncodePCMToBuffer(t.Context(), nil)
+		require.Error(t, err)
+	})
+	t.Run("empty pcm", func(t *testing.T) {
+		t.Parallel()
+		_, err := EncodePCMToBuffer(t.Context(), bufferBaseOpts(nil))
+		require.Error(t, err)
+	})
+	t.Run("unsupported bit depth", func(t *testing.T) {
+		t.Parallel()
+		opts := bufferBaseOpts(makeTestPCM(100))
+		opts.BitDepth = 24
+		_, err := EncodePCMToBuffer(t.Context(), opts)
+		require.Error(t, err)
+	})
+}
+
+func TestEncodePCMToBuffer_CancelledBeforeStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := EncodePCMToBuffer(ctx, bufferBaseOpts(makeTestPCM(10000)))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestEncodePCMToBuffer_CancelledDuringEncode exercises the per-chunk ctx check
+// inside the shared gain loop via the buffer path (the entry guard consumes one
+// Err() call, so after=1 cancels at the first gain-loop iteration).
+func TestEncodePCMToBuffer_CancelledDuringEncode(t *testing.T) {
+	t.Parallel()
+	opts := bufferBaseOpts(makeTestPCM(2*gainScratchBytes + 777))
+	opts.GainDB = 3.0 // gain path runs the per-chunk ctx check
+	ctx := &errAfterCtx{Context: t.Context(), after: 1}
+	_, err := EncodePCMToBuffer(ctx, opts)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/internal/audiocore/flac/gate.go
+++ b/internal/audiocore/flac/gate.go
@@ -9,10 +9,13 @@ import (
 // encoder. The value "native" enables the go-flac path; any other value (or
 // unset) keeps the FFmpeg exporter.
 //
-// This is a temporary opt-in gate. When the native encoder is trusted, the gate
-// is removed and FLAC always routes to the native path (normalization still
-// falls back to FFmpeg). Keep the read confined to NativeEncoderEnabled so the
-// gate is a single deletion site.
+// This is a temporary opt-in gate shared by every native FLAC path: the
+// detection save path (EncodePCM) and the BirdWeather soundscape upload path
+// (EncodePCMToBuffer + audionorm normalization). When the native encoder is
+// trusted, the gate is removed and FLAC always routes to the native path. The
+// detection save path still falls back to FFmpeg when EBU R128 normalization is
+// enabled; the BirdWeather path normalizes natively via audionorm. Keep the read
+// confined to NativeEncoderEnabled so the gate is a single deletion site.
 const envFlacEncoder = "BIRDNET_FLAC_ENCODER"
 
 // nativeEncoderValue is the only env value that enables the native encoder.

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/alerting"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -1095,10 +1096,21 @@ type audioEncodingResult struct {
 	ext    string
 }
 
-// encodeAudioForUpload handles the PCM to FLAC encoding using FFmpeg
-// FFmpeg is required as BirdWeather only accepts FLAC format
+// encodeAudioForUpload encodes the PCM soundscape to FLAC for upload. With the
+// BIRDNET_FLAC_ENCODER=native gate on it uses the native go-flac + audionorm
+// path (no FFmpeg dependency); otherwise it falls back to the FFmpeg encoder,
+// which BirdWeather has always required for its FLAC-only API.
 func (b *BwClient) encodeAudioForUpload(settings *conf.Settings, pcmData []byte, timestamp string) (*audioEncodingResult, error) {
 	log := GetLogger()
+
+	// Native path first: gated by the same flag as the detection save path. This
+	// must be checked BEFORE the FFmpeg-availability guard so a host without
+	// FFmpeg can still upload natively.
+	if flac.NativeEncoderEnabled() && flac.SupportedBitDepth(conf.BitDepth) {
+		log.Debug("Using native go-flac encoder for BirdWeather upload",
+			logger.String("timestamp", timestamp))
+		return b.encodeWithNativeFLAC(pcmData, timestamp)
+	}
 
 	// Use the validated FFmpeg path from settings (validated at startup)
 	// This avoids redundant exec.LookPath calls on every upload

--- a/internal/birdweather/encode_native.go
+++ b/internal/birdweather/encode_native.go
@@ -1,0 +1,120 @@
+// encode_native.go implements the FFmpeg-free FLAC encoding path for BirdWeather
+// soundscape uploads. It is selected by the same BIRDNET_FLAC_ENCODER=native gate
+// as the detection save path (see internal/audiocore/flac). Loudness is matched
+// to the FFmpeg path's target (-23 LUFS) using the native audionorm library,
+// which additionally applies true-peak limiting the old volume-filter path
+// lacked.
+package birdweather
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/audiocore/flac"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// maxGainDB bounds the normalization gain, matching the FFmpeg path's safety
+// limit so a near-silent clip is not over-amplified into loud static.
+const maxGainDB = 30.0
+
+// encodeWithNativeFLAC encodes PCM to an in-memory FLAC buffer using the native
+// go-flac encoder and audionorm loudness normalization, with no FFmpeg
+// dependency. Pass 1 measures integrated loudness and true peak; the planned
+// gain (clamped to +/-maxGainDB) is then applied in Go while the original bytes
+// are streamed into the encoder. pcmData is not modified.
+func (b *BwClient) encodeWithNativeFLAC(pcmData []byte, timestamp string) (*audioEncodingResult, error) {
+	log := GetLogger()
+
+	// Bound the encode pass so a slow host (e.g. a Raspberry Pi on a tired SD
+	// card) cannot hang the upload, matching the FFmpeg path's timeout. The
+	// pass-1 measurement below is pure in-memory CPU work and needs no deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), encodingTimeout)
+	defer cancel()
+
+	// Pass 1: measure loudness + true peak. Reads a throwaway int16 view of the
+	// PCM; the original bytes are never mutated.
+	samples := pcmInt16FromBytes(pcmData)
+	meas, err := audionorm.MeasureInt16(samples, conf.SampleRate, conf.NumChannels)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("birdweather").
+			Category(errors.CategoryAudio).
+			Context("operation", "native_flac_measure").
+			Context("timestamp", timestamp).
+			Build()
+	}
+
+	opts := audionorm.DefaultOptions()
+	opts.SampleRate = conf.SampleRate
+	opts.Channels = conf.NumChannels
+	// Target the same loudness as the FFmpeg path. The default -1.0 dBTP ceiling
+	// is kept, adding inter-sample-peak protection the volume filter lacked.
+	opts.TargetLUFS = targetIntegratedLoudnessLUFS
+
+	res := audionorm.PlanGain(meas, opts)
+
+	// Clamp to the same +/-30 dB bound the FFmpeg path used. Silence yields
+	// GainDB == 0 (audionorm returns -Inf LUFS), so quiet clips stay quiet
+	// instead of being boosted into noise.
+	gainDB := res.GainDB
+	switch {
+	case gainDB > maxGainDB:
+		b.logGainLimit(log, "Limiting gain to prevent excessive amplification",
+			"calculated_gain", res.GainDB, "max_gain", maxGainDB)
+		gainDB = maxGainDB
+	case gainDB < -maxGainDB:
+		b.logGainLimit(log, "Limiting gain to prevent excessive attenuation",
+			"calculated_gain", res.GainDB, "min_gain", -maxGainDB)
+		gainDB = -maxGainDB
+	}
+
+	log.Debug("Native FLAC loudness analysis",
+		logger.Float64("measured_lufs", meas.IntegratedLUFS),
+		logger.Float64("true_peak_dbtp", meas.TruePeakDBTP),
+		logger.Float64("target_lufs", opts.TargetLUFS),
+		logger.Float64("gain_db", gainDB),
+		logger.Bool("peak_limited", res.PeakLimited))
+
+	// Pass 2: apply the gain in Go and encode to FLAC in memory.
+	buf, err := flac.EncodePCMToBuffer(ctx, &flac.BufferOptions{
+		PCMData:    pcmData,
+		SampleRate: conf.SampleRate,
+		Channels:   conf.NumChannels,
+		BitDepth:   conf.BitDepth,
+		GainDB:     gainDB,
+	})
+	if err != nil {
+		// logFLACEncodingError downgrades timeout/cancel to WARN to avoid Sentry
+		// noise on slow hosts; everything else is logged at ERROR there.
+		logFLACEncodingError(err)
+		return nil, errors.New(err).
+			Component("birdweather").
+			Category(errors.CategoryAudio).
+			Context("operation", "native_flac_encode").
+			Context("timestamp", timestamp).
+			Build()
+	}
+
+	log.Info("Encoded audio to FLAC format (native go-flac)",
+		logger.String("timestamp", timestamp),
+		logger.Int("bytes", buf.Len()))
+	return &audioEncodingResult{buffer: buf, ext: "flac"}, nil
+}
+
+// pcmInt16FromBytes reinterprets interleaved little-endian 16-bit PCM bytes as
+// []int16 for loudness measurement. PCM samples are signed, so each pair is read
+// as a uint16 and cast to int16 (a Uint16-only read would turn negative samples
+// into large positives and corrupt the measurement). A trailing odd byte (not
+// produced by real int16 PCM) is ignored. The returned slice is a copy; the
+// source bytes are not modified.
+func pcmInt16FromBytes(b []byte) []int16 {
+	out := make([]int16, len(b)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(b[i*2:])) //nolint:gosec // G115: intentional uint16->int16 bit reinterpretation for signed PCM
+	}
+	return out
+}

--- a/internal/birdweather/encode_native_test.go
+++ b/internal/birdweather/encode_native_test.go
@@ -1,0 +1,122 @@
+package birdweather
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/audionorm"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	goflac "github.com/tphakala/go-flac/pcm"
+)
+
+// sinePCM builds mono 48 kHz 16-bit LE PCM of a 440 Hz sine at the given peak
+// dBFS, as interleaved bytes.
+func sinePCM(samples int, dbfs float64) []byte {
+	amp := math.Pow(10, dbfs/20) * 32767
+	b := make([]byte, samples*2)
+	for i := range samples {
+		v := int16(amp * math.Sin(2*math.Pi*440*float64(i)/float64(conf.SampleRate)))
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(v)) //nolint:gosec // G115: sample within int16 range
+	}
+	return b
+}
+
+// decodeToInt16 decodes a FLAC byte stream back to []int16.
+func decodeToInt16(t *testing.T, flacBytes []byte) []int16 {
+	t.Helper()
+	dec, err := goflac.NewDecoder(bytes.NewReader(flacBytes))
+	require.NoError(t, err)
+	decoded, err := io.ReadAll(dec)
+	require.NoError(t, err)
+	out := make([]int16, len(decoded)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(decoded[i*2:])) //nolint:gosec // G115: PCM bit reinterpretation
+	}
+	return out
+}
+
+// TestEncodeWithNativeFLAC verifies the native upload path produces a valid,
+// loudness-normalized FLAC stream without any FFmpeg dependency.
+func TestEncodeWithNativeFLAC(t *testing.T) {
+	t.Parallel()
+	// Explicitly no FFmpeg path: the native path must not need it.
+	client := &BwClient{Settings: &conf.Settings{}}
+
+	// A quiet (-30 dBFS) 1 s sine; normalization should boost it toward -23 LUFS.
+	pcm := sinePCM(conf.SampleRate, -30)
+
+	res, err := client.encodeWithNativeFLAC(pcm, testTimestamp)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.buffer)
+	assert.Equal(t, "flac", res.ext)
+
+	flacBytes := res.buffer.Bytes()
+	require.GreaterOrEqual(t, len(flacBytes), 4)
+	assert.Equal(t, "fLaC", string(flacBytes[:4]), "FLAC signature not found")
+
+	// Re-measure the decoded output: it should sit near the target loudness.
+	out := decodeToInt16(t, flacBytes)
+	meas, err := audionorm.MeasureInt16(out, conf.SampleRate, conf.NumChannels)
+	require.NoError(t, err)
+	assert.InDelta(t, targetIntegratedLoudnessLUFS, meas.IntegratedLUFS, 1.5,
+		"native path should normalize the decoded clip toward the target loudness")
+}
+
+// TestEncodeWithNativeFLAC_DoesNotMutateInput proves the gain is applied to a
+// scratch copy, never to the caller's PCM buffer.
+func TestEncodeWithNativeFLAC_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	client := &BwClient{Settings: &conf.Settings{}}
+
+	pcm := sinePCM(20000, -30) // quiet -> non-zero boost, exercising the gain path
+	orig := bytes.Clone(pcm)
+
+	_, err := client.encodeWithNativeFLAC(pcm, testTimestamp)
+	require.NoError(t, err)
+	assert.Equal(t, orig, pcm, "native encode must not mutate the caller's PCM buffer")
+}
+
+// TestEncodeWithNativeFLAC_Silence keeps silent input unchanged (gain 0) rather
+// than boosting noise, the deliberate behavior change from the FFmpeg path.
+func TestEncodeWithNativeFLAC_Silence(t *testing.T) {
+	t.Parallel()
+	client := &BwClient{Settings: &conf.Settings{}}
+
+	pcm := make([]byte, conf.SampleRate*2) // all-zero (silent) 1 s clip
+	res, err := client.encodeWithNativeFLAC(pcm, testTimestamp)
+	require.NoError(t, err)
+	require.NotNil(t, res.buffer)
+
+	out := decodeToInt16(t, res.buffer.Bytes())
+	for _, s := range out {
+		require.Zero(t, s, "silent input must stay silent (no gain applied)")
+	}
+}
+
+// TestPCMInt16FromBytes_SignedRoundTrip is the regression guard for the signed
+// cast: a Uint16-only read would turn negative samples into large positives and
+// corrupt the loudness measurement.
+func TestPCMInt16FromBytes_SignedRoundTrip(t *testing.T) {
+	t.Parallel()
+	want := []int16{0, -1, 1, 32767, -32768, 1234, -1234}
+	b := make([]byte, len(want)*2)
+	for i, s := range want {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s)) //nolint:gosec // G115: building signed test PCM
+	}
+	assert.Equal(t, want, pcmInt16FromBytes(b))
+}
+
+// TestPCMInt16FromBytes_OddTrailingByte drops a trailing odd byte (never present
+// in real int16 PCM) instead of panicking.
+func TestPCMInt16FromBytes_OddTrailingByte(t *testing.T) {
+	t.Parallel()
+	got := pcmInt16FromBytes([]byte{0x01, 0x02, 0x03})
+	assert.Len(t, got, 1)
+	assert.Equal(t, int16(0x0201), got[0])
+}


### PR DESCRIPTION
## Summary

BirdWeather soundscape uploads have always shelled out to FFmpeg for FLAC encoding (a two-pass loudnorm analysis followed by a volume-filter encode). That subprocess is the source of recurring upload failures on resource-constrained hosts: encode timeouts, broken pipes, and missing or misconfigured ffmpeg paths (especially in container/add-on deployments).

This adds a fully native Go encoding path so a BirdWeather upload needs no FFmpeg binary at all when the existing `BIRDNET_FLAC_ENCODER=native` gate is enabled, the same gate that already selects the native detection-clip encoder.

Both paths are kept side by side: with the gate off (the default) the FFmpeg encoder runs unchanged; with it on, `encodeAudioForUpload` dispatches to the native path **before** the ffmpeg-availability guard, so a host with no ffmpeg can still upload.

## What's in it

- **Forklift a pure-Go loudness library** into `internal/audiocore/audionorm`: EBU R128 / ITU-R BS.1770-4 integrated-loudness + true-peak measurement and two-pass normalization, no cgo. The production files are byte-identical to the upstream library apart from exporting `PlanGain` for measure-then-plan callers.
- **In-memory FLAC output** (`flac.EncodePCMToBuffer`): shares the pooled go-flac encoder core with the existing file path (`EncodePCM`); the buffer sink uses no seektable (a `bytes.Buffer` is not seekable, and short upload clips do not need one). The pooled encoder's writer is de-pinned before it returns to the pool so it does not retain the encoded clip.
- **Native BirdWeather path** (`encodeWithNativeFLAC`): measures loudness with audionorm, plans the gain to the same -23 LUFS target the FFmpeg path used, adds a -1.0 dBTP true-peak ceiling the old `volume` filter lacked, clamps to +/-30 dB, and applies the gain during encode without mutating the source PCM. Silent input stays silent rather than being boosted into static.

## Notes

- `github.com/tphakala/simd` is bumped `v1.3.0 -> v1.4.0-rc.2`; audionorm's true-peak path uses its `MaxAbs` / `ConvolveValidMaxAbsMulti` kernels. Existing simd consumers (`internal/audiocore/convert`, `internal/audiocore/resample`) still pass with `-race`.
- Default behavior is unchanged: with the gate off, the FFmpeg encoder path is byte-for-byte the same as before.

## Test Plan

- [x] `go build ./...`
- [x] `golangci-lint run` (full project, 0 issues)
- [x] `go test -race ./internal/audiocore/flac/ ./internal/audiocore/audionorm/ ./internal/birdweather/ ./internal/audiocore/convert/ ./internal/audiocore/resample/`
- [x] New tests: buffer round-trip / gain / stereo / no-seektable / validation / cancellation; native BirdWeather encode normalizes a decoded clip toward -23 LUFS, leaves silence silent, does not mutate input, and the signed PCM byte->int16 conversion round-trips negative samples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EBU R128 (two-pass) loudness normalization with integrated loudness measurement and true-peak ceiling limiting.
  * Introduced native Go FLAC encoding for BirdWeather soundscape uploads (with loudness normalization).
  * Added in-memory FLAC encoding support to produce a FLAC byte buffer from PCM.
* **Tests**
  * Added comprehensive coverage for loudness metering/normalization, true-peak estimation, PCM gain application, plus benchmarks and examples.
* **Chores**
  * Updated the SIMD library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->