### PR TITLE
feat(memory): low-memory runtime detection and memory policy foundation

### DIFF
--- a/cmd/benchmark/benchmark.go
+++ b/cmd/benchmark/benchmark.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/tphakala/birdnet-go/internal/analysis"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -15,6 +16,9 @@ func Command(settings *conf.Settings) *cobra.Command {
 		Use:   "benchmark",
 		Short: "Run BirdNET inference benchmark",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Apply the runtime memory policy before loading the model, so the
+			// benchmark reflects the same configuration serve runs under.
+			analysis.ApplyMemoryPolicy(settings)
 			return runBenchmark(settings)
 		},
 	}

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -29,6 +29,10 @@ web interface, database) and runs until interrupted.
 
 The "realtime" command is an alias for backward compatibility.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Apply the runtime memory policy before any inference threads start,
+			// so the glibc arena cap takes effect. Gated by lowmemory.mode.
+			analysis.ApplyMemoryPolicy(settings)
+
 			// Print system details early, before any service starts.
 			analysis.PrintSystemDetails(settings)
 

--- a/internal/analysis/startup.go
+++ b/internal/analysis/startup.go
@@ -11,6 +11,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
+// bytesPerMiB converts byte counts to MiB for human-readable startup logging.
+const bytesPerMiB int64 = 1024 * 1024
+
 // ApplyMemoryPolicy detects the effective system memory (host RAM or cgroup cap)
 // and applies the runtime memory policy for constrained systems: a soft
 // GOMEMLIMIT backstop on the Go heap and a glibc malloc arena cap. It is gated by
@@ -34,9 +37,9 @@ func ApplyMemoryPolicy(settings *conf.Settings) {
 	log.Info("memory policy: low-memory controls active",
 		logger.String("mode", mode),
 		logger.String("reason", d.Reason),
-		logger.Int64("detected_ram_mb", d.TotalRAMBytes/(1024*1024)),
+		logger.Int64("detected_ram_mb", d.TotalRAMBytes/bytesPerMiB),
 		logger.Bool("gomemlimit_applied", res.Applied.MemLimitApplied),
-		logger.Int64("gomemlimit_mb", res.Applied.GoMemLimitBytes/(1024*1024)),
+		logger.Int64("gomemlimit_mb", res.Applied.GoMemLimitBytes/bytesPerMiB),
 		logger.Bool("arena_cap_applied", res.Applied.ArenaApplied),
 		logger.Int("arena_max", res.Applied.ArenaMax))
 }

