### PR TITLE
fix: use -stimeout for RTSP on FFmpeg 4.x where -timeout triggers listen mode

### DIFF
--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -13,33 +13,57 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // ffmpegTimeoutParam is the FFmpeg flag name for the connection timeout parameter.
 const ffmpegTimeoutParam = "-timeout"
 
-// ffmpegRTSPTimeoutParam is the RTSP-specific stream timeout flag.
-// Older FFmpeg used -stimeout for RTSP, but it was removed in FFmpeg 5.x+.
-// Using -timeout works across all supported versions.
+// ffmpegStimeoutMaxMajor is the first FFmpeg major version that removed -stimeout.
+// FFmpeg < 5 needs -stimeout for RTSP; 5.x+ uses -timeout.
+const ffmpegStimeoutMaxMajor = 5
+
+// ffmpegRTSPTimeoutParam is the RTSP timeout flag for FFmpeg 5.x+ and unknown versions.
 const ffmpegRTSPTimeoutParam = "-timeout"
 
-// ffmpegLegacyRTSPTimeoutParam is the deprecated -stimeout flag that older FFmpeg
-// used for RTSP. We no longer emit it, but we still recognise it in user-supplied
-// parameters so a carried-over value is honoured and the unsupported flag is
-// stripped before reaching FFmpeg.
+// ffmpegLegacyRTSPTimeoutParam is the RTSP timeout flag required by FFmpeg 4.x.
 const ffmpegLegacyRTSPTimeoutParam = "-stimeout"
 
+// ffmpegMajorCache stores detected FFmpeg major versions by binary path.
+var ffmpegMajorCache sync.Map
+
 // timeoutParamForSource returns the correct FFmpeg timeout flag for the given source type.
