### PR TITLE
fix(settings): escape '/' in Base URL pattern so it is valid under the RegExp v flag

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -723,7 +723,7 @@
         label={t('settings.security.baseUrlLabel')}
         placeholder={t('settings.security.placeholders.baseUrl')}
         helpText={t('settings.security.baseUrlHelp')}
-        pattern="^https?://[^/:]+.*$"
+        pattern="^https?://[^\/:]+.*$"
         validationMessage={t('settings.security.baseUrlValidation')}
         disabled={store.isLoading || store.isSaving}
         onchange={updateBaseUrl}

--- a/frontend/src/test/svelte-pattern-attributes.test.ts
+++ b/frontend/src/test/svelte-pattern-attributes.test.ts
@@ -43,9 +43,10 @@ function collectSvelteFiles(dir: string): string[] {
 // The negative lookbehind excludes hyphenated/word-prefixed attributes such as
 // data-pattern= or aria-pattern=, which are not HTML form-control patterns and
 // are never compiled by the browser. Optional whitespace around `=` tolerates
-// hand-formatted markup. Dynamic bindings (pattern={expr}) cannot be evaluated
-// statically and are intentionally skipped.
-const PATTERN_ATTR = /(?<![\w-])pattern\s*=\s*(["'])(.*?)\1/g;
+// hand-formatted markup, and the `s` flag lets a value span multiple lines so
+// such an attribute is validated rather than silently skipped. Dynamic bindings
+// (pattern={expr}) cannot be evaluated statically and are intentionally skipped.
+const PATTERN_ATTR = /(?<![\w-])pattern\s*=\s*(["'])(.*?)\1/gs;
 
 interface FoundPattern {
   file: string;

--- a/frontend/src/test/svelte-pattern-attributes.test.ts
+++ b/frontend/src/test/svelte-pattern-attributes.test.ts
@@ -42,9 +42,10 @@ function collectSvelteFiles(dir: string): string[] {
 // the closing quote to the opening one and yields the value in a single group.
 // The negative lookbehind excludes hyphenated/word-prefixed attributes such as
 // data-pattern= or aria-pattern=, which are not HTML form-control patterns and
-// are never compiled by the browser. Dynamic bindings (pattern={expr}) cannot
-// be evaluated statically and are intentionally skipped.
-const PATTERN_ATTR = /(?<![\w-])pattern=(["'])(.*?)\1/g;
+// are never compiled by the browser. Optional whitespace around `=` tolerates
+// hand-formatted markup. Dynamic bindings (pattern={expr}) cannot be evaluated
+// statically and are intentionally skipped.
+const PATTERN_ATTR = /(?<![\w-])pattern\s*=\s*(["'])(.*?)\1/g;
 
 interface FoundPattern {
   file: string;
@@ -54,7 +55,12 @@ interface FoundPattern {
 function extractPatterns(): FoundPattern[] {
   const results: FoundPattern[] = [];
   for (const file of collectSvelteFiles(SRC_DIR)) {
-    const text = readFileSync(file, 'utf8');
+    // Strip <script> and <style> blocks so a JS/TS variable or CSS token named
+    // `pattern` cannot be mistaken for an HTML form-control pattern attribute
+    // (only the markup region carries real pattern="" attributes).
+    const text = readFileSync(file, 'utf8')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
     for (const m of text.matchAll(PATTERN_ATTR)) {
       results.push({ file: relative(SRC_DIR, file), value: m[2] });
     }

--- a/frontend/src/test/svelte-pattern-attributes.test.ts
+++ b/frontend/src/test/svelte-pattern-attributes.test.ts
@@ -1,0 +1,85 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- test-only: scans this repo's own src/ tree for .svelte files; paths are derived from the source layout, not user input */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+/**
+ * Guard: every static `pattern="..."` attribute in a Svelte component must be a
+ * regular expression the browser can actually compile.
+ *
+ * Browsers compile the HTML form-control `pattern` attribute as
+ * `new RegExp("^(?:" + pattern + ")$", "v")`. The `v` (unicodeSets) flag, now
+ * the default in current Chromium/Safari, treats `( ) [ ] { } / - \ |` as
+ * reserved inside a character class, so an unescaped `/` in `[^/:]` throws
+ * "Invalid character in character class". The attribute then silently fails to
+ * validate anything (and logs a console error). Escaping it (`[^\/:]`) is valid
+ * in both the legacy and `v` engines.
+ *
+ * This test compiles each pattern exactly as the browser does so a bad pattern
+ * fails here in CI instead of silently in the field.
+ */
+
+const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Recursively collect all .svelte files under a directory. */
+function collectSvelteFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dist') continue;
+      found.push(...collectSvelteFiles(full));
+    } else if (entry.endsWith('.svelte')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+// Static pattern="..." / pattern='...' attributes. The backreference (\1) ties
+// the closing quote to the opening one and yields the value in a single group.
+// The negative lookbehind excludes hyphenated/word-prefixed attributes such as
+// data-pattern= or aria-pattern=, which are not HTML form-control patterns and
+// are never compiled by the browser. Dynamic bindings (pattern={expr}) cannot
+// be evaluated statically and are intentionally skipped.
+const PATTERN_ATTR = /(?<![\w-])pattern=(["'])(.*?)\1/g;
+
+interface FoundPattern {
+  file: string;
+  value: string;
+}
+
+function extractPatterns(): FoundPattern[] {
+  const results: FoundPattern[] = [];
+  for (const file of collectSvelteFiles(SRC_DIR)) {
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(PATTERN_ATTR)) {
+      results.push({ file: relative(SRC_DIR, file), value: m[2] });
+    }
+  }
+  return results;
+}
+
+describe('Svelte pattern="" attributes compile under the browser v flag', () => {
+  const patterns = extractPatterns();
+
+  it('finds at least one pattern attribute to validate', () => {
+    // Sanity check so a refactor that hides patterns from the scanner does not
+    // turn this guard into a silent no-op.
+    expect(patterns.length).toBeGreaterThan(0);
+  });
+
+  it.each(patterns.map(p => [p.file, p.value] as const))(
+    '%s: pattern %j is a valid v-flag regex',
+    (file, value) => {
+      // Mirror exactly how the browser compiles a form-control pattern.
+      expect(
+        // eslint-disable-next-line security/detect-non-literal-regexp -- intentional: this test compiles each component's pattern attribute to verify it is a valid v-flag regex
+        () => new RegExp(`^(?:${value})$`, 'v'),
+        `Invalid pattern="${value}" in ${file}. The v flag reserves ( ) [ ] { } / - \\ | inside character classes; escape them (e.g. [^/:] -> [^\\/:]).`
+      ).not.toThrow();
+    }
+  );
+});


### PR DESCRIPTION
## Summary

The Base URL field on the Security settings page used the HTML `pattern` attribute `^https?://[^/:]+.*$`. Browsers compile a form-control `pattern` as `new RegExp("^(?:" + pattern + ")$", "v")`, and under the `v` (unicodeSets) flag, now the default in current Chromium/Safari, `/` is reserved inside a character class. So the attribute threw `Invalid character in character class` at runtime, which made the browser **silently skip that field's native validation** and log a console error.

The fix escapes the slash inside the character class (`[^\/:]`). That is equivalent in both the legacy and `v` regex engines, so the set of accepted Base URLs is unchanged; it just lets native validation run again.

Found while running the Security page in a real browser during QA.

## Changes

- `frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte`: escape `/` in the Base URL `pattern` (`[^/:]` -> `[^\/:]`).
- `frontend/src/test/svelte-pattern-attributes.test.ts` (new): a Vitest guard that scans every `.svelte` static `pattern=` attribute and asserts it compiles the way the browser does (`new RegExp("^(?:" + value + ")$", "v")`), so this whole class of bug fails in CI instead of silently in the field. Includes a sanity check so the scan can't become a silent no-op.

## Test Plan

- [x] New guard test passes (3/3); verified it fails on the pre-fix pattern and passes on the fix.
- [x] Confirmed `[^\/:]` accepts/rejects exactly the same inputs as `[^/:]` (no validation regression).
- [x] `npm run typecheck` (0 errors), `eslint` + `prettier` clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks that scan Svelte source files for static `pattern="..."` attributes and verify each value compiles correctly in the browser’s pattern validation engine.
* **Bug Fixes**
  * Updated the Security settings “Base URL” input pattern validation to use a more compatible pattern form, improving reliability of matching and reserved character handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->