### PR TITLE
fix(audio): atomic WAV writes + shared audiotemp helper

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -384,7 +384,7 @@ func (c *Controller) findEncodingTempPath(relClipPath string) (string, bool) {
 
 // isExportTempFor reports whether name is an in-progress export temp file for the
 // clip file named base. It matches the per-export unique form
-// "<base>.<pid>.<seq>.temp" (pid and seq are integers, see ffmpeg.uniqueTempPath)
+// "<base>.<pid>.<seq>.temp" (pid and seq are integers, see audiotemp.UniquePath)
 // and the pre-fix "<base>.temp" form, but NOT unrelated sidecar temps that merely
 // share the prefix and suffix, e.g. a spectrogram's "<base>.png.<pid>.<seq>.temp".
 func isExportTempFor(name, base string) bool {

--- a/internal/audiocore/audiotemp/audiotemp.go
+++ b/internal/audiocore/audiotemp/audiotemp.go
@@ -1,0 +1,68 @@
+// Package audiotemp centralizes the temp-file naming and atomic-finalize
+// contract shared by BirdNET-Go's audio clip writers: the FFmpeg exporter, the
+// native FLAC encoder, and the WAV writer. Each writes a clip to a process-
+// unique temp file and atomically renames it into place, so two simultaneous
+// detections that resolve to the same clip path (see GitHub #3323) dedup safely
+// instead of colliding on a shared temp or corrupting the final file mid-write.
+package audiotemp
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// Ext is the suffix of an in-progress export's temp file. A clip is finalized by
+// atomically renaming "<clip>...Ext" onto "<clip>"; diskmanager skips any file
+// ending in Ext, so a temp is never treated as a finished clip. diskmanager keeps
+// its own copy of this literal (diskmanager.tempFileExt); the two must stay in
+// sync, or in-progress clips would stop being skipped during cleanup.
+const Ext = ".temp"
+
+// osWindows is runtime.GOOS on Windows, where concurrent same-target renames
+// need a retry (see Finalize).
+const osWindows = "windows"
+
+const (
+	renameRetryAttempts = 8
+	renameRetryDelay    = 15 * time.Millisecond
+)
+
+// seq makes every temp file unique within the process. Two exports targeting the
+// same final clip (e.g. two audio sources detecting the same species in the same
+// one-second window at the same rounded confidence) must not share one temp
+// file: otherwise the first rename wins and the rest fail with ENOENT, and two
+// writers could corrupt the shared temp before it is renamed. See GitHub #3323.
+//
+//nolint:gochecknoglobals // process-wide monotonic counter for unique temp names
+var seq atomic.Uint64
+
+// UniquePath returns a process-unique temp path for outputPath. The result still
+// ends in Ext so diskmanager keeps skipping it during cleanup, and the pid +
+// counter prefix avoids colliding with a stale temp left by a crashed run that
+// happens to share the recordings directory.
+func UniquePath(outputPath string) string {
+	return fmt.Sprintf("%s.%d.%d%s", outputPath, os.Getpid(), seq.Add(1), Ext)
+}
+
+// Finalize atomically renames the unique temp file onto the final clip path. On
+// non-Windows platforms it is a single os.Rename (rename(2) is atomic and the
+// kernel serializes concurrent renames to the same target). On Windows,
+// MoveFileEx can transiently fail with a sharing violation when two concurrent
+// exports rename onto the same path; Finalize retries a bounded number of times
+// there to absorb it.
+func Finalize(tempPath, finalPath string) error {
+	err := os.Rename(tempPath, finalPath)
+	if err == nil || runtime.GOOS != osWindows {
+		return err
+	}
+	for attempt := 1; attempt < renameRetryAttempts; attempt++ {
+		time.Sleep(renameRetryDelay)
+		if err = os.Rename(tempPath, finalPath); err == nil {
+			return nil
+		}
+	}
+	return err
+}

--- a/internal/audiocore/audiotemp/audiotemp_test.go
+++ b/internal/audiocore/audiotemp/audiotemp_test.go
@@ -1,0 +1,109 @@
+package audiotemp_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
+)
+
+func TestUniquePath_PrefixedByOutputAndEndsInExt(t *testing.T) {
+	t.Parallel()
+	out := filepath.Join("clips", "2026", "05", "turdus_merula_84p_20260531T084138Z.flac")
+	p := audiotemp.UniquePath(out)
+	assert.True(t, strings.HasPrefix(p, out+"."), "temp path must start with the output path plus a dot: %s", p)
+	assert.True(t, strings.HasSuffix(p, audiotemp.Ext), "temp path must end in Ext: %s", p)
+}
+
+// TestUniquePath_DistinctAcrossConcurrentCalls is the core guarantee: concurrent
+// exports targeting the same output path must each get a different temp path.
+func TestUniquePath_DistinctAcrossConcurrentCalls(t *testing.T) {
+	t.Parallel()
+	const n = 256
+	const out = "clip.flac"
+	var wg sync.WaitGroup
+	paths := make([]string, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			paths[i] = audiotemp.UniquePath(out)
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]struct{}, n)
+	for _, p := range paths {
+		_, dup := seen[p]
+		require.Falsef(t, dup, "duplicate temp path generated: %s", p)
+		seen[p] = struct{}{}
+	}
+	assert.Len(t, seen, n)
+}
+
+func TestFinalize_RenamesTempToFinal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	final := filepath.Join(dir, "clip.wav")
+	temp := audiotemp.UniquePath(final)
+	require.NoError(t, os.WriteFile(temp, []byte("payload"), 0o600))
+
+	require.NoError(t, audiotemp.Finalize(temp, final))
+
+	got, err := os.ReadFile(final)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(got))
+	assert.NoFileExists(t, temp, "temp must be gone after a successful rename")
+}
+
+// TestFinalize_MissingTempErrorsAndLeavesNoFinal pins the atomic guarantee: when
+// the rename fails (here, the temp does not exist), Finalize returns an error and
+// does not create the final clip.
+func TestFinalize_MissingTempErrorsAndLeavesNoFinal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	final := filepath.Join(dir, "clip.wav")
+	missing := audiotemp.UniquePath(final) // never created
+
+	err := audiotemp.Finalize(missing, final)
+	require.Error(t, err, "renaming a nonexistent temp must fail")
+	assert.NoFileExists(t, final, "a failed finalize must not create the final clip")
+}
+
+// TestFinalize_ConcurrentSameTargetAllSucceed verifies that many exports
+// finalizing onto the same path all succeed (last writer wins) and leave no temp
+// behind, on every platform (the Windows path additionally exercises the retry).
+func TestFinalize_ConcurrentSameTargetAllSucceed(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	final := filepath.Join(dir, "clip.wav")
+	const n = 16
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			temp := audiotemp.UniquePath(final)
+			if writeErr := os.WriteFile(temp, []byte{byte(i)}, 0o600); writeErr != nil {
+				errs[i] = writeErr
+				return
+			}
+			errs[i] = audiotemp.Finalize(temp, final)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "finalize %d must not fail", i)
+	}
+	require.FileExists(t, final, "exactly one final clip must remain")
+	leftover, err := filepath.Glob(filepath.Join(dir, "*"+audiotemp.Ext))
+	require.NoError(t, err)
+	assert.Empty(t, leftover, "no temp files should remain after concurrent finalize")
+}

