### PR TITLE
fix(ci): render test-failure summary and make ONNX setup path Windows-safe

### DIFF
--- a/.github/actions/setup-onnxruntime/action.yml
+++ b/.github/actions/setup-onnxruntime/action.yml
@@ -51,7 +51,7 @@ runs:
           windows-amd64)
             curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-win-x64-${VERSION}.zip" \
               -o "${ONNX_DIR}.zip"
-            TMPDIR_WIN=$(mktemp -d)
+            TMPDIR_WIN=$(mktemp -d "${RUNNER_TEMP}/tmp.XXXXXX")
             unzip -q "${ONNX_DIR}.zip" -d "$TMPDIR_WIN"
             cp -r "$TMPDIR_WIN"/onnxruntime-*/* "${ONNX_DIR}/"
             rm -rf "$TMPDIR_WIN" "${ONNX_DIR}.zip"
@@ -61,7 +61,7 @@ runs:
               -o "${ONNX_DIR}.tgz"
             # BSD tar on macOS treats ./ as a path component, so --strip-components=1
             # only strips ./ instead of the full directory prefix. Use cp instead.
-            TMPDIR_ORT=$(mktemp -d)
+            TMPDIR_ORT=$(mktemp -d "${RUNNER_TEMP}/tmp.XXXXXX")
             tar -xzf "${ONNX_DIR}.tgz" -C "$TMPDIR_ORT"
             cp -R "$TMPDIR_ORT"/onnxruntime-*/* "${ONNX_DIR}/"
             rm -rf "$TMPDIR_ORT" "${ONNX_DIR}.tgz"

--- a/.github/actions/setup-onnxruntime/action.yml
+++ b/.github/actions/setup-onnxruntime/action.yml
@@ -18,7 +18,13 @@ runs:
       id: cache-onnxruntime
       uses: actions/cache@v5
       with:
-        path: /tmp/onnxruntime
+        # Use runner.temp, not /tmp. actions/cache evaluates `path` in Node, which
+        # on a native Windows runner reads /tmp as the absolute path C:\tmp, while
+        # the shell: bash steps (Git Bash/MSYS) map /tmp to a different directory.
+        # On a cache hit Node would then restore the libs where the bash verify
+        # step cannot find them. runner.temp (Node) and $RUNNER_TEMP (bash) resolve
+        # to the same directory on every OS, so the two stay in agreement.
+        path: ${{ runner.temp }}/onnxruntime
         key: onnxruntime-${{ inputs.target-platform }}-${{ inputs.onnxruntime-version }}
 
     - name: Download ONNX Runtime
@@ -26,38 +32,39 @@ runs:
       shell: bash
       run: |
         VERSION="${{ inputs.onnxruntime-version }}"
