### PR TITLE
fix(datastore): use '!' as LIKE escape char to fix MySQL 1064 error

### DIFF
--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -194,6 +194,7 @@ jobs:
           go test -tags=integration -race -timeout 300s -v \
             ./internal/datastore/v2 \
             ./internal/datastore/v2/repository/... \
+            ./internal/datastore/v2only \
             ./internal/mqtt/... \
             ./internal/spectrogram/... \
             ./internal/testutil/containers/... \

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2755,7 +2755,14 @@ func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scie
 		LastSeenDate string `gorm:"column:last_seen_date"`
 	}
 
-	escapedScientificName := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(scientificName)
+	// Escape LIKE metacharacters using '!' as the escape character. '!' is not
+	// special in any SQL dialect's string literals, so the generated SQL is
+	// identical and valid on MySQL, SQLite, and Postgres. A backslash escape
+	// ('\') must NOT be used here: MySQL's default sql_mode treats a lone
+	// backslash in a string literal as an escape character, so "ESCAPE '\'"
+	// swallows the closing quote and raises a syntax error (Error 1064). SQLite
+	// does not treat backslash as special, which is why this only broke MySQL.
+	escapedScientificName := strings.NewReplacer(`!`, `!!`, `%`, `!%`, `_`, `!_`).Replace(scientificName)
 	prefix := ds.manager.TablePrefix()
 	query := ds.manager.DB().WithContext(ctx).
 		Table(prefix+"detections d").
@@ -2763,7 +2770,12 @@ func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scie
 		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
 		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
 		Where("d.detected_at < ?", before.Unix()).
