### PR TITLE
fix(spectrogram): classify context-cancelled exec failures as operational on Windows

### DIFF
--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -341,6 +341,17 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 
 	// Try Sox first (faster, direct processing)
 	if err := g.generateWithSoxFile(soxCtx, settings, audioPath, outputPath, width, raw, options.preValidatedDuration, profile); err != nil {
+		// If the caller's context is already done (client disconnect, shutdown, or
+		// caller-imposed timeout), the result is no longer wanted. Skip the FFmpeg
+		// fallback: it runs on a context detached from the parent (see
+		// CreateFreshFFmpegContext) and would otherwise render to completion for a
+		// dead request, wasting CPU/memory and emitting a misleading "Both Sox and
+		// FFmpeg generation failed" error. The Sox error is already classified
+		// operational by generateWithSoxFile, so return it as-is.
+		if ctx.Err() != nil {
+			return err
+		}
+
 		g.log().Warn("Sox spectrogram generation failed, falling back to FFmpeg",
 			logger.String("audio_path", audioPath),
 			logger.Error(err),
@@ -544,7 +555,7 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Se
 			Context("width", width).
 			Context("raw", raw).
 			Context("sox_output", output.String())
-		if IsOperationalError(err) {
+		if isOperationalExecError(ctx, err) {
 			eb = eb.Priority(errors.PriorityLow)
 		}
 		return eb.Build()
@@ -679,7 +690,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Context("raw", raw).
 			Context("ffmpeg_output", ffmpegOutput.String()).
 			Context("sox_output", soxOutput.String())
-		if IsOperationalError(err) {
+		if isOperationalExecError(ctx, err) {
 			eb = eb.Priority(errors.PriorityLow)
 		}
 		return eb.Build()
@@ -711,7 +722,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 			Context("raw", raw).
 			Context("ffmpeg_output", ffmpegOutput.String()).
 			Context("sox_output", soxOutput.String())
-		if IsOperationalError(soxWaitErr) {
+		if isOperationalExecError(ctx, soxWaitErr) {
 			eb = eb.Priority(errors.PriorityLow)
 		}
 		return eb.Build()
@@ -815,7 +826,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 			Context("raw", raw).
 			Context("sox_stderr", stderr.String()).
 			Context("pcm_bytes", len(pcmData))
-		if IsOperationalError(err) {
+		if isOperationalExecError(ctx, err) {
 			eb = eb.Priority(errors.PriorityLow)
 		}
 		return eb.Build()
@@ -896,7 +907,7 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 			Context("width", width).
 			Context("raw", raw).
 			Context("ffmpeg_output", output.String())
-		if IsOperationalError(err) {
+		if isOperationalExecError(ctx, err) {
 			eb = eb.Priority(errors.PriorityLow)
 		}
 		return eb.Build()

--- a/internal/spectrogram/utils.go
+++ b/internal/spectrogram/utils.go
@@ -115,8 +115,10 @@ func BuildSpectrogramPath(clipPath string) (string, error) {
 //
 // The function checks for operational errors in this order:
 // 1. Context errors (Canceled, DeadlineExceeded)
-// 2. Process exit codes (SIGKILL=137, SIGTERM=143) - more reliable than string matching
-// 3. String matching for "signal: killed" - fallback for compatibility
+// 2. An operational classification already attached upstream: a CategorySystem
+//    EnhancedError tagged PriorityLow (set by the generator via isOperationalExecError)
+// 3. Process exit codes (SIGKILL=137, SIGTERM=143) - more reliable than string matching
+// 4. String matching for "signal: killed" - fallback for compatibility
 func IsOperationalError(err error) bool {
 	if err == nil {
 		return false
@@ -124,6 +126,21 @@ func IsOperationalError(err error) bool {
 
 	// Check standard context errors
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// Honor an operational classification already attached upstream. The generator
+	// tags context-driven interruptions as a CategorySystem error with PriorityLow
+	// using the governing context (see isOperationalExecError); that is the only
+	// reliable signal on Windows, where a context-killed process exits with status 1
+	// and never matches the signal-based checks below. Requiring CategorySystem (the
+	// category the generator pairs with these interruptions) keeps an unrelated
+	// PriorityLow error from being misread as operational. Downstream consumers
+	// (prerenderer, API media handlers) then get a consistent answer without
+	// re-deriving it from a platform-dependent surface error.
+	var enhanced *errors.EnhancedError
+	if errors.As(err, &enhanced) && enhanced.GetPriority() == errors.PriorityLow &&
+		enhanced.Category == errors.CategorySystem {
 		return true
 	}
 
@@ -138,6 +155,30 @@ func IsOperationalError(err error) bool {
 
 	// Fallback to string matching for compatibility with other error types
 	return strings.Contains(err.Error(), signalKilledMessage)
+}
+
+// isOperationalExecError reports whether a failed external-process execution should
+// be treated as an expected operational event (context cancellation or deadline)
+// rather than a genuine failure. It checks the governing context first because the
+// surface error from an exec that was canceled, timed out, or skipped due to an
+// already-done context is platform-dependent and not always recognizable by
+// IsOperationalError:
+//
+//   - On Windows a context-killed process exits with status 1 (TerminateProcess),
+//     which has no Unix signal semantics, so it never matches the SIGKILL/SIGTERM
+//     exit codes or the "signal: killed" string that IsOperationalError looks for.
+//   - On Windows, Cmd.Start resolves the executable before it observes context
+//     cancellation, so an already-canceled context combined with a missing binary
+//     surfaces as "executable file not found" instead of context.Canceled.
+//
+// ctx.Err() is the reliable, platform-independent signal: if the context that
+// governed the exec is done, the failure is attributable to cancellation/timeout
+// regardless of how the OS reported it.
+func isOperationalExecError(ctx context.Context, err error) bool {
+	if ctx != nil && ctx.Err() != nil {
+		return true
+	}
+	return IsOperationalError(err)
 }
 
 // BuildSpectrogramPathWithParams builds a spectrogram path with size/raw encoded in filename.

--- a/internal/spectrogram/utils_test.go
+++ b/internal/spectrogram/utils_test.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	apperrors "github.com/tphakala/birdnet-go/internal/errors"
 )
 
 func TestSizeToPixels(t *testing.T) {
@@ -400,9 +404,15 @@ func TestIsOperationalError_ExitCodes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Generate a real *exec.ExitError with the specified exit code
-			// Use 'sh -c "exit N"' to produce the desired exit code
-			cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode)) // #nosec G204 - exit code is from hardcoded test table
+			// Generate a real *exec.ExitError with the specified exit code.
+			// Use the platform shell to produce the desired exit code: "sh -c exit N"
+			// on Unix, "cmd /c exit N" on Windows (which lacks sh).
+			var cmd *exec.Cmd
+			if runtime.GOOS == "windows" {
+				cmd = exec.Command("cmd", "/c", fmt.Sprintf("exit %d", tt.exitCode)) // #nosec G204 - exit code is from hardcoded test table
+			} else {
+				cmd = exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode)) // #nosec G204 - exit code is from hardcoded test table
+			}
 			err := cmd.Run()
 
 			require.Error(t, err, "command should fail with exit code %d", tt.exitCode)
@@ -417,6 +427,84 @@ func TestIsOperationalError_ExitCodes(t *testing.T) {
 			assert.Equal(t, tt.want, got, "IsOperationalError should return %v for exit code %d", tt.want, tt.exitCode)
 		})
 	}
+}
+
+// TestIsOperationalError_HonorsPriorityLow verifies that an error already tagged
+// with PriorityLow by the generator is treated as operational. This is the bridge
+// that gives downstream consumers a correct, platform-independent answer on Windows,
+// where a context-killed process exits with status 1 and never matches the
+// signal-based checks.
+func TestIsOperationalError_HonorsPriorityLow(t *testing.T) {
+	t.Parallel()
+
+	// A Windows-style "exit status 1" tagged PriorityLow by the generator.
+	lowPriorityErr := apperrors.Newf("exit status 1").
+		Component("spectrogram").
+		Category(apperrors.CategorySystem).
+		Priority(apperrors.PriorityLow).
+		Build()
+	assert.True(t, IsOperationalError(lowPriorityErr),
+		"a CategorySystem error carrying PriorityLow should be classified as operational")
+
+	// Production propagates the error wrapped (fmt.Errorf("...: %w", err)); errors.As
+	// must still reach the EnhancedError through the wrap.
+	assert.True(t, IsOperationalError(fmt.Errorf("generate spectrogram: %w", lowPriorityErr)),
+		"a wrapped PriorityLow CategorySystem error should still be classified as operational")
+
+	// The same surface error without an explicit priority is a genuine failure and
+	// must still surface as a notification.
+	genuineErr := apperrors.Newf("exit status 1").
+		Component("spectrogram").
+		Category(apperrors.CategorySystem).
+		Build()
+	assert.False(t, IsOperationalError(genuineErr),
+		"an enhanced error without PriorityLow should not be classified as operational")
+
+	// PriorityLow alone is not sufficient: a low-priority error in a category other
+	// than the CategorySystem the generator pairs with interruptions must not be
+	// misread as operational.
+	otherCategoryLowErr := apperrors.Newf("non-fatal validation issue").
+		Component("spectrogram").
+		Category(apperrors.CategoryValidation).
+		Priority(apperrors.PriorityLow).
+		Build()
+	assert.False(t, IsOperationalError(otherCategoryLowErr),
+		"a PriorityLow error in a non-system category should not be classified as operational")
+}
+
+// TestIsOperationalExecError verifies the context-aware classification helper used at
+// the generator exec sites: a done context means the failure is attributable to
+// cancellation/timeout regardless of the platform-dependent surface error.
+func TestIsOperationalExecError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("canceled context is operational regardless of surface error", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		// Errors that IsOperationalError alone would reject (the exact Windows
+		// surfaces: missing-binary lookup error and TerminateProcess exit code 1).
+		assert.True(t, isOperationalExecError(ctx, fmt.Errorf("executable file not found in PATH")))
+		assert.True(t, isOperationalExecError(ctx, fmt.Errorf("exit status 1")))
+	})
+
+	t.Run("deadline-exceeded context is operational", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+		t.Cleanup(cancel)
+		<-ctx.Done()
+		assert.True(t, isOperationalExecError(ctx, fmt.Errorf("exit status 1")))
+	})
+
+	t.Run("live context delegates to IsOperationalError", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		assert.False(t, isOperationalExecError(ctx, fmt.Errorf("exit status 1")),
+			"a genuine failure under a live context stays non-operational")
+		assert.True(t, isOperationalExecError(ctx, context.Canceled),
+			"a surfaced context.Canceled is operational even under a live context")
+		assert.True(t, isOperationalExecError(ctx, fmt.Errorf("process failed: %s", signalKilledMessage)))
+	})
 }
 
 func TestSizeToPixelsRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary

