### PR TITLE
test: fix flaky native Windows unit tests (cross-platform cleanup, batch 3)

### DIFF
--- a/internal/audiocore/ffmpeg/manager_test.go
+++ b/internal/audiocore/ffmpeg/manager_test.go
@@ -322,14 +322,21 @@ func TestManager_RestartStreamResetsBackoff(t *testing.T) {
 	t.Cleanup(func() { _ = mgr.Shutdown() })
 
 	const sourceID = "restart-backoff"
-	require.NoError(t, mgr.StartStream(
-		newTestManagerConfig(sourceID, "rtsp://restart.example.com/stream")))
 
-	// Access the internal stream to set up backoff state.
-	mgr.mu.RLock()
-	stream := mgr.streams[sourceID]
-	mgr.mu.RUnlock()
-	require.NotNil(t, stream)
+	// Register the stream directly instead of via StartStream, which would launch
+	// the Run loop. That loop races this test: on platforms where the config's
+	// FFmpeg path fails fast (e.g. the non-absolute /usr/bin/ffmpeg on Windows),
+	// startProcess records a failure and re-increments the very counters this
+	// test checks, right after the manual restart resets them. Registering the
+	// stream directly isolates the unit under test (Manager.RestartStream ->
+	// Stream.Restart(true) resets the backoff counters) and makes it
+	// deterministic on every platform. Shutdown still stops the stream safely.
+	stream := NewStream(
+		newTestManagerConfig(sourceID, "rtsp://restart.example.com/stream"),
+		nil, nil, nil, nil)
+	mgr.mu.Lock()
+	mgr.streams[sourceID] = stream
+	mgr.mu.Unlock()
 
 	// Simulate accumulated failures.
 	stream.restartCountMu.Lock()

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -397,6 +397,15 @@ func (s *AudioSettings) applyFfmpegFormatFallback() {
 	}
 }
 
