### PR TITLE
fix(dashboard): remove permanent horizontal scrollbar in daily stats grid

### DIFF
--- a/frontend/src/lib/desktop/components/ui/VerificationBadges.svelte
+++ b/frontend/src/lib/desktop/components/ui/VerificationBadges.svelte
@@ -20,6 +20,7 @@
     md: 'size-3.5',
   };
 
+  // eslint-disable-next-line security/detect-object-injection -- iconSizeMap is a typed Record keyed by the size prop union, not user input
   let iconClass = $derived(iconSizeMap[size]);
 
   let verificationVariant = $derived<StatusVariant>(

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -4,6 +4,8 @@ import { createComponentTestFactory } from '../../../../../test/render-helpers';
 import { setBasePath, resetBasePath } from '$lib/utils/urlHelpers';
 import Species from './Species.svelte';
 
+/* eslint-disable security/detect-object-injection -- bracket access in this file is constant numeric indexing into NodeLists (querySelectorAll(...)[CONSTANT]) in assertions, not user-controlled keys. */
+
 /** Must match SORT_STORAGE_KEY in Species.svelte. */
 const SORT_STORAGE_KEY = 'analytics.species.sortOrder';
 

--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -78,10 +78,11 @@ Responsive Breakpoints:
     resolveNoveltyCategory,
     noveltyCategoryColorVar,
   } from '$lib/desktop/features/dashboard/utils/noveltyCategory';
-  import { ChevronLeft, ChevronRight, Star, Sunrise, Sunset, XCircle } from '@lucide/svelte';
+  import { ChevronLeft, ChevronRight, Star, XCircle } from '@lucide/svelte';
   import { untrack } from 'svelte';
   import AnimatedCounter from './AnimatedCounter.svelte';
   import BirdThumbnailPopup from './BirdThumbnailPopup.svelte';
+  import SunTimeTooltip from './SunTimeTooltip.svelte';
 
   const logger = loggers.ui;
 
