### PR TITLE
fix(species): de-duplicate the Active species list at the display boundary

### DIFF
--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -143,6 +143,80 @@ func convertLabels(labels []string, resolver *classifier.Orchestrator, locale st
 	return species
 }
 
+// dedupeSpeciesForDisplay collapses rows that resolve to the same displayed
+// species into a single row, for the user-facing range-filter species lists.
+//
+// Two entries are the same species when their localized common names match
+// (case- and Unicode-NFC-insensitive); entries without a common name fall back
+// to their scientific name so genuinely unresolved labels are not all merged
+// into one bucket. This intentionally collapses both a geomodel-scored species
+// and its force-include override copy (which carry different label strings for
+// the same species) and a pair of taxonomic synonyms that localize to the same
+// common name (e.g. "Cnephaeus nilssonii" and "Eptesicus nilssonii" both
+// resolving to the Finnish "pohjanlepakko").
+//
+// De-duplication happens only here, at the display boundary, never in the
+// functional inclusion set: conf.Settings.IsSpeciesIncluded matches detections
+// on the scientific-name set, so both synonyms must remain in the included
+// species for the engine to detect either name. The key is the same common name
+// already resolved for display, so the survivor row is exactly what the user
+// sees.
+//
+// Because the key is the resolved common name, two genuinely distinct species
+// that happen to share one localized common name would also collapse. That is
+// an accepted trade-off: OpenFauna common names are authoritative for display,
+// the effect is display-only, and both scientific names remain in the inclusion
+// set so detection of the hidden species is unaffected.
+//
+// On collision the higher score wins, so a force-included species at the
+// always-active 1.0 sentinel survives over its lower range-filter probability.
+// The first occurrence's position is preserved (the input arrives sorted by
+// score descending), keeping the output order stable and deterministic.
+func dedupeSpeciesForDisplay(species []RangeFilterSpecies) []RangeFilterSpecies {
+	if len(species) < 2 {
+		return species
+	}
+	indexByKey := make(map[string]int, len(species))
+	deduped := make([]RangeFilterSpecies, 0, len(species))
+	for _, sp := range species {
+		key := normalizeForLookup(sp.CommonName)
+		if key == "" {
+			key = normalizeForLookup(sp.ScientificName)
+		}
+		if key == "" {
+			// No name to key on: keep the row rather than collapsing every
+			// identity-less row into a single bucket.
+			deduped = append(deduped, sp)
+			continue
+		}
+		if idx, ok := indexByKey[key]; ok {
+			if speciesScoreHigher(sp, deduped[idx]) {
+				// Preserve the first occurrence's position, but surface the
+				// higher-scored variant (defensive: the input is already sorted
+				// score-descending, so this rarely triggers).
+				deduped[idx] = sp
+			}
+			continue
+		}
+		indexByKey[key] = len(deduped)
+		deduped = append(deduped, sp)
+	}
+	return deduped
+}
+
+// speciesScoreHigher reports whether a has a strictly higher score than b. A nil
+// score (label-only display rows) sorts below any real score, so a scored entry
+// always wins over an unscored one.
+func speciesScoreHigher(a, b RangeFilterSpecies) bool {
+	if a.Score == nil {
+		return false
+	}
+	if b.Score == nil {
+		return true
+	}
+	return *a.Score > *b.Score
+}
+
 // Location represents geographic coordinates
 type Location struct {
 	Latitude  float64 `json:"latitude"`
@@ -358,10 +432,15 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 // @Router /api/v2/range/species/count [get]
 func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 	settings := c.currentSettings()
-	includedSpecies := settings.GetIncludedSpecies()
+
+	// Count the de-duplicated display list so the count matches what
+	// /range/species/list renders (the same collapse of force-include override
+	// copies and localized taxonomic synonyms).
+	birdnetInstance, _ := c.getBirdNETInstance()
+	speciesList := dedupeSpeciesForDisplay(convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale))
 
 	response := RangeFilterSpeciesCount{
-		Count:       len(includedSpecies),
+		Count:       len(speciesList),
 		LastUpdated: settings.BirdNET.RangeFilter.LastUpdated,
 		Threshold:   settings.BirdNET.RangeFilter.Threshold,
 		Location: Location{
@@ -386,7 +465,7 @@ func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
 	includedSpecies := settings.GetIncludedSpecies()
 
 	birdnetInstance, _ := c.getBirdNETInstance()
-	speciesList := convertLabels(includedSpecies, birdnetInstance, settings.BirdNET.Locale)
+	speciesList := dedupeSpeciesForDisplay(convertLabels(includedSpecies, birdnetInstance, settings.BirdNET.Locale))
 
 	// Extract taxonomy groups from species list via taxonomy DB
 	var genera []string
@@ -515,7 +594,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}
 
-	speciesList := convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale())
+	speciesList := dedupeSpeciesForDisplay(convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale()))
 
 	response := RangeFilterTestResponse{
 		Species:   speciesList,
@@ -623,7 +702,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		settings := c.currentSettings()
 
 		birdnetInstance, _ := c.getBirdNETInstance()
-		speciesList = convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale)
+		speciesList = dedupeSpeciesForDisplay(convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale))
 		location = Location{
 			Latitude:  settings.BirdNET.Latitude,
 			Longitude: settings.BirdNET.Longitude,
@@ -682,7 +761,7 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 		return nil, Location{}, 0, err
 	}
 
