### PR TITLE
fix(datastore): derive v2 detections table name from manager prefix; harden orphan cleanup

### DIFF
--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -54,7 +54,8 @@ func (m *mockAppMetadataRepo) Set(_ context.Context, key, value string) error {
 // fakeV2Manager implements the subset of datastoreV2.Manager used by
 // hasZeroDetections (DB() and optionally TablePrefix()).
 type fakeV2Manager struct {
-	db *gorm.DB
+	db          *gorm.DB
+	tablePrefix string
 }
 
 func (f *fakeV2Manager) Initialize() error    { return nil }
@@ -65,12 +66,22 @@ func (f *fakeV2Manager) CheckpointWAL() error { return nil }
 func (f *fakeV2Manager) Delete() error        { return nil }
 func (f *fakeV2Manager) Exists() bool         { return true }
 func (f *fakeV2Manager) IsMySQL() bool        { return false }
-func (f *fakeV2Manager) TablePrefix() string  { return "" }
+func (f *fakeV2Manager) TablePrefix() string  { return f.tablePrefix }
 
 // newFakeV2ManagerWithDetections creates a fakeV2Manager backed by an
 // in-memory SQLite database.  If count > 0, it inserts that many dummy
 // rows into a "detections" table.
 func newFakeV2ManagerWithDetections(t *testing.T, count int) *fakeV2Manager {
+	t.Helper()
+	// Bare (no-prefix) "detections" table matching what hasZeroDetections queries.
+	return newFakeV2ManagerWithTable(t, "detections", "", count)
+}
+
+// newFakeV2ManagerWithTable creates a fakeV2Manager backed by an in-memory SQLite
+// database with a single arbitrary table (e.g. "v2_detections") holding count rows,
+// and reports the given prefix from TablePrefix(). Used to verify that table names are
+// derived from the manager's prefix rather than guessed from the dialect.
+func newFakeV2ManagerWithTable(t *testing.T, tableName, prefix string, count int) *fakeV2Manager {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
@@ -82,13 +93,12 @@ func newFakeV2ManagerWithDetections(t *testing.T, count int) *fakeV2Manager {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sqlDB.Close() })
 
-	// Create a minimal "detections" table matching what hasZeroDetections queries.
-	require.NoError(t, db.Exec("CREATE TABLE IF NOT EXISTS detections (id INTEGER PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE IF NOT EXISTS "+tableName+" (id INTEGER PRIMARY KEY)").Error)
 	for i := range count {
-		require.NoError(t, db.Exec("INSERT INTO detections (id) VALUES (?)", i+1).Error)
+		require.NoError(t, db.Exec("INSERT INTO "+tableName+" (id) VALUES (?)", i+1).Error)
 	}
 
-	return &fakeV2Manager{db: db}
+	return &fakeV2Manager{db: db, tablePrefix: prefix}
 }
 
 // =============================================================================

--- a/internal/api/v2/prerequisites.go
+++ b/internal/api/v2/prerequisites.go
@@ -636,12 +636,11 @@ func (c *Controller) checkExistingV2Data() PrerequisiteCheck {
 		return check
 	}
 
-	// Check if detections table has data
+	// Check if detections table has data. Derive the table name from the manager's
+	// actual prefix (empty for fresh installs, "v2_" during migration) instead of
+	// guessing from the dialect, matching every other v2 consumer.
 	var count int64
