### PR TITLE
feat(inference): native OpenVINO f16 backend for BirdNET v2.4 (opt-in, ARMv8.2/A76)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,15 @@ linters:
     rules:
       - path: frontend/
         text: ".*"
+      # The OpenVINO cgo binding passes Go pointer addresses (&var) into C
+      # output parameters, so go tool cgo emits _cgoCheckPointer(_, 0 == 0)
+      # safety checks. gocritic's dupSubExpr flags that generated "0 == 0" and
+      # maps it back to the source call lines. The finding is in cgo-generated
+      # code, not handwritten code, so it is excluded for this file only.
+      - path: internal/inference/openvino/backend_openvino.go
+        text: "dupSubExpr"
+        linters:
+          - gocritic
   enable:
     # Existing linters
     - copyloopvar

--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -63,6 +63,8 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"BirdNET.Labels":             {categories: []hotReloadCategory{hotReloadRuntime}},
 	"BirdNET.UseXNNPACK":         {categories: []hotReloadCategory{hotReloadFresh}, action: "reload_birdnet"},
 	"BirdNET.ONNXRuntimePath":    {categories: []hotReloadCategory{hotReloadRestart}},
+	"BirdNET.OpenVINOPath":       {categories: []hotReloadCategory{hotReloadRestart}},
+	"BirdNET.Backend":            {categories: []hotReloadCategory{hotReloadFresh}, action: "reload_birdnet"},
 	"BirdNET.Version":            {categories: []hotReloadCategory{hotReloadFresh}, action: "reload_birdnet"},
 
 	// --- Perch ---

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2292,6 +2292,16 @@ func birdnetSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 		return true
 	}
 
+	// Check for changes in BirdNET inference backend preference
+	if oldSettings.BirdNET.Backend != currentSettings.BirdNET.Backend {
+		return true
+	}
+
+	// Check for changes in OpenVINO shared library path
+	if oldSettings.BirdNET.OpenVINOPath != currentSettings.BirdNET.OpenVINOPath {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2292,13 +2292,12 @@ func birdnetSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 		return true
 	}
 
-	// Check for changes in BirdNET inference backend preference
+	// Check for changes in BirdNET inference backend preference. OpenVINOPath is
+	// intentionally NOT checked here: it is restart-required (the OpenVINO core
+	// loads the library once via InitOpenVINO and libopenvino_c cannot be safely
+	// unloaded), so a runtime path change is declared hotReloadRestart, matching
+	// ONNXRuntimePath.
 	if oldSettings.BirdNET.Backend != currentSettings.BirdNET.Backend {
-		return true
-	}
-
-	// Check for changes in OpenVINO shared library path
-	if oldSettings.BirdNET.OpenVINOPath != currentSettings.BirdNET.OpenVINOPath {
 		return true
 	}
 

--- a/internal/api/v2/settings_restart_test.go
+++ b/internal/api/v2/settings_restart_test.go
@@ -159,6 +159,7 @@ func TestHotReloadRestartFieldsCovered(t *testing.T) {
 	// marker yet, with the reason. See docs/superpowers/specs/2026-06-16-restart-required-tracking.md.
 	restartExempt := map[string]string{
 		"BirdNET.ONNXRuntimePath": "model/runtime path; model changes already route through reload_birdnet",
+		"BirdNET.OpenVINOPath":    "OpenVINO library path; loaded once at init and not safely unloadable, so it takes effect on restart (mirrors ONNXRuntimePath)",
 		"Models":                  "model registry path; restart-vs-reload undecided",
 		"Perch":                   "perch model path; not wired",
 		"BSG":                     "BSG model path; not wired",

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -231,12 +231,19 @@ func (bn *BirdNET) usesONNXBackend() bool {
 }
 
 // initializeModel loads and initializes the primary BirdNET model.
-// Dispatches to the ONNX or TFLite backend (see usesONNXBackend).
+// Dispatches to OpenVINO (A76 image, gated), ONNX, or TFLite (see
+// usesONNXBackend / shouldTryOpenVINO). OpenVINO failures fall back to ONNX.
 func (bn *BirdNET) initializeModel() error {
 	if bn.usesONNXBackend() {
+		if bn.shouldTryOpenVINO() {
+			err := bn.initializeOpenVINOModel()
+			if err == nil {
+				return nil
+			}
+			GetLogger().Warn("OpenVINO backend unavailable, falling back to ONNX Runtime", logger.Error(err))
+		}
 		return bn.initializeONNXModel()
 	}
-
 	return bn.initializeTFLiteModel()
 }
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -241,6 +241,9 @@ func (bn *BirdNET) initializeModel() error {
 				return nil
 			}
 			GetLogger().Warn("OpenVINO backend unavailable, falling back to ONNX Runtime", logger.Error(err))
+		} else if bn.Settings.BirdNET.Backend == conf.BackendPrefOpenVINO {
+			GetLogger().Warn("backend is set to 'openvino' but it cannot be used here; using ONNX Runtime",
+				logger.String("reason", "requires the openvino build, an ARMv8.2/A76+ CPU with native f16, and the BirdNET v2.4 model"))
 		}
 		return bn.initializeONNXModel()
 	}

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -26,7 +26,7 @@ func (bn *BirdNET) shouldTryOpenVINO() bool {
 		return false
 	}
 	if bn.ModelInfo.ID != DefaultModelVersion {
-		return false // BirdNET v2.4 only for the PoC
+		return false // Only the BirdNET v2.4 identity is validated for the OpenVINO f16 path.
 	}
 	return cpuspec.HasNativeF16()
 }
