### PR TITLE
fix(classifier): run model-load warm-up outside o.mu

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -103,6 +103,22 @@ type Orchestrator struct {
 	modelRSS         map[string]int64
 	runtimeBaseline  int64
 	baselineCaptured bool
+
+	// pendingWarmups queues deferred warm-ups recorded by model loaders while
+	// they hold o.mu (write lock). Drained by runPendingWarmups after o.mu is
+	// released, so the warm-up inference runs via the serialized inference path
+	// instead of stalling PredictModel on o.mu. Appended only
+	// under o.mu.Lock(); snapshotted and cleared under o.mu by the drainer.
+	pendingWarmups []pendingWarmup
+}
+
+// pendingWarmup defers a freshly-registered model's warm-up + RSS measurement
+// until after o.mu is released. Running the warm-up inference under o.mu would
+// block every PredictModel/ModelInfos caller (which wait on o.mu.RLock) for the
+// inference duration.
+type pendingWarmup struct {
+	modelID string // o.models key of the freshly registered instance
+	before  uint64 // process RSS sampled before the build (0 = RSS unavailable)
 }
 
 // CurrentSettings returns the latest settings snapshot published via
@@ -1473,61 +1489,77 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 			Build()
 	}
 
-	o.mu.Lock()
-	defer o.mu.Unlock()
+	// Drain the deferred warm-up after o.mu is released, on every return path.
+	// Loaders queue the warm-up via deferWarmup while holding o.mu; running it
+	// here (outside o.mu, via the serialized inference path) is what keeps a
+	// runtime install from stalling live inference. Deferring it
+	// (rather than calling it only on success) guarantees a loader that queues a
+	// warm-up and then fails cannot orphan an entry in the queue for a later load.
+	defer o.runPendingWarmups()
 
-	if o.models == nil {
-		return errors.Newf("orchestrator has been deleted, cannot load model").
-			Component("classifier.orchestrator").
-			Category(errors.CategorySystem).
-			Build()
-	}
+	// Build and register the model under o.mu (loaders write directly to
+	// o.models).
+	if err := func() error {
+		o.mu.Lock()
+		defer o.mu.Unlock()
 
-	if _, exists := o.models[registryID]; exists {
-		log.Debug("model already loaded, skipping",
-			logger.String("registry_id", registryID))
-		return nil
-	}
-
-	loader, implemented := modelLoaders[registryID]
-	if !implemented {
-		log.Warn("Loader not yet implemented",
-			logger.String("registry_id", registryID))
-		return errors.Newf("loader not yet implemented for model %s", registryID).
-			Component("classifier.orchestrator").
-			Category(errors.CategoryModelInit).
-			Context("registry_id", registryID).
-			Build()
-	}
-
-	// Give the new model the full thread budget. Inference is serialized by
-	// inferenceMu so concurrent CPU contention cannot occur.
-	dynamicThreads := o.currentSettings().BirdNET.Threads
-	if dynamicThreads <= 0 {
-		dynamicThreads = runtime.NumCPU()
-	}
-
-	log.Info("Loading model dynamically",
-		logger.String("registry_id", registryID),
-		logger.Int("threads", dynamicThreads))
-
-	if err := loader(o, dynamicThreads); err != nil {
-		return err
-	}
-
-	log.Info("Model loaded dynamically",
-		logger.String("registry_id", registryID))
-
-	// Start nighttime scheduler if bat model was just loaded and suncalc is available.
-	// Create a fresh scheduler to handle the unload/reload case where the
-	// previous scheduler's stopChan was closed.
-	if registryID == RegistryIDBat {
-		if old := o.scheduler.Load(); old != nil && old.sunCalc != nil {
-			old.stop()
-			s := newNighttimeScheduler(old.sunCalc)
-			o.scheduler.Store(s)
-			o.startBatScheduler(s)
+		if o.models == nil {
+			return errors.Newf("orchestrator has been deleted, cannot load model").
+				Component("classifier.orchestrator").
+				Category(errors.CategorySystem).
+				Build()
 		}
+
+		if _, exists := o.models[registryID]; exists {
+			log.Debug("model already loaded, skipping",
+				logger.String("registry_id", registryID))
+			return nil
+		}
+
+		loader, implemented := modelLoaders[registryID]
+		if !implemented {
+			log.Warn("Loader not yet implemented",
+				logger.String("registry_id", registryID))
+			return errors.Newf("loader not yet implemented for model %s", registryID).
+				Component("classifier.orchestrator").
+				Category(errors.CategoryModelInit).
+				Context("registry_id", registryID).
+				Build()
+		}
+
+		// Give the new model the full thread budget. Inference is serialized by
+		// inferenceMu so concurrent CPU contention cannot occur.
+		dynamicThreads := o.currentSettings().BirdNET.Threads
+		if dynamicThreads <= 0 {
+			dynamicThreads = runtime.NumCPU()
+		}
+
+		log.Info("Loading model dynamically",
+			logger.String("registry_id", registryID),
+			logger.Int("threads", dynamicThreads))
+
+		if err := loader(o, dynamicThreads); err != nil {
+			return err
+		}
+
+		log.Info("Model loaded dynamically",
+			logger.String("registry_id", registryID))
+
+		// Start nighttime scheduler if bat model was just loaded and suncalc is available.
+		// Create a fresh scheduler to handle the unload/reload case where the
+		// previous scheduler's stopChan was closed.
+		if registryID == RegistryIDBat {
+			if old := o.scheduler.Load(); old != nil && old.sunCalc != nil {
+				old.stop()
+				s := newNighttimeScheduler(old.sunCalc)
+				o.scheduler.Store(s)
+				o.startBatScheduler(s)
+			}
+		}
+
+		return nil
+	}(); err != nil {
+		return err
 	}
 
 	return nil
@@ -1872,6 +1904,12 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 				logger.String("registry_id", registryID),
 				logger.Error(loadErr))
 		}
