### PR TITLE
refactor(frontend): extract shared anchor/flip positioning helper

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SelectDropdown.svelte
+++ b/frontend/src/lib/desktop/components/forms/SelectDropdown.svelte
@@ -385,7 +385,7 @@
   // own option list. Those don't move the trigger and would otherwise recompute
   // the same position on every scroll tick.
   function handleScroll(event: Event) {
-    if (dropdownElement?.contains(event.target as Node)) return;
+    if (event.target instanceof Node && dropdownElement?.contains(event.target)) return;
     updateDropdownPosition();
   }
 

--- a/frontend/src/lib/desktop/components/forms/SelectDropdown.svelte
+++ b/frontend/src/lib/desktop/components/forms/SelectDropdown.svelte
@@ -5,6 +5,7 @@
   import { X, ChevronDown, Check } from '@lucide/svelte';
   import { dropdown } from '$lib/utils/transitions';
   import { portal } from '$lib/utils/portal';
+  import { computeAnchorPosition, type AnchorPosition } from '$lib/utils/anchorPosition';
   import {
     safeGet,
     safeArrayAccess,
@@ -90,8 +91,18 @@
   let inputElement = $state<HTMLInputElement>();
   let buttonElement = $state<HTMLButtonElement>();
 
-  // Position state for fixed dropdown
-  let dropdownPosition = $state({ top: 0, left: 0, width: 0, openAbove: false });
+  // Gap in px between the trigger button and the dropdown menu.
+  const DROPDOWN_OFFSET = 4;
+
+  // Position state for the fixed, portaled dropdown. `width` tracks the trigger
+  // width; the rest comes from the shared anchor/flip helper.
+  let dropdownPosition = $state<AnchorPosition & { width: number }>({
+    placement: 'below',
+    top: 0,
+    bottom: null,
+    left: 0,
+    width: 0,
+  });
 
   // Portal target: nearest dialog ancestor (for focus containment) or body
   let portalTarget = $derived.by(
@@ -209,25 +220,24 @@
     return selectedOptions[0].label;
   });
 
-  // Calculate dropdown position based on button element
-  // Uses viewport coordinates for fixed positioning
+  // Calculate dropdown position based on the button element, using viewport
+  // coordinates for fixed positioning. The flip decision uses the dropdown's real
+  // rendered height once it is in the DOM, falling back to the maxHeight cap before
+  // the first layout (so a short list no longer flips above prematurely).
   function updateDropdownPosition() {
     if (!buttonElement) return;
 
     const rect = buttonElement.getBoundingClientRect();
-    const viewportHeight = globalThis.innerHeight;
-    const gap = 4; // px gap between button and dropdown
-    const spaceBelow = viewportHeight - rect.bottom - gap;
-    const spaceAbove = rect.top - gap;
-    // Open above if not enough space below and more space above
-    const openAbove = spaceBelow < maxHeight && spaceAbove > spaceBelow;
+    const position = computeAnchorPosition({
+      triggerRect: rect,
+      floatingHeight: dropdownElement?.offsetHeight ?? 0,
+      floatingWidth: rect.width,
+      estimatedHeight: maxHeight,
+      offset: DROPDOWN_OFFSET,
+      align: 'start',
+    });
 
-    dropdownPosition = {
-      top: openAbove ? rect.top - gap : rect.bottom + gap,
-      left: rect.left,
-      width: rect.width,
-      openAbove,
-    };
+    dropdownPosition = { ...position, width: rect.width };
   }
 
   // Event handlers
@@ -370,14 +380,26 @@
     }
   }
 
+  // Capture-phase scroll handler: reposition when an outer/ancestor container
+  // scrolls (which moves the trigger), but ignore scrolls inside the dropdown's
+  // own option list. Those don't move the trigger and would otherwise recompute
+  // the same position on every scroll tick.
+  function handleScroll(event: Event) {
+    if (dropdownElement?.contains(event.target as Node)) return;
+    updateDropdownPosition();
+  }
+
   $effect(() => {
     if (isOpen) {
+      // Re-measure now that the dropdown is in the DOM, so the flip decision uses
+      // its real height rather than the pre-layout maxHeight estimate.
+      updateDropdownPosition();
       document.addEventListener('click', handleClickOutside);
-      window.addEventListener('scroll', updateDropdownPosition, true);
+      window.addEventListener('scroll', handleScroll, true);
       window.addEventListener('resize', updateDropdownPosition);
       return () => {
         document.removeEventListener('click', handleClickOutside);
-        window.removeEventListener('scroll', updateDropdownPosition, true);
+        window.removeEventListener('scroll', handleScroll, true);
         window.removeEventListener('resize', updateDropdownPosition);
       };
     }
@@ -467,10 +489,8 @@
           'fixed z-[2100] font-sans bg-[var(--color-base-100)] rounded-md shadow-xl border border-[var(--color-base-content)]/20 overflow-hidden',
           dropdownClassName
         )}
-        style:top={dropdownPosition.openAbove ? 'auto' : `${dropdownPosition.top}px`}
-        style:bottom={dropdownPosition.openAbove
-          ? `${globalThis.innerHeight - dropdownPosition.top}px`
-          : 'auto'}
+        style:top={dropdownPosition.top !== null ? `${dropdownPosition.top}px` : 'auto'}
+        style:bottom={dropdownPosition.bottom !== null ? `${dropdownPosition.bottom}px` : 'auto'}
         style:left="{dropdownPosition.left}px"
         style:width="{dropdownPosition.width}px"
         style:max-height="{maxHeight}px"