-func timeoutParamForSource(st audiocore.SourceType) string {
+func timeoutParamForSource(st audiocore.SourceType, ffmpegMajor int) string {
+	if st == audiocore.SourceTypeRTSP && ffmpegMajor > 0 && ffmpegMajor < ffmpegStimeoutMaxMajor {
+		return ffmpegLegacyRTSPTimeoutParam
+	}
 	if st == audiocore.SourceTypeRTSP {
 		return ffmpegRTSPTimeoutParam
 	}
 	return ffmpegTimeoutParam
+}
+
+// resolveFfmpegMajor returns the cached or detected FFmpeg major version for a binary path.
+func resolveFfmpegMajor(ffmpegPath string) int {
+	if ffmpegPath == "" {
+		return 0
+	}
+	if cached, ok := ffmpegMajorCache.Load(ffmpegPath); ok {
+		if major, ok := cached.(int); ok {
+			return major
+		}
+	}
+
+	_, major, _ := conf.GetFfmpegVersionFrom(ffmpegPath)
+	ffmpegMajorCache.Store(ffmpegPath, major)
+
+	return major
 }
 
 // stripTimeoutParams returns a copy of params with any -timeout/-stimeout key-value pairs removed.
@@ -453,10 +477,11 @@ func appendChannelArgs(args []string, channelMode string, sourceChannels int, nu
 
 // buildInputArgs constructs the pre-input FFmpeg flags (transport, timeout, extra parameters).
 // This mirrors the logic in Stream.buildFFmpegInputArgs but accepts explicit parameters.
-// RTSP streams use -timeout for connection timeout.
+// RTSP streams use the timeout flag supported by the configured FFmpeg major version.
 func buildInputArgs(cfg *StreamConfig, ffmpegParameters []string) []string {
 	args := make([]string, 0, 8+len(ffmpegParameters))
-	timeoutFlag := timeoutParamForSource(cfg.sourceType())
+	ffmpegMajor := resolveFfmpegMajor(cfg.FFmpegPath)
+	timeoutFlag := timeoutParamForSource(cfg.sourceType(), ffmpegMajor)
 
 	if cfg.sourceType() == audiocore.SourceTypeRTSP {
 		args = append(args, "-rtsp_transport", cfg.Transport)

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -49,6 +49,11 @@ func timeoutParamForSource(st audiocore.SourceType, ffmpegMajor int) string {
 	return ffmpegTimeoutParam
 }
 
+// ffmpegVersionProbeTimeout bounds the one-time `ffmpeg -version` probe so a
+// hung or wrapped binary cannot stall stream startup. On timeout the probe
+// yields major 0, which falls back to the safe -timeout default.
+const ffmpegVersionProbeTimeout = 5 * time.Second
+
 // resolveFfmpegMajor returns the cached or detected FFmpeg major version for a binary path.
 func resolveFfmpegMajor(ffmpegPath string) int {
 	if ffmpegPath == "" {
@@ -60,8 +65,17 @@ func resolveFfmpegMajor(ffmpegPath string) int {
 		}
 	}
 
-	_, major, _ := conf.GetFfmpegVersionFrom(ffmpegPath)
-	ffmpegMajorCache.Store(ffmpegPath, major)
+	ctx, cancel := context.WithTimeout(context.Background(), ffmpegVersionProbeTimeout)
+	defer cancel()
+
+	_, major, _ := conf.GetFfmpegVersionFromContext(ctx, ffmpegPath)
+	// Only cache a successful detection. Caching a failed probe (major 0) would
+	// pin the safe -timeout fallback for the process lifetime, so a transient
+	// first-probe failure on a real FFmpeg 4.x host would silently suppress
+	// -stimeout until restart. Re-probing on the next start is cheap.
+	if major > 0 {
+		ffmpegMajorCache.Store(ffmpegPath, major)
+	}
 
 	return major
 }

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -37,6 +39,11 @@ const ffmpegLegacyRTSPTimeoutParam = "-stimeout"
 
 // ffmpegMajorCache stores detected FFmpeg major versions by binary path.
 var ffmpegMajorCache sync.Map
+
+// ffmpegMajorGroup coalesces concurrent first-time version probes for the same
+// binary path, so a burst of streams starting at once spawns a single
+// `ffmpeg -version` process instead of one per stream.
+var ffmpegMajorGroup singleflight.Group
 
 // timeoutParamForSource returns the correct FFmpeg timeout flag for the given source type.
 func timeoutParamForSource(st audiocore.SourceType, ffmpegMajor int) string {
@@ -65,19 +72,35 @@ func resolveFfmpegMajor(ffmpegPath string) int {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), ffmpegVersionProbeTimeout)
-	defer cancel()
+	// Coalesce concurrent cold-cache probes for the same path into one
+	// `ffmpeg -version` execution.
+	val, _, _ := ffmpegMajorGroup.Do(ffmpegPath, func() (any, error) {
+		// Re-check the cache: another caller may have populated it while this
+		// call was waiting for the singleflight slot.
+		if cached, ok := ffmpegMajorCache.Load(ffmpegPath); ok {
+			if major, ok := cached.(int); ok {
+				return major, nil
+			}
+		}
 
-	_, major, _ := conf.GetFfmpegVersionFromContext(ctx, ffmpegPath)
-	// Only cache a successful detection. Caching a failed probe (major 0) would
-	// pin the safe -timeout fallback for the process lifetime, so a transient
-	// first-probe failure on a real FFmpeg 4.x host would silently suppress
-	// -stimeout until restart. Re-probing on the next start is cheap.
-	if major > 0 {
-		ffmpegMajorCache.Store(ffmpegPath, major)
+		ctx, cancel := context.WithTimeout(context.Background(), ffmpegVersionProbeTimeout)
+		defer cancel()
+
+		_, major, _ := conf.GetFfmpegVersionFromContext(ctx, ffmpegPath)
+		// Only cache a successful detection. Caching a failed probe (major 0)
+		// would pin the safe -timeout fallback for the process lifetime, so a
+		// transient first-probe failure on a real FFmpeg 4.x host would silently
+		// suppress -stimeout until restart. Re-probing on the next start is cheap.
+		if major > 0 {
+			ffmpegMajorCache.Store(ffmpegPath, major)
+		}
+		return major, nil
+	})
+
+	if major, ok := val.(int); ok {
+		return major
 	}
-
-	return major
+	return 0
 }
 
 // stripTimeoutParams returns a copy of params with any -timeout/-stimeout key-value pairs removed.

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -2,6 +2,7 @@ package ffmpeg
 
 import (
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func TestBuildFFmpegArgs_RTSP(t *testing.T) {
 	require.Less(t, rtspIdx+1, len(args), "-rtsp_transport must have a value")
 	assert.Equal(t, "tcp", args[rtspIdx+1])
 
-	// RTSP must use -timeout; the legacy -stimeout was removed in FFmpeg 5.x+.
+	// Empty FFmpegPath yields an unknown version, which safely falls back to -timeout.
 	timeoutIdx := slices.Index(args, "-timeout")
 	require.NotEqual(t, -1, timeoutIdx, "expected -timeout flag for RTSP")
 	assert.Equal(t, -1, slices.Index(args, "-stimeout"), "RTSP must not use legacy -stimeout")
@@ -99,7 +100,7 @@ func TestBuildFFmpegArgs_CustomTimeout(t *testing.T) {
 		Transport: "tcp",
 	}
 
-	// User provides -timeout; RTSP now also uses -timeout.
+	// Empty FFmpegPath yields an unknown version, so RTSP uses -timeout.
 	customParams := []string{"-timeout", "5000000"}
 	args := BuildFFmpegArgs(cfg, customParams)
 
@@ -125,11 +126,80 @@ func TestBuildFFmpegArgs_CustomTimeout(t *testing.T) {
 func TestTimeoutParamForSource(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeRTSP))
-	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeHTTP))
-	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeHLS))
-	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeRTMP))
-	assert.Equal(t, "-timeout", timeoutParamForSource(audiocore.SourceTypeUDP))
+	tests := []struct {
+		name        string
+		sourceType  audiocore.SourceType
+		ffmpegMajor int
+		want        string
+	}{
+		{"rtsp_ffmpeg4_uses_stimeout", audiocore.SourceTypeRTSP, 4, "-stimeout"},
+		{"rtsp_ffmpeg5_uses_timeout", audiocore.SourceTypeRTSP, 5, "-timeout"},
+		{"rtsp_ffmpeg6_uses_timeout", audiocore.SourceTypeRTSP, 6, "-timeout"},
+		{"rtsp_ffmpeg7_uses_timeout", audiocore.SourceTypeRTSP, 7, "-timeout"},
+		{"rtsp_unknown_uses_timeout", audiocore.SourceTypeRTSP, 0, "-timeout"},
+		{"http_ffmpeg4_uses_timeout", audiocore.SourceTypeHTTP, 4, "-timeout"},
+		{"http_ffmpeg7_uses_timeout", audiocore.SourceTypeHTTP, 7, "-timeout"},
+		{"hls_ffmpeg4_uses_timeout", audiocore.SourceTypeHLS, 4, "-timeout"},
+		{"hls_ffmpeg7_uses_timeout", audiocore.SourceTypeHLS, 7, "-timeout"},
+		{"rtmp_ffmpeg4_uses_timeout", audiocore.SourceTypeRTMP, 4, "-timeout"},
+		{"rtmp_ffmpeg7_uses_timeout", audiocore.SourceTypeRTMP, 7, "-timeout"},
+		{"udp_ffmpeg4_uses_timeout", audiocore.SourceTypeUDP, 4, "-timeout"},
+		{"udp_ffmpeg7_uses_timeout", audiocore.SourceTypeUDP, 7, "-timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, timeoutParamForSource(tt.sourceType, tt.ffmpegMajor))
+		})
+	}
+}
+
+func TestBuildFFmpegArgs_RTSP_LegacyFFmpeg4(t *testing.T) {
+	tests := []struct {
+		name          string
+		ffmpegPath    string
+		ffmpegMajor   int
+		wantFlag      string
+		forbiddenFlag string
+	}{
+		{
+			name:          "ffmpeg4_uses_stimeout",
+			ffmpegPath:    "/fake/ffmpeg4",
+			ffmpegMajor:   4,
+			wantFlag:      "-stimeout",
+			forbiddenFlag: "-timeout",
+		},
+		{
+			name:          "ffmpeg7_uses_timeout",
+			ffmpegPath:    "/fake/ffmpeg7",
+			ffmpegMajor:   7,
+			wantFlag:      "-timeout",
+			forbiddenFlag: "-stimeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ffmpegMajorCache.Store(tt.ffmpegPath, tt.ffmpegMajor)
+			t.Cleanup(func() {
+				ffmpegMajorCache.Delete(tt.ffmpegPath)
+			})
+
+			cfg := &StreamConfig{
+				URL:        "rtsp://camera.example.com/live",
+				Type:       "rtsp",
+				Transport:  "tcp",
+				FFmpegPath: tt.ffmpegPath,
+			}
+
+			args := BuildFFmpegArgs(cfg, nil)
+
+			assertFlagValue(t, args, tt.wantFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10))
+			assert.NotContains(t, args, tt.forbiddenFlag)
+		})
+	}
 }
 
 func TestStripTimeoutParams(t *testing.T) {

--- a/internal/audiocore/ffmpeg/process_test.go
+++ b/internal/audiocore/ffmpeg/process_test.go
@@ -202,6 +202,23 @@ func TestBuildFFmpegArgs_RTSP_LegacyFFmpeg4(t *testing.T) {
 	}
 }
 
