### PR TITLE
fix(audio): bump go-flac to v0.3.1 for iOS-compatible FLAC clips

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.42.0
 	github.com/tphakala/go-audio-resampler v1.4.0
-	github.com/tphakala/go-flac v0.3.0
+	github.com/tphakala/go-flac v0.3.1
 	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
 	github.com/tphakala/simd v1.4.0-rc.2
 	github.com/yalue/onnxruntime_go v1.30.1

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/tphakala/go-audio-resampler v1.4.0 h1:Iv71vuUVzH2apR9tw4TrWDRvjNOc1e8Qr58TKl6IaLo=
 github.com/tphakala/go-audio-resampler v1.4.0/go.mod h1:mDVvtgIkzupYeqTcxRIJeEED53yrCTu2BP3mAYpiYj0=
-github.com/tphakala/go-flac v0.3.0 h1:hC0Tli8dAYjOB54kD3k8rTarS9sRA/MyiTJzK6MSgJ0=
-github.com/tphakala/go-flac v0.3.0/go.mod h1:d6cu4zAcEOyHq1mHJHvKH92v8i7/MmreUtcPsx7FhNs=
+github.com/tphakala/go-flac v0.3.1 h1:UtHQRyaq8pf7w0DAx/5JWVXBGNizYpS3RgOA9Tg88c8=
+github.com/tphakala/go-flac v0.3.1/go.mod h1:d6cu4zAcEOyHq1mHJHvKH92v8i7/MmreUtcPsx7FhNs=
 github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7 h1:fJtEs8rODoFDk8HDRwvNxIYEgsUUrEAvqPdllxF0cmg=
 github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7/go.mod h1:xCgggryHiQ3nD0Sy0oCZESPWmzThLKKB28Vky5m6HCo=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a h1:BBvsu7Mes8McH6ikyagnU9y2N8hjoDxvDNCl162hwdA=


### PR DESCRIPTION
## Summary

Bumps `github.com/tphakala/go-flac` from v0.3.0 to v0.3.1.

go-flac v0.3.1 writes explicit sample-rate and bit-depth codes in FLAC frame headers instead of coding them as `0` ("read from STREAMINFO"). Apple's CoreAudio decoder (behind iOS/iPadOS/macOS Safari's `<audio>` element) rejects code `0`, so detection clips produced by the native FLAC encoder fetched fine over HTTP (206) but never became playable on iOS. With v0.3.1 they play. ffmpeg, libFLAC, Chrome and Firefox tolerated code 0 and were unaffected either way.

Root cause was confirmed on a real device with a controlled bisection. Upstream fix: tphakala/go-flac#34.

## Changes

- `go.mod` / `go.sum`: go-flac v0.3.0 -> v0.3.1. No source changes; the go-flac public API is unchanged (the fix lives in its internal frame encoder).

## Impact

- Native FLAC clip export (`BIRDNET_FLAC_ENCODER=native`) now produces iOS-compatible FLAC clips.
- Also benefits the native BirdWeather FLAC upload path.

## Test Plan

- [x] `go build` and `go test` of `internal/audiocore/flac` and `internal/birdweather` pass on v0.3.1
- [x] `go mod verify` clean
- [x] go-flac v0.3.1 CI green; libFLAC `flac -t` validates the output; decoded PCM is identical (only frame-header bytes change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a Go dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->