### PR TITLE
feat(inference): run BirdNET v2.4 on the OpenVINO iGPU at f32

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -136,6 +136,10 @@ func (c *Controller) registerHealthChecks() {
 			status := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
 			return status.Available, status.Initialized, status.Version, status.LibraryPath, status.Error
 		}),
+		checks.NewOpenVINOAvailabilityCheck(func() (supported, active bool) {
+			status := inference.CheckOpenVINOAvailability()
+			return status.Supported, status.Active
+		}),
 		checks.NewRangeFilterCheck(func() checks.RangeFilterStatusInfo {
 			orch, err := c.getBirdNETInstance()
 			if err != nil || orch == nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/events"
+	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -120,6 +121,19 @@ func (a *App) Shutdown(ctx context.Context) error {
 	for _, svc := range core {
 		if err := svc.Stop(coreCtx); err != nil {
 			allErrs = append(allErrs, errors.New(err).Component(componentApp).Category(errors.CategorySystem).Context("operation", "service_stop").Context("service", svc.Name()).Build())
+		}
+	}
+
+	// Tier 2: process-global inference runtimes (ORT / OpenVINO cores). Free them
+	// only on a CLEAN shutdown: if any service above timed out, a native thread
+	// may still be inside an inference call, and tearing the shared runtime out
+	// from under it would segfault. Both calls are no-ops if never initialized.
+	if len(allErrs) == 0 {
+		if err := inference.DestroyONNXRuntime(); err != nil {
+			allErrs = append(allErrs, errors.New(err).Component(componentApp).Category(errors.CategorySystem).Context("operation", "destroy_onnxruntime").Build())
+		}
+		if err := inference.DestroyOpenVINO(); err != nil {
+			allErrs = append(allErrs, errors.New(err).Component(componentApp).Category(errors.CategorySystem).Context("operation", "destroy_openvino").Build())
 		}
 	}
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -179,6 +179,18 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Build()
 	}
 
+	// bn now owns native inference backends. If a later construction step fails and
+	// aborts, close them so a partially-built BirdNET does not leak the native
+	// classifier/range filter or leave the OpenVINO active-classifier counter
+	// incremented (which would make diagnostics report OpenVINO as in use for the
+	// rest of the process lifetime).
+	constructed := false
+	defer func() {
+		if !constructed {
+			bn.Delete()
+		}
+	}()
+
 	if err := bn.initializeMetaModel(settings); err != nil {
 		GetLogger().Warn("Range filter initialization failed, starting without species filtering (fix via Settings > Species)",
 			logger.Error(err),
@@ -211,6 +223,7 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			Build()
 	}
 
+	constructed = true
 	return bn, nil
 }
 
@@ -243,7 +256,7 @@ func (bn *BirdNET) initializeModel() error {
 			GetLogger().Warn("OpenVINO backend unavailable, falling back to ONNX Runtime", logger.Error(err))
 		} else if bn.Settings.BirdNET.Backend == conf.BackendPrefOpenVINO {
 			GetLogger().Warn("backend is set to 'openvino' but it cannot be used here; using ONNX Runtime",
-				logger.String("reason", "requires the openvino build, an ARMv8.2/A76+ CPU with native f16, and the BirdNET v2.4 model"))
+				logger.String("reason", "requires the openvino build, the BirdNET v2.4 model, and a supported device (an ARMv8.2/A76+ CPU with native f16, or an Intel OpenVINO GPU)"))
 		}
 		return bn.initializeONNXModel()
 	}

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -20,6 +20,7 @@ const birdnetLogitsOutputIndex = 0
 type openVINOPlan struct {
 	device      string // inference.OVDeviceCPU or inference.OVDeviceGPU
 	outputIndex int    // logits output port index
+	precision   string // INFERENCE_PRECISION_HINT; "" = backend default (f16)
 }
 
 // openVINOPlanFor decides whether and how to run a model on the OpenVINO backend,
