### PR TITLE
fix(classifier): read live settings in model loaders; harden ReloadModel re-key under entry lock

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1115,12 +1115,26 @@ func (o *Orchestrator) ReloadModel() error {
 	o.ScientificIndex = sciIndex
 
 	// Re-key the models map in case the model ID changed after reload (Forgejo #270).
+	//
+	// Snapshot each entry's instance under its own e.mu before reading ModelID().
+	// This is defensive, not a fix for a live bug: today ReloadModel and
+	// ReloadSecondaryModels (which swaps e.instance under e.mu, outside o.mu) are
+	// both invoked only from the single-goroutine monitor event loop, so they never
+	// interleave and this re-key, holding o.mu, already excludes every other
+	// e.instance writer. The per-entry lock removes the reliance on that non-local
+	// serialization invariant, so a future second caller cannot turn the re-key read
+	// into a data race. e.mu is a leaf lock here (taken while holding o.mu and
+	// releasing nothing else under it), so the established o.mu -> e.mu order holds
+	// and this cannot deadlock.
 	newModels := make(map[string]*modelEntry, len(o.models))
 	for _, e := range o.models {
-		if e.instance == nil {
+		e.mu.Lock()
+		inst := e.instance
+		e.mu.Unlock()
+		if inst == nil {
 			continue // skip entries closed by concurrent Delete
 		}
-		newModels[e.instance.ModelID()] = e
+		newModels[inst.ModelID()] = e
 	}
 	o.models = newModels
 
@@ -1773,7 +1787,11 @@ func (o *Orchestrator) computeThreadAllocation(settings *conf.Settings, primaryI
 func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 	log := GetLogger()
 
-	for _, configID := range o.Settings.Models.Enabled {
+	// Read the live published settings snapshot rather than the deprecated
+	// o.Settings pointer, consistent with the per-model loaders (loadPerch/loadBat).
+	settings := o.currentSettings()
+
+	for _, configID := range settings.Models.Enabled {
 		registryID, known := ResolveConfigModelID(configID)
 		if !known {
 			log.Warn("skipping unknown model ID in models.enabled",

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1116,25 +1116,26 @@ func (o *Orchestrator) ReloadModel() error {
 
 	// Re-key the models map in case the model ID changed after reload (Forgejo #270).
 	//
-	// Snapshot each entry's instance under its own e.mu before reading ModelID().
-	// This is defensive, not a fix for a live bug: today ReloadModel and
-	// ReloadSecondaryModels (which swaps e.instance under e.mu, outside o.mu) are
-	// both invoked only from the single-goroutine monitor event loop, so they never
-	// interleave and this re-key, holding o.mu, already excludes every other
-	// e.instance writer. The per-entry lock removes the reliance on that non-local
-	// serialization invariant, so a future second caller cannot turn the re-key read
-	// into a data race. e.mu is a leaf lock here (taken while holding o.mu and
-	// releasing nothing else under it), so the established o.mu -> e.mu order holds
-	// and this cannot deadlock.
+	// Read each entry's instance and its ModelID under the entry's own e.mu. This is
+	// defensive, not a fix for a live bug: today ReloadModel and ReloadSecondaryModels
+	// (which swaps e.instance under e.mu, outside o.mu) are both invoked only from the
+	// single-goroutine monitor event loop, so they never interleave and this re-key,
+	// holding o.mu, already excludes every other e.instance writer. Keeping the
+	// ModelID() read inside e.mu removes reliance on that non-local serialization
+	// invariant (and on ModelID being an immutable accessor) so a future second caller
+	// cannot turn the re-key into a data race. e.mu is a leaf lock here (taken while
+	// holding o.mu and acquiring nothing else under it), so the established
+	// o.mu -> e.mu order holds and this cannot deadlock.
 	newModels := make(map[string]*modelEntry, len(o.models))
 	for _, e := range o.models {
 		e.mu.Lock()
-		inst := e.instance
-		e.mu.Unlock()
-		if inst == nil {
+		if e.instance == nil {
+			e.mu.Unlock()
 			continue // skip entries closed by concurrent Delete
 		}
-		newModels[inst.ModelID()] = e
+		modelID := e.instance.ModelID()
+		e.mu.Unlock()
+		newModels[modelID] = e
 	}
 	o.models = newModels
 

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -9,9 +9,15 @@ import (
 func (o *Orchestrator) loadBat(threads int) error {
 	log := GetLogger()
 
-	classifierModel := o.Settings.Bat.ClassifierModel
-	labelPath := o.Settings.Bat.LabelPath
-	embeddingModel := o.Settings.Bat.EmbeddingModel
+	// Read the live published settings snapshot once (mirroring loadPerch) rather
+	// than the deprecated o.Settings pointer, so an out-of-band LoadModel after a
+	// hot-reload builds against the same configuration the rest of the orchestrator
+	// sees instead of a possibly-staler pointer.
+	settings := o.currentSettings()
+
+	classifierModel := settings.Bat.ClassifierModel
+	labelPath := settings.Bat.LabelPath
+	embeddingModel := settings.Bat.EmbeddingModel
 
 	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
 		m, l, e := o.resolveInstalledPaths(RegistryIDBat)
@@ -34,16 +40,16 @@ func (o *Orchestrator) loadBat(threads int) error {
 			Build()
 	}
 
-	if err := checkORTOrFail(o.Settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
+	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
 		return err
 	}
 
 	cfg := BatModelConfig{
 		EmbeddingModelPath:  embeddingModel,
-		EmbeddingLabels:     o.Settings.BirdNET.Labels,
+		EmbeddingLabels:     settings.BirdNET.Labels,
 		ClassifierModelPath: classifierModel,
 		ClassifierLabelPath: labelPath,
-		ONNXRuntimePath:     o.Settings.BirdNET.ONNXRuntimePath,
+		ONNXRuntimePath:     settings.BirdNET.ONNXRuntimePath,
 		Threads:             threads,
 	}
 


### PR DESCRIPTION
## Summary

Two small, low-risk hardening changes in the classifier orchestrator, plus an on-theme consistency cleanup.

1. **`loadBat` reads the live published settings snapshot.** It previously read the deprecated `o.Settings` pointer directly. On an out-of-band `LoadModel` after a config hot-reload, that pointer can be staler than what the rest of the orchestrator sees, so the Bat model could be built against stale paths (it only worked because `resolveInstalledPaths` re-derives the paths from disk as a fallback). It now captures `settings := o.currentSettings()` once and reads everything from that, mirroring the sibling `loadPerch`.

2. **`loadAdditionalModels` uses the same accessor.** It still read `o.Settings.Models.Enabled` directly in the range header. Switched to `o.currentSettings()` for consistency, leaving the construction path with no direct deprecated-pointer reads. Currently safe (construction-time only), so this is a consistency cleanup rather than a bug fix.

3. **`ReloadModel` re-key loop snapshots `entry.instance` under the per-entry mutex** before reading `ModelID()`, instead of reading `entry.instance` while holding only `o.mu`. This is defensive, not a live-bug fix: today `ReloadModel` and `ReloadSecondaryModels` (which swaps `entry.instance` under `entry.mu`, outside `o.mu`) both run only on the single-goroutine monitor event loop, so they never interleave. The per-entry lock removes reliance on that implicit serialization invariant so a future second caller cannot turn the re-key read into a data race. `entry.mu` stays a leaf lock taken under `o.mu`, preserving the documented `o.mu -> inferenceMu -> entry.mu` order, so there is no deadlock risk.

No config keys, API fields, DB schema, or CLI flags change. Behavior is preserved for existing users; change 1 only ever moves to an at-least-as-fresh settings snapshot.

## Test Plan
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/classifier/` (full package, passes)
- [x] Lock-order / deadlock analysis: confirmed `entry.mu` is always a leaf lock and no path acquires `o.mu` while holding `entry.mu`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model reloading stability by rebuilding internal model mappings using safely snapshotted instances.
  * Enhanced dynamic model loading to use the latest live settings snapshot, ensuring model configuration stays consistent and avoids unsafe reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->