### PR TITLE
fix(species): rank settings picker autocomplete local-first

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -287,6 +287,11 @@
   // since the pickers live on the Custom/Include/Exclude tabs.
   let localSpeciesSet = $state<Set<string>>(new Set());
   let isLoadingLocalSpecies = false;
+  // Inputs (location + range threshold) the locality set was last loaded for. Lets the
+  // loaders refresh when the user changes location or threshold while skipping a
+  // redundant refetch when those inputs are unchanged. Plain (non-reactive) like the
+  // loading guard; the picker-tab effect reads it via untrack.
+  let localSpeciesKey: string | null = null;
 
   // Input values for species inputs
   let includeInputValue = $state('');
@@ -671,8 +676,9 @@
       // Feed the picker locality set from the same probable list. Refresh it on every
       // active-species reload (e.g. after a location change or retry) so it never goes
       // stale. The Active tab loads first by default, so this also primes the set and
-      // the tab-independent loader below normally never has to refetch the range filter.
+      // stamps the key, so the tab-independent loader below normally never refetches.
       localSpeciesSet = buildLocalSpeciesSet(response.species ?? [], threshold);
+      localSpeciesKey = localSpeciesKeyFor(birdnetData);
 
       // Check if a species (by common or scientific name) is in a name set.
       // Handles users who add species by scientific name to include/config lists.
@@ -747,6 +753,17 @@
   // Build the picker locality set (normalized common + scientific names) from a
   // range-filter probable-species response, keeping only species at/above the
   // threshold (i.e. actually probable at the configured location).
