### PR TITLE
feat(inference): hot-reload OpenVINO secondary models on device/backend change

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -460,6 +460,15 @@ func (cm *ControlMonitor) handleReloadBirdnet() {
 		GetLogger().Info("API controller common name map updated with new labels")
 	}
 
+	// Reload OV-capable secondary models (e.g. Perch) so a backend/OpenVINO-device
+	// change moves them onto the new device without a restart. No-ops when the
+	// backend/device is unchanged. The primary already reloaded above, so a
+	// secondary failure is surfaced but does not fail the overall reload.
+	if err := cm.bn.ReloadSecondaryModels(); err != nil {
+		GetLogger().Error("Failed to reload secondary models", logger.Error(err))
+		cm.notifyError("Failed to reload secondary models", err)
+	}
+
 	emitHotReload("birdnet_model")
 }
 

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2304,10 +2304,11 @@ func birdnetSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 	// Check for changes in the OpenVINO device preference. Switching CPU<->GPU
 	// recompiles the model on the new device, so a reload is needed; the OpenVINO
 	// core itself stays loaded (only the compiled model and infer request are
-	// rebuilt), so this is hot-reloadable, not restart-required. NOTE: this reload
-	// rebuilds the primary BirdNET classifier; secondary models (e.g. Perch) that
-	// also honor this device preference are rebuilt only on restart (the reload
-	// path reloads the primary model, not the secondary instances).
+	// rebuilt), so this is hot-reloadable, not restart-required. The reload path
+	// (handleReloadBirdnet) rebuilds the primary BirdNET classifier and then
+	// reloads the OV-capable secondary models (e.g. Perch) via
+	// Orchestrator.ReloadSecondaryModels, so a device/backend change applies to
+	// both without a restart.
 	if oldSettings.BirdNET.OpenVINODevice != currentSettings.BirdNET.OpenVINODevice {
 		return true
 	}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -37,6 +37,16 @@ type entryRef struct {
 	entry *modelEntry
 }
 
+// secondaryBackendKey identifies the inference backend / OpenVINO device that
+// the OV-capable secondary models were last built against. ReloadSecondaryModels
+// uses it as a change-detection gate so an unrelated reload_birdnet trigger
+// (locale, thresholds) does not needlessly rebuild a large secondary model.
+type secondaryBackendKey struct {
+	backend  string
+	ovDevice string
+	ovPath   string
+}
+
 // Orchestrator manages classifier model instances and provides the primary
 // inference API. It replaces direct *BirdNET usage at all call sites.
 // Supports multiple models with per-model locking and name resolution.
@@ -77,6 +87,16 @@ type Orchestrator struct {
 	// Nighttime scheduling for bat model. Stored as atomic.Pointer so
 	// IsModelActive (called on every monitor tick) reads lock-free.
 	scheduler atomic.Pointer[nighttimeScheduler]
+
+	// secondaryBackend records the backend triplet ReloadSecondaryModels last
+	// built the OV-capable secondaries against, so it can skip a rebuild when
+	// reload_birdnet fires for an unrelated setting. With a single OV-capable
+	// secondary (Perch) and a restart-required OpenVINOPath, this equals the
+	// triplet every loaded secondary actually runs on, because LoadModel builds a
+	// runtime-installed secondary from the same current settings. Adding a second
+	// OV-capable secondary would need per-entry triplet tracking to stay exact
+	// across out-of-band loads (tracked separately). Guarded by o.mu.
+	secondaryBackend secondaryBackendKey
 }
 
 // CurrentSettings returns the latest settings snapshot published via
@@ -140,6 +160,15 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 		primary: bn,
 	}
 	o.settingsAtomic.Store(settings)
+
+	// Seed the secondary-model backend gate with the startup triplet so the first
+	// reload_birdnet for an unrelated setting (e.g. a locale change) does not
+	// spuriously rebuild the secondaries (zero value would mismatch "onnx").
+	o.secondaryBackend = secondaryBackendKey{
+		backend:  settings.BirdNET.Backend,
+		ovDevice: settings.BirdNET.OpenVINODevice,
+		ovPath:   settings.BirdNET.OpenVINOPath,
+	}
 
 	// Pre-compute thread allocation so model constructors receive their share.
 	// BirdNET already uses settings.BirdNET.Threads at construction; additional