--- a/internal/audiocore/convert/encode.go
+++ b/internal/audiocore/convert/encode.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
@@ -57,6 +58,17 @@ func SavePCMDataToWAV(filePath string, pcmData []byte, sampleRate, bitDepth int)
 			Build()
 	}
 
+	// Reject a non-positive sample rate up front: the WAV encoder divides by it
+	// and would otherwise panic with an integer divide-by-zero.
+	if sampleRate <= 0 {
+		return errors.Newf("invalid sample rate %d: SavePCMDataToWAV requires a positive sample rate", sampleRate).
+			Component("audiocore/convert").
+			Category(errors.CategoryValidation).
+			Context("operation", "save_pcm_to_wav").
+			Context("sample_rate", sampleRate).
+			Build()
+	}
+
 	bytesPerSample := bitDepth / 8
 	if len(pcmData)%bytesPerSample != 0 {
 		return errors.Newf("PCM data size (%d bytes) is not aligned with bit depth (%d bits, %d bytes per sample)", len(pcmData), bitDepth, bytesPerSample).
@@ -78,18 +90,35 @@ func SavePCMDataToWAV(filePath string, pcmData []byte, sampleRate, bitDepth int)
 			Build()
 	}
 
-	outFile, err := os.Create(filePath) //nolint:gosec // G304: filePath is constructed programmatically, not from raw user input
+	// Write to a process-unique temp file and atomically rename it onto the final
+	// path, so concurrent saves of the same clip (see GitHub #3323) cannot
+	// interleave into one file and a failed save never leaves a partial clip.
+	tempPath := audiotemp.UniquePath(filePath)
+	outFile, err := os.Create(tempPath) //nolint:gosec // G304: tempPath derives from filePath, which is constructed programmatically, not from raw user input
 	if err != nil {
 		return errors.New(err).
 			Component("audiocore/convert").
 			Category(errors.CategoryFileIO).
 			Context("operation", "save_pcm_to_wav").
-			Context("file_operation", "create_file").
+			Context("file_operation", "create_temp_file").
 			Build()
 	}