-        mkdir -p /tmp/onnxruntime
+        ONNX_DIR="${RUNNER_TEMP}/onnxruntime"
+        mkdir -p "${ONNX_DIR}"
 
         case "${{ inputs.target-platform }}" in
           linux-amd64)
             curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-x64-${VERSION}.tgz" \
-              -o /tmp/onnxruntime.tgz
-            tar -xzf /tmp/onnxruntime.tgz -C /tmp/onnxruntime --strip-components=1
-            rm /tmp/onnxruntime.tgz
+              -o "${ONNX_DIR}.tgz"
+            tar -xzf "${ONNX_DIR}.tgz" -C "${ONNX_DIR}" --strip-components=1
+            rm "${ONNX_DIR}.tgz"
             ;;
           linux-arm64)
             curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-aarch64-${VERSION}.tgz" \
-              -o /tmp/onnxruntime.tgz
-            tar -xzf /tmp/onnxruntime.tgz -C /tmp/onnxruntime --strip-components=1
-            rm /tmp/onnxruntime.tgz
+              -o "${ONNX_DIR}.tgz"
+            tar -xzf "${ONNX_DIR}.tgz" -C "${ONNX_DIR}" --strip-components=1
+            rm "${ONNX_DIR}.tgz"
             ;;
           windows-amd64)
             curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-win-x64-${VERSION}.zip" \
-              -o /tmp/onnxruntime.zip
-            TMPDIR=$(mktemp -d)
-            unzip -q /tmp/onnxruntime.zip -d "$TMPDIR"
-            cp -r "$TMPDIR"/onnxruntime-*/* /tmp/onnxruntime/
-            rm -rf "$TMPDIR" /tmp/onnxruntime.zip
+              -o "${ONNX_DIR}.zip"
+            TMPDIR_WIN=$(mktemp -d)
+            unzip -q "${ONNX_DIR}.zip" -d "$TMPDIR_WIN"
+            cp -r "$TMPDIR_WIN"/onnxruntime-*/* "${ONNX_DIR}/"
+            rm -rf "$TMPDIR_WIN" "${ONNX_DIR}.zip"
             ;;
           darwin-arm64)
             curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-osx-arm64-${VERSION}.tgz" \
-              -o /tmp/onnxruntime.tgz
+              -o "${ONNX_DIR}.tgz"
             # BSD tar on macOS treats ./ as a path component, so --strip-components=1
             # only strips ./ instead of the full directory prefix. Use cp instead.
             TMPDIR_ORT=$(mktemp -d)
-            tar -xzf /tmp/onnxruntime.tgz -C "$TMPDIR_ORT"
-            cp -R "$TMPDIR_ORT"/onnxruntime-*/* /tmp/onnxruntime/
-            rm -rf "$TMPDIR_ORT" /tmp/onnxruntime.tgz
+            tar -xzf "${ONNX_DIR}.tgz" -C "$TMPDIR_ORT"
+            cp -R "$TMPDIR_ORT"/onnxruntime-*/* "${ONNX_DIR}/"
+            rm -rf "$TMPDIR_ORT" "${ONNX_DIR}.tgz"
             ;;
           *)
             echo "::error::Unsupported platform: ${{ inputs.target-platform }}"
@@ -68,22 +75,23 @@ runs:
     - name: Verify download and repair symlinks
       shell: bash
       run: |
-        if [ ! -d /tmp/onnxruntime/lib ]; then
-          echo "::error::ONNX Runtime lib directory missing at /tmp/onnxruntime/lib"
-          echo "Contents of /tmp/onnxruntime:"
-          ls -laR /tmp/onnxruntime 2>/dev/null || echo "(directory does not exist)"
+        ONNX_DIR="${RUNNER_TEMP}/onnxruntime"
+        if [ ! -d "${ONNX_DIR}/lib" ]; then
+          echo "::error::ONNX Runtime lib directory missing at ${ONNX_DIR}/lib"
+          echo "Contents of ${ONNX_DIR}:"
+          ls -laR "${ONNX_DIR}" 2>/dev/null || echo "(directory does not exist)"
           exit 1
         fi
         echo "ONNX Runtime lib contents:"
-        ls -la /tmp/onnxruntime/lib/
+        ls -la "${ONNX_DIR}/lib/"
 
         # Repair dylib symlink if broken or missing after cache restore
         case "${{ inputs.target-platform }}" in
           darwin-arm64)
-            if [ ! -e /tmp/onnxruntime/lib/libonnxruntime.dylib ]; then
-              target=$(find /tmp/onnxruntime/lib -maxdepth 1 -name 'libonnxruntime.*.dylib' -not -name '*.dSYM' -type f | head -1)
+            if [ ! -e "${ONNX_DIR}/lib/libonnxruntime.dylib" ]; then
+              target=$(find "${ONNX_DIR}/lib" -maxdepth 1 -name 'libonnxruntime.*.dylib' -not -name '*.dSYM' -type f | head -1)
               if [ -n "$target" ]; then
-                ln -sf "$(basename "$target")" /tmp/onnxruntime/lib/libonnxruntime.dylib
+                ln -sf "$(basename "$target")" "${ONNX_DIR}/lib/libonnxruntime.dylib"
                 echo "Repaired missing symlink: libonnxruntime.dylib -> $(basename "$target")"
               fi
             fi