@@ -1104,6 +1133,150 @@ func (o *Orchestrator) ReloadModel() error {
 	return nil
 }
 
+// ReloadSecondaryModels rebuilds the OV-capable secondary models (currently
+// Perch) when the BirdNET inference backend or OpenVINO device preference
+// changes at runtime, so they move to the new device without a full restart.
+// It mirrors the primary reload's transactional safety: each model is built on
+// the new backend BEFORE the old instance is closed, and a build failure leaves
+// the old instance serving (one model failing does not abort the others).
+//
+// It is a no-op when the backend/device/path triplet is unchanged since the
+// last build, so an unrelated reload_birdnet trigger (locale, thresholds) does
+// not rebuild a large secondary model. The triplet is advanced unconditionally
+// before the build loop: a hard build failure is reported once rather than
+// retried on every subsequent unrelated reload; the user re-toggles the device
+// setting to retry.
+//
+// Returns the first build error encountered (for caller notification). The
+// reload itself does not fail on a secondary error because the primary model
+// has already reloaded by the time this runs.
+//
+// Lock discipline mirrors UnloadModel: o.mu is held only to gate and snapshot,
+// then released before the (potentially slow, JIT-compiling) builds; the swap
+// takes entry.mu alone, which cannot deadlock against PredictModel
+// (o.mu.RLock -> inferenceMu -> entry.mu) because entry.mu is acquired here as
+// a leaf lock while holding nothing else.
+func (o *Orchestrator) ReloadSecondaryModels() error {
+	log := GetLogger()
+
+	// Read the fresh settings published by the primary reload that ran just
+	// before this (ReloadModel atomically swapped the settings pointer).
+	settings := o.currentSettings()
+	triplet := secondaryBackendKey{
+		backend:  settings.BirdNET.Backend,
+		ovDevice: settings.BirdNET.OpenVINODevice,
+		ovPath:   settings.BirdNET.OpenVINOPath,
+	}
+
+	// Gate and snapshot under the write lock (the gate field is written here),
+	// then release o.mu before the slow builds.
+	o.mu.Lock()
+	if o.models == nil {
+		o.mu.Unlock()
+		return errors.Newf("orchestrator has been deleted, cannot reload secondary models").
+			Component("classifier.orchestrator").
+			Category(errors.CategorySystem).
+			Build()
+	}
+	if o.secondaryBackend == triplet {
+		o.mu.Unlock()
+		log.Debug("secondary models already built on current backend/device, skipping reload",
+			logger.String("backend", triplet.backend),
+			logger.String("ov_device", triplet.ovDevice))
+		return nil
+	}
+	// Advance the gate unconditionally (see method doc): a failed rebuild is not
+	// retried on the next unrelated reload.
+	o.secondaryBackend = triplet
+	primaryID := o.ModelInfo.ID
+	refs := make([]entryRef, 0, len(openvinoCapableSecondaryBuilders))
+	for id, entry := range o.models {
+		if _, ok := openvinoCapableSecondaryBuilders[id]; ok {
+			refs = append(refs, entryRef{id: id, entry: entry})
+		}
+	}
+	o.mu.Unlock()
+
+	if len(refs) == 0 {
+		return nil
+	}
+
+	// Full per-model thread budget (inference is serialized by inferenceMu),
+	// matching loadAdditionalModels.
+	threadAlloc := o.computeThreadAllocation(settings, primaryID)
+
+	// The builders below run outside o.mu. They construct from the settings
+	// snapshot and may read o.modelsDir (via resolveInstalledPaths), which is set
+	// once at startup by SetModelsDir before the pipeline (and thus this reload
+	// path) starts, so the read is safe without o.mu.
+
+	var firstErr error
+	for _, ref := range refs {
+		builder := openvinoCapableSecondaryBuilders[ref.id]
+		// A secondary present in o.models but absent from settings.Models.Enabled
+		// (e.g. installed at runtime then disabled in config) is not keyed in
+		// threadAlloc; fall back to the full budget, matching LoadModel's default
+		// (inference is serialized by inferenceMu, so each model gets all threads).
+		threads := threadAlloc[ref.id]
+		if threads <= 0 {
+			threads = settings.BirdNET.Threads
+			if threads <= 0 {
+				threads = runtime.NumCPU()
+			}
+		}
+		newInst, err := builder(o, settings, threads)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.Error("failed to rebuild secondary model on backend/device change; keeping existing instance",
+				logger.String("registry_id", ref.id),
+				logger.String("backend", triplet.backend),
+				logger.String("ov_device", triplet.ovDevice),
+				logger.Error(err))
+			continue
+		}
+
+		// Swap the new instance into the existing entry under entry.mu so it
+		// cannot race an in-flight PredictModel. Keeping the same *modelEntry
+		// preserves the per-entry mutex identity and the globalInferenceCounters
+		// keying.
+		ref.entry.mu.Lock()
+		old := ref.entry.instance
+		if old == nil {
+			// Entry was torn down by a concurrent Delete/Unload; do not resurrect
+			// a detached entry. Close the freshly built instance and skip.
+			ref.entry.mu.Unlock()
+			if err := newInst.Close(); err != nil {
+				log.Warn("failed to close orphaned secondary model instance after reload",
+					logger.String("registry_id", ref.id),
+					logger.Error(err))
+			}
+			continue
+		}
+		ref.entry.instance = newInst
+		ref.entry.mu.Unlock()
+
+		// Close the old instance after releasing entry.mu: native teardown can be
+		// slow, and no goroutine can reach the old instance once the swap is
+		// published (PredictModel reads entry.instance under entry.mu on every
+		// call). Building the new instance before closing the old keeps the OV
+		// active-classifier counter from transiently dropping to zero.
+		if err := old.Close(); err != nil {
+			log.Warn("failed to close old secondary model instance after reload",
+				logger.String("registry_id", ref.id),
+				logger.Error(err))
+		}
+
+		log.Info("secondary model reloaded on new backend/device",
+			logger.String("registry_id", ref.id),
+			logger.String("backend", triplet.backend),
+			logger.String("ov_device", triplet.ovDevice))
+	}
+
+	return firstErr
+}
+
 // Delete releases all resources held by the Orchestrator and its models.
 // After calling Delete, the Orchestrator must not be used.
 func (o *Orchestrator) Delete() {
@@ -1164,6 +1337,30 @@ func (o *Orchestrator) IsModelLoaded(registryID string) bool {
 var modelLoaders = map[string]func(o *Orchestrator, threads int) error{
 	RegistryIDPerchV2: (*Orchestrator).loadPerch,
 	RegistryIDBat:     (*Orchestrator).loadBat,
+}
+
+// secondaryModelBuilder constructs (but does not register) a secondary model
+// instance from a settings snapshot, for the transactional hot-reload path.
+type secondaryModelBuilder func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error)
+
+// openvinoCapableSecondaryBuilders maps the registry IDs of secondary models
+// whose construction honors the BirdNET inference backend / OpenVINO device
+// preference to a builder returning a fresh, unregistered instance.
+// ReloadSecondaryModels rebuilds exactly these models when the backend/device
+// changes at runtime. ORT-only secondaries (e.g. Bat, which consumes only
+// ONNXRuntimePath) are intentionally absent: rebuilding them on a device change
+// would be wasted native work. Giving a new secondary OpenVINO support is a
+// one-line entry here, paired with the OV fields on its loader config.
+var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
+	RegistryIDPerchV2: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
+		// Explicit nil-on-error return avoids the typed-nil interface trap (a
+		// nil *Perch wrapped in a non-nil ModelInstance).
+		p, err := o.buildPerch(settings, threads)
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	},
 }
 
 // LoadModel dynamically loads a model into the Orchestrator at runtime.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1195,6 +1195,10 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 			refs = append(refs, entryRef{id: id, entry: entry})
 		}
 	}
