### PR TITLE
feat(inference): OpenVINO backend for Perch v2 (ARM A76 CPU + Intel iGPU)

### DIFF
--- a/internal/api/v2/hotreload_coverage_test.go
+++ b/internal/api/v2/hotreload_coverage_test.go
@@ -65,6 +65,7 @@ var hotReloadRegistry = map[string]hotReloadEntry{
 	"BirdNET.ONNXRuntimePath":    {categories: []hotReloadCategory{hotReloadRestart}},
 	"BirdNET.OpenVINOPath":       {categories: []hotReloadCategory{hotReloadRestart}},
 	"BirdNET.Backend":            {categories: []hotReloadCategory{hotReloadFresh}, action: "reload_birdnet"},
+	"BirdNET.OpenVINODevice":     {categories: []hotReloadCategory{hotReloadFresh}, action: "reload_birdnet"},
 	"BirdNET.Version":            {categories: []hotReloadCategory{hotReloadFresh}, action: "reload_birdnet"},
 
 	// --- Perch ---

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2301,6 +2301,17 @@ func birdnetSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 		return true
 	}
 
+	// Check for changes in the OpenVINO device preference. Switching CPU<->GPU
+	// recompiles the model on the new device, so a reload is needed; the OpenVINO
+	// core itself stays loaded (only the compiled model and infer request are
+	// rebuilt), so this is hot-reloadable, not restart-required. NOTE: this reload
+	// rebuilds the primary BirdNET classifier; secondary models (e.g. Perch) that
+	// also honor this device preference are rebuilt only on restart (the reload
+	// path reloads the primary model, not the secondary instances).
+	if oldSettings.BirdNET.OpenVINODevice != currentSettings.BirdNET.OpenVINODevice {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -90,6 +90,11 @@ func openVINOCPUAllowed(devicePref string) bool {
 // is idempotent and fast on repeat); a load failure means no usable OV at all.
 func openVINOGPUAvailable(libraryPath string) bool {
 	if err := inference.InitOpenVINO(libraryPath); err != nil {
+		// Surface the load failure: without this, an explicit openvino/gpu opt-in
+		// with a bad OpenVINOPath would silently fall back to ORT carrying only a
+		// generic "not eligible" message, hiding the real library-load cause.
+		GetLogger().Warn("OpenVINO library load failed during device planning; treating GPU as unavailable",
+			logger.Error(err))
 		return false
 	}
 	return inference.OpenVINOHasDevice(inference.OVDeviceGPU)

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -2,6 +2,7 @@ package classifier
 
 import (
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -11,24 +12,115 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// shouldTryOpenVINO reports whether the OpenVINO f16 backend should be attempted
-// for the primary classifier before falling back to ORT. All of: built with the
-// openvino tag, model is the BirdNET v2.4 identity on the ONNX backend, the CPU
-// has native f16 (ASIMDHP/A76+), and config does not opt out.
-func (bn *BirdNET) shouldTryOpenVINO() bool {
+// birdnetLogitsOutputIndex is the output port index of the BirdNET v2.4 logits
+// (a single-output graph). Perch v2 uses a different index (see perchLogitsOutputIndex).
+const birdnetLogitsOutputIndex = 0
+
+// openVINOPlan describes how a model should run on the OpenVINO backend.
+type openVINOPlan struct {
+	device      string // inference.OVDeviceCPU or inference.OVDeviceGPU
+	outputIndex int    // logits output port index
+}
+
+// openVINOPlanFor decides whether and how to run a model on the OpenVINO backend,
+// returning the plan and true when OV should be attempted, or false to use ORT.
+//
+//   - backendPref:  settings.BirdNET.Backend ("auto"/"onnx"/"openvino").
+//   - devicePref:   settings.BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu").
+//   - modelID:      the model registry identity (drives the GPU fence).
+//   - libraryPath:  settings.BirdNET.OpenVINOPath (libopenvino_c location).
+//   - outputIndex:  the logits output port for this model.
+//
+// BirdNET v2.4 is fenced off the GPU this release (only Perch may target the Intel
+// iGPU). cpuspec.HasNativeF16() is true only on ARMv8.2+ (A76), which keeps amd64
+// CPU out of the auto path (a non-win); an explicit "cpu" device is still allowed
+// on amd64 for benchmarking/advanced use. The plan helper loads the OpenVINO core
+// (idempotent) only when it must enumerate devices for a GPU decision, so it is
+// independent of caller ordering.
+func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outputIndex int) (openVINOPlan, bool) {
 	if !openvinoBackendAvailable {
+		return openVINOPlan{}, false
+	}
+	if backendPref == conf.BackendPrefONNX {
+		return openVINOPlan{}, false
+	}
+
+	allowGPU := modelID != DefaultModelVersion // BirdNET v2.4 stays CPU-only.
+
+	var device string
+	switch devicePref {
+	case conf.OVDeviceGPU:
+		if !allowGPU || !openVINOGPUAvailable(libraryPath) {
+			return openVINOPlan{}, false
+		}
+		device = inference.OVDeviceGPU
+	case conf.OVDeviceCPU:
+		if !openVINOCPUAllowed(devicePref) {
+			return openVINOPlan{}, false
+		}
+		device = inference.OVDeviceCPU
+	default: // "auto" or ""
+		switch {
+		case allowGPU && openVINOGPUAvailable(libraryPath):
+			device = inference.OVDeviceGPU
+		case openVINOCPUAllowed(devicePref):
+			device = inference.OVDeviceCPU
+		default:
+			return openVINOPlan{}, false
+		}
+	}
+
+	return openVINOPlan{device: device, outputIndex: outputIndex}, true
+}
+
+// openVINOCPUAllowed reports whether the OpenVINO CPU device may be used. The f16
+// CPU kernels are safe only on ARMv8.2+ (HasNativeF16); on ARMv8.0 (A72) they
+// would SIGILL, so the CPU path is rejected there. An explicit "cpu" preference
+// on amd64 is allowed without the ARM f16 gate because the x86 CPU plugin is
+// SIGILL-safe; auto never reaches this on amd64 (HasNativeF16 is false there).
+func openVINOCPUAllowed(devicePref string) bool {
+	if cpuspec.HasNativeF16() {
+		return true
+	}
+	return devicePref == conf.OVDeviceCPU && runtime.GOARCH == "amd64"
+}
+
+// openVINOGPUAvailable reports whether an OpenVINO GPU device (Intel iGPU/dGPU via
+// the Intel GPU plugin) is present. It loads the OpenVINO core first (InitOpenVINO
+// is idempotent and fast on repeat); a load failure means no usable OV at all.
+func openVINOGPUAvailable(libraryPath string) bool {
+	if err := inference.InitOpenVINO(libraryPath); err != nil {
 		return false
 	}
-	// Explicit ONNX preference opts out. "openvino" and "auto"/"" still require
-	// the f16 hardware gate below (an explicit opt-in must not bypass it, or a
-	// non-A76 host would SIGILL on f16 kernels) and the supported model.
-	if bn.Settings.BirdNET.Backend == conf.BackendPrefONNX {
-		return false
-	}
+	return inference.OpenVINOHasDevice(inference.OVDeviceGPU)
+}
+
+// openVINOPlan returns the OpenVINO plan for the primary BirdNET classifier, or
+// false to use ORT. The primary classifier path applies sigmoid post-processing,
+// so only the BirdNET v2.4 identity is valid here; Perch (softmax) runs its own
+// OpenVINO path in the Perch ModelInstance (perch_onnx.go), never through this
+// primary path. The plan also carries the device (CPU/GPU) and logits output index.
+func (bn *BirdNET) openVINOPlan() (openVINOPlan, bool) {
 	if bn.ModelInfo.ID != DefaultModelVersion {
-		return false // Only the BirdNET v2.4 identity is validated for the OpenVINO f16 path.
+		return openVINOPlan{}, false
 	}
-	return cpuspec.HasNativeF16()
+	return openVINOPlanFor(
+		bn.Settings.BirdNET.Backend,
+		bn.Settings.BirdNET.OpenVINODevice,
+		bn.ModelInfo.ID,
+		bn.Settings.BirdNET.OpenVINOPath,
+		birdnetLogitsOutputIndex,
+	)
+}
+
+// shouldTryOpenVINO reports whether the OpenVINO backend should be attempted for
+// the primary classifier before falling back to ORT. True only when built with
+// the openvino tag, the model is the BirdNET v2.4 identity, config does not opt
+// out, and a supported device is available (ARM A76 f16 CPU; the GPU is fenced
+// off for BirdNET this release).
+func (bn *BirdNET) shouldTryOpenVINO() bool {
+	_, ok := bn.openVINOPlan()
+	return ok
 }
 
 // initializeOpenVINOModel loads the FP32 ONNX classifier via the OpenVINO
@@ -39,6 +131,13 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	start := time.Now()
 	log := GetLogger()
 	settings := bn.Settings
+
+	plan, ok := bn.openVINOPlan()
+	if !ok {
+		return errors.Newf("OpenVINO is not eligible for this model or host").
+			Category(errors.CategoryModelInit).
+			Context("model_id", bn.ModelInfo.ID).Build()
+	}
 
 	modelPath := bn.onnxModelPath()
 	if modelPath == "" {
@@ -60,8 +159,10 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	}
 
 	classifier, err := inference.NewOpenVINOClassifier(modelPath, inference.OpenVINOClassifierOptions{
-		Labels:  settings.BirdNET.Labels,
-		Threads: settings.BirdNET.Threads,
+		Labels:      settings.BirdNET.Labels,
+		Threads:     settings.BirdNET.Threads,
+		Device:      plan.device,
+		OutputIndex: plan.outputIndex,
 	})
 	if err != nil {
 		return errors.New(err).Category(errors.CategoryModelInit).
@@ -72,6 +173,8 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	bn.classifier = classifier
 	log.Info("OpenVINO model initialized",
 		logger.String("model", modelPath),
-		logger.Int("species", classifier.NumSpecies()))
+		logger.String("device", plan.device),
+		logger.Int("species", classifier.NumSpecies()),
+		logger.String("init_time", time.Since(start).String()))
 	return nil
 }

--- a/internal/classifier/openvino_gating_openvino_test.go
+++ b/internal/classifier/openvino_gating_openvino_test.go
@@ -3,11 +3,13 @@
 package classifier
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/cpuspec"
+	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
 // TestShouldTryOpenVINO_Tagged_OptOut verifies Backend="onnx" opts out even when the
@@ -40,4 +42,41 @@ func TestShouldTryOpenVINO_Tagged_HardwareGateDecides(t *testing.T) {
 	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
 	assert.Equal(t, cpuspec.HasNativeF16(), bn.shouldTryOpenVINO(),
 		"with tag, supported model, and opt-in, the result must equal native-f16 capability")
+}
+
+// TestOpenVINOPlan_BirdNETFencedOffGPU verifies BirdNET v2.4 never targets the
+// GPU: an explicit device=gpu yields no plan, and an auto plan (when produced)
+// is always the CPU device. These cases never enumerate devices (the GPU branch
+// short-circuits on the BirdNET fence), so the test needs no libopenvino_c.
+func TestOpenVINOPlan_BirdNETFencedOffGPU(t *testing.T) {
+	t.Parallel()
+	_, ok := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceGPU, DefaultModelVersion, "", birdnetLogitsOutputIndex)
+	assert.False(t, ok, "BirdNET v2.4 + device=gpu must not produce a plan (GPU is fenced off)")
+
+	if plan, ok := openVINOPlanFor(conf.BackendPrefAuto, conf.OVDeviceAuto, DefaultModelVersion, "", birdnetLogitsOutputIndex); ok {
+		assert.Equal(t, inference.OVDeviceCPU, plan.device, "BirdNET auto plan must be CPU, never GPU")
+	}
+}
+
+// TestOpenVINOPlan_ExplicitCPU verifies the explicit CPU device gate: allowed on
+// ARMv8.2 (HasNativeF16) and on amd64 (x86 OV CPU is SIGILL-safe), rejected on
+// ARMv8.0 (A72). It carries the requested output index through. The explicit-CPU
+// path never enumerates devices, so no libopenvino_c is required.
+func TestOpenVINOPlan_ExplicitCPU(t *testing.T) {
+	t.Parallel()
+	plan, ok := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceCPU, RegistryIDPerchV2, "", perchLogitsOutputIndex)
+	expected := cpuspec.HasNativeF16() || runtime.GOARCH == "amd64"
+	assert.Equal(t, expected, ok, "explicit CPU is allowed on ARM A76 or amd64, not on ARM A72")
+	if ok {
+		assert.Equal(t, inference.OVDeviceCPU, plan.device)
+		assert.Equal(t, perchLogitsOutputIndex, plan.outputIndex)
+	}
+}
+
+// TestOpenVINOPlan_ONNXOptOut verifies Backend=onnx opts out for any model,
+// including Perch, without touching the OpenVINO library.
+func TestOpenVINOPlan_ONNXOptOut(t *testing.T) {
+	t.Parallel()
+	_, ok := openVINOPlanFor(conf.BackendPrefONNX, conf.OVDeviceAuto, RegistryIDPerchV2, "", perchLogitsOutputIndex)
+	assert.False(t, ok, "Backend=onnx must opt out of OpenVINO for Perch too")
 }

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -39,9 +39,12 @@ func (o *Orchestrator) loadPerch(threads int) error {
 		LabelPath:       labelPath,
 		ONNXRuntimePath: o.Settings.BirdNET.ONNXRuntimePath,
 		Threads:         threads,
+		Backend:         o.Settings.BirdNET.Backend,
+		OpenVINOPath:    o.Settings.BirdNET.OpenVINOPath,
+		OpenVINODevice:  o.Settings.BirdNET.OpenVINODevice,
 	}
 
-	perch, err := NewPerch(cfg)
+	perch, err := NewPerch(&cfg)
 	if err != nil {
 		return errors.New(err).
 			Component("classifier.orchestrator").

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +16,16 @@ import (
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// perchLogitsOutputIndex is the output port index of the Perch v2 species logits.
+// Perch v2 is a multi-output graph: embedding[1536] at index 0, then
+// spatial_embedding, spectrogram, and the label logits[14795] at index 3. This
+// matches the ORT path's LogitsIndex for Perch (internal/inference/onnx
+// detection.go). If a future Perch graph reorders its outputs, the OpenVINO
+// classifier's NumClasses-vs-label-count check (NewOpenVINOClassifier) catches the
+// mismatch at load and falls back to ORT, so a stale index degrades safely rather
+// than silently returning the wrong tensor.
+const perchLogitsOutputIndex = 3
 
 // Perch represents a loaded Google Perch v2 model.
 // Implements ModelInstance. Goroutine-safe via internal mutex.
@@ -30,10 +42,17 @@ type PerchConfig struct {
 	LabelPath       string // Path to the Perch v2 label file
 	ONNXRuntimePath string // Path to ONNX Runtime shared library
 	Threads         int    // CPU threads for inference (0 = default)
+
+	// OpenVINO opt-in, sourced from BirdNET settings. When the configured model is
+	// the no_dft Perch variant and the gate allows it, Perch runs on OpenVINO
+	// (ARM A76 f16 CPU or Intel iGPU); any failure falls back to ORT.
+	Backend        string // BirdNET.Backend ("auto"/"onnx"/"openvino")
+	OpenVINOPath   string // BirdNET.OpenVINOPath (libopenvino_c location)
+	OpenVINODevice string // BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu")
 }
 
 // NewPerch creates a new Perch v2 model instance.
-func NewPerch(cfg PerchConfig) (*Perch, error) {
+func NewPerch(cfg *PerchConfig) (*Perch, error) {
 	log := GetLogger()
 
 	// Load and parse labels
@@ -59,25 +78,32 @@ func NewPerch(cfg PerchConfig) (*Perch, error) {
 			Build()
 	}
 
-	// Initialize ONNX Runtime
-	if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
-		return nil, errors.New(err).
-			Category(errors.CategoryModelInit).
-			Context("onnx_runtime_path", cfg.ONNXRuntimePath).
-			Build()
-	}
+	// Prefer the OpenVINO backend when eligible (Perch no_dft model + gate),
+	// falling back to ORT on any failure. OpenVINO must never make Perch fail to
+	// load, so tryPerchOpenVINO logs and swallows OV errors and returns ok=false.
+	classifier, ok := tryPerchOpenVINO(cfg, labels)
+	if !ok {
+		// Initialize ONNX Runtime
+		if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
+			return nil, errors.New(err).
+				Category(errors.CategoryModelInit).
+				Context("onnx_runtime_path", cfg.ONNXRuntimePath).
+				Build()
+		}
 
-	// Create ONNX classifier
-	classifier, err := inference.NewONNXClassifier(cfg.ModelPath, inference.ONNXClassifierOptions{
-		Labels:  labels,
-		Threads: cfg.Threads,
-	})
-	if err != nil {
-		return nil, errors.New(err).
-			Category(errors.CategoryModelInit).
-			Context("model_path", cfg.ModelPath).
-			Context("label_count", len(labels)).
-			Build()
+		// Create ONNX classifier
+		var cerr error
+		classifier, cerr = inference.NewONNXClassifier(cfg.ModelPath, inference.ONNXClassifierOptions{
+			Labels:  labels,
+			Threads: cfg.Threads,
+		})
+		if cerr != nil {
+			return nil, errors.New(cerr).
+				Category(errors.CategoryModelInit).
+				Context("model_path", cfg.ModelPath).
+				Context("label_count", len(labels)).
+				Build()
+		}
 	}
 
 	info := ModelInfo{
@@ -97,6 +123,59 @@ func NewPerch(cfg PerchConfig) (*Perch, error) {
 		labels:     labels,
 		info:       info,
 	}, nil
+}
+
+// tryPerchOpenVINO attempts to build an OpenVINO classifier for Perch v2. It
+// returns (classifier, true) on success or (nil, false) to fall back to ORT.
+// Any failure (ineligible model, gate denied, init/compile/validation error) is
+// logged and swallowed: OpenVINO must never make Perch fail to load. OV is only
+// attempted for the no_dft model variant, since the stock perch_v2.onnx cannot
+// compile on OpenVINO (a dynamic-rank DFT op).
+func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, bool) {
+	if !isPerchNoDFT(cfg.ModelPath) {
+		return nil, false
+	}
+	plan, ok := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDPerchV2, cfg.OpenVINOPath, perchLogitsOutputIndex)
+	if !ok {
+		return nil, false
+	}
+
+	log := GetLogger()
+	// InitOpenVINO is idempotent: the auto/GPU plan above may already have loaded the
+	// core to enumerate devices, but the explicit-CPU plan path does not, so init
+	// here to cover it. A load failure means no usable OpenVINO; fall back to ORT.
+	if err := inference.InitOpenVINO(cfg.OpenVINOPath); err != nil {
+		log.Warn("Perch OpenVINO init failed; using ONNX Runtime", logger.Error(err))
+		return nil, false
+	}
+
+	start := time.Now()
+	classifier, err := inference.NewOpenVINOClassifier(cfg.ModelPath, inference.OpenVINOClassifierOptions{
+		Labels:      labels,
+		Threads:     cfg.Threads,
+		Device:      plan.device,
+		OutputIndex: plan.outputIndex,
+	})
+	if err != nil {
+		log.Warn("Perch OpenVINO classifier init failed; using ONNX Runtime",
+			logger.String("device", plan.device),
+			logger.Error(err))
+		return nil, false
+	}
+
+	log.Info("Perch v2 model using OpenVINO backend",
+		logger.String("device", plan.device),
+		logger.Int("species", classifier.NumSpecies()),
+		logger.String("init_time", time.Since(start).String()))
+	return classifier, true
+}
+
+// isPerchNoDFT reports whether the model file is the OpenVINO-compatible Perch
+// no_dft variant. The model gallery does not yet ship a distinct identity for it,
+// so it is detected by filename (contains "no_dft" or "no-dft").
+func isPerchNoDFT(modelPath string) bool {
+	base := strings.ToLower(filepath.Base(modelPath))
+	return strings.Contains(base, "no_dft") || strings.Contains(base, "no-dft")
 }
 
 // Predict runs inference on the given audio samples.

--- a/internal/classifier/perch_openvino_functional_test.go
+++ b/internal/classifier/perch_openvino_functional_test.go
@@ -1,0 +1,66 @@
+//go:build openvino
+
+package classifier
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/inference"
+)
+
+// perchInputSampleCount is the Perch v2 input length (32 kHz * 5 s).
+const perchInputSampleCount = 160000
+
+// TestPerchOpenVINO_Functional is a hardware/lib/model-gated test that builds a
+// Perch v2 classifier on the OpenVINO backend through the same tryPerchOpenVINO
+// path NewPerch uses, then runs one inference. Set OV_TEST_PERCH_MODEL (a
+// perch_v2_no_dft ONNX) and OV_TEST_PERCH_LABELS to run it; OV_TEST_DEVICE picks
+// "auto" (default), "cpu", or "gpu", and OV_TEST_LIB optionally points at
+// libopenvino_c. It is skipped otherwise so normal CI stays green.
+//
+// It proves the end-to-end Perch OV path: the no_dft gate, device selection, the
+// index-3 logits output, and the #1112 fix (NumSpecies reflects the real model
+// output dimension, so it equals the label count rather than echoing it).
+func TestPerchOpenVINO_Functional(t *testing.T) {
+	model := os.Getenv("OV_TEST_PERCH_MODEL")
+	labelPath := os.Getenv("OV_TEST_PERCH_LABELS")
+	if model == "" || labelPath == "" {
+		t.Skip("set OV_TEST_PERCH_MODEL and OV_TEST_PERCH_LABELS to run the Perch OpenVINO functional test")
+	}
+
+	labelData, err := os.ReadFile(labelPath)
+	require.NoError(t, err)
+	labels, err := ParsePerchLabels(labelData)
+	require.NoError(t, err)
+	require.NotEmpty(t, labels)
+
+	device := os.Getenv("OV_TEST_DEVICE")
+	if device == "" {
+		device = conf.OVDeviceAuto
+	}
+
+	cfg := PerchConfig{
+		ModelPath:      model,
+		LabelPath:      labelPath,
+		OpenVINOPath:   os.Getenv("OV_TEST_LIB"),
+		Backend:        conf.BackendPrefOpenVINO,
+		OpenVINODevice: device,
+	}
+	t.Cleanup(func() { _ = inference.DestroyOpenVINO() })
+
+	c, ok := tryPerchOpenVINO(&cfg, labels)
+	require.True(t, ok, "Perch OpenVINO classifier must be created for the no_dft model")
+	require.NotNil(t, c)
+	t.Cleanup(func() { c.Close() })
+
+	// #1112: NumSpecies must reflect the real model output dimension (== label
+	// count), not merely echo len(labels).
+	require.Equal(t, len(labels), c.NumSpecies())
+
+	logits, err := c.Predict(make([]float32, perchInputSampleCount))
+	require.NoError(t, err)
+	require.Len(t, logits, len(labels), "Perch OV must return the index-3 logits, one per label")
+}

--- a/internal/classifier/perch_openvino_test.go
+++ b/internal/classifier/perch_openvino_test.go
@@ -1,0 +1,45 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestIsPerchNoDFT pins the filename-based detection of the OpenVINO-compatible
+// Perch no_dft model variant. Stock perch_v2.onnx (and any other file) must not
+// match, since only no_dft compiles on OpenVINO.
+func TestIsPerchNoDFT(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/models/perch_v2_no_dft.onnx", true},
+		{"/models/perch_v2_no-dft.onnx", true},
+		{"perch_v2_NO_DFT.onnx", true}, // case-insensitive
+		{"/data/Perch-No-DFT.onnx", true},
+		{"/models/perch_v2.onnx", false},
+		{"/models/birdnet-v24.onnx", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, isPerchNoDFT(tc.path), "isPerchNoDFT(%q)", tc.path)
+	}
+}
+
+// TestTryPerchOpenVINO_StockModelFallsBack verifies that a stock (non-no_dft)
+// Perch model never attempts OpenVINO and falls back to ORT, regardless of build
+// tag or host. The isPerchNoDFT gate short-circuits before any library load, so
+// this is deterministic everywhere (no libopenvino_c required).
+func TestTryPerchOpenVINO_StockModelFallsBack(t *testing.T) {
+	t.Parallel()
+	c, ok := tryPerchOpenVINO(&PerchConfig{
+		ModelPath:      "/models/perch_v2.onnx",
+		Backend:        conf.BackendPrefOpenVINO,
+		OpenVINODevice: conf.OVDeviceAuto,
+	}, []string{"a", "b"})
+	assert.False(t, ok, "stock perch_v2 must not use OpenVINO")
+	assert.Nil(t, c)
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1218,6 +1218,7 @@ type BirdNETConfig struct {
 	ONNXRuntimePath    string              `yaml:"onnxruntimepath,omitempty" json:"onnxRuntimePath,omitempty"` // path to ONNX Runtime shared library (required for ONNX models)
 	OpenVINOPath       string              `yaml:"openvinopath,omitempty" json:"openVinoPath,omitempty"`       // path to libopenvino_c shared library (OpenVINO image variants only)
 	Backend            string              `yaml:"backend,omitempty" json:"backend,omitempty"`                 // inference backend preference: "auto" (default), "onnx", or "openvino"
+	OpenVINODevice     string              `yaml:"openvinodevice,omitempty" json:"openVinoDevice,omitempty"`   // OpenVINO device preference: "auto" (default), "cpu", or "gpu"
 }
 
 // Inference backend preferences for BirdNET.Backend.
@@ -1225,6 +1226,15 @@ const (
 	BackendPrefAuto     = "auto"
 	BackendPrefONNX     = "onnx"
 	BackendPrefOpenVINO = "openvino"
+)
+
+// OpenVINO device preferences for BirdNET.OpenVINODevice. "auto" picks the GPU
+// (Intel iGPU) when present for eligible models, else the f16 CPU path; "cpu"
+// and "gpu" force a device. An empty string is treated as "auto".
+const (
+	OVDeviceAuto = "auto"
+	OVDeviceCPU  = "cpu"
+	OVDeviceGPU  = "gpu"
 )
 
 // RangeFilterSettings contains settings for the range filter

--- a/internal/conf/config_openvino_test.go
+++ b/internal/conf/config_openvino_test.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,4 +14,36 @@ func TestBirdNETBackendPreferenceField(t *testing.T) {
 	s.BirdNET.OpenVINOPath = "/usr/lib/libopenvino_c.so"
 	assert.Equal(t, "openvino", s.BirdNET.Backend)
 	assert.Equal(t, "/usr/lib/libopenvino_c.so", s.BirdNET.OpenVINOPath)
+}
+
+func TestBirdNETOpenVINODeviceField(t *testing.T) {
+	t.Parallel()
+	var s Settings
+	s.BirdNET.OpenVINODevice = OVDeviceGPU
+	assert.Equal(t, "gpu", s.BirdNET.OpenVINODevice)
+}
+
+// TestValidateOpenVINODevice verifies that known device preferences are accepted
+// and an unknown value produces a (non-fatal) warning that falls back to auto.
+func TestValidateOpenVINODevice(t *testing.T) {
+	t.Parallel()
+	hasDeviceWarning := func(r ValidationResult) bool {
+		for _, w := range r.Warnings {
+			if strings.Contains(w, "openvinodevice") {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, dev := range []string{"", OVDeviceAuto, OVDeviceCPU, OVDeviceGPU} {
+		cfg := &BirdNETConfig{OpenVINODevice: dev}
+		assert.Falsef(t, hasDeviceWarning(ValidateBirdNETSettings(cfg)),
+			"device %q must be accepted without a warning", dev)
+	}
+
+	cfg := &BirdNETConfig{OpenVINODevice: "tpu"}
+	res := ValidateBirdNETSettings(cfg)
+	assert.True(t, hasDeviceWarning(res), "an unknown openvinodevice must warn")
+	assert.True(t, res.Valid, "an unknown openvinodevice must not invalidate the config")
 }

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -51,6 +51,13 @@ func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
 			fmt.Sprintf("BirdNET backend '%s' is not recognised; must be 'auto', 'onnx', or 'openvino' - will use 'auto'", cfg.Backend))
 	}
 
+	// OpenVINODevice must be one of the known device strings when non-empty.
+	// Unknown values fall back safely to auto, so this is a warning, not an error.
+	if cfg.OpenVINODevice != "" && cfg.OpenVINODevice != OVDeviceAuto && cfg.OpenVINODevice != OVDeviceCPU && cfg.OpenVINODevice != OVDeviceGPU {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("BirdNET openvinodevice '%s' is not recognised; must be 'auto', 'cpu', or 'gpu' - will use 'auto'", cfg.OpenVINODevice))
+	}
+
 	checkRange(&result, cfg.RangeFilter.Threshold, 0, 1, "RangeFilter threshold must be between 0 and 1")
 
 	// Locale validation and normalization (pure transformation)

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -1,6 +1,7 @@
 package inference
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -12,11 +13,20 @@ var (
 	ovInitialized bool
 )
 
+// OpenVINO device names accepted by OpenVINOClassifierOptions.Device. They are
+// the device strings the OpenVINO backend expects ("CPU", "GPU").
+const (
+	OVDeviceCPU = ov.DeviceCPU
+	OVDeviceGPU = ov.DeviceGPU
+)
+
 // OpenVINOClassifierOptions configures the OpenVINO species classifier.
 type OpenVINOClassifierOptions struct {
-	Labels        []string // species labels; required (drives NumSpecies)
-	Threads       int      // INFERENCE_NUM_THREADS; 0 = OpenVINO auto-tune
+	Labels        []string // species labels; required (validated against model output)
+	Threads       int      // INFERENCE_NUM_THREADS; 0 = OpenVINO auto-tune (CPU only)
 	PrecisionHint string   // INFERENCE_PRECISION_HINT; "" defaults to f16
+	Device        string   // ov.DeviceCPU (default) or ov.DeviceGPU
+	OutputIndex   int      // logits output port index; 0 default, 3 for Perch v2
 }
 
 type openvinoClassifier struct {
@@ -36,15 +46,38 @@ func NewOpenVINOClassifier(modelPath string, opts OpenVINOClassifierOptions) (Cl
 	if prec == "" {
 		prec = ov.DefaultPrecisionHint
 	}
-	threads := opts.Threads
-	if threads < 0 {
-		threads = 0
-	}
-	c, err := ov.NewClassifier(modelPath, ov.Options{PrecisionHint: prec, Threads: threads})
+	threads := max(opts.Threads, 0)
+	c, err := ov.NewClassifier(modelPath, ov.Options{
+		PrecisionHint: prec,
+		Threads:       threads,
+		Device:        opts.Device,
+		OutputIndex:   opts.OutputIndex,
+	})
 	if err != nil {
 		return nil, err
 	}
-	return &openvinoClassifier{c: c, numSpecies: len(opts.Labels)}, nil
+	// Validate the model's real output dimension against the label count. The OV
+	// backend reports NumClasses from the compiled model (not the label list), so
+	// a mismatch is a genuine model/label inconsistency: reject it and let the
+	// caller fall back to ORT. (Issue #1112: when numSpecies was len(labels) this
+	// check was tautological and could never catch a wrong model or label file.)
+	if n := c.NumClasses(); n != len(opts.Labels) {
+		_ = c.Close()
+		return nil, errors.Newf("OpenVINO model output dimension %d does not match label count %d", n, len(opts.Labels)).
+			Category(errors.CategoryValidation).Build()
+	}
+	return &openvinoClassifier{c: c, numSpecies: c.NumClasses()}, nil
+}
+
+// OpenVINOHasDevice reports whether the named OpenVINO device (e.g. ov.DeviceGPU)
+// is available. It returns false on any error (backend not compiled in, core not
+// initialized, or query failure), so callers can use it as a plain gate.
+func OpenVINOHasDevice(name string) bool {
+	devs, err := ov.AvailableDevices()
+	if err != nil {
+		return false
+	}
+	return slices.Contains(devs, name)
 }
 
 func (c *openvinoClassifier) Predict(samples []float32) ([]float32, error) {

--- a/internal/inference/openvino/backend_openvino.go
+++ b/internal/inference/openvino/backend_openvino.go
@@ -367,7 +367,10 @@ static ov_status_e ovbind_output_class_count(const ov_compiled_model_t* compiled
     int64_t count = 1;
     for (int64_t i = 0; i < shape.rank; i++) {
         int64_t d = shape.dims[i];
-        if (d <= 0) {
+        // Reject non-positive dims and guard the running product against signed
+        // int64 overflow (CWE-190): a malformed or huge shape must fail safe and
+        // fall back to ORT, not wrap into undefined behavior.
+        if (d <= 0 || count > INT64_MAX / d) {
             OVB.shape_free(&shape);
             return OVBIND_ERR_BAD_OUTPUT;
         }

--- a/internal/inference/openvino/backend_openvino.go
+++ b/internal/inference/openvino/backend_openvino.go
@@ -49,6 +49,11 @@ typedef ov_status_e (*fn_infer_request_infer)(ov_infer_request_t*);
 typedef ov_status_e (*fn_infer_request_get_output_tensor_by_index)(const ov_infer_request_t*, const size_t, ov_tensor_t**);
 typedef void        (*fn_infer_request_free)(ov_infer_request_t*);
 typedef const char* (*fn_get_last_err_msg)(void);
+typedef ov_status_e (*fn_compiled_model_outputs_size)(const ov_compiled_model_t*, size_t*);
+typedef ov_status_e (*fn_compiled_model_output_by_index)(const ov_compiled_model_t*, const size_t, ov_output_const_port_t**);
+typedef ov_status_e (*fn_const_port_get_shape)(const ov_output_const_port_t*, ov_shape_t*);
+typedef ov_status_e (*fn_core_get_available_devices)(const ov_core_t*, ov_available_devices_t*);
+typedef void        (*fn_available_devices_free)(ov_available_devices_t*);
 
 // ovbind_t is the process-global table of resolved OpenVINO symbols, filled by
 // ovbind_load(path).
@@ -78,6 +83,11 @@ typedef struct {
     fn_infer_request_get_output_tensor_by_index infer_request_get_output_tensor_by_index;
     fn_infer_request_free                       infer_request_free;
     fn_get_last_err_msg                         get_last_err_msg;
+    fn_compiled_model_outputs_size              compiled_model_outputs_size;
+    fn_compiled_model_output_by_index           compiled_model_output_by_index;
+    fn_const_port_get_shape                     const_port_get_shape;
+    fn_core_get_available_devices               core_get_available_devices;
+    fn_available_devices_free                   available_devices_free;
 } ovbind_t;
 
 static ovbind_t OVB; // process-global resolved symbol table
@@ -154,6 +164,11 @@ static const char* ovbind_load(const char* path) {
     OVBIND_RESOLVE(infer_request_get_output_tensor_by_index, fn_infer_request_get_output_tensor_by_index, "ov_infer_request_get_output_tensor_by_index");
     OVBIND_RESOLVE(infer_request_free,                       fn_infer_request_free,                       "ov_infer_request_free");
     OVBIND_RESOLVE(get_last_err_msg,                         fn_get_last_err_msg,                         "ov_get_last_err_msg");
+    OVBIND_RESOLVE(compiled_model_outputs_size,              fn_compiled_model_outputs_size,              "ov_compiled_model_outputs_size");
+    OVBIND_RESOLVE(compiled_model_output_by_index,           fn_compiled_model_output_by_index,           "ov_compiled_model_output_by_index");
+    OVBIND_RESOLVE(const_port_get_shape,                     fn_const_port_get_shape,                     "ov_const_port_get_shape");
+    OVBIND_RESOLVE(core_get_available_devices,               fn_core_get_available_devices,               "ov_core_get_available_devices");
+    OVBIND_RESOLVE(available_devices_free,                   fn_available_devices_free,                   "ov_available_devices_free");
     return NULL;
 }
 
@@ -310,6 +325,88 @@ static void ovbind_infer_request_free(ov_infer_request_t* req) {
 static const char* ovbind_get_last_err_msg(void) {
     return OVB.get_last_err_msg();
 }
+
+// OVBIND_ERR_BAD_OUTPUT is returned when the requested output index is out of
+// range or the selected output port has a non-positive (dynamic/unresolved)
+// element count. Like OVBIND_ERR_BAD_INPUT_SHAPE it sits far outside the
+// ov_status_e range so the Go caller can tell it apart from a real OpenVINO
+// status, report a clear error, and fall back to ORT.
+#define OVBIND_ERR_BAD_OUTPUT (-1001)
+
+// ovbind_output_class_count computes the number of classes in the compiled
+// model's output at index `idx` by multiplying its post-compile static shape
+// dimensions, writing the result to *out_count. The model was reshaped to a
+// static batch of 1 before compile, so every output dimension is static and the
+// product over all dims equals batch(1) * classes = classes. All
+// ov_output_const_port_t / ov_shape_t handling stays in C so cgo never touches
+// the dynamically allocated dims array. The output port is freed on every path,
+// and the shape only after a successful get_shape, so no handle leaks on error.
+static ov_status_e ovbind_output_class_count(const ov_compiled_model_t* compiled, size_t idx, int64_t* out_count) {
+    size_t nout = 0;
+    ov_status_e st = OVB.compiled_model_outputs_size(compiled, &nout);
+    if (st != OK) {
+        return st;
+    }
+    if (idx >= nout) {
+        return OVBIND_ERR_BAD_OUTPUT;
+    }
+
+    ov_output_const_port_t* port = NULL;
+    st = OVB.compiled_model_output_by_index(compiled, idx, &port);
+    if (st != OK) {
+        return st;
+    }
+
+    ov_shape_t shape;
+    st = OVB.const_port_get_shape(port, &shape);
+    OVB.output_const_port_free(port);
+    if (st != OK) {
+        return st;
+    }
+
+    int64_t count = 1;
+    for (int64_t i = 0; i < shape.rank; i++) {
+        int64_t d = shape.dims[i];
+        if (d <= 0) {
+            OVB.shape_free(&shape);
+            return OVBIND_ERR_BAD_OUTPUT;
+        }
+        count *= d;
+    }
+    OVB.shape_free(&shape);
+
+    if (count <= 0) {
+        return OVBIND_ERR_BAD_OUTPUT;
+    }
+    *out_count = count;
+    return OK;
+}
+
+// ovbind_get_available_devices fills *devices with the device names the loaded
+// core can see (e.g. "CPU", "GPU"). The caller must free it with
+// ovbind_free_available_devices. ovbind_devices_count / ovbind_devices_at read
+// the list without cgo pointer arithmetic over the char** array.
+static ov_status_e ovbind_get_available_devices(const ov_core_t* core, ov_available_devices_t* devices) {
+    return OVB.core_get_available_devices(core, devices);
+}
+
+static void ovbind_free_available_devices(ov_available_devices_t* devices) {
+    OVB.available_devices_free(devices);
+}
+
+static size_t ovbind_devices_count(const ov_available_devices_t* devices) {
+    // Guard against a NULL array with a nonzero size. The OpenVINO C API does not
+    // promise this combination when the status is OK, but treat it as "no devices"
+    // rather than dereference NULL in ovbind_devices_at.
+    if (devices->devices == NULL) {
+        return 0;
+    }
+    return devices->size;
+}
+
+static const char* ovbind_devices_at(const ov_available_devices_t* devices, size_t i) {
+    return devices->devices[i];
+}
 */
 import "C" //nolint:gocritic // dupImport: cgo import "C" must be separate from regular imports
 
@@ -325,13 +422,8 @@ import (
 )
 
 const (
-	// deviceCPU is the OpenVINO device name the backend targets. ARMv8.2 f16
-	// acceleration runs on the CPU plugin.
-	deviceCPU = "CPU"
 	// inputPortIndex is the index of the single audio input tensor.
 	inputPortIndex = 0
-	// outputPortIndex is the index of the single logits output tensor.
-	outputPortIndex = 0
 	// expectedInputRank is the rank of the model input shape, [batch, samples].
 	expectedInputRank = 2
 	// float32Bytes is the size in bytes of one float32 element.
@@ -437,10 +529,12 @@ func DestroyOV() error {
 // callers serialize access. The process-global core is shared and is not owned
 // here.
 type classifier struct {
-	compiled *C.ov_compiled_model_t
-	req      *C.ov_infer_request_t
-	inBuf    unsafe.Pointer
-	samples  int
+	compiled    *C.ov_compiled_model_t
+	req         *C.ov_infer_request_t
+	inBuf       unsafe.Pointer
+	samples     int
+	outputIndex int
+	numClasses  int
 }
 
 // reshapeToStaticBatch1 reshapes the model's single input to a static
@@ -467,9 +561,11 @@ func reshapeToStaticBatch1(model *C.ov_model_t, modelPath string) (int, error) {
 	return 0, lastErr("ov_model_reshape_single_input", st, modelPath)
 }
 
-// NewClassifier reads modelPath, compiles it for the CPU device at
-// opts.PrecisionHint, creates one infer request, and binds a C-owned input
-// tensor sized to the model's input shape. InitOV must have succeeded first;
+// NewClassifier reads modelPath, compiles it for opts.Device (CPU or GPU) at
+// opts.PrecisionHint, creates one infer request, binds a C-owned input tensor
+// sized to the model's input shape, and reads the element count of the selected
+// output port (opts.OutputIndex) from the compiled model so NumClasses reflects
+// the model rather than a label list. InitOV must have succeeded first;
 // otherwise it returns ErrOpenVINOUnavailable. The returned Classifier is not
 // goroutine-safe.
 func NewClassifier(modelPath string, opts Options) (Classifier, error) {
@@ -492,8 +588,24 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 	if precision == "" {
 		precision = DefaultPrecisionHint
 	}
+
+	device := opts.Device
+	if device == "" {
+		device = DeviceCPU
+	}
+	if device != DeviceCPU && device != DeviceGPU {
+		return nil, errors.Newf("openvino: unsupported device %q (want %q or %q)", device, DeviceCPU, DeviceGPU).
+			Category(errors.CategoryModelInit).Build()
+	}
+	if opts.OutputIndex < 0 {
+		return nil, errors.Newf("openvino: negative output index %d", opts.OutputIndex).
+			Category(errors.CategoryModelInit).Build()
+	}
+
 	threads := ""
-	if opts.Threads > 0 {
+	// INFERENCE_NUM_THREADS is a CPU-plugin property; the GPU plugin rejects it,
+	// so only pass a thread count when compiling for the CPU device.
+	if device == DeviceCPU && opts.Threads > 0 {
 		threads = strconv.Itoa(opts.Threads)
 	}
 
@@ -513,7 +625,7 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 		return nil, err
 	}
 
-	cDev := C.CString(deviceCPU)
+	cDev := C.CString(device)
 	defer C.free(unsafe.Pointer(cDev))
 	cPrec := C.CString(precision)
 	defer C.free(unsafe.Pointer(cPrec))
@@ -530,6 +642,20 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 	// below operates on the compiled model, not the read model).
 	C.ovbind_model_free(model)
 	model = nil
+
+	// Read the real element count of the selected output port from the compiled
+	// model (static after the batch-1 reshape). NumClasses reflects the model,
+	// not the label list, so the caller can validate the label count against it
+	// (issue #1112) and a wrong OutputIndex is rejected before any inference.
+	var classCount C.int64_t
+	if st := C.ovbind_output_class_count(compiled, C.size_t(opts.OutputIndex), &classCount); !ovOK(st) {
+		C.ovbind_compiled_model_free(compiled)
+		if int(st) == int(C.OVBIND_ERR_BAD_OUTPUT) {
+			return nil, errors.Newf("openvino: output index %d is out of range or has a non-static shape", opts.OutputIndex).
+				Category(errors.CategoryModelInit).Build()
+		}
+		return nil, lastErr("ov_compiled_model_output shape", st, modelPath)
+	}
 
 	var req *C.ov_infer_request_t
 	if st := C.ovbind_compiled_model_create_infer_request(compiled, &req); !ovOK(st) {
@@ -577,10 +703,12 @@ func NewClassifier(modelPath string, opts Options) (Classifier, error) {
 	C.ovbind_tensor_free(inTensor)
 
 	return &classifier{
-		compiled: compiled,
-		req:      req,
-		inBuf:    inBuf,
-		samples:  samples,
+		compiled:    compiled,
+		req:         req,
+		inBuf:       inBuf,
+		samples:     samples,
+		outputIndex: opts.OutputIndex,
+		numClasses:  int(classCount),
 	}, nil
 }
 
@@ -609,7 +737,7 @@ func (c *classifier) PredictRaw(samples []float32) ([]float32, error) {
 	}
 
 	var outTensor *C.ov_tensor_t
-	if st := C.ovbind_get_output_tensor(c.req, outputPortIndex, &outTensor); !ovOK(st) {
+	if st := C.ovbind_get_output_tensor(c.req, C.size_t(c.outputIndex), &outTensor); !ovOK(st) {
 		return nil, lastErr("ov_infer_request_get_output_tensor_by_index", st)
 	}
 	defer C.ovbind_tensor_free(outTensor)
@@ -635,6 +763,10 @@ func (c *classifier) PredictRaw(samples []float32) ([]float32, error) {
 	return out, nil
 }
 
+// NumClasses returns the element count of the selected output port, read from
+// the compiled model in NewClassifier.
+func (c *classifier) NumClasses() int { return c.numClasses }
+
 // Close frees the infer request, compiled model, and the C input buffer, in
 // that order. The read model was already freed right after compile in
 // NewClassifier. Close does not touch the process-global core. Close is
@@ -653,4 +785,41 @@ func (c *classifier) Close() error {
 		c.inBuf = nil
 	}
 	return nil
+}
+
+// AvailableDevices returns the OpenVINO device names visible to the loaded core
+// (e.g. "CPU", "GPU"). "GPU" appears only when the Intel GPU plugin and a
+// supported iGPU/dGPU are present. InitOV must have succeeded first; otherwise
+// it returns ErrOpenVINOUnavailable. Used to gate the GPU path on Intel GPU
+// presence before falling back to the CPU device or ORT.
+func AvailableDevices() ([]string, error) {
+	// Pin to one OS thread so the query and any ov_get_last_err_msg fetch
+	// (C thread-local storage) run on the same thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Hold ovMu for the whole core-using section so a concurrent DestroyOV cannot
+	// free ovCore mid-query. AvailableDevices takes no other ovMu-guarded path.
+	ovMu.Lock()
+	defer ovMu.Unlock()
+	if !ovLoaded || ovCore == nil {
+		return nil, ErrOpenVINOUnavailable
+	}
+
+	var list C.ov_available_devices_t
+	if st := C.ovbind_get_available_devices(ovCore, &list); !ovOK(st) {
+		return nil, lastErr("ov_core_get_available_devices", st)
+	}
+	defer C.ovbind_free_available_devices(&list)
+
+	n := int(C.ovbind_devices_count(&list))
+	devices := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		cName := C.ovbind_devices_at(&list, C.size_t(i))
+		if cName == nil {
+			continue
+		}
+		devices = append(devices, C.GoString(cName))
+	}
+	return devices, nil
 }

--- a/internal/inference/openvino/backend_openvino_test.go
+++ b/internal/inference/openvino/backend_openvino_test.go
@@ -5,15 +5,30 @@ package openvino
 import (
 	"math"
 	"os"
+	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// finiteSampleCount is how many leading output logits each round-trip test spot-
+// checks for NaN/Inf.
+const finiteSampleCount = 8
 
 // Input/output dimensions of the BirdNET v2.4 classifier (named to avoid magic numbers).
 const (
 	birdNETInputSamples  = 144000
 	birdNETOutputClasses = 6522
+)
+
+// Input/output dimensions of the Perch v2 (no_dft) classifier. Its species logits
+// are the 4th output (index 3); index 0 is the 1536-d embedding.
+const (
+	perchInputSamples      = 160000
+	perchOutputClasses     = 14795
+	perchLogitsOutputIndex = 3
+	perchEmbeddingClasses  = 1536
 )
 
 // TestOpenVINORoundTrip is a hardware/lib-gated smoke test. Set OV_TEST_MODEL to a
@@ -38,7 +53,70 @@ func TestOpenVINORoundTrip(t *testing.T) {
 
 	// Outputs are raw pre-activation logits (often negative), so do not assert a
 	// [0,1] range; just sanity-check that the first few are finite (not NaN/Inf).
-	for i, v := range out[:8] {
+	for i, v := range out[:finiteSampleCount] {
 		require.Falsef(t, math.IsNaN(float64(v)) || math.IsInf(float64(v), 0), "out[%d] not finite: %v", i, v)
 	}
+}
+
+// TestOpenVINOPerchRoundTrip is a hardware/lib-gated smoke test for the Perch v2
+// multi-output graph. Set OV_TEST_PERCH_MODEL to a perch_v2_no_dft ONNX path to
+// run it. OV_TEST_DEVICE selects the device ("CPU" default, or "GPU"); a GPU run
+// is skipped if no GPU is enumerated. It proves the OutputIndex selection (logits
+// at index 3, not the index-0 embedding) and that NumClasses reports the real
+// model output dimension.
+func TestOpenVINOPerchRoundTrip(t *testing.T) {
+	model := os.Getenv("OV_TEST_PERCH_MODEL")
+	if model == "" {
+		t.Skip("set OV_TEST_PERCH_MODEL to a perch_v2_no_dft ONNX to run the Perch OpenVINO round-trip")
+	}
+	require.NoError(t, InitOV(os.Getenv("OV_TEST_LIB")))
+	t.Cleanup(func() { _ = DestroyOV() })
+
+	device := os.Getenv("OV_TEST_DEVICE")
+	if device == "" {
+		device = DeviceCPU
+	}
+	if device == DeviceGPU {
+		devs, err := AvailableDevices()
+		require.NoError(t, err)
+		if !slices.Contains(devs, DeviceGPU) {
+			t.Skipf("no GPU device enumerated (have %v)", devs)
+		}
+	}
+
+	c, err := NewClassifier(model, Options{
+		PrecisionHint: DefaultPrecisionHint,
+		Device:        device,
+		OutputIndex:   perchLogitsOutputIndex,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// NumClasses must reflect the index-3 logits output (14795), not the labels
+	// or the index-0 embedding (1536).
+	require.Equal(t, perchOutputClasses, c.NumClasses())
+
+	out, err := c.PredictRaw(make([]float32, perchInputSamples))
+	require.NoError(t, err)
+	require.Len(t, out, perchOutputClasses)
+	require.NotEqual(t, perchEmbeddingClasses, len(out), "output must be logits (idx 3), not the embedding (idx 0)")
+
+	for i, v := range out[:finiteSampleCount] {
+		require.Falsef(t, math.IsNaN(float64(v)) || math.IsInf(float64(v), 0), "out[%d] not finite: %v", i, v)
+	}
+}
+
+// TestOpenVINOAvailableDevices verifies device enumeration returns at least the
+// CPU device once the core is loaded. Lib-gated via OV_TEST_LIB / standard paths.
+func TestOpenVINOAvailableDevices(t *testing.T) {
+	if os.Getenv("OV_TEST_MODEL") == "" && os.Getenv("OV_TEST_PERCH_MODEL") == "" {
+		t.Skip("set OV_TEST_MODEL or OV_TEST_PERCH_MODEL to run device enumeration (needs libopenvino_c)")
+	}
+	require.NoError(t, InitOV(os.Getenv("OV_TEST_LIB")))
+	t.Cleanup(func() { _ = DestroyOV() })
+
+	devs, err := AvailableDevices()
+	require.NoError(t, err)
+	assert.Contains(t, devs, DeviceCPU, "CPU device must always be enumerated")
+	t.Logf("OpenVINO devices: %v", devs)
 }

--- a/internal/inference/openvino/openvino.go
+++ b/internal/inference/openvino/openvino.go
@@ -7,8 +7,16 @@ package openvino
 import "github.com/tphakala/birdnet-go/internal/errors"
 
 // DefaultPrecisionHint is the OpenVINO INFERENCE_PRECISION_HINT used for the
-// f16 acceleration path on ARMv8.2 CPUs.
+// f16 acceleration path on ARMv8.2 CPUs and the Intel iGPU.
 const DefaultPrecisionHint = "f16"
+
+const (
+	// DeviceCPU is the OpenVINO CPU device. ARMv8.2 f16 acceleration runs here.
+	DeviceCPU = "CPU"
+	// DeviceGPU is the OpenVINO GPU device (Intel iGPU via intel_gpu_plugin). It
+	// supports f16 natively and offloads inference from the CPU cores.
+	DeviceGPU = "GPU"
+)
 
 // ErrOpenVINOUnavailable is returned when the OpenVINO backend is not compiled
 // in (no "openvino" build tag) or libopenvino_c cannot be loaded at runtime.
@@ -23,6 +31,10 @@ var ErrOpenVINOUnavailable = errors.NewStd("openvino: backend unavailable")
 type Classifier interface {
 	// PredictRaw runs one inference and returns raw logits in label order.
 	PredictRaw(samples []float32) ([]float32, error)
+	// NumClasses reports the element count of the model's selected logits output,
+	// read from the compiled model (not derived from the label list). Callers use
+	// it to validate the model output against the label count.
+	NumClasses() int
 	// Close releases the compiled model and infer request. It does not touch
 	// the process-global core (see DestroyOV).
 	Close() error
@@ -32,6 +44,14 @@ type Classifier interface {
 type Options struct {
 	// PrecisionHint is the OpenVINO INFERENCE_PRECISION_HINT (e.g. "f16").
 	PrecisionHint string
-	// Threads sets INFERENCE_NUM_THREADS. 0 lets OpenVINO auto-tune.
+	// Threads sets INFERENCE_NUM_THREADS (CPU device only; ignored for GPU).
+	// 0 lets OpenVINO auto-tune.
 	Threads int
+	// Device is the OpenVINO device to compile for: DeviceCPU (default) or
+	// DeviceGPU. An empty string is treated as DeviceCPU.
+	Device string
+	// OutputIndex is the index of the logits output port to read. 0 (default)
+	// for single-output models like BirdNET v2.4; 3 for the Perch v2 multi-output
+	// graph whose species logits are the 4th output.
+	OutputIndex int
 }

--- a/internal/inference/openvino/stub_noopenvino.go
+++ b/internal/inference/openvino/stub_noopenvino.go
@@ -11,6 +11,11 @@ func NewClassifier(_ string, _ Options) (Classifier, error) {
 	return nil, ErrOpenVINOUnavailable
 }
 
+// AvailableDevices always fails without the openvino build tag.
+func AvailableDevices() ([]string, error) {
+	return nil, ErrOpenVINOUnavailable
+}
+
 // InitOV always fails without the openvino build tag.
 func InitOV(_ string) error { return ErrOpenVINOUnavailable }
 

--- a/internal/inference/openvino_notag_test.go
+++ b/internal/inference/openvino_notag_test.go
@@ -1,0 +1,37 @@
+//go:build !openvino
+
+package inference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
+)
+
+// These tests assert the no-tag stub behaviour and are scoped to the !openvino
+// build. In the openvino build with a real libopenvino_c present, InitOpenVINO("")
+// would actually load the process-global core and NewOpenVINOClassifier would
+// reach the native model read, so these no-tag invariants do not hold there; the
+// tagged build is exercised by the lib-gated functional tests instead.
+
+// TestNewOpenVINOClassifier_UnavailableWithoutTag verifies that without the
+// openvino build tag, construction fails with the sentinel so the classifier
+// dispatch falls back to ORT.
+func TestNewOpenVINOClassifier_UnavailableWithoutTag(t *testing.T) {
+	t.Parallel()
+	c, err := NewOpenVINOClassifier("/x.onnx", OpenVINOClassifierOptions{Labels: []string{"a"}})
+	assert.Nil(t, c)
+	assert.ErrorIs(t, err, ov.ErrOpenVINOUnavailable)
+}
+
+// TestInitOpenVINO_GuardWithoutTag verifies that without the openvino build tag,
+// InitOpenVINO returns an error via the stub and does NOT mark the runtime as
+// initialized, leaving DestroyOpenVINO a safe no-op.
+func TestInitOpenVINO_GuardWithoutTag(t *testing.T) {
+	// Do not call t.Parallel: this test touches package-global init state.
+	require.Error(t, InitOpenVINO(""))
+	assert.False(t, IsOpenVINOInitialized())
+	assert.NoError(t, DestroyOpenVINO()) // no-op when never initialized
+}

--- a/internal/inference/openvino_test.go
+++ b/internal/inference/openvino_test.go
@@ -5,32 +5,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
 )
 
-func TestNewOpenVINOClassifier_UnavailableWithoutTag(t *testing.T) {
-	t.Parallel()
-	// In the default (no openvino tag) build, construction must fail with the
-	// sentinel so the classifier dispatch falls back to ORT.
-	c, err := NewOpenVINOClassifier("/x.onnx", OpenVINOClassifierOptions{Labels: []string{"a"}})
-	assert.Nil(t, c)
-	assert.ErrorIs(t, err, ov.ErrOpenVINOUnavailable)
-}
-
+// TestNewOpenVINOClassifier_RequiresLabels verifies the labels precondition,
+// which holds in every build (the check runs before any OpenVINO call).
 func TestNewOpenVINOClassifier_RequiresLabels(t *testing.T) {
 	t.Parallel()
 	c, err := NewOpenVINOClassifier("/x.onnx", OpenVINOClassifierOptions{})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "requires labels")
 	assert.Nil(t, c)
-}
-
-// TestInitOpenVINO_GuardWithoutTag verifies that without the openvino build tag,
-// InitOpenVINO returns an error via the stub and does NOT mark the runtime as
-// initialized, leaving DestroyOpenVINO a safe no-op.
-func TestInitOpenVINO_GuardWithoutTag(t *testing.T) {
-	// Do not call t.Parallel: this test touches package-global init state.
-	require.Error(t, InitOpenVINO(""))
-	assert.False(t, IsOpenVINOInitialized())
-	assert.NoError(t, DestroyOpenVINO()) // no-op when never initialized
 }


### PR DESCRIPTION
## Summary

Extends the native OpenVINO inference backend (added for BirdNET v2.4 in #3547) to the Google Perch v2 classifier, opt-in behind the `openvino` build tag with graceful fallback to ONNX Runtime. Default builds (no tag) are byte-for-byte unchanged.

Perch v2 runs as a secondary `ModelInstance` and applies softmax (unlike the primary BirdNET path, which applies sigmoid), so OpenVINO is wired into `NewPerch` (where Perch actually runs), not the primary `shouldTryOpenVINO` path. The two paths share a single device-plan helper.

### Backend changes
- **cgo binding**: per-classifier output port index (Perch's species logits are output index 3, behind `embedding`/`spatial_embedding`/`spectrogram`), CPU/GPU device selection, `INFERENCE_NUM_THREADS` omitted for the GPU plugin, a real output-dimension query from the compiled model, and Intel-GPU enumeration via `ov_core_get_available_devices`.
- **Output validation**: the OpenVINO classifier now reports `NumClasses` from the compiled model's selected output and validates it against the label count, so a model/label mismatch is caught at load and falls back to ORT instead of being masked (previously the count was derived from the label list, making the check tautological).
- **Device gating** (`openVINOPlanFor`): auto-selects the Intel iGPU when present, else the ARM A76 (ASIMDHP/f16) CPU; BirdNET v2.4 stays CPU-only; explicit override via a new `BirdNET.OpenVINODevice` config (`auto`/`cpu`/`gpu`, hot-reloadable). No frontend changes.
- Perch uses OpenVINO only for the `no_dft` model variant; the stock `perch_v2.onnx` cannot compile on OpenVINO (a dynamic-rank DFT op) and stays on ORT.

### Scope
Backend only. Shipping the `perch_v2_no_dft` model via the model gallery (arch-aware) and any frontend/UI for the device knob are follow-ups.

## Related Issues
Relates to #3239 (Intel iGPU offloading of Perch v2).
Builds on #3547.

## Test Plan
- [x] Builds clean with and without the `openvino` tag; `go vet -tags openvino` clean; default-build `golangci-lint` clean.
- [x] Unit tests pass with `-race` (gating, config validation/hot-reload, Perch no_dft detection, build-tag-split stub tests).
- [x] Lib-gated functional tests verify the index-3 logits output (14795 classes, not the 1536 embedding) and the NumClasses/label validation.
- [x] Output parity vs ONNX Runtime (top-5 identical) verified on amd64 CPU, amd64 Intel Iris Xe iGPU, and Raspberry Pi 5 (Cortex-A76, f16 CPU).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenVINO device preference (auto/cpu/gpu) for BirdNET inference and enabled hot-reload for device changes.
  * Expanded Perch v2 to use OpenVINO when compatible, with safe fallback to ONNX Runtime.
* **Improvements**
  * Improved settings handling by warning on unknown OpenVINO device values and falling back to auto.
* **Tests**
  * Added/expanded OpenVINO unit, functional, and backend smoke tests, including device enumeration and logits output validation, plus non-OpenVINO stub behavior checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->