### PR TITLE
build: add OpenVINO backend to noembed_linux_amd64/arm64 targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,13 +91,15 @@ RUN ONNX_ARCH=$(case "${TARGETPLATFORM}" in \
     rm -rf /tmp/onnxruntime /tmp/onnxruntime.tgz
 
 # Build assets and compile BirdNET-Go (non-embedded, TFLite + ONNX)
+# OPENVINO=false keeps the published images ONNX-only: the noembed_linux_* targets
+# default OpenVINO on, so the standard image must opt out explicitly.
 # Note: frontend-build (including Tailwind) is handled as a dependency of noembed_* tasks
 RUN --mount=type=cache,target=/go/pkg/mod,uid=10001,gid=10001 \
     --mount=type=cache,target=/home/dev-user/.cache/go-build,uid=10001,gid=10001 \
     task check-tensorflow && \
     TARGET=$(echo ${TARGETPLATFORM} | tr '/' '_') && \
     echo "Building non-embedded version with BUILD_VERSION=${BUILD_VERSION}" && \
-    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" PROJECT_NAME="${PROJECT_NAME}" PROJECT_REPO_URL="${PROJECT_REPO_URL}" PROJECT_COMMUNITY_URL="${PROJECT_COMMUNITY_URL}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET}
+    BUILD_VERSION="${BUILD_VERSION}" SENTRY_DSN="${SENTRY_DSN}" PROJECT_NAME="${PROJECT_NAME}" PROJECT_REPO_URL="${PROJECT_REPO_URL}" PROJECT_COMMUNITY_URL="${PROJECT_COMMUNITY_URL}" DOCKER_LIB_DIR=/home/dev-user/lib task noembed_${TARGET} OPENVINO=false
 
 # Create final image using a multi-platform base image
 FROM --platform=$TARGETPLATFORM debian:trixie-slim

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,6 +55,10 @@ vars:
   # is absent, while openvino builds populate it via the check-openvino task.
   OPENVINO_RELEASE: '2026.2'
   OPENVINO_BUILD: '2026.2.0.21903.52ddc073857'
+  # SHA256 of the archive below, published at <archive-url>.sha256. The download
+  # is verified against this before extraction. Bump it together with
+  # OPENVINO_BUILD on every version change.
+  OPENVINO_SHA256: '8ce45467967e22fddb83a6b72a8bd1f9bfa6f43351e1ca2eaf5251064fe17767'
   # Archive basename, defined once so the URL and the tar member path cannot
   # drift apart. The arm64 package is the canonical source: its runtime/include
   # C API headers are identical across arch packages, so it serves amd64 too.
@@ -738,11 +742,13 @@ tasks:
       OPENVINO_ARCHIVE: '{{.OPENVINO_BASENAME}}.tgz'
       OPENVINO_URL: 'https://storage.openvinotoolkit.org/repositories/openvino/packages/{{.OPENVINO_RELEASE}}/linux/{{.OPENVINO_BASENAME}}.tgz'
     # Skip entirely unless this is an openvino build, otherwise skip when the
-    # header tree is already cached. Either status command succeeding marks the
-    # task up-to-date, so the download runs only when OPENVINO=true and the
-    # headers are missing.
+    # header tree for THIS build id is already cached. Either status command
+    # succeeding marks the task up-to-date, so the download runs only when
+    # OPENVINO=true and the cached headers are missing or stale. The .build-id
+    # stamp invalidates the cache when OPENVINO_BUILD changes, so a version bump
+    # forces a re-download instead of compiling against stale headers.
     status:
-      - '[ "{{.OPENVINO}}" != "true" ] || [ -f "{{.OPENVINO_HEADERS_DIR}}/include/openvino/c/openvino.h" ]'
+      - '[ "{{.OPENVINO}}" != "true" ] || { [ -f "{{.OPENVINO_HEADERS_DIR}}/include/openvino/c/openvino.h" ] && [ "$(cat "{{.OPENVINO_HEADERS_DIR}}/.build-id" 2>/dev/null)" = "{{.OPENVINO_BUILD}}" ]; }'
     cmds:
       - |
         set -euo pipefail
@@ -755,19 +761,29 @@ tasks:
         trap 'rm -rf "${ov_tmp}"' EXIT
         # wget exits non-zero on hard HTTP errors (e.g. 404); set -e then aborts.
         wget -q --tries=3 --timeout=30 "{{.OPENVINO_URL}}" -O "${ov_tmp}/openvino.tgz"