+  // Identifies the inputs the locality set was last loaded for, so both loaders refetch
+  // when the user changes location or the range-filter threshold but not otherwise.
+  function localSpeciesKeyFor(birdnetData: {
+    latitude: number;
+    longitude: number;
+    rangeFilter?: { threshold: number };
+  }): string {
+    const threshold = birdnetData.rangeFilter?.threshold ?? DEFAULT_RANGE_FILTER_THRESHOLD;
+    return `${birdnetData.latitude},${birdnetData.longitude},${threshold}`;
+  }
+
   function buildLocalSpeciesSet(
     species: Array<{ scientificName?: string; commonName?: string; score?: number }>,
     threshold: number
@@ -773,8 +790,10 @@
     locationConfigured?: boolean;
     rangeFilter?: { threshold: number };
   }) {
-    if (isLoadingLocalSpecies || localSpeciesSet.size > 0) return;
     if (!(birdnetData.locationConfigured ?? false)) return;
+    const key = localSpeciesKeyFor(birdnetData);
+    // Skip if already loading, or already loaded for these exact inputs.
+    if (isLoadingLocalSpecies || localSpeciesKey === key) return;
     isLoadingLocalSpecies = true;
     try {
       const response = await api.post<{
@@ -787,6 +806,7 @@
       });
       // Go serializes a nil slice as JSON null, so guard before iterating.
       localSpeciesSet = buildLocalSpeciesSet(response.species ?? [], response.threshold);
+      localSpeciesKey = key;
     } catch (error) {
       logger.error('Failed to load local species set for picker ranking:', error);
     } finally {
@@ -852,9 +872,11 @@
       birdnetData.longitude !== undefined &&
       (birdnetData.locationConfigured ?? false);
     if (!hasRealCoordinates || currentTab === 'active') return;
-    // Read the set size without tracking, so writing the set does not re-trigger
-    // this effect.
-    if (untrack(() => localSpeciesSet.size) > 0) return;
+    // Refetch only when the location/threshold inputs differ from what the set was last
+    // loaded for, so changing location on a picker tab refreshes ranking but an
+    // unrelated birdnet edit or tab switch does not. Read the key untracked so the
+    // loader's own write to it cannot re-trigger this effect.
+    if (untrack(() => localSpeciesKey) === localSpeciesKeyFor(birdnetData)) return;
 
     // Defer out of the effect's synchronous context (same rationale as the active
     // species loader above) to avoid mutating state during the reactive update.

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -668,12 +668,11 @@
       // Cross-reference with include/exclude and config lists (using captured values)
       const threshold = response.threshold;
 
-      // Feed the picker locality set from the same probable list. Populating here
-      // means the Active tab (which loads first by default) primes it, so the
-      // tab-independent loader below never has to refetch the range filter.
-      if (localSpeciesSet.size === 0) {
-        localSpeciesSet = buildLocalSpeciesSet(response.species ?? [], threshold);
-      }
+      // Feed the picker locality set from the same probable list. Refresh it on every
+      // active-species reload (e.g. after a location change or retry) so it never goes
+      // stale. The Active tab loads first by default, so this also primes the set and
+      // the tab-independent loader below normally never has to refetch the range filter.
+      localSpeciesSet = buildLocalSpeciesSet(response.species ?? [], threshold);
 
       // Check if a species (by common or scientific name) is in a name set.
       // Handles users who add species by scientific name to include/config lists.
@@ -951,8 +950,14 @@
   function isLocalPrediction(prediction: SpeciesPrediction): boolean {
     const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
     if (localSpeciesSet.has(valueKey)) return true;
+    // Bidirectional alias fallback for range entries that carried only one name form:
+    // resolve a common-name value to its scientific alias, and a scientific-name value
+    // to its common alias, then re-check the set.
     const scientific = speciesNameMaps.commonToScientific.get(valueKey);
-    return scientific !== undefined && localSpeciesSet.has(normalizeForLookup(scientific));
+    if (scientific !== undefined && localSpeciesSet.has(normalizeForLookup(scientific)))
+      return true;
+    const common = speciesNameMaps.scientificToCommon.get(valueKey);
+    return common !== undefined && localSpeciesSet.has(normalizeForLookup(common));
   }
 
   // Build ranked, capped autocomplete predictions for a picker. rankPredictions

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -749,12 +749,15 @@
   // range-filter probable-species response, keeping only species at/above the
   // threshold (i.e. actually probable at the configured location).
   function buildLocalSpeciesSet(
-    species: Array<{ scientificName: string; commonName: string; score: number }>,
+    species: Array<{ scientificName?: string; commonName?: string; score?: number }>,
     threshold: number
   ): Set<string> {
     const next = new Set<string>();
     for (const s of species) {
-      if (s.score < threshold) continue;
+      // The range-filter entry fields are all optional; a missing score must NOT
+      // pass the threshold (undefined < threshold is false), or non-probable species
+      // would be marked local and skew ranking.
+      if (typeof s.score !== 'number' || s.score < threshold) continue;
       if (s.commonName) next.add(normalizeForLookup(s.commonName));
       if (s.scientificName) next.add(normalizeForLookup(s.scientificName));
     }

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -63,7 +63,11 @@
     type SpeciesNameMaps,
   } from '$lib/utils/speciesNames';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
-  import { rankPredictions, type SpeciesPrediction } from '$lib/utils/speciesPredictions';
+  import {
+    rankPredictions,
+    toLocalizedPredictions,
+    type SpeciesPrediction,
+  } from '$lib/utils/speciesPredictions';
   import {
     ArrowLeftRight,
     ChevronRight,
@@ -269,17 +273,7 @@
   // (localizeSpeciesLabel reads the dictionary store, so this $derived tracks it and
   // refreshes labels on locale switch). Precomputing here keeps ~12k dictionary
   // lookups and NFC normalizations OUT of the per-keystroke filter hot path.
-  let searchableSpecies = $derived<SpeciesPrediction[]>(
-    allSpecies.map(value => {
-      const label = localizeSpeciesLabel(value);
-      return {
-        value,
-        label,
-        normalizedValue: normalizeForLookup(value),
-        normalizedLabel: normalizeForLookup(label),
-      };
-    })
-  );
+  let searchableSpecies = $derived(toLocalizedPredictions(allSpecies, localizeSpeciesLabel));
 
   // Species predictions state
   let includePredictions = $state<string[]>([]);
@@ -668,7 +662,7 @@
       }>('/api/v2/range/species/test', {
         latitude: birdnetData.latitude,
         longitude: birdnetData.longitude,
-        threshold: birdnetData.rangeFilter?.threshold ?? 0.01,
+        threshold: birdnetData.rangeFilter?.threshold ?? DEFAULT_RANGE_FILTER_THRESHOLD,
       });
 
       // Cross-reference with include/exclude and config lists (using captured values)
@@ -678,7 +672,7 @@
       // means the Active tab (which loads first by default) primes it, so the
       // tab-independent loader below never has to refetch the range filter.
       if (localSpeciesSet.size === 0) {
-        localSpeciesSet = buildLocalSpeciesSet(response.species, threshold);
+        localSpeciesSet = buildLocalSpeciesSet(response.species ?? [], threshold);
       }
 
       // Check if a species (by common or scientific name) is in a name set.
@@ -695,7 +689,8 @@
       const configKeys = new Set(Object.keys(currentConfig ?? {}).map(s => normalizeForLookup(s)));
 
       // Filter species that pass the threshold OR are manually included
-      const mappedSpecies: ActiveSpecies[] = response.species
+      // Go serializes a nil slice as JSON null, so guard before iterating.
+      const mappedSpecies: ActiveSpecies[] = (response.species ?? [])
         .filter(
           s => s.score >= threshold || isInNameSet(includeSet, s.commonName, s.scientificName)
         )
@@ -786,9 +781,10 @@
       }>('/api/v2/range/species/test', {
         latitude: birdnetData.latitude,
         longitude: birdnetData.longitude,
-        threshold: birdnetData.rangeFilter?.threshold ?? 0.01,
+        threshold: birdnetData.rangeFilter?.threshold ?? DEFAULT_RANGE_FILTER_THRESHOLD,
       });
-      localSpeciesSet = buildLocalSpeciesSet(response.species, response.threshold);
+      // Go serializes a nil slice as JSON null, so guard before iterating.
+      localSpeciesSet = buildLocalSpeciesSet(response.species ?? [], response.threshold);
     } catch (error) {
       logger.error('Failed to load local species set for picker ranking:', error);
     } finally {
@@ -940,6 +936,11 @@
   // it instead of being cut off by an arbitrary alphabetical slice.
   const PREDICTION_LIMIT = 25;
 
+  // Fallback range-filter threshold used when the user has not configured one, matching
+  // the range-filter test endpoint's own default. Keeps probable-species probes
+  // consistent across the active-species and picker-locality loaders.
+  const DEFAULT_RANGE_FILTER_THRESHOLD = 0.01;
+
   // True when a prediction's canonical value is in the range-filtered probable set
   // for the configured location. The set is keyed by normalized common AND scientific
   // names, so the prediction's pre-normalized canonical value (a common name) hits
@@ -951,23 +952,17 @@
     return scientific !== undefined && localSpeciesSet.has(normalizeForLookup(scientific));
   }
 