-		Where("(l.scientific_name = ? OR l.scientific_name LIKE ? ESCAPE '\\')", scientificName, escapedScientificName+`\_%`).
+		// Match the bare scientific name exactly, or a legacy concatenated label
+		// stored as "ScientificName_CommonName". The "!_%" suffix is "literal
+		// underscore separator, then anything" ('!_' is an escaped underscore,
+		// '%' is the wildcard), mirroring how such labels are split on the first
+		// underscore (see detection.ExtractScientificName).
+		Where("(l.scientific_name = ? OR l.scientific_name LIKE ? ESCAPE '!')", scientificName, escapedScientificName+`!_%`).
 		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive))
 
 	if err := query.Scan(&result).Error; err != nil {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2741,6 +2741,19 @@ func (ds *Datastore) GetSpeciesDetectionDatesInPeriod(ctx context.Context, start
 	return results, nil
 }
 
+// scientificNameLikeEscaper escapes the LIKE metacharacters %, _, and the escape
+// character itself in a user-supplied scientific name, using '!' as the escape
+// character. '!' is not special in any SQL dialect's string literals, so the
+// generated SQL is identical and valid on MySQL, SQLite, and Postgres. A backslash
+// escape ('\') must NOT be used: MySQL's default sql_mode treats a lone backslash
+// in a string literal as an escape character, so "ESCAPE '\'" swallows the closing
+// quote and raises a syntax error (Error 1064). SQLite does not treat backslash as
+// special, which is why that only broke MySQL.
+//
+// It is a package-level value because strings.Replacer precomputes its matcher and
+// is safe for concurrent use, so there is no need to rebuild it on every call.
+var scientificNameLikeEscaper = strings.NewReplacer(`!`, `!!`, `%`, `!%`, `_`, `!_`)
+
 // GetSpeciesLastDetectionDateBefore returns the last detection date before the given date.
 func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scientificName, beforeDate string) (string, error) {
 	before, err := time.ParseInLocation(time.DateOnly, beforeDate, ds.timezone)
@@ -2755,14 +2768,8 @@ func (ds *Datastore) GetSpeciesLastDetectionDateBefore(ctx context.Context, scie
 		LastSeenDate string `gorm:"column:last_seen_date"`
 	}
 
-	// Escape LIKE metacharacters using '!' as the escape character. '!' is not
-	// special in any SQL dialect's string literals, so the generated SQL is
-	// identical and valid on MySQL, SQLite, and Postgres. A backslash escape
-	// ('\') must NOT be used here: MySQL's default sql_mode treats a lone
-	// backslash in a string literal as an escape character, so "ESCAPE '\'"
-	// swallows the closing quote and raises a syntax error (Error 1064). SQLite
-	// does not treat backslash as special, which is why this only broke MySQL.
-	escapedScientificName := strings.NewReplacer(`!`, `!!`, `%`, `!%`, `_`, `!_`).Replace(scientificName)
+	// Escape LIKE metacharacters with '!' (see scientificNameLikeEscaper).
+	escapedScientificName := scientificNameLikeEscaper.Replace(scientificName)
 	prefix := ds.manager.TablePrefix()
 	query := ds.manager.DB().WithContext(ctx).
 		Table(prefix+"detections d").

--- a/internal/datastore/v2only/datastore_mysql_like_escape_test.go
+++ b/internal/datastore/v2only/datastore_mysql_like_escape_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package v2only
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+)
+
+// setupMySQLDatastore starts a MySQL testcontainer and builds a fully-wired
+// v2only Datastore against it. It returns the datastore (timezone forced to UTC
+// for deterministic date bucketing) and registers container/datastore cleanup.
+func setupMySQLDatastore(t *testing.T) *Datastore {
+	t.Helper()
+
+	ctx := t.Context()
+
+	cfg := &containers.MySQLConfig{
+		Database:     "birdnet_like_escape",
+		RootPassword: "test",
+		Username:     "testuser",
+		Password:     "testpass",
+		ImageTag:     "8.0",
+	}
+	container, err := containers.NewMySQLContainer(ctx, cfg)
+	require.NoError(t, err, "failed to start MySQL container")
+	t.Cleanup(func() {
+		// context.Background(), not t.Context(): the test context is canceled
+		// just before cleanups run, so reusing it would abort termination.
+		if err := container.Terminate(context.Background()); err != nil { //nolint:gocritic // cleanup must outlive the test context
+			t.Logf("failed to terminate MySQL container: %v", err)
+		}
+	})
+
+	host, err := container.GetHost(ctx)
+	require.NoError(t, err)
+	port, err := container.GetPort(ctx)
+	require.NoError(t, err)
+
+	testLogger := logger.NewConsoleLogger("v2only_mysql_test", logger.LogLevelDebug)
+	manager, err := v2.NewMySQLManager(&v2.MySQLConfig{
+		Host:     host,
+		Port:     strconv.Itoa(port),
+		Username: cfg.Username,
+		Password: cfg.Password,
+		Database: cfg.Database,
+		Logger:   testLogger,
+	})
+	require.NoError(t, err, "failed to create MySQL manager")
+	require.NoError(t, manager.Initialize(), "failed to initialize MySQL schema")
+
+	// isMySQL=true selects the MySQL dialect in every repository constructor.
+	dsCfg := buildConfigForManager(t, manager, testLogger, true, nil)
+	ds, err := New(dsCfg)
+	require.NoError(t, err, "failed to create v2only datastore")
+	t.Cleanup(func() { _ = ds.Close() })
+
+	// Force UTC so detection date bucketing is deterministic and independent of
+	// the test host's local zone.
+	ds.timezone = time.UTC
+	return ds
+}
+
+// TestV2OnlyDatastore_GetSpeciesLastDetectionDateBefore_MySQL reproduces the MySQL
+// Error 1064 syntax error in the LIKE ... ESCAPE clause. The original code used a
+// backslash escape character; MySQL's default sql_mode treats a lone backslash in
+// a string literal as an escape, so the literal never terminates and the server
+// returns Error 1064. The bug is invisible on SQLite (backslash is not special
+// there), which is why the SQLite-only test path masked it. Exercising the query
+// against a real MySQL backend makes the syntax error surface.
+func TestV2OnlyDatastore_GetSpeciesLastDetectionDateBefore_MySQL(t *testing.T) {
+	ds := setupMySQLDatastore(t)
+	ctx := t.Context()
+
+	const cutoff = "2024-06-15"
+	day := func(d int) time.Time { return time.Date(2024, 6, d, 12, 0, 0, 0, time.UTC) }
+
+	t.Run("exact match does not raise error 1064", func(t *testing.T) {
+		// The core regression assertion: before the fix this call returns
+		// "Error 1064 (42000): You have an error in your SQL syntax".
+		seedDetection(t, ds, "Turdus merula", day(10))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Turdus merula", cutoff)
+		require.NoError(t, err, "MySQL must not raise a 1064 syntax error")
+		assert.Equal(t, "2024-06-10", got)
+	})
+
+	t.Run("concatenated label matches via LIKE prefix", func(t *testing.T) {
+		// Legacy labels stored as "Scientific_Common" must still match a query
+		// for the bare scientific name through the LIKE '<name>_%' arm.
+		seedDetection(t, ds, "Strix aluco_lehtopöllö", day(11))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Strix aluco", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-11", got)
+	})
+
+	t.Run("percent in name is escaped to a literal, not a wildcard", func(t *testing.T) {
+		// "Ab%cd_Name" is the real match; "AbZZcd_Name" is a decoy that would be
+		// matched too if '%' were treated as a LIKE wildcard instead of a literal.
+		seedDetection(t, ds, "Ab%cd_Name", day(11))
+		seedDetection(t, ds, "AbZZcd_Name", day(13))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Ab%cd", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-11", got,
+			"decoy detection must not be matched: '%%' must be a literal, not a wildcard")
+	})
+
+	t.Run("underscore in name is escaped to a literal, not a wildcard", func(t *testing.T) {
+		// "Ax_cy_Name" is the real match; "AxXcy_Name" is a decoy that would be
+		// matched too if '_' were treated as a single-character LIKE wildcard.
+		seedDetection(t, ds, "Ax_cy_Name", day(11))
+		seedDetection(t, ds, "AxXcy_Name", day(13))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Ax_cy", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-11", got,
+			"decoy detection must not be matched: '_' must be a literal, not a wildcard")
+	})
+}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -38,13 +38,27 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 	err = manager.Initialize()
 	require.NoError(t, err)
 
