### PR TITLE
feat(analytics): registry-driven tabbed hub for Advanced Analytics (foundation)

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
@@ -1,0 +1,201 @@
+<!--
+  AnalyticsControlBar: the shared, sticky filter bar for the analytics hub.
+
+  Holds the controls that apply across charts: date range (preset + custom),
+  species selection (reusing SpeciesSelector), and a source/mic filter. All
+  state lives in the URL via the hub; this component is presentational: it reads
+  the resolved params and reports changes through `onParamsChange`.
+
+  Each control honors the active tab's chart `supports` flags: when no chart in
+  the active tab filters by species (e.g. Biodiversity), the species selector is
+  disabled with an explanation rather than silently ignored. The source filter
+  is present but inert in PR0 (no backend wiring yet) and says so.
+-->
+<script lang="ts">
+  import { t } from '$lib/i18n';
+  import SpeciesSelector from '$lib/components/ui/SpeciesSelector.svelte';
+  import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
+  import type { Species } from '$lib/types/species';
+  import { formatDateForAPI } from '../registry/analyticsParams';
+  import type { AnalyticsParams, DateRangePreset } from '../registry/types';
+
+  interface Props {
+    params: AnalyticsParams;
+    availableSpecies: Species[];
+    loadingSpecies?: boolean;
+    /** Whether any chart in the active tab filters by species. */
+    speciesApplicable?: boolean;
+    onParamsChange: (_partial: Partial<AnalyticsParams>) => void;
+  }
+
+  let {
+    params,
+    availableSpecies,
+    loadingSpecies = false,
+    speciesApplicable = true,
+    onParamsChange,
+  }: Props = $props();
+
+  // Backend caps multi-species queries; keep the legacy client limit.
+  const MAX_SPECIES = 10;
+
+  const dateRangeOptions = $derived([
+    { value: 'week', label: t('analytics.advanced.dateRangeOptions.week') },
+    { value: 'month', label: t('analytics.advanced.dateRangeOptions.month') },
+    { value: 'quarter', label: t('analytics.advanced.dateRangeOptions.quarter') },
+    { value: 'year', label: t('analytics.advanced.dateRangeOptions.year') },
+    { value: 'custom', label: t('analytics.advanced.dateRangeOptions.custom') },
+  ]);
+
+  // Source filter is inert in PR0: a single "All sources" option, disabled.
+  const sourceOptions = $derived([{ value: '', label: t('analytics.hub.controls.sourceAll') }]);
+
+  // Custom date inputs reflect the resolved range so switching to "custom"
+  // starts from whatever was showing, and reloads restore the typed dates.
+  const customStart = $derived(params.start || formatDateForAPI(params.startDate));
+  const customEnd = $derived(params.end || formatDateForAPI(params.endDate));
+
+  function handleRangeChange(value: string | string[]): void {
+    const range = (Array.isArray(value) ? value[0] : value) as DateRangePreset;
+    if (range === 'custom') {
+      // Seed the custom inputs (and the URL) from the currently resolved range.
+      onParamsChange({ range, start: customStart, end: customEnd });
+    } else {
+      onParamsChange({ range });
+    }
+  }
+
+  function handleStartChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    onParamsChange({ range: 'custom', start: value, end: customEnd });
+  }
+
+  function handleEndChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    onParamsChange({ range: 'custom', start: customStart, end: value });
+  }
+</script>
+
+<div class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]">
+  <div class="p-4 sm:p-6 overflow-visible space-y-4">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6">
+      <!-- Date range -->
+      <div class="space-y-2">
+        <SelectDropdown
+          value={params.range}
+          options={dateRangeOptions}
+          onChange={handleRangeChange}
+          label={t('analytics.advanced.dateRange')}
+          variant="select"
+          size="sm"
+          menuSize="sm"
+        />
+
+        {#if params.range === 'custom'}
+          <div class="grid grid-cols-2 gap-2 mt-2">
+            <label for="analyticsStartDate" class="sr-only"
+              >{t('analytics.advanced.filters.startDate')}</label
+            >
+            <input
+              id="analyticsStartDate"
+              type="date"
+              class="input w-full"
+              value={customStart}
+              max={customEnd}
+              onchange={handleStartChange}
+              aria-label={t('analytics.advanced.filters.startDate')}
+            />
+            <label for="analyticsEndDate" class="sr-only"
+              >{t('analytics.advanced.filters.endDate')}</label
+            >
+            <input
+              id="analyticsEndDate"
+              type="date"
+              class="input w-full"
+              value={customEnd}
+              min={customStart}
+              onchange={handleEndChange}
+              aria-label={t('analytics.advanced.filters.endDate')}
+            />
+          </div>
+        {/if}
+      </div>
+
+      <!-- Source / mic filter (present but inert in PR0) -->
+      <div class="space-y-1">
+        <SelectDropdown
+          value={params.source}
+          options={sourceOptions}
+          disabled={true}
+          label={t('analytics.hub.controls.source')}
+          helpText={t('analytics.hub.controls.sourceComingSoon')}
+          variant="select"
+          size="sm"
+          menuSize="sm"
+        />
+      </div>
+    </div>
+
+    <!-- Species selection -->
+    <div class="space-y-2">
+      <div class="flex items-baseline justify-between gap-2">
+        <span id="analyticsSpeciesLabel" class="label-text font-medium"
+          >{t('analytics.advanced.speciesSelection', {
+            count: params.species.length,
+            max: MAX_SPECIES,
+          })}</span
+        >
+        <span
+          id="analyticsSpeciesHint"
+          class="label-text-alt text-xs text-[var(--color-base-content)] opacity-60"
+        >
+          {speciesApplicable
+            ? t('analytics.advanced.speciesSelectionHint')
+            : t('analytics.hub.controls.speciesNotApplicable')}
+        </span>
+      </div>
+
+      <div
+        class="w-full min-h-[100px] relative"
+        role="group"
+        aria-labelledby="analyticsSpeciesLabel"
+        aria-describedby="analyticsSpeciesHint"
+      >
+        <SpeciesSelector
+          species={availableSpecies}
+          selected={params.species}
+          variant="chip"
+          size="md"
+          maxSelections={MAX_SPECIES}
+          placeholder={t('analytics.advanced.speciesPlaceholder')}
+          searchable={true}
+          showFrequency={true}
+          categorized={false}
+          disabled={!speciesApplicable}
+          loading={loadingSpecies}
+          emptyText={t('analytics.advanced.noSpeciesFound')}
+          className="w-full"
+          on:change={e => onParamsChange({ species: e.detail.selected })}
+        >
+          {#snippet speciesDisplay(species)}
+            <div class="flex items-center justify-between gap-2">
+              <div class="flex-1 min-w-0">
+                <div class="font-medium truncate">{species.commonName}</div>
+                <div class="text-xs text-[var(--color-base-content)] opacity-60 truncate italic">
+                  {species.scientificName}
+                </div>
+              </div>
+              {#if species.count !== undefined}
+                <div
+                  class="inline-flex items-center px-2 py-1 text-xs font-medium rounded-full bg-[var(--color-base-200)]/50 text-[var(--color-base-content)]"
+                >
+                  {t('analytics.advanced.detections', { count: species.count ?? 0 })}
+                </div>
+              {/if}
+            </div>
+          {/snippet}
+        </SpeciesSelector>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
@@ -1,17 +1,21 @@
 <!--
-  AnalyticsControlBar: the shared, sticky filter bar for the analytics hub.
+  AnalyticsControlBar: the shared filter toolbar for the analytics hub.
 
-  Holds the controls that apply across charts: date range (preset + custom),
+  A slim, page-colored toolbar (not a card) that sits under the tab bar. The
+  controls that apply across charts live here: date range (preset + custom),
   species selection (reusing SpeciesSelector), and a source/mic filter. All
-  state lives in the URL via the hub; this component is presentational: it reads
-  the resolved params and reports changes through `onParamsChange`.
+  state lives in the URL via the hub; this component is presentational and
+  reports changes through `onParamsChange`.
 
-  Each control honors the active tab's chart `supports` flags: when no chart in
-  the active tab filters by species (e.g. Biodiversity), the species selector is
-  disabled with an explanation rather than silently ignored. The source filter
-  is present but inert in PR0 (no backend wiring yet) and says so.
+  The species chip selector is the tall control, so it is collapsed behind a
+  toggle (the date range stays visible) to keep the toolbar compact. Each
+  control honors the active tab's chart `supports` flags: when no chart in the
+  active tab filters by species (e.g. Biodiversity), the species toggle is
+  disabled with an explanation. The source filter is present but inert in PR0.
 -->
 <script lang="ts">
+  import { ChevronDown, ChevronRight } from '@lucide/svelte';
+
   import { t } from '$lib/i18n';
   import SpeciesSelector from '$lib/components/ui/SpeciesSelector.svelte';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
@@ -39,6 +43,10 @@
   // Backend caps multi-species queries; keep the legacy client limit.
   const MAX_SPECIES = 10;
 
+  // The tall chip selector starts collapsed to keep the toolbar slim; the toggle
+  // shows the current count so the selection is never hidden without a hint.
+  let speciesExpanded = $state(false);
+
   const dateRangeOptions = $derived([
     { value: 'week', label: t('analytics.advanced.dateRangeOptions.week') },
     { value: 'month', label: t('analytics.advanced.dateRangeOptions.month') },
@@ -54,6 +62,13 @@
   // starts from whatever was showing, and reloads restore the typed dates.
   const customStart = $derived(params.start || formatDateForAPI(params.startDate));
   const customEnd = $derived(params.end || formatDateForAPI(params.endDate));
+
+  const speciesLabel = $derived(
+    t('analytics.advanced.speciesSelection', {
+      count: params.species.length,
+      max: MAX_SPECIES,
+    })
+  );
 
   function handleRangeChange(value: string | string[]): void {
     const range = (Array.isArray(value) ? value[0] : value) as DateRangePreset;
@@ -76,91 +91,112 @@
   }
 </script>
 
-<div class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]">
-  <div class="p-4 sm:p-6 overflow-visible space-y-4">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6">
-      <!-- Date range -->
-      <div class="space-y-2">
-        <SelectDropdown
-          value={params.range}
-          options={dateRangeOptions}
-          onChange={handleRangeChange}
-          label={t('analytics.advanced.dateRange')}
-          variant="select"
-          size="sm"
-          menuSize="sm"
-        />
-
-        {#if params.range === 'custom'}
-          <div class="grid grid-cols-2 gap-2 mt-2">
-            <label for="analyticsStartDate" class="sr-only"
-              >{t('analytics.advanced.filters.startDate')}</label
-            >
-            <input
-              id="analyticsStartDate"
-              type="date"
-              class="input w-full"
-              value={customStart}
-              max={customEnd}
-              onchange={handleStartChange}
-              aria-label={t('analytics.advanced.filters.startDate')}
-            />
-            <label for="analyticsEndDate" class="sr-only"
-              >{t('analytics.advanced.filters.endDate')}</label
-            >
-            <input
-              id="analyticsEndDate"
-              type="date"
-              class="input w-full"
-              value={customEnd}
-              min={customStart}
-              onchange={handleEndChange}
-              aria-label={t('analytics.advanced.filters.endDate')}
-            />
-          </div>
-        {/if}
-      </div>
-
-      <!-- Source / mic filter (present but inert in PR0) -->
-      <div class="space-y-1">
-        <SelectDropdown
-          value={params.source}
-          options={sourceOptions}
-          disabled={true}
-          label={t('analytics.hub.controls.source')}
-          helpText={t('analytics.hub.controls.sourceComingSoon')}
-          variant="select"
-          size="sm"
-          menuSize="sm"
-        />
-      </div>
+<div class="pb-3 border-b border-[var(--color-base-300)]/60">
+  <!-- Compact controls row: date range + source always visible, species behind a toggle -->
+  <div class="flex flex-wrap items-end gap-x-4 gap-y-2">
+    <!-- Date range -->
+    <div class="w-44 max-w-full space-y-1">
+      <SelectDropdown
+        value={params.range}
+        options={dateRangeOptions}
+        onChange={handleRangeChange}
+        label={t('analytics.advanced.dateRange')}
+        variant="select"
+        size="sm"
+        menuSize="sm"
+      />
     </div>
 
-    <!-- Species selection -->
-    <div class="space-y-2">
-      <div class="flex items-baseline justify-between gap-2">
-        <span id="analyticsSpeciesLabel" class="label-text font-medium"
-          >{t('analytics.advanced.speciesSelection', {
-            count: params.species.length,
-            max: MAX_SPECIES,
-          })}</span
-        >
-        <span
-          id="analyticsSpeciesHint"
-          class="label-text-alt text-xs text-[var(--color-base-content)] opacity-60"
-        >
-          {speciesApplicable
-            ? t('analytics.advanced.speciesSelectionHint')
-            : t('analytics.hub.controls.speciesNotApplicable')}
-        </span>
+    {#if params.range === 'custom'}
+      <div class="flex items-end gap-2">
+        <div class="space-y-1">
+          <label
+            for="analyticsStartDate"
+            class="text-xs font-medium text-[var(--color-base-content)]/70"
+            >{t('analytics.advanced.filters.startDate')}</label
+          >
+          <input
+            id="analyticsStartDate"
+            type="date"
+            class="input input-sm"
+            value={customStart}
+            max={customEnd}
+            onchange={handleStartChange}
+            aria-label={t('analytics.advanced.filters.startDate')}
+          />
+        </div>
+        <div class="space-y-1">
+          <label
+            for="analyticsEndDate"
+            class="text-xs font-medium text-[var(--color-base-content)]/70"
+            >{t('analytics.advanced.filters.endDate')}</label
+          >
+          <input
+            id="analyticsEndDate"
+            type="date"
+            class="input input-sm"
+            value={customEnd}
+            min={customStart}
+            onchange={handleEndChange}
+            aria-label={t('analytics.advanced.filters.endDate')}
+          />
+        </div>
       </div>
+    {/if}
 
-      <div
-        class="w-full min-h-[100px] relative"
-        role="group"
-        aria-labelledby="analyticsSpeciesLabel"
-        aria-describedby="analyticsSpeciesHint"
-      >
+    <!-- Source / mic filter (present but inert in PR0; reason in the hover tooltip
+         to keep the toolbar row aligned and compact). -->
+    <div class="w-44 max-w-full space-y-1" title={t('analytics.hub.controls.sourceComingSoon')}>
+      <SelectDropdown
+        value={params.source}
+        options={sourceOptions}
+        disabled={true}
+        label={t('analytics.hub.controls.source')}
+        variant="select"
+        size="sm"
+        menuSize="sm"
+      />
+    </div>
+
+    <div class="grow"></div>
+
+    <!-- Species toggle: expands the chip selector; shows the current count -->
+    <button
+      id="analyticsSpeciesToggle"
+      type="button"
+      class="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium border border-[var(--color-base-300)] hover:bg-[var(--color-base-100)] disabled:opacity-50 disabled:cursor-not-allowed"
+      aria-expanded={speciesExpanded}
+      aria-controls="analyticsSpeciesPanel"
+      disabled={!speciesApplicable}
+      title={speciesApplicable ? undefined : t('analytics.hub.controls.speciesNotApplicable')}
+      onclick={() => (speciesExpanded = !speciesExpanded)}
+    >
+      {#if speciesExpanded}
+        <ChevronDown class="h-4 w-4" aria-hidden="true" />
+      {:else}
+        <ChevronRight class="h-4 w-4" aria-hidden="true" />
+      {/if}
+      <span>{speciesLabel}</span>
+    </button>
+  </div>
+
+  {#if !speciesApplicable}
+    <p class="mt-2 text-xs text-[var(--color-base-content)]/60">
+      {t('analytics.hub.controls.speciesNotApplicable')}
+    </p>
+  {:else if speciesExpanded}
+    <!-- Collapsible species selector -->
+    <div
+      id="analyticsSpeciesPanel"
+      class="mt-3"
+      role="group"
+      aria-labelledby="analyticsSpeciesToggle"
+      aria-describedby="analyticsSpeciesHint"
+    >
+      <p id="analyticsSpeciesHint" class="mb-2 text-xs text-[var(--color-base-content)]/60">
+        {t('analytics.advanced.speciesSelectionHint')}
+      </p>
+      <div class="w-full min-h-[100px] relative">
         <SpeciesSelector
           species={availableSpecies}
           selected={params.species}
@@ -171,7 +207,6 @@
           searchable={true}
           showFrequency={true}
           categorized={false}
-          disabled={!speciesApplicable}
           loading={loadingSpecies}
           emptyText={t('analytics.advanced.noSpeciesFound')}
           className="w-full"
@@ -197,5 +232,5 @@
         </SpeciesSelector>
       </div>
     </div>
-  </div>
+  {/if}
 </div>

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.svelte
@@ -70,6 +70,12 @@
     })
   );
 
+  // The panel is only open when species filtering applies AND the user expanded
+  // it. Deriving this (rather than reading speciesExpanded directly) keeps the
+  // toggle's chevron, aria-expanded, and aria-controls consistent when the active
+  // tab switches to one whose charts do not filter by species.
+  const speciesPanelOpen = $derived(speciesApplicable && speciesExpanded);
+
   function handleRangeChange(value: string | string[]): void {
     const range = (Array.isArray(value) ? value[0] : value) as DateRangePreset;
     if (range === 'custom') {
@@ -144,8 +150,9 @@
       </div>
     {/if}
 
-    <!-- Source / mic filter (present but inert in PR0; reason in the hover tooltip
-         to keep the toolbar row aligned and compact). -->
+    <!-- Source / mic filter (present but inert in PR0). The reason is a hover
+         tooltip (keeps the toolbar row aligned/compact) plus a visually-hidden
+         line so screen-reader users in reading order also get the explanation. -->
     <div class="w-44 max-w-full space-y-1" title={t('analytics.hub.controls.sourceComingSoon')}>
       <SelectDropdown
         value={params.source}
@@ -156,6 +163,7 @@
         size="sm"
         menuSize="sm"
       />
+      <span class="sr-only">{t('analytics.hub.controls.sourceComingSoon')}</span>
     </div>
 
     <div class="grow"></div>
@@ -165,13 +173,13 @@
       id="analyticsSpeciesToggle"
       type="button"
       class="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium border border-[var(--color-base-300)] hover:bg-[var(--color-base-100)] disabled:opacity-50 disabled:cursor-not-allowed"
-      aria-expanded={speciesExpanded}
-      aria-controls="analyticsSpeciesPanel"
+      aria-expanded={speciesPanelOpen}
+      aria-controls={speciesPanelOpen ? 'analyticsSpeciesPanel' : undefined}
       disabled={!speciesApplicable}
       title={speciesApplicable ? undefined : t('analytics.hub.controls.speciesNotApplicable')}
       onclick={() => (speciesExpanded = !speciesExpanded)}
     >
-      {#if speciesExpanded}
+      {#if speciesPanelOpen}
         <ChevronDown class="h-4 w-4" aria-hidden="true" />
       {:else}
         <ChevronRight class="h-4 w-4" aria-hidden="true" />
@@ -184,7 +192,7 @@
     <p class="mt-2 text-xs text-[var(--color-base-content)]/60">
       {t('analytics.hub.controls.speciesNotApplicable')}
     </p>
-  {:else if speciesExpanded}
+  {:else if speciesPanelOpen}
     <!-- Collapsible species selector -->
     <div
       id="analyticsSpeciesPanel"

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
@@ -41,7 +41,8 @@ describe('AnalyticsControlBar', () => {
     });
 
     expect(screen.getByText('analytics.hub.controls.source')).toBeInTheDocument();
-    expect(screen.getByText('analytics.hub.controls.sourceComingSoon')).toBeInTheDocument();
+    // The "coming soon" reason is a hover tooltip on the source control wrapper.
+    expect(screen.getByTitle('analytics.hub.controls.sourceComingSoon')).toBeInTheDocument();
   });
 
   it('explains when species filtering does not apply to the active tab', () => {

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
@@ -96,4 +96,42 @@ describe('AnalyticsControlBar', () => {
 
     expect(onParamsChange).toHaveBeenCalledWith(expect.objectContaining({ range: 'month' }));
   });
+
+  it('expands and collapses the species selector via the toggle', async () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: { params: makeParams(), availableSpecies: species, onParamsChange },
+    });
+
+    const toggle = document.getElementById('analyticsSpeciesToggle') as HTMLButtonElement;
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // Collapsed by default: the species panel is not in the DOM.
+    expect(document.querySelector('#analyticsSpeciesPanel')).not.toBeInTheDocument();
+
+    await fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(document.querySelector('#analyticsSpeciesPanel')).toBeInTheDocument();
+
+    await fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('#analyticsSpeciesPanel')).not.toBeInTheDocument();
+  });
+
+  it('disables the species toggle (collapsed, aria-expanded false) when species filtering does not apply', () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: {
+        params: makeParams(),
+        availableSpecies: species,
+        speciesApplicable: false,
+        onParamsChange,
+      },
+    });
+
+    const toggle = document.getElementById('analyticsSpeciesToggle') as HTMLButtonElement;
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).not.toHaveAttribute('aria-controls');
+    expect(document.querySelector('#analyticsSpeciesPanel')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/AnalyticsControlBar.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+
+import AnalyticsControlBar from './AnalyticsControlBar.svelte';
+import { parseAnalyticsParams } from '../registry/analyticsParams';
+import { createSpeciesId } from '$lib/types/species';
+import type { Species } from '$lib/types/species';
+import type { AnalyticsParams } from '../registry/types';
+
+afterEach(() => cleanup());
+
+const NOW = new Date(2026, 5, 19, 12, 0, 0);
+
+const species: Species[] = [
+  {
+    id: createSpeciesId('Turdus merula'),
+    commonName: 'Common Blackbird',
+    scientificName: 'Turdus merula',
+    count: 120,
+  },
+  {
+    id: createSpeciesId('Parus major'),
+    commonName: 'Great Tit',
+    scientificName: 'Parus major',
+    count: 80,
+  },
+];
+
+function makeParams(overrides: Partial<AnalyticsParams> = {}): AnalyticsParams {
+  return {
+    ...parseAnalyticsParams('', { defaultTab: 'patterns', now: NOW }),
+    ...overrides,
+  };
+}
+
+describe('AnalyticsControlBar', () => {
+  it('renders the source filter as inert with an explanation', () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: { params: makeParams(), availableSpecies: species, onParamsChange },
+    });
+
+    expect(screen.getByText('analytics.hub.controls.source')).toBeInTheDocument();
+    expect(screen.getByText('analytics.hub.controls.sourceComingSoon')).toBeInTheDocument();
+  });
+
+  it('explains when species filtering does not apply to the active tab', () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: {
+        params: makeParams(),
+        availableSpecies: species,
+        speciesApplicable: false,
+        onParamsChange,
+      },
+    });
+
+    expect(
+      screen.getAllByText('analytics.hub.controls.speciesNotApplicable').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('reports custom date edits through onParamsChange', async () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: {
+        params: makeParams({ range: 'custom', start: '2026-01-01', end: '2026-02-01' }),
+        availableSpecies: species,
+        onParamsChange,
+      },
+    });
+
+    const startInput = screen.getByLabelText('analytics.advanced.filters.startDate');
+    await fireEvent.change(startInput, { target: { value: '2026-01-15' } });
+
+    expect(onParamsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ range: 'custom', start: '2026-01-15', end: '2026-02-01' })
+    );
+  });
+
+  it('reports a preset range change through onParamsChange', async () => {
+    const onParamsChange = vi.fn();
+    render(AnalyticsControlBar, {
+      props: { params: makeParams({ range: 'week' }), availableSpecies: species, onParamsChange },
+    });
+
+    // Open the date-range dropdown (trigger shows the current value label).
+    const trigger = screen.getByText('analytics.advanced.dateRangeOptions.week').closest('button');
+    expect(trigger).not.toBeNull();
+    await fireEvent.click(trigger as HTMLButtonElement);
+
+    // Pick the "month" option.
+    const monthOption = await screen.findByText('analytics.advanced.dateRangeOptions.month');
+    await fireEvent.click(monthOption);
+
+    expect(onParamsChange).toHaveBeenCalledWith(expect.objectContaining({ range: 'month' }));
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/ChartCard.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ChartCard.svelte
@@ -1,0 +1,240 @@
+<!--
+  ChartCard: shared chrome for every analytics chart.
+
+  Owns the card frame, title/description, optional per-card options toolbar and
+  export-menu stub, and the full state matrix: loading, error (with retry),
+  empty ("no data for these filters"), a distinct "not enough data yet" state
+  driven by `minDataPoints`, and the chart itself. It drives the registry
+  `fetch` from the shared params and maps the result onto the chart component
+  via the registry `mapProps`, so individual charts no longer carry their own
+  loading/empty markup.
+-->
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { Inbox, Sprout, TriangleAlert, RefreshCw, Download } from '@lucide/svelte';
+
+  import { t } from '$lib/i18n';
+  import { getLogger } from '$lib/utils/logger';
+  import { formatDateForAPI } from '../registry/analyticsParams';
+  import type { AnalyticsParams, ChartDef } from '../registry/types';
+
+  interface Props {
+    chart: ChartDef;
+    params: AnalyticsParams;
+    /** Scientific -> common name map (for series labels). */
+    speciesNames?: Map<string, string>;
+    /**
+     * True while the hub is still loading the species list. Used to suppress the
+     * empty state for species-driven charts before the top-species auto-select
+     * lands, so a fresh load shows a continuous spinner instead of flashing
+     * "no data" (matches the legacy page's hold-until-species-resolved behavior).
+     */
+    speciesLoading?: boolean;
+    /** Lets a chart request shared-param changes (e.g. brush selecting a range). */
+    onParamsChange?: (_partial: Partial<AnalyticsParams>) => void;
+  }
+
+  let { chart, params, speciesNames, speciesLoading = false, onParamsChange }: Props = $props();
+
+  const logger = getLogger('analytics-chart-card');
+
+  // Per-card display options (e.g. the trend chart's relative/zoom/brush toggles).
+  // ChartCard owns the state; the controls component reads it and reports changes
+  // via setOption. Seed once from the registry; `chart` is stable per card
+  // instance (it is keyed by id in the parent {#each}).
+  let options = $state<Record<string, unknown>>(
+    untrack(() => ({ ...(chart.defaultOptions ?? {}) }))
+  );
+  function setOption(key: string, value: unknown): void {
+    options = { ...options, [key]: value };
+  }
+
+  // Fetch lifecycle state.
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let result = $state<unknown>(null);
+  let reloadNonce = $state(0);
+  let controller: AbortController | null = null;
+
+  // The fetch only depends on the params the chart actually consumes. Charts
+  // that ignore species/source (e.g. diversity) do not refetch when those
+  // change. Keyed on the resolved dates so it reflects exactly what is fetched.
+  const fetchKey = $derived(
+    JSON.stringify({
+      start: formatDateForAPI(params.startDate),
+      end: formatDateForAPI(params.endDate),
+      species: chart.supports.species ? [...params.species].sort() : [],
+      source: chart.supports.source ? params.source : '',
+      nonce: reloadNonce,
+    })
+  );
+
+  $effect(() => {
+    // Track only fetchKey; read the live params untracked so options/tab changes
+    // never trigger a refetch.
+    void fetchKey;
+    const currentParams = untrack(() => params);
+    const currentChart = untrack(() => chart);
+
+    controller?.abort();
+    const ac = new AbortController();
+    controller = ac;
+
+    loading = true;
+    error = null;
+
+    currentChart
+      .fetch(currentParams, ac.signal)
+      .then(data => {
+        if (ac.signal.aborted) return;
+        result = data;
+        loading = false;
+      })
+      .catch((err: unknown) => {
+        if (ac.signal.aborted || (err instanceof Error && err.name === 'AbortError')) return;
+        logger.error('Chart fetch failed', err, { chart: currentChart.id });
+        error = t('analytics.errors.loadFailed');
+        loading = false;
+      });
+
+    return () => ac.abort();
+  });
+
+  function retry(): void {
+    reloadNonce += 1;
+  }
+
+  // Number of data points in the current result, for the empty / not-enough checks.
+  const dataCount = $derived.by(() => {
+    if (result == null) return 0;
+    if (chart.countDataPoints) return chart.countDataPoints(result);
+    return Array.isArray(result) ? result.length : 0;
+  });
+
+  // A species-driven chart with no selection yet, while the hub is still loading
+  // the species list, is mid-auto-select: keep the spinner up instead of flashing
+  // the empty state.
+  const isPending = $derived(
+    chart.supports.species && params.species.length === 0 && speciesLoading
+  );
+
+  const hasResult = $derived(result !== null);
+  const isEmpty = $derived(hasResult && dataCount === 0 && !isPending);
+  const isNotEnough = $derived(
+    hasResult && chart.minDataPoints != null && dataCount > 0 && dataCount < chart.minDataPoints
+  );
+  const showChart = $derived(hasResult && !isEmpty && !isNotEnough);
+
+  // Map the fetched data + params (+ options/callbacks) onto the chart component's props.
+  const resolvedProps = $derived.by<Record<string, unknown> | null>(() => {
+    if (!showChart) return null;
+    const ctx = {
+      options,
+      onParamsChange: onParamsChange ?? (() => {}),
+      speciesNames: speciesNames ?? new Map<string, string>(),
+    };
+    return chart.mapProps ? chart.mapProps(result, params, ctx) : { data: result };
+  });
+
+  const titleId = $derived(`chart-card-${chart.id}-title`);
+  const exportHintId = $derived(`chart-card-${chart.id}-export-hint`);
+</script>
+
+<section
+  id={chart.id}
+  class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]"
+  aria-labelledby={titleId}
+>
+  <div class="p-6">
+    <!-- Header: title/description on the left, per-card controls + export on the right -->
+    <div class="flex flex-wrap items-start justify-between gap-x-4 gap-y-2 mb-4">
+      <div class="min-w-0">
+        <h3 id={titleId} class="text-lg font-semibold">{t(chart.titleKey)}</h3>
+        <p class="text-sm text-[var(--color-base-content)] opacity-70">{t(chart.descKey)}</p>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-3 shrink-0">
+        {#if chart.controls}
+          {@const Controls = chart.controls}
+          <Controls {options} {setOption} />
+        {/if}
+
+        {#if chart.export}
+          <!-- Export menu stub: real CSV export arrives with the new endpoints. -->
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium border border-[var(--color-base-200)] text-[var(--color-base-content)] opacity-60 cursor-not-allowed"
+            disabled
+            title={t('analytics.hub.card.exportComingSoon')}
+            aria-describedby={exportHintId}
+          >
+            <Download class="h-4 w-4" />
+            <span>{t('analytics.hub.card.export')}</span>
+          </button>
+          <span id={exportHintId} class="sr-only">{t('analytics.hub.card.exportComingSoon')}</span>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Body: state machine + chart, with a loading overlay that preserves the chart underneath -->
+    <div class="h-96 relative">
+      {#if error}
+        <div class="absolute inset-0 flex items-center justify-center rounded-lg" role="alert">
+          <div class="text-center max-w-sm px-4">
+            <TriangleAlert class="h-10 w-10 mx-auto mb-3 text-[var(--color-error)]" />
+            <p class="text-lg mb-1">{t('analytics.hub.card.error')}</p>
+            <p class="text-sm text-[var(--color-base-content)] opacity-70 mb-4">{error}</p>
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium border border-[var(--color-base-300)] hover:bg-[var(--color-base-200)]"
+              onclick={retry}
+            >
+              <RefreshCw class="h-4 w-4" />
+              <span>{t('analytics.hub.card.retry')}</span>
+            </button>
+          </div>
+        </div>
+      {:else if isEmpty}
+        <div
+          class="absolute inset-0 flex items-center justify-center text-[var(--color-base-content)] opacity-60 rounded-lg"
+          role="status"
+        >
+          <div class="text-center px-4">
+            <Inbox class="h-10 w-10 mx-auto mb-3 opacity-70" />
+            <p class="text-lg mb-2">{t(chart.emptyKey)}</p>
+            <p class="text-sm">{t(chart.emptyHintKey)}</p>
+          </div>
+        </div>
+      {:else if isNotEnough}
+        <div
+          class="absolute inset-0 flex items-center justify-center text-[var(--color-base-content)] opacity-70 rounded-lg"
+          role="status"
+        >
+          <div class="text-center px-4">
+            <Sprout class="h-10 w-10 mx-auto mb-3 text-[var(--color-success)] opacity-80" />
+            <p class="text-lg mb-2">{t('analytics.hub.card.notEnoughData')}</p>
+            <p class="text-sm">
+              {t('analytics.hub.card.notEnoughDataHint', { min: chart.minDataPoints ?? 0 })}
+            </p>
+          </div>
+        </div>
+      {:else if resolvedProps}
+        {@const ChartComponent = chart.component}
+        <ChartComponent {...resolvedProps} />
+      {/if}
+
+      {#if loading || isPending}
+        <div
+          class="absolute inset-0 bg-[var(--color-base-100)]/80 backdrop-blur-xs flex items-center justify-center rounded-lg"
+          role="status"
+          aria-busy="true"
+          aria-label={t('analytics.advanced.aria.loadingAnalytics')}
+        >
+          <div
+            class="w-12 h-12 border-4 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin"
+          ></div>
+        </div>
+      {/if}
+    </div>
+  </div>
+</section>

--- a/frontend/src/lib/desktop/features/analytics/components/ChartCard.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/ChartCard.svelte
@@ -70,34 +70,38 @@
   );
 
   $effect(() => {
-    // Track only fetchKey; read the live params untracked so options/tab changes
-    // never trigger a refetch.
+    // fetchKey is the ONLY tracked dependency. The whole body runs untracked so
+    // that the synchronous param reads inside chart.fetch() (which run before its
+    // first await) are not picked up as effect dependencies. Otherwise re-resolved
+    // Date objects / unrelated param changes would refetch despite an unchanged key.
     void fetchKey;
-    const currentParams = untrack(() => params);
-    const currentChart = untrack(() => chart);
+    return untrack(() => {
+      const currentParams = params;
+      const currentChart = chart;
 
-    controller?.abort();
-    const ac = new AbortController();
-    controller = ac;
+      controller?.abort();
+      const ac = new AbortController();
+      controller = ac;
 
-    loading = true;
-    error = null;
+      loading = true;
+      error = null;
 
-    currentChart
-      .fetch(currentParams, ac.signal)
-      .then(data => {
-        if (ac.signal.aborted) return;
-        result = data;
-        loading = false;
-      })
-      .catch((err: unknown) => {
-        if (ac.signal.aborted || (err instanceof Error && err.name === 'AbortError')) return;
-        logger.error('Chart fetch failed', err, { chart: currentChart.id });
-        error = t('analytics.errors.loadFailed');
-        loading = false;
-      });
+      currentChart
+        .fetch(currentParams, ac.signal)
+        .then(data => {
+          if (ac.signal.aborted) return;
+          result = data;
+          loading = false;
+        })
+        .catch((err: unknown) => {
+          if (ac.signal.aborted || (err instanceof Error && err.name === 'AbortError')) return;
+          logger.error('Chart fetch failed', err, { chart: currentChart.id });
+          error = t('analytics.errors.loadFailed');
+          loading = false;
+        });
 
-    return () => ac.abort();
+      return () => ac.abort();
+    });
   });
 
   function retry(): void {
@@ -123,7 +127,9 @@
   const isNotEnough = $derived(
     hasResult && chart.minDataPoints != null && dataCount > 0 && dataCount < chart.minDataPoints
   );
-  const showChart = $derived(hasResult && !isEmpty && !isNotEnough);
+  // Require real data points: never mount the (heavy) D3 chart with an empty
+  // dataset under the spinner while a species auto-select is still pending.
+  const showChart = $derived(hasResult && dataCount > 0 && !isNotEnough);
 
   // Map the fetched data + params (+ options/callbacks) onto the chart component's props.
   const resolvedProps = $derived.by<Record<string, unknown> | null>(() => {

--- a/frontend/src/lib/desktop/features/analytics/components/ChartCard.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/ChartCard.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+import ChartCard from './ChartCard.svelte';
+import TrendChartOptions from './TrendChartOptions.svelte';
+import StubChart from './__tests__/StubChart.svelte';
+import { parseAnalyticsParams } from '../registry/analyticsParams';
+import type { AnalyticsParams, ChartDef } from '../registry/types';
+
+// The shared setup mocks `t` to echo the key, so assertions match i18n keys.
+
+afterEach(() => cleanup());
+
+const params: AnalyticsParams = parseAnalyticsParams('?range=week', {
+  defaultTab: 'patterns',
+  now: new Date(2026, 5, 19, 12, 0, 0),
+});
+
+function makeDef(overrides: Partial<ChartDef> = {}): ChartDef {
+  return {
+    id: 'stub-chart',
+    group: 'patterns',
+    titleKey: 'analytics.advanced.charts.timeOfDay.title',
+    descKey: 'analytics.advanced.charts.timeOfDay.description',
+    emptyKey: 'analytics.advanced.charts.timeOfDay.noData',
+    emptyHintKey: 'analytics.advanced.charts.timeOfDay.noDataHint',
+    component: StubChart,
+    fetch: vi.fn().mockResolvedValue([]),
+    size: 'full',
+    supports: { species: true, source: false },
+    ...overrides,
+  };
+}
+
+describe('ChartCard state matrix', () => {
+  it('shows the loading state before the fetch resolves', () => {
+    // A never-resolving fetch keeps the card in the loading state.
+    const def = makeDef({ fetch: vi.fn(() => new Promise<unknown>(() => {})) });
+    render(ChartCard, { props: { chart: def, params } });
+
+    expect(screen.getByLabelText('analytics.advanced.aria.loadingAnalytics')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when the fetch returns no data', async () => {
+    const def = makeDef({ fetch: vi.fn().mockResolvedValue([]) });
+    render(ChartCard, { props: { chart: def, params } });
+
+    expect(
+      await screen.findByText('analytics.advanced.charts.timeOfDay.noData')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows the distinct "not enough data yet" state below minDataPoints', async () => {
+    const def = makeDef({
+      minDataPoints: 5,
+      fetch: vi.fn().mockResolvedValue([{ a: 1 }, { a: 2 }]), // 2 < 5
+    });
+    render(ChartCard, { props: { chart: def, params } });
+
+    expect(await screen.findByText('analytics.hub.card.notEnoughData')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-chart')).not.toBeInTheDocument();
+    // Not the same as the generic empty state.
+    expect(
+      screen.queryByText('analytics.advanced.charts.timeOfDay.noData')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the chart when enough data is returned', async () => {
+    const rows = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }];
+    const def = makeDef({ minDataPoints: 5, fetch: vi.fn().mockResolvedValue(rows) });
+    render(ChartCard, { props: { chart: def, params } });
+
+    const stub = await screen.findByTestId('stub-chart');
+    expect(stub).toHaveAttribute('data-count', '5');
+    expect(screen.queryByText('analytics.hub.card.notEnoughData')).not.toBeInTheDocument();
+  });
+
+  it('shows the error state and recovers via retry', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([{ a: 1 }, { a: 2 }]);
+    const def = makeDef({ fetch: fetchMock });
+    render(ChartCard, { props: { chart: def, params } });
+
+    expect(await screen.findByText('analytics.hub.card.error')).toBeInTheDocument();
+    const retry = screen.getByText('analytics.hub.card.retry');
+
+    await fireEvent.click(retry);
+
+    expect(await screen.findByTestId('stub-chart')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ChartCard chrome', () => {
+  it('renders the title and description from the registry', () => {
+    render(ChartCard, { props: { chart: makeDef(), params } });
+    expect(screen.getByText('analytics.advanced.charts.timeOfDay.title')).toBeInTheDocument();
+    expect(screen.getByText('analytics.advanced.charts.timeOfDay.description')).toBeInTheDocument();
+  });
+
+  it('shows a disabled export stub only when the chart enables export', () => {
+    const { unmount } = render(ChartCard, { props: { chart: makeDef(), params } });
+    expect(screen.queryByText('analytics.hub.card.export')).not.toBeInTheDocument();
+    unmount();
+
+    render(ChartCard, { props: { chart: makeDef({ export: 'csv' }), params } });
+    const exportBtn = screen.getByText('analytics.hub.card.export').closest('button');
+    expect(exportBtn).toBeDisabled();
+  });
+
+  it('renders a per-card controls toolbar when the chart provides one', () => {
+    const def = makeDef({
+      controls: TrendChartOptions,
+      defaultOptions: { showRelative: false, enableZoom: true, enableBrush: false },
+    });
+    render(ChartCard, { props: { chart: def, params } });
+    expect(screen.getByText('analytics.advanced.options.relativeTrends')).toBeInTheDocument();
+    expect(screen.getByText('analytics.advanced.options.zoomPan')).toBeInTheDocument();
+  });
+});
+
+describe('ChartCard refetch gating', () => {
+  const withSpecies = (species: string[]): AnalyticsParams => ({
+    ...parseAnalyticsParams('?range=week', {
+      defaultTab: 'patterns',
+      now: new Date(2026, 5, 19, 12, 0, 0),
+    }),
+    species,
+  });
+
+  it('refetches when selected species change for a species-driven chart', async () => {
+    const fetchMock = vi.fn().mockResolvedValue([{ a: 1 }]);
+    const def = makeDef({ supports: { species: true, source: false }, fetch: fetchMock });
+    const { rerender } = render(ChartCard, {
+      props: { chart: def, params: withSpecies(['Turdus merula']) },
+    });
+    await tick();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await rerender({ chart: def, params: withSpecies(['Turdus merula', 'Parus major']) });
+    await tick();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT refetch when species change for a chart that ignores species', async () => {
+    const fetchMock = vi.fn().mockResolvedValue([{ a: 1 }]);
+    const def = makeDef({ supports: { species: false, source: false }, fetch: fetchMock });
+    const { rerender } = render(ChartCard, {
+      props: { chart: def, params: withSpecies(['Turdus merula']) },
+    });
+    await tick();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await rerender({ chart: def, params: withSpecies(['Turdus merula', 'Parus major']) });
+    await tick();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ChartCard brush -> onParamsChange chain', () => {
+  it('routes a chart-initiated range change up through onParamsChange', async () => {
+    const onParamsChange = vi.fn();
+    const def = makeDef({
+      fetch: vi.fn().mockResolvedValue([{ a: 1 }]),
+      // Mirrors the trend chart's mapProps wiring of onDateRangeChange.
+      mapProps: (data, _params, ctx) => ({
+        data,
+        trigger: () =>
+          ctx.onParamsChange({ range: 'custom', start: '2026-01-01', end: '2026-01-31' }),
+      }),
+    });
+    render(ChartCard, { props: { chart: def, params, onParamsChange } });
+
+    await fireEvent.click(await screen.findByTestId('stub-trigger'));
+
+    expect(onParamsChange).toHaveBeenCalledWith(
+      expect.objectContaining({ range: 'custom', start: '2026-01-01', end: '2026-01-31' })
+    );
+  });
+});
+
+describe('ChartCard pending (species auto-select)', () => {
+  it('holds the loading state instead of flashing empty while species load', async () => {
+    const def = makeDef({
+      supports: { species: true, source: false },
+      fetch: vi.fn().mockResolvedValue([]),
+    });
+    // No species selected yet and the hub is still loading the species list.
+    render(ChartCard, { props: { chart: def, params, speciesLoading: true } });
+    await tick();
+
+    expect(screen.getByLabelText('analytics.advanced.aria.loadingAnalytics')).toBeInTheDocument();
+    expect(
+      screen.queryByText('analytics.advanced.charts.timeOfDay.noData')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state once species loading finishes with no data', async () => {
+    const def = makeDef({
+      supports: { species: true, source: false },
+      fetch: vi.fn().mockResolvedValue([]),
+    });
+    render(ChartCard, { props: { chart: def, params, speciesLoading: false } });
+
+    expect(
+      await screen.findByText('analytics.advanced.charts.timeOfDay.noData')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/TrendChartOptions.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/TrendChartOptions.svelte
@@ -1,0 +1,41 @@
+<!--
+  Per-card display options for the Daily Species Trend chart.
+
+  Rendered by ChartCard in the card header for charts that declare `controls`.
+  Keeps chart-specific toggles (relative trends, zoom/pan, brush selection) out
+  of the shared AnalyticsControlBar while preserving the legacy behavior. State
+  is owned by ChartCard; this component reads `options` and reports changes via
+  `setOption` (it never mutates `options` directly).
+-->
+<script lang="ts">
+  import { t } from '$lib/i18n';
+  import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
+  import type { ChartControlsProps } from '../registry/types';
+
+  let { options, setOption }: ChartControlsProps = $props();
+</script>
+
+<div
+  class="flex flex-wrap items-center gap-x-4 gap-y-1"
+  role="group"
+  aria-label={t('analytics.advanced.chartOptions')}
+>
+  <Checkbox
+    checked={Boolean(options.showRelative)}
+    onchange={checked => setOption('showRelative', checked)}
+    label={t('analytics.advanced.options.relativeTrends')}
+    size="sm"
+  />
+  <Checkbox
+    checked={Boolean(options.enableZoom)}
+    onchange={checked => setOption('enableZoom', checked)}
+    label={t('analytics.advanced.options.zoomPan')}
+    size="sm"
+  />
+  <Checkbox
+    checked={Boolean(options.enableBrush)}
+    onchange={checked => setOption('enableBrush', checked)}
+    label={t('analytics.advanced.options.brushSelection')}
+    size="sm"
+  />
+</div>

--- a/frontend/src/lib/desktop/features/analytics/components/__tests__/StubChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/__tests__/StubChart.svelte
@@ -1,0 +1,14 @@
+<!-- Test fixture: a trivial chart component for ChartCard tests (no D3). -->
+<script lang="ts">
+  interface Props {
+    data?: unknown[];
+    /** Optional callback wired by a test's mapProps (e.g. to simulate a brush). */
+    trigger?: () => void;
+  }
+  let { data = [], trigger }: Props = $props();
+</script>
+
+<div data-testid="stub-chart" data-count={Array.isArray(data) ? data.length : 0}>stub chart</div>
+{#if trigger}
+  <button type="button" data-testid="stub-trigger" onclick={() => trigger?.()}>trigger</button>
+{/if}

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
@@ -144,10 +144,11 @@
         .domain(dateRange || safeDateExtent)
         .range([0, 100]),
       y: scaleLinear()
-        // Floor the domain max at 1 so an all-zero range keeps zero pinned to the
-        // bottom instead of a degenerate [0,0] domain that .nice() expands into
-        // negative space. No-op for any real data (counts/percentages are >= 1).
-        .domain([0, Math.max(safeCountExtent[1] || 0, 1) * 1.1])
+        // Default a zero/empty max to 1 so an all-zero range keeps zero pinned to
+        // the bottom instead of a degenerate [0,0] domain that .nice() expands into
+        // negative space. `|| 1` only replaces a falsy (0) max, so a real fractional
+        // max in relative/percentage mode (e.g. 0.5%) is preserved, not squashed.
+        .domain([0, (safeCountExtent[1] || 1) * 1.1])
         .range([100, 0]),
     };
   });
@@ -426,10 +427,8 @@
         onEnd: selection => {
           if (selection) {
             const [x1, x2] = selection;
-            const dateRange: [Date, Date] = [xScale.invert(x1), xScale.invert(x2)];
-            onDateRangeChange?.(dateRange);
-          } else {
-            // Brush cleared
+            const brushRange: [Date, Date] = [xScale.invert(x1), xScale.invert(x2)];
+            onDateRangeChange?.(brushRange);
           }
         },
       });

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
@@ -61,6 +61,12 @@
     onDateRangeChange,
   }: Props = $props();
 
+  // Non-degenerate fallback for the y-domain max (so an all-zero range keeps zero
+  // at the bottom) plus a fixed headroom above the max. `|| MIN_Y_DOMAIN_MAX` only
+  // replaces a falsy max, preserving a real fractional max in percentage mode.
+  const MIN_Y_DOMAIN_MAX = 1;
+  const Y_AXIS_HEADROOM = 1.1;
+
   // Component state
   let tooltip: ChartTooltip | null = null;
   let zoomTransform: ZoomTransform | null = null;
@@ -148,7 +154,7 @@
         // the bottom instead of a degenerate [0,0] domain that .nice() expands into
         // negative space. `|| 1` only replaces a falsy (0) max, so a real fractional
         // max in relative/percentage mode (e.g. 0.5%) is preserved, not squashed.
-        .domain([0, (safeCountExtent[1] || 1) * 1.1])
+        .domain([0, (safeCountExtent[1] || MIN_Y_DOMAIN_MAX) * Y_AXIS_HEADROOM])
         .range([100, 0]),
     };
   });

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/DailySpeciesTrendChart.svelte
@@ -144,7 +144,10 @@
         .domain(dateRange || safeDateExtent)
         .range([0, 100]),
       y: scaleLinear()
-        .domain([0, (safeCountExtent[1] || 0) * 1.1])
+        // Floor the domain max at 1 so an all-zero range keeps zero pinned to the
+        // bottom instead of a degenerate [0,0] domain that .nice() expands into
+        // negative space. No-op for any real data (counts/percentages are >= 1).
+        .domain([0, Math.max(safeCountExtent[1] || 0, 1) * 1.1])
         .range([100, 0]),
     };
   });

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesDiversityChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesDiversityChart.svelte
@@ -65,7 +65,10 @@
 
     const safeDateExtent: [Date, Date] =
       dateExtent[0] && dateExtent[1] ? [dateExtent[0], dateExtent[1]] : [new Date(), new Date()];
-    const safeMaxCount = countExtent[1] !== undefined ? countExtent[1] : 10;
+    // Floor the domain max at 1: unique-species counts are non-negative, so an
+    // all-zero range must keep zero at the bottom rather than collapse to a
+    // degenerate [0,0] domain (which .nice() expands symmetrically into negatives).
+    const safeMaxCount = Math.max(countExtent[1] ?? 0, 1);
 
     return {
       x: safeDateExtent,

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesDiversityChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesDiversityChart.svelte
@@ -65,10 +65,11 @@
 
     const safeDateExtent: [Date, Date] =
       dateExtent[0] && dateExtent[1] ? [dateExtent[0], dateExtent[1]] : [new Date(), new Date()];
-    // Floor the domain max at 1: unique-species counts are non-negative, so an
-    // all-zero range must keep zero at the bottom rather than collapse to a
-    // degenerate [0,0] domain (which .nice() expands symmetrically into negatives).
-    const safeMaxCount = Math.max(countExtent[1] ?? 0, 1);
+    // Unique-species counts are non-negative. Default a zero/empty max to 1 so an
+    // all-zero range keeps zero at the bottom rather than collapse to a degenerate
+    // [0,0] domain (which .nice() expands symmetrically into negatives). `|| 1`
+    // only replaces a falsy (0/undefined) max, preserving any real positive max.
+    const safeMaxCount = countExtent[1] || 1;
 
     return {
       x: safeDateExtent,

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesDiversityChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesDiversityChart.svelte
@@ -30,6 +30,9 @@
 
   // Chart styling constants
   const Y_SCALE_HEADROOM = 1.1;
+  // Non-degenerate fallback for the y-domain max when the range has no data, so
+  // an all-zero range keeps zero at the bottom instead of collapsing to [0,0].
+  const MIN_Y_DOMAIN_MAX = 1;
   const MAX_X_TICKS = 8;
   const TICK_SPACING_PX = 80;
   const Y_TICK_COUNT = 6;
@@ -69,7 +72,7 @@
     // all-zero range keeps zero at the bottom rather than collapse to a degenerate
     // [0,0] domain (which .nice() expands symmetrically into negatives). `|| 1`
     // only replaces a falsy (0/undefined) max, preserving any real positive max.
-    const safeMaxCount = countExtent[1] || 1;
+    const safeMaxCount = countExtent[1] || MIN_Y_DOMAIN_MAX;
 
     return {
       x: safeDateExtent,

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -67,11 +67,16 @@
     const visible = visibleData;
     if (!visible.length) return null;
 
-    const maxCount =
+    const rawMaxCount =
       max(
         visible.flatMap(s => s.data),
         d => d.count
       ) ?? 0;
+    // Detection counts are non-negative integers. Floor the domain max at 1 so an
+    // all-zero series pins zero to the bottom of the chart instead of producing a
+    // degenerate [0,0] domain that .nice() expands symmetrically (centering zero
+    // and rendering negative ticks). For any real data (max >= 1) this is a no-op.
+    const maxCount = Math.max(rawMaxCount, 1);
 
     return {
       x: scaleLinear().domain([0, 23]).range([0, 100]), // Percentage-based for responsiveness

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -72,11 +72,11 @@
         visible.flatMap(s => s.data),
         d => d.count
       ) ?? 0;
-    // Detection counts are non-negative integers. Floor the domain max at 1 so an
-    // all-zero series pins zero to the bottom of the chart instead of producing a
-    // degenerate [0,0] domain that .nice() expands symmetrically (centering zero
-    // and rendering negative ticks). For any real data (max >= 1) this is a no-op.
-    const maxCount = Math.max(rawMaxCount, 1);
+    // Detection counts are non-negative. Default an all-zero/empty max to 1 so the
+    // series pins zero to the bottom instead of producing a degenerate [0,0] domain
+    // that .nice() expands symmetrically (centering zero and rendering negative
+    // ticks). `|| 1` only replaces a falsy (0) max, preserving any real positive max.
+    const maxCount = rawMaxCount || 1;
 
     return {
       x: scaleLinear().domain([0, 23]).range([0, 100]), // Percentage-based for responsiveness

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/TimeOfDaySpeciesChart.svelte
@@ -37,6 +37,11 @@
 
   let { data = [], width = 800, height = 400, selectedSpecies = [] }: Props = $props();
 
+  // Non-degenerate fallback for the y-domain max (counts are non-negative; an
+  // all-zero range keeps zero at the bottom) plus a fixed headroom above the max.
+  const MIN_Y_DOMAIN_MAX = 1;
+  const Y_AXIS_HEADROOM = 1.1;
+
   // Component state
   let tooltip: ChartTooltip | null = null;
 
@@ -76,12 +81,12 @@
     // series pins zero to the bottom instead of producing a degenerate [0,0] domain
     // that .nice() expands symmetrically (centering zero and rendering negative
     // ticks). `|| 1` only replaces a falsy (0) max, preserving any real positive max.
-    const maxCount = rawMaxCount || 1;
+    const maxCount = rawMaxCount || MIN_Y_DOMAIN_MAX;
 
     return {
       x: scaleLinear().domain([0, 23]).range([0, 100]), // Percentage-based for responsiveness
       y: scaleLinear()
-        .domain([0, maxCount * 1.1])
+        .domain([0, maxCount * Y_AXIS_HEADROOM])
         .range([100, 0]), // Inverted for SVG
     };
   });

--- a/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.svelte
@@ -240,24 +240,13 @@
 </script>
 
 <div class="col-span-12" role="region" aria-label={t('analytics.advanced.title')}>
-  <!-- Sticky shared control bar -->
-  <div class="sticky top-0 z-20 bg-[var(--color-base-100)] py-2">
-    <AnalyticsControlBar
-      {params}
-      {availableSpecies}
-      {loadingSpecies}
-      {speciesApplicable}
-      onParamsChange={partial => applyParams(partial, 'push')}
-    />
-  </div>
-
-  <!-- Tab bar -->
-  <!-- Scroll rather than wrap: longer locales (DE/FI) keep a single clean tab
-       strip instead of wrapping into a broken double border. -->
+  <!-- Tab bar: primary navigation, above the filters. Scrolls rather than wraps
+       so longer locales (DE/FI) keep a single clean strip; overflow-y is hidden
+       so the horizontal scroll container never shows a stray vertical bar. -->
   <div
     role="tablist"
     aria-label={t('analytics.hub.aria.tabs')}
-    class="mt-4 flex flex-nowrap gap-1 overflow-x-auto border-b border-[var(--color-base-200)]"
+    class="flex flex-nowrap gap-1 overflow-x-auto overflow-y-hidden border-b border-[var(--color-base-300)]/60"
   >
     {#each TABS as tab (tab.group)}
       {@const Icon = tab.icon}
@@ -279,6 +268,17 @@
         <span>{t(tab.labelKey)}</span>
       </button>
     {/each}
+  </div>
+
+  <!-- Compact filter toolbar (below the tabs) -->
+  <div class="mt-3">
+    <AnalyticsControlBar
+      {params}
+      {availableSpecies}
+      {loadingSpecies}
+      {speciesApplicable}
+      onParamsChange={partial => applyParams(partial, 'push')}
+    />
   </div>
 
   <!-- Active tab panel: only this tab's charts are mounted -->

--- a/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.svelte
@@ -204,7 +204,9 @@
   // this effect into a fetch loop.
   $effect(() => {
     void rangeKey;
-    fetchAvailableSpecies();
+    // Run untracked: the synchronous param reads inside fetchAvailableSpecies must
+    // not become effect dependencies, so only rangeKey drives the refetch.
+    untrack(() => fetchAvailableSpecies());
     return () => speciesController?.abort();
   });
 

--- a/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.svelte
@@ -1,819 +1,320 @@
-<!-- Advanced Analytics Page with D3.js Charts -->
-<script lang="ts">
-  import { onMount } from 'svelte';
-  import { t } from '$lib/i18n';
+<!--
+  Analytics hub (PR0 foundation).
 
-  import TimeOfDaySpeciesChart from '../components/charts/d3/TimeOfDaySpeciesChart.svelte';
-  import DailySpeciesTrendChart from '../components/charts/d3/DailySpeciesTrendChart.svelte';
-  import SpeciesDiversityChart from '../components/charts/d3/SpeciesDiversityChart.svelte';
-  import SpeciesSelector from '$lib/components/ui/SpeciesSelector.svelte';
-  import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
-  import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
-  import Input from '$lib/desktop/components/ui/Input.svelte';
-  import type { Species, SpeciesId } from '$lib/types/species';
-  import { createSpeciesId } from '$lib/types/species';
+  Registry-driven tabbed surface for the Advanced Analytics route: a sticky
+  shared control bar, a tab bar whose active tab lives in the `?tab=` URL param,
+  and a responsive grid of ChartCards for the active tab only. Date range,
+  species, source, and active tab all live in URL query params, so views are
+  deep-linkable and survive reload and Back/Forward.
+
+  PR0 migrates the three existing charts (time-of-day species, daily species
+  trend, species diversity) onto the registry with no behavior change. The
+  Overview and Review & Accuracy tabs are intentionally empty here; later PRs
+  populate them.
+-->
+<script lang="ts">
+  import { onMount, untrack } from 'svelte';
+  import {
+    Activity,
+    TrendingUp,
+    Leaf,
+    LayoutDashboard,
+    BadgeCheck,
+    Construction,
+  } from '@lucide/svelte';
+
+  import { t } from '$lib/i18n';
   import { getLogger } from '$lib/utils/logger';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
-  import { parseLocalDateString } from '$lib/utils/date';
+  import type { Species, SpeciesFrequency } from '$lib/types/species';
+  import { createSpeciesId } from '$lib/types/species';
 
-  const logger = getLogger('advanced-analytics');
+  import AnalyticsControlBar from '../components/AnalyticsControlBar.svelte';
+  import ChartCard from '../components/ChartCard.svelte';
+  import { chartsForGroup, groupHasCharts } from '../registry/charts';
+  import {
+    GROUP_ORDER,
+    formatDateForAPI,
+    parseAnalyticsParams,
+    resolveDateRange,
+    serializeAnalyticsParams,
+  } from '../registry/analyticsParams';
+  import type { AnalyticsParams, ChartGroup } from '../registry/types';
 
-  // Chart data interfaces
-  interface TimeOfDayDatum {
-    hour: number;
-    count: number;
-  }
+  const logger = getLogger('analytics-hub');
 
-  interface TimeOfDaySpeciesData {
-    species: string;
-    commonName: string;
-    data: TimeOfDayDatum[];
-    visible: boolean;
-  }
+  // Default landing tab: the first group (in display order) that actually has
+  // charts. Self-adjusts to Overview once PR0b populates it, so PR0 never lands
+  // the user on an empty tab.
+  const defaultTab: ChartGroup = GROUP_ORDER.find(groupHasCharts) ?? 'overview';
 
-  interface DailyTrendDatum {
-    date: Date;
-    count: number;
-  }
+  // Match the legacy behavior: auto-select the top species when none are in the URL.
+  const AUTO_SELECT_TOP = 5;
+  const SPECIES_SUMMARY_LIMIT = 50;
 
-  interface DailyTrendSpeciesData {
-    species: string;
-    commonName: string;
-    data: DailyTrendDatum[];
-    visible: boolean;
-  }
-
-  // API response interfaces
   interface SpeciesSummaryResponse {
     scientific_name?: string;
     common_name?: string;
     count?: number;
   }
 
-  interface HourlyDataItem {
-    hour: number;
-    count: number;
+  // Tab metadata (label key + icon), in display order.
+  const TABS: { group: ChartGroup; labelKey: string; icon: typeof Activity }[] = [
+    { group: 'overview', labelKey: 'analytics.hub.tabs.overview', icon: LayoutDashboard },
+    { group: 'patterns', labelKey: 'analytics.hub.tabs.patterns', icon: Activity },
+    { group: 'trends', labelKey: 'analytics.hub.tabs.trends', icon: TrendingUp },
+    { group: 'biodiversity', labelKey: 'analytics.hub.tabs.biodiversity', icon: Leaf },
+    { group: 'quality', labelKey: 'analytics.hub.tabs.quality', icon: BadgeCheck },
+  ];
+
+  function readParams(): AnalyticsParams {
+    const search = typeof window !== 'undefined' ? window.location.search : '';
+    return parseAnalyticsParams(search, { defaultTab });
   }
 
-  interface DailyDataItem {
-    date: string;
-    count: number;
-  }
+  let params = $state<AnalyticsParams>(readParams());
 
-  interface SpeciesDailyData {
-    start_date: string;
-    end_date: string;
-    species: string;
-    data: DailyDataItem[];
-    total: number;
-  }
-
-  interface DiversityDataItem {
-    date: string;
-    unique_species: number;
-  }
-
-  interface DiversityResponse {
-    start_date: string;
-    end_date: string;
-    data: DiversityDataItem[];
-    max_diversity: number;
-  }
-
-  interface DiversityDatum {
-    date: Date;
-    uniqueSpecies: number;
-  }
-
-  // Component state
-  let isLoading = $state(false);
-  let error = $state<string | null>(null);
-
-  // Date range controls
-  let dateRange = $state<'week' | 'month' | 'quarter' | 'year' | 'custom'>('month');
-  let startDate = $state('');
-  let endDate = $state('');
-
-  // Species selection
+  // Species available for the current range: powers the selector and provides
+  // the scientific -> common name map used to label chart series.
   let availableSpecies = $state<Species[]>([]);
-  let selectedSpecies = $state<SpeciesId[]>([]);
-  let maxSpecies = 10;
-
-  // Abort controllers for preventing race conditions
+  let loadingSpecies = $state(false);
   let speciesController: AbortController | null = null;
-  let timeOfDayController: AbortController | null = null;
-  let dailyTrendController: AbortController | null = null;
-  let diversityController: AbortController | null = null;
 
-  // Chart options
-  let showRelativeTrends = $state(false);
-  let enableZoom = $state(true);
-  let enableBrush = $state(false);
-
-  // Chart data
-  let timeOfDayData = $state<TimeOfDaySpeciesData[]>([]);
-  let dailyTrendData = $state<DailyTrendSpeciesData[]>([]);
-  let diversityData = $state<DiversityDatum[]>([]);
-
-  // Date range options for custom Select component
-  const dateRangeOptions = $derived([
-    { value: 'week', label: t('analytics.advanced.dateRangeOptions.week') },
-    { value: 'month', label: t('analytics.advanced.dateRangeOptions.month') },
-    { value: 'quarter', label: t('analytics.advanced.dateRangeOptions.quarter') },
-    { value: 'year', label: t('analytics.advanced.dateRangeOptions.year') },
-    { value: 'custom', label: t('analytics.advanced.dateRangeOptions.custom') },
-  ]);
-
-  // Computed date range
-  const computedDateRange = $derived(
-    (() => {
-      const today = new Date();
-      let start: Date, end: Date;
-
-      switch (dateRange) {
-        case 'week':
-          end = today;
-          start = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
-          break;
-        case 'month':
-          end = today;
-          start = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
-          break;
-        case 'quarter':
-          end = today;
-          start = new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
-          break;
-        case 'year':
-          end = today;
-          start = new Date(today.getTime() - 365 * 24 * 60 * 60 * 1000);
-          break;
-        case 'custom':
-          start = startDate
-            ? (parseLocalDateString(startDate) ??
-              new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000))
-            : new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
-          end = endDate ? (parseLocalDateString(endDate) ?? today) : today;
-          break;
-        default:
-          end = today;
-          start = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
-      }
-
-      return [start, end] as [Date, Date];
-    })()
+  const speciesNames = $derived(
+    new Map(availableSpecies.map(s => [s.scientificName ?? s.id, s.commonName]))
   );
 
-  // Format date for API calls (avoid timezone issues)
-  function formatDateForAPI(date: Date): string {
-    const year = date.getFullYear();
-    const month = (date.getMonth() + 1).toString().padStart(2, '0');
-    const day = date.getDate().toString().padStart(2, '0');
-    return `${year}-${month}-${day}`;
+  const activeCharts = $derived(chartsForGroup(params.tab));
+  const speciesApplicable = $derived(activeCharts.some(c => c.supports.species));
+  const activeTabLabelKey = $derived(
+    TABS.find(tab => tab.group === params.tab)?.labelKey ?? 'analytics.hub.tabs.overview'
+  );
+
+  // --- URL state -----------------------------------------------------------
+
+  function writeUrl(mode: 'push' | 'replace'): void {
+    if (typeof window === 'undefined') return;
+    const qs = serializeAnalyticsParams(params, { defaultTab });
+    const url = window.location.pathname + (qs ? `?${qs}` : '');
+    if (mode === 'replace') {
+      window.history.replaceState(window.history.state, '', url);
+    } else {
+      window.history.pushState(window.history.state, '', url);
+    }
   }
 
-  // Fetch available species
-  async function fetchAvailableSpecies() {
+  function applyParams(partial: Partial<AnalyticsParams>, mode: 'push' | 'replace' = 'push'): void {
+    const next: AnalyticsParams = { ...params, ...partial };
+    // Keep the parsed dates in sync with range/start/end.
+    const [startDate, endDate] = resolveDateRange(next.range, next.start, next.end);
+    next.startDate = startDate;
+    next.endDate = endDate;
+    params = next;
+    writeUrl(mode);
+  }
+
+  function selectTab(group: ChartGroup): void {
+    if (group === params.tab) return;
+    applyParams({ tab: group }, 'push');
+  }
+
+  // Browser Back/Forward: re-read params from the URL without writing (no loop).
+  onMount(() => {
+    const handlePopState = () => {
+      params = readParams();
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  });
+
+  // --- Available species ----------------------------------------------------
+
+  // Refetch the species list only when the resolved date range changes.
+  const rangeKey = $derived(
+    `${formatDateForAPI(params.startDate)}|${formatDateForAPI(params.endDate)}`
+  );
+
+  function classifyFrequency(count: number): SpeciesFrequency {
+    if (count > 100) return 'very-common';
+    if (count > 50) return 'common';
+    if (count > 10) return 'uncommon';
+    return 'rare';
+  }
+
+  async function fetchAvailableSpecies(): Promise<void> {
+    const snapshot = untrack(() => params);
+    speciesController?.abort();
+    const ac = new AbortController();
+    speciesController = ac;
+    loadingSpecies = true;
+
     try {
-      // Abort any previous species fetch
-      if (speciesController) {
-        speciesController.abort();
-      }
-      speciesController = new AbortController();
-
-      const [start, end] = computedDateRange;
-      const params = new URLSearchParams({
-        start_date: formatDateForAPI(start),
-        end_date: formatDateForAPI(end),
-        limit: '50', // Get top 50 species
+      const search = new URLSearchParams({
+        start_date: formatDateForAPI(snapshot.startDate),
+        end_date: formatDateForAPI(snapshot.endDate),
+        limit: String(SPECIES_SUMMARY_LIMIT),
       });
-
-      const response = await fetch(buildAppUrl(`/api/v2/analytics/species/summary?${params}`), {
-        signal: speciesController.signal,
+      const response = await fetch(buildAppUrl(`/api/v2/analytics/species/summary?${search}`), {
+        signal: ac.signal,
       });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
+      if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
       const data: unknown = await response.json();
-
+      // Invariant: id === scientificName for real rows. The species selector,
+      // the URL `species` param, the registry fetchers' `species` query arg, and
+      // the chart series keys all identify a species by its scientific name, so
+      // id must equal scientificName for the round-trip to work. (The index
+      // fallback only applies to degenerate rows missing a scientific name.)
       availableSpecies = Array.isArray(data)
         ? (data as SpeciesSummaryResponse[]).map((item, index) => {
             const count = item.count ?? 0;
-            const frequency =
-              count > 100
-                ? 'very-common'
-                : count > 50
-                  ? 'common'
-                  : count > 10
-                    ? 'uncommon'
-                    : 'rare';
             return {
               id: createSpeciesId(item.scientific_name ?? `species-${index}`),
               commonName: item.common_name ?? t('common.unknown'),
               scientificName: item.scientific_name ?? t('common.unknown'),
-              frequency: frequency as 'very-common' | 'common' | 'uncommon' | 'rare',
+              frequency: classifyFrequency(count),
               category: t('analytics.advanced.categories.birds'),
               description: t('analytics.advanced.detections', { count }),
-              count, // Keep count for backwards compatibility
+              count,
             };
           })
         : [];
 
-      // Auto-select top species if none selected (limited by backend cap)
-      if (selectedSpecies.length === 0 && availableSpecies.length > 0) {
-        const maxToSelect = Math.min(availableSpecies.length, 5, 10); // Client wants 5, backend allows 10
-        selectedSpecies = availableSpecies.slice(0, maxToSelect).map(s => s.id);
+      // Auto-select the top species when the URL specifies none. Written via
+      // replace so the deep-link is reproducible without adding a history entry.
+      if (untrack(() => params).species.length === 0 && availableSpecies.length > 0) {
+        const top = availableSpecies
+          .slice(0, Math.min(availableSpecies.length, AUTO_SELECT_TOP))
+          .map(s => s.scientificName ?? s.id);
+        applyParams({ species: top }, 'replace');
       }
     } catch (err) {
-      // Don't log abort errors as they're expected
-      if (err instanceof Error && err.name === 'AbortError') {
-        return;
-      }
-      logger.error('Error fetching available species:', err);
+      if (err instanceof Error && err.name === 'AbortError') return;
+      logger.error('Failed to fetch available species', err);
       availableSpecies = [];
-    }
-  }
-
-  // Fetch time of day data for selected species
-  async function fetchTimeOfDayData() {
-    if (selectedSpecies.length === 0) {
-      timeOfDayData = [];
-      return;
-    }
-
-    try {
-      // Abort any previous time of day fetch
-      if (timeOfDayController) {
-        timeOfDayController.abort();
-      }
-      timeOfDayController = new AbortController();
-
-      const [start] = computedDateRange;
-      const params = new URLSearchParams({
-        date: formatDateForAPI(start),
-        min_confidence: '0',
-      });
-
-      // Add species parameters (convert IDs back to scientific names)
-      selectedSpecies.forEach(speciesId => {
-        const species = availableSpecies.find(s => s.id === speciesId);
-        if (species?.scientificName) {
-          params.append('species', species.scientificName);
-        }
-      });
-
-      const response = await fetch(buildAppUrl(`/api/v2/analytics/time/hourly/batch?${params}`), {
-        signal: timeOfDayController.signal,
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const data: unknown = await response.json();
-
-      if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid hourly batch response: expected an object');
-      }
-
-      // Convert API response to chart format
-      const newTimeOfDayData: TimeOfDaySpeciesData[] = Object.entries(
-        data as Record<string, unknown>
-      ).map(([species, hourlyData]) => {
-        const speciesInfo = availableSpecies.find(s => s.scientificName === species);
-        return {
-          species,
-          commonName: speciesInfo?.commonName ?? species,
-          data: Array.isArray(hourlyData)
-            ? (hourlyData as HourlyDataItem[]).map(item => ({
-                hour: typeof item.hour === 'number' ? item.hour : 0,
-                count: typeof item.count === 'number' ? item.count : 0,
-              }))
-            : [],
-          visible: true,
-        };
-      });
-
-      // Only update if we have valid data
-      if (newTimeOfDayData.length > 0) {
-        timeOfDayData = newTimeOfDayData;
-      }
-    } catch (err) {
-      // Don't log abort errors as they're expected
-      if (err instanceof Error && err.name === 'AbortError') {
-        return;
-      }
-      logger.error('Error fetching time of day data:', err);
-      // Don't clear existing data on error, just log it
-    }
-  }
-
-  // Fetch daily trend data for selected species
-  async function fetchDailyTrendData() {
-    if (selectedSpecies.length === 0) {
-      dailyTrendData = [];
-      return;
-    }
-
-    try {
-      // Abort any previous daily trend fetch
-      if (dailyTrendController) {
-        dailyTrendController.abort();
-      }
-      dailyTrendController = new AbortController();
-
-      const [start, end] = computedDateRange;
-      const params = new URLSearchParams({
-        start_date: formatDateForAPI(start),
-        end_date: formatDateForAPI(end),
-      });
-
-      // Add species parameters (convert IDs back to scientific names)
-      selectedSpecies.forEach(speciesId => {
-        const species = availableSpecies.find(s => s.id === speciesId);
-        if (species?.scientificName) {
-          params.append('species', species.scientificName);
-        }
-      });
-
-      const response = await fetch(buildAppUrl(`/api/v2/analytics/time/daily/batch?${params}`), {
-        signal: dailyTrendController.signal,
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const data: unknown = await response.json();
-
-      if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid daily batch response: expected an object');
-      }
-
-      // Convert API response to chart format
-      const newDailyTrendData: DailyTrendSpeciesData[] = Object.entries(
-        data as Record<string, unknown>
-      ).map(([species, trendData]) => {
-        const speciesInfo = availableSpecies.find(s => s.scientificName === species);
-
-        // Validate that trendData has the expected structure
-        if (!trendData || typeof trendData !== 'object') {
-          return {
-            species,
-            commonName: speciesInfo?.commonName ?? species,
-            data: [],
-            visible: true,
-          };
-        }
-
-        const apiData = trendData as SpeciesDailyData;
-        const dataArray = Array.isArray(apiData.data) ? apiData.data : [];
-
-        return {
-          species,
-          commonName: speciesInfo?.commonName ?? species,
-          data: dataArray
-            .map(item => {
-              if (!item || typeof item !== 'object') return null;
-
-              const date = parseLocalDateString(item.date);
-              const count = typeof item.count === 'number' ? item.count : 0;
-
-              // Skip invalid dates
-              if (!date || isNaN(date.getTime())) return null;
-
-              return { date, count };
-            })
-            .filter((item): item is DailyTrendDatum => item !== null),
-          visible: true,
-        };
-      });
-
-      // Only update if we have valid data
-      if (newDailyTrendData.length > 0) {
-        dailyTrendData = newDailyTrendData;
-      }
-    } catch (err) {
-      // Don't log abort errors as they're expected
-      if (err instanceof Error && err.name === 'AbortError') {
-        return;
-      }
-      logger.error('Error fetching daily trend data:', err);
-      // Don't clear existing data on error, just log it
-    }
-  }
-
-  // Fetch species diversity data (independent of species selection)
-  async function fetchDiversityData() {
-    try {
-      if (diversityController) {
-        diversityController.abort();
-      }
-      diversityController = new AbortController();
-
-      const [start, end] = computedDateRange;
-      const params = new URLSearchParams({
-        start_date: formatDateForAPI(start),
-        end_date: formatDateForAPI(end),
-      });
-
-      const response = await fetch(buildAppUrl(`/api/v2/analytics/species/diversity?${params}`), {
-        signal: diversityController.signal,
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const data: unknown = await response.json();
-
-      if (!data || typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Invalid diversity response: expected an object');
-      }
-
-      const result = data as DiversityResponse;
-
-      diversityData = (result.data ?? [])
-        .map(item => {
-          const date = parseLocalDateString(item.date);
-          if (!date || isNaN(date.getTime())) return null;
-          return { date, uniqueSpecies: item.unique_species };
-        })
-        .filter((item): item is DiversityDatum => item !== null);
-    } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
-        return;
-      }
-      logger.error('Error fetching diversity data:', err);
-    }
-  }
-
-  // Fetch all data
-  async function fetchAllData() {
-    isLoading = true;
-    error = null;
-
-    try {
-      // Fetch species list and diversity data in parallel (diversity is species-independent)
-      await Promise.all([fetchAvailableSpecies(), fetchDiversityData()]);
-
-      if (selectedSpecies.length > 0) {
-        await Promise.all([fetchTimeOfDayData(), fetchDailyTrendData()]);
-      } else {
-        // Clear species-dependent chart data if no species selected
-        timeOfDayData = [];
-        dailyTrendData = [];
-      }
-    } catch (err) {
-      // Don't log abort errors as they're expected
-      if (err instanceof Error && err.name === 'AbortError') {
-        return;
-      }
-      logger.error('Error fetching analytics data:', err);
-      error = t('analytics.errors.loadFailed');
     } finally {
-      isLoading = false;
+      if (!ac.signal.aborted) loadingSpecies = false;
     }
   }
 
-  // Handle date range changes
-  function handleDateRangeChange(range: [Date, Date]) {
-    startDate = formatDateForAPI(range[0]);
-    endDate = formatDateForAPI(range[1]);
-    dateRange = 'custom';
-    fetchAllData();
-  }
-
-  // Initialize default custom date inputs on mount
-  onMount(() => {
-    const today = new Date();
-    const monthAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
-
-    startDate = formatDateForAPI(monthAgo);
-    endDate = formatDateForAPI(today);
-  });
-
-  // Watch for changes that require data refresh
+  // Refetch only when the resolved date range changes. `rangeKey` is day-granular
+  // (built from formatDateForAPI), which is load-bearing: the auto-select below
+  // writes params via `applyParams` (re-resolving the dates with a fresh clock),
+  // and day-granularity keeps `rangeKey` stable so that write does not re-trigger
+  // this effect into a fetch loop.
   $effect(() => {
-    // Only fetch if we have a valid date range and are not in the initial loading phase
-    if (dateRange !== 'custom' || (dateRange === 'custom' && startDate && endDate)) {
-      // Debounce multiple rapid changes
-      const timeoutId = setTimeout(() => {
-        fetchAllData();
-      }, 100);
-
-      return () => clearTimeout(timeoutId);
-    }
+    void rangeKey;
+    fetchAvailableSpecies();
+    return () => speciesController?.abort();
   });
+
+  // Roving-tabindex keyboard navigation for the tab bar. Focus moves by id so we
+  // avoid holding element refs (and the array-index access that comes with them).
+  function handleTabKeydown(event: KeyboardEvent): void {
+    const currentIndex = TABS.findIndex(tab => tab.group === params.tab);
+    if (currentIndex < 0) return;
+
+    let nextIndex = currentIndex;
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % TABS.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + TABS.length) % TABS.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = TABS.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = TABS.at(nextIndex);
+    if (!next) return;
+    selectTab(next.group);
+    document.getElementById(`analytics-tab-${next.group}`)?.focus();
+  }
 </script>
 
-<div class="col-span-12 space-y-6" role="region" aria-label="Advanced Analytics">
-  <!-- Error Display -->
-  {#if error}
-    <div
-      class="p-4 bg-[color-mix(in_srgb,var(--color-error)_10%,transparent)] border border-[var(--color-error)] text-[var(--color-error)] rounded-lg flex items-center gap-3"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="stroke-current shrink-0 h-6 w-6"
-        fill="none"
-        viewBox="0 0 24 24"
+<div class="col-span-12" role="region" aria-label={t('analytics.advanced.title')}>
+  <!-- Sticky shared control bar -->
+  <div class="sticky top-0 z-20 bg-[var(--color-base-100)] py-2">
+    <AnalyticsControlBar
+      {params}
+      {availableSpecies}
+      {loadingSpecies}
+      {speciesApplicable}
+      onParamsChange={partial => applyParams(partial, 'push')}
+    />
+  </div>
+
+  <!-- Tab bar -->
+  <!-- Scroll rather than wrap: longer locales (DE/FI) keep a single clean tab
+       strip instead of wrapping into a broken double border. -->
+  <div
+    role="tablist"
+    aria-label={t('analytics.hub.aria.tabs')}
+    class="mt-4 flex flex-nowrap gap-1 overflow-x-auto border-b border-[var(--color-base-200)]"
+  >
+    {#each TABS as tab (tab.group)}
+      {@const Icon = tab.icon}
+      {@const isActive = params.tab === tab.group}
+      <button
+        type="button"
+        role="tab"
+        id={`analytics-tab-${tab.group}`}
+        aria-selected={isActive}
+        aria-controls={`analytics-panel-${tab.group}`}
+        tabindex={isActive ? 0 : -1}
+        class="inline-flex shrink-0 items-center gap-2 whitespace-nowrap px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] rounded-t-md {isActive
+          ? 'border-[var(--color-primary)] text-[var(--color-primary)]'
+          : 'border-transparent text-[var(--color-base-content)] opacity-70 hover:opacity-100 hover:border-[var(--color-base-300)]'}"
+        onclick={() => selectTab(tab.group)}
+        onkeydown={handleTabKeydown}
       >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
-        />
-      </svg>
-      <span>{error}</span>
-    </div>
-  {/if}
-
-  <!-- Controls Section -->
-  <div
-    class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]"
-  >
-    <div class="p-6 overflow-visible">
-      <h2 class="text-lg font-semibold mb-4">{t('analytics.advanced.chartControls')}</h2>
-
-      <!-- Top Row: Date Range and Chart Options -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-4">
-        <!-- Date Range Selection -->
-        <div class="space-y-2">
-          <SelectDropdown
-            bind:value={dateRange}
-            options={dateRangeOptions}
-            label={t('analytics.advanced.dateRange')}
-            variant="select"
-            size="sm"
-            menuSize="sm"
-          />
-
-          {#if dateRange === 'custom'}
-            <div class="grid grid-cols-2 gap-2 mt-2">
-              <label for="startDateInput" class="sr-only"
-                >{t('analytics.advanced.filters.startDate')}</label
-              >
-              <Input
-                id="startDateInput"
-                type="date"
-                bind:value={startDate}
-                max={endDate}
-                aria-label={t('analytics.advanced.filters.startDate')}
-              />
-              <label for="endDateInput" class="sr-only"
-                >{t('analytics.advanced.filters.endDate')}</label
-              >
-              <Input
-                id="endDateInput"
-                type="date"
-                bind:value={endDate}
-                min={startDate}
-                aria-label={t('analytics.advanced.filters.endDate')}
-              />
-            </div>
-          {/if}
-        </div>
-
-        <!-- Chart Options -->
-        <div class="space-y-2">
-          <div class="label">
-            <span class="label-text font-medium">{t('analytics.advanced.chartOptions')}</span>
-          </div>
-
-          <div class="flex flex-wrap gap-x-6 gap-y-2">
-            <Checkbox
-              bind:checked={showRelativeTrends}
-              label={t('analytics.advanced.options.relativeTrends')}
-              size="sm"
-            />
-
-            <Checkbox
-              bind:checked={enableZoom}
-              label={t('analytics.advanced.options.zoomPan')}
-              size="sm"
-            />
-
-            <Checkbox
-              bind:checked={enableBrush}
-              label={t('analytics.advanced.options.brushSelection')}
-              size="sm"
-            />
-          </div>
-        </div>
-      </div>
-
-      <!-- Bottom Row: Species Selection (Full Width) -->
-      <div class="space-y-2">
-        <div class="flex items-baseline justify-between">
-          <span class="label-text font-medium"
-            >{t('analytics.advanced.speciesSelection', {
-              count: selectedSpecies.length,
-              max: maxSpecies,
-            })}</span
-          >
-          <span class="label-text-alt text-xs text-[var(--color-base-content)] opacity-60">
-            {t('analytics.advanced.speciesSelectionHint')}
-          </span>
-        </div>
-
-        <div class="w-full">
-          <div class="min-h-[100px] relative">
-            <SpeciesSelector
-              species={availableSpecies}
-              selected={selectedSpecies}
-              variant="chip"
-              size="md"
-              maxSelections={maxSpecies}
-              placeholder={t('analytics.advanced.speciesPlaceholder')}
-              searchable={true}
-              showFrequency={true}
-              categorized={false}
-              loading={isLoading}
-              emptyText={t('analytics.advanced.noSpeciesFound')}
-              className="w-full"
-              on:change={e => {
-                selectedSpecies = e.detail.selected.map(createSpeciesId);
-                // Refresh chart data when species selection changes
-                if (selectedSpecies.length > 0) {
-                  fetchTimeOfDayData();
-                  fetchDailyTrendData();
-                } else {
-                  // Clear data if no species selected
-                  timeOfDayData = [];
-                  dailyTrendData = [];
-                }
-              }}
-            >
-              {#snippet speciesDisplay(species)}
-                <div class="flex items-center justify-between gap-2">
-                  <div class="flex-1 min-w-0">
-                    <div class="font-medium truncate">{species.commonName}</div>
-                    <div
-                      class="text-xs text-[var(--color-base-content)] opacity-60 truncate italic"
-                    >
-                      {species.scientificName}
-                    </div>
-                  </div>
-                  {#if species.count !== undefined}
-                    <div
-                      class="inline-flex items-center px-2 py-1 text-xs font-medium rounded-full bg-[var(--color-base-200)]/50 text-[var(--color-base-content)]"
-                    >
-                      {t('analytics.advanced.detections', { count: species.count ?? 0 })}
-                    </div>
-                  {/if}
-                </div>
-              {/snippet}
-            </SpeciesSelector>
-          </div>
-        </div>
-      </div>
-    </div>
+        <Icon class="h-4 w-4" aria-hidden="true" />
+        <span>{t(tab.labelKey)}</span>
+      </button>
+    {/each}
   </div>
 
-  <!-- Charts Section -->
-  <div class="grid grid-cols-1 gap-6">
-    <!-- Time of Day Chart -->
-    <div
-      class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]"
-    >
-      <div class="p-6">
-        <h2 class="text-lg font-semibold">{t('analytics.advanced.charts.timeOfDay.title')}</h2>
-        <p class="text-sm text-[var(--color-base-content)] opacity-70 mb-4">
-          {t('analytics.advanced.charts.timeOfDay.description')}
-        </p>
-
-        <div class="h-96 relative">
-          <TimeOfDaySpeciesChart data={timeOfDayData} {selectedSpecies} width={1200} height={384} />
-
-          {#if isLoading}
-            <div
-              class="absolute inset-0 bg-[var(--color-base-100)]/80 backdrop-blur-xs flex items-center justify-center rounded-lg"
-              role="status"
-              aria-busy="true"
-              aria-label={t('analytics.advanced.aria.loadingAnalytics')}
-            >
-              <div
-                class="w-12 h-12 border-4 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin"
-              ></div>
-              <span class="sr-only">{t('analytics.advanced.aria.loadingAnalytics')}</span>
-            </div>
-          {:else if timeOfDayData.length === 0}
-            <div
-              class="absolute inset-0 flex items-center justify-center text-[var(--color-base-content)] opacity-60 rounded-lg"
-              role="status"
-              aria-label={t('analytics.advanced.charts.timeOfDay.noData')}
-            >
-              <div class="text-center">
-                <p class="text-lg mb-2">{t('analytics.advanced.charts.timeOfDay.noData')}</p>
-                <p class="text-sm">{t('analytics.advanced.charts.timeOfDay.noDataHint')}</p>
-              </div>
-            </div>
-          {/if}
-        </div>
-      </div>
-    </div>
-
-    <!-- Daily Trend Chart -->
-    <div
-      class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]"
-    >
-      <div class="p-6">
-        <h2 class="text-lg font-semibold">{t('analytics.advanced.charts.dailyTrend.title')}</h2>
-        <p class="text-sm text-[var(--color-base-content)] opacity-70 mb-4">
-          {t('analytics.advanced.charts.dailyTrend.description')}
-        </p>
-
-        <div class="h-96 relative">
-          <DailySpeciesTrendChart
-            data={dailyTrendData}
-            {selectedSpecies}
-            dateRange={computedDateRange}
-            showRelative={showRelativeTrends}
-            {enableZoom}
-            {enableBrush}
-            onDateRangeChange={handleDateRangeChange}
-            width={1200}
-            height={384}
-          />
-
-          {#if isLoading}
-            <div
-              class="absolute inset-0 bg-[var(--color-base-100)]/80 backdrop-blur-xs flex items-center justify-center rounded-lg"
-              role="status"
-              aria-busy="true"
-              aria-label={t('analytics.advanced.aria.loadingTrends')}
-            >
-              <div
-                class="w-12 h-12 border-4 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin"
-              ></div>
-              <span class="sr-only">{t('analytics.advanced.aria.loadingTrends')}</span>
-            </div>
-          {:else if dailyTrendData.length === 0}
-            <div
-              class="absolute inset-0 flex items-center justify-center text-[var(--color-base-content)] opacity-60 rounded-lg"
-              role="status"
-              aria-label={t('analytics.advanced.charts.dailyTrend.noData')}
-            >
-              <div class="text-center">
-                <p class="text-lg mb-2">{t('analytics.advanced.charts.dailyTrend.noData')}</p>
-                <p class="text-sm">{t('analytics.advanced.charts.dailyTrend.noDataHint')}</p>
-              </div>
-            </div>
-          {/if}
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Species Diversity Chart (Full Width) -->
+  <!-- Active tab panel: only this tab's charts are mounted -->
   <div
-    class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)]"
+    role="tabpanel"
+    id={`analytics-panel-${params.tab}`}
+    aria-labelledby={`analytics-tab-${params.tab}`}
+    tabindex="0"
+    class="mt-6 focus-visible:outline-none"
   >
-    <div class="p-6">
-      <h2 class="text-lg font-semibold">{t('analytics.advanced.charts.diversity.title')}</h2>
-      <p class="text-sm text-[var(--color-base-content)] opacity-70 mb-4">
-        {t('analytics.advanced.charts.diversity.description')}
-      </p>
-
-      <div class="h-96 relative">
-        <SpeciesDiversityChart
-          data={diversityData}
-          dateRange={computedDateRange}
-          width={1200}
-          height={384}
-        />
-
-        {#if isLoading}
-          <div
-            class="absolute inset-0 bg-[var(--color-base-100)]/80 backdrop-blur-xs flex items-center justify-center rounded-lg"
-            role="status"
-            aria-busy="true"
-            aria-label={t('analytics.advanced.aria.loadingDiversity')}
-          >
-            <div
-              class="w-12 h-12 border-4 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin"
-            ></div>
-            <span class="sr-only">{t('analytics.advanced.aria.loadingDiversity')}</span>
-          </div>
-        {:else if diversityData.length === 0}
-          <div
-            class="absolute inset-0 flex items-center justify-center text-[var(--color-base-content)] opacity-60 rounded-lg"
-            role="status"
-            aria-label={t('analytics.advanced.charts.diversity.noData')}
-          >
-            <div class="text-center">
-              <p class="text-lg mb-2">{t('analytics.advanced.charts.diversity.noData')}</p>
-              <p class="text-sm">{t('analytics.advanced.charts.diversity.noDataHint')}</p>
-            </div>
-          </div>
-        {/if}
+    {#if activeCharts.length === 0}
+      <!-- Coming soon: populated in later PRs. Never a blank wall. -->
+      <div
+        class="bg-[var(--color-base-100)] rounded-xl shadow-sm border border-[var(--color-base-200)] p-12"
+        role="status"
+      >
+        <div class="flex flex-col items-center text-center text-[var(--color-base-content)]">
+          <Construction class="h-12 w-12 mb-4 opacity-40" aria-hidden="true" />
+          <p class="text-lg font-medium mb-1">{t(activeTabLabelKey)}</p>
+          <p class="text-sm opacity-70 max-w-md">{t('analytics.hub.comingSoon.description')}</p>
+        </div>
       </div>
-    </div>
+    {:else}
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {#each activeCharts as chart (chart.id)}
+          <div class={chart.size === 'normal' ? 'lg:col-span-1' : 'lg:col-span-2'}>
+            <ChartCard
+              {chart}
+              {params}
+              {speciesNames}
+              speciesLoading={loadingSpecies}
+              onParamsChange={partial => applyParams(partial, 'push')}
+            />
+          </div>
+        {/each}
+      </div>
+    {/if}
   </div>
 </div>
-
-<style>
-  /* Card-like containers */
-  .bg-\[var\(--color-base-100\)\] {
-    transition: box-shadow 0.2s ease;
-  }
-</style>

--- a/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/AdvancedAnalytics.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+// Replace the real registry (which mounts heavy D3 charts) with stub charts so
+// the hub test focuses on tab/URL behavior and active-tab mounting.
+vi.mock('../registry/charts', async () => {
+  const StubChart = (await import('../components/__tests__/StubChart.svelte')).default;
+  const make = (id: string, group: string) => ({
+    id,
+    group,
+    titleKey: `title.${id}`,
+    descKey: `desc.${id}`,
+    emptyKey: `empty.${id}`,
+    emptyHintKey: `emptyHint.${id}`,
+    component: StubChart,
+    fetch: vi.fn().mockResolvedValue([{ a: 1 }, { a: 2 }]),
+    size: 'full' as const,
+    supports: { species: group !== 'biodiversity', source: false },
+  });
+  const defs = [
+    make('time-of-day-species', 'patterns'),
+    make('daily-species-trend', 'trends'),
+    make('species-diversity', 'biodiversity'),
+  ];
+  return {
+    CHART_REGISTRY: defs,
+    chartsForGroup: (g: string) => defs.filter(d => d.group === g),
+    groupHasCharts: (g: string) => defs.some(d => d.group === g),
+  };
+});
+
+import AdvancedAnalytics from './AdvancedAnalytics.svelte';
+
+const PATH = '/ui/advanced-analytics';
+
+// The shared setup mocks window.location with a plain (writable) object that
+// does NOT reflect history.pushState. So we set location fields directly to
+// simulate the address bar, and spy on history to assert what the hub writes.
+function setLocation(search: string): void {
+  window.location.pathname = PATH;
+  window.location.search = search;
+}
+
+function mockFetch() {
+  return vi.fn(async (url: string) => {
+    if (typeof url === 'string' && url.includes('/analytics/species/summary')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [
+          { scientific_name: 'Turdus merula', common_name: 'Common Blackbird', count: 120 },
+          { scientific_name: 'Parus major', common_name: 'Great Tit', count: 80 },
+        ],
+      } as unknown as Response;
+    }
+    return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+  });
+}
+
+let pushSpy: ReturnType<typeof vi.spyOn>;
+let replaceSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  setLocation('');
+  globalThis.fetch = mockFetch() as unknown as typeof fetch;
+  pushSpy = vi.spyOn(window.history, 'pushState');
+  replaceSpy = vi.spyOn(window.history, 'replaceState');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  setLocation('');
+});
+
+const tab = (name: string) => screen.getByRole('tab', { name });
+const pushedUrls = (): string[] => pushSpy.mock.calls.map((c: unknown[]) => String(c[2]));
+
+describe('Analytics hub: tabs, URL state, active-tab mounting', () => {
+  it('lands on the first populated tab (Activity Patterns) by default', async () => {
+    render(AdvancedAnalytics);
+    await tick();
+
+    expect(tab('analytics.hub.tabs.patterns')).toHaveAttribute('aria-selected', 'true');
+
+    // Only the active tab's chart is mounted.
+    expect(document.querySelector('#time-of-day-species')).toBeInTheDocument();
+    expect(document.querySelector('#daily-species-trend')).not.toBeInTheDocument();
+    expect(document.querySelector('#species-diversity')).not.toBeInTheDocument();
+  });
+
+  it('switches tabs, writes ?tab= to the URL, and swaps which chart is mounted', async () => {
+    render(AdvancedAnalytics);
+    await tick();
+
+    await fireEvent.click(tab('analytics.hub.tabs.trends'));
+    await tick();
+
+    expect(pushedUrls().some(u => u.includes('tab=trends'))).toBe(true);
+    expect(document.querySelector('#daily-species-trend')).toBeInTheDocument();
+    expect(document.querySelector('#time-of-day-species')).not.toBeInTheDocument();
+  });
+
+  it('restores the tab from the URL on Back/Forward (popstate)', async () => {
+    render(AdvancedAnalytics);
+    await tick();
+
+    await fireEvent.click(tab('analytics.hub.tabs.biodiversity'));
+    await tick();
+    expect(document.querySelector('#species-diversity')).toBeInTheDocument();
+
+    // Simulate the browser Back button returning to the tab-less URL.
+    setLocation('');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    await tick();
+
+    expect(tab('analytics.hub.tabs.patterns')).toHaveAttribute('aria-selected', 'true');
+    expect(document.querySelector('#time-of-day-species')).toBeInTheDocument();
+    expect(document.querySelector('#species-diversity')).not.toBeInTheDocument();
+  });
+
+  it('restores the active tab from the initial URL on load (reload)', async () => {
+    setLocation('?tab=trends');
+    render(AdvancedAnalytics);
+    await tick();
+
+    expect(tab('analytics.hub.tabs.trends')).toHaveAttribute('aria-selected', 'true');
+    expect(document.querySelector('#daily-species-trend')).toBeInTheDocument();
+  });
+
+  it('shows a coming-soon placeholder for tabs without charts', async () => {
+    render(AdvancedAnalytics);
+    await tick();
+
+    await fireEvent.click(tab('analytics.hub.tabs.overview'));
+    await tick();
+
+    await waitFor(() =>
+      expect(screen.getByText('analytics.hub.comingSoon.description')).toBeInTheDocument()
+    );
+    expect(document.querySelector('#time-of-day-species')).not.toBeInTheDocument();
+  });
+
+  it('auto-selects top species into the URL when none are specified', async () => {
+    render(AdvancedAnalytics);
+    // Auto-select writes species via replaceState once the summary resolves.
+    await waitFor(() =>
+      expect(replaceSpy.mock.calls.some((c: unknown[]) => String(c[2]).includes('species='))).toBe(
+        true
+      )
+    );
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_RANGE,
+  formatDateForAPI,
+  parseAnalyticsParams,
+  resolveDateRange,
+  serializeAnalyticsParams,
+} from './analyticsParams';
+import type { AnalyticsParams, ChartGroup } from './types';
+
+// Fixed clock for deterministic rolling-window resolution.
+const NOW = new Date(2026, 5, 19, 12, 0, 0); // 2026-06-19 local
+const DEFAULT_TAB: ChartGroup = 'patterns';
+
+describe('formatDateForAPI', () => {
+  it('formats a date as local YYYY-MM-DD with zero padding', () => {
+    expect(formatDateForAPI(new Date(2026, 0, 5))).toBe('2026-01-05');
+    expect(formatDateForAPI(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+});
+
+describe('resolveDateRange', () => {
+  it('resolves preset windows ending at now', () => {
+    const [weekStart, weekEnd] = resolveDateRange('week', '', '', NOW);
+    expect(formatDateForAPI(weekEnd)).toBe('2026-06-19');
+    expect(formatDateForAPI(weekStart)).toBe('2026-06-12');
+
+    const [monthStart] = resolveDateRange('month', '', '', NOW);
+    expect(formatDateForAPI(monthStart)).toBe('2026-05-20'); // 30 days back
+
+    const [yearStart] = resolveDateRange('year', '', '', NOW);
+    expect(formatDateForAPI(yearStart)).toBe('2025-06-19');
+  });
+
+  it('uses provided custom dates', () => {
+    const [start, end] = resolveDateRange('custom', '2026-01-01', '2026-02-15', NOW);
+    expect(formatDateForAPI(start)).toBe('2026-01-01');
+    expect(formatDateForAPI(end)).toBe('2026-02-15');
+  });
+
+  it('falls back to a one-month window for custom with missing dates', () => {
+    const [start, end] = resolveDateRange('custom', '', '', NOW);
+    expect(formatDateForAPI(start)).toBe('2026-05-20');
+    expect(formatDateForAPI(end)).toBe('2026-06-19');
+  });
+});
+
+describe('parseAnalyticsParams', () => {
+  it('returns defaults for an empty query', () => {
+    const p = parseAnalyticsParams('', { defaultTab: DEFAULT_TAB, now: NOW });
+    expect(p.tab).toBe(DEFAULT_TAB);
+    expect(p.range).toBe(DEFAULT_RANGE);
+    expect(p.species).toEqual([]);
+    expect(p.source).toBe('');
+  });
+
+  it('parses a full query (with or without leading ?)', () => {
+    const search = '?tab=trends&range=week&species=Turdus%20merula,Parus%20major&source=mic1';
+    const p = parseAnalyticsParams(search, { defaultTab: DEFAULT_TAB, now: NOW });
+    expect(p.tab).toBe('trends');
+    expect(p.range).toBe('week');
+    expect(p.species).toEqual(['Turdus merula', 'Parus major']);
+    expect(p.source).toBe('mic1');
+
+    const p2 = parseAnalyticsParams('tab=biodiversity', { defaultTab: DEFAULT_TAB, now: NOW });
+    expect(p2.tab).toBe('biodiversity');
+  });
+
+  it('falls back on invalid tab/range values', () => {
+    const p = parseAnalyticsParams('?tab=bogus&range=decade', {
+      defaultTab: DEFAULT_TAB,
+      now: NOW,
+    });
+    expect(p.tab).toBe(DEFAULT_TAB);
+    expect(p.range).toBe(DEFAULT_RANGE);
+  });
+
+  it('parses custom range with start/end into Date objects', () => {
+    const p = parseAnalyticsParams('?range=custom&start=2026-03-01&end=2026-03-31', {
+      defaultTab: DEFAULT_TAB,
+      now: NOW,
+    });
+    expect(p.range).toBe('custom');
+    expect(p.start).toBe('2026-03-01');
+    expect(p.end).toBe('2026-03-31');
+    expect(formatDateForAPI(p.startDate)).toBe('2026-03-01');
+    expect(formatDateForAPI(p.endDate)).toBe('2026-03-31');
+  });
+
+  it('trims and drops empty species entries', () => {
+    const p = parseAnalyticsParams('?species=Turdus%20merula,,%20Parus%20major%20,', {
+      defaultTab: DEFAULT_TAB,
+      now: NOW,
+    });
+    expect(p.species).toEqual(['Turdus merula', 'Parus major']);
+  });
+});
+
+describe('serializeAnalyticsParams', () => {
+  const base = (overrides: Partial<AnalyticsParams>): AnalyticsParams => ({
+    ...parseAnalyticsParams('', { defaultTab: DEFAULT_TAB, now: NOW }),
+    ...overrides,
+  });
+
+  it('omits defaults and empties', () => {
+    const qs = serializeAnalyticsParams(base({}), { defaultTab: DEFAULT_TAB });
+    expect(qs).toBe('');
+  });
+
+  it('omits the default tab but serialises others', () => {
+    expect(serializeAnalyticsParams(base({ tab: DEFAULT_TAB }), { defaultTab: DEFAULT_TAB })).toBe(
+      ''
+    );
+    expect(
+      serializeAnalyticsParams(base({ tab: 'biodiversity' }), { defaultTab: DEFAULT_TAB })
+    ).toContain('tab=biodiversity');
+  });
+
+  it('only serialises start/end for custom ranges', () => {
+    const preset = serializeAnalyticsParams(
+      base({ range: 'week', start: '2026-01-01', end: '2026-02-01' }),
+      { defaultTab: DEFAULT_TAB }
+    );
+    expect(preset).toBe('range=week');
+
+    const custom = serializeAnalyticsParams(
+      base({ range: 'custom', start: '2026-01-01', end: '2026-02-01' }),
+      { defaultTab: DEFAULT_TAB }
+    );
+    expect(custom).toContain('range=custom');
+    expect(custom).toContain('start=2026-01-01');
+    expect(custom).toContain('end=2026-02-01');
+  });
+
+  it('serialises species as a comma list', () => {
+    const qs = serializeAnalyticsParams(base({ species: ['Turdus merula', 'Parus major'] }), {
+      defaultTab: DEFAULT_TAB,
+    });
+    const parsed = new URLSearchParams(qs);
+    expect(parsed.get('species')).toBe('Turdus merula,Parus major');
+  });
+});
+
+describe('round-trip (reload + Back/Forward fidelity)', () => {
+  // parse(serialize(p)) must equal p for the URL-relevant fields, so reloading a
+  // serialised URL and navigating Back/Forward restore the same view.
+  const cases: Partial<AnalyticsParams>[] = [
+    {},
+    { tab: 'trends' },
+    { tab: 'biodiversity', range: 'year' },
+    { range: 'week', species: ['Turdus merula', 'Parus major', 'Erithacus rubecula'] },
+    { range: 'custom', start: '2026-01-01', end: '2026-02-01', species: ['Parus major'] },
+    { source: 'mic-2' },
+  ];
+
+  it.each(cases)('round-trips %o', overrides => {
+    const original = {
+      ...parseAnalyticsParams('', { defaultTab: DEFAULT_TAB, now: NOW }),
+      ...overrides,
+    };
+    const qs = serializeAnalyticsParams(original, { defaultTab: DEFAULT_TAB });
+    const restored = parseAnalyticsParams(qs, { defaultTab: DEFAULT_TAB, now: NOW });
+
+    expect(restored.tab).toBe(original.tab);
+    expect(restored.range).toBe(original.range);
+    expect(restored.species).toEqual(original.species);
+    expect(restored.source).toBe(original.source);
+    // Presets carry empty start/end (omitted from the URL), custom carries them;
+    // both round-trip back to the original value.
+    expect(restored.start).toBe(original.start);
+    expect(restored.end).toBe(original.end);
+    // The derived Date pair the charts consume must be resolved consistently
+    // from the restored range/start/end (catches a parse that swaps or fails to
+    // re-resolve the dates).
+    const [expStart, expEnd] = resolveDateRange(restored.range, restored.start, restored.end, NOW);
+    expect(formatDateForAPI(restored.startDate)).toBe(formatDateForAPI(expStart));
+    expect(formatDateForAPI(restored.endDate)).toBe(formatDateForAPI(expEnd));
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.ts
@@ -31,7 +31,16 @@ const VALID_RANGES = new Set<string>(['week', 'month', 'quarter', 'year', 'custo
 /** Default range when the URL omits `range`. Matches the legacy page default. */
 export const DEFAULT_RANGE: DateRangePreset = 'month';
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+/**
+ * Subtracts whole calendar days from a date in local time. Using setDate (rather
+ * than millisecond arithmetic) keeps preset windows DST-safe: a "7 days ago"
+ * boundary lands on the correct local date even across a DST transition.
+ */
+function subtractLocalDays(base: Date, days: number): Date {
+  const d = new Date(base);
+  d.setDate(d.getDate() - days);
+  return d;
+}
 
 /** Rolling-window lengths in days for the preset ranges. */
 const RANGE_DAYS: Record<Exclude<DateRangePreset, 'custom'>, number> = {
@@ -63,7 +72,7 @@ export function resolveDateRange(
   now: Date = new Date()
 ): [Date, Date] {
   if (range === 'custom') {
-    const monthAgo = new Date(now.getTime() - RANGE_DAYS.month * DAY_MS);
+    const monthAgo = subtractLocalDays(now, RANGE_DAYS.month);
     const startDate = start ? (parseLocalDateString(start) ?? monthAgo) : monthAgo;
     const endDate = end ? (parseLocalDateString(end) ?? now) : now;
     return [startDate, endDate];
@@ -71,7 +80,7 @@ export function resolveDateRange(
 
   // eslint-disable-next-line security/detect-object-injection -- range is a typed preset enum, not user input
   const days = RANGE_DAYS[range];
-  return [new Date(now.getTime() - days * DAY_MS), now];
+  return [subtractLocalDays(now, days), now];
 }
 
 interface ParseOptions {
@@ -105,10 +114,16 @@ export function parseAnalyticsParams(search: string, opts: ParseOptions = {}): A
 
   const speciesRaw = sp.get('species') ?? '';
   const species = speciesRaw
-    ? speciesRaw
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean)
+    ? // Dedupe so a hand-edited URL with repeats (?species=A,A) does not produce
+      // duplicate selections / duplicate D3 series keys.
+      [
+        ...new Set(
+          speciesRaw
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+        ),
+      ]
     : [];
 
   const source = sp.get('source') ?? '';

--- a/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.ts
@@ -98,7 +98,8 @@ interface ParseOptions {
  * URL never throws or renders a broken view.
  */
 export function parseAnalyticsParams(search: string, opts: ParseOptions = {}): AnalyticsParams {
-  const sp = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  // URLSearchParams strips a single leading '?' itself, so pass the value as-is.
+  const sp = new URLSearchParams(search);
   const now = opts.now ?? new Date();
   const defaultTab = opts.defaultTab ?? 'overview';
 

--- a/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/analyticsParams.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure (de)serialisation of analytics hub state to/from the URL query string,
+ * plus date-range resolution. Kept free of Svelte and DOM dependencies so it is
+ * directly unit-testable and reusable by the control bar, the hub page, and the
+ * registry fetchers.
+ *
+ * URL contract (all in the `?query`):
+ *   tab     active tab group (omitted when it equals the default tab)
+ *   range   week|month|quarter|year|custom (omitted when `month`, the default)
+ *   start   YYYY-MM-DD, only meaningful (and serialised) when range=custom
+ *   end     YYYY-MM-DD, only meaningful (and serialised) when range=custom
+ *   species comma-separated scientific names (omitted when none selected)
+ *   source  audio source/mic id (omitted when all; inert in PR0)
+ */
+import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
+
+import type { AnalyticsParams, ChartGroup, DateRangePreset } from './types';
+
+/** Tab groups in display order. */
+export const GROUP_ORDER: readonly ChartGroup[] = [
+  'overview',
+  'patterns',
+  'trends',
+  'biodiversity',
+  'quality',
+] as const;
+
+const VALID_GROUPS = new Set<string>(GROUP_ORDER);
+const VALID_RANGES = new Set<string>(['week', 'month', 'quarter', 'year', 'custom']);
+
+/** Default range when the URL omits `range`. Matches the legacy page default. */
+export const DEFAULT_RANGE: DateRangePreset = 'month';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Rolling-window lengths in days for the preset ranges. */
+const RANGE_DAYS: Record<Exclude<DateRangePreset, 'custom'>, number> = {
+  week: 7,
+  month: 30,
+  quarter: 90,
+  year: 365,
+};
+
+/**
+ * Local YYYY-MM-DD formatter for API calls. Aliases the project's canonical
+ * `getLocalDateString` util under a domain name used throughout the analytics
+ * hub (avoids the UTC shift that `toISOString()` would introduce).
+ */
+export const formatDateForAPI = getLocalDateString;
+
+/**
+ * Resolves a range preset (and optional custom start/end) into a concrete
+ * `[start, end]` Date pair. Mirrors the legacy AdvancedAnalytics behavior:
+ * presets are rolling windows ending at `now`; custom uses the provided dates
+ * with a one-month fallback when missing.
+ *
+ * `now` is injectable so callers (and tests) get deterministic ranges.
+ */
+export function resolveDateRange(
+  range: DateRangePreset,
+  start: string,
+  end: string,
+  now: Date = new Date()
+): [Date, Date] {
+  if (range === 'custom') {
+    const monthAgo = new Date(now.getTime() - RANGE_DAYS.month * DAY_MS);
+    const startDate = start ? (parseLocalDateString(start) ?? monthAgo) : monthAgo;
+    const endDate = end ? (parseLocalDateString(end) ?? now) : now;
+    return [startDate, endDate];
+  }
+
+  // eslint-disable-next-line security/detect-object-injection -- range is a typed preset enum, not user input
+  const days = RANGE_DAYS[range];
+  return [new Date(now.getTime() - days * DAY_MS), now];
+}
+
+interface ParseOptions {
+  /** Tab used when `?tab=` is absent or invalid. */
+  defaultTab?: ChartGroup;
+  /** Injectable clock for deterministic range resolution. */
+  now?: Date;
+}
+
+/**
+ * Parses an analytics hub state from a URL query string (e.g. the value of
+ * `window.location.search`, with or without a leading `?`).
+ *
+ * Invalid `tab`/`range` values fall back to defaults so a hand-edited or stale
+ * URL never throws or renders a broken view.
+ */
+export function parseAnalyticsParams(search: string, opts: ParseOptions = {}): AnalyticsParams {
+  const sp = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const now = opts.now ?? new Date();
+  const defaultTab = opts.defaultTab ?? 'overview';
+
+  const rawTab = sp.get('tab');
+  const tab: ChartGroup = rawTab && VALID_GROUPS.has(rawTab) ? (rawTab as ChartGroup) : defaultTab;
+
+  const rawRange = sp.get('range');
+  const range: DateRangePreset =
+    rawRange && VALID_RANGES.has(rawRange) ? (rawRange as DateRangePreset) : DEFAULT_RANGE;
+
+  const start = sp.get('start') ?? '';
+  const end = sp.get('end') ?? '';
+
+  const speciesRaw = sp.get('species') ?? '';
+  const species = speciesRaw
+    ? speciesRaw
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+    : [];
+
+  const source = sp.get('source') ?? '';
+
+  const [startDate, endDate] = resolveDateRange(range, start, end, now);
+
+  return { tab, range, start, end, species, source, startDate, endDate };
+}
+
+interface SerializeOptions {
+  /** Tab that is omitted from the URL (the default landing tab). */
+  defaultTab?: ChartGroup;
+}
+
+/**
+ * Serialises analytics hub state into a query string (no leading `?`), omitting
+ * defaults and empties so URLs stay clean and deep-linkable. The output is the
+ * exact inverse of {@link parseAnalyticsParams} given matching options.
+ */
+export function serializeAnalyticsParams(
+  params: AnalyticsParams,
+  opts: SerializeOptions = {}
+): string {
+  const sp = new URLSearchParams();
+  const defaultTab = opts.defaultTab ?? 'overview';
+
+  if (params.tab !== defaultTab) {
+    sp.set('tab', params.tab);
+  }
+  if (params.range !== DEFAULT_RANGE) {
+    sp.set('range', params.range);
+  }
+  // start/end are only meaningful for custom ranges; presets are self-describing.
+  if (params.range === 'custom') {
+    if (params.start) sp.set('start', params.start);
+    if (params.end) sp.set('end', params.end);
+  }
+  if (params.species.length > 0) {
+    sp.set('species', params.species.join(','));
+  }
+  if (params.source) {
+    sp.set('source', params.source);
+  }
+
+  return sp.toString();
+}

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -173,7 +173,11 @@ async function fetchDiversity(
     .map(item => {
       const date = parseLocalDateString(item.date);
       if (!date || isNaN(date.getTime())) return null;
-      return { date, uniqueSpecies: item.unique_species };
+      const uniqueSpecies =
+        typeof item.unique_species === 'number' && Number.isFinite(item.unique_species)
+          ? item.unique_species
+          : 0;
+      return { date, uniqueSpecies };
     })
     .filter((item): item is DiversityDatum => item !== null);
 }

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -1,0 +1,264 @@
+/**
+ * Analytics chart registry.
+ *
+ * Single source of truth for which charts render in which tab. PR0 migrates the
+ * three existing Advanced Analytics charts onto this registry with no behavior
+ * change: the fetchers below are lifted verbatim from the legacy
+ * `AdvancedAnalytics.svelte` (same endpoints, params, and parsing), and the
+ * `mapProps` mappers reproduce the props the page used to pass each chart.
+ *
+ * Later PRs add Tier-1 charts to the empty `overview`/`quality` groups.
+ */
+import { buildAppUrl } from '$lib/utils/urlHelpers';
+import { parseLocalDateString } from '$lib/utils/date';
+
+import TimeOfDaySpeciesChart from '../components/charts/d3/TimeOfDaySpeciesChart.svelte';
+import DailySpeciesTrendChart from '../components/charts/d3/DailySpeciesTrendChart.svelte';
+import SpeciesDiversityChart from '../components/charts/d3/SpeciesDiversityChart.svelte';
+import TrendChartOptions from '../components/TrendChartOptions.svelte';
+
+import { formatDateForAPI } from './analyticsParams';
+import type { AnalyticsParams, ChartDef } from './types';
+
+// --- Fetch result shapes (network layer, before name enrichment) ----------
+
+interface TimeOfDayDatum {
+  hour: number;
+  count: number;
+}
+interface TimeOfDaySeries {
+  species: string;
+  data: TimeOfDayDatum[];
+}
+
+interface DailyTrendDatum {
+  date: Date;
+  count: number;
+}
+interface DailyTrendSeries {
+  species: string;
+  data: DailyTrendDatum[];
+}
+
+interface DiversityDatum {
+  date: Date;
+  uniqueSpecies: number;
+}
+
+// Raw API response fragments we read defensively.
+interface SpeciesDailyData {
+  data?: unknown;
+}
+interface DailyDataItem {
+  date: string;
+  count?: number;
+}
+interface DiversityResponse {
+  data?: { date: string; unique_species: number }[];
+}
+
+function ensureOk(response: Response): void {
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+}
+
+// --- Fetchers (verbatim endpoints/params from the legacy page) -------------
+
+/**
+ * Hourly detection counts for the range's start date, per selected species.
+ * Endpoint and the single-date semantics match the legacy page exactly.
+ */
+async function fetchTimeOfDay(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<TimeOfDaySeries[]> {
+  if (params.species.length === 0) return [];
+
+  const search = new URLSearchParams({
+    date: formatDateForAPI(params.startDate),
+    min_confidence: '0',
+  });
+  params.species.forEach(name => search.append('species', name));
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/time/hourly/batch?${search}`), {
+    signal,
+  });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Invalid hourly batch response: expected an object');
+  }
+
+  return Object.entries(data as Record<string, unknown>).map(([species, hourlyData]) => ({
+    species,
+    data: Array.isArray(hourlyData)
+      ? (hourlyData as TimeOfDayDatum[]).map(item => ({
+          hour: typeof item.hour === 'number' ? item.hour : 0,
+          count: typeof item.count === 'number' ? item.count : 0,
+        }))
+      : [],
+  }));
+}
+
+/** Daily detection counts across the range, per selected species. */
+async function fetchDailyTrend(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<DailyTrendSeries[]> {
+  if (params.species.length === 0) return [];
+
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+  });
+  params.species.forEach(name => search.append('species', name));
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/time/daily/batch?${search}`), {
+    signal,
+  });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Invalid daily batch response: expected an object');
+  }
+
+  return Object.entries(data as Record<string, unknown>).map(([species, trendData]) => {
+    if (!trendData || typeof trendData !== 'object') {
+      return { species, data: [] };
+    }
+    const apiData = trendData as SpeciesDailyData;
+    const dataArray: unknown[] = Array.isArray(apiData.data) ? apiData.data : [];
+
+    return {
+      species,
+      data: dataArray
+        .map(raw => {
+          if (!raw || typeof raw !== 'object') return null;
+          const item = raw as DailyDataItem;
+          const date = parseLocalDateString(item.date);
+          const count = typeof item.count === 'number' ? item.count : 0;
+          if (!date || isNaN(date.getTime())) return null;
+          return { date, count };
+        })
+        .filter((item): item is DailyTrendDatum => item !== null),
+    };
+  });
+}
+
+/** Unique-species-per-day diversity across the range (species-independent). */
+async function fetchDiversity(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<DiversityDatum[]> {
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+  });
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/species/diversity?${search}`), {
+    signal,
+  });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Invalid diversity response: expected an object');
+  }
+
+  const result = data as DiversityResponse;
+  return (result.data ?? [])
+    .map(item => {
+      const date = parseLocalDateString(item.date);
+      if (!date || isNaN(date.getTime())) return null;
+      return { date, uniqueSpecies: item.unique_species };
+    })
+    .filter((item): item is DiversityDatum => item !== null);
+}
+
+// --- Registry --------------------------------------------------------------
+
+export const CHART_REGISTRY: ChartDef[] = [
+  {
+    id: 'time-of-day-species',
+    group: 'patterns',
+    titleKey: 'analytics.advanced.charts.timeOfDay.title',
+    descKey: 'analytics.advanced.charts.timeOfDay.description',
+    emptyKey: 'analytics.advanced.charts.timeOfDay.noData',
+    emptyHintKey: 'analytics.advanced.charts.timeOfDay.noDataHint',
+    component: TimeOfDaySpeciesChart,
+    fetch: fetchTimeOfDay,
+    mapProps: (data, params, ctx) => ({
+      data: (data as TimeOfDaySeries[]).map(series => ({
+        species: series.species,
+        commonName: ctx.speciesNames.get(series.species) ?? series.species,
+        data: series.data,
+        visible: true,
+      })),
+      selectedSpecies: params.species,
+    }),
+    size: 'full',
+    supports: { species: true, source: false },
+  },
+  {
+    id: 'daily-species-trend',
+    group: 'trends',
+    titleKey: 'analytics.advanced.charts.dailyTrend.title',
+    descKey: 'analytics.advanced.charts.dailyTrend.description',
+    emptyKey: 'analytics.advanced.charts.dailyTrend.noData',
+    emptyHintKey: 'analytics.advanced.charts.dailyTrend.noDataHint',
+    component: DailySpeciesTrendChart,
+    controls: TrendChartOptions,
+    defaultOptions: { showRelative: false, enableZoom: true, enableBrush: false },
+    fetch: fetchDailyTrend,
+    mapProps: (data, params, ctx) => ({
+      data: (data as DailyTrendSeries[]).map(series => ({
+        species: series.species,
+        commonName: ctx.speciesNames.get(series.species) ?? series.species,
+        data: series.data,
+        visible: true,
+      })),
+      selectedSpecies: params.species,
+      dateRange: [params.startDate, params.endDate] as [Date, Date],
+      showRelative: Boolean(ctx.options.showRelative),
+      enableZoom: Boolean(ctx.options.enableZoom),
+      enableBrush: Boolean(ctx.options.enableBrush),
+      onDateRangeChange: (range: [Date, Date]) =>
+        ctx.onParamsChange({
+          range: 'custom',
+          start: formatDateForAPI(range[0]),
+          end: formatDateForAPI(range[1]),
+        }),
+    }),
+    size: 'full',
+    supports: { species: true, source: false },
+  },
+  {
+    id: 'species-diversity',
+    group: 'biodiversity',
+    titleKey: 'analytics.advanced.charts.diversity.title',
+    descKey: 'analytics.advanced.charts.diversity.description',
+    emptyKey: 'analytics.advanced.charts.diversity.noData',
+    emptyHintKey: 'analytics.advanced.charts.diversity.noDataHint',
+    component: SpeciesDiversityChart,
+    fetch: fetchDiversity,
+    mapProps: (data, params) => ({
+      data,
+      dateRange: [params.startDate, params.endDate] as [Date, Date],
+    }),
+    size: 'full',
+    supports: { species: false, source: false },
+  },
+];
+
+/** Charts registered for a given tab group, in registry order. */
+export function chartsForGroup(group: ChartDef['group']): ChartDef[] {
+  return CHART_REGISTRY.filter(chart => chart.group === group);
+}
+
+/** Whether any registered chart belongs to the given group. */
+export function groupHasCharts(group: ChartDef['group']): boolean {
+  return CHART_REGISTRY.some(chart => chart.group === group);
+}

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -173,10 +173,8 @@ async function fetchDiversity(
     .map(item => {
       const date = parseLocalDateString(item.date);
       if (!date || isNaN(date.getTime())) return null;
-      const uniqueSpecies =
-        typeof item.unique_species === 'number' && Number.isFinite(item.unique_species)
-          ? item.unique_species
-          : 0;
+      // Number.isFinite is false for non-numbers (no coercion) and NaN/Infinity.
+      const uniqueSpecies = Number.isFinite(item.unique_species) ? item.unique_species : 0;
       return { date, uniqueSpecies };
     })
     .filter((item): item is DiversityDatum => item !== null);

--- a/frontend/src/lib/desktop/features/analytics/registry/types.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/types.ts
@@ -1,0 +1,147 @@
+/**
+ * Analytics chart registry types.
+ *
+ * The registry is the single source of truth for which charts render in which
+ * tab of the analytics hub. Each `ChartDef` describes one chart: how to fetch
+ * its data, which control-bar filters it honors, how to map the fetched data
+ * onto the concrete D3 chart component, and the chrome metadata `ChartCard`
+ * needs (title, description, sizing, "not enough data yet" threshold).
+ *
+ * Adding a statistic is one `ChartDef` plus a chart component plus (later) an
+ * endpoint. See `charts.ts` for the registered entries.
+ */
+import type { Component } from 'svelte';
+
+/**
+ * A chart component held in the registry. The registry is heterogeneous (each
+ * chart has its own prop shape) and maps data -> props at runtime via
+ * `ChartDef.mapProps`, so the component type is intentionally permissive; the
+ * concrete prop types are enforced where each chart is authored, not here.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous registry; props validated per-chart, not at the registry boundary
+export type AnyChartComponent = Component<any>;
+
+/** Tab groups shown in the hub, in display order. */
+export type ChartGroup = 'overview' | 'patterns' | 'trends' | 'biodiversity' | 'quality';
+
+/** Date-range presets shared by the control bar and the registry fetchers. */
+export type DateRangePreset = 'week' | 'month' | 'quarter' | 'year' | 'custom';
+
+/**
+ * Resolved analytics parameters shared across the control bar, the registry
+ * fetchers, and the chart components.
+ *
+ * `start`/`end` are the canonical URL-serialised form (YYYY-MM-DD, station-local
+ * time). `startDate`/`endDate` are the parsed `Date` objects the D3 charts
+ * consume; they are derived from `range`/`start`/`end` so callers never have to
+ * re-parse.
+ */
+export interface AnalyticsParams {
+  /** Active tab. */
+  tab: ChartGroup;
+  /** Selected date-range preset. */
+  range: DateRangePreset;
+  /** Effective range start (YYYY-MM-DD, local). */
+  start: string;
+  /** Effective range end (YYYY-MM-DD, local). */
+  end: string;
+  /** Selected species, by scientific name. Empty means none selected. */
+  species: string[];
+  /** Selected audio source/mic id. Empty means all sources. Inert in PR0. */
+  source: string;
+  /** Parsed range start (derived from range/start). */
+  startDate: Date;
+  /** Parsed range end (derived from range/end). */
+  endDate: Date;
+}
+
+/** Which shared control-bar filters a chart honors. */
+export interface ChartSupports {
+  species: boolean;
+  source: boolean;
+}
+
+/** Relative width a card occupies in the responsive grid. */
+export type ChartSize = 'normal' | 'wide' | 'full';
+
+/**
+ * Context handed to a `ChartDef.mapProps` so a chart can wire fetched data,
+ * per-card options, and a way to request shared-param changes (e.g. a brush
+ * gesture rewriting the date range) onto its component props.
+ */
+export interface ChartPropsContext {
+  /** Per-card display options owned by ChartCard (seeded from `defaultOptions`). */
+  options: Record<string, unknown>;
+  /** Request a change to the shared params (writes URL state in the hub). */
+  onParamsChange: (_partial: Partial<AnalyticsParams>) => void;
+  /**
+   * Scientific name -> server-provided common name, sourced from the species
+   * summary endpoint the hub already fetches. Lets charts label series without
+   * an extra request (the per-visitor dictionary, when enabled, still wins via
+   * `localizeSpeciesName`).
+   */
+  speciesNames: Map<string, string>;
+}
+
+/**
+ * Per-card display options toolbar. Rendered by ChartCard in the card header
+ * for charts that declare `controls`. Receives the current `options` and a
+ * `setOption` callback; it must not mutate `options` directly.
+ */
+export interface ChartControlsProps {
+  options: Record<string, unknown>;
+  setOption: (_key: string, _value: unknown) => void;
+}
+
+export interface ChartDef {
+  /** Stable id; also the per-card DOM anchor. */
+  id: string;
+  /** Tab this chart belongs to. */
+  group: ChartGroup;
+  /** i18n key for the card title. */
+  titleKey: string;
+  /** i18n key for the card description. */
+  descKey: string;
+  /** i18n key for the empty-state title (no data for the current params). */
+  emptyKey: string;
+  /** i18n key for the empty-state hint. */
+  emptyHintKey: string;
+  /** The D3 chart component (wraps BaseChart). */
+  component: AnyChartComponent;
+  /**
+   * Optional per-card display-options toolbar, rendered in the card header.
+   * Keeps chart-specific controls out of the shared control bar.
+   */
+  controls?: AnyChartComponent;
+  /** Seed values for ChartCard's per-card options state. */
+  defaultOptions?: Record<string, unknown>;
+  /**
+   * Fetches the chart's data for the given params. Implementations should
+   * honor the `AbortSignal` so stale in-flight requests are cancelled.
+   */
+  fetch: (_params: AnalyticsParams, _signal?: AbortSignal) => Promise<unknown>;
+  /**
+   * Maps fetched data + params (+ options/callbacks) onto the chart component's
+   * props. Defaults to `{ data }` when omitted.
+   */
+  mapProps?: (
+    _data: unknown,
+    _params: AnalyticsParams,
+    _ctx: ChartPropsContext
+  ) => Record<string, unknown>;
+  /** Relative size in the responsive grid. */
+  size: ChartSize;
+  /** Which shared filters this chart honors. */
+  supports: ChartSupports;
+  /** Below this many data points, ChartCard shows "not enough data yet". */
+  minDataPoints?: number;
+  /**
+   * Counts data points in a fetch result for the empty / not-enough-data
+   * checks. Defaults to array length (or 0 for non-arrays).
+   */
+  countDataPoints?: (_data: unknown) => number;
+  /** Enables CSV export (stubbed in PR0). */
+  export?: 'csv';
+  /** Caps the number of species rendered (e.g. ridgeline top-N). */
+  maxSpecies?: number;
+}

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1284,6 +1284,23 @@ export type TranslationKey =
   | 'terminal.detached'
   | 'terminal.detachedDescription'
   | 'terminal.reattach'
+  | 'analytics.hub.tabs.overview'
+  | 'analytics.hub.tabs.patterns'
+  | 'analytics.hub.tabs.trends'
+  | 'analytics.hub.tabs.biodiversity'
+  | 'analytics.hub.tabs.quality'
+  | 'analytics.hub.aria.tabs'
+  | 'analytics.hub.controls.source'
+  | 'analytics.hub.controls.sourceAll'
+  | 'analytics.hub.controls.sourceComingSoon'
+  | 'analytics.hub.controls.speciesNotApplicable'
+  | 'analytics.hub.card.error'
+  | 'analytics.hub.card.retry'
+  | 'analytics.hub.card.notEnoughData'
+  | 'analytics.hub.card.notEnoughDataHint' // params: min
+  | 'analytics.hub.card.export'
+  | 'analytics.hub.card.exportComingSoon'
+  | 'analytics.hub.comingSoon.description'
   | 'analytics.title'
   | 'analytics.loadingError'
   | 'analytics.stats.totalDetections'
@@ -3907,6 +3924,7 @@ export type TranslationParams = {
   'system.database.migration.prerequisites.criticalCount': { count: string | number };
   'system.database.migration.prerequisites.warningCount': { count: string | number };
   'system.inference.coDetectedHelp': { seconds: string | number };
+  'analytics.hub.card.notEnoughDataHint': { min: string | number };
   'analytics.advanced.speciesSelection': { count: string | number; max: string | number };
   'analytics.advanced.detections': { count: string | number };
   'settings.notFound.message': { section: string | number };

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1648,6 +1648,35 @@
     "reattach": "Připojit zpět"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Přehled",
+        "patterns": "Vzorce aktivity",
+        "trends": "Trendy",
+        "biodiversity": "Biodiverzita",
+        "quality": "Kontrola a přesnost"
+      },
+      "aria": {
+        "tabs": "Sekce analýzy"
+      },
+      "controls": {
+        "source": "Zdroj",
+        "sourceAll": "Všechny zdroje",
+        "sourceComingSoon": "Filtrování podle zdroje přijde v pozdější aktualizaci.",
+        "speciesNotApplicable": "Grafy v této sekci nefiltrují podle druhu."
+      },
+      "card": {
+        "error": "Tento graf se nepodařilo načíst",
+        "retry": "Zkusit znovu",
+        "notEnoughData": "Zatím není dostatek dat",
+        "notEnoughDataHint": "Tento graf potřebuje alespoň {min} datových bodů. Pokračujte v nahrávání a vraťte se brzy.",
+        "export": "Exportovat",
+        "exportComingSoon": "Export do CSV brzy přijde."
+      },
+      "comingSoon": {
+        "description": "Tato sekce se připravuje a přijde v některé z příštích aktualizací."
+      }
+    },
     "title": "Přehled",
     "loadingError": "Nepodařilo se načíst některá analytická data. Zkuste to prosím později.",
     "stats": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1648,6 +1648,35 @@
     "reattach": "Tilknyt igen"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Oversigt",
+        "patterns": "Aktivitetsmønstre",
+        "trends": "Tendenser",
+        "biodiversity": "Biodiversitet",
+        "quality": "Gennemgang og nøjagtighed"
+      },
+      "aria": {
+        "tabs": "Analyseafsnit"
+      },
+      "controls": {
+        "source": "Kilde",
+        "sourceAll": "Alle kilder",
+        "sourceComingSoon": "Filtrering efter kilde kommer i en senere opdatering.",
+        "speciesNotApplicable": "Diagrammerne i dette afsnit filtrerer ikke efter art."
+      },
+      "card": {
+        "error": "Diagrammet kunne ikke indlæses",
+        "retry": "Prøv igen",
+        "notEnoughData": "Ikke nok data endnu",
+        "notEnoughDataHint": "Dette diagram kræver mindst {min} datapunkter. Fortsæt optagelsen, og kig forbi igen snart.",
+        "export": "Eksporter",
+        "exportComingSoon": "CSV-eksport kommer snart."
+      },
+      "comingSoon": {
+        "description": "Dette afsnit er under opbygning og kommer i en kommende opdatering."
+      }
+    },
     "title": "Oversigt",
     "loadingError": "Kunne ikke indlæse nogle analysedata. Prøv venligst igen senere.",
     "stats": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1648,6 +1648,35 @@
     "reattach": "Wieder anhängen"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Übersicht",
+        "patterns": "Aktivitätsmuster",
+        "trends": "Trends",
+        "biodiversity": "Artenvielfalt",
+        "quality": "Überprüfung & Genauigkeit"
+      },
+      "aria": {
+        "tabs": "Analysebereiche"
+      },
+      "controls": {
+        "source": "Quelle",
+        "sourceAll": "Alle Quellen",
+        "sourceComingSoon": "Die Filterung nach Quelle kommt in einem späteren Update.",
+        "speciesNotApplicable": "Die Diagramme in diesem Bereich filtern nicht nach Art."
+      },
+      "card": {
+        "error": "Dieses Diagramm konnte nicht geladen werden",
+        "retry": "Erneut versuchen",
+        "notEnoughData": "Noch nicht genügend Daten",
+        "notEnoughDataHint": "Dieses Diagramm benötigt mindestens {min} Datenpunkte. Nimm weiter auf und schau bald wieder vorbei.",
+        "export": "Exportieren",
+        "exportComingSoon": "CSV-Export kommt bald."
+      },
+      "comingSoon": {
+        "description": "Dieser Bereich befindet sich im Aufbau und kommt in einem kommenden Update."
+      }
+    },
     "title": "Übersicht",
     "loadingError": "Fehler beim Laden einiger Analysedaten. Bitte versuchen Sie es später erneut.",
     "stats": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1648,6 +1648,35 @@
     "reattach": "Reattach"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Overview",
+        "patterns": "Activity Patterns",
+        "trends": "Trends",
+        "biodiversity": "Biodiversity",
+        "quality": "Review & Accuracy"
+      },
+      "aria": {
+        "tabs": "Analytics sections"
+      },
+      "controls": {
+        "source": "Source",
+        "sourceAll": "All sources",
+        "sourceComingSoon": "Filtering by source arrives in a later update.",
+        "speciesNotApplicable": "The charts in this section do not filter by species."
+      },
+      "card": {
+        "error": "Couldn't load this chart",
+        "retry": "Retry",
+        "notEnoughData": "Not enough data yet",
+        "notEnoughDataHint": "This chart needs at least {min} data points. Keep recording and check back soon.",
+        "export": "Export",
+        "exportComingSoon": "CSV export is coming soon."
+      },
+      "comingSoon": {
+        "description": "This section is under construction and will arrive in an upcoming update."
+      }
+    },
     "title": "Overview",
     "loadingError": "Failed to load some analytics data. Please try again later.",
     "stats": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1648,6 +1648,35 @@
     "reattach": "Reconectar"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Resumen",
+        "patterns": "Patrones de actividad",
+        "trends": "Tendencias",
+        "biodiversity": "Biodiversidad",
+        "quality": "Revisión y precisión"
+      },
+      "aria": {
+        "tabs": "Secciones de análisis"
+      },
+      "controls": {
+        "source": "Fuente",
+        "sourceAll": "Todas las fuentes",
+        "sourceComingSoon": "El filtrado por fuente llegará en una próxima actualización.",
+        "speciesNotApplicable": "Los gráficos de esta sección no filtran por especie."
+      },
+      "card": {
+        "error": "No se pudo cargar este gráfico",
+        "retry": "Reintentar",
+        "notEnoughData": "Aún no hay datos suficientes",
+        "notEnoughDataHint": "Este gráfico necesita al menos {min} puntos de datos. Sigue grabando y vuelve pronto.",
+        "export": "Exportar",
+        "exportComingSoon": "La exportación CSV llegará pronto."
+      },
+      "comingSoon": {
+        "description": "Esta sección está en construcción y llegará en una próxima actualización."
+      }
+    },
     "title": "Resumen",
     "loadingError": "Error al cargar algunos datos analíticos. Por favor, inténtalo más tarde.",
     "stats": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1648,6 +1648,35 @@
     "reattach": "Liitä takaisin"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Yleiskatsaus",
+        "patterns": "Aktiivisuuskuviot",
+        "trends": "Trendit",
+        "biodiversity": "Luonnon monimuotoisuus",
+        "quality": "Tarkistus ja tarkkuus"
+      },
+      "aria": {
+        "tabs": "Analyysiosiot"
+      },
+      "controls": {
+        "source": "Lähde",
+        "sourceAll": "Kaikki lähteet",
+        "sourceComingSoon": "Suodatus lähteen mukaan tulee myöhemmässä päivityksessä.",
+        "speciesNotApplicable": "Tämän osion kaaviot eivät suodata lajin mukaan."
+      },
+      "card": {
+        "error": "Kaavion lataaminen epäonnistui",
+        "retry": "Yritä uudelleen",
+        "notEnoughData": "Ei vielä tarpeeksi tietoja",
+        "notEnoughDataHint": "Tämä kaavio tarvitsee vähintään {min} datapistettä. Jatka tallentamista ja palaa pian takaisin.",
+        "export": "Vie",
+        "exportComingSoon": "CSV-vienti tulee pian."
+      },
+      "comingSoon": {
+        "description": "Tämä osio on rakenteilla ja tulee tulevassa päivityksessä."
+      }
+    },
     "title": "Yleiskatsaus",
     "loadingError": "Joidenkin analytiikkatietojen lataus epäonnistui. Yritä myöhemmin uudelleen.",
     "stats": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1648,6 +1648,35 @@
     "reattach": "Rattacher"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Vue d'ensemble",
+        "patterns": "Schémas d'activité",
+        "trends": "Tendances",
+        "biodiversity": "Biodiversité",
+        "quality": "Vérification et précision"
+      },
+      "aria": {
+        "tabs": "Sections d'analyse"
+      },
+      "controls": {
+        "source": "Source",
+        "sourceAll": "Toutes les sources",
+        "sourceComingSoon": "Le filtrage par source arrivera dans une prochaine mise à jour.",
+        "speciesNotApplicable": "Les graphiques de cette section ne filtrent pas par espèce."
+      },
+      "card": {
+        "error": "Impossible de charger ce graphique",
+        "retry": "Réessayer",
+        "notEnoughData": "Pas encore assez de données",
+        "notEnoughDataHint": "Ce graphique nécessite au moins {min} points de données. Continuez l'enregistrement et revenez bientôt.",
+        "export": "Exporter",
+        "exportComingSoon": "L'export CSV arrive bientôt."
+      },
+      "comingSoon": {
+        "description": "Cette section est en cours de construction et arrivera dans une prochaine mise à jour."
+      }
+    },
     "title": "Vue d'ensemble",
     "loadingError": "Échec du chargement de certaines données analytiques. Veuillez réessayer plus tard.",
     "stats": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1648,6 +1648,35 @@
     "reattach": "Újracsatlakozás"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Áttekintés",
+        "patterns": "Tevékenységi minták",
+        "trends": "Trendek",
+        "biodiversity": "Biodiverzitás",
+        "quality": "Ellenőrzés és pontosság"
+      },
+      "aria": {
+        "tabs": "Elemzési szakaszok"
+      },
+      "controls": {
+        "source": "Forrás",
+        "sourceAll": "Minden forrás",
+        "sourceComingSoon": "A forrás szerinti szűrés egy későbbi frissítésben érkezik.",
+        "speciesNotApplicable": "Az ebben a szakaszban lévő diagramok nem szűrnek faj szerint."
+      },
+      "card": {
+        "error": "Nem sikerült betölteni ezt a diagramot",
+        "retry": "Újra",
+        "notEnoughData": "Még nincs elég adat",
+        "notEnoughDataHint": "Ehhez a diagramhoz legalább {min} adatpont szükséges. Folytassa a rögzítést, és nézzen vissza hamarosan.",
+        "export": "Exportálás",
+        "exportComingSoon": "A CSV-exportálás hamarosan érkezik."
+      },
+      "comingSoon": {
+        "description": "Ez a szakasz fejlesztés alatt áll, és egy közelgő frissítésben érkezik."
+      }
+    },
     "title": "Áttekintés",
     "loadingError": "Néhány analitikai adat betöltése sikertelen. Próbálja később újra.",
     "stats": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1648,6 +1648,35 @@
     "reattach": "Riattacca"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Panoramica",
+        "patterns": "Modelli di attività",
+        "trends": "Tendenze",
+        "biodiversity": "Biodiversità",
+        "quality": "Revisione e accuratezza"
+      },
+      "aria": {
+        "tabs": "Sezioni di analisi"
+      },
+      "controls": {
+        "source": "Sorgente",
+        "sourceAll": "Tutte le sorgenti",
+        "sourceComingSoon": "Il filtro per sorgente arriverà in un prossimo aggiornamento.",
+        "speciesNotApplicable": "I grafici in questa sezione non filtrano per specie."
+      },
+      "card": {
+        "error": "Impossibile caricare questo grafico",
+        "retry": "Riprova",
+        "notEnoughData": "Dati ancora insufficienti",
+        "notEnoughDataHint": "Questo grafico richiede almeno {min} punti dati. Continua a registrare e torna presto.",
+        "export": "Esporta",
+        "exportComingSoon": "L'esportazione CSV arriverà presto."
+      },
+      "comingSoon": {
+        "description": "Questa sezione è in costruzione e arriverà in un prossimo aggiornamento."
+      }
+    },
     "title": "Panoramica",
     "loadingError": "Impossibile caricare alcuni dati analitici. Riprova più tardi.",
     "stats": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1648,6 +1648,35 @@
     "reattach": "Pievienot atpakaļ"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Pārskats",
+        "patterns": "Aktivitātes modeļi",
+        "trends": "Tendences",
+        "biodiversity": "Bioloģiskā daudzveidība",
+        "quality": "Pārskatīšana un precizitāte"
+      },
+      "aria": {
+        "tabs": "Analīzes sadaļas"
+      },
+      "controls": {
+        "source": "Avots",
+        "sourceAll": "Visi avoti",
+        "sourceComingSoon": "Filtrēšana pēc avota būs pieejama vēlākā atjauninājumā.",
+        "speciesNotApplicable": "Šīs sadaļas diagrammas nefiltrē pēc sugas."
+      },
+      "card": {
+        "error": "Neizdevās ielādēt šo diagrammu",
+        "retry": "Mēģināt vēlreiz",
+        "notEnoughData": "Vēl nav pietiekami daudz datu",
+        "notEnoughDataHint": "Šai diagrammai nepieciešami vismaz {min} datu punkti. Turpiniet ierakstīšanu un atgriezieties drīz.",
+        "export": "Eksportēt",
+        "exportComingSoon": "CSV eksports būs pieejams drīz."
+      },
+      "comingSoon": {
+        "description": "Šī sadaļa tiek izstrādāta un būs pieejama kādā no nākamajiem atjauninājumiem."
+      }
+    },
     "title": "Pārskats",
     "loadingError": "Neizdevās ielādēt dažus analītikas datus. Lūdzu, mēģiniet vēlāk.",
     "stats": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1648,6 +1648,35 @@
     "reattach": "Fest til igjen"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Oversikt",
+        "patterns": "Aktivitetsmønstre",
+        "trends": "Trender",
+        "biodiversity": "Biologisk mangfold",
+        "quality": "Gjennomgang og nøyaktighet"
+      },
+      "aria": {
+        "tabs": "Analyseseksjoner"
+      },
+      "controls": {
+        "source": "Kilde",
+        "sourceAll": "Alle kilder",
+        "sourceComingSoon": "Filtrering etter kilde kommer i en senere oppdatering.",
+        "speciesNotApplicable": "Diagrammene i denne seksjonen filtrerer ikke etter art."
+      },
+      "card": {
+        "error": "Kunne ikke laste dette diagrammet",
+        "retry": "Prøv igjen",
+        "notEnoughData": "Ikke nok data ennå",
+        "notEnoughDataHint": "Dette diagrammet trenger minst {min} datapunkter. Fortsett å ta opp, og kom tilbake snart.",
+        "export": "Eksporter",
+        "exportComingSoon": "CSV-eksport kommer snart."
+      },
+      "comingSoon": {
+        "description": "Denne seksjonen er under utvikling og kommer i en kommende oppdatering."
+      }
+    },
     "title": "Oversikt",
     "loadingError": "Innlasting av noen analysedata mislyktes. Prøv igjen senere.",
     "stats": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1648,6 +1648,35 @@
     "reattach": "Opnieuw koppelen"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Overzicht",
+        "patterns": "Activiteitspatronen",
+        "trends": "Trends",
+        "biodiversity": "Biodiversiteit",
+        "quality": "Controle en nauwkeurigheid"
+      },
+      "aria": {
+        "tabs": "Analysesecties"
+      },
+      "controls": {
+        "source": "Bron",
+        "sourceAll": "Alle bronnen",
+        "sourceComingSoon": "Filteren op bron komt in een latere update.",
+        "speciesNotApplicable": "De grafieken in deze sectie filteren niet op soort."
+      },
+      "card": {
+        "error": "Kan deze grafiek niet laden",
+        "retry": "Opnieuw proberen",
+        "notEnoughData": "Nog niet genoeg gegevens",
+        "notEnoughDataHint": "Deze grafiek heeft minstens {min} gegevenspunten nodig. Blijf opnemen en kom snel terug.",
+        "export": "Exporteren",
+        "exportComingSoon": "CSV-export komt binnenkort."
+      },
+      "comingSoon": {
+        "description": "Deze sectie is in aanbouw en komt in een toekomstige update."
+      }
+    },
     "title": "Aantallen",
     "loadingError": "Kon analyse gegevens niet inladen. Probeer het later opnieuw.",
     "stats": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1648,6 +1648,35 @@
     "reattach": "Podłącz ponownie"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Przegląd",
+        "patterns": "Wzorce aktywności",
+        "trends": "Trendy",
+        "biodiversity": "Bioróżnorodność",
+        "quality": "Przegląd i dokładność"
+      },
+      "aria": {
+        "tabs": "Sekcje analizy"
+      },
+      "controls": {
+        "source": "Źródło",
+        "sourceAll": "Wszystkie źródła",
+        "sourceComingSoon": "Filtrowanie według źródła pojawi się w późniejszej aktualizacji.",
+        "speciesNotApplicable": "Wykresy w tej sekcji nie filtrują według gatunku."
+      },
+      "card": {
+        "error": "Nie można załadować tego wykresu",
+        "retry": "Ponów próbę",
+        "notEnoughData": "Wciąż za mało danych",
+        "notEnoughDataHint": "Ten wykres wymaga co najmniej {min} punktów danych. Kontynuuj nagrywanie i wróć wkrótce.",
+        "export": "Eksportuj",
+        "exportComingSoon": "Eksport CSV pojawi się wkrótce."
+      },
+      "comingSoon": {
+        "description": "Ta sekcja jest w budowie i pojawi się w nadchodzącej aktualizacji."
+      }
+    },
     "title": "Przegląd",
     "loadingError": "Nie udało się załadować niektórych danych analitycznych. Spróbuj ponownie później.",
     "stats": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1648,6 +1648,35 @@
     "reattach": "Reconectar"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Visão geral",
+        "patterns": "Padrões de atividade",
+        "trends": "Tendências",
+        "biodiversity": "Biodiversidade",
+        "quality": "Revisão e precisão"
+      },
+      "aria": {
+        "tabs": "Seções de análise"
+      },
+      "controls": {
+        "source": "Fonte",
+        "sourceAll": "Todas as fontes",
+        "sourceComingSoon": "A filtragem por fonte chegará numa atualização futura.",
+        "speciesNotApplicable": "Os gráficos desta seção não filtram por espécie."
+      },
+      "card": {
+        "error": "Não foi possível carregar este gráfico",
+        "retry": "Tentar novamente",
+        "notEnoughData": "Ainda não há dados suficientes",
+        "notEnoughDataHint": "Este gráfico precisa de pelo menos {min} pontos de dados. Continue gravando e volte em breve.",
+        "export": "Exportar",
+        "exportComingSoon": "A exportação CSV chegará em breve."
+      },
+      "comingSoon": {
+        "description": "Esta seção está em construção e chegará numa atualização futura."
+      }
+    },
     "title": "Visão geral",
     "loadingError": "Falha ao carregar alguns dados analíticos. Por favor, tente novamente mais tarde.",
     "stats": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1648,6 +1648,35 @@
     "reattach": "Pripojiť späť"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Prehľad",
+        "patterns": "Vzorce aktivity",
+        "trends": "Trendy",
+        "biodiversity": "Biodiverzita",
+        "quality": "Kontrola a presnosť"
+      },
+      "aria": {
+        "tabs": "Sekcie analýzy"
+      },
+      "controls": {
+        "source": "Zdroj",
+        "sourceAll": "Všetky zdroje",
+        "sourceComingSoon": "Filtrovanie podľa zdroja príde v neskoršej aktualizácii.",
+        "speciesNotApplicable": "Grafy v tejto sekcii nefiltrujú podľa druhu."
+      },
+      "card": {
+        "error": "Tento graf sa nepodarilo načítať",
+        "retry": "Skúsiť znova",
+        "notEnoughData": "Zatiaľ nie je dostatok údajov",
+        "notEnoughDataHint": "Tento graf potrebuje aspoň {min} dátových bodov. Pokračujte v nahrávaní a vráťte sa čoskoro.",
+        "export": "Exportovať",
+        "exportComingSoon": "Export do CSV čoskoro príde."
+      },
+      "comingSoon": {
+        "description": "Táto sekcia sa pripravuje a príde v niektorej z budúcich aktualizácií."
+      }
+    },
     "title": "Prehľad",
     "loadingError": "Nepodarilo sa načítať niektoré analytické dáta. Skúste to neskôr.",
     "stats": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1648,6 +1648,35 @@
     "reattach": "Återanslut"
   },
   "analytics": {
+    "hub": {
+      "tabs": {
+        "overview": "Översikt",
+        "patterns": "Aktivitetsmönster",
+        "trends": "Trender",
+        "biodiversity": "Biologisk mångfald",
+        "quality": "Granskning och noggrannhet"
+      },
+      "aria": {
+        "tabs": "Analysavsnitt"
+      },
+      "controls": {
+        "source": "Källa",
+        "sourceAll": "Alla källor",
+        "sourceComingSoon": "Filtrering efter källa kommer i en senare uppdatering.",
+        "speciesNotApplicable": "Diagrammen i det här avsnittet filtrerar inte efter art."
+      },
+      "card": {
+        "error": "Det gick inte att läsa in det här diagrammet",
+        "retry": "Försök igen",
+        "notEnoughData": "Inte tillräckligt med data ännu",
+        "notEnoughDataHint": "Det här diagrammet behöver minst {min} datapunkter. Fortsätt spela in och titta tillbaka snart.",
+        "export": "Exportera",
+        "exportComingSoon": "CSV-export kommer snart."
+      },
+      "comingSoon": {
+        "description": "Det här avsnittet är under uppbyggnad och kommer i en kommande uppdatering."
+      }
+    },
     "title": "Översikt",
     "loadingError": "Kunde inte ladda vissa analysdata. Försök igen senare.",
     "stats": {


### PR DESCRIPTION
## Summary

Rebuilds the Advanced Analytics page as an extensible, registry-driven **tabbed hub** and migrates the three existing charts onto it. This is the foundation for the broader analytics redesign; it is frontend-only, changes no API or datastore, and preserves each chart's behavior.

- **Chart registry** (`registry/types.ts`, `registry/charts.ts`): a `ChartDef` describes each chart (group, i18n keys, component, fetch, mapProps, `supports` flags, size, `minDataPoints`). The registry is the single source of truth for which charts render in which tab. Adding a stat becomes one registry entry + a component + (later) an endpoint.
- **`ChartCard.svelte`**: shared chrome owning loading, empty, a distinct "not enough data yet" state, error + retry, an optional per-card options toolbar, and an export-menu stub. It drives the registry `fetch` from the shared params and maps the result onto the chart.
- **`AnalyticsControlBar.svelte`**: a slim, page-colored toolbar with date range, a collapsible species selector (reusing `SpeciesSelector`), and a source/mic filter (present but inert for now). Bound to URL query params; honors each chart's `supports` flags.
- **Tabbed hub** (`pages/AdvancedAnalytics.svelte`): tab bar on top with the active tab in `?tab=`; date range / species / source also in the URL, so views are deep-linkable and survive reload and Back/Forward. Only the active tab mounts its charts (D3 cleans up on unmount).
- **Migrated charts**: time-of-day species, daily species trend, and species diversity keep identical endpoints, params, parsing, and interactions; their data fetching moved into the registry and their hand-rolled per-card chrome was removed.
- **Chart axis fix**: chart Y domains now default an all-zero/empty range to a max of 1, so empty ranges pin zero to the bottom instead of rendering a centered zero with negative ticks.
- **i18n**: new hub keys (tab labels, card states, control hints) added to `en.json` and translated across all locales; generated types regenerated.

The separate Analytics overview page and route are left untouched (folded in by a later change).

## Test plan

- [x] `npm run check:all` (format, eslint, stylelint, svelte-check, ast-grep) clean
- [x] `npm test` green (2259 tests; new unit tests for URL param round-trip, ChartCard state matrix + refetch gating + brush callback + pending state, the control bar, and the tabbed hub URL state / active-tab mounting / Back-Forward)
- [x] Production build (`task`) succeeds
- [x] Manual: verified in a browser against the built binary (tabs, URL state, deep links, Back/Forward, collapsible filter, empty/error states, light theme); E2E `analytics.spec.js` extended for the tabbed hub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Launched the analytics hub page with tabbed navigation (Overview, Activity Patterns, Trends, Biodiversity, Quality).
- Added URL-synced analytics filtering (date range presets + custom start/end) with species controls where applicable.
- Introduced reusable analytics UI pieces: shared chart cards with consistent states, and per-chart options for daily species trends.

**Bug Fixes**
- Improved chart axis scaling to avoid degenerate or zero-range rendering for empty/all-zero datasets.

**Internationalization**
- Added localized analytics hub UI text for controls, card states, and “coming soon” messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->