### PR TITLE
perf(analysis): initialize species tracker from the database asynchronously

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -416,11 +416,11 @@ func initSpeciesTracker(settings *conf.Settings, ds datastore.Interface) *specie
 	}
 
 	tracker := species.NewTrackerFromSettings(ds, &hemisphereAwareTracking)
-	if err := tracker.InitFromDatabase(); err != nil {
-		GetLogger().Error("Failed to initialize species tracker from database, continuing with new detections",
-			logger.Error(err),
-			logger.String("operation", "species_tracker_init"))
-	}
+	// Load historical state in the background so the multi-query database scan
+	// does not block startup (it gates the HTTP server on large databases). The
+	// tracker suppresses new-species status until the load completes, so no
+	// spurious "new species" notifications fire from the not-yet-populated maps.
+	tracker.InitFromDatabaseAsync()
 
 	hemisphere := conf.DetectHemisphere(settings.BirdNET.Latitude)
 	GetLogger().Info("Species tracking enabled",

--- a/internal/analysis/species/database.go
+++ b/internal/analysis/species/database.go
@@ -11,9 +11,17 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// InitFromDatabase populates the tracker from historical data
-// This should be called once during initialization
+// InitFromDatabase populates the tracker from historical data.
+// This should be called once during initialization. It uses a background
+// context (no cancellation); the startup path uses InitFromDatabaseAsync, which
+// supplies a cancellable context via initFromDatabaseContext.
 func (t *SpeciesTracker) InitFromDatabase() error {
+	return t.initFromDatabaseContext(context.Background())
+}
+
+// initFromDatabaseContext performs the historical load under the given context,
+// so a shutdown during a background warm-up can abort the in-flight DB scan.
+func (t *SpeciesTracker) initFromDatabaseContext(ctx context.Context) error {
 	if t.ds == nil {
 		return errors.Newf("datastore is nil").
 			Component("new-species-tracker").
@@ -32,7 +40,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 	defer t.mu.Unlock()
 
 	// Step 1: Load lifetime tracking data (existing logic)
-	if err := t.loadLifetimeDataFromDatabase(now); err != nil {
+	if err := t.loadLifetimeDataFromDatabase(ctx, now); err != nil {
 		return errors.New(err).
 			Component("new-species-tracker").
 			Category(errors.CategoryDatabase).
@@ -41,7 +49,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 			Build()
 	}
 
-	if err := t.loadNoveltyEpisodesFromDatabase(now); err != nil {
+	if err := t.loadNoveltyEpisodesFromDatabase(ctx, now); err != nil {
 		getLog().Error("Failed to restore novelty episodes from database",
 			logger.Error(err),
 			logger.String("operation", "load_novelty_episodes"),
@@ -50,7 +58,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 
 	// Step 2: Load yearly tracking data if enabled
 	if t.yearlyEnabled {
-		if err := t.loadYearlyDataFromDatabase(now); err != nil {
+		if err := t.loadYearlyDataFromDatabase(ctx, now); err != nil {
 			return errors.New(err).
 				Component("new-species-tracker").
 				Category(errors.CategoryDatabase).
@@ -62,7 +70,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 
 	// Step 3: Load seasonal tracking data if enabled
 	if t.seasonalEnabled {
-		if err := t.loadSeasonalDataFromDatabase(now); err != nil {
+		if err := t.loadSeasonalDataFromDatabase(ctx, now); err != nil {
 			return errors.New(err).
 				Component("new-species-tracker").
 				Category(errors.CategoryDatabase).
@@ -80,7 +88,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 	// 3. Graceful degradation: New notifications will still be suppressed (just not historical ones)
 	// 4. Self-healing: As new notifications are sent, the suppression state rebuilds automatically
 	// 5. The table will be created by GORM AutoMigrate on first run
-	if err := t.loadNotificationHistoryFromDatabase(now); err != nil {
+	if err := t.loadNotificationHistoryFromDatabase(ctx, now); err != nil {
 		getLog().Error("Failed to load notification history from database",
 			logger.Error(err),
 			logger.String("operation", "load_notification_history"),
@@ -89,6 +97,13 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 	}
 
 	t.lastSyncTime = now
+
+	// Drop any cached status computed against the pre-load maps. Status entries
+	// cached during a background warm-up (or before a runtime reconfigure reload)
+	// would otherwise mask the freshly loaded history for the cache TTL.
+	if len(t.statusCache) > 0 {
+		t.statusCache = make(map[string]cachedSpeciesStatus, initialSpeciesCapacity)
+	}
 
 	getLog().Debug("Database initialization complete",
 		logger.Int("lifetime_species", len(t.speciesFirstSeen)),
@@ -101,14 +116,13 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 }
 
 // loadLifetimeDataFromDatabase loads all-time first detection data
-func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
+func (t *SpeciesTracker) loadLifetimeDataFromDatabase(ctx context.Context, now time.Time) error {
 	endDate := now.Format(time.DateOnly)
 	startDate := "1900-01-01" // Load from beginning of time to get all historical data
 
-	// TODO(graceful-shutdown): Accept context parameter to enable graceful cancellation during shutdown
-	// TODO(context-timeout): Add timeout context (e.g., 60s) for database initialization operations
+	// TODO(context-timeout): Add a timeout to ctx (e.g., 60s) for the load operations
 	// TODO(telemetry): Report initialization timeouts/failures to internal/telemetry for monitoring
-	newSpeciesData, err := t.ds.GetNewSpeciesDetections(context.Background(), startDate, endDate, defaultDBQueryLimit, 0)
+	newSpeciesData, err := t.ds.GetNewSpeciesDetections(ctx, startDate, endDate, defaultDBQueryLimit, 0)
 	if err != nil {
 		return errors.Newf("failed to load lifetime species data from database: %w", err).
 			Component("new-species-tracker").
@@ -168,13 +182,12 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
 }
 
 // loadNoveltyEpisodesFromDatabase reconstructs active novelty episodes from detection dates.
-func (t *SpeciesTracker) loadNoveltyEpisodesFromDatabase(now time.Time) error {
+func (t *SpeciesTracker) loadNoveltyEpisodesFromDatabase(ctx context.Context, now time.Time) error {
 	history, ok := t.ds.(speciesDetectionHistoryDatastore)
 	if !ok {
 		return nil
 	}
 
-	ctx := context.Background()
 	endDate := trackerDateOnly(now)
 	startDate := endDate.AddDate(0, 0, -(t.windowDays + 1))
 
@@ -327,13 +340,12 @@ func sameTrackerDate(a, b time.Time) bool {
 }
 
 // loadYearlyDataFromDatabase loads first detection data for the current year
-func (t *SpeciesTracker) loadYearlyDataFromDatabase(now time.Time) error {
+func (t *SpeciesTracker) loadYearlyDataFromDatabase(ctx context.Context, now time.Time) error {
 	startDate, endDate := t.getYearDateRange(now)
 
 	// Use GetSpeciesFirstDetectionInPeriod for yearly tracking
-	// TODO(graceful-shutdown): Accept context parameter for graceful cancellation
 	// TODO(telemetry): Report database load failures to internal/telemetry
-	yearlyData, err := t.ds.GetSpeciesFirstDetectionInPeriod(context.Background(), startDate, endDate, defaultDBQueryLimit, 0)
+	yearlyData, err := t.ds.GetSpeciesFirstDetectionInPeriod(ctx, startDate, endDate, defaultDBQueryLimit, 0)
 	if err != nil {
 		return errors.Newf("failed to load yearly species data from database: %w", err).
 			Component("new-species-tracker").
@@ -383,7 +395,7 @@ func (t *SpeciesTracker) loadYearlyDataFromDatabase(now time.Time) error {
 }
 
 // loadSingleSeasonData loads data for a single season from the database.
-func (t *SpeciesTracker) loadSingleSeasonData(seasonName string, now time.Time) (map[string]time.Time, error) {
+func (t *SpeciesTracker) loadSingleSeasonData(ctx context.Context, seasonName string, now time.Time) (map[string]time.Time, error) {
 	startDate, endDate := t.getSeasonDateRange(seasonName, now)
 
 	getLog().Debug("Loading data for season",
@@ -392,9 +404,8 @@ func (t *SpeciesTracker) loadSingleSeasonData(seasonName string, now time.Time) 
 		logger.String("end_date", endDate))
 
 	// Get first detection of each species within this season period
-	// TODO(graceful-shutdown): Accept context parameter for cancellation during shutdown
 	// TODO(telemetry): Report seasonal data load failures to internal/telemetry
-	seasonalData, err := t.ds.GetSpeciesFirstDetectionInPeriod(context.Background(), startDate, endDate, defaultDBQueryLimit, 0)
+	seasonalData, err := t.ds.GetSpeciesFirstDetectionInPeriod(ctx, startDate, endDate, defaultDBQueryLimit, 0)
 	if err != nil {
 		return nil, errors.Newf("failed to load seasonal species data from database for %s: %w", seasonName, err).
 			Component("new-species-tracker").
@@ -443,7 +454,7 @@ func (t *SpeciesTracker) allSeasonsEmpty() bool {
 }
 
 // loadSeasonalDataFromDatabase loads first detection data for each season in the current year
-func (t *SpeciesTracker) loadSeasonalDataFromDatabase(now time.Time) error {
+func (t *SpeciesTracker) loadSeasonalDataFromDatabase(ctx context.Context, now time.Time) error {
 	// Preserve existing seasonal maps if we have them
 	existingSeasonData := t.speciesBySeason
 	hasExistingData := len(existingSeasonData) > 0
@@ -456,7 +467,7 @@ func (t *SpeciesTracker) loadSeasonalDataFromDatabase(now time.Time) error {
 		logger.Bool("has_existing_data", hasExistingData))
 
 	for seasonName := range t.seasons {
-		seasonMap, err := t.loadSingleSeasonData(seasonName, now)
+		seasonMap, err := t.loadSingleSeasonData(ctx, seasonName, now)
 		if err != nil {
 			return err
 		}
@@ -474,11 +485,21 @@ func (t *SpeciesTracker) loadSeasonalDataFromDatabase(now time.Time) error {
 
 // loadNotificationHistoryFromDatabase loads recent notification history from database
 // This prevents duplicate "new species" notifications after restart (BG-17 fix)
-func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(now time.Time) error {
+func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(ctx context.Context, now time.Time) error {
 	// Only load if notification suppression is enabled
 	if t.notificationSuppressionWindow <= 0 {
 		getLog().Debug("Notification suppression disabled, skipping history load")
 		return nil
+	}
+
+	// This is the last load step and GetActiveNotificationHistory takes no context,
+	// so honor a cancelled load (shutdown during warm-up) by skipping it here rather
+	// than issuing one more query. Treated as a clean skip, not an error.
+	select {
+	case <-ctx.Done():
+		getLog().Debug("Notification history load skipped: initialization cancelled")
+		return nil
+	default:
 	}
 
 	// Load notifications from past 2x suppression window to ensure coverage

--- a/internal/analysis/species/maintenance.go
+++ b/internal/analysis/species/maintenance.go
@@ -348,6 +348,13 @@ func (t *SpeciesTracker) CleanupOldNotificationRecords(currentTime time.Time) in
 // This should be called during application shutdown or when the tracker is no longer needed.
 // It waits for any in-flight async database operations to complete before returning.
 func (t *SpeciesTracker) Close() error {
+	// Cancel any in-flight background historical load first so shutdown does not
+	// block on a long DB scan started by InitFromDatabaseAsync. Done lock-free
+	// (the loader holds t.mu for the scan), and cancel is idempotent.
+	if cancel := t.initCancel.Load(); cancel != nil {
+		(*cancel)()
+	}
+
 	// Wait for any in-flight async database operations (notification persistence/cleanup)
 	// This prevents goroutine leaks and ensures data is persisted before shutdown
 	t.asyncOpsWg.Wait()

--- a/internal/analysis/species/novelty_test.go
+++ b/internal/analysis/species/novelty_test.go
@@ -119,8 +119,8 @@ func TestLoadNoveltyEpisodesFromDatabase_RestoresActiveEpisode(t *testing.T) {
 
 	tracker := testNoveltyTracker(7)
 	tracker.ds = ds
-	require.NoError(t, tracker.loadLifetimeDataFromDatabase(now))
-	require.NoError(t, tracker.loadNoveltyEpisodesFromDatabase(now))
+	require.NoError(t, tracker.loadLifetimeDataFromDatabase(t.Context(), now))
+	require.NoError(t, tracker.loadNoveltyEpisodesFromDatabase(t.Context(), now))
 
 	_, _, novelty := tracker.CheckAndUpdateSpeciesWithNovelty(scientificName, now.Add(2*time.Hour))
 
@@ -196,8 +196,8 @@ func TestLoadNoveltyEpisodesFromDatabase(t *testing.T) {
 
 			tracker := testNoveltyTracker(7)
 			tracker.ds = tt.ds
-			require.NoError(t, tracker.loadLifetimeDataFromDatabase(now))
-			require.NoError(t, tracker.loadNoveltyEpisodesFromDatabase(now))
+			require.NoError(t, tracker.loadLifetimeDataFromDatabase(t.Context(), now))
+			require.NoError(t, tracker.loadNoveltyEpisodesFromDatabase(t.Context(), now))
 
 			// Inspect the restored episode directly, before any new detection
 			// re-runs the live path and overwrites the restored value.

--- a/internal/analysis/species/species_tracker.go
+++ b/internal/analysis/species/species_tracker.go
@@ -25,6 +25,14 @@ const (
 	// Capacity hints for map allocations
 	initialSpeciesCapacity = 100 // Initial capacity for species maps
 
+	// speciesTrackerInitTimeout bounds the background warm-up load so a stalled
+	// datastore query cannot keep the tracker suppressed forever or block
+	// shutdown indefinitely. It is a generous safety net, NOT a tuning knob: the
+	// normal load takes seconds, so this only fires for a genuinely stuck query.
+	// Keep it large; too short would abort a legitimately slow load on a big
+	// database or slow storage and briefly flag every species as new.
+	speciesTrackerInitTimeout = 5 * time.Minute
+
 	// Time calculations
 	hoursPerDay          = 24
 	seasonBufferDays     = 7 // Days buffer for season comparison
@@ -351,8 +359,9 @@ func (t *SpeciesTracker) IsWarming() bool {
 // block startup (notably the HTTP server). The tracker enters the warming state
 // immediately and leaves it once the load finishes, succeed or fail; on failure
 // it still goes live and self-heals from new detections. The load is registered
-// with asyncOpsWg so Close waits for it, and runs under a cancellable context so
-// Close can abort it during shutdown.
+// with asyncOpsWg so Close waits for it, and runs under a cancellable,
+// timeout-bounded context so Close can abort it during shutdown and a stalled
+// query cannot keep the tracker warming forever.
 //
 // Use this on the startup path only. Runtime reconfiguration keeps calling the
 // synchronous InitFromDatabase, which is a rare, user-initiated action; a
@@ -360,7 +369,7 @@ func (t *SpeciesTracker) IsWarming() bool {
 func (t *SpeciesTracker) InitFromDatabaseAsync() {
 	t.warming.Store(true)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), speciesTrackerInitTimeout)
 	t.initCancel.Store(&cancel)
 
 	// Stamp the sync time now, before any detection can flow, so an early

--- a/internal/analysis/species/species_tracker.go
+++ b/internal/analysis/species/species_tracker.go
@@ -7,6 +7,7 @@ package species
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -192,6 +193,29 @@ type SpeciesTracker struct {
 	// Goroutine lifecycle management for graceful shutdown
 	// Tracks in-flight async database operations (notification persistence/cleanup)
 	asyncOpsWg sync.WaitGroup
+
+	// warming is true while the background historical load started by
+	// InitFromDatabaseAsync is in flight. While warming, the public hot-path
+	// methods short-circuit (returning "not new") BEFORE acquiring t.mu, so the
+	// HTTP server stays responsive and no spurious new-species notifications
+	// fire from empty maps. It is an atomic so those guards never block on the
+	// mutex the background load holds. Default false: a directly-constructed
+	// tracker (synchronous InitFromDatabase, or none) behaves normally.
+	//
+	// Guarded methods (suppress while warming): GetSpeciesStatus,
+	// GetBatchSpeciesStatus, UpdateSpecies, IsNewSpecies, CheckAndUpdateSpecies,
+	// CheckAndUpdateSpeciesWithNovelty, GetSpeciesCount. The notification
+	// helpers (ShouldSuppressNotification, RecordNotificationSent) are
+	// intentionally NOT guarded: they are only reached from the new-species
+	// notification branch, which the suppressed isNew already prevents during
+	// warm-up, so they cannot run mid-load.
+	warming atomic.Bool
+
+	// initCancel cancels the in-flight background load started by
+	// InitFromDatabaseAsync. Close calls it (lock-free) so a shutdown landing in
+	// the warm-up window aborts the DB scan instead of blocking on it. nil when
+	// no async load was started.
+	initCancel atomic.Pointer[context.CancelFunc]
 }
 
 // seasonDates represents the start date for a season
@@ -305,7 +329,55 @@ func (t *SpeciesTracker) GetWindowDays() int {
 
 // GetSpeciesCount returns the number of tracked species
 func (t *SpeciesTracker) GetSpeciesCount() int {
+	// During the background warm-up load the maps are still being populated and
+	// the background goroutine holds t.mu; report 0 without blocking.
+	if t.warming.Load() {
+		return 0
+	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return len(t.speciesFirstSeen)
+}
+
+// IsWarming reports whether the background historical load started by
+// InitFromDatabaseAsync is still in flight. While warming, new-species status is
+// suppressed so the tracker never reports a spurious "new species" from an
+// not-yet-populated database load. Intended for tests and diagnostics.
+func (t *SpeciesTracker) IsWarming() bool {
+	return t.warming.Load()
+}
+
+// InitFromDatabaseAsync runs the historical load in the background so it does not
+// block startup (notably the HTTP server). The tracker enters the warming state
+// immediately and leaves it once the load finishes, succeed or fail; on failure
+// it still goes live and self-heals from new detections. The load is registered
+// with asyncOpsWg so Close waits for it, and runs under a cancellable context so
+// Close can abort it during shutdown.
+//
+// Use this on the startup path only. Runtime reconfiguration keeps calling the
+// synchronous InitFromDatabase, which is a rare, user-initiated action; a
+// concurrent SyncIfNeeded reload is harmless (it serializes on t.mu).
+func (t *SpeciesTracker) InitFromDatabaseAsync() {
+	t.warming.Store(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.initCancel.Store(&cancel)
+
+	// Stamp the sync time now, before any detection can flow, so an early
+	// SyncIfNeeded during the warm-up window does not kick off a redundant
+	// second full load on top of this one (lastSyncTime would otherwise be zero).
+	t.mu.Lock()
+	t.lastSyncTime = time.Now()
+	t.mu.Unlock()
+
+	t.asyncOpsWg.Go(func() {
+		defer t.warming.Store(false)
+		defer cancel()
+		if err := t.initFromDatabaseContext(ctx); err != nil {
+			getLog().Error("species tracker background initialization failed; continuing with live detections",
+				logger.Error(err),
+				logger.String("operation", "species_tracker_async_init"),
+				logger.String("impact", "new-species history unavailable until the next successful sync"))
+		}
+	})
 }

--- a/internal/analysis/species/species_tracker_async_init_test.go
+++ b/internal/analysis/species/species_tracker_async_init_test.go
@@ -1,0 +1,209 @@
+// species_tracker_async_init_test.go
+//
+// Tests for asynchronous species-tracker initialization (startup-speed fix).
+// On startup the historical load runs in the background so it does not block
+// the HTTP server. While the load is in flight the tracker is "warming" and
+// must suppress new-species status so it never fires spurious notifications,
+// then resume normal behavior once the load completes.
+
+package species
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+// asyncTestSettings returns lifetime-only tracking settings to keep the mock
+// surface small (yearly/seasonal loads are exercised elsewhere).
+func asyncTestSettings() *conf.SpeciesTrackingSettings {
+	return &conf.SpeciesTrackingSettings{
+		Enabled:              true,
+		NewSpeciesWindowDays: 14,
+		SyncIntervalMinutes:  60,
+		YearlyTracking:       conf.YearlyTrackingSettings{Enabled: false, WindowDays: 7},
+		SeasonalTracking:     conf.SeasonalTrackingSettings{Enabled: false},
+	}
+}
+
+// TestNewTrackerIsNotWarming verifies a directly-constructed tracker behaves
+// normally (not warming) so existing synchronous tests are unaffected.
+func TestNewTrackerIsNotWarming(t *testing.T) {
+	t.Parallel()
+
+	ds := mocks.NewMockInterface(t)
+	tracker := NewTrackerFromSettings(ds, asyncTestSettings())
+
+	assert.False(t, tracker.IsWarming(), "freshly constructed tracker must not be warming")
+}
+
+// TestInitFromDatabaseAsyncSuppressesNewSpeciesWhileWarming validates the core
+// behavior: while the background load is in flight, the tracker reports no new
+// species and records nothing, then serves the loaded historical state once done.
+func TestInitFromDatabaseAsyncSuppressesNewSpeciesWhileWarming(t *testing.T) {
+	t.Parallel()
+
+	unblock := make(chan struct{})
+	ds := mocks.NewMockInterface(t)
+	// Block the first historical query to hold the tracker in the warming state.
+	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) { <-unblock }).
+		Return([]datastore.NewSpeciesData{
+			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-01"}, // 20 days before detection
+		}, nil).Maybe()
+	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+		Return([]datastore.NotificationHistory{}, nil).Maybe()
+	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.NewSpeciesData{}, nil).Maybe()
+	ds.On("GetSpeciesDetectionDatesInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.SpeciesDetectionDate{}, nil).Maybe()
+
+	tracker := NewTrackerFromSettings(ds, asyncTestSettings())
+	tracker.InitFromDatabaseAsync()
+
+	require.True(t, tracker.IsWarming(), "tracker must be warming immediately after async init starts")
+
+	detectionTime := time.Date(2024, 10, 21, 10, 0, 0, 0, time.UTC)
+
+	// While warming: a species that IS in the database must not be flagged new,
+	// and the detection must not be recorded into the (still empty) maps.
+	isNew, _ := tracker.CheckAndUpdateSpecies("Branta canadensis", detectionTime)
+	assert.False(t, isNew, "new-species status must be suppressed while warming")
+	assert.Equal(t, 0, tracker.GetSpeciesCount(), "detections must not be recorded while warming")
+
+	status := tracker.GetSpeciesStatus("Branta canadensis", detectionTime)
+	assert.False(t, status.IsNew, "GetSpeciesStatus must report IsNew=false while warming")
+	// FirstSeenTime must be the zero value while warming: the SSE feed and the
+	// detections REST handler derive "new species" from
+	// !FirstSeenTime.IsZero() && note.Date == FirstSeenTime, so a today-dated
+	// FirstSeenTime here would flag every live detection as new during warm-up.
+	assert.True(t, status.FirstSeenTime.IsZero(), "warming status must leave FirstSeenTime zero to avoid spurious new-species in SSE/detections")
+
+	// Let the background load complete.
+	close(unblock)
+	require.Eventually(t, func() bool { return !tracker.IsWarming() }, 2*time.Second, 10*time.Millisecond,
+		"tracker must leave the warming state after the load completes")
+
+	// After load: the species loaded from the database (first seen 20 days before
+	// the detection, outside the 14-day window) is known, not new.
+	assert.Equal(t, 1, tracker.GetSpeciesCount(), "loaded historical species must be present after warm-up")
+	isNew, days := tracker.CheckAndUpdateSpecies("Branta canadensis", detectionTime)
+	assert.False(t, isNew, "known species must not be flagged new after the load completes")
+	assert.Equal(t, 20, days, "days-since-first must reflect the loaded historical first-seen date")
+}
+
+// TestInitFromDatabaseAsyncGoesLiveOnError verifies the tracker leaves the
+// warming state (goes live) even when the historical load fails, so detections
+// are processed normally afterwards rather than being suppressed forever.
+func TestInitFromDatabaseAsyncGoesLiveOnError(t *testing.T) {
+	t.Parallel()
+
+	ds := mocks.NewMockInterface(t)
+	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.NewSpeciesData(nil), assert.AnError).Maybe()
+	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+		Return([]datastore.NotificationHistory{}, nil).Maybe()
+
+	tracker := NewTrackerFromSettings(ds, asyncTestSettings())
+	tracker.InitFromDatabaseAsync()
+
+	require.Eventually(t, func() bool { return !tracker.IsWarming() }, 2*time.Second, 10*time.Millisecond,
+		"tracker must leave the warming state even when the load fails")
+
+	// Live again: a never-before-seen species is now correctly flagged new.
+	isNew, _ := tracker.CheckAndUpdateSpecies("Turdus merula", time.Now())
+	assert.True(t, isNew, "tracker must process detections normally after a failed load")
+}
+
+// TestInitFromDatabaseAsyncCloseCancelsLoad verifies Close cancels the in-flight
+// background load via context rather than blocking on it until the DB scan ends,
+// so a shutdown landing in the warm-up window returns promptly.
+func TestInitFromDatabaseAsyncCloseCancelsLoad(t *testing.T) {
+	t.Parallel()
+
+	released := make(chan struct{})
+	ds := mocks.NewMockInterface(t)
+	// The load blocks until either the context is cancelled (shutdown) or the
+	// test explicitly releases it, mirroring a long DB scan that honors ctx.
+	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctx, _ := args.Get(0).(context.Context)
+			select {
+			case <-ctx.Done():
+			case <-released:
+			}
+		}).
+		Return([]datastore.NewSpeciesData{}, nil).Maybe()
+	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+		Return([]datastore.NotificationHistory{}, nil).Maybe()
+	ds.On("GetSpeciesDetectionDatesInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.SpeciesDetectionDate{}, nil).Maybe()
+
+	tracker := NewTrackerFromSettings(ds, asyncTestSettings())
+	tracker.InitFromDatabaseAsync()
+	require.True(t, tracker.IsWarming())
+
+	// Close must cancel the load's context and return promptly, not block until
+	// the (otherwise indefinite) scan finishes.
+	done := make(chan error, 1)
+	go func() { done <- tracker.Close() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		close(released) // unblock the goroutine so the test can exit cleanly
+		t.Fatal("Close did not return promptly; the background load was not cancelled")
+	}
+
+	assert.False(t, tracker.IsWarming(), "tracker must leave the warming state after Close cancels the load")
+}
+
+// TestInitFromDatabaseAsyncNoRaceUnderConcurrentDetections drives detections
+// concurrently with the background load to surface data races under -race.
+func TestInitFromDatabaseAsyncNoRaceUnderConcurrentDetections(t *testing.T) {
+	t.Parallel()
+
+	unblock := make(chan struct{})
+	ds := mocks.NewMockInterface(t)
+	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) { <-unblock }).
+		Return([]datastore.NewSpeciesData{
+			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-01"},
+		}, nil).Maybe()
+	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+		Return([]datastore.NotificationHistory{}, nil).Maybe()
+	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.NewSpeciesData{}, nil).Maybe()
+	ds.On("GetSpeciesDetectionDatesInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]datastore.SpeciesDetectionDate{}, nil).Maybe()
+
+	tracker := NewTrackerFromSettings(ds, asyncTestSettings())
+	tracker.InitFromDatabaseAsync()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		now := time.Now()
+		for range 200 {
+			tracker.CheckAndUpdateSpecies("Branta canadensis", now)
+			_ = tracker.GetSpeciesStatus("Branta canadensis", now)
+			_ = tracker.GetSpeciesCount()
+			_ = tracker.IsNewSpecies("Branta canadensis")
+		}
+	}()
+
+	close(unblock)
+	<-done
+	require.Eventually(t, func() bool { return !tracker.IsWarming() }, 2*time.Second, 10*time.Millisecond)
+
+	// Final state reflects the loaded historical data.
+	assert.GreaterOrEqual(t, tracker.GetSpeciesCount(), 1)
+}

--- a/internal/analysis/species/species_tracker_database_reliability_test.go
+++ b/internal/analysis/species/species_tracker_database_reliability_test.go
@@ -135,7 +135,7 @@ func TestLoadLifetimeDataFromDatabase_CriticalReliability(t *testing.T) {
 
 			// Test the critical loadLifetimeDataFromDatabase function
 			now := time.Now()
-			err := tracker.loadLifetimeDataFromDatabase(now)
+			err := tracker.loadLifetimeDataFromDatabase(t.Context(), now)
 
 			if tt.expectedError {
 				require.Error(t, err, "Expected error for scenario: %s", tt.name)
@@ -277,7 +277,7 @@ func TestLoadYearlyDataFromDatabase_CriticalReliability(t *testing.T) {
 			require.NotNil(t, tracker)
 
 			// Test loadYearlyDataFromDatabase directly
-			err := tracker.loadYearlyDataFromDatabase(tt.currentTime)
+			err := tracker.loadYearlyDataFromDatabase(t.Context(), tt.currentTime)
 
 			if tt.expectedError {
 				require.Error(t, err, "Expected error for scenario: %s", tt.name)

--- a/internal/analysis/species/species_tracker_helper_functions_test.go
+++ b/internal/analysis/species/species_tracker_helper_functions_test.go
@@ -250,7 +250,7 @@ func TestLoadNotificationHistoryFromDatabase_EdgeCases(t *testing.T) {
 			tracker := createNotificationTracker(mockDS, tt.suppressionWindow, tt.notificationLastSentNil)
 
 			now := time.Date(2025, 6, 20, 10, 0, 0, 0, time.UTC)
-			err := tracker.loadNotificationHistoryFromDatabase(now)
+			err := tracker.loadNotificationHistoryFromDatabase(t.Context(), now)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -657,7 +657,7 @@ func TestLoadSingleSeasonData_ErrorPaths(t *testing.T) {
 			}
 
 			now := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
-			result, err := tracker.loadSingleSeasonData(tt.seasonName, now)
+			result, err := tracker.loadSingleSeasonData(t.Context(), tt.seasonName, now)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/internal/analysis/species/species_tracker_uncovered_test.go
+++ b/internal/analysis/species/species_tracker_uncovered_test.go
@@ -169,7 +169,7 @@ func TestSpeciesTracker_loadYearlyDataFromDatabase(t *testing.T) {
 
 		tracker := NewTrackerFromSettings(ds, settings)
 		now := time.Now()
-		err := tracker.loadYearlyDataFromDatabase(now)
+		err := tracker.loadYearlyDataFromDatabase(t.Context(), now)
 		require.NoError(t, err)
 
 		// Check data was loaded
@@ -198,7 +198,7 @@ func TestSpeciesTracker_loadYearlyDataFromDatabase(t *testing.T) {
 		tracker.speciesThisYear["Existing"] = time.Now().Add(-20 * 24 * time.Hour)
 
 		now := time.Now()
-		err := tracker.loadYearlyDataFromDatabase(now)
+		err := tracker.loadYearlyDataFromDatabase(t.Context(), now)
 		require.NoError(t, err)
 
 		// Check existing data preserved
@@ -221,7 +221,7 @@ func TestSpeciesTracker_loadYearlyDataFromDatabase(t *testing.T) {
 
 		tracker := NewTrackerFromSettings(ds, settings)
 		now := time.Now()
-		err := tracker.loadYearlyDataFromDatabase(now)
+		err := tracker.loadYearlyDataFromDatabase(t.Context(), now)
 		assert.Error(t, err)
 	})
 }
@@ -269,7 +269,7 @@ func TestSpeciesTracker_loadSeasonalDataFromDatabase(t *testing.T) {
 		tracker.currentSeason = testSeasonSpring
 
 		now := time.Now()
-		err := tracker.loadSeasonalDataFromDatabase(now)
+		err := tracker.loadSeasonalDataFromDatabase(t.Context(), now)
 		require.NoError(t, err)
 
 		// Check data was loaded
@@ -296,7 +296,7 @@ func TestSpeciesTracker_loadSeasonalDataFromDatabase(t *testing.T) {
 		tracker.seasons = nil // No season maps
 
 		now := time.Now()
-		err := tracker.loadSeasonalDataFromDatabase(now)
+		err := tracker.loadSeasonalDataFromDatabase(t.Context(), now)
 		// Should not error but not load anything
 		require.NoError(t, err)
 		if tracker.speciesBySeason != nil {
@@ -334,7 +334,7 @@ func TestSpeciesTracker_loadSeasonalDataFromDatabase(t *testing.T) {
 		tracker.speciesBySeason[testSeasonSpring]["Existing"] = time.Now().Add(-10 * 24 * time.Hour)
 
 		now := time.Now()
-		err := tracker.loadSeasonalDataFromDatabase(now)
+		err := tracker.loadSeasonalDataFromDatabase(t.Context(), now)
 		require.NoError(t, err)
 
 		// Check existing data preserved

--- a/internal/analysis/species/status.go
+++ b/internal/analysis/species/status.go
@@ -9,9 +9,39 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+// warmingSpeciesStatus is the suppressed status returned while the background
+// historical load is in flight. Every "new" flag is false so the warm-up window
+// never produces a spurious new-species result; the periods are reported as
+// unknown (sentinel -1 / empty season) until the load completes.
+//
+// FirstSeenTime is deliberately left as the zero value, not currentTime: some
+// consumers (the SSE feed and the detections REST handler) derive "is new
+// species" as `!FirstSeenTime.IsZero() && note.Date == FirstSeenTime`, so a
+// today-dated FirstSeenTime here would flag every live detection as new during
+// warm-up, exactly the spurious result this suppression exists to prevent.
+func warmingSpeciesStatus(currentTime time.Time) SpeciesStatus {
+	return SpeciesStatus{
+		FirstSeenTime:     time.Time{},
+		IsNew:             false,
+		DaysSinceFirst:    -1,
+		LastUpdatedTime:   currentTime,
+		DaysSinceLastSeen: -1,
+		IsNewThisYear:     false,
+		IsNewThisSeason:   false,
+		DaysThisYear:      -1,
+		DaysThisSeason:    -1,
+	}
+}
+
 // GetSpeciesStatus returns the tracking status for a species with caching for performance
 // This method implements cache-first lookup with TTL validation to minimize expensive computations
 func (t *SpeciesTracker) GetSpeciesStatus(scientificName string, currentTime time.Time) SpeciesStatus {
+	// Suppress new-species status while the background load populates the maps.
+	// Checked before t.mu so it never blocks on the lock the loader holds.
+	if t.warming.Load() {
+		return warmingSpeciesStatus(currentTime)
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -251,6 +281,15 @@ func (t *SpeciesTracker) cleanupExpiredCacheWithForce(currentTime time.Time, for
 func (t *SpeciesTracker) GetBatchSpeciesStatus(scientificNames []string, currentTime time.Time) map[string]SpeciesStatus {
 	if len(scientificNames) == 0 {
 		return make(map[string]SpeciesStatus)
+	}
+
+	// Suppress new-species status while the background load populates the maps.
+	if t.warming.Load() {
+		results := make(map[string]SpeciesStatus, len(scientificNames))
+		for _, scientificName := range scientificNames {
+			results[scientificName] = warmingSpeciesStatus(currentTime)
+		}
+		return results
 	}
 
 	t.mu.Lock()

--- a/internal/analysis/species/update.go
+++ b/internal/analysis/species/update.go
@@ -139,6 +139,13 @@ func (t *SpeciesTracker) updateSeasonalTrackingLocked(scientificName string, det
 // UpdateSpecies updates the first seen time for a species if necessary
 // Returns true if this is a new species detection
 func (t *SpeciesTracker) UpdateSpecies(scientificName string, detectionTime time.Time) bool {
+	// While the background load is in flight the maps are not yet populated, so
+	// every species would look new. Suppress (return not-new) and skip recording;
+	// the detection is still persisted by the caller and tracked from the next one.
+	if t.warming.Load() {
+		return false
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -159,6 +166,12 @@ func (t *SpeciesTracker) UpdateSpecies(scientificName string, detectionTime time
 
 // IsNewSpecies checks if a species is considered "new" within the configured window
 func (t *SpeciesTracker) IsNewSpecies(scientificName string) bool {
+	// Suppress while warming: the maps are empty mid-load, so an unguarded check
+	// would report every species as never-seen-before.
+	if t.warming.Load() {
+		return false
+	}
+
 	t.mu.RLock()
 	firstSeen, exists := t.speciesFirstSeen[scientificName]
 	t.mu.RUnlock()
@@ -227,6 +240,19 @@ func (t *SpeciesTracker) CheckAndUpdateSpecies(scientificName string, detectionT
 // CheckAndUpdateSpeciesWithNovelty atomically checks species status, updates
 // tracking, and returns novelty episode details for alert rules.
 func (t *SpeciesTracker) CheckAndUpdateSpeciesWithNovelty(scientificName string, detectionTime time.Time) (isNew bool, daysSinceFirstSeen int, novelty NoveltyStatus) {
+	// While warming, suppress new-species/novelty and skip recording so the empty
+	// maps cannot produce a spurious first-detection. Checked before t.mu so it
+	// never blocks on the lock the background loader holds.
+	//
+	// daysSinceFirstSeen is 0 here, NOT the -1 "unknown" sentinel used by
+	// warmingSpeciesStatus: this value flows to events.NewDetectionEvent, which
+	// rejects a negative daysSinceFirstSeen. A -1 would drop the ordinary
+	// detection.occurred event for every detection during warm-up and break
+	// alert rules. With isNew=false the value is not interpreted as "new today".
+	if t.warming.Load() {
+		return false, 0, inactiveNoveltyStatus(inactiveNoveltyValue)
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 


### PR DESCRIPTION
## Summary

On startup the species tracker loaded its entire detection history synchronously inside `processor.New`, before the HTTP server started. On large databases (hundreds of thousands of detections, especially on SD-card storage) this blocked the web UI for ~20 seconds or more after a restart.

This moves the historical load to a background goroutine. While it runs, the tracker is "warming": the hot-path methods short-circuit before taking the tracker mutex and report no new species, so the web UI comes up immediately and no spurious "new species" notifications fire from the not-yet-populated maps. The load runs under a cancellable context so shutdown can abort it instead of blocking on the scan.

## What changed

- `warming atomic.Bool` gate with lock-free guards on the new-species read/write paths (`GetSpeciesStatus`, `GetBatchSpeciesStatus`, `UpdateSpecies`, `IsNewSpecies`, `CheckAndUpdateSpecies`/`WithNovelty`, `GetSpeciesCount`).
- The warming status leaves `FirstSeenTime` as the zero value so the SSE feed and detections REST handler (which derive "new species" from `!FirstSeenTime.IsZero() && note.Date == FirstSeenTime`) do not flag live detections as new during warm-up.
- A cancellable context is threaded into the load; `Close()` cancels it on shutdown so a stop during warm-up returns promptly instead of blocking on the DB scan. This also resolves the long-standing graceful-shutdown/timeout TODOs in the load path.
- `lastSyncTime` is stamped when the async load starts so an early periodic sync does not kick off a redundant second full load during warm-up.
- `InitFromDatabase` now clears `statusCache` at the end of the load (also fixes a stale-cache window on runtime reconfigure).

## Behavioral note

A genuinely-new species first detected during the brief warm-up window has its new-species notification delayed to that species' next detection; the detection row itself is always persisted. For repeat-vocalizing birds the practical effect is nil.

## Test Plan

- [x] `go test -race ./internal/analysis/species/ ./internal/analysis/processor/` passes
- [x] `golangci-lint run` clean (0 issues)
- [x] New tests cover warm-up suppression, go-live-on-error, zero `FirstSeenTime`, `Close` cancelling the load, and concurrent detections under `-race`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Species tracker historical loading now runs asynchronously to reduce startup blocking.
  * “New species” and related novelty/status reporting are suppressed until warm-up completes, preventing premature/spurious notifications.
  * Database warm-up is more cancellation-aware, improving consistency during shutdown.
* **Bug Fixes**
  * Shutdown no longer waits on long background scans; termination is faster and more reliable.
* **Tests**
  * Added/updated coverage to validate async initialization, warming suppression behavior, error handling, and race-safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->