+
+	// Cleanup: close the temp file (idempotent) and remove it unless committed.
+	committed := false
+	fileOpen := true
+	closeFile := func() error {
+		if !fileOpen {
+			return nil
+		}
+		fileOpen = false
+		return outFile.Close()
+	}
 	defer func() {
-		// Best-effort close; encoder.Close() is the authoritative finalization step.
-		_ = outFile.Close()
+		_ = closeFile()
+		if !committed {
+			_ = os.Remove(tempPath)
+		}
 	}()
 
 	enc := wav.NewEncoder(outFile, sampleRate, bitDepth, wavNumChannels, wavAudioFormat)
@@ -128,6 +157,38 @@ func SavePCMDataToWAV(filePath string, pcmData []byte, sampleRate, bitDepth int)
 			Build()
 	}
 
+	// Flush the temp file to stable storage before renaming so a crash right
+	// after the rename cannot leave an empty or partial clip (matches the FLAC
+	// encoder's sync-before-rename).
+	if err := outFile.Sync(); err != nil {
+		return errors.New(err).
+			Component("audiocore/convert").
+			Category(errors.CategoryFileIO).
+			Context("operation", "save_pcm_to_wav").
+			Context("file_operation", "sync_temp_file").
+			Build()
+	}
+
+	// Close the temp file before renaming: flush its contents and release the
+	// handle so the rename succeeds on Windows (which cannot rename an open file).
+	if err := closeFile(); err != nil {
+		return errors.New(err).
+			Component("audiocore/convert").
+			Category(errors.CategoryFileIO).
+			Context("operation", "save_pcm_to_wav").
+			Context("file_operation", "close_temp_file").
+			Build()
+	}
+
+	if err := audiotemp.Finalize(tempPath, filePath); err != nil {
+		return errors.New(err).
+			Component("audiocore/convert").
+			Category(errors.CategoryFileIO).
+			Context("operation", "save_pcm_to_wav").
+			Context("file_operation", "finalize_rename").
+			Build()
+	}
+	committed = true
 	return nil
 }
 