-  // Build ranked, capped autocomplete predictions for a picker. Filters the
-  // precomputed searchableSpecies by the typed input (canonical value OR localized
-  // label, so a visitor can search by the name they see), drops species already in
-  // `excludeList`, then ranks exact > local > non-local and caps to PREDICTION_LIMIT.
-  // Returns canonical values; the picker localizes them for display.
+  // Build ranked, capped autocomplete predictions for a picker. rankPredictions
+  // matches the typed input against each species' canonical value OR localized label
+  // (so a visitor can search by the name they see), drops species already in
+  // `excludeList` via the exclude predicate, ranks exact > local > non-local, and
+  // caps to PREDICTION_LIMIT. Returns canonical values; the picker localizes them.
   function computeRankedPredictions(input: string, excludeList: string[]): string[] {
-    const needle = normalizeForLookup(input);
-    const matches = searchableSpecies.filter(prediction => {
-      const valueKey = prediction.normalizedValue ?? '';
-      const labelKey = prediction.normalizedLabel ?? '';
-      if (!valueKey.includes(needle) && !labelKey.includes(needle)) return false;
-      // Alias-aware exclusion runs only on the small matched subset, not all ~12k.
-      return !isSpeciesInList(prediction.value, excludeList, speciesNameMaps);
-    });
-    return rankPredictions(matches, needle, {
+    return rankPredictions(searchableSpecies, input, {
       limit: PREDICTION_LIMIT,
       isLocal: isLocalPrediction,
+      // Alias-aware exclusion; rankPredictions only runs it on matched candidates.
+      exclude: prediction => isSpeciesInList(prediction.value, excludeList, speciesNameMaps),
     }).map(prediction => prediction.value);
   }
 

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -63,6 +63,7 @@
     type SpeciesNameMaps,
   } from '$lib/utils/speciesNames';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import { rankPredictions, type SpeciesPrediction } from '$lib/utils/speciesPredictions';
   import {
     ArrowLeftRight,
     ChevronRight,
@@ -263,10 +264,35 @@
   // Derived species list: contains both common and scientific names for bidirectional search
   let allSpecies = $derived(speciesListState.data);
 
+  // Predictions paired with their localized labels and pre-normalized lookup keys.
+  // Rebuilt only when the species list, name maps, or visitor locale change
+  // (localizeSpeciesLabel reads the dictionary store, so this $derived tracks it and
+  // refreshes labels on locale switch). Precomputing here keeps ~12k dictionary
+  // lookups and NFC normalizations OUT of the per-keystroke filter hot path.
+  let searchableSpecies = $derived<SpeciesPrediction[]>(
+    allSpecies.map(value => {
+      const label = localizeSpeciesLabel(value);
+      return {
+        value,
+        label,
+        normalizedValue: normalizeForLookup(value),
+        normalizedLabel: normalizeForLookup(label),
+      };
+    })
+  );
+
   // Species predictions state
   let includePredictions = $state<string[]>([]);
   let excludePredictions = $state<string[]>([]);
   let configPredictions = $state<string[]>([]);
+
+  // Range-filtered probable-species set for the configured location, keyed by
+  // normalized common AND scientific name. Lets the picker autocomplete rank
+  // species probable at this location ahead of global look-alikes (e.g. native
+  // woodpeckers ahead of exotic ones). Loaded independently of the Active tab,
+  // since the pickers live on the Custom/Include/Exclude tabs.
+  let localSpeciesSet = $state<Set<string>>(new Set());
+  let isLoadingLocalSpecies = false;
 
   // Input values for species inputs
   let includeInputValue = $state('');
@@ -648,6 +674,13 @@
       // Cross-reference with include/exclude and config lists (using captured values)
       const threshold = response.threshold;
 
+      // Feed the picker locality set from the same probable list. Populating here
+      // means the Active tab (which loads first by default) primes it, so the
+      // tab-independent loader below never has to refetch the range filter.
+      if (localSpeciesSet.size === 0) {
+        localSpeciesSet = buildLocalSpeciesSet(response.species, threshold);
+      }
+
       // Check if a species (by common or scientific name) is in a name set.
       // Handles users who add species by scientific name to include/config lists.
       const isInNameSet = (
@@ -717,6 +750,52 @@
     }
   }
 
+  // Build the picker locality set (normalized common + scientific names) from a
+  // range-filter probable-species response, keeping only species at/above the
+  // threshold (i.e. actually probable at the configured location).
+  function buildLocalSpeciesSet(
+    species: Array<{ scientificName: string; commonName: string; score: number }>,
+    threshold: number
+  ): Set<string> {
+    const next = new Set<string>();
+    for (const s of species) {
+      if (s.score < threshold) continue;
+      if (s.commonName) next.add(normalizeForLookup(s.commonName));
+      if (s.scientificName) next.add(normalizeForLookup(s.scientificName));
+    }
+    return next;
+  }
+
+  // Load the picker locality set independently of the Active tab. loadActiveSpecies
+  // also populates it, so this only fetches when the visitor opens a picker tab
+  // without having visited Active. Non-fatal on error: the picker still ranks by
+  // exact/prefix, just without local prioritization.
+  async function loadLocalSpeciesSet(birdnetData: {
+    latitude: number;
+    longitude: number;
+    locationConfigured?: boolean;
+    rangeFilter?: { threshold: number };
+  }) {
+    if (isLoadingLocalSpecies || localSpeciesSet.size > 0) return;
+    if (!(birdnetData.locationConfigured ?? false)) return;
+    isLoadingLocalSpecies = true;
+    try {
+      const response = await api.post<{
+        species: Array<{ scientificName: string; commonName: string; score: number }>;
+        threshold: number;
+      }>('/api/v2/range/species/test', {
+        latitude: birdnetData.latitude,
+        longitude: birdnetData.longitude,
+        threshold: birdnetData.rangeFilter?.threshold ?? 0.01,
+      });
+      localSpeciesSet = buildLocalSpeciesSet(response.species, response.threshold);
+    } catch (error) {
+      logger.error('Failed to load local species set for picker ranking:', error);
+    } finally {
+      isLoadingLocalSpecies = false;
+    }
+  }
+
   // Auto-load active species when tab becomes active and settings are loaded
   $effect(() => {
     // Track these as dependencies - re-run when they change
@@ -757,6 +836,33 @@
         loadActiveSpecies(birdnetData);
       });
     }
