### PR TITLE
fix(api): include secondary-model species in range filter CSV export

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -179,11 +179,11 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | Method | Route                   | Handler                       | Auth | Description                                                 |
 | ------ | ----------------------- | ----------------------------- | ---- | ----------------------------------------------------------- |
 | GET    | `/range/status`         | `GetRangeFilterStatus`        | ❌   | Per-classifier geomodel coverage, auto-selection, threshold |
-| GET    | `/range/species/scores` | `GetRangeFilterSpeciesScores` | ❌   | All species with raw geomodel scores (no threshold cutoff)  |
+| GET    | `/range/species/scores` | `GetRangeFilterSpeciesScores` | ❌   | Raw geomodel scores, primary model only; excludes always-active secondary models (e.g. bats) by design |
 | GET    | `/range/species/count`  | `GetRangeFilterSpeciesCount`  | ❌   | Species count with range filter                             |
 | GET    | `/range/species/list`   | `GetRangeFilterSpeciesList`   | ❌   | Species list with taxonomy groups                           |
-| GET    | `/range/species/csv`    | `GetRangeFilterSpeciesCSV`    | ❌   | Export species list as CSV download                         |
-| POST   | `/range/species/test`   | `TestRangeFilter`             | ❌   | Test range filter configuration                             |
+| GET    | `/range/species/csv`    | `GetRangeFilterSpeciesCSV`    | ❌   | Export species as CSV; with custom params includes always-active secondary models (matches the test endpoint); no-param export returns the persisted filter |
+| POST   | `/range/species/test`   | `TestRangeFilter`             | ❌   | Test range filter; returns the active set (range-filtered birds plus always-active secondary models) |
 | POST   | `/range/rebuild`        | `RebuildRangeFilter`          | ❌   | Rebuild range filter data                                   |
 
 ### Search (`search.go`)

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -249,9 +249,17 @@ func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, birdnetInstance.RangeFilterStatus())
 }
 
-// GetRangeFilterSpeciesScores returns all species with their raw geomodel probability scores
+// GetRangeFilterSpeciesScores returns all species with their raw geomodel probability scores.
+//
+// This is a geomodel diagnostic endpoint: it intentionally uses the primary-only
+// GetProbableSpeciesWithSettings, NOT the multi-model union. Always-active
+// secondary-model species (bats/Perch) are excluded by design because they have
+// no geomodel and therefore no probability score; representing them with the
+// always-active 1.0 sentinel here would misrepresent it as a genuine 100%
+// geomodel confidence. Endpoints that report the active species set (POST
+// /range/species/test and the CSV export) do include secondary-model species.
 // @Summary Get range filter species scores
-// @Description Returns all species with raw geomodel scores, using current or custom location and week
+// @Description Returns all species with raw geomodel scores (primary model only), using current or custom location and week. Always-active secondary-model species (e.g. bats) are excluded by design as they have no geomodel score.
 // @Tags range
 // @Produce json
 // @Param lat query number false "Custom latitude (uses current settings if not provided)"
@@ -312,10 +320,12 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		week = float32(parsed)
 	}
 
-	// Build test settings with zero threshold to get ALL species with scores
+	// Build test settings with zero threshold to get ALL geomodel species with scores
 	testSettings := c.buildTestSettings(lat, lon, 0)
 
-	// Get all species with their raw scores
+	// Primary-only by design: this endpoint reports raw geomodel scores, so
+	// always-active secondary-model species (bats/Perch) that have no geomodel
+	// score are intentionally not included here. See the function doc comment.
 	speciesScores, err := birdnetInstance.GetProbableSpeciesWithSettings(now, week, testSettings)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to get species scores", http.StatusInternalServerError)
