### PR TITLE
fix(audio): unique temp file per export to stop clip collisions (#3323)

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -365,10 +365,9 @@ func (c *Controller) findEncodingTempPath(relClipPath string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	prefix := filepath.Base(relClipPath) + "."
+	base := filepath.Base(relClipPath)
 	for _, entry := range entries {
-		name := entry.Name()
-		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ffmpeg.TempExt) {
+		if !isExportTempFor(entry.Name(), base) {
 			continue
 		}
 		info, infoErr := entry.Info()
@@ -377,10 +376,40 @@ func (c *Controller) findEncodingTempPath(relClipPath string) (string, bool) {
 		}
 		// Guard against stale temp files from failed exports.
 		if time.Since(info.ModTime()) < audioEncodingMaxAge {
-			return filepath.Join(dir, name), true
+			return filepath.Join(dir, entry.Name()), true
 		}
 	}
 	return "", false
+}
+
+// isExportTempFor reports whether name is an in-progress export temp file for the
+// clip file named base. It matches the per-export unique form
+// "<base>.<pid>.<seq>.temp" (pid and seq are integers, see ffmpeg.uniqueTempPath)
+// and the pre-fix "<base>.temp" form, but NOT unrelated sidecar temps that merely
+// share the prefix and suffix, e.g. a spectrogram's "<base>.png.<pid>.<seq>.temp".
+func isExportTempFor(name, base string) bool {
+	// Pre-fix format: exactly "<base>.temp".
+	if name == base+ffmpeg.TempExt {
+		return true
+	}
+	// Unique format: "<base>.<pid>.<seq>.temp" with integer pid and seq.
+	middle, ok := strings.CutPrefix(name, base+".")
+	if !ok {
+		return false
+	}
+	middle, ok = strings.CutSuffix(middle, ffmpeg.TempExt)
+	if !ok {
+		return false
+	}
+	pidStr, seqStr, ok := strings.Cut(middle, ".")
+	if !ok {
+		return false
+	}
+	if _, err := strconv.Atoi(pidStr); err != nil {
+		return false
+	}
+	_, err := strconv.Atoi(seqStr)
+	return err == nil
 }
 
 // isAudioBeingEncoded reports whether a recent in-progress export temp file

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -350,19 +350,46 @@ func parseRawParameter(rawParam string) bool {
 	}
 }
 
-// isAudioBeingEncoded checks if an audio file at the given relative path is
-// currently being encoded by FFmpeg. FFmpeg exports use a temporary file with
-// a ".temp" suffix that is atomically renamed upon completion. If a recent
-// temp file exists, the audio is still being written and the caller should
-// return 503 instead of 404.
-func (c *Controller) isAudioBeingEncoded(relClipPath string) bool {
-	tempPath := relClipPath + ffmpeg.TempExt
-	info, err := c.SFS.StatRel(tempPath)
+// findEncodingTempPath looks for an in-progress export temp file for relClipPath
+// and, if a recent one exists, returns its path (relative to the SecureFS root)
+// and true. Exports write to a per-export unique temp file named
+// "<clip>.<pid>.<seq>.temp" (see ffmpeg.ExportAudio / flac.EncodePCM) that is
+// atomically renamed to the final clip on completion, so the clip's directory is
+// scanned for any matching temp. The pre-fix "<clip>.temp" name is matched too,
+// so a temp written by an older build mid-upgrade is handled. Returning the
+// concrete path lets a waiting caller poll that fixed name with StatRel instead
+// of re-scanning the directory on every tick.
+func (c *Controller) findEncodingTempPath(relClipPath string) (string, bool) {
+	dir := filepath.Dir(relClipPath)
+	entries, err := c.SFS.ReadDirRel(dir)
 	if err != nil {
-		return false
+		return "", false
 	}
-	// Guard against stale temp files from failed exports
-	return time.Since(info.ModTime()) < audioEncodingMaxAge
+	prefix := filepath.Base(relClipPath) + "."
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ffmpeg.TempExt) {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		// Guard against stale temp files from failed exports.
+		if time.Since(info.ModTime()) < audioEncodingMaxAge {
+			return filepath.Join(dir, name), true
+		}
+	}
+	return "", false
+}
+
+// isAudioBeingEncoded reports whether a recent in-progress export temp file
+// exists for relClipPath. Callers that then wait for the clip should use
+// findEncodingTempPath directly so they can poll the temp's fixed name with
+// StatRel rather than re-scanning the directory each tick.
+func (c *Controller) isAudioBeingEncoded(relClipPath string) bool {
+	_, ok := c.findEncodingTempPath(relClipPath)
+	return ok
 }
 
 // handleAudioNotReady returns a 503 Service Unavailable response with a
