### PR TITLE
fix(datastore): require detections table for MySQL fresh v2 schema check

### DIFF
--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -696,6 +696,12 @@ func hasUnmigratedLegacyMySQL(settings *conf.Settings, log logger.Logger) bool {
 //  2. A migration state record with COMPLETED status
 //
 // This prevents false positives from partially initialized databases.
+//
+// Unlike CheckMySQLHasFreshV2Schema, this intentionally does NOT also require the
+// detections data table to exist. SQLite stores the v2 schema in a dedicated file
+// (not prefix-shared tables), and initializeV2OnlyMode's SQLite branch always runs
+// Initialize()/AutoMigrate on the chosen file in both outcomes, so a marker-without-data
+// file is repaired in place rather than wedging the app. The #3575 wedge is MySQL-only.
 func CheckSQLiteHasV2Schema(dbPath string) bool {
 	// Check if file exists first - GORM/SQLite with mode=ro may still create an empty file
 	// even when opening in read-only mode, which causes issues when checking non-existent
@@ -747,9 +753,18 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 	return state.State == entities.MigrationStatusCompleted
 }
 
-// CheckMySQLHasFreshV2Schema checks if a MySQL database has fresh v2 tables (without v2_ prefix).
-// This is used to determine whether to use v2_ prefix for migration mode or no prefix for fresh installs.
-// Returns true if the fresh v2 schema exists (migration_states table without prefix).
+// CheckMySQLHasFreshV2Schema reports whether a MySQL database holds a complete,
+// usable fresh (no v2_ prefix) v2 schema. It drives the prefix decision in
+// initializeV2OnlyMode: no prefix for fresh installs, v2_ prefix for migration mode.
+//
+// It returns true only when BOTH conditions hold:
+//  1. a no-prefix migration_states row exists with state == COMPLETED, AND
+//  2. the no-prefix `detections` data table physically exists.
+//
+// Requiring the real data table (not just the completed marker) prevents a stale
+// marker left by a backend switch (e.g. SQLite -> MySQL) or a partial/aborted init
+// from wedging the app in enhanced mode against a missing `detections` table
+// (GitHub #3575).
 func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
 	dsn := buildMySQLStartupDSN(settings)
 
@@ -766,30 +781,49 @@ func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
 	}
 	defer func() { _ = sqlDB.Close() }()
 
-	// Check if fresh v2 migration_states table exists (no prefix).
-	// Also check for the old singular name "migration_state" (pre-PR #2165).
-	var tableCount int64
-	err = db.Raw("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name IN ('migration_states', 'migration_state')",
-		settings.Output.MySQL.Database).Scan(&tableCount).Error
-	if err != nil || tableCount == 0 {
+	return hasCompleteFreshV2Schema(db)
+}
+
+// hasCompleteFreshV2Schema is the dialect-agnostic core behind CheckMySQLHasFreshV2Schema.
+// It reports whether the connected database holds a complete, usable fresh (no v2_
+// prefix) v2 schema: a no-prefix migration_states (or pre-PR #2165 singular
+// migration_state) row with state == COMPLETED AND a physical no-prefix `detections`
+// data table.
+//
+// It uses GORM's migrator for table existence so the same code path can be unit-tested
+// against SQLite (in CI, where MySQL is unavailable) while production calls it for MySQL.
+func hasCompleteFreshV2Schema(db *gorm.DB) bool {
+	// Resolve the migration-state table name. Plural is current; the singular
+	// "migration_state" predates PR #2165 (which removed TableName() overrides).
+	migrationTable := ""
+	for _, name := range []string{"migration_states", "migration_state"} {
+		if db.Migrator().HasTable(name) {
+			migrationTable = name
+			break
+		}
+	}
+	if migrationTable == "" {
 		return false
 	}
 
-	// Determine which table name exists
-	var tableName string
-	err = db.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_name IN ('migration_states', 'migration_state') LIMIT 1",
-		settings.Output.MySQL.Database).Scan(&tableName).Error
-	if err != nil || tableName == "" {
-		return false
-	}
-
-	// Check if migration state is COMPLETED
+	// The migration must be marked COMPLETED.
 	var state entities.MigrationState
-	if err := db.Table(tableName).First(&state).Error; err != nil {
+	if err := db.Table(migrationTable).First(&state).Error; err != nil {
+		return false
+	}
+	if state.State != entities.MigrationStatusCompleted {
 		return false
 	}
 
-	return state.State == entities.MigrationStatusCompleted
+	// A COMPLETED marker alone is NOT sufficient evidence of a usable fresh v2 schema:
+	// the real `detections` data table must also exist. A stale marker can survive a
+	// backend switch (e.g. SQLite -> MySQL) or a partial/aborted init, and without this
+	// guard the prefix decision in initializeV2OnlyMode would pick the no-prefix schema
+	// so every v2 query targets a bare `detections` table that was never created,
+	// wedging the app in enhanced mode (GitHub #3575). Returning false makes
+	// initializeV2OnlyMode fall back to the v2_ prefixed schema, whose tables are
+	// (re)created by the subsequent Initialize()/AutoMigrate.
+	return db.Migrator().HasTable("detections")
 }
 
 // cleanupOrphanedBareV2Tables removes bare v2 tables that were created by a broken nightly

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -299,6 +299,107 @@ func TestCheckSQLiteHasV2Schema(t *testing.T) {
 	})
 }
 