@@ -604,6 +614,12 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 			return c.HandleError(ctx, err, "Failed to get species list", http.StatusInternalServerError)
 		}
 	} else {
+		// No custom parameters: export the currently persisted range filter
+		// species (the applied filter, consistent with /range/species/list and
+		// /range/species/count). The custom-parameter branch above recomputes the
+		// full active set via getTestSpeciesList, which also includes always-active
+		// secondary-model species. The settings UI always sends parameters, so it
+		// hits that branch; this branch is the no-argument fallback.
 		settings := c.currentSettings()
 
 		birdnetInstance, _ := c.getBirdNETInstance()
@@ -636,7 +652,15 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 	return ctx.Blob(http.StatusOK, "text/csv; charset=utf-8", csvBytes)
 }
 
-// getTestSpeciesList gets species list with test parameters (helper for CSV export)
+// getTestSpeciesList gets species list with test parameters (helper for CSV export).
+//
+// It uses GetAllProbableSpeciesWithSettings (the multi-model union) rather than
+// the primary-only GetProbableSpeciesWithSettings so the CSV export matches what
+// the user sees in the Active Species view for the same coordinates and
+// threshold: range-filtered bird species plus always-active secondary-model
+// species (bats/Perch). This is the path the settings UI's CSV download takes
+// (it always sends parameters), so a user who sees bats in the Active Species
+// preview gets the same bats when exporting those parameters to CSV.
 func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilterSpecies, Location, float32, error) {
 	// Check if BirdNET is available
 	birdnetInstance, err := c.getBirdNETInstance()
@@ -650,8 +674,10 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 	testDate := time.Now()
 	week := calculateWeek(testDate)
 
-	// Get probable species for the test parameters
-	speciesScores, err := birdnetInstance.GetProbableSpeciesWithSettings(testDate, week, testSettings)
+	// Get probable species for the test parameters, including always-active
+	// secondary-model species so the export stays consistent with the Active
+	// Species view (POST /range/species/test uses the same union method).
+	speciesScores, err := birdnetInstance.GetAllProbableSpeciesWithSettings(testDate, week, testSettings)
 	if err != nil {
 		return nil, Location{}, 0, err
 	}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -678,6 +678,15 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 		}
 	}
 
+	// The primary's range-filtered scores arrive pre-sorted descending, but the
+	// secondary-model and bat species above are appended after that sort with a
+	// flat always-active score of 1.0. Re-sort the merged slice so the full set
+	// is ordered by score descending, matching the primary path's contract:
+	// otherwise always-active species (the maximum 1.0) would trail behind
+	// low-probability birds in consumers that do not re-sort (the CSV export and
+	// the range-filter test preview).
+	sort.Sort(ByScore(scores))
+
 	return scores, nil
 }
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -684,8 +684,10 @@ func (o *Orchestrator) GetAllProbableSpeciesWithSettings(date time.Time, week fl
 	// is ordered by score descending, matching the primary path's contract:
 	// otherwise always-active species (the maximum 1.0) would trail behind
 	// low-probability birds in consumers that do not re-sort (the CSV export and
-	// the range-filter test preview).
-	sort.Sort(ByScore(scores))
+	// the range-filter test preview). A stable sort keeps the deterministic append
+	// order of the equal-scored 1.0 species (secondary models are walked in
+	// sorted-by-ID order above), so the output does not shuffle run to run.
+	sort.Stable(ByScore(scores))
 
 	return scores, nil
 }