+	// Sort by registry ID so the rebuild order (and thus logs and the returned
+	// firstErr when several secondaries fail) is deterministic across the random
+	// map iteration order.
+	slices.SortFunc(refs, func(a, b entryRef) int { return strings.Compare(a.id, b.id) })
 	o.mu.Unlock()
 
 	if len(refs) == 0 {

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -1,16 +1,22 @@
 package classifier
 
 import (
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// loadPerch creates and registers a Perch v2 model instance from settings.
-func (o *Orchestrator) loadPerch(threads int) error {
-	log := GetLogger()
-
-	modelPath := o.Settings.Perch.ModelPath
-	labelPath := o.Settings.Perch.LabelPath
+// buildPerch constructs a Perch v2 model instance from the given settings
+// snapshot WITHOUT registering it in o.models. loadPerch uses it for the
+// initial registration; the hot-reload path (ReloadSecondaryModels) uses it
+// directly so it can build the new instance on the new backend/device before
+// transactionally swapping it into the existing modelEntry.
+//
+// The settings snapshot is passed in (rather than read inside) so the caller
+// builds with the exact settings it gated the reload decision on.
+func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch, error) {
+	modelPath := settings.Perch.ModelPath
+	labelPath := settings.Perch.LabelPath
 
 	if modelPath == "" || labelPath == "" {
 		m, l, _ := o.resolveInstalledPaths(RegistryIDPerchV2)
@@ -23,34 +29,44 @@ func (o *Orchestrator) loadPerch(threads int) error {
 	}
 
 	if modelPath == "" || labelPath == "" {
-		return errors.Newf("Perch v2 model files not installed or configured").
+		return nil, errors.Newf("Perch v2 model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDPerchV2).
 			Build()
 	}
 
-	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Perch v2", RegistryIDPerchV2, "classifier.orchestrator"); err != nil {
-		return err
+	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Perch v2", RegistryIDPerchV2, "classifier.orchestrator"); err != nil {
+		return nil, err
 	}
 
 	cfg := PerchConfig{
 		ModelPath:       modelPath,
 		LabelPath:       labelPath,
-		ONNXRuntimePath: o.Settings.BirdNET.ONNXRuntimePath,
+		ONNXRuntimePath: settings.BirdNET.ONNXRuntimePath,
 		Threads:         threads,
-		Backend:         o.Settings.BirdNET.Backend,
-		OpenVINOPath:    o.Settings.BirdNET.OpenVINOPath,
-		OpenVINODevice:  o.Settings.BirdNET.OpenVINODevice,
+		Backend:         settings.BirdNET.Backend,
+		OpenVINOPath:    settings.BirdNET.OpenVINOPath,
+		OpenVINODevice:  settings.BirdNET.OpenVINODevice,
 	}
 
 	perch, err := NewPerch(&cfg)
 	if err != nil {
-		return errors.New(err).
+		return nil, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDPerchV2).
 			Build()
+	}
+
+	return perch, nil
+}
+
+// loadPerch creates and registers a Perch v2 model instance from settings.
+func (o *Orchestrator) loadPerch(threads int) error {
+	perch, err := o.buildPerch(o.currentSettings(), threads)
+	if err != nil {
+		return err
 	}
 
 	o.models[perch.ModelID()] = &modelEntry{instance: perch}
@@ -59,7 +75,7 @@ func (o *Orchestrator) loadPerch(threads int) error {
 	// and the BirdNETLabelResolver (already registered) maps scientific -> common
 	// for species shared between both models.
 
-	log.Info("Perch v2 model loaded into Orchestrator",
+	GetLogger().Info("Perch v2 model loaded into Orchestrator",
 		logger.String("model_id", perch.ModelID()),
 		logger.Int("species", perch.NumSpecies()))
 

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -1,0 +1,271 @@
+package classifier
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// testSecondaryID and testSecondaryID2 are synthetic registry IDs used to
+// register fake OV-capable secondary builders for the ReloadSecondaryModels tests.
+const (
+	testSecondaryID  = "TestSecondary_OV"
+	testSecondaryID2 = "TestSecondary2_OV"
+)
+
+// fakeModelVersion is the version string reported by the test fake.
+const fakeModelVersion = "1.0"
+
+// reloadFakeModel is a ModelInstance that records Close calls so tests can assert
+// the old instance is torn down after a swap.
+type reloadFakeModel struct {
+	id      string
+	closes  atomic.Int32
+	onClose func()
+}
+
+func (m *reloadFakeModel) Predict(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+	return []datastore.Results{{Species: "Turdus merula", Confidence: 0.9}}, nil
+}
+func (m *reloadFakeModel) Spec() ModelSpec      { return ModelSpec{} }
+func (m *reloadFakeModel) ModelID() string      { return m.id }
+func (m *reloadFakeModel) ModelName() string    { return "reload-fake-" + m.id }
+func (m *reloadFakeModel) ModelVersion() string { return fakeModelVersion }
+func (m *reloadFakeModel) NumSpecies() int      { return 1 }
+func (m *reloadFakeModel) Labels() []string     { return []string{"Turdus merula_Common Blackbird"} }
+func (m *reloadFakeModel) Close() error {
+	m.closes.Add(1)
+	if m.onClose != nil {
+		m.onClose()
+	}
+	return nil
+}
+
+// registerTestSecondaryBuilder adds a builder under id for the duration of the
+// test, restoring the global map on cleanup. The map is a package global, so the
+// tests that use it must not run in parallel.
+func registerTestSecondaryBuilder(t *testing.T, id string, build secondaryModelBuilder) {
+	t.Helper()
+	_, existed := openvinoCapableSecondaryBuilders[id]
+	require.False(t, existed, "test builder %s already registered", id)
+	openvinoCapableSecondaryBuilders[id] = build
+	t.Cleanup(func() { delete(openvinoCapableSecondaryBuilders, id) })
+}
+
+// setGlobalBackend publishes test settings with the given backend/device so
+// o.currentSettings() (which prefers the global snapshot) returns them.
+func setGlobalBackend(t *testing.T, backend, ovDevice, ovPath string) {
+	t.Helper()
+	s := conftest.GetTestSettings()
+	s.BirdNET.Backend = backend
+	s.BirdNET.OpenVINODevice = ovDevice
+	s.BirdNET.OpenVINOPath = ovPath
+	conftest.SetTestSettings(s)
+	t.Cleanup(func() { conftest.SetTestSettings(nil) })
+}
+
+func TestReloadSecondaryModels_SwapsAndClosesOld(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "/opt/ov")
+
+	old := &reloadFakeModel{id: testSecondaryID}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[testSecondaryID] = &modelEntry{instance: old}
+	// Loaded on a different backend so the gate fires.
+	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+
+	var built atomic.Int32
+	newInst := &reloadFakeModel{id: testSecondaryID}
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, settings *conf.Settings, _ int) (ModelInstance, error) {
+		built.Add(1)
+		// Builder must receive the fresh (gated) settings snapshot.
+		assert.Equal(t, "openvino", settings.BirdNET.Backend)
+		assert.Equal(t, "gpu", settings.BirdNET.OpenVINODevice)
+		return newInst, nil
+	})
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	assert.Equal(t, int32(1), built.Load(), "builder should run once")
+	assert.Same(t, ModelInstance(newInst), o.models[testSecondaryID].instance, "new instance should be swapped in")
+	assert.Equal(t, int32(1), old.closes.Load(), "old instance should be closed once")
+	assert.Equal(t, int32(0), newInst.closes.Load(), "new instance must not be closed")
+	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}, o.secondaryBackend,
+		"gate should advance to the new triplet")
+}
+
+func TestReloadSecondaryModels_NoOpWhenTripletUnchanged(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "/opt/ov")
+
+	old := &reloadFakeModel{id: testSecondaryID}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[testSecondaryID] = &modelEntry{instance: old}
+	// Already on the current triplet: reload must be a no-op.
+	o.secondaryBackend = secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}
+
+	var built atomic.Int32
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		built.Add(1)
+		return &reloadFakeModel{id: testSecondaryID}, nil
+	})
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	assert.Equal(t, int32(0), built.Load(), "builder must not run when triplet is unchanged")
+	assert.Same(t, ModelInstance(old), o.models[testSecondaryID].instance, "instance must be untouched")
+	assert.Equal(t, int32(0), old.closes.Load(), "old instance must not be closed")
+}
+
+func TestReloadSecondaryModels_KeepsOldOnBuildFailure(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+
+	old := &reloadFakeModel{id: testSecondaryID}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[testSecondaryID] = &modelEntry{instance: old}
+	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+
+	buildErr := errors.Newf("simulated build failure").Build()
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		return nil, buildErr
+	})
+
+	err := o.ReloadSecondaryModels()
+	require.Error(t, err, "build failure should be returned to the caller")
+
+	assert.Same(t, ModelInstance(old), o.models[testSecondaryID].instance, "old instance must keep serving on build failure")
+	assert.Equal(t, int32(0), old.closes.Load(), "old instance must not be closed when its rebuild fails")
+	// Advance-always: the gate moves to the new triplet so an unrelated reload
+	// does not retry the failed build.
+	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu"}, o.secondaryBackend,
+		"gate should still advance after a build failure")
+}
+
+func TestReloadSecondaryModels_SkipsNonOVCapableSecondary(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+
+	// A non-OV-capable secondary (no builder registered, e.g. ORT-only Bat) must
+	// not be touched by the reload.
+	batLike := &reloadFakeModel{id: RegistryIDBat}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[RegistryIDBat] = &modelEntry{instance: batLike}
+	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	assert.Same(t, ModelInstance(batLike), o.models[RegistryIDBat].instance, "non-OV secondary must be untouched")
+	assert.Equal(t, int32(0), batLike.closes.Load(), "non-OV secondary must not be closed")
+}
+
+func TestReloadSecondaryModels_OrphanedEntrySkipsSwapAndClosesNew(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	// Entry is present in the map but its instance was torn down by a concurrent
+	// Delete/Unload (instance == nil). The reload must not resurrect a detached
+	// entry; it must close the freshly built instance and leave the entry nil.
+	o.models[testSecondaryID] = &modelEntry{instance: nil}
+	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+
+	built := &reloadFakeModel{id: testSecondaryID}
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		return built, nil
+	})
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	assert.Nil(t, o.models[testSecondaryID].instance, "orphaned entry must not be resurrected")
+	assert.Equal(t, int32(1), built.closes.Load(), "freshly built instance must be closed when the entry was orphaned")
+}
+
+func TestReloadSecondaryModels_PartialFailureAmongMultiple(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+
+	oldOK := &reloadFakeModel{id: testSecondaryID}
+	oldFail := &reloadFakeModel{id: testSecondaryID2}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[testSecondaryID] = &modelEntry{instance: oldOK}
+	o.models[testSecondaryID2] = &modelEntry{instance: oldFail}
+	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+
+	newOK := &reloadFakeModel{id: testSecondaryID}
+	buildErr := errors.Newf("simulated build failure for second secondary").Build()
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		return newOK, nil
+	})
+	registerTestSecondaryBuilder(t, testSecondaryID2, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		return nil, buildErr
+	})
+
+	err := o.ReloadSecondaryModels()
+	require.Error(t, err, "a build failure among multiple secondaries must be returned")
+
+	// One failure must not abort the others: the model that built successfully is
+	// swapped and its old instance closed.
+	assert.Same(t, ModelInstance(newOK), o.models[testSecondaryID].instance, "successful secondary should be swapped in")
+	assert.Equal(t, int32(1), oldOK.closes.Load(), "old instance of the successful secondary should be closed")
+	// The model whose build failed keeps its old instance, not closed.
+	assert.Same(t, ModelInstance(oldFail), o.models[testSecondaryID2].instance, "failed secondary should keep serving its old instance")
+	assert.Equal(t, int32(0), oldFail.closes.Load(), "old instance of the failed secondary must not be closed")
+}
+
+// TestReloadSecondaryModels_RaceWithPredict exercises the entry.mu swap against
+// concurrent PredictModel calls. Run with -race to prove the swap is race-free.
+func TestReloadSecondaryModels_RaceWithPredict(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	o.models[testSecondaryID] = &modelEntry{instance: &reloadFakeModel{id: testSecondaryID}}
+	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		return &reloadFakeModel{id: testSecondaryID}, nil
+	})
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	ctx := t.Context()
+	sample := [][]float32{make([]float32, 16)} // arbitrary non-empty frame; the fake model ignores the shape
+
+	for range 4 {
+		wg.Go(func() {
+			for !stop.Load() {
+				// The swap happens entirely under entry.mu and PredictModel reads
+				// entry.instance under the same lock, so a predict never sees a
+				// half-closed instance. This loop's job is to give the race
+				// detector concurrent readers against the swapping writer.
+				_, _ = o.PredictModel(ctx, testSecondaryID, sample)
+			}
+		})
+	}
+
+	// Force a rebuild on each iteration by alternating the device so the gate
+	// keeps firing (the previous successful reload advanced it to the prior value).
+	// Publish directly (not via setGlobalBackend) to avoid stacking 40 cleanups;
+	// the initial setGlobalBackend already registered the reset-to-nil cleanup.
+	devices := []string{"cpu", "gpu"}
+	for i := range 40 {
+		s := conftest.GetTestSettings()
+		s.BirdNET.Backend = "openvino"
+		s.BirdNET.OpenVINODevice = devices[i%2]
+		conftest.SetTestSettings(s)
+		require.NoError(t, o.ReloadSecondaryModels())
+	}
+
+	stop.Store(true)
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Changing `BirdNET.OpenVINODevice` or `BirdNET.Backend` at runtime fires the `reload_birdnet` control signal, which previously rebuilt only the primary BirdNET classifier. Secondary models (Perch) kept their startup device/backend until a full restart.