+
+		// Warm up the freshly-loaded model now that o.mu is released, before the
+		// next model's build. Draining per-iteration (rather than once after the
+		// loop) keeps RSS accounting accurate: this model's RSS-after is measured
+		// before the next model allocates its arena.
+		o.runPendingWarmups()
 	}
 
 	return nil

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -64,8 +64,12 @@ func (o *Orchestrator) loadBat(threads int) error {
 			Build()
 	}
 
-	o.warmupAndRecordRSS(bat.ModelID(), before, bat)
 	o.models[bat.ModelID()] = &modelEntry{instance: bat}
+	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
+	// warm-up inference runs via the serialized inference path instead of stalling
+	// live inference on o.mu. The entry is registered above first
+	// so the drainer can find it by key.
+	o.deferWarmup(bat.ModelID(), before)
 
 	log.Info("Bat model loaded into Orchestrator",
 		logger.String("model_id", bat.ModelID()),

--- a/internal/classifier/orchestrator_memory.go
+++ b/internal/classifier/orchestrator_memory.go
@@ -10,8 +10,11 @@ import (
 
 // warmupTimeout bounds the best-effort warm-up inference run during model load.
 // It is intentionally short: a legitimate first inference completes well under
-// 5 s even on a Raspberry Pi 5, and the warm-up holds o.mu (callers of
-// PredictModel block on o.mu.RLock during a dynamic load). On timeout the
+// 5 s even on a Raspberry Pi 5. The warm-up no longer runs under o.mu; the
+// initial-load paths defer it and run it via the serialized inference path
+// (warmupRegisteredModel takes inferenceMu, not o.mu), so PredictModel/ModelInfos
+// callers are not blocked on o.mu during a dynamic load. The
+// bound caps how long a wedged warm-up can hold inferenceMu. On timeout the
 // warm-up aborts gracefully and RSS just undercounts for that model.
 const warmupTimeout = 5 * time.Second
 
@@ -73,6 +76,61 @@ func (o *Orchestrator) warmup(modelID string, instance ModelInstance) {
 			logger.String("model", modelID),
 			logger.Error(err))
 	}
+}
+
+// deferWarmup queues a freshly-registered model for warm-up after o.mu is
+// released, instead of warming it up inline. Model loaders call this while they
+// hold o.mu (write lock); running the warm-up inference here would block every
+// PredictModel/ModelInfos caller on o.mu for the inference duration. The caller
+// drains the queue via runPendingWarmups once o.mu is free.
+// Must be called with o.mu held.
+func (o *Orchestrator) deferWarmup(modelID string, before uint64) {
+	o.pendingWarmups = append(o.pendingWarmups, pendingWarmup{modelID: modelID, before: before})
+}
+
+// runPendingWarmups drains the deferred warm-up queue, running each warm-up via
+// the serialized inference path (warmupRegisteredModel) so it never holds o.mu.
+// The queue is snapshotted and cleared under o.mu so concurrent loader appends
+// cannot race the slice header and an entry is never warmed twice. Safe to call
+// with o.mu NOT held (it must not be: it acquires o.mu itself).
+func (o *Orchestrator) runPendingWarmups() {
+	o.mu.Lock()
+	pending := o.pendingWarmups
+	o.pendingWarmups = nil
+	o.mu.Unlock()
+
+	for _, w := range pending {
+		o.warmupRegisteredModel(w.modelID, w.before)
+	}
+}
+
+// warmupRegisteredModel runs the deferred warm-up + RSS measurement for a model
+// already published in o.models. It mirrors PredictModel's lock protocol
+// (o.mu.RLock to fetch the entry, release, then inferenceMu, then entry.mu) so
+// it behaves like a normal first inference: it never holds o.mu and serializes
+// with live inference via inferenceMu. The warm-up is skipped if the entry was
+// unloaded (absent, or instance == nil) before it ran, so a teardown that races
+// the load leaves no stale modelRSS entry. Unlike PredictModel it does not record
+// into globalInferenceCounters (warmupAndRecordRSS calls instance.Predict
+// directly), so the warm-up does not pollute inference stats.
+func (o *Orchestrator) warmupRegisteredModel(modelID string, before uint64) {
+	o.mu.RLock()
+	entry, ok := o.models[modelID]
+	o.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	o.inferenceMu.Lock()
+	defer o.inferenceMu.Unlock()
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.instance == nil {
+		return
+	}
+
+	o.warmupAndRecordRSS(modelID, before, entry.instance)
 }
 
 // ModelRSS returns a copy of the per-model host-RSS deltas (bytes) and the

