### PR TITLE
fix(classifier): serialize ReloadSecondaryModels warm-up via inferenceMu

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1326,10 +1326,19 @@ func (o *Orchestrator) ReloadSecondaryModels() error {
 
 		// Warm up the freshly built (still private) instance before publishing it,
 		// so the first real inference does not pay the lazy-allocation cost, and
-		// re-measure its host RSS. This is lock-free and safe: newInst is not yet in
-		// the entry, and o.mu is not held in this build/swap section, so it does not
-		// stall live inference (unlike the initial load paths).
-		o.warmupAndRecordRSS(ref.id, before, newInst)
+		// re-measure its host RSS. newInst is not yet in the entry, so the warm-up
+		// needs no entry.mu, but it IS an inference: hold inferenceMu so it
+		// serializes with live PredictModel calls rather than running a second model
+		// session concurrently. That honors the inferenceMu invariant ("serializes
+		// inference across all models") and avoids the CPU/memory contention on
+		// constrained hardware that serialized inference exists to prevent. It never
+		// holds o.mu, so PredictModel/ModelInfos map readers are not blocked; it only
+		// queues briefly behind live inference (bounded by warmupTimeout).
+		func() {
+			o.inferenceMu.Lock()
+			defer o.inferenceMu.Unlock()
+			o.warmupAndRecordRSS(ref.id, before, newInst)
+		}()
 
 		// Swap the new instance into the existing entry under entry.mu so it
 		// cannot race an in-flight PredictModel. Keeping the same *modelEntry

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,6 +101,58 @@ func TestReloadSecondaryModels_SwapsAndClosesOld(t *testing.T) {
 	assert.Equal(t, int32(0), newInst.closes.Load(), "new instance must not be closed")
 	assert.Equal(t, secondaryBackendKey{backend: "openvino", ovDevice: "gpu", ovPath: "/opt/ov"}, o.models[testSecondaryID].backend,
 		"entry triplet should advance to the new backend")
+}
+
+// TestReloadSecondaryModels_WarmupHoldsInferenceMu verifies that the hot-reload
+// warm-up of the freshly built secondary serializes via inferenceMu, so it cannot
+// run a second model session concurrently with live inference. Mutation check:
+// this fails if the warm-up runs without inferenceMu (the pre-fix behavior).
+func TestReloadSecondaryModels_WarmupHoldsInferenceMu(t *testing.T) {
+	setGlobalBackend(t, "openvino", "gpu", "/opt/ov")
+
+	old := &reloadFakeModel{id: testSecondaryID}
+	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
+	o.ModelInfo.ID = permanentRegistryID
+	// Loaded on a different backend so the per-entry gate fires and the rebuild runs.
+	o.models[testSecondaryID] = &modelEntry{instance: old, backend: secondaryBackendKey{backend: "onnx"}}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	// A non-empty Spec makes the warm-up actually run Predict (sized from the spec);
+	// the blocking Predict lets us observe inferenceMu while the warm-up is in flight.
+	newInst := &mockModelInstance{
+		id:   testSecondaryID,
+		spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+		predict: func(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+			close(started)
+			<-release
+			return nil, nil
+		},
+	}
+	registerTestSecondaryBuilder(t, testSecondaryID, func(_ *Orchestrator, _ *conf.Settings, _ int) (ModelInstance, error) {
+		return newInst, nil
+	})
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = o.ReloadSecondaryModels() }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reload warm-up Predict did not start")
+	}
+
+	// While the warm-up inference runs, inferenceMu must be held so a live
+	// PredictModel cannot run a second model session concurrently.
+	assert.False(t, o.inferenceMu.TryLock(), "reload warm-up must hold inferenceMu during Predict")
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReloadSecondaryModels did not finish")
+	}
+	assert.Same(t, ModelInstance(newInst), o.models[testSecondaryID].instance, "new instance should be swapped in")
 }
 
 func TestReloadSecondaryModels_NoOpWhenTripletUnchanged(t *testing.T) {

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -143,8 +143,14 @@ func TestReloadSecondaryModels_WarmupHoldsInferenceMu(t *testing.T) {
 	}
 
 	// While the warm-up inference runs, inferenceMu must be held so a live
-	// PredictModel cannot run a second model session concurrently.
-	assert.False(t, o.inferenceMu.TryLock(), "reload warm-up must hold inferenceMu during Predict")
+	// PredictModel cannot run a second model session concurrently. Capture the
+	// result and release if TryLock unexpectedly succeeds, so a regression does
+	// not leak the lock past the failing assertion.
+	locked := !o.inferenceMu.TryLock()
+	if !locked {
+		o.inferenceMu.Unlock()
+	}
+	assert.True(t, locked, "reload warm-up must hold inferenceMu during Predict")
 
 	close(release)
 	select {


### PR DESCRIPTION
## Summary

The hot-reload warm-up of a freshly built secondary model (`ReloadSecondaryModels`, used on a `BirdNET.OpenVINODevice`/`Backend` change) ran its inference lock-free. It could therefore execute concurrently with a live `PredictModel` call: two model sessions inferring at once, exactly the CPU/memory contention the `inferenceMu` "serialize inference across all models" invariant exists to prevent on constrained hardware (e.g. Pi5).

This wraps the warm-up in `inferenceMu`. The new instance is still private (not yet published in the entry), so the warm-up needs no `entry.mu`; it takes `inferenceMu` alone, releases it, then the swap takes `entry.mu`, preserving the `o.mu -> inferenceMu -> entry.mu` ordering with no nesting (no deadlock vs `PredictModel`, which takes `inferenceMu` then `entry.mu`, nor vs `Delete`/`Unload`, which never take `inferenceMu`). The warm-up never holds `o.mu`, so map readers (`PredictModel`/`ModelInfos`) stay unblocked; it only queues briefly behind live inference (bounded by `warmupTimeout`).

This brings the reload warm-up in line with the initial-load warm-up path (`warmupRegisteredModel`), which already serializes via `inferenceMu`.

## Test Plan

- [x] `go test -race ./internal/classifier/` passes (incl. the existing concurrent-`PredictModel` reload race test)
- [x] `golangci-lint run ./...` clean
- [x] New `TestReloadSecondaryModels_WarmupHoldsInferenceMu`: blocks the warm-up `Predict` and asserts `inferenceMu` is held; mutation-verified (fails when the warm-up runs lock-free)
- [x] Independent review (Gemini): deadlock-safe, correct, no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization during secondary model reloads so warm-up prediction runs in a coordinated manner with live inference, preventing concurrent prediction conflicts and improving runtime stability.

* **Tests**
  * Added a concurrency-focused test to verify warm-up prediction properly holds the inference lock during secondary model reload, ensuring the correct model swap behavior after reload completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->