+func TestResolveFfmpegMajor_DoesNotCacheFailedProbe(t *testing.T) {
+	// A path that cannot be executed yields major 0 and must NOT be cached, so a
+	// later start re-probes instead of permanently pinning the -timeout fallback
+	// (which would suppress -stimeout on a real FFmpeg 4.x host after a transient
+	// first-probe failure).
+	const badPath = "/nonexistent/ffmpeg-resolve-probe-test"
+	ffmpegMajorCache.Delete(badPath)
+	t.Cleanup(func() {
+		ffmpegMajorCache.Delete(badPath)
+	})
+
+	require.Equal(t, 0, resolveFfmpegMajor(badPath), "unresolvable binary must report unknown version")
+
+	_, cached := ffmpegMajorCache.Load(badPath)
+	assert.False(t, cached, "a failed probe must not be cached")
+}
+
 func TestStripTimeoutParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -16,13 +17,20 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 )
 
-// ffmpegTimeoutFlag is the FFmpeg connection timeout flag emitted for all source
-// types, including RTSP (the legacy -stimeout was removed in FFmpeg 5.x+).
+// ffmpegTimeoutFlag is the connection timeout flag expected when these tests
+// pin a modern FFmpeg version, including RTSP sources.
 const ffmpegTimeoutFlag = "-timeout"
 