+  });
+
+  // Load the picker locality set when location is configured but the visitor is on a
+  // picker tab (Custom/Include/Exclude) rather than Active, so local prioritization
+  // works without first visiting Active. The Active tab's own loader covers that tab
+  // and feeds the same set, so this skips it; it also skips once the set is loaded.
+  $effect(() => {
+    const currentTab = activeTab;
+    const settingsLoading = store.isLoading;
+    const birdnetData = store.formData?.birdnet;
+    const hasOriginalData = store.originalData?.birdnet !== undefined;
+    if (settingsLoading || !hasOriginalData || !birdnetData) return;
+
+    const hasRealCoordinates =
+      birdnetData.latitude !== undefined &&
+      birdnetData.longitude !== undefined &&
+      (birdnetData.locationConfigured ?? false);
+    if (!hasRealCoordinates || currentTab === 'active') return;
+    // Read the set size without tracking, so writing the set does not re-trigger
+    // this effect.
+    if (untrack(() => localSpeciesSet.size) > 0) return;
+
+    // Defer out of the effect's synchronous context (same rationale as the active
+    // species loader above) to avoid mutating state during the reactive update.
+    queueMicrotask(() => {
+      loadLocalSpeciesSet(birdnetData);
+    });
   });
 
   // CSV download function for active species
@@ -828,13 +934,41 @@
     return localizeSpeciesName(scientific, value);
   }
 
-  // Match a candidate against the typed input by its canonical value OR its
-  // localized label, so a visitor can find a species by typing the name they see.
-  function predictionMatchesInput(species: string, needle: string): boolean {
-    return (
-      normalizeForLookup(species).includes(needle) ||
-      normalizeForLookup(localizeSpeciesLabel(species)).includes(needle)
-    );
+  // Maximum predictions surfaced per picker. The source list is the full global
+  // multi-model species union (~12k entries), so the cap keeps the dropdown usable;
+  // rankPredictions guarantees exact, prefix, and locally-relevant matches survive
+  // it instead of being cut off by an arbitrary alphabetical slice.
+  const PREDICTION_LIMIT = 25;
+
+  // True when a prediction's canonical value is in the range-filtered probable set
+  // for the configured location. The set is keyed by normalized common AND scientific
+  // names, so the prediction's pre-normalized canonical value (a common name) hits
+  // directly; the scientific alias is checked as a fallback for scientific-only entries.
+  function isLocalPrediction(prediction: SpeciesPrediction): boolean {
+    const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
+    if (localSpeciesSet.has(valueKey)) return true;
+    const scientific = speciesNameMaps.commonToScientific.get(valueKey);
+    return scientific !== undefined && localSpeciesSet.has(normalizeForLookup(scientific));
+  }
+
+  // Build ranked, capped autocomplete predictions for a picker. Filters the
+  // precomputed searchableSpecies by the typed input (canonical value OR localized
+  // label, so a visitor can search by the name they see), drops species already in
+  // `excludeList`, then ranks exact > local > non-local and caps to PREDICTION_LIMIT.
+  // Returns canonical values; the picker localizes them for display.
+  function computeRankedPredictions(input: string, excludeList: string[]): string[] {
+    const needle = normalizeForLookup(input);
+    const matches = searchableSpecies.filter(prediction => {
+      const valueKey = prediction.normalizedValue ?? '';
+      const labelKey = prediction.normalizedLabel ?? '';
+      if (!valueKey.includes(needle) && !labelKey.includes(needle)) return false;
+      // Alias-aware exclusion runs only on the small matched subset, not all ~12k.
+      return !isSpeciesInList(prediction.value, excludeList, speciesNameMaps);
+    });
+    return rankPredictions(matches, needle, {
+      limit: PREDICTION_LIMIT,
+      isLocal: isLocalPrediction,
+    }).map(prediction => prediction.value);
   }
 
   function updateIncludePredictions(input: string) {
@@ -844,15 +978,7 @@
         includePredictions = [];
         return;
       }
-
-      const needle = normalizeForLookup(input);
-      includePredictions = allSpecies
-        .filter(
-          species =>
-            predictionMatchesInput(species, needle) &&
-            !isSpeciesInList(species, settings.include, speciesNameMaps)
-        )
-        .slice(0, 10);
+      includePredictions = computeRankedPredictions(input, settings.include);
     }, 150); // Debounce by 150ms
   }
 
@@ -863,15 +989,7 @@
         excludePredictions = [];
         return;
       }
