### PR TITLE
fix(container): start under arbitrary UID without HOME override

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,0 +1,56 @@
+name: Container test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "Docker/**"
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/container-test.yml"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "Docker/**"
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/container-test.yml"
+
+concurrency:
+  group: container-test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  arbitrary-uid-start:
+    name: Arbitrary-UID startup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build container image (amd64, load locally)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: birdnet-go:test
+          platforms: linux/amd64
+          # Reads the registry cache the publish workflow populates (anonymous,
+          # public); writes/reads the PR-scoped GHA cache. Never pushes.
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Arbitrary-UID startup smoke test
+        run: Docker/test/arbitrary-uid-smoke.sh birdnet-go:test

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -78,6 +78,16 @@ else
     # Running in rootless mode (already running as target user)
     echo "Running in rootless mode (current UID: $CURRENT_UID)"
 
+    # Arbitrary-UID containers (K8s runAsNonRoot, no /etc/passwd entry) inherit
+    # HOME=/ (or empty), which is not writable. Config resolution then does
+    # `mkdir /.config` and the app aborts. Point HOME at the writable /config
+    # mount so config resolution and the symlink below work without the operator
+    # having to set HOME explicitly.
+    if [ -z "$HOME" ] || [ ! -w "$HOME" ]; then
+        export HOME=/config
+        echo "Adjusted HOME to /config for rootless config access"
+    fi
+
     # Just ensure directories exist (permissions already set in Dockerfile)
     mkdir -p /config /data/clips /data/models 2>/dev/null || true
 

--- a/Docker/test/arbitrary-uid-smoke.sh
+++ b/Docker/test/arbitrary-uid-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Smoke test: the container must start as an arbitrary, non-root UID with no
+# /etc/passwd entry (K8s runAsNonRoot / OpenShift) WITHOUT the operator setting
+# HOME or BIRDNET_UID/BIRDNET_GID.
+#
+# This guards two regression classes that previously broke rootless startup:
+#   1. Entrypoint writing /etc/localtime under `set -e` (timezone block) — fails
+#      with "Permission denied" for non-root users.
+#   2. Config resolution falling back to HOME=/ → `mkdir /.config: permission
+#      denied` → "Cannot load settings" → startup abort.
+#
+# Usage: Docker/test/arbitrary-uid-smoke.sh <image-ref>
+#
+# Notes on the environment (this is the part that matters):
+#   --user 568:568   arbitrary UID/GID with no passwd entry (do NOT pass
+#                    BIRDNET_UID/GID, and do NOT set HOME — that would mask
+#                    the bug this test exists to catch).
+#   --tmpfs mounts   writable by any UID, the docker equivalent of a K8s
+#                    emptyDir + fsGroup. A host bind mount owned by another UID
+#                    would fail the entrypoint's writability preflight for an
+#                    unrelated reason. /data needs >=1GB for the preflight.
+set -euo pipefail
+
+IMAGE="${1:?usage: arbitrary-uid-smoke.sh <image-ref>}"
+UID_GID="${SMOKE_UID_GID:-568:568}"
+TIMEOUT_SECONDS="${SMOKE_TIMEOUT:-90}"
+
+# Markers, kept in one place so assertions and docs stay in sync.
+START_MARKER="BirdNET-Go starting"
+FAIL_MARKERS="APPLICATION STARTUP FAILED|Cannot load settings|permission denied|/etc/localtime.*Permission denied"
+
+echo "==> Starting '$IMAGE' as --user $UID_GID (no HOME, no BIRDNET_UID)"
+cid=$(docker run -d \
+    --user "$UID_GID" \
+    --tmpfs /config:size=64m \
+    --tmpfs /data:size=1200m \
+    -e TZ=Europe/Helsinki \
+    "$IMAGE")
+cleanup() { docker rm -f "$cid" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+status="timeout"
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    logs=$(docker logs "$cid" 2>&1 || true)
+    if grep -q "$START_MARKER" <<<"$logs"; then
+        status="ok"
+        break
+    fi
+    if grep -Eq "$FAIL_MARKERS" <<<"$logs"; then
+        status="failed"
+        break
+    fi
+    if [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || echo false)" != "true" ]; then
+        status="exited"
+        break
+    fi
+    sleep 2
+done
+
+echo "----- container logs (tail) -----"
+docker logs "$cid" 2>&1 | tail -40
+echo "---------------------------------"
+
+if [ "$status" != "ok" ]; then
+    echo "FAIL: container did not reach startup as an arbitrary UID (status=$status)"
+    exit 1
+fi
+
+# Config must resolve under the writable /config mount, not /.
+if ! docker logs "$cid" 2>&1 | grep -Eq "config_file=/config(/|\b)"; then
+    echo "FAIL: config_file did not resolve under /config (HOME fallback regressed?)"
+    exit 1
+fi
+
+echo "PASS: started as $UID_GID with no HOME override; config resolved under /config"

--- a/Docker/test/arbitrary-uid-smoke.sh
+++ b/Docker/test/arbitrary-uid-smoke.sh
@@ -48,7 +48,7 @@ while [ "$SECONDS" -lt "$deadline" ]; do
         status="ok"
         break
     fi
-    if grep -Eq "$FAIL_MARKERS" <<<"$logs"; then
+    if grep -Eiq "$FAIL_MARKERS" <<<"$logs"; then
         status="failed"
         break
     fi
@@ -69,7 +69,7 @@ if [ "$status" != "ok" ]; then
 fi
 
 # Config must resolve under the writable /config mount, not /.
-if ! docker logs "$cid" 2>&1 | grep -Eq "config_file=/config(/|\b)"; then
+if ! docker logs "$cid" 2>&1 | grep -Eq "config_file=/config(/|[[:space:]]|$)"; then
     echo "FAIL: config_file did not resolve under /config (HOME fallback regressed?)"
     exit 1
 fi


### PR DESCRIPTION
Arbitrary-UID containers (K8s runAsNonRoot, OpenShift) have no /etc/passwd entry, so the process inherits HOME=/ (or empty). Config resolution then resolves the config dir under $HOME and runs `mkdir /.config`, which fails with "permission denied", aborting startup with "Cannot load settings". Operators had to work around it by setting HOME=/config explicitly.

Point HOME at the writable /config mount in the entrypoint's rootless branch when the inherited HOME is empty or unwritable, so the container starts as any non-root UID out of the box.

Since arbitrary-UID usage keeps regressing, this also adds a startup smoke test (Docker/test/ arbitrary-uid-smoke.sh) in a dedicated container-test.yml workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI “Container test” workflow that builds an amd64 container locally and runs a rootless arbitrary-UID smoke test.
* **Bug Fixes**
  * Improved rootless startup by setting `HOME` to `/config` when it’s unset or not writable, ensuring config resolution and symlink creation work correctly.
* **Tests**
  * Replaced the arbitrary-UID smoke test to more thoroughly validate rootless startup, failure modes, and `/config`-based configuration resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->