### PR TITLE
fix(mqtt): handle scheme-less broker addresses in TLS and DNS paths

### DIFF
--- a/internal/mqtt/broker.go
+++ b/internal/mqtt/broker.go
@@ -1,0 +1,100 @@
+// broker.go: parsing of MQTT broker addresses into scheme/host/port components.
+//
+// MQTT broker addresses are commonly written without a scheme (for example
+// "mybroker:1883"), a form Go's url.Parse mishandles: it rejects scheme-less IP
+// literals ("first path segment in URL cannot contain colon") and silently
+// reads a scheme-less alphabetic host as the URL scheme. parseBroker is the
+// single, IPv6-safe parser that every broker-address consumer in this package
+// routes through, so the TLS ServerName, DNS resolution, and the connection
+// test stages all interpret the configured broker identically.
+
+package mqtt
+
+import (
+	"net"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+const (
+	// defaultMQTTPort is the port assumed when a broker address omits one.
+	defaultMQTTPort = "1883"
+	// localhostIP is substituted when a broker address is given as a bare
+	// ":port", mirroring paho's ClientOptions.AddBroker.
+	localhostIP = "127.0.0.1"
+)
+
+// schemeImpliesTLS reports whether a broker URL scheme selects a TLS transport.
+func schemeImpliesTLS(scheme string) bool {
+	switch scheme {
+	case "ssl", "tls", "mqtts":
+		return true
+	default:
+		return false
+	}
+}
+
+// brokerParts holds the components of a parsed MQTT broker address.
+type brokerParts struct {
+	scheme string // transport scheme without "://" (empty when none was given)
+	host   string // hostname or IP literal, without IPv6 brackets
+	port   string // port, or "" when the address omitted one
+}
+
+// hostPort returns the host:port form, substituting the default MQTT port when
+// the address omitted one. IPv6 hosts are bracketed via net.JoinHostPort.
+func (b brokerParts) hostPort() string {
+	port := b.port
+	if port == "" {
+		port = defaultMQTTPort
+	}
+	return net.JoinHostPort(b.host, port)
+}
+
+// parseBroker splits an MQTT broker address into its scheme, host, and port. It
+// tolerates the scheme-less "host:port" form and is IPv6-safe, accepting both
+// bracketed "[2001:db8::1]:1883" and bare "2001:db8::1" literals. A genuinely
+// malformed address (such as an unterminated IPv6 bracket) returns an error.
+func parseBroker(broker string) (brokerParts, error) {
+	s := strings.TrimSpace(broker)
+
+	var scheme string
+	if before, after, found := strings.Cut(s, "://"); found {
+		scheme = before
+		s = after
+	}
+
+	host, port, err := splitBrokerHostPort(s)
+	if err != nil {
+		return brokerParts{}, err
+	}
+	return brokerParts{scheme: scheme, host: host, port: port}, nil
+}
+
+// splitBrokerHostPort splits a scheme-less "host:port" into host and port. It is
+// IPv6-safe, tolerates a missing port, and accepts a bare IPv6 literal. A
+// leading ":port" implies the local host, mirroring paho's ClientOptions.AddBroker.
+func splitBrokerHostPort(s string) (host, port string, err error) {
+	// A leading single ":" (port only, not an IPv6 "::") implies localhost.
+	if strings.HasPrefix(s, ":") && !strings.HasPrefix(s, "::") {
+		s = localhostIP + s
+	}
+
+	if h, p, splitErr := net.SplitHostPort(s); splitErr == nil {
+		return h, p, nil
+	}
+
+	// net.SplitHostPort failed: either there is no port, or this is a bare IPv6
+	// literal. A value opened with "[" must also close with "]".
+	if strings.HasPrefix(s, "[") {
+		if !strings.HasSuffix(s, "]") {
+			return "", "", errors.Newf("failed to parse broker address %q: unterminated IPv6 bracket", s).
+				Component("mqtt").
+				Category(errors.CategoryConfiguration).
+				Build()
+		}
+		return s[1 : len(s)-1], "", nil
+	}
+	return s, "", nil
+}

--- a/internal/mqtt/broker.go
+++ b/internal/mqtt/broker.go
@@ -27,9 +27,11 @@ const (
 )
 
 // schemeImpliesTLS reports whether a broker URL scheme selects a TLS transport.
+// "wss" (WebSocket Secure) is included so a wss broker's TLS config (CA, client
+// cert, InsecureSkipVerify) is applied, consistent with the other TLS schemes.
 func schemeImpliesTLS(scheme string) bool {
 	switch scheme {
-	case "ssl", "tls", "mqtts":
+	case "ssl", "tls", "mqtts", "wss":
 		return true
 	default:
 		return false

--- a/internal/mqtt/broker.go
+++ b/internal/mqtt/broker.go
@@ -68,10 +68,7 @@ func parseBroker(broker string) (brokerParts, error) {
 	if strings.Contains(s, "://") {
 		u, err := url.Parse(s)
 		if err != nil {
-			return brokerParts{}, errors.Newf("failed to parse broker address %q: %v", broker, err).
-				Component("mqtt").
-				Category(errors.CategoryConfiguration).
-				Build()
+			return brokerParts{}, malformedBrokerError(broker, err.Error())
 		}
 		return brokerParts{scheme: strings.ToLower(u.Scheme), host: u.Hostname(), port: u.Port()}, nil
 	}
@@ -100,12 +97,26 @@ func splitBrokerHostPort(s string) (host, port string, err error) {
 	// literal. A value opened with "[" must also close with "]".
 	if strings.HasPrefix(s, "[") {
 		if !strings.HasSuffix(s, "]") {
-			return "", "", errors.Newf("failed to parse broker address %q: unterminated IPv6 bracket", s).
-				Component("mqtt").
-				Category(errors.CategoryConfiguration).
-				Build()
+			return "", "", malformedBrokerError(s, "unterminated IPv6 bracket")
 		}
-		return s[1 : len(s)-1], "", nil
+		host = s[1 : len(s)-1]
+	} else {
+		host = s
 	}
-	return s, "", nil
+	// A returned host must never contain a bracket character. Brackets are only
+	// valid as a matched IPv6 delimiter pair (stripped above); a leftover "[" or
+	// "]" is malformed and would otherwise yield a non-dial-able host:port.
+	if strings.ContainsAny(host, "[]") {
+		return "", "", malformedBrokerError(s, "stray bracket in host")
+	}
+	return host, "", nil
+}
+
+// malformedBrokerError builds a consistent configuration error for a broker
+// address that cannot be parsed into a usable host.
+func malformedBrokerError(addr, reason string) error {
+	return errors.Newf("failed to parse broker address %q: %s", addr, reason).
+		Component("mqtt").
+		Category(errors.CategoryConfiguration).
+		Build()
 }

--- a/internal/mqtt/broker.go
+++ b/internal/mqtt/broker.go
@@ -12,6 +12,7 @@ package mqtt
 
 import (
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -52,26 +53,34 @@ func (b brokerParts) hostPort() string {
 	return net.JoinHostPort(b.host, port)
 }
 
-// parseBroker splits an MQTT broker address into its scheme, host, and port. It
-// tolerates the scheme-less "host:port" form and is IPv6-safe, accepting both
-// bracketed "[2001:db8::1]:1883" and bare "2001:db8::1" literals. A genuinely
-// malformed address (such as an unterminated IPv6 bracket) returns an error.
+// parseBroker splits an MQTT broker address into its scheme, host, and port.
+//
+// An address that carries a scheme is a full URL: url.Parse handles it
+// correctly, including paths (ws://host/mqtt), userinfo, and IPv6 brackets, and
+// matches how the paho client parses the same string. Scheme-less "host:port"
+// addresses, which url.Parse mishandles, fall back to splitBrokerHostPort
+// (IPv6-safe, accepting both bracketed and bare literals). A genuinely malformed
+// address (such as an unterminated IPv6 bracket) returns an error. Schemes are
+// normalized to lowercase since they are case-insensitive (RFC 3986).
 func parseBroker(broker string) (brokerParts, error) {
 	s := strings.TrimSpace(broker)
 
-	var scheme string
-	if before, after, found := strings.Cut(s, "://"); found {
-		// Schemes are case-insensitive (RFC 3986); normalize so TLS inference
-		// matches regardless of the casing the user typed.
-		scheme = strings.ToLower(before)
-		s = after
+	if strings.Contains(s, "://") {
+		u, err := url.Parse(s)
+		if err != nil {
+			return brokerParts{}, errors.Newf("failed to parse broker address %q: %v", broker, err).
+				Component("mqtt").
+				Category(errors.CategoryConfiguration).
+				Build()
+		}
+		return brokerParts{scheme: strings.ToLower(u.Scheme), host: u.Hostname(), port: u.Port()}, nil
 	}
 
 	host, port, err := splitBrokerHostPort(s)
 	if err != nil {
 		return brokerParts{}, err
 	}
-	return brokerParts{scheme: scheme, host: host, port: port}, nil
+	return brokerParts{scheme: "", host: host, port: port}, nil
 }
 
 // splitBrokerHostPort splits a scheme-less "host:port" into host and port. It is

--- a/internal/mqtt/broker.go
+++ b/internal/mqtt/broker.go
@@ -61,7 +61,9 @@ func parseBroker(broker string) (brokerParts, error) {
 
 	var scheme string
 	if before, after, found := strings.Cut(s, "://"); found {
-		scheme = before
+		// Schemes are case-insensitive (RFC 3986); normalize so TLS inference
+		// matches regardless of the casing the user typed.
+		scheme = strings.ToLower(before)
 		s = after
 	}
 

--- a/internal/mqtt/broker_test.go
+++ b/internal/mqtt/broker_test.go
@@ -1,0 +1,141 @@
+// broker_test.go: tests for the canonical MQTT broker-address parser.
+
+package mqtt
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseBroker verifies scheme/host/port extraction across scheme-less,
+// scheme-prefixed, IPv6, and malformed broker addresses. The scheme-less
+// host:port forms are the regression cases for the original TLS bug.
+func TestParseBroker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		broker     string
+		wantScheme string
+		wantHost   string
+		wantPort   string
+		wantErr    bool
+	}{
+		// Scheme-less forms (the regression cases).
+		{"scheme-less hostname with port", "mybroker:1883", "", "mybroker", "1883", false},
+		{"scheme-less IPv4 with port", "192.168.1.5:1883", "", "192.168.1.5", "1883", false},
+		{"scheme-less bracketed IPv6 with port", "[::1]:1883", "", "::1", "1883", false},
+		{"scheme-less bare hostname", "mybroker", "", "mybroker", "", false},
+		{"scheme-less bare IPv4", "192.168.1.5", "", "192.168.1.5", "", false},
+		{"scheme-less bare IPv6", "2001:db8::1", "", "2001:db8::1", "", false},
+		// The "::" guard must keep bare IPv6 from being mistaken for a ":port".
+		{"bare IPv6 loopback not localhost-prefixed", "::1", "", "::1", "", false},
+		{"bare IPv6 unspecified", "::", "", "::", "", false},
+		{"bracketed IPv6 without port", "[::1]", "", "::1", "", false},
+		{"leading colon implies localhost", ":1883", "", "127.0.0.1", "1883", false},
+		{"empty broker", "", "", "", "", false},
+		{"surrounding whitespace trimmed", "  tcp://host:1883  ", "tcp", "host", "1883", false},
+
+		// Scheme-prefixed forms.
+		{"tcp scheme", "tcp://mybroker:1883", "tcp", "mybroker", "1883", false},
+		{"ssl scheme", "ssl://host:8883", "ssl", "host", "8883", false},
+		{"tls scheme", "tls://host:8883", "tls", "host", "8883", false},
+		{"mqtts scheme", "mqtts://host:8883", "mqtts", "host", "8883", false},
+		{"tcp scheme with bracketed IPv6", "tcp://[2001:db8::1]:1883", "tcp", "2001:db8::1", "1883", false},
+		{"ssl scheme with IPv4", "ssl://192.168.1.5:8883", "ssl", "192.168.1.5", "8883", false},
+
+		// Malformed addresses.
+		{"unterminated IPv6 bracket", "[malformed", "", "", "", true},
+		{"unterminated IPv6 bracket with scheme", "tcp://[malformed", "", "", "", true},
+		{"unterminated IPv6 bracket with port", "[2001:db8::1:1883", "", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parts, err := parseBroker(tt.broker)
+			if tt.wantErr {
+				require.Error(t, err, "parseBroker(%q) expected an error", tt.broker)
+				return
+			}
+			require.NoError(t, err, "parseBroker(%q) unexpected error", tt.broker)
+			assert.Equal(t, tt.wantScheme, parts.scheme, "parseBroker(%q) scheme mismatch", tt.broker)
+			assert.Equal(t, tt.wantHost, parts.host, "parseBroker(%q) host mismatch", tt.broker)
+			assert.Equal(t, tt.wantPort, parts.port, "parseBroker(%q) port mismatch", tt.broker)
+		})
+	}
+}
+
+// TestBrokerHostPort verifies the host:port form used by the connection-test
+// TCP/TLS dial stage: IPv6 bracketing via net.JoinHostPort and the default-port
+// fallback when the address omitted a port.
+func TestBrokerHostPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		broker string
+		want   string
+	}{
+		{"bare hostname gets default port", "mybroker", "mybroker:1883"},
+		{"hostname with port preserved", "mybroker:1883", "mybroker:1883"},
+		{"scheme stripped, port preserved", "tcp://mybroker:1883", "mybroker:1883"},
+		{"bare IPv6 bracketed with default port", "2001:db8::1", "[2001:db8::1]:1883"},
+		{"bracketed IPv6 with port preserved", "[::1]:1883", "[::1]:1883"},
+		{"bracketed IPv6 without port gets default", "[::1]", "[::1]:1883"},
+		{"bare IPv4 gets default port", "192.168.1.5", "192.168.1.5:1883"},
+		{"scheme-prefixed host gets default port", "ssl://host", "host:1883"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			parts, err := parseBroker(tt.broker)
+			require.NoError(t, err, "parseBroker(%q) unexpected error", tt.broker)
+			assert.Equal(t, tt.want, parts.hostPort(), "hostPort for %q mismatch", tt.broker)
+		})
+	}
+}
+
+// TestBrokerHostIsIP exercises the parse-then-classify path the connection-test
+// flow uses to decide whether to skip the DNS stage (net.ParseIP on the parsed
+// host). Malformed inputs are covered as errors by TestParseBroker.
+func TestBrokerHostIsIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		broker string
+		wantIP bool
+	}{
+		{"IPv4", "192.168.1.1", true},
+		{"IPv4 with scheme and port", "tcp://192.168.1.1:1883", true},
+		{"IPv4 loopback", "127.0.0.1", true},
+		{"bare IPv6 loopback", "::1", true},
+		{"bracketed IPv6", "[::1]", true},
+		{"bracketed IPv6 with port", "[::1]:1883", true},
+		{"scheme with bracketed IPv6", "tcp://[2001:db8::1]:1883", true},
+		{"bare IPv6 global", "2001:db8::1", true},
+		{"arbitrary scheme with IPv4", "invalid://192.168.1.1", true},
+		{"hostname", "localhost", false},
+		{"FQDN with port", "test.mosquitto.org:1883", false},
+		{"subdomain with scheme", "mqtt://mqtt.example.com:1883", false},
+		{"empty", "", false},
+		{"invalid IPv4", "256.256.256.256", false},
+		{"invalid IPv6", "2001:zz::1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			parts, err := parseBroker(tt.broker)
+			require.NoError(t, err, "parseBroker(%q) unexpected error", tt.broker)
+			assert.Equal(t, tt.wantIP, net.ParseIP(parts.host) != nil,
+				"IP classification for %q (host=%q) mismatch", tt.broker, parts.host)
+		})
+	}
+}