--- a/internal/analysis/startup.go
+++ b/internal/analysis/startup.go
@@ -7,8 +7,39 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/mempolicy"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
+
+// ApplyMemoryPolicy detects the effective system memory (host RAM or cgroup cap)
+// and applies the runtime memory policy for constrained systems: a soft
+// GOMEMLIMIT backstop on the Go heap and a glibc malloc arena cap. It is gated by
+// the lowmemory.mode override (auto/on/off) and must run before inference threads
+// start so the arena cap takes effect. These are cheap backstops; profiling shows
+// the dominant memory cost is loaded model weights, which is addressed separately
+// by model gating and quantization (the RAM-reduction epic).
+func ApplyMemoryPolicy(settings *conf.Settings) {
+	log := GetLogger()
+	mode := settings.LowMemory.GetMode()
+	res := mempolicy.Configure(mode)
+	d := res.Decision
+
+	if !d.Active {
+		log.Info("memory policy: low-memory controls inactive",
+			logger.String("mode", mode),
+			logger.String("reason", d.Reason))
+		return
+	}
+
+	log.Info("memory policy: low-memory controls active",
+		logger.String("mode", mode),
+		logger.String("reason", d.Reason),
+		logger.Int64("detected_ram_mb", d.TotalRAMBytes/(1024*1024)),
+		logger.Bool("gomemlimit_applied", res.Applied.MemLimitApplied),
+		logger.Int64("gomemlimit_mb", res.Applied.GoMemLimitBytes/(1024*1024)),
+		logger.Bool("arena_cap_applied", res.Applied.ArenaApplied),
+		logger.Int("arena_max", res.Applied.ArenaMax))
+}
 
 // InitializeMetrics initializes the Prometheus metrics manager.
 func InitializeMetrics() (*observability.Metrics, error) {

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -77,6 +77,9 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	// --- Models ---
 	"Models": {categories: []hotReloadCategory{hotReloadRestart}},
 
+	// --- LowMemory (applied once at startup: mallopt before threads, GOMEMLIMIT) ---
+	"LowMemory": {categories: []hotReloadCategory{hotReloadRestart}},
+
 	// --- TaxonomySynonyms ---
 	"TaxonomySynonyms": {categories: []hotReloadCategory{hotReloadFresh}},
 

--- a/internal/api/v2/settings_restart_test.go
+++ b/internal/api/v2/settings_restart_test.go
@@ -163,6 +163,7 @@ func TestHotReloadRestartFieldsCovered(t *testing.T) {
 		"Perch":                   "perch model path; not wired",
 		"BSG":                     "BSG model path; not wired",
 		"Realtime.Audio.Watchdog": "no UI controls (project decision)",
+		"LowMemory":               "startup-only memory policy; not exposed via the live settings API",
 	}
 
 	for path, entry := range hotReloadRegistry {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"iter"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -1297,9 +1298,14 @@ type LowMemoryConfig struct {
 // GetMode returns the effective low-memory mode, defaulting to "auto" for empty
 // or unrecognized values. Mirrors SpectrogramPreRender.GetMode.
 func (c *LowMemoryConfig) GetMode() string {
-	switch c.Mode {
-	case LowMemoryModeOn, LowMemoryModeOff, LowMemoryModeAuto:
-		return c.Mode
+	// Case-insensitive and whitespace-tolerant so the mode is robust even on a
+	// LowMemoryConfig that has not been through ValidateSettings (e.g. tests).
+	mode := strings.TrimSpace(c.Mode)
+	switch {
+	case strings.EqualFold(mode, LowMemoryModeOn):
+		return LowMemoryModeOn
+	case strings.EqualFold(mode, LowMemoryModeOff):
+		return LowMemoryModeOff
 	default:
 		return LowMemoryModeAuto
 	}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1276,6 +1276,35 @@ type ModelsConfig struct {
 	Installed []string `yaml:"installed,omitempty" json:"installed,omitempty"` // list of installed model IDs managed by the model gallery
 }
 
+// Low-memory mode constants for the manual override.
+const (
+	LowMemoryModeAuto = "auto" // detect from system memory (default)
+	LowMemoryModeOn   = "on"   // force low-memory controls on
+	LowMemoryModeOff  = "off"  // force low-memory controls off
+)
+
+// LowMemoryConfig is the manual override for the runtime memory policy. The
+// policy (memory detection, GOMEMLIMIT, glibc arena cap, and future feature
+// gating) lives in internal/mempolicy; this only carries the operator's choice.
+//
+// This setting is applied once at startup (the arena cap must precede inference
+// threads), so changing it requires a restart; it is intentionally not exposed
+// as a hot-reloadable section.
+type LowMemoryConfig struct {
+	Mode string `yaml:"mode" json:"mode" mapstructure:"mode"` // "auto" (default), "on", "off"
+}
+
+// GetMode returns the effective low-memory mode, defaulting to "auto" for empty
+// or unrecognized values. Mirrors SpectrogramPreRender.GetMode.
+func (c *LowMemoryConfig) GetMode() string {
+	switch c.Mode {
+	case LowMemoryModeOn, LowMemoryModeOff, LowMemoryModeAuto:
+		return c.Mode
+	default:
+		return LowMemoryModeAuto
+	}
+}
+
 // BasicAuth holds settings for the password authentication
 type BasicAuth struct {
 	Enabled        bool          `yaml:"enabled" json:"enabled"`               // true to enable password authentication
@@ -1620,6 +1649,8 @@ type Settings struct {
 	Bat     BatConfig     `yaml:"bat" json:"bat"`         // Bat detection configuration
 	BSG     BSGConfig     `yaml:"bsg" json:"bsg"`         // BSG regional bird model configuration
 	Models  ModelsConfig  `yaml:"models" json:"models"`   // Global model enablement and management
+
+	LowMemory LowMemoryConfig `yaml:"lowmemory" json:"lowMemory" mapstructure:"lowmemory"` // Low-memory mode override (auto/on/off) for constrained systems
 
 	TaxonomySynonyms map[string]string `yaml:"taxonomySynonyms" json:"taxonomySynonyms" mapstructure:"taxonomySynonyms"` // Optional scientific-name synonym overrides merged with built-ins
 

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -62,7 +62,7 @@ func setDefaultConfig() {
 	viper.SetDefault("main.timeas24h", true)
 
 	// Low-memory mode: auto-detect constrained systems by default.
-	viper.SetDefault("lowmemory.mode", "auto")
+	viper.SetDefault("lowmemory.mode", LowMemoryModeAuto)
 
 	// BirdNET configuration
 	viper.SetDefault("birdnet.debug", false)

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -61,6 +61,9 @@ func setDefaultConfig() {
 	viper.SetDefault("main.name", "BirdNET-Go")
 	viper.SetDefault("main.timeas24h", true)
 
+	// Low-memory mode: auto-detect constrained systems by default.
+	viper.SetDefault("lowmemory.mode", "auto")
+
 	// BirdNET configuration
 	viper.SetDefault("birdnet.debug", false)
 	viper.SetDefault("birdnet.sensitivity", 1.0)

--- a/internal/conf/lowmemory_test.go
+++ b/internal/conf/lowmemory_test.go
@@ -1,0 +1,63 @@
+package conf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLowMemoryConfigGetMode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"empty defaults to auto", "", LowMemoryModeAuto},
+		{"auto", "auto", LowMemoryModeAuto},
+		{"on", "on", LowMemoryModeOn},
+		{"off", "off", LowMemoryModeOff},
+		{"unknown defaults to auto", "lowmem", LowMemoryModeAuto},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := LowMemoryConfig{Mode: tt.mode}
+			assert.Equal(t, tt.want, c.GetMode())
+		})
+	}
+}
+
+func TestValidateNormalizesInvalidLowMemoryMode(t *testing.T) {
+	s := createMinimalValidSettings()
+	s.LowMemory.Mode = "bogus"
+
+	require.NoError(t, ValidateSettings(s))
+
+	assert.Equal(t, LowMemoryModeAuto, s.LowMemory.Mode, "invalid mode should normalize to auto")
+	assert.Contains(t, strings.Join(s.ValidationWarnings, " "), "lowmemory.mode",
+		"a validation warning should record the invalid mode")
+}
+
+func TestValidatePreservesValidLowMemoryMode(t *testing.T) {
+	s := createMinimalValidSettings()
+	s.LowMemory.Mode = LowMemoryModeOn
+
+	require.NoError(t, ValidateSettings(s))
+
+	assert.Equal(t, LowMemoryModeOn, s.LowMemory.Mode, "valid mode must be preserved")
+}
+
+func TestValidateCanonicalizesLowMemoryModeCase(t *testing.T) {
+	s := createMinimalValidSettings()
+	s.LowMemory.Mode = " On "
+
+	require.NoError(t, ValidateSettings(s))
+
+	assert.Equal(t, LowMemoryModeOn, s.LowMemory.Mode,
+		"case and whitespace should canonicalize, preserving the operator's intent")
+	assert.NotContains(t, strings.Join(s.ValidationWarnings, " "), "lowmemory.mode",
+		"a valid (if cased) mode should not produce a warning")
+}

--- a/internal/conf/lowmemory_test.go
+++ b/internal/conf/lowmemory_test.go
@@ -20,6 +20,9 @@ func TestLowMemoryConfigGetMode(t *testing.T) {
 		{"on", "on", LowMemoryModeOn},
 		{"off", "off", LowMemoryModeOff},
 		{"unknown defaults to auto", "lowmem", LowMemoryModeAuto},
+		{"uppercase ON", "ON", LowMemoryModeOn},
+		{"mixed-case Off with whitespace", " Off ", LowMemoryModeOff},
+		{"mixed-case Auto", "Auto", LowMemoryModeAuto},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strings"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -186,6 +187,18 @@ func ValidateSettings(settings *Settings) error {
 
 	// Sanitize Main.Name: strip HTML tags as defense in depth
 	settings.Main.Name = sanitizeStringField(settings.Main.Name)
+
+	// Validate low-memory mode (non-fatal). Canonicalize case/whitespace so a
+	// value like "On" or " off " keeps the operator's intent; normalize genuinely
+	// invalid values to "auto" with a warning.
+	switch normalized := strings.ToLower(strings.TrimSpace(settings.LowMemory.Mode)); normalized {
+	case "", LowMemoryModeAuto, LowMemoryModeOn, LowMemoryModeOff:
+		settings.LowMemory.Mode = normalized
+	default:
+		settings.ValidationWarnings = append(settings.ValidationWarnings,
+			fmt.Sprintf("invalid lowmemory.mode %q; using %q", settings.LowMemory.Mode, LowMemoryModeAuto))
+		settings.LowMemory.Mode = LowMemoryModeAuto
+	}
 
 	// Default empty BirdNET locale to "en" so downstream label loading
 	// always has a valid locale to work with.

--- a/internal/mempolicy/apply.go
+++ b/internal/mempolicy/apply.go
@@ -2,6 +2,7 @@ package mempolicy
 
 import (
 	"math"
+	"os"
 	"runtime"
 	"runtime/debug"
 )
@@ -12,6 +13,11 @@ type Setters struct {
 	// CurrentMemLimit returns the currently configured GOMEMLIMIT (math.MaxInt64
 	// when unset), so Apply can avoid overriding an operator-provided limit.
 	CurrentMemLimit func() int64
+	// GoMemLimitEnvSet reports whether the operator set the GOMEMLIMIT env var.
+	// This distinguishes "unset" from "explicitly set to a max/off value", which
+	// both read back as math.MaxInt64 from the runtime; either way an explicit
+	// env value is operator intent we must not override.
+	GoMemLimitEnvSet func() bool
 	// SetMemoryLimit sets the soft Go memory limit (debug.SetMemoryLimit).
 	SetMemoryLimit func(int64) int64
 	// SetArenaMax caps glibc malloc arenas (mallopt). Returns true on success.
@@ -42,12 +48,15 @@ func Apply(d Decision, s Setters) Applied {
 	}
 
 	if d.GoMemLimitBytes > 0 && s.SetMemoryLimit != nil {
+		operatorSet := s.GoMemLimitEnvSet != nil && s.GoMemLimitEnvSet()
 		current := int64(math.MaxInt64)
 		if s.CurrentMemLimit != nil {
 			current = s.CurrentMemLimit()
 		}
-		// Only set when no explicit limit is already in effect (e.g. GOMEMLIMIT env).
-		if current == math.MaxInt64 {
+		// Respect an operator-set GOMEMLIMIT: skip when the env var is set (any
+		// value, including a max/off value, both of which read back as MaxInt64)
+		// or when a limit is already in effect.
+		if !operatorSet && current == math.MaxInt64 {
 			s.SetMemoryLimit(d.GoMemLimitBytes)
 			a.MemLimitApplied = true
 			a.GoMemLimitBytes = d.GoMemLimitBytes
@@ -70,9 +79,10 @@ func Configure(mode string) Result {
 	total := DetectTotalMemory()
 	d := Decide(total, runtime.NumCPU(), mode)
 	a := Apply(d, Setters{
-		CurrentMemLimit: func() int64 { return debug.SetMemoryLimit(-1) },
-		SetMemoryLimit:  debug.SetMemoryLimit,
-		SetArenaMax:     setArenaMax,
+		CurrentMemLimit:  func() int64 { return debug.SetMemoryLimit(-1) },
+		GoMemLimitEnvSet: func() bool { _, ok := os.LookupEnv("GOMEMLIMIT"); return ok },
+		SetMemoryLimit:   debug.SetMemoryLimit,
+		SetArenaMax:      setArenaMax,
 	})
 	return Result{Decision: d, Applied: a}
 }

--- a/internal/mempolicy/apply.go
+++ b/internal/mempolicy/apply.go
@@ -1,0 +1,78 @@
+package mempolicy
+
+import (
+	"math"
+	"runtime"
+	"runtime/debug"
+)
+
+// Setters holds the side-effecting functions Apply uses. They are injectable so
+// the policy can be unit-tested without touching real runtime/native state.
+type Setters struct {
+	// CurrentMemLimit returns the currently configured GOMEMLIMIT (math.MaxInt64
+	// when unset), so Apply can avoid overriding an operator-provided limit.
+	CurrentMemLimit func() int64
+	// SetMemoryLimit sets the soft Go memory limit (debug.SetMemoryLimit).
+	SetMemoryLimit func(int64) int64
+	// SetArenaMax caps glibc malloc arenas (mallopt). Returns true on success.
+	SetArenaMax func(int) bool
+}
+
+// Applied records what Apply actually changed, for logging and assertions.
+type Applied struct {
+	MemLimitApplied bool
+	ArenaApplied    bool
+	GoMemLimitBytes int64
+	ArenaMax        int
+}
+
+// Apply enacts a Decision through the injected setters. It is a no-op when the
+// decision is inactive. An operator-set GOMEMLIMIT is respected (not overridden).
+func Apply(d Decision, s Setters) Applied {
+	var a Applied
+	if !d.Active {
+		return a
+	}
+
+	if d.ArenaMax > 0 && s.SetArenaMax != nil {
+		if ok := s.SetArenaMax(d.ArenaMax); ok {
+			a.ArenaApplied = true
+			a.ArenaMax = d.ArenaMax
+		}
+	}
+
+	if d.GoMemLimitBytes > 0 && s.SetMemoryLimit != nil {
+		current := int64(math.MaxInt64)
+		if s.CurrentMemLimit != nil {
+			current = s.CurrentMemLimit()
+		}
+		// Only set when no explicit limit is already in effect (e.g. GOMEMLIMIT env).
+		if current == math.MaxInt64 {
+			s.SetMemoryLimit(d.GoMemLimitBytes)
+			a.MemLimitApplied = true
+			a.GoMemLimitBytes = d.GoMemLimitBytes
+		}
+	}
+
+	return a
+}
+
+// Result bundles the decision and what was applied, for the caller to log.
+type Result struct {
+	Decision Decision
+	Applied  Applied
+}
+
+// Configure detects system memory, decides the policy for the given config mode,
+// and applies it using the real runtime/native setters. Call this once, early in
+// startup, before inference threads spin up.
+func Configure(mode string) Result {
+	total := DetectTotalMemory()
+	d := Decide(total, runtime.NumCPU(), mode)
+	a := Apply(d, Setters{
+		CurrentMemLimit: func() int64 { return debug.SetMemoryLimit(-1) },
+		SetMemoryLimit:  debug.SetMemoryLimit,
+		SetArenaMax:     setArenaMax,
+	})
+	return Result{Decision: d, Applied: a}
+}

--- a/internal/mempolicy/arena_linux.go
+++ b/internal/mempolicy/arena_linux.go
@@ -1,0 +1,24 @@
+//go:build linux && cgo
+
+package mempolicy
+
+/*
+#include <malloc.h>
+
+// M_ARENA_MAX is a glibc extension. All of this project's Linux build targets
+// are glibc (Debian); the guard keeps the file compilable on a libc that omits
+// the constant (e.g. musl), where mallopt is a no-op and the call reports failure.
+#ifndef M_ARENA_MAX
+#define M_ARENA_MAX -8
+#endif
+*/
+import "C"
+
+// setArenaMax caps glibc malloc arenas via mallopt(M_ARENA_MAX, n), returning
+// true on success (glibc returns 1). It must run before the malloc-heavy
+// inference threads start to have effect. Profiling shows this is a cheap
+// backstop, not a primary memory lever: the dominant cost is loaded model
+// weights (see the package doc).
+func setArenaMax(n int) bool {
+	return C.mallopt(C.M_ARENA_MAX, C.int(n)) == 1
+}

--- a/internal/mempolicy/arena_linux.go
+++ b/internal/mempolicy/arena_linux.go
@@ -3,11 +3,12 @@
 package mempolicy
 
 /*
-#include <malloc.h>
-
-// M_ARENA_MAX is a glibc extension. All of this project's Linux build targets
-// are glibc (Debian); the guard keeps the file compilable on a libc that omits
-// the constant (e.g. musl), where mallopt is a no-op and the call reports failure.
+// mallopt and M_ARENA_MAX are glibc malloc tuning hooks, declared here directly
+// rather than via <malloc.h> so the file compiles on any libc that links mallopt
+// without exposing the glibc extension. musl provides mallopt as a no-op but
+// omits M_ARENA_MAX (the value -8 matches glibc); older musl omitted the
+// declaration entirely, which this extern restores.
+extern int mallopt(int, int);
 #ifndef M_ARENA_MAX
 #define M_ARENA_MAX -8
 #endif
@@ -18,7 +19,8 @@ import "C"
 // true on success (glibc returns 1). It must run before the malloc-heavy
 // inference threads start to have effect. Profiling shows this is a cheap
 // backstop, not a primary memory lever: the dominant cost is loaded model
-// weights (see the package doc).
+// weights (see the package doc). On musl the call links and returns 0, so this
+// reports the cap was not applied.
 func setArenaMax(n int) bool {
 	return C.mallopt(C.M_ARENA_MAX, C.int(n)) == 1
 }

--- a/internal/mempolicy/arena_stub.go
+++ b/internal/mempolicy/arena_stub.go
@@ -1,0 +1,7 @@
+//go:build !linux || !cgo
+
+package mempolicy
+
+// setArenaMax is a no-op where glibc malloc / cgo is unavailable (non-Linux,
+// or cgo-disabled builds). Returning false signals the cap was not applied.
+func setArenaMax(int) bool { return false }

--- a/internal/mempolicy/detect.go
+++ b/internal/mempolicy/detect.go
@@ -1,0 +1,103 @@
+package mempolicy
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/mem"
+)
+
+// cgroup memory-limit file locations, relative to the filesystem root.
+const (
+	cgroupV2MaxPath = "sys/fs/cgroup/memory.max"
+	cgroupV1MaxPath = "sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+// cgroupV1UnlimitedThreshold guards against the cgroup v1 "unlimited" sentinel,
+// which is a near-MaxInt64 value (commonly 0x7FFFFFFFFFFFF000). Any value at or
+// above this is treated as no limit.
+const cgroupV1UnlimitedThreshold int64 = 1 << 62
+
+// DetectTotalMemory returns the effective memory ceiling for this process:
+// the smaller of host RAM and any cgroup memory limit. Returns 0 if unknown.
+// The cgroup check matters inside containers (e.g. Docker --memory=512m), where
+// host RAM reporting would otherwise mask the real limit.
+func DetectTotalMemory() int64 {
+	return effectiveTotal(hostTotalMemory(), detectCgroupLimit("/"))
+}
+
+// hostTotalMemory returns total physical RAM in bytes via gopsutil, or 0 on error.
+func hostTotalMemory() int64 {
+	vm, err := mem.VirtualMemory()
+	if err != nil || vm == nil {
+		return 0
+	}
+	if vm.Total > uint64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	return int64(vm.Total)
+}
+
+// effectiveTotal picks the binding limit between host RAM and a cgroup cap.
+// A non-positive value means "unknown/unlimited" for that source.
+func effectiveTotal(host, cgroup int64) int64 {
+	switch {
+	case cgroup <= 0:
+		return host
+	case host <= 0:
+		return cgroup
+	case cgroup < host:
+		return cgroup
+	default:
+		return host
+	}
+}
+
+// detectCgroupLimit reads the cgroup memory limit under root, preferring cgroup
+// v2 (memory.max) and falling back to v1 (memory.limit_in_bytes). Returns 0 when
+// there is no limit or no cgroup files (root is parameterized for testability).
+func detectCgroupLimit(root string) int64 {
+	if data, err := os.ReadFile(filepath.Join(root, cgroupV2MaxPath)); err == nil {
+		// v2 present: "max" means unlimited, a number is the cap.
+		if v, ok := parseCgroupV2Max(string(data)); ok {
+			return v
+		}
+		return 0
+	}
+	if data, err := os.ReadFile(filepath.Join(root, cgroupV1MaxPath)); err == nil {
+		if v, ok := parseCgroupV1Limit(string(data)); ok {
+			return v
+		}
+	}
+	return 0
+}
+
+// parseCgroupV2Max parses memory.max: a byte count, or "max" for unlimited.
+func parseCgroupV2Max(s string) (int64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "max" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v <= 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseCgroupV1Limit parses memory.limit_in_bytes, treating the near-MaxInt64
+// sentinel as "no limit".
+func parseCgroupV1Limit(s string) (int64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v <= 0 || v >= cgroupV1UnlimitedThreshold {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/mempolicy/detect.go
+++ b/internal/mempolicy/detect.go
@@ -3,6 +3,7 @@ package mempolicy
 import (
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -74,24 +75,44 @@ func effectiveTotal(host, cgroup int64) int64 {
 // unlimited value and the real per-container cap lives in a subtree.
 func detectCgroupLimit(root string) int64 {
 	v2Sub, v1Sub := cgroupSubPaths(root)
-
-	// cgroup v2 (unified): process subtree first, then the cgroup mount root.
-	for _, rel := range distinctPaths(
-		filepath.Join(cgroupV2Base, v2Sub, cgroupV2File),
-		cgroupV2MaxPath,
-	) {
-		if data, err := os.ReadFile(filepath.Join(root, rel)); err == nil {
-			// v2 present: "max" means unlimited, a number is the cap.
-			if v, ok := parseCgroupV2Max(string(data)); ok {
-				return v
-			}
-			return 0
-		}
+	if limit, found := cgroupV2Limit(root, v2Sub); found {
+		return limit
 	}
+	return cgroupV1Limit(root, v1Sub)
+}
 
-	// cgroup v1: the memory controller subtree first, then the mount root.
+// cgroupV2Limit returns the effective cgroup v2 memory limit by taking the
+// minimum memory.max from the process's cgroup up through its ancestors to the
+// unified mount root: a cgroup's effective limit is bounded by every ancestor, so
+// a "max" leaf can still be capped by a parent (e.g. a Kubernetes pod cgroup).
+// found is true when any memory.max file exists (v2 is the active hierarchy); a
+// returned limit of 0 then means no limit is set at any level.
+func cgroupV2Limit(root, sub string) (limit int64, found bool) {
+	if sub == "" {
+		sub = "/"
+	}
+	for {
+		if data, err := os.ReadFile(filepath.Join(root, cgroupV2Base, sub, cgroupV2File)); err == nil {
+			found = true
+			// "max" means unlimited at this level; a number caps the subtree.
+			if v, ok := parseCgroupV2Max(string(data)); ok && (limit == 0 || v < limit) {
+				limit = v
+			}
+		}
+		if sub == "/" {
+			break
+		}
+		sub = path.Dir(sub) // cgroup paths are always slash-separated
+	}
+	return limit, found
+}
+
+// cgroupV1Limit reads the cgroup v1 memory limit from the process's memory
+// controller subtree, falling back to the controller mount root. Returns 0 when
+// no limit is found (also the path for non-v1 systems, where the files are absent).
+func cgroupV1Limit(root, sub string) int64 {
 	for _, rel := range distinctPaths(
-		filepath.Join(cgroupV1MemBase, v1Sub, cgroupV1File),
+		filepath.Join(cgroupV1MemBase, sub, cgroupV1File),
 		cgroupV1MaxPath,
 	) {
 		if data, err := os.ReadFile(filepath.Join(root, rel)); err == nil {
@@ -117,14 +138,14 @@ func cgroupSubPaths(root string) (v2Sub, v1Sub string) {
 		if len(parts) != 3 {
 			continue
 		}
-		controllers, path := parts[1], parts[2]
+		controllers, cgPath := parts[1], parts[2]
 		if parts[0] == "0" && controllers == "" {
-			v2Sub = path // unified v2 line: "0::<path>"
+			v2Sub = cgPath // unified v2 line: "0::<path>"
 			continue
 		}
 		for c := range strings.SplitSeq(controllers, ",") {
 			if c == "memory" {
-				v1Sub = path
+				v1Sub = cgPath
 			}
 		}
 	}

--- a/internal/mempolicy/detect.go
+++ b/internal/mempolicy/detect.go
@@ -14,6 +14,13 @@ import (
 const (
 	cgroupV2MaxPath = "sys/fs/cgroup/memory.max"
 	cgroupV1MaxPath = "sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+	// Bases for resolving the process's own cgroup subtree (see detectCgroupLimit).
+	cgroupV2Base    = "sys/fs/cgroup"        // unified (v2) mount
+	cgroupV1MemBase = "sys/fs/cgroup/memory" // v1 memory controller mount
+	cgroupV2File    = "memory.max"
+	cgroupV1File    = "memory.limit_in_bytes"
+	procSelfCgroup  = "proc/self/cgroup"
 )
 
 // cgroupV1UnlimitedThreshold guards against the cgroup v1 "unlimited" sentinel,
@@ -59,20 +66,84 @@ func effectiveTotal(host, cgroup int64) int64 {
 // detectCgroupLimit reads the cgroup memory limit under root, preferring cgroup
 // v2 (memory.max) and falling back to v1 (memory.limit_in_bytes). Returns 0 when
 // there is no limit or no cgroup files (root is parameterized for testability).
+//
+// It resolves the process's own cgroup subtree from /proc/self/cgroup and reads
+// the limit there before falling back to the cgroup mount root. The subtree path
+// matters when the container does not have a private cgroup namespace (e.g.
+// Docker --cgroupns=host, or cgroup v1), where the mount root holds the host's
+// unlimited value and the real per-container cap lives in a subtree.
 func detectCgroupLimit(root string) int64 {
-	if data, err := os.ReadFile(filepath.Join(root, cgroupV2MaxPath)); err == nil {
-		// v2 present: "max" means unlimited, a number is the cap.
-		if v, ok := parseCgroupV2Max(string(data)); ok {
-			return v
+	v2Sub, v1Sub := cgroupSubPaths(root)
+
+	// cgroup v2 (unified): process subtree first, then the cgroup mount root.
+	for _, rel := range distinctPaths(
+		filepath.Join(cgroupV2Base, v2Sub, cgroupV2File),
+		cgroupV2MaxPath,
+	) {
+		if data, err := os.ReadFile(filepath.Join(root, rel)); err == nil {
+			// v2 present: "max" means unlimited, a number is the cap.
+			if v, ok := parseCgroupV2Max(string(data)); ok {
+				return v
+			}
+			return 0
 		}
-		return 0
 	}
-	if data, err := os.ReadFile(filepath.Join(root, cgroupV1MaxPath)); err == nil {
-		if v, ok := parseCgroupV1Limit(string(data)); ok {
-			return v
+
+	// cgroup v1: the memory controller subtree first, then the mount root.
+	for _, rel := range distinctPaths(
+		filepath.Join(cgroupV1MemBase, v1Sub, cgroupV1File),
+		cgroupV1MaxPath,
+	) {
+		if data, err := os.ReadFile(filepath.Join(root, rel)); err == nil {
+			if v, ok := parseCgroupV1Limit(string(data)); ok {
+				return v
+			}
 		}
 	}
 	return 0
+}
+
+// cgroupSubPaths parses /proc/self/cgroup for the process's cgroup path under the
+// v2 unified hierarchy and the v1 memory controller. Either is "" when absent (a
+// namespaced container reports "/", which resolves back to the mount root).
+func cgroupSubPaths(root string) (v2Sub, v1Sub string) {
+	data, err := os.ReadFile(filepath.Join(root, procSelfCgroup))
+	if err != nil {
+		return "", ""
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		// Format: hierarchy-ID:controller-list:cgroup-path
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		controllers, path := parts[1], parts[2]
+		if parts[0] == "0" && controllers == "" {
+			v2Sub = path // unified v2 line: "0::<path>"
+			continue
+		}
+		for c := range strings.SplitSeq(controllers, ",") {
+			if c == "memory" {
+				v1Sub = path
+			}
+		}
+	}
+	return v2Sub, v1Sub
+}
+
+// distinctPaths returns the inputs with duplicates removed, preserving order. A
+// subtree path of "/" or "" cleans to the same path as the mount root, so this
+// avoids reading the same file twice.
+func distinctPaths(paths ...string) []string {
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // parseCgroupV2Max parses memory.max: a byte count, or "max" for unlimited.

--- a/internal/mempolicy/detect_test.go
+++ b/internal/mempolicy/detect_test.go
@@ -142,6 +142,17 @@ func TestDetectCgroupLimit(t *testing.T) {
 		got := detectCgroupLimit(root)
 		assert.Equal(t, int64(134217728), got)
 	})
+
+	t.Run("cgroup v2 takes ancestor limit when leaf is max", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, procSelfCgroup), "0::/pod/container\n")
+		// The process's own cgroup is unlimited, but the parent pod cgroup caps it.
+		writeFile(t, filepath.Join(root, cgroupV2Base, "pod", "container", cgroupV2File), "max\n")
+		writeFile(t, filepath.Join(root, cgroupV2Base, "pod", cgroupV2File), "268435456\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(268435456), got)
+	})
 }
 
 func TestEffectiveTotal(t *testing.T) {

--- a/internal/mempolicy/detect_test.go
+++ b/internal/mempolicy/detect_test.go
@@ -114,6 +114,34 @@ func TestDetectCgroupLimit(t *testing.T) {
 		got := detectCgroupLimit(root)
 		assert.Zero(t, got)
 	})
+
+	t.Run("cgroup v2 reads process subtree (host cgroupns)", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, procSelfCgroup), "0::/docker/abc123\n")
+		// Only the subtree holds the cap; the mount root would be the host's.
+		writeFile(t, filepath.Join(root, cgroupV2Base, "docker", "abc123", cgroupV2File), "536870912\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(536870912), got)
+	})
+
+	t.Run("cgroup v2 falls back to mount root when subtree file absent", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, procSelfCgroup), "0::/docker/abc123\n")
+		writeFile(t, filepath.Join(root, cgroupV2MaxPath), "268435456\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(268435456), got)
+	})
+
+	t.Run("cgroup v1 reads memory controller subtree", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, procSelfCgroup), "7:memory:/docker/abc123\n3:cpu,cpuacct:/docker/abc123\n")
+		writeFile(t, filepath.Join(root, cgroupV1MemBase, "docker", "abc123", cgroupV1File), "134217728\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(134217728), got)
+	})
 }
 
 func TestEffectiveTotal(t *testing.T) {

--- a/internal/mempolicy/detect_test.go
+++ b/internal/mempolicy/detect_test.go
@@ -1,0 +1,135 @@
+package mempolicy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCgroupV2Max(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in     string
+		want   int64
+		wantOK bool
+	}{
+		{"536870912\n", 536870912, true},
+		{"max\n", 0, false},
+		{"max", 0, false},
+		{"", 0, false},
+		{"  268435456 ", 268435456, true},
+		{"garbage", 0, false},
+		{"0", 0, false},
+		{"-5", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseCgroupV2Max(tt.in)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseCgroupV1Limit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		in     string
+		want   int64
+		wantOK bool
+	}{
+		{"real limit", "536870912\n", 536870912, true},
+		{"v1 unlimited sentinel", "9223372036854771712\n", 0, false},
+		{"max int64 sentinel", "9223372036854775807\n", 0, false},
+		{"empty", "", 0, false},
+		{"garbage", "nope", 0, false},
+		{"zero", "0", 0, false},
+		{"negative", "-1", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseCgroupV1Limit(tt.in)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// detectCgroupLimit reads cgroup files under a fake root, so we can exercise
+// the v2-first, v1-fallback logic with t.TempDir().
+func TestDetectCgroupLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cgroup v2 limit", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, cgroupV2MaxPath), "536870912\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(536870912), got)
+	})
+
+	t.Run("cgroup v2 unlimited", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, cgroupV2MaxPath), "max\n")
+		got := detectCgroupLimit(root)
+		assert.Zero(t, got)
+	})
+
+	t.Run("cgroup v1 fallback", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, cgroupV1MaxPath), "268435456\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(268435456), got)
+	})
+
+	t.Run("no cgroup files", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		got := detectCgroupLimit(root)
+		assert.Zero(t, got)
+	})
+
+	t.Run("cgroup v2 takes precedence over v1", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, cgroupV2MaxPath), "536870912\n")
+		writeFile(t, filepath.Join(root, cgroupV1MaxPath), "268435456\n")
+		got := detectCgroupLimit(root)
+		assert.Equal(t, int64(536870912), got)
+	})
+
+	t.Run("cgroup v2 max short-circuits, v1 ignored", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, cgroupV2MaxPath), "max\n")
+		writeFile(t, filepath.Join(root, cgroupV1MaxPath), "268435456\n")
+		got := detectCgroupLimit(root)
+		assert.Zero(t, got)
+	})
+}
+
+func TestEffectiveTotal(t *testing.T) {
+	t.Parallel()
+	// cgroup limit lower than host -> cgroup wins (the container case).
+	assert.Equal(t, int64(512*mib), effectiveTotal(8*gib, 512*mib))
+	// cgroup unlimited (0) -> host wins.
+	assert.Equal(t, int64(8*gib), effectiveTotal(8*gib, 0))
+	// cgroup higher than host (unusual) -> host wins.
+	assert.Equal(t, int64(2*gib), effectiveTotal(2*gib, 8*gib))
+	// host unknown -> cgroup wins if present.
+	assert.Equal(t, int64(512*mib), effectiveTotal(0, 512*mib))
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/internal/mempolicy/mempolicy.go
+++ b/internal/mempolicy/mempolicy.go
@@ -1,0 +1,143 @@
+// Package mempolicy applies startup memory controls for memory-constrained
+// systems (the foundation for the low-memory mode tracked in the RAM-reduction
+// epic). It detects the effective system memory limit (host RAM or cgroup cap),
+// derives a policy, and applies two native controls early in startup:
+//
+//   - mallopt(M_ARENA_MAX, N) to cap glibc per-thread malloc arenas, bounding
+//     per-thread arena fragmentation.
+//   - debug.SetMemoryLimit (GOMEMLIMIT) as a soft backstop on the Go heap.
+//
+// The model is held constant; this package only tunes the runtime. Both controls
+// are gated behind detection plus a manual config override (auto/on/off), so
+// high-memory systems are unaffected. They are cheap backstops, not the primary
+// memory lever: profiling found that neither the arena cap nor GOMEMLIMIT
+// meaningfully reduces resident memory, because the bulk is loaded model weights
+// (and ONNX Runtime's own arena), not reclaimable glibc fragmentation. The
+// dominant memory levers are model-level (gating and quantization) and live
+// elsewhere; this package is the detection and apply seam they build on.
+package mempolicy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Mode values for the manual config override.
+const (
+	ModeAuto = "auto" // enable controls when detected memory is at/below the threshold
+	ModeOn   = "on"   // force controls on regardless of detected memory
+	ModeOff  = "off"  // force controls off regardless of detected memory
+)
+
+const bytesPerMiB = 1024 * 1024
+
+// Policy tunables. Named to avoid magic numbers; documented for future tuning.
+const (
+	// autoThresholdBytes is the detected-memory ceiling at/below which auto mode
+	// activates. 1.25 GiB covers 512 MB and 1 GB constrained boxes while leaving
+	// 2 GB+ systems untouched.
+	autoThresholdBytes = 1280 * bytesPerMiB
+
+	// arenaMaxCeiling bounds the glibc malloc arena cap (M_ARENA_MAX). Capping
+	// arenas bounds per-thread arena fragmentation, but glibc's default is 8*cores,
+	// so capping too low throttles malloc concurrency on multi-core systems. The
+	// effective cap is min(NumCPU, ceiling): the ceiling keeps the cap from
+	// exceeding what fragmentation control needs, while NumCPU keeps it from
+	// dropping below the machine's own parallelism on small-core boxes.
+	arenaMaxCeiling = 4
+
+	// nativeReserveBytes is the estimated non-Go resident footprint (embedded model
+	// + TFLite/XNNPACK + ONNX CGO arenas + OS) carved out before deriving GOMEMLIMIT,
+	// so the soft limit bounds only Go's own memory. Measured native footprint for
+	// the default single-model config is ~330 MB; 350 MiB leaves margin.
+	nativeReserveBytes = 350 * bytesPerMiB
+
+	// minGoMemLimitBytes floors the derived GOMEMLIMIT so a very small box never
+	// gets a limit so tight that the GC thrashes.
+	minGoMemLimitBytes = 96 * bytesPerMiB
+)
+
+// Decision is the pure result of evaluating the policy. It carries no side
+// effects; Apply turns it into runtime changes.
+type Decision struct {
+	Active          bool   // whether low-memory controls should be applied
+	GoMemLimitBytes int64  // soft GOMEMLIMIT to set; 0 means leave unset
+	ArenaMax        int    // glibc M_ARENA_MAX to set; 0 means do not cap
+	TotalRAMBytes   int64  // effective detected memory (0 = unknown)
+	Reason          string // human-readable explanation for logging
+}
+
+// Decide evaluates the memory policy from detected memory, the available CPU
+// count, and the config mode. It is pure and fully unit-testable.
+func Decide(totalRAMBytes int64, numCPU int, mode string) Decision {
+	m := normalizeMode(mode)
+
+	var active bool
+	var reason string
+	switch m {
+	case ModeOn:
+		active = true
+		reason = "low-memory mode forced on by config"
+	case ModeOff:
+		reason = "low-memory mode forced off by config"
+	default: // ModeAuto
+		switch {
+		case totalRAMBytes <= 0:
+			reason = "auto: system memory unknown, low-memory controls left off"
+		case totalRAMBytes <= autoThresholdBytes:
+			active = true
+			reason = fmt.Sprintf("auto: detected %d MiB at/below %d MiB threshold",
+				totalRAMBytes/bytesPerMiB, autoThresholdBytes/bytesPerMiB)
+		default:
+			reason = fmt.Sprintf("auto: detected %d MiB above %d MiB threshold",
+				totalRAMBytes/bytesPerMiB, autoThresholdBytes/bytesPerMiB)
+		}
+	}
+
+	d := Decision{Active: active, TotalRAMBytes: totalRAMBytes, Reason: reason}
+	if active {
+		d.ArenaMax = arenaMaxFor(numCPU)
+		d.GoMemLimitBytes = deriveGoMemLimit(totalRAMBytes)
+	}
+	return d
+}
+
+// arenaMaxFor returns the glibc malloc arena cap for the given CPU count:
+// min(numCPU, arenaMaxCeiling), floored at 1 so an unknown/zero count still
+// yields a valid cap. This keeps the cap from throttling malloc below the
+// machine's parallelism while still bounding arena fragmentation.
+func arenaMaxFor(numCPU int) int {
+	if numCPU < 1 {
+		numCPU = 1
+	}
+	if numCPU > arenaMaxCeiling {
+		return arenaMaxCeiling
+	}
+	return numCPU
+}
+
+// deriveGoMemLimit returns a soft GOMEMLIMIT for the detected memory, or 0 when
+// memory is unknown. The value reserves the native footprint and is floored to
+// avoid GC thrashing on tiny boxes.
+func deriveGoMemLimit(totalRAMBytes int64) int64 {
+	if totalRAMBytes <= 0 {
+		return 0
+	}
+	v := totalRAMBytes - nativeReserveBytes
+	if v < minGoMemLimitBytes {
+		return minGoMemLimitBytes
+	}
+	return v
+}
+
+// normalizeMode coerces user input to a known mode, defaulting to auto.
+func normalizeMode(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case ModeOn:
+		return ModeOn
+	case ModeOff:
+		return ModeOff
+	default:
+		return ModeAuto
+	}
+}

--- a/internal/mempolicy/mempolicy_test.go
+++ b/internal/mempolicy/mempolicy_test.go
@@ -206,6 +206,25 @@ func TestApply_RespectsExistingMemLimitOverride(t *testing.T) {
 	assert.True(t, res.ArenaApplied, "arena cap still applies")
 }
 
+func TestApply_RespectsOperatorGoMemLimitEnv(t *testing.T) {
+	t.Parallel()
+	// Operator set GOMEMLIMIT env to a max/off value: the current limit reads as
+	// MaxInt64 (looks unset), but the env signal marks explicit intent we keep.
+	d := Decide(512*mib, testNumCPU, ModeOn)
+	require.True(t, d.Active)
+
+	memCalled := false
+	res := Apply(d, Setters{
+		GoMemLimitEnvSet: func() bool { return true },
+		CurrentMemLimit:  func() int64 { return math.MaxInt64 },
+		SetMemoryLimit:   func(int64) int64 { memCalled = true; return math.MaxInt64 },
+		SetArenaMax:      func(int) bool { return true },
+	})
+	assert.False(t, memCalled, "must not override GOMEMLIMIT when the env var is set, even at a max/off value")
+	assert.False(t, res.MemLimitApplied)
+	assert.True(t, res.ArenaApplied, "arena cap still applies")
+}
+
 func TestApply_ArenaUnsupportedStillSetsMemLimit(t *testing.T) {
 	t.Parallel()
 	// Platform where setArenaMax reports failure (non-glibc / non-cgo / mallopt fail).

--- a/internal/mempolicy/mempolicy_test.go
+++ b/internal/mempolicy/mempolicy_test.go
@@ -1,0 +1,224 @@
+package mempolicy
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mib = 1024 * 1024
+	gib = 1024 * mib
+	// testNumCPU is above arenaMaxCeiling, so arenaMaxFor(testNumCPU) == ceiling.
+	testNumCPU = 8
+)
+
+func TestNormalizeMode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"auto", ModeAuto},
+		{"on", ModeOn},
+		{"off", ModeOff},
+		{"AUTO", ModeAuto},
+		{"On", ModeOn},
+		{" off ", ModeOff},
+		{"", ModeAuto},
+		{"garbage", ModeAuto},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, normalizeMode(tt.in))
+		})
+	}
+}
+
+func TestDecide(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		total        int64
+		mode         string
+		wantActive   bool
+		wantArena    int
+		wantMemLimit int64 // -1 = "non-zero, don't assert exact"
+	}{
+		{
+			name: "auto enables on 512MB box", total: 512 * mib, mode: ModeAuto,
+			wantActive: true, wantArena: arenaMaxFor(testNumCPU), wantMemLimit: -1,
+		},
+		{
+			name: "auto enables on 1GB box", total: 1 * gib, mode: ModeAuto,
+			wantActive: true, wantArena: arenaMaxFor(testNumCPU), wantMemLimit: -1,
+		},
+		{
+			name: "auto enables exactly at threshold", total: autoThresholdBytes, mode: ModeAuto,
+			wantActive: true, wantArena: arenaMaxFor(testNumCPU), wantMemLimit: -1,
+		},
+		{
+			name: "auto disabled one byte over threshold", total: autoThresholdBytes + 1, mode: ModeAuto,
+			wantActive: false, wantArena: 0, wantMemLimit: 0,
+		},
+		{
+			name: "auto disabled mid-gap 2GiB", total: 2 * gib, mode: ModeAuto,
+			wantActive: false, wantArena: 0, wantMemLimit: 0,
+		},
+		{
+			name: "auto disabled on 4GB box", total: 4 * gib, mode: ModeAuto,
+			wantActive: false, wantArena: 0, wantMemLimit: 0,
+		},
+		{
+			name: "auto disabled when RAM unknown", total: 0, mode: ModeAuto,
+			wantActive: false, wantArena: 0, wantMemLimit: 0,
+		},
+		{
+			name: "on forces active even on big box", total: 16 * gib, mode: ModeOn,
+			wantActive: true, wantArena: arenaMaxFor(testNumCPU), wantMemLimit: -1,
+		},
+		{
+			name: "off forces inactive even on tiny box", total: 256 * mib, mode: ModeOff,
+			wantActive: false, wantArena: 0, wantMemLimit: 0,
+		},
+		{
+			name: "on with unknown RAM still caps arenas, no memlimit", total: 0, mode: ModeOn,
+			wantActive: true, wantArena: arenaMaxFor(testNumCPU), wantMemLimit: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := Decide(tt.total, testNumCPU, tt.mode)
+			assert.Equal(t, tt.wantActive, d.Active, "Active")
+			assert.Equal(t, tt.wantArena, d.ArenaMax, "ArenaMax")
+			assert.Equal(t, tt.total, d.TotalRAMBytes, "TotalRAMBytes")
+			switch tt.wantMemLimit {
+			case 0:
+				assert.Zero(t, d.GoMemLimitBytes, "GoMemLimitBytes should be unset")
+			case -1:
+				assert.Positive(t, d.GoMemLimitBytes, "GoMemLimitBytes should be set")
+			default:
+				assert.Equal(t, tt.wantMemLimit, d.GoMemLimitBytes)
+			}
+			assert.NotEmpty(t, d.Reason, "Reason should explain the decision")
+		})
+	}
+}
+
+func TestDeriveGoMemLimit(t *testing.T) {
+	t.Parallel()
+	// Unknown RAM => skip (0).
+	assert.Zero(t, deriveGoMemLimit(0))
+	// Tiny box => floored, never below the thrash floor.
+	assert.Equal(t, int64(minGoMemLimitBytes), deriveGoMemLimit(256*mib))
+	// 512MB box: total - nativeReserve, above the floor.
+	got := deriveGoMemLimit(512 * mib)
+	assert.Equal(t, int64(512*mib-nativeReserveBytes), got)
+	assert.GreaterOrEqual(t, got, int64(minGoMemLimitBytes))
+	// 1GB box: comfortably total - reserve.
+	assert.Equal(t, int64(1*gib-nativeReserveBytes), deriveGoMemLimit(1*gib))
+}
+
+func TestArenaMaxFor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		numCPU int
+		want   int
+	}{
+		{-2, 1},               // negative floored to 1
+		{0, 1},                // unknown/zero floored to 1
+		{1, 1},                // single core
+		{2, 2},                // dual core, below ceiling
+		{4, arenaMaxCeiling},  // exactly at ceiling
+		{8, arenaMaxCeiling},  // above ceiling -> capped
+		{64, arenaMaxCeiling}, // many cores -> capped
+	}
+	for _, tt := range tests {
+		assert.Equalf(t, tt.want, arenaMaxFor(tt.numCPU), "arenaMaxFor(%d)", tt.numCPU)
+	}
+}
+
+func TestApply_SetsBothControlsWhenActive(t *testing.T) {
+	t.Parallel()
+	var gotMemLimit int64
+	var gotArena int
+	memCalled, arenaCalled := false, false
+
+	d := Decide(512*mib, testNumCPU, ModeAuto)
+	require.True(t, d.Active)
+
+	res := Apply(d, Setters{
+		CurrentMemLimit: func() int64 { return math.MaxInt64 }, // not already set
+		SetMemoryLimit: func(v int64) int64 {
+			memCalled = true
+			gotMemLimit = v
+			return math.MaxInt64
+		},
+		SetArenaMax: func(n int) bool {
+			arenaCalled = true
+			gotArena = n
+			return true
+		},
+	})
+
+	assert.True(t, memCalled, "SetMemoryLimit must be called")
+	assert.True(t, arenaCalled, "SetArenaMax must be called")
+	assert.Equal(t, d.GoMemLimitBytes, gotMemLimit)
+	assert.Equal(t, arenaMaxFor(testNumCPU), gotArena)
+	assert.True(t, res.MemLimitApplied)
+	assert.True(t, res.ArenaApplied)
+}
+
+func TestApply_NoopWhenInactive(t *testing.T) {
+	t.Parallel()
+	d := Decide(8*gib, testNumCPU, ModeAuto)
+	require.False(t, d.Active)
+
+	called := false
+	res := Apply(d, Setters{
+		CurrentMemLimit: func() int64 { return math.MaxInt64 },
+		SetMemoryLimit:  func(int64) int64 { called = true; return math.MaxInt64 },
+		SetArenaMax:     func(int) bool { called = true; return true },
+	})
+	assert.False(t, called, "no setters should run when inactive")
+	assert.False(t, res.MemLimitApplied)
+	assert.False(t, res.ArenaApplied)
+}
+
+func TestApply_RespectsExistingMemLimitOverride(t *testing.T) {
+	t.Parallel()
+	// Operator already set GOMEMLIMIT (env) -> current != MaxInt64; don't override it.
+	d := Decide(512*mib, testNumCPU, ModeOn)
+	require.True(t, d.Active)
+
+	memCalled := false
+	res := Apply(d, Setters{
+		CurrentMemLimit: func() int64 { return 200 * mib }, // already set
+		SetMemoryLimit:  func(int64) int64 { memCalled = true; return 200 * mib },
+		SetArenaMax:     func(int) bool { return true },
+	})
+	assert.False(t, memCalled, "must not override an operator-set GOMEMLIMIT")
+	assert.False(t, res.MemLimitApplied)
+	assert.True(t, res.ArenaApplied, "arena cap still applies")
+}
+
+func TestApply_ArenaUnsupportedStillSetsMemLimit(t *testing.T) {
+	t.Parallel()
+	// Platform where setArenaMax reports failure (non-glibc / non-cgo / mallopt fail).
+	d := Decide(512*mib, testNumCPU, ModeOn)
+	require.True(t, d.Active)
+
+	res := Apply(d, Setters{
+		CurrentMemLimit: func() int64 { return math.MaxInt64 },
+		SetMemoryLimit:  func(int64) int64 { return math.MaxInt64 },
+		SetArenaMax:     func(int) bool { return false },
+	})
+
+	assert.False(t, res.ArenaApplied, "arena cap not applied when the setter reports failure")
+	assert.Zero(t, res.ArenaMax, "ArenaMax stays unset when the cap did not apply")
+	assert.True(t, res.MemLimitApplied, "GOMEMLIMIT still applies independently of the arena cap")
+}


### PR DESCRIPTION
## Summary

This adds `internal/mempolicy`, a startup memory-policy foundation for running on memory-constrained systems. At startup it detects the effective memory limit (host RAM and the cgroup v2/v1 cap, so a container memory limit binds even when host RAM is large) and, when the policy is active, applies two cheap native controls before any inference threads start:

- A soft `GOMEMLIMIT` backstop on the Go heap via `debug.SetMemoryLimit` (only when the operator has not already set `GOMEMLIMIT`).
- A glibc malloc arena cap via `mallopt(M_ARENA_MAX, n)`, with `n = min(NumCPU, 4)` so it bounds per-thread arena fragmentation without throttling malloc concurrency on multi-core boxes.

It is gated behind a `lowmemory.mode` config override (`auto`/`on`/`off`, default `auto`); `auto` activates at or below 1.25 GiB detected memory, leaving larger systems untouched. The setting is applied once at startup (the arena cap must precede inference threads), so it is intentionally restart-only rather than hot-reloadable, and it respects an operator-set `GOMEMLIMIT`. The policy is wired into the `serve`/`realtime` and `benchmark` commands.

The decision logic is a pure function with injected setters, so it is fully unit-tested (memory thresholds, cgroup v2/v1 parsing and unlimited sentinels, arena cap derivation, operator-override handling) without touching real runtime state.

## Why these controls are conservative

Profiling on constrained hardware showed these runtime controls are cheap backstops, not the primary memory lever: resident memory is dominated by loaded model weights, not reclaimable glibc fragmentation. The larger memory wins (model gating and quantization) are model-level and are deliberately out of scope here, so this PR holds the model constant and only adds the detection and apply seam they will build on. On a high-memory system the policy is inactive and changes nothing.

## Test Plan

- [x] `go test -race ./internal/mempolicy/... ./internal/conf/...`
- [x] `golangci-lint run` clean on changed packages, `gofmt` clean
- [x] Full build (`task`) green
- [x] Verified at startup on a 16-core host: detection, GOMEMLIMIT, and the arena cap all applied and logged; binary starts cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `lowmemory.mode` configuration (`auto`, `on`, `off`) with automatic defaulting and normalization.
  * Detects effective memory constraints (including container/cgroup limits) to tune runtime memory usage.
  * Applies the memory policy early at startup for both the serve and benchmark commands when enabled.

* **Tests**
  * Added unit tests for mode parsing/validation and for constraint detection and limit-selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->