### PR TITLE
fix(ci): prevent concurrent npm install race in frontend-install

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -9,6 +9,7 @@ on:
       - "**/*.go"
       - "go.mod"
       - "go.sum"
+      - "Taskfile.yml"
       - ".github/workflows/container-test.yml"
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - "**/*.go"
       - "go.mod"
       - "go.sum"
+      - "Taskfile.yml"
       - ".github/workflows/container-test.yml"
 
 concurrency:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -758,6 +758,17 @@ tasks:
   frontend-install:
     desc: Install frontend dependencies
     dir: frontend
+    # run: once guarantees a single execution per `task` invocation even when
+    # reached through multiple dependency paths. frontend-build depends on both
+    # frontend-install and frontend-typecheck, and frontend-typecheck also
+    # depends on frontend-install, forming a diamond. With the default
+    # run: always, go-task runs frontend-build's deps concurrently and executes
+    # frontend-install twice in parallel, so two `npm install` processes write
+    # the same node_modules at once. That race truncates large files (e.g.
+    # typescript.js), and svelte-check then fails with "Unexpected end of input".
+    # The race is timing dependent, which is why it flaked only intermittently
+    # and mostly on the arm64 runner.
+    run: once
     cmds:
       - |
         max_retries=3


### PR DESCRIPTION
## Summary

The `ONNX-only arm64 startup` container-test job has been failing intermittently during the frontend build with:

```
node_modules/typescript/lib/typescript.js:90434
        const
SyntaxError: Unexpected end of input
    at Object.<anonymous> (.../svelte-check/dist/src/index.js)
```

`typescript.js` is truncated, so `svelte-check` cannot load it. The corruption comes from **two `npm install` processes writing the same `node_modules` at the same time**.

## Root cause

In `Taskfile.yml`, `frontend-build` declares `deps: [frontend-install, frontend-typecheck]`, and `frontend-typecheck` also declares `deps: [frontend-install]`. That is a diamond. go-task runs a task's deps concurrently, and with the default `run: always` it executes `frontend-install` **twice in parallel**. The two concurrent `npm install` runs race and truncate large files such as `typescript.js`. The CI log confirms it: one install finished at ~12s, a second was still running until ~22s, and `svelte-check` ran at ~12s against the half-written `node_modules`.

The race is timing dependent, which is why it flaked only intermittently and mostly on the slower arm64 runner while the amd64 job stayed green.

## Fix

Mark `frontend-install` with `run: once` so go-task collapses the diamond to a single execution; dependent tasks that reach it concurrently wait for the one in-flight install instead of starting their own.

## Verification

- Reproduced the double-execution locally with a minimal Taskfile (default `run: always` ran the shared install twice concurrently); confirmed `run: once` yields exactly one install with the dependent task correctly waiting for it to finish.
- All ~14 tasks that depend on `frontend-install`/`frontend-build` only need `node_modules` populated before they run, so a single install satisfies every consumer. `run: once` is orthogonal to the existing `sources`/`generates` checksum caching and does not affect the internal retry loop.

## Test Plan
- [ ] `ONNX-only arm64 startup` container-test job passes (the path that was failing)
- [ ] `Arbitrary-UID startup` amd64 container-test job stays green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved intermittent build failures caused by duplicate parallel execution of frontend installation processes.

* **Chores**
  * Updated CI/CD workflow to trigger on task configuration file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->