### PR TITLE
fix(errors): suppress operational spectrogram interruptions from Sentry telemetry

### DIFF
--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -178,6 +178,32 @@ func isContextCancellation(err error) bool {
 	return Is(err, context.Canceled) || Is(err, context.DeadlineExceeded)
 }
 
+// isSuppressibleOperationalError reports whether ee is an expected operational
+// interruption that should not be forwarded to Sentry. Such interruptions arise
+// routinely during graceful shutdown, client disconnects, and request timeouts
+// (e.g. an HTTP client disconnects mid-query, or Sox/FFmpeg is killed when the
+// requesting client navigates away).
+//
+// Two signals qualify:
+//   - A context sentinel (context.Canceled / context.DeadlineExceeded) anywhere in
+//     the chain, for either CategoryDatabase or CategorySystem. Database and system
+//     operations observe these directly when interrupted.
+//   - PriorityLow, but ONLY for CategorySystem. An external OS process killed by a
+//     cancelled context does not surface a context sentinel (on Windows it exits with
+//     status 1, on Linux a mid-run kill surfaces as "signal: killed"), so the producer
+//     (the spectrogram generator) tags the CategorySystem error PriorityLow using the
+//     governing context, which is the only platform-independent signal. PriorityLow is
+//     deliberately NOT honored for CategoryDatabase: the datastore tags genuine
+//     query/scan/cleanup failures PriorityLow to control user-notification routing, not
+//     to mark them expected, and a real DB fault (corruption, lock contention) during
+//     such a low-priority job must still reach Sentry.
+func isSuppressibleOperationalError(ee *EnhancedError) bool {
+	if isContextCancellation(ee.Err) {
+		return ee.Category == CategoryDatabase || ee.Category == CategorySystem
+	}
+	return ee.Category == CategorySystem && ee.GetPriority() == PriorityLow
+}
+
 // shouldReportToSentry determines if an error should be sent to Sentry
 // It filters out operational/configuration errors that aren't code bugs
 func shouldReportToSentry(ee *EnhancedError) bool {
@@ -185,13 +211,12 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 		return true
 	}
 
-	// Database and system operations frequently observe context.Canceled and
-	// context.DeadlineExceeded during graceful shutdown and client-disconnect
-	// conditions (e.g. an HTTP client disconnects mid-query, or Sox/FFmpeg is
-	// killed when the requesting client navigates away). These are not code
-	// bugs; suppressing here prevents hundreds of duplicate events per day
-	// from drowning legitimate errors.
-	if (ee.Category == CategoryDatabase || ee.Category == CategorySystem) && isContextCancellation(ee.Err) {
+	// Suppress expected operational interruptions for database/system operations
+	// (graceful shutdown, client disconnect, request timeout). These are not code
+	// bugs; suppressing prevents hundreds of duplicate events per day from drowning
+	// legitimate errors. See isSuppressibleOperationalError for why PriorityLow is
+	// honored alongside the context sentinels.
+	if isSuppressibleOperationalError(ee) {
 		return false
 	}
 

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -437,3 +437,121 @@ func TestShouldReportToSentry_AllowsNonDatabaseContextCancellation(t *testing.T)
 	assert.True(t, shouldReportToSentry(ee),
 		"context.Canceled outside CategoryDatabase should still be forwarded to Sentry")
 }
