### PR TITLE
fix(notification): make List ordering deterministic for equal timestamps

### DIFF
--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -444,3 +444,141 @@ func TestInMemoryStore_GetReturnsIndependentParamsAndExpiry(t *testing.T) {
 	assert.True(t, got2.ExpiresAt.Equal(originalExpiry),
 		"mutating a returned notification's ExpiresAt must not affect the stored copy")
 }
+
+// listIDs returns the IDs of all notifications from store.List, in order.
+func listIDs(t *testing.T, store *InMemoryStore) []string {
+	t.Helper()
+	got, err := store.List(nil)
+	require.NoError(t, err)
+	ids := make([]string, len(got))
+	for i, n := range got {
+		ids[i] = n.ID
+	}
+	return ids
+}
+
+// TestInMemoryStoreListDeterministicOrderOnEqualTimestamps verifies that List
+// returns a stable, creation-ordered result when notifications share the same
+// Timestamp. Equal timestamps are routine on coarse-resolution clocks (Windows'
+// ~15ms monotonic tick) and possible anywhere under load. Without a tiebreaker,
+// List relied on an unstable sort over a map-ordered slice, so the order of
+// equal-timestamp notifications (and which one a Limit:1 query returned) was
+// nondeterministic.
+func TestInMemoryStoreListDeterministicOrderOnEqualTimestamps(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(1000)
+	fixedTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	const count = 50
+	createdIDs := make([]string, count)
+	for i := range count {
+		n := NewNotification(TypeInfo, PriorityLow, "title", "message")
+		n.Timestamp = fixedTime // force identical timestamps to exercise the tiebreaker
+		createdIDs[i] = n.ID
+		mustStoreSave(t, store, n)
+	}
+
+	// Expected order: newest-created first. With all timestamps equal, the
+	// creation-sequence tiebreaker orders by descending seq, i.e. reverse
+	// insertion order.
+	wantIDs := make([]string, count)
+	for i := range count {
+		wantIDs[i] = createdIDs[count-1-i]
+	}
+
+	first := listIDs(t, store)
+	assert.Equal(t, wantIDs, first,
+		"List must order equal-timestamp notifications newest-created first")
+
+	// Repeat to defeat Go's per-range map-iteration randomization: a non-total
+	// ordering would surface different orders across calls within one process.
+	for range 20 {
+		assert.Equal(t, first, listIDs(t, store),
+			"List order must be identical across repeated calls")
+	}
+
+	// Limit:1 must deterministically return the most recently created.
+	limited, err := store.List(&FilterOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.Equal(t, createdIDs[count-1], limited[0].ID,
+		"Limit:1 must return the newest-created notification")
+}
+
+// TestInMemoryStoreListOrdersByTimestampNewestFirst verifies the primary sort
+// key: notifications with distinct timestamps are returned newest-first. This
+// guards the timestamp comparison direction independently of the equal-timestamp
+// tiebreaker (a sign error here would be invisible to the all-equal-timestamp
+// test above).
+func TestInMemoryStoreListOrdersByTimestampNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(1000)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	const count = 10
+	// Save oldest-to-newest; List must return newest-first.
+	wantNewestFirst := make([]string, count)
+	for i := range count {
+		n := NewNotification(TypeInfo, PriorityLow, "title", "message")
+		n.Timestamp = base.Add(time.Duration(i) * time.Minute)
+		mustStoreSave(t, store, n)
+		wantNewestFirst[count-1-i] = n.ID // newest (largest i) goes first
+	}
+
+	assert.Equal(t, wantNewestFirst, listIDs(t, store),
+		"List must return distinct-timestamp notifications newest-first")
+}
+
+// TestInMemoryStoreListSeqZeroFallsBackToID verifies the final tiebreaker:
+// notifications built without NewNotification (seq == 0, e.g. struct literals)
+// that share a Timestamp are ordered deterministically by ascending ID.
+func TestInMemoryStoreListSeqZeroFallsBackToID(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(1000)
+	fixedTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Insertion order deliberately differs from sorted-ID order; all seq == 0.
+	for _, id := range []string{"d", "a", "c", "b"} {
+		mustStoreSave(t, store, &Notification{
+			ID:        id,
+			Type:      TypeInfo,
+			Priority:  PriorityLow,
+			Status:    StatusUnread,
+			Timestamp: fixedTime,
+		})
+	}
+
+	assert.Equal(t, []string{"a", "b", "c", "d"}, listIDs(t, store),
+		"equal-timestamp seq-0 notifications must sort by ascending ID")
+}
+
+// TestInMemoryStoreRemoveOldestDeterministicOnEqualTimestamps verifies that
+// eviction at capacity is deterministic when notifications share a Timestamp:
+// the earliest-created (lowest seq) entry is evicted, consistent with List
+// ranking it last.
+func TestInMemoryStoreRemoveOldestDeterministicOnEqualTimestamps(t *testing.T) {
+	t.Parallel()
+
+	const maxSize = 3
+	store := NewInMemoryStore(maxSize)
+	fixedTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	const total = 5
+	created := make([]string, total)
+	for i := range total {
+		n := NewNotification(TypeInfo, PriorityLow, "title", "message")
+		n.Timestamp = fixedTime
+		created[i] = n.ID
+		mustStoreSave(t, store, n)
+	}
+
+	// The two earliest-created (created[0], created[1]) must have been evicted;
+	// the three most recently created remain, newest-first.
+	got := listIDs(t, store)
+	require.Len(t, got, maxSize)
+	assert.Equal(t, []string{created[4], created[3], created[2]}, got,
+		"eviction must drop the earliest-created equal-timestamp notifications")
+}

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -582,3 +582,34 @@ func TestInMemoryStoreRemoveOldestDeterministicOnEqualTimestamps(t *testing.T) {
 	assert.Equal(t, []string{created[4], created[3], created[2]}, got,
 		"eviction must drop the earliest-created equal-timestamp notifications")
 }