-
-      const needle = normalizeForLookup(input);
-      excludePredictions = allSpecies
-        .filter(
-          species =>
-            predictionMatchesInput(species, needle) &&
-            !isSpeciesInList(species, settings.exclude, speciesNameMaps)
-        )
-        .slice(0, 10);
+      excludePredictions = computeRankedPredictions(input, settings.exclude);
     }, 150); // Debounce by 150ms
   }
 
@@ -882,18 +1000,10 @@
         configPredictions = [];
         return;
       }
-
-      const needle = normalizeForLookup(input);
       // Exclude the currently-editing species from the collision check so its
       // own alias remains selectable during rename operations.
       const existingConfigKeys = Object.keys(settings.config).filter(key => key !== editingSpecies);
-      configPredictions = allSpecies
-        .filter(
-          species =>
-            predictionMatchesInput(species, needle) &&
-            !isSpeciesInList(species, existingConfigKeys, speciesNameMaps)
-        )
-        .slice(0, 10);
+      configPredictions = computeRankedPredictions(input, existingConfigKeys);
     }, 150); // Debounce by 150ms
   }
 

--- a/frontend/src/lib/utils/speciesPredictions.test.ts
+++ b/frontend/src/lib/utils/speciesPredictions.test.ts
@@ -201,6 +201,52 @@ describe('rankPredictions', () => {
     const rest = result.slice(1).map(p => p.label);
     expect(rest).toEqual([...rest].sort((a, b) => a.localeCompare(b)));
   });
+
+  it('without isLocal, a non-local prefix match outranks a plain contains match', () => {
+    // Mirror of the locality test: with no isLocal, nothing is local, so the prefix
+    // match (tikkasirkku) leads and käpytikka is just another contains match. This
+    // proves the isLocal fallback actually flips the ranking, not that it is no-op.
+    const labels = rankPredictions(predictions, 'tikka').map(p => p.label);
+    expect(labels[0]).toBe('tikkasirkku');
+    expect(labels.indexOf('tikkasirkku')).toBeLessThan(labels.indexOf('käpytikka'));
+  });
+
+  it('matches case- and NFC-insensitively in the rank path (uppercase, NFD query)', () => {
+    // The candidate label is the NFC string "valkoselkätikka"; an uppercase query
+    // with a combining diaeresis (NFD form) must still match after normalization.
+    const nfdUpper = 'VALKOSELKA\u0308'; // NFD: base A + U+0308 combining diaeresis
+    expect(nfdUpper.normalize('NFC')).not.toBe(nfdUpper); // guard: query really is NFD
+    const result = rankPredictions(predictions, nfdUpper, { isLocal });
+    expect(result.map(p => p.label)).toContain('valkoselkätikka');
+  });
+
+  it('drops predictions rejected by the exclude predicate', () => {
+    const result = rankPredictions(predictions, 'peippo', {
+      isLocal,
+      exclude: p => p.value === 'Fringilla coelebs',
+    });
+    expect(result.map(p => p.value)).not.toContain('Fringilla coelebs');
+    // Other matches are unaffected.
+    expect(result.map(p => p.label)).toContain('viherpeippo');
+  });
+
+  it('only evaluates exclude on entries that matched the query', () => {
+    // exclude must never see a non-match (it can be expensive); assert it is only
+    // called with predictions whose value or label contains the query.
+    const seen: string[] = [];
+    rankPredictions(predictions, 'tikka', {
+      isLocal,
+      exclude: p => {
+        seen.push(p.value);
+        return false;
+      },
+    });
+    expect(seen.length).toBeGreaterThan(0);
+    // No "...peippo" species should ever be offered to exclude for a "tikka" query;
+    // exclude must run only on already-matched candidates, never the full list.
+    expect(seen).not.toContain('Fringilla coelebs');
+    expect(seen).not.toContain('Chloris chloris');
+  });
 });
 
 describe('matchTypedToCanonical', () => {

--- a/frontend/src/lib/utils/speciesPredictions.test.ts
+++ b/frontend/src/lib/utils/speciesPredictions.test.ts
@@ -11,6 +11,7 @@ import {
   toLocalizedPredictions,
   filterLocalizedPredictions,
   matchTypedToCanonical,
+  rankPredictions,
   type SpeciesPrediction,
 } from './speciesPredictions';
 
@@ -114,6 +115,91 @@ describe('filterLocalizedPredictions', () => {
     const result = filterLocalizedPredictions(predictions, '', { excludeValue: 'Tornipöllö' });
     expect(result.map(p => p.value)).not.toContain('Barn Owl');
     expect(result).toHaveLength(2);
+  });
+});
+
+describe('rankPredictions', () => {
+  // Mirrors the real bug: many global "...peippo" / "...tikka" look-alikes plus the
+  // native species the visitor actually wants. Labels are Finnish (the visitor
+  // locale); values are the canonical scientific names.
+  const predictions: SpeciesPrediction[] = [
+    { value: 'Chloris chloris', label: 'viherpeippo' },
+    { value: 'Fringilla montifringilla', label: 'järripeippo' },
+    { value: 'Amadina fasciata', label: 'viiltopeippo' },
+    { value: 'Fringilla coelebs', label: 'peippo' },
+    { value: 'Dendrocopos major', label: 'käpytikka' },
+    { value: 'Dendrocopos leucotos', label: 'valkoselkätikka' },
+    { value: 'Blythipicus pyrrhotis', label: 'tuliniskatikka' },
+    { value: 'Camarhynchus pallidus', label: 'tikkasirkku' },
+  ];
+  // The species probable at the configured (Finnish) location.
+  const localValues = new Set([
+    'Fringilla coelebs',
+    'Chloris chloris',
+    'Fringilla montifringilla',
+    'Dendrocopos major',
+    'Dendrocopos leucotos',
+  ]);
+  const isLocal = (p: SpeciesPrediction): boolean => localValues.has(p.value);
+
+  it('ranks an exact label match first even when look-alikes sort earlier alphabetically', () => {
+    // The exact "peippo" (Fringilla coelebs) is buried mid-list; it must lead.
+    const result = rankPredictions(predictions, 'peippo', { isLocal });
+    expect(result[0].label).toBe('peippo');
+  });
+
+  it('surfaces native (local) contains-matches above a non-native prefix match', () => {
+    // "tikka" is a compound-word suffix: native woodpeckers (käpytikka,
+    // valkoselkätikka) merely contain it, while the non-native tikkasirkku starts
+    // with it. Locality must outrank prefix so the natives lead.
+    const labels = rankPredictions(predictions, 'tikka', { isLocal }).map(p => p.label);
+    expect(labels[0]).toBe('käpytikka'); // alphabetically first local contains-match
+    expect(labels.indexOf('käpytikka')).toBeLessThan(labels.indexOf('tikkasirkku'));
+    expect(labels.indexOf('valkoselkätikka')).toBeLessThan(labels.indexOf('tikkasirkku'));
+    // Non-local entries (prefix or contains) trail the local ones.
+    expect(labels.indexOf('tikkasirkku')).toBeLessThan(labels.indexOf('tuliniskatikka'));
+  });
+
+  it('ranks a local prefix match above a local contains match', () => {
+    // "peippo" starts the local label "peippo" (exact, tier 0) but is a prefix of
+    // nothing else here; use "peip" so the exact drops out and only prefix/contains
+    // remain. peippo (local prefix) must precede viherpeippo (local contains).
+    const labels = rankPredictions(predictions, 'peip', { isLocal }).map(p => p.label);
+    expect(labels.indexOf('peippo')).toBeLessThan(labels.indexOf('viherpeippo'));
+    expect(labels.indexOf('peippo')).toBeLessThan(labels.indexOf('järripeippo'));
+  });
+
+  it('matches the canonical value, not only the label', () => {
+    const result = rankPredictions(predictions, 'coelebs', { isLocal });
+    expect(result.map(p => p.value)).toEqual(['Fringilla coelebs']);
+  });
+
+  it('drops non-matching predictions', () => {
+    const result = rankPredictions(predictions, 'peippo', { isLocal });
+    expect(result.every(p => p.label.includes('peippo'))).toBe(true);
+  });
+
+  it('caps the result to the limit while keeping the best-ranked entries', () => {
+    const result = rankPredictions(predictions, 'peippo', { isLocal, limit: 2 });
+    expect(result).toHaveLength(2);
+    // The exact match must survive the cap rather than being sliced off.
+    expect(result[0].label).toBe('peippo');
+  });
+
+  it('returns nothing for an empty (or whitespace-only) query', () => {
+    expect(rankPredictions(predictions, '   ', { isLocal })).toEqual([]);
+  });
+
+  it('returns nothing for a zero or negative limit', () => {
+    expect(rankPredictions(predictions, 'peippo', { isLocal, limit: 0 })).toEqual([]);
+    expect(rankPredictions(predictions, 'peippo', { isLocal, limit: -1 })).toEqual([]);
+  });
+
+  it('sorts alphabetically by label within a tier when no locality info is given', () => {
+    const result = rankPredictions(predictions, 'peippo');
+    expect(result[0].label).toBe('peippo'); // exact still leads
+    const rest = result.slice(1).map(p => p.label);
+    expect(rest).toEqual([...rest].sort((a, b) => a.localeCompare(b)));
   });
 });
 