-	tableName := "detections"
-	if c.isUsingMySQL() {
-		tableName = "v2_detections"
-	}
+	tableName := c.V2Manager.TablePrefix() + "detections"
 
 	if err := db.Table(tableName).Count(&count).Error; err != nil {
 		// Table might not exist yet, which is fine

--- a/internal/api/v2/prerequisites_test.go
+++ b/internal/api/v2/prerequisites_test.go
@@ -328,6 +328,64 @@ func TestCheckExistingV2Data_NilManager(t *testing.T) {
 	assert.Equal(t, CheckSeverityWarning, check.Severity)
 }
 
+// TestCheckExistingV2Data_UsesManagerTablePrefix verifies checkExistingV2Data derives
+// the detections table name from the manager's TablePrefix() (empty for fresh installs,
+// "v2_" during migration) rather than guessing from the dialect. The last case is the
+// regression guard: with a prefix set, a bare "detections" table must NOT be counted.
+func TestCheckExistingV2Data_UsesManagerTablePrefix(t *testing.T) {
+	t.Attr("component", "migration")
+	t.Attr("type", "unit")
+	t.Attr("feature", "prerequisites")
+
+	tests := []struct {
+		name        string
+		tableName   string
+		prefix      string
+		count       int
+		wantStatus  string
+		wantMessage string
+	}{
+		{
+			name:        "prefixed v2_detections with data is counted",
+			tableName:   "v2_detections",
+			prefix:      "v2_",
+			count:       3,
+			wantStatus:  CheckStatusWarning,
+			wantMessage: "3",
+		},
+		{
+			name:        "fresh-install bare detections with data is counted",
+			tableName:   "detections",
+			prefix:      "",
+			count:       2,
+			wantStatus:  CheckStatusWarning,
+			wantMessage: "2",
+		},
+		{
+			name:        "prefix set but only bare detections exists is not counted",
+			tableName:   "detections",
+			prefix:      "v2_",
+			count:       5,
+			wantStatus:  CheckStatusPassed,
+			wantMessage: "No existing migration data found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &Controller{V2Manager: newFakeV2ManagerWithTable(t, tt.tableName, tt.prefix, tt.count)}
+
+			check := controller.checkExistingV2Data()
+
+			assert.Equal(t, "existing_v2_data", check.ID)
+			assert.Equal(t, tt.wantStatus, check.Status)
+			if tt.wantMessage != "" {
+				assert.Contains(t, check.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
 // TestCheckWritePermission_Success tests checkWritePermission in a writable directory.
 func TestCheckWritePermission_Success(t *testing.T) {
 	t.Attr("component", "migration")

--- a/internal/datastore/v2/mysql_manager_test.go
+++ b/internal/datastore/v2/mysql_manager_test.go
@@ -22,13 +22,17 @@ func getMySQLConfig() *MySQLConfig {
 		port = "3306"
 	}
 
+	// UseV2Prefix defaults to false (fresh-install, no-prefix layout), matching a
+	// generic MySQL deployment. Tests that exercise the migration (v2_ prefixed)
+	// layout set cfg.UseV2Prefix = true explicitly.
 	return &MySQLConfig{
-		Host:     host,
-		Port:     port,
-		Username: os.Getenv("MYSQL_TEST_USER"),
-		Password: os.Getenv("MYSQL_TEST_PASSWORD"),
-		Database: os.Getenv("MYSQL_TEST_DATABASE"),
-		Debug:    false,
+		Host:        host,
+		Port:        port,
+		Username:    os.Getenv("MYSQL_TEST_USER"),
+		Password:    os.Getenv("MYSQL_TEST_PASSWORD"),
+		Database:    os.Getenv("MYSQL_TEST_DATABASE"),
+		UseV2Prefix: false,
+		Debug:       false,
 	}
 }
 
@@ -61,9 +65,9 @@ func TestV2TableName(t *testing.T) {
 }
 
 func TestMySQLManager_IsMySQL(t *testing.T) {
-	// This test doesn't require a real MySQL connection
-	// We're just testing the interface
+	// Exercises the migration (v2_ prefixed) layout, so opt into the prefix.
 	cfg := skipIfNoMySQL(t)
+	cfg.UseV2Prefix = true
 
 	mgr, err := NewMySQLManager(cfg)
 	require.NoError(t, err)
@@ -74,7 +78,9 @@ func TestMySQLManager_IsMySQL(t *testing.T) {
 }
 
 func TestMySQLManager_Initialize(t *testing.T) {
+	// Verifies the v2_ prefixed (migration) schema, so opt into the prefix.
 	cfg := skipIfNoMySQL(t)
+	cfg.UseV2Prefix = true
 
 	mgr, err := NewMySQLManager(cfg)
 	require.NoError(t, err)

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -848,18 +848,23 @@ func cleanupOrphanedBareV2Tables(db *gorm.DB, database string) {
 
 	// Bare v2-only tables that do NOT collide with legacy tables.
 	// Drop in reverse dependency order (children before parents).
-	// Table names use the OLD singular forms (migration_state, alert_history) because
-	// the orphaned tables were created by code with TableName() overrides.
+	// Both naming forms are listed: the OLD singular forms (migration_state,
+	// alert_history) left by pre-PR #2165 code with TableName() overrides, and the
+	// current GORM-pluralized forms (migration_states, alert_histories) that a more
+	// recent broken nightly would leave behind. FK checks are disabled below, so an
+	// entry that does not exist is a harmless no-op (DROP TABLE IF EXISTS).
 	orphanedTables := []string{
 		// Alert children first, then parent
 		"alert_actions",
 		"alert_conditions",
 		"alert_history",
+		"alert_histories",
 		"alert_rules",
 		// Detection children first, then parent
 		"detection_locks",
 		"detection_comments",
 		"detection_reviews",
+		"detection_model_contributions",
 		"detection_predictions",
 		"detections",
 		// Labels before its reference tables (labels has FKs to ai_models, label_types, taxonomic_classes)
@@ -868,29 +873,40 @@ func cleanupOrphanedBareV2Tables(db *gorm.DB, database string) {
 		"ai_models",
 		"taxonomic_classes",
 		"label_types",
+		// Application metadata and event log (no FK dependencies)
+		"app_events",
+		"app_metadata",
 		// Migration tracking
 		"migration_dirty_ids",
 		"migration_state",
+		"migration_states",
 	}
 
 	// Use db.Connection to pin all operations to a single pooled connection,
 	// ensuring SET FOREIGN_KEY_CHECKS applies to the same connection as the DROPs.
 	// FK checks must be disabled because preserved legacy tables (dynamic_thresholds,
 	// notification_histories, etc.) may have FK constraints pointing to orphaned tables.
-	if err := db.Connection(func(tx *gorm.DB) error {
+	if err := db.Connection(func(tx *gorm.DB) (retErr error) {
 		if err := tx.Exec("SET FOREIGN_KEY_CHECKS = 0").Error; err != nil {
 			reportStartupError("mysql", "cleanupOrphanedTables_disableFK", err, database)
 			return err
 		}
+		// Re-enable FK checks via defer so the pooled connection is never returned
+		// with referential integrity disabled, even if a DROP panics. On a clean run,
+		// surface a re-enable failure as the closure error (skipping the success
+		// telemetry below), preserving the original inline behavior.
+		defer func() {
+			if err := tx.Exec("SET FOREIGN_KEY_CHECKS = 1").Error; err != nil {
+				reportStartupError("mysql", "cleanupOrphanedTables_enableFK", err, database)
+				if retErr == nil {
+					retErr = err
+				}
+			}
+		}()
 		for _, table := range orphanedTables {
 			if err := tx.Exec(fmt.Sprintf("DROP TABLE IF EXISTS `%s`", table)).Error; err != nil {
 				reportStartupError("mysql", "cleanupOrphanedTable_"+table, err, database)
 			}
-		}
-
-		if err := tx.Exec("SET FOREIGN_KEY_CHECKS = 1").Error; err != nil {
-			reportStartupError("mysql", "cleanupOrphanedTables_enableFK", err, database)
-			return err
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
## Summary

Three small follow-ups from the gate review of #3576 (MySQL fresh v2 schema check).

### 1. `checkExistingV2Data` uses the manager's table prefix
`internal/api/v2/prerequisites.go` derived the migration-target detections table name by guessing `"v2_detections"` from the MySQL dialect flag. On a fresh-install MySQL deployment (no `v2_` prefix) that queried the wrong table, and the missing-table error was swallowed into a "no existing data" pass. It now uses `c.V2Manager.TablePrefix() + "detections"`, matching every other v2 consumer (`system.go`, `app.go`, `insights.go`, `support.go`, `v2only/datastore.go`). This was the last dialect-guess holdout for v2 table names. SQLite and mid-migration MySQL behavior is byte-identical; only fresh-install MySQL is corrected. The check is a non-blocking warning, so no migration gating changes.

### 2. `cleanupOrphanedBareV2Tables` hardening
`internal/datastore/v2/startup.go`:
- Re-enable `SET FOREIGN_KEY_CHECKS = 1` via a deferred named-return closure, so the pinned connection is never left with FK checks disabled if a `DROP` panics. Happy-path behavior (including surfacing a re-enable failure) is preserved.
- Complete the orphaned-table drop list: add the GORM-pluralized names (`migration_states`, `alert_histories`) that a post-PR-#2165 broken nightly would create, plus three v2-only tables it previously missed (`detection_model_contributions`, `app_events`, `app_metadata`), aligning it with the canonical drop list in `MySQLManager.Delete()`. Entries are `DROP TABLE IF EXISTS`, so absent names are harmless no-ops. This branch only runs when bare v2 tables coexist with a legacy `notes` table, never against a healthy install.

### 3. MySQL manager test config
`internal/datastore/v2/mysql_manager_test.go`: `getMySQLConfig` now defaults `UseV2Prefix=false` (fresh-install layout), and the two tests that assert the `v2_` prefixed schema (`TestMySQLManager_IsMySQL`, `TestMySQLManager_Initialize`) opt in explicitly. This fixes those tests failing when `MYSQL_TEST_*` is configured (they asserted the prefix while the config produced no prefix).

## Test Plan

- [x] New regression test `TestCheckExistingV2Data_UsesManagerTablePrefix` (SQLite-backed, runs in CI): asserts the check honors the manager prefix, including a guard that a bare `detections` table is NOT counted when the prefix is `v2_` (fails on the old code).
- [x] Verified the full `internal/datastore/v2` and `internal/api/v2` suites against a real MariaDB 11, including the previously-failing `TestMySQLManager_*` tests.
- [x] `golangci-lint run` clean (full project), `go build ./...` clean, `-race` suites green.

Follow-up to #3576.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database schema detection to correctly use configured table naming conventions during migration checks.

* **Chores**
  * Enhanced database cleanup to handle a broader set of orphaned table variants and improve foreign key constraint handling during setup.
  * Updated configuration defaults for MySQL schema initialization.

* **Tests**
  * Added test coverage for table prefix behavior in prerequisite checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->