+
+// TestInMemoryStoreRemoveOldestSeqZeroFallsBackToID verifies eviction's final
+// tiebreaker: when entries share a Timestamp and seq (the seq == 0 struct-literal
+// case), removeOldest drops the highest ID, mirroring List which ranks the
+// highest ID last.
+func TestInMemoryStoreRemoveOldestSeqZeroFallsBackToID(t *testing.T) {
+	t.Parallel()
+
+	const maxSize = 2
+	store := NewInMemoryStore(maxSize)
+	fixedTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	save := func(id string) {
+		mustStoreSave(t, store, &Notification{
+			ID:        id,
+			Type:      TypeInfo,
+			Priority:  PriorityLow,
+			Status:    StatusUnread,
+			Timestamp: fixedTime,
+		})
+	}
+
+	// Fill to {a, c} (all seq == 0, same timestamp), then saving "b" must evict
+	// the highest current ID ("c"), leaving {a, b}.
+	save("a")
+	save("c")
+	save("b")
+
+	assert.Equal(t, []string{"a", "b"}, listIDs(t, store),
+		"seq-0 eviction must drop the highest ID (the entry List ranks last)")
+}

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -579,26 +579,34 @@ func (s *InMemoryStore) DeleteExpired() error {
 }
 
 // removeOldest removes the oldest notification to make room. "Oldest" is the