+	// useV2Prefix=false, isMySQL=false for the SQLite test path.
+	cfg = buildConfigForManager(t, manager, testLogger, false, labels)
+
+	// tempDir is auto-cleaned by t.TempDir(); no additional cleanup needed
+	return cfg, func() {}
+}
+
+// buildConfigForManager wires the repositories, seeds the required lookup-table
+// entries, and assembles a *Config for an already-initialized v2 manager. The
+// isMySQL flag is threaded into every repository constructor so the same wiring
+// drives both the SQLite (in-memory) and MySQL (testcontainer) test paths.
+func buildConfigForManager(t *testing.T, manager v2.Manager, testLogger logger.Logger, isMySQL bool, labels []string) *Config {
+	t.Helper()
+
 	db := manager.DB()
 
 	// Create lookup table entries for tests
 	// The LabelType and TaxonomicClass tables should be created by Initialize()
 	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, false)
 	taxClassRepo := repository.NewTaxonomicClassRepository(db, nil, false)
-	modelRepo := repository.NewModelRepository(db, nil, false, false)
+	modelRepo := repository.NewModelRepository(db, nil, false, isMySQL)
 
 	ctx := t.Context()
 
@@ -62,16 +76,17 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 
 	avesClassID := avesClass.ID
 
-	// Create repositories (useV2Prefix = false for SQLite, isMySQL = false)
-	detectionRepo := repository.NewDetectionRepository(db, nil, false, false)
-	labelRepo := repository.NewLabelRepository(db, nil, false, false)
-	sourceRepo := repository.NewAudioSourceRepository(db, nil, false, false)
-	weatherRepo := repository.NewWeatherRepository(db, nil, false, false)
-	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, false, false)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, false, false)
-	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, false, false)
+	// Create repositories. useV2Prefix=false (fresh install / clean table names);
+	// isMySQL selects the dialect-specific SQL the repositories generate.
+	detectionRepo := repository.NewDetectionRepository(db, nil, false, isMySQL)
+	labelRepo := repository.NewLabelRepository(db, nil, false, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(db, nil, false, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(db, nil, false, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, false, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, false, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, false, isMySQL)
 
-	cfg = &Config{
+	return &Config{
 		Manager:            manager,
 		Detection:          detectionRepo,
 		Label:              labelRepo,
@@ -88,9 +103,6 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 		AvesClassID:        &avesClassID,
 		Labels:             labels,
 	}
-
-	// tempDir is auto-cleaned by t.TempDir(); no additional cleanup needed
-	return cfg, func() {}
 }
 
 // setupTestDatastore creates a V2OnlyDatastore with an in-memory SQLite database for testing.
@@ -111,6 +123,116 @@ func setupTestDatastoreWithLabels(t *testing.T, labels []string) (ds *Datastore,
 	ds, err := New(cfg)
 	require.NoError(t, err)
 	return ds, func() { _ = ds.Close(); cfgCleanup() }
+}
+
+// seedDetection creates (or reuses) a label for sciName and inserts one detection
+// at the given instant. The label scientific_name is stored verbatim so callers
+// can exercise both bare names and legacy "Scientific_Common" concatenated labels.
+// Shared by the SQLite and MySQL (integration) datastore tests.
+func seedDetection(t *testing.T, ds *Datastore, sciName string, at time.Time) *entities.Detection {
+	t.Helper()
+	ctx := t.Context()
+	label, err := ds.label.GetOrCreate(ctx, sciName, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
+	require.NoError(t, err, "failed to create label %q", sciName)
+	det := &entities.Detection{
+		ModelID:    ds.defaultModelID,
+		LabelID:    label.ID,
+		DetectedAt: at.Unix(),
+		Confidence: 0.9,
+	}
+	require.NoError(t, ds.detection.Save(ctx, det), "failed to save detection for %q", sciName)
+	return det
+}
+
+// TestV2OnlyDatastore_GetSpeciesLastDetectionDateBefore exercises the LIKE ... ESCAPE
+// query on SQLite. It is portable regression coverage for the escaping logic: the
+// MySQL-specific syntax failure is reproduced in the //go:build integration test,
+// while these cases pin the matching semantics (exact match, the latest date before
+// the cutoff, the legacy concatenated-label prefix match, and that %/_ in the queried
+// name are treated as literals rather than LIKE wildcards).
+func TestV2OnlyDatastore_GetSpeciesLastDetectionDateBefore(t *testing.T) {
+	t.Parallel()
+
+	ds, cleanup := setupTestDatastore(t)
+	defer cleanup()
+	ds.timezone = time.UTC
+	ctx := t.Context()
+
+	const cutoff = "2024-06-15"
+	day := func(d int) time.Time { return time.Date(2024, 6, d, 12, 0, 0, 0, time.UTC) }
+
+	t.Run("returns the latest detection date before the cutoff", func(t *testing.T) {
+		seedDetection(t, ds, "Turdus merula", day(10))
+		seedDetection(t, ds, "Turdus merula", day(13))
+		seedDetection(t, ds, "Turdus merula", day(20)) // on/after cutoff: excluded
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Turdus merula", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-13", got)
+	})
+
+	t.Run("returns empty when the only detection is on or after the cutoff", func(t *testing.T) {
+		seedDetection(t, ds, "Erithacus rubecula", day(20))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Erithacus rubecula", cutoff)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("matches a legacy concatenated label via the LIKE prefix", func(t *testing.T) {
+		seedDetection(t, ds, "Strix aluco_lehtopöllö", day(11))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Strix aluco", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-11", got)
+	})
+
+	t.Run("treats percent in the queried name as a literal, not a wildcard", func(t *testing.T) {
+		seedDetection(t, ds, "Ab%cd_Name", day(11))
+		seedDetection(t, ds, "AbZZcd_Name", day(13)) // decoy: matched only if % is a wildcard
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Ab%cd", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-11", got)
+	})
+
+	t.Run("treats underscore in the queried name as a literal, not a wildcard", func(t *testing.T) {
+		seedDetection(t, ds, "Ax_cy_Name", day(11))
+		seedDetection(t, ds, "AxXcy_Name", day(13)) // decoy: matched only if _ is a wildcard
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Ax_cy", cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, "2024-06-11", got)
+	})
+
+	t.Run("excludes a detection at exactly the cutoff instant", func(t *testing.T) {
+		// before.Unix() is midnight at the start of the cutoff date in ds.timezone,
+		// and the filter is a strict less-than, so a detection at exactly that
+		// instant must be excluded.
+		seedDetection(t, ds, "Cyanistes caeruleus", time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC))
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Cyanistes caeruleus", cutoff)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("excludes detections reviewed as false positive", func(t *testing.T) {
+		det := seedDetection(t, ds, "Fringilla coelebs", day(10))
+		require.NoError(t, ds.manager.DB().Create(&entities.DetectionReview{
+			DetectionID: det.ID,
+			Verified:    entities.VerificationFalsePositive,
+		}).Error)
+
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Fringilla coelebs", cutoff)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns empty for an unknown species", func(t *testing.T) {
+		got, err := ds.GetSpeciesLastDetectionDateBefore(ctx, "Nonexistent species", cutoff)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
 }
 
 type nilInjectingLabelRepository struct {


### PR DESCRIPTION
## Summary

`GetSpeciesLastDetectionDateBefore` in the v2only datastore built a `LIKE ... ESCAPE` clause with a backslash escape character. The Go string `"... ESCAPE '\\'"` renders to the SQL text `ESCAPE '\'`, and MySQL's default `sql_mode` treats a lone backslash in a string literal as an escape character, so the string literal never terminates and the server returns `Error 1064 (42000)`. SQLite does not treat backslash as special, so only MySQL backends were affected and the SQLite-only test path masked the bug. The failure breaks the new-species-tracker novelty / absence-return detection path on MySQL.

The fix switches the `LIKE` escape character to `!`, which is not special in any SQL dialect's string literals, and escapes `%`, `_`, and `!` in the queried scientific name accordingly. The generated SQL is now valid and identical on MySQL, SQLite, and Postgres. This is the only `ESCAPE '\\'` occurrence in the datastore.

## Changes

- `internal/datastore/v2only/datastore.go`: use `!` as the `LIKE` escape character and escape the pattern with it; document why backslash must not be used.
- Add a MySQL testcontainer integration test (`//go:build integration`) that reproduces the 1064 error against a real MySQL backend, plus a portable SQLite functional test covering exact match, the legacy `Scientific_Common` concatenated-label prefix match, literal `%`/`_` escaping, the strict cutoff boundary, and the false-positive review exclusion.
- Wire `./internal/datastore/v2only` into the CI `testcontainer-tests` job so the new integration test actually runs.

## Test Plan

- [x] `go test ./internal/datastore/v2only/` (SQLite) passes
- [x] `go test -tags=integration ./internal/datastore/v2only/` reproduces Error 1064 before the fix and passes after (verified against MySQL 8.0)
- [x] `golangci-lint run` clean (full project)
- [x] `internal/analysis/species` (the caller) passes under `-race`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved species name matching for MySQL by correcting LIKE escaping behavior, preventing SQL syntax errors and ensuring `%`, `_`, and legacy label formats are treated as literals.

* **Tests**
  * Added/expanded regression tests for `GetSpeciesLastDetectionDateBefore` on both SQLite and MySQL, including cutoff edge cases, legacy prefix matching, and special-character escaping.

* **Chores**
  * Updated CI integration test runs to include the additional datastore v2-only package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->