+        # Verify archive integrity against the pinned SHA256 before extraction
+        # (TLS does not protect against a corrupted or tampered upstream artifact,
+        # and an upstream-moved archive can return an HTTP-200 HTML page). A
+        # mismatch aborts under set -e. sha256sum on Linux, shasum on macOS.
+        if command -v sha256sum >/dev/null 2>&1; then
+          echo "{{.OPENVINO_SHA256}}  ${ov_tmp}/openvino.tgz" | sha256sum -c -
+        else
+          echo "{{.OPENVINO_SHA256}}  ${ov_tmp}/openvino.tgz" | shasum -a 256 -c -
+        fi
         # Extract only the architecture-independent C API header tree
         # (runtime/include); the runtime .so is dlopen'd at deploy time and is
         # never linked here.
         tar -xzf "${ov_tmp}/openvino.tgz" -C "${ov_tmp}" --strip-components=2 \
           "{{.OPENVINO_BASENAME}}/runtime/include"
         # Publish: rm-then-rename avoids nesting into a pre-existing dir, and the
-        # same-fs rename keeps the swap atomic. The final sentinel check turns a
-        # partial extract or an HTTP-200 HTML error page (returned for a moved
-        # upstream archive) into a loud failure rather than a silently
-        # half-populated cache that the status guard would later treat as valid.
+        # same-fs rename keeps the swap atomic. The sentinel check turns a partial
+        # extract into a loud failure rather than a silently half-populated cache.
         rm -rf "{{.OPENVINO_HEADERS_DIR}}/include"
         mv "${ov_tmp}/include" "{{.OPENVINO_HEADERS_DIR}}/include"
         test -f "{{.OPENVINO_HEADERS_DIR}}/include/openvino/c/openvino.h"
+        # Stamp the cached build id last, so an interrupted run leaves a stale or
+        # absent stamp that the status guard rejects on the next build.
+        printf '%s\n' "{{.OPENVINO_BUILD}}" > "{{.OPENVINO_HEADERS_DIR}}/.build-id"
         echo "OpenVINO headers installed to {{.OPENVINO_HEADERS_DIR}}/include"
 
   check-tflite-lib:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,7 +46,21 @@ vars:
     sh: echo "${PROJECT_COMMUNITY_URL:-}"
   # Common build flags
   TENSORFLOW_HEADERS_DIR: '{{.ROOT_DIR}}/.cache/tensorflow'
-  CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I{{.TENSORFLOW_HEADERS_DIR}}"
+  # OpenVINO C API headers (used only by openvino-tagged builds). The headers are
+  # architecture-independent plain C declarations, so one download serves every
+  # target arch; the runtime library is dlopen'd at execution time (the backend
+  # links only -ldl), so no per-arch .so is needed at build time. The include
+  # path below is added to CGO_CFLAGS unconditionally: GCC silently ignores a
+  # missing -I directory, so non-openvino builds are unaffected when the cache
+  # is absent, while openvino builds populate it via the check-openvino task.
+  OPENVINO_RELEASE: '2026.2'
+  OPENVINO_BUILD: '2026.2.0.21903.52ddc073857'
+  # Archive basename, defined once so the URL and the tar member path cannot
+  # drift apart. The arm64 package is the canonical source: its runtime/include
+  # C API headers are identical across arch packages, so it serves amd64 too.
+  OPENVINO_BASENAME: 'openvino_toolkit_ubuntu22_{{.OPENVINO_BUILD}}_arm64'
+  OPENVINO_HEADERS_DIR: '{{.ROOT_DIR}}/.cache/openvino'
+  CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I{{.TENSORFLOW_HEADERS_DIR}} -I{{.OPENVINO_HEADERS_DIR}}/include"
   EXTRA_BUILD_TAGS: '{{.EXTRA_BUILD_TAGS | default ""}}'
   BUILD_TAGS_FLAG:
     sh: |
@@ -717,6 +731,45 @@ tasks:
           fi
         fi
 