@@ -93,12 +101,13 @@ runs:
     - name: Install ONNX Runtime to system path
       shell: bash
       run: |
+        ONNX_DIR="${RUNNER_TEMP}/onnxruntime"
         case "${{ inputs.target-platform }}" in
           linux-amd64)
-            sudo cp /tmp/onnxruntime/lib/libonnxruntime*.so* /usr/lib/
+            sudo cp "${ONNX_DIR}"/lib/libonnxruntime*.so* /usr/lib/
             sudo ldconfig
             ;;
           linux-arm64)
-            sudo cp /tmp/onnxruntime/lib/libonnxruntime*.so* /usr/aarch64-linux-gnu/lib/
+            sudo cp "${ONNX_DIR}"/lib/libonnxruntime*.so* /usr/aarch64-linux-gnu/lib/
             ;;
         esac

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -81,7 +81,12 @@ jobs:
           CI: true
           MQTT_TEST_BROKER: tcp://localhost:1883
         run: |
-          set -euo pipefail
+          # Drop errexit (-e) but keep nounset + pipefail: a failing `go test`
+          # makes the pipeline non-zero, and with -e the shell would abort right
+          # here, before TEST_EXIT_CODE=${PIPESTATUS[0]} runs, so the failure
+          # summary below never renders. The explicit `exit $TEST_EXIT_CODE` still
+          # fails the step. (macos-test.yml / windows-test.yml use the same pattern.)
+          set -uo pipefail
 
           # Run tests with JSON output
           # Note: We must capture PIPESTATUS immediately after the pipeline

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -105,7 +105,7 @@ jobs:
           # Silicon, so DYLD_* env vars (stripped by SIP from child test binaries)
           # are not needed.
           sudo mkdir -p /usr/local/lib
-          sudo cp -a /tmp/onnxruntime/lib/libonnxruntime*.dylib /usr/local/lib/
+          sudo cp -a "${RUNNER_TEMP}"/onnxruntime/lib/libonnxruntime*.dylib /usr/local/lib/
 
       - name: Run unit tests
         env:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -132,10 +132,10 @@ jobs:
             fi
           elif [ "${{ matrix.goos }}" = "windows" ]; then
             cp /usr/x86_64-w64-mingw32/lib/tensorflowlite_c.dll artifacts/