--- a/frontend/src/lib/desktop/components/ui/ActionMenu.svelte
+++ b/frontend/src/lib/desktop/components/ui/ActionMenu.svelte
@@ -31,10 +31,14 @@
     CircleX,
   } from '@lucide/svelte';
   import { dropdown } from '$lib/utils/transitions';
+  import { computeAnchorPosition, applyAnchorPosition } from '$lib/utils/anchorPosition';
   import { auth } from '$lib/stores/auth';
   import { t } from '$lib/i18n';
 
   let canEdit = $derived(!$auth.security.enabled || $auth.security.accessAllowed);
+
+  // Gap in px between the trigger button and the menu.
+  const MENU_OFFSET = 8;
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
     /** The detection object containing data for this action menu */
@@ -95,27 +99,19 @@
   function updateMenuPosition() {
     if (!menuElement || !buttonElement) return;
 
-    const buttonRect = buttonElement.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - buttonRect.bottom;
-    const spaceAbove = buttonRect.top;
-    const menuHeight = menuElement.offsetHeight;
-
-    // Position menu relative to viewport
-    menuElement.style.position = 'fixed';
+    // Align the menu's right edge with the button (clamped into the viewport so a
+    // wide menu near the left edge cannot overflow off-screen), flipping above when
+    // there is not enough room below.
+    const position = computeAnchorPosition({
+      triggerRect: buttonElement.getBoundingClientRect(),
+      floatingHeight: menuElement.offsetHeight,
+      floatingWidth: menuElement.offsetWidth,
+      offset: MENU_OFFSET,
+      align: 'end',
+    });
+    applyAnchorPosition(menuElement, position);
+    // Stacking is owned by the component (kept above overlay content).
     menuElement.style.zIndex = '9999';
-
-    // Determine vertical position
-    if (spaceBelow < menuHeight && spaceAbove > spaceBelow) {
-      menuElement.style.bottom = `${window.innerHeight - buttonRect.top + 8}px`;
-      menuElement.style.top = 'auto';
-    } else {
-      menuElement.style.top = `${buttonRect.bottom + 8}px`;
-      menuElement.style.bottom = 'auto';
-    }
-
-    // Always align menu's right edge with button's right edge
-    menuElement.style.left = 'auto';
-    menuElement.style.right = `${window.innerWidth - buttonRect.right}px`;
   }
 
   /** Toggles the menu open/closed state and updates position when opening */

--- a/frontend/src/lib/desktop/components/ui/DatePicker.svelte
+++ b/frontend/src/lib/desktop/components/ui/DatePicker.svelte
@@ -43,13 +43,19 @@ Accessibility:
 - Focus management and visual indicators
 -->
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { cn } from '$lib/utils/cn.js';
   import { Calendar, ChevronLeft, ChevronRight } from '@lucide/svelte';
   import { dropdown } from '$lib/utils/transitions';
+  import { computeAnchorPosition } from '$lib/utils/anchorPosition';
   import { getLocalDateString } from '$lib/utils/date.js';
   import { t } from '$lib/i18n';
   import type { HTMLAttributes } from 'svelte/elements';
+
+  // Gap in px between the trigger and the calendar, and pre-layout size estimates
+  // used only before the calendar's real dimensions can be measured.
+  const CALENDAR_OFFSET = 4;
+  const CALENDAR_WIDTH_ESTIMATE = 280;
+  const CALENDAR_HEIGHT_ESTIMATE = 360;
 
   type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
@@ -127,20 +133,25 @@ Accessibility:
   // Generate a unique ID for this datepicker instance
   const pickerId = $state(Math.random().toString(36).slice(2, 9));
 
-  // Calculate dropdown position based on trigger button's bounding rect
+  // Calculate dropdown position based on the trigger button's bounding rect.
+  // When flipping above, the helper anchors the calendar's bottom edge, so the
+  // placement stays aligned regardless of the calendar's (month-dependent) height.
   function updateDropdownPosition() {
     const trigger =
       document.querySelector(`[data-datepicker-id="${pickerId}"]`) ||
       wrapperRef?.querySelector('.datepicker-trigger');
     if (!trigger) return;
-    const rect = trigger.getBoundingClientRect();
-    const calendarWidth = calendarRef?.offsetWidth ?? 280;
-    const calendarHeight = calendarRef?.offsetHeight ?? 0;
-    const maxLeft = Math.max(8, window.innerWidth - calendarWidth - 8);
-    const left = Math.min(Math.max(rect.left, 8), maxLeft);
-    const fitsBelow = rect.bottom + 4 + calendarHeight <= window.innerHeight - 8;
-    const top = fitsBelow ? rect.bottom + 4 : Math.max(8, rect.top - calendarHeight - 4);
-    dropdownStyle = `position: fixed; top: ${top}px; left: ${left}px; z-index: 1100;`;
+    const position = computeAnchorPosition({
+      triggerRect: trigger.getBoundingClientRect(),
+      floatingHeight: calendarRef?.offsetHeight ?? 0,
+      floatingWidth: calendarRef?.offsetWidth ?? CALENDAR_WIDTH_ESTIMATE,
+      estimatedHeight: CALENDAR_HEIGHT_ESTIMATE,
+      offset: CALENDAR_OFFSET,
+      align: 'start',
+    });
+    const vertical =
+      position.top !== null ? `top: ${position.top}px` : `bottom: ${position.bottom}px`;
+    dropdownStyle = `position: fixed; ${vertical}; left: ${position.left}px; z-index: 1100;`;
   }
 
   // State for keyboard navigation focus
