### PR TITLE
fix(spectrogram): write PNG atomically via temp + rename

### DIFF
--- a/internal/audiocore/audiotemp/audiotemp.go
+++ b/internal/audiocore/audiotemp/audiotemp.go
@@ -4,6 +4,10 @@
 // unique temp file and atomically renames it into place, so two simultaneous
 // detections that resolve to the same clip path (see GitHub #3323) dedup safely
 // instead of colliding on a shared temp or corrupting the final file mid-write.
+//
+// The spectrogram generator reuses the same naming (UniquePath) and finalize
+// retry via FinalizeWith, injecting a SecureFS rename so its writes stay inside
+// the os.Root sandbox.
 package audiotemp
 
 import (
@@ -54,13 +58,22 @@ func UniquePath(outputPath string) string {
 // exports rename onto the same path; Finalize retries a bounded number of times
 // there to absorb it.
 func Finalize(tempPath, finalPath string) error {
-	err := os.Rename(tempPath, finalPath)
+	return FinalizeWith(tempPath, finalPath, os.Rename)
+}
+
+// FinalizeWith is Finalize with a caller-supplied rename function. Callers whose
+// files live behind a path-validated boundary (e.g. SecureFS / os.Root) inject
+// their own rename so the move stays inside the sandbox, while still reusing the
+// Windows sharing-violation retry. Both rename targets must already be on the
+// same filesystem for the rename to be atomic. Finalize itself passes os.Rename.
+func FinalizeWith(tempPath, finalPath string, rename func(oldpath, newpath string) error) error {
+	err := rename(tempPath, finalPath)
 	if err == nil || runtime.GOOS != osWindows {
 		return err
 	}
 	for attempt := 1; attempt < renameRetryAttempts; attempt++ {
 		time.Sleep(renameRetryDelay)
-		if err = os.Rename(tempPath, finalPath); err == nil {
+		if err = rename(tempPath, finalPath); err == nil {
 			return nil
 		}
 	}

--- a/internal/audiocore/audiotemp/audiotemp_test.go
+++ b/internal/audiocore/audiotemp/audiotemp_test.go
@@ -3,6 +3,7 @@ package audiotemp_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 func TestUniquePath_PrefixedByOutputAndEndsInExt(t *testing.T) {
@@ -106,4 +108,43 @@ func TestFinalize_ConcurrentSameTargetAllSucceed(t *testing.T) {
 	leftover, err := filepath.Glob(filepath.Join(dir, "*"+audiotemp.Ext))
 	require.NoError(t, err)
 	assert.Empty(t, leftover, "no temp files should remain after concurrent finalize")
+}
+
+// TestFinalizeWith_UsesInjectedRename verifies FinalizeWith routes the move
+// through the caller-supplied rename function (the SecureFS rename the
+// spectrogram generator injects) and returns its result unchanged on success.
+func TestFinalizeWith_UsesInjectedRename(t *testing.T) {
+	t.Parallel()
+	var gotOld, gotNew string
+	calls := 0
+	rename := func(oldpath, newpath string) error {
+		calls++
+		gotOld, gotNew = oldpath, newpath
+		return nil
+	}
+
+	require.NoError(t, audiotemp.FinalizeWith("clip.png.1.2.temp", "clip.png", rename))
+	assert.Equal(t, 1, calls, "rename must be called exactly once on success")
+	assert.Equal(t, "clip.png.1.2.temp", gotOld)
+	assert.Equal(t, "clip.png", gotNew)
+}
+
+// TestFinalizeWith_PropagatesRenameError verifies a rename failure surfaces to
+// the caller. On non-Windows the rename is attempted exactly once (no retry); the
+// Windows retry path is covered by TestFinalize_ConcurrentSameTargetAllSucceed.
+func TestFinalizeWith_PropagatesRenameError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.NewStd("rename failed")
+	calls := 0
+	rename := func(_, _ string) error {
+		calls++
+		return sentinel
+	}
+
+	err := audiotemp.FinalizeWith("a.temp", "a.png", rename)
+	require.ErrorIs(t, err, sentinel)
+	assert.GreaterOrEqual(t, calls, 1, "rename must be attempted at least once")
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, 1, calls, "non-Windows must not retry a failed rename")
+	}
 }

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -330,6 +331,21 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		return err
 	}
 
+	// Generate into a process-unique temp file in the same directory, then
+	// atomically rename it onto outputPath, so a crash/kill mid-write or two
+	// concurrent generations of the same path can never leave a partial or
+	// corrupt .png at the final path. The temp name reuses
+	// audiotemp.UniquePath ("<outputPath>.<pid>.<seq>.temp"), a form
+	// isExportTempFor already ignores so the audio-clip temp scan never mistakes
+	// a spectrogram temp for an in-progress audio export.
+	tempPath := audiotemp.UniquePath(outputPath)
+	defer func() {
+		// Best-effort cleanup. On success the temp was renamed away, so Remove
+		// returns a not-exist error we intentionally ignore; on any failure path
+		// (sox+ffmpeg fail, ctx cancel, rename fail) it deletes the partial.
+		_ = g.sfs.Remove(tempPath)
+	}()
+
 	// Capture one settings snapshot for the whole generation so SoxPath,
 	// Style, DynamicRange, etc. all read from the same view. A UI edit that
 	// lands mid-generation cannot split the output across two snapshots.
@@ -340,7 +356,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 	defer soxCancel()
 
 	// Try Sox first (faster, direct processing)
-	if err := g.generateWithSoxFile(soxCtx, settings, audioPath, outputPath, width, raw, options.preValidatedDuration, profile); err != nil {
+	if err := g.generateWithSoxFile(soxCtx, settings, audioPath, tempPath, width, raw, options.preValidatedDuration, profile); err != nil {
 		// If the caller's context is already done (client disconnect, shutdown, or
 		// caller-imposed timeout), the result is no longer wanted. Skip the FFmpeg
 		// fallback: it runs on a context detached from the parent (see
@@ -365,13 +381,25 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		defer ffmpegCancel()
 
 		// Fallback to FFmpeg pipeline with fresh context
-		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, settings, audioPath, outputPath, width, raw, profile); ffmpegErr != nil {
+		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, settings, audioPath, tempPath, width, raw, profile); ffmpegErr != nil {
 			g.log().Error("Both Sox and FFmpeg generation failed",
 				logger.String("audio_path", audioPath),
 				logger.String("sox_error", err.Error()),
 				logger.String("ffmpeg_error", ffmpegErr.Error()))
 			return ffmpegErr
 		}
+	}
+
+	// Atomically publish the finished spectrogram. g.sfs.Rename keeps the move
+	// inside the SecureFS sandbox (os.Root); FinalizeWith reuses audiotemp's
+	// Windows rename-retry for transient sharing violations.
+	if err := audiotemp.FinalizeWith(tempPath, outputPath, g.sfs.Rename); err != nil {
+		return errors.New(err).
+			Component("spectrogram").
+			Category(errors.CategoryFileIO).
+			Context("operation", "finalize_spectrogram").
+			Context("output_path", outputPath).
+			Build()
 	}
 
 	g.log().Info("Spectrogram generation from file completed",
@@ -451,6 +479,16 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 		return err
 	}
 
+	// Generate into a process-unique temp file, then atomically rename it onto
+	// outputPath, so an interrupted or concurrent render never leaves a partial
+	// or corrupt .png at the final path. See GenerateFromFile.
+	tempPath := audiotemp.UniquePath(outputPath)
+	defer func() {
+		// Best-effort: harmless not-exist error on success (temp already
+		// renamed away); deletes the partial on any failure path.
+		_ = g.sfs.Remove(tempPath)
+	}()
+
 	// Capture one settings snapshot for the whole generation so all reads
 	// (SoxPath, Style, DynamicRange, Export.Length) are consistent even if
 	// the user saves settings mid-render.
@@ -461,8 +499,18 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 	defer cancel()
 
 	// Generate directly from PCM stdin (no FFmpeg needed)
-	if err := g.generateWithSoxPCM(ctx, settings, pcmData, outputPath, width, raw, sampleRate, profile); err != nil {
+	if err := g.generateWithSoxPCM(ctx, settings, pcmData, tempPath, width, raw, sampleRate, profile); err != nil {
 		return err
+	}
+
+	// Atomically publish the finished spectrogram (see GenerateFromFile).
+	if err := audiotemp.FinalizeWith(tempPath, outputPath, g.sfs.Rename); err != nil {
+		return errors.New(err).
+			Component("spectrogram").
+			Category(errors.CategoryFileIO).
+			Context("operation", "finalize_spectrogram").
+			Context("output_path", outputPath).
+			Build()
 	}
 
 	g.log().Info("Spectrogram generation from PCM completed",

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -226,6 +226,7 @@ func partialWriteSoxStub(t *testing.T) string {
 // .png, so this test discriminates the fix from the old behaviour. POSIX-only
 // (the stub is a shell script).
 func TestGenerator_GenerateFromPCM_RuntimeFailureLeavesNoPartialFinal(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == osWindows {
 		t.Skip("partial-write Sox stub requires a POSIX shell")
 	}
@@ -247,6 +248,7 @@ func TestGenerator_GenerateFromPCM_RuntimeFailureLeavesNoPartialFinal(t *testing
 // cross-platform smoke test; the temp-cleanup-after-partial-write guarantee is
 // covered by TestGenerator_GenerateFromPCM_RuntimeFailureLeavesNoPartialFinal.
 func TestGenerator_GenerateFromPCM_FailureLeavesNoPartialOutput(t *testing.T) {
+	t.Parallel()
 	env := setupTestEnv(t)
 	// Leave SoxPath unset to force a failure before any image is written.
 	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
@@ -263,6 +265,7 @@ func TestGenerator_GenerateFromPCM_FailureLeavesNoPartialOutput(t *testing.T) {
 // counterpart of the early config-validation smoke test: both Sox and the FFmpeg
 // fallback fail path validation, so nothing is published.
 func TestGenerator_GenerateFromFile_FailureLeavesNoPartialOutput(t *testing.T) {
+	t.Parallel()
 	env := setupTestEnv(t)
 	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
 
@@ -283,6 +286,7 @@ func TestGenerator_GenerateFromFile_FailureLeavesNoPartialOutput(t *testing.T) {
 // unit test cannot cheaply, prove the no-partial-window invariant directly.
 // Requires a real Sox.
 func TestGenerator_GenerateFromPCM_AtomicWrite(t *testing.T) {
+	t.Parallel()
 	soxPath := requireSoxAvailable(t)
 	env := setupTestEnv(t)
 	env.Settings.Realtime.Audio.SoxPath = soxPath

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -182,6 +184,125 @@ func TestGenerator_GenerateFromFile_MissingBinaries(t *testing.T) {
 
 	err = gen.GenerateFromFile(t.Context(), audioPath, outputPath, 400, false)
 	assert.Error(t, err, "GenerateFromFile() should error when binaries not configured")
+}
+
+// assertNoSpectrogramTemp fails if any "<outputPath>.<pid>.<seq>.temp" sidecar
+// temp from an interrupted or raced render was left behind next to outputPath.
+// outputPath must not contain glob metacharacters (callers pass t.TempDir paths).
+func assertNoSpectrogramTemp(t *testing.T, outputPath string) {
+	t.Helper()
+	leftover, err := filepath.Glob(outputPath + ".*" + audiotemp.Ext)
+	require.NoError(t, err)
+	assert.Empty(t, leftover, "spectrogram temp files must not be left behind")
+}
+
+// partialWriteSoxStub returns a path to an executable stub that mimics a Sox
+// runtime failure: it writes partial bytes to its "-o <target>" argument and then
+// exits non-zero. Pointing the generator at this stub forces the failure to occur
+// AFTER the output file has been opened and partially written, which is the path
+// the temp-then-rename design must contain. POSIX-only (uses /bin/sh).
+func partialWriteSoxStub(t *testing.T) string {
+	t.Helper()
+	stub := filepath.Join(t.TempDir(), "sox")
+	// Scan args for "-o" and write to the following argument, so the stub finds
+	// the output target regardless of its position in the Sox command line.
+	script := "#!/bin/sh\n" +
+		"prev=\"\"\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$prev\" = \"-o\" ]; then printf 'PARTIAL' > \"$a\"; fi\n" +
+		"  prev=\"$a\"\n" +
+		"done\n" +
+		"exit 1\n"
+	require.NoError(t, os.WriteFile(stub, []byte(script), 0o700)) //nolint:gosec // G306: test stub must be executable
+	return stub
+}
+
+// TestGenerator_GenerateFromPCM_RuntimeFailureLeavesNoPartialFinal is the core
+// regression guard for the atomic-write fix. A Sox runtime failure writes partial
+// bytes to its output target then fails; the temp-then-rename design must keep
+// those partial bytes in the temp file (cleaned up on the failure) and NEVER
+// publish them to the final path. On the previous non-atomic code (which passed
+// the final path as Sox's -o) this same stub would have left a corrupt final
+// .png, so this test discriminates the fix from the old behaviour. POSIX-only
+// (the stub is a shell script).
+func TestGenerator_GenerateFromPCM_RuntimeFailureLeavesNoPartialFinal(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("partial-write Sox stub requires a POSIX shell")
+	}
+	env := setupTestEnv(t)
+	env.Settings.Realtime.Audio.SoxPath = partialWriteSoxStub(t)
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	outputPath := filepath.Join(env.TempDir, "rt.png")
+	err := gen.GenerateFromPCM(t.Context(), []byte{0, 1, 2, 3, 4, 5, 6, 7}, outputPath, 400, false, 0)
+
+	require.Error(t, err, "a Sox runtime failure must surface as an error")
+	assert.NoFileExists(t, outputPath, "a partial write must NOT be published to the final path")
+	assertNoSpectrogramTemp(t, outputPath)
+}
+
+// TestGenerator_GenerateFromPCM_FailureLeavesNoPartialOutput covers the early
+// config-validation failure (Sox not configured): the entry point returns an
+// error before any subprocess runs and publishes nothing. This is a cheap,
+// cross-platform smoke test; the temp-cleanup-after-partial-write guarantee is
+// covered by TestGenerator_GenerateFromPCM_RuntimeFailureLeavesNoPartialFinal.
+func TestGenerator_GenerateFromPCM_FailureLeavesNoPartialOutput(t *testing.T) {
+	env := setupTestEnv(t)
+	// Leave SoxPath unset to force a failure before any image is written.
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	outputPath := filepath.Join(env.TempDir, "fail.png")
+	err := gen.GenerateFromPCM(t.Context(), []byte{0, 1, 2, 3}, outputPath, 400, false, 0)
+
+	require.Error(t, err)
+	assert.NoFileExists(t, outputPath, "a failed render must not leave a partial final .png")
+	assertNoSpectrogramTemp(t, outputPath)
+}
+
+// TestGenerator_GenerateFromFile_FailureLeavesNoPartialOutput is the file-input
+// counterpart of the early config-validation smoke test: both Sox and the FFmpeg
+// fallback fail path validation, so nothing is published.
+func TestGenerator_GenerateFromFile_FailureLeavesNoPartialOutput(t *testing.T) {
+	env := setupTestEnv(t)
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	audioPath := filepath.Join(env.TempDir, "in.wav")
+	require.NoError(t, os.WriteFile(audioPath, []byte("fake audio"), 0o600))
+	outputPath := filepath.Join(env.TempDir, "fail.png")
+
+	err := gen.GenerateFromFile(t.Context(), audioPath, outputPath, 400, false)
+
+	require.Error(t, err)
+	assert.NoFileExists(t, outputPath, "a failed render must not leave a partial final .png")
+	assertNoSpectrogramTemp(t, outputPath)
+}
+
+// TestGenerator_GenerateFromPCM_AtomicWrite verifies the success path: the final
+// spectrogram is published and the temp sidecar is removed. It asserts the
+// post-conditions (final exists, non-empty, no leftover temp); it does not, and a
+// unit test cannot cheaply, prove the no-partial-window invariant directly.
+// Requires a real Sox.
+func TestGenerator_GenerateFromPCM_AtomicWrite(t *testing.T) {
+	soxPath := requireSoxAvailable(t)
+	env := setupTestEnv(t)
+	env.Settings.Realtime.Audio.SoxPath = soxPath
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	// 0.5s of 16-bit mono PCM with a non-constant signal so Sox has content.
+	// 251 is a prime, so the byte ramp never settles into a constant value.
+	pcm := make([]byte, defaultSampleRate) // defaultSampleRate bytes = 0.5s of int16 mono
+	for i := range pcm {
+		pcm[i] = byte(i % 251)
+	}
+
+	outputPath := filepath.Join(env.TempDir, "ok.png")
+	err := gen.GenerateFromPCM(t.Context(), pcm, outputPath, 400, true, defaultSampleRate)
+	require.NoError(t, err)
+
+	info, statErr := os.Stat(outputPath)
+	require.NoError(t, statErr, "the final spectrogram must exist after a successful render")
+	assert.Positive(t, info.Size(), "the published spectrogram must be non-empty")
+	assertNoSpectrogramTemp(t, outputPath)
 }
 
 // TestAudioDurationCache_Cleanup tests that the cache evicts old entries when exceeding max size


### PR DESCRIPTION
## Summary

The spectrogram PNG was written directly to its final path by sox/ffmpeg (`-o finalPath`), so a crash or kill mid-write, or two concurrent generations of the same path, could leave a partial or corrupt `.png` at the final path. The serve fast-path treats any nonzero file as a finished spectrogram, so it would then serve that corrupt image.

`GenerateFromFile` and `GenerateFromPCM` now render into a process-unique temp file in the same directory (`audiotemp.UniquePath`) and atomically rename it onto the final path via SecureFS (`os.Root.Rename`), removing the temp on every failure path. The temp name reuses the existing `audiotemp` naming that the audio-export scan (`isExportTempFor`) and diskmanager already skip, so it is never mistaken for an audio clip or a finished spectrogram. On failure nothing is published, so the serve fast-path correctly misses and regenerates instead of serving a partial.

`audiotemp` gains `FinalizeWith(temp, final, renameFn)` so the spectrogram can inject the sandboxed SecureFS rename while reusing the existing Windows rename-retry; `Finalize` delegates to `FinalizeWith(os.Rename)`, byte-for-byte unchanged for the existing audio-clip writers (FFmpeg/FLAC/WAV).

This mirrors the recently-landed atomic-write treatment for audio clips, extending it to the spectrogram sidecar.

## Test Plan
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/spectrogram/ ./internal/audiocore/audiotemp/`
- [x] Stub-sox runtime-failure test: a sox stub writes partial bytes to its `-o` target then exits non-zero; asserts the partial lands only in the temp (cleaned up) and never at the final path. This would fail on the old code (which passed the final path as `-o`), so it discriminates the fix.
- [x] Real-sox success test: asserts the final spectrogram is published and no temp sidecar remains.
- [x] Unit tests for `FinalizeWith` (injected-rename success and error propagation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spectrogram generation now writes to process-unique temporary files and atomically publishes to the final output to prevent partial/corrupt files.
  * Improved Windows reliability by retrying the finalization step when the publish/rename initially fails.

* **Tests**
  * Added coverage ensuring runtime and configuration failures never leave partial final outputs or leftover spectrogram temp artifacts.
  * Added tests validating atomic-write behavior on successful spectrogram generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->