+// newSchemaCheckDB opens a fresh temp-file SQLite GORM DB for hasCompleteFreshV2Schema
+// tests. SQLite stands in for MySQL here: hasCompleteFreshV2Schema is dialect-agnostic
+// (it uses GORM's migrator), so the same decision logic runs in CI without a MySQL server.
+func newSchemaCheckDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "schema_check.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return db
+}
+
+// seedMigrationStatesTable creates the plural migration_states table and inserts a
+// singleton row (id=1) with the given state.
+func seedMigrationStatesTable(t *testing.T, db *gorm.DB, status entities.MigrationStatus) {
+	t.Helper()
+	require.NoError(t, db.AutoMigrate(&entities.MigrationState{}))
+	now := time.Now()
+	require.NoError(t, db.Save(&entities.MigrationState{
+		ID:          1,
+		State:       status,
+		StartedAt:   &now,
+		CompletedAt: &now,
+	}).Error)
+}
+
+// createBareDetectionsTable creates a placeholder no-prefix detections table. Only its
+// existence matters to hasCompleteFreshV2Schema, so a minimal schema is sufficient.
+func createBareDetectionsTable(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec("CREATE TABLE detections (id INTEGER PRIMARY KEY)").Error)
+}
+
+// TestHasCompleteFreshV2Schema covers the GitHub #3575 guard: a "completed"
+// migration_states marker is treated as a usable fresh v2 schema only when the real
+// detections data table also exists.
+func TestHasCompleteFreshV2Schema(t *testing.T) {
+	t.Run("completed marker with detections table", func(t *testing.T) {
+		db := newSchemaCheckDB(t)
+		seedMigrationStatesTable(t, db, entities.MigrationStatusCompleted)
+		createBareDetectionsTable(t, db)
+
+		assert.True(t, hasCompleteFreshV2Schema(db),
+			"completed marker plus detections table is a usable fresh v2 schema")
+	})
+
+	t.Run("completed marker without detections table", func(t *testing.T) {
+		// This is the #3575 wedge: a stale completed marker survives a backend switch
+		// or partial init, but the detections data table was never created.
+		db := newSchemaCheckDB(t)
+		seedMigrationStatesTable(t, db, entities.MigrationStatusCompleted)
+
+		assert.False(t, hasCompleteFreshV2Schema(db),
+			"completed marker without a detections table must not be treated as fresh v2")
+	})
+
+	t.Run("detections table but state not completed", func(t *testing.T) {
+		db := newSchemaCheckDB(t)
+		seedMigrationStatesTable(t, db, entities.MigrationStatusIdle)
+		createBareDetectionsTable(t, db)
+
+		assert.False(t, hasCompleteFreshV2Schema(db),
+			"a non-completed migration state is not a finished v2 install")
+	})
+
+	t.Run("no migration_states table", func(t *testing.T) {
+		db := newSchemaCheckDB(t)
+		createBareDetectionsTable(t, db)
+
+		assert.False(t, hasCompleteFreshV2Schema(db),
+			"missing migration state table means no v2 schema")
+	})
+
+	t.Run("migration_states table exists but is empty", func(t *testing.T) {
+		// Exercises the First() ErrRecordNotFound branch: the table was created but
+		// the singleton state row was never written.
+		db := newSchemaCheckDB(t)
+		require.NoError(t, db.AutoMigrate(&entities.MigrationState{}))
+		createBareDetectionsTable(t, db)
+
+		assert.False(t, hasCompleteFreshV2Schema(db),
+			"an empty migration_states table (no state row) is not a finished v2 install")
+	})
+
+	t.Run("legacy singular migration_state table name", func(t *testing.T) {
+		// Pre-PR #2165 databases used the singular "migration_state" table name.
+		db := newSchemaCheckDB(t)
+		require.NoError(t, db.Exec("CREATE TABLE migration_state (id INTEGER PRIMARY KEY, state TEXT)").Error)
+		require.NoError(t, db.Exec("INSERT INTO migration_state (id, state) VALUES (1, ?)",
+			string(entities.MigrationStatusCompleted)).Error)
+		createBareDetectionsTable(t, db)
+
+		assert.True(t, hasCompleteFreshV2Schema(db),
+			"legacy singular table name must still resolve")
+	})
+}
+
 // createLegacySQLite creates a minimal legacy SQLite database with a notes table
 // containing the specified number of records starting from ID 1.
 func createLegacySQLite(t *testing.T, path string, recordCount int) {
@@ -520,4 +621,36 @@ func TestCheckMySQLHasFreshV2Schema_NativePasswordAuth(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_ = CheckMySQLHasFreshV2Schema(settings)
 	})