-// entry List ranks last: earliest Timestamp, and among equal timestamps the
-// lowest creation sequence (the earliest created). Using seq as the tiebreaker
-// keeps eviction deterministic and consistent with List's ordering on
-// coarse-resolution clocks where timestamps routinely collide; without it the
-// victim among equal-timestamp entries was whichever the randomized map range
-// happened to visit first.
+// entry List ranks last, so removeOldest uses the inverse of List's total
+// order: earliest Timestamp, then lowest creation sequence (earliest created),
+// then highest ID as a final fallback for notifications built without
+// NewNotification (seq 0). This keeps eviction deterministic and consistent
+// with List on coarse-resolution clocks where timestamps routinely collide;
+// without it the victim among tied entries was whichever the randomized map
+// range happened to visit first.
 func (s *InMemoryStore) removeOldest() {
 	var oldestID string
 	var oldestTime time.Time
 	var oldestSeq uint64
 
 	for id, notif := range s.notifications {
-		switch {
-		case oldestID == "": // first candidate
-		case notif.Timestamp.Before(oldestTime): // strictly older
-		case notif.Timestamp.Equal(oldestTime) && notif.seq < oldestSeq: // same time, created earlier
-		default:
+		if oldestID == "" {
+			oldestID, oldestTime, oldestSeq = id, notif.Timestamp, notif.seq
 			continue
 		}
-		oldestID, oldestTime, oldestSeq = id, notif.Timestamp, notif.seq
+		// Mirror sortNotificationsByTime, inverted to find the element it ranks
+		// last: earlier Timestamp, then lower seq, then higher ID. The ID args
+		// are reversed (oldestID, id) so a larger id compares as "older".
+		older := cmp.Or(
+			notif.Timestamp.Compare(oldestTime),
+			cmp.Compare(notif.seq, oldestSeq),
+			strings.Compare(oldestID, id),
+		) < 0
+		if older {
+			oldestID, oldestTime, oldestSeq = id, notif.Timestamp, notif.seq
+		}
 	}
 
 	if oldestID != "" {

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -602,7 +601,7 @@ func (s *InMemoryStore) removeOldest() {
 		older := cmp.Or(
 			notif.Timestamp.Compare(oldestTime),
 			cmp.Compare(notif.seq, oldestSeq),
-			strings.Compare(oldestID, id),
+			cmp.Compare(oldestID, id),
 		) < 0
 		if older {
 			oldestID, oldestTime, oldestSeq = id, notif.Timestamp, notif.seq
@@ -678,7 +677,7 @@ func sortNotificationsByTime(notifications []*Notification) {
 		return cmp.Or(
 			b.Timestamp.Compare(a.Timestamp), // newest first
 			cmp.Compare(b.seq, a.seq),        // later creation first on equal timestamps
-			strings.Compare(a.ID, b.ID),      // stable fallback for seq-less notifications
+			cmp.Compare(a.ID, b.ID),          // stable fallback for seq-less notifications
 		)
 	})
 }

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -4,11 +4,13 @@
 package notification
 
 import (
+	"cmp"
 	"fmt"
 	"reflect"
 	"slices"
-	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -128,7 +130,23 @@ type Notification struct {
 	// Set to "bell" for in-app only, "push" for push providers only.
 	// Transient routing field; never serialized or persisted.
 	DeliveryTarget string `json:"-"`
+
+	// seq is a process-local monotonic creation sequence assigned by
+	// NewNotification. It exists solely to give List a deterministic,
+	// creation-ordered tiebreaker when two notifications share a Timestamp
+	// (routine on coarse-resolution clocks and under load). Unexported and
+	// never serialized or persisted; copied by Clone so the store's copy
+	// keeps the original creation order.
+	seq uint64
 }
+
+// notificationSeq assigns a process-wide, strictly increasing sequence number
+// to each notification created via NewNotification. It is the tiebreaker that
+// makes InMemoryStore.List ordering deterministic for notifications that share
+// a Timestamp: results are gathered by ranging a Go map (randomized order), so
+// without a real tiebreaker an unstable timestamp-only sort produced arbitrary
+// ordering for equal timestamps.
+var notificationSeq atomic.Uint64
 
 // NewNotification creates a new notification with a unique ID and timestamp
 func NewNotification(notifType Type, priority Priority, title, message string) *Notification {
@@ -140,6 +158,7 @@ func NewNotification(notifType Type, priority Priority, title, message string) *
 		Title:     title,
 		Message:   message,
 		Timestamp: time.Now(),
+		seq:       notificationSeq.Add(1),
 		Metadata:  make(map[string]any),
 	}
 }
@@ -250,6 +269,7 @@ func (n *Notification) Clone() *Notification {
 		TitleKey:       n.TitleKey,
 		MessageKey:     n.MessageKey,
 		DeliveryTarget: n.DeliveryTarget,
+		seq:            n.seq,
 	}
 
 	// Deep copy ExpiresAt
@@ -558,16 +578,27 @@ func (s *InMemoryStore) DeleteExpired() error {
 	return nil
 }
 
-// removeOldest removes the oldest notification to make room
+// removeOldest removes the oldest notification to make room. "Oldest" is the
+// entry List ranks last: earliest Timestamp, and among equal timestamps the
+// lowest creation sequence (the earliest created). Using seq as the tiebreaker
+// keeps eviction deterministic and consistent with List's ordering on
+// coarse-resolution clocks where timestamps routinely collide; without it the
+// victim among equal-timestamp entries was whichever the randomized map range
+// happened to visit first.
 func (s *InMemoryStore) removeOldest() {
 	var oldestID string
 	var oldestTime time.Time
+	var oldestSeq uint64
 
 	for id, notif := range s.notifications {
-		if oldestID == "" || notif.Timestamp.Before(oldestTime) {
-			oldestID = id
-			oldestTime = notif.Timestamp
+		switch {
+		case oldestID == "": // first candidate
+		case notif.Timestamp.Before(oldestTime): // strictly older
+		case notif.Timestamp.Equal(oldestTime) && notif.seq < oldestSeq: // same time, created earlier
+		default:
+			continue
 		}
+		oldestID, oldestTime, oldestSeq = id, notif.Timestamp, notif.seq
 	}
 
 	if oldestID != "" {
@@ -627,10 +658,20 @@ func (s *InMemoryStore) GetUnreadCount() (int, error) {
 	return s.Count(&FilterOptions{Status: []Status{StatusUnread}})
 }
 
-// sortNotificationsByTime sorts notifications by timestamp (newest first)
+// sortNotificationsByTime sorts notifications newest-first by a deterministic
+// total order. The primary key is Timestamp (descending). Ties are broken by
+// the creation sequence (descending, so the more recently created wins) and,
+// as a final fallback for notifications built without NewNotification (seq 0),
+// by ID. A total order is required because the input is gathered by ranging a
+// Go map, whose iteration order is randomized; a timestamp-only comparison
+// would leave equal-timestamp notifications in arbitrary, run-varying order.
 func sortNotificationsByTime(notifications []*Notification) {
-	sort.Slice(notifications, func(i, j int) bool {
-		return notifications[i].Timestamp.After(notifications[j].Timestamp)
+	slices.SortFunc(notifications, func(a, b *Notification) int {
+		return cmp.Or(
+			b.Timestamp.Compare(a.Timestamp), // newest first
+			cmp.Compare(b.seq, a.seq),        // later creation first on equal timestamps
+			strings.Compare(a.ID, b.ID),      // stable fallback for seq-less notifications
+		)
 	})
 }
 


### PR DESCRIPTION
## Summary

`InMemoryStore.List` gathered matching notifications by ranging a Go map (randomized iteration order) and then sorted them with an unstable, timestamp-only `sort.Slice`. Notifications created within the same clock tick share a `Timestamp`, which is routine on coarse-resolution clocks (Windows' ~15ms monotonic tick) and possible anywhere under load. Their relative order in `List` output, and which one a `Limit:1` query returned, was therefore arbitrary and varied from run to run.

This came up while stabilizing native Windows unit tests, where a `List(Limit:1)` returned a prior subtest's notification instead of the just-created one. The test was isolated at the time; this fixes the underlying production fragility.

## Changes

- Add a process-local monotonic creation sequence (`seq`) to `Notification`, assigned by `NewNotification` via an atomic counter and copied by `Clone`. It is unexported and never serialized or persisted (transient, like `DeliveryTarget`).
- `sortNotificationsByTime` now imposes a deterministic total order: `Timestamp` desc, then `seq` desc (most recently created wins on a tie), then `ID` asc as a final fallback for notifications built without `NewNotification` (`seq` 0). Switched from `sort.Slice` to `slices.SortFunc` + `cmp.Or`.
- `removeOldest` gains the same `seq` tiebreaker so eviction at capacity is deterministic and consistent with `List`'s ordering.

No API or wire-format change: `seq` is unexported with no JSON tag, so it never appears in REST responses. Ordering for distinct timestamps is unchanged (still newest-first).

## Test Plan

- [x] `go test -race ./internal/notification/...` passes (including `-count=5` on the new tests)
- [x] New tests cover all three comparator keys: equal-timestamp creation order (+ stable across 20 repeated calls + `Limit:1`), distinct-timestamp newest-first, and the `seq`-0 ID fallback, plus deterministic eviction
- [x] `golangci-lint run ./internal/notification/...` clean
- [x] Downstream `internal/api/v2` notification tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage to verify notification listing order and capacity-based eviction are deterministic, including equal-timestamp and edge-case scenarios.
* **Bug Fixes**
  * Improved notification ordering and eviction tie-breaking to ensure consistent “newest first” behavior when multiple items share the same time.
* **Refactor**
  * Updated the internal notification ordering logic to use a fully deterministic strategy so list results and eviction decisions remain aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->