### PR TITLE
feat(system): AI Models "Last heard" diagnostic feed (throttled, cross-model, range-marked)

### DIFF
--- a/frontend/src/lib/desktop/features/system/inference.types.ts
+++ b/frontend/src/lib/desktop/features/system/inference.types.ts
@@ -76,12 +76,19 @@ export interface ModelMetricKeys {
   errorRate: string;
 }
 
-/** Most recent detection produced by a model. */
+/** A recent detection in a model's "Last heard" feed (throttled per species). */
 export interface InferenceLastDetection {
   species: string;
   scientificName: string;
   confidence: number;
   atUnix: number;
+  /**
+   * Whether the species passes the range filter. True when in range or the range
+   * filter is inactive (e.g. no location configured). When the range filter is
+   * active it is false for out-of-range birds and for non-avian and human classes,
+   * which are shown for diagnostics but are not saved as detections.
+   */
+  inRange: boolean;
 }
 
 /** A single loaded model and its current state. */
@@ -106,7 +113,7 @@ export interface InferenceModel {
   paused?: boolean;
   /** Human-readable reason the model is paused, when paused (e.g. "Night schedule"). */
   scheduleLabel?: string;
-  /** Most recent above-threshold detections, newest first (up to 10). */
+  /** Most recent above-threshold predictions, newest first (up to 20). */
   recentDetections?: InferenceLastDetection[];
 }
 

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -434,14 +434,17 @@
   // CO_DETECTION_TOLERANCE_SEC of this detection, for cross-model correlation.
   function coDetectingModels(modelId: string, d: InferenceLastDetection): string[] {
     if (!snapshot) return [];
-    const key = d.scientificName || d.species;
-    if (!key) return [];
+    if (!d.scientificName && !d.species) return [];
     const names: string[] = [];
     for (const m of snapshot.models) {
       if (m.id === modelId) continue;
+      // Match on the scientific name when both have one, else on the common name,
+      // so a species that one model labels scientifically and another labels by
+      // common name still correlates.
       const hit = m.recentDetections?.some(
         o =>
-          (o.scientificName || o.species) === key &&
+          ((!!o.scientificName && o.scientificName === d.scientificName) ||
+            (!!o.species && o.species === d.species)) &&
           Math.abs(o.atUnix - d.atUnix) <= CO_DETECTION_TOLERANCE_SEC
       );
       if (hit) names.push(m.detectionName || m.name);

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -438,15 +438,17 @@
     const names: string[] = [];
     for (const m of snapshot.models) {
       if (m.id === modelId) continue;
-      // Match on the scientific name when both have one, else on the common name,
-      // so a species that one model labels scientifically and another labels by
-      // common name still correlates.
-      const hit = m.recentDetections?.some(
-        o =>
-          ((!!o.scientificName && o.scientificName === d.scientificName) ||
-            (!!o.species && o.species === d.species)) &&
-          Math.abs(o.atUnix - d.atUnix) <= CO_DETECTION_TOLERANCE_SEC
-      );
+      // When both entries have a scientific name, that is the authoritative
+      // identity: compare it and do not fall back to the common name (two
+      // different species can share a common name). Only fall back to the
+      // species key when one side lacks a scientific name.
+      const hit = m.recentDetections?.some(o => {
+        const sameSpecies =
+          o.scientificName && d.scientificName
+            ? o.scientificName === d.scientificName
+            : (o.scientificName || o.species) === (d.scientificName || d.species);
+        return sameSpecies && Math.abs(o.atUnix - d.atUnix) <= CO_DETECTION_TOLERANCE_SEC;
+      });
       if (hit) names.push(m.detectionName || m.name);
     }
     return names;
@@ -840,7 +842,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      {#each rows as d, i (`${d.scientificName || d.species}-${d.atUnix}-${i}`)}
+                      {#each rows as d (`${d.scientificName || d.species}-${d.atUnix}`)}
                         {@const coNames = coDetectingModels(model.id, d)}
                         <tr class="border-t border-[var(--border-100)]">
                           <td class="py-0.5 pr-2 text-base-content">

--- a/frontend/src/lib/desktop/views/SystemInference.svelte
+++ b/frontend/src/lib/desktop/views/SystemInference.svelte
@@ -25,15 +25,17 @@
   import { ReconnectingEventSource } from '$lib/utils/ReconnectingEventSource';
   import { loggers } from '$lib/utils/logger';
   import { connectionState } from '$lib/stores/connectionState.svelte';
-  import { formatBytesCompact, formatNumber, formatRelativeTime } from '$lib/utils/formatters';
+  import { formatBytesCompact, formatNumber } from '$lib/utils/formatters';
+  import { getLocalTimeString, formatLocalDateTime } from '$lib/utils/date';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import Badge from '$lib/desktop/components/ui/Badge.svelte';
   import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
   import Sparkline from '$lib/desktop/features/system/components/Sparkline.svelte';
-  import { Brain, Cpu, MemoryStick, Activity, Minus, Pause } from '@lucide/svelte';
+  import { Brain, Cpu, MemoryStick, Activity, Minus, Pause, MapPinOff } from '@lucide/svelte';
   import type {
     InferenceStatusResponse,
     InferenceModel,
+    InferenceLastDetection,
     BackendStatus,
     OpenVINOBackendStatus,
   } from '$lib/desktop/features/system/inference.types';
@@ -60,6 +62,21 @@
 
   // Conversions for spec display.
   const HZ_PER_KHZ = 1000;
+
+  // Flat 0 baseline shown in the latency sparkline before real samples flow (the
+  // chart needs >= 2 points to draw a line; an all-zeros series renders as a flat
+  // line at the bottom). Used until the live series has at least two points.
+  const EMPTY_SPARKLINE_BASELINE = [0, 0];
+
+  // Tolerance (seconds) for treating the same species in two models' feeds as one
+  // co-detection. Detection timestamps are per-model wall-clock at second
+  // granularity, and models analyze different segment lengths, so co-detections of
+  // one bird land a few seconds apart; this stays well under the per-species
+  // throttle so it never matches two different occurrences within a model.
+  const CO_DETECTION_TOLERANCE_SEC = 3;
+
+  // Rows per column in the two-column Last-heard layout (backend retains 2x this).
+  const LAST_HEARD_COLUMN_ROWS = 10;
 
   interface MetricPoint {
     timestamp: string;
@@ -369,7 +386,7 @@
     snapshot ? snapshot.backends.openvino : null
   );
 
-  // Spec line for a model: sample rate in kHz, clip length in seconds.
+  // Spec line for a model: sample rate in kHz, segment length in seconds.
   function sampleRateKhz(hz: number): string {
     return (hz / HZ_PER_KHZ).toFixed(hz % HZ_PER_KHZ === 0 ? 0 : 1);
   }
@@ -411,6 +428,25 @@
     const current = series[series.length - 1] ?? 0;
     const peak = Math.max(...series);
     return `${current.toFixed(1)} ${t('system.inference.unitMs')} · ${t('system.inference.peak')} ${peak.toFixed(1)}`;
+  }
+
+  // Short names of other loaded models whose feed contains the same species within
+  // CO_DETECTION_TOLERANCE_SEC of this detection, for cross-model correlation.
+  function coDetectingModels(modelId: string, d: InferenceLastDetection): string[] {
+    if (!snapshot) return [];
+    const key = d.scientificName || d.species;
+    if (!key) return [];
+    const names: string[] = [];
+    for (const m of snapshot.models) {
+      if (m.id === modelId) continue;
+      const hit = m.recentDetections?.some(
+        o =>
+          (o.scientificName || o.species) === key &&
+          Math.abs(o.atUnix - d.atUnix) <= CO_DETECTION_TOLERANCE_SEC
+      );
+      if (hit) names.push(m.detectionName || m.name);
+    }
+    return names;
   }
 </script>
 
@@ -732,78 +768,149 @@
                 {/if}
               </div>
 
-              <!-- Latency sparkline + recent detections (Last heard) side by side -->
-              <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div>
-                  <div class="text-xs text-muted mb-1 flex items-center gap-1">
-                    <Activity class="w-3 h-3 shrink-0" aria-hidden="true" />
-                    {t('system.inference.latencyChart')}
-                    {#if latencySeries.length > 0}
-                      <span class="ml-auto font-mono tabular-nums text-base-content">
-                        {latencySummary(latencySeries)}
-                      </span>
-                    {/if}
-                  </div>
-                  <div class="h-10">
-                    <Sparkline
-                      data={latencySeries}
-                      color={LATENCY_COLOR}
-                      decorative
-                      emptyLabel={t('system.inference.noDataYet')}
-                    />
-                  </div>
+              <!-- Latency sparkline (full width) -->
+              <div>
+                <div class="text-xs text-muted mb-1 flex items-center gap-1">
+                  <Activity class="w-3 h-3 shrink-0" aria-hidden="true" />
+                  {t('system.inference.latencyChart')}
+                  {#if latencySeries.length > 0}
+                    <span class="ml-auto font-mono tabular-nums text-base-content">
+                      {latencySummary(latencySeries)}
+                    </span>
+                  {/if}
                 </div>
-                <div>
-                  <div class="text-xs text-muted mb-1">{t('system.inference.lastHeard')}</div>
-                  <!-- min-height sized for the full 10-row ring so the card does not
-                       resize as detections fill in after a restart. -->
-                  <div class="min-h-[11rem]">
-                    {#if model.recentDetections && model.recentDetections.length > 0}
-                      <table class="w-full text-xs table-fixed">
-                        <thead class="text-muted">
-                          <tr>
-                            <th class="text-left font-normal py-0.5">
-                              {t('system.inference.species')}
-                            </th>
-                            <th
-                              class="text-right font-normal py-0.5 w-16"
-                              title={t('common.labels.confidence')}
-                              aria-label={t('common.labels.confidence')}
-                            >
-                              {t('system.inference.confidenceColumn')}
-                            </th>
-                            <th class="text-right font-normal py-0.5 w-20">
-                              {t('system.inference.heardWhen')}
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {#each model.recentDetections as d, i (`${d.atUnix}-${i}`)}
-                            <tr class="border-t border-[var(--border-100)]">
-                              <td
-                                class="truncate py-0.5 pr-2 text-base-content"
+                <div class="h-10">
+                  <!-- Before real samples flow, draw a flat 0 baseline (the chart
+                       needs >= 2 points) instead of an empty/placeholder state. -->
+                  <Sparkline
+                    data={latencySeries.length >= 2 ? latencySeries : EMPTY_SPARKLINE_BASELINE}
+                    color={LATENCY_COLOR}
+                    decorative
+                  />
+                </div>
+              </div>
+
+              <!-- Recent detections (Last heard): a per-species-throttled feed (the
+                   same species is recorded at most once per the model's segment
+                   interval). Shown as two columns of ten (newest ten on the left,
+                   the next ten on the right) with absolute timestamps and the other
+                   models that detected the same species within the tolerance, so
+                   detections can be correlated across models. -->
+              <div>
+                <div class="text-xs text-muted">{t('system.inference.lastHeard')}</div>
+                <!-- The feed shows everything each model fires on above the base
+                     threshold, so it includes non-bird, human, and out-of-range
+                     predictions that are not saved. Explain it so they are not
+                     mistaken for saved detections. -->
+                <div class="text-[11px] text-muted mb-1 leading-snug">
+                  {t('system.inference.lastHeardHint')}
+                </div>
+
+                {#snippet feedTable(rows: InferenceLastDetection[])}
+                  <table class="w-full text-xs table-fixed">
+                    <thead class="text-muted">
+                      <tr>
+                        <th class="text-left font-normal py-0.5 pr-2">
+                          {t('system.inference.species')}
+                        </th>
+                        <th
+                          class="text-left font-normal py-0.5 w-12 whitespace-nowrap"
+                          title={t('common.labels.confidence')}
+                          aria-label={t('common.labels.confidence')}
+                        >
+                          {t('system.inference.confidenceColumn')}
+                        </th>
+                        <th class="text-left font-normal py-0.5 w-16 whitespace-nowrap">
+                          {t('system.inference.heardWhen')}
+                        </th>
+                        <th
+                          class="text-left font-normal py-0.5 pl-2 w-20 whitespace-nowrap"
+                          title={t('system.inference.coDetectedHelp', {
+                            seconds: CO_DETECTION_TOLERANCE_SEC,
+                          })}
+                          aria-label={t('system.inference.coDetectedHelp', {
+                            seconds: CO_DETECTION_TOLERANCE_SEC,
+                          })}
+                        >
+                          {t('system.inference.coDetectedColumn')}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {#each rows as d, i (`${d.scientificName || d.species}-${d.atUnix}-${i}`)}
+                        {@const coNames = coDetectingModels(model.id, d)}
+                        <tr class="border-t border-[var(--border-100)]">
+                          <td class="py-0.5 pr-2 text-base-content">
+                            <div class="flex items-center gap-1 min-w-0">
+                              {#if !d.inRange}
+                                <!-- Did not pass the range filter (non-avian, human,
+                                     or out-of-range): shown for diagnostics but not
+                                     saved as a detection. -->
+                                <span
+                                  class="shrink-0 inline-flex text-muted"
+                                  role="img"
+                                  title={t('system.inference.outOfRangeHelp')}
+                                  aria-label={t('system.inference.outOfRangeHelp')}
+                                >
+                                  <MapPinOff class="w-3 h-3" aria-hidden="true" />
+                                </span>
+                              {/if}
+                              <span
+                                class="truncate"
                                 title={d.scientificName
                                   ? `${d.species} (${d.scientificName})`
                                   : d.species}
                               >
                                 {d.species}
-                              </td>
-                              <td
-                                class="text-right py-0.5 font-mono tabular-nums text-base-content"
-                              >
-                                {Math.round(d.confidence * 100)}%
-                              </td>
-                              <td class="text-right py-0.5 text-muted whitespace-nowrap">
-                                {formatRelativeTime(d.atUnix * 1000)}
-                              </td>
-                            </tr>
-                          {/each}
-                        </tbody>
-                      </table>
-                    {:else}
-                      <div class="text-xs text-muted">{t('system.inference.lastHeardNever')}</div>
-                    {/if}
-                  </div>
+                              </span>
+                            </div>
+                          </td>
+                          <td class="text-left py-0.5 font-mono tabular-nums text-base-content">
+                            {Math.round(d.confidence * 100)}%
+                          </td>
+                          <td
+                            class="text-left py-0.5 font-mono tabular-nums text-muted whitespace-nowrap"
+                            title={formatLocalDateTime(new Date(d.atUnix * 1000))}
+                          >
+                            {getLocalTimeString(new Date(d.atUnix * 1000))}
+                          </td>
+                          <td
+                            class="truncate py-0.5 pl-2 text-muted"
+                            title={coNames.length > 0 ? coNames.join(', ') : undefined}
+                          >
+                            {#if coNames.length > 0}
+                              {coNames.join(', ')}
+                            {:else}
+                              -
+                            {/if}
+                          </td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                {/snippet}
+
+                <!-- min-height sized for the full ten rows per column so the card
+                     does not resize as detections fill in after a restart. -->
+                <div class="min-h-[12rem]">
+                  {#if model.recentDetections && model.recentDetections.length > 0}
+                    {@const left = model.recentDetections.slice(0, LAST_HEARD_COLUMN_ROWS)}
+                    {@const right = model.recentDetections.slice(
+                      LAST_HEARD_COLUMN_ROWS,
+                      LAST_HEARD_COLUMN_ROWS * 2
+                    )}
+                    <!-- Two newspaper columns: newest ten on the left, next ten on
+                         the right. The left table stays half-width even before the
+                         right column fills, so the species column never hogs the card. -->
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-6 items-start">
+                      {@render feedTable(left)}
+                      {#if right.length > 0}
+                        {@render feedTable(right)}
+                      {/if}
+                    </div>
+                  {:else}
+                    <div class="text-xs text-muted">{t('system.inference.lastHeardNever')}</div>
+                  {/if}
                 </div>
               </div>
 

--- a/frontend/src/lib/desktop/views/SystemInference.test.ts
+++ b/frontend/src/lib/desktop/views/SystemInference.test.ts
@@ -432,7 +432,7 @@ describe('SystemInference', () => {
     expect(capturedHistoryUrl).not.toContain('inference.model-1.error_rate');
   });
 
-  it('renders the Last heard table with recent detections (species and confidence)', async () => {
+  it('renders the Last heard feed with recent detections (species and confidence)', async () => {
     const model = makeModel({
       recentDetections: [
         {
@@ -440,12 +440,14 @@ describe('SystemInference', () => {
           scientificName: 'Fringilla coelebs',
           confidence: 0.87,
           atUnix: Math.floor(Date.now() / 1000) - 60,
+          inRange: true,
         },
         {
           species: 'European Robin',
           scientificName: 'Erithacus rubecula',
           confidence: 0.42,
           atUnix: Math.floor(Date.now() / 1000) - 120,
+          inRange: true,
         },
       ],
     });
@@ -462,6 +464,137 @@ describe('SystemInference', () => {
     expect(text).toContain('87%');
     expect(text).toContain('European Robin');
     expect(text).toContain('42%');
+  });
+
+  it('shows the same species more than once in the throttled feed', async () => {
+    // The feed is chronological, not collapsed: a species detected again after
+    // its throttle interval appears as a separate row (no ×N counter, no range).
+    const now = Math.floor(Date.now() / 1000);
+    const model = makeModel({
+      recentDetections: [
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.81,
+          atUnix: now - 2,
+          inRange: true,
+        },
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.77,
+          atUnix: now - 12,
+          inRange: true,
+        },
+      ],
+    });
+    installApi(makeSnapshot([model]));
+
+    const { container } = inferenceTest.render({});
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(model.name);
+    });
+    // Two separate rows for the same species, each with its own confidence.
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    const text = container.textContent;
+    expect(text).toContain('81%');
+    expect(text).toContain('77%');
+    expect(text).not.toContain('×');
+  });
+
+  it('lists other models that detected the same species within tolerance (Also column)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const birdnet = makeModel({
+      id: 'model-1',
+      name: 'BirdNET GLOBAL 6K',
+      detectionName: 'BirdNET',
+      recentDetections: [
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.8,
+          atUnix: now - 5,
+          inRange: true,
+        },
+        {
+          species: 'Common Blackbird',
+          scientificName: 'Turdus merula',
+          confidence: 0.7,
+          atUnix: now - 30,
+          inRange: true,
+        },
+      ],
+    });
+    const perch = makeModel({
+      id: 'model-2',
+      name: 'Perch',
+      detectionName: 'Perch',
+      metricKeys: {
+        avgMs: 'inference.model-2.avg_ms',
+        rtf: 'inference.model-2.rtf',
+        throughput: 'inference.model-2.throughput',
+        errorRate: 'inference.model-2.error_rate',
+      },
+      // Robin 1s from BirdNET's Robin (within tolerance); no Blackbird.
+      recentDetections: [
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.75,
+          atUnix: now - 6,
+          inRange: true,
+        },
+      ],
+    });
+    installApi(makeSnapshot([birdnet, perch]));
+
+    const { container } = inferenceTest.render({});
+    await waitFor(() => {
+      expect(container.textContent).toContain('BirdNET GLOBAL 6K');
+    });
+
+    // The "Also" column is the 4th cell of each detection row.
+    const alsoCells = Array.from(container.querySelectorAll('tbody tr td:nth-child(4)')).map(c =>
+      c.textContent.trim()
+    );
+    expect(alsoCells).toContain('Perch'); // BirdNET's Robin co-detected by Perch
+    expect(alsoCells).toContain('BirdNET'); // Perch's Robin co-detected by BirdNET
+    expect(alsoCells).toContain('-'); // Blackbird had no co-detection
+  });
+
+  it('marks out-of-range / non-avian predictions with an icon, not in-range ones', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const model = makeModel({
+      recentDetections: [
+        {
+          species: 'Engine',
+          scientificName: 'Engine',
+          confidence: 0.7,
+          atUnix: now - 2,
+          inRange: false,
+        },
+        {
+          species: 'European Robin',
+          scientificName: 'Erithacus rubecula',
+          confidence: 0.8,
+          atUnix: now - 10,
+          inRange: true,
+        },
+      ],
+    });
+    installApi(makeSnapshot([model]));
+
+    const { container } = inferenceTest.render({});
+    await waitFor(() => {
+      expect(container.textContent).toContain(model.name);
+    });
+
+    // Exactly one out-of-range marker (Engine); the in-range Robin has none.
+    const markers = container.querySelectorAll('[aria-label="system.inference.outOfRangeHelp"]');
+    expect(markers).toHaveLength(1);
+    expect(container.textContent).toContain('Engine');
+    expect(container.textContent).toContain('European Robin');
   });
 
   it('shows the lastHeardNever label when there are no recent detections', async () => {

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1211,9 +1211,13 @@ export type TranslationKey =
   | 'system.inference.pausedScheduleHelp'
   | 'system.inference.activityPaused'
   | 'system.inference.lastHeard'
+  | 'system.inference.lastHeardHint'
   | 'system.inference.lastHeardNever'
   | 'system.inference.confidenceColumn'
   | 'system.inference.heardWhen'
+  | 'system.inference.coDetectedColumn'
+  | 'system.inference.coDetectedHelp' // params: seconds
+  | 'system.inference.outOfRangeHelp'
   | 'system.inference.peak'
   | 'system.inference.activityActive'
   | 'system.inference.activityIdle'
@@ -1233,7 +1237,6 @@ export type TranslationKey =
   | 'system.inference.invocationsHelp'
   | 'system.inference.noModelsHint'
   | 'system.inference.noModelsHintLink'
-  | 'system.inference.noDataYet'
   | 'system.metrics.cpu'
   | 'system.metrics.memory'
   | 'system.metrics.temperature'
@@ -3903,6 +3906,7 @@ export type TranslationParams = {
   };
   'system.database.migration.prerequisites.criticalCount': { count: string | number };
   'system.database.migration.prerequisites.warningCount': { count: string | number };
+  'system.inference.coDetectedHelp': { seconds: string | number };
   'analytics.advanced.speciesSelection': { count: string | number; max: string | number };
   'analytics.advanced.detections': { count: string | number };
   'settings.notFound.message': { section: string | number };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Délka segmentu",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Tento model běží pouze podle plánu a je momentálně pozastaven, takže nezpracovává zvuk.",
       "activityPaused": "Pozastaveno plánem",
       "lastHeard": "Naposledy slyšeno",
+      "lastHeardHint": "Nedávné predikce nad prahem, pro diagnostiku. Zahrnuje neptačí a mimo-oblastní výsledky, které se neukládají jako detekce.",
       "lastHeardNever": "Zatím nic neslyšeno",
       "confidenceColumn": "Spol.",
       "heardWhen": "Kdy",
+      "coDetectedColumn": "Také",
+      "coDetectedHelp": "Jiné modely, které tento druh zachytily do {seconds} s",
+      "outOfRangeHelp": "Mimo oblastní filtr (zobrazeno pro diagnostiku, neuloženo jako detekce)",
       "peak": "špička",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmentlængde",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Denne model kører kun efter en tidsplan og er i øjeblikket sat på pause, så den behandler ikke lyd.",
       "activityPaused": "Pauseret af tidsplan",
       "lastHeard": "Sidst hørt",
+      "lastHeardHint": "Seneste forudsigelser over tærsklen, til diagnostik. Inkluderer ikke-fugle- og uden for område-resultater, der ikke gemmes som registreringer.",
       "lastHeardNever": "Intet hørt endnu",
       "confidenceColumn": "Konf.",
       "heardWhen": "Hvornår",
+      "coDetectedColumn": "Også",
+      "coDetectedHelp": "Andre modeller, der registrerede denne art inden for {seconds} s",
+      "outOfRangeHelp": "Uden for områdefilteret (vist til diagnostik, ikke gemt som registrering)",
       "peak": "spids",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmentlänge",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Dieses Modell läuft nur nach Zeitplan und ist derzeit pausiert, sodass es keine Audiodaten verarbeitet.",
       "activityPaused": "Durch Zeitplan pausiert",
       "lastHeard": "Zuletzt gehört",
+      "lastHeardHint": "Aktuelle Vorhersagen über dem Schwellenwert, zur Diagnose. Enthält Nicht-Vogel- und außerhalb des Bereichs liegende Ergebnisse, die nicht als Erkennungen gespeichert werden.",
       "lastHeardNever": "Noch nichts gehört",
       "confidenceColumn": "Konf.",
       "heardWhen": "Wann",
+      "coDetectedColumn": "Auch",
+      "coDetectedHelp": "Andere Modelle, die diese Art innerhalb von {seconds}s erkannt haben",
+      "outOfRangeHelp": "Außerhalb des Bereichsfilters (zur Diagnose angezeigt, nicht als Erkennung gespeichert)",
       "peak": "Peak",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segment length",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "This model only runs on a schedule and is currently paused, so it is not processing audio.",
       "activityPaused": "Paused by schedule",
       "lastHeard": "Last heard",
+      "lastHeardHint": "Recent above-threshold predictions, for diagnostics. Includes non-bird and out-of-range results that are not saved as detections.",
       "lastHeardNever": "Nothing heard yet",
       "confidenceColumn": "Conf.",
       "heardWhen": "When",
+      "coDetectedColumn": "Also",
+      "coDetectedHelp": "Other models that detected this species within {seconds}s",
+      "outOfRangeHelp": "Outside the range filter (shown for diagnostics, not saved as a detection)",
       "peak": "peak",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Longitud del segmento",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Este modelo solo funciona según un programa y actualmente está pausado, por lo que no está procesando audio.",
       "activityPaused": "Pausado por programación",
       "lastHeard": "Escuchado por última vez",
+      "lastHeardHint": "Predicciones recientes por encima del umbral, para diagnóstico. Incluye resultados no aviares y fuera de rango que no se guardan como detecciones.",
       "lastHeardNever": "Aún no se ha escuchado nada",
       "confidenceColumn": "Conf.",
       "heardWhen": "Cuándo",
+      "coDetectedColumn": "Tamb.",
+      "coDetectedHelp": "Otros modelos que detectaron esta especie en {seconds}s",
+      "outOfRangeHelp": "Fuera del filtro de rango (mostrado para diagnóstico, no guardado como detección)",
       "peak": "pico",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmentin pituus",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Tämä malli toimii vain aikataulun mukaan ja on tällä hetkellä tauolla, joten se ei käsittele ääntä.",
       "activityPaused": "Tauolla aikataulun mukaan",
       "lastHeard": "Viimeksi kuultu",
+      "lastHeardHint": "Viimeisimmät kynnyksen ylittävät ennusteet, diagnostiikkaa varten. Sisältää muut kuin lintu- ja alueen ulkopuoliset tulokset, joita ei tallenneta havaintoina.",
       "lastHeardNever": "Ei vielä kuultu mitään",
       "confidenceColumn": "Varm.",
       "heardWhen": "Milloin",
+      "coDetectedColumn": "Myös",
+      "coDetectedHelp": "Muut mallit, jotka havaitsivat tämän lajin {seconds}s sisällä",
+      "outOfRangeHelp": "Aluesuodattimen ulkopuolella (näytetään diagnostiikkaa varten, ei tallenneta havaintona)",
       "peak": "huippu",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Longueur du segment",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Ce modèle ne fonctionne que selon un calendrier et est actuellement en pause, il ne traite donc pas l'audio.",
       "activityPaused": "Mis en pause par le calendrier",
       "lastHeard": "Entendu pour la dernière fois",
+      "lastHeardHint": "Prédictions récentes au-dessus du seuil, pour diagnostic. Inclut les résultats non aviaires et hors zone qui ne sont pas enregistrés comme détections.",
       "lastHeardNever": "Rien d'entendu pour le moment",
       "confidenceColumn": "Conf.",
       "heardWhen": "Quand",
+      "coDetectedColumn": "Aussi",
+      "coDetectedHelp": "Autres modèles ayant détecté cette espèce en {seconds}s",
+      "outOfRangeHelp": "Hors du filtre de zone (affiché pour diagnostic, non enregistré comme détection)",
       "peak": "pic",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Szegmens hossza",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Ez a modell csak ütemezés szerint fut, és jelenleg szünetel, így nem dolgoz fel hangot.",
       "activityPaused": "Ütemezés miatt szünetel",
       "lastHeard": "Utoljára hallva",
+      "lastHeardHint": "Legutóbbi küszöb feletti előrejelzések, diagnosztikához. Tartalmazza a nem madár és tartományon kívüli eredményeket, amelyek nem kerülnek mentésre észlelésként.",
       "lastHeardNever": "Még semmi sem hallatszott",
       "confidenceColumn": "Konf.",
       "heardWhen": "Mikor",
+      "coDetectedColumn": "Még",
+      "coDetectedHelp": "Más modellek, amelyek {seconds} mp-en belül észlelték ezt a fajt",
+      "outOfRangeHelp": "A területszűrőn kívül (diagnosztikához megjelenítve, nem mentve észlelésként)",
       "peak": "csúcs",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Lunghezza segmento",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Questo modello funziona solo in base a una pianificazione ed è attualmente in pausa, quindi non sta elaborando l'audio.",
       "activityPaused": "In pausa da pianificazione",
       "lastHeard": "Sentito l'ultima volta",
+      "lastHeardHint": "Previsioni recenti sopra la soglia, per diagnostica. Include risultati non aviari e fuori intervallo che non vengono salvati come rilevamenti.",
       "lastHeardNever": "Ancora niente sentito",
       "confidenceColumn": "Conf.",
       "heardWhen": "Quando",
+      "coDetectedColumn": "Anche",
+      "coDetectedHelp": "Altri modelli che hanno rilevato questa specie entro {seconds}s",
+      "outOfRangeHelp": "Fuori dal filtro di area (mostrato per diagnostica, non salvato come rilevamento)",
       "peak": "picco",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmenta garums",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Šis modelis darbojas tikai pēc grafika un šobrīd ir apturēts, tāpēc tas neapstrādā audio.",
       "activityPaused": "Apturēts pēc grafika",
       "lastHeard": "Pēdējoreiz dzirdēts",
+      "lastHeardHint": "Nesenās prognozes virs sliekšņa, diagnostikai. Ietver ne-putnu un ārpus diapazona rezultātus, kas netiek saglabāti kā atklājumi.",
       "lastHeardNever": "Vēl nekas nav dzirdēts",
       "confidenceColumn": "Tic.",
       "heardWhen": "Kad",
+      "coDetectedColumn": "Arī",
+      "coDetectedHelp": "Citi modeļi, kas konstatēja šo sugu {seconds}s laikā",
+      "outOfRangeHelp": "Ārpus apgabala filtra (rādīts diagnostikai, nav saglabāts kā atklājums)",
       "peak": "pīķis",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "Procesors",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmentlengde",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Denne modellen kjører kun etter en tidsplan og er for øyeblikket pauset, så den behandler ikke lyd.",
       "activityPaused": "Pauset av tidsplan",
       "lastHeard": "Sist hørt",
+      "lastHeardHint": "Nylige prediksjoner over terskelen, for diagnostikk. Inkluderer ikke-fugl- og utenfor område-resultater som ikke lagres som deteksjoner.",
       "lastHeardNever": "Ingenting hørt ennå",
       "confidenceColumn": "Konf.",
       "heardWhen": "Når",
+      "coDetectedColumn": "Også",
+      "coDetectedHelp": "Andre modeller som registrerte denne arten innen {seconds}s",
+      "outOfRangeHelp": "Utenfor områdefilteret (vist for diagnostikk, ikke lagret som deteksjon)",
       "peak": "topp",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmentlengte",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Dit model draait alleen volgens een schema en is momenteel gepauzeerd, dus het verwerkt geen audio.",
       "activityPaused": "Gepauzeerd door schema",
       "lastHeard": "Laatst gehoord",
+      "lastHeardHint": "Recente voorspellingen boven de drempel, voor diagnostiek. Bevat niet-vogel- en buiten-bereik-resultaten die niet als detecties worden opgeslagen.",
       "lastHeardNever": "Nog niets gehoord",
       "confidenceColumn": "Betr.",
       "heardWhen": "Wanneer",
+      "coDetectedColumn": "Ook",
+      "coDetectedHelp": "Andere modellen die deze soort binnen {seconds}s detecteerden",
+      "outOfRangeHelp": "Buiten het bereikfilter (getoond voor diagnostiek, niet opgeslagen als detectie)",
       "peak": "piek",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Długość segmentu",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Ten model działa tylko zgodnie z harmonogramem i jest obecnie wstrzymany, więc nie przetwarza dźwięku.",
       "activityPaused": "Wstrzymano przez harmonogram",
       "lastHeard": "Ostatnio słyszano",
+      "lastHeardHint": "Ostatnie predykcje powyżej progu, do diagnostyki. Obejmuje wyniki nieptasie i spoza zasięgu, które nie są zapisywane jako wykrycia.",
       "lastHeardNever": "Jeszcze nic nie usłyszano",
       "confidenceColumn": "Pewn.",
       "heardWhen": "Kiedy",
+      "coDetectedColumn": "Też",
+      "coDetectedHelp": "Inne modele, które wykryły ten gatunek w ciągu {seconds}s",
+      "outOfRangeHelp": "Poza filtrem zasięgu (pokazane do diagnostyki, niezapisane jako wykrycie)",
       "peak": "szczyt",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Duração do segmento",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Este modelo só funciona de acordo com um cronograma e está atualmente pausado, portanto não está processando áudio.",
       "activityPaused": "Pausado por agendamento",
       "lastHeard": "Ouvido pela última vez",
+      "lastHeardHint": "Previsões recentes acima do limiar, para diagnóstico. Inclui resultados não aviários e fora do alcance que não são guardados como deteções.",
       "lastHeardNever": "Nada ouvido ainda",
       "confidenceColumn": "Conf.",
       "heardWhen": "Quando",
+      "coDetectedColumn": "Também",
+      "coDetectedHelp": "Outros modelos que detetaram esta espécie em {seconds}s",
+      "outOfRangeHelp": "Fora do filtro de área (mostrado para diagnóstico, não guardado como deteção)",
       "peak": "pico",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Dĺžka segmentu",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Tento model beží iba podľa plánu a momentálne je pozastavený, takže nespracováva zvuk.",
       "activityPaused": "Pozastavené plánom",
       "lastHeard": "Naposledy počuté",
+      "lastHeardHint": "Nedávne predpovede nad prahom, na diagnostiku. Zahŕňa nevtáčie a mimo oblasti výsledky, ktoré sa neukladajú ako detekcie.",
       "lastHeardNever": "Zatiaľ nič nepočuté",
       "confidenceColumn": "Spoľ.",
       "heardWhen": "Kedy",
+      "coDetectedColumn": "Tiež",
+      "coDetectedHelp": "Iné modely, ktoré tento druh zachytili do {seconds}s",
+      "outOfRangeHelp": "Mimo oblastného filtra (zobrazené na diagnostiku, neuložené ako detekcia)",
       "peak": "špička",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1536,7 +1536,7 @@
       "stock": "Stock",
       "custom": "Custom",
       "sampleRate": "Sample rate",
-      "clipLength": "Clip length",
+      "clipLength": "Segmentlängd",
       "species": "Species",
       "invocations": "Segments analysed",
       "avgLatency": "Avg latency",
@@ -1566,9 +1566,13 @@
       "pausedScheduleHelp": "Denna modell körs endast enligt ett schema och är för närvarande pausad, så den bearbetar inte ljud.",
       "activityPaused": "Pausad av schema",
       "lastHeard": "Sist hörd",
+      "lastHeardHint": "Senaste förutsägelser över tröskeln, för diagnostik. Inkluderar icke-fågel- och utanför område-resultat som inte sparas som detekteringar.",
       "lastHeardNever": "Inget hört än",
       "confidenceColumn": "Konf.",
       "heardWhen": "När",
+      "coDetectedColumn": "Även",
+      "coDetectedHelp": "Andra modeller som upptäckte denna art inom {seconds}s",
+      "outOfRangeHelp": "Utanför områdesfiltret (visas för diagnostik, sparas inte som detektering)",
       "peak": "topp",
       "activityActive": "Inference active",
       "activityIdle": "Idle",
@@ -1587,8 +1591,7 @@
       "fp16Help": "16-bit floating point. Hardware that supports it can run some models faster and with less memory.",
       "invocationsHelp": "Total audio segments this model has analysed since startup.",
       "noModelsHint": "No audio source configured yet?",
-      "noModelsHintLink": "Configure audio sources",
-      "noDataYet": "No data yet"
+      "noModelsHintLink": "Configure audio sources"
     },
     "metrics": {
       "cpu": "CPU",

--- a/internal/analysis/processor/last_detection_cache.go
+++ b/internal/analysis/processor/last_detection_cache.go
@@ -1,17 +1,30 @@
-// last_detection_cache.go - Per-model in-memory ring of recent detections.
+// last_detection_cache.go - Per-model in-memory feed of recently heard species.
 package processor
 
 import (
-	"github.com/tphakala/birdnet-go/internal/detection"
+	"math"
+	"time"
 )
 
-// lastDetectionRingSize is the number of most-recent above-threshold detections
-// retained per model for the inference-status "Last heard" view.
-const lastDetectionRingSize = 10
+// lastDetectionCap is the number of most-recent detections retained per model for
+// the inference-status "Last heard" feed. The frontend shows them as two columns
+// of ten.
+const lastDetectionCap = 20
 
-// LastDetection holds a snapshot of a single above-threshold detection for one
-// AI model. It is intentionally lightweight: only the fields needed by the
-// inference-status page are captured.
+// detectionThrottleTarget is the spacing the Last-heard feed aims for between
+// repeat entries of the same species. The actual per-model interval snaps this to
+// a whole number of the model's analysis segments (clip length), so feed entries
+// line up with segment boundaries (e.g. 9s for 3s BirdNET segments, 10s for 5s
+// Perch segments). Throttling keeps a continuously singing bird from flooding the
+// feed while still showing its detection cadence over time.
+const detectionThrottleTarget = 9 * time.Second
+
+// LastDetection holds a snapshot of one above-threshold prediction for one AI
+// model. The feed records every prediction above the base confidence threshold
+// (including non-avian, human, and out-of-range species), not only the ones that
+// pass every filter and get saved, so it shows what the model is actually firing
+// on. It is intentionally lightweight: only the fields the inference-status "Last
+// heard" feed needs are captured.
 type LastDetection struct {
 	// Species is the common name of the detected species.
 	Species string
@@ -21,55 +34,113 @@ type LastDetection struct {
 	Confidence float64
 	// AtUnix is the Unix timestamp (seconds) of when the detection occurred.
 	AtUnix int64
+	// InRange reports whether the species passes the range filter. It is true when
+	// the species is in range, or when the range filter is not active (e.g. no
+	// location configured). When the range filter is active it is false for
+	// out-of-range birds and for non-avian and human classes; those are shown for
+	// diagnostics but are not saved as real detections.
+	InRange bool
 }
 
-// detectionRing is a fixed-capacity circular buffer of the most recent
-// above-threshold detections for a single model. head is the index where the
-// next write lands; count is the number of valid entries (capped at the ring
-// size). It is not goroutine-safe on its own; the Processor's lastDetectionMu
-// guards every access.
-type detectionRing struct {
-	items [lastDetectionRingSize]LastDetection
-	head  int
-	count int
+// recentDetectionList is a small, most-recent-first feed of a single model's
+// recent detections, capped at lastDetectionCap entries. A species is recorded at
+// most once per throttle interval so a continuously singing bird does not flood
+// the feed (see observe). It is not goroutine-safe on its own; the Processor's
+// lastDetectionMu guards every access.
+type recentDetectionList struct {
+	// items is ordered most-recent-first; its length never exceeds lastDetectionCap.
+	items []LastDetection
+}
+
+// detectionThrottle returns the minimum spacing between recorded detections of
+// the same species for a model whose analysis segment (clip) length is clip. It
+// is clip scaled to the whole multiple closest to detectionThrottleTarget, with a
+// floor of one segment; an unknown clip length (<= 0) falls back to the target.
+func detectionThrottle(clip time.Duration) time.Duration {
+	if clip <= 0 {
+		return detectionThrottleTarget
+	}
+	n := max(int64(math.Round(float64(detectionThrottleTarget)/float64(clip))), 1)
+	return time.Duration(n) * clip
+}
+
+// speciesKey returns the stable identity used to rate-limit repeated detections
+// of the same species. ScientificName is preferred because it is
+// locale-independent; CommonName is the fallback when the scientific name is
+// missing. It is empty for an unidentified detection.
+func speciesKey(scientific, common string) string {
+	if scientific != "" {
+		return scientific
+	}
+	return common
+}
+
+// observe prepends one detection to the front of the feed, unless the same
+// species was already recorded within throttleSec seconds (in which case it is
+// dropped, keeping a continuously singing bird from flooding the feed). The
+// oldest entry is evicted once the cap is reached. The scan and shift are
+// O(lastDetectionCap), far cheaper than the surrounding lock acquisition.
+func (l *recentDetectionList) observe(common, scientific string, confidence float64, atUnix int64, inRange bool, throttleSec int64) {
+	key := speciesKey(scientific, common)
+	// Throttle: scan newest-first for this species' most recent feed entry. If it
+	// is within throttleSec, drop this detection; otherwise record it.
+	for i := range l.items {
+		if speciesKey(l.items[i].ScientificName, l.items[i].Species) != key {
+			continue
+		}
+		if atUnix-l.items[i].AtUnix < throttleSec {
+			return
+		}
+		break
+	}
+
+	entry := LastDetection{
+		Species:        common,
+		ScientificName: scientific,
+		Confidence:     confidence,
+		AtUnix:         atUnix,
+		InRange:        inRange,
+	}
+	// Prepend the new entry, shifting existing entries down one slot and dropping
+	// the oldest once the cap is reached. Grow the slice by one slot only while
+	// under the cap; at the cap the last (oldest) entry is overwritten by the
+	// shift. copy handles the overlapping move correctly.
+	if len(l.items) < lastDetectionCap {
+		l.items = append(l.items, LastDetection{})
+	}
+	copy(l.items[1:], l.items[:len(l.items)-1])
+	l.items[0] = entry
 }
 
 // lastDetectionCache and lastDetectionMu are added to the Processor struct in
-// processor.go. They are zero-value safe: the map and per-model rings are
-// lazily initialised in updateLastDetection.
+// processor.go. They are zero-value safe: the map and per-model feeds are lazily
+// initialised in updateLastDetection.
 
-// updateLastDetection records res as the most recent detection for modelID,
-// appending it to that model's ring (oldest entry evicted once full). Only
-// above-threshold detections reach this path (it is called post-threshold),
-// so every retained entry is an above-threshold detection. Empty modelID is
-// silently skipped. The write lock is held only for the ring update so the
-// detection hot path is minimally impacted. res is passed by pointer to avoid
-// copying the large detection.Result value.
-func (p *Processor) updateLastDetection(modelID string, res *detection.Result) {
-	if modelID == "" || res == nil {
+// updateLastDetection records one above-threshold prediction for modelID in the
+// "Last heard" feed, subject to the per-species throttle (see
+// recentDetectionList.observe). The caller records every prediction above the base
+// confidence threshold (including non-avian, human, and out-of-range species), so
+// inRange marks whether the species passes the range filter. Empty modelID is
+// silently skipped. throttle is the minimum spacing between recorded detections of
+// the same species (derived from the model's clip length by the caller). The write
+// lock is held only for the feed update so the detection hot path is minimally
+// impacted.
+func (p *Processor) updateLastDetection(modelID, commonName, scientificName string, confidence float64, at time.Time, inRange bool, throttle time.Duration) {
+	if modelID == "" {
 		return
 	}
-	entry := LastDetection{
-		Species:        res.Species.CommonName,
-		ScientificName: res.Species.ScientificName,
-		Confidence:     res.Confidence,
-		AtUnix:         res.Timestamp.Unix(),
-	}
+	throttleSec := int64(throttle / time.Second)
 	p.lastDetectionMu.Lock()
 	defer p.lastDetectionMu.Unlock()
 	if p.lastDetectionCache == nil {
-		p.lastDetectionCache = make(map[string]*detectionRing)
+		p.lastDetectionCache = make(map[string]*recentDetectionList)
 	}
-	ring := p.lastDetectionCache[modelID]
-	if ring == nil {
-		ring = &detectionRing{}
-		p.lastDetectionCache[modelID] = ring
+	list := p.lastDetectionCache[modelID]
+	if list == nil {
+		list = &recentDetectionList{}
+		p.lastDetectionCache[modelID] = list
 	}
-	ring.items[ring.head] = entry
-	ring.head = (ring.head + 1) % lastDetectionRingSize
-	if ring.count < lastDetectionRingSize {
-		ring.count++
-	}
+	list.observe(commonName, scientificName, confidence, at.Unix(), inRange, throttleSec)
 }
 
 // GetLastDetection returns the most recent detection for modelID and whether an
@@ -78,34 +149,26 @@ func (p *Processor) updateLastDetection(modelID string, res *detection.Result) {
 func (p *Processor) GetLastDetection(modelID string) (LastDetection, bool) {
 	p.lastDetectionMu.RLock()
 	defer p.lastDetectionMu.RUnlock()
-	ring := p.lastDetectionCache[modelID]
-	if ring == nil || ring.count == 0 {
+	list := p.lastDetectionCache[modelID]
+	if list == nil || len(list.items) == 0 {
 		return LastDetection{}, false
 	}
-	// The most recent write is one slot behind head (head points at the next
-	// write position). Wrap to the end of the array when head is at index 0.
-	newest := (ring.head - 1 + lastDetectionRingSize) % lastDetectionRingSize
-	return ring.items[newest], true
+	return list.items[0], true
 }
 
-// GetRecentDetections returns a newest-first copy of the recent above-threshold
-// detections for modelID, up to lastDetectionRingSize entries. The returned
-// slice is freshly allocated under the read lock with values copied out, so it
-// never shares backing storage with the ring; the caller may retain or mutate
-// it freely while the hot path keeps writing. Returns nil when no entry exists.
+// GetRecentDetections returns a newest-first copy of the recent detections for
+// modelID, up to lastDetectionCap entries. The returned slice is freshly
+// allocated under the read lock with values copied out, so it never shares
+// backing storage with the cache; the caller may retain or mutate it freely while
+// the hot path keeps writing. Returns nil when no entry exists.
 func (p *Processor) GetRecentDetections(modelID string) []LastDetection {
 	p.lastDetectionMu.RLock()
 	defer p.lastDetectionMu.RUnlock()
-	ring := p.lastDetectionCache[modelID]
-	if ring == nil || ring.count == 0 {
+	list := p.lastDetectionCache[modelID]
+	if list == nil || len(list.items) == 0 {
 		return nil
 	}
-	out := make([]LastDetection, ring.count)
-	// Walk backwards from the most recent write so the result is newest-first.
-	idx := (ring.head - 1 + lastDetectionRingSize) % lastDetectionRingSize
-	for i := range ring.count {
-		out[i] = ring.items[idx]
-		idx = (idx - 1 + lastDetectionRingSize) % lastDetectionRingSize
-	}
+	out := make([]LastDetection, len(list.items))
+	copy(out, list.items)
 	return out
 }

--- a/internal/analysis/processor/last_detection_cache.go
+++ b/internal/analysis/processor/last_detection_cache.go
@@ -88,7 +88,14 @@ func (l *recentDetectionList) observe(common, scientific string, confidence floa
 		if speciesKey(l.items[i].ScientificName, l.items[i].Species) != key {
 			continue
 		}
-		if atUnix-l.items[i].AtUnix < throttleSec {
+		// Compare the absolute gap so a backward clock jump (NTP correction or
+		// out-of-order processing, where atUnix can be earlier than the stored
+		// entry) does not silently drop detections until the clock catches up.
+		gap := atUnix - l.items[i].AtUnix
+		if gap < 0 {
+			gap = -gap
+		}
+		if gap < throttleSec {
 			return
 		}
 		break

--- a/internal/analysis/processor/last_detection_cache.go
+++ b/internal/analysis/processor/last_detection_cache.go
@@ -89,8 +89,10 @@ func (l *recentDetectionList) observe(common, scientific string, confidence floa
 			continue
 		}
 		// Compare the absolute gap so a backward clock jump (NTP correction or
-		// out-of-order processing, where atUnix can be earlier than the stored
-		// entry) does not silently drop detections until the clock catches up.
+		// out-of-order processing, where atUnix can be earlier than a stored entry)
+		// does not silently drop detections. Scan every same-species entry, not
+		// just the most recent: with out-of-order timestamps the closest entry in
+		// time may not be the front one, so drop if ANY is within the throttle.
 		gap := atUnix - l.items[i].AtUnix
 		if gap < 0 {
 			gap = -gap
@@ -98,7 +100,6 @@ func (l *recentDetectionList) observe(common, scientific string, confidence floa
 		if gap < throttleSec {
 			return
 		}
-		break
 	}
 
 	entry := LastDetection{

--- a/internal/analysis/processor/last_detection_cache_test.go
+++ b/internal/analysis/processor/last_detection_cache_test.go
@@ -141,6 +141,25 @@ func TestLastDetectionCache_Throttle(t *testing.T) {
 	}, atUnix, "only detections spaced >= throttle apart are kept, newest first")
 }
 
+// TestLastDetectionCache_ThrottleBackwardClock verifies a backward clock jump does
+// not silently drop detections: a detection earlier than the stored one but beyond
+// the throttle interval is still recorded (the gap is compared in absolute terms).
+func TestLastDetectionCache_ThrottleBackwardClock(t *testing.T) {
+	t.Parallel()
+
+	p := minimalProcessor()
+	base := time.Unix(10000, 0)
+	feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base)
+	// Clock jumps back 20s (> 9s throttle): the absolute gap is 20, so this is
+	// recorded rather than silently dropped (the bug the absolute-gap fix targets).
+	feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base.Add(-20*time.Second))
+
+	recent := p.GetRecentDetections("m")
+	require.Len(t, recent, 2, "a backward clock jump beyond the throttle is recorded, not silently dropped")
+	assert.Equal(t, base.Add(-20*time.Second).Unix(), recent[0].AtUnix)
+	assert.Equal(t, base.Unix(), recent[1].AtUnix)
+}
+
 // TestLastDetectionCache_DifferentSpeciesNotThrottled verifies the throttle is
 // per species: distinct species detected within the interval are all recorded.
 func TestLastDetectionCache_DifferentSpeciesNotThrottled(t *testing.T) {

--- a/internal/analysis/processor/last_detection_cache_test.go
+++ b/internal/analysis/processor/last_detection_cache_test.go
@@ -9,19 +9,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/detection"
 )
 
-// makeResult is a test helper that builds a detection.Result with the given fields.
-func makeResult(commonName, scientificName string, confidence float64, ts time.Time) detection.Result {
-	return detection.Result{
-		Species: detection.Species{
-			CommonName:     commonName,
-			ScientificName: scientificName,
-		},
-		Confidence: confidence,
-		Timestamp:  ts,
-	}
+// testThrottle is the throttle most feed tests use; distinct species are never
+// throttled regardless of its value, so it only matters for repeat-species tests.
+const testThrottle = 9 * time.Second
+
+// feed records one in-range detection in modelID's feed using testThrottle.
+func feed(p *Processor, modelID, common, scientific string, conf float64, ts time.Time) {
+	p.updateLastDetection(modelID, common, scientific, conf, ts, true, testThrottle)
 }
 
 // minimalProcessor returns a zero-value Processor suitable for testing the cache.
@@ -31,17 +27,40 @@ func minimalProcessor() *Processor {
 	return &Processor{}
 }
 
-// TestLastDetectionCache_UpdateThenGet verifies that updateLastDetection stores a
-// detection and GetLastDetection retrieves it correctly.
+// TestDetectionThrottle verifies the per-model interval is the model's clip length
+// snapped to the whole multiple closest to detectionThrottleTarget (9s), with a
+// floor of one segment and a default for an unknown clip length.
+func TestDetectionThrottle(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		clip time.Duration
+		want time.Duration
+	}{
+		{"birdnet 3s segments -> 9s", 3 * time.Second, 9 * time.Second},
+		{"perch 5s segments -> 10s", 5 * time.Second, 10 * time.Second},
+		{"1s segments -> 9s", 1 * time.Second, 9 * time.Second},
+		{"9s segments -> 9s", 9 * time.Second, 9 * time.Second},
+		{"20s segments floor at one segment", 20 * time.Second, 20 * time.Second},
+		{"unknown clip length falls back to target", 0, detectionThrottleTarget},
+		{"negative clip length falls back to target", -1, detectionThrottleTarget},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, detectionThrottle(tt.clip))
+		})
+	}
+}
+
+// TestLastDetectionCache_UpdateThenGet verifies that a recorded detection is
+// retrieved by GetLastDetection with its fields intact.
 func TestLastDetectionCache_UpdateThenGet(t *testing.T) {
 	t.Parallel()
 
 	p := minimalProcessor()
-
 	ts := time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC)
-	res := makeResult("Common Blackbird", "Turdus merula", 0.91, ts)
-
-	p.updateLastDetection("birdnet-v2.4", &res)
+	feed(p, "birdnet-v2.4", "Common Blackbird", "Turdus merula", 0.91, ts)
 
 	got, ok := p.GetLastDetection("birdnet-v2.4")
 	require.True(t, ok, "expected cache hit for known modelID")
@@ -49,40 +68,100 @@ func TestLastDetectionCache_UpdateThenGet(t *testing.T) {
 	assert.Equal(t, "Turdus merula", got.ScientificName)
 	assert.InDelta(t, 0.91, got.Confidence, 1e-9)
 	assert.Equal(t, ts.Unix(), got.AtUnix)
+	assert.True(t, got.InRange, "feed helper records in-range detections")
 }
 
-// TestLastDetectionCache_MostRecentWins verifies that a later call to
-// updateLastDetection always overwrites the cache entry, even when the newer
-// detection has lower confidence (most-recent wins, not highest-confidence).
-func TestLastDetectionCache_MostRecentWins(t *testing.T) {
+// TestLastDetectionCache_InRangeRecorded verifies the InRange flag is stored and
+// returned as given, so the frontend can mark out-of-range / non-avian predictions.
+func TestLastDetectionCache_InRangeRecorded(t *testing.T) {
 	t.Parallel()
 
 	p := minimalProcessor()
+	base := time.Unix(1000, 0)
+	// In-range bird and an out-of-range / non-avian prediction (distinct species).
+	p.updateLastDetection("m", "European Robin", "Erithacus rubecula", 0.8, base, true, testThrottle)
+	p.updateLastDetection("m", "Engine", "Engine", 0.7, base.Add(time.Second), false, testThrottle)
 
+	recent := p.GetRecentDetections("m")
+	require.Len(t, recent, 2)
+	// Newest first: Engine (out of range), then Robin (in range).
+	assert.Equal(t, "Engine", recent[0].Species)
+	assert.False(t, recent[0].InRange, "non-avian prediction is flagged out of range")
+	assert.Equal(t, "European Robin", recent[1].Species)
+	assert.True(t, recent[1].InRange, "in-range bird keeps InRange true")
+}
+
+// TestLastDetectionCache_NewestAtFront verifies that a later detection becomes the
+// head returned by GetLastDetection (most-recent first feed).
+func TestLastDetectionCache_NewestAtFront(t *testing.T) {
+	t.Parallel()
+
+	p := minimalProcessor()
 	ts1 := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
-	res1 := makeResult("Common Blackbird", "Turdus merula", 0.95, ts1)
-	p.updateLastDetection("birdnet-v2.4", &res1)
-
-	// Second detection: lower confidence but more recent. It must win.
-	ts2 := ts1.Add(5 * time.Second)
-	res2 := makeResult("European Robin", "Erithacus rubecula", 0.55, ts2)
-	p.updateLastDetection("birdnet-v2.4", &res2)
+	feed(p, "birdnet-v2.4", "Common Blackbird", "Turdus merula", 0.95, ts1)
+	feed(p, "birdnet-v2.4", "European Robin", "Erithacus rubecula", 0.55, ts1.Add(5*time.Second))
 
 	got, ok := p.GetLastDetection("birdnet-v2.4")
 	require.True(t, ok)
-	assert.Equal(t, "European Robin", got.Species, "most-recent detection must overwrite; lower confidence must not block it")
-	assert.Equal(t, "Erithacus rubecula", got.ScientificName)
-	assert.InDelta(t, 0.55, got.Confidence, 1e-9)
-	assert.Equal(t, ts2.Unix(), got.AtUnix)
+	assert.Equal(t, "European Robin", got.Species, "most-recent detection must be the head")
+
+	recent := p.GetRecentDetections("birdnet-v2.4")
+	assert.Equal(t, []string{"European Robin", "Common Blackbird"}, speciesMarkers(recent), "feed is newest first")
+}
+
+// TestLastDetectionCache_Throttle is the core feed guarantee: the same species is
+// recorded at most once per throttle interval, so a continuously singing bird does
+// not flood the feed, while detections spaced beyond the interval are all kept.
+func TestLastDetectionCache_Throttle(t *testing.T) {
+	t.Parallel()
+
+	p := minimalProcessor()
+	base := time.Unix(1000, 0)
+	robin := func(offset time.Duration) {
+		feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base.Add(offset))
+	}
+
+	// Throttle is 9s. Detections at 0, 5, 9, 12, 18 seconds.
+	robin(0)
+	robin(5 * time.Second)
+	robin(9 * time.Second)
+	robin(12 * time.Second)
+	robin(18 * time.Second)
+
+	recent := p.GetRecentDetections("m")
+	atUnix := make([]int64, len(recent))
+	for i := range recent {
+		atUnix[i] = recent[i].AtUnix
+	}
+	// Recorded: t=0 (first), t=9 (9-0 >= 9), t=18 (18-9 >= 9). Dropped: t=5, t=12.
+	assert.Equal(t, []int64{
+		base.Add(18 * time.Second).Unix(),
+		base.Add(9 * time.Second).Unix(),
+		base.Unix(),
+	}, atUnix, "only detections spaced >= throttle apart are kept, newest first")
+}
+
+// TestLastDetectionCache_DifferentSpeciesNotThrottled verifies the throttle is
+// per species: distinct species detected within the interval are all recorded.
+func TestLastDetectionCache_DifferentSpeciesNotThrottled(t *testing.T) {
+	t.Parallel()
+
+	p := minimalProcessor()
+	base := time.Unix(2000, 0)
+	feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base)
+	feed(p, "m", "Common Blackbird", "Turdus merula", 0.7, base.Add(time.Second))
+	feed(p, "m", "Great Tit", "Parus major", 0.7, base.Add(2*time.Second))
+
+	recent := p.GetRecentDetections("m")
+	assert.Equal(t, []string{"Great Tit", "Common Blackbird", "European Robin"}, speciesMarkers(recent),
+		"distinct species within the interval are all recorded, newest first")
 }
 
 // TestLastDetectionCache_UnknownModelReturnsNotFound verifies that GetLastDetection
 // returns ok=false for a modelID that has never been updated.
 func TestLastDetectionCache_UnknownModelReturnsNotFound(t *testing.T) {
 	t.Parallel()
-
 	p := minimalProcessor()
-
 	_, ok := p.GetLastDetection("nonexistent-model")
 	assert.False(t, ok, "GetLastDetection must return ok=false for an unknown modelID")
 }
@@ -93,10 +172,7 @@ func TestLastDetectionCache_EmptyModelIDSkipped(t *testing.T) {
 	t.Parallel()
 
 	p := minimalProcessor()
-
-	ts := time.Now()
-	res := makeResult("Common Blackbird", "Turdus merula", 0.80, ts)
-	p.updateLastDetection("", &res)
+	feed(p, "", "Common Blackbird", "Turdus merula", 0.80, time.Now())
 
 	_, ok := p.GetLastDetection("")
 	assert.False(t, ok, "empty modelID must be skipped; no cache entry must be created")
@@ -108,12 +184,9 @@ func TestLastDetectionCache_IndependentModels(t *testing.T) {
 	t.Parallel()
 
 	p := minimalProcessor()
-
 	ts := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
-	ra := makeResult("Common Blackbird", "Turdus merula", 0.90, ts)
-	rb := makeResult("European Robin", "Erithacus rubecula", 0.80, ts.Add(time.Second))
-	p.updateLastDetection("model-a", &ra)
-	p.updateLastDetection("model-b", &rb)
+	feed(p, "model-a", "Common Blackbird", "Turdus merula", 0.90, ts)
+	feed(p, "model-b", "European Robin", "Erithacus rubecula", 0.80, ts.Add(time.Second))
 
 	gotA, okA := p.GetLastDetection("model-a")
 	require.True(t, okA)
@@ -124,17 +197,17 @@ func TestLastDetectionCache_IndependentModels(t *testing.T) {
 	assert.Equal(t, "European Robin", gotB.Species)
 }
 
-const ringTestModelID = "birdnet-v2.4"
+const lastDetTestModelID = "birdnet-v2.4"
 
-// seedRing inserts n detections marked "sp-0".."sp-(n-1)" into modelID's ring,
-// each one second apart starting at base. The species common name doubles as an
-// ordered marker so tests can assert ordering without tracking timestamps.
-func seedRing(t *testing.T, p *Processor, modelID string, n int, base time.Time) {
+// seedDistinctSpecies inserts n detections of DISTINCT species marked
+// "sp-0".."sp-(n-1)" into modelID's feed, each one second apart starting at base.
+// Distinct species are never throttled, so this exercises pure feed ordering and
+// capping. The species common name doubles as an ordered marker.
+func seedDistinctSpecies(t *testing.T, p *Processor, modelID string, n int, base time.Time) {
 	t.Helper()
 	for i := range n {
 		marker := "sp-" + strconv.Itoa(i)
-		res := makeResult(marker, "sci-"+marker, 0.5, base.Add(time.Duration(i)*time.Second))
-		p.updateLastDetection(modelID, &res)
+		feed(p, modelID, marker, "sci-"+marker, 0.5, base.Add(time.Duration(i)*time.Second))
 	}
 }
 
@@ -148,53 +221,62 @@ func speciesMarkers(dets []LastDetection) []string {
 	return out
 }
 
-// TestRecentDetections_OrderingAndWrap covers insertion ordering, newest-first
-// output, and wrap-around past the ring size.
-func TestRecentDetections_OrderingAndWrap(t *testing.T) {
+// TestRecentDetections_FeedOrderingAndCap covers insertion ordering, newest-first
+// output, and capping past lastDetectionCap.
+func TestRecentDetections_FeedOrderingAndCap(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		inserts  int
-		expected []string // newest-first species markers
+		name    string
+		inserts int
 	}{
-		{
-			name:     "single entry",
-			inserts:  1,
-			expected: []string{"sp-0"},
-		},
-		{
-			name:     "three entries newest first",
-			inserts:  3,
-			expected: []string{"sp-2", "sp-1", "sp-0"},
-		},
-		{
-			name:     "exactly full ring",
-			inserts:  lastDetectionRingSize,
-			expected: []string{"sp-9", "sp-8", "sp-7", "sp-6", "sp-5", "sp-4", "sp-3", "sp-2", "sp-1", "sp-0"},
-		},
-		{
-			name:     "wrap-around keeps newest ten",
-			inserts:  lastDetectionRingSize + 5,
-			expected: []string{"sp-14", "sp-13", "sp-12", "sp-11", "sp-10", "sp-9", "sp-8", "sp-7", "sp-6", "sp-5"},
-		},
+		{"single entry", 1},
+		{"three entries", 3},
+		{"exactly full feed", lastDetectionCap},
+		{"over cap keeps newest", lastDetectionCap + 5},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := minimalProcessor()
-			seedRing(t, p, ringTestModelID, tt.inserts, time.Unix(1000, 0))
+			seedDistinctSpecies(t, p, lastDetTestModelID, tt.inserts, time.Unix(1000, 0))
 
-			recent := p.GetRecentDetections(ringTestModelID)
-			require.Len(t, recent, len(tt.expected))
-			assert.Equal(t, tt.expected, speciesMarkers(recent), "recent detections must be newest-first")
+			// Distinct species are never throttled, so the feed keeps the newest
+			// min(inserts, cap) markers, newest first.
+			kept := min(tt.inserts, lastDetectionCap)
+			expected := make([]string, kept)
+			for i := range kept {
+				expected[i] = "sp-" + strconv.Itoa(tt.inserts-1-i)
+			}
 
-			// GetLastDetection returns the single most-recent entry.
-			last, ok := p.GetLastDetection(ringTestModelID)
+			recent := p.GetRecentDetections(lastDetTestModelID)
+			require.Len(t, recent, kept)
+			assert.Equal(t, expected, speciesMarkers(recent), "recent detections must be newest-first, capped")
+
+			last, ok := p.GetLastDetection(lastDetTestModelID)
 			require.True(t, ok)
-			assert.Equal(t, tt.expected[0], last.Species, "GetLastDetection must return the newest entry")
+			assert.Equal(t, expected[0], last.Species, "GetLastDetection must return the newest entry")
 		})
+	}
+}
+
+// TestRecentDetections_SameSpeciesRepeatsWhenSpaced verifies the feed shows the
+// same species more than once when detections are spaced beyond the throttle, so
+// the detection cadence over time is visible (not collapsed into one entry).
+func TestRecentDetections_SameSpeciesRepeatsWhenSpaced(t *testing.T) {
+	t.Parallel()
+
+	p := minimalProcessor()
+	base := time.Unix(3000, 0)
+	for i := range 3 {
+		// 10s apart, beyond the 9s throttle, so each is recorded.
+		feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base.Add(time.Duration(i)*10*time.Second))
+	}
+	recent := p.GetRecentDetections("m")
+	require.Len(t, recent, 3, "spaced repeats of one species are kept as separate feed entries")
+	for _, d := range recent {
+		assert.Equal(t, "European Robin", d.Species)
 	}
 }
 
@@ -206,50 +288,71 @@ func TestRecentDetections_AbsentModel(t *testing.T) {
 	assert.Nil(t, p.GetRecentDetections(""), "empty model returns nil slice")
 }
 
+// TestRecentDetections_SpeciesKeyThrottleFallback verifies the throttle identity
+// falls back to the common name when the scientific name is empty, and unidentified
+// detections (both names empty) throttle as a single bucket.
+func TestRecentDetections_SpeciesKeyThrottleFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scientific throttles by common name", func(t *testing.T) {
+		t.Parallel()
+		p := minimalProcessor()
+		base := time.Unix(9000, 0)
+		feed(p, "m", "Mystery Bird", "", 0.6, base)
+		feed(p, "m", "Mystery Bird", "", 0.7, base.Add(time.Second)) // within throttle
+		assert.Len(t, p.GetRecentDetections("m"), 1, "same common name with empty scientific is throttled")
+	})
+
+	t.Run("both names empty throttle as one bucket", func(t *testing.T) {
+		t.Parallel()
+		p := minimalProcessor()
+		base := time.Unix(9100, 0)
+		for i := range 3 {
+			feed(p, "m", "", "", 0.5, base.Add(time.Duration(i)*time.Second))
+		}
+		assert.Len(t, p.GetRecentDetections("m"), 1, "unidentified detections throttle as a single bucket")
+	})
+}
+
 // TestRecentDetections_IndependentCopy proves the returned slice does not alias
-// the ring's backing array: mutating it, and continuing to write to the ring,
+// the feed's backing array: mutating it, and continuing to write to the feed,
 // must not corrupt a previously returned snapshot.
 func TestRecentDetections_IndependentCopy(t *testing.T) {
 	t.Parallel()
 	p := minimalProcessor()
-	seedRing(t, p, ringTestModelID, 3, time.Unix(3000, 0))
+	seedDistinctSpecies(t, p, lastDetTestModelID, 3, time.Unix(3000, 0))
 
-	snapshot := p.GetRecentDetections(ringTestModelID)
+	snapshot := p.GetRecentDetections(lastDetTestModelID)
 	require.Len(t, snapshot, 3)
 	original := slices.Clone(speciesMarkers(snapshot))
 
-	// Mutating the returned slice must not affect the ring.
+	// Mutating the returned slice must not affect the feed.
 	snapshot[0].Species = "MUTATED"
-	snapshot[0].Confidence = 999
 
-	// Continuing to write to the ring (enough to overwrite every slot) must not
+	// Continuing to write to the feed (enough distinct species to fill it) must not
 	// mutate the earlier snapshot beyond the local change above.
-	seedRing(t, p, ringTestModelID, lastDetectionRingSize, time.Unix(4000, 0))
+	seedDistinctSpecies(t, p, lastDetTestModelID, lastDetectionCap, time.Unix(4000, 0))
 
-	assert.Equal(t, original[1], snapshot[1].Species, "ring writes must not mutate a prior snapshot")
-	assert.Equal(t, original[2], snapshot[2].Species, "ring writes must not mutate a prior snapshot")
+	assert.Equal(t, original[1], snapshot[1].Species, "feed writes must not mutate a prior snapshot")
+	assert.Equal(t, original[2], snapshot[2].Species, "feed writes must not mutate a prior snapshot")
 
-	// A fresh read never carries the mutation applied to the earlier snapshot.
-	fresh := p.GetRecentDetections(ringTestModelID)
-	require.Len(t, fresh, lastDetectionRingSize)
+	fresh := p.GetRecentDetections(lastDetTestModelID)
+	require.Len(t, fresh, lastDetectionCap)
 	for _, d := range fresh {
-		assert.NotEqual(t, "MUTATED", d.Species, "mutating a snapshot must not leak into the ring")
+		assert.NotEqual(t, "MUTATED", d.Species, "mutating a snapshot must not leak into the feed")
 	}
 }
 
-// TestRecentDetections_PerModelIsolation verifies each model keeps its own ring.
+// TestRecentDetections_PerModelIsolation verifies each model keeps its own feed.
 func TestRecentDetections_PerModelIsolation(t *testing.T) {
 	t.Parallel()
 	p := minimalProcessor()
 	base := time.Unix(5000, 0)
 
-	a0 := makeResult("a0", "sci-a0", 0.5, base)
-	b0 := makeResult("b0", "sci-b0", 0.5, base.Add(time.Second))
-	a1 := makeResult("a1", "sci-a1", 0.5, base.Add(2*time.Second))
-	p.updateLastDetection("model-a", &a0)
-	p.updateLastDetection("model-b", &b0)
-	p.updateLastDetection("model-a", &a1)
+	feed(p, "model-a", "a0", "sci-a0", 0.5, base)
+	feed(p, "model-b", "b0", "sci-b0", 0.5, base.Add(time.Second))
+	feed(p, "model-a", "a1", "sci-a1", 0.5, base.Add(2*time.Second))
 
-	assert.Equal(t, []string{"a1", "a0"}, speciesMarkers(p.GetRecentDetections("model-a")), "model-a ring is isolated")
-	assert.Equal(t, []string{"b0"}, speciesMarkers(p.GetRecentDetections("model-b")), "model-b ring is isolated")
+	assert.Equal(t, []string{"a1", "a0"}, speciesMarkers(p.GetRecentDetections("model-a")), "model-a feed is isolated")
+	assert.Equal(t, []string{"b0"}, speciesMarkers(p.GetRecentDetections("model-b")), "model-b feed is isolated")
 }

--- a/internal/analysis/processor/last_detection_cache_test.go
+++ b/internal/analysis/processor/last_detection_cache_test.go
@@ -160,6 +160,27 @@ func TestLastDetectionCache_ThrottleBackwardClock(t *testing.T) {
 	assert.Equal(t, base.Unix(), recent[1].AtUnix)
 }
 
+// TestLastDetectionCache_ThrottleScansAllEntries verifies that with out-of-order
+// timestamps the throttle drops a detection within the window of ANY same-species
+// entry, not just the most recent one (the front entry may not be the closest in
+// time after a backward jump).
+func TestLastDetectionCache_ThrottleScansAllEntries(t *testing.T) {
+	t.Parallel()
+
+	p := minimalProcessor()
+	base := time.Unix(10000, 0)
+	feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base)                       // t=10000
+	feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base.Add(-15*time.Second))  // t=9985, gap 15 -> recorded, becomes front
+	// t=9994: 9s from the front (9985) but only 6s from the older 10000 entry.
+	// Must be dropped because it is within the throttle of the older entry.
+	feed(p, "m", "European Robin", "Erithacus rubecula", 0.7, base.Add(-6*time.Second))
+
+	recent := p.GetRecentDetections("m")
+	require.Len(t, recent, 2, "within the throttle of any same-species entry must be dropped")
+	assert.Equal(t, base.Add(-15*time.Second).Unix(), recent[0].AtUnix)
+	assert.Equal(t, base.Unix(), recent[1].AtUnix)
+}
+
 // TestLastDetectionCache_DifferentSpeciesNotThrottled verifies the throttle is
 // per species: distinct species detected within the interval are all recorded.
 func TestLastDetectionCache_DifferentSpeciesNotThrottled(t *testing.T) {

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -135,12 +135,13 @@ type Processor struct {
 	// Periodic pipeline stats (inference activity per source/model)
 	pipelineStats *PipelineStats
 
-	// Per-model recent-detection cache: a fixed-size ring of the last
-	// lastDetectionRingSize above-threshold detections per model. lastDetectionMu
-	// guards lastDetectionCache and every ring it holds. The map and per-model
-	// rings are lazily initialised in updateLastDetection so zero-value Processors
-	// are safe to use in unit tests without a constructor call.
-	lastDetectionCache map[string]*detectionRing
+	// Per-model recent-detection cache: a fixed-capacity, most-recent-first feed of
+	// the last lastDetectionCap detections per model, throttled per species so a
+	// continuously singing bird does not flood it. lastDetectionMu guards
+	// lastDetectionCache and every feed it holds. The map and per-model feeds are
+	// lazily initialised in updateLastDetection so zero-value Processors are safe to
+	// use in unit tests without a constructor call.
+	lastDetectionCache map[string]*recentDetectionList
 	lastDetectionMu    sync.RWMutex
 
 	// Extended capture fields
@@ -789,10 +790,6 @@ func (p *Processor) processDetections(item classifier.Results) {
 
 		// Unlock the mutex to allow other goroutines to access shared resources
 		p.pendingMutex.Unlock()
-
-		// Record this detection as the most recent for its model. Called outside
-		// pendingMutex to keep the per-model cache update cheap and independent.
-		p.updateLastDetection(item.ModelID, &det.Result)
 	}
 
 	// Broadcast updated pending detections snapshot for "currently hearing" UI.
@@ -815,6 +812,14 @@ func (p *Processor) processResults(settings *conf.Settings, item classifier.Resu
 
 	// Sync species tracker if needed
 	p.syncSpeciesTrackerIfNeeded()
+
+	// Per-model "Last heard" feed parameters, computed once per chunk: the
+	// per-species throttle (from the model's segment length) and a single shared
+	// timestamp for every prediction in this chunk. ModelRegistry is read-only
+	// after init; an unknown model ID yields a zero clip length and the default
+	// throttle.
+	feedThrottle := detectionThrottle(classifier.ModelRegistry[item.ModelID].Spec.ClipLength)
+	feedTime := time.Now().Add(-detection.DetectionTimeOffset)
 
 	// Process each result in item.Results
 	for _, result := range item.Results {
@@ -845,6 +850,17 @@ func (p *Processor) processResults(settings *conf.Settings, item classifier.Resu
 
 		// Check if detection should be filtered
 		shouldSkip, _ := p.shouldFilterDetection(settings, result, commonName, scientificName, speciesLowercase, baseThreshold, item.Source.ID, item.ModelID)
+
+		// Record every prediction above the base confidence threshold in the
+		// per-model "Last heard" diagnostic feed, including non-avian classes,
+		// human vocalizations, and out-of-range birds, tagged with whether the
+		// species passes the range filter. This is independent of whether the
+		// detection is saved below (saved detections also clear this bar).
+		if result.Confidence > baseThreshold {
+			inRange := !shouldApplyRangeFilter(item.ModelID, settings) || settings.IsSpeciesIncluded(result.Species)
+			p.updateLastDetection(item.ModelID, commonName, scientificName, float64(result.Confidence), feedTime, inRange, feedThrottle)
+		}
+
 		if shouldSkip {
 			continue
 		}

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -94,8 +94,9 @@ type InferenceModelStatus struct {
 	Sources       []ModelSourceInfo  `json:"sources"`
 	MetricKeys    ModelMetricKeys    `json:"metricKeys"`
 	LastDetection *LastDetectionInfo `json:"lastDetection,omitempty"`
-	// RecentDetections is the newest-first list of up to 10 recent above-threshold
-	// detections for this model (the "Last heard" table). Empty when none.
+	// RecentDetections is the newest-first feed of up to 20 recent above-threshold
+	// detections for this model (the "Last heard" table), throttled per species so
+	// a continuously singing bird does not flood it. Empty when none.
 	RecentDetections []LastDetectionInfo `json:"recentDetections"`
 }
 
@@ -186,6 +187,11 @@ type LastDetectionInfo struct {
 	Confidence float64 `json:"confidence"`
 	// AtUnix is the Unix timestamp (seconds) of when the detection occurred.
 	AtUnix int64 `json:"atUnix"`
+	// InRange reports whether the species passes the range filter. True when in
+	// range or the range filter is inactive (e.g. no location configured). When
+	// the range filter is active it is false for out-of-range birds and for
+	// non-avian and human classes, which are shown for diagnostics but not saved.
+	InRange bool `json:"inRange"`
 }
 
 // deviceCPU and deviceGPU are the OpenVINO device name strings used when
@@ -353,7 +359,7 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 		}
 	}
 
-	// Compute per-model last detection and the recent-detections ring (newest
+	// Compute per-model last detection and the recent-detections list (newest
 	// first), converting from processor.LastDetection to the API-local
 	// LastDetectionInfo via field assignment (no type import needed).
 	var lastDetections map[string]*LastDetectionInfo
@@ -377,6 +383,7 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 					ScientificName: recent[j].ScientificName,
 					Confidence:     recent[j].Confidence,
 					AtUnix:         recent[j].AtUnix,
+					InRange:        recent[j].InRange,
 				}
 			}
 			latest := converted[0]

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -316,6 +316,7 @@ func TestBuildModelStatus_LastDetection(t *testing.T) {
 			ScientificName: "Erithacus rubecula",
 			Confidence:     0.92,
 			AtUnix:         1718000000,
+			InRange:        true,
 		},
 	}
 
@@ -326,6 +327,7 @@ func TestBuildModelStatus_LastDetection(t *testing.T) {
 	assert.Equal(t, "Erithacus rubecula", got.LastDetection.ScientificName)
 	assert.InDelta(t, 0.92, got.LastDetection.Confidence, 0.001)
 	assert.Equal(t, int64(1718000000), got.LastDetection.AtUnix)
+	assert.True(t, got.LastDetection.InRange)
 }
 
 // TestInferenceModelStatus_JSONContract locks in the Phase A JSON field names
@@ -343,8 +345,8 @@ func TestInferenceModelStatus_JSONContract(t *testing.T) {
 		Paused:        true,
 		ScheduleLabel: "Night schedule",
 		RecentDetections: []LastDetectionInfo{
-			{Species: "Common Pipistrelle", ScientificName: "Pipistrellus pipistrellus", Confidence: 0.81, AtUnix: 1718000200},
-			{Species: "Soprano Pipistrelle", ScientificName: "Pipistrellus pygmaeus", Confidence: 0.74, AtUnix: 1718000100},
+			{Species: "Common Pipistrelle", ScientificName: "Pipistrellus pipistrellus", Confidence: 0.81, AtUnix: 1718000200, InRange: true},
+			{Species: "Soprano Pipistrelle", ScientificName: "Pipistrellus pygmaeus", Confidence: 0.74, AtUnix: 1718000100, InRange: false},
 		},
 	}
 
@@ -354,7 +356,7 @@ func TestInferenceModelStatus_JSONContract(t *testing.T) {
 	var m map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(raw, &m))
 
-	// The four new keys are present under their contract names.
+	// The Phase A keys are present under their contract names.
 	assert.JSONEq(t, `"CPU"`, string(m["device"]))
 	assert.JSONEq(t, `true`, string(m["paused"]))
 	assert.JSONEq(t, `"Night schedule"`, string(m["scheduleLabel"]))
@@ -367,7 +369,17 @@ func TestInferenceModelStatus_JSONContract(t *testing.T) {
 	assert.Equal(t, "Common Pipistrelle", recent[0].Species, "recentDetections must be newest-first")
 	assert.Equal(t, int64(1718000200), recent[0].AtUnix)
 
-	// An empty ring still serializes as [] (never null) and an empty
+	// The nested field names are part of the contract: assert their JSON keys.
+	var rows []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(m["recentDetections"], &rows))
+	require.NotEmpty(t, rows)
+	firstRow := rows[0]
+	for _, key := range []string{"species", "scientificName", "confidence", "atUnix", "inRange"} {
+		require.Contains(t, firstRow, key, "recentDetections element must carry the %q key", key)
+	}
+	assert.JSONEq(t, `true`, string(firstRow["inRange"]))
+
+	// An empty list still serializes as [] (never null) and an empty
 	// scheduleLabel is omitted from the object entirely.
 	active := InferenceModelStatus{ID: "x", Device: deviceUnknown, RecentDetections: []LastDetectionInfo{}}
 	rawActive, err := json.Marshal(active)


### PR DESCRIPTION
## Summary

Reworks the per-model **Last heard** view on the AI Models & Inference page from a chronological ring of saved detections into a diagnostic feed of what each model is actually firing on, with cross-model correlation aids.

**Backend** (`internal/analysis/processor`)
- **Per-species throttle**: a species is recorded at most once per the model's segment-aligned interval (`clip x round(9s/clip)` -> 9s for BirdNET, 10s for Perch), so a continuously singing bird does not flood the feed while its cadence stays visible. The blind circular buffer becomes a slice-backed most-recent-first list, cap 20.
- **All above-threshold predictions**: recording moved into `processResults`, before the range and privacy filters, so the feed shows non-bird classes, human vocalizations, and out-of-range birds, each tagged with an `inRange` flag.
- The **save path is unchanged** (DB rows + audio clips): human and out-of-range species are still never saved.

**API** (`internal/api/v2`): `LastDetectionInfo` gains `inRange` (additive; existing fields unchanged).

**Frontend** (`SystemInference.svelte`)
- Two newspaper columns of ten (20 total), newest first.
- Absolute 24-hour timestamps (`HH:MM:SS`, full date+time on hover) for cross-model correlation.
- "Also" column listing other models that detected the same species within +/-3s.
- A range-filter icon next to species the filter rejects (diagnostic, not saved) and a caption explaining the feed.
- Empty latency sparkline draws a flat 0 baseline until samples arrive.
- Spec label "Clip length" renamed to "Segment length" across all 16 locales.

## Privacy note

This view now surfaces **human vocalization classes** (and other non-bird/out-of-range predictions) so the model's raw above-threshold output can be inspected, e.g. to troubleshoot the privacy filter. This is **shown only**, never recorded:
- The feed is an **in-memory ring** on the processor: label + scientific name + confidence + timestamp + range flag. **No audio**, never written to the database or disk, not included in support dumps or telemetry, cleared on restart.
- The **save path is unchanged** - human and out-of-range species are not persisted as detections or clips.
- The view is behind the existing authenticated system endpoint.

## Test Plan

- [x] `go test -race ./internal/analysis/processor/` and the inference API tests pass
- [x] `golangci-lint` clean on changed packages
- [x] Frontend `npm run check:all` (typecheck, lint, ast) clean; component tests pass; i18n in sync across 16 locales
- [ ] Manual: verify the two-column feed, absolute timestamps, the "Also" co-detection column, the range-filter icon on non-bird/out-of-range entries, and that human/out-of-range entries appear in the feed but are not saved as detections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added co-detection correlation to the “Last heard” feed, showing which other loaded models detected the same species.
  * Added out-of-range diagnostics: detections now indicate whether they fall within the active range filter.
  * Expanded recent prediction history from 10 to 20 items.

* **Improvements**
  * Improved latency sparkline rendering for sparse data.
  * Refreshed the “Last heard” layout with clearer “heard when” times and improved table/columns for diagnostics.

* **Localization**
  * Updated inference/help text across multiple languages to match the new diagnostics and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->