@@ -43,7 +43,8 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	modelPath := bn.onnxModelPath()
 	if modelPath == "" {
 		return errors.Newf("OpenVINO classifier model path is empty").
-			Category(errors.CategoryModelInit).Build()
+			Category(errors.CategoryModelInit).
+			Context("model_id", bn.ModelInfo.ID).Build()
 	}
 	rawPath := modelPath
 	modelPath = os.ExpandEnv(modelPath)

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -1,0 +1,76 @@
+package classifier
+
+import (
+	"os"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/cpuspec"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// shouldTryOpenVINO reports whether the OpenVINO f16 backend should be attempted
+// for the primary classifier before falling back to ORT. All of: built with the
+// openvino tag, model is the BirdNET v2.4 identity on the ONNX backend, the CPU
+// has native f16 (ASIMDHP/A76+), and config does not opt out.
+func (bn *BirdNET) shouldTryOpenVINO() bool {
+	if !openvinoBackendAvailable {
+		return false
+	}
+	// Explicit ONNX preference opts out. "openvino" and "auto"/"" still require
+	// the f16 hardware gate below (an explicit opt-in must not bypass it, or a
+	// non-A76 host would SIGILL on f16 kernels) and the supported model.
+	if bn.Settings.BirdNET.Backend == conf.BackendPrefONNX {
+		return false
+	}
+	if bn.ModelInfo.ID != DefaultModelVersion {
+		return false // BirdNET v2.4 only for the PoC
+	}
+	return cpuspec.HasNativeF16()
+}
+
+// initializeOpenVINOModel loads the FP32 ONNX classifier via the OpenVINO
+// backend. Returns a non-nil error on any failure so the caller falls back to
+// ORT; it never panics, so a missing library or unsupported model cannot
+// prevent startup.
+func (bn *BirdNET) initializeOpenVINOModel() error {
+	start := time.Now()
+	log := GetLogger()
+	settings := bn.Settings
+
+	modelPath := bn.onnxModelPath()
+	if modelPath == "" {
+		return errors.Newf("OpenVINO classifier model path is empty").
+			Category(errors.CategoryModelInit).Build()
+	}
+	rawPath := modelPath
+	modelPath = os.ExpandEnv(modelPath)
+	modelPath, err := conf.ExpandTildePath(modelPath)
+	if err != nil {
+		return errors.New(err).Category(errors.CategoryFileIO).Context("path", rawPath).Build()
+	}
+
+	if err := inference.InitOpenVINO(settings.BirdNET.OpenVINOPath); err != nil {
+		return errors.New(err).Category(errors.CategoryModelInit).
+			Context("openvino_path", settings.BirdNET.OpenVINOPath).
+			Timing("openvino-init", time.Since(start)).Build()
+	}
+
+	classifier, err := inference.NewOpenVINOClassifier(modelPath, inference.OpenVINOClassifierOptions{
+		Labels:  settings.BirdNET.Labels,
+		Threads: settings.BirdNET.Threads,
+	})
+	if err != nil {
+		return errors.New(err).Category(errors.CategoryModelInit).
+			ModelContext(modelPath, bn.ModelInfo.ID).
+			Timing("openvino-model-init", time.Since(start)).Build()
+	}
+
+	bn.classifier = classifier
+	log.Info("OpenVINO model initialized",
+		logger.String("model", modelPath),
+		logger.Int("species", classifier.NumSpecies()))
+	return nil
+}

--- a/internal/classifier/openvino_available.go
+++ b/internal/classifier/openvino_available.go
@@ -1,0 +1,7 @@
+//go:build openvino
+
+package classifier
+
+// openvinoBackendAvailable reports whether this build links the OpenVINO
+// backend. True only under the "openvino" build tag (rpi5 image).
+const openvinoBackendAvailable = true

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -1,0 +1,48 @@
+//go:build !openvino
+
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestShouldTryOpenVINO_FalseWithoutTag verifies that without the openvino build
+// tag, shouldTryOpenVINO returns false regardless of config or CPU state.
+func TestShouldTryOpenVINO_FalseWithoutTag(t *testing.T) {
+	t.Parallel()
+	// In the default build openvinoBackendAvailable is false, so the gate must
+	// be false regardless of config/CPU.
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.Settings.BirdNET.Backend = conf.BackendPrefOpenVINO
+	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
+	assert.Equal(t, openvinoBackendAvailable, bn.shouldTryOpenVINO(),
+		"without the openvino tag, shouldTryOpenVINO must be false")
+}
+
+// TestShouldTryOpenVINO_OptOut verifies that Backend="onnx" forces shouldTryOpenVINO
+// to false even if everything else would allow it.
+func TestShouldTryOpenVINO_OptOut(t *testing.T) {
+	t.Parallel()
+	// Backend="onnx" forces OFF even if everything else allows it.
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.Settings.BirdNET.Backend = conf.BackendPrefONNX
+	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
+	assert.False(t, bn.shouldTryOpenVINO())
+}
+
+// TestInitializeModel_FallsBackToORTWithoutOpenVINO verifies the dispatch contract:
+// without the openvino tag, shouldTryOpenVINO is false so initializeModel on an
+// ONNX-backed model goes straight to the ONNX path.
+func TestInitializeModel_FallsBackToORTWithoutOpenVINO(t *testing.T) {
+	t.Parallel()
+	// Without the openvino tag, shouldTryOpenVINO is false, so initializeModel
+	// on an ONNX-backed model must go straight to the ONNX path. We assert the
+	// gate, which is the observable contract in a CI (no-tag) build.
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
+	assert.False(t, bn.shouldTryOpenVINO())
+}

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -19,7 +19,7 @@ func TestShouldTryOpenVINO_FalseWithoutTag(t *testing.T) {
 	bn := &BirdNET{Settings: &conf.Settings{}}
 	bn.Settings.BirdNET.Backend = conf.BackendPrefOpenVINO
 	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
-	assert.Equal(t, openvinoBackendAvailable, bn.shouldTryOpenVINO(),
+	assert.False(t, bn.shouldTryOpenVINO(),
 		"without the openvino tag, shouldTryOpenVINO must be false")
 }
 
@@ -34,10 +34,10 @@ func TestShouldTryOpenVINO_OptOut(t *testing.T) {
 	assert.False(t, bn.shouldTryOpenVINO())
 }
 
-// TestInitializeModel_FallsBackToORTWithoutOpenVINO verifies the dispatch contract:
-// without the openvino tag, shouldTryOpenVINO is false so initializeModel on an
-// ONNX-backed model goes straight to the ONNX path.
-func TestInitializeModel_FallsBackToORTWithoutOpenVINO(t *testing.T) {
+// TestShouldTryOpenVINO_FalseForAutoWithoutTag pins the no-tag gate predicate
+// for the default/auto backend: without the openvino build tag, shouldTryOpenVINO
+// is false even when the model ID and CPU would otherwise qualify.
+func TestShouldTryOpenVINO_FalseForAutoWithoutTag(t *testing.T) {
 	t.Parallel()
 	// Without the openvino tag, shouldTryOpenVINO is false, so initializeModel
 	// on an ONNX-backed model must go straight to the ONNX path. We assert the

--- a/internal/classifier/openvino_gating_openvino_test.go
+++ b/internal/classifier/openvino_gating_openvino_test.go
@@ -1,0 +1,43 @@
+//go:build openvino
+
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/cpuspec"
+)
+
+// TestShouldTryOpenVINO_Tagged_OptOut verifies Backend="onnx" opts out even when the
+// openvino backend is compiled in.
+func TestShouldTryOpenVINO_Tagged_OptOut(t *testing.T) {
+	t.Parallel()
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.Settings.BirdNET.Backend = conf.BackendPrefONNX
+	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
+	assert.False(t, bn.shouldTryOpenVINO(), "Backend=onnx must opt out even with the openvino tag")
+}
+
+// TestShouldTryOpenVINO_Tagged_WrongModel verifies a non-v2.4 model never uses OpenVINO.
+func TestShouldTryOpenVINO_Tagged_WrongModel(t *testing.T) {
+	t.Parallel()
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.Settings.BirdNET.Backend = conf.BackendPrefAuto
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V2.3", Backend: BackendONNX}
+	assert.False(t, bn.shouldTryOpenVINO(), "a non-v2.4 model must not use OpenVINO in the PoC")
+}
+
+// TestShouldTryOpenVINO_Tagged_HardwareGateDecides verifies that with the tag, a
+// supported model, and no opt-out, the native-f16 (ASIMDHP) capability is the final
+// deciding factor: true on ARMv8.2 (rpi5), false elsewhere (amd64). This makes the
+// test robust on any host.
+func TestShouldTryOpenVINO_Tagged_HardwareGateDecides(t *testing.T) {
+	t.Parallel()
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.Settings.BirdNET.Backend = conf.BackendPrefOpenVINO
+	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
+	assert.Equal(t, cpuspec.HasNativeF16(), bn.shouldTryOpenVINO(),
+		"with tag, supported model, and opt-in, the result must equal native-f16 capability")
+}

--- a/internal/classifier/openvino_unavailable.go
+++ b/internal/classifier/openvino_unavailable.go
@@ -1,0 +1,7 @@
+//go:build !openvino
+
+package classifier
+
+// openvinoBackendAvailable reports whether this build links the OpenVINO
+// backend. False for normal builds; the dispatch never attempts OpenVINO.
+const openvinoBackendAvailable = false

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1216,7 +1216,16 @@ type BirdNETConfig struct {
 	Labels             []string            `yaml:"-" json:"-"`                                                 // list of available species labels, runtime value
 	UseXNNPACK         bool                `yaml:"usexnnpack" json:"useXnnpack"`                               // true to use XNNPACK delegate for inference acceleration
 	ONNXRuntimePath    string              `yaml:"onnxruntimepath,omitempty" json:"onnxRuntimePath,omitempty"` // path to ONNX Runtime shared library (required for ONNX models)
+	OpenVINOPath       string              `yaml:"openvinopath,omitempty" json:"openVinoPath,omitempty"`       // path to libopenvino_c shared library (OpenVINO image variants only)
+	Backend            string              `yaml:"backend,omitempty" json:"backend,omitempty"`                 // inference backend preference: "auto" (default), "onnx", or "openvino"
 }
+
+// Inference backend preferences for BirdNET.Backend.
+const (
+	BackendPrefAuto     = "auto"
+	BackendPrefONNX     = "onnx"
+	BackendPrefOpenVINO = "openvino"
+)
 
 // RangeFilterSettings contains settings for the range filter
 type RangeFilterSettings struct {

--- a/internal/conf/config_openvino_test.go
+++ b/internal/conf/config_openvino_test.go
@@ -1,0 +1,16 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBirdNETBackendPreferenceField(t *testing.T) {
+	t.Parallel()
+	var s Settings
+	s.BirdNET.Backend = BackendPrefOpenVINO
+	s.BirdNET.OpenVINOPath = "/usr/lib/libopenvino_c.so"
+	assert.Equal(t, "openvino", s.BirdNET.Backend)
+	assert.Equal(t, "/usr/lib/libopenvino_c.so", s.BirdNET.OpenVINOPath)
+}

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -44,6 +44,13 @@ func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
 		result.Errors = append(result.Errors, "RangeFilter model must be either empty (v2 default), 'latest', 'legacy', or 'v3'")
 	}
 
+	// Backend must be one of the known preference strings when non-empty.
+	// Unknown values fall back safely to auto, so this is a warning, not an error.
+	if cfg.Backend != "" && cfg.Backend != BackendPrefAuto && cfg.Backend != BackendPrefONNX && cfg.Backend != BackendPrefOpenVINO {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("BirdNET backend '%s' is not recognised; must be 'auto', 'onnx', or 'openvino' - will use 'auto'", cfg.Backend))
+	}
+
 	checkRange(&result, cfg.RangeFilter.Threshold, 0, 1, "RangeFilter threshold must be between 0 and 1")
 
 	// Locale validation and normalization (pure transformation)

--- a/internal/cpuspec/fp16_linux_arm64.go
+++ b/internal/cpuspec/fp16_linux_arm64.go
@@ -1,0 +1,15 @@
+//go:build linux && arm64
+
+package cpuspec
+
+import "golang.org/x/sys/cpu"
+
+// HasNativeF16 reports whether the CPU supports native half-precision SIMD
+// (ASIMDHP). True only on ARMv8.2+ cores such as the Cortex-A76 (rpi5). Used to
+// gate the OpenVINO f16 backend so a non-A76 host falls back to ORT instead of
+// executing f16 kernels it cannot decode (SIGILL). golang.org/x/sys/cpu reads
+// the ASIMDHP HWCAP bit at package init; cpu.ARM64.HasASIMDHP is false on
+// ARMv8.0 cores (A53/A72), which lack native f16.
+func HasNativeF16() bool {
+	return cpu.ARM64.HasASIMDHP
+}

--- a/internal/cpuspec/fp16_other.go
+++ b/internal/cpuspec/fp16_other.go
@@ -1,0 +1,7 @@
+//go:build !(linux && arm64)
+
+package cpuspec
+
+// HasNativeF16 reports whether the CPU supports native half-precision SIMD.
+// Off linux/arm64 the OpenVINO f16 path is never used, so this is always false.
+func HasNativeF16() bool { return false }

--- a/internal/cpuspec/fp16_test.go
+++ b/internal/cpuspec/fp16_test.go
@@ -14,6 +14,8 @@ func TestHasNativeF16_NonArm64IsFalse(t *testing.T) {
 	// predicate must be false: OpenVINO f16 is strictly A76+/ARMv8.2.
 	if runtime.GOARCH != "arm64" || runtime.GOOS != "linux" {
 		assert.False(t, HasNativeF16(), "HasNativeF16 must be false off linux/arm64")
+	} else {
+		t.Skip("on linux/arm64 HasNativeF16 depends on CPU HWCAP; no fixed assertion")
 	}
 }
 

--- a/internal/cpuspec/fp16_test.go
+++ b/internal/cpuspec/fp16_test.go
@@ -1,0 +1,24 @@
+// Package cpuspec provides CPU feature detection for BirdNET-Go backend selection.
+package cpuspec
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasNativeF16_NonArm64IsFalse(t *testing.T) {
+	t.Parallel()
+	// On any non-(linux/arm64) build host (e.g. the amd64 CI runner), the
+	// predicate must be false: OpenVINO f16 is strictly A76+/ARMv8.2.
+	if runtime.GOARCH != "arm64" || runtime.GOOS != "linux" {
+		assert.False(t, HasNativeF16(), "HasNativeF16 must be false off linux/arm64")
+	}
+}
+
+func TestHasNativeF16_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+	// Must be safe to call on every platform.
+	_ = HasNativeF16()
+}

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -1,0 +1,101 @@
+package inference
+
+import (
+	"sync"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
+)
+
+var (
+	ovInitMu      sync.Mutex
+	ovInitialized bool
+)
+
+// OpenVINOClassifierOptions configures the OpenVINO species classifier.
+type OpenVINOClassifierOptions struct {
+	Labels        []string // species labels; required (drives NumSpecies)
+	Threads       int      // INFERENCE_NUM_THREADS; 0 = OpenVINO auto-tune
+	PrecisionHint string   // INFERENCE_PRECISION_HINT; "" defaults to f16
+}
+
+type openvinoClassifier struct {
+	c          ov.Classifier
+	numSpecies int
+}
+
+// NewOpenVINOClassifier creates a Classifier backed by the native OpenVINO
+// backend. InitOpenVINO must be called first; if the OpenVINO core is not
+// initialized (or the backend is not compiled in), construction returns
+// ov.ErrOpenVINOUnavailable, which the caller treats as fall back to ORT.
+func NewOpenVINOClassifier(modelPath string, opts OpenVINOClassifierOptions) (Classifier, error) {
+	if len(opts.Labels) == 0 {
+		return nil, errors.Newf("OpenVINO classifier requires labels").Build()
+	}
+	prec := opts.PrecisionHint
+	if prec == "" {
+		prec = ov.DefaultPrecisionHint
+	}
+	threads := opts.Threads
+	if threads < 0 {
+		threads = 0
+	}
+	c, err := ov.NewClassifier(modelPath, ov.Options{PrecisionHint: prec, Threads: threads})
+	if err != nil {
+		return nil, err
+	}
+	return &openvinoClassifier{c: c, numSpecies: len(opts.Labels)}, nil
+}
+
+func (c *openvinoClassifier) Predict(samples []float32) ([]float32, error) {
+	if c.c == nil {
+		return nil, ov.ErrOpenVINOUnavailable
+	}
+	return c.c.PredictRaw(samples)
+}
+
+func (c *openvinoClassifier) NumSpecies() int { return c.numSpecies }
+
+func (c *openvinoClassifier) Close() {
+	if c.c != nil {
+		_ = c.c.Close()
+		c.c = nil
+	}
+}
+
+// InitOpenVINO initializes the OpenVINO runtime (loads libopenvino_c and the
+// process-global core). Safe to call repeatedly; retries after failure for
+// hot-reload recovery. Mirrors InitONNXRuntime.
+func InitOpenVINO(libraryPath string) error {
+	ovInitMu.Lock()
+	defer ovInitMu.Unlock()
+	if ovInitialized {
+		return nil
+	}
+	if err := ov.InitOV(libraryPath); err != nil {
+		return err
+	}
+	ovInitialized = true
+	return nil
+}
+
+// DestroyOpenVINO tears down the OpenVINO core. Call only on shutdown.
+func DestroyOpenVINO() error {
+	ovInitMu.Lock()
+	defer ovInitMu.Unlock()
+	if !ovInitialized {
+		return nil
+	}
+	if err := ov.DestroyOV(); err != nil {
+		return err
+	}
+	ovInitialized = false
+	return nil
+}
+
+// IsOpenVINOInitialized reports whether the OpenVINO core is initialized.
+func IsOpenVINOInitialized() bool {
+	ovInitMu.Lock()
+	defer ovInitMu.Unlock()
+	return ovInitialized
+}

--- a/internal/inference/openvino/backend_openvino.go
+++ b/internal/inference/openvino/backend_openvino.go
@@ -1,0 +1,612 @@
+//go:build openvino
+
+// This file holds the real OpenVINO backend, compiled only under the "openvino"
+// build tag. It ports the validated Phase 0 cgo spike, swapping the spike's
+// link-time linking for a runtime dlopen + dlsym of libopenvino_c. The package
+// links against -ldl only: linking -lopenvino_c at build time would make ld.so
+// abort the process before main() when the library is absent, which would
+// defeat the graceful fallback to the ONNX Runtime backend that this feature
+// depends on. Every OpenVINO function is therefore resolved through a process
+// global symbol table (OVB) and called via fixed-arity static C wrappers so
+// that cgo never calls a C function pointer (or a C variadic function) directly
+// with Go arguments.
+
+package openvino
+
+/*
+#cgo LDFLAGS: -ldl
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <openvino/c/openvino.h>
+
+// Function-pointer typedefs for every OpenVINO C entry point we call. The C
+// header declares these symbols, but we never reference them by name at link
+// time; we resolve each one with dlsym so the binary keeps loading when
+// libopenvino_c is absent.
+typedef ov_status_e (*fn_core_create)(ov_core_t**);
+typedef void        (*fn_core_free)(ov_core_t*);
+typedef ov_status_e (*fn_core_read_model)(const ov_core_t*, const char*, const char*, ov_model_t**);
+typedef ov_status_e (*fn_core_compile_model)(const ov_core_t*, const ov_model_t*, const char*, const size_t, ov_compiled_model_t**, ...);
+typedef void        (*fn_model_free)(ov_model_t*);
+typedef ov_status_e (*fn_model_const_input)(const ov_model_t*, ov_output_const_port_t**);
+typedef ov_status_e (*fn_port_get_partial_shape)(const ov_output_const_port_t*, ov_partial_shape_t*);
+typedef void        (*fn_output_const_port_free)(ov_output_const_port_t*);
+typedef ov_status_e (*fn_partial_shape_create)(const int64_t, const ov_dimension_t*, ov_partial_shape_t*);
+typedef ov_status_e (*fn_model_reshape_single_input)(const ov_model_t*, const ov_partial_shape_t);
+typedef void        (*fn_partial_shape_free)(ov_partial_shape_t*);
+typedef ov_status_e (*fn_compiled_model_create_infer_request)(const ov_compiled_model_t*, ov_infer_request_t**);
+typedef void        (*fn_compiled_model_free)(ov_compiled_model_t*);
+typedef ov_status_e (*fn_shape_create)(const int64_t, const int64_t*, ov_shape_t*);
+typedef ov_status_e (*fn_shape_free)(ov_shape_t*);
+typedef ov_status_e (*fn_tensor_create_from_host_ptr)(const ov_element_type_e, const ov_shape_t, void*, ov_tensor_t**);
+typedef ov_status_e (*fn_tensor_get_size)(const ov_tensor_t*, size_t*);
+typedef ov_status_e (*fn_tensor_data)(const ov_tensor_t*, void**);
+typedef void        (*fn_tensor_free)(ov_tensor_t*);
+typedef ov_status_e (*fn_infer_request_set_input_tensor_by_index)(ov_infer_request_t*, const size_t, const ov_tensor_t*);
+typedef ov_status_e (*fn_infer_request_infer)(ov_infer_request_t*);
+typedef ov_status_e (*fn_infer_request_get_output_tensor_by_index)(const ov_infer_request_t*, const size_t, ov_tensor_t**);
+typedef void        (*fn_infer_request_free)(ov_infer_request_t*);
+typedef const char* (*fn_get_last_err_msg)(void);
+
+// ovbind_t is the process-global table of resolved OpenVINO symbols, filled by
+// ovbind_load(path).
+typedef struct {
+    void* handle;
+    fn_core_create                              core_create;
+    fn_core_free                                core_free;
+    fn_core_read_model                          core_read_model;
+    fn_core_compile_model                       core_compile_model;
+    fn_model_free                               model_free;
+    fn_model_const_input                        model_const_input;
+    fn_port_get_partial_shape                   port_get_partial_shape;
+    fn_output_const_port_free                   output_const_port_free;
+    fn_partial_shape_create                     partial_shape_create;
+    fn_model_reshape_single_input               model_reshape_single_input;
+    fn_partial_shape_free                       partial_shape_free;
+    fn_compiled_model_create_infer_request      compiled_model_create_infer_request;
+    fn_compiled_model_free                      compiled_model_free;
+    fn_shape_create                             shape_create;
+    fn_shape_free                               shape_free;
+    fn_tensor_create_from_host_ptr              tensor_create_from_host_ptr;
+    fn_tensor_get_size                          tensor_get_size;
+    fn_tensor_data                              tensor_data;
+    fn_tensor_free                              tensor_free;
+    fn_infer_request_set_input_tensor_by_index  infer_request_set_input_tensor_by_index;
+    fn_infer_request_infer                      infer_request_infer;
+    fn_infer_request_get_output_tensor_by_index infer_request_get_output_tensor_by_index;
+    fn_infer_request_free                       infer_request_free;
+    fn_get_last_err_msg                         get_last_err_msg;
+} ovbind_t;
+
+static ovbind_t OVB; // process-global resolved symbol table
+
+// _ovbind_errbuf holds a COPY of the dlsym failure message. dlerror() returns a
+// pointer into libdl's own static buffer, which dlclose() overwrites, so the
+// macro copies the string bytes here before dlclose and returns this buffer.
+// memset of OVB does not touch it. It is process-static and written only on the
+// single-threaded InitOV failure path under ovMu, so it needs no locking.
+static char _ovbind_errbuf[256];
+
+// OVBIND_RESOLVE resolves one symbol into OVB. On failure it COPIES the
+// dlerror() string into _ovbind_errbuf FIRST (the pointer dlerror returns is
+// into libdl's static buffer, which dlclose overwrites), then dlcloses the
+// handle and zeroes the ENTIRE OVB table so that OVB.handle is non-NULL if and
+// only if every symbol is resolved. Without this, a partial resolution (e.g. an
+// older libopenvino_c missing a newer symbol) would leave OVB.handle set, and a
+// later InitOV retry would see the handle, skip re-resolution, and later call a
+// NULL function pointer. Returns the copied error string from ovbind_load.
+#define OVBIND_RESOLVE(field, type, name)                                     \
+    do {                                                                      \
+        OVB.field = (type)dlsym(OVB.handle, name);                            \
+        if (!OVB.field) {                                                     \
+            const char* _e = dlerror();                                       \
+            snprintf(_ovbind_errbuf, sizeof(_ovbind_errbuf), "%s",            \
+                     _e ? _e : "dlsym failed");                               \
+            dlclose(OVB.handle);                                              \
+            memset(&OVB, 0, sizeof(OVB));                                     \
+            return _ovbind_errbuf;                                            \
+        }                                                                     \
+    } while (0)
+
+// ovbind_load dlopens libopenvino_c from path (or by soname when empty) with
+// RTLD_NOW | RTLD_GLOBAL. RTLD_GLOBAL lets the OpenVINO core find its plugin
+// shared objects (CPU plugin, tbb) through the standard loader search, exactly
+// as the Python wheel and the spike's LD_LIBRARY_PATH arrangement do. It then
+// resolves every symbol the backend calls. Returns NULL on success, or the
+// first dlerror() string on failure.
+static const char* ovbind_load(const char* path) {
+    if (OVB.handle) {
+        return NULL; // already loaded
+    }
+    OVB.handle = dlopen(path && path[0] ? path : "libopenvino_c.so", RTLD_NOW | RTLD_GLOBAL);
+    if (!OVB.handle) {
+        return dlerror();
+    }
+    OVBIND_RESOLVE(core_create,                              fn_core_create,                              "ov_core_create");
+    OVBIND_RESOLVE(core_free,                                fn_core_free,                                "ov_core_free");
+    OVBIND_RESOLVE(core_read_model,                          fn_core_read_model,                          "ov_core_read_model");
+    OVBIND_RESOLVE(core_compile_model,                       fn_core_compile_model,                       "ov_core_compile_model");
+    OVBIND_RESOLVE(model_free,                               fn_model_free,                               "ov_model_free");
+    OVBIND_RESOLVE(model_const_input,                        fn_model_const_input,                        "ov_model_const_input");
+    OVBIND_RESOLVE(port_get_partial_shape,                   fn_port_get_partial_shape,                   "ov_port_get_partial_shape");
+    OVBIND_RESOLVE(output_const_port_free,                   fn_output_const_port_free,                   "ov_output_const_port_free");
+    OVBIND_RESOLVE(partial_shape_create,                     fn_partial_shape_create,                     "ov_partial_shape_create");
+    OVBIND_RESOLVE(model_reshape_single_input,               fn_model_reshape_single_input,               "ov_model_reshape_single_input");
+    OVBIND_RESOLVE(partial_shape_free,                       fn_partial_shape_free,                       "ov_partial_shape_free");
+    OVBIND_RESOLVE(compiled_model_create_infer_request,      fn_compiled_model_create_infer_request,      "ov_compiled_model_create_infer_request");
+    OVBIND_RESOLVE(compiled_model_free,                      fn_compiled_model_free,                      "ov_compiled_model_free");
+    OVBIND_RESOLVE(shape_create,                             fn_shape_create,                             "ov_shape_create");
+    OVBIND_RESOLVE(shape_free,                               fn_shape_free,                               "ov_shape_free");
+    OVBIND_RESOLVE(tensor_create_from_host_ptr,              fn_tensor_create_from_host_ptr,              "ov_tensor_create_from_host_ptr");
+    OVBIND_RESOLVE(tensor_get_size,                          fn_tensor_get_size,                          "ov_tensor_get_size");
+    OVBIND_RESOLVE(tensor_data,                              fn_tensor_data,                              "ov_tensor_data");
+    OVBIND_RESOLVE(tensor_free,                              fn_tensor_free,                              "ov_tensor_free");
+    OVBIND_RESOLVE(infer_request_set_input_tensor_by_index,  fn_infer_request_set_input_tensor_by_index,  "ov_infer_request_set_input_tensor_by_index");
+    OVBIND_RESOLVE(infer_request_infer,                      fn_infer_request_infer,                      "ov_infer_request_infer");
+    OVBIND_RESOLVE(infer_request_get_output_tensor_by_index, fn_infer_request_get_output_tensor_by_index, "ov_infer_request_get_output_tensor_by_index");
+    OVBIND_RESOLVE(infer_request_free,                       fn_infer_request_free,                       "ov_infer_request_free");
+    OVBIND_RESOLVE(get_last_err_msg,                         fn_get_last_err_msg,                         "ov_get_last_err_msg");
+    return NULL;
+}
+
+// Fixed-arity static wrappers. Go calls these, never an OVB.<fn> pointer
+// directly, so cgo always sees an ordinary C function.
+
+static ov_status_e ovbind_core_create(ov_core_t** core) {
+    return OVB.core_create(core);
+}
+
+static void ovbind_core_free(ov_core_t* core) {
+    OVB.core_free(core);
+}
+
+static ov_status_e ovbind_core_read_model(const ov_core_t* core, const char* model_path, ov_model_t** model) {
+    return OVB.core_read_model(core, model_path, NULL, model);
+}
+
+// ovbind_compile wraps the variadic ov_core_compile_model (cgo cannot call C
+// variadic functions). Ported verbatim from the spike's ovspike_compile: each
+// property is a (key, value) pair, so property_args_size is 2 per pair.
+static ov_status_e ovbind_compile(const ov_core_t* core, const ov_model_t* model,
+                                  const char* dev, const char* prec, const char* nthreads,
+                                  ov_compiled_model_t** out) {
+    if (nthreads != NULL && nthreads[0] != '\0') {
+        return OVB.core_compile_model(core, model, dev, 4, out,
+                                      "INFERENCE_PRECISION_HINT", prec,
+                                      "INFERENCE_NUM_THREADS", nthreads);
+    }
+    return OVB.core_compile_model(core, model, dev, 2, out,
+                                  "INFERENCE_PRECISION_HINT", prec);
+}
+
+static void ovbind_model_free(ov_model_t* model) {
+    OVB.model_free(model);
+}
+
+// OVBIND_RESHAPE_RANK is the expected input rank [batch, samples].
+#define OVBIND_RESHAPE_RANK 2
+// OVBIND_BATCH_DIM_INDEX / OVBIND_SAMPLE_DIM_INDEX index the input dimensions.
+#define OVBIND_BATCH_DIM_INDEX 0
+#define OVBIND_SAMPLE_DIM_INDEX 1
+// OVBIND_ERR_BAD_INPUT_SHAPE is returned when the input is not a rank-2 shape
+// with a static sample dimension. It is deliberately far outside the ov_status_e
+// range (OK..-17, all small negatives) so it cannot collide with a genuine
+// OpenVINO status, letting the Go caller distinguish "bad model shape" from a
+// real reshape failure and report a clear error instead of a stale
+// ov_get_last_err_msg. The model is rejected and the caller falls back to ORT.
+#define OVBIND_ERR_BAD_INPUT_SHAPE (-1000)
+
+// ovbind_reshape_static_batch1 reshapes the model's single input to a static
+// [1, samples] shape and writes the derived sample count to *out_samples. The
+// BirdNET v2.4 model has a dynamic batch dimension, so the partial input shape
+// (not the static shape) must be read; only the sample dimension is static.
+// All ov_partial_shape_t / ov_output_const_port_t handling stays in C so cgo
+// never touches the dynamically allocated dims arrays. Returns OK on success.
+static ov_status_e ovbind_reshape_static_batch1(const ov_model_t* model, int64_t* out_samples) {
+    ov_output_const_port_t* port = NULL;
+    ov_status_e st = OVB.model_const_input(model, &port);
+    if (st != OK) {
+        return st;
+    }
+
+    ov_partial_shape_t ps;
+    st = OVB.port_get_partial_shape(port, &ps);
+    OVB.output_const_port_free(port);
+    if (st != OK) {
+        return st;
+    }
+
+    // Require a static rank of 2 and a static (min == max), positive sample
+    // dimension. ov_rank_t is an ov_dimension_t, so a static rank has min == max.
+    if (ps.rank.min != ps.rank.max || ps.rank.max != OVBIND_RESHAPE_RANK ||
+        ps.dims[OVBIND_SAMPLE_DIM_INDEX].min != ps.dims[OVBIND_SAMPLE_DIM_INDEX].max ||
+        ps.dims[OVBIND_SAMPLE_DIM_INDEX].min <= 0) {
+        OVB.partial_shape_free(&ps);
+        return OVBIND_ERR_BAD_INPUT_SHAPE;
+    }
+    int64_t samples = ps.dims[OVBIND_SAMPLE_DIM_INDEX].max;
+    OVB.partial_shape_free(&ps);
+
+    ov_dimension_t nd[OVBIND_RESHAPE_RANK];
+    nd[OVBIND_BATCH_DIM_INDEX].min = 1;
+    nd[OVBIND_BATCH_DIM_INDEX].max = 1;
+    nd[OVBIND_SAMPLE_DIM_INDEX].min = samples;
+    nd[OVBIND_SAMPLE_DIM_INDEX].max = samples;
+
+    ov_partial_shape_t nps;
+    st = OVB.partial_shape_create(OVBIND_RESHAPE_RANK, nd, &nps);
+    if (st != OK) {
+        return st;
+    }
+    st = OVB.model_reshape_single_input(model, nps);
+    OVB.partial_shape_free(&nps);
+    if (st == OK) {
+        *out_samples = samples;
+    }
+    return st;
+}
+
+static ov_status_e ovbind_compiled_model_create_infer_request(const ov_compiled_model_t* compiled, ov_infer_request_t** req) {
+    return OVB.compiled_model_create_infer_request(compiled, req);
+}
+
+static void ovbind_compiled_model_free(ov_compiled_model_t* compiled) {
+    OVB.compiled_model_free(compiled);
+}
+
+static ov_status_e ovbind_shape_create(const int64_t rank, const int64_t* dims, ov_shape_t* shape) {
+    return OVB.shape_create(rank, dims, shape);
+}
+
+static ov_status_e ovbind_shape_free(ov_shape_t* shape) {
+    return OVB.shape_free(shape);
+}
+
+static ov_status_e ovbind_tensor_create_from_host_ptr(const ov_element_type_e type, const ov_shape_t shape, void* host_ptr, ov_tensor_t** tensor) {
+    return OVB.tensor_create_from_host_ptr(type, shape, host_ptr, tensor);
+}
+
+static ov_status_e ovbind_tensor_get_size(const ov_tensor_t* tensor, size_t* size) {
+    return OVB.tensor_get_size(tensor, size);
+}
+
+static ov_status_e ovbind_tensor_data(const ov_tensor_t* tensor, void** data) {
+    return OVB.tensor_data(tensor, data);
+}
+
+static void ovbind_tensor_free(ov_tensor_t* tensor) {
+    OVB.tensor_free(tensor);
+}
+
+static ov_status_e ovbind_set_input_tensor(ov_infer_request_t* req, const size_t idx, const ov_tensor_t* tensor) {
+    return OVB.infer_request_set_input_tensor_by_index(req, idx, tensor);
+}
+
+static ov_status_e ovbind_infer(ov_infer_request_t* req) {
+    return OVB.infer_request_infer(req);
+}
+
+static ov_status_e ovbind_get_output_tensor(const ov_infer_request_t* req, const size_t idx, ov_tensor_t** tensor) {
+    return OVB.infer_request_get_output_tensor_by_index(req, idx, tensor);
+}
+
+static void ovbind_infer_request_free(ov_infer_request_t* req) {
+    OVB.infer_request_free(req);
+}
+
+static const char* ovbind_get_last_err_msg(void) {
+    return OVB.get_last_err_msg();
+}
+*/
+import "C" //nolint:gocritic // dupImport: cgo import "C" must be separate from regular imports
+
+import "unsafe" //nolint:gocritic // dupImport: false positive with cgo import "C"
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+const (
+	// deviceCPU is the OpenVINO device name the backend targets. ARMv8.2 f16
+	// acceleration runs on the CPU plugin.
+	deviceCPU = "CPU"
+	// inputPortIndex is the index of the single audio input tensor.
+	inputPortIndex = 0
+	// outputPortIndex is the index of the single logits output tensor.
+	outputPortIndex = 0
+	// expectedInputRank is the rank of the model input shape, [batch, samples].
+	expectedInputRank = 2
+	// float32Bytes is the size in bytes of one float32 element.
+	float32Bytes = 4
+)
+
+// ovOK reports whether an OpenVINO status code is success (OK == 0). It is a
+// helper so the success comparison appears once rather than at every call site
+// (and avoids a gocritic dupSubExpr false positive in the cgo-rewritten file).
+func ovOK(status C.ov_status_e) bool {
+	return status == C.OK
+}
+
+var (
+	// ovMu guards the process-global core and its loaded flag. It serializes
+	// InitOV and DestroyOV only; per-classifier inference is unsynchronized and
+	// callers must serialize Classifier access (see the Classifier doc).
+	ovMu sync.Mutex
+	// ovLoaded reports whether the library is loaded and the core is created.
+	ovLoaded bool
+	// ovCore is the process-global ov_core_t shared by all classifiers.
+	ovCore *C.ov_core_t
+)
+
+// lastErr builds an EnhancedError from the OpenVINO status code and the
+// library's last error message, prefixed by the failing operation.
+func lastErr(op string, status C.ov_status_e) error {
+	msg := C.GoString(C.ovbind_get_last_err_msg())
+	return errors.Newf("openvino: %s failed: status=%d: %s", op, int(status), msg).Build()
+}
+
+// InitOV dlopens libopenvino_c (libraryPath, or by soname when empty) and
+// creates the process-global core. It is idempotent and safe to retry after a
+// failure so hot-reload recovery can re-attempt with a corrected path. It
+// mirrors inference.InitONNXRuntime semantics. The core is freed only by
+// DestroyOV, never on a model reload.
+func InitOV(libraryPath string) error {
+	ovMu.Lock()
+	defer ovMu.Unlock()
+	if ovLoaded {
+		return nil
+	}
+
+	cPath := C.CString(libraryPath)
+	defer C.free(unsafe.Pointer(cPath))
+	if msg := C.ovbind_load(cPath); msg != nil {
+		return errors.Newf("openvino: failed to load libopenvino_c: %s", C.GoString(msg)).Build()
+	}
+
+	var core *C.ov_core_t
+	if st := C.ovbind_core_create(&core); !ovOK(st) {
+		return lastErr("ov_core_create", st)
+	}
+	ovCore = core
+	ovLoaded = true
+	return nil
+}
+
+// DestroyOV frees the process-global core and resets state so InitOV can run
+// again. Call it only on application shutdown or a catastrophic re-init, never
+// on a routine model reload (that path uses Classifier.Close). It returns nil
+// when nothing is loaded.
+func DestroyOV() error {
+	ovMu.Lock()
+	defer ovMu.Unlock()
+	if !ovLoaded {
+		return nil
+	}
+	if ovCore != nil {
+		C.ovbind_core_free(ovCore)
+		ovCore = nil
+	}
+	ovLoaded = false
+	// The dlopen handle (OVB.handle) is intentionally NOT dlclosed here: it is
+	// kept open for the process lifetime so the resolved symbol table is reused
+	// if InitOV runs again. Do not add a dlclose here; that would reintroduce a
+	// partial-state inconsistency and break the load invariant.
+	return nil
+}
+
+// classifier holds the per-model OpenVINO state: a compiled model, one infer
+// request, and a C-malloc'd input buffer that OpenVINO may retain across
+// infer() calls (a Go-owned buffer would violate cgo pointer rules). It is NOT
+// goroutine-safe; callers serialize access. The process-global core is shared
+// and is not owned here.
+type classifier struct {
+	model    *C.ov_model_t
+	compiled *C.ov_compiled_model_t
+	req      *C.ov_infer_request_t
+	inBuf    unsafe.Pointer
+	samples  int
+}
+
+// reshapeToStaticBatch1 reshapes the model's single input to a static
+// [1, samples] shape and returns the per-segment sample count. The sample count
+// is read from the model's partial input shape (its sample dimension is static
+// even though the batch dimension is dynamic), so it is derived rather than
+// hardcoded. The reshape mirrors the spike's "key" step: OpenVINO cannot
+// compile or infer a dynamic-batch model without a static input shape. The
+// read-validate-reshape sequence runs atomically in C so cgo never handles the
+// dynamically allocated partial-shape dims.
+func reshapeToStaticBatch1(model *C.ov_model_t) (int, error) {
+	var samples C.int64_t
+	st := C.ovbind_reshape_static_batch1(model, &samples)
+	if ovOK(st) {
+		return int(samples), nil
+	}
+	// A bad input shape is signalled by a distinct out-of-range sentinel rather
+	// than a genuine ov_status_e, so report it directly: the reshape was never
+	// reached and ov_get_last_err_msg would return a stale or empty message.
+	if int(st) == int(C.OVBIND_ERR_BAD_INPUT_SHAPE) {
+		return 0, errors.Newf("openvino: model input is not a static rank-2 shape; cannot reshape for batch-1 inference").
+			Category(errors.CategoryModelInit).Build()
+	}
+	return 0, lastErr("ov_model_reshape_single_input", st)
+}
+
+// NewClassifier reads modelPath, compiles it for the CPU device at
+// opts.PrecisionHint, creates one infer request, and binds a C-owned input
+// tensor sized to the model's input shape. InitOV must have succeeded first;
+// otherwise it returns ErrOpenVINOUnavailable. The returned Classifier is not
+// goroutine-safe.
+func NewClassifier(modelPath string, opts Options) (Classifier, error) {
+	ovMu.Lock()
+	loaded := ovLoaded
+	core := ovCore
+	ovMu.Unlock()
+	if !loaded || core == nil {
+		return nil, ErrOpenVINOUnavailable
+	}
+
+	precision := opts.PrecisionHint
+	if precision == "" {
+		precision = DefaultPrecisionHint
+	}
+	threads := ""
+	if opts.Threads > 0 {
+		threads = strconv.Itoa(opts.Threads)
+	}
+
+	cPath := C.CString(modelPath)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var model *C.ov_model_t
+	if st := C.ovbind_core_read_model(core, cPath, &model); !ovOK(st) {
+		return nil, lastErr("ov_core_read_model", st)
+	}
+
+	// Reshape the input to static [1, samples] before compiling. BirdNET v2.4
+	// has a dynamic batch dimension, which OpenVINO cannot compile or infer.
+	samples, err := reshapeToStaticBatch1(model)
+	if err != nil {
+		C.ovbind_model_free(model)
+		return nil, err
+	}
+
+	cDev := C.CString(deviceCPU)
+	defer C.free(unsafe.Pointer(cDev))
+	cPrec := C.CString(precision)
+	defer C.free(unsafe.Pointer(cPrec))
+	cThreads := C.CString(threads)
+	defer C.free(unsafe.Pointer(cThreads))
+
+	var compiled *C.ov_compiled_model_t
+	if st := C.ovbind_compile(core, model, cDev, cPrec, cThreads, &compiled); !ovOK(st) {
+		C.ovbind_model_free(model)
+		return nil, lastErr("ov_core_compile_model", st)
+	}
+
+	var req *C.ov_infer_request_t
+	if st := C.ovbind_compiled_model_create_infer_request(compiled, &req); !ovOK(st) {
+		C.ovbind_compiled_model_free(compiled)
+		C.ovbind_model_free(model)
+		return nil, lastErr("ov_compiled_model_create_infer_request", st)
+	}
+
+	// Allocate the input buffer in C memory so OpenVINO may retain the pointer
+	// across infer() without violating cgo pointer-passing rules.
+	inBuf := C.malloc(C.size_t(samples) * C.size_t(float32Bytes))
+	if inBuf == nil {
+		C.ovbind_infer_request_free(req)
+		C.ovbind_compiled_model_free(compiled)
+		C.ovbind_model_free(model)
+		return nil, errors.Newf("openvino: failed to allocate %d-sample input buffer", samples).Build()
+	}
+
+	dims := []C.int64_t{1, C.int64_t(samples)}
+	var shape C.ov_shape_t
+	if st := C.ovbind_shape_create(expectedInputRank, &dims[0], &shape); !ovOK(st) {
+		C.free(inBuf)
+		C.ovbind_infer_request_free(req)
+		C.ovbind_compiled_model_free(compiled)
+		C.ovbind_model_free(model)
+		return nil, lastErr("ov_shape_create", st)
+	}
+
+	var inTensor *C.ov_tensor_t
+	if st := C.ovbind_tensor_create_from_host_ptr(C.F32, shape, inBuf, &inTensor); !ovOK(st) {
+		C.ovbind_shape_free(&shape)
+		C.free(inBuf)
+		C.ovbind_infer_request_free(req)
+		C.ovbind_compiled_model_free(compiled)
+		C.ovbind_model_free(model)
+		return nil, lastErr("ov_tensor_create_from_host_ptr", st)
+	}
+	C.ovbind_shape_free(&shape)
+
+	if st := C.ovbind_set_input_tensor(req, inputPortIndex, inTensor); !ovOK(st) {
+		C.ovbind_tensor_free(inTensor)
+		C.free(inBuf)
+		C.ovbind_infer_request_free(req)
+		C.ovbind_compiled_model_free(compiled)
+		C.ovbind_model_free(model)
+		return nil, lastErr("ov_infer_request_set_input_tensor_by_index", st)
+	}
+	// The tensor keeps a reference to inBuf; the wrapper handle itself is no
+	// longer needed once the request holds it.
+	C.ovbind_tensor_free(inTensor)
+
+	return &classifier{
+		model:    model,
+		compiled: compiled,
+		req:      req,
+		inBuf:    inBuf,
+		samples:  samples,
+	}, nil
+}
+
+// PredictRaw copies samples into the C input buffer, runs one inference, and
+// returns a freshly allocated Go slice of the raw output logits. It returns an
+// error if the input length does not match the model's input sample count. Not
+// goroutine-safe.
+func (c *classifier) PredictRaw(samples []float32) ([]float32, error) {
+	if c.req == nil || c.inBuf == nil {
+		return nil, ErrOpenVINOUnavailable
+	}
+	if len(samples) != c.samples {
+		return nil, errors.Newf("openvino: input length %d does not match model input %d", len(samples), c.samples).Build()
+	}
+
+	dst := unsafe.Slice((*float32)(c.inBuf), c.samples)
+	copy(dst, samples)
+
+	if st := C.ovbind_infer(c.req); !ovOK(st) {
+		return nil, lastErr("ov_infer_request_infer", st)
+	}
+
+	var outTensor *C.ov_tensor_t
+	if st := C.ovbind_get_output_tensor(c.req, outputPortIndex, &outTensor); !ovOK(st) {
+		return nil, lastErr("ov_infer_request_get_output_tensor_by_index", st)
+	}
+	defer C.ovbind_tensor_free(outTensor)
+
+	var n C.size_t
+	if st := C.ovbind_tensor_get_size(outTensor, &n); !ovOK(st) {
+		return nil, lastErr("ov_tensor_get_size", st)
+	}
+
+	var dataPtr unsafe.Pointer
+	if st := C.ovbind_tensor_data(outTensor, &dataPtr); !ovOK(st) {
+		return nil, lastErr("ov_tensor_data", st)
+	}
+
+	src := unsafe.Slice((*float32)(dataPtr), int(n))
+	out := make([]float32, int(n))
+	copy(out, src)
+	return out, nil
+}
+
+// Close frees the infer request, compiled model, read model, and the C input
+// buffer, in that order. It does not touch the process-global core. Close is
+// idempotent.
+func (c *classifier) Close() error {
+	if c.req != nil {
+		C.ovbind_infer_request_free(c.req)
+		c.req = nil
+	}
+	if c.compiled != nil {
+		C.ovbind_compiled_model_free(c.compiled)
+		c.compiled = nil
+	}
+	if c.model != nil {
+		C.ovbind_model_free(c.model)
+		c.model = nil
+	}
+	if c.inBuf != nil {
+		C.free(c.inBuf)
+		c.inBuf = nil
+	}
+	return nil
+}

--- a/internal/inference/openvino/backend_openvino.go
+++ b/internal/inference/openvino/backend_openvino.go
@@ -122,7 +122,13 @@ static const char* ovbind_load(const char* path) {
     }
     OVB.handle = dlopen(path && path[0] ? path : "libopenvino_c.so", RTLD_NOW | RTLD_GLOBAL);
     if (!OVB.handle) {
-        return dlerror();
+        // POSIX allows dlerror() to return NULL; copy into the static buffer
+        // with a non-NULL fallback so the Go caller never sees a nil message
+        // and mistakes failure for success (which would call a NULL pointer).
+        const char* e = dlerror();
+        snprintf(_ovbind_errbuf, sizeof(_ovbind_errbuf), "%s",
+                 (e != NULL) ? e : "dlopen failed (no dlerror message)");
+        return _ovbind_errbuf;
     }
     OVBIND_RESOLVE(core_create,                              fn_core_create,                              "ov_core_create");
     OVBIND_RESOLVE(core_free,                                fn_core_free,                                "ov_core_free");
@@ -166,6 +172,11 @@ static ov_status_e ovbind_core_read_model(const ov_core_t* core, const char* mod
     return OVB.core_read_model(core, model_path, NULL, model);
 }
 
+// ov_core_compile_model counts its variadic property args as 2 per property
+// (a key and a value), so the property_args_size is 2 * the number of props.
+#define OVBIND_COMPILE_ARGS_1PROP 2
+#define OVBIND_COMPILE_ARGS_2PROPS 4
+
 // ovbind_compile wraps the variadic ov_core_compile_model (cgo cannot call C
 // variadic functions). Ported verbatim from the spike's ovspike_compile: each
 // property is a (key, value) pair, so property_args_size is 2 per pair.
@@ -173,11 +184,11 @@ static ov_status_e ovbind_compile(const ov_core_t* core, const ov_model_t* model
                                   const char* dev, const char* prec, const char* nthreads,
                                   ov_compiled_model_t** out) {
     if (nthreads != NULL && nthreads[0] != '\0') {
-        return OVB.core_compile_model(core, model, dev, 4, out,
+        return OVB.core_compile_model(core, model, dev, OVBIND_COMPILE_ARGS_2PROPS, out,
                                       "INFERENCE_PRECISION_HINT", prec,
                                       "INFERENCE_NUM_THREADS", nthreads);
     }
-    return OVB.core_compile_model(core, model, dev, 2, out,
+    return OVB.core_compile_model(core, model, dev, OVBIND_COMPILE_ARGS_1PROP, out,
                                   "INFERENCE_PRECISION_HINT", prec);
 }
 
@@ -305,7 +316,9 @@ import "C" //nolint:gocritic // dupImport: cgo import "C" must be separate from 
 import "unsafe" //nolint:gocritic // dupImport: false positive with cgo import "C"
 
 import (
+	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -344,9 +357,16 @@ var (
 )
 
 // lastErr builds an EnhancedError from the OpenVINO status code and the
-// library's last error message, prefixed by the failing operation.
-func lastErr(op string, status C.ov_status_e) error {
+// library's last error message, prefixed by the failing operation. Any
+// scrubPaths (e.g. the model or library path) are redacted from the OpenVINO
+// message so file paths do not leak into errors or telemetry.
+func lastErr(op string, status C.ov_status_e, scrubPaths ...string) error {
 	msg := C.GoString(C.ovbind_get_last_err_msg())
+	for _, p := range scrubPaths {
+		if p != "" {
+			msg = strings.ReplaceAll(msg, p, "<path>")
+		}
+	}
 	return errors.Newf("openvino: %s failed: status=%d: %s", op, int(status), msg).Build()
 }
 
@@ -356,6 +376,11 @@ func lastErr(op string, status C.ov_status_e) error {
 // mirrors inference.InitONNXRuntime semantics. The core is freed only by
 // DestroyOV, never on a model reload.
 func InitOV(libraryPath string) error {
+	// Pin to one OS thread so the dlopen/create call and any ov_get_last_err_msg
+	// fetch (C thread-local storage) run on the same thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ovMu.Lock()
 	defer ovMu.Unlock()
 	if ovLoaded {
@@ -365,7 +390,11 @@ func InitOV(libraryPath string) error {
 	cPath := C.CString(libraryPath)
 	defer C.free(unsafe.Pointer(cPath))
 	if msg := C.ovbind_load(cPath); msg != nil {
-		return errors.Newf("openvino: failed to load libopenvino_c: %s", C.GoString(msg)).Build()
+		errMsg := C.GoString(msg)
+		if libraryPath != "" {
+			errMsg = strings.ReplaceAll(errMsg, libraryPath, "<path>")
+		}
+		return errors.Newf("openvino: failed to load libopenvino_c: %s", errMsg).Build()
 	}
 
 	var core *C.ov_core_t
@@ -401,11 +430,13 @@ func DestroyOV() error {
 
 // classifier holds the per-model OpenVINO state: a compiled model, one infer
 // request, and a C-malloc'd input buffer that OpenVINO may retain across
-// infer() calls (a Go-owned buffer would violate cgo pointer rules). It is NOT
-// goroutine-safe; callers serialize access. The process-global core is shared
-// and is not owned here.
+// infer() calls (a Go-owned buffer would violate cgo pointer rules). The read
+// model (ov_model_t) is freed right after compile, since the compiled model is
+// self-contained and holding the read model would double the per-classifier
+// memory footprint on the memory-constrained rpi5. It is NOT goroutine-safe;
+// callers serialize access. The process-global core is shared and is not owned
+// here.
 type classifier struct {
-	model    *C.ov_model_t
 	compiled *C.ov_compiled_model_t
 	req      *C.ov_infer_request_t
 	inBuf    unsafe.Pointer
@@ -420,7 +451,7 @@ type classifier struct {
 // compile or infer a dynamic-batch model without a static input shape. The
 // read-validate-reshape sequence runs atomically in C so cgo never handles the
 // dynamically allocated partial-shape dims.
-func reshapeToStaticBatch1(model *C.ov_model_t) (int, error) {
+func reshapeToStaticBatch1(model *C.ov_model_t, modelPath string) (int, error) {
 	var samples C.int64_t
 	st := C.ovbind_reshape_static_batch1(model, &samples)
 	if ovOK(st) {
@@ -433,7 +464,7 @@ func reshapeToStaticBatch1(model *C.ov_model_t) (int, error) {
 		return 0, errors.Newf("openvino: model input is not a static rank-2 shape; cannot reshape for batch-1 inference").
 			Category(errors.CategoryModelInit).Build()
 	}
-	return 0, lastErr("ov_model_reshape_single_input", st)
+	return 0, lastErr("ov_model_reshape_single_input", st, modelPath)
 }
 
 // NewClassifier reads modelPath, compiles it for the CPU device at
@@ -442,13 +473,20 @@ func reshapeToStaticBatch1(model *C.ov_model_t) (int, error) {
 // otherwise it returns ErrOpenVINOUnavailable. The returned Classifier is not
 // goroutine-safe.
 func NewClassifier(modelPath string, opts Options) (Classifier, error) {
+	// Pin to one OS thread so every OpenVINO call here and any
+	// ov_get_last_err_msg fetch (C thread-local storage) run on the same thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Hold ovMu for the whole core-using section: a concurrent DestroyOV must not
+	// free ovCore while read_model/compile are running on it. NewClassifier calls
+	// no other function that takes ovMu, so this cannot deadlock.
 	ovMu.Lock()
-	loaded := ovLoaded
-	core := ovCore
-	ovMu.Unlock()
-	if !loaded || core == nil {
+	defer ovMu.Unlock()
+	if !ovLoaded || ovCore == nil {
 		return nil, ErrOpenVINOUnavailable
 	}
+	core := ovCore
 
 	precision := opts.PrecisionHint
 	if precision == "" {
@@ -464,12 +502,12 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 
 	var model *C.ov_model_t
 	if st := C.ovbind_core_read_model(core, cPath, &model); !ovOK(st) {
-		return nil, lastErr("ov_core_read_model", st)
+		return nil, lastErr("ov_core_read_model", st, modelPath)
 	}
 
 	// Reshape the input to static [1, samples] before compiling. BirdNET v2.4
 	// has a dynamic batch dimension, which OpenVINO cannot compile or infer.
-	samples, err := reshapeToStaticBatch1(model)
+	samples, err := reshapeToStaticBatch1(model, modelPath)
 	if err != nil {
 		C.ovbind_model_free(model)
 		return nil, err
@@ -485,14 +523,18 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 	var compiled *C.ov_compiled_model_t
 	if st := C.ovbind_compile(core, model, cDev, cPrec, cThreads, &compiled); !ovOK(st) {
 		C.ovbind_model_free(model)
-		return nil, lastErr("ov_core_compile_model", st)
+		return nil, lastErr("ov_core_compile_model", st, modelPath)
 	}
+	// The compiled model is self-contained; free the read model now to avoid
+	// doubling the per-classifier memory footprint (the create_infer_request
+	// below operates on the compiled model, not the read model).
+	C.ovbind_model_free(model)
+	model = nil
 
 	var req *C.ov_infer_request_t
 	if st := C.ovbind_compiled_model_create_infer_request(compiled, &req); !ovOK(st) {
 		C.ovbind_compiled_model_free(compiled)
-		C.ovbind_model_free(model)
-		return nil, lastErr("ov_compiled_model_create_infer_request", st)
+		return nil, lastErr("ov_compiled_model_create_infer_request", st, modelPath)
 	}
 
 	// Allocate the input buffer in C memory so OpenVINO may retain the pointer
@@ -501,7 +543,6 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 	if inBuf == nil {
 		C.ovbind_infer_request_free(req)
 		C.ovbind_compiled_model_free(compiled)
-		C.ovbind_model_free(model)
 		return nil, errors.Newf("openvino: failed to allocate %d-sample input buffer", samples).Build()
 	}
 
@@ -511,7 +552,6 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 		C.free(inBuf)
 		C.ovbind_infer_request_free(req)
 		C.ovbind_compiled_model_free(compiled)
-		C.ovbind_model_free(model)
 		return nil, lastErr("ov_shape_create", st)
 	}
 
@@ -521,7 +561,6 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 		C.free(inBuf)
 		C.ovbind_infer_request_free(req)
 		C.ovbind_compiled_model_free(compiled)
-		C.ovbind_model_free(model)
 		return nil, lastErr("ov_tensor_create_from_host_ptr", st)
 	}
 	C.ovbind_shape_free(&shape)
@@ -531,7 +570,6 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 		C.free(inBuf)
 		C.ovbind_infer_request_free(req)
 		C.ovbind_compiled_model_free(compiled)
-		C.ovbind_model_free(model)
 		return nil, lastErr("ov_infer_request_set_input_tensor_by_index", st)
 	}
 	// The tensor keeps a reference to inBuf; the wrapper handle itself is no
@@ -539,7 +577,6 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 	C.ovbind_tensor_free(inTensor)
 
 	return &classifier{
-		model:    model,
 		compiled: compiled,
 		req:      req,
 		inBuf:    inBuf,
@@ -552,6 +589,11 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 // error if the input length does not match the model's input sample count. Not
 // goroutine-safe.
 func (c *classifier) PredictRaw(samples []float32) ([]float32, error) {
+	// Pin to one OS thread so the infer call and any ov_get_last_err_msg fetch
+	// (C thread-local storage) run on the same thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if c.req == nil || c.inBuf == nil {
 		return nil, ErrOpenVINOUnavailable
 	}
@@ -581,6 +623,11 @@ func (c *classifier) PredictRaw(samples []float32) ([]float32, error) {
 	if st := C.ovbind_tensor_data(outTensor, &dataPtr); !ovOK(st) {
 		return nil, lastErr("ov_tensor_data", st)
 	}
+	// ov_tensor_data can return OK with a nil buffer; unsafe.Slice on a nil
+	// pointer with n > 0 is undefined behavior, so guard it.
+	if dataPtr == nil {
+		return nil, errors.Newf("openvino: ov_tensor_data returned a nil data pointer").Build()
+	}
 
 	src := unsafe.Slice((*float32)(dataPtr), int(n))
 	out := make([]float32, int(n))
@@ -588,8 +635,9 @@ func (c *classifier) PredictRaw(samples []float32) ([]float32, error) {
 	return out, nil
 }
 
-// Close frees the infer request, compiled model, read model, and the C input
-// buffer, in that order. It does not touch the process-global core. Close is
+// Close frees the infer request, compiled model, and the C input buffer, in
+// that order. The read model was already freed right after compile in
+// NewClassifier. Close does not touch the process-global core. Close is
 // idempotent.
 func (c *classifier) Close() error {
 	if c.req != nil {
@@ -599,10 +647,6 @@ func (c *classifier) Close() error {
 	if c.compiled != nil {
 		C.ovbind_compiled_model_free(c.compiled)
 		c.compiled = nil
-	}
-	if c.model != nil {
-		C.ovbind_model_free(c.model)
-		c.model = nil
 	}
 	if c.inBuf != nil {
 		C.free(c.inBuf)

--- a/internal/inference/openvino/backend_openvino_test.go
+++ b/internal/inference/openvino/backend_openvino_test.go
@@ -1,0 +1,38 @@
+//go:build openvino
+
+package openvino
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Input/output dimensions of the BirdNET v2.4 classifier (named to avoid magic numbers).
+const (
+	birdNETInputSamples  = 144000
+	birdNETOutputClasses = 6522
+)
+
+// TestOpenVINORoundTrip is a hardware/lib-gated smoke test. Set OV_TEST_MODEL to a
+// BirdNET v2.4 FP32 ONNX path to run it; it is skipped otherwise so normal CI (which
+// has no libopenvino_c) stays green. OV_TEST_LIB optionally points at the
+// libopenvino_c shared library; empty searches the standard loader paths.
+func TestOpenVINORoundTrip(t *testing.T) {
+	model := os.Getenv("OV_TEST_MODEL")
+	if model == "" {
+		t.Skip("set OV_TEST_MODEL to a BirdNET v2.4 FP32 ONNX to run the OpenVINO round-trip")
+	}
+	require.NoError(t, InitOV(os.Getenv("OV_TEST_LIB")))
+	t.Cleanup(func() { _ = DestroyOV() })
+
+	c, err := NewClassifier(model, Options{PrecisionHint: DefaultPrecisionHint})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	out, err := c.PredictRaw(make([]float32, birdNETInputSamples))
+	require.NoError(t, err)
+	assert.Len(t, out, birdNETOutputClasses)
+}

--- a/internal/inference/openvino/backend_openvino_test.go
+++ b/internal/inference/openvino/backend_openvino_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +34,7 @@ func TestOpenVINORoundTrip(t *testing.T) {
 
 	out, err := c.PredictRaw(make([]float32, birdNETInputSamples))
 	require.NoError(t, err)
-	assert.Len(t, out, birdNETOutputClasses)
+	require.Len(t, out, birdNETOutputClasses)
 
 	// Outputs are raw pre-activation logits (often negative), so do not assert a
 	// [0,1] range; just sanity-check that the first few are finite (not NaN/Inf).

--- a/internal/inference/openvino/backend_openvino_test.go
+++ b/internal/inference/openvino/backend_openvino_test.go
@@ -3,6 +3,7 @@
 package openvino
 
 import (
+	"math"
 	"os"
 	"testing"
 
@@ -35,4 +36,10 @@ func TestOpenVINORoundTrip(t *testing.T) {
 	out, err := c.PredictRaw(make([]float32, birdNETInputSamples))
 	require.NoError(t, err)
 	assert.Len(t, out, birdNETOutputClasses)
+
+	// Outputs are raw pre-activation logits (often negative), so do not assert a
+	// [0,1] range; just sanity-check that the first few are finite (not NaN/Inf).
+	for i, v := range out[:8] {
+		require.Falsef(t, math.IsNaN(float64(v)) || math.IsInf(float64(v), 0), "out[%d] not finite: %v", i, v)
+	}
 }

--- a/internal/inference/openvino/openvino.go
+++ b/internal/inference/openvino/openvino.go
@@ -18,7 +18,8 @@ const DefaultPrecisionHint = "f16"
 var ErrOpenVINOUnavailable = errors.NewStd("openvino: backend unavailable")
 
 // Classifier runs inference and returns raw pre-activation logits. It is NOT
-// goroutine-safe; callers must serialize access (the classifier holds mu).
+// goroutine-safe; callers must serialize access (BirdNET.mu serializes the full
+// native call; this implementation has no internal mutex).
 type Classifier interface {
 	// PredictRaw runs one inference and returns raw logits in label order.
 	PredictRaw(samples []float32) ([]float32, error)

--- a/internal/inference/openvino/openvino.go
+++ b/internal/inference/openvino/openvino.go
@@ -1,0 +1,36 @@
+// Package openvino provides a native OpenVINO inference backend for BirdNET
+// classification, dynamically loaded from libopenvino_c at runtime. The real
+// implementation is compiled only under the "openvino" build tag; other builds
+// get stubs that report ErrOpenVINOUnavailable so callers degrade to ORT.
+package openvino
+
+import "github.com/tphakala/birdnet-go/internal/errors"
+
+// DefaultPrecisionHint is the OpenVINO INFERENCE_PRECISION_HINT used for the
+// f16 acceleration path on ARMv8.2 CPUs.
+const DefaultPrecisionHint = "f16"
+
+// ErrOpenVINOUnavailable is returned when the OpenVINO backend is not compiled
+// in (no "openvino" build tag) or libopenvino_c cannot be loaded at runtime.
+// Callers treat it as "fall back to ORT". Declared with errors.NewStd (the
+// internal/errors passthrough to stdlib errors.New) so it is a plain sentinel
+// usable with errors.Is.
+var ErrOpenVINOUnavailable = errors.NewStd("openvino: backend unavailable")
+
+// Classifier runs inference and returns raw pre-activation logits. It is NOT
+// goroutine-safe; callers must serialize access (the classifier holds mu).
+type Classifier interface {
+	// PredictRaw runs one inference and returns raw logits in label order.
+	PredictRaw(samples []float32) ([]float32, error)
+	// Close releases the compiled model and infer request. It does not touch
+	// the process-global core (see DestroyOV).
+	Close() error
+}
+
+// Options configures a Classifier.
+type Options struct {
+	// PrecisionHint is the OpenVINO INFERENCE_PRECISION_HINT (e.g. "f16").
+	PrecisionHint string
+	// Threads sets INFERENCE_NUM_THREADS. 0 lets OpenVINO auto-tune.
+	Threads int
+}

--- a/internal/inference/openvino/openvino_stub_test.go
+++ b/internal/inference/openvino/openvino_stub_test.go
@@ -1,0 +1,21 @@
+//go:build !openvino
+
+package openvino
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStub_ReturnsUnavailable(t *testing.T) {
+	t.Parallel()
+	require.ErrorIs(t, InitOV(""), ErrOpenVINOUnavailable)
+
+	c, err := NewClassifier("/nonexistent.onnx", Options{PrecisionHint: "f16"})
+	assert.Nil(t, c)
+	require.ErrorIs(t, err, ErrOpenVINOUnavailable)
+
+	require.ErrorIs(t, DestroyOV(), ErrOpenVINOUnavailable)
+}

--- a/internal/inference/openvino/stub_noopenvino.go
+++ b/internal/inference/openvino/stub_noopenvino.go
@@ -1,0 +1,18 @@
+//go:build !openvino
+
+package openvino
+
+// This file is built when the "openvino" tag is absent. Every entry point
+// reports ErrOpenVINOUnavailable so the classifier falls back to ORT and no
+// libopenvino_c symbol is referenced.
+
+// NewClassifier always fails without the openvino build tag.
+func NewClassifier(_ string, _ Options) (Classifier, error) {
+	return nil, ErrOpenVINOUnavailable
+}
+
+// InitOV always fails without the openvino build tag.
+func InitOV(_ string) error { return ErrOpenVINOUnavailable }
+
+// DestroyOV always fails without the openvino build tag.
+func DestroyOV() error { return ErrOpenVINOUnavailable }

--- a/internal/inference/openvino_test.go
+++ b/internal/inference/openvino_test.go
@@ -20,7 +20,17 @@ func TestNewOpenVINOClassifier_UnavailableWithoutTag(t *testing.T) {
 func TestNewOpenVINOClassifier_RequiresLabels(t *testing.T) {
 	t.Parallel()
 	c, err := NewOpenVINOClassifier("/x.onnx", OpenVINOClassifierOptions{})
-	assert.Nil(t, c)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "requires labels")
+	require.ErrorContains(t, err, "requires labels")
+	assert.Nil(t, c)
+}
+
+// TestInitOpenVINO_GuardWithoutTag verifies that without the openvino build tag,
+// InitOpenVINO returns an error via the stub and does NOT mark the runtime as
+// initialized, leaving DestroyOpenVINO a safe no-op.
+func TestInitOpenVINO_GuardWithoutTag(t *testing.T) {
+	// Do not call t.Parallel: this test touches package-global init state.
+	require.Error(t, InitOpenVINO(""))
+	assert.False(t, IsOpenVINOInitialized())
+	assert.NoError(t, DestroyOpenVINO()) // no-op when never initialized
 }

--- a/internal/inference/openvino_test.go
+++ b/internal/inference/openvino_test.go
@@ -1,0 +1,26 @@
+package inference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
+)
+
+func TestNewOpenVINOClassifier_UnavailableWithoutTag(t *testing.T) {
+	t.Parallel()
+	// In the default (no openvino tag) build, construction must fail with the
+	// sentinel so the classifier dispatch falls back to ORT.
+	c, err := NewOpenVINOClassifier("/x.onnx", OpenVINOClassifierOptions{Labels: []string{"a"}})
+	assert.Nil(t, c)
+	assert.ErrorIs(t, err, ov.ErrOpenVINOUnavailable)
+}
+
+func TestNewOpenVINOClassifier_RequiresLabels(t *testing.T) {
+	t.Parallel()
+	c, err := NewOpenVINOClassifier("/x.onnx", OpenVINOClassifierOptions{})
+	assert.Nil(t, c)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "requires labels")
+}


### PR DESCRIPTION
## Summary

Adds a native OpenVINO f16 inference backend for the BirdNET v2.4 classifier, as an opt-in alternative to the ONNX Runtime CPU path. On ARMv8.2 CPUs with native half-precision (Cortex-A76, e.g. Raspberry Pi 5) it runs the classifier roughly 2x faster than ORT's CPU EP by using OpenVINO's f16 ARM kernels, which ORT cannot use.

The feature lands dark and is opt-in:
- Gated behind the `openvino` build tag. Without the tag the OpenVINO code compiles to a stub and a build-time constant dead-code-eliminates the dispatch branch, so default builds are byte-for-byte unchanged.
- Even with the tag it is only attempted for the BirdNET v2.4 model on a CPU that reports native f16 (ASIMDHP HWCAP), and only when not opted out via config. Anything else uses ONNX Runtime.
- Any failure (library missing, unsupported CPU/model, init error) falls back to ONNX Runtime via a normal error path. It never panics and never blocks startup.

## How it works

The backend mirrors the existing ONNX backend across three layers and implements the same `inference.Classifier` interface:
- `internal/inference/openvino/`: low-level binding that `dlopen`s `libopenvino_c` at runtime (links `-ldl` only, never `-lopenvino_c`, so a missing library degrades gracefully instead of aborting the process before `main`). Process-global core; per-classifier compiled model and infer request.
- `internal/inference/openvino.go`: adapter mirroring `onnx.go`.
- `internal/classifier`: gating (`shouldTryOpenVINO`) plus dispatch wired into `initializeModel` with ONNX fallback.

OpenVINO consumes the same FP32 ONNX model and runs it at f16; ONNX Runtime runs the same file at f32 as the fallback. New hot-reloadable config: `birdnet.openvinopath` and a `birdnet.backend` preference (`auto`/`onnx`/`openvino`). CPU capability detection added in `internal/cpuspec` (`HasNativeF16`, linux/arm64 via `golang.org/x/sys/cpu`).

This is the CPU/ARM half of the OpenVINO interest in #3239; the Intel iGPU / Perch offload path is intentionally out of scope here and left as a follow-up.

## Validation

On a Raspberry Pi 5 (Cortex-A76), BirdNET v2.4 FP32, f16:
- Roughly 2x faster than ONNX Runtime CPU (median ~40 ms vs ~85 ms).
- Output parity with ORT (top-1 match, negligible confidence delta).
- Leak-free over 10,000 iterations (peak RSS flat).
- Graceful fallback to ONNX Runtime confirmed when the library is absent or the CPU lacks f16.

Default (no build tag) builds and the existing ONNX/TFLite paths are unaffected.

## Related

Relates to #3239.

## Test plan

- [x] Default build: `go build ./...` and `go test -race ./internal/...` (OpenVINO inert, ONNX/TFLite unchanged)
- [x] `openvino`-tagged build compiles; gated round-trip test passes on A76 hardware
- [x] Graceful fallback verified (lib absent, non-f16 CPU, non-v2.4 model)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenVINO inference backend with configurable backend selection (**auto**, **onnx**, **openvino**) and an OpenVINO library path setting.
  * When enabled and supported (CPU native f16), the app attempts OpenVINO inference; otherwise it cleanly falls back to ONNX.
  * Improved hot-reload behavior: changing the backend triggers the hot-reload path; OpenVINO path is handled with restart semantics.
* **Tests**
  * Added build-tag aware unit tests for OpenVINO dispatch, availability/unavailable behavior, and hardware f16 gating (plus an OpenVINO smoke test).
* **Chores**
  * Updated lint configuration to exclude a specific OpenVINO-related false positive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->