+// ffmpegVersionDetector resolves the version of the ffmpeg binary at a validated
+// path by executing it. It is a package variable so unit tests can replace it
+// with a stub. validateAudioSettings runs across many parallel test cases that
+// configure placeholder ffmpeg paths (stub files under t.TempDir()), and
+// concurrently exec'ing such a non-executable stub crashes the Windows race
+// detector with STATUS_STACK_BUFFER_OVERRUN. Production always uses the real
+// detector; only tests override it (see validate_audio_export_test.go).
+var ffmpegVersionDetector = GetFfmpegVersionFrom
+
 // validateAudioSettings validates the audio settings and sets ffmpeg and sox paths
 func validateAudioSettings(settings *AudioSettings) error {
 	// Validate and determine the effective FFmpeg path
@@ -408,7 +417,7 @@ func validateAudioSettings(settings *AudioSettings) error {
 		settings.FfmpegPath = validatedFfmpegPath // Store the validated path (explicit or from PATH)
 
 		// Detect FFmpeg version using the validated path (not PATH lookup)
-		version, major, minor := GetFfmpegVersionFrom(validatedFfmpegPath)
+		version, major, minor := ffmpegVersionDetector(validatedFfmpegPath)
 		settings.FfmpegVersion = version
 		settings.FfmpegMajor = major
 		settings.FfmpegMinor = minor

--- a/internal/conf/validate_audio_export_test.go
+++ b/internal/conf/validate_audio_export_test.go
@@ -12,6 +12,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// init stubs ffmpeg version detection for the entire conf test binary. Many
+// tests set FfmpegPath to placeholder stubs (see fakeFFmpegPath) that must
+// never actually be executed: validateAudioSettings runs across hundreds of
+// parallel subtests, and on Windows the race detector aborts with
+// STATUS_STACK_BUFFER_OVERRUN when those subtests concurrently exec a non-PE
+// stub. The detected version is incidental to what these tests assert (export
+// type normalization), and returning ("", 0, 0) matches what executing the
+// existing no-op stub already yields on every platform, so the stub is
+// behavior-preserving aside from not spawning a subprocess. Set once here
+// before any test runs, so no parallel test races on the package variable.
+func init() {
+	ffmpegVersionDetector = func(string) (version string, major, minor int) {
+		return "", 0, 0
+	}
+}
+
 // fakeFFmpegPath writes an executable stub inside t.TempDir() and returns its
 // path. Tests need a resolvable, host-agnostic FfmpegPath because
 // validateAudioSettings invokes ValidateToolPath, which clears FfmpegPath when

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -542,6 +542,16 @@ func TestCollector_InferenceErrorRateCounterReset(t *testing.T) {
 	collector.SetInferenceCounters(counters1)
 	collector.collect() // seeding tick; nothing written to store
 
+	// Backdate the seeded snapshot so the second tick observes a positive elapsed
+	// interval. The two collect() calls run back-to-back, and on platforms with
+	// coarse monotonic-clock granularity (e.g. Windows) both snapshots can read an
+	// identical timestamp, yielding elapsed == 0 and a throughput of 0 that fails
+	// the assertion below. Subtracting a full second is robust regardless of clock
+	// resolution; Add preserves the monotonic reading so the delta stays positive.
+	if prev, ok := collector.prevInferenceSnaps["ModelF"]; ok {
+		prev.CollectedAt = prev.CollectedAt.Add(-time.Second)
+	}
+
 	// Tick 2: inject a fresh CounterMap with lower absolute values so that
 	// current < previous on both InvokeCount and InvokeErrors. This simulates
 	// a counter reset (e.g. the underlying counters were replaced).


### PR DESCRIPTION
## Summary

Three tests intermittently failed the non-blocking native `windows-amd64` unit-test job. All three are test-side flakes caused by Windows-specific timing or process behavior, not product bugs. Production behavior is unchanged (the one production-side change is a behavior-identical test seam).

This is a follow-up to the earlier cross-platform cleanup batches that brought the Windows suite from ~346 failures to a clean baseline; these were the remaining intermittent flakes.

## Fixes

**`ffmpeg` `TestManager_RestartStreamResetsBackoff`**
`StartStream` launched the `Run` loop, which on Windows fails ffmpeg path validation instantly (the test config's `/usr/bin/ffmpeg` is not absolute on Windows) and re-increments the backoff counters right after the manual restart reset them. On Linux `/usr/bin/ffmpeg` is absolute, so the process starts and the failure is deferred, masking the race. The test now registers the stream directly so it deterministically verifies `RestartStream -> Restart(true)` without the racing loop. `Shutdown` still stops the never-run stream safely (`cleanupProcess` is nil-safe).

**`observability` `TestCollector_InferenceErrorRateCounterReset`**
Two back-to-back `collect()` calls can read an identical monotonic timestamp on Windows's coarse clock, making `elapsed == 0` and throughput `0`, which fails the `throughput > 0` assertion. The seeded snapshot is now backdated by one second so the second tick sees a positive interval. `time.Add` preserves the monotonic reading, so the delta stays `>= 1s` on every platform. The error-rate assertion is unaffected.

**`internal/conf` package crash**
`validateAudioSettings` exec'd a placeholder ffmpeg stub for version detection across many parallel subtests. On Windows the non-PE stub crashes the race detector with `STATUS_STACK_BUFFER_OVERRUN` (`0xC0000409`) when exec'd concurrently, taking down the whole package with no test-level failure. A `ffmpegVersionDetector` seam is added and stubbed in the conf test `init()` so no subprocess is spawned. Returning `("", 0, 0)` matches what executing the existing no-op stub already yielded on every platform, so the change is behavior-preserving aside from not spawning a subprocess. The single production call site is rerouted through the seam; the var defaults to the real detector and is never reassigned outside tests.

## Verification

Reproduced and verified on Windows:
- `internal/conf`: 0 failures in 40 runs (previously crashed roughly 1 run in 3-10).
- `observability`: 0 failures in 15 runs.
- The conf crash requires both `-race` and concurrent exec; serialized (`-test.parallel=1`) and non-race runs never reproduced it.

All three packages pass on Linux with `-race`, and `golangci-lint` reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by eliminating race conditions in stream management tests.
  * Enhanced test infrastructure to support cross-platform compatibility and prevent timing-related test failures.
  * Updated test fixtures to properly handle clock granularity variations across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->