+}
+
+// TestCheckMySQLHasFreshV2Schema_RequiresDetectionsTable reproduces the GitHub #3575
+// wedge against a real MySQL server: a no-prefix migration_states "completed" marker
+// must NOT be treated as a usable fresh v2 schema when the detections data table is
+// missing. Otherwise initializeV2OnlyMode picks useV2Prefix=false and every v2 query
+// targets a bare `detections` table that does not exist.
+func TestCheckMySQLHasFreshV2Schema_RequiresDetectionsTable(t *testing.T) {
+	cfg := skipIfNoMySQL(t)
+	settings := mysqlTestSettings(cfg)
+
+	// Build a healthy fresh (no v2_ prefix) v2 schema. cfg.UseV2Prefix is false, so
+	// NewMySQLManager creates clean, no-prefix table names.
+	mgr, err := NewMySQLManager(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.Delete()
+		_ = mgr.Close()
+	})
+	require.NoError(t, mgr.Initialize())
+	require.NoError(t, mgr.DB().Model(&entities.MigrationState{}).
+		Where("id = 1").
+		Update("state", entities.MigrationStatusCompleted).Error)
+
+	// Healthy: completed marker AND detections table present.
+	assert.True(t, CheckMySQLHasFreshV2Schema(settings),
+		"a completed marker with a detections table is a usable fresh v2 schema")
+
+	// #3575: drop the detections data table but leave the completed marker behind.
+	require.NoError(t, mgr.DB().Migrator().DropTable("detections"))
+	assert.False(t, CheckMySQLHasFreshV2Schema(settings),
+		"a stale completed marker without a detections table must not be treated as fresh v2")
 }


### PR DESCRIPTION
## Summary

Switching the output database from SQLite to MySQL could wedge the app in enhanced (v2) mode against a MySQL database that had a `migration_states` "completed" marker but no `detections` data table. Every v2 query then failed with `Error 1146 (42S02): Table 'birdnet.detections' doesn't exist`, the migration status reported `completed`, prerequisites returned `can_start=false`, and there was no in-app way to recover.

### Root cause

`CheckMySQLHasFreshV2Schema` decides the v2 table prefix in `initializeV2OnlyMode` (`useV2Prefix = !isFreshV2`). It returned `true` based solely on a no-prefix `migration_states` row with `state == completed`, never checking that the actual `detections` data table existed. A stale marker (surviving a backend switch or a partial/aborted init) made it pick the no-prefix schema, so every v2 query targeted a bare `detections` table that was never created.

### Fix

A completed marker alone is no longer sufficient evidence of a usable fresh v2 schema: the real `detections` data table must also exist. The check is refactored into a small dialect-agnostic helper `hasCompleteFreshV2Schema` that uses GORM's migrator. When `detections` is absent the function now returns `false`, so `initializeV2OnlyMode` falls back to the `v2_` prefixed schema and the subsequent `Initialize()`/`AutoMigrate` (re)creates the tables instead of wedging. The change is purely a tightening: it can only flip a previous `true` into `false` for an already-broken database. A healthy fresh install always creates `detections` (via `AutoMigrate`) before writing the completed marker, so it is unaffected.

The SQLite sibling (`CheckSQLiteHasV2Schema`) intentionally does not need the same guard (SQLite uses a dedicated file, not prefix-shared tables, and both branches AutoMigrate the chosen file), and that reasoning is now documented in code.

## Related Issues

Fixes #3575

## Test Plan

- [x] New SQLite-backed unit tests (`TestHasCompleteFreshV2Schema`) run in CI and cover: completed+detections, completed-without-detections (the wedge), not-completed, missing migration table, empty migration table, and the legacy singular `migration_state` name.
- [x] New MySQL-gated integration test (`TestCheckMySQLHasFreshV2Schema_RequiresDetectionsTable`) reproduces the wedge against a real server: build a fresh schema (true), drop `detections` leaving the marker (false). Verified locally against MariaDB 11.
- [x] `golangci-lint run` clean, full build and the `internal/analysis` / `internal/datastore/v2only` suites pass with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database initialization schema validation to ensure required tables physically exist before recognizing a schema as ready, preventing initialization errors on incomplete setups

* **Tests**
  * Added regression tests validating schema detection properly handles missing tables, incomplete migration markers, and legacy table naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->