@@ -804,17 +805,7 @@ Responsive Breakpoints:
     {@const tIdx = sunTime.indexOf('T')}
     {@const formattedTime = tIdx !== -1 ? sunTime.substring(tIdx + 1, tIdx + 6) : ''}
     {#if formattedTime}
-      <div
-        class="sun-icon-wrapper"
-        title={t(`dashboard.dailySummary.daylight.${sunType}`, { time: formattedTime })}
-      >
-        {#if sunType === 'sunrise'}
-          <Sunrise class="size-3.5 text-orange-700" />
-        {:else}
-          <Sunset class="size-3.5 text-rose-700" />
-        {/if}
-        <span class="sun-tooltip sun-tooltip-{sunType}">{formattedTime}</span>
-      </div>
+      <SunTimeTooltip {sunType} time={formattedTime} />
     {/if}
   {/if}
 {/snippet}
@@ -1733,72 +1724,5 @@ Responsive Breakpoints:
 
   :global([data-theme='light']) .daylight-dusk {
     background-color: rgb(139 92 246 / 0.15); /* violet-500/15 */
-  }
-
-  /* Sun icon wrapper and tooltip styles */
-  .sun-icon-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 1.25rem; /* 20px - matches grid-daylight-height */
-    position: relative;
-    cursor: pointer;
-  }
-
-  .sun-tooltip {
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    margin-bottom: 4px;
-    padding: 2px 6px;
-    font-size: 10px;
-    font-weight: 600;
-    white-space: nowrap;
-    border-radius: 4px;
-    opacity: 0;
-    visibility: hidden;
-    transition:
-      opacity 0.15s ease-in-out,
-      visibility 0.15s ease-in-out;
-    pointer-events: none;
-
-    /* Force a new stacking context to escape sticky header */
-    isolation: isolate;
-    z-index: 1100;
-  }
-
-  .sun-icon-wrapper:hover .sun-tooltip {
-    opacity: 1;
-    visibility: visible;
-  }
-
-  /* Sunrise tooltip - orange theme */
-  .sun-tooltip-sunrise {
-    background-color: #fff7ed; /* orange-50 */
-    color: #c2410c; /* orange-700 */
-    border: 1px solid #fed7aa; /* orange-200 */
-    box-shadow: 0 2px 8px rgb(251 146 60 / 0.25);
-  }
-
-  :global([data-theme='dark']) .sun-tooltip-sunrise {
-    background-color: #431407; /* orange-950 */
-    color: #fdba74; /* orange-300 */
-    border: 1px solid #7c2d12; /* orange-900 */
-  }
-
-  /* Sunset tooltip - rose/pink theme */
-  .sun-tooltip-sunset {
-    background-color: #fff1f2; /* rose-50 */
-    color: #be123c; /* rose-700 */
-    border: 1px solid #fecdd3; /* rose-200 */
-    box-shadow: 0 2px 8px rgb(251 113 133 / 0.25);
-  }
-
-  :global([data-theme='dark']) .sun-tooltip-sunset {
-    background-color: #4c0519; /* rose-950 */
-    color: #fda4af; /* rose-300 */
-    border: 1px solid #881337; /* rose-900 */
   }
 </style>

--- a/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
@@ -28,15 +28,15 @@
 
   let { sunType, time }: Props = $props();
 
-  // Unique id per instance for aria-describedby. Math.random (not
-  // crypto.randomUUID) because BirdNET-Go commonly runs on plain HTTP, where
-  // the secure-context crypto API is undefined.
-  const tooltipId = `sun-tooltip-${Math.random().toString(36).slice(2, 10)}`;
-
   // Positioning tuning (px).
   const VIEWPORT_MARGIN = 8; // minimum gap kept from viewport edges
   const OFFSET_Y = 6; // gap between the icon and the tooltip
-  const TOOLTIP_HEIGHT_ESTIMATE = 20; // fallback before the tooltip is mounted
+  // Size fallbacks used on the first pass, before the tooltip is mounted and
+  // can be measured. The width estimate matters: with a 0 fallback the
+  // horizontal clamp degenerates (half-width 0) and a near-edge tooltip could
+  // momentarily render past the viewport on the first hover.
+  const TOOLTIP_WIDTH_ESTIMATE = 44; // ~width of "HH:MM"
+  const TOOLTIP_HEIGHT_ESTIMATE = 20;
 
   let show = $state(false);
   let triggerEl: HTMLElement | undefined = $state();
@@ -54,9 +54,20 @@
   function position() {
     if (!triggerEl) return;
     const rect = triggerEl.getBoundingClientRect();
-    const vw = window.innerWidth;
+    // clientWidth excludes a vertical scrollbar, so the horizontal clamp keeps
+    // the tooltip clear of the scrollbar (and the viewport edge), not under it.
+    const vw = document.documentElement.clientWidth || window.innerWidth;
     const vh = window.innerHeight;
-    const width = tooltipEl?.offsetWidth ?? 0;
+
+    // If the icon has scrolled fully out of view (the grid wrapper can be
+    // scrolled while the pointer stays still, so mouseleave may not fire),
+    // close instead of leaving the tooltip orphaned on screen.
+    if (rect.right < 0 || rect.left > vw || rect.bottom < 0 || rect.top > vh) {
+      show = false;
+      return;
+    }
+
+    const width = tooltipEl?.offsetWidth || TOOLTIP_WIDTH_ESTIMATE;
     const height = tooltipEl?.offsetHeight || TOOLTIP_HEIGHT_ESTIMATE;
 
     // Center horizontally over the icon, clamped so the tooltip (drawn with
@@ -111,7 +122,6 @@
   class="sun-icon-wrapper"
   role="img"
   aria-label={label}
-  aria-describedby={show ? tooltipId : undefined}
   onmouseenter={open}
   onmouseleave={close}
 >
@@ -123,11 +133,13 @@
 </div>
 
 {#if show}
+  <!-- Decorative duplicate of the wrapper's aria-label (which carries the full
+       localized "Sunrise at HH:MM"); hidden from assistive tech to avoid a
+       redundant announcement. -->
   <span
     bind:this={tooltipEl}
     use:portal
-    id={tooltipId}
-    role="tooltip"
+    aria-hidden="true"
     class="sun-tooltip sun-tooltip-{sunType}"
     style:z-index={Z_INDEX.PORTAL_TOOLTIP}
     style:left="{tipLeft}px"

--- a/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
@@ -1,0 +1,208 @@
+<!--
+  SunTimeTooltip.svelte - sunrise/sunset icon with a styled hover tooltip.
+
+  Renders the sunrise or sunset icon for a daylight-row cell and shows the
+  formatted time in a small styled tooltip on hover.
+
+  The tooltip is portaled to <body> and positioned with position:fixed against
+  the icon's viewport rect. This is deliberate: the daylight row lives inside
+  the daily-summary grid's overflow-x:auto scroll wrapper. An in-DOM,
+  absolutely-positioned tooltip there both widened the wrapper's scrollable area
+  (a permanent horizontal scrollbar, since the icon sits near the grid's right
+  edge) and was itself clipped by that same container. Portaling the tooltip out
+  of the scroll wrapper avoids both problems while keeping the styled look.
+
+  Mirrors the positioning approach used by BirdThumbnailPopup.svelte.
+-->
+
+<script lang="ts">
+  import { t } from '$lib/i18n';
+  import { portal } from '$lib/utils/portal';
+  import { Z_INDEX } from '$lib/utils/z-index';
+  import { Sunrise, Sunset } from '@lucide/svelte';
+
+  interface Props {
+    sunType: 'sunrise' | 'sunset';
+    time: string; // formatted "HH:MM"
+  }
+
+  let { sunType, time }: Props = $props();
+
+  // Unique id per instance for aria-describedby. Math.random (not
+  // crypto.randomUUID) because BirdNET-Go commonly runs on plain HTTP, where
+  // the secure-context crypto API is undefined.
+  const tooltipId = `sun-tooltip-${Math.random().toString(36).slice(2, 10)}`;
+
+  // Positioning tuning (px).
+  const VIEWPORT_MARGIN = 8; // minimum gap kept from viewport edges
+  const OFFSET_Y = 6; // gap between the icon and the tooltip
+  const TOOLTIP_HEIGHT_ESTIMATE = 20; // fallback before the tooltip is mounted
+
+  let show = $state(false);
+  let triggerEl: HTMLElement | undefined = $state();
+  let tooltipEl: HTMLElement | undefined = $state();
+  let tipLeft = $state(0);
+  // Exactly one of tipTop / tipBottom is non-null: 'below' pins the top edge,
+  // 'above' pins the bottom edge so the height never has to be known exactly.
+  let tipTop = $state<number | null>(null);
+  let tipBottom = $state<number | null>(null);
+
+  // Localized accessible label, e.g. "Sunrise at 05:23". Reuses the existing
+  // daylight keys, so no new i18n strings are introduced.
+  const label = $derived(t(`dashboard.dailySummary.daylight.${sunType}`, { time }));
+
+  function position() {
+    if (!triggerEl) return;
+    const rect = triggerEl.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const width = tooltipEl?.offsetWidth ?? 0;
+    const height = tooltipEl?.offsetHeight || TOOLTIP_HEIGHT_ESTIMATE;
+
+    // Center horizontally over the icon, clamped so the tooltip (drawn with
+    // translateX(-50%)) stays within the viewport margins.
+    const half = width / 2;
+    const centerX = rect.left + rect.width / 2;
+    tipLeft = Math.max(VIEWPORT_MARGIN + half, Math.min(centerX, vw - VIEWPORT_MARGIN - half));
+
+    // Prefer above the icon; flip below only when there is not enough room.
+    if (rect.top >= height + OFFSET_Y + VIEWPORT_MARGIN) {
+      tipBottom = vh - rect.top + OFFSET_Y;
+      tipTop = null;
+    } else {
+      tipTop = rect.bottom + OFFSET_Y;
+      tipBottom = null;
+    }
+  }
+
+  function open() {
+    show = true;
+    // First pass uses size estimates (the tooltip is not mounted yet); the rAF
+    // pass re-measures once it is in the DOM, like BirdThumbnailPopup.
+    position();
+    globalThis.requestAnimationFrame(() => {
+      if (show) position();
+    });
+  }
+
+  function close() {
+    show = false;
+  }
+
+  // Keep the tooltip anchored to its icon while shown. It is portaled to <body>
+  // with position:fixed, so without this it would drift on scroll/resize.
+  $effect(() => {
+    if (!show) return;
+
+    const reposition = () => position();
+    // Capture phase so scrolls inside nested overflow containers are caught too.
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  });
+</script>
+
+<div
+  bind:this={triggerEl}
+  class="sun-icon-wrapper"
+  role="img"
+  aria-label={label}
+  aria-describedby={show ? tooltipId : undefined}
+  onmouseenter={open}
+  onmouseleave={close}
+>
+  {#if sunType === 'sunrise'}
+    <Sunrise class="size-3.5 text-orange-700" aria-hidden="true" />
+  {:else}
+    <Sunset class="size-3.5 text-rose-700" aria-hidden="true" />
+  {/if}
+</div>
+
+{#if show}
+  <span
+    bind:this={tooltipEl}
+    use:portal
+    id={tooltipId}
+    role="tooltip"
+    class="sun-tooltip sun-tooltip-{sunType}"
+    style:z-index={Z_INDEX.PORTAL_TOOLTIP}
+    style:left="{tipLeft}px"
+    style:top={tipTop !== null ? `${tipTop}px` : undefined}
+    style:bottom={tipBottom !== null ? `${tipBottom}px` : undefined}
+  >
+    {time}
+  </span>
+{/if}
+
+<style>
+  /* Centers the sunrise/sunset icon within its daylight-row grid cell. */
+  .sun-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 1.25rem; /* 20px - matches grid-daylight-height */
+  }
+
+  /* Portaled to <body>; positioned via fixed coordinates set inline above.
+     translateX(-50%) centers the box on the computed `left`. */
+  .sun-tooltip {
+    position: fixed;
+    transform: translateX(-50%);
+    padding: 2px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    white-space: nowrap;
+    border-radius: 4px;
+    pointer-events: none;
+    animation: sun-tooltip-fade 0.12s ease-out;
+  }
+
+  @keyframes sun-tooltip-fade {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sun-tooltip {
+      animation: none;
+    }
+  }
+
+  /* Sunrise tooltip - orange theme */
+  .sun-tooltip-sunrise {
+    background-color: #fff7ed; /* orange-50 */
+    color: #c2410c; /* orange-700 */
+    border: 1px solid #fed7aa; /* orange-200 */
+    box-shadow: 0 2px 8px rgb(251 146 60 / 0.25);
+  }
+
+  :global([data-theme='dark']) .sun-tooltip-sunrise {
+    background-color: #431407; /* orange-950 */
+    color: #fdba74; /* orange-300 */
+    border: 1px solid #7c2d12; /* orange-900 */
+  }
+
+  /* Sunset tooltip - rose/pink theme */
+  .sun-tooltip-sunset {
+    background-color: #fff1f2; /* rose-50 */
+    color: #be123c; /* rose-700 */
+    border: 1px solid #fecdd3; /* rose-200 */
+    box-shadow: 0 2px 8px rgb(251 113 133 / 0.25);
+  }
+
+  :global([data-theme='dark']) .sun-tooltip-sunset {
+    background-color: #4c0519; /* rose-950 */
+    color: #fda4af; /* rose-300 */
+    border: 1px solid #881337; /* rose-900 */
+  }
+</style>

--- a/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
@@ -105,12 +105,24 @@
   $effect(() => {
     if (!show) return;
 
-    const reposition = () => position();
-    // Capture phase so scrolls inside nested overflow containers are caught too.
-    window.addEventListener('scroll', reposition, true);
+    // Coalesce bursts of scroll/resize events into one reposition per frame.
+    // position() reads layout (getBoundingClientRect/offsetWidth), so throttling
+    // with rAF avoids layout thrashing during momentum scroll.
+    let frameId: number | null = null;
+    const reposition = () => {
+      if (frameId !== null) return;
+      frameId = globalThis.requestAnimationFrame(() => {
+        frameId = null;
+        position();
+      });
+    };
+    // Capture phase so scrolls inside nested overflow containers are caught too;
+    // passive since this handler never calls preventDefault.
+    window.addEventListener('scroll', reposition, { capture: true, passive: true });
     window.addEventListener('resize', reposition);
 
     return () => {
+      if (frameId !== null) globalThis.cancelAnimationFrame(frameId);
       window.removeEventListener('scroll', reposition, true);
       window.removeEventListener('resize', reposition);
     };

--- a/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SunTimeTooltip.svelte
@@ -163,13 +163,16 @@
 {/if}
 
 <style>
-  /* Centers the sunrise/sunset icon within its daylight-row grid cell. */
+  /* Centers the sunrise/sunset icon within its daylight-row grid cell.
+     cursor: help (not pointer) cues the hover tooltip without implying the icon
+     is clickable, which it is not. */
   .sun-icon-wrapper {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
     height: 1.25rem; /* 20px - matches grid-daylight-height */
+    cursor: help;
   }
 
   /* Portaled to <body>; positioned via fixed coordinates set inline above.

--- a/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
+++ b/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
@@ -76,6 +76,7 @@
     for (const m of models) {
       const s = getModelStatus(m);
       if (s == null) continue;
+      // eslint-disable-next-line security/detect-object-injection -- priority is a typed Record<StatusLevel, number>; s and worst are StatusLevel values, not user input
       if (worst == null || priority[s] > priority[worst]) worst = s;
     }
     return worst;


### PR DESCRIPTION
## Summary

The dashboard "Daily Summary" grid showed a horizontal scrollbar at every viewport width, even when the grid fit comfortably. The cause was the styled sunrise/sunset time tooltip in the daylight row: an absolutely-positioned, fixed-width element centered over its sun icon. When the sun icon falls in a near-edge hour column, half the tooltip extends a few pixels past the grid's right edge. Because it lived inside the `overflow-x:auto` grid wrapper, that overflow was added to the wrapper's `scrollWidth`, producing a persistent scrollbar whose width is independent of the viewport. The same tooltip was also clipped on hover, since `overflow-x:auto` forces `overflow-y` to compute to `auto`, so the wrapper clipped both axes.

The styled tooltip is kept, but moved into a small `SunTimeTooltip` component that portals it to `<body>` and positions it with `position:fixed` against the icon's viewport rect (reusing the existing `portal` action and `Z_INDEX.PORTAL_TOOLTIP`, mirroring `BirdThumbnailPopup`). Out of the scroll wrapper, the tooltip can neither widen the scrollable area nor be clipped, so the scrollbar is gone. Intended horizontal scrolling on narrow screens (grid min-width 900px) is preserved.

### Details
- New `SunTimeTooltip.svelte`: sun icon plus a portaled, fixed-position tooltip. Clamps against `clientWidth` so it stays clear of a vertical scrollbar, seeds a width estimate for the first positioning pass, and closes itself if the icon scrolls out of view (the grid wrapper can scroll while the pointer stays still, so `mouseleave` may not fire).
- Accessibility: the icon wrapper carries the full localized "Sunrise at HH:MM" via `aria-label` (`role="img"`); the visual tooltip is decorative and `aria-hidden`. This is more robust than the previous native `title`, which was inconsistently exposed and clipped.
- `DailySummaryCard.svelte`: renders the component from the shared `sunIcon` snippet (all three responsive grids), and drops the old inline tooltip span, its CSS, and the now-unused lucide imports.
- Also quiets 10 pre-existing `security/detect-object-injection` false positives (typed Record lookups and constant NodeList indexing) so the lint output is clean.

## Test Plan
- [x] `npm run check:all` clean (0 errors, typecheck 0/0, eslint 0 problems, css lint + ast-grep clean)
- [x] Verified on a live instance: no horizontal scrollbar at 1280px and 1920px; the styled sunrise/sunset tooltip renders and is positioned above its icon
- [x] Confirmed intended horizontal scroll still works below the 900px grid min-width
- [ ] Visually confirm the tooltip hover and theming (light/dark) in the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sunrise/sunset tooltip component with viewport-aware positioning, smooth fade-in animation, and accessibility-friendly labeling.

* **Refactor**
  * Updated the Daily Summary Card to render sunrise/sunset visuals using the new dedicated tooltip component, improving UI consistency.

* **Bug Fixes**
  * Suppressed targeted security lint warnings in specific UI and test files to avoid false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->