--- a/internal/mqtt/broker_test.go
+++ b/internal/mqtt/broker_test.go
@@ -46,6 +46,7 @@ func TestParseBroker(t *testing.T) {
 		{"mqtts scheme", "mqtts://host:8883", "mqtts", "host", "8883", false},
 		{"tcp scheme with bracketed IPv6", "tcp://[2001:db8::1]:1883", "tcp", "2001:db8::1", "1883", false},
 		{"ssl scheme with IPv4", "ssl://192.168.1.5:8883", "ssl", "192.168.1.5", "8883", false},
+		{"uppercase scheme normalized to lowercase", "MQTTS://host:8883", "mqtts", "host", "8883", false},
 
 		// Malformed addresses.
 		{"unterminated IPv6 bracket", "[malformed", "", "", "", true},

--- a/internal/mqtt/broker_test.go
+++ b/internal/mqtt/broker_test.go
@@ -4,6 +4,7 @@ package mqtt
 
 import (
 	"net"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,8 @@ func TestParseBroker(t *testing.T) {
 		{"unterminated IPv6 bracket", "[malformed", "", "", "", true},
 		{"unterminated IPv6 bracket with scheme", "tcp://[malformed", "", "", "", true},
 		{"unterminated IPv6 bracket with port", "[2001:db8::1:1883", "", "", "", true},
+		{"stray closing bracket", "]", "", "", "", true},
+		{"stray bracket inside brackets", "[]]", "", "", "", true},
 	}
 
 	for _, tt := range tests {
@@ -73,6 +76,64 @@ func TestParseBroker(t *testing.T) {
 			assert.Equal(t, tt.wantPort, parts.port, "parseBroker(%q) port mismatch", tt.broker)
 		})
 	}
+}
+
+// TestParseBrokerMatchesURLParse is a differential/characterization test: for
+// every scheme-full broker address across the dimensions paho accepts (scheme x
+// host-type x port x path), parseBroker must extract the same host and port as
+// net/url.Parse, the reference the paho client itself uses. This pins the
+// engine-swap equivalence that a path-less, hand-picked corpus missed: it fails
+// on any parser that lets a URL path or userinfo leak into the host or port.
+func TestParseBrokerMatchesURLParse(t *testing.T) {
+	t.Parallel()
+
+	schemes := []string{"tcp", "ssl", "tls", "mqtts", "ws", "wss"}
+	hosts := []string{"mybroker", "broker.example.com", "192.168.1.5", "[2001:db8::1]", "[::1]"}
+	ports := []string{"", ":1883", ":8883"}
+	paths := []string{"", "/mqtt", "/path/to/mqtt"}
+
+	for _, sc := range schemes {
+		for _, h := range hosts {
+			for _, p := range ports {
+				for _, pa := range paths {
+					addr := sc + "://" + h + p + pa
+					t.Run(addr, func(t *testing.T) {
+						t.Parallel()
+						u, err := url.Parse(addr)
+						require.NoError(t, err, "url.Parse(%q)", addr)
+						parts, err := parseBroker(addr)
+						require.NoError(t, err, "parseBroker(%q)", addr)
+						assert.Equal(t, u.Hostname(), parts.host, "host for %q", addr)
+						assert.Equal(t, u.Port(), parts.port, "port for %q", addr)
+					})
+				}
+			}
+		}
+	}
+}
+
+// FuzzParseBroker asserts parseBroker never panics on arbitrary input and that
+// a successfully-parsed non-empty host always yields a dial-safe host:port.
+func FuzzParseBroker(f *testing.F) {
+	for _, s := range []string{
+		"tcp://h:1883", "mybroker:1883", "[::1]:1883", "ws://h/mqtt",
+		"wss://h:8883/mqtt", "", ":1883", "[malformed", "::1", "MQTTS://h:8883",
+	} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, broker string) {
+		parts, err := parseBroker(broker) // must never panic
+		if err != nil {
+			return
+		}
+		if parts.host == "" {
+			return
+		}
+		hp := parts.hostPort()
+		if _, _, splitErr := net.SplitHostPort(hp); splitErr != nil {
+			t.Errorf("parseBroker(%q).hostPort()=%q is not a valid host:port: %v", broker, hp, splitErr)
+		}
+	})
 }
 
 // TestBrokerHostPort verifies the host:port form used by the connection-test

--- a/internal/mqtt/broker_test.go
+++ b/internal/mqtt/broker_test.go
@@ -47,6 +47,10 @@ func TestParseBroker(t *testing.T) {
 		{"tcp scheme with bracketed IPv6", "tcp://[2001:db8::1]:1883", "tcp", "2001:db8::1", "1883", false},
 		{"ssl scheme with IPv4", "ssl://192.168.1.5:8883", "ssl", "192.168.1.5", "8883", false},
 		{"uppercase scheme normalized to lowercase", "MQTTS://host:8883", "mqtts", "host", "8883", false},
+		// Scheme-full URLs with a path are parsed via url.Parse (the path must
+		// not leak into the host/port).
+		{"ws scheme with path", "ws://mybroker/mqtt", "ws", "mybroker", "", false},
+		{"wss scheme with port and path", "wss://mybroker:8883/mqtt", "wss", "mybroker", "8883", false},
 
 		// Malformed addresses.
 		{"unterminated IPv6 bracket", "[malformed", "", "", "", true},

--- a/internal/mqtt/broker_test.go
+++ b/internal/mqtt/broker_test.go
@@ -136,6 +136,22 @@ func FuzzParseBroker(f *testing.F) {
 	})
 }
 
+// TestSchemeImpliesTLS pins which broker schemes auto-enable TLS. wss (secure
+// WebSocket) implies TLS; plain ws does not.
+func TestSchemeImpliesTLS(t *testing.T) {
+	t.Parallel()
+
+	tls := []string{"ssl", "tls", "mqtts", "wss"}
+	plain := []string{"tcp", "mqtt", "ws", ""}
+
+	for _, s := range tls {
+		assert.True(t, schemeImpliesTLS(s), "scheme %q should imply TLS", s)
+	}
+	for _, s := range plain {
+		assert.False(t, schemeImpliesTLS(s), "scheme %q should not imply TLS", s)
+	}
+}
+
 // TestBrokerHostPort verifies the host:port form used by the connection-test
 // TCP/TLS dial stage: IPv6 bracketing via net.JoinHostPort and the default-port
 // fallback when the address omitted a port.

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -76,8 +76,13 @@ func NewClient(settings *conf.Settings, observabilityMetrics *observability.Metr
 	config.TLS.ClientCert = settings.Realtime.MQTT.TLS.ClientCert
 	config.TLS.ClientKey = settings.Realtime.MQTT.TLS.ClientKey
 
-	// Auto-detect TLS from the broker URL scheme
-	if parts, err := parseBroker(config.Broker); err == nil && schemeImpliesTLS(parts.scheme) {
+	// Validate the broker address up front (fail fast on a malformed address)
+	// and auto-detect TLS from its scheme.
+	parts, err := parseBroker(config.Broker)
+	if err != nil {
+		return nil, err
+	}
+	if schemeImpliesTLS(parts.scheme) {
 		config.TLS.Enabled = true
 		log.Info("TLS enabled based on broker URL scheme")
 	}

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -8,7 +8,6 @@ import (
 	stderrors "errors"
 	"io"
 	"net"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -77,8 +76,8 @@ func NewClient(settings *conf.Settings, observabilityMetrics *observability.Metr
 	config.TLS.ClientCert = settings.Realtime.MQTT.TLS.ClientCert
 	config.TLS.ClientKey = settings.Realtime.MQTT.TLS.ClientKey
 
-	// Auto-detect TLS from broker URL scheme
-	if strings.HasPrefix(config.Broker, "ssl://") || strings.HasPrefix(config.Broker, "tls://") || strings.HasPrefix(config.Broker, "mqtts://") {
+	// Auto-detect TLS from the broker URL scheme
+	if parts, err := parseBroker(config.Broker); err == nil && schemeImpliesTLS(parts.scheme) {
 		config.TLS.Enabled = true
 		log.Info("TLS enabled based on broker URL scheme")
 	}
@@ -661,8 +660,8 @@ func (c *client) configureClientOptions(log logger.Logger) (*mqtt.ClientOptions,
 
 // performDNSResolution resolves the broker hostname if it's not an IP address
 func (c *client) performDNSResolution(ctx context.Context, log logger.Logger) error {
-	// Parse the broker URL
-	u, err := url.Parse(c.config.Broker)
+	// Parse the broker address (tolerates scheme-less "host:port" addresses)
+	parts, err := parseBroker(c.config.Broker)
 	if err != nil {
 		log.Error("Invalid broker URL",
 			logger.Error(err))
@@ -678,7 +677,7 @@ func (c *client) performDNSResolution(ctx context.Context, log logger.Logger) er
 	// Perform DNS resolution (potentially blocking network I/O)
 	dnsCtx, dnsCancel := context.WithTimeout(ctx, DNSLookupTimeout)
 	defer dnsCancel()
-	host := u.Hostname()
+	host := parts.host
 	if net.ParseIP(host) == nil {
 		log.Debug("Resolving broker hostname",
 			logger.String("host", host))
@@ -1172,9 +1171,11 @@ func (c *client) createTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// extractBrokerHostname extracts the hostname from the broker URL
+// extractBrokerHostname extracts the hostname from the broker address for use
+// as the TLS ServerName. It routes through parseBroker so scheme-less and IPv6
+// broker addresses are handled consistently with the rest of the package.
 func (c *client) extractBrokerHostname() (string, error) {
-	u, err := url.Parse(c.config.Broker)
+	parts, err := parseBroker(c.config.Broker)
 	if err != nil {
 		return "", errors.Newf("failed to parse broker URL for TLS config: %v", err).
 			Component("mqtt").
@@ -1182,7 +1183,7 @@ func (c *client) extractBrokerHostname() (string, error) {
 			Context("broker", c.config.Broker).
 			Build()
 	}
-	return u.Hostname(), nil
+	return parts.host, nil
 }
 
 // loadCACertificate loads the CA certificate into the TLS config

--- a/internal/mqtt/client_test.go
+++ b/internal/mqtt/client_test.go
@@ -658,6 +658,8 @@ func TestExtractBrokerHostname(t *testing.T) {
 		{"tcp scheme with port", "tcp://mybroker:1883", "mybroker", false},
 		{"ssl scheme with port", "ssl://host:8883", "host", false},
 		{"mqtts scheme with IPv6", "mqtts://[2001:db8::1]:8883", "2001:db8::1", false},
+		{"ws scheme with path", "ws://mybroker/mqtt", "mybroker", false},
+		{"wss scheme with port and path", "wss://mybroker:8883/mqtt", "mybroker", false},
 		{"Malformed bracketed host", "tcp://[malformed", "", true},
 	}
 

--- a/internal/mqtt/client_test.go
+++ b/internal/mqtt/client_test.go
@@ -638,50 +638,43 @@ func createTestClient(t *testing.T, broker string) (Client, *observability.Metri
 	return client, metrics
 }
 
-// TestIsIPAddress verifies the IP address detection function
-func TestIsIPAddress(t *testing.T) {
+// TestExtractBrokerHostname verifies the TLS ServerName hostname extraction
+// across scheme-less and scheme-prefixed broker addresses. Scheme-less
+// host:port addresses previously failed url.Parse with "first path segment in
+// URL cannot contain colon" (or silently yielded an empty hostname).
+func TestExtractBrokerHostname(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name     string
-		input    string
-		expected bool
+		name         string
+		broker       string
+		wantHostname string
+		wantErr      bool
 	}{
-		// IPv4 addresses
-		{"Simple IPv4", "192.168.1.1", true},
-		{"IPv4 with tcp protocol", "tcp://192.168.1.1:1883", true},
-		{"IPv4 with mqtt protocol", "mqtt://10.0.0.1:1883", true},
-		{"IPv4 localhost", "127.0.0.1", true},
-		{"IPv4 with port", "127.0.0.1:1883", true},
-
-		// IPv6 addresses
-		{"Simple IPv6", "::1", true},
-		{"IPv6 localhost with brackets", "[::1]", true},
-		{"IPv6 with port", "[::1]:1883", true},
-		{"IPv6 with tcp protocol", "tcp://[2001:db8::1]:1883", true},
-		{"IPv6 with mqtt protocol", "mqtt://[2001:db8::1]:1883", true},
-		{"IPv6 address only", "2001:db8::1", true},
-		{"IPv6 with brackets", "[2001:db8::1]", true},
-
-		// Hostnames (should return false)
-		{"Simple hostname", "localhost", false},
-		{"Hostname with protocol", "mqtt://localhost:1883", false},
-		{"FQDN", "broker.hivemq.com", false},
-		{"FQDN with port", "test.mosquitto.org:1883", false},
-		{"Subdomain", "mqtt.example.com", false},
-
-		// Invalid inputs (should return false)
-		{"Empty string", "", false},
-		{"Invalid hostname", "not-an-ip", false},
-		{"Invalid IPv4", "256.256.256.256", false},
-		{"Invalid IPv6", "2001:zz::1", false},
-		{"Invalid protocol", "invalid://192.168.1.1", false},
-		{"Malformed IPv6 brackets", "[2001:db8::1", false},
-		{"IPv6 without closing bracket", "[2001:db8::1:1883", false},
+		{"Scheme-less hostname with port", "mybroker:1883", "mybroker", false},
+		{"Scheme-less IPv4 with port", "192.168.1.5:1883", "192.168.1.5", false},
+		{"Scheme-less IPv6 with port", "[::1]:1883", "::1", false},
+		{"Scheme-less bare hostname", "mybroker", "mybroker", false},
+		{"tcp scheme with port", "tcp://mybroker:1883", "mybroker", false},
+		{"ssl scheme with port", "ssl://host:8883", "host", false},
+		{"mqtts scheme with IPv6", "mqtts://[2001:db8::1]:8883", "2001:db8::1", false},
+		{"Malformed bracketed host", "tcp://[malformed", "", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isIPAddress(tt.input)
-			assert.Equal(t, tt.expected, result, "isIPAddress(%q) result mismatch", tt.input)
+			t.Parallel()
+
+			c := &client{config: Config{Broker: tt.broker}}
+			hostname, err := c.extractBrokerHostname()
+			if tt.wantErr {
+				require.Error(t, err, "extractBrokerHostname for %q expected an error", tt.broker)
+				assert.Contains(t, err.Error(), "failed to parse broker URL for TLS config",
+					"error message should describe the TLS parse failure")
+				return
+			}
+			require.NoError(t, err, "extractBrokerHostname for %q unexpected error", tt.broker)
+			assert.Equal(t, tt.wantHostname, hostname, "extractBrokerHostname for %q hostname mismatch", tt.broker)
 		})
 	}
 }
@@ -890,6 +883,19 @@ func TestPerformDNSResolution(t *testing.T) {
 		{
 			name:        "IPv6 address (no DNS needed)",
 			broker:      "tcp://[::1]:1883",
+			expectError: false,
+		},
+		{
+			// Regression: scheme-less IPv4 previously failed url.Parse with
+			// "first path segment in URL cannot contain colon".
+			name:        "Scheme-less IPv4 (no DNS needed)",
+			broker:      "8.8.8.8:1883",
+			expectError: false,
+		},
+		{
+			// Regression: scheme-less IPv6 literal previously failed url.Parse.
+			name:        "Scheme-less IPv6 (no DNS needed)",
+			broker:      "[::1]:1883",
 			expectError: false,
 		},
 		{

--- a/internal/mqtt/testdata/fuzz/FuzzParseBroker/c33edf86d30af382
+++ b/internal/mqtt/testdata/fuzz/FuzzParseBroker/c33edf86d30af382
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("[]]")

--- a/internal/mqtt/testdata/fuzz/FuzzParseBroker/e1fc401e772c0b2c
+++ b/internal/mqtt/testdata/fuzz/FuzzParseBroker/e1fc401e772c0b2c
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("]")

--- a/internal/mqtt/testing.go
+++ b/internal/mqtt/testing.go
@@ -101,48 +101,6 @@ func (s TestStage) String() string {
 	}
 }
 
-// isIPAddress checks if the given host is an IP address
-func isIPAddress(host string) bool {
-	// Remove protocol prefix if present
-	if strings.Contains(host, "://") {
-		parts := strings.Split(host, "://")
-		if len(parts) != 2 {
-			return false
-		}
-		// Only allow mqtt and tcp protocols
-		if parts[0] != "mqtt" && parts[0] != "tcp" {
-			return false
-		}
-		host = parts[1]
-	}
-
-	// Handle IPv6 addresses with brackets
-	if strings.HasPrefix(host, "[") {
-		// Extract the IPv6 address from within brackets
-		end := strings.LastIndex(host, "]")
-		if end == -1 {
-			return false // Malformed IPv6 address with opening bracket but no closing bracket
-		}
-		// Extract the address without brackets
-		host = host[1:end]
-	} else if strings.Contains(host, ":") {
-		// If it contains a colon but no brackets, it could be either:
-		// 1. An IPv4 address with port (e.g. "192.168.1.1:1883")
-		// 2. A raw IPv6 address (e.g. "::1" or "2001:db8::1")
-
-		// If it has more than 2 colons, assume it's IPv6
-		if strings.Count(host, ":") <= 1 {
-			// Likely IPv4 with port, remove the port
-			host = strings.Split(host, ":")[0]
-		}
-		// Otherwise leave it as is for IPv6 parsing
-	}
-
-	// Try to parse as IP address
-	ip := net.ParseIP(host)
-	return ip != nil
-}
-
 // Timeout constants for various test stages
 const (
 	dnsTimeout  = 5 * time.Second
@@ -259,13 +217,12 @@ func (c *client) testDNSStage(ctx context.Context, brokerHost string) TestResult
 	})
 }
 
-// testTCPStage performs TCP connection testing
-func (c *client) testTCPStage(ctx context.Context) TestResult {
+// testTCPStage performs TCP connection testing against the given host:port.
+func (c *client) testTCPStage(ctx context.Context, hostPort string) TestResult {
 	tcpCtx, tcpCancel := context.WithTimeout(ctx, tcpTimeout)
 	defer tcpCancel()
 
 	return runNetworkTest(tcpCtx, TCPConnection, func(ctx context.Context) error {
-		hostPort := extractHostPort(c.config.Broker)
 		if c.config.TLS.Enabled {
 			return c.testTLSConnection(ctx, hostPort)
 		}
@@ -428,8 +385,17 @@ func (c *client) TestConnection(ctx context.Context, resultChan chan<- TestResul
 		return
 	}
 
-	brokerHost := extractHost(c.config.Broker)
-	c.runTestStages(ctx, brokerHost, sendResult)
+	// Parse the broker address once and thread the components through the
+	// stages, so every stage interprets the broker identically.
+	broker, err := parseBroker(c.config.Broker)
+	if err != nil {
+		sendResult(TestResult{
+			Success: false, Stage: "Test Setup", Message: "Invalid broker address",
+			Error: err.Error(), State: stateFailed,
+		})
+		return
+	}
+	c.runTestStages(ctx, broker, sendResult)
 }
 
 // createResultSender creates a function that sends test results with proper state management
@@ -502,7 +468,7 @@ func logTestResult(result *TestResult) {
 }
 
 // runTestStages executes the test stages in sequence
-func (c *client) runTestStages(ctx context.Context, brokerHost string, sendResult func(TestResult)) {
+func (c *client) runTestStages(ctx context.Context, broker brokerParts, sendResult func(TestResult)) {
 	runStage := func(stage TestStage, test func() TestResult) bool {
 		sendResult(TestResult{
 			Success: true,
@@ -514,15 +480,15 @@ func (c *client) runTestStages(ctx context.Context, brokerHost string, sendResul
 		return result.Success
 	}
 
-	// Stage 1: DNS Resolution (skip if IP address)
-	if !isIPAddress(brokerHost) {
-		if !runStage(DNSResolution, func() TestResult { return c.testDNSStage(ctx, brokerHost) }) {
+	// Stage 1: DNS Resolution (skip when the host is already an IP literal)
+	if net.ParseIP(broker.host) == nil {
+		if !runStage(DNSResolution, func() TestResult { return c.testDNSStage(ctx, broker.host) }) {
 			return
 		}
 	}
 
 	// Stage 2: TCP Connection
-	if !runStage(TCPConnection, func() TestResult { return c.testTCPStage(ctx) }) {
+	if !runStage(TCPConnection, func() TestResult { return c.testTCPStage(ctx, broker.hostPort()) }) {
 		return
 	}
 
@@ -546,73 +512,4 @@ func constructTestTopic(baseTopic string) string {
 	}
 
 	return baseTopic + "/test"
-}
-
-// extractHost extracts the hostname from broker URL
-func extractHost(broker string) string {
-	// Remove protocol prefix if present
-	if strings.Contains(broker, "://") {
-		parts := strings.Split(broker, "://")
-		if len(parts) != 2 {
-			return broker
-		}
-		broker = parts[1]
-	}
-
-	// Handle IPv6 addresses with brackets
-	if strings.HasPrefix(broker, "[") {
-		end := strings.LastIndex(broker, "]")
-		if end == -1 {
-			return broker // Malformed IPv6 address
-		}
-		return broker[1:end] // Return without brackets
-	}
-
-	// For IPv4 or hostname, remove port if present
-	if strings.Count(broker, ":") <= 1 {
-		if i := strings.LastIndex(broker, ":"); i != -1 {
-			return broker[:i]
-		}
-	}
-	// For IPv6 without brackets or no port, return as is
-	return broker
-}
-
-// extractHostPort extracts host:port from broker URL
-func extractHostPort(broker string) string {
-	// Remove protocol prefix if present
-	if strings.Contains(broker, "://") {
-		parts := strings.Split(broker, "://")
-		if len(parts) != 2 {
-			return broker
-		}
-		broker = parts[1]
-	}
-
-	// Handle IPv6 addresses
-	if strings.HasPrefix(broker, "[") {
-		// IPv6 with port
-		if i := strings.LastIndex(broker, "]:"); i != -1 {
-			return broker
-		}
-		// IPv6 without port
-		if strings.HasSuffix(broker, "]") {
-			return broker[:len(broker)-1] + "]:1883"
-		}
-		// Malformed IPv6
-		return broker
-	}
-
-	// Check if this might be a raw IPv6 address
-	if strings.Count(broker, ":") > 1 {
-		// Add brackets and port
-		return "[" + broker + "]:1883"
-	}
-
-	// IPv4 or hostname
-	if !strings.Contains(broker, ":") {
-		return broker + ":1883"
-	}
-
-	return broker
 }


### PR DESCRIPTION
## Summary

MQTT broker addresses written without a scheme (e.g. `mybroker:1883` or `192.168.1.5:1883`) were mishandled by `url.Parse`:

- IP/IPv6 literals with a port errored with `first path segment in URL cannot contain colon`.
- Alphabetic hosts were silently parsed as the URL *scheme*, leaving an empty hostname.

This broke TLS `ServerName` extraction (`extractBrokerHostname`) and DNS pre-resolution (`performDNSResolution`) for a common, valid broker-address format. The connection itself still worked because the paho client normalizes scheme-less addresses internally, so the bug was latent until TLS config was built (TLS enabled, or a connection test).

## What changed

- New canonical, IPv6-safe broker parser `parseBroker` (`net.SplitHostPort`-based) in `internal/mqtt/broker.go`. It tolerates scheme-less `host:port`, bracketed and bare IPv6, a leading `:port` (localhost), and reports an error for genuinely malformed input (such as an unterminated IPv6 bracket).
- Routed **every** broker-address consumer through it: `extractBrokerHostname`, `performDNSResolution`, the TLS scheme auto-detect in `NewClient`, and the connection-test stages.
- Removed three divergent hand-rolled parsers (`extractHost`, `extractHostPort`, `isIPAddress`); the connection-test flow now parses the broker once and threads the components through the stages.

## Test Plan

- [x] New table-driven tests: `TestParseBroker`, `TestBrokerHostPort`, `TestBrokerHostIsIP`, `TestExtractBrokerHostname`, plus scheme-less regression cases in `TestPerformDNSResolution`. They cover scheme-less, scheme-prefixed, bracketed/bare IPv6, leading-colon localhost, empty, and malformed addresses, and pin the `::` vs `:port` disambiguation guard.
- [x] `go test -race ./internal/mqtt/` passes.
- [x] `golangci-lint run` clean; `go vet` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT broker address parsing for both scheme-less and scheme-prefixed inputs, including whitespace trimming, default ports, and robust IPv6 support (bare and bracketed), with clearer validation errors.
  * Refined TLS auto-detection and TLS Server Name extraction, and ensured DNS resolution is skipped for literal IP brokers.

* **Tests**
  * Expanded table-driven, differential, and fuzz coverage for broker parsing; added TLS hostname and DNS-resolution regression cases.

* **Refactor**
  * Centralized broker parsing so client behavior and MQTT connection test stages share consistent host/port handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->