@@ -271,6 +282,11 @@ Accessibility:
       : t('components.datePicker.aria.calendarClosed');
     if (opening) {
       focusedDate = selectedDate || new Date();
+      // Position synchronously so the calendar's first painted frame is already
+      // fixed-positioned (no static-flow flash). The element is not in the DOM yet,
+      // so this uses the height estimate; the open-gated effect re-measures the real
+      // height once it mounts. The "above" anchor is bottom-pinned (Invariant A), so
+      // an estimate that differs from the real height cannot misalign it.
       updateDropdownPosition();
     }
   }
@@ -411,22 +427,17 @@ Accessibility:
     }
   }
 
-  onMount(() => {
-    document.addEventListener('click', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  });
-
-  // Reposition or close dropdown on scroll/resize
+  // Reposition on scroll/resize and handle click-outside, but only while the
+  // calendar is open so a closed picker keeps no global listeners.
   $effect(() => {
     if (showCalendar) {
       updateDropdownPosition();
       const handleReposition = () => updateDropdownPosition();
+      document.addEventListener('click', handleClickOutside);
       window.addEventListener('scroll', handleReposition, true);
       window.addEventListener('resize', handleReposition);
       return () => {
+        document.removeEventListener('click', handleClickOutside);
         window.removeEventListener('scroll', handleReposition, true);
         window.removeEventListener('resize', handleReposition);
       };

--- a/frontend/src/lib/desktop/components/ui/DatePicker.svelte
+++ b/frontend/src/lib/desktop/components/ui/DatePicker.svelte
@@ -129,19 +129,15 @@ Accessibility:
   );
   let calendarRef = $state<HTMLDivElement>();
   let buttonRef = $state<HTMLButtonElement>();
-  let wrapperRef: HTMLDivElement | null = $state(null);
   let dropdownStyle = $state('');
-
-  // Generate a unique ID for this datepicker instance
-  const pickerId = $state(Math.random().toString(36).slice(2, 9));
 
   // Calculate dropdown position based on the trigger button's bounding rect.
   // When flipping above, the helper anchors the calendar's bottom edge, so the
   // placement stays aligned regardless of the calendar's (month-dependent) height.
   function updateDropdownPosition() {
-    const trigger =
-      document.querySelector(`[data-datepicker-id="${pickerId}"]`) ||
-      wrapperRef?.querySelector('.datepicker-trigger');
+    // buttonRef is bound to the trigger, so use it directly rather than querying the
+    // DOM on every scroll/resize reposition.
+    const trigger = buttonRef;
     if (!trigger) return;
     const position = computeAnchorPosition({
       triggerRect: trigger.getBoundingClientRect(),
@@ -467,12 +463,11 @@ Accessibility:
   });
 </script>
 
-<div bind:this={wrapperRef} class={cn('relative datepicker-wrapper', className)}>
+<div class={cn('relative datepicker-wrapper', className)}>
   <!-- Date Input Button -->
   <button
     bind:this={buttonRef}
     type="button"
-    data-datepicker-id={pickerId}
     {...restProps}
     class={cn('datepicker-trigger', sizeClass, disabled && 'opacity-50 cursor-not-allowed')}
     onclick={toggleCalendar}

--- a/frontend/src/lib/desktop/components/ui/DatePicker.svelte
+++ b/frontend/src/lib/desktop/components/ui/DatePicker.svelte
@@ -56,6 +56,8 @@ Accessibility:
   const CALENDAR_OFFSET = 4;
   const CALENDAR_WIDTH_ESTIMATE = 280;
   const CALENDAR_HEIGHT_ESTIMATE = 360;
+  // Stacking order for the portaled-style fixed calendar (above page chrome).
+  const CALENDAR_Z_INDEX = 1100;
 
   type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
@@ -151,7 +153,7 @@ Accessibility:
     });
     const vertical =
       position.top !== null ? `top: ${position.top}px` : `bottom: ${position.bottom}px`;
-    dropdownStyle = `position: fixed; ${vertical}; left: ${position.left}px; z-index: 1100;`;
+    dropdownStyle = `position: fixed; ${vertical}; left: ${position.left}px; z-index: ${CALENDAR_Z_INDEX};`;
   }
 
   // State for keyboard navigation focus
@@ -432,14 +434,13 @@ Accessibility:
   $effect(() => {
     if (showCalendar) {
       updateDropdownPosition();
-      const handleReposition = () => updateDropdownPosition();
       document.addEventListener('click', handleClickOutside);
-      window.addEventListener('scroll', handleReposition, true);
-      window.addEventListener('resize', handleReposition);
+      window.addEventListener('scroll', updateDropdownPosition, true);
+      window.addEventListener('resize', updateDropdownPosition);
       return () => {
         document.removeEventListener('click', handleClickOutside);
-        window.removeEventListener('scroll', handleReposition, true);
-        window.removeEventListener('resize', handleReposition);
+        window.removeEventListener('scroll', updateDropdownPosition, true);
+        window.removeEventListener('resize', updateDropdownPosition);
       };
     }
   });

--- a/frontend/src/lib/desktop/components/ui/DatePicker.test.ts
+++ b/frontend/src/lib/desktop/components/ui/DatePicker.test.ts
@@ -579,19 +579,28 @@ describe('DatePicker Component', () => {
       expect(gridcells.length).toBeGreaterThan(30); // At least 31 date buttons plus empty cells
     });
 
-    it('cleans up event listeners on unmount', () => {
+    it('adds the click-outside listener only while open and removes it on unmount', async () => {
       const onChange = vi.fn();
       const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
       const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
 
       const { unmount } = render(DatePicker, { value: '', onChange });
 
-      // Should add click listener
+      // The click-outside listener is gated on the calendar being open, so a
+      // closed picker keeps no global document listener.
+      expect(addEventListenerSpy).not.toHaveBeenCalledWith('click', expect.any(Function));
+
+      // Opening the calendar registers the listener.
+      const button = screen.getByLabelText('Select date');
+      await user.click(button);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
       expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
 
       unmount();
 
-      // Should remove click listener
+      // Unmounting while open tears the listener down.
       expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
 
       addEventListenerSpy.mockRestore();

--- a/frontend/src/lib/desktop/features/dashboard/components/AudioSettingsButton.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/AudioSettingsButton.svelte
@@ -16,6 +16,7 @@
 <script lang="ts">
   import { Volume2 } from '@lucide/svelte';
   import { dropdown } from '$lib/utils/transitions';
+  import { computeAnchorPosition, applyAnchorPosition } from '$lib/utils/anchorPosition';
   import { t } from '$lib/i18n';
   import { SPEED_OPTIONS, DEFAULT_PLAYBACK_SPEED } from '$lib/utils/audio';
 
@@ -50,6 +51,8 @@
   const GAIN_MIN_DB = -20;
   const FILTER_HP_MIN_FREQ = 20;
   const FILTER_HP_MAX_FREQ = 5000;
+  // Gap in px between the trigger button and the settings menu.
+  const MENU_OFFSET = 8;
 
   // Generate unique ID for this component instance
   const instanceId = Math.random().toString(36).slice(2, 9);
@@ -73,26 +76,19 @@
   function updateMenuPosition() {
     if (!menuElement || !buttonElement) return;
 
-    const buttonRect = buttonElement.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - buttonRect.bottom;
-    const spaceAbove = buttonRect.top;
-    const menuHeight = menuElement.offsetHeight;
-
-    menuElement.style.position = 'fixed';
+    // Align the menu's right edge with the button (clamped into the viewport so a
+    // wide menu near the left edge cannot overflow off-screen), flipping above when
+    // there is not enough room below.
+    const position = computeAnchorPosition({
+      triggerRect: buttonElement.getBoundingClientRect(),
+      floatingHeight: menuElement.offsetHeight,
+      floatingWidth: menuElement.offsetWidth,
+      offset: MENU_OFFSET,
+      align: 'end',
+    });
+    applyAnchorPosition(menuElement, position);
+    // Stacking is owned by the component (kept above overlay content).
     menuElement.style.zIndex = '9999';
-
-    // Position below or above based on available space
-    if (spaceBelow < menuHeight && spaceAbove > spaceBelow) {
-      menuElement.style.bottom = `${window.innerHeight - buttonRect.top + 8}px`;
-      menuElement.style.top = 'auto';
-    } else {
-      menuElement.style.top = `${buttonRect.bottom + 8}px`;
-      menuElement.style.bottom = 'auto';
-    }
-
-    // Align to right edge of button
-    menuElement.style.left = 'auto';
-    menuElement.style.right = `${window.innerWidth - buttonRect.right}px`;
   }
 
   function handleToggle(event: MouseEvent) {
@@ -158,11 +154,13 @@
     }
   });
 
-  // Cleanup on unmount
+  // Cleanup on unmount: if the menu is open when the component is destroyed, notify
+  // the parent so its open-menu tracking stays in sync (mirrors ActionMenu). Avoid
+  // mutating $state during teardown.
   $effect(() => {
     return () => {
       if (showSettings) {
-        showSettings = false;
+        onMenuClose?.();
       }
     };
   });

--- a/frontend/src/lib/desktop/features/dashboard/components/AudioSettingsButton.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/AudioSettingsButton.svelte
@@ -195,6 +195,8 @@
       onkeydown={e => {
         if (e.key === 'Escape') {
           showSettings = false;
+          onMenuClose?.();
+          buttonElement?.focus();
         }
         e.stopPropagation();
       }}

--- a/frontend/src/lib/utils/anchorPosition.test.ts
+++ b/frontend/src/lib/utils/anchorPosition.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeAnchorPosition,
+  applyAnchorPosition,
+  type TriggerRect,
+  type AnchorPosition,
+} from './anchorPosition';
+
+const VIEWPORT = { width: 1000, height: 800 };
+
+/** Build a trigger rect; defaults to a small trigger near the top-left. */
+function rect(overrides: Partial<TriggerRect> = {}): TriggerRect {
+  return {
+    top: 100,
+    bottom: 130,
+    left: 200,
+    right: 300,
+    width: 100,
+    ...overrides,
+  };
+}
+
+describe('computeAnchorPosition', () => {
+  describe('placement decision', () => {
+    it('places below when there is room below the trigger', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect(),
+        floatingHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(pos.placement).toBe('below');
+      expect(pos.top).toBe(130 + 8); // triggerRect.bottom + default offset
+      expect(pos.bottom).toBeNull();
+    });
+
+    it('flips above when there is not enough room below and more room above', () => {
+      // Trigger low in the viewport: bottom at 760, only 40px below, plenty above.
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ top: 730, bottom: 760 }),
+        floatingHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(pos.placement).toBe('above');
+      expect(pos.bottom).toBe(800 - 730 + 8); // viewport.height - triggerRect.top + offset
+      expect(pos.top).toBeNull();
+    });
+
+    it('stays below when room below is tight but there is even less room above', () => {
+      // Trigger high: top at 30 (little above), bottom at 700 (100px below).
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ top: 30, bottom: 700 }),
+        floatingHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      // spaceBelow (100) < height+offset (208) would suggest flipping, but
+      // spaceAbove (30) is not greater than spaceBelow (100), so it stays below.
+      expect(pos.placement).toBe('below');
+    });
+
+    it('flips earlier when an earlyFlipBuffer is provided', () => {
+      const base = {
+        triggerRect: rect({ top: 400, bottom: 430 }),
+        floatingHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      };
+      // spaceBelow = 370, height+offset = 208 -> stays below without a buffer.
+      expect(computeAnchorPosition(base).placement).toBe('below');
+      // With a large buffer the required room below exceeds the available space,
+      // and there is more room above (spaceAbove 400 > spaceBelow 370) -> flips.
+      expect(computeAnchorPosition({ ...base, earlyFlipBuffer: 200 }).placement).toBe('above');
+    });
+  });
+
+  describe('Invariant A: "above" anchors the bottom edge (height-independent)', () => {
+    it('produces the same bottom value regardless of element height', () => {
+      const triggerRect = rect({ top: 730, bottom: 760 });
+      const shortPopup = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      const tallPopup = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 340,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(shortPopup.placement).toBe('above');
+      expect(tallPopup.placement).toBe('above');
+      // The bottom edge meets the trigger identically; only the upward extent differs.
+      expect(shortPopup.bottom).toBe(tallPopup.bottom);
+    });
+
+    it('regression (PR #3498): an estimate that differs from the real height does not misalign the above edge', () => {
+      const triggerRect = rect({ top: 730, bottom: 760 });
+      // First pass uses an estimate (real height not yet measured).
+      const estimated = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 0,
+        estimatedHeight: 280,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      // After layout, the real height (340) is larger than the estimate (280).
+      const measured = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 340,
+        estimatedHeight: 280,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(estimated.placement).toBe('above');
+      expect(measured.placement).toBe('above');
+      // Because "above" anchors the bottom edge, the wrong estimate cannot shift it.
+      expect(estimated.bottom).toBe(measured.bottom);
+    });
+
+    it('clamps the bottom so a tall element flipped above keeps its top edge on-screen', () => {
+      // Short viewport, mid trigger: flips above (more room above than below), but the
+      // element is taller than the space above, so an unclamped bottom anchor would
+      // push the top edge off the top of the viewport.
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ top: 300, bottom: 330 }),
+        floatingHeight: 400,
+        floatingWidth: 100,
+        viewport: { width: 1000, height: 600 },
+      });
+      expect(pos.placement).toBe('above');
+      // bottom clamped to viewport.height - height - viewportMargin = 600 - 400 - 8 = 192,
+      // which puts the top edge at 600 - 192 - 400 = 8 (== viewportMargin), still on-screen.
+      expect(pos.bottom).toBe(192);
+      expect(pos.top).toBeNull();
+    });
+  });
+
+  describe('Invariant B: measured height with estimate fallback', () => {
+    it('uses the estimate for the flip decision when the height is not yet measured (offsetHeight 0)', () => {
+      // DatePicker first-open case: low trigger, height still 0 at first call.
+      const triggerRect = rect({ top: 730, bottom: 760 });
+      const withoutEstimate = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 0,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      const withEstimate = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 0,
+        estimatedHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      // Height 0 with no estimate -> spaceBelow(40) < offset(8) is false -> stays below
+      // (the pre-fix DatePicker bug: a 0 height always "fits below").
+      expect(withoutEstimate.placement).toBe('below');
+      // With an estimate the helper correctly flips above on the first pass.
+      expect(withEstimate.placement).toBe('above');
+    });
+
+    it('prefers the measured height over the estimate when both are present', () => {
+      const triggerRect = rect({ top: 730, bottom: 760 });
+      // Measured height is small enough to fit below would-be... but here it is large.
+      const pos = computeAnchorPosition({
+        triggerRect,
+        floatingHeight: 300,
+        estimatedHeight: 10, // would wrongly keep it below if used
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(pos.placement).toBe('above');
+    });
+  });
+
+  describe('horizontal alignment and clamping', () => {
+    it('aligns the left edge to the trigger for align=start', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ left: 200, right: 300 }),
+        floatingHeight: 100,
+        floatingWidth: 100,
+        align: 'start',
+        viewport: VIEWPORT,
+      });
+      expect(pos.left).toBe(200);
+    });
+
+    it('aligns the right edge to the trigger for align=end', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ left: 600, right: 700 }),
+        floatingHeight: 100,
+        floatingWidth: 250,
+        align: 'end',
+        viewport: VIEWPORT,
+      });
+      expect(pos.left).toBe(700 - 250); // right edge aligns with trigger right
+    });
+
+    it('centres on the trigger for align=center', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ left: 400, right: 500, width: 100 }),
+        floatingHeight: 100,
+        floatingWidth: 200,
+        align: 'center',
+        viewport: VIEWPORT,
+      });
+      expect(pos.left).toBe(400 + 50 - 100); // trigger centre minus half the element width
+    });
+
+    it('regression (#1086): clamps the left edge when an end-aligned element would overflow the left viewport edge', () => {
+      // Narrow trigger near the left edge with a wide menu pinned to its right edge.
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ left: 10, right: 40, width: 30 }),
+        floatingHeight: 100,
+        floatingWidth: 250, // 40 - 250 = -210 would overflow off-screen left
+        align: 'end',
+        viewportMargin: 8,
+        viewport: VIEWPORT,
+      });
+      expect(pos.left).toBe(8); // clamped to the viewport margin
+    });
+
+    it('clamps the right edge so the element never overflows the right viewport edge', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ left: 950, right: 990, width: 40 }),
+        floatingHeight: 100,
+        floatingWidth: 200,
+        align: 'start',
+        viewportMargin: 8,
+        viewport: VIEWPORT,
+      });
+      // maxLeft = 1000 - 200 - 8 = 792
+      expect(pos.left).toBe(792);
+    });
+  });
+
+  describe('Invariant D: exactly one vertical edge is set', () => {
+    it('sets top and clears bottom when below', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect(),
+        floatingHeight: 100,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(pos.top).not.toBeNull();
+      expect(pos.bottom).toBeNull();
+    });
+
+    it('sets bottom and clears top when above', () => {
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ top: 730, bottom: 760 }),
+        floatingHeight: 200,
+        floatingWidth: 100,
+        viewport: VIEWPORT,
+      });
+      expect(pos.bottom).not.toBeNull();
+      expect(pos.top).toBeNull();
+    });
+  });
+
+  it('honours a custom offset', () => {
+    const pos = computeAnchorPosition({
+      triggerRect: rect(),
+      floatingHeight: 100,
+      floatingWidth: 100,
+      offset: 4,
+      viewport: VIEWPORT,
+    });
+    expect(pos.top).toBe(130 + 4);
+  });
+
+  it('applies the default viewport margin (8) when none is provided', () => {
+    // Right-edge clamp with the default margin: maxLeft = 1000 - 200 - 8 = 792.
+    const pos = computeAnchorPosition({
+      triggerRect: rect({ left: 950, right: 990, width: 40 }),
+      floatingHeight: 100,
+      floatingWidth: 200,
+      align: 'start',
+      viewport: VIEWPORT,
+    });
+    expect(pos.left).toBe(792);
+  });
+
+  it('uses a strict flip comparison at the boundary (does not flip when room below exactly equals need)', () => {
+    // spaceBelow exactly equals height + offset -> the `<` test is false -> stays below.
+    // trigger bottom 592 -> spaceBelow = 800 - 592 = 208 == 200 + 8.
+    const pos = computeAnchorPosition({
+      triggerRect: rect({ top: 560, bottom: 592 }),
+      floatingHeight: 200,
+      floatingWidth: 100,
+      offset: 8,
+      viewport: VIEWPORT,
+    });
+    expect(pos.placement).toBe('below');
+  });
+});
+
+describe('applyAnchorPosition', () => {
+  it('sets position fixed, the active vertical edge, and left; clears the inactive edges (below)', () => {
+    const el = document.createElement('div');
+    const position: AnchorPosition = { placement: 'below', top: 138, bottom: null, left: 200 };
+    applyAnchorPosition(el, position);
+    expect(el.style.position).toBe('fixed');
+    expect(el.style.top).toBe('138px');
+    expect(el.style.bottom).toBe('auto');
+    expect(el.style.left).toBe('200px');
+    expect(el.style.right).toBe('auto');
+  });
+
+  it('anchors the bottom edge and clears top when above', () => {
+    const el = document.createElement('div');
+    const position: AnchorPosition = { placement: 'above', top: null, bottom: 78, left: 200 };
+    applyAnchorPosition(el, position);
+    expect(el.style.bottom).toBe('78px');
+    expect(el.style.top).toBe('auto');
+    expect(el.style.left).toBe('200px');
+  });
+
+  it('does not set z-index (the consumer owns stacking)', () => {
+    const el = document.createElement('div');
+    applyAnchorPosition(el, { placement: 'below', top: 10, bottom: null, left: 20 });
+    expect(el.style.zIndex).toBe('');
+  });
+});

