### PR TITLE
fix(privacy): recognize Perch v2 and localized human/dog classes in privacy and dog-bark filters

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -41,11 +41,6 @@ import (
 var _ PreRendererSubmit = (*spectrogram.PreRenderer)(nil)
 
 // Species identification constants for filtering
-const (
-	speciesDog   = "dog"
-	speciesHuman = "human"
-)
-
 // DefaultFlushInterval is the interval for checking and flushing pending detections
 const DefaultFlushInterval = 1 * time.Second
 
@@ -837,8 +832,8 @@ func (p *Processor) processResults(settings *conf.Settings, item classifier.Resu
 
 		// Handle dog and human detection, this sets LastDogDetection and LastHumanDetection which is
 		// later used to discard detection if privacy filter or dog bark filters are enabled in settings.
-		p.handleDogDetection(settings, item, speciesLowercase, result)
-		p.handleHumanDetection(settings, item, speciesLowercase, result)
+		p.handleDogDetection(settings, item, result)
+		p.handleHumanDetection(settings, item, result)
 
 		// Determine confidence threshold and check filters
 		baseThreshold := p.getBaseConfidenceThreshold(settings, commonName, scientificName, item.ModelID)
@@ -980,8 +975,9 @@ func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
 
 // shouldFilterDetection checks if a detection should be filtered out
 func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datastore.Results, commonName, scientificName, speciesLowercase string, baseThreshold float32, source, modelID string) (shouldFilter bool, confidenceThreshold float32) {
-	// Check human detection privacy filter
-	if strings.Contains(strings.ToLower(commonName), speciesHuman) && result.Confidence > baseThreshold {
+	// Check human detection privacy filter. Match the raw label so Perch v2's
+	// FSD50K human classes are caught too, not just BirdNET's "Human *" classes.
+	if isHumanVocalization(result.Species) && result.Confidence > baseThreshold {
 		return true, 0 // Filter out human detections for privacy
 	}
 
@@ -1255,8 +1251,8 @@ func (p *Processor) syncSpeciesTrackerIfNeeded() {
 // handleDogDetection handles the detection of dog barks and updates the last detection timestamp.
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) handleDogDetection(settings *conf.Settings, item classifier.Results, speciesLowercase string, result datastore.Results) {
-	if settings.Realtime.DogBarkFilter.Enabled && strings.Contains(speciesLowercase, speciesDog) &&
+func (p *Processor) handleDogDetection(settings *conf.Settings, item classifier.Results, result datastore.Results) {
+	if settings.Realtime.DogBarkFilter.Enabled && isDogDetection(result.Species) &&
 		result.Confidence > settings.Realtime.DogBarkFilter.Confidence {
 		GetLogger().Info("dog detection filtered",
 			logger.Float32("confidence", result.Confidence),
@@ -1272,9 +1268,9 @@ func (p *Processor) handleDogDetection(settings *conf.Settings, item classifier.
 // handleHumanDetection handles the detection of human vocalizations and updates the last detection timestamp.
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifier.Results, speciesLowercase string, result datastore.Results) {
+func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifier.Results, result datastore.Results) {
 	// only check this if privacy filter is enabled
-	if settings.Realtime.PrivacyFilter.Enabled && strings.Contains(speciesLowercase, "human ") &&
+	if settings.Realtime.PrivacyFilter.Enabled && isHumanVocalization(result.Species) &&
 		result.Confidence > settings.Realtime.PrivacyFilter.Confidence {
 		GetLogger().Info("human detection filtered",
 			logger.Float32("confidence", result.Confidence),

--- a/internal/analysis/processor/vocalization_labels.go
+++ b/internal/analysis/processor/vocalization_labels.go
@@ -1,0 +1,132 @@
+// vocalization_labels.go classifies raw classifier labels as human or dog
+// vocalizations for the privacy filter and the dog bark filter.
+//
+// Why match the RAW label (result.Species) instead of the enriched common name:
+//
+//  1. Locale stability. BirdNET loads a locale-specific label file, so for a
+//     German user the dog class arrives as "Dog_Hund" and the human classes as
+//     "Human vocal_Mensch Stimme" etc. SplitSpeciesName uses the part after "_"
+//     as the common name ("Hund", "Mensch Stimme"), which contains no "dog" or
+//     "human" token, so matching the enriched name silently failed for every
+//     non-English locale. The part BEFORE the "_" (the scientific portion) is
+//     always English ("Dog", "Human vocal", ...), so matching the raw label
+//     works regardless of the configured locale.
+//
+//  2. Collision safety. A bare "human"/"dog" substring match also fires on bird
+//     binomials that merely contain those letters, e.g. the cicada "Pacarina
+//     schumanni" (...sc-human-ni) or the katydid "Poecilimon doga" (...doga).
+//     Anchoring on the raw-label prefix ("human ", "dog_") excludes them.
+//
+//  3. Perch v2 (trained on iNaturalist 2024 + FSD50K) emits AudioSet-ontology
+//     sound classes ("Speech", "Bark", "Growling", ...) that carry no "human"/
+//     "dog" token at all, and whose underscore-joined forms ("Human_voice")
+//     SplitSpeciesName mangles into "voice". Those are matched exactly against
+//     the raw label here.
+package processor
+
+import "strings"
+
+const (
+	// birdnetHumanLabelPrefix matches BirdNET's human classes by the English
+	// scientific portion of the raw label ("Human vocal_...", "Human non-vocal_...",
+	// "Human whistle_..."), which is the same across every locale. The trailing
+	// space is load-bearing: "human vocal" matches, but the cicada "Pacarina
+	// schumanni" (which contains the substring "human") does not.
+	birdnetHumanLabelPrefix = "human "
+	// birdnetDogLabelPrefix matches BirdNET's "Dog" class by its raw-label form
+	// "Dog_<localized common name>" (e.g. "Dog_Dog", "Dog_Hund"). The underscore
+	// is load-bearing: the class matches, but the katydid "Poecilimon doga"
+	// (which contains the substring "dog") does not.
+	birdnetDogLabelPrefix = "dog_"
+)
+
+// perchHumanLabels enumerates the raw Perch v2 (FSD50K) labels treated as human
+// vocalizations by the privacy filter. The set is deliberately broad: it covers
+// the full AudioSet "Human sounds" branch present in the Perch label set (voice,
+// other vocalizations, respiratory, digestive, hand, locomotion, and group
+// actions) so any sign of a human near the microphone engages the filter, the
+// same way BirdNET filters both "Human vocal" and "Human non-vocal". Non-human
+// AudioSet classes that merely co-occur with people (e.g. "Car_passing_by",
+// "Thump_and_thud") are intentionally excluded.
+//
+//nolint:gochecknoglobals // immutable lookup table, read-only after init
+var perchHumanLabels = map[string]struct{}{
+	// Speech and voice.
+	"Speech":                           {},
+	"Speech_synthesizer":               {},
+	"Male_speech_and_man_speaking":     {},
+	"Female_speech_and_woman_speaking": {},
+	"Child_speech_and_kid_speaking":    {},
+	"Conversation":                     {},
+	"Chatter":                          {},
+	"Human_voice":                      {},
+	"Human_group_actions":              {},
+	"Whispering":                       {},
+	"Shout":                            {},
+	"Yell":                             {},
+	"Screaming":                        {},
+	// Other human vocalizations.
+	"Singing":             {},
+	"Male_singing":        {},
+	"Female_singing":      {},
+	"Laughter":            {},
+	"Giggle":              {},
+	"Chuckle_and_chortle": {},
+	"Crying_and_sobbing":  {},
+	"Gasp":                {},
+	"Sigh":                {},
+	// Non-vocal human body sounds (parallels BirdNET "Human non-vocal").
+	"Cough":                   {},
+	"Sneeze":                  {},
+	"Breathing":               {},
+	"Respiratory_sounds":      {},
+	"Burping_and_eructation":  {},
+	"Fart":                    {},
+	"Chewing_and_mastication": {},
+	// Human taxon (iNaturalist) - humans detected as a species, not a sound.
+	"Homo sapiens": {},
+	// Human actions and group sounds.
+	"Crowd":              {},
+	"Cheering":           {},
+	"Applause":           {},
+	"Clapping":           {},
+	"Finger_snapping":    {},
+	"Hands":              {},
+	"Walk_and_footsteps": {},
+	"Run":                {},
+}
+
+// perchDogLabels enumerates the raw Perch v2 labels treated as a dog by the dog
+// bark filter: the FSD50K dog sound classes plus the domestic dog taxon. Wild
+// canids (wolf, coyote, jackal) are intentionally excluded so they remain
+// detectable as wildlife rather than being suppressed as background barking.
+//
+//nolint:gochecknoglobals // immutable lookup table, read-only after init
+var perchDogLabels = map[string]struct{}{
+	"Dog":              {}, // FSD50K dog
+	"Bark":             {}, // FSD50K bark
+	"Growling":         {}, // FSD50K growl
+	"Canis familiaris": {}, // domestic dog (iNaturalist taxon)
+}
+
+// isHumanVocalization reports whether a raw classifier label represents a human
+// sound that should engage the privacy filter. rawLabel is the untransformed
+// result.Species value. Perch v2 classes are matched exactly; BirdNET classes
+// are matched by the locale-stable English label prefix.
+func isHumanVocalization(rawLabel string) bool {
+	if _, ok := perchHumanLabels[rawLabel]; ok {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(rawLabel), birdnetHumanLabelPrefix)
+}
+
+// isDogDetection reports whether a raw classifier label represents a dog for the
+// dog bark filter. rawLabel is the untransformed result.Species value. Perch v2
+// classes are matched exactly; BirdNET's "Dog" class is matched by the
+// locale-stable English label prefix.
+func isDogDetection(rawLabel string) bool {
+	if _, ok := perchDogLabels[rawLabel]; ok {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(rawLabel), birdnetDogLabelPrefix)
+}

--- a/internal/analysis/processor/vocalization_labels.go
+++ b/internal/analysis/processor/vocalization_labels.go
@@ -22,6 +22,10 @@
 //     "dog" token at all, and whose underscore-joined forms ("Human_voice")
 //     SplitSpeciesName mangles into "voice". Those are matched exactly against
 //     the raw label here.
+//
+// Matching is case-insensitive: the raw label is lowercased once and compared
+// against the lowercase keys / prefixes below, so a custom or future label file
+// with different casing still engages the filters.
 package processor
 
 import "strings"
@@ -47,86 +51,92 @@ const (
 // actions) so any sign of a human near the microphone engages the filter, the
 // same way BirdNET filters both "Human vocal" and "Human non-vocal". Non-human
 // AudioSet classes that merely co-occur with people (e.g. "Car_passing_by",
-// "Thump_and_thud") are intentionally excluded.
+// "Thump_and_thud") are intentionally excluded. Keys are lowercase; lookups
+// lowercase the raw label first (see isHumanVocalization).
 //
 //nolint:gochecknoglobals // immutable lookup table, read-only after init
 var perchHumanLabels = map[string]struct{}{
 	// Speech and voice.
-	"Speech":                           {},
-	"Speech_synthesizer":               {},
-	"Male_speech_and_man_speaking":     {},
-	"Female_speech_and_woman_speaking": {},
-	"Child_speech_and_kid_speaking":    {},
-	"Conversation":                     {},
-	"Chatter":                          {},
-	"Human_voice":                      {},
-	"Human_group_actions":              {},
-	"Whispering":                       {},
-	"Shout":                            {},
-	"Yell":                             {},
-	"Screaming":                        {},
+	"speech":                           {},
+	"speech_synthesizer":               {},
+	"male_speech_and_man_speaking":     {},
+	"female_speech_and_woman_speaking": {},
+	"child_speech_and_kid_speaking":    {},
+	"conversation":                     {},
+	"chatter":                          {},
+	"human_voice":                      {},
+	"human_group_actions":              {},
+	"whispering":                       {},
+	"shout":                            {},
+	"yell":                             {},
+	"screaming":                        {},
 	// Other human vocalizations.
-	"Singing":             {},
-	"Male_singing":        {},
-	"Female_singing":      {},
-	"Laughter":            {},
-	"Giggle":              {},
-	"Chuckle_and_chortle": {},
-	"Crying_and_sobbing":  {},
-	"Gasp":                {},
-	"Sigh":                {},
+	"singing":             {},
+	"male_singing":        {},
+	"female_singing":      {},
+	"laughter":            {},
+	"giggle":              {},
+	"chuckle_and_chortle": {},
+	"crying_and_sobbing":  {},
+	"gasp":                {},
+	"sigh":                {},
 	// Non-vocal human body sounds (parallels BirdNET "Human non-vocal").
-	"Cough":                   {},
-	"Sneeze":                  {},
-	"Breathing":               {},
-	"Respiratory_sounds":      {},
-	"Burping_and_eructation":  {},
-	"Fart":                    {},
-	"Chewing_and_mastication": {},
+	"cough":                   {},
+	"sneeze":                  {},
+	"breathing":               {},
+	"respiratory_sounds":      {},
+	"burping_and_eructation":  {},
+	"fart":                    {},
+	"chewing_and_mastication": {},
 	// Human taxon (iNaturalist) - humans detected as a species, not a sound.
-	"Homo sapiens": {},
+	"homo sapiens": {},
 	// Human actions and group sounds.
-	"Crowd":              {},
-	"Cheering":           {},
-	"Applause":           {},
-	"Clapping":           {},
-	"Finger_snapping":    {},
-	"Hands":              {},
-	"Walk_and_footsteps": {},
-	"Run":                {},
+	"crowd":              {},
+	"cheering":           {},
+	"applause":           {},
+	"clapping":           {},
+	"finger_snapping":    {},
+	"hands":              {},
+	"walk_and_footsteps": {},
+	"run":                {},
 }
 
 // perchDogLabels enumerates the raw Perch v2 labels treated as a dog by the dog
 // bark filter: the FSD50K dog sound classes plus the domestic dog taxon. Wild
 // canids (wolf, coyote, jackal) are intentionally excluded so they remain
 // detectable as wildlife rather than being suppressed as background barking.
+// "Growling" is the AudioSet child of the Dog class (dog growling), so it stays.
+// Keys are lowercase; lookups lowercase the raw label first (see isDogDetection).
 //
 //nolint:gochecknoglobals // immutable lookup table, read-only after init
 var perchDogLabels = map[string]struct{}{
-	"Dog":              {}, // FSD50K dog
-	"Bark":             {}, // FSD50K bark
-	"Growling":         {}, // FSD50K growl
-	"Canis familiaris": {}, // domestic dog (iNaturalist taxon)
+	"dog":              {}, // FSD50K dog
+	"bark":             {}, // FSD50K bark
+	"growling":         {}, // FSD50K dog growl (AudioSet child of Dog)
+	"canis familiaris": {}, // domestic dog (iNaturalist taxon)
 }
 
 // isHumanVocalization reports whether a raw classifier label represents a human
 // sound that should engage the privacy filter. rawLabel is the untransformed
-// result.Species value. Perch v2 classes are matched exactly; BirdNET classes
-// are matched by the locale-stable English label prefix.
+// result.Species value. Matching is case-insensitive: Perch v2 classes are
+// matched exactly; BirdNET classes are matched by the locale-stable English
+// label prefix.
 func isHumanVocalization(rawLabel string) bool {
-	if _, ok := perchHumanLabels[rawLabel]; ok {
+	lowered := strings.ToLower(rawLabel)
+	if _, ok := perchHumanLabels[lowered]; ok {
 		return true
 	}
-	return strings.HasPrefix(strings.ToLower(rawLabel), birdnetHumanLabelPrefix)
+	return strings.HasPrefix(lowered, birdnetHumanLabelPrefix)
 }
 
 // isDogDetection reports whether a raw classifier label represents a dog for the
-// dog bark filter. rawLabel is the untransformed result.Species value. Perch v2
-// classes are matched exactly; BirdNET's "Dog" class is matched by the
-// locale-stable English label prefix.
+// dog bark filter. rawLabel is the untransformed result.Species value. Matching
+// is case-insensitive: Perch v2 classes are matched exactly; BirdNET's "Dog"
+// class is matched by the locale-stable English label prefix.
 func isDogDetection(rawLabel string) bool {
-	if _, ok := perchDogLabels[rawLabel]; ok {
+	lowered := strings.ToLower(rawLabel)
+	if _, ok := perchDogLabels[lowered]; ok {
 		return true
 	}
-	return strings.HasPrefix(strings.ToLower(rawLabel), birdnetDogLabelPrefix)
+	return strings.HasPrefix(lowered, birdnetDogLabelPrefix)
 }

--- a/internal/analysis/processor/vocalization_labels_test.go
+++ b/internal/analysis/processor/vocalization_labels_test.go
@@ -1,0 +1,247 @@
+package processor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+func TestIsHumanVocalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawLabel string
+		want     bool
+	}{
+		// BirdNET v2.4 classes, English (matched via the locale-stable prefix).
+		{"BirdNET human vocal", "Human vocal_Human vocal", true},
+		{"BirdNET human non-vocal", "Human non-vocal_Human non-vocal", true},
+		{"BirdNET human whistle", "Human whistle_Human whistle", true},
+		// BirdNET v2.4 classes, non-English locale. The common name is localized
+		// ("Mensch Stimme"), so only raw-label matching catches these.
+		{"BirdNET human vocal (de)", "Human vocal_Mensch Stimme", true},
+		{"BirdNET human non-vocal (de)", "Human non-vocal_Mensch Geräusch", true},
+		{"BirdNET human whistle (de)", "Human whistle_Mensch Pfeifen", true},
+		// Perch v2 speech/voice classes (exact raw-label match).
+		{"Perch Speech", "Speech", true},
+		{"Perch Human_voice", "Human_voice", true},
+		{"Perch male speech", "Male_speech_and_man_speaking", true},
+		{"Perch female speech", "Female_speech_and_woman_speaking", true},
+		{"Perch child speech", "Child_speech_and_kid_speaking", true},
+		{"Perch Conversation", "Conversation", true},
+		{"Perch Chatter", "Chatter", true},
+		{"Perch Whispering", "Whispering", true},
+		{"Perch Speech_synthesizer", "Speech_synthesizer", true},
+		{"Perch Human_group_actions", "Human_group_actions", true},
+		{"Perch Screaming", "Screaming", true},
+		{"Perch Shout", "Shout", true},
+		// Perch v2 other vocalizations.
+		{"Perch Singing", "Singing", true},
+		{"Perch Laughter", "Laughter", true},
+		{"Perch Crying_and_sobbing", "Crying_and_sobbing", true},
+		{"Perch Sigh", "Sigh", true},
+		// Perch v2 non-vocal human sounds and actions.
+		{"Perch Cough", "Cough", true},
+		{"Perch Breathing", "Breathing", true},
+		{"Perch Fart", "Fart", true},
+		{"Perch Applause", "Applause", true},
+		{"Perch Clapping", "Clapping", true},
+		{"Perch Crowd", "Crowd", true},
+		{"Perch Walk_and_footsteps", "Walk_and_footsteps", true},
+		{"Perch Run", "Run", true},
+		// Human taxon (the human species itself).
+		{"Perch Homo sapiens", "Homo sapiens", true},
+		// Negatives: bird binomials that merely contain the substring "human".
+		{"cicada Pacarina schumanni", "Pacarina schumanni", false},
+		{"warbler Phylloscopus humei", "Phylloscopus humei", false},
+		{"BirdNET American Robin", "Turdus migratorius_American Robin", false},
+		// Negatives: non-human FSD50K classes that co-occur with people.
+		{"Perch Thump_and_thud", "Thump_and_thud", false},
+		{"Perch Car_passing_by", "Car_passing_by", false},
+		// Negatives: dog labels are not human.
+		{"Perch Bark is not human", "Bark", false},
+		{"Perch Dog is not human", "Dog", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isHumanVocalization(tt.rawLabel))
+		})
+	}
+}
+
+func TestIsDogDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawLabel string
+		want     bool
+	}{
+		// BirdNET v2.4 dog class, English and a non-English locale.
+		{"BirdNET Dog (en)", "Dog_Dog", true},
+		{"BirdNET Dog (de)", "Dog_Hund", true},
+		// Perch v2 dog sound classes and the domestic dog taxon.
+		{"Perch Dog", "Dog", true},
+		{"Perch Bark", "Bark", true},
+		{"Perch Growling", "Growling", true},
+		{"Perch Canis familiaris", "Canis familiaris", true},
+		// Negatives: bird/insect binomials that merely contain the substring "dog".
+		// Tachyspiza rhodogaster is a real bird (Vinous-breasted Sparrowhawk); the
+		// old "dog" substring match would have wrongly filtered it.
+		{"hawk Tachyspiza rhodogaster", "Tachyspiza rhodogaster", false},
+		{"katydid Poecilimon doga", "Poecilimon doga", false},
+		{"cicada Cicada mordoganensis", "Cicada mordoganensis", false},
+		{"cricket Lepidogryllus comparatus", "Lepidogryllus comparatus", false},
+		{"cricket Lepidogryllus parvulus", "Lepidogryllus parvulus", false},
+		// Negatives: wild canids stay detectable as wildlife.
+		{"wolf Canis lupus", "Canis lupus", false},
+		{"coyote Canis latrans", "Canis latrans", false},
+		{"jackal Canis aureus", "Canis aureus", false},
+		// Negatives: humans and birds are not dogs.
+		{"Perch Speech is not dog", "Speech", false},
+		{"bird Turdus merula", "Turdus merula", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isDogDetection(tt.rawLabel))
+		})
+	}
+}
+
+// TestDetectionHandlers_RecordTimestamp proves both recording handlers store a
+// detection timestamp for the labels the old substring match missed: Perch v2
+// FSD50K classes and localized (non-English) BirdNET classes.
+func TestDetectionHandlers_RecordTimestamp(t *testing.T) {
+	t.Parallel()
+
+	const source = "src1"
+	start := time.Date(2026, 6, 19, 8, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		species string
+		enable  func(s *conf.Settings)
+		record  func(p *Processor, s *conf.Settings, item classifier.Results, r datastore.Results)
+		stored  func(p *Processor) (time.Time, bool)
+	}{
+		{
+			name:    "privacy filter records Perch speech",
+			species: "Speech",
+			enable: func(s *conf.Settings) {
+				s.Realtime.PrivacyFilter.Enabled = true
+				s.Realtime.PrivacyFilter.Confidence = 0.05
+			},
+			record: (*Processor).handleHumanDetection,
+			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastHumanDetection[source]; return v, ok },
+		},
+		{
+			name:    "privacy filter records localized BirdNET human",
+			species: "Human vocal_Mensch Stimme",
+			enable: func(s *conf.Settings) {
+				s.Realtime.PrivacyFilter.Enabled = true
+				s.Realtime.PrivacyFilter.Confidence = 0.05
+			},
+			record: (*Processor).handleHumanDetection,
+			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastHumanDetection[source]; return v, ok },
+		},
+		{
+			name:    "dog bark filter records Perch bark",
+			species: "Bark",
+			enable: func(s *conf.Settings) {
+				s.Realtime.DogBarkFilter.Enabled = true
+				s.Realtime.DogBarkFilter.Confidence = 0.05
+			},
+			record: (*Processor).handleDogDetection,
+			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastDogDetection[source]; return v, ok },
+		},
+		{
+			name:    "dog bark filter records localized BirdNET dog",
+			species: "Dog_Hund",
+			enable: func(s *conf.Settings) {
+				s.Realtime.DogBarkFilter.Enabled = true
+				s.Realtime.DogBarkFilter.Confidence = 0.05
+			},
+			record: (*Processor).handleDogDetection,
+			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastDogDetection[source]; return v, ok },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &conf.Settings{}
+			tt.enable(settings)
+
+			p := &Processor{
+				LastHumanDetection: make(map[string]time.Time),
+				LastDogDetection:   make(map[string]time.Time),
+			}
+			item := classifier.Results{StartTime: start}
+			item.Source.ID = source
+			result := datastore.Results{Species: tt.species, Confidence: 0.9}
+
+			tt.record(p, settings, item, result)
+
+			got, ok := tt.stored(p)
+			assert.True(t, ok, "handler should record a detection timestamp")
+			assert.Equal(t, start, got)
+		})
+	}
+}
+
+// TestShouldFilterDetection_DropsHumanLabels covers the third changed call site:
+// shouldFilterDetection must drop a human-labeled detection from being saved
+// (Perch v2 class and a localized BirdNET class), while letting a normal bird
+// through.
+func TestShouldFilterDetection_DropsHumanLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		species    string
+		wantFilter bool
+	}{
+		{"Perch speech is dropped", "Speech", true},
+		{"localized BirdNET human is dropped", "Human vocal_Mensch Stimme", true},
+		{"normal bird is not dropped by the human filter", "Turdus merula", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Processor{}
+			settings := &conf.Settings{}
+			result := datastore.Results{Species: tt.species, Confidence: 0.9}
+
+			shouldFilter, _ := p.shouldFilterDetection(
+				settings,
+				result,
+				tt.species, // commonName (unused by the human branch)
+				tt.species, // scientificName
+				tt.species, // speciesLowercase
+				0.7,        // baseThreshold (Confidence 0.9 > 0.7 triggers the human branch)
+				"Backyard",
+				"Perch_V2",
+			)
+
+			if tt.wantFilter {
+				assert.True(t, shouldFilter, "human-labeled detection must be filtered out")
+			} else {
+				// A normal bird is not dropped by the human privacy branch. Other
+				// branches may still pass it through; the human check must not fire.
+				assert.False(t, shouldFilter, "non-human detection must not hit the human privacy filter")
+			}
+		})
+	}
+}