-	speciesList := convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale())
+	speciesList := dedupeSpeciesForDisplay(convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale()))
 
 	location := Location{
 		Latitude:  req.Latitude,

--- a/internal/api/v2/range_dedup_test.go
+++ b/internal/api/v2/range_dedup_test.go
@@ -1,0 +1,172 @@
+// range_dedup_test.go: tests for display-boundary de-duplication of the
+// range-filter species lists (collapsing force-include override copies and
+// localized taxonomic synonyms into a single displayed row).
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedupeSpeciesForDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []RangeFilterSpecies
+		want []RangeFilterSpecies
+	}{
+		{
+			name: "nil input",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "single entry unchanged",
+			in:   []RangeFilterSpecies{{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)}},
+			want: []RangeFilterSpecies{{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)}},
+		},
+		{
+			// R1: a geomodel-scored species and its force-include override copy
+			// carry different label strings but the same resolved common name.
+			// They collapse to one row at the always-active 1.0 score.
+			name: "override copy collapses, 1.0 wins",
+			in: []RangeFilterSpecies{
+				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
+				{Label: "Corvus cornix_Hooded Crow", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
+			},
+			want: []RangeFilterSpecies{
+				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
+			},
+		},
+		{
+			// R4: two taxonomic synonyms that localize to the same common name
+			// collapse to a single displayed row (max score wins).
+			name: "synonyms with same common name collapse",
+			in: []RangeFilterSpecies{
+				{Label: "Eptesicus nilssonii", ScientificName: "Eptesicus nilssonii", CommonName: "pohjanlepakko", Score: new(1.0)},
+				{Label: "Cnephaeus nilssonii_Northern Bat", ScientificName: "Cnephaeus nilssonii", CommonName: "pohjanlepakko", Score: new(0.01)},
+			},
+			want: []RangeFilterSpecies{
+				{Label: "Eptesicus nilssonii", ScientificName: "Eptesicus nilssonii", CommonName: "pohjanlepakko", Score: new(1.0)},
+			},
+		},
+		{
+			name: "distinct species are kept",
+			in: []RangeFilterSpecies{
+				{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
+				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.73)},
+			},
+			want: []RangeFilterSpecies{
+				{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
+				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.73)},
+			},
+		},
+		{
+			name: "case insensitive common name collapse",
+			in: []RangeFilterSpecies{
+				{ScientificName: "Eptesicus nilssonii", CommonName: "Pohjanlepakko", Score: new(0.5)},
+				{ScientificName: "Cnephaeus nilssonii", CommonName: "pohjanlepakko", Score: new(0.5)},
+			},
+			want: []RangeFilterSpecies{
+				{ScientificName: "Eptesicus nilssonii", CommonName: "Pohjanlepakko", Score: new(0.5)},
+			},
+		},
+		{
+			// Genuine NFC vs NFD: composed "ö" (U+00F6) vs decomposed "o" + U+0308.
+			// normalizeForLookup recomposes via norm.NFC, so both key identically.
+			// This pins the NFC half of the key; ToLower alone would not collapse them.
+			name: "NFC and NFD decomposed common name collapse",
+			in: []RangeFilterSpecies{
+				{ScientificName: "Strix aluco", CommonName: "Lehtop\u00f6ll\u00f6", Score: new(0.6)},
+				{ScientificName: "Syrnium aluco", CommonName: "Lehtopo\u0308llo\u0308", Score: new(0.4)},
+			},
+			want: []RangeFilterSpecies{
+				{ScientificName: "Strix aluco", CommonName: "Lehtop\u00f6ll\u00f6", Score: new(0.6)},
+			},
+		},
+		{
+			// Without a common name, fall back to the scientific name so unrelated
+			// unresolved rows are not all merged into one bucket.
+			name: "empty common name falls back to scientific name",
+			in: []RangeFilterSpecies{
+				{Label: "Foobarus_x", ScientificName: "Foobarus x"},
+				{Label: "Foobarus x", ScientificName: "Foobarus x"},
+				{Label: "Bazquxus y", ScientificName: "Bazquxus y"},
+			},
+			want: []RangeFilterSpecies{
+				{Label: "Foobarus_x", ScientificName: "Foobarus x"},
+				{Label: "Bazquxus y", ScientificName: "Bazquxus y"},
+			},
+		},
+		{
+			// Rows with neither common nor scientific name have no identity to key
+			// on and must not collapse into a single bucket.
+			name: "identity-less rows are all kept",
+			in: []RangeFilterSpecies{
+				{Label: "a"},
+				{Label: "b"},
+			},
+			want: []RangeFilterSpecies{
+				{Label: "a"},
+				{Label: "b"},
+			},
+		},
+		{
+			// Defensive: even when the higher score is not first, the survivor
+			// surfaces the higher score while keeping the first position.
+			name: "higher score wins regardless of order",
+			in: []RangeFilterSpecies{
+				{Label: "Corvus cornix_Hooded Crow", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
+				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
+			},
+			want: []RangeFilterSpecies{
+				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
+			},
+		},
+		{
+			// A scored entry beats an unscored (label-only) entry for the same species.
+			name: "scored entry wins over unscored",
+			in: []RangeFilterSpecies{
+				{ScientificName: "Parus major", CommonName: "talitiainen"},
+				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.42)},
+			},
+			want: []RangeFilterSpecies{
+				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.42)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := dedupeSpeciesForDisplay(tt.in)
+			require.Len(t, got, len(tt.want))
+			for i := range tt.want {
+				assert.Equal(t, tt.want[i].ScientificName, got[i].ScientificName, "row %d scientific name", i)
+				assert.Equal(t, tt.want[i].CommonName, got[i].CommonName, "row %d common name", i)
+				assert.Equal(t, tt.want[i].Label, got[i].Label, "row %d label", i)
+				if tt.want[i].Score == nil {
+					assert.Nil(t, got[i].Score, "row %d score", i)
+				} else {
+					require.NotNil(t, got[i].Score, "row %d score", i)
+					assert.InDelta(t, *tt.want[i].Score, *got[i].Score, 1e-9, "row %d score value", i)
+				}
+			}
+		})
+	}
+}
+
+func TestSpeciesScoreHigher(t *testing.T) {
+	t.Parallel()
+	assert.True(t, speciesScoreHigher(RangeFilterSpecies{Score: new(1.0)}, RangeFilterSpecies{Score: new(0.5)}))
+	assert.False(t, speciesScoreHigher(RangeFilterSpecies{Score: new(0.5)}, RangeFilterSpecies{Score: new(1.0)}))
+	assert.False(t, speciesScoreHigher(RangeFilterSpecies{Score: new(0.5)}, RangeFilterSpecies{Score: new(0.5)}))
+	// nil score sorts below any real score.
+	assert.False(t, speciesScoreHigher(RangeFilterSpecies{}, RangeFilterSpecies{Score: new(0.0)}))
+	assert.True(t, speciesScoreHigher(RangeFilterSpecies{Score: new(0.0)}, RangeFilterSpecies{}))
+	assert.False(t, speciesScoreHigher(RangeFilterSpecies{}, RangeFilterSpecies{}))
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -538,9 +538,20 @@ func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float
 // When the primary is not a universal predictor (legacy TFLite range filter
 // with no geomodel) there is no coverage set to consult, so every non-primary
 // label whose scientific name is not already represented is added at score 1.0
-// (exclude honored), preserving prior multi-classifier behavior. Deduplication
-// is by scientific name throughout, never exact label, because the geomodel and
-// Perch use different label conventions for the same species.
+// (exclude honored), preserving prior multi-classifier behavior. Non-primary
+// additions are deduped against the primary by scientific name (never exact
+// label), because the geomodel and Perch use different label conventions for
+// the same species.
+//
+// This does NOT collapse near-duplicates that already exist within the primary
+// scores: a force-included species can appear both at its range-filter score and
+// as the override's score-1.0 entry (the two carry different label strings), and
+// two taxonomic synonyms for one taxon (e.g. "Cnephaeus nilssonii" vs the older
+// "Eptesicus nilssonii") are deliberately kept as distinct scientific names so
+// both pass the scientific-name inclusion gate (conf.Settings.IsSpeciesIncluded)
+// during audio processing. Those near-duplicates are collapsed for the user only
+// at the display boundary (dedupeSpeciesForDisplay in internal/api/v2/range.go),
+// keyed on the resolved common name, so the functional inclusion set stays intact.
 //
 // The bat model is handled separately from the loop above: it has no geomodel,
 // so its species can never be range-filtered. They are all included as

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -337,6 +337,15 @@ func resolveOverrideLabels(settings *conf.Settings, geoLabels []string) []string
 // Used by the universal geomodel path in getProbableSpecies. Each entry is
 // canonicalized via resolveOverrideLabels so localized common names enter the
 // set as their canonical model labels rather than the raw user string.
+//
+// Dedup here is by exact label and intentionally narrow: it only avoids
+// re-appending a label already present verbatim. A force-included species that
+// the geomodel also scored can therefore appear twice (its range-filter score
+// plus this score-1.0 entry) when the two carry different label strings; that is
+// expected. The score-1.0 entry must be kept so the species reads as
+// always-active, and same-taxon near-duplicates are collapsed for the user at
+// the display boundary (dedupeSpeciesForDisplay in internal/api/v2/range.go),
+// not here, so the functional inclusion set keeps every scientific name.
 func addUserOverrideSpeciesScores(bn *BirdNET, speciesScores *[]SpeciesScore, settings *conf.Settings, geoLabels []string) {
 	seen := make(map[string]bool, len(*speciesScores))
 	for _, ss := range *speciesScores {

--- a/internal/detection/species.go
+++ b/internal/detection/species.go
@@ -66,7 +66,18 @@ func ParseSpeciesString(species string) Species {
 
 // ExtractScientificName returns the scientific name portion from a
 // "ScientificName_CommonName" label string.
+//
+// It applies the same sanitization as ParseSpeciesString, in the same order
+// (trim surrounding whitespace, then drop carriage returns), before splitting,
+// so a scientific name extracted here keys identically to one obtained via
+// ParseSpeciesString. Model label files commonly carry a trailing CR on CRLF
+// lines, and a stray leading/trailing space would otherwise hash the same
+// species to two distinct keys across the call sites that mix the two
+// extractors (for example the scientific-name dedup keys in the orchestrator's
+// probable-species merge).
 func ExtractScientificName(label string) string {
+	label = strings.TrimSpace(label)
+	label = strings.ReplaceAll(label, "\r", "")
 	if sci, _, ok := strings.Cut(label, "_"); ok {
 		return sci
 	}

--- a/internal/detection/species_test.go
+++ b/internal/detection/species_test.go
@@ -21,6 +21,11 @@ func TestExtractScientificName(t *testing.T) {
 		{"scientific name only", "Turdus merula", "Turdus merula"},
 		{"non-species label", "noise", "noise"},
 		{"empty string", "", ""},
+		{"trailing carriage return", "Turdus merula_Common Blackbird\r", "Turdus merula"},
+		{"carriage return before underscore", "Turdus merula\r_Common Blackbird", "Turdus merula"},
+		{"leading whitespace", "  Turdus merula_Common Blackbird", "Turdus merula"},
+		{"trailing whitespace scientific only", "Turdus merula  ", "Turdus merula"},
+		{"carriage return scientific only", "Turdus merula\r", "Turdus merula"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The Settings > Species **Active** list (and the related range-filter species endpoints) could show the same species twice on a multi-model setup:

1. **Same scientific name, two rows.** A force-included species appeared both at its range-filter probability (e.g. `Corvus cornix` 0.71) and at the always-active `1.00` override copy. The two rows carry different label strings for the same species, so the existing exact-label dedup never merged them.
2. **Taxonomic synonyms, two rows.** A species predicted by the v3 geomodel under one accepted name and force-included under an OpenFauna-resolved synonym (e.g. `Cnephaeus nilssonii` vs the older `Eptesicus nilssonii`, both localizing to the Finnish "pohjanlepakko") showed as two rows; a scientific-name dedup cannot merge two valid synonyms.

### Fix

Collapse rows at the **display boundary**, keyed on the resolved common name (falling back to the scientific name when unresolved), keeping the higher score so a force-included species stays marked always-active (`1.00`). Applied consistently to every range-filter species display surface: `POST /range/species/test`, `GET /range/species/list`, `GET /range/species/count`, and the CSV export. The raw diagnostic `GET /range/species/scores` is intentionally left un-deduplicated.

The **functional inclusion set is intentionally untouched.** `conf.Settings.IsSpeciesIncluded` matches detections on the scientific-name set, so both synonyms must remain in the included species for the engine to detect either name. De-duplication is purely cosmetic and never hides a species from detection.

Also aligns `detection.ExtractScientificName` with `ParseSpeciesString` (trim whitespace and strip CR before splitting) so the same label no longer hashes to two distinct scientific-name dedup keys.

## Test Plan

- [x] New unit tests for the dedup helper: override-copy collapse, synonym collapse, case- and NFC/NFD-insensitive keys, scientific-name fallback, identity-less rows kept, max-score-wins, scored-beats-unscored.
- [x] New `ExtractScientificName` cases covering CR/whitespace on both label sides.
- [x] `go build ./...`, `go vet`, `golangci-lint` (full project, 0 issues), and `go test -race` for `internal/api/v2`, `internal/detection`, `internal/classifier` all pass.
- [ ] Verify on the live multi-model station that the Active list shows one row per species.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Species entries in API range endpoints now de-duplicate when multiple labels resolve to the same localized common name, prioritizing higher scores.

* **Tests**
  * Added comprehensive test coverage for species de-duplication logic across various collision scenarios.
  * Extended input sanitization tests to handle Windows line-ending formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->