### PR TITLE
fix(classifier): track inference backend per secondary model entry

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1222,10 +1222,18 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 		// Per-entry gate: read the triplet this entry's instance was built against
 		// under entry.mu and skip the rebuild when it already matches the current
 		// settings. The read pairs with the swap below, which publishes the new
-		// triplet under the same lock.
+		// triplet under the same lock. Also skip an entry whose instance was already
+		// torn down by a concurrent Delete/Unload (instance == nil): building a fresh
+		// (potentially multi-second, JIT-compiling) instance for a detached entry
+		// would only be discarded by the orphan guard at swap time. The post-build
+		// guard still covers a teardown that races the build itself.
 		ref.entry.mu.Lock()
 		current := ref.entry.backend
+		orphaned := ref.entry.instance == nil
 		ref.entry.mu.Unlock()
+		if orphaned {
+			continue
+		}
 		if current == triplet {
 			log.Debug("secondary model already built on current backend/device, skipping reload",
 				logger.String("registry_id", ref.id),

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -28,6 +28,15 @@ import (
 type modelEntry struct {
 	instance ModelInstance
 	mu       sync.Mutex // per-model lock; prevents inference on one model from blocking another
+
+	// backend records the inference-backend triplet this entry's instance was last
+	// built against. It is only set and read for OV-capable secondary models (those
+	// in openvinoCapableSecondaryBuilders); ReloadSecondaryModels compares it
+	// per-entry against the current settings to decide whether a backend/device
+	// change requires rebuilding this specific model. Guarded by mu, the same lock
+	// that guards instance, so the triplet is always published with the instance it
+	// describes. Non-secondary entries (e.g. the primary) leave it at the zero value.
+	backend secondaryBackendKey
 }
 
 // entryRef pairs a registry ID with its model entry for the snapshot-then-iterate
@@ -37,10 +46,11 @@ type entryRef struct {
 	entry *modelEntry
 }
 
-// secondaryBackendKey identifies the inference backend / OpenVINO device that
-// the OV-capable secondary models were last built against. ReloadSecondaryModels
-// uses it as a change-detection gate so an unrelated reload_birdnet trigger
-// (locale, thresholds) does not needlessly rebuild a large secondary model.
+// secondaryBackendKey identifies the inference backend / OpenVINO device that an
+// OV-capable secondary model was last built against. Each modelEntry stores its
+// own key (see modelEntry.backend); ReloadSecondaryModels uses it as a per-entry
+// change-detection gate so an unrelated reload_birdnet trigger (locale,
+// thresholds) does not needlessly rebuild a large secondary model.
 type secondaryBackendKey struct {
 	backend  string
 	ovDevice string
@@ -87,16 +97,6 @@ type Orchestrator struct {
 	// Nighttime scheduling for bat model. Stored as atomic.Pointer so
 	// IsModelActive (called on every monitor tick) reads lock-free.
 	scheduler atomic.Pointer[nighttimeScheduler]
-
-	// secondaryBackend records the backend triplet ReloadSecondaryModels last
-	// built the OV-capable secondaries against, so it can skip a rebuild when
-	// reload_birdnet fires for an unrelated setting. With a single OV-capable
-	// secondary (Perch) and a restart-required OpenVINOPath, this equals the
-	// triplet every loaded secondary actually runs on, because LoadModel builds a
-	// runtime-installed secondary from the same current settings. Adding a second
-	// OV-capable secondary would need per-entry triplet tracking to stay exact
-	// across out-of-band loads (tracked separately). Guarded by o.mu.
-	secondaryBackend secondaryBackendKey
 }
 
 // CurrentSettings returns the latest settings snapshot published via
@@ -161,14 +161,11 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	}
 	o.settingsAtomic.Store(settings)
 
-	// Seed the secondary-model backend gate with the startup triplet so the first
-	// reload_birdnet for an unrelated setting (e.g. a locale change) does not
-	// spuriously rebuild the secondaries (zero value would mismatch "onnx").
-	o.secondaryBackend = secondaryBackendKey{
-		backend:  settings.BirdNET.Backend,
-		ovDevice: settings.BirdNET.OpenVINODevice,
-		ovPath:   settings.BirdNET.OpenVINOPath,
-	}
+	// Each OV-capable secondary records the startup triplet on its own modelEntry
+	// when its loader registers it below (see loadPerch), so the first
+	// reload_birdnet for an unrelated setting (e.g. a locale change) sees a
+	// matching triplet and does not spuriously rebuild it. No orchestrator-wide
+	// gate to seed here anymore.
 
 	// Pre-compute thread allocation so model constructors receive their share.
 	// BirdNET already uses settings.BirdNET.Threads at construction; additional
@@ -1133,6 +1130,19 @@ func (o *Orchestrator) ReloadModel() error {
 	return nil
 }
 
+// secondaryTripletFor returns the inference-backend triplet that OV-capable
+// secondary models build against. The secondaries share the primary's OpenVINO
+// configuration, so the triplet is derived from settings.BirdNET. Each modelEntry
+// records this (modelEntry.backend) at build time so ReloadSecondaryModels can
+// detect a per-model backend/device change.
+func secondaryTripletFor(settings *conf.Settings) secondaryBackendKey {
+	return secondaryBackendKey{
+		backend:  settings.BirdNET.Backend,
+		ovDevice: settings.BirdNET.OpenVINODevice,
+		ovPath:   settings.BirdNET.OpenVINOPath,
+	}
+}
+
 // ReloadSecondaryModels rebuilds the OV-capable secondary models (currently
 // Perch) when the BirdNET inference backend or OpenVINO device preference
 // changes at runtime, so they move to the new device without a full restart.
@@ -1140,36 +1150,39 @@ func (o *Orchestrator) ReloadModel() error {
 // the new backend BEFORE the old instance is closed, and a build failure leaves
 // the old instance serving (one model failing does not abort the others).
 //
-// It is a no-op when the backend/device/path triplet is unchanged since the
-// last build, so an unrelated reload_birdnet trigger (locale, thresholds) does
-// not rebuild a large secondary model. The triplet is advanced unconditionally
-// before the build loop: a hard build failure is reported once rather than
-// retried on every subsequent unrelated reload; the user re-toggles the device
-// setting to retry.
+// The change-detection gate is per-entry (modelEntry.backend): each OV-capable
+// secondary is rebuilt only when its own recorded triplet differs from the
+// current settings, so an unrelated reload_birdnet trigger (locale, thresholds)
+// does not rebuild a large secondary model. Per-entry tracking (vs a single
+// orchestrator-wide gate) stays exact when a secondary is installed out-of-band
+// at runtime (LoadModel records the entry's triplet at load) and when more than
+// one OV-capable secondary is loaded. Each entry's triplet is advanced
+// unconditionally once its rebuild is reconciled: a hard build failure is
+// reported once and the gate still advances, so it is not retried on every
+// subsequent unrelated reload; the user re-toggles the device setting to retry.
 //
 // Returns the first build error encountered (for caller notification). The
 // reload itself does not fail on a secondary error because the primary model
 // has already reloaded by the time this runs.
 //
-// Lock discipline mirrors UnloadModel: o.mu is held only to gate and snapshot,
-// then released before the (potentially slow, JIT-compiling) builds; the swap
-// takes entry.mu alone, which cannot deadlock against PredictModel
-// (o.mu.RLock -> inferenceMu -> entry.mu) because entry.mu is acquired here as
-// a leaf lock while holding nothing else.
+// Lock discipline mirrors UnloadModel: o.mu is held only to snapshot the entry
+// set, then released before the (potentially slow, JIT-compiling) builds; the
+// per-entry gate read and the swap take entry.mu alone, which cannot deadlock
+// against PredictModel (o.mu.RLock -> inferenceMu -> entry.mu) because entry.mu
+// is acquired here as a leaf lock while holding nothing else. ReloadSecondaryModels
+// is invoked from the serialized reload path, so concurrent invocations are not
+// expected; if two ever interleaved, the per-entry gate makes the worst case a
+// redundant rebuild, never a corrupted swap.
 func (o *Orchestrator) ReloadSecondaryModels() error {
 	log := GetLogger()
 
 	// Read the fresh settings published by the primary reload that ran just
 	// before this (ReloadModel atomically swapped the settings pointer).
 	settings := o.currentSettings()
-	triplet := secondaryBackendKey{
-		backend:  settings.BirdNET.Backend,
-		ovDevice: settings.BirdNET.OpenVINODevice,
-		ovPath:   settings.BirdNET.OpenVINOPath,
-	}
+	triplet := secondaryTripletFor(settings)
 
-	// Gate and snapshot under the write lock (the gate field is written here),
-	// then release o.mu before the slow builds.
+	// Snapshot the OV-capable secondary entries under o.mu, then release it before
+	// the per-entry gate checks and slow builds.
 	o.mu.Lock()
 	if o.models == nil {
 		o.mu.Unlock()
@@ -1178,16 +1191,6 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 			Category(errors.CategorySystem).
 			Build()
 	}
-	if o.secondaryBackend == triplet {
-		o.mu.Unlock()
-		log.Debug("secondary models already built on current backend/device, skipping reload",
-			logger.String("backend", triplet.backend),
-			logger.String("ov_device", triplet.ovDevice))
-		return nil
-	}
-	// Advance the gate unconditionally (see method doc): a failed rebuild is not
-	// retried on the next unrelated reload.
-	o.secondaryBackend = triplet
 	primaryID := o.ModelInfo.ID
 	refs := make([]entryRef, 0, len(openvinoCapableSecondaryBuilders))
 	for id, entry := range o.models {
@@ -1216,7 +1219,21 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 
 	var firstErr error
 	for _, ref := range refs {
-		builder := openvinoCapableSecondaryBuilders[ref.id]
+		// Per-entry gate: read the triplet this entry's instance was built against
+		// under entry.mu and skip the rebuild when it already matches the current
+		// settings. The read pairs with the swap below, which publishes the new
+		// triplet under the same lock.
+		ref.entry.mu.Lock()
+		current := ref.entry.backend
+		ref.entry.mu.Unlock()
+		if current == triplet {
+			log.Debug("secondary model already built on current backend/device, skipping reload",
+				logger.String("registry_id", ref.id),
+				logger.String("backend", triplet.backend),
+				logger.String("ov_device", triplet.ovDevice))
+			continue
+		}
+
 		// A secondary present in o.models but absent from settings.Models.Enabled
 		// (e.g. installed at runtime then disabled in config) is not keyed in
 		// threadAlloc; fall back to the full budget, matching LoadModel's default
@@ -1228,11 +1245,20 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 				threads = runtime.NumCPU()
 			}
 		}
-		newInst, err := builder(o, settings, threads)
+		newInst, err := openvinoCapableSecondaryBuilders[ref.id](o, settings, threads)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
+			// Hard build failure: keep the old instance serving, but advance this
+			// entry's gate (advance-always) so an unrelated reload does not retry the
+			// failed build. Skip the advance if the entry was torn down while building
+			// (a detached entry's gate is moot).
+			ref.entry.mu.Lock()
+			if ref.entry.instance != nil {
+				ref.entry.backend = triplet
+			}
+			ref.entry.mu.Unlock()
 			log.Error("failed to rebuild secondary model on backend/device change; keeping existing instance",
 				logger.String("registry_id", ref.id),
 				logger.String("backend", triplet.backend),
@@ -1251,14 +1277,15 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 			// Entry was torn down by a concurrent Delete/Unload; do not resurrect
 			// a detached entry. Close the freshly built instance and skip.
 			ref.entry.mu.Unlock()
-			if err := newInst.Close(); err != nil {
+			if cerr := newInst.Close(); cerr != nil {
 				log.Warn("failed to close orphaned secondary model instance after reload",
 					logger.String("registry_id", ref.id),
-					logger.Error(err))
+					logger.Error(cerr))
 			}
 			continue
 		}
 		ref.entry.instance = newInst
+		ref.entry.backend = triplet
 		ref.entry.mu.Unlock()
 
 		// Close the old instance after releasing entry.mu: native teardown can be
@@ -1266,10 +1293,10 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 		// published (PredictModel reads entry.instance under entry.mu on every
 		// call). Building the new instance before closing the old keeps the OV
 		// active-classifier counter from transiently dropping to zero.
-		if err := old.Close(); err != nil {
+		if cerr := old.Close(); cerr != nil {
 			log.Warn("failed to close old secondary model instance after reload",
 				logger.String("registry_id", ref.id),
-				logger.Error(err))
+				logger.Error(cerr))
 		}
 
 		log.Info("secondary model reloaded on new backend/device",

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -64,12 +64,21 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 
 // loadPerch creates and registers a Perch v2 model instance from settings.
 func (o *Orchestrator) loadPerch(threads int) error {
-	perch, err := o.buildPerch(o.currentSettings(), threads)
+	// Capture the settings snapshot once so the recorded backend triplet matches
+	// the exact configuration the instance was built against. This is what makes
+	// an out-of-band runtime install (LoadModel) reconcile correctly: the entry
+	// records its own triplet, so a later ReloadSecondaryModels rebuilds it only
+	// when the backend/device actually changes (Forgejo #1119).
+	settings := o.currentSettings()
+	perch, err := o.buildPerch(settings, threads)
 	if err != nil {
 		return err
 	}
 
-	o.models[perch.ModelID()] = &modelEntry{instance: perch}
+	o.models[perch.ModelID()] = &modelEntry{
+		instance: perch,
+		backend:  secondaryTripletFor(settings),
+	}
 
 	// No separate Perch label resolver needed. Perch returns scientific names,
 	// and the BirdNETLabelResolver (already registered) maps scientific -> common

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -79,9 +79,8 @@ func TestReloadSecondaryModels_SwapsAndClosesOld(t *testing.T) {
 	old := &reloadFakeModel{id: testSecondaryID}
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	o.models[testSecondaryID] = &modelEntry{instance: old}
-	// Loaded on a different backend so the gate fires.
-	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+	// Loaded on a different backend so the per-entry gate fires.
+	o.models[testSecondaryID] = &modelEntry{instance: old, backend: secondaryBackendKey{backend: "onnx"}}
 
 	var built atomic.Int32
 	newInst := &reloadFakeModel{id: testSecondaryID}
@@ -99,8 +98,8 @@ func TestReloadSecondaryModels_SwapsAndClosesOld(t *testing.T) {
 	assert.Same(t, ModelInstance(newInst), o.models[testSecondaryID].instance, "new instance should be swapped in")
 	assert.Equal(t, int32(1), old.closes.Load(), "old instance should be closed once")
 	assert.Equal(t, int32(0), newInst.closes.Load(), "new instance must not be closed")
-	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}, o.secondaryBackend,
-		"gate should advance to the new triplet")
+	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}, o.models[testSecondaryID].backend,
+		"entry triplet should advance to the new backend")
 }
 
 func TestReloadSecondaryModels_NoOpWhenTripletUnchanged(t *testing.T) {
@@ -109,9 +108,8 @@ func TestReloadSecondaryModels_NoOpWhenTripletUnchanged(t *testing.T) {
 	old := &reloadFakeModel{id: testSecondaryID}
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	o.models[testSecondaryID] = &modelEntry{instance: old}
 	// Already on the current triplet: reload must be a no-op.
-	o.secondaryBackend = secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}
+	o.models[testSecondaryID] = &modelEntry{instance: old, backend: secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}}
 
 	var built atomic.Int32
 	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
@@ -132,8 +130,7 @@ func TestReloadSecondaryModels_KeepsOldOnBuildFailure(t *testing.T) {
 	old := &reloadFakeModel{id: testSecondaryID}
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	o.models[testSecondaryID] = &modelEntry{instance: old}
-	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+	o.models[testSecondaryID] = &modelEntry{instance: old, backend: secondaryBackendKey{backend: "onnx"}}
 
 	buildErr := errors.Newf("simulated build failure").Build()
 	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
@@ -145,10 +142,10 @@ func TestReloadSecondaryModels_KeepsOldOnBuildFailure(t *testing.T) {
 
 	assert.Same(t, ModelInstance(old), o.models[testSecondaryID].instance, "old instance must keep serving on build failure")
 	assert.Equal(t, int32(0), old.closes.Load(), "old instance must not be closed when its rebuild fails")
-	// Advance-always: the gate moves to the new triplet so an unrelated reload
-	// does not retry the failed build.
-	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu"}, o.secondaryBackend,
-		"gate should still advance after a build failure")
+	// Advance-always: the entry's triplet moves to the new triplet so an unrelated
+	// reload does not retry the failed build.
+	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu"}, o.models[testSecondaryID].backend,
+		"entry triplet should still advance after a build failure")
 }
 
 func TestReloadSecondaryModels_SkipsNonOVCapableSecondary(t *testing.T) {
@@ -160,7 +157,6 @@ func TestReloadSecondaryModels_SkipsNonOVCapableSecondary(t *testing.T) {
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
 	o.models[RegistryIDBat] = &modelEntry{instance: batLike}
-	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
 
 	require.NoError(t, o.ReloadSecondaryModels())
 
@@ -176,8 +172,9 @@ func TestReloadSecondaryModels_OrphanedEntrySkipsSwapAndClosesNew(t *testing.T) 
 	// Entry is present in the map but its instance was torn down by a concurrent
 	// Delete/Unload (instance == nil). The reload must not resurrect a detached
 	// entry; it must close the freshly built instance and leave the entry nil.
-	o.models[testSecondaryID] = &modelEntry{instance: nil}
-	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+	// backend differs from the current triplet so the per-entry gate fires and the
+	// builder runs; the orphan (instance == nil) is only discovered at swap time.
+	o.models[testSecondaryID] = &modelEntry{instance: nil, backend: secondaryBackendKey{backend: "onnx"}}
 
 	built := &reloadFakeModel{id: testSecondaryID}
 	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
@@ -197,9 +194,9 @@ func TestReloadSecondaryModels_PartialFailureAmongMultiple(t *testing.T) {
 	oldFail := &reloadFakeModel{id: testSecondaryID2}
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	o.models[testSecondaryID] = &modelEntry{instance: oldOK}
-	o.models[testSecondaryID2] = &modelEntry{instance: oldFail}
-	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+	// Both entries are on a different backend so the per-entry gate fires for each.
+	o.models[testSecondaryID] = &modelEntry{instance: oldOK, backend: secondaryBackendKey{backend: "onnx"}}
+	o.models[testSecondaryID2] = &modelEntry{instance: oldFail, backend: secondaryBackendKey{backend: "onnx"}}
 
 	newOK := &reloadFakeModel{id: testSecondaryID}
 	buildErr := errors.Newf("simulated build failure for second secondary").Build()
@@ -229,8 +226,7 @@ func TestReloadSecondaryModels_RaceWithPredict(t *testing.T) {
 
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	o.models[testSecondaryID] = &modelEntry{instance: &reloadFakeModel{id: testSecondaryID}}
-	o.secondaryBackend = secondaryBackendKey{backend: "onnx"}
+	o.models[testSecondaryID] = &modelEntry{instance: &reloadFakeModel{id: testSecondaryID}, backend: secondaryBackendKey{backend: "onnx"}}
 
 	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
 		return &reloadFakeModel{id: testSecondaryID}, nil
@@ -253,8 +249,8 @@ func TestReloadSecondaryModels_RaceWithPredict(t *testing.T) {
 		})
 	}
 
-	// Force a rebuild on each iteration by alternating the device so the gate
-	// keeps firing (the previous successful reload advanced it to the prior value).
+	// Force a rebuild on each iteration by alternating the device so the per-entry
+	// gate keeps firing (the previous successful reload advanced it to the prior value).
 	// Publish directly (not via setGlobalBackend) to avoid stacking 40 cleanups;
 	// the initial setGlobalBackend already registered the reset-to-nil cleanup.
 	devices := []string{"cpu", "gpu"}
@@ -268,4 +264,48 @@ func TestReloadSecondaryModels_RaceWithPredict(t *testing.T) {
 
 	stop.Store(true)
 	wg.Wait()
+}
+
+// TestReloadSecondaryModels_PerEntryTripletRebuildsOnlyStale is the core
+// Forgejo #1119 behavior: with per-entry triplet tracking, a reload rebuilds only
+// the secondaries whose own recorded triplet differs from the current settings.
+// One secondary is already on the current triplet (e.g. installed out-of-band by
+// LoadModel after the backend change, which records the entry's triplet at load);
+// the other is stale. A single orchestrator-wide gate could not represent this
+// mixed state and would rebuild both or neither.
+func TestReloadSecondaryModels_PerEntryTripletRebuildsOnlyStale(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+	currentTriplet := secondaryBackendKey{backend: "openvino", ovDevice: "gpu"}
+
+	upToDate := &reloadFakeModel{id: testSecondaryID}
+	stale := &reloadFakeModel{id: testSecondaryID2}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	// testSecondaryID is already on the current triplet; testSecondaryID2 is stale.
+	o.models[testSecondaryID] = &modelEntry{instance: upToDate, backend: currentTriplet}
+	o.models[testSecondaryID2] = &modelEntry{instance: stale, backend: secondaryBackendKey{backend: "onnx"}}
+
+	var builtUpToDate, builtStale atomic.Int32
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		builtUpToDate.Add(1)
+		return &reloadFakeModel{id: testSecondaryID}, nil
+	})
+	newStale := &reloadFakeModel{id: testSecondaryID2}
+	registerTestSecondaryBuilder(t, testSecondaryID2, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		builtStale.Add(1)
+		return newStale, nil
+	})
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	// The up-to-date secondary must be left completely untouched.
+	assert.Equal(t, int32(0), builtUpToDate.Load(), "up-to-date secondary must not be rebuilt")
+	assert.Same(t, ModelInstance(upToDate), o.models[testSecondaryID].instance, "up-to-date instance must be unchanged")
+	assert.Equal(t, int32(0), upToDate.closes.Load(), "up-to-date instance must not be closed")
+
+	// The stale secondary must be rebuilt and its triplet advanced.
+	assert.Equal(t, int32(1), builtStale.Load(), "stale secondary must be rebuilt once")
+	assert.Same(t, ModelInstance(newStale), o.models[testSecondaryID2].instance, "stale instance must be swapped in")
+	assert.Equal(t, int32(1), stale.closes.Load(), "stale old instance must be closed")
+	assert.Equal(t, currentTriplet, o.models[testSecondaryID2].backend, "stale entry triplet must advance to current")
 }

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -169,22 +169,52 @@ func TestReloadSecondaryModels_OrphanedEntrySkipsSwapAndClosesNew(t *testing.T) 
 
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	// Entry is present in the map but its instance was torn down by a concurrent
-	// Delete/Unload (instance == nil). The reload must not resurrect a detached
-	// entry; it must close the freshly built instance and leave the entry nil.
-	// backend differs from the current triplet so the per-entry gate fires and the
-	// builder runs; the orphan (instance == nil) is only discovered at swap time.
-	o.models[testSecondaryID] = &modelEntry{instance: nil, backend: secondaryBackendKey{backend: "onnx"}}
+	// The entry has a live instance and a stale triplet, so the per-entry gate
+	// fires and the build runs. The builder simulates a concurrent Delete/Unload
+	// tearing the entry down (instance == nil) WHILE the slow build is in flight;
+	// the post-build orphan guard must then close the freshly built instance and
+	// must not resurrect the detached entry. (The already-orphaned-before-build
+	// case is covered by TestReloadSecondaryModels_AlreadyOrphanedSkipsBuild.)
+	o.models[testSecondaryID] = &modelEntry{instance: &reloadFakeModel{id: testSecondaryID}, backend: secondaryBackendKey{backend: "onnx"}}
 
 	built := &reloadFakeModel{id: testSecondaryID}
 	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		// Tear the entry down mid-build to race the swap.
+		e := o.models[testSecondaryID]
+		e.mu.Lock()
+		e.instance = nil
+		e.mu.Unlock()
 		return built, nil
 	})
 
 	require.NoError(t, o.ReloadSecondaryModels())
 
 	assert.Nil(t, o.models[testSecondaryID].instance, "orphaned entry must not be resurrected")