The cross-platform CI now runs the unit suite on native Windows, which exposed that `internal/spectrogram` misclassifies a context-cancelled/timed-out external-process (sox/ffmpeg) failure as a genuine failure on Windows, producing spurious dashboard error notifications.

Root cause: `IsOperationalError` inferred "was this an operational cancellation?" purely from the surface error (Unix signal exit codes 137/143, the `signal: killed` string, and context sentinels). On Windows none of these match:

- A context-killed process exits with status 1 (`TerminateProcess`), not a Unix signal.
- `os/exec` resolves the executable before it observes context cancellation, so an already-cancelled context combined with a missing binary surfaces as `executable file not found` rather than `context.Canceled`.

On Linux the same interruptions are caught (context sentinel or `signal: killed`), which is why this only surfaced once the suite ran on Windows.

## What changed

- Add `isOperationalExecError(ctx, err)`: treat a failed exec as operational when `ctx.Err() != nil` (the only reliable, platform-independent signal), else fall back to `IsOperationalError`. Use it at the five generator exec-classification sites that set `PriorityLow`.
- `IsOperationalError` now also honors a propagated `CategorySystem` + `PriorityLow` tag, so downstream consumers (pre-renderer, API media handlers) get a consistent answer without re-deriving it from a platform-dependent surface error. Narrowed to `CategorySystem` so an unrelated low-priority error is not misread as operational.
- Skip the FFmpeg fallback in `GenerateFromFile` when the caller's context is already done, so a client disconnect no longer triggers a detached FFmpeg render that runs to completion for a dead request (and no misleading "Both Sox and FFmpeg generation failed" error).
- Make `TestIsOperationalError_ExitCodes` cross-platform (`cmd /c` on Windows, `sh -c` on Unix), and add unit tests for the context-aware helper and the priority-honoring path (including wrapped-error and non-system-category cases).

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/spectrogram/` (Linux)
- [x] `go test -race -run "Spectrogram|Operational" ./internal/api/v2/` (downstream consumers)
- [x] `golangci-lint run ./internal/...` (0 issues)
- [x] Built a Windows test binary (cgo via mingw) and ran it on a Windows VM: the previously failing `TestOperationalErrors_SetLowPriority` now passes, and the full `internal/spectrogram` suite is green on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during spectrogram generation to prevent wasted processing when operations are canceled, and to avoid misleading error messages when fallback processes are skipped.

* **Tests**
  * Enhanced error classification tests with platform-specific test generation and context-aware error handling verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->