### PR TITLE
fix(settings): preserve unsaved Security edits across TLS cert ops

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -192,8 +192,10 @@
       certInfo = await settingsAPI.tls.generateSelfSigned({
         validity: settings?.selfSignedValidity ?? '1825d',
       });
-      // Reload settings to sync frontend with backend TLSMode change
-      await settingsActions.loadSettings();
+      // Sync only the TLS mode the backend just persisted. A full loadSettings()
+      // reload would overwrite the whole store and discard any unsaved edits the
+      // user made in other Security fields. The backend sets mode to "selfsigned".
+      settingsActions.syncTLSMode(certInfo?.mode ?? 'selfsigned');
       // The backend marks restart-required for TLS cert operations; refresh the
       // shared restart state so the global RestartBanner reflects it.
       await fetchRestartStatus();
@@ -216,8 +218,10 @@
         privateKey: uploadKey,
         caCertificate: uploadCA || undefined,
       });
-      // Reload settings to sync frontend with backend TLSMode change
-      await settingsActions.loadSettings();
+      // Sync only the TLS mode the backend just persisted. A full loadSettings()
+      // reload would overwrite the whole store and discard any unsaved edits the
+      // user made in other Security fields. The backend sets mode to "manual".
+      settingsActions.syncTLSMode(certInfo?.mode ?? 'manual');
       // The backend marks restart-required for TLS cert operations; refresh the
       // shared restart state so the global RestartBanner reflects it.
       await fetchRestartStatus();
@@ -243,8 +247,11 @@
     try {
       await settingsAPI.tls.deleteCertificate();
       certInfo = null;
-      // Reload settings to sync frontend with backend TLSMode reset to none
-      await settingsActions.loadSettings();
+      // Sync only the TLS mode the backend just persisted (reset to none). The
+      // DELETE endpoint returns no body, so use "" directly. A full loadSettings()
+      // reload would overwrite the whole store and discard any unsaved edits the
+      // user made in other Security fields.
+      settingsActions.syncTLSMode('');
       // The backend marks restart-required for TLS cert operations; refresh the
       // shared restart state so the global RestartBanner reflects it.
       await fetchRestartStatus();

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -569,3 +569,142 @@ describe('Settings Store - UI Locale Preservation (#2756/#2760)', () => {
     expect(setLocale).not.toHaveBeenCalled();
   });
 });
