### PR TITLE
test: fix remaining native Windows unit-test failures (cross-platform cleanup, batch 2)

### DIFF
--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1575,6 +1575,12 @@ func TestJobTypeStatistics(t *testing.T) {
 		MockAction: MockAction{
 			Description: "Retry Action",
 			ExecuteFunc: func(data any) error {
+				// Sleep longer than the system monotonic-clock granularity so the
+				// measured execution duration is reliably non-zero. Windows' clock
+				// resolution (~15ms) otherwise lets the start/end timestamp reads
+				// land in one tick, producing a 0 duration and a 0 MinDuration stat
+				// that fails the "duration should be positive" assertions below.
+				time.Sleep(25 * time.Millisecond)
 				// Increment counter and check
 				retryCounter++
 				// Fail on first attempt, succeed on retry

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1575,12 +1575,6 @@ func TestJobTypeStatistics(t *testing.T) {
 		MockAction: MockAction{
 			Description: "Retry Action",
 			ExecuteFunc: func(data any) error {
-				// Sleep longer than the system monotonic-clock granularity so the
-				// measured execution duration is reliably non-zero. Windows' clock
-				// resolution (~15ms) otherwise lets the start/end timestamp reads
-				// land in one tick, producing a 0 duration and a 0 MinDuration stat
-				// that fails the "duration should be positive" assertions below.
-				time.Sleep(25 * time.Millisecond)
 				// Increment counter and check
 				retryCounter++
 				// Fail on first attempt, succeed on retry
@@ -1664,10 +1658,18 @@ func TestJobTypeStatistics(t *testing.T) {
 	assert.Equal(t, 0, stats.ActionStats[retryType].Failed, "Retry action should have 0 failure")
 	assert.Equal(t, 1, stats.ActionStats[retryType].Retried, "Retry action should have 1 retry")
 	assert.False(t, stats.ActionStats[retryType].LastSuccessfulTime.IsZero(), "Last successful time should be set")
-	assert.Greater(t, stats.ActionStats[retryType].TotalDuration, time.Duration(0), "Total duration should be positive")
-	assert.Greater(t, stats.ActionStats[retryType].AverageDuration, time.Duration(0), "Average duration should be positive")
-	assert.Greater(t, stats.ActionStats[retryType].MinDuration, time.Duration(0), "Min duration should be positive")
-	assert.Greater(t, stats.ActionStats[retryType].MaxDuration, time.Duration(0), "Max duration should be positive")
+	// Windows' coarse monotonic clock (~15ms) can measure a fast action's
+	// execution as exactly 0, so per-action duration stats are not reliably
+	// positive there. Keep the positivity assertion on Linux/macOS, where the
+	// clock is fine-grained; the count/retry aggregation above is still checked
+	// on every platform. (Driving the action with a real sleep to force a
+	// non-zero span perturbs this timing-sensitive test's retry scheduling.)
+	if runtime.GOOS != "windows" {
+		assert.Greater(t, stats.ActionStats[retryType].TotalDuration, time.Duration(0), "Total duration should be positive")
+		assert.Greater(t, stats.ActionStats[retryType].AverageDuration, time.Duration(0), "Average duration should be positive")
+		assert.Greater(t, stats.ActionStats[retryType].MinDuration, time.Duration(0), "Min duration should be positive")
+		assert.Greater(t, stats.ActionStats[retryType].MaxDuration, time.Duration(0), "Max duration should be positive")
+	}
 
 	// Test JSON output
 	jsonStr, err := stats.ToJSON()

--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -197,7 +197,12 @@ func TestValidateCommandPath_PathTraversalCleaned(t *testing.T) {
 func TestValidateCommandPath_NonExistentFile(t *testing.T) {
 	t.Parallel()
 
-	_, err := validateCommandPath("/tmp/this_file_definitely_does_not_exist_12345.sh")
+	// Use an OS-absolute path so validateCommandPath reaches the os.Stat check on
+	// every platform: a Unix literal like "/tmp/..." is not absolute on Windows
+	// (filepath.IsAbs is false), so it short-circuits with CategoryValidation
+	// before the missing-file (CategoryFileIO) branch runs. t.TempDir() is
+	// absolute everywhere and the file inside it does not exist.
+	_, err := validateCommandPath(filepath.Join(t.TempDir(), "this_file_definitely_does_not_exist_12345.sh"))
 	require.Error(t, err)
 
 	// Regression: a missing file must produce a single enhanced error with

--- a/internal/analysis/realtime_shutdown_test.go
+++ b/internal/analysis/realtime_shutdown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
 	"testing"
@@ -130,6 +131,11 @@ func TestShutdownSequenceWithContext(t *testing.T) {
 
 // Helper function to test signal handling without actually sending signals to the process
 func TestSignalNotification(t *testing.T) {
+	// os.Process.Signal only supports os.Kill on Windows, so SIGINT cannot be
+	// delivered to self there to exercise signal.Notify delivery.
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot deliver SIGINT to self on Windows")
+	}
 	t.Run("signal channel receives notifications", func(t *testing.T) {
 		sigChan := make(chan os.Signal, 1)
 

--- a/internal/analysis/species/species_tracker_utility_test.go
+++ b/internal/analysis/species/species_tracker_utility_test.go
@@ -389,7 +389,12 @@ func TestCacheManagement_CriticalReliability(t *testing.T) {
 	tracker.ExpireCacheForTesting(species1)
 	cached, exists := tracker.statusCache[species1]
 	assert.True(t, exists, "Expired entry should still exist")
-	assert.Greater(t, time.Since(cached.timestamp), time.Hour,
+	// ExpireCacheForTesting sets the timestamp to exactly now-1h. On a coarse
+	// system clock (e.g. Windows' ~15ms timer) the time.Now() inside time.Since
+	// can equal the one used to stamp it, yielding exactly 1h rather than
+	// strictly greater. GreaterOrEqual still proves the entry is well past the
+	// 30s cache TTL, i.e. expired.
+	assert.GreaterOrEqual(t, time.Since(cached.timestamp), time.Hour,
 		"Cache timestamp should be expired")
 
 	// Test 4: ClearCacheForTesting

--- a/internal/api/v2/filesystem_test.go
+++ b/internal/api/v2/filesystem_test.go
@@ -588,7 +588,7 @@ func TestValidateSymlinkTarget(t *testing.T) {
 				// use a Windows-absolute target there to exercise the escaping-
 				// symlink rejection on every OS.
 				outside := "/etc"
-				if runtime.GOOS == "windows" {
+				if runtime.GOOS == OSWindows {
 					outside = `C:\Windows`
 				}
 				err := os.Symlink(outside, symlinkPath)

--- a/internal/api/v2/filesystem_test.go
+++ b/internal/api/v2/filesystem_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -581,7 +582,16 @@ func TestValidateSymlinkTarget(t *testing.T) {
 			name: "Invalid symlink to outside base",
 			setup: func() string {
 				symlinkPath := filepath.Join(tempDir, "escape_link")
-				err := os.Symlink("/etc", symlinkPath)
+				// An absolute path outside the sandbox base. "/etc" is absolute
+				// on Unix but drive-relative on Windows (filepath.IsAbs is false),
+				// where it would resolve inside the base and not be rejected, so
+				// use a Windows-absolute target there to exercise the escaping-
+				// symlink rejection on every OS.
+				outside := "/etc"
+				if runtime.GOOS == "windows" {
+					outside = `C:\Windows`
+				}
+				err := os.Symlink(outside, symlinkPath)
 				require.NoError(t, err)
 				return symlinkPath
 			},

--- a/internal/api/v2/filesystem_test.go
+++ b/internal/api/v2/filesystem_test.go
@@ -553,35 +553,43 @@ func TestValidateSymlinkTarget(t *testing.T) {
 	targetFile := filepath.Join(targetDir, "file.txt")
 	require.NoError(t, os.WriteFile(targetFile, []byte("target"), 0o600))
 
+	// symlinkOrSkip creates a symlink and skips the subtest if the OS denies it.
+	// Creating symlinks on Windows requires SeCreateSymbolicLinkPrivilege
+	// (admin or Developer Mode). CI runners have it, but a local developer may
+	// not, so skip rather than fail when creation is not permitted.
+	symlinkOrSkip := func(t *testing.T, target, link string) string {
+		t.Helper()
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("skipping: cannot create symlink (needs privilege/Developer Mode on Windows): %v", err)
+		}
+		return link
+	}
+
 	tests := []struct {
 		name        string
-		setup       func() string // Returns symlink path
+		setup       func(t *testing.T) string // Returns symlink path; may t.Skip if symlinks are unavailable
 		expectError bool
 	}{
 		{
 			name: "Valid symlink within base",
-			setup: func() string {
-				symlinkPath := filepath.Join(tempDir, "valid_link")
-				err := os.Symlink(targetDir, symlinkPath)
-				require.NoError(t, err)
-				return symlinkPath
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return symlinkOrSkip(t, targetDir, filepath.Join(tempDir, "valid_link"))
 			},
 			expectError: false,
 		},
 		{
 			name: "Valid relative symlink within base",
-			setup: func() string {
-				symlinkPath := filepath.Join(tempDir, "relative_link")
-				err := os.Symlink("target", symlinkPath)
-				require.NoError(t, err)
-				return symlinkPath
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return symlinkOrSkip(t, "target", filepath.Join(tempDir, "relative_link"))
 			},
 			expectError: false,
 		},
 		{
 			name: "Invalid symlink to outside base",
-			setup: func() string {
-				symlinkPath := filepath.Join(tempDir, "escape_link")
+			setup: func(t *testing.T) string {
+				t.Helper()
 				// An absolute path outside the sandbox base. "/etc" is absolute
 				// on Unix but drive-relative on Windows (filepath.IsAbs is false),
 				// where it would resolve inside the base and not be rejected, so
@@ -591,19 +599,15 @@ func TestValidateSymlinkTarget(t *testing.T) {
 				if runtime.GOOS == OSWindows {
 					outside = `C:\Windows`
 				}
-				err := os.Symlink(outside, symlinkPath)
-				require.NoError(t, err)
-				return symlinkPath
+				return symlinkOrSkip(t, outside, filepath.Join(tempDir, "escape_link"))
 			},
 			expectError: true,
 		},
 		{
 			name: "Invalid symlink with parent traversal",
-			setup: func() string {
-				symlinkPath := filepath.Join(tempDir, "traversal_link")
-				err := os.Symlink("../../../etc", symlinkPath)
-				require.NoError(t, err)
-				return symlinkPath
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return symlinkOrSkip(t, "../../../etc", filepath.Join(tempDir, "traversal_link"))
 			},
 			expectError: true,
 		},
@@ -612,7 +616,7 @@ func TestValidateSymlinkTarget(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Note: Not parallel because setup creates files in shared directory
-			symlinkPath := tc.setup()
+			symlinkPath := tc.setup(t)
 
 			err := controller.validateSymlinkTarget(symlinkPath)
 			if tc.expectError {

--- a/internal/api/v2/filesystem_test.go
+++ b/internal/api/v2/filesystem_test.go
@@ -560,7 +560,16 @@ func TestValidateSymlinkTarget(t *testing.T) {
 	symlinkOrSkip := func(t *testing.T, target, link string) string {
 		t.Helper()
 		if err := os.Symlink(target, link); err != nil {
-			t.Skipf("skipping: cannot create symlink (needs privilege/Developer Mode on Windows): %v", err)
+			// Without SeCreateSymbolicLinkPrivilege (admin or Developer Mode)
+			// os.Symlink fails on Windows with ERROR_PRIVILEGE_NOT_HELD. Gate the
+			// skip on GOOS, not errors.Is(err, os.ErrPermission): syscall.Errno.Is
+			// maps only ERROR_ACCESS_DENIED/EACCES/EPERM to os.ErrPermission, so
+			// it would NOT match ERROR_PRIVILEGE_NOT_HELD and the skip would never
+			// fire. On Unix a symlink failure is a genuine error and must fail.
+			if runtime.GOOS == OSWindows {
+				t.Skipf("skipping: cannot create symlink (needs privilege/Developer Mode on Windows): %v", err)
+			}
+			require.NoError(t, err)
 		}
 		return link
 	}

--- a/internal/api/v2/media_ffmpeg_optimization_test.go
+++ b/internal/api/v2/media_ffmpeg_optimization_test.go
@@ -20,6 +20,11 @@ func getSoxSpectrogramArgsHelper(t *testing.T, ctx context.Context, audioPath, o
 	tempDir := t.TempDir()
 	sfs, err := securefs.New(tempDir)
 	require.NoError(t, err, "Failed to create SecureFS")
+	// securefs.New holds an open os.Root handle on tempDir. On Windows that
+	// handle blocks t.TempDir()'s RemoveAll cleanup ("being used by another
+	// process"), which fails the test even though its assertions passed. Close
+	// it before the TempDir teardown (t.Cleanup is LIFO).
+	t.Cleanup(func() { _ = sfs.Close() })
 	gen := spectrogram.NewGenerator(settings, sfs, logger.Global().Module("spectrogram.test"))
 	return gen.GetSoxSpectrogramArgsForTest(ctx, audioPath, outputPath, width, raw)
 }
@@ -30,6 +35,9 @@ func getSoxSpectrogramArgsBenchHelper(b *testing.B, ctx context.Context, audioPa
 	tempDir := b.TempDir()
 	sfs, err := securefs.New(tempDir)
 	require.NoError(b, err, "Failed to create SecureFS")
+	// Release the os.Root handle before b.TempDir() cleanup (see the test helper
+	// above for the Windows rationale).
+	b.Cleanup(func() { _ = sfs.Close() })
 	gen := spectrogram.NewGenerator(settings, sfs, logger.Global().Module("spectrogram.test"))
 	return gen.GetSoxSpectrogramArgsForTest(ctx, audioPath, outputPath, width, raw)
 }

--- a/internal/api/v2/test_utils_test.go
+++ b/internal/api/v2/test_utils_test.go
@@ -181,6 +181,14 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 	if err != nil {
 		t.Fatalf("Failed to create test API controller: %v", err)
 	}
+	// Handler tests assert on in-memory settings and the HTTP response, not on
+	// disk persistence. Disable disk saves so settings-mutating handlers (e.g.
+	// IgnoreSpecies -> toggleSpeciesInIgnoredList -> conf.SaveSettings) do not
+	// write to the real default config path. On Windows that write fails (the
+	// default config directory is not provisioned in the test environment),
+	// surfacing as a 500; on Linux it silently pollutes the machine's config.
+	// All dedicated settings tests already set this flag.
+	controller.DisableSaveSettings = true
 
 	// Register cleanup to stop background goroutines
 	t.Cleanup(func() {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"sync"
 	"syscall"
 	"testing"
@@ -260,6 +261,12 @@ func TestApp_ShutdownContinuesOnError(t *testing.T) {
 
 func TestApp_Wait_ShutdownOnSignal(t *testing.T) {
 	t.Parallel()
+	// os.Process.Signal only supports os.Kill on Windows, so SIGINT cannot be
+	// delivered to self there. The no-signal teardown path through Wait() is
+	// covered cross-platform by TestRequestShutdownUnblocksWait.
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot deliver SIGINT to self on Windows")
+	}
 	var order []string
 	var mu sync.Mutex
 

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -225,15 +225,18 @@ func New(settings *conf.Settings) (*BwClient, error) {
 func (b *BwClient) RandomizeLocation(radiusMeters float64) (latitude, longitude float64) {
 	log := GetLogger()
 
-	// Create a new local random generator seeded with current Unix time
-	rnd := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()))) //nolint:gosec // G404: weak randomness acceptable for upload retry jitter, not security-critical
-
 	// Calculate the degree offset using metersPerDegree approximation
 	degreeOffset := radiusMeters / metersPerDegree
 
-	// Generate random offsets within +/- degreeOffset
-	latOffset := (rnd.Float64() - randomCenterOffset) * randomOffsetMultiplier * degreeOffset
-	lonOffset := (rnd.Float64() - randomCenterOffset) * randomOffsetMultiplier * degreeOffset
+	// Generate random offsets within +/- degreeOffset. Use the top-level
+	// math/rand/v2 generator (auto-seeded at startup, goroutine-safe) instead of
+	// seeding a fresh PCG from time.Now() on every call: successive calls within
+	// the same clock tick (coarse on Windows, ~15ms) would seed identically and
+	// produce the same "random" offset, defeating the location-fuzzing privacy
+	// guarantee. math/rand/v2 is not crypto-secure, which is fine for privacy
+	// fuzzing of an already-approximate coordinate.
+	latOffset := (rand.Float64() - randomCenterOffset) * randomOffsetMultiplier * degreeOffset
+	lonOffset := (rand.Float64() - randomCenterOffset) * randomOffsetMultiplier * degreeOffset
 
 	// Apply the offsets to the original coordinates and truncate to 4 decimal places
 	latitude = math.Floor((b.Latitude+latOffset)*coordinatePrecisionFactor) / coordinatePrecisionFactor

--- a/internal/conf/env_test.go
+++ b/internal/conf/env_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -549,7 +550,15 @@ func TestValidateEnvRangeFilterThreshold(t *testing.T) {
 }
 
 func TestValueCanonicalization(t *testing.T) {
-	// Test that values are canonicalized to correct types after validation
+	// Test that values are canonicalized to correct types after validation.
+	// Model paths must be absolute; "/path/to/model" is absolute on Unix but not
+	// on Windows (filepath.IsAbs wants a drive), so use a platform-absolute path
+	// there. canonicalizeValue only trims the model path, so the expected value
+	// is just the trimmed input on either OS.
+	modelPathRaw, modelPathWant := " /path/to/model ", "/path/to/model"
+	if runtime.GOOS == "windows" {
+		modelPathRaw, modelPathWant = ` C:\path\to\model `, `C:\path\to\model`
+	}
 	tests := []struct {
 		name          string
 		envVar        string
@@ -579,7 +588,7 @@ func TestValueCanonicalization(t *testing.T) {
 		// String canonicalization
 		{"locale lowercase", "BIRDNET_LOCALE", "EN-US", "birdnet.locale", typeString, "en-us"},
 		{"locale with spaces", "BIRDNET_LOCALE", " de-DE ", "birdnet.locale", typeString, "de-de"},
-		{"model path trimmed", "BIRDNET_MODELPATH", " /path/to/model ", "birdnet.modelpath", typeString, "/path/to/model"},
+		{"model path trimmed", "BIRDNET_MODELPATH", modelPathRaw, "birdnet.modelpath", typeString, modelPathWant},
 		{"range filter model", "BIRDNET_RANGEFILTER_MODEL", " latest ", "birdnet.rangefilter.model", typeString, "latest"},
 	}
 

--- a/internal/conf/env_test.go
+++ b/internal/conf/env_test.go
@@ -556,7 +556,7 @@ func TestValueCanonicalization(t *testing.T) {
 	// there. canonicalizeValue only trims the model path, so the expected value
 	// is just the trimmed input on either OS.
 	modelPathRaw, modelPathWant := " /path/to/model ", "/path/to/model"
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		modelPathRaw, modelPathWant = ` C:\path\to\model `, `C:\path\to\model`
 	}
 	tests := []struct {

--- a/internal/conf/tls_test.go
+++ b/internal/conf/tls_test.go
@@ -79,7 +79,7 @@ func verifyCertificatePermissions(t *testing.T, path string, expectedPerm os.Fil
 	// call. Production still requests 0600/0644/0700; the bits just are not
 	// observable on NTFS. Skip only the perm comparison there so the rest of the
 	// save/retrieve flow stays exercised.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return
 	}
 	assert.Equal(t, expectedPerm, info.Mode().Perm(), "File has wrong permissions")

--- a/internal/conf/tls_test.go
+++ b/internal/conf/tls_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -73,6 +74,14 @@ func verifyCertificatePermissions(t *testing.T, path string, expectedPerm os.Fil
 	t.Helper()
 	info, err := os.Stat(path)
 	require.NoError(t, err, "Failed to stat file")
+	// Windows does not represent Unix permission bits: os.Stat reports 0666 for
+	// files and 0777 for directories regardless of the mode passed to the create
+	// call. Production still requests 0600/0644/0700; the bits just are not
+	// observable on NTFS. Skip only the perm comparison there so the rest of the
+	// save/retrieve flow stays exercised.
+	if runtime.GOOS == "windows" {
+		return
+	}
 	assert.Equal(t, expectedPerm, info.Mode().Perm(), "File has wrong permissions")
 }
 

--- a/internal/conf/validate_hardening_test.go
+++ b/internal/conf/validate_hardening_test.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"math"
+	"runtime"
 	"testing"
 	"time"
 
@@ -101,6 +102,15 @@ func TestValidateSettings_MainNameSanitized(t *testing.T) {
 
 func TestValidateExportPath(t *testing.T) {
 	t.Parallel()
+	// "absolute" is OS-specific: "/var/data/clips" is absolute on Unix but
+	// relative on Windows (filepath.IsAbs wants a drive), where validateExportPath
+	// would route it through the IsLocal branch and reject it. Use platform-
+	// absolute paths so the "absolute path allowed" cases exercise the
+	// absolute-path branch on every OS.
+	absPath, absDockerPath := "/var/data/clips", "/data/clips/"
+	if runtime.GOOS == "windows" {
+		absPath, absDockerPath = `C:\var\data\clips`, `C:\data\clips\`
+	}
 	tests := []struct {
 		name    string
 		path    string
@@ -113,8 +123,8 @@ func TestValidateExportPath(t *testing.T) {
 		{"parent traversal rejected", "../../../etc/passwd", true, "path traversal"},
 		{"hidden traversal rejected", "foo/../../../etc/passwd", true, "path traversal"},
 		{"double dot in middle rejected", "data/../secret", true, "path traversal"},
-		{"absolute path allowed", "/var/data/clips", false, ""},
-		{"absolute docker path allowed", "/data/clips/", false, ""},
+		{"absolute path allowed", absPath, false, ""},
+		{"absolute docker path allowed", absDockerPath, false, ""},
 		{"absolute path with traversal rejected", "/var/data/../etc/passwd", true, "path traversal"},
 		{"null byte rejected", "clips\x00/etc/passwd", true, "null bytes"},
 		{"windows-style path treated as relative on unix", "C:\\data\\clips", false, ""},

--- a/internal/conf/validate_hardening_test.go
+++ b/internal/conf/validate_hardening_test.go
@@ -108,7 +108,7 @@ func TestValidateExportPath(t *testing.T) {
 	// absolute paths so the "absolute path allowed" cases exercise the
 	// absolute-path branch on every OS.
 	absPath, absDockerPath := "/var/data/clips", "/data/clips/"
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		absPath, absDockerPath = `C:\var\data\clips`, `C:\data\clips\`
 	}
 	tests := []struct {

--- a/internal/datastore/sqlite_security_test.go
+++ b/internal/datastore/sqlite_security_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,8 +42,14 @@ func TestCreateBackup_FilePermissions(t *testing.T) {
 
 	info, err := os.Stat(backupPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
-		"backup file should have 0600 permissions")
+	// Windows does not represent Unix permission bits: os.Stat reports 0666 for
+	// regular files regardless of the mode passed to OpenFile. The backup is
+	// still created with 0o600 in production; the bits just are not observable
+	// here. Skip the perm assertion on Windows; the rest of the test still runs.
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+			"backup file should have 0600 permissions")
+	}
 }
 
 func TestCheckWritePermission_NoSymlinkFollow(t *testing.T) {
@@ -79,6 +86,12 @@ func TestCheckWritePermission_CleansUpTempFile(t *testing.T) {
 
 func TestCheckWritePermission_FailsOnReadOnlyDir(t *testing.T) {
 	t.Parallel()
+	// chmod cannot make a directory unwritable for its owner on Windows, so
+	// the write-permission probe still succeeds and no error is returned. The
+	// scenario this test asserts is only reproducible on Unix.
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod cannot make a directory unwritable for the owner on Windows")
+	}
 	tmpDir := t.TempDir()
 
 	// Make directory read-only

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -260,19 +260,22 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 	// Create a temporary directory
 	tempDir := t.TempDir()
 
-	// Create a mix of valid and invalid files
+	// Create a mix of valid and invalid files. Build paths with filepath.Join so
+	// the keys match GetAudioFiles' filepath.Walk output, which uses the OS
+	// separator (backslashes on Windows); plain "tempDir + \"/...\"" would not
+	// match the processed paths there.
 	validFiles := []string{
-		tempDir + "/bubo_bubo_80p_20210102T150405Z.wav",
-		tempDir + "/anas_platyrhynchos_70p_20210103T150405Z.mp3",
-		tempDir + "/erithacus_rubecula_60p_20210104T150405Z.flac",
-		tempDir + "/turdus_migratorius_94p_20210105T150405Z_86s.m4a",  // with duration suffix
-		tempDir + "/cyanocitta_cristata_89p_20210106T150405Z_38s.wav", // with duration suffix
+		filepath.Join(tempDir, "bubo_bubo_80p_20210102T150405Z.wav"),
+		filepath.Join(tempDir, "anas_platyrhynchos_70p_20210103T150405Z.mp3"),
+		filepath.Join(tempDir, "erithacus_rubecula_60p_20210104T150405Z.flac"),
+		filepath.Join(tempDir, "turdus_migratorius_94p_20210105T150405Z_86s.m4a"),  // with duration suffix
+		filepath.Join(tempDir, "cyanocitta_cristata_89p_20210106T150405Z_38s.wav"), // with duration suffix
 	}
 
 	invalidFiles := []string{
-		tempDir + "/invalid_file.wav",                   // Invalid format
-		tempDir + "/bubo_bubo_XXp_20210102T150405Z.wav", // Invalid confidence
-		tempDir + "/bubo_bubo_80p_invalid.wav",          // Invalid timestamp
+		filepath.Join(tempDir, "invalid_file.wav"),                   // Invalid format
+		filepath.Join(tempDir, "bubo_bubo_XXp_20210102T150405Z.wav"), // Invalid confidence
+		filepath.Join(tempDir, "bubo_bubo_80p_invalid.wav"),          // Invalid timestamp
 	}
 
 	// Create all the files

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -276,9 +276,13 @@ func TestSortFiles(t *testing.T) {
 	assert.Equal(t, "bubo_bubo", files[1].Species, "Bubo bubo (oldest) should be second")
 	assert.Equal(t, "bubo_bubo", files[2].Species, "Bubo bubo (newest) should be third")
 
-	// Verify the count map is correct
-	assert.Equal(t, 1, speciesCount["anas_platyrhynchos"]["/base/dir1"])
-	assert.Equal(t, 2, speciesCount["bubo_bubo"]["/base/dir1"])
+	// Verify the count map is correct. buildSpeciesSubDirCountMap keys by
+	// filepath.Dir(file.Path), which uses the OS separator (backslashes on
+	// Windows), so derive the expected sub-directory key the same way rather
+	// than hardcoding a forward-slash literal.
+	subDir := filepath.Dir(files[0].Path)
+	assert.Equal(t, 1, speciesCount["anas_platyrhynchos"][subDir])
+	assert.Equal(t, 2, speciesCount["bubo_bubo"][subDir])
 }
 
 // ----- Tests for Usage-Based Cleanup -----

--- a/internal/events/deduplicator.go
+++ b/internal/events/deduplicator.go
@@ -38,6 +38,7 @@ type ErrorDeduplicator struct {
 	// LRU tracking
 	entries  []*lruEntry
 	entryMap map[uint64]int // Maps hash to index in entries slice
+	lruSeq   uint64         // Monotonic access counter; breaks lastUsed ties (all mutated under mu)
 
 	// Metrics
 	totalSeen       atomic.Uint64
@@ -64,6 +65,11 @@ type dedupeEntry struct {
 type lruEntry struct {
 	hash     uint64
 	lastUsed time.Time
+	// seq is a monotonic access stamp used to break lastUsed ties. Coarse system
+	// clocks (e.g. Windows' ~15ms timer) can give several entries the same
+	// lastUsed within one tick, leaving eviction order undefined; the larger seq
+	// is the more recently used entry.
+	seq uint64
 }
 
 // NewErrorDeduplicator creates a new error deduplicator
@@ -137,9 +143,11 @@ func (ed *ErrorDeduplicator) ShouldProcess(event ErrorEvent) bool {
 		ed.cache[hash] = entry
 
 		// Add to LRU tracking
+		ed.lruSeq++
 		lru := &lruEntry{
 			hash:     hash,
 			lastUsed: now,
+			seq:      ed.lruSeq,
 		}
 		ed.entries = append(ed.entries, lru)
 		ed.entryMap[hash] = len(ed.entries) - 1
@@ -226,7 +234,9 @@ func (ed *ErrorDeduplicator) calculateHash(event ErrorEvent) uint64 {
 // updateLRU updates the LRU position of an entry
 func (ed *ErrorDeduplicator) updateLRU(hash uint64, now time.Time) {
 	if idx, ok := ed.entryMap[hash]; ok {
+		ed.lruSeq++
 		ed.entries[idx].lastUsed = now
+		ed.entries[idx].seq = ed.lruSeq
 	}
 }
 
@@ -236,14 +246,20 @@ func (ed *ErrorDeduplicator) evictOldest() {
 		return
 	}
 
-	// Find oldest entry
+	// Find oldest entry. Primary key is lastUsed; seq breaks ties when several
+	// entries share a coarse-clock timestamp (the smaller seq is the least
+	// recently used). On platforms with a fine clock the tie branch is unused
+	// and behavior is identical to comparing lastUsed alone.
 	oldestIdx := 0
 	oldestTime := ed.entries[0].lastUsed
+	oldestSeq := ed.entries[0].seq
 
 	for i := 1; i < len(ed.entries); i++ {
-		if ed.entries[i].lastUsed.Before(oldestTime) {
+		e := ed.entries[i]
+		if e.lastUsed.Before(oldestTime) || (e.lastUsed.Equal(oldestTime) && e.seq < oldestSeq) {
 			oldestIdx = i
-			oldestTime = ed.entries[i].lastUsed
+			oldestTime = e.lastUsed
+			oldestSeq = e.seq
 		}
 	}
 

--- a/internal/events/deduplicator.go
+++ b/internal/events/deduplicator.go
@@ -247,9 +247,11 @@ func (ed *ErrorDeduplicator) evictOldest() {
 	}
 
 	// Find oldest entry. Primary key is lastUsed; seq breaks ties when several
-	// entries share a coarse-clock timestamp (the smaller seq is the least
-	// recently used). On platforms with a fine clock the tie branch is unused
-	// and behavior is identical to comparing lastUsed alone.
+	// entries share an identical timestamp (the smaller seq is the least
+	// recently used). Ties are the norm on coarse clocks (Windows ~15ms) and
+	// rare but possible on a fine clock (two touches in the same nanosecond);
+	// whenever the tie branch fires it evicts the genuine LRU, which matches or
+	// improves the old lastUsed-only result, so it is never a regression.
 	oldestIdx := 0
 	oldestTime := ed.entries[0].lastUsed
 	oldestSeq := ed.entries[0].seq

--- a/internal/monitor/critical_paths_test.go
+++ b/internal/monitor/critical_paths_test.go
@@ -3,12 +3,25 @@ package monitor
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
+
+// skipWindowsUnixPaths skips a test on Windows. The critical-path helpers
+// normalize paths with filepath.Clean/Abs, which rewrites Unix literals like
+// "/" and "/var/..." to OS-native form (e.g. "D:\") on Windows, so the tests'
+// hardcoded forward-slash expectations cannot match. The production code itself
+// is cross-platform and is exercised on Windows by system_monitor_test.go.
+func skipWindowsUnixPaths(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("asserts Unix path semantics; paths are normalized to OS-native form on Windows")
+	}
+}
 
 // Test constants for path testing.
 const (
@@ -18,6 +31,7 @@ const (
 
 func TestGetCriticalPaths(t *testing.T) {
 	t.Parallel()
+	skipWindowsUnixPaths(t)
 
 	tests := []struct {
 		name         string
@@ -161,6 +175,7 @@ func TestDeduplicatePaths(t *testing.T) {
 
 func TestMergePaths(t *testing.T) {
 	t.Parallel()
+	skipWindowsUnixPaths(t)
 
 	configured := []string{"/custom", "/data"}
 	critical := []string{"/", "/data", "/config"}
@@ -179,6 +194,7 @@ func TestMergePaths(t *testing.T) {
 
 func TestSystemMonitorIntegration(t *testing.T) {
 	t.Parallel()
+	skipWindowsUnixPaths(t)
 
 	// Create a test configuration
 	config := &conf.Settings{}
@@ -213,6 +229,7 @@ func TestSystemMonitorIntegration(t *testing.T) {
 
 func TestGetMonitoringPathsInfo(t *testing.T) {
 	t.Parallel()
+	skipWindowsUnixPaths(t)
 
 	settings := &conf.Settings{}
 	settings.Realtime.Monitoring.Disk.Paths = []string{"/custom", "/data"}

--- a/internal/monitor/mount_resolver_test.go
+++ b/internal/monitor/mount_resolver_test.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -120,6 +121,13 @@ func TestResolveMountPointFromPartitionsNoMatch(t *testing.T) {
 
 func TestGroupPathsByMountPoint(t *testing.T) {
 	t.Parallel()
+	// Uses real Unix filesystem paths ("/", "/tmp") and asserts both survive
+	// mount-point grouping. On Windows neither is a valid path, so one is
+	// dropped and the count assertion fails. The grouping logic is covered
+	// cross-platform by the mock-partition tests in this file.
+	if runtime.GOOS == "windows" {
+		t.Skip("uses real Unix filesystem paths not present on Windows")
+	}
 
 	// Test with real filesystem - paths that exist
 	paths := []string{"/", "/tmp"}

--- a/internal/notification/detection_consumer_test.go
+++ b/internal/notification/detection_consumer_test.go
@@ -147,14 +147,6 @@ func TestDetectionNotificationConsumer_PreSanitizedLocations(t *testing.T) {
 		RateLimitWindow:    1 * time.Minute,
 		RateLimitMaxEvents: 100,
 	}
-	service := NewService(config)
-	require.NotNil(t, service)
-	defer service.Stop()
-
-	// Create detection consumer
-	consumer := NewDetectionNotificationConsumer(service)
-	require.NotNil(t, consumer)
-
 	// Test cases for pre-sanitized locations from audio source registry
 	// In the new architecture, detection events already contain sanitized display names
 	testCases := []struct {
@@ -191,6 +183,19 @@ func TestDetectionNotificationConsumer_PreSanitizedLocations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Use a fresh service per case so the List below returns only this
+			// case's notification. The cases otherwise share one service and
+			// List(Limit:1) would rely on timestamp ordering to pick "the latest";
+			// on a coarse clock (Windows ~15ms) several cases get the same
+			// timestamp and the unstable sort returns an arbitrary one, picking a
+			// prior case's notification.
+			service := NewService(config)
+			require.NotNil(t, service)
+			t.Cleanup(service.Stop)
+
+			consumer := NewDetectionNotificationConsumer(service)
+			require.NotNil(t, consumer)
+
 			// Create a new species detection event with pre-sanitized location
 			// This simulates how the real system works: detection events contain
 			// already-sanitized display names from the audio source registry

--- a/internal/securefs/securefs_test.go
+++ b/internal/securefs/securefs_test.go
@@ -34,6 +34,15 @@ func setupSecureFS(t *testing.T) (sfs *SecureFS, tempDir string) {
 	sfs, err = New(tempDir)
 	require.NoError(t, err, "Failed to create SecureFS")
 
+	// Close the os.Root handle when the test ends. Several callers discard the
+	// returned *SecureFS (e.g. `_, tempDir := setupSecureFS(t)`), so without this
+	// the open directory handle leaks and intermittently blocks t.TempDir's
+	// RemoveAll on Windows ("being used by another process"). Callers that also
+	// register their own sfs.Close cleanup are fine: Close ignores a second call
+	// (os.Root.Close returns an ignored error, no panic). t.Cleanup is LIFO, so
+	// this runs before the TempDir teardown registered by t.TempDir above.
+	t.Cleanup(func() { _ = sfs.Close() })
+
 	return sfs, tempDir
 }
 

--- a/internal/securefs/securefs_test.go
+++ b/internal/securefs/securefs_test.go
@@ -311,6 +311,12 @@ func setupSymlinkTest(t *testing.T, tempDir string) (outsideDir, symlinkPath str
 		t.Skip("Skipping symlink test due to permission issues")
 		return "", ""
 	}
+	// Remove the directory symlink before t.TempDir()'s RemoveAll runs. On
+	// Windows a leftover directory reparse point makes the parent TempDir
+	// cleanup fail with "being used by another process", which fails the test.
+	// t.Cleanup is LIFO, so this runs before the TempDir teardown registered
+	// earlier by setupSecureFS.
+	t.Cleanup(func() { _ = os.Remove(symlinkPath) })
 
 	return outsideDir, symlinkPath
 }
@@ -369,7 +375,9 @@ func TestReadlinkReturnsTargetString(t *testing.T) {
 
 	target, err := sfs.Readlink(absSymlink)
 	require.NoError(t, err, "Readlink should return target string")
-	assert.Equal(t, "/etc/passwd", target)
+	// Readlink returns the OS-native target; Windows uses backslashes. Normalize
+	// to forward slashes so the comparison checks the path, not the separator.
+	assert.Equal(t, "/etc/passwd", filepath.ToSlash(target))
 
 	// Test 2: Symlink with relative escaping target - Readlink should return the target string
 	relEscapeSymlink := filepath.Join(tempDir, "rel_escape.txt")
@@ -378,7 +386,7 @@ func TestReadlinkReturnsTargetString(t *testing.T) {
 
 	target, err = sfs.Readlink(relEscapeSymlink)
 	require.NoError(t, err, "Readlink should return target string")
-	assert.Equal(t, "../../etc/passwd", target)
+	assert.Equal(t, "../../etc/passwd", filepath.ToSlash(target))
 }
 
 // TestReadDir verifies the ReadDir function
@@ -542,7 +550,7 @@ func TestFollowingEscapingSymlinkFails(t *testing.T) {
 	// Readlink should succeed (returns the target string)
 	target, err := sfs.Readlink(symlinkPath)
 	require.NoError(t, err, "Readlink failed")
-	assert.Equal(t, "../../etc/passwd", target)
+	assert.Equal(t, "../../etc/passwd", filepath.ToSlash(target))
 
 	// But trying to Open the symlink should fail because it escapes the sandbox
 	// The security is enforced when following the link, not when reading its target

--- a/internal/security/persistence_test.go
+++ b/internal/security/persistence_test.go
@@ -19,6 +19,10 @@ import (
 // Shared context for tests in this file
 var ctx = context.Background()
 
+// osWindows is the runtime.GOOS value for Windows, used to guard assertions
+// that rely on Unix file-permission or read-only-directory semantics.
+const osWindows = "windows"
+
 // TestTokenPersistence tests saving and loading of access tokens
 func TestTokenPersistence(t *testing.T) {
 	// Create a temporary directory for testing
@@ -81,7 +85,7 @@ func TestTokenPersistence(t *testing.T) {
 	// Windows reports 0666 for regular files regardless of the mode saveTokens
 	// requests; the 0600 bits are not observable on NTFS. Skip only the perm
 	// comparison there.
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != osWindows {
 		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "Tokens file should have 0600 permissions")
 	}
 }
@@ -126,7 +130,7 @@ func TestFilesystemStore(t *testing.T) {
 	// Windows reports 0777 for directories regardless of the mode requested; the
 	// DirPermissions bits are not observable on NTFS. Skip only the perm
 	// comparison there.
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != osWindows {
 		assert.Equal(t, os.FileMode(DirPermissions), info.Mode().Perm(), "Sessions directory should have secure permissions")
 	}
 }
@@ -248,7 +252,7 @@ func TestUnwritableTokensDirectory(t *testing.T) {
 	// there, so saveTokens succeeds and no error is returned. (The previous
 	// guard used os.Getenv("GOOS"), which is always empty because GOOS is a
 	// build constant, not an environment variable, so the skip never fired.)
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		t.Skip("Skipping on Windows as permission handling is different")
 	}
 

--- a/internal/security/persistence_test.go
+++ b/internal/security/persistence_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -77,7 +78,12 @@ func TestTokenPersistence(t *testing.T) {
 	// Verify file permissions
 	info, err := os.Stat(filepath.Join(tempDir, "tokens.json"))
 	require.NoError(t, err, "Failed to stat tokens file")
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "Tokens file should have 0600 permissions")
+	// Windows reports 0666 for regular files regardless of the mode saveTokens
+	// requests; the 0600 bits are not observable on NTFS. Skip only the perm
+	// comparison there.
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "Tokens file should have 0600 permissions")
+	}
 }
 
 // TestFilesystemStore tests that the FilesystemStore is initialized correctly
@@ -117,7 +123,12 @@ func TestFilesystemStore(t *testing.T) {
 	info, err := os.Stat(sessionsDir)
 	require.NoError(t, err, "Failed to stat sessions directory")
 	assert.True(t, info.IsDir(), "Sessions path should be a directory")
-	assert.Equal(t, os.FileMode(DirPermissions), info.Mode().Perm(), "Sessions directory should have secure permissions")
+	// Windows reports 0777 for directories regardless of the mode requested; the
+	// DirPermissions bits are not observable on NTFS. Skip only the perm
+	// comparison there.
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(DirPermissions), info.Mode().Perm(), "Sessions directory should have secure permissions")
+	}
 }
 
 // TestLocalNetworkCookieStore tests configuring cookie store for local network access
@@ -233,8 +244,11 @@ func TestLoadCorruptedTokensFile(t *testing.T) {
 
 // Let's also add a test for unwritable directories
 func TestUnwritableTokensDirectory(t *testing.T) {
-	// Skip on Windows as permission handling differs
-	if os.Getenv("GOOS") == "windows" {
+	// Skip on Windows: chmod cannot make a directory unwritable for its owner
+	// there, so saveTokens succeeds and no error is returned. (The previous
+	// guard used os.Getenv("GOOS"), which is always empty because GOOS is a
+	// build constant, not an environment variable, so the skip never fired.)
+	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows as permission handling is different")
 	}
 

--- a/internal/support/collector_test.go
+++ b/internal/support/collector_test.go
@@ -147,11 +147,13 @@ func TestCollector_getLogSearchPaths(t *testing.T) {
 
 	paths := c.getLogSearchPaths()
 
-	// Should have at least the base paths
+	// Should have at least the base paths. getLogSearchPaths builds entries with
+	// filepath.Join, which uses the OS separator (backslashes on Windows), so
+	// build the expected values the same way to compare structure, not separator.
 	expectedPaths := []string{
 		"logs",
-		"/var/lib/birdnet/logs",
-		"/etc/birdnet/logs",
+		filepath.Join("/var/lib/birdnet", "logs"),
+		filepath.Join("/etc/birdnet", "logs"),
 	}
 
 	assert.GreaterOrEqual(t, len(paths), len(expectedPaths), "Expected at least %d paths", len(expectedPaths))

--- a/internal/support/collector_test.go
+++ b/internal/support/collector_test.go
@@ -148,12 +148,13 @@ func TestCollector_getLogSearchPaths(t *testing.T) {
 	paths := c.getLogSearchPaths()
 
 	// Should have at least the base paths. getLogSearchPaths builds entries with
-	// filepath.Join, which uses the OS separator (backslashes on Windows), so
-	// build the expected values the same way to compare structure, not separator.
+	// filepath.Join, which uses the OS separator (backslashes on Windows).
+	// filepath.FromSlash converts these forward-slash literals to the same
+	// OS-native form so the comparison checks structure, not separator.
 	expectedPaths := []string{
 		"logs",
-		filepath.Join("/var/lib/birdnet", "logs"),
-		filepath.Join("/etc/birdnet", "logs"),
+		filepath.FromSlash("/var/lib/birdnet/logs"),
+		filepath.FromSlash("/etc/birdnet/logs"),
 	}
 
 	assert.GreaterOrEqual(t, len(paths), len(expectedPaths), "Expected at least %d paths", len(expectedPaths))


### PR DESCRIPTION
## Summary

This is batch 2 of the native Windows unit-test cleanup (batch 1 was #3554). The `unit-tests (windows-amd64)` job is non-blocking (`continue-on-error: true`) but had a backlog of platform-specific failures. This PR takes the job from **64 failing tests to 0**, verified against the run's uploaded `gotest.log` (the green check alone is not proof, since the job is `continue-on-error`; the actual test step now passes with 0 failures).

Almost everything here is test-only: the tests made Unix assumptions that do not hold on the native Windows runner. Two small production fixes are included where the failure exposed a genuine cross-platform defect. No Linux or macOS behavior changes.

## What was failing and why

| Cluster | Tests | Root cause | Fix |
|---|---|---|---|
| File-mode / read-only | conf TLS, datastore, security (8) | Windows reports 0666/0777 regardless of `chmod`, and `chmod` cannot make a dir unwritable for its owner | guard the OS-specific assertions with `runtime.GOOS` (Linux still asserts the real mode) |
| Path separators / absolute paths | conf, processor, support, diskmanager (10) | tests hardcoded Unix `/` literals or built keys with string concat; production uses `filepath` (backslashes on Windows); `/foo` is not absolute on Windows | `filepath.Join`/`ToSlash`/`FromSlash` and OS-conditional absolute paths |
| Disk/mount monitoring | monitor (5) | tests assert Unix path/mount-layout semantics; the production monitor is cross-platform and passes on Windows | skip only the Unix-specific tests (the 12+ mock-partition tests keep running on Windows) |
| Symlinks | securefs, api/v2 (4) | `os.Symlink` succeeds on the runner; failures were a separator mismatch and a directory-reparse-point handle blocking `TempDir` cleanup | `filepath.ToSlash`, a `t.Cleanup` to remove the dir symlink, an OS-absolute "outside base" target |
| OS signals | analysis, app (2) | `os.Process.Signal` supports only `os.Kill` on Windows, so SIGINT-to-self is unsupported | skip on Windows (the no-signal teardown path stays covered by a sibling test) |
| Timer granularity | jobqueue, species, events (3) | Windows' ~15ms monotonic clock collapses fast operations to a 0 duration / tied timestamps | a `GreaterOrEqual` bound, a `runtime.GOOS` guard on duration-positivity, and a deterministic LRU tiebreaker (below) |
| api/v2 species exclusion 500s | TestIgnoreSpecies, TestGetExcludedSpecies, TestIgnoreSpeciesConcurrency | the test helper let the toggle run a real `conf.SaveSettings()`; on a clean Windows runner no default config exists so the save fails (500). The handlers assert in-memory state, not disk persistence | set `DisableSaveSettings = true` in the shared helper (matches every other settings test; also stops Linux config pollution) |
| SoX spectrogram args | TestGetSoxSpectrogramArgs_* | a leaked `securefs` `os.Root` handle blocked `TempDir` cleanup on Windows (assertions passed) | close the handle via `t.Cleanup`/`b.Cleanup` |
| securefs path-within-base | TestIsPathWithinBaseValid and siblings | `setupSecureFS` returned the `*SecureFS` and four tests discarded it (`_, tempDir := ...`), leaking the `os.Root` handle; it intermittently blocked Windows `TempDir` cleanup (passed only when GC finalized the fd first) | make `setupSecureFS` own the `Close` cleanup so every caller is covered |

## Production changes (2)

Both are safe cross-platform improvements, not behavior changes for existing users:

1. **`internal/birdweather/birdweather_client.go`** - `RandomizeLocation` re-seeded a PCG generator from `time.Now().UnixNano()` on every call. Rapid successive calls within one clock tick (coarse on Windows) seeded identically and produced identical "random" offsets, defeating the location-fuzzing privacy guarantee on every platform. Now uses the top-level `math/rand/v2` generator (auto-seeded, goroutine-safe). Return range and truncation are unchanged.

2. **`internal/events/deduplicator.go`** - the dedup LRU `evictOldest` compared only `lastUsed` with no tiebreaker, so entries sharing a timestamp (the norm on a coarse clock) had undefined eviction order and a freshly-touched entry could be evicted instead of the true LRU. Added a monotonic access sequence (maintained under the existing mutex) as a tiebreaker. On a fine clock this only resolves the previously-undefined tie case, picking the genuine LRU, so it is never a regression.

## Notes for review

- `internal/api/v2/filesystem.go` `validateSymlinkTarget` treats a leading-separator target (`/etc`) as relative on Windows. This is only a defense-in-depth pre-check; the enforcing gate is Go's `os.Root` sandbox (which correctly rejects rooted/absolute symlink targets), so this is not a security gap. I left it as-is and only made the test's target OS-absolute. Hardening it to treat rooted targets as absolute would make the two layers agree if you want that follow-up.
- `internal/notification` `List` sorts by timestamp with an unstable sort and no tiebreaker, so near-simultaneous notifications have nondeterministic order. I fixed the affected test by isolating per-case state rather than changing the production sort; a stable sort with an ID tiebreaker would be a reasonable follow-up.

## Verification

- The native `unit-tests (windows-amd64)` job now passes with **0 failing tests** (down from 64), confirmed from the uploaded `gotest.log` on the final commit, not just the masked check.
- All other CI checks are green: lint, `unit-tests` (linux), `unit-tests (macos-arm64)`, `cross-build` (windows/amd64 and linux/arm64), integration-tests, testcontainer-tests.
- Each touched package passes on Linux with no regression; the full `internal/api/v2` package passes (the shared-helper change was audited against all 56 of its callers). `go build ./...` is clean; `go vet` and `-race` pass on both production-change packages.
- Reviewed through the pre-push gate (reuse, correctness, quality, integration, regression, test-quality) plus an independent Gemini pass: no correctness, race, regression, or wiring issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic error deduplication behavior when multiple entries share the same recency timestamp.
* **Tests**
  * Improved cross-platform reliability, especially on Windows, for signals, file permissions, path formatting, symlink support, and timing/clock granularity.
  * Reduced intermittent failures by tightening cleanup of temporary/open handles and using OS-appropriate absolute paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->