@@ -27,16 +28,18 @@ type openVINOPlan struct {
 //
 //   - backendPref:  settings.BirdNET.Backend ("auto"/"onnx"/"openvino").
 //   - devicePref:   settings.BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu").
-//   - modelID:      the model registry identity (drives the GPU fence).
+//   - modelID:      the model registry identity (drives the precision policy).
 //   - libraryPath:  settings.BirdNET.OpenVINOPath (libopenvino_c location).
 //   - outputIndex:  the logits output port for this model.
 //
-// BirdNET v2.4 is fenced off the GPU this release (only Perch may target the Intel
-// iGPU). cpuspec.HasNativeF16() is true only on ARMv8.2+ (A76), which keeps amd64
-// CPU out of the auto path (a non-win); an explicit "cpu" device is still allowed
-// on amd64 for benchmarking/advanced use. The plan helper loads the OpenVINO core
-// (idempotent) only when it must enumerate devices for a GPU decision, so it is
-// independent of caller ordering.
+// Both BirdNET v2.4 and Perch may target the Intel iGPU; the per-(model, device)
+// precision is chosen by openVINOPrecisionFor (BirdNET v2.4 is forced to f32 on
+// the GPU because the GPU f16 kernel miscompiles it). cpuspec.HasNativeF16() is
+// true only on ARMv8.2+ (A76), which keeps amd64 CPU out of the auto path (a
+// non-win); an explicit "cpu" device is still allowed on amd64 for
+// benchmarking/advanced use. The plan helper loads the OpenVINO core (idempotent)
+// only when it must enumerate devices for a GPU decision, so it is independent of
+// caller ordering.
 func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outputIndex int) (openVINOPlan, bool) {
 	if !openvinoBackendAvailable {
 		return openVINOPlan{}, false
@@ -45,12 +48,10 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 		return openVINOPlan{}, false
 	}
 
-	allowGPU := modelID != DefaultModelVersion // BirdNET v2.4 stays CPU-only.
-
 	var device string
 	switch devicePref {
 	case conf.OVDeviceGPU:
-		if !allowGPU || !openVINOGPUAvailable(libraryPath) {
+		if !openVINOGPUAvailable(libraryPath) {
 			return openVINOPlan{}, false
 		}
 		device = inference.OVDeviceGPU
@@ -61,7 +62,7 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 		device = inference.OVDeviceCPU
 	default: // "auto" or ""
 		switch {
-		case allowGPU && openVINOGPUAvailable(libraryPath):
+		case openVINOGPUAvailable(libraryPath):
 			device = inference.OVDeviceGPU
 		case openVINOCPUAllowed(devicePref):
 			device = inference.OVDeviceCPU
@@ -70,7 +71,29 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 		}
 	}
 
-	return openVINOPlan{device: device, outputIndex: outputIndex}, true
+	return openVINOPlan{
+		device:      device,
+		outputIndex: outputIndex,
+		precision:   openVINOPrecisionFor(modelID, device),
+	}, true
+}
+
+// openVINOPrecisionFor returns the INFERENCE_PRECISION_HINT for a (model, device)
+// pair, or "" to use the backend default (f16).
+//
+// BirdNET v2.4 is forced to f32 on the GPU: the Intel GPU plugin's f16 kernel
+// miscompiles this single-output sigmoid model. Validated on an Iris Xe iGPU
+// (2026-06-18), f16 collapses on realistic low-SNR audio (max confidence error
+// ~0.8, wrong top-1, confidences fall to ~0) while a loud single-species clip
+// survives by luck; f32 is bit-exact with ORT (~6e-6) and still ~4.6x faster than
+// ORT CPU. CPU f16 (incl. ARM A76) and Perch v2 f16-GPU are unaffected, so the
+// override is scoped to BirdNET-on-GPU. Do NOT widen it to f16 without re-running
+// the inference/openvino_parity_functional_test.go soundscape parity check.
+func openVINOPrecisionFor(modelID, device string) string {
+	if device == inference.OVDeviceGPU && modelID == DefaultModelVersion {
+		return inference.OVPrecisionF32
+	}
+	return ""
 }
 
 // openVINOCPUAllowed reports whether the OpenVINO CPU device may be used. The f16
@@ -104,7 +127,8 @@ func openVINOGPUAvailable(libraryPath string) bool {
 // false to use ORT. The primary classifier path applies sigmoid post-processing,
 // so only the BirdNET v2.4 identity is valid here; Perch (softmax) runs its own
 // OpenVINO path in the Perch ModelInstance (perch_onnx.go), never through this
-// primary path. The plan also carries the device (CPU/GPU) and logits output index.
+// primary path. The plan carries the device (CPU/GPU), logits output index, and
+// the precision hint (f32 on the GPU for BirdNET v2.4; see openVINOPrecisionFor).
 func (bn *BirdNET) openVINOPlan() (openVINOPlan, bool) {
 	if bn.ModelInfo.ID != DefaultModelVersion {
 		return openVINOPlan{}, false
@@ -121,8 +145,8 @@ func (bn *BirdNET) openVINOPlan() (openVINOPlan, bool) {
 // shouldTryOpenVINO reports whether the OpenVINO backend should be attempted for
 // the primary classifier before falling back to ORT. True only when built with
 // the openvino tag, the model is the BirdNET v2.4 identity, config does not opt
-// out, and a supported device is available (ARM A76 f16 CPU; the GPU is fenced
-// off for BirdNET this release).
+// out, and a supported device is available (ARM A76 f16 CPU, or the Intel iGPU at
+// f32; see openVINOPrecisionFor for why BirdNET v2.4 uses f32 on the GPU).
 func (bn *BirdNET) shouldTryOpenVINO() bool {
 	_, ok := bn.openVINOPlan()
 	return ok
@@ -164,10 +188,11 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	}
 
 	classifier, err := inference.NewOpenVINOClassifier(modelPath, inference.OpenVINOClassifierOptions{
-		Labels:      settings.BirdNET.Labels,
-		Threads:     settings.BirdNET.Threads,
-		Device:      plan.device,
-		OutputIndex: plan.outputIndex,
+		Labels:        settings.BirdNET.Labels,
+		Threads:       settings.BirdNET.Threads,
+		Device:        plan.device,
+		OutputIndex:   plan.outputIndex,
+		PrecisionHint: plan.precision,
 	})
 	if err != nil {
 		return errors.New(err).Category(errors.CategoryModelInit).

--- a/internal/classifier/openvino_gating_openvino_test.go
+++ b/internal/classifier/openvino_gating_openvino_test.go
@@ -32,30 +32,27 @@ func TestShouldTryOpenVINO_Tagged_WrongModel(t *testing.T) {
 }
 
 // TestShouldTryOpenVINO_Tagged_HardwareGateDecides verifies that with the tag, a
-// supported model, and no opt-out, the native-f16 (ASIMDHP) capability is the final
-// deciding factor: true on ARMv8.2 (rpi5), false elsewhere (amd64). This makes the
-// test robust on any host.
+// supported model, and no opt-out, the hardware is the final deciding factor:
+// eligibility is true when the host has ARM A76 f16 CPU acceleration OR an
+// available Intel OpenVINO GPU (BirdNET v2.4 runs there at f32). This keeps the
+// test robust on any host (rpi5 A76, amd64+iGPU, or amd64 CPU-only).
 func TestShouldTryOpenVINO_Tagged_HardwareGateDecides(t *testing.T) {
 	t.Parallel()
 	bn := &BirdNET{Settings: &conf.Settings{}}
 	bn.Settings.BirdNET.Backend = conf.BackendPrefOpenVINO
 	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
-	assert.Equal(t, cpuspec.HasNativeF16(), bn.shouldTryOpenVINO(),
-		"with tag, supported model, and opt-in, the result must equal native-f16 capability")
-}
-
-// TestOpenVINOPlan_BirdNETFencedOffGPU verifies BirdNET v2.4 never targets the
-// GPU: an explicit device=gpu yields no plan, and an auto plan (when produced)
-// is always the CPU device. These cases never enumerate devices (the GPU branch
-// short-circuits on the BirdNET fence), so the test needs no libopenvino_c.
-func TestOpenVINOPlan_BirdNETFencedOffGPU(t *testing.T) {
-	t.Parallel()
-	_, ok := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceGPU, DefaultModelVersion, "", birdnetLogitsOutputIndex)
-	assert.False(t, ok, "BirdNET v2.4 + device=gpu must not produce a plan (GPU is fenced off)")
-
-	if plan, ok := openVINOPlanFor(conf.BackendPrefAuto, conf.OVDeviceAuto, DefaultModelVersion, "", birdnetLogitsOutputIndex); ok {
-		assert.Equal(t, inference.OVDeviceCPU, plan.device, "BirdNET auto plan must be CPU, never GPU")
-	}
+	// Compute the same hardware availability the planner uses (auto path: GPU
+	// preferred when present, else the ARM f16 CPU gate). The hardware portion of
+	// `expected` is intentionally mirror-logic of the implementation, so it proves
+	// nothing about the device decision itself; what this test actually guards is
+	// that the tag/opt-in/model gates upstream do NOT block eligibility (a
+	// regression that ignored the openvino tag, the BirdNET v2.4 model gate, or the
+	// opt-in would make `shouldTryOpenVINO` diverge from `expected` on a capable
+	// host). The fixed-expectation gate coverage lives in the sibling _OptOut,
+	// _WrongModel, and TestOpenVINOPlan_* tests.
+	expected := cpuspec.HasNativeF16() || openVINOGPUAvailable("")
+	assert.Equal(t, expected, bn.shouldTryOpenVINO(),
+		"with tag, supported model, and opt-in, eligibility must equal ARM f16 CPU capability or OV GPU availability")
 }
 
 // TestOpenVINOPlan_ExplicitCPU verifies the explicit CPU device gate: allowed on

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -1,0 +1,29 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/inference"
+)
+
+// TestOpenVINOPrecisionFor verifies the per-(model, device) precision policy:
+// BirdNET v2.4 is forced to f32 on the GPU (its GPU f16 kernel miscompiles this
+// model; validated on Iris Xe), while CPU and Perch keep the f16 default.
+//
+// This is intentionally NOT behind the openvino build tag: openVINOPrecisionFor
+// lives in a tag-agnostic file and compiles into every build, but CI never builds
+// the openvino tag, so a regression that reverted the f32 forcing (re-enabling the
+// broken f16 GPU path) would otherwise pass CI green. This pure-policy check has no
+// hardware dependency and runs in the default test suite.
+func TestOpenVINOPrecisionFor(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(DefaultModelVersion, inference.OVDeviceGPU),
+		"BirdNET v2.4 on the GPU must be forced to f32")
+	assert.Empty(t, openVINOPrecisionFor(DefaultModelVersion, inference.OVDeviceCPU),
+		"BirdNET v2.4 on CPU keeps the f16 default")
+	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceGPU),
+		"Perch on the GPU keeps f16 (validated parity with f32)")
+	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceCPU),
+		"Perch on CPU keeps the f16 default")
+}

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -151,10 +151,11 @@ func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, 
 
 	start := time.Now()
 	classifier, err := inference.NewOpenVINOClassifier(cfg.ModelPath, inference.OpenVINOClassifierOptions{
-		Labels:      labels,
-		Threads:     cfg.Threads,
-		Device:      plan.device,
-		OutputIndex: plan.outputIndex,
+		Labels:        labels,
+		Threads:       cfg.Threads,
+		Device:        plan.device,
+		OutputIndex:   plan.outputIndex,
+		PrecisionHint: plan.precision, // "" => f16 default; Perch f16-GPU validated OK
 	})
 	if err != nil {
 		log.Warn("Perch OpenVINO classifier init failed; using ONNX Runtime",

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -413,6 +413,61 @@ func (c *ORTAvailabilityCheck) Run(_ context.Context) health.Result {
 	}
 }
 
+// OpenVINOAvailabilityCheck reports whether the optional OpenVINO acceleration
+// backend is compiled in and active. Unlike ORT (required for several models),
+// OpenVINO is optional, so absence is never an error: the check is skipped on
+// builds without the backend, and otherwise reports active vs. fell-back-to-ORT.
+type OpenVINOAvailabilityCheck struct {
+	getStatus func() (supported, active bool)
+}
+
+// NewOpenVINOAvailabilityCheck creates an OpenVINOAvailabilityCheck using the
+// given status provider. active reports whether a classifier is actually running
+// on OpenVINO (not merely that the core was loaded for device probing).
+func NewOpenVINOAvailabilityCheck(getStatus func() (supported, active bool)) *OpenVINOAvailabilityCheck {
+	return &OpenVINOAvailabilityCheck{getStatus: getStatus}
+}
+
+// Name returns the check identifier.
+func (c *OpenVINOAvailabilityCheck) Name() string { return "openvino_availability" }
+
+// Category returns the analysis category.
+func (c *OpenVINOAvailabilityCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// Run reports OpenVINO backend state. It is skipped on builds without the
+// backend (the common case), and healthy otherwise: OpenVINO is an optional
+// accelerator, so falling back to ORT is normal, not a fault.
+func (c *OpenVINOAvailabilityCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getStatus == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	supported, active := c.getStatus()
+	if !supported {
+		// Not an OpenVINO build: report Skipped rather than a misleading
+		// always-"inactive" line. Skipped checks remain in the diagnostics payload
+		// (like every other optional check) but do not count toward the aggregate
+		// health status, so default builds are not penalized for lacking OpenVINO.
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	msg := "OpenVINO compiled in, not in use (ONNX Runtime active)"
+	if active {
+		msg = "OpenVINO backend active"
+	}
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     health.StatusHealthy,
+		Message:    msg,
+		Details:    map[string]any{"supported": supported, "active": active},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
 // Threshold constants for the results-queue detection-drop check. Each dropped
 // detection is a species that was heard but never recorded, so even a single
 // drop within the window is worth a warning; a high or sustained rate (the

--- a/internal/health/checks/analysis_test.go
+++ b/internal/health/checks/analysis_test.go
@@ -251,6 +251,43 @@ func TestORTAvailabilityCheck_FoundNotInitialized(t *testing.T) {
 	assert.Contains(t, result.Message, "not yet initialized")
 }
 
+func TestOpenVINOAvailabilityCheck_NotSupported(t *testing.T) {
+	t.Parallel()
+	// Default build: OpenVINO not compiled in. The check stays silent (skipped)
+	// rather than reporting an always-"inactive" line.
+	check := NewOpenVINOAvailabilityCheck(func() (bool, bool) { return false, false })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
+func TestOpenVINOAvailabilityCheck_Active(t *testing.T) {
+	t.Parallel()
+	check := NewOpenVINOAvailabilityCheck(func() (bool, bool) { return true, true })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	// "backend active" is unique to the active message; the not-in-use message also
+	// contains the bare token "active" ("ONNX Runtime active"), so asserting the
+	// full phrase catches a flag inversion that "active" alone would not.
+	assert.Contains(t, result.Message, "backend active")
+}
+
+func TestOpenVINOAvailabilityCheck_SupportedNotInUse(t *testing.T) {
+	t.Parallel()
+	// Built with the openvino tag but no classifier is running on it (the core may
+	// have loaded for device probing, but inference fell back to ORT).
+	check := NewOpenVINOAvailabilityCheck(func() (bool, bool) { return true, false })
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "not in use")
+}
+
+func TestOpenVINOAvailabilityCheck_NilProvider(t *testing.T) {
+	t.Parallel()
+	check := NewOpenVINOAvailabilityCheck(nil)
+	result := check.Run(t.Context())
+	assert.Equal(t, health.StatusSkipped, result.Status)
+}
+
 // --- Helper tests ---
 
 func TestSanitizeID(t *testing.T) {

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -333,10 +333,19 @@ func findONNXRuntimeLibrary() string {
 }
 
 // DestroyONNXRuntime tears down the ONNX Runtime environment.
-// Resets initialization state so InitONNXRuntime can be called again.
+// Resets initialization state so InitONNXRuntime can be called again. It is a
+// no-op (returns nil) when the runtime was never initialized, mirroring
+// DestroyOpenVINO, so a shutdown teardown can call it unconditionally without
+// ort.DestroyORT reporting "InitializeRuntime has not been called".
 func DestroyONNXRuntime() error {
 	ortInitMu.Lock()
 	defer ortInitMu.Unlock()
+	if !ortInitialized {
+		return nil
+	}
+	if err := ort.DestroyORT(); err != nil {
+		return err
+	}
 	ortInitialized = false
-	return ort.DestroyORT()
+	return nil
 }

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	ov "github.com/tphakala/birdnet-go/internal/inference/openvino"
@@ -13,12 +14,24 @@ var (
 	ovInitialized bool
 )
 
+// ovActiveClassifiers counts OpenVINO classifiers currently serving inference.
+// It is NOT the same as ovInitialized: the device planner loads the OpenVINO core
+// (setting ovInitialized) merely to enumerate devices, even on a host that then
+// falls back to ORT. Diagnostics must report "OpenVINO active" only when a
+// classifier is actually running on it, so they read this counter, not the
+// core-loaded flag.
+var ovActiveClassifiers atomic.Int64
+
 // OpenVINO device names accepted by OpenVINOClassifierOptions.Device. They are
 // the device strings the OpenVINO backend expects ("CPU", "GPU").
 const (
 	OVDeviceCPU = ov.DeviceCPU
 	OVDeviceGPU = ov.DeviceGPU
 )
+
+// OVPrecisionF32 is the INFERENCE_PRECISION_HINT for full f32 inference, used to
+// override the f16 default where the GPU plugin miscompiles a model at f16.
+const OVPrecisionF32 = ov.PrecisionF32
 
 // OpenVINOClassifierOptions configures the OpenVINO species classifier.
 type OpenVINOClassifierOptions struct {
@@ -66,6 +79,7 @@ func NewOpenVINOClassifier(modelPath string, opts OpenVINOClassifierOptions) (Cl
 		return nil, errors.Newf("OpenVINO model output dimension %d does not match label count %d", n, len(opts.Labels)).
 			Category(errors.CategoryValidation).Build()
 	}
+	ovActiveClassifiers.Add(1)
 	return &openvinoClassifier{c: c, numSpecies: c.NumClasses()}, nil
 }
 
@@ -93,6 +107,7 @@ func (c *openvinoClassifier) Close() {
 	if c.c != nil {
 		_ = c.c.Close()
 		c.c = nil
+		ovActiveClassifiers.Add(-1)
 	}
 }
 
@@ -131,4 +146,29 @@ func IsOpenVINOInitialized() bool {
 	ovInitMu.Lock()
 	defer ovInitMu.Unlock()
 	return ovInitialized
+}
+
+// OpenVINOStatus describes whether the OpenVINO backend is compiled in and
+// whether it is actually serving inference. It mirrors ORTStatus for the
+// diagnostics surface. Supported distinguishes "not an openvino build" from
+// "openvino build that fell back to ORT", which is the key signal for confirming
+// an opt-in took effect.
+type OpenVINOStatus struct {
+	// Supported is true when this build links the OpenVINO backend (built with
+	// the "openvino" tag).
+	Supported bool `json:"supported"`
+	// Active is true when at least one classifier is currently running on the
+	// OpenVINO backend. This is deliberately NOT "core loaded": the device planner
+	// loads the core just to enumerate devices even on hosts that then fall back to
+	// ORT, so the core-loaded flag would falsely report OpenVINO as in use.
+	Active bool `json:"active"`
+}
+
+// CheckOpenVINOAvailability reports the OpenVINO backend status. It never mutates
+// global OpenVINO state (it does not attempt to load the library).
+func CheckOpenVINOAvailability() OpenVINOStatus {
+	return OpenVINOStatus{
+		Supported: ov.Supported,
+		Active:    ovActiveClassifiers.Load() > 0,
+	}
 }

--- a/internal/inference/openvino/backend_openvino.go
+++ b/internal/inference/openvino/backend_openvino.go
@@ -424,6 +424,10 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+// Supported reports whether the OpenVINO backend is compiled into this build.
+// True here (built under the "openvino" tag); false in stub_noopenvino.go.
+const Supported = true
+
 const (
 	// inputPortIndex is the index of the single audio input tensor.
 	inputPortIndex = 0

--- a/internal/inference/openvino/openvino.go
+++ b/internal/inference/openvino/openvino.go
@@ -10,6 +10,11 @@ import "github.com/tphakala/birdnet-go/internal/errors"
 // f16 acceleration path on ARMv8.2 CPUs and the Intel iGPU.
 const DefaultPrecisionHint = "f16"
 
+// PrecisionF32 is the OpenVINO INFERENCE_PRECISION_HINT for full f32 inference.
+// Used to override the f16 default for models that the GPU plugin miscompiles at
+// f16 (see classifier.openVINOPrecisionFor for the BirdNET v2.4 iGPU case).
+const PrecisionF32 = "f32"
+
 const (
 	// DeviceCPU is the OpenVINO CPU device. ARMv8.2 f16 acceleration runs here.
 	DeviceCPU = "CPU"

--- a/internal/inference/openvino/stub_noopenvino.go
+++ b/internal/inference/openvino/stub_noopenvino.go
@@ -6,6 +6,10 @@ package openvino
 // reports ErrOpenVINOUnavailable so the classifier falls back to ORT and no
 // libopenvino_c symbol is referenced.
 
+// Supported reports whether the OpenVINO backend is compiled into this build.
+// False here (no "openvino" build tag); true in backend_openvino.go.
+const Supported = false
+
 // NewClassifier always fails without the openvino build tag.
 func NewClassifier(_ string, _ Options) (Classifier, error) {
 	return nil, ErrOpenVINOUnavailable

--- a/internal/inference/openvino_parity_functional_test.go
+++ b/internal/inference/openvino_parity_functional_test.go
@@ -244,7 +244,7 @@ func readLabels(t *testing.T, path string) []string {
 	t.Helper()
 	f, err := os.Open(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = f.Close() })
+	defer func() { _ = f.Close() }()
 	var labels []string
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/internal/inference/openvino_parity_functional_test.go
+++ b/internal/inference/openvino_parity_functional_test.go
@@ -1,0 +1,301 @@
+//go:build openvino
+
+package inference
+
+import (
+	"bufio"
+	"encoding/binary"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenVINOParity_Functional is a hardware/lib/model-gated parity test that
+// runs the SAME ONNX model through both the ONNX Runtime backend (the reference)
+// and the OpenVINO backend, on identical input, and compares their outputs. It is
+// the evidence harness behind enabling BirdNET v2.4 on the Intel iGPU (the GPU
+// fence in classifier.openVINOPlanFor): it measures how far OpenVINO f16 drifts
+// from ORT f32 for the BirdNET v2.4 sigmoid model, the way Perch was validated.
+//
+// It is skipped unless OV_TEST_PARITY_MODEL and OV_TEST_PARITY_LABELS are set, so
+// normal CI stays green. Env knobs:
+//
+//   - OV_TEST_PARITY_MODEL:   path to the FP32 ONNX model (e.g. birdnet-v24.onnx).
+//   - OV_TEST_PARITY_LABELS:  labels file, one per line; its count must equal the
+//     model output dimension.
+//   - OV_TEST_PARITY_AUDIO:   optional raw little-endian float32 PCM file of input
+//     samples (e.g. 48 kHz mono, 3 s = 144000 samples for BirdNET v2.4). Zeros if
+//     unset, but a real clip gives a meaningful top-k and a realistic f16 error.
+//   - OV_TEST_DEVICE:         "cpu", "gpu", or "auto"/"" (defaults to "GPU" here,
+//     since the iGPU is what the fence removal is about). Mapped to OV device.
+//   - OV_TEST_PRECISION:      "", "f16", or "f32" INFERENCE_PRECISION_HINT. Empty
+//     uses the backend default (f16). Use "f32" for the GPU-precision experiment.
+//   - OV_TEST_LIB / OV_TEST_ORT_LIB: optional libopenvino_c / libonnxruntime paths.
+//   - OV_TEST_MAX_CONF_ERR:   max allowed |sigmoid(ov)-sigmoid(ort)| (default 0.05).
+func TestOpenVINOParity_Functional(t *testing.T) {
+	modelPath := os.Getenv("OV_TEST_PARITY_MODEL")
+	labelPath := os.Getenv("OV_TEST_PARITY_LABELS")
+	if modelPath == "" || labelPath == "" {
+		t.Skip("set OV_TEST_PARITY_MODEL and OV_TEST_PARITY_LABELS to run the OpenVINO parity test")
+	}
+
+	labels := readLabels(t, labelPath)
+	require.NotEmpty(t, labels)
+
+	samples := readAudioOrZeros(t, os.Getenv("OV_TEST_PARITY_AUDIO"))
+
+	device := mapDevice(os.Getenv("OV_TEST_DEVICE"))
+	precision := os.Getenv("OV_TEST_PRECISION")
+
+	maxConfErr := 0.05
+	if v := os.Getenv("OV_TEST_MAX_CONF_ERR"); v != "" {
+		parsed, err := strconv.ParseFloat(v, 64)
+		require.NoError(t, err)
+		maxConfErr = parsed
+	}
+
+	// Reference backend: ONNX Runtime (f32).
+	require.NoError(t, InitONNXRuntime(os.Getenv("OV_TEST_ORT_LIB")))
+	t.Cleanup(func() { _ = DestroyONNXRuntime() })
+	ort, err := NewONNXClassifier(modelPath, ONNXClassifierOptions{Labels: labels, Threads: 1})
+	require.NoError(t, err)
+	t.Cleanup(ort.Close)
+
+	// Candidate backend: OpenVINO on the selected device/precision.
+	require.NoError(t, InitOpenVINO(os.Getenv("OV_TEST_LIB")))
+	t.Cleanup(func() { _ = DestroyOpenVINO() })
+	ov, err := NewOpenVINOClassifier(modelPath, OpenVINOClassifierOptions{
+		Labels:        labels,
+		Threads:       1,
+		Device:        device,
+		PrecisionHint: precision,
+	})
+	require.NoError(t, err)
+	t.Cleanup(ov.Close)
+
+	require.Equal(t, len(labels), ort.NumSpecies())
+	require.Equal(t, len(labels), ov.NumSpecies(), "#1112: OV NumSpecies must equal real model output dim")
+
+	ortLogits, err := ort.Predict(samples)
+	require.NoError(t, err)
+	ovLogits, err := ov.Predict(samples)
+	require.NoError(t, err)
+	require.Len(t, ortLogits, len(labels))
+	require.Len(t, ovLogits, len(labels))
+
+	// Element-wise error in logits and in post-sigmoid confidence.
+	var maxLogitErr, maxConfDiff float64
+	for i := range ortLogits {
+		if d := math.Abs(float64(ovLogits[i] - ortLogits[i])); d > maxLogitErr {
+			maxLogitErr = d
+		}
+		if d := math.Abs(sigmoid(ovLogits[i]) - sigmoid(ortLogits[i])); d > maxConfDiff {
+			maxConfDiff = d
+		}
+	}
+
+	ortTop := topK(ortLogits, 5)
+	ovTop := topK(ovLogits, 5)
+
+	t.Logf("device=%s precision=%q model=%s", device, precision, modelPath)
+	t.Logf("max |logit_ov - logit_ort| = %.6g", maxLogitErr)
+	t.Logf("max |conf_ov  - conf_ort | = %.6g (sigmoid)", maxConfDiff)
+	t.Logf("ORT top-5: %s", fmtTop(ortTop, ortLogits, labels))
+	t.Logf("OV  top-5: %s", fmtTop(ovTop, ovLogits, labels))
+
+	require.Equal(t, ortTop[0], ovTop[0],
+		"top-1 species must match between ORT and OpenVINO (ORT=%q OV=%q)",
+		labels[ortTop[0]], labels[ovTop[0]])
+	require.LessOrEqual(t, maxConfDiff, maxConfErr,
+		"OpenVINO confidence drift from ORT exceeds tolerance")
+
+	// Optional latency comparison: only a GPU win over ORT CPU justifies routing
+	// BirdNET to the iGPU. Set OV_TEST_PARITY_ITERS to time both backends.
+	if iters := os.Getenv("OV_TEST_PARITY_ITERS"); iters != "" {
+		n, err := strconv.Atoi(iters)
+		require.NoError(t, err)
+		require.Positive(t, n, "OV_TEST_PARITY_ITERS must be > 0")
+		t.Logf("ORT median: %s/seg", medianPredict(t, ort, samples, n))
+		t.Logf("OV  median: %s/seg", medianPredict(t, ov, samples, n))
+	}
+}
+
+// medianPredict times n inferences (after 3 warmup runs) and returns the median.
+func medianPredict(t *testing.T, c Classifier, samples []float32, n int) time.Duration {
+	t.Helper()
+	for range 3 {
+		_, err := c.Predict(samples)
+		require.NoError(t, err)
+	}
+	ds := make([]time.Duration, n)
+	for i := range n {
+		start := time.Now()
+		_, err := c.Predict(samples)
+		require.NoError(t, err)
+		ds[i] = time.Since(start)
+	}
+	sort.Slice(ds, func(a, b int) bool { return ds[a] < ds[b] })
+	return ds[n/2]
+}
+
+// TestOpenVINOPrecisionDivergence_Functional compares the SAME model on the same
+// OpenVINO device at f16 vs f32, with no ORT reference. It is the decisive check
+// for "does this device's f16 kernel break this model on realistic input" without
+// needing the ORT output-port conventions to line up, so it works for multi-output
+// models like Perch v2 (logits at OV_TEST_DIVERGE_OUTPUT_INDEX, default 0).
+//
+// Skipped unless OV_TEST_DIVERGE_MODEL and OV_TEST_DIVERGE_LABELS are set. Other
+// env: OV_TEST_DIVERGE_AUDIO (raw f32 input), OV_TEST_DIVERGE_OUTPUT_INDEX,
+// OV_TEST_DEVICE (default "gpu"), OV_TEST_LIB, OV_TEST_DIVERGE_MAX_CONF_ERR
+// (default 0.15: cross-precision drift is inherently larger than ORT-vs-f32, e.g.
+// Perch v2 f16-GPU is ~0.08 while a broken model like BirdNET v2.4 f16-GPU is
+// ~0.8; the top-1 match assertion is the primary catch for a catastrophic
+// divergence). The divergence knob is named distinctly from the parity test's
+// OV_TEST_MAX_CONF_ERR so the two tolerances cannot be conflated.
+func TestOpenVINOPrecisionDivergence_Functional(t *testing.T) {
+	modelPath := os.Getenv("OV_TEST_DIVERGE_MODEL")
+	labelPath := os.Getenv("OV_TEST_DIVERGE_LABELS")
+	if modelPath == "" || labelPath == "" {
+		t.Skip("set OV_TEST_DIVERGE_MODEL and OV_TEST_DIVERGE_LABELS to run the OpenVINO precision divergence test")
+	}
+
+	labels := readLabels(t, labelPath)
+	samples := readAudioOrZeros(t, os.Getenv("OV_TEST_DIVERGE_AUDIO"))
+	device := mapDevice(os.Getenv("OV_TEST_DEVICE"))
+
+	outputIndex := 0
+	if v := os.Getenv("OV_TEST_DIVERGE_OUTPUT_INDEX"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		require.NoError(t, err)
+		outputIndex = parsed
+	}
+	maxConfErr := 0.15
+	if v := os.Getenv("OV_TEST_DIVERGE_MAX_CONF_ERR"); v != "" {
+		parsed, err := strconv.ParseFloat(v, 64)
+		require.NoError(t, err)
+		maxConfErr = parsed
+	}
+
+	require.NoError(t, InitOpenVINO(os.Getenv("OV_TEST_LIB")))
+	t.Cleanup(func() { _ = DestroyOpenVINO() })
+
+	build := func(precision string) Classifier {
+		c, err := NewOpenVINOClassifier(modelPath, OpenVINOClassifierOptions{
+			Labels:        labels,
+			Threads:       1,
+			Device:        device,
+			OutputIndex:   outputIndex,
+			PrecisionHint: precision,
+		})
+		require.NoError(t, err)
+		t.Cleanup(c.Close)
+		return c
+	}
+
+	f32, f16 := build("f32"), build("f16")
+	f32Logits, err := f32.Predict(samples)
+	require.NoError(t, err)
+	f16Logits, err := f16.Predict(samples)
+	require.NoError(t, err)
+
+	var maxLogitErr, maxConfDiff float64
+	for i := range f32Logits {
+		if d := math.Abs(float64(f16Logits[i] - f32Logits[i])); d > maxLogitErr {
+			maxLogitErr = d
+		}
+		if d := math.Abs(sigmoid(f16Logits[i]) - sigmoid(f32Logits[i])); d > maxConfDiff {
+			maxConfDiff = d
+		}
+	}
+	f32Top, f16Top := topK(f32Logits, 5), topK(f16Logits, 5)
+	t.Logf("device=%s outputIndex=%d model=%s", device, outputIndex, modelPath)
+	t.Logf("max |logit_f16 - logit_f32| = %.6g", maxLogitErr)
+	t.Logf("max |conf_f16  - conf_f32 | = %.6g (sigmoid)", maxConfDiff)
+	t.Logf("f32 top-5: %s", fmtTop(f32Top, f32Logits, labels))
+	t.Logf("f16 top-5: %s", fmtTop(f16Top, f16Logits, labels))
+
+	require.Equal(t, f32Top[0], f16Top[0],
+		"f16 top-1 must match f32 top-1 (f32=%q f16=%q)", labels[f32Top[0]], labels[f16Top[0]])
+	require.LessOrEqual(t, maxConfDiff, maxConfErr, "f16 confidence drift from f32 exceeds tolerance")
+}
+
+func sigmoid(x float32) float64 { return 1.0 / (1.0 + math.Exp(-float64(x))) }
+
+// mapDevice maps an OV_TEST_DEVICE value to an OpenVINO device string, defaulting
+// to the GPU since the iGPU path is what these parity runs exist to validate.
+func mapDevice(v string) string {
+	switch strings.ToLower(v) {
+	case "cpu":
+		return OVDeviceCPU
+	case "", "gpu", "auto":
+		return OVDeviceGPU
+	default:
+		return v
+	}
+}
+
+func readLabels(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	var labels []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			labels = append(labels, line)
+		}
+	}
+	require.NoError(t, sc.Err())
+	return labels
+}
+
+// readAudioOrZeros reads a raw little-endian float32 PCM file, or returns a
+// silent BirdNET-v2.4-sized buffer when no path is given.
+func readAudioOrZeros(t *testing.T, path string) []float32 {
+	t.Helper()
+	const birdnetV24Samples = 144000 // 48 kHz * 3 s
+	if path == "" {
+		return make([]float32, birdnetV24Samples)
+	}
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Zero(t, len(data)%4, "audio file must be whole float32 samples")
+	out := make([]float32, len(data)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(data[i*4:]))
+	}
+	return out
+}
+
+func topK(logits []float32, k int) []int {
+	idx := make([]int, len(logits))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool { return logits[idx[a]] > logits[idx[b]] })
+	if k > len(idx) {
+		k = len(idx)
+	}
+	return idx[:k]
+}
+
+func fmtTop(top []int, logits []float32, labels []string) string {
+	var b strings.Builder
+	for n, i := range top {
+		if n > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(labels[i])
+		b.WriteString("=")
+		b.WriteString(strconv.FormatFloat(sigmoid(logits[i]), 'f', 4, 64))
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

BirdNET v2.4 was fenced to CPU-only on the OpenVINO backend. This change lets it also run on the Intel iGPU, pinned to f32, because the GPU plugin's f16 kernel miscompiles this specific model.

Validated on an Intel Iris Xe iGPU:

| Config | soundscape accuracy vs ORT | latency (1 thread) |
|--------|----------------------------|--------------------|
| ORT CPU (current default) | reference | 38.5 ms/seg |
| **GPU f32** | **bit-exact (~6e-6)** | **8.4 ms/seg (4.6x faster, frees the CPU)** |
| GPU f16 (OpenVINO default) | **broken (~0.8 err, wrong top-1)** | n/a |
| CPU f16 / f32 | ~1e-5 | n/a |

f16 collapses on realistic low-SNR audio (a loud single-species clip happens to survive), so the f32 override is scoped to BirdNET-on-GPU in `openVINOPrecisionFor`. CPU f16 (including ARM A76) and Perch f16-GPU were validated unaffected and keep f16.

This is opt-in and backend-only: it changes runtime behavior only for builds compiled with the `openvino` tag, with `Backend != onnx` and an available Intel GPU. Default builds are byte-for-byte unchanged.

### Also in this change

- **inference**: `DestroyONNXRuntime` is now a no-op when the runtime was never initialized (mirroring `DestroyOpenVINO`), and app shutdown tears down both process-global inference cores once, only on a clean shutdown (guarded so a service that timed out mid-inference cannot segfault the teardown).
- **diagnostics**: a new `openvino_availability` health check reports whether a classifier is actually running on OpenVINO versus falling back to ORT, tracked by an active-classifier count rather than the core-loaded flag (the device planner loads the core just to enumerate devices).
- **classifier**: `NewBirdNET` now closes its native backends when construction fails after model init (e.g. an invalid locale), fixing a pre-existing resource leak and keeping the active-classifier count in sync.

## Test Plan

- [x] `go build ./...` and `go build -tags openvino ./...`
- [x] `golangci-lint run` clean (0 issues)
- [x] `go test -race` on affected packages
- [x] New build-tag-free precision-policy unit test runs in CI
- [x] Hardware-validated on an Iris Xe iGPU via env-gated parity and f16-vs-f32 divergence functional tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenVINO backend availability monitoring to system health diagnostics.

* **Bug Fixes**
  * Improved shutdown handling to safely release native inference runtimes only after earlier services stop cleanly.
  * Enhanced initialization/teardown safeguards to prevent leaks when setup fails or runtimes were never initialized.
  * Refined OpenVINO hardware/precision selection for more reliable model behavior.

* **Tests**
  * Added and expanded OpenVINO precision and functional parity testing across devices and precision modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->