-// ffmpegLegacyTimeoutFlag is the deprecated RTSP -stimeout flag. It must never be
-// emitted, but is still recognised when present in user-supplied parameters.
+// ffmpegLegacyTimeoutFlag is the legacy RTSP timeout flag. It must not be
+// emitted for the modern FFmpeg version pinned by these tests.
 const ffmpegLegacyTimeoutFlag = "-stimeout"
+
+const testFFmpegModernMajor = 7
+
+var seedFFmpegMajorRefs struct {
+	sync.Mutex
+	counts map[string]int
+}
 
 // newTestConfig returns a minimal StreamConfig suitable for unit tests.
 func newTestConfig() StreamConfig {
@@ -38,6 +46,32 @@ func newTestConfig() StreamConfig {
 		Transport:  "tcp",
 		LogLevel:   "error",
 	}
+}
+
+// seedFFmpegMajor pins the FFmpeg major version for a path in the package cache
+// so timeout-flag selection is deterministic in tests, independent of the
+// host's installed ffmpeg. It cleans up after the test.
+func seedFFmpegMajor(t *testing.T, ffmpegPath string, major int) {
+	t.Helper()
+
+	seedFFmpegMajorRefs.Lock()
+	if seedFFmpegMajorRefs.counts == nil {
+		seedFFmpegMajorRefs.counts = make(map[string]int)
+	}
+	seedFFmpegMajorRefs.counts[ffmpegPath]++
+	ffmpegMajorCache.Store(ffmpegPath, major)
+	seedFFmpegMajorRefs.Unlock()
+
+	t.Cleanup(func() {
+		seedFFmpegMajorRefs.Lock()
+		defer seedFFmpegMajorRefs.Unlock()
+
+		seedFFmpegMajorRefs.counts[ffmpegPath]--
+		if seedFFmpegMajorRefs.counts[ffmpegPath] == 0 {
+			delete(seedFFmpegMajorRefs.counts, ffmpegPath)
+			ffmpegMajorCache.Delete(ffmpegPath)
+		}
+	})
 }
 
 // newTestStream creates a Stream for testing with no-op callbacks.