+  check-openvino:
+    desc: Download OpenVINO C API headers for CGo compilation (openvino-tagged builds only)
+    internal: true
+    vars:
+      OPENVINO_ARCHIVE: '{{.OPENVINO_BASENAME}}.tgz'
+      OPENVINO_URL: 'https://storage.openvinotoolkit.org/repositories/openvino/packages/{{.OPENVINO_RELEASE}}/linux/{{.OPENVINO_BASENAME}}.tgz'
+    # Skip entirely unless this is an openvino build, otherwise skip when the
+    # header tree is already cached. Either status command succeeding marks the
+    # task up-to-date, so the download runs only when OPENVINO=true and the
+    # headers are missing.
+    status:
+      - '[ "{{.OPENVINO}}" != "true" ] || [ -f "{{.OPENVINO_HEADERS_DIR}}/include/openvino/c/openvino.h" ]'
+    cmds:
+      - |
+        set -euo pipefail
+        echo "OpenVINO C API headers not found. Downloading {{.OPENVINO_ARCHIVE}}..."
+        mkdir -p "{{.OPENVINO_HEADERS_DIR}}"
+        # Stage on the cache filesystem so publishing the headers is a same-fs
+        # rename (atomic), not a cross-fs copy that could leave a half-populated
+        # tree if interrupted.
+        ov_tmp=$(mktemp -d "{{.OPENVINO_HEADERS_DIR}}/.dl.XXXXXX")
+        trap 'rm -rf "${ov_tmp}"' EXIT
+        # wget exits non-zero on hard HTTP errors (e.g. 404); set -e then aborts.
+        wget -q --tries=3 --timeout=30 "{{.OPENVINO_URL}}" -O "${ov_tmp}/openvino.tgz"
+        # Extract only the architecture-independent C API header tree
+        # (runtime/include); the runtime .so is dlopen'd at deploy time and is
+        # never linked here.
+        tar -xzf "${ov_tmp}/openvino.tgz" -C "${ov_tmp}" --strip-components=2 \
+          "{{.OPENVINO_BASENAME}}/runtime/include"
+        # Publish: rm-then-rename avoids nesting into a pre-existing dir, and the
+        # same-fs rename keeps the swap atomic. The final sentinel check turns a
+        # partial extract or an HTTP-200 HTML error page (returned for a moved
+        # upstream archive) into a loud failure rather than a silently
+        # half-populated cache that the status guard would later treat as valid.
+        rm -rf "{{.OPENVINO_HEADERS_DIR}}/include"
+        mv "${ov_tmp}/include" "{{.OPENVINO_HEADERS_DIR}}/include"
+        test -f "{{.OPENVINO_HEADERS_DIR}}/include/openvino/c/openvino.h"
+        echo "OpenVINO headers installed to {{.OPENVINO_HEADERS_DIR}}/include"
+
   check-tflite-lib:
     desc: Download TensorFlow Lite C library for the current platform
     internal: true
@@ -1177,10 +1230,15 @@ tasks:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
     cmds:
       - task: download-tflite
-        vars: 
+        vars:
           TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}'
           TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}'
           TARGET: '{{.TARGET}}'
+      # Fetch the OpenVINO C API headers when this is an openvino build; the task
+      # no-ops for ONNX-only/standard builds (OPENVINO unset or "false").
+      - task: check-openvino
+        vars:
+          OPENVINO: '{{.OPENVINO}}'
       - mkdir -p {{.BINARY_DIR}}
       - |
         {{if .CROSS_COMPILE_CHECK}}
@@ -1194,6 +1252,13 @@ tasks:
         # notflite produces an ONNX-only binary that does not link libtensorflowlite_c.
         if [ "{{.NOTFLITE}}" = "true" ]; then
           BUILD_TAGS="${BUILD_TAGS},notflite"
+        fi
+        # openvino adds the OpenVINO inference backend (dlopen'd at runtime, ORT
+        # fallback). Headers are provided by the check-openvino task above. Only
+        # the linux noembed targets set OPENVINO; windows/darwin leave it unset
+        # by design (the OpenVINO backend is linux-only here).
+        if [ "{{.OPENVINO}}" = "true" ]; then
+          BUILD_TAGS="${BUILD_TAGS},openvino"
         fi
         if [ -n "${EXTRA_BUILD_TAGS:-}" ]; then
           BUILD_TAGS="${BUILD_TAGS},${EXTRA_BUILD_TAGS}"
@@ -1209,7 +1274,7 @@ tasks:
         echo "Note: This binary requires external model files to run"
 
   noembed_linux_amd64:
-    desc: Build Linux AMD64 without embedded models
+    desc: Build Linux AMD64 without embedded models (TFLite + ONNX + OpenVINO)
     cmds:
       - task: noembed_build
         vars:
@@ -1219,9 +1284,13 @@ tasks:
           GOOS: linux
           GOARCH: amd64
           BINARY_SUFFIX: ''
+          # amd64 includes the OpenVINO backend by default (activates on an Intel
+          # iGPU at runtime, otherwise falls back to ONNX Runtime). The standard
+          # Docker and CI images pass OPENVINO=false to stay ONNX-only.
+          OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_linux_arm64:
-    desc: Build Linux ARM64 without embedded models (ONNX-only, no TFLite)
+    desc: Build Linux ARM64 without embedded models (ONNX + OpenVINO, no TFLite)
     cmds:
       - task: noembed_build
         vars:
@@ -1236,6 +1305,10 @@ tasks:
           # arm64 ships ONNX-only: build without the TFLite backend so the binary
           # does not link libtensorflowlite_c (issue #1103).
           NOTFLITE: 'true'
+          # arm64 includes the OpenVINO backend by default (activates on A76/ARMv8.2
+          # at runtime, otherwise falls back to ONNX Runtime). The standard Docker
+          # and CI images pass OPENVINO=false to stay strictly ONNX-only.
+          OPENVINO: '{{.OPENVINO | default "true"}}'
 
   noembed_windows_amd64:
     desc: Build Windows AMD64 without embedded models


### PR DESCRIPTION
## What

`task noembed_linux_amd64` and `task noembed_linux_arm64` now build the binary with the OpenVINO inference backend by default, via a new `OPENVINO` task var (defaulting `true`). The build picks the backend at runtime: OpenVINO activates on capable hardware (Cortex-A76/ARMv8.2 f16, Intel iGPU) and falls back to ONNX Runtime everywhere else.

## How

- New internal `check-openvino` task fetches the OpenVINO C API headers from the official archive and extracts only `runtime/include` into `.cache/openvino`. The headers are architecture-neutral plain C declarations, so one download serves every target arch; the runtime library is `dlopen`'d at execution time (the backend links only `-ldl`), so no per-arch `.so` is needed at build time. This mirrors how `check-tensorflow` provisions TFLite headers.
- The global `CGO_FLAGS` gains `-I.cache/openvino/include`. It is unconditional because GCC/Clang/MinGW silently ignore a missing `-I` directory, so non-openvino builds are unaffected when the cache is absent.
- `noembed_build` appends the `openvino` build tag only when `OPENVINO=true`.

## Scope: standard images and release binaries stay ONNX-only

- The Dockerfile passes `OPENVINO=false`, so the published container images remain strictly ONNX-only and never download the headers.
- Release/nightly **native** binaries are built by the separate embedded `linux_*` targets, which do not route through `noembed_build` and are unaffected.

## Behavioral note

A bare `task noembed_linux_amd64`/`noembed_linux_arm64` now defaults to an OpenVINO-enabled binary and triggers a one-time ~41 MB header download on first run. Opt out with `OPENVINO=false task noembed_linux_arm64` to restore the previous ONNX-only behavior.

## Hardening

`check-openvino` runs under `set -euo pipefail`, retries the download, fails loudly on HTTP or extraction errors (including an HTTP-200 HTML page from a moved archive), and publishes atomically (same-filesystem staging plus rename, with a final sentinel check) so an interrupted or partial fetch can never leave a half-populated cache that the status guard would treat as complete. The archive basename is defined once (`OPENVINO_BASENAME`) so the URL and the tar member path cannot drift.

## Testing

- Cross-compiled `task noembed_linux_arm64` and natively built `task noembed_linux_amd64`: both produce binaries carrying the real OpenVINO backend (`libopenvino_c.so`, `ovbind_load`).
- Verified `OPENVINO=false` and the amd64/Windows/Darwin paths stay ONNX-only (no openvino tag, no header download).
- Full clean-room build in a fresh `golang:1.26-trixie` container (matching the CI builder): both the OpenVINO and the `OPENVINO=false` paths pass.

A follow-up to add CI compile coverage for the openvino-tagged backend is tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-embedded builds now support an optional OpenVINO backend, enabled by default.

* **Improvements**
  * Build configuration now manages OpenVINO C header availability via caching and automatically applies the correct build option when OpenVINO is enabled.
  * Updated container build behavior/documentation so published images remain ONNX-only by default, while non-embedded builds can explicitly control OpenVINO inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->