--- a/frontend/src/lib/utils/speciesPredictions.ts
+++ b/frontend/src/lib/utils/speciesPredictions.ts
@@ -106,6 +106,100 @@ export function filterLocalizedPredictions(
   return out;
 }
 
+/** Options for {@link rankPredictions}. */
+interface RankOptions {
+  /** Maximum number of predictions to return. Defaults to unbounded. */
+  limit?: number;
+  /**
+   * Reports whether a prediction is locally relevant (e.g. present in the
+   * range-filtered probable-species set for the configured location). Locally
+   * relevant entries rank above other "contains" matches so common local species
+   * surface ahead of global look-alikes.
+   */
+  isLocal?: (prediction: SpeciesPrediction) => boolean;
+}
+
+/**
+ * Rank predictions for an autocomplete query so the most useful entries surface
+ * first, then cap the result. Matching is against BOTH the localized label and the
+ * canonical value (NFC + case-insensitive). Ranking tiers, best first:
+ *   0. exact match (label or value equals the query)
+ *   1. locally-relevant prefix match (isLocal, label or value starts with the query)
+ *   2. locally-relevant "contains" match (isLocal)
+ *   3. non-local prefix match
+ *   4. any other "contains" match
+ * Locality outranks prefix so that, in compound-word languages, typing a root word
+ * (e.g. Finnish "tikka") surfaces native species that merely contain it ahead of
+ * non-native species that happen to start with it. Within a tier, entries sort
+ * alphabetically by label. Non-matching predictions are dropped. An empty query
+ * returns [] (callers only predict once the visitor has typed), avoiding a
+ * meaningless full-list dump.
+ *
+ * This exists because the settings pickers autocomplete against the full global
+ * multi-model species union (~12k entries): without ranking, a naive filter+slice
+ * buries exact and locally-relevant matches behind alphabetically earlier global
+ * look-alikes (e.g. typing the Finnish "tikka" surfaced only exotic woodpeckers
+ * while the native ones were cut off past the cap).
+ */
+export function rankPredictions(
+  predictions: SpeciesPrediction[],
+  query: string,
+  options: RankOptions = {}
+): SpeciesPrediction[] {
+  const needle = normalizeForLookup(query.trim());
+  if (needle.length === 0) return [];
+
+  // Clamp the limit to a non-negative integer; short-circuit a zero/invalid bound.
+  const limitRaw = options.limit ?? Number.POSITIVE_INFINITY;
+  const limit = Number.isFinite(limitRaw)
+    ? Math.max(0, Math.floor(limitRaw))
+    : Number.POSITIVE_INFINITY;
+  if (limit === 0) return [];
+
+  const isLocal = options.isLocal;
+
+  interface RankedPrediction {
+    prediction: SpeciesPrediction;
+    tier: number;
+    local: boolean;
+  }
+
+  const ranked: RankedPrediction[] = [];
+  for (const prediction of predictions) {
+    const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
+    const labelKey = prediction.normalizedLabel ?? normalizeForLookup(prediction.label);
+    if (!valueKey.includes(needle) && !labelKey.includes(needle)) continue;
+
+    const local = isLocal?.(prediction) ?? false;
+    const isExact = valueKey === needle || labelKey === needle;
+    const isPrefix = valueKey.startsWith(needle) || labelKey.startsWith(needle);
+    let tier: number;
+    if (isExact) {
+      tier = 0;
+    } else if (local && isPrefix) {
+      tier = 1;
+    } else if (local) {
+      tier = 2;
+    } else if (isPrefix) {
+      tier = 3;
+    } else {
+      tier = 4;
+    }
+    ranked.push({ prediction, tier, local });
+  }
+
+  ranked.sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier;
+    // Tier 0 (exact) can mix local/non-local; keep local first there. Other tiers
+    // are locality-homogeneous, so this is a no-op for them.
+    if (a.local !== b.local) return a.local ? -1 : 1;
+    return a.prediction.label.localeCompare(b.prediction.label);
+  });
+
+  const capped = limit === Number.POSITIVE_INFINITY ? ranked : ranked.slice(0, limit);
+  return capped.map(entry => entry.prediction);
+}
+
 /**
  * Resolve typed free text to a canonical value by matching it (NFC +
  * case-insensitive) against a prediction's label OR value, returning the matched

--- a/frontend/src/lib/utils/speciesPredictions.ts
+++ b/frontend/src/lib/utils/speciesPredictions.ts
@@ -106,8 +106,20 @@ export function filterLocalizedPredictions(
   return out;
 }
 
-/** Options for {@link rankPredictions}. */
-interface RankOptions {
+// Ranking tiers for rankPredictions, best (lowest) first. Locality outranks prefix
+// so a typed root word surfaces native species that merely contain it ahead of
+// non-native look-alikes that happen to start with it.
+const TIER_EXACT = 0;
+const TIER_LOCAL_PREFIX = 1;
+const TIER_LOCAL_CONTAINS = 2;
+const TIER_PREFIX = 3;
+const TIER_CONTAINS = 4;
+
+/**
+ * Options for {@link rankPredictions}. Generic over the prediction type so a caller
+ * passing a richer type (extending SpeciesPrediction) keeps it through the callbacks.
+ */
+interface RankOptions<T extends SpeciesPrediction = SpeciesPrediction> {
   /** Maximum number of predictions to return. Defaults to unbounded. */
   limit?: number;
   /**
@@ -116,13 +128,13 @@ interface RankOptions {
    * relevant entries rank above other "contains" matches so common local species
    * surface ahead of global look-alikes.
    */
-  isLocal?: (prediction: SpeciesPrediction) => boolean;
+  isLocal?: (prediction: T) => boolean;
   /**
    * Drops a prediction from the results (e.g. species already in the target list).
    * Evaluated only for entries that already matched the query, so an expensive,
    * alias-aware exclusion check runs on the small matched subset, not the full list.
    */
-  exclude?: (prediction: SpeciesPrediction) => boolean;
+  exclude?: (prediction: T) => boolean;
 }
 
 /**
@@ -147,11 +159,11 @@ interface RankOptions {
  * look-alikes (e.g. typing the Finnish "tikka" surfaced only exotic woodpeckers
  * while the native ones were cut off past the cap).
  */
-export function rankPredictions(
-  predictions: SpeciesPrediction[],
+export function rankPredictions<T extends SpeciesPrediction>(
+  predictions: T[],
   query: string,
-  options: RankOptions = {}
-): SpeciesPrediction[] {
+  options: RankOptions<T> = {}
+): T[] {
   const needle = normalizeForLookup(query.trim());
   if (needle.length === 0) return [];
 
@@ -166,7 +178,7 @@ export function rankPredictions(
   const exclude = options.exclude;
 
   interface RankedPrediction {
-    prediction: SpeciesPrediction;
+    prediction: T;
     tier: number;
     local: boolean;
   }
@@ -184,15 +196,15 @@ export function rankPredictions(
     const isPrefix = valueKey.startsWith(needle) || labelKey.startsWith(needle);
     let tier: number;
     if (isExact) {
-      tier = 0;
+      tier = TIER_EXACT;
     } else if (local && isPrefix) {
-      tier = 1;
+      tier = TIER_LOCAL_PREFIX;
     } else if (local) {
-      tier = 2;
+      tier = TIER_LOCAL_CONTAINS;
     } else if (isPrefix) {
-      tier = 3;
+      tier = TIER_PREFIX;
     } else {
-      tier = 4;
+      tier = TIER_CONTAINS;
     }
     ranked.push({ prediction, tier, local });
   }

--- a/frontend/src/lib/utils/speciesPredictions.ts
+++ b/frontend/src/lib/utils/speciesPredictions.ts
@@ -117,6 +117,12 @@ interface RankOptions {
    * surface ahead of global look-alikes.
    */
   isLocal?: (prediction: SpeciesPrediction) => boolean;
+  /**
+   * Drops a prediction from the results (e.g. species already in the target list).
+   * Evaluated only for entries that already matched the query, so an expensive,
+   * alias-aware exclusion check runs on the small matched subset, not the full list.
+   */
+  exclude?: (prediction: SpeciesPrediction) => boolean;
 }
 
 /**
@@ -131,9 +137,9 @@ interface RankOptions {
  * Locality outranks prefix so that, in compound-word languages, typing a root word
  * (e.g. Finnish "tikka") surfaces native species that merely contain it ahead of
  * non-native species that happen to start with it. Within a tier, entries sort
- * alphabetically by label. Non-matching predictions are dropped. An empty query
- * returns [] (callers only predict once the visitor has typed), avoiding a
- * meaningless full-list dump.
+ * alphabetically by label. Non-matching predictions, and any the optional
+ * `exclude` predicate rejects, are dropped. An empty query returns [] (callers
+ * only predict once the visitor has typed), avoiding a meaningless full-list dump.
  *
  * This exists because the settings pickers autocomplete against the full global
  * multi-model species union (~12k entries): without ranking, a naive filter+slice
@@ -157,6 +163,7 @@ export function rankPredictions(
   if (limit === 0) return [];
 
   const isLocal = options.isLocal;
+  const exclude = options.exclude;
 
   interface RankedPrediction {
     prediction: SpeciesPrediction;
@@ -169,6 +176,8 @@ export function rankPredictions(
     const valueKey = prediction.normalizedValue ?? normalizeForLookup(prediction.value);
     const labelKey = prediction.normalizedLabel ?? normalizeForLookup(prediction.label);
     if (!valueKey.includes(needle) && !labelKey.includes(needle)) continue;
+    // Exclusion runs only after the match check, so it never touches non-matches.
+    if (exclude?.(prediction)) continue;
 
     const local = isLocal?.(prediction) ?? false;
     const isExact = valueKey === needle || labelKey === needle;


### PR DESCRIPTION
## Summary

The species pickers on the Settings > Species page (Include / Exclude / Custom config) autocompleted against the full global multi-model species union (~12k entries from `/api/v2/species/all`) and selected matches with a naive `filter(...).slice(0, 10)` in scientific-name-alphabetical order, with no relevance ranking and no locality preference.

For compound-name locales this buried the species users actually want. With a Finnish locale, typing `peippo` (chaffinch, *Fringilla coelebs*) matched 77 entries and the exact match landed at rank 24, cut off by the slice; the visible 10 were early-alphabet exotics. Typing `tikka` matched 192 entries and every native woodpecker (`käpytikka`, `valkoselkätikka`, `harmaapäätikka` at rank 164) was cut off, leaving only non-native species. Nothing was missing from the data; the autocomplete was picking the wrong 10.

## Changes

- Add a pure, unit-tested `rankPredictions()` helper that ranks matches **exact > local-prefix > local-contains > non-local-prefix > non-local-contains**, then caps. Locality outranks prefix so a typed root word surfaces native species that contain it ahead of non-native ones that merely start with it. It also takes an optional `exclude` predicate (applied only to matched candidates).
- Load a range-filtered probable-species set (keyed by normalized common and scientific names) independently of the Active tab, so the pickers can flag locally-relevant species. The Active tab's loader primes the same set to avoid a redundant range-filter fetch.
- Precompute a `$derived` list of predictions with localized labels and pre-normalized keys (via the existing `toLocalizedPredictions` helper), keeping ~12k dictionary lookups and NFC normalizations out of the per-keystroke filter and ensuring labels refresh on locale switch.
- Raise the per-picker ranking pool from 10 to 25; ranking guarantees exact and locally-relevant matches survive it. The full list stays the source, so rare/vagrant species remain pickable by typing the full name.
- Guard `response.species` with `?? []` in both range-filter loaders (a Go nil slice serializes to JSON `null`), and hoist the repeated `0.01` threshold fallback to a named constant.

## Test Plan

- [x] `rankPredictions` unit tests (exact-first, locality-over-prefix, NFC + case-insensitive, exclude predicate, cap keeps best-ranked): 34 pass
- [x] Settings + util + form component suites: 1326 pass
- [x] `svelte-check` 0 errors, eslint + prettier clean
- [x] Verified against a live multi-model station: `peippo` now returns the chaffinch first; `tikka` now lists the native woodpeckers ahead of exotics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Species autocomplete now returns ranked, locale- and location-aware suggestions, prioritizing exact and locally relevant matches for improved picker relevance.

* **Bug Fixes**
  * Improved handling of missing species data to prevent disruption in autocomplete and active-species loading.
  * Better threshold fallback behavior for range-based species filtering.
  * Refined include/exclude autocomplete updates to avoid incorrect collisions while editing.

* **Tests**
  * Added automated test coverage for ranked species prediction behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->