@@ -802,6 +836,7 @@ func TestStream_BuildFFmpegInputArgs_RTSP(t *testing.T) {
 	t.Parallel()
 
 	cfg := newTestConfig()
+	seedFFmpegMajor(t, cfg.FFmpegPath, testFFmpegModernMajor)
 	cfg.Type = "rtsp"
 	stream := newTestStreamWithConfig(t, &cfg)
 
@@ -817,6 +852,7 @@ func TestStream_BuildFFmpegInputArgs_HTTP(t *testing.T) {
 	t.Parallel()
 
 	cfg := newTestConfig()
+	seedFFmpegMajor(t, cfg.FFmpegPath, testFFmpegModernMajor)
 	cfg.URL = "http://192.168.1.183/stream"
 	cfg.Type = "http"
 	stream := newTestStreamWithConfig(t, &cfg)
@@ -832,6 +868,7 @@ func TestStream_BuildFFmpegInputArgs_InvalidTimeout(t *testing.T) {
 	t.Parallel()
 
 	cfg := newTestConfig() // default is RTSP
+	seedFFmpegMajor(t, cfg.FFmpegPath, testFFmpegModernMajor)
 	stream := newTestStreamWithConfig(t, &cfg)
 
 	params := []string{"-timeout", "abc", "-loglevel", "debug"}
@@ -858,6 +895,8 @@ func TestStream_BuildFFmpegInputArgs_InvalidTimeout(t *testing.T) {
 
 func TestStream_BuildFFmpegInputArgs_ProtocolSpecific(t *testing.T) {
 	t.Parallel()
+	cfg := newTestConfig()
+	seedFFmpegMajor(t, cfg.FFmpegPath, testFFmpegModernMajor)
 
 	tests := []struct {
 		name              string

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -529,6 +529,9 @@ func GetFfmpegVersionFrom(ffmpegPath string) (version string, major, minor int) 
 // binary cannot block the caller indefinitely. Returns empty string and 0,0
 // if detection fails or the context is cancelled.
 func GetFfmpegVersionFromContext(ctx context.Context, ffmpegPath string) (version string, major, minor int) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	cmd := exec.CommandContext(ctx, ffmpegPath, "-version") //nolint:gosec // G204: ffmpegPath validated by ValidateToolPath before reaching here
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -3,6 +3,7 @@ package conf
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -520,7 +521,15 @@ func GetFfprobeBinaryName() string {
 // GetFfmpegVersionFrom detects the ffmpeg version by executing the binary at
 // the given path. Returns empty string and 0,0 if detection fails.
 func GetFfmpegVersionFrom(ffmpegPath string) (version string, major, minor int) {
-	cmd := exec.Command(ffmpegPath, "-version") //nolint:gosec // G204: ffmpegPath validated by ValidateToolPath before reaching here
+	return GetFfmpegVersionFromContext(context.Background(), ffmpegPath)
+}
+
+// GetFfmpegVersionFromContext is like GetFfmpegVersionFrom but bounds the
+// `ffmpeg -version` probe with the supplied context, so a hung or wrapped
+// binary cannot block the caller indefinitely. Returns empty string and 0,0
+// if detection fails or the context is cancelled.
+func GetFfmpegVersionFromContext(ctx context.Context, ffmpegPath string) (version string, major, minor int) {
+	cmd := exec.CommandContext(ctx, ffmpegPath, "-version") //nolint:gosec // G204: ffmpegPath validated by ValidateToolPath before reaching here
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", 0, 0


### PR DESCRIPTION
## Summary

This makes the FFmpeg RTSP timeout flag version-aware so RTSP streams open correctly on FFmpeg 4.x as well as 5.x and newer. For RTSP sources, BirdNET-Go now emits `-stimeout` when the detected FFmpeg major version is below 5 and `-timeout` otherwise; non-RTSP sources and unknown or empty FFmpeg paths keep the existing `-timeout` behavior, so nothing changes for modern containers.

## Why this matters

On systems shipping FFmpeg 4.x, most notably Debian 12, RTSP capture currently fails to start. BirdNET-Go passes `-timeout` unconditionally for RTSP, but FFmpeg 4.x interprets `-timeout` on the RTSP demuxer as the listen/server timeout rather than the connection timeout. As a result ffmpeg tries to bind and listen instead of connecting to the camera, and the stream dies with `Unable to open RTSP for listening (Cannot assign requested address)`. This is the failure reported in issue #3331 and confirmed on the thread.

The connection-timeout flag was renamed across FFmpeg versions: 4.x uses `-stimeout` for the RTSP socket timeout, while 5.x removed `-stimeout` and repurposed `-timeout` for the connection timeout. The code had moved to `-timeout` to follow the modern FFmpeg behavior, which is correct for 5.x+ but breaks 4.x. Selecting the flag based on the installed FFmpeg version resolves the conflict without regressing modern setups. The value itself is expressed in microseconds for both flags on 4.x, so no unit conversion is involved.

## How it works

The version is detected from `StreamConfig.FFmpegPath` using the existing `conf.GetFfmpegVersionFrom` helper, which already parses 4.x correctly. Because `buildInputArgs` runs on every process start, the detected major version is cached per binary path so the `ffmpeg -version` probe happens at most once per path. A failed or absent probe yields major zero, which falls through to the safe `-timeout` default. The runtime path (`Stream.buildFFmpegInputArgs`) shares `buildInputArgs`, so the live capture path and the unit-tested argument builder stay in lockstep.

## Testing

The package tests cover RTSP on FFmpeg 4.x selecting `-stimeout`, RTSP on 5/6/7 and unknown versions selecting `-timeout`, and non-RTSP sources always using `-timeout`. The existing stream tests pin a modern FFmpeg major in the cache so they remain deterministic regardless of the host's installed ffmpeg, since otherwise they would have started failing on exactly the FFmpeg 4.x hosts this change targets. `go test -race ./internal/audiocore/ffmpeg/...`, `go vet`, and `golangci-lint run` on the package all pass. The behavior was also verified end to end against a stub FFmpeg 4.4.2 binary, which produced `-stimeout` for RTSP, and against a modern stub, which produced `-timeout`.

Fixes #3331

Implemented with AI assistance per the project's AI-assisted development guidelines; all changes were reviewed and tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming timeout-flag handling for FFmpeg-backed sources. RTSP now selects the appropriate timeout option based on the detected FFmpeg major version, with a safe default when version detection is unavailable.

* **Tests**
  * Expanded and table-driven coverage for timeout-flag selection across multiple stream source types and FFmpeg versions, including legacy behavior and probe-failure scenarios.

* **Refactor**
  * Updated FFmpeg version probing to be context-aware and added caching for successful detections to keep timeout behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->