+
+describe('Settings Store - syncTLSMode preserves unsaved Security edits', () => {
+  const baseSecurity = () => ({
+    baseUrl: '',
+    host: '',
+    autoTls: false,
+    tlsMode: '',
+    tlsPort: '8443',
+    selfSignedValidity: '1825d',
+    redirectToHttps: false,
+    basicAuth: { enabled: false, username: '', password: '' },
+    oauthProviders: [],
+    allowSubnetBypass: { enabled: false, subnet: '' },
+  });
+
+  const seed = (
+    formSecurity: ReturnType<typeof baseSecurity>,
+    originalSecurity: ReturnType<typeof baseSecurity>
+  ) => {
+    settingsStore.set({
+      formData: {
+        main: { name: 'TestNode' },
+        birdnet: {} as BirdNetSettings,
+        security: formSecurity,
+      } as SettingsFormData,
+      originalData: {
+        main: { name: 'TestNode' },
+        birdnet: {} as BirdNetSettings,
+        security: originalSecurity,
+      } as SettingsFormData,
+      isLoading: false,
+      isSaving: false,
+      activeSection: 'security',
+      error: null,
+      dataLoaded: true,
+    });
+  };
+
+  it('syncs tlsMode/autoTls into both formData and originalData (no spurious diff)', () => {
+    seed(baseSecurity(), baseSecurity());
+
+    settingsActions.syncTLSMode('selfsigned');
+
+    const s = get(settingsStore);
+    // Synced into both copies, so change detection sees no pending edit.
+    expect(s.formData.security?.tlsMode).toBe('selfsigned');
+    expect(s.originalData.security?.tlsMode).toBe('selfsigned');
+    expect(s.formData.security?.autoTls).toBe(false);
+    expect(s.originalData.security?.autoTls).toBe(false);
+  });
+
+  it('preserves unsaved edits in other Security fields', () => {
+    // The user typed a new Basic Auth password but has NOT saved it yet.
+    const form = {
+      ...baseSecurity(),
+      tlsMode: 'manual',
+      basicAuth: { enabled: true, username: '', password: 'unsaved-secret' },
+    };
+    const original = {
+      ...baseSecurity(),
+      tlsMode: '',
+      basicAuth: { enabled: false, username: '', password: '' },
+    };
+    seed(form, original);
+
+    settingsActions.syncTLSMode('manual');
+
+    const s = get(settingsStore);
+    // TLS mode is synced in both copies.
+    expect(s.formData.security?.tlsMode).toBe('manual');
+    expect(s.originalData.security?.tlsMode).toBe('manual');
+
+    // The unsaved password edit survives in formData...
+    expect(s.formData.security?.basicAuth.password).toBe('unsaved-secret');
+    expect(s.formData.security?.basicAuth.enabled).toBe(true);
+    // ...and is NOT promoted into the originalData baseline (still unsaved).
+    expect(s.originalData.security?.basicAuth.password).toBe('');
+    expect(s.originalData.security?.basicAuth.enabled).toBe(false);
+
+    // Other top-level fields must not vanish from either copy.
+    expect(s.formData.security?.tlsPort).toBe('8443');
+    expect(s.formData.security?.selfSignedValidity).toBe('1825d');
+    expect(s.originalData.security?.tlsPort).toBe('8443');
+  });
+
+  it('sets autoTls true for the autotls mode (both copies)', () => {
+    seed(baseSecurity(), baseSecurity());
+
+    settingsActions.syncTLSMode('autotls');
+
+    const s = get(settingsStore);
+    expect(s.formData.security?.tlsMode).toBe('autotls');
+    expect(s.originalData.security?.tlsMode).toBe('autotls');
+    expect(s.formData.security?.autoTls).toBe(true);
+    expect(s.originalData.security?.autoTls).toBe(true);
+  });
+
+  it('resets to none mode (empty string) on delete (both copies)', () => {
+    seed(
+      { ...baseSecurity(), tlsMode: 'selfsigned', autoTls: false },
+      { ...baseSecurity(), tlsMode: 'selfsigned', autoTls: false }
+    );
+
+    settingsActions.syncTLSMode('');
+
+    const s = get(settingsStore);
+    expect(s.formData.security?.tlsMode).toBe('');
+    expect(s.originalData.security?.tlsMode).toBe('');
+    expect(s.formData.security?.autoTls).toBe(false);
+    expect(s.originalData.security?.autoTls).toBe(false);
+  });
+
+  it('falls back to default security fields when the section is absent', () => {
+    // Defensive branch: a store seeded before the security section loaded.
+    // The sync must still yield a complete security object, not a bare
+    // { tlsMode, autoTls } that strips required fields.
+    settingsStore.set({
+      formData: { main: { name: 'TestNode' }, birdnet: {} as BirdNetSettings } as SettingsFormData,
+      originalData: {} as SettingsFormData,
+      isLoading: false,
+      isSaving: false,
+      activeSection: 'security',
+      error: null,
+      dataLoaded: true,
+    });
+
+    settingsActions.syncTLSMode('manual');
+
+    const s = get(settingsStore);
+    expect(s.formData.security?.tlsMode).toBe('manual');
+    expect(s.formData.security?.autoTls).toBe(false);
+    // Required fields are present (sourced from createEmptySettings defaults),
+    // not missing as they would be with a bare {} fallback.
+    expect(s.formData.security?.tlsPort).toBe('8443');
+    expect(s.formData.security?.basicAuth).toBeDefined();
+    expect(s.originalData.security?.tlsMode).toBe('manual');
+    expect(s.originalData.security?.basicAuth).toBeDefined();
+  });
+});

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -571,6 +571,10 @@ describe('Settings Store - UI Locale Preservation (#2756/#2760)', () => {
 });
 
 describe('Settings Store - syncTLSMode preserves unsaved Security edits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   const baseSecurity = () => ({
     baseUrl: '',
     host: '',

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -1269,6 +1269,36 @@ export const settingsActions = {
     });
   },
 