This adds `Orchestrator.ReloadSecondaryModels`, called from `handleReloadBirdnet` after the primary reload, so a device/backend change now also moves the OpenVINO-capable secondaries (currently Perch) onto the new device without a restart.

## How it works

- **Transactional build-then-swap:** each secondary is rebuilt on the new backend, then swapped into the existing `modelEntry` under `entry.mu` (mirroring `UnloadModel`'s lock discipline). A build failure leaves the old instance serving, and one model failing never aborts the others. Building the new instance before closing the old keeps the OpenVINO active-classifier counter from transiently hitting zero.
- **Backend-triplet gate:** a `{backend, OpenVINO device, OpenVINO path}` gate skips the rebuild when `reload_birdnet` fires for an unrelated setting (locale, thresholds), so the 14795-class Perch is not rebuilt needlessly. The gate is seeded at construction and advanced on each reload.
- **Scope:** `loadPerch` is split into `buildPerch` (construct from a settings snapshot, no map write) and `loadPerch` (register). Bat stays ORT-only and is excluded from the reload because its construction ignores the OpenVINO preference; adding a future OV-capable secondary is a one-line entry in `openvinoCapableSecondaryBuilders`.

## Test Plan

- [x] Unit tests: swap-and-close-old, no-op when the triplet is unchanged, keep-old-on-build-failure (advance-always gate), skip non-OV secondary, orphaned-entry guard, multi-secondary partial failure.
- [x] `go test -race` over a reload running concurrently with `PredictModel` on the same secondary (the `entry.mu` swap is race-free).
- [x] `golangci-lint run` clean; full classifier package passes with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Secondary models (e.g., Perch) now support hot-reloading when OpenVINO device or backend settings change, eliminating the need to restart the application.

* **Tests**
  * Added comprehensive test suite for secondary model hot-reload functionality, including concurrency and failure scenario validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->