@@ -379,7 +406,7 @@ func (c *Controller) handleAudioNotReady(ctx echo.Context) error {
 // timeout, false if encoding is still ongoing or the temp file disappeared.
 // This reduces 503 responses by waiting server-side instead of requiring
 // the client to retry.
-func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath string) bool {
+func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath, tempPath string) bool {
 	waitCtx, cancel := context.WithTimeout(ctx.Request().Context(), audioWaitTimeout)
 	defer cancel()
 
@@ -392,10 +419,12 @@ func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath string) bool
 		if _, err := c.SFS.StatRel(relClipPath); err == nil {
 			return true
 		}
-		// If the temp file is gone, encoding has finished or failed.
-		// Re-check for the final file to handle the TOCTOU race where encoding
-		// completed (atomic rename) between the StatRel and isAudioBeingEncoded calls.
-		if !c.isAudioBeingEncoded(relClipPath) {
+		// If the temp file is gone (or went stale, i.e. a failed export left it
+		// behind), encoding has finished or failed. Poll the concrete temp path
+		// with a cheap StatRel (no directory re-scan); re-check the final file to
+		// handle the TOCTOU race where encoding completed (atomic rename) between
+		// the two StatRel calls.
+		if info, err := c.SFS.StatRel(tempPath); err != nil || time.Since(info.ModTime()) >= audioEncodingMaxAge {
 			_, err := c.SFS.StatRel(relClipPath)
 			return err == nil
 		}
@@ -451,10 +480,11 @@ func (c *Controller) waitForAudioFileGrace(ctx echo.Context, relClipPath string)
 // created the temp file yet or already renamed it. Returns nil if the file was
 // successfully served, or the original/translated error otherwise.
 func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, logFields ...logger.Field) error {
-	if c.isAudioBeingEncoded(relClipPath) {
+	if tempPath, encoding := c.findEncodingTempPath(relClipPath); encoding {
 		// Wait server-side for the file to appear instead of immediately
-		// returning 503, reducing unnecessary client round-trips.
-		if c.waitForAudioFile(ctx, relClipPath) {
+		// returning 503, reducing unnecessary client round-trips. Pass the
+		// concrete temp path so the wait loop polls it directly.
+		if c.waitForAudioFile(ctx, relClipPath, tempPath) {
 			// File appeared — serve it now
 			if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
 				return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after encoding completed")

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -1334,6 +1334,37 @@ func TestGetSpectrogramLogger(t *testing.T) {
 // TestServeAudioClipWaitsForEncoding verifies that when an audio file is being
 // encoded (temp file exists), the server waits for the final file to appear
 // instead of immediately returning 503.
+// TestIsExportTempFor verifies the in-progress-encoding temp matcher accepts the
+// export temp formats and rejects unrelated sidecar temps that merely share the
+// clip's prefix and the ".temp" suffix (GitHub #3323).
+func TestIsExportTempFor(t *testing.T) {
+	t.Parallel()
+	const base = "turdus_merula_84p_20260531T084138Z.m4a"
+	tests := []struct {
+		name string
+		file string
+		want bool
+	}{
+		{"unique format", base + ".12345.1" + ffmpeg.TempExt, true},
+		{"unique format large seq", base + ".987.4096" + ffmpeg.TempExt, true},
+		{"pre-fix legacy format", base + ffmpeg.TempExt, true},
+		{"final clip", base, false},
+		{"final clip other ext", base + ".part", false},
+		{"sidecar spectrogram temp", base + ".png.12345.1" + ffmpeg.TempExt, false},
+		{"different clip", "other_99p_20260531T084138Z.m4a.12345.1" + ffmpeg.TempExt, false},
+		{"non-integer pid", base + ".abc.1" + ffmpeg.TempExt, false},
+		{"non-integer seq", base + ".12345.x" + ffmpeg.TempExt, false},
+		{"missing seq", base + ".12345" + ffmpeg.TempExt, false},
+		{"extra middle segment", base + ".12345.1.2" + ffmpeg.TempExt, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isExportTempFor(tt.file, base))
+		})
+	}
+}
+
 func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 	e, controller, tempDir := setupMediaTestEnvironment(t)
 

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -1339,7 +1339,10 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 
 	audioFilename := "encoding-test.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
-	tempFilePath := audioFilePath + ffmpeg.TempExt
+	// Mirror the per-export unique temp name "<clip>.<pid>.<seq>.temp" the real
+	// exporters write, so this exercises the directory-scan detection in
+	// isAudioBeingEncoded rather than a fixed name that production never produces.
+	tempFilePath := audioFilePath + ".99999.1" + ffmpeg.TempExt
 
 	// Create the temp file to simulate in-progress encoding
 	err := os.WriteFile(tempFilePath, []byte("temp encoding data"), 0o600)
@@ -1396,7 +1399,10 @@ func TestServeAudioClipReturns503AfterTimeout(t *testing.T) {
 
 	audioFilename := "slow-encoding.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
-	tempFilePath := audioFilePath + ffmpeg.TempExt
+	// Mirror the per-export unique temp name "<clip>.<pid>.<seq>.temp" the real
+	// exporters write, so this exercises the directory-scan detection in
+	// isAudioBeingEncoded rather than a fixed name that production never produces.
+	tempFilePath := audioFilePath + ".99999.1" + ffmpeg.TempExt
 
 	// Create only the temp file — final file never appears
 	err := os.WriteFile(tempFilePath, []byte("temp encoding data"), 0o600)

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -119,7 +119,7 @@ func GetFFmpegFormat(sampleRate, numChannels, bitDepth int) (sampleRateStr, chan
 
 // getSoxBinaryName returns the platform-appropriate sox binary name.
 func getSoxBinaryName() string {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return "sox.exe"
 	}
 

--- a/internal/audiocore/ffmpeg/export.go
+++ b/internal/audiocore/ffmpeg/export.go
@@ -9,17 +9,69 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+// osWindows is runtime.GOOS on Windows, where concurrent same-target renames
+// need a retry (see finalizeExport).
+const osWindows = "windows"
+
 // TempExt is the temporary file extension used when exporting audio with FFmpeg.
 // Audio files are written with this suffix during encoding and renamed upon
 // completion to ensure atomic file operations.
 const TempExt = ".temp"
+
+// tempSeq makes every export's temp file unique within the process. Two exports
+// targeting the same OutputPath (e.g. two audio sources detecting the same
+// species in the same one-second window at the same rounded confidence, see
+// GitHub #3323) must not share one temp file: otherwise the first rename wins
+// and the rest fail with ENOENT, and concurrent FFmpeg writers can corrupt the
+// shared temp before it is renamed into place.
+//
+//nolint:gochecknoglobals // process-wide monotonic counter for unique temp names
+var tempSeq atomic.Uint64
+
+// uniqueTempPath returns a process-unique temp path for outputPath. The result
+// still ends in TempExt so diskmanager keeps skipping it during cleanup, and the
+// pid + counter prefix avoids colliding with a stale temp left by a crashed run
+// that happens to share the recordings directory.
+func uniqueTempPath(outputPath string) string {
+	return fmt.Sprintf("%s.%d.%d%s", outputPath, os.Getpid(), tempSeq.Add(1), TempExt)
+}
+
+// Concurrent exports that dedupe onto the same final clip (see uniqueTempPath /
+// GitHub #3323) finish with an atomic rename. POSIX rename(2) is atomic and the
+// kernel serializes concurrent renames to the same target, but Windows
+// MoveFileEx can transiently fail with a sharing violation when two renames hit
+// the same path at once; these bound a short Windows-only retry.
+const (
+	renameRetryAttempts = 8
+	renameRetryDelay    = 15 * time.Millisecond
+)
+
+// finalizeExport atomically renames the unique temp file onto the final clip
+// path. On non-Windows platforms it is a single os.Rename (identical behavior to
+// before). On Windows it retries a bounded number of times to absorb the sharing
+// violations that concurrent same-target renames can raise.
+func finalizeExport(tempPath, finalPath string) error {
+	err := os.Rename(tempPath, finalPath)
+	if err == nil || runtime.GOOS != osWindows {
+		return err
+	}
+	for attempt := 1; attempt < renameRetryAttempts; attempt++ {
+		time.Sleep(renameRetryDelay)
+		if err = os.Rename(tempPath, finalPath); err == nil {
+			return nil
+		}
+	}
+	return err
+}
 
 // minExportPhaseTimeout is the minimum time allowed for a single FFmpeg export phase.
 const minExportPhaseTimeout = 30 * time.Second
@@ -124,8 +176,10 @@ func ExportAudio(ctx context.Context, opts *ExportOptions) error {
 			Build()
 	}
 
-	// Write to a temp file first for atomic finalisation.
-	tempPath := opts.OutputPath + TempExt
+	// Write to a unique temp file first for atomic finalisation. The temp name
+	// must be unique per export so concurrent exports targeting the same final
+	// path do not share one temp file (see uniqueTempPath / GitHub #3323).
+	tempPath := uniqueTempPath(opts.OutputPath)
 	defer func() {
 		// Best-effort cleanup of the temp file if export failed.
 		if _, statErr := os.Stat(tempPath); statErr == nil {
@@ -165,8 +219,8 @@ func ExportAudio(ctx context.Context, opts *ExportOptions) error {
 		return err
 	}
 
-	// Atomic rename to final path.
-	if err := os.Rename(tempPath, opts.OutputPath); err != nil {
+	// Atomic rename to final path (Windows-safe under concurrent dedup).
+	if err := finalizeExport(tempPath, opts.OutputPath); err != nil {
 		return errors.Newf("failed to finalize export output: %w", err).
 			Component("audiocore/ffmpeg").
 			Category(errors.CategoryFileIO).

--- a/internal/audiocore/ffmpeg/export_test.go
+++ b/internal/audiocore/ffmpeg/export_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,60 @@ func TestExportAudio_MP3(t *testing.T) {
 
 	// The temp file must be removed after successful export.
 	assert.NoFileExists(t, outPath+ffmpeg.TempExt)
+}
+
+// TestExportAudio_ConcurrentSamePathNoTempCollision reproduces GitHub #3323 for
+// the FFmpeg export path: when several exports target the same OutputPath (two
+// audio sources detect the same species in the same one-second window at the
+// same rounded confidence, producing an identical clip name), each export must
+// use its own temp file. Previously every export wrote to the shared
+// OutputPath+TempExt and renamed it into place, so the first rename won and the
+// rest failed with ENOENT ("no such file or directory"), permanently dropping
+// those clips. All exports must succeed and leave a valid clip behind.
+func TestExportAudio_ConcurrentSamePathNoTempCollision(t *testing.T) {
+	t.Parallel()
+
+	ffmpegPath, err := findFFmpegBinary()
+	if err != nil {
+		t.Skip("FFmpeg not available:", err)
+	}
+
+	const workers = 16
+	outDir := t.TempDir()
+	// AAC/m4a is the format from the issue report.
+	outPath := filepath.Join(outDir, "columba_palumbus_95p_20260531T083828Z.m4a")
+	pcm := makePCMSilence(t, 1)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximise collision
+			errs[i] = ffmpeg.ExportAudio(t.Context(), &ffmpeg.ExportOptions{
+				PCMData:    pcm,
+				OutputPath: outPath,
+				Format:     ffmpeg.FormatAAC,
+				Bitrate:    "128k",
+				SampleRate: 48000,
+				Channels:   1,
+				BitDepth:   16,
+				FFmpegPath: ffmpegPath,
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "concurrent export %d must not fail on a shared temp path", i)
+	}
+	assert.FileExists(t, outPath)
+	leftover, globErr := filepath.Glob(filepath.Join(outDir, "*"+ffmpeg.TempExt))
+	require.NoError(t, globErr)
+	assert.Empty(t, leftover, "no temp files should remain after concurrent exports")
 }
 
 // TestExportAudio_FLAC verifies that PCM audio can be exported to a FLAC file.

--- a/internal/audiocore/ffmpeg/validate.go
+++ b/internal/audiocore/ffmpeg/validate.go
@@ -355,7 +355,7 @@ func isFileSizeStable(ctx context.Context, path string, initialSize int64) bool 
 
 // getFfprobeBinaryName returns the platform-appropriate ffprobe binary name.
 func getFfprobeBinaryName() string {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return "ffprobe.exe"
 	}
 	return "ffprobe"

--- a/internal/audiocore/flac/encode.go
+++ b/internal/audiocore/flac/encode.go
@@ -3,17 +3,25 @@ package flac
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	goflac "github.com/tphakala/go-flac/pcm"
 )
 
 const (
+	// osWindows is runtime.GOOS on Windows, where concurrent same-target renames
+	// need a retry (see finalizeEncode).
+	osWindows = "windows"
+
 	// tempExt is appended to the output path while encoding; the file is renamed
 	// to the final path on success. Intentionally duplicated from ffmpeg.TempExt
 	// (same value ".temp") rather than imported, to keep this package free of any
@@ -72,10 +80,56 @@ type Options struct {
 // constant-true condition into the call site.
 func SupportedBitDepth(bitDepth int) bool { return bitDepth == bitDepth16 }
 
+// tempSeq makes every export's temp file unique within the process. Two exports
+// targeting the same OutputPath (e.g. two audio sources detecting the same
+// species in the same one-second window at the same rounded confidence, see
+// GitHub #3323) must not share one temp file: otherwise the first rename wins
+// and the rest fail with ENOENT, and concurrent writers can corrupt the shared
+// temp before it is renamed into place.
+//
+//nolint:gochecknoglobals // process-wide monotonic counter for unique temp names
+var tempSeq atomic.Uint64
+
+// uniqueTempPath returns a process-unique temp path for outputPath. The result
+// still ends in tempExt so diskmanager keeps skipping it during cleanup, and
+// the pid + counter prefix avoids colliding with a stale temp left by a crashed
+// run that happens to share the recordings directory.
+func uniqueTempPath(outputPath string) string {
+	return fmt.Sprintf("%s.%d.%d%s", outputPath, os.Getpid(), tempSeq.Add(1), tempExt)
+}
+
+// Concurrent exports that dedupe onto the same final clip (see uniqueTempPath /
+// GitHub #3323) finish with an atomic rename. POSIX rename(2) is atomic and the
+// kernel serializes concurrent renames to the same target, but Windows
+// MoveFileEx can transiently fail with a sharing violation when two renames hit
+// the same path at once; these bound a short Windows-only retry.
+const (
+	renameRetryAttempts = 8
+	renameRetryDelay    = 15 * time.Millisecond
+)
+
+// finalizeEncode atomically renames the unique temp file onto the final clip
+// path. On non-Windows platforms it is a single os.Rename (identical behavior to
+// before). On Windows it retries a bounded number of times to absorb the sharing
+// violations that concurrent same-target renames can raise.
+func finalizeEncode(tempPath, finalPath string) error {
+	err := os.Rename(tempPath, finalPath)
+	if err == nil || runtime.GOOS != osWindows {
+		return err
+	}
+	for attempt := 1; attempt < renameRetryAttempts; attempt++ {
+		time.Sleep(renameRetryDelay)
+		if err = os.Rename(tempPath, finalPath); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
 // EncodePCM encodes opts.PCMData to a FLAC file at opts.OutputPath. The write is
-// atomic: data is encoded to OutputPath+tempExt and renamed on success, with the
-// temp file removed on any failure. A non-zero GainDB is applied in Go before
-// encoding; opts.PCMData itself is never modified.
+// atomic: data is encoded to a unique per-export temp file and renamed on
+// success, with the temp file removed on any failure. A non-zero GainDB is
+// applied in Go before encoding; opts.PCMData itself is never modified.
 func EncodePCM(ctx context.Context, opts *Options) (err error) {
 	if opts == nil {
 		return errors.Newf("flac encode: nil options").
@@ -106,7 +160,7 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 			Build()
 	}
 
-	tempPath := opts.OutputPath + tempExt
+	tempPath := uniqueTempPath(opts.OutputPath)
 	f, createErr := os.Create(tempPath) //nolint:gosec // path derived from validated config
 	if createErr != nil {
 		return errors.New(createErr).
@@ -163,7 +217,7 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 			Build()
 	}
 
-	if renameErr := os.Rename(tempPath, opts.OutputPath); renameErr != nil {
+	if renameErr := finalizeEncode(tempPath, opts.OutputPath); renameErr != nil {
 		return errors.New(renameErr).
 			Component("audiocore/flac").
 			Category(errors.CategoryFileIO).

--- a/internal/audiocore/flac/encode_test.go
+++ b/internal/audiocore/flac/encode_test.go
@@ -65,6 +65,56 @@ func TestEncodePCM_RoundTripLossless(t *testing.T) {
 	assert.Equal(t, pcm, decodeFLAC(t, path), "decoded PCM must equal input (lossless)")
 }
 
+// assertNoTempLeftover fails if any temp file remains in the output directory.
+// It replaces the older exact-path checks (outputPath + ".temp"): the temp file
+// now carries a per-export unique token before the suffix, so cleanup is
+// verified by globbing the directory rather than by a fixed name.
+func assertNoTempLeftover(t *testing.T, outputPath string) {
+	t.Helper()
+	leftover, err := filepath.Glob(filepath.Join(filepath.Dir(outputPath), "*"+tempExt))
+	require.NoError(t, err)
+	assert.Empty(t, leftover, "no %s files should remain in %s", tempExt, filepath.Dir(outputPath))
+}
+
+// TestEncodePCM_ConcurrentSamePathNoTempCollision reproduces GitHub #3323: when
+// several exports target the same OutputPath (e.g. two audio sources detect the
+// same species in the same one-second window at the same rounded confidence),
+// each must encode to its own temp file. Previously every export wrote to the
+// shared OutputPath+tempExt and renamed it into place, so the first rename won
+// and the rest failed with ENOENT ("no such file or directory"), permanently
+// dropping those clips (and the shared temp could be corrupted by concurrent
+// writers). All exports must succeed and leave a valid lossless clip behind.
+func TestEncodePCM_ConcurrentSamePathNoTempCollision(t *testing.T) {
+	t.Parallel()
+	const workers = 32
+	dir := t.TempDir()
+	path := filepath.Join(dir, "columba_palumbus_95p_20260531T083828Z.flac")
+	pcm := makeTestPCM(20000)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximise collision
+			errs[i] = EncodePCM(t.Context(), baseOpts(path, pcm))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "concurrent export %d must not fail on a shared temp path", i)
+	}
+	// Every worker encodes identical PCM, so whichever export wins the last
+	// rename (last-writer-wins dedup) the surviving clip decodes to the same
+	// bytes; this assertion is deterministic only because the inputs are equal.
+	assert.Equal(t, pcm, decodeFLAC(t, path), "the surviving clip must be a valid lossless FLAC")
+	assertNoTempLeftover(t, path)
+}
+
 func TestEncodePCM_GainRoundTrip(t *testing.T) {
 	t.Parallel()
 	pcm := makeTestPCM(10000)
@@ -156,7 +206,7 @@ func TestEncodePCM_CancelledBeforeStart(t *testing.T) {
 	err := EncodePCM(ctx, opts)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.NoFileExists(t, opts.OutputPath)
-	assert.NoFileExists(t, opts.OutputPath+".temp")
+	assertNoTempLeftover(t, opts.OutputPath)
 }
 
 // errAfterCtx returns nil from Err() for the first `after` calls, then
@@ -191,7 +241,7 @@ func TestEncodePCM_CancelledDuringEncode(t *testing.T) {
 	err := EncodePCM(ctx, opts)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.NoFileExists(t, opts.OutputPath)
-	assert.NoFileExists(t, opts.OutputPath+".temp")
+	assertNoTempLeftover(t, opts.OutputPath)
 }
 
 // TestEncoderReuseAfterAbortedWrite verifies the pooling safety contract that
@@ -286,7 +336,7 @@ func TestEncodePCM_NoTempFileLeftOnSuccess(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "clip.flac")
 	require.NoError(t, EncodePCM(t.Context(), baseOpts(path, makeTestPCM(5000))))
 	assert.FileExists(t, path)
-	assert.NoFileExists(t, path+".temp")
+	assertNoTempLeftover(t, path)
 }
 
 func TestEncodePCM_EmitsSeekTable(t *testing.T) {

--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -802,6 +802,35 @@ func (sfs *SecureFS) ReadDir(path string) ([]os.DirEntry, error) {
 	return entries, nil
 }
 
+// ReadDirRel reads the directory at relPath (relative to the SecureFS root) and
+// returns its entries. Unlike ReadDir, which resolves its argument against the
+// process working directory, ReadDirRel validates relPath the same way StatRel
+// does, so it correctly lists directories addressed relative to the root, which
+// is the form stored clip paths use.
+func (sfs *SecureFS) ReadDirRel(relPath string) ([]os.DirEntry, error) {
+	validatedRelPath, err := sfs.ValidateRelativePath(relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dirFile, err := sfs.root.Open(validatedRelPath)
+	if err != nil {
+		return nil, errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "open_directory_rel").Build()
+	}
+	defer func() {
+		if closeErr := dirFile.Close(); closeErr != nil {
+			GetLogger().Warn("Failed to close directory", logger.Error(closeErr))
+		}
+	}()
+
+	entries, err := dirFile.ReadDir(0) // 0 means read all entries
+	if err != nil {
+		return nil, errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "read_directory_entries_rel").Build()
+	}
+
+	return entries, nil
+}
+
 // BaseDir returns the absolute base directory path of the secure filesystem.
 func (sfs *SecureFS) BaseDir() string {
 	return sfs.baseDir


### PR DESCRIPTION
## Summary

Fixes clip loss when two audio sources detect the same species in the same one-second window at the same rounded confidence. Both exports resolved to the same `<clip>.temp` file, so the first `os.Rename` won and the rest failed with `ENOENT` ("no such file or directory"), permanently dropping those clips. The shared temp could also be corrupted by two concurrent writers.

Each export now writes a process-unique `<clip>.<pid>.<seq>.temp` and atomically renames it onto the final path (last-writer-wins safe dedup), in both the FFmpeg and native FLAC paths. The name still ends in `.temp`, so the diskmanager cleanup keeps skipping it.

Follow-on fixes the temp-name change required:

- **Media API.** `isAudioBeingEncoded` stat-ed the fixed `<clip>.temp` name and would now always miss, silently disabling the "wait server-side / 503 Retry-After while encoding" behavior. It now scans the clip's directory for any matching temp via a new `SecureFS.ReadDirRel` (the existing `ReadDir` resolves relative to the process working directory, which is wrong for root-relative clip paths), capturing the concrete temp path once so `waitForAudioFile` polls a fixed name with an O(1) `StatRel` instead of re-scanning the directory on every tick.
- **Windows.** `finalizeExport` / `finalizeEncode` add a bounded Windows-only rename retry to absorb the sharing violations that concurrent same-target renames can raise there. POSIX `rename(2)` is atomic and serialized, so there is no behavior change on Linux/macOS.

## Related Issues

Fixes #3323

## Test Plan

- [x] New concurrency regression tests for both export paths (`TestExportAudio_ConcurrentSamePathNoTempCollision`, `TestEncodePCM_ConcurrentSamePathNoTempCollision`) reproduce the exact ENOENT failure on the old shared-temp code and pass on the fix
- [x] Updated the media encoding-detection tests to use the realistic unique-temp name so they exercise the real scan path
- [x] `go build ./...` clean, `golangci-lint run` reports 0 issues, `go test -race` passes on securefs, ffmpeg, flac, api/v2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SecureFS directory listing via a relative-path API.
  * Improved “audio still encoding” detection by scanning for in-progress export temp files and waiting on the correct temp target.

* **Bug Fixes**
  * Prevented temp-file collisions when multiple exports target the same output path concurrently.
  * Improved atomic finalize behavior on Windows to reduce transient rename/race failures.

* **Tests**
  * Added/updated concurrency and detection tests, including temp-filename pattern coverage and checks for no leftover temp artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->