--- a/internal/classifier/orchestrator_memory_test.go
+++ b/internal/classifier/orchestrator_memory_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // fakeInstance is a minimal ModelInstance for warm-up/RSS tests.
@@ -62,4 +64,200 @@ func TestModelRSS_ReturnsCopy(t *testing.T) {
 	m["A"] = 999
 	m2, _ := o.ModelRSS()
 	assert.Equal(t, int64(10), m2["A"], "ModelRSS must return a copy; mutation of returned map must not affect the original")
+}
+
+// TestRunPendingWarmups_WarmsAndRecordsRSS verifies the deferred warm-up path:
+// a model registered in o.models and queued via deferWarmup is warmed up (one
+// sized inference) and its RSS delta recorded when runPendingWarmups drains the
+// queue. This is the post-publish, lock-free replacement for the old inline
+// warm-up that ran under o.mu.
+func TestRunPendingWarmups_WarmsAndRecordsRSS(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+	inst := &fakeInstance{id: "Test_Model", sampleRate: 48000, clip: 3 * time.Second}
+
+	before := o.captureRSSBefore()
+	if before == 0 {
+		t.Skip("process RSS unavailable on this platform")
+	}
+	// Register the entry first (mirrors the loader: build -> register -> defer).
+	o.models[inst.ModelID()] = &modelEntry{instance: inst}
+	o.deferWarmup(inst.ModelID(), before)
+	o.runPendingWarmups()
+
+	require.Equal(t, 144000, inst.predictedN, "warm-up dummy size (48000 * 3s)")
+	perModel, _ := o.ModelRSS()
+	require.Contains(t, perModel, inst.ModelID(), "expected modelRSS entry after deferred warm-up")
+	assert.GreaterOrEqual(t, perModel[inst.ModelID()], int64(0), "RSS delta must be clamped to >= 0")
+	assert.Empty(t, o.pendingWarmups, "queue must be drained")
+}
+
+// TestRunPendingWarmups_SkipsRemovedEntry verifies that draining a warm-up whose
+// model was unloaded (absent from o.models) before the drain is a no-op: no
+// panic, no stale modelRSS entry. Covers the teardown race where UnloadModel
+// removes the entry between registration and the deferred warm-up.
+func TestRunPendingWarmups_SkipsRemovedEntry(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+	o.deferWarmup("Removed_Model", 123)
+
+	require.NotPanics(t, func() { o.runPendingWarmups() })
+	perModel, _ := o.ModelRSS()
+	assert.NotContains(t, perModel, "Removed_Model", "no RSS recorded for an absent entry")
+}
+
+// TestRunPendingWarmups_SkipsNilInstance verifies that an entry whose instance
+// was already torn down (instance == nil) records nothing. Covers the teardown
+// race where UnloadModel nils the instance before the deferred warm-up runs.
+func TestRunPendingWarmups_SkipsNilInstance(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{
+		models:   map[string]*modelEntry{"Orphan_Model": {instance: nil}},
+		modelRSS: make(map[string]int64),
+	}
+	o.deferWarmup("Orphan_Model", 123)
+
+	require.NotPanics(t, func() { o.runPendingWarmups() })
+	perModel, _ := o.ModelRSS()
+	assert.NotContains(t, perModel, "Orphan_Model", "no RSS recorded for a torn-down entry")
+}
+
+// TestRunPendingWarmups_DrainsAllQueuedModels verifies the drain loop warms up
+// EVERY queued model, not just the first. A regression that drained only one
+// entry, or mis-snapshotted the queue, would be caught here.
+func TestRunPendingWarmups_DrainsAllQueuedModels(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+	before := o.captureRSSBefore()
+	if before == 0 {
+		t.Skip("process RSS unavailable on this platform")
+	}
+	a := &fakeInstance{id: "Model_A", sampleRate: 48000, clip: 3 * time.Second}
+	b := &fakeInstance{id: "Model_B", sampleRate: 48000, clip: 3 * time.Second}
+	o.models[a.ModelID()] = &modelEntry{instance: a}
+	o.models[b.ModelID()] = &modelEntry{instance: b}
+	o.deferWarmup(a.ModelID(), before)
+	o.deferWarmup(b.ModelID(), before)
+	o.runPendingWarmups()
+
+	assert.Equal(t, 144000, a.predictedN, "Model_A warm-up must run")
+	assert.Equal(t, 144000, b.predictedN, "Model_B warm-up must run")
+	perModel, _ := o.ModelRSS()
+	assert.Contains(t, perModel, a.ModelID(), "Model_A RSS must be recorded")
+	assert.Contains(t, perModel, b.ModelID(), "Model_B RSS must be recorded")
+	assert.Empty(t, o.pendingWarmups, "queue must be fully drained")
+}
+
+// TestRunPendingWarmups_WarmupFailureIsNonFatal verifies that a warm-up whose
+// inference returns an error is non-fatal: it still records the RSS delta (the
+// allocation already happened) and does not panic or abort the drain.
+func TestRunPendingWarmups_WarmupFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+	before := o.captureRSSBefore()
+	if before == 0 {
+		t.Skip("process RSS unavailable on this platform")
+	}
+	inst := &fakeInstance{
+		id:         "Failing_Model",
+		sampleRate: 48000,
+		clip:       3 * time.Second,
+		predictErr: errors.Newf("simulated warm-up failure").Build(),
+	}
+	o.models[inst.ModelID()] = &modelEntry{instance: inst}
+	o.deferWarmup(inst.ModelID(), before)
+
+	require.NotPanics(t, func() { o.runPendingWarmups() })
+	assert.Equal(t, 144000, inst.predictedN, "warm-up Predict is still invoked despite the error")
+	perModel, _ := o.ModelRSS()
+	assert.Contains(t, perModel, inst.ModelID(), "RSS is still recorded after a non-fatal warm-up failure")
+}
+
+// TestLoadModel_RunsDeferredWarmup is the wiring guard: it proves LoadModel
+// actually drains the deferred warm-up after releasing o.mu. A fake loader is
+// registered for a synthetic model so the test does not need real model files.
+// Guards against a regression that removes LoadModel's runPendingWarmups drain.
+func TestLoadModel_RunsDeferredWarmup(t *testing.T) {
+	// Mutates the package-global ModelRegistry/modelLoaders, so not parallel.
+	const testID = "GateTest_WarmupWiring"
+	inst := &fakeInstance{id: testID, sampleRate: 48000, clip: 3 * time.Second}
+
+	ModelRegistry[testID] = ModelInfo{ID: testID, Spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second}}
+	t.Cleanup(func() { delete(ModelRegistry, testID) })
+	modelLoaders[testID] = func(o *Orchestrator, _ int) error {
+		// Mirror the real loaders: capture before-build RSS, register the entry,
+		// then defer the warm-up (all under o.mu, which LoadModel holds here).
+		b := o.captureRSSBefore()
+		o.models[testID] = &modelEntry{instance: inst}
+		o.deferWarmup(testID, b)
+		return nil
+	}
+	t.Cleanup(func() { delete(modelLoaders, testID) })
+
+	o := &Orchestrator{models: map[string]*modelEntry{}, modelRSS: make(map[string]int64)}
+	o.updateSettings(&conf.Settings{})
+
+	require.NoError(t, o.LoadModel(testID))
+
+	// The deferred warm-up must have run (proves LoadModel drained the queue).
+	assert.Equal(t, 144000, inst.predictedN, "LoadModel must run the deferred warm-up")
+	assert.Empty(t, o.pendingWarmups, "LoadModel must drain the warm-up queue")
+}
+
+// TestRunPendingWarmups_DoesNotHoldMapLockDuringWarmup is the core regression
+// guard: while the deferred warm-up inference runs, callers that take
+// o.mu.RLock (PredictModel, ModelInfos, PrimaryModelID) must not block. The
+// warm-up serializes via inferenceMu instead, exactly like a normal inference.
+func TestRunPendingWarmups_DoesNotHoldMapLockDuringWarmup(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	inst := &mockModelInstance{
+		id:   "Blocking_Model",
+		spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+		predict: func(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+			close(started)
+			<-release
+			return nil, nil
+		},
+	}
+	o := &Orchestrator{
+		models:   map[string]*modelEntry{inst.id: {instance: inst}},
+		modelRSS: make(map[string]int64),
+	}
+	o.deferWarmup(inst.id, 1)
+
+	done := make(chan struct{})
+	go func() { defer close(done); o.runPendingWarmups() }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("warm-up Predict did not start")
+	}
+
+	// The map lock must be free while the warm-up inference is in flight.
+	gotLock := make(chan struct{})
+	go func() {
+		// Mirror a PredictModel-style map read: fetch an entry under o.mu.RLock.
+		o.mu.RLock()
+		_, ok := o.models[inst.id]
+		o.mu.RUnlock()
+		_ = ok
+		close(gotLock)
+	}()
+	select {
+	case <-gotLock:
+	case <-time.After(2 * time.Second):
+		t.Fatal("o.mu.RLock blocked during warm-up: warm-up must not hold the orchestrator map lock")
+	}
+
+	// The warm-up must hold inferenceMu (it serializes via the inference path).
+	assert.False(t, o.inferenceMu.TryLock(), "warm-up must hold inferenceMu during Predict")
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runPendingWarmups did not finish")
+	}
 }

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -76,12 +76,16 @@ func (o *Orchestrator) loadPerch(threads int) error {
 	if err != nil {
 		return err
 	}
-	o.warmupAndRecordRSS(perch.ModelID(), before, perch)
 
 	o.models[perch.ModelID()] = &modelEntry{
 		instance: perch,
 		backend:  secondaryTripletFor(settings),
 	}
+	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
+	// warm-up inference runs via the serialized inference path instead of stalling
+	// live inference on o.mu. The entry is registered above first
+	// so the drainer can find it by key.
+	o.deferWarmup(perch.ModelID(), before)
 
 	// No separate Perch label resolver needed. Perch returns scientific names,
 	// and the BirdNETLabelResolver (already registered) maps scientific -> common

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -421,8 +421,11 @@ func (c *Collector) collectInference(points map[string]float64) {
 }
 
 // collectModelRSS sets the per-model RSS Prometheus gauge each tick. RSS is set
-// at load and stable until reload; setting it every tick is idempotent and
-// handles model add/remove. RSS is not written to the ring buffer in Phase 1.
+// shortly after load (the warm-up + measurement is deferred and run off o.mu,
+// so it lands a moment after the model becomes visible) and stable until reload;
+// setting it every tick is idempotent and handles model add/remove, and the tick
+// cadence naturally picks up the value once the deferred warm-up records it. RSS
+// is not written to the ring buffer in Phase 1.
 func (c *Collector) collectModelRSS() {
 	if c.modelRSSFunc == nil || c.rssGauge == nil {
 		return


### PR DESCRIPTION
## Summary

The per-model RSS-delta warm-up inference ran while the model loader held `o.mu.Lock()`. For a runtime model install (`LoadModel`, via the model gallery) this briefly blocked all inference: `PredictModel`, `ModelInfos`, and `PrimaryModelID` all wait on `o.mu.RLock()` for the warm-up duration (bounded by `warmupTimeout`, 5s).

This defers the warm-up off the lock:

- Loaders (`loadPerch`, `loadBat`) now register the model entry, then queue the warm-up via `deferWarmup` instead of warming up inline.
- The caller drains the queue via `runPendingWarmups` after releasing `o.mu`, running the warm-up through a serialized path (`inferenceMu` then `entry.mu`) like a normal first inference, without recording into `globalInferenceCounters`.
- `loadAdditionalModels` drains per loop iteration so each model's RSS-after sample is taken before the next model allocates its arena (accurate accounting).
- `LoadModel` drains via `defer`, so a loader that queues a warm-up and then fails cannot orphan a pending entry in the queue.
- Teardown races with `UnloadModel`/`Delete` are handled by re-fetching the entry under `o.mu.RLock()` and skipping a torn-down model (absent, or `instance == nil`), leaving no stale `modelRSS` entry.

The primary warm-up (`NewOrchestrator`) and the secondary hot-reload warm-up (`ReloadSecondaryModels`) already run lock-free and are unchanged.

Lock ordering (`o.mu` -> `inferenceMu` -> `entry.mu`) is unchanged; the new `warmupRegisteredModel` mirrors `PredictModel`'s protocol exactly.

## Test Plan

- [x] `go test -race ./internal/classifier/` passes
- [x] `golangci-lint run ./...` clean
- [x] New unit tests: deferred warm-up records RSS; multi-model drain loop warms every queued model; non-fatal warm-up failure still records; teardown-skip paths (absent entry / nil instance); `LoadModel` drain wiring
- [x] Regression guard proves `o.mu.RLock()` stays free while a warm-up inference is in flight (mutation-verified: fails when the warm-up holds `o.mu`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Model initialization no longer blocks inference requests; warm-up operations now execute after setup completes.

* **Performance**
  * Memory profiling accuracy improved by measuring memory deltas per-model during initialization rather than all at once.

* **Reliability**
  * Warm-up failures are non-fatal and handled gracefully without impacting system stability.

* **Tests**
  * Expanded test coverage for warm-up deferral behavior, including failure scenarios and concurrency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->