--- a/internal/audiocore/convert/encode_test.go
+++ b/internal/audiocore/convert/encode_test.go
@@ -4,12 +4,69 @@ import (
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 )
+
+// TestSavePCMDataToWAV_ConcurrentSamePathNoCorruption reproduces the WAV
+// counterpart of GitHub #3323: when several detections resolve to the same clip
+// path, the WAV writer must not let concurrent saves interleave into one file.
+// Each worker writes a worker-distinct constant sample value, so a clean result
+// (one writer's complete WAV, finalized atomically) is uniform, while an
+// interleaved write mixes values from different writers. The save must use a
+// per-write unique temp file and an atomic rename, like the FFmpeg/FLAC paths.
+func TestSavePCMDataToWAV_ConcurrentSamePathNoCorruption(t *testing.T) {
+	t.Parallel()
+	const (
+		workers = 32
+		samples = 96000 // 2 s mono 16-bit
+	)
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "columba_palumbus_95p_20260531T083828Z.wav")
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			pcm := make([]byte, samples*2)
+			for j := range samples {
+				binary.LittleEndian.PutUint16(pcm[j*2:], uint16(1000+i)) //nolint:gosec // G115: small positive test constant
+			}
+			<-start // release all workers together to maximise collision
+			errs[i] = convert.SavePCMDataToWAV(filePath, pcm, 48000, 16)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "concurrent WAV save %d must not fail", i)
+	}
+
+	// The surviving clip must be exactly one worker's complete, uncorrupted WAV:
+	// a valid header whose data size matches a full write, and a payload of a
+	// single repeated value (not an interleaved mix of different workers).
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(data), 44, "valid WAV header expected")
+	dataSize := binary.LittleEndian.Uint32(data[40:44])
+	require.Equal(t, uint32(samples*2), dataSize, "data chunk size must match one complete write")
+	require.GreaterOrEqual(t, len(data), 44+samples*2, "file must hold the full payload")
+
+	payload := data[44 : 44+samples*2]
+	first := binary.LittleEndian.Uint16(payload[0:2])
+	for off := 2; off < len(payload); off += 2 {
+		v := binary.LittleEndian.Uint16(payload[off:])
+		require.Equalf(t, first, v, "sample at byte offset %d differs (%d vs %d): interleaved/corrupt WAV", off, v, first)
+	}
+}
 
 // makePCM16Bytes generates a simple mono 16-bit PCM byte slice from int16 samples.
 func makePCM16Bytes(t *testing.T, samples []int16) []byte {
@@ -105,6 +162,16 @@ func TestSavePCMDataToWAV(t *testing.T) {
 		err := convert.SavePCMDataToWAV(filepath.Join(dir, "out.wav"), []byte{0x01, 0x02, 0x03}, 48000, 16)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not aligned")
+	})
+
+	t.Run("non-positive sample rate returns error, not a panic", func(t *testing.T) {
+		t.Parallel()
+		for _, sr := range []int{0, -1} {
+			dir := t.TempDir()
+			err := convert.SavePCMDataToWAV(filepath.Join(dir, "out.wav"), makePCM16Bytes(t, []int16{0, 1}), sr, 16)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "sample rate")
+		}
 	})
 
 	t.Run("creates parent directories", func(t *testing.T) {

--- a/internal/audiocore/ffmpeg/export.go
+++ b/internal/audiocore/ffmpeg/export.go
@@ -9,69 +9,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
-// osWindows is runtime.GOOS on Windows, where concurrent same-target renames
-// need a retry (see finalizeExport).
+// osWindows is runtime.GOOS on Windows, where the sox and ffprobe binaries carry
+// a .exe suffix (see getSoxBinaryName / getFfprobeBinaryName).
 const osWindows = "windows"
 
-// TempExt is the temporary file extension used when exporting audio with FFmpeg.
-// Audio files are written with this suffix during encoding and renamed upon
-// completion to ensure atomic file operations.
-const TempExt = ".temp"
-
-// tempSeq makes every export's temp file unique within the process. Two exports
-// targeting the same OutputPath (e.g. two audio sources detecting the same
-// species in the same one-second window at the same rounded confidence, see
-// GitHub #3323) must not share one temp file: otherwise the first rename wins
-// and the rest fail with ENOENT, and concurrent FFmpeg writers can corrupt the
-// shared temp before it is renamed into place.
-//
-//nolint:gochecknoglobals // process-wide monotonic counter for unique temp names
-var tempSeq atomic.Uint64
-
-// uniqueTempPath returns a process-unique temp path for outputPath. The result
-// still ends in TempExt so diskmanager keeps skipping it during cleanup, and the
-// pid + counter prefix avoids colliding with a stale temp left by a crashed run
-// that happens to share the recordings directory.
-func uniqueTempPath(outputPath string) string {
-	return fmt.Sprintf("%s.%d.%d%s", outputPath, os.Getpid(), tempSeq.Add(1), TempExt)
-}
-
-// Concurrent exports that dedupe onto the same final clip (see uniqueTempPath /
-// GitHub #3323) finish with an atomic rename. POSIX rename(2) is atomic and the
-// kernel serializes concurrent renames to the same target, but Windows
-// MoveFileEx can transiently fail with a sharing violation when two renames hit
-// the same path at once; these bound a short Windows-only retry.
-const (
-	renameRetryAttempts = 8
-	renameRetryDelay    = 15 * time.Millisecond
-)
-
-// finalizeExport atomically renames the unique temp file onto the final clip
-// path. On non-Windows platforms it is a single os.Rename (identical behavior to
-// before). On Windows it retries a bounded number of times to absorb the sharing
-// violations that concurrent same-target renames can raise.
-func finalizeExport(tempPath, finalPath string) error {
-	err := os.Rename(tempPath, finalPath)
-	if err == nil || runtime.GOOS != osWindows {
-		return err
-	}
-	for attempt := 1; attempt < renameRetryAttempts; attempt++ {
-		time.Sleep(renameRetryDelay)
-		if err = os.Rename(tempPath, finalPath); err == nil {
-			return nil
-		}
-	}
-	return err
-}
+// TempExt is the temporary file extension used when exporting audio. It aliases
+// audiotemp.Ext; the process-unique temp name and the atomic, Windows-safe rename
+// live in the shared audiotemp package (see ExportAudio / GitHub #3323).
+const TempExt = audiotemp.Ext
 
 // minExportPhaseTimeout is the minimum time allowed for a single FFmpeg export phase.
 const minExportPhaseTimeout = 30 * time.Second
@@ -176,10 +129,10 @@ func ExportAudio(ctx context.Context, opts *ExportOptions) error {
 			Build()
 	}
 
-	// Write to a unique temp file first for atomic finalisation. The temp name
-	// must be unique per export so concurrent exports targeting the same final
-	// path do not share one temp file (see uniqueTempPath / GitHub #3323).
-	tempPath := uniqueTempPath(opts.OutputPath)
+	// Write to a unique temp file first for atomic finalisation, so concurrent
+	// exports targeting the same final path do not share one temp file (see
+	// audiotemp / GitHub #3323).
+	tempPath := audiotemp.UniquePath(opts.OutputPath)
 	defer func() {
 		// Best-effort cleanup of the temp file if export failed.
 		if _, statErr := os.Stat(tempPath); statErr == nil {
@@ -220,7 +173,7 @@ func ExportAudio(ctx context.Context, opts *ExportOptions) error {
 	}
 
 	// Atomic rename to final path (Windows-safe under concurrent dedup).
-	if err := finalizeExport(tempPath, opts.OutputPath); err != nil {
+	if err := audiotemp.Finalize(tempPath, opts.OutputPath); err != nil {
 		return errors.Newf("failed to finalize export output: %w", err).
 			Component("audiocore/ffmpeg").
 			Category(errors.CategoryFileIO).

--- a/internal/audiocore/flac/encode.go
+++ b/internal/audiocore/flac/encode.go
@@ -3,30 +3,22 @@ package flac
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
-	"sync/atomic"
-	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	goflac "github.com/tphakala/go-flac/pcm"
 )
 
 const (
-	// osWindows is runtime.GOOS on Windows, where concurrent same-target renames
-	// need a retry (see finalizeEncode).
-	osWindows = "windows"
-
 	// tempExt is appended to the output path while encoding; the file is renamed
-	// to the final path on success. Intentionally duplicated from ffmpeg.TempExt
-	// (same value ".temp") rather than imported, to keep this package free of any
-	// dependency on the ffmpeg package it is meant to replace.
-	tempExt = ".temp"
+	// to the final path on success. It aliases audiotemp.Ext (a leaf package with
+	// no dependency on the ffmpeg package this encoder is meant to replace).
+	tempExt = audiotemp.Ext
 
 	// defaultCompressionLevel matches FFmpeg's default FLAC compression level and
 	// go-flac's benchmark default.
@@ -80,52 +72,6 @@ type Options struct {
 // constant-true condition into the call site.
 func SupportedBitDepth(bitDepth int) bool { return bitDepth == bitDepth16 }
 
-// tempSeq makes every export's temp file unique within the process. Two exports
-// targeting the same OutputPath (e.g. two audio sources detecting the same
-// species in the same one-second window at the same rounded confidence, see
-// GitHub #3323) must not share one temp file: otherwise the first rename wins
-// and the rest fail with ENOENT, and concurrent writers can corrupt the shared
-// temp before it is renamed into place.
-//
-//nolint:gochecknoglobals // process-wide monotonic counter for unique temp names
-var tempSeq atomic.Uint64
-
-// uniqueTempPath returns a process-unique temp path for outputPath. The result
-// still ends in tempExt so diskmanager keeps skipping it during cleanup, and
-// the pid + counter prefix avoids colliding with a stale temp left by a crashed
-// run that happens to share the recordings directory.
-func uniqueTempPath(outputPath string) string {
-	return fmt.Sprintf("%s.%d.%d%s", outputPath, os.Getpid(), tempSeq.Add(1), tempExt)
-}
-
-// Concurrent exports that dedupe onto the same final clip (see uniqueTempPath /
-// GitHub #3323) finish with an atomic rename. POSIX rename(2) is atomic and the
-// kernel serializes concurrent renames to the same target, but Windows
-// MoveFileEx can transiently fail with a sharing violation when two renames hit
-// the same path at once; these bound a short Windows-only retry.
-const (
-	renameRetryAttempts = 8
-	renameRetryDelay    = 15 * time.Millisecond
-)
-
-// finalizeEncode atomically renames the unique temp file onto the final clip
-// path. On non-Windows platforms it is a single os.Rename (identical behavior to
-// before). On Windows it retries a bounded number of times to absorb the sharing
-// violations that concurrent same-target renames can raise.
-func finalizeEncode(tempPath, finalPath string) error {
-	err := os.Rename(tempPath, finalPath)
-	if err == nil || runtime.GOOS != osWindows {
-		return err
-	}
-	for attempt := 1; attempt < renameRetryAttempts; attempt++ {
-		time.Sleep(renameRetryDelay)
-		if err = os.Rename(tempPath, finalPath); err == nil {
-			return nil
-		}
-	}
-	return err
-}
-
 // EncodePCM encodes opts.PCMData to a FLAC file at opts.OutputPath. The write is
 // atomic: data is encoded to a unique per-export temp file and renamed on
 // success, with the temp file removed on any failure. A non-zero GainDB is
@@ -160,7 +106,7 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 			Build()
 	}
 
-	tempPath := uniqueTempPath(opts.OutputPath)
+	tempPath := audiotemp.UniquePath(opts.OutputPath)
 	f, createErr := os.Create(tempPath) //nolint:gosec // path derived from validated config
 	if createErr != nil {
 		return errors.New(createErr).
@@ -217,7 +163,7 @@ func EncodePCM(ctx context.Context, opts *Options) (err error) {
 			Build()
 	}
 
-	if renameErr := finalizeEncode(tempPath, opts.OutputPath); renameErr != nil {
+	if renameErr := audiotemp.Finalize(tempPath, opts.OutputPath); renameErr != nil {
 		return errors.New(renameErr).
 			Component("audiocore/flac").
 			Category(errors.CategoryFileIO).


### PR DESCRIPTION
## Summary

The WAV clip writer (`convert.SavePCMDataToWAV`) wrote directly to the final path with `os.Create`, with no temp file and no atomic rename. Two simultaneous detections that resolve to the same clip path (the same collision class fixed for FFmpeg/FLAC in #3556) could interleave into one file, and a crash or failure mid-write left a partial clip. It now writes to a process-unique temp file, fsyncs and closes it, then atomically renames it onto the final path (removing the temp on failure), matching the FFmpeg and native FLAC export paths.

This is the third export path needing the unique-temp + atomic-rename + Windows-retry contract, so rather than copy it a third time, the contract is extracted into a small new leaf package `internal/audiocore/audiotemp` (`UniquePath`, `Finalize`, `Ext`). The FFmpeg exporter and FLAC encoder are refactored to use it; their `TempExt`/`tempExt` constants now alias `audiotemp.Ext`, so the media API's in-progress-encoding detection and the diskmanager `.temp` cleanup are unchanged (verified byte-for-byte behavior-preserving).

Also fixes a latent panic: `SavePCMDataToWAV` now rejects a non-positive sample rate up front, instead of reaching the WAV encoder and panicking with an integer divide-by-zero.

## Test Plan

- [x] New concurrency guard test for the WAV path, plus tests for the new `audiotemp` package (unique-path under concurrency, rename, concurrent-finalize, and the rename error path)
- [x] Regression test for the sample-rate validation (0 and -1 return an error, no panic)
- [x] Existing FFmpeg/FLAC concurrency tests still pass after the refactor (behavior-preserving)
- [x] `go build ./...` clean, `golangci-lint run ./internal/audiocore/... ./internal/api/v2/...` reports 0 issues, `go test -race` passes on audiotemp, convert, ffmpeg, flac, and the analysis/processor consumer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced audio export reliability through atomic file finalization and improved temp file handling
  * Fixed potential data corruption when exporting multiple audio files to the same destination simultaneously
  * Added validation for audio sample rates during export operations

* **Tests**
  * Added comprehensive tests for concurrent audio export scenarios
  * Expanded validation testing for export parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->