--- a/internal/classifier/orchestrator_allspecies_test.go
+++ b/internal/classifier/orchestrator_allspecies_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -344,6 +345,63 @@ func TestGetAllProbableSpecies_BatModelAlwaysActive(t *testing.T) {
 
 	assert.False(t, hasScientificName(scores, "Pipistrellus pipistrellus"),
 		"excluded bat species must not be added")
+}
+
+// TestGetAllProbableSpecies_SortedByScoreDescending verifies that always-active
+// secondary-model species (score 1.0), which are appended after the primary's
+// pre-sorted range-filtered scores, are re-sorted into the merged result so the
+// full list stays ordered by score descending. Without the final re-sort a 1.0
+// bat species trails behind a low-probability bird, which the CSV export and the
+// range-filter test preview render in raw (unsorted) order.
+func TestGetAllProbableSpecies_SortedByScoreDescending(t *testing.T) {
+	settings := universalSettings(t)
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = false
+
+	// Primary returns a single low-probability bird; the bat is appended at 1.0
+	// after the primary's descending sort, so an unsorted merge would place it last.
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: []string{"Turdus merula_Common Blackbird"},
+		scores: []SpeciesScore{
+			{Score: 0.02, Label: "Turdus merula_Common Blackbird"},
+		},
+		rawScores: []float32{0.02},
+	}
+
+	const primaryID = "BirdNET_V3"
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	bn.ModelInfo.ID = primaryID
+	bn.rangeFilter = rf
+
+	batModel := &mockModelInstance{
+		id:     RegistryIDBat,
+		labels: []string{"Myotis daubentonii"},
+	}
+
+	o := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: bn.ModelInfo, // mirror the primary, as NewOrchestrator does
+		primary:   bn,
+		models: map[string]*modelEntry{
+			primaryID:     {instance: bn},
+			RegistryIDBat: {instance: batModel},
+		},
+	}
+
+	scores, err := o.GetAllProbableSpeciesWithSettings(time.Now(), 0, settings)
+	require.NoError(t, err)
+	require.Len(t, scores, 2)
+
+	// The always-active bat (1.0) must sort ahead of the low-probability bird (0.02).
+	assert.Equal(t, "Myotis daubentonii", scores[0].Label,
+		"always-active 1.0 species must sort before lower-scored birds")
+	assert.InDelta(t, 1.0, scores[0].Score, 0.0001)
+
+	// The merged list as a whole must be ordered by score descending.
+	assert.True(t, sort.IsSorted(ByScore(scores)),
+		"merged species list must be sorted by score descending")
 }
 
 // TestGetAllProbableSpecies_BatModelDedupedByScientificName verifies that a bat


### PR DESCRIPTION
## Summary

The range filter CSV export (`GET /api/v2/range/species/csv`) diverged from the Active Species view after the recent multi-model union change. `POST /range/species/test` returns range-filtered birds **plus** always-active secondary-model species (bats/Perch), and that feeds the Active Species preview. But the CSV helper still used the primary-only `GetProbableSpeciesWithSettings`, so a user who saw bats in the preview got a bird-only file when exporting the same coordinates and threshold.

## Changes

- **CSV export now matches the Active Species view.** `getTestSpeciesList` routes through `GetAllProbableSpeciesWithSettings` (the same union method the test endpoint uses), so the export includes always-active secondary-model species. The settings UI always sends parameters, so this is the path it hits.
- **`GET /range/species/scores` is deliberately kept primary-only.** It reports raw geomodel probability scores, and always-active species have no geomodel score (the `1.0` they carry is a structural sentinel, not a probability). Including them would misrepresent the diagnostic output as genuine 100% geomodel confidence. The by-design split is documented in the handler doc comments and the API README.
- **Ordering fix in `GetAllProbableSpeciesWithSettings`.** It appended always-active species (score `1.0`) after the primary's descending-sorted scores without re-sorting, so the maximum-score species trailed behind low-probability birds in consumers that do not re-sort (the CSV export and the range-filter test preview). The merged slice is now re-sorted by score descending, with a regression test.

## Compatibility

- CSV column schema is unchanged (only additional rows for multi-model setups).
- Default single-model (bird-only) installs see no change: the union method returns the same set when no secondary models are loaded.
- The `1.0` score serializes cleanly into the existing score column.

## Testing

- `go build ./...`, `golangci-lint run` clean.
- New regression test `TestGetAllProbableSpecies_SortedByScoreDescending`; existing union and range endpoint tests pass with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured combined species results are consistently sorted by descending score when merging primary and always-active secondary-model species.

* **Documentation**
  * Updated Range Filter API v2 documentation for `/range/species/*` to clarify primary-only score behavior, differences in CSV export outputs, and what the test endpoint returns.

* **Tests**
  * Added coverage to verify merged results are sorted correctly by score (including always-active secondary-model species).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->