-	assert.Equal(t, int32(1), built.closes.Load(), "freshly built instance must be closed when the entry was orphaned")
+	assert.Equal(t, int32(1), built.closes.Load(), "freshly built instance must be closed when the entry was orphaned during the build")
+}
+
+// TestReloadSecondaryModels_AlreadyOrphanedSkipsBuild verifies the up-front gate
+// skip: an entry whose instance was already torn down before the reload starts
+// (instance == nil) must be skipped WITHOUT running the (slow, JIT-compiling)
+// builder, since any instance built for a detached entry would only be discarded.
+func TestReloadSecondaryModels_AlreadyOrphanedSkipsBuild(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "")
+
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	// Already orphaned, with a stale triplet that would otherwise fire the gate.
+	o.models[testSecondaryID] = &modelEntry{instance: nil, backend: secondaryBackendKey{backend: "onnx"}}
+
+	var built atomic.Int32
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		built.Add(1)
+		return &reloadFakeModel{id: testSecondaryID}, nil
+	})
+
+	require.NoError(t, o.ReloadSecondaryModels())
+
+	assert.Equal(t, int32(0), built.Load(), "builder must not run for an already-orphaned entry")
+	assert.Nil(t, o.models[testSecondaryID].instance, "orphaned entry must stay nil")
 }
 
 func TestReloadSecondaryModels_PartialFailureAmongMultiple(t *testing.T) {


### PR DESCRIPTION
## Summary

`ReloadSecondaryModels` hot-reloads OpenVINO-capable secondary models (currently Perch) onto a new device when the BirdNET inference backend or OpenVINO device preference changes at runtime. It previously gated the rebuild on a single orchestrator-wide backend triplet that recorded one value for all secondaries. That shared gate could not stay exact once a secondary was installed out-of-band at runtime (`LoadModel`) or once more than one OV-capable secondary is loaded: an out-of-band install was never reconciled against it.

This moves the triplet onto each `modelEntry`, so the reload rebuilds only the secondaries whose own recorded backend/device/path differs from the current settings.

- `modelEntry` gains a `backend secondaryBackendKey` field, guarded by the entry's existing per-model mutex (always published together with the instance it describes).
- `loadPerch` records the triplet at registration, so a runtime install reconciles correctly on the next reload.
- `ReloadSecondaryModels` reads and advances the triplet per entry under `entry.mu`; the advance-always-on-failure behavior is preserved per entry (a hard build failure keeps the old instance serving and is not retried on the next unrelated reload).
- The single `Orchestrator.secondaryBackend` field and its `NewOrchestrator` seeding are removed; a shared `secondaryTripletFor(settings)` helper is used by both `loadPerch` and the reload.

No config, API, DB, or CLI surface changes; all touched symbols are unexported internals.

## Test Plan

- [x] `go test -race ./internal/classifier/` (full package, including the reload suite)
- [x] New test `TestReloadSecondaryModels_PerEntryTripletRebuildsOnlyStale` proves only the stale secondary rebuilds while an up-to-date one is left untouched, which a single shared gate could not express
- [x] `golangci-lint run` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized secondary model reloading to rebuild only models whose configuration has changed, reducing unnecessary processing.

* **Reliability**
  * Improved handling of edge cases during model reloads, including better management of failed rebuilds and cleanup of inactive models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->