### PR TITLE
feat(inference): inference status endpoint with RSS-delta and RTF instrumentation (Phase 1)

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -422,6 +422,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 | GET    | `/system/audio/sources`          | `ListAudioSources`        | ✅   | Active audio sources (all types)     |
 | GET    | `/system/network-interfaces`     | `GetNetworkInterfaces`    | ✅   | IPv4 network interfaces for binding  |
 | GET    | `/system/models`                 | `GetActiveModels`         | ✅   | Active model metadata                |
+| GET    | `/system/inference`              | `GetInferenceStatus`      | ✅   | Read-only snapshot of the inference subsystem: hardware, backends, loaded models with stats, RAM, and source attachment. |
 
 ### Events (`events.go`, `events_aggregation.go`)
 

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -2,8 +2,16 @@
 package api
 
 import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/cpuspec"
+	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
 // sourceTypeSoundCard is the source type label for local ALSA/sound card captures.
@@ -104,6 +112,119 @@ type ModelSourceInfo struct {
 type ModelMetricKeys struct {
 	AvgMs string `json:"avgMs"`
 	RTF   string `json:"rtf"`
+}
+
+// deviceCPU and deviceGPU are the OpenVINO device name strings used when
+// probing which compute devices are available for inference.
+const (
+	deviceCPU = "CPU"
+	deviceGPU = "GPU"
+)
+
+// buildModelStatus assembles an InferenceModelStatus for one loaded model from
+// its registry info, a non-destructive stats peek, the per-model RSS map, and
+// the pre-computed source attachment list. It is a pure function with no side
+// effects and is safe to call concurrently.
+func buildModelStatus(info *classifier.ModelInfo, snap inferencestats.PeekSnapshot, rss map[string]int64, sources []ModelSourceInfo) InferenceModelStatus {
+	clipSec := info.Spec.ClipLength.Seconds()
+
+	avgMs := 0.0
+	if snap.InvokeCount > 0 {
+		avgMs = float64(snap.InvokeTotalUs) / float64(snap.InvokeCount) / 1000.0
+	}
+	maxMs := float64(snap.InvokeMaxUs) / 1000.0
+
+	var rtf *float64
+	if snap.InvokeCount > 0 && clipSec > 0 {
+		v := (avgMs / 1000.0) / clipSec
+		rtf = &v
+	}
+
+	mem := ModelMemoryInfo{Approximate: true}
+	if rss != nil {
+		if b, ok := rss[info.ID]; ok {
+			mem.ApproxRssBytes = &b
+		}
+	}
+
+	if sources == nil {
+		sources = []ModelSourceInfo{}
+	}
+
+	return InferenceModelStatus{
+		ID:               info.ID,
+		Name:             info.Name,
+		Backend:          info.Backend,
+		DetectionName:    info.DetectionName,
+		DetectionVersion: info.DetectionVersion,
+		Quantization:     string(info.Quantization),
+		IsStock:          info.IsStock,
+		Spec:             ModelSpecInfo{SampleRate: info.Spec.SampleRate, ClipLengthSec: clipSec},
+		NumSpecies:       info.NumSpecies,
+		Stats:            ModelStats{Invocations: snap.InvokeCount, AvgMs: avgMs, MaxMs: maxMs, RTF: rtf},
+		Memory:           mem,
+		Sources:          sources,
+		MetricKeys:       ModelMetricKeys{AvgMs: inferencestats.MetricKey(info.ID), RTF: inferencestats.RTFMetricKey(info.ID)},
+	}
+}
+
+// GetInferenceStatus handles GET /api/v2/system/inference. It returns a
+// read-only snapshot of the inference subsystem: hardware, backends, loaded
+// models with per-model stats and memory, and source attachment. The snapshot
+// is assembled from live sources on every request so it reflects hot-reload
+// changes without any caching.
+func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
+	settings := c.currentSettings()
+
+	resp := InferenceStatusResponse{
+		SnapshotAtUnix: time.Now().Unix(),
+	}
+
+	// Hardware.
+	envType, _ := sysinfo.GetEnvironment()
+	resp.Hardware = HardwareInfo{
+		Arch:        sysinfo.GetCPUArch(),
+		CPUModel:    sysinfo.GetCPUModel(),
+		Environment: envType,
+		FP16:        cpuspec.HasNativeF16(),
+	}
+
+	// Backends: TFLite is always compiled in; ORT and OpenVINO are probed.
+	resp.Backends.TFLite = BackendStatus{Available: true}
+	ort := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
+	resp.Backends.ONNX = BackendStatus{Available: ort.Available, Initialized: ort.Initialized, Version: ort.Version}
+	ov := inference.CheckOpenVINOAvailability()
+	resp.Backends.OpenVINO = OpenVINOBackendStatus{Supported: ov.Supported, Active: ov.Active}
+	if ov.Supported {
+		for _, d := range []string{deviceCPU, deviceGPU} {
+			if inference.OpenVINOHasDevice(d) {
+				resp.Backends.OpenVINO.Devices = append(resp.Backends.OpenVINO.Devices, d)
+			}
+		}
+	}
+
+	// Models: fetch loaded model list, RSS, and inference counters.
+	var infos []classifier.ModelInfo
+	if c.ModelManager != nil {
+		infos = c.ModelManager.ModelInfos()
+	}
+	var rss map[string]int64
+	primaryID := ""
+	if c.Processor != nil {
+		if bn := c.Processor.GetBirdNET(); bn != nil {
+			rss, resp.RuntimeBaselineBytes = bn.ModelRSS()
+			primaryID = bn.PrimaryModelID()
+		}
+	}
+	counters := classifier.GetInferenceCounters().PeekAll()
+	attachments := buildSourceAttachments(settings, infos, primaryID)
+
+	resp.Models = make([]InferenceModelStatus, 0, len(infos))
+	for i := range infos {
+		resp.Models = append(resp.Models, buildModelStatus(&infos[i], counters[infos[i].ID], rss, attachments[infos[i].ID]))
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 // buildSourceAttachments computes, per loaded model registry ID, the audio

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -79,9 +79,13 @@ type ModelSpecInfo struct {
 }
 
 // ModelStats holds invocation counts and latency for a single model.
-// avgMs is the lifetime average; maxMs is the peak since the last metrics
+// AvgMs is the lifetime average; MaxMs is the peak since the last metrics
 // collection tick (a recent-window peak, since the collector resets it every
-// interval); rtf is nil when there have been no invocations.
+// interval); RTF is nil when there have been no invocations.
+//
+// RTF is the lifetime cumulative-average real-time factor: (avgMs / 1000) / clipSec.
+// This differs from the per-model ring-buffer series at MetricKeys.RTF, which is
+// an interval-windowed average computed by the collector on each tick.
 type ModelStats struct {
 	Invocations int64    `json:"invocations"`
 	AvgMs       float64  `json:"avgMs"`
@@ -181,7 +185,7 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 	}
 
 	// Hardware.
-	envType, _ := sysinfo.GetEnvironment()
+	envType, _ := sysinfo.GetEnvironment() // detail (sub-type) intentionally omitted in Phase 1
 	resp.Hardware = HardwareInfo{
 		Arch:        sysinfo.GetCPUArch(),
 		CPUModel:    sysinfo.GetCPUModel(),

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -1,0 +1,147 @@
+// internal/api/v2/inference_status.go
+package api
+
+import (
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// sourceTypeSoundCard is the source type label for local ALSA/sound card captures.
+const sourceTypeSoundCard = "soundcard"
+
+// InferenceStatusResponse is the top-level payload for GET /api/v2/system/inference.
+type InferenceStatusResponse struct {
+	Hardware             HardwareInfo           `json:"hardware"`
+	Backends             BackendsInfo           `json:"backends"`
+	Models               []InferenceModelStatus `json:"models"`
+	RuntimeBaselineBytes int64                  `json:"runtimeBaselineBytes,omitempty"`
+	SnapshotAtUnix       int64                  `json:"snapshotAtUnix"`
+}
+
+// HardwareInfo describes the host CPU/environment reported at snapshot time.
+type HardwareInfo struct {
+	Arch        string `json:"arch"`
+	CPUModel    string `json:"cpuModel"`
+	Environment string `json:"environment"`
+	FP16        bool   `json:"fp16"`
+}
+
+// BackendsInfo groups availability status for all supported inference backends.
+type BackendsInfo struct {
+	TFLite   BackendStatus         `json:"tflite"`
+	ONNX     BackendStatus         `json:"onnx"`
+	OpenVINO OpenVINOBackendStatus `json:"openvino"`
+}
+
+// BackendStatus reports whether an inference backend is available and initialized.
+type BackendStatus struct {
+	Available   bool   `json:"available"`
+	Initialized bool   `json:"initialized,omitempty"`
+	Version     string `json:"version,omitempty"`
+}
+
+// OpenVINOBackendStatus extends BackendStatus with OpenVINO-specific device info.
+type OpenVINOBackendStatus struct {
+	Supported bool     `json:"supported"`
+	Active    bool     `json:"active"`
+	Devices   []string `json:"devices,omitempty"`
+}
+
+// InferenceModelStatus describes one loaded model and its runtime statistics.
+type InferenceModelStatus struct {
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	Backend          string            `json:"backend"`
+	DetectionName    string            `json:"detectionName,omitempty"`
+	DetectionVersion string            `json:"detectionVersion,omitempty"`
+	Quantization     string            `json:"quantization,omitempty"`
+	IsStock          bool              `json:"isStock"`
+	Spec             ModelSpecInfo     `json:"spec"`
+	NumSpecies       int               `json:"numSpecies"`
+	Stats            ModelStats        `json:"stats"`
+	Memory           ModelMemoryInfo   `json:"memory"`
+	Sources          []ModelSourceInfo `json:"sources"`
+	MetricKeys       ModelMetricKeys   `json:"metricKeys"`
+}
+
+// ModelSpecInfo carries the audio input requirements of a model.
+type ModelSpecInfo struct {
+	SampleRate    int     `json:"sampleRate"`
+	ClipLengthSec float64 `json:"clipLengthSec"`
+}
+
+// ModelStats holds invocation counts and latency for a single model.
+// avgMs is the lifetime average; maxMs is the peak since the last metrics
+// collection tick (a recent-window peak, since the collector resets it every
+// interval); rtf is nil when there have been no invocations.
+type ModelStats struct {
+	Invocations int64    `json:"invocations"`
+	AvgMs       float64  `json:"avgMs"`
+	MaxMs       float64  `json:"maxMs"`
+	RTF         *float64 `json:"rtf,omitempty"`
+}
+
+// ModelMemoryInfo reports the estimated RSS contribution of a loaded model.
+// ApproxRssBytes is nil when the platform does not support measurement.
+type ModelMemoryInfo struct {
+	ApproxRssBytes *int64 `json:"approxRssBytes,omitempty"`
+	Approximate    bool   `json:"approximate"`
+}
+
+// ModelSourceInfo describes one audio source attached to a model.
+// Fallback is true when the source is attached to the primary model by default
+// rather than by an explicit config selection.
+type ModelSourceInfo struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     string `json:"type,omitempty"`
+	Fallback bool   `json:"fallback,omitempty"`
+}
+
+// ModelMetricKeys carries the Prometheus-style metric key names for a model's
+// latency and real-time-factor time series, so clients can look them up without
+// hardcoding.
+type ModelMetricKeys struct {
+	AvgMs string `json:"avgMs"`
+	RTF   string `json:"rtf"`
+}
+
+// buildSourceAttachments computes, per loaded model registry ID, the audio
+// sources attached to it from configuration. A source whose Models resolve to a
+// loaded model attaches there; a source with no resolvable model falls back to
+// the primary model with Fallback=true. Live registry enrichment (DisplayName,
+// State) is deferred to Phase 2; Phase 1 uses config identity.
+func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelInfo, primaryID string) map[string][]ModelSourceInfo {
+	loaded := make(map[string]bool, len(models))
+	for i := range models {
+		loaded[models[i].ID] = true
+	}
+	out := make(map[string][]ModelSourceInfo)
+
+	attach := func(name, sourceType string, configModels []string) {
+		target := ""
+		for _, cm := range configModels {
+			if regID, ok := classifier.ResolveConfigModelID(cm); ok && loaded[regID] {
+				target = regID
+				break
+			}
+		}
+		if target != "" {
+			out[target] = append(out[target], ModelSourceInfo{ID: name, Name: name, Type: sourceType, Fallback: false})
+			return
+		}
+		if primaryID != "" {
+			out[primaryID] = append(out[primaryID], ModelSourceInfo{ID: name, Name: name, Type: sourceType, Fallback: true})
+		}
+	}
+
+	for i := range settings.Realtime.Audio.Sources {
+		src := settings.Realtime.Audio.Sources[i]
+		attach(src.Name, sourceTypeSoundCard, src.Models)
+	}
+	for i := range settings.Realtime.RTSP.Streams {
+		st := settings.Realtime.RTSP.Streams[i]
+		attach(st.Name, st.Type, st.Models)
+	}
+	return out
+}

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -21,9 +21,8 @@ import (
 func TestBuildSourceAttachments(t *testing.T) {
 	t.Parallel()
 
-	// "BirdNET_V2.4" has no exported constant; use the literal that ModelRegistry
-	// uses as its key (verified in internal/classifier/model_registry.go line 131).
-	const primaryID = "BirdNET_V2.4"
+	// classifier.DefaultModelVersion is the registry key for the primary BirdNET model.
+	const primaryID = classifier.DefaultModelVersion
 
 	// Two loaded models: the primary BirdNET and Perch.
 	models := []classifier.ModelInfo{
@@ -46,19 +45,15 @@ func TestBuildSourceAttachments(t *testing.T) {
 
 	// Perch_V2 should have exactly Front Yard, attached without fallback.
 	perch := got[classifier.RegistryIDPerchV2]
-	if len(perch) != 1 || perch[0].Name != "Front Yard" || perch[0].Fallback {
-		t.Fatalf("Perch_V2 attachments = %+v, want [{Name:Front Yard Fallback:false}]", perch)
-	}
+	require.Len(t, perch, 1, "Perch_V2 attachments")
+	assert.Equal(t, "Front Yard", perch[0].Name, "Perch_V2 source name")
+	assert.False(t, perch[0].Fallback, "Perch_V2 source must not be a fallback")
 
 	// Primary should have Garage and Cam1, both as fallbacks.
 	prim := got[primaryID]
-	if len(prim) != 2 {
-		t.Fatalf("primary attachments = %+v, want 2 entries (Garage, Cam1)", prim)
-	}
+	require.Len(t, prim, 2, "primary attachments must have 2 entries (Garage, Cam1)")
 	for _, s := range prim {
-		if !s.Fallback {
-			t.Fatalf("primary attachment %q has Fallback=false, want true", s.Name)
-		}
+		assert.True(t, s.Fallback, "primary attachment %q should have Fallback=true", s.Name)
 	}
 }
 
@@ -69,7 +64,7 @@ func TestBuildSourceAttachments(t *testing.T) {
 func TestBuildSourceAttachments_ResolvesButNotLoaded(t *testing.T) {
 	t.Parallel()
 
-	const primaryID = "BirdNET_V2.4"
+	const primaryID = classifier.DefaultModelVersion
 
 	// Only BirdNET is loaded; Perch is deliberately NOT loaded.
 	models := []classifier.ModelInfo{
@@ -87,18 +82,13 @@ func TestBuildSourceAttachments_ResolvesButNotLoaded(t *testing.T) {
 
 	// Perch_V2 should have NO attachments (not loaded).
 	perch := got[classifier.RegistryIDPerchV2]
-	if len(perch) != 0 {
-		t.Fatalf("Perch_V2 attachments = %+v, want empty (Perch not loaded)", perch)
-	}
+	assert.Empty(t, perch, "Perch_V2 attachments must be empty (Perch not loaded)")
 
 	// Primary should have Studio as a fallback.
 	prim := got[primaryID]
-	if len(prim) != 1 {
-		t.Fatalf("primary attachments = %+v, want 1 entry (Studio)", prim)
-	}
-	if prim[0].Name != "Studio" || !prim[0].Fallback {
-		t.Fatalf("primary[0] = {Name:%q Fallback:%v}, want {Name:Studio Fallback:true}", prim[0].Name, prim[0].Fallback)
-	}
+	require.Len(t, prim, 1, "primary attachments must have 1 entry (Studio)")
+	assert.Equal(t, "Studio", prim[0].Name, "primary source name")
+	assert.True(t, prim[0].Fallback, "primary source must be a fallback")
 }
 
 // TestBuildModelStatus verifies that buildModelStatus correctly computes
@@ -120,24 +110,14 @@ func TestBuildModelStatus(t *testing.T) {
 
 	got := buildModelStatus(&info, snap, rss, nil)
 
-	if got.Stats.Invocations != 1000 {
-		t.Errorf("invocations = %d, want 1000", got.Stats.Invocations)
-	}
-	if got.Stats.AvgMs < 47.1 || got.Stats.AvgMs > 47.3 {
-		t.Errorf("avgMs = %v, want ~47.2", got.Stats.AvgMs)
-	}
-	if got.Stats.MaxMs != 130 {
-		t.Errorf("maxMs = %v, want 130", got.Stats.MaxMs)
-	}
-	if got.Stats.RTF == nil || *got.Stats.RTF < 0.0156 || *got.Stats.RTF > 0.0158 {
-		t.Errorf("rtf = %v, want ~0.0157", got.Stats.RTF)
-	}
-	if got.Memory.ApproxRssBytes == nil || *got.Memory.ApproxRssBytes != rssVal {
-		t.Errorf("approxRssBytes = %v, want %d", got.Memory.ApproxRssBytes, rssVal)
-	}
-	if got.MetricKeys.RTF != "inference.BirdNET_V2_4.rtf" {
-		t.Errorf("metricKeys.rtf = %q", got.MetricKeys.RTF)
-	}
+	assert.Equal(t, int64(1000), got.Stats.Invocations, "invocations")
+	assert.InDelta(t, 47.2, got.Stats.AvgMs, 0.1, "avgMs")
+	assert.InDelta(t, 130.0, got.Stats.MaxMs, 0.01, "maxMs")
+	require.NotNil(t, got.Stats.RTF, "rtf must not be nil with non-zero invocations")
+	assert.InDelta(t, 0.0157, *got.Stats.RTF, 0.0001, "rtf")
+	require.NotNil(t, got.Memory.ApproxRssBytes, "approxRssBytes must not be nil when RSS is available")
+	assert.Equal(t, rssVal, *got.Memory.ApproxRssBytes, "approxRssBytes")
+	assert.Equal(t, "inference.BirdNET_V2_4.rtf", got.MetricKeys.RTF, "metricKeys.rtf")
 }
 
 // TestBuildModelStatus_ZeroInvocations verifies that buildModelStatus returns
@@ -146,15 +126,9 @@ func TestBuildModelStatus_ZeroInvocations(t *testing.T) {
 	t.Parallel()
 	info := classifier.ModelInfo{ID: "X", Spec: classifier.ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second}}
 	got := buildModelStatus(&info, inferencestats.PeekSnapshot{}, nil, nil)
-	if got.Stats.RTF != nil {
-		t.Error("rtf must be nil with zero invocations (no divide-by-zero)")
-	}
-	if got.Memory.ApproxRssBytes != nil {
-		t.Error("approxRssBytes must be nil when RSS unavailable")
-	}
-	if !got.Memory.Approximate {
-		t.Error("memory.approximate must always be true")
-	}
+	assert.Nil(t, got.Stats.RTF, "rtf must be nil with zero invocations (no divide-by-zero)")
+	assert.Nil(t, got.Memory.ApproxRssBytes, "approxRssBytes must be nil when RSS unavailable")
+	assert.True(t, got.Memory.Approximate, "memory.approximate must always be true")
 }
 
 // TestGetInferenceStatus_HTTP200 verifies that GetInferenceStatus returns HTTP

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -2,9 +2,16 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -92,4 +99,81 @@ func TestBuildSourceAttachments_ResolvesButNotLoaded(t *testing.T) {
 	if prim[0].Name != "Studio" || !prim[0].Fallback {
 		t.Fatalf("primary[0] = {Name:%q Fallback:%v}, want {Name:Studio Fallback:true}", prim[0].Name, prim[0].Fallback)
 	}
+}
+
+// TestBuildModelStatus verifies that buildModelStatus correctly computes
+// average latency, peak latency, RTF, and memory from a non-zero PeekSnapshot.
+func TestBuildModelStatus(t *testing.T) {
+	t.Parallel()
+	rssVal := int64(125_000_000)
+	info := classifier.ModelInfo{
+		ID:           "BirdNET_V2.4",
+		Name:         "BirdNET v2.4",
+		Backend:      "ONNX",
+		Quantization: classifier.QuantizationINT8,
+		IsStock:      true,
+		NumSpecies:   6522,
+		Spec:         classifier.ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+	}
+	snap := inferencestats.PeekSnapshot{InvokeCount: 1000, InvokeTotalUs: 47_200_000, InvokeMaxUs: 130_000}
+	rss := map[string]int64{"BirdNET_V2.4": rssVal}
+
+	got := buildModelStatus(&info, snap, rss, nil)
+
+	if got.Stats.Invocations != 1000 {
+		t.Errorf("invocations = %d, want 1000", got.Stats.Invocations)
+	}
+	if got.Stats.AvgMs < 47.1 || got.Stats.AvgMs > 47.3 {
+		t.Errorf("avgMs = %v, want ~47.2", got.Stats.AvgMs)
+	}
+	if got.Stats.MaxMs != 130 {
+		t.Errorf("maxMs = %v, want 130", got.Stats.MaxMs)
+	}
+	if got.Stats.RTF == nil || *got.Stats.RTF < 0.0156 || *got.Stats.RTF > 0.0158 {
+		t.Errorf("rtf = %v, want ~0.0157", got.Stats.RTF)
+	}
+	if got.Memory.ApproxRssBytes == nil || *got.Memory.ApproxRssBytes != rssVal {
+		t.Errorf("approxRssBytes = %v, want %d", got.Memory.ApproxRssBytes, rssVal)
+	}
+	if got.MetricKeys.RTF != "inference.BirdNET_V2_4.rtf" {
+		t.Errorf("metricKeys.rtf = %q", got.MetricKeys.RTF)
+	}
+}
+
+// TestBuildModelStatus_ZeroInvocations verifies that buildModelStatus returns
+// nil RTF and nil ApproxRssBytes when there are no invocations or no RSS data.
+func TestBuildModelStatus_ZeroInvocations(t *testing.T) {
+	t.Parallel()
+	info := classifier.ModelInfo{ID: "X", Spec: classifier.ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second}}
+	got := buildModelStatus(&info, inferencestats.PeekSnapshot{}, nil, nil)
+	if got.Stats.RTF != nil {
+		t.Error("rtf must be nil with zero invocations (no divide-by-zero)")
+	}
+	if got.Memory.ApproxRssBytes != nil {
+		t.Error("approxRssBytes must be nil when RSS unavailable")
+	}
+	if !got.Memory.Approximate {
+		t.Error("memory.approximate must always be true")
+	}
+}
+
+// TestGetInferenceStatus_HTTP200 verifies that GetInferenceStatus returns HTTP
+// 200 and a valid InferenceStatusResponse with TFLite marked available. It uses
+// the shared setupTestEnvironment harness (minimalController + Echo) to exercise
+// the handler over httptest without starting any background goroutines.
+func TestGetInferenceStatus_HTTP200(t *testing.T) {
+	// NOT parallel: publishTestSettings in setupTestEnvironment mutates global state.
+	e, _, controller := setupTestEnvironment(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/inference", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, controller.GetInferenceStatus(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp InferenceStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp), "response body must unmarshal to InferenceStatusResponse")
+	assert.True(t, resp.Backends.TFLite.Available, "TFLite backend must always report Available=true")
+	assert.NotZero(t, resp.SnapshotAtUnix, "SnapshotAtUnix must be a non-zero Unix timestamp")
 }

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -1,0 +1,95 @@
+// internal/api/v2/inference_status_test.go
+package api
+
+import (
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestBuildSourceAttachments verifies that buildSourceAttachments correctly
+// routes audio sources to their configured model, or to the primary fallback
+// when no configured model resolves to a loaded model.
+func TestBuildSourceAttachments(t *testing.T) {
+	t.Parallel()
+
+	// "BirdNET_V2.4" has no exported constant; use the literal that ModelRegistry
+	// uses as its key (verified in internal/classifier/model_registry.go line 131).
+	const primaryID = "BirdNET_V2.4"
+
+	// Two loaded models: the primary BirdNET and Perch.
+	models := []classifier.ModelInfo{
+		{ID: primaryID},
+		{ID: classifier.RegistryIDPerchV2},
+	}
+
+	settings := &conf.Settings{}
+	// Front Yard uses conf.ModelIDPerchV2 ("perch_v2"), which ResolveConfigModelID
+	// maps to classifier.RegistryIDPerchV2 ("Perch_V2"). Fallback must be false.
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "Front Yard", Models: []string{conf.ModelIDPerchV2}},
+		{Name: "Garage", Models: nil}, // no models: falls back to primary
+	}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{Name: "Cam1", Type: "rtsp", Models: []string{"unknown_model"}}, // unresolved: falls back to primary
+	}
+
+	got := buildSourceAttachments(settings, models, primaryID)
+
+	// Perch_V2 should have exactly Front Yard, attached without fallback.
+	perch := got[classifier.RegistryIDPerchV2]
+	if len(perch) != 1 || perch[0].Name != "Front Yard" || perch[0].Fallback {
+		t.Fatalf("Perch_V2 attachments = %+v, want [{Name:Front Yard Fallback:false}]", perch)
+	}
+
+	// Primary should have Garage and Cam1, both as fallbacks.
+	prim := got[primaryID]
+	if len(prim) != 2 {
+		t.Fatalf("primary attachments = %+v, want 2 entries (Garage, Cam1)", prim)
+	}
+	for _, s := range prim {
+		if !s.Fallback {
+			t.Fatalf("primary attachment %q has Fallback=false, want true", s.Name)
+		}
+	}
+}
+
+// TestBuildSourceAttachments_ResolvesButNotLoaded verifies that a source whose
+// config model alias resolves to a registry ID, but that registry ID is NOT in
+// the loaded models list, falls back to primary with Fallback=true. This catches
+// regressions where the guard `ok && loaded[regID]` is loosened to just `ok`.
+func TestBuildSourceAttachments_ResolvesButNotLoaded(t *testing.T) {
+	t.Parallel()
+
+	const primaryID = "BirdNET_V2.4"
+
+	// Only BirdNET is loaded; Perch is deliberately NOT loaded.
+	models := []classifier.ModelInfo{
+		{ID: primaryID},
+	}
+
+	settings := &conf.Settings{}
+	// Studio uses conf.ModelIDPerchV2, which resolves to classifier.RegistryIDPerchV2,
+	// but Perch is not in the loaded models. Must fall back to primary with Fallback=true.
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "Studio", Models: []string{conf.ModelIDPerchV2}},
+	}
+
+	got := buildSourceAttachments(settings, models, primaryID)
+
+	// Perch_V2 should have NO attachments (not loaded).
+	perch := got[classifier.RegistryIDPerchV2]
+	if len(perch) != 0 {
+		t.Fatalf("Perch_V2 attachments = %+v, want empty (Perch not loaded)", perch)
+	}
+
+	// Primary should have Studio as a fallback.
+	prim := got[primaryID]
+	if len(prim) != 1 {
+		t.Fatalf("primary attachments = %+v, want 1 entry (Studio)", prim)
+	}
+	if prim[0].Name != "Studio" || !prim[0].Fallback {
+		t.Fatalf("primary[0] = {Name:%q Fallback:%v}, want {Name:Studio Fallback:true}", prim[0].Name, prim[0].Fallback)
+	}
+}

--- a/internal/api/v2/metrics_history.go
+++ b/internal/api/v2/metrics_history.go
@@ -228,6 +228,24 @@ func (c *Controller) initMetricsHistoryRoutes() {
 		// Wire BirdNET inference counters
 		collector.SetInferenceCounters(classifier.GetInferenceCounters())
 
+		// Wire per-model clip length and RSS functions for RTF computation and RSS gauges
+		if c.Processor != nil {
+			if bn := c.Processor.GetBirdNET(); bn != nil {
+				collector.SetModelClipFunc(func() map[string]float64 {
+					infos := bn.ModelInfos()
+					out := make(map[string]float64, len(infos))
+					for i := range infos {
+						out[infos[i].ID] = infos[i].Spec.ClipLength.Seconds()
+					}
+					return out
+				})
+				collector.SetModelRSSFunc(bn.ModelRSS)
+			}
+		}
+		if c.metrics != nil && c.metrics.BirdNET != nil {
+			collector.SetInferenceGaugeSetters(c.metrics.BirdNET.SetInferenceRTF, c.metrics.BirdNET.SetModelRSSBytes)
+		}
+
 		// Wire health counter collection (drops, overruns, stream restarts)
 		if c.healthMetricsStore != nil {
 			collector.SetHealthStore(c.healthMetricsStore)

--- a/internal/api/v2/metrics_history.go
+++ b/internal/api/v2/metrics_history.go
@@ -243,7 +243,7 @@ func (c *Controller) initMetricsHistoryRoutes() {
 			}
 		}
 		if c.metrics != nil && c.metrics.BirdNET != nil {
-			collector.SetInferenceGaugeSetters(c.metrics.BirdNET.SetInferenceRTF, c.metrics.BirdNET.SetModelRSSBytes)
+			collector.SetInferenceGaugeSetters(c.metrics.BirdNET.SetInferenceRTF, c.metrics.BirdNET.SetModelRSSBytes, c.metrics.BirdNET.DeleteInferenceMetrics)
 		}
 
 		// Wire health counter collection (drops, overruns, stream restarts)

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -404,6 +404,7 @@ func (c *Controller) initSystemRoutes() {
 	protectedGroup.GET("/network-interfaces", c.GetNetworkInterfaces)
 	protectedGroup.GET("/restart-status", c.GetRestartStatus)
 	protectedGroup.GET("/models", c.GetActiveModels)
+	protectedGroup.GET("/inference", c.GetInferenceStatus)
 
 	// Audio device routes (all protected)
 	audioGroup := protectedGroup.Group("/audio")

--- a/internal/classifier/inferencestats/counters.go
+++ b/internal/classifier/inferencestats/counters.go
@@ -72,6 +72,13 @@ func MetricKey(modelID string) string {
 	return "inference." + SanitizeModelID(modelID) + ".avg_ms"
 }
 
+// RTFMetricKey returns the ring-buffer series key for a model's real-time factor.
+// Single source of truth shared by the collector (writer) and the inference
+// status endpoint (which advertises it in metricKeys). Pure helper.
+func RTFMetricKey(modelID string) string {
+	return "inference." + SanitizeModelID(modelID) + ".rtf"
+}
+
 // CounterMap tracks per-model inference counters. Safe for concurrent use.
 type CounterMap struct {
 	models sync.Map // model ID (string) -> *Counters

--- a/internal/classifier/inferencestats/counters_test.go
+++ b/internal/classifier/inferencestats/counters_test.go
@@ -176,6 +176,15 @@ func TestCounterMap_PeekAll_Empty(t *testing.T) {
 	assert.Empty(t, peek)
 }
 
+func TestRTFMetricKey(t *testing.T) {
+	t.Parallel()
+	got := RTFMetricKey("BirdNET V2.4")
+	want := "inference.BirdNET_V2_4.rtf"
+	if got != want {
+		t.Fatalf("RTFMetricKey = %q, want %q", got, want)
+	}
+}
+
 func TestCounterMap_PeekAll_DoesNotInterfereWithSnapshot(t *testing.T) {
 	t.Parallel()
 	m := &CounterMap{}

--- a/internal/classifier/inferencestats/counters_test.go
+++ b/internal/classifier/inferencestats/counters_test.go
@@ -178,10 +178,22 @@ func TestCounterMap_PeekAll_Empty(t *testing.T) {
 
 func TestRTFMetricKey(t *testing.T) {
 	t.Parallel()
-	got := RTFMetricKey("BirdNET V2.4")
-	want := "inference.BirdNET_V2_4.rtf"
-	if got != want {
-		t.Fatalf("RTFMetricKey = %q, want %q", got, want)
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Spaces and dots replaced, normalized form.
+		{input: "BirdNET V2.4", want: "inference.BirdNET_V2_4.rtf"},
+		// Already-clean id: must round-trip without modification.
+		{input: "Perch_V2", want: "inference.Perch_V2.rtf"},
+		// Empty string: produces "inference..rtf" (degenerate but must not panic).
+		{input: "", want: "inference..rtf"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, RTFMetricKey(tt.input))
+		})
 	}
 }
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1691,6 +1691,15 @@ func (o *Orchestrator) Debug(format string, v ...any) {
 	primary.Debug(format, v...)
 }
 
+// PrimaryModelID returns the registry ID of the primary model. It reads the
+// o.mu-guarded primary identity under the read lock, so it is safe to call
+// concurrently with model reloads. Returns "" if no primary is set.
+func (o *Orchestrator) PrimaryModelID() string {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.ModelInfo.ID
+}
+
 // ModelInfos returns ModelInfo for all registered models. Thread-safe.
 // Used by the pipeline to build ModelTarget lists for buffer fan-out.
 // For the primary model entry, the live o.ModelInfo is returned rather than the

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -97,6 +97,12 @@ type Orchestrator struct {
 	// Nighttime scheduling for bat model. Stored as atomic.Pointer so
 	// IsModelActive (called on every monitor tick) reads lock-free.
 	scheduler atomic.Pointer[nighttimeScheduler]
+
+	// Per-model host RSS-delta accounting (see orchestrator_memory.go).
+	rssMu            sync.Mutex
+	modelRSS         map[string]int64
+	runtimeBaseline  int64
+	baselineCaptured bool
 }
 
 // CurrentSettings returns the latest settings snapshot published via
@@ -136,6 +142,17 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 			primaryInfo = &info
 		}
 	}
+
+	// Capture host RSS before the primary model allocates its arena. We need o
+	// to exist first (captureRSSBefore records the runtime baseline on first call),
+	// so build o with an empty models map and then insert the primary below.
+	o := &Orchestrator{
+		Settings: settings,
+		models:   map[string]*modelEntry{},
+		modelRSS: make(map[string]int64),
+	}
+	rssBefore := o.captureRSSBefore()
+
 	bn, err := NewBirdNET(settings, primaryInfo)
 	if err != nil {
 		return nil, err
@@ -144,21 +161,17 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	resolver := NewBirdNETLabelResolver(bn.Labels())
 	ofResolver := openfauna.NewResolver()
 
-	o := &Orchestrator{
-		Settings:        settings,
-		ModelInfo:       bn.ModelInfo,
-		TaxonomyMap:     bn.TaxonomyMap,
-		TaxonomyPath:    bn.TaxonomyPath,
-		ScientificIndex: bn.ScientificIndex,
-		// OpenFauna first so it overrides label/taxonomy names everywhere
-		// ResolveName is consulted (display + inference).
-		nameResolvers: []NameResolver{ofResolver, resolver},
-		openfauna:     ofResolver,
-		models: map[string]*modelEntry{
-			bn.ModelInfo.ID: {instance: bn},
-		},
-		primary: bn,
-	}
+	// Populate the remaining fields now that bn is available.
+	o.ModelInfo = bn.ModelInfo
+	o.TaxonomyMap = bn.TaxonomyMap
+	o.TaxonomyPath = bn.TaxonomyPath
+	o.ScientificIndex = bn.ScientificIndex
+	// OpenFauna first so it overrides label/taxonomy names everywhere
+	// ResolveName is consulted (display + inference).
+	o.nameResolvers = []NameResolver{ofResolver, resolver}
+	o.openfauna = ofResolver
+	o.models[bn.ModelInfo.ID] = &modelEntry{instance: bn}
+	o.primary = bn
 	o.settingsAtomic.Store(settings)
 
 	// Each OV-capable secondary records the startup triplet on its own modelEntry
@@ -166,6 +179,10 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	// reload_birdnet for an unrelated setting (e.g. a locale change) sees a
 	// matching triplet and does not spuriously rebuild it. No orchestrator-wide
 	// gate to seed here anymore.
+
+	// Warm up the primary model and record RSS delta. This calls instance.Predict
+	// directly (single-threaded construction; no lock is held here).
+	o.warmupAndRecordRSS(bn.ModelInfo.ID, rssBefore, bn)
 
 	// Pre-compute thread allocation so model constructors receive their share.
 	// BirdNET already uses settings.BirdNET.Threads at construction; additional

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1313,6 +1313,12 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 		ref.entry.backend = triplet
 		ref.entry.mu.Unlock()
 
+		// Clear the stale RSS entry so the API reports n/a rather than a wrong
+		// number until the next warm-up or RSS measurement.
+		o.rssMu.Lock()
+		delete(o.modelRSS, ref.id)
+		o.rssMu.Unlock()
+
 		// Close the old instance after releasing entry.mu: native teardown can be
 		// slow, and no goroutine can reach the old instance once the swap is
 		// published (PredictModel reads entry.instance under entry.mu on every
@@ -1353,6 +1359,10 @@ func (o *Orchestrator) Delete() {
 	o.primary = nil
 	o.models = nil
 	o.mu.Unlock()
+
+	o.rssMu.Lock()
+	o.modelRSS = make(map[string]int64)
+	o.rssMu.Unlock()
 
 	for id, entry := range models {
 		entry.mu.Lock()
@@ -1557,6 +1567,10 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	defer entry.mu.Unlock()
 
 	globalInferenceCounters.Delete(registryID)
+
+	o.rssMu.Lock()
+	delete(o.modelRSS, registryID)
+	o.rssMu.Unlock()
 
 	if entry.instance != nil {
 		modelID := entry.instance.ModelID()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1270,6 +1270,7 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 				threads = runtime.NumCPU()
 			}
 		}
+		before := o.captureRSSBefore()
 		newInst, err := openvinoCapableSecondaryBuilders[ref.id](o, settings, threads)
 		if err != nil {
 			if firstErr == nil {
@@ -1292,6 +1293,13 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 			continue
 		}
 
+		// Warm up the freshly built (still private) instance before publishing it,
+		// so the first real inference does not pay the lazy-allocation cost, and
+		// re-measure its host RSS. This is lock-free and safe: newInst is not yet in
+		// the entry, and o.mu is not held in this build/swap section, so it does not
+		// stall live inference (unlike the initial load paths).
+		o.warmupAndRecordRSS(ref.id, before, newInst)
+
 		// Swap the new instance into the existing entry under entry.mu so it
 		// cannot race an in-flight PredictModel. Keeping the same *modelEntry
 		// preserves the per-entry mutex identity and the globalInferenceCounters
@@ -1307,17 +1315,15 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 					logger.String("registry_id", ref.id),
 					logger.Error(cerr))
 			}
+			// Remove the RSS entry we just recorded since the model will not be published.
+			o.rssMu.Lock()
+			delete(o.modelRSS, ref.id)
+			o.rssMu.Unlock()
 			continue
 		}
 		ref.entry.instance = newInst
 		ref.entry.backend = triplet
 		ref.entry.mu.Unlock()
-
-		// Clear the stale RSS entry so the API reports n/a rather than a wrong
-		// number until the next warm-up or RSS measurement.
-		o.rssMu.Lock()
-		delete(o.modelRSS, ref.id)
-		o.rssMu.Unlock()
 
 		// Close the old instance after releasing entry.mu: native teardown can be
 		// slow, and no goroutine can reach the old instance once the swap is

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -6,8 +6,10 @@ import (
 )
 
 // loadBat creates and registers a bat detection model instance from settings.
+// o.mu.Lock() is held by the caller.
 func (o *Orchestrator) loadBat(threads int) error {
 	log := GetLogger()
+	before := o.captureRSSBefore()
 
 	classifierModel := o.Settings.Bat.ClassifierModel
 	labelPath := o.Settings.Bat.LabelPath
@@ -56,6 +58,7 @@ func (o *Orchestrator) loadBat(threads int) error {
 			Build()
 	}
 
+	o.warmupAndRecordRSS(bat.ModelID(), before, bat)
 	o.models[bat.ModelID()] = &modelEntry{instance: bat}
 
 	log.Info("Bat model loaded into Orchestrator",

--- a/internal/classifier/orchestrator_memory.go
+++ b/internal/classifier/orchestrator_memory.go
@@ -9,9 +9,11 @@ import (
 )
 
 // warmupTimeout bounds the best-effort warm-up inference run during model load.
-// First-inference lazy allocation can be slow, so this is generous; it only
-// guards against a wedged backend.
-const warmupTimeout = 30 * time.Second
+// It is intentionally short: a legitimate first inference completes well under
+// 5 s even on a Raspberry Pi 5, and the warm-up holds o.mu (callers of
+// PredictModel block on o.mu.RLock during a dynamic load). On timeout the
+// warm-up aborts gracefully and RSS just undercounts for that model.
+const warmupTimeout = 5 * time.Second
 
 // captureRSSBefore reads the current process RSS to use as the "before" sample
 // for a model load. On the first call it also records the process-wide runtime

--- a/internal/classifier/orchestrator_memory.go
+++ b/internal/classifier/orchestrator_memory.go
@@ -1,0 +1,87 @@
+package classifier
+
+import (
+	"context"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+// warmupTimeout bounds the best-effort warm-up inference run during model load.
+// First-inference lazy allocation can be slow, so this is generous; it only
+// guards against a wedged backend.
+const warmupTimeout = 30 * time.Second
+
+// captureRSSBefore reads the current process RSS to use as the "before" sample
+// for a model load. On the first call it also records the process-wide runtime
+// baseline (Go runtime + app, before any model arena) so the first-loaded model
+// does not visually absorb the entire shared runtime cost. Returns 0 when RSS is
+// unavailable on the platform; callers treat 0 as "do not record a delta".
+func (o *Orchestrator) captureRSSBefore() uint64 {
+	rss, err := sysinfo.CurrentProcessRSS()
+	if err != nil {
+		return 0
+	}
+	o.rssMu.Lock()
+	if !o.baselineCaptured {
+		o.runtimeBaseline = int64(rss)
+		o.baselineCaptured = true
+	}
+	o.rssMu.Unlock()
+	return rss
+}
+
+// warmupAndRecordRSS runs a best-effort warm-up inference on the freshly built
+// instance to force lazy allocation, then records RSS_after - RSS_before as the
+// host-RAM delta attributable to this model. The warm-up calls instance.Predict
+// directly (never o.PredictModel) to avoid the re-entrant o.mu lock and to keep
+// the warm-up out of the global inference counters. Negative deltas (OS page
+// reclamation, measurement noise) are clamped to zero. RSS is host-RAM only and
+// approximate.
+func (o *Orchestrator) warmupAndRecordRSS(modelID string, before uint64, instance ModelInstance) {
+	o.warmup(modelID, instance)
+
+	after, err := sysinfo.CurrentProcessRSS()
+	if err != nil || before == 0 {
+		return // RSS unavailable: leave the model out of modelRSS (endpoint shows n/a)
+	}
+	delta := int64(after) - int64(before)
+	if delta < 0 {
+		delta = 0
+	}
+	o.rssMu.Lock()
+	o.modelRSS[modelID] = delta
+	o.rssMu.Unlock()
+}
+
+// warmup runs a single silent inference sized from the model spec. Failures are
+// non-fatal and logged at debug level; the model still loads.
+func (o *Orchestrator) warmup(modelID string, instance ModelInstance) {
+	spec := instance.Spec()
+	n := int(float64(spec.SampleRate) * spec.ClipLength.Seconds())
+	if n <= 0 {
+		return
+	}
+	dummy := [][]float32{make([]float32, n)}
+	ctx, cancel := context.WithTimeout(context.Background(), warmupTimeout)
+	defer cancel()
+	if _, err := instance.Predict(ctx, dummy); err != nil {
+		GetLogger().Debug("warm-up inference failed (non-fatal)",
+			logger.String("model", modelID),
+			logger.Error(err))
+	}
+}
+
+// ModelRSS returns a copy of the per-model host-RSS deltas (bytes) and the
+// process RSS baseline captured before the first model load. Safe for concurrent
+// use; the returned map is a copy.
+func (o *Orchestrator) ModelRSS() (perModel map[string]int64, runtimeBaseline int64) {
+	o.rssMu.Lock()
+	defer o.rssMu.Unlock()
+	out := make(map[string]int64, len(o.modelRSS))
+	for k, v := range o.modelRSS {
+		out[k] = v
+	}
+	return out, o.runtimeBaseline
+}

--- a/internal/classifier/orchestrator_memory_test.go
+++ b/internal/classifier/orchestrator_memory_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -34,34 +36,30 @@ func (f *fakeInstance) Labels() []string     { return nil }
 func (f *fakeInstance) Close() error         { return nil }
 
 func TestWarmupAndRecordRSS_RecordsNonNegativeDelta(t *testing.T) {
+	t.Parallel()
 	o := &Orchestrator{modelRSS: make(map[string]int64)}
 	inst := &fakeInstance{id: "Test_Model", sampleRate: 48000, clip: 3 * time.Second}
 
 	before := o.captureRSSBefore()
+	if before == 0 {
+		t.Skip("process RSS unavailable on this platform")
+	}
 	o.warmupAndRecordRSS(inst.ModelID(), before, inst)
 
 	// Warm-up must size the dummy clip from the spec (48000 * 3s = 144000).
-	if inst.predictedN != 144000 {
-		t.Fatalf("warm-up dummy size = %d, want 144000", inst.predictedN)
-	}
+	require.Equal(t, 144000, inst.predictedN, "warm-up dummy size")
+
 	perModel, baseline := o.ModelRSS()
-	if _, ok := perModel[inst.ModelID()]; !ok {
-		t.Fatal("expected modelRSS entry for Test_Model")
-	}
-	if perModel[inst.ModelID()] < 0 {
-		t.Fatalf("RSS delta must be clamped to >= 0, got %d", perModel[inst.ModelID()])
-	}
-	if baseline < 0 {
-		t.Fatalf("runtime baseline must be >= 0, got %d", baseline)
-	}
+	require.Contains(t, perModel, inst.ModelID(), "expected modelRSS entry for Test_Model")
+	assert.GreaterOrEqual(t, perModel[inst.ModelID()], int64(0), "RSS delta must be clamped to >= 0")
+	assert.GreaterOrEqual(t, baseline, int64(0), "runtime baseline must be >= 0")
 }
 
 func TestModelRSS_ReturnsCopy(t *testing.T) {
+	t.Parallel()
 	o := &Orchestrator{modelRSS: map[string]int64{"A": 10}}
 	m, _ := o.ModelRSS()
 	m["A"] = 999
 	m2, _ := o.ModelRSS()
-	if m2["A"] != 10 {
-		t.Fatalf("ModelRSS must return a copy; got mutated value %d", m2["A"])
-	}
+	assert.Equal(t, int64(10), m2["A"], "ModelRSS must return a copy; mutation of returned map must not affect the original")
 }

--- a/internal/classifier/orchestrator_memory_test.go
+++ b/internal/classifier/orchestrator_memory_test.go
@@ -1,0 +1,67 @@
+package classifier
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// fakeInstance is a minimal ModelInstance for warm-up/RSS tests.
+type fakeInstance struct {
+	id         string
+	sampleRate int
+	clip       time.Duration
+	predictedN int
+	predictErr error
+}
+
+func (f *fakeInstance) Predict(_ context.Context, samples [][]float32) ([]datastore.Results, error) {
+	if len(samples) > 0 {
+		f.predictedN = len(samples[0])
+	}
+	return nil, f.predictErr
+}
+func (f *fakeInstance) Spec() ModelSpec {
+	return ModelSpec{SampleRate: f.sampleRate, ClipLength: f.clip}
+}
+func (f *fakeInstance) ModelID() string      { return f.id }
+func (f *fakeInstance) ModelName() string    { return f.id }
+func (f *fakeInstance) ModelVersion() string { return "test" }
+func (f *fakeInstance) NumSpecies() int      { return 1 }
+func (f *fakeInstance) Labels() []string     { return nil }
+func (f *fakeInstance) Close() error         { return nil }
+
+func TestWarmupAndRecordRSS_RecordsNonNegativeDelta(t *testing.T) {
+	o := &Orchestrator{modelRSS: make(map[string]int64)}
+	inst := &fakeInstance{id: "Test_Model", sampleRate: 48000, clip: 3 * time.Second}
+
+	before := o.captureRSSBefore()
+	o.warmupAndRecordRSS(inst.ModelID(), before, inst)
+
+	// Warm-up must size the dummy clip from the spec (48000 * 3s = 144000).
+	if inst.predictedN != 144000 {
+		t.Fatalf("warm-up dummy size = %d, want 144000", inst.predictedN)
+	}
+	perModel, baseline := o.ModelRSS()
+	if _, ok := perModel[inst.ModelID()]; !ok {
+		t.Fatal("expected modelRSS entry for Test_Model")
+	}
+	if perModel[inst.ModelID()] < 0 {
+		t.Fatalf("RSS delta must be clamped to >= 0, got %d", perModel[inst.ModelID()])
+	}
+	if baseline < 0 {
+		t.Fatalf("runtime baseline must be >= 0, got %d", baseline)
+	}
+}
+
+func TestModelRSS_ReturnsCopy(t *testing.T) {
+	o := &Orchestrator{modelRSS: map[string]int64{"A": 10}}
+	m, _ := o.ModelRSS()
+	m["A"] = 999
+	m2, _ := o.ModelRSS()
+	if m2["A"] != 10 {
+		t.Fatalf("ModelRSS must return a copy; got mutated value %d", m2["A"])
+	}
+}

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -63,6 +63,7 @@ func (o *Orchestrator) buildPerch(settings *conf.Settings, threads int) (*Perch,
 }
 
 // loadPerch creates and registers a Perch v2 model instance from settings.
+// o.mu.Lock() is held by the caller.
 func (o *Orchestrator) loadPerch(threads int) error {
 	// Capture the settings snapshot once so the recorded backend triplet matches
 	// the exact configuration the instance was built against. This is what makes
@@ -70,10 +71,12 @@ func (o *Orchestrator) loadPerch(threads int) error {
 	// records its own triplet, so a later ReloadSecondaryModels rebuilds it only
 	// when the backend/device actually changes (Forgejo #1119).
 	settings := o.currentSettings()
+	before := o.captureRSSBefore()
 	perch, err := o.buildPerch(settings, threads)
 	if err != nil {
 		return err
 	}
+	o.warmupAndRecordRSS(perch.ModelID(), before, perch)
 
 	o.models[perch.ModelID()] = &modelEntry{
 		instance: perch,

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -52,7 +52,8 @@ func newTestOrchestrator(t *testing.T, mocks ...*mockModelInstance) *Orchestrato
 		models[m.id] = &modelEntry{instance: m}
 	}
 	return &Orchestrator{
-		models: models,
+		models:   models,
+		modelRSS: make(map[string]int64),
 	}
 }
 

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -39,6 +39,14 @@ type Collector struct {
 	inferenceCounters  *inferencestats.CounterMap
 	prevInferenceSnaps map[string]*inferencestats.Snapshot
 
+	// Per-model clip length provider for RTF computation (optional, set via SetModelClipFunc)
+	modelClipFunc func() map[string]float64
+	// Per-model RSS byte provider (optional, set via SetModelRSSFunc)
+	modelRSSFunc func() (map[string]int64, int64)
+	// Prometheus gauge setters (optional, set via SetInferenceGaugeSetters)
+	rtfGauge func(model string, rtf float64)
+	rssGauge func(model string, bytes int64)
+
 	// Health counter tracking (optional, set via SetHealthStore/SetHealthEvents)
 	healthStore     *HealthMetricsStore
 	healthEvents    *HealthEventBuffer
@@ -131,6 +139,7 @@ func (c *Collector) collect() {
 		c.store.RecordBatch(points)
 	}
 
+	c.collectModelRSS()
 	c.collectHealthCounters()
 }
 
@@ -235,6 +244,9 @@ func (c *Collector) SetDBCounters(counters *dbstats.Counters) {
 // usToMs converts microseconds to milliseconds.
 const usToMs = 1000.0
 
+// usPerSecond is the number of microseconds per second, used for RTF computation.
+const usPerSecond = 1_000_000.0
+
 // collectDatabase computes database latency and throughput metrics from
 // atomic counter snapshots. Requires two consecutive snapshots for deltas.
 func (c *Collector) collectDatabase(points map[string]float64) {
@@ -275,6 +287,23 @@ func (c *Collector) collectDatabase(points map[string]float64) {
 // Must be called before Start. If not called, inference metrics are skipped.
 func (c *Collector) SetInferenceCounters(counters *inferencestats.CounterMap) {
 	c.inferenceCounters = counters
+}
+
+// SetModelClipFunc sets a function that returns each model's clip length in seconds.
+// Used to compute the real-time factor (RTF = avg_inference_s / clip_s).
+// Must be called before Start.
+func (c *Collector) SetModelClipFunc(f func() map[string]float64) { c.modelClipFunc = f }
+
+// SetModelRSSFunc sets a function that returns per-model host RSS deltas in bytes
+// and the runtime baseline. Used to update the RSS Prometheus gauge each tick.
+// Must be called before Start.
+func (c *Collector) SetModelRSSFunc(f func() (map[string]int64, int64)) { c.modelRSSFunc = f }
+
+// SetInferenceGaugeSetters injects the Prometheus gauge setter functions for RTF
+// and RSS. Both are nil-safe; only non-nil functions are called.
+func (c *Collector) SetInferenceGaugeSetters(rtf func(string, float64), rss func(string, int64)) {
+	c.rtfGauge = rtf
+	c.rssGauge = rss
 }
 
 // AudioRouterSnapshot holds cumulative counter values for a single audio source.
@@ -321,6 +350,11 @@ func (c *Collector) collectInference(points map[string]float64) {
 		return
 	}
 
+	var clips map[string]float64
+	if c.modelClipFunc != nil {
+		clips = c.modelClipFunc()
+	}
+
 	snaps := c.inferenceCounters.SnapshotAll()
 
 	if c.prevInferenceSnaps == nil {
@@ -346,6 +380,17 @@ func (c *Collector) collectInference(points map[string]float64) {
 		if deltaInvokes > 0 {
 			deltaUs := snap.InvokeTotalUs - prev.InvokeTotalUs
 			points[key] = float64(deltaUs) / float64(deltaInvokes) / usToMs
+
+			if clips != nil {
+				if clip, ok := clips[modelID]; ok && clip > 0 {
+					intervalAvgSec := (float64(deltaUs) / float64(deltaInvokes)) / usPerSecond
+					rtf := intervalAvgSec / clip
+					points[inferencestats.RTFMetricKey(modelID)] = rtf
+					if c.rtfGauge != nil {
+						c.rtfGauge(modelID, rtf)
+					}
+				}
+			}
 		} else {
 			points[key] = 0
 		}
@@ -358,6 +403,19 @@ func (c *Collector) collectInference(points map[string]float64) {
 		if _, ok := snaps[modelID]; !ok {
 			delete(c.prevInferenceSnaps, modelID)
 		}
+	}
+}
+
+// collectModelRSS sets the per-model RSS Prometheus gauge each tick. RSS is set
+// at load and stable until reload; setting it every tick is idempotent and
+// handles model add/remove. RSS is not written to the ring buffer in Phase 1.
+func (c *Collector) collectModelRSS() {
+	if c.modelRSSFunc == nil || c.rssGauge == nil {
+		return
+	}
+	perModel, _ := c.modelRSSFunc()
+	for id, bytes := range perModel {
+		c.rssGauge(id, bytes)
 	}
 }
 

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -44,8 +44,13 @@ type Collector struct {
 	// Per-model RSS byte provider (optional, set via SetModelRSSFunc)
 	modelRSSFunc func() (map[string]int64, int64)
 	// Prometheus gauge setters (optional, set via SetInferenceGaugeSetters)
-	rtfGauge func(model string, rtf float64)
-	rssGauge func(model string, bytes int64)
+	rtfGauge             func(model string, rtf float64)
+	rssGauge             func(model string, bytes int64)
+	inferenceGaugeDelete func(model string)
+	// gaugeModels tracks which model IDs have had a gauge label set so stale
+	// series can be pruned after unload. Accessed only from the collect()
+	// goroutine, so no mutex is needed.
+	gaugeModels map[string]struct{}
 
 	// Health counter tracking (optional, set via SetHealthStore/SetHealthEvents)
 	healthStore     *HealthMetricsStore
@@ -142,6 +147,7 @@ func (c *Collector) collect() {
 	}
 
 	c.collectModelRSS()
+	c.pruneInferenceGauges()
 	c.collectHealthCounters()
 }
 
@@ -301,11 +307,13 @@ func (c *Collector) SetModelClipFunc(f func() map[string]float64) { c.modelClipF
 // Must be called before Start.
 func (c *Collector) SetModelRSSFunc(f func() (map[string]int64, int64)) { c.modelRSSFunc = f }
 
-// SetInferenceGaugeSetters injects the Prometheus gauge setter functions for RTF
-// and RSS. Both are nil-safe; only non-nil functions are called.
-func (c *Collector) SetInferenceGaugeSetters(rtf func(string, float64), rss func(string, int64)) {
+// SetInferenceGaugeSetters injects the Prometheus gauge setter functions for RTF,
+// RSS, and deletion. All are nil-safe; only non-nil functions are called.
+// Must be called before Start.
+func (c *Collector) SetInferenceGaugeSetters(rtf func(string, float64), rss func(string, int64), del func(string)) {
 	c.rtfGauge = rtf
 	c.rssGauge = rss
+	c.inferenceGaugeDelete = del
 }
 
 // AudioRouterSnapshot holds cumulative counter values for a single audio source.
@@ -390,6 +398,10 @@ func (c *Collector) collectInference(points map[string]float64) {
 					points[inferencestats.RTFMetricKey(modelID)] = rtf
 					if c.rtfGauge != nil {
 						c.rtfGauge(modelID, rtf)
+						if c.gaugeModels == nil {
+							c.gaugeModels = make(map[string]struct{})
+						}
+						c.gaugeModels[modelID] = struct{}{}
 					}
 				}
 			}
@@ -418,6 +430,27 @@ func (c *Collector) collectModelRSS() {
 	perModel, _ := c.modelRSSFunc()
 	for id, bytes := range perModel {
 		c.rssGauge(id, bytes)
+		if c.gaugeModels == nil {
+			c.gaugeModels = make(map[string]struct{})
+		}
+		c.gaugeModels[id] = struct{}{}
+	}
+}
+
+// pruneInferenceGauges deletes gauge label values for models that are no longer
+// loaded, preventing stale Prometheus series after unload/reload. The canonical
+// loaded set is modelClipFunc() (all loaded models, independent of RSS
+// availability). No-op until the clip func and delete callback are wired.
+func (c *Collector) pruneInferenceGauges() {
+	if c.modelClipFunc == nil || c.inferenceGaugeDelete == nil || len(c.gaugeModels) == 0 {
+		return
+	}
+	loaded := c.modelClipFunc()
+	for id := range c.gaugeModels {
+		if _, ok := loaded[id]; !ok {
+			c.inferenceGaugeDelete(id)
+			delete(c.gaugeModels, id)
+		}
 	}
 }
 

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -100,7 +100,9 @@ func (c *Collector) Start(ctx context.Context) {
 
 // Metric key constants for collected system metrics.
 const (
-	// expectedMetricCount is the pre-allocation hint for the number of metrics collected per tick.
+	// expectedMetricCount is a lower-bound hint for the map pre-allocation per tick.
+	// Per-model RTF keys add len(models) more entries each tick, so the map may grow
+	// beyond this value. This is intentional: the map grows as needed.
 	expectedMetricCount = 12
 
 	metricCPUTotal          = "cpu.total"

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -247,6 +247,7 @@ func TestCollector_EmitsRTFKeyAndGauge(t *testing.T) {
 	collector.SetInferenceGaugeSetters(
 		func(model string, rtf float64) { gotRTFModel = model; gotRTF = rtf },
 		func(_ string, _ int64) {},
+		func(_ string) {},
 	)
 
 	// First tick: establishes the previous snapshot (no rtf emitted yet).

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -234,6 +234,36 @@ func TestCollector_InferenceIdlePeriod(t *testing.T) {
 	assert.InDelta(t, 0.0, avgPts[0].Value, 0.001, "idle period should record 0")
 }
 
+func TestCollector_EmitsRTFKeyAndGauge(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore(60)
+	counters := &inferencestats.CounterMap{}
+	collector := NewCollector(store, time.Second, func() float64 { return 0 })
+	collector.SetInferenceCounters(counters)
+	collector.SetModelClipFunc(func() map[string]float64 { return map[string]float64{"M": 3.0} })
+
+	var gotRTFModel string
+	var gotRTF float64
+	collector.SetInferenceGaugeSetters(
+		func(model string, rtf float64) { gotRTFModel = model; gotRTF = rtf },
+		func(_ string, _ int64) {},
+	)
+
+	// First tick: establishes the previous snapshot (no rtf emitted yet).
+	counters.RecordInvoke("M", 30_000) // 30 ms
+	collector.collect()
+
+	// Second tick: one more 30 ms invocation -> interval avg 30 ms, rtf = 0.030s / 3s = 0.01.
+	counters.RecordInvoke("M", 30_000)
+	collector.collect()
+
+	pts := store.Get(inferencestats.RTFMetricKey("M"), 10)
+	require.Len(t, pts, 1, "expected an inference.M.rtf ring-buffer point")
+
+	assert.Equal(t, "M", gotRTFModel, "rtf gauge model should be M")
+	assert.InDelta(t, 0.01, gotRTF, 0.001, "rtf should be approx 0.01")
+}
+
 func TestReadThermalZone_OutOfRangeTemperature(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -259,6 +259,7 @@ func TestCollector_EmitsRTFKeyAndGauge(t *testing.T) {
 
 	pts := store.Get(inferencestats.RTFMetricKey("M"), 10)
 	require.Len(t, pts, 1, "expected an inference.M.rtf ring-buffer point")
+	assert.InDelta(t, 0.01, pts[0].Value, 0.001, "ring-buffer RTF value")
 
 	assert.Equal(t, "M", gotRTFModel, "rtf gauge model should be M")
 	assert.InDelta(t, 0.01, gotRTF, 0.001, "rtf should be approx 0.01")

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -247,6 +247,20 @@ func (m *BirdNETMetrics) SetModelRSSBytes(model string, bytes int64) {
 	m.ModelRSSBytes.WithLabelValues(model).Set(float64(bytes))
 }
 
+// DeleteInferenceMetrics removes a model's inference gauge label values, e.g.
+// after the model is unloaded, so Prometheus stops reporting stale series. Nil-safe.
+func (m *BirdNETMetrics) DeleteInferenceMetrics(model string) {
+	if m == nil {
+		return
+	}
+	if m.InferenceRTF != nil {
+		m.InferenceRTF.DeleteLabelValues(model)
+	}
+	if m.ModelRSSBytes != nil {
+		m.ModelRSSBytes.DeleteLabelValues(model)
+	}
+}
+
 // categorizeError returns a category string for the error type using enhanced error categories
 func categorizeError(err error) string {
 	if err == nil {

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -9,6 +9,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+const (
+	metricNameInferenceRTF  = "birdnet_inference_rtf"
+	metricNameModelRSSBytes = "birdnet_model_rss_bytes"
+	labelModel              = "model"
+)
+
 // BirdNETMetrics contains all Prometheus metrics related to BirdNET operations.
 type BirdNETMetrics struct {
 	DetectionCounter *prometheus.CounterVec
@@ -29,6 +35,10 @@ type BirdNETMetrics struct {
 	// Current state gauges
 	ActiveProcessingGauge prometheus.Gauge
 	ModelLoadedGauge      prometheus.Gauge
+
+	// Inference status gauges (AI Models page).
+	InferenceRTF  *prometheus.GaugeVec
+	ModelRSSBytes *prometheus.GaugeVec
 
 	registry *prometheus.Registry
 }
@@ -149,6 +159,21 @@ func (m *BirdNETMetrics) initMetrics() error {
 		},
 	)
 
+	m.InferenceRTF = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: metricNameInferenceRTF,
+			Help: "Real-time factor per model (inference time divided by audio clip duration). Lower is faster.",
+		},
+		[]string{labelModel},
+	)
+	m.ModelRSSBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: metricNameModelRSSBytes,
+			Help: "Approximate host resident set size in bytes attributed to a loaded model at load time.",
+		},
+		[]string{labelModel},
+	)
+
 	return nil
 }
 
@@ -204,6 +229,22 @@ func (m *BirdNETMetrics) RecordModelLoad(model string, err error) {
 // SetActiveProcessing sets the number of active processing operations
 func (m *BirdNETMetrics) SetActiveProcessing(count float64) {
 	m.ActiveProcessingGauge.Set(count)
+}
+
+// SetInferenceRTF sets the real-time factor gauge for a model. Nil-safe.
+func (m *BirdNETMetrics) SetInferenceRTF(model string, rtf float64) {
+	if m == nil || m.InferenceRTF == nil {
+		return
+	}
+	m.InferenceRTF.WithLabelValues(model).Set(rtf)
+}
+
+// SetModelRSSBytes sets the approximate per-model host RSS gauge. Nil-safe.
+func (m *BirdNETMetrics) SetModelRSSBytes(model string, bytes int64) {
+	if m == nil || m.ModelRSSBytes == nil {
+		return
+	}
+	m.ModelRSSBytes.WithLabelValues(model).Set(float64(bytes))
 }
 
 // categorizeError returns a category string for the error type using enhanced error categories
@@ -267,6 +308,10 @@ func (m *BirdNETMetrics) Describe(ch chan<- *prometheus.Desc) {
 	// State gauges
 	m.ActiveProcessingGauge.Describe(ch)
 	m.ModelLoadedGauge.Describe(ch)
+
+	// Inference status gauges
+	m.InferenceRTF.Describe(ch)
+	m.ModelRSSBytes.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -289,6 +334,10 @@ func (m *BirdNETMetrics) Collect(ch chan<- prometheus.Metric) {
 	// State gauges
 	m.ActiveProcessingGauge.Collect(ch)
 	m.ModelLoadedGauge.Collect(ch)
+
+	// Inference status gauges
+	m.InferenceRTF.Collect(ch)
+	m.ModelRSSBytes.Collect(ch)
 }
 
 // RecordOperation implements the Recorder interface.

--- a/internal/observability/metrics/birdnet_test.go
+++ b/internal/observability/metrics/birdnet_test.go
@@ -4,36 +4,61 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInferenceGauges(t *testing.T) {
-	t.Helper()
+	t.Parallel()
 	reg := prometheus.NewRegistry()
 	m, err := NewBirdNETMetrics(reg)
-	if err != nil {
-		t.Fatalf("NewBirdNETMetrics: %v", err)
-	}
+	require.NoError(t, err, "NewBirdNETMetrics")
+
 	m.SetInferenceRTF("BirdNET_V2.4", 0.016)
 	m.SetModelRSSBytes("BirdNET_V2.4", 125_000_000)
 
 	mfs, err := reg.Gather()
-	if err != nil {
-		t.Fatalf("Gather: %v", err)
-	}
-	names := map[string]bool{}
+	require.NoError(t, err, "Gather")
+
+	byName := make(map[string]*dto.MetricFamily, len(mfs))
 	for _, mf := range mfs {
-		names[mf.GetName()] = true
+		byName[mf.GetName()] = mf
 	}
-	if !names["birdnet_inference_rtf"] {
-		t.Error("birdnet_inference_rtf not registered/exposed")
+
+	// Verify birdnet_inference_rtf is present and has the expected sample.
+	require.Contains(t, byName, "birdnet_inference_rtf", "birdnet_inference_rtf not registered/exposed")
+	rtfFound := findGaugeValue(byName["birdnet_inference_rtf"], "model", "BirdNET_V2.4")
+	require.NotNil(t, rtfFound, "expected birdnet_inference_rtf sample with label model=BirdNET_V2.4")
+	assert.InDelta(t, 0.016, *rtfFound, 1e-9, "birdnet_inference_rtf value for BirdNET_V2.4")
+
+	// Verify birdnet_model_rss_bytes is present and has the expected sample.
+	require.Contains(t, byName, "birdnet_model_rss_bytes", "birdnet_model_rss_bytes not registered/exposed")
+	rssFound := findGaugeValue(byName["birdnet_model_rss_bytes"], "model", "BirdNET_V2.4")
+	require.NotNil(t, rssFound, "expected birdnet_model_rss_bytes sample with label model=BirdNET_V2.4")
+	assert.InDelta(t, 1.25e8, *rssFound, 1.0, "birdnet_model_rss_bytes value for BirdNET_V2.4")
+}
+
+// findGaugeValue searches a MetricFamily for a metric with the given label name/value
+// and returns its gauge value, or nil if not found.
+func findGaugeValue(mf *dto.MetricFamily, labelName, labelValue string) *float64 {
+	if mf == nil {
+		return nil
 	}
-	if !names["birdnet_model_rss_bytes"] {
-		t.Error("birdnet_model_rss_bytes not registered/exposed")
+	for _, metric := range mf.GetMetric() {
+		for _, lp := range metric.GetLabel() {
+			if lp.GetName() == labelName && lp.GetValue() == labelValue {
+				v := metric.GetGauge().GetValue()
+				return &v
+			}
+		}
 	}
+	return nil
 }
 
 // SetInferenceRTF / SetModelRSSBytes must be nil-safe.
 func TestInferenceGauges_NilSafe(t *testing.T) {
+	t.Parallel()
 	var m *BirdNETMetrics
 	m.SetInferenceRTF("x", 1) // must not panic
 	m.SetModelRSSBytes("x", 1)

--- a/internal/observability/metrics/birdnet_test.go
+++ b/internal/observability/metrics/birdnet_test.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestInferenceGauges(t *testing.T) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	m, err := NewBirdNETMetrics(reg)
+	if err != nil {
+		t.Fatalf("NewBirdNETMetrics: %v", err)
+	}
+	m.SetInferenceRTF("BirdNET_V2.4", 0.016)
+	m.SetModelRSSBytes("BirdNET_V2.4", 125_000_000)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	if !names["birdnet_inference_rtf"] {
+		t.Error("birdnet_inference_rtf not registered/exposed")
+	}
+	if !names["birdnet_model_rss_bytes"] {
+		t.Error("birdnet_model_rss_bytes not registered/exposed")
+	}
+}
+
+// SetInferenceRTF / SetModelRSSBytes must be nil-safe.
+func TestInferenceGauges_NilSafe(t *testing.T) {
+	var m *BirdNETMetrics
+	m.SetInferenceRTF("x", 1) // must not panic
+	m.SetModelRSSBytes("x", 1)
+}

--- a/internal/sysinfo/memory.go
+++ b/internal/sysinfo/memory.go
@@ -1,0 +1,24 @@
+// Package sysinfo: process memory helpers.
+package sysinfo
+
+import (
+	"os"
+
+	"github.com/shirou/gopsutil/v3/process"
+)
+
+// CurrentProcessRSS returns the resident set size (host RAM) of the current
+// process in bytes. It is cross-platform via gopsutil. Callers treat any error
+// as "RSS unavailable on this platform" and degrade gracefully rather than
+// reporting a misleading zero.
+func CurrentProcessRSS() (uint64, error) {
+	p, err := process.NewProcess(int32(os.Getpid()))
+	if err != nil {
+		return 0, err
+	}
+	mi, err := p.MemoryInfo()
+	if err != nil {
+		return 0, err
+	}
+	return mi.RSS, nil
+}

--- a/internal/sysinfo/memory_test.go
+++ b/internal/sysinfo/memory_test.go
@@ -1,0 +1,14 @@
+package sysinfo
+
+import "testing"
+
+func TestCurrentProcessRSS(t *testing.T) {
+	t.Parallel()
+	rss, err := CurrentProcessRSS()
+	if err != nil {
+		t.Fatalf("CurrentProcessRSS returned error: %v", err)
+	}
+	if rss == 0 {
+		t.Fatal("expected non-zero RSS for the running test process")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 (backend foundation) of the AI Models and Inference status page. It is purely additive: a new read-only, auth-protected endpoint plus supporting instrumentation, with no changes to existing config keys, API responses, or the database schema.

- New endpoint `GET /api/v2/system/inference` returning a single coherent snapshot of the inference subsystem: hardware (arch, CPU model, environment, FP16 support), backend availability and versions (TFLite, ONNX Runtime, OpenVINO with active devices), and per-model status (identity, backend, quantization, audio spec, species count, invocation stats, approximate host RSS, and source attachment). The snapshot is assembled live on each request, so it reflects hot-reload changes (model add/remove, source reassignment) without caching.
- Per-model host RSS-delta accounting captured at model load, with a warm-up inference that forces lazy allocation before the measurement. RSS is explicitly approximate and host-RAM-only (it excludes GPU VRAM), and reports n/a when unavailable rather than a misleading zero.
- New observability: a per-model real-time-factor ring-buffer key `inference.<id>.rtf` emitted by the existing collector, plus two Prometheus gauges, `birdnet_inference_rtf` and `birdnet_model_rss_bytes`.
- Source-to-model attachment computed as a config-to-registry join, rather than reaching into audio pipeline internals.

Latency percentiles (p50/p95) and the frontend page are deliberately out of scope for this phase. The endpoint ships invocation count, lifetime average latency, recent peak latency, and RTF.

## Implementation notes

- The endpoint reads per-model inference counters non-destructively (PeekAll), so the collector's interval delta tracking is untouched.
- The primary model identity is read under the orchestrator read lock. The warm-up runs directly on the freshly built instance (never through the locked inference path), and is bounded by a short timeout so a stalled backend cannot block inference for long.
- `model_rss_bytes` entries are cleared on model unload, on the teardown path, and on secondary-model reload.

## Test Plan

- [x] `go test -race ./internal/sysinfo/... ./internal/classifier/... ./internal/observability/... ./internal/api/v2/...` passes
- [x] `golangci-lint run` clean on the changed packages
- [ ] CI green on all platforms
- [ ] `GET /api/v2/system/inference` returns 200 with the expected JSON shape on a running instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected system inference status endpoint (`/system/inference`) showing backend availability, loaded models, and current inference snapshot details.
  * Added per-model observability for real-time factor (RTF) and approximate model RSS.
* **Bug Fixes**
  * Improved consistency of per-model metrics updates and cleanup when models are reloaded/unloaded.
* **Tests**
  * Added/expanded unit tests covering inference status responses, RTF computation/gauges, and RSS tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->