-            cp /tmp/onnxruntime/lib/*.dll artifacts/
+            cp "${RUNNER_TEMP}"/onnxruntime/lib/*.dll artifacts/
           elif [ "${{ matrix.goos }}" = "darwin" ]; then
             cp /opt/homebrew/lib/libtensorflowlite_c.dylib artifacts/
-            cp /tmp/onnxruntime/lib/libonnxruntime.dylib artifacts/
+            cp "${RUNNER_TEMP}"/onnxruntime/lib/libonnxruntime.dylib artifacts/
           fi
 
           # Copy platform-specific README

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -125,10 +125,10 @@ jobs:
             fi
           elif [ "${{ matrix.goos }}" = "windows" ]; then
             cp /usr/x86_64-w64-mingw32/lib/tensorflowlite_c.dll artifacts/
-            cp /tmp/onnxruntime/lib/*.dll artifacts/
+            cp "${RUNNER_TEMP}"/onnxruntime/lib/*.dll artifacts/
           elif [ "${{ matrix.goos }}" = "darwin" ]; then
             cp /opt/homebrew/lib/libtensorflowlite_c.dylib artifacts/
-            cp /tmp/onnxruntime/lib/libonnxruntime.dylib artifacts/
+            cp "${RUNNER_TEMP}"/onnxruntime/lib/libonnxruntime.dylib artifacts/
           fi
           
           # Copy platform-specific README

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -110,11 +110,12 @@ jobs:
 
       - name: Setup ONNX Runtime
         run: |
-          # Inlined instead of the setup-onnxruntime composite action: that action
-          # caches to /tmp/onnxruntime, and on Windows actions/cache (Node) and Git
-          # Bash interpret /tmp as different directories, so a cache hit restores
-          # the libs where the bash verify step cannot see them. Download into the
-          # workspace, where Node and bash agree. (No caching; the zip is small.)
+          # Inlined instead of the setup-onnxruntime composite action. The action
+          # now caches under runner.temp, where actions/cache (Node) and Git Bash
+          # agree even on Windows, so it would work here too. This job still
+          # downloads into the workspace because it is simpler: no cache for a
+          # small zip, and the libs land next to the cygpath DLL-search wiring
+          # below. (Historically the action used /tmp, which diverged on Windows.)
           curl -fsSL -o onnxruntime.zip \
             "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-win-x64-${ONNXRUNTIME_VERSION}.zip"
           tmp="$(mktemp -d)"


### PR DESCRIPTION
Two cross-platform CI workflow fixes surfaced during the native macOS/Windows test rollout. No Go code changes; CI configuration only.

## 1. `golangci-test.yml`: test-failure summary never rendered

The "Run unit tests" step used `set -euo pipefail`. With `-e` + `pipefail`, a failing `go test` makes the pipeline non-zero and the shell aborts the step at the pipeline, before the `; TEST_EXIT_CODE=${PIPESTATUS[0]}` assignment runs. So the "Quick Preview of Failures" job-summary block and the later "Generate test failure report" step never executed on failure. CI still went red correctly (the abort is itself non-zero), so gating was never broken; only the nice job-summary preview was lost.

Fix: drop `-e`, keep `-uo pipefail`, so `PIPESTATUS` is captured and the summary renders. The explicit `exit $TEST_EXIT_CODE` still fails the step. This matches the pattern `macos-test.yml` and `windows-test.yml` already use.

## 2. `setup-onnxruntime` action: `/tmp` cache path breaks on native Windows runners

The composite action used `/tmp/onnxruntime` for both the `actions/cache` `path:` (evaluated by Node, which reads `/tmp` as the absolute path `C:\tmp` on Windows) and its `shell: bash` steps (Git Bash/MSYS, which maps `/tmp` to a different directory). On Linux and macOS the two agree; on a native Windows runner they diverge, so on a cache hit `actions/cache` restores the libs where the bash "Verify download" step cannot see them and it fails.

Fix: use `runner.temp` for the cache `path:` and `$RUNNER_TEMP` in the bash steps, which resolve to the same directory on every OS. The consumer copy steps that read the action's output directory were updated to match:

- `macos-test.yml` (copy to `/usr/local/lib`)
- `release-build.yml` (copy `*.dll` for windows-on-ubuntu, `libonnxruntime.dylib` for darwin-on-macos into `artifacts/`)
- `nightly-build.yml` (same two copies)

No workflow hits the Windows divergence today (release/nightly cross-compile Windows on ubuntu where `/tmp` is consistent, and `windows-test.yml` inlines its own ONNX download), so this is a latent fix that unblocks running the shared action on a native Windows runner with caching. Also renamed a `TMPDIR` scratch var in the action's windows case so it no longer shadows the POSIX `TMPDIR` env var.

## Validation

- `actionlint` (with shellcheck) on all changed workflows: no new findings on any changed line; the 53 reported items are all pre-existing `info`/`style`/`warning` suggestions on untouched lines.
- YAML parses for all six files.
- Independent review of the diff for correctness (missed paths, `runner.temp` vs `$RUNNER_TEMP` consistency, MSYS quoting, `-e`/`-u` safety, glob quoting).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to store and cache ONNX Runtime artifacts in platform-appropriate temporary directories (using runner temp) instead of hardcoded paths, improving cross-platform consistency.
  * Updated library verification/repair and installation steps to match the new temporary artifact location.
  * Refined unit test shell error handling to ensure test exit codes are captured and reported reliably.
  * Aligned release and test workflow artifact copy paths for Windows/macOS to use the new temporary location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->