--- a/internal/analysis/processor/vocalization_labels_test.go
+++ b/internal/analysis/processor/vocalization_labels_test.go
@@ -56,6 +56,10 @@ func TestIsHumanVocalization(t *testing.T) {
 		{"Perch Run", "Run", true},
 		// Human taxon (the human species itself).
 		{"Perch Homo sapiens", "Homo sapiens", true},
+		// Case-insensitive matching (custom/future label files may vary casing).
+		{"Perch speech lowercase", "speech", true},
+		{"Perch HUMAN_VOICE uppercase", "HUMAN_VOICE", true},
+		{"BirdNET human prefix lowercase", "human vocal_human vocal", true},
 		// Negatives: bird binomials that merely contain the substring "human".
 		{"cicada Pacarina schumanni", "Pacarina schumanni", false},
 		{"warbler Phylloscopus humei", "Phylloscopus humei", false},
@@ -92,6 +96,9 @@ func TestIsDogDetection(t *testing.T) {
 		{"Perch Bark", "Bark", true},
 		{"Perch Growling", "Growling", true},
 		{"Perch Canis familiaris", "Canis familiaris", true},
+		// Case-insensitive matching.
+		{"Perch bark lowercase", "bark", true},
+		{"BirdNET DOG_DOG uppercase", "DOG_DOG", true},
 		// Negatives: bird/insect binomials that merely contain the substring "dog".
 		// Tachyspiza rhodogaster is a real bird (Vinous-breasted Sparrowhawk); the
 		// old "dog" substring match would have wrongly filtered it.
@@ -118,61 +125,42 @@ func TestIsDogDetection(t *testing.T) {
 }
 
 // TestDetectionHandlers_RecordTimestamp proves both recording handlers store a
-// detection timestamp for the labels the old substring match missed: Perch v2
-// FSD50K classes and localized (non-English) BirdNET classes.
+// detection timestamp for the labels the old substring match missed (Perch v2
+// FSD50K classes and localized non-English BirdNET classes), and do NOT record
+// when the filter is disabled or the confidence is below the threshold. It also
+// confirms each handler writes only its own map, never the other filter's.
 func TestDetectionHandlers_RecordTimestamp(t *testing.T) {
 	t.Parallel()
 
 	const source = "src1"
 	start := time.Date(2026, 6, 19, 8, 0, 0, 0, time.UTC)
 
+	enablePrivacy := func(s *conf.Settings) {
+		s.Realtime.PrivacyFilter.Enabled = true
+		s.Realtime.PrivacyFilter.Confidence = 0.05
+	}
+	enableDog := func(s *conf.Settings) {
+		s.Realtime.DogBarkFilter.Enabled = true
+		s.Realtime.DogBarkFilter.Confidence = 0.05
+	}
+
 	tests := []struct {
-		name    string
-		species string
-		enable  func(s *conf.Settings)
-		record  func(p *Processor, s *conf.Settings, item classifier.Results, r datastore.Results)
-		stored  func(p *Processor) (time.Time, bool)
+		name       string
+		species    string
+		confidence float32
+		enable     func(s *conf.Settings)
+		record     func(p *Processor, s *conf.Settings, item classifier.Results, r datastore.Results)
+		isHuman    bool // true: should write LastHumanDetection; false: LastDogDetection
+		wantStored bool
 	}{
-		{
-			name:    "privacy filter records Perch speech",
-			species: "Speech",
-			enable: func(s *conf.Settings) {
-				s.Realtime.PrivacyFilter.Enabled = true
-				s.Realtime.PrivacyFilter.Confidence = 0.05
-			},
-			record: (*Processor).handleHumanDetection,
-			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastHumanDetection[source]; return v, ok },
-		},
-		{
-			name:    "privacy filter records localized BirdNET human",
-			species: "Human vocal_Mensch Stimme",
-			enable: func(s *conf.Settings) {
-				s.Realtime.PrivacyFilter.Enabled = true
-				s.Realtime.PrivacyFilter.Confidence = 0.05
-			},
-			record: (*Processor).handleHumanDetection,
-			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastHumanDetection[source]; return v, ok },
-		},
-		{
-			name:    "dog bark filter records Perch bark",
-			species: "Bark",
-			enable: func(s *conf.Settings) {
-				s.Realtime.DogBarkFilter.Enabled = true
-				s.Realtime.DogBarkFilter.Confidence = 0.05
-			},
-			record: (*Processor).handleDogDetection,
-			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastDogDetection[source]; return v, ok },
-		},
-		{
-			name:    "dog bark filter records localized BirdNET dog",
-			species: "Dog_Hund",
-			enable: func(s *conf.Settings) {
-				s.Realtime.DogBarkFilter.Enabled = true
-				s.Realtime.DogBarkFilter.Confidence = 0.05
-			},
-			record: (*Processor).handleDogDetection,
-			stored: func(p *Processor) (time.Time, bool) { v, ok := p.LastDogDetection[source]; return v, ok },
-		},
+		{"privacy records Perch speech", "Speech", 0.9, enablePrivacy, (*Processor).handleHumanDetection, true, true},
+		{"privacy records localized BirdNET human", "Human vocal_Mensch Stimme", 0.9, enablePrivacy, (*Processor).handleHumanDetection, true, true},
+		{"privacy disabled does not record", "Speech", 0.9, func(_ *conf.Settings) {}, (*Processor).handleHumanDetection, true, false},
+		{"privacy below threshold does not record", "Speech", 0.01, enablePrivacy, (*Processor).handleHumanDetection, true, false},
+		{"dog records Perch bark", "Bark", 0.9, enableDog, (*Processor).handleDogDetection, false, true},
+		{"dog records localized BirdNET dog", "Dog_Hund", 0.9, enableDog, (*Processor).handleDogDetection, false, true},
+		{"dog disabled does not record", "Bark", 0.9, func(_ *conf.Settings) {}, (*Processor).handleDogDetection, false, false},
+		{"dog below threshold does not record", "Bark", 0.01, enableDog, (*Processor).handleDogDetection, false, false},
 	}
 
 	for _, tt := range tests {
@@ -188,13 +176,21 @@ func TestDetectionHandlers_RecordTimestamp(t *testing.T) {
 			}
 			item := classifier.Results{StartTime: start}
 			item.Source.ID = source
-			result := datastore.Results{Species: tt.species, Confidence: 0.9}
+			result := datastore.Results{Species: tt.species, Confidence: tt.confidence}
 
 			tt.record(p, settings, item, result)
 
-			got, ok := tt.stored(p)
-			assert.True(t, ok, "handler should record a detection timestamp")
-			assert.Equal(t, start, got)
+			target, other := p.LastHumanDetection, p.LastDogDetection
+			if !tt.isHuman {
+				target, other = p.LastDogDetection, p.LastHumanDetection
+			}
+
+			got, ok := target[source]
+			assert.Equal(t, tt.wantStored, ok, "unexpected record state in target map")
+			if tt.wantStored {
+				assert.Equal(t, start, got)
+			}
+			assert.Empty(t, other, "handler must not write the other filter's map")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The privacy filter (human voice detection) and the dog bark filter only recognized BirdNET's English class labels. They matched a `"human"` / `"dog"` substring against the enriched, localized common name, which had three problems:

- **Perch v2 missed entirely.** Google Perch v2 emits AudioSet/FSD50K sound classes (`Speech`, `Bark`, `Growling`, `Human_voice`, ...) that carry no "human"/"dog" token, so neither filter ever fired for Perch detections.
- **Broken for non-English locales.** Labels are loaded per-locale, so a German user's `Dog_Hund` / `Human vocal_Mensch Stimme` split to common names `Hund` / `Mensch Stimme`, which the substring match could not see. Both filters were silently inert for every non-English locale.
- **False positives on real species.** The substring also matched bird/insect binomials that merely contain those letters: the cicada *Pacarina schumanni* ("sc**human**ni"), the hawk *Tachyspiza rhodogaster* ("rho**dog**aster"), and dozens of Polish/Serbian bird names containing "dog" were being wrongly filtered.

## Fix

Match the **raw classifier label** instead of the localized common name:

- An exact set of Perch v2 (FSD50K) human and dog classes.
- A locale-stable English prefix (`"Human "` / `"Dog_"`) for the BirdNET classes. The scientific portion of a BirdNET label is English in all 42 locale files, so the prefix matches everywhere; the trailing space / underscore anchors the match so the binomial collisions above are excluded.

New `internal/analysis/processor/vocalization_labels.go` holds the sets and the `isHumanVocalization` / `isDogDetection` helpers, wired into `handleHumanDetection`, `handleDogDetection`, and `shouldFilterDetection`.

The human set covers the full AudioSet "Human sounds" branch present in Perch (speech, vocalizations, respiratory, digestive, hand, locomotion, group actions) plus the `Homo sapiens` taxon. The dog set is the domestic dog plus dog sounds; wild canids (wolf, coyote, jackal) are intentionally excluded so they remain detectable as wildlife.

## Behavior change

With the default-on privacy filter, Perch v2 human-class detections are now suppressed for privacy (they were silently saved before). The set is intentionally broad, matching BirdNET's existing vocal + non-vocal coverage.

## Test plan

- [x] `go test -race ./internal/analysis/processor/` (new table tests cover Perch classes, localized BirdNET labels, binomial-collision negatives, and all three call sites)
- [x] `golangci-lint run` clean
- [x] `go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced human vocalization privacy filter with broader support across different audio models and analysis systems
  * Improved dog detection and vocalization classification for more reliable identification

* **Tests**
  * Added comprehensive unit tests for audio label classification and privacy filtering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->