### PR TITLE
test: fix macOS-only cross-platform unit-test failures

### DIFF
--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -235,17 +235,22 @@ func TestEncodeFlacUsingFFmpeg(t *testing.T) {
 }
 
 func getFFmpegPath() string {
-	// Try to get FFmpeg path from environment variable first
-	path := os.Getenv("FFMPEG_PATH")
-	if path != "" {
+	// Honor an explicit override first.
+	if path := os.Getenv("FFMPEG_PATH"); path != "" {
 		return path
 	}
 
-	// Fall back to a common system location on Linux/macOS
-	if _, err := os.Stat("/usr/bin/ffmpeg"); err == nil {
-		return "/usr/bin/ffmpeg"
+	// Resolve the binary to an absolute path via PATH. The production encoder
+	// (ValidateFFmpegPath) requires an absolute path, and FFmpeg lives in
+	// different places across platforms (e.g. /usr/bin on Linux, /opt/homebrew/bin
+	// on macOS), so the old hardcoded /usr/bin/ffmpeg fell through to the bare
+	// "ffmpeg" name on macOS and was rejected as non-absolute. LookPath returns an
+	// absolute path for a binary found on PATH.
+	if path, err := exec.LookPath(conf.GetFfmpegBinaryName()); err == nil {
+		return path
 	}
 
-	// Fall back to just the binary name, assuming it's in PATH
-	return "ffmpeg"
+	// Last resort: the bare binary name. Callers requiring an absolute path will
+	// reject it, but TestEncodeFlacUsingFFmpeg skips when LookPath finds nothing.
+	return conf.GetFfmpegBinaryName()
 }

--- a/internal/monitor/mount_resolver_test.go
+++ b/internal/monitor/mount_resolver_test.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -277,8 +278,15 @@ func TestGroupPathsWithPartitions_RootPathFallbackInContainer(t *testing.T) {
 func TestGroupPathsWithPartitions_MixedRootAndVolumePaths(t *testing.T) {
 	t.Parallel()
 
-	// Create a real temp directory to use as a volume mount path
-	tempDir := t.TempDir()
+	// Create a real temp directory to use as a volume mount path. Resolve symlinks
+	// up front: groupPathsWithPartitions calls filepath.EvalSymlinks on each path
+	// before matching it against the partition list. On macOS, t.TempDir() lives
+	// under /var, which is a symlink to /private/var, so without resolving here the
+	// mock partition mount point (the unresolved temp dir) would not prefix-match
+	// the resolved path, and the path would land in the no-device fallback group
+	// instead of matching its partition.
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 
 	// Simulate container with volume mounts: "/" not in partitions,
 	// but tempDir is a partition mount


### PR DESCRIPTION
First slice of the cross-platform test cleanup: the two macOS (arm64) native-CI failures. Test-side fixes only; production code is unchanged. The much larger Windows backlog is a separate effort and will land in follow-up PRs.

## `internal/monitor` TestGroupPathsWithPartitions_MixedRootAndVolumePaths

The test set a mock partition's mount point to `t.TempDir()` and passed the same dir as a path. `groupPathsWithPartitions` calls `filepath.EvalSymlinks` before matching, and on macOS `t.TempDir()` lives under `/var`, a symlink to `/private/var`. So the resolved path no longer prefix-matched the unresolved mount point, and the path fell through to the no-device fallback group (`Device ""` instead of the expected `/dev/sda1`).

Fix: resolve the temp dir with `filepath.EvalSymlinks` up front so the mock partition and the path agree on every platform. The other cases in this file use a mock helper that skips symlink resolution, so they were unaffected.

## `internal/birdweather` TestEncodeFlacUsingFFmpeg

`getFFmpegPath()` fell back to a hardcoded `/usr/bin/ffmpeg`, then to the bare name `"ffmpeg"`. On macOS FFmpeg is at `/opt/homebrew/bin/ffmpeg`, so it returned the relative `"ffmpeg"`, which the production encoder (`ValidateFFmpegPath`) rejects as non-absolute. The test did not skip because Homebrew FFmpeg is on PATH.

Fix: resolve the binary with `exec.LookPath` (returns an absolute path) using `conf.GetFfmpegBinaryName()`, so it works on Linux, macOS, and Windows.

## Validation

- Both tests pass locally with `-race` on Linux (FFmpeg present, so the birdweather test runs rather than skipping).
- `golangci-lint` on `internal/monitor` and `internal/birdweather`: 0 issues.
- The `macos-test` job on this PR provides the real macOS verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFmpeg executable path resolution for more reliable operation across different environments, including support for custom path overrides.
  * Enhanced symlink handling in path resolution to improve compatibility with macOS file systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->