+
+// TestShouldReportToSentry_FiltersLowPrioritySystemInterruptions verifies that a
+// CategorySystem error explicitly tagged PriorityLow is suppressed even when its
+// surface error is not a context sentinel. The spectrogram generator tags
+// context-driven Sox/FFmpeg interruptions this way using the governing context,
+// because the OS surface error is platform-dependent: on Windows a context-killed
+// process exits with status 1 (no context sentinel) and on Linux a mid-run kill
+// surfaces as "signal: killed", so isContextCancellation alone misses them.
+//
+// PriorityLow is honored ONLY for CategorySystem. CategoryDatabase + PriorityLow is
+// deliberately NOT suppressed: the datastore tags genuine query/scan/cleanup failures
+// PriorityLow for user-notification routing, and a real DB fault (corruption, lock
+// contention) during such a low-priority job must still reach Sentry.
+func TestShouldReportToSentry_FiltersLowPrioritySystemInterruptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		component  string
+		category   ErrorCategory
+		priority   string
+		err        error
+		wantReport bool
+	}{
+		{
+			name:       "Windows exit-status-1 system error tagged PriorityLow is suppressed",
+			component:  "spectrogram",
+			category:   CategorySystem,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("exit status 1"),
+			wantReport: false,
+		},
+		{
+			name:       "signal-killed system error tagged PriorityLow is suppressed",
+			component:  "spectrogram",
+			category:   CategorySystem,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("process failed: signal: killed"),
+			wantReport: false,
+		},
+		{
+			name:       "wrapped PriorityLow system error is suppressed",
+			component:  "spectrogram",
+			category:   CategorySystem,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("generate spectrogram: %w", fmt.Errorf("exit status 1")),
+			wantReport: false,
+		},
+		{
+			// Regression guard: a genuine DB fault must reach Sentry even though the
+			// datastore tags it PriorityLow for notification routing.
+			name:       "genuine database error tagged PriorityLow is still reported",
+			component:  "datastore",
+			category:   CategoryDatabase,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("database disk image is malformed"),
+			wantReport: true,
+		},
+		{
+			name:       "database scan failure tagged PriorityLow is still reported",
+			component:  "datastore",
+			category:   CategoryDatabase,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("sql: Scan error on column index 0"),
+			wantReport: true,
+		},
+		{
+			// The pre-existing context-sentinel suppression still applies to
+			// CategoryDatabase (independent of priority).
+			name:       "database PriorityLow context cancellation is still suppressed",
+			component:  "datastore",
+			category:   CategoryDatabase,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("iterate rows: %w", context.Canceled),
+			wantReport: false,
+		},
+		{
+			name:       "system error without an explicit priority is reported",
+			component:  "spectrogram",
+			category:   CategorySystem,
+			priority:   "",
+			err:        fmt.Errorf("exit status 1"),
+			wantReport: true,
+		},
+		{
+			// Pins the predicate as == PriorityLow, not != "": a high-priority
+			// system error must NOT be suppressed.
+			name:       "high-priority system error is reported",
+			component:  "spectrogram",
+			category:   CategorySystem,
+			priority:   PriorityHigh,
+			err:        fmt.Errorf("exit status 1"),
+			wantReport: true,
+		},
+		{
+			name:       "PriorityLow in a non-operational category is reported",
+			component:  "birdnet",
+			category:   CategoryWorker,
+			priority:   PriorityLow,
+			err:        fmt.Errorf("exit status 1"),
+			wantReport: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := New(tt.err).Component(tt.component).Category(tt.category)
+			if tt.priority != "" {
+				b = b.Priority(tt.priority)
+			}
+			ee := b.Build()
+			got := shouldReportToSentry(ee)
+			assert.Equal(t, tt.wantReport, got,
+				"shouldReportToSentry for %q = %v, want %v", tt.name, got, tt.wantReport)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #3561. That PR fixed the log/dashboard classification of context-cancelled spectrogram (Sox/FFmpeg) interruptions on Windows, but the **Sentry telemetry** path still forwarded them as if they were code bugs.

`shouldReportToSentry` only recognized operational interruptions via context sentinels (`context.Canceled` / `context.DeadlineExceeded`). A context-killed external process does not surface a sentinel: on Windows it exits with status 1 (`TerminateProcess`), and on Linux a mid-run kill surfaces as `signal: killed`. So these expected interruptions reached Sentry on every platform (Windows for all of them; both platforms for mid-run kills), creating noise.

The spectrogram generator already tags these `CategorySystem` errors `PriorityLow` using the governing context (the only platform-independent signal). This change honors that tag in the suppression path.

## What changed

- New helper `isSuppressibleOperationalError`: suppresses a `CategoryDatabase`/`CategorySystem` error on a context sentinel (unchanged), and additionally suppresses `CategorySystem` errors tagged `PriorityLow`.
- **`PriorityLow` is honored only for `CategorySystem`, not `CategoryDatabase`.** The datastore tags genuine query/scan/cleanup failures `PriorityLow` purely to control user-notification routing; a real DB fault (corruption, lock contention) during such a low-priority job must still reach Sentry. Database errors keep only the pre-existing context-sentinel suppression.
- Extracted the check into a helper to keep `shouldReportToSentry` under the cyclomatic-complexity limit.
- Tests: assert `CategorySystem`+`PriorityLow` interruptions are suppressed (incl. wrapped errors), and guard that genuine `CategoryDatabase`+`PriorityLow` faults are still reported, that DB context cancellations are still suppressed, and that only `PriorityLow` (not any non-empty priority) is suppressed.

## Test Plan

- [x] `go build ./...`
- [x] `go test -race ./internal/errors/`
- [x] `golangci-lint run ./internal/...` (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal error suppression logic to improve code maintainability and clarity.
  * Enhanced filtering to suppress low-priority system interruptions, reducing telemetry noise.

* **Tests**
  * Added comprehensive test coverage validating error suppression behavior across multiple scenarios and operational interruption cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->