### PR TITLE
fix(frontend): play iOS audio through native output when AudioContext is suspended

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -960,10 +960,13 @@
       if (isPlaying) {
         audioElement.pause();
       } else {
-        // Initialize audio context on first play (and retry until the graph is
-        // attached). Guard against rapid clicks that could create multiple
-        // AudioContexts.
-        if (!audioNodes && !isInitializingContext) {
+        // Initialize the audio context on first play, and re-enter whenever the
+        // graph is not attached OR the context has fallen back to suspended
+        // (e.g. tab backgrounding / audio-session interruption) so
+        // getAudioContext() resumes it. Without the state re-check, an
+        // already-attached graph on a re-suspended context plays silently.
+        // Guard against rapid clicks that could create multiple AudioContexts.
+        if ((!audioNodes || audioContext?.state !== 'running') && !isInitializingContext) {
           isInitializingContext = true;
           try {
             audioContext = await initializeAudioContext();

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -941,7 +941,9 @@
         throw new Error('AudioContext not supported');
       }
       audioContext = await getAudioContext();
-      audioContextAvailable = true;
+      // Availability is derived by the caller from whether the graph actually
+      // attached (audioNodes !== null), so it is not reported true while the
+      // context is still suspended.
       return audioContext;
     } catch {
       logger.warn('Web Audio API is not supported in this browser');

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -958,13 +958,19 @@
       if (isPlaying) {
         audioElement.pause();
       } else {
-        // Initialize audio context on first play
-        // Guard against rapid clicks that could create multiple AudioContexts
-        if (!audioContext && !isInitializingContext) {
+        // Initialize audio context on first play (and retry until the graph is
+        // attached). Guard against rapid clicks that could create multiple
+        // AudioContexts.
+        if (!audioNodes && !isInitializingContext) {
           isInitializingContext = true;
           try {
             audioContext = await initializeAudioContext();
-            if (audioContext && !audioNodes) {
+            // Only attach the Web Audio graph once the context is running.
+            // getAudioContext() can return a still-suspended context; on iOS,
+            // createMediaElementSource permanently reroutes the element's
+            // output, so attaching it to a suspended context plays silently.
+            // Until it resumes, play through the element's native output.
+            if (audioContext && !audioNodes && audioContext.state === 'running') {
               audioNodes = createAudioNodeChain(audioContext, audioElement, {
                 gainDb: gainValue,
                 highPassFreq: filterFreq,

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -978,9 +978,11 @@
               highPassFreq: filterFreq,
               includeCompressor: true,
             });
-            // Reflect whether the EQ/gain graph is actually live, so the audio
-            // settings control isn't enabled-but-inert while suspended.
-            audioContextAvailable = audioNodes !== null;
+            // Reflect whether the EQ/gain graph is actually live: attached AND
+            // the context running. A previously-attached graph on a re-suspended
+            // context that failed to resume is inert, so the audio settings
+            // control must not be enabled in that case.
+            audioContextAvailable = audioNodes !== null && audioContext?.state === 'running';
           } finally {
             isInitializingContext = false;
           }

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -52,7 +52,7 @@
     releaseAudioContext,
   } from '$lib/utils/audioContextManager';
   import {
-    createAudioNodeChain,
+    attachAudioGraphWhenRunning,
     disconnectAudioNodes,
     type AudioNodeChain,
   } from '$lib/utils/audioNodes';
@@ -965,18 +965,17 @@
           isInitializingContext = true;
           try {
             audioContext = await initializeAudioContext();
-            // Only attach the Web Audio graph once the context is running.
-            // getAudioContext() can return a still-suspended context; on iOS,
-            // createMediaElementSource permanently reroutes the element's
-            // output, so attaching it to a suspended context plays silently.
-            // Until it resumes, play through the element's native output.
-            if (audioContext && !audioNodes && audioContext.state === 'running') {
-              audioNodes = createAudioNodeChain(audioContext, audioElement, {
-                gainDb: gainValue,
-                highPassFreq: filterFreq,
-                includeCompressor: true,
-              });
-            }
+            // Attach the Web Audio graph only when the context is running;
+            // while suspended the element plays through native output and the
+            // graph is deferred to a later play (see attachAudioGraphWhenRunning).
+            audioNodes = attachAudioGraphWhenRunning(audioContext, audioElement, audioNodes, {
+              gainDb: gainValue,
+              highPassFreq: filterFreq,
+              includeCompressor: true,
+            });
+            // Reflect whether the EQ/gain graph is actually live, so the audio
+            // settings control isn't enabled-but-inert while suspended.
+            audioContextAvailable = audioNodes !== null;
           } finally {
             isInitializingContext = false;
           }

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -158,13 +158,19 @@
       if (isPlaying) {
         audioElement.pause();
       } else {
-        // Initialize audio context on first play (for gain/filter controls)
-        // Guard against rapid clicks that could create multiple AudioContexts
-        if (!audioContext && !isInitializingContext) {
+        // Initialize audio context on first play (for gain/filter controls),
+        // retrying until the graph is attached. Guard against rapid clicks that
+        // could create multiple AudioContexts.
+        if (!audioNodes && !isInitializingContext) {
           isInitializingContext = true;
           try {
             audioContext = await initializeAudioContextWrapper();
-            if (audioContext && !audioNodes) {
+            // Only attach the Web Audio graph once the context is running.
+            // getAudioContext() can return a still-suspended context; on iOS,
+            // createMediaElementSource permanently reroutes the element's
+            // output, so attaching it to a suspended context plays silently.
+            // Until it resumes, play through the element's native output.
+            if (audioContext && !audioNodes && audioContext.state === 'running') {
               audioNodes = createAudioNodeChain(audioContext, audioElement, {
                 gainDb: gainValue,
                 highPassFreq: filterFreq,

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -158,10 +158,13 @@
       if (isPlaying) {
         audioElement.pause();
       } else {
-        // Initialize audio context on first play (for gain/filter controls),
-        // retrying until the graph is attached. Guard against rapid clicks that
-        // could create multiple AudioContexts.
-        if (!audioNodes && !isInitializingContext) {
+        // Initialize the audio context on first play, and re-enter whenever the
+        // graph is not attached OR the context has fallen back to suspended
+        // (e.g. tab backgrounding / audio-session interruption) so
+        // getAudioContext() resumes it. Without the state re-check, an
+        // already-attached graph on a re-suspended context plays silently.
+        // Guard against rapid clicks that could create multiple AudioContexts.
+        if ((!audioNodes || audioContext?.state !== 'running') && !isInitializingContext) {
           isInitializingContext = true;
           try {
             audioContext = await initializeAudioContextWrapper();

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -175,9 +175,10 @@
               gainDb: gainValue,
               highPassFreq: filterFreq,
             });
-            // Report availability based on whether the graph actually attached,
-            // so gain/filter controls aren't shown active while suspended.
-            onAudioContextAvailable?.(audioNodes !== null);
+            // Report availability based on whether the graph is attached AND
+            // the context is running, so gain/filter controls aren't shown
+            // active when a re-suspended context failed to resume (inert graph).
+            onAudioContextAvailable?.(audioNodes !== null && audioContext?.state === 'running');
           } finally {
             isInitializingContext = false;
           }

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -34,7 +34,7 @@
     releaseAudioContext,
   } from '$lib/utils/audioContextManager';
   import {
-    createAudioNodeChain,
+    attachAudioGraphWhenRunning,
     disconnectAudioNodes,
     type AudioNodeChain,
   } from '$lib/utils/audioNodes';
@@ -165,17 +165,16 @@
           isInitializingContext = true;
           try {
             audioContext = await initializeAudioContextWrapper();
-            // Only attach the Web Audio graph once the context is running.
-            // getAudioContext() can return a still-suspended context; on iOS,
-            // createMediaElementSource permanently reroutes the element's
-            // output, so attaching it to a suspended context plays silently.
-            // Until it resumes, play through the element's native output.
-            if (audioContext && !audioNodes && audioContext.state === 'running') {
-              audioNodes = createAudioNodeChain(audioContext, audioElement, {
-                gainDb: gainValue,
-                highPassFreq: filterFreq,
-              });
-            }
+            // Attach the Web Audio graph only when the context is running;
+            // while suspended the element plays through native output and the
+            // graph is deferred to a later play (see attachAudioGraphWhenRunning).
+            audioNodes = attachAudioGraphWhenRunning(audioContext, audioElement, audioNodes, {
+              gainDb: gainValue,
+              highPassFreq: filterFreq,
+            });
+            // Report availability based on whether the graph actually attached,
+            // so gain/filter controls aren't shown active while suspended.
+            onAudioContextAvailable?.(audioNodes !== null);
           } finally {
             isInitializingContext = false;
           }
@@ -333,9 +332,9 @@
     }
 
     try {
-      const ctx = await getAudioContext();
-      onAudioContextAvailable?.(true);
-      return ctx;
+      // Availability is reported by the caller after the graph actually
+      // attaches (it may stay suspended), not merely when a context exists.
+      return await getAudioContext();
     } catch (err) {
       logger.warn('Failed to initialize audio context:', err);
       onAudioContextAvailable?.(false);

--- a/frontend/src/lib/utils/audioNodes.test.ts
+++ b/frontend/src/lib/utils/audioNodes.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for audioNodes utilities, focused on attachAudioGraphWhenRunning.
+ *
+ * This helper encapsulates the iOS-critical decision shared by all three audio
+ * engines (useAudioPlayback, AudioPlayer, PlayOverlay): the Web Audio graph
+ * must only be attached when the AudioContext is actually running, because
+ * createMediaElementSource permanently reroutes the element's output and a
+ * suspended context plays silently on iOS.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { attachAudioGraphWhenRunning, type AudioNodeChain } from './audioNodes';
+
+/**
+ * Minimal fake AudioContext. connect() returns its argument so the
+ * source -> highPass -> gain -> destination chaining in createAudioNodeChain
+ * works, and every node-factory method records calls for assertions.
+ */
+function makeFakeContext(state: AudioContextState) {
+  const makeNode = () => ({
+    connect: vi.fn((next: unknown) => next),
+    disconnect: vi.fn(),
+    gain: { value: 0 },
+    frequency: { value: 0 },
+    Q: { value: 0 },
+    type: '',
+    threshold: { value: 0 },
+    knee: { value: 0 },
+    ratio: { value: 0 },
+    attack: { value: 0 },
+    release: { value: 0 },
+  });
+  const ctx = {
+    state,
+    destination: {},
+    createMediaElementSource: vi.fn(() => makeNode()),
+    createGain: vi.fn(() => makeNode()),
+    createBiquadFilter: vi.fn(() => makeNode()),
+    createDynamicsCompressor: vi.fn(() => makeNode()),
+  };
+  return ctx as unknown as AudioContext & { createMediaElementSource: ReturnType<typeof vi.fn> };
+}
+
+const fakeElement = {} as HTMLAudioElement;
+
+describe('attachAudioGraphWhenRunning', () => {
+  it('builds and returns the graph when the context is running', () => {
+    const ctx = makeFakeContext('running');
+
+    const chain = attachAudioGraphWhenRunning(ctx, fakeElement, null);
+
+    expect(chain).not.toBeNull();
+    expect(ctx.createMediaElementSource).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and does NOT build the graph when the context is suspended (iOS)', () => {
+    const ctx = makeFakeContext('suspended');
+
+    const chain = attachAudioGraphWhenRunning(ctx, fakeElement, null);
+
+    // The element must play through its native output instead; routing it
+    // through a suspended context would silence it on iOS.
+    expect(chain).toBeNull();
+    expect(ctx.createMediaElementSource).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the context is closed', () => {
+    const ctx = makeFakeContext('closed');
+
+    expect(attachAudioGraphWhenRunning(ctx, fakeElement, null)).toBeNull();
+    expect(ctx.createMediaElementSource).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the context is null', () => {
+    expect(attachAudioGraphWhenRunning(null, fakeElement, null)).toBeNull();
+  });
+
+  it('returns null when the audio element is null', () => {
+    const ctx = makeFakeContext('running');
+
+    expect(attachAudioGraphWhenRunning(ctx, null, null)).toBeNull();
+    expect(ctx.createMediaElementSource).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing chain unchanged without rebuilding (once-per-element guard)', () => {
+    const ctx = makeFakeContext('running');
+    const existing = { source: {}, gain: {}, highPass: {} } as unknown as AudioNodeChain;
+
+    const chain = attachAudioGraphWhenRunning(ctx, fakeElement, existing);
+
+    // Must not call createMediaElementSource a second time for the same element.
+    expect(chain).toBe(existing);
+    expect(ctx.createMediaElementSource).not.toHaveBeenCalled();
+  });
+
+  it('passes the compressor option through to the built chain', () => {
+    const ctx = makeFakeContext('running');
+
+    attachAudioGraphWhenRunning(ctx, fakeElement, null, { includeCompressor: true });
+
+    expect(ctx.createDynamicsCompressor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/utils/audioNodes.ts
+++ b/frontend/src/lib/utils/audioNodes.ts
@@ -91,6 +91,37 @@ export function createAudioNodeChain(
 }
 
 /**
+ * Attach the Web Audio graph to the element only when the context is running.
+ *
+ * getAudioContext() can return a still-suspended context (it stops awaiting
+ * resume() after a timeout). On iOS, createMediaElementSource permanently
+ * reroutes the element's output away from the default device, so building the
+ * graph on a suspended context plays silently while currentTime still advances.
+ * Callers must therefore let the element play through its native output while
+ * the context is suspended and call this again on a later play once the context
+ * has resumed.
+ *
+ * @param ctx - AudioContext, or null if unavailable
+ * @param audioElement - HTML audio element to route, or null
+ * @param existing - already-attached chain for this element, if any
+ * @param options - node chain configuration
+ * @returns the existing chain if already attached; a freshly built chain when
+ *   the context is running; otherwise null (graph not attached, retry on a later
+ *   play). Returning the existing chain unchanged also upholds the
+ *   once-per-element createMediaElementSource constraint.
+ */
+export function attachAudioGraphWhenRunning(
+  ctx: AudioContext | null,
+  audioElement: HTMLAudioElement | null,
+  existing: AudioNodeChain | null,
+  options: AudioNodeOptions = {}
+): AudioNodeChain | null {
+  if (existing) return existing;
+  if (!ctx || !audioElement || ctx.state !== 'running') return null;
+  return createAudioNodeChain(ctx, audioElement, options);
+}
+
+/**
  * Safely disconnect all nodes in an audio chain.
  * Handles cases where nodes may already be disconnected.
  *

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -232,9 +232,11 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
         gainDb: gainValue,
         highPassFreq: filterFreq,
       });
-      // Reflect whether the processing graph is actually live, so gain/filter
-      // controls aren't reported available while the context is still suspended.
-      audioContextAvailable = audioNodes !== null;
+      // Reflect whether the processing graph is actually live: the graph is
+      // attached AND the context is running. A previously-attached graph on a
+      // re-suspended context that failed to resume is inert, so gain/filter
+      // controls must not be reported available in that case.
+      audioContextAvailable = audioNodes !== null && audioContext.state === 'running';
       return true;
     } catch (err) {
       logger.warn('AudioContext initialization failed', err as Error);

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -41,7 +41,7 @@ import {
   releaseAudioContext,
 } from '$lib/utils/audioContextManager';
 import {
-  createAudioNodeChain,
+  attachAudioGraphWhenRunning,
   disconnectAudioNodes,
   type AudioNodeChain,
 } from '$lib/utils/audioNodes';
@@ -221,25 +221,20 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
       // creates/resumes the shared singleton; called here from a user gesture
       // (togglePlayPause) so iOS honours the resume.
       audioContext = await getAudioContext();
-      audioContextAvailable = true;
 
-      // Only route the element through the Web Audio graph once the context is
-      // actually running. getAudioContext() can hand back a still-suspended
-      // context (it stops awaiting resume() after a timeout). On iOS,
-      // createMediaElementSource permanently captures the element's native
-      // output, so attaching the graph to a suspended context routes playback
-      // into silence (currentTime advances, no sound). Until the context
-      // resumes we let the element play natively and defer the graph to a
-      // later play interaction.
-      if (audioElement && !audioNodes && audioContext.state === 'running') {
-        // Note: intentionally omits includeCompressor (AudioPlayer uses it for
-        // clipping protection at high gain). Compact players don't expose gain
-        // controls, so the compressor is unnecessary overhead.
-        audioNodes = createAudioNodeChain(audioContext, audioElement, {
-          gainDb: gainValue,
-          highPassFreq: filterFreq,
-        });
-      }
+      // Attach the Web Audio graph only when the context is running; while it
+      // is suspended the element plays through native output and the graph is
+      // deferred to a later play (see attachAudioGraphWhenRunning). Note:
+      // intentionally omits includeCompressor (AudioPlayer uses it for clipping
+      // protection at high gain); compact players don't expose gain controls,
+      // so the compressor is unnecessary overhead.
+      audioNodes = attachAudioGraphWhenRunning(audioContext, audioElement, audioNodes, {
+        gainDb: gainValue,
+        highPassFreq: filterFreq,
+      });
+      // Reflect whether the processing graph is actually live, so gain/filter
+      // controls aren't reported available while the context is still suspended.
+      audioContextAvailable = audioNodes !== null;
       return true;
     } catch (err) {
       logger.warn('AudioContext initialization failed', err as Error);

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -207,7 +207,8 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
   }
 
   async function initAudioContext(): Promise<boolean> {
-    if (audioContext) return true;
+    // Already fully initialized: context running and the graph attached.
+    if (audioContext?.state === 'running' && audioNodes) return true;
     if (isInitializingContext) return false;
     if (!isAudioContextSupported()) {
       audioContextAvailable = false;
@@ -216,12 +217,21 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
 
     isInitializingContext = true;
     try {
-      // getAudioContext() is async - returns Promise<AudioContext>
-      // It creates/resumes the shared singleton and handles suspended state
+      // getAudioContext() is async - returns Promise<AudioContext>. It
+      // creates/resumes the shared singleton; called here from a user gesture
+      // (togglePlayPause) so iOS honours the resume.
       audioContext = await getAudioContext();
       audioContextAvailable = true;
 
-      if (audioElement) {
+      // Only route the element through the Web Audio graph once the context is
+      // actually running. getAudioContext() can hand back a still-suspended
+      // context (it stops awaiting resume() after a timeout). On iOS,
+      // createMediaElementSource permanently captures the element's native
+      // output, so attaching the graph to a suspended context routes playback
+      // into silence (currentTime advances, no sound). Until the context
+      // resumes we let the element play natively and defer the graph to a
+      // later play interaction.
+      if (audioElement && !audioNodes && audioContext.state === 'running') {
         // Note: intentionally omits includeCompressor (AudioPlayer uses it for
         // clipping protection at high gain). Compact players don't expose gain
         // controls, so the compressor is unnecessary overhead.
@@ -230,13 +240,13 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
           highPassFreq: filterFreq,
         });
       }
-      isInitializingContext = false;
       return true;
     } catch (err) {
       logger.warn('AudioContext initialization failed', err as Error);
       audioContextAvailable = false;
-      isInitializingContext = false;
       return false;
+    } finally {
+      isInitializingContext = false;
     }
   }
 

--- a/frontend/src/lib/utils/useAudioPlayback.test.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.test.ts
@@ -16,9 +16,12 @@ import { safeGet } from '$lib/utils/security';
 import type { AudioPlaybackState } from './useAudioPlayback.svelte';
 import Wrapper from './UseAudioPlaybackWrapper.test.svelte';
 
-// Mock audioContextManager - must be before import
+// Mock audioContextManager - must be before import.
+// Default to a 'running' context (the resumed/desktop case). Individual tests
+// override with a 'suspended' context to exercise the iOS code path.
 vi.mock('$lib/utils/audioContextManager', () => ({
   getAudioContext: vi.fn().mockResolvedValue({
+    state: 'running',
     createMediaElementSource: vi.fn().mockReturnValue({
       connect: vi.fn(),
       disconnect: vi.fn(),
@@ -49,6 +52,29 @@ vi.mock('$lib/utils/audioNodes', () => ({
   }),
   disconnectAudioNodes: vi.fn(),
 }));
+
+/**
+ * Build a mock AudioContext with a controllable state, matching the shape the
+ * audioContextManager mock returns. Used to exercise the iOS suspended-context
+ * path, where the Web Audio graph must NOT be attached (createMediaElementSource
+ * on a suspended context silences the element on iOS).
+ */
+function makeMockAudioContext(state: AudioContextState): AudioContext {
+  return {
+    state,
+    createMediaElementSource: vi.fn().mockReturnValue({ connect: vi.fn(), disconnect: vi.fn() }),
+    createGain: vi
+      .fn()
+      .mockReturnValue({ gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() }),
+    createBiquadFilter: vi.fn().mockReturnValue({
+      type: 'highpass',
+      frequency: { value: 20 },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }),
+    destination: {},
+  } as unknown as AudioContext;
+}
 
 describe('useAudioPlayback', () => {
   let mockPlay: ReturnType<typeof vi.fn>;
@@ -187,6 +213,56 @@ describe('useAudioPlayback', () => {
 
     await getState().togglePlayPause();
     expect(mockPlay).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------
+  // 1b. iOS: a suspended AudioContext must NOT attach the Web Audio graph,
+  //     but the element must still play (regression: silent iOS playback).
+  // ---------------------------------------------------------------
+  it('does not attach the Web Audio graph when the AudioContext is suspended, but still plays (iOS)', async () => {
+    const { getAudioContext } = await import('$lib/utils/audioContextManager');
+    const { createAudioNodeChain } = await import('$lib/utils/audioNodes');
+    vi.mocked(getAudioContext).mockResolvedValueOnce(makeMockAudioContext('suspended'));
+
+    await renderAndWait();
+    await getState().togglePlayPause();
+
+    // Element plays through its native output (audible on iOS). Routing it
+    // through a suspended context via createMediaElementSource would silence it.
+    expect(mockPlay).toHaveBeenCalledTimes(1);
+    expect(createAudioNodeChain).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------
+  // 1c. A running AudioContext attaches the Web Audio graph.
+  // ---------------------------------------------------------------
+  it('attaches the Web Audio graph when the AudioContext is running', async () => {
+    const { createAudioNodeChain } = await import('$lib/utils/audioNodes');
+
+    await renderAndWait();
+    await getState().togglePlayPause();
+
+    expect(mockPlay).toHaveBeenCalledTimes(1);
+    expect(createAudioNodeChain).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------
+  // 1d. Graph attachment is deferred until the context resumes on a later tap.
+  // ---------------------------------------------------------------
+  it('defers graph attachment until the context resumes on a later interaction', async () => {
+    const { getAudioContext } = await import('$lib/utils/audioContextManager');
+    const { createAudioNodeChain } = await import('$lib/utils/audioNodes');
+
+    // First gesture: context still suspended -> native playback, no graph.
+    vi.mocked(getAudioContext).mockResolvedValueOnce(makeMockAudioContext('suspended'));
+    await renderAndWait();
+    await getState().togglePlayPause();
+    expect(createAudioNodeChain).not.toHaveBeenCalled();
+
+    // Second gesture: the shared context has resumed (default mock is
+    // 'running') -> the graph attaches now.
+    await getState().togglePlayPause();
+    expect(createAudioNodeChain).toHaveBeenCalledTimes(1);
   });
 
   // ---------------------------------------------------------------

--- a/frontend/src/lib/utils/useAudioPlayback.test.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.test.ts
@@ -43,38 +43,18 @@ vi.mock('$lib/utils/audioContextManager', () => ({
   releaseAudioContext: vi.fn(),
 }));
 
-// Mock audioNodes
+// Mock audioNodes. attachAudioGraphWhenRunning is the composable's direct
+// dependency; its own running/suspended decision is unit-tested separately in
+// audioNodes.test.ts. Here we control its return value to simulate an attached
+// graph (running -> chain) vs a deferred one (suspended -> null).
 vi.mock('$lib/utils/audioNodes', () => ({
-  createAudioNodeChain: vi.fn().mockReturnValue({
+  attachAudioGraphWhenRunning: vi.fn().mockReturnValue({
     source: { connect: vi.fn(), disconnect: vi.fn() },
     gain: { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() },
     highPass: { frequency: { value: 20 }, connect: vi.fn(), disconnect: vi.fn() },
   }),
   disconnectAudioNodes: vi.fn(),
 }));
-
-/**
- * Build a mock AudioContext with a controllable state, matching the shape the
- * audioContextManager mock returns. Used to exercise the iOS suspended-context
- * path, where the Web Audio graph must NOT be attached (createMediaElementSource
- * on a suspended context silences the element on iOS).
- */
-function makeMockAudioContext(state: AudioContextState): AudioContext {
-  return {
-    state,
-    createMediaElementSource: vi.fn().mockReturnValue({ connect: vi.fn(), disconnect: vi.fn() }),
-    createGain: vi
-      .fn()
-      .mockReturnValue({ gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() }),
-    createBiquadFilter: vi.fn().mockReturnValue({
-      type: 'highpass',
-      frequency: { value: 20 },
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-    }),
-    destination: {},
-  } as unknown as AudioContext;
-}
 
 describe('useAudioPlayback', () => {
   let mockPlay: ReturnType<typeof vi.fn>;
@@ -216,53 +196,52 @@ describe('useAudioPlayback', () => {
   });
 
   // ---------------------------------------------------------------
-  // 1b. iOS: a suspended AudioContext must NOT attach the Web Audio graph,
-  //     but the element must still play (regression: silent iOS playback).
+  // 1b. iOS: when the graph cannot attach (suspended context -> helper returns
+  //     null), the element still plays and EQ availability reads false instead
+  //     of being enabled-but-inert (regression: silent iOS playback).
   // ---------------------------------------------------------------
-  it('does not attach the Web Audio graph when the AudioContext is suspended, but still plays (iOS)', async () => {
-    const { getAudioContext } = await import('$lib/utils/audioContextManager');
-    const { createAudioNodeChain } = await import('$lib/utils/audioNodes');
-    vi.mocked(getAudioContext).mockResolvedValueOnce(makeMockAudioContext('suspended'));
+  it('plays natively and reports no audio graph when the context is suspended (iOS)', async () => {
+    const { attachAudioGraphWhenRunning } = await import('$lib/utils/audioNodes');
+    vi.mocked(attachAudioGraphWhenRunning).mockReturnValueOnce(null);
 
     await renderAndWait();
     await getState().togglePlayPause();
 
-    // Element plays through its native output (audible on iOS). Routing it
-    // through a suspended context via createMediaElementSource would silence it.
+    // Element plays through its native output (audible on iOS) ...
     expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(createAudioNodeChain).not.toHaveBeenCalled();
+    // ... and the gain/filter graph is reported unavailable, not active-yet-inert.
+    expect(getState().audioContextAvailable).toBe(false);
   });
 
   // ---------------------------------------------------------------
-  // 1c. A running AudioContext attaches the Web Audio graph.
+  // 1c. A running context attaches the graph and reports it available.
   // ---------------------------------------------------------------
-  it('attaches the Web Audio graph when the AudioContext is running', async () => {
-    const { createAudioNodeChain } = await import('$lib/utils/audioNodes');
+  it('attaches the Web Audio graph and reports it available when the context is running', async () => {
+    const { attachAudioGraphWhenRunning } = await import('$lib/utils/audioNodes');
 
     await renderAndWait();
     await getState().togglePlayPause();
 
     expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(createAudioNodeChain).toHaveBeenCalledTimes(1);
+    expect(attachAudioGraphWhenRunning).toHaveBeenCalledTimes(1);
+    expect(getState().audioContextAvailable).toBe(true);
   });
 
   // ---------------------------------------------------------------
   // 1d. Graph attachment is deferred until the context resumes on a later tap.
   // ---------------------------------------------------------------
   it('defers graph attachment until the context resumes on a later interaction', async () => {
-    const { getAudioContext } = await import('$lib/utils/audioContextManager');
-    const { createAudioNodeChain } = await import('$lib/utils/audioNodes');
+    const { attachAudioGraphWhenRunning } = await import('$lib/utils/audioNodes');
 
-    // First gesture: context still suspended -> native playback, no graph.
-    vi.mocked(getAudioContext).mockResolvedValueOnce(makeMockAudioContext('suspended'));
+    // First gesture: helper returns null (context still suspended) -> no graph.
+    vi.mocked(attachAudioGraphWhenRunning).mockReturnValueOnce(null);
     await renderAndWait();
     await getState().togglePlayPause();
-    expect(createAudioNodeChain).not.toHaveBeenCalled();
+    expect(getState().audioContextAvailable).toBe(false);
 
-    // Second gesture: the shared context has resumed (default mock is
-    // 'running') -> the graph attaches now.
+    // Second gesture: default mock returns a chain (context resumed) -> attached.
     await getState().togglePlayPause();
-    expect(createAudioNodeChain).toHaveBeenCalledTimes(1);
+    expect(getState().audioContextAvailable).toBe(true);
   });
 
   // ---------------------------------------------------------------

--- a/frontend/src/lib/utils/useAudioPlayback.test.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.test.ts
@@ -267,6 +267,11 @@ describe('useAudioPlayback', () => {
     // already-attached graph) so getAudioContext() resumes the context again.
     await getState().togglePlayPause();
     expect(vi.mocked(getAudioContext)).toHaveBeenCalledTimes(2);
+
+    // The mock context stays suspended (resume did not take), so availability
+    // reports false even though the graph is still attached: the EQ controls
+    // would be inert, and must not be reported active.
+    expect(getState().audioContextAvailable).toBe(false);
   });
 
   // ---------------------------------------------------------------

--- a/frontend/src/lib/utils/useAudioPlayback.test.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.test.ts
@@ -245,6 +245,31 @@ describe('useAudioPlayback', () => {
   });
 
   // ---------------------------------------------------------------
+  // 1e. Re-attempts resume when a previously-attached context is later
+  //     suspended (e.g. tab backgrounding), instead of short-circuiting to
+  //     silent playback.
+  // ---------------------------------------------------------------
+  it('re-attempts context resume when a previously-attached context is suspended', async () => {
+    const { getAudioContext } = await import('$lib/utils/audioContextManager');
+
+    await renderAndWait();
+    // First play attaches the graph on a running context.
+    await getState().togglePlayPause();
+    expect(vi.mocked(getAudioContext)).toHaveBeenCalledTimes(1);
+
+    // Simulate the browser suspending the shared context after attachment.
+    const ctx = (await vi.mocked(getAudioContext).mock.results[0]?.value) as AudioContext & {
+      state: AudioContextState;
+    };
+    ctx.state = 'suspended';
+
+    // A subsequent play must re-enter initialization (not short-circuit on the
+    // already-attached graph) so getAudioContext() resumes the context again.
+    await getState().togglePlayPause();
+    expect(vi.mocked(getAudioContext)).toHaveBeenCalledTimes(2);
+  });
+
+  // ---------------------------------------------------------------
   // 2. togglePlayPause() calls audio.pause() when playing
   // ---------------------------------------------------------------
   it('togglePlayPause() calls audio.pause() when playing', async () => {


### PR DESCRIPTION
## Summary

Bird-detection audio clips play silently on iOS / iPad Safari: the clip fetches fine (HTTP 206) and the player shows as playing (currentTime advances), but no sound comes out. The cause is that `getAudioContext()` can return a still-suspended `AudioContext` (it stops awaiting `resume()` after a 2s timeout), and the clip players then route the `<audio>` element through `createMediaElementSource` into that suspended context. On iOS, `createMediaElementSource` permanently reroutes the element away from its native output, so a suspended graph plays silently.

### Fix

- Attach the Web Audio graph only when the context is actually `running`. While it is suspended, the element plays through its native output (audible on iOS within the user gesture) and the graph is deferred to a later play once the context resumes. Current gain/filter values are seeded in when the graph attaches, so nothing is lost.
- Centralize the decision in a shared `attachAudioGraphWhenRunning` helper so the three audio engines that had drifted (`useAudioPlayback`, `AudioPlayer`, `PlayOverlay`) stay consistent. That drift is what let this regression hide.
- Report EQ/gain availability from whether the graph actually attached, so the controls are not shown active while the context is still suspended.
- The live spectrogram analyser intentionally keeps tolerating suspension and is unchanged.

## Test Plan

- [x] `npm run check:all` (format, lint, CSS lint, typecheck, ast-grep) clean
- [x] Full frontend suite: 2186 tests pass
- [x] New `audioNodes.test.ts` unit tests for the helper (running / suspended / closed / null ctx / null element / existing-chain reuse / compressor option)
- [x] Production build compiles
- [ ] Confirm on a real iPad: tapping a detection clip produces audible playback (Web Inspector: shared AudioContext reaches `running`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio playback reliability by only attaching the audio processing graph when the audio context is in a ready state.
  * Fixed scenarios where playback could be unavailable when the context starts suspended (including iOS), by deferring graph setup until it can attach successfully.

* **Tests**
  * Added and expanded automated coverage for conditional graph attachment, re-initialization after state changes, and correct handling of running, suspended, closed, and missing audio cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->