### PR TITLE
refactor(openfauna): centralize reverse common-name resolution helpers

### DIFF
--- a/internal/analysis/processor/extended_capture.go
+++ b/internal/analysis/processor/extended_capture.go
@@ -192,20 +192,23 @@ func resolveSpeciesFilter(configSpecies, labels []string, taxonomyDB *classifier
 	// species (e.g. Finnish "mopsilepakko" -> "Barbastella barbastellus") that have
 	// no embedded common name in the model labels and are not in the taxonomy DB.
 	if len(unresolved) > 0 {
-		reverse := openfauna.LookupScientificNames(unresolved, locale)
+		// The shared helper returns scientific names already lower-cased, keyed per
+		// entry so the per-entry "matched" tracking (and the unresolved warning below)
+		// still works; it centralizes the lower-casing/locale handling shared with the
+		// range-filter exclude matcher.
+		reverse := openfauna.ReverseResolveToScientificNames(unresolved, locale)
 		stillUnresolved := unresolved[:0]
 		for _, entry := range unresolved {
 			matched := false
 			for _, sci := range reverse[entry] {
-				sciLower := strings.ToLower(sci)
 				// Only resolve to species a loaded model can actually emit. OpenFauna
 				// may return scientific names for the localized common name that are
 				// not in any loaded model's labels; resolving to those would silently
 				// match a species nothing can detect and skip the unresolved warning.
-				if !scientificNames[sciLower] {
+				if !scientificNames[sci] {
 					continue
 				}
-				resolved[sciLower] = true
+				resolved[sci] = true
 				matched = true
 			}
 			if !matched {

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -573,14 +573,10 @@ func newExcludeMatcher(excludeList []string, locale string) excludeMatcher {
 	if len(excludeList) == 0 {
 		return m
 	}
-	for _, sciNames := range openfauna.LookupScientificNames(excludeList, locale) {
-		for _, sci := range sciNames {
-			if m.reverseSci == nil {
-				m.reverseSci = make(map[string]struct{}, len(excludeList))
-			}
-			m.reverseSci[strings.ToLower(sci)] = struct{}{}
-		}
-	}
+	// Reverse-resolve localized common-name entries to a flat set of lower-cased
+	// scientific names via the shared helper, which centralizes the lower-casing and
+	// locale handling (matches() also lower-cases the label's scientific name).
+	m.reverseSci = openfauna.ReverseResolveToScientificSet(excludeList, locale)
 	return m
 }
 

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -576,7 +576,12 @@ func newExcludeMatcher(excludeList []string, locale string) excludeMatcher {
 	// Reverse-resolve localized common-name entries to a flat set of lower-cased
 	// scientific names via the shared helper, which centralizes the lower-casing and
 	// locale handling (matches() also lower-cases the label's scientific name).
-	m.reverseSci = openfauna.ReverseResolveToScientificSet(excludeList, locale)
+	// Leave reverseSci nil when nothing resolves so matches() keeps its nil-guard
+	// fast path and skips the per-label ToLower + map lookup on the hot rebuild loop
+	// (matches() runs per geomodel score during a range-filter rebuild).
+	if sciSet := openfauna.ReverseResolveToScientificSet(excludeList, locale); len(sciSet) > 0 {
+		m.reverseSci = sciSet
+	}
 	return m
 }
 

--- a/internal/classifier/range_filter_exclude_test.go
+++ b/internal/classifier/range_filter_exclude_test.go
@@ -44,6 +44,19 @@ func TestExcludeMatcher_Empty(t *testing.T) {
 	assert.False(t, m.matches("Vulpes vulpes"))
 }
 
+// TestExcludeMatcher_NoReverseResolution_LeavesReverseSciNil verifies that when a
+// non-empty exclude list reverse-resolves to nothing (e.g. a scientific-name-only
+// entry that is not a localized common name), reverseSci stays nil. This preserves
+// the matches() nil-guard fast path so it skips the per-label ToLower + map lookup on
+// the hot rebuild loop instead of probing an empty map for every label.
+func TestExcludeMatcher_NoReverseResolution_LeavesReverseSciNil(t *testing.T) {
+	t.Parallel()
+	m := newExcludeMatcher([]string{"Zzz Notaspecies"}, "fi")
+	assert.Nil(t, m.reverseSci, "reverseSci must stay nil when nothing reverse-resolves")
+	// The forward path is unaffected: the unresolved entry simply never matches.
+	assert.False(t, m.matches("Turdus merula_Common Blackbird"))
+}
+
 // TestExcludeMatcher_CaseInsensitive proves matching normalizes case on both paths:
 // EqualFold on the forward (scientific/common) match, and a lower-cased scientific-name
 // set on the reverse match (where the entry is also case-folded by OpenFauna's lookup).

--- a/internal/openfauna/openfauna.go
+++ b/internal/openfauna/openfauna.go
@@ -445,6 +445,47 @@ func LookupScientificNames(commonNames []string, bngLocale string) map[string][]
 	return out
 }
 
+// ReverseResolveToScientificNames reverse-resolves localized common-name entries to their
+// lower-cased scientific name(s) for the given BirdNET locale. It is a thin convenience over
+// LookupScientificNames that applies the lower-casing callers need when matching against
+// lower-cased scientific names, so the lower-casing and locale handling live in one place
+// instead of being duplicated (and able to drift) across call sites.
+//
+// The result is keyed by the caller's original entry strings; entries that resolve to no
+// scientific name are absent. Each entry's scientific names keep the sorted, de-duplicated
+// order from LookupScientificNames and are lower-cased. Returns an empty (non-nil) map when
+// entries is empty or nothing resolves. Like LookupScientificNames this is O(dataset) per
+// call and must not be used on a hot path.
+func ReverseResolveToScientificNames(entries []string, bngLocale string) map[string][]string {
+	resolved := LookupScientificNames(entries, bngLocale)
+	out := make(map[string][]string, len(resolved))
+	for entry, sciNames := range resolved {
+		lowered := make([]string, len(sciNames))
+		for i, sci := range sciNames {
+			lowered[i] = strings.ToLower(sci)
+		}
+		out[entry] = lowered
+	}
+	return out
+}
+
+// ReverseResolveToScientificSet reverse-resolves localized common-name entries to a single
+// flat set of lower-cased scientific names for the given BirdNET locale, flattening the
+// per-entry result of ReverseResolveToScientificNames. It serves callers that only need to
+// test membership of a label's scientific name (e.g. the range-filter exclude matcher) and
+// do not care which entry produced which name. Returns an empty (non-nil) set when entries
+// is empty or nothing resolves. O(dataset) per call; not for hot paths.
+func ReverseResolveToScientificSet(entries []string, bngLocale string) map[string]struct{} {
+	resolved := ReverseResolveToScientificNames(entries, bngLocale)
+	set := make(map[string]struct{}, len(resolved))
+	for _, sciNames := range resolved {
+		for _, sci := range sciNames {
+			set[sci] = struct{}{}
+		}
+	}
+	return set
+}
+
 // LookupCommonNames is the forward, batched companion to LookupScientificNames:
 // for each requested scientific name it returns the localized common name in the
 // locale mapped from bngLocale, resolving every request in a single pass over the

--- a/internal/openfauna/openfauna_test.go
+++ b/internal/openfauna/openfauna_test.go
@@ -316,3 +316,66 @@ func TestLookupScientificNames_HonorsLocale_Embedded(t *testing.T) {
 	assert.NotContains(t, LookupScientificNames([]string{"Kettu"}, "de")["Kettu"], "Vulpes vulpes",
 		"the reverse lookup must honor the active locale")
 }
+
+func TestReverseResolveToScientificNames_LowerCasesPerEntry_Embedded(t *testing.T) {
+	t.Parallel()
+
+	got := ReverseResolveToScientificNames([]string{"mopsilepakko", "Kettu", "drone"}, "fi")
+	// Scientific names are lower-cased and keyed by the caller's original entry string.
+	assert.Contains(t, got["mopsilepakko"], "barbastella barbastellus", "bat, lower-cased")
+	assert.Contains(t, got["Kettu"], "vulpes vulpes", "fox, lower-cased")
+	// A non-fauna string must be absent from the result, not present as an empty entry.
+	assert.NotContains(t, got, "drone", "an unmatched name must be absent from the result")
+}
+
+func TestReverseResolveToScientificNames_EmptyInput_Embedded(t *testing.T) {
+	t.Parallel()
+
+	got := ReverseResolveToScientificNames(nil, "fi")
+	assert.NotNil(t, got, "must return an empty, non-nil map for empty input")
+	assert.Empty(t, got)
+}
+
+func TestReverseResolveToScientificSet_FlattensAndLowerCases_Embedded(t *testing.T) {
+	t.Parallel()
+
+	got := ReverseResolveToScientificSet([]string{"mopsilepakko", "Kettu", "Ilves"}, "fi")
+	// The per-entry results are flattened into one lower-cased membership set.
+	assert.Contains(t, got, "barbastella barbastellus", "bat")
+	assert.Contains(t, got, "vulpes vulpes", "fox")
+	assert.Contains(t, got, "lynx lynx", "lynx")
+}
+
+func TestReverseResolveToScientificSet_EmptyInput_Embedded(t *testing.T) {
+	t.Parallel()
+
+	got := ReverseResolveToScientificSet(nil, "fi")
+	assert.NotNil(t, got, "must return an empty, non-nil set for empty input")
+	assert.Empty(t, got)
+}
+
+func TestReverseResolveToScientificNames_MultiResolutionAllLowerCased_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// "Hairy Woodpecker" carries two scientific names in the dataset (a genus split),
+	// so this exercises the per-element lower-casing loop on a multi-element slice:
+	// every name must be lower-cased, not just the first.
+	got := ReverseResolveToScientificNames([]string{"Hairy Woodpecker"}, "en")
+	names := got["Hairy Woodpecker"]
+	require.Len(t, names, 2, "this common name must resolve to two scientific names in the dataset")
+	assert.Contains(t, names, "dryobates villosus")
+	assert.Contains(t, names, "leuconotopicus villosus")
+	for _, n := range names {
+		assert.Equal(t, strings.ToLower(n), n, "every resolved scientific name must be lower-cased, not just the first")
+	}
+}
+
+func TestReverseResolveToScientificSet_FlattensMultiResolutionEntry_Embedded(t *testing.T) {
+	t.Parallel()
+
+	// A single entry resolving to multiple scientific names must contribute ALL of them
+	// to the flat set, not just the first, so the inner flatten loop is exercised.
+	got := ReverseResolveToScientificSet([]string{"Hairy Woodpecker"}, "en")
+	assert.Contains(t, got, "dryobates villosus")
+	assert.Contains(t, got, "leuconotopicus villosus")
+}


### PR DESCRIPTION
## Summary

`openfauna.LookupScientificNames` was wrapped with near-identical "lower-case each returned scientific name into a set" logic at two production sites (`classifier.newExcludeMatcher` and `processor.resolveSpeciesFilter`), so the lower-casing and locale handling could drift between them. This centralizes that logic.

## Changes

Two cohesive helpers in the `openfauna` package (the set is built on the names helper, so the lower-casing lives in exactly one place):

- `ReverseResolveToScientificNames(entries, locale) map[string][]string`: the per-entry, lower-cased result. `resolveSpeciesFilter` uses this because it needs per-entry attribution for its loaded-model gating and unresolved-entry warning.
- `ReverseResolveToScientificSet(entries, locale) map[string]struct{}`: a flat membership set, built by flattening the per-entry helper. `newExcludeMatcher` uses this for fast scientific-name membership tests.

### Why two functions

The two call sites have genuinely different needs: the exclude matcher only tests membership (flat set), while the species filter must know which entry produced which name (to track matched/unmatched entries and warn about config typos). A single flat set cannot serve the filter without losing that attribution.

### Third caller left as-is

`resolveOverrideLabels` also calls `LookupScientificNames`, but it appends scientific names **case-preserved** to a `[]string` of candidate labels for matching (not a lower-cased set), so neither helper fits and migrating it would corrupt the canonical label casing. It is intentionally unchanged.

## Behavior preservation

- `newExcludeMatcher`: previously left `reverseSci` nil when nothing resolved; now it is an empty non-nil map. `matches()` nil-guards and then probes the map, so the result is identical.
- `resolveSpeciesFilter`: the inline `strings.ToLower` is removed because the helper already lower-cases; the `scientificNames`/`resolved` maps are lower-keyed, so the gating and warning logic are unchanged.

## Testing

- New tests cover lower-casing, per-entry keying, flattening, empty-input non-nil returns, and a multi-resolution common name (`"Hairy Woodpecker"` resolves to two scientific names) so the per-element lower-casing loop and multi-element flatten are exercised.
- `go build ./...`, `golangci-lint run`, and the affected packages' tests pass with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added convenience APIs to reverse-resolve localized common names to lower-cased scientific names and to build a de-duplicated scientific-name set.
* **Refactor**
  * Updated species/exclude matching to use the new reverse-resolution helpers for consistent scientific-name casing and cleaner matching logic.
* **Tests**
  * Expanded unit test coverage for reverse-resolution behavior (lower-casing, empty input handling, multi-resolution flattening) and for exclude matching when no reverse matches are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->