--- a/frontend/src/lib/utils/anchorPosition.test.ts
+++ b/frontend/src/lib/utils/anchorPosition.test.ts
@@ -136,6 +136,24 @@ describe('computeAnchorPosition', () => {
       expect(pos.bottom).toBe(192);
       expect(pos.top).toBeNull();
     });
+
+    it('keeps the top edge at the margin (bottom overflows) for an element taller than the viewport', () => {
+      // Element (400) taller than the whole viewport (300). The clamp pins the top edge
+      // at viewportMargin and lets the bottom overflow, rather than hiding the top content.
+      const viewport = { width: 1000, height: 300 };
+      const pos = computeAnchorPosition({
+        triggerRect: rect({ top: 150, bottom: 180 }),
+        floatingHeight: 400,
+        floatingWidth: 100,
+        viewport,
+      });
+      expect(pos.placement).toBe('above');
+      // maxBottom = 300 - 400 - 8 = -108 (negative is intended: bottom edge below the viewport)
+      expect(pos.bottom).toBe(-108);
+      // top edge = viewport.height - bottom - height = 300 - (-108) - 400 = 8 == viewportMargin
+      const topEdge = viewport.height - (pos.bottom as number) - 400;
+      expect(topEdge).toBe(8);
+    });
   });
 
   describe('Invariant B: measured height with estimate fallback', () => {

--- a/frontend/src/lib/utils/anchorPosition.ts
+++ b/frontend/src/lib/utils/anchorPosition.ts
@@ -1,0 +1,199 @@
+/**
+ * Shared anchor/flip positioning helper for portaled popups and dropdowns.
+ *
+ * Viewport-aware "flip above/below the trigger" placement was hand-rolled
+ * independently across many components, which let the same class of bug drift
+ * in and out of each copy (most visibly a hardcoded height estimate misaligning
+ * the "above" placement). This helper centralises the geometry so every consumer
+ * shares one implementation with the following invariants baked in:
+ *
+ * - A. The "above" placement anchors the element's BOTTOM edge to a viewport
+ *      coordinate, never a `top` derived from the element height, so alignment is
+ *      independent of the rendered height: a wrong or not-yet-measured height
+ *      only changes how far the element extends upward. The single exception is
+ *      when the element is taller than the space above the trigger, where the
+ *      bottom is clamped so the top edge stays within the viewport (otherwise the
+ *      top would be pushed off-screen); that is the only case where height affects
+ *      the above anchor.
+ * - B. The element height is measured (`offsetHeight`); the estimate is used only
+ *      when the measured height is not yet available (`<= 0`).
+ * - C. One flip formula, with an optional early-flip buffer.
+ * - D. Exactly one of `top` / `bottom` is non-null in the result; the consumer
+ *      sets that edge and clears the other.
+ *
+ * The helper computes geometry only. Portal ownership, z-index, transitions, and
+ * listener lifecycle stay with each consumer (see {@link applyAnchorPosition} for
+ * a small applier for components that write inline styles imperatively).
+ */
+
+/** Vertical placement relative to the trigger. */
+export type Placement = 'above' | 'below';
+
+/**
+ * Horizontal alignment of the floating element relative to the trigger.
+ * - `start`: align the floating element's left edge to the trigger's left edge.
+ * - `end`: align the floating element's right edge to the trigger's right edge.
+ * - `center`: centre the floating element on the trigger.
+ *
+ * The result is always clamped into the viewport regardless of alignment.
+ */
+export type HorizontalAlign = 'start' | 'end' | 'center';
+
+/** Minimal trigger rectangle (a subset of DOMRect, so it is easy to construct in tests). */
+export interface TriggerRect {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+}
+
+export interface AnchorPositionInput {
+  /** Trigger bounding rect in viewport coordinates (from `getBoundingClientRect()`). */
+  triggerRect: TriggerRect;
+  /**
+   * Measured height of the floating element (`offsetHeight`). When `<= 0` (not yet
+   * laid out) the helper falls back to {@link AnchorPositionInput.estimatedHeight}.
+   * `offsetHeight` is used rather than `getBoundingClientRect().height` because it
+   * ignores enter-transition `scale()` transforms.
+   */
+  floatingHeight: number;
+  /** Measured width of the floating element, used for clamping and `end`/`center` alignment. */
+  floatingWidth: number;
+  /** Fallback height used only when `floatingHeight <= 0`. Defaults to 0. */
+  estimatedHeight?: number;
+  /** Gap in px between the trigger and the floating element. Defaults to 8. */
+  offset?: number;
+  /** Minimum gap in px kept from the viewport edges. Defaults to 8. */
+  viewportMargin?: number;
+  /**
+   * Extra space (px) required below the trigger before staying below; flips above
+   * earlier when set. Defaults to 0.
+   */
+  earlyFlipBuffer?: number;
+  /** Horizontal alignment relative to the trigger. Defaults to `start`. */
+  align?: HorizontalAlign;
+  /**
+   * Viewport size in px. Defaults to the current `window` dimensions. Pass an
+   * explicit value in tests (or for non-window viewports).
+   */
+  viewport?: { width: number; height: number };
+}
+
+export interface AnchorPosition {
+  placement: Placement;
+  /** Set (px from viewport top) when placement is `below`; null otherwise (Invariant A/D). */
+  top: number | null;
+  /** Set (px from viewport bottom) when placement is `above`; null otherwise (Invariant A/D). */
+  bottom: number | null;
+  /** Left edge in px, clamped into the viewport. */
+  left: number;
+}
+
+const DEFAULT_OFFSET = 8;
+const DEFAULT_VIEWPORT_MARGIN = 8;
+
+function resolveViewport(viewport: AnchorPositionInput['viewport']): {
+  width: number;
+  height: number;
+} {
+  if (viewport) return viewport;
+  // Browser-only fallback: every consumer is a client-side popup that positions from
+  // an event handler, rAF, or an open-gated effect, never during SSR. Tests always
+  // pass an explicit viewport. A future SSR consumer must pass `viewport` explicitly.
+  return { width: globalThis.innerWidth, height: globalThis.innerHeight };
+}
+
+/**
+ * Compute a viewport-aware flip position for a floating element anchored to a trigger.
+ *
+ * Returns a placement plus exactly one vertical anchor edge (`top` for `below`,
+ * `bottom` for `above`) and a clamped `left`. See the module docblock for the
+ * invariants this enforces.
+ */
+export function computeAnchorPosition(input: AnchorPositionInput): AnchorPosition {
+  const {
+    triggerRect,
+    floatingHeight,
+    floatingWidth,
+    estimatedHeight = 0,
+    offset = DEFAULT_OFFSET,
+    viewportMargin = DEFAULT_VIEWPORT_MARGIN,
+    earlyFlipBuffer = 0,
+    align = 'start',
+  } = input;
+
+  const viewport = resolveViewport(input.viewport);
+
+  // Invariant B: prefer the measured height; the estimate is only a pre-layout fallback.
+  const height = floatingHeight > 0 ? floatingHeight : estimatedHeight;
+
+  const spaceBelow = viewport.height - triggerRect.bottom;
+  const spaceAbove = triggerRect.top;
+
+  // Invariant C: a single flip formula. Flip above only when there is not enough
+  // room below for the element plus its gap (and optional buffer) AND there is
+  // genuinely more room above than below.
+  const flipAbove = spaceBelow < height + offset + earlyFlipBuffer && spaceAbove > spaceBelow;
+
+  // Invariant A: "above" anchors the bottom edge; "below" anchors the top edge.
+  let placement: Placement;
+  let top: number | null;
+  let bottom: number | null;
+  if (flipAbove) {
+    placement = 'above';
+    bottom = viewport.height - triggerRect.top + offset;
+    // Invariant A clamp: if the element is taller than the space above the trigger,
+    // anchoring its bottom would push the top edge off-screen. Cap the bottom so the
+    // top edge stays at least `viewportMargin` from the viewport top.
+    const maxBottom = viewport.height - height - viewportMargin;
+    if (bottom > maxBottom) {
+      bottom = Math.max(viewportMargin, maxBottom);
+    }
+    top = null;
+  } else {
+    placement = 'below';
+    top = triggerRect.bottom + offset;
+    bottom = null;
+  }
+
+  // Horizontal alignment, then clamp into the viewport so the element can never
+  // overflow either edge regardless of which edge it aligns to.
+  let idealLeft: number;
+  switch (align) {
+    case 'end':
+      idealLeft = triggerRect.right - floatingWidth;
+      break;
+    case 'center':
+      idealLeft = triggerRect.left + triggerRect.width / 2 - floatingWidth / 2;
+      break;
+    case 'start':
+    default:
+      idealLeft = triggerRect.left;
+      break;
+  }
+  const maxLeft = Math.max(viewportMargin, viewport.width - floatingWidth - viewportMargin);
+  const left = Math.min(Math.max(idealLeft, viewportMargin), maxLeft);
+
+  return { placement, top, bottom, left };
+}
+
+/**
+ * Apply a computed {@link AnchorPosition} to an element's inline styles.
+ *
+ * For consumers that position imperatively (rather than via Svelte `style:`
+ * bindings). Sets `position: fixed`, the single active vertical edge, and `left`,
+ * and clears the inactive edges. Does NOT touch `z-index`; the consumer owns that.
+ */
+export function applyAnchorPosition(element: HTMLElement, position: AnchorPosition): void {
+  element.style.position = 'fixed';
+  element.style.left = `${position.left}px`;
+  element.style.right = 'auto';
+  if (position.top !== null) {
+    element.style.top = `${position.top}px`;
+    element.style.bottom = 'auto';
+  } else {
+    element.style.bottom = `${position.bottom}px`;
+    element.style.top = 'auto';
+  }
+}

--- a/frontend/src/lib/utils/anchorPosition.ts
+++ b/frontend/src/lib/utils/anchorPosition.ts
@@ -148,7 +148,10 @@ export function computeAnchorPosition(input: AnchorPositionInput): AnchorPositio
     // top edge stays at least `viewportMargin` from the viewport top.
     const maxBottom = viewport.height - height - viewportMargin;
     if (bottom > maxBottom) {
-      bottom = Math.max(viewportMargin, maxBottom);
+      // Pin the top edge at the margin so the header / first content stays visible;
+      // an element taller than the available space lets its bottom overflow instead.
+      // (maxBottom can go below viewportMargin for such elements, which is intended.)
+      bottom = maxBottom;
     }
     top = null;
   } else {


### PR DESCRIPTION
## Summary

Viewport-aware "flip above/below the trigger" positioning was hand-rolled independently across several popup/dropdown components, which let the same class of bug drift in and out of each copy. This extracts a single pure helper, `frontend/src/lib/utils/anchorPosition.ts`, and migrates the `position: fixed` cohort onto it.

`computeAnchorPosition()` owns the geometry with these invariants:
- the "above" placement anchors the element's bottom edge (height-independent), never a `top` derived from an estimated height; the bottom is clamped only when the element is taller than the space above, so its top edge stays on-screen
- the element height is measured (`offsetHeight`), with the estimate used only before the first layout
- one flip formula, with an optional early-flip buffer
- exactly one of `top`/`bottom` is returned; `left` is clamped into the viewport

`applyAnchorPosition()` applies the result for components that write inline styles imperatively. Portal ownership, z-index, transitions, and listener lifecycle stay with each consumer.

Migrated `ActionMenu`, `AudioSettingsButton`, `DatePicker`, and `SelectDropdown`. This also fixes three latent positioning bugs found while reviewing those files:
- `DatePicker` mis-flipped on first open (the "above" case was top-anchored with an unguarded zero height). It now bottom-anchors, positions synchronously on open so the first painted frame is already fixed-positioned, and gates its click-outside listener on the open state instead of binding it for the component's whole lifetime.
- `ActionMenu` / `AudioSettingsButton` menus could overflow the left viewport edge (right-pinned with no left clamp). The shared helper clamps the horizontal axis after alignment.
- `SelectDropdown` flipped above prematurely because the flip decision used the static `maxHeight` cap instead of the measured dropdown height.

While in these files I also: made `AudioSettingsButton` call `onMenuClose()` on unmount-while-open (keeps the parent's open-menu tracking in sync, mirroring `ActionMenu`) instead of mutating state during teardown, and made `SelectDropdown`'s capture-phase scroll handler ignore scrolls inside the dropdown's own list so internal scrolling no longer thrashes the position.

`SpeciesInput`, `EditorSpeciesInput`, `BirdThumbnailPopup`, and `SunTimeTooltip` keep their own positioners for now (they use a different coordinate strategy or need side-placement/arrow modes) and migrate incrementally in follow-ups.

## Test Plan

- [x] `npm run check:all` (prettier, eslint, stylelint, svelte-check) passes with 0 errors
- [x] Full frontend test suite passes (2198 tests)
- [x] New `anchorPosition.test.ts` (25 cases) covers the flip decision, the bottom-anchor invariant and its top clamp, the estimate-vs-measured regression, and the viewport clamp
- [ ] Manual: open `DatePicker` low in a tall page, confirm it flips above and aligns to the trigger top
- [ ] Manual: open an `ActionMenu` / audio-settings menu near the left viewport edge, confirm it does not clip off-screen
- [ ] Manual: open a short `SelectDropdown` near the bottom of a modal, confirm it opens downward (no premature flip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a shared, viewport-aware anchoring utility for consistent fixed-position dropdown/menu placement.

* **Bug Fixes**
  * Improved placement for dropdowns, action menus, audio settings menus, and the DatePicker with consistent flipping and clamping.
  * Updated scroll behavior to recompute open menu positioning only when needed, avoiding redundant updates during internal scrolling.
  * Refined DatePicker listener lifecycle and improved menu close/cleanup behavior, including returning focus after Escape.

* **Tests**
  * Added comprehensive unit tests covering anchor placement, flipping, and viewport clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->