+  /**
+   * Sync the TLS mode after a certificate operation (upload, generate, delete)
+   * that the backend has ALREADY persisted to disk. Only tlsMode and autoTls are
+   * updated, and they are updated in BOTH formData and originalData so the change
+   * does not register as an unsaved edit. Crucially, every other field in the
+   * security section is left untouched, so unsaved edits the user made elsewhere
+   * in the Security form (for example a typed-but-unsaved Basic Auth password)
+   * are preserved. This replaces a full loadSettings() reload, which overwrote
+   * the entire store and discarded those unsaved edits.
+   */
+  syncTLSMode(mode: string) {
+    settingsStore.update(state => {
+      const autoTls = mode === 'autotls';
+      // Fall back to the store's own defaults (not a bare {}) if a security
+      // section is somehow absent, so required fields are never stripped. In
+      // practice this never fires: the cert handlers that call this only run
+      // after settings have loaded, so security is always populated.
+      const sync = (security?: SecuritySettings): SecuritySettings => ({
+        ...(security ?? createEmptySettings().security ?? ({} as SecuritySettings)),
+        tlsMode: mode,
+        autoTls,
+      });
+      return {
+        ...state,
+        formData: { ...state.formData, security: sync(state.formData.security) },
+        originalData: { ...state.originalData, security: sync(state.originalData.security) },
+      };
+    });
+  },
+
   updateTaxonomySynonyms(synonyms: Record<string, string>) {
     settingsStore.update(state => ({
       ...state,


### PR DESCRIPTION
## Summary

The TLS certificate handlers on the Security settings page (`handleGenerateCert`, `handleUploadCert`, `handleDeleteCert`) called `settingsActions.loadSettings()` after the cert operation to resync the backend-persisted TLS mode. `loadSettings()` overwrites the entire settings store (both `formData` and `originalData`), so any unsaved edits the user had typed into other Security fields (a Basic Auth password, an OAuth provider, a subnet, the self-signed validity) were silently discarded the moment a cert operation completed.

This replaces the full reload with a targeted `settingsActions.syncTLSMode(mode)` store action that updates only `tlsMode` and `autoTls`, in both `formData` and `originalData`. Updating both copies reflects that the backend already persisted the mode, so it does not show up as a spurious unsaved-changes diff, while every other Security field is left untouched. The handlers pass the mode the backend reports: `certInfo.mode` for upload and generate, and `""` (none) for delete, which returns no body.

The pre-existing `fetchRestartStatus()` calls are unchanged, so the restart-required banner still appears after a cert operation.

## Changes

- `frontend/src/lib/stores/settings.ts`: add `settingsActions.syncTLSMode(mode)`, which syncs `tlsMode`/`autoTls` into both store copies and falls back to the store defaults if the security section is somehow absent (so required fields are never stripped).
- `frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte`: replace the three `loadSettings()` calls with `syncTLSMode(...)`.
- `frontend/src/lib/stores/settings.test.ts`: unit tests for both-copies sync, preservation of an unsaved Basic Auth password, the autotls mapping, the delete reset, and the defaults fallback.

## Test Plan

- [x] `npx vitest run src/lib/stores/settings.test.ts` (22 passing)
- [x] `npm run typecheck` (0 errors)
- [x] `eslint` + `prettier` clean on changed files
- [ ] Manual: with an unsaved edit in another Security field (e.g. a typed Basic Auth password), upload / generate / delete a cert and confirm the edit survives and the restart banner still appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TLS certificate actions (generate, upload, delete) so they no longer overwrite unsaved changes in other Security settings fields.
  * Improved post-certificate behavior by updating only the TLS mode-related values to stay in sync without clearing unrelated form edits.
* **Tests**
  * Added/extended automated tests to verify TLS mode synchronization, including preserving unrelated unsaved Security changes and handling missing security defaults correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->