### PR TITLE
feat(classifier): log OpenVINO backend selection and decline reason

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -253,22 +253,23 @@ func (bn *BirdNET) usesONNXBackend() bool {
 
 // initializeModel loads and initializes the primary BirdNET model.
 // Dispatches to OpenVINO (A76 image, gated), ONNX, or TFLite (see
-// usesONNXBackend / shouldTryOpenVINO). OpenVINO failures fall back to ONNX.
+// usesONNXBackend / openVINOPlan). OpenVINO failures fall back to ONNX, and a
+// declined OpenVINO attempt is logged with the reason (see logOpenVINODeclined),
+// so the chosen backend is never silent in the journal.
 func (bn *BirdNET) initializeModel() error {
-	if bn.usesONNXBackend() {
-		if bn.shouldTryOpenVINO() {
-			err := bn.initializeOpenVINOModel()
-			if err == nil {
-				return nil
-			}
-			GetLogger().Warn("OpenVINO backend unavailable, falling back to ONNX Runtime", logger.Error(err))
-		} else if bn.Settings.BirdNET.Backend == conf.BackendPrefOpenVINO {
-			GetLogger().Warn("backend is set to 'openvino' but it cannot be used here; using ONNX Runtime",
-				logger.String("reason", "requires the openvino build, the BirdNET v2.4 model, and a supported device (an ARMv8.2/A76+ CPU with native f16, or an Intel OpenVINO GPU)"))
-		}
-		return bn.initializeONNXModel()
+	if !bn.usesONNXBackend() {
+		return bn.initializeTFLiteModel()
 	}
-	return bn.initializeTFLiteModel()
+	if _, ok, reason := bn.openVINOPlan(); ok {
+		err := bn.initializeOpenVINOModel()
+		if err == nil {
+			return nil
+		}
+		GetLogger().Warn("OpenVINO backend unavailable, falling back to ONNX Runtime", logger.Error(err))
+	} else {
+		logOpenVINODeclined(bn.ModelInfo.ID, bn.Settings.BirdNET.Backend, reason)
+	}
+	return bn.initializeONNXModel()
 }
 
 // initializeTFLiteModel loads and initializes a TFLite model as the classifier backend.

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -16,6 +16,19 @@ import (
 // (a single-output graph). Perch v2 uses a different index (see perchLogitsOutputIndex).
 const birdnetLogitsOutputIndex = 0
 
+// OpenVINO decline reasons. openVINOPlanFor / openVINOPlan return one of these as
+// the third value when OpenVINO is not used, so the init path can log exactly why
+// the backend was declined instead of falling back silently (see logOpenVINODeclined).
+const (
+	ovReasonNotBuilt       = "binary not built with OpenVINO support"
+	ovReasonBackendONNX    = "backend is set to onnx"
+	ovReasonGPUUnavailable = "gpu device requested but not available"
+	ovReasonCPUUnsupported = "cpu device not supported on this host (needs an ARMv8.2+/A76 CPU with native f16)"
+	ovReasonNoDevice       = "no supported OpenVINO device (needs an ARMv8.2+/A76 CPU with native f16, or an Intel OpenVINO GPU)"
+	ovReasonNotBirdNETv24  = "model is not the stock BirdNET v2.4 classifier"
+	ovReasonNotPerchNoDFT  = "model is not the Perch no_dft variant"
+)
+
 // openVINOPlan describes how a model should run on the OpenVINO backend.
 type openVINOPlan struct {
 	device      string // inference.OVDeviceCPU or inference.OVDeviceGPU
@@ -25,6 +38,8 @@ type openVINOPlan struct {
 
 // openVINOPlanFor decides whether and how to run a model on the OpenVINO backend,
 // returning the plan and true when OV should be attempted, or false to use ORT.
+// The third return value is a human-readable reason when OV is declined (empty
+// when accepted), so callers can log why instead of falling back silently.
 //
 //   - backendPref:  settings.BirdNET.Backend ("auto"/"onnx"/"openvino").
 //   - devicePref:   settings.BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu").
@@ -40,24 +55,24 @@ type openVINOPlan struct {
 // benchmarking/advanced use. The plan helper loads the OpenVINO core (idempotent)
 // only when it must enumerate devices for a GPU decision, so it is independent of
 // caller ordering.
-func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outputIndex int) (openVINOPlan, bool) {
+func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outputIndex int) (plan openVINOPlan, ok bool, reason string) {
 	if !openvinoBackendAvailable {
-		return openVINOPlan{}, false
+		return openVINOPlan{}, false, ovReasonNotBuilt
 	}
 	if backendPref == conf.BackendPrefONNX {
-		return openVINOPlan{}, false
+		return openVINOPlan{}, false, ovReasonBackendONNX
 	}
 
 	var device string
 	switch devicePref {
 	case conf.OVDeviceGPU:
 		if !openVINOGPUAvailable(libraryPath) {
-			return openVINOPlan{}, false
+			return openVINOPlan{}, false, ovReasonGPUUnavailable
 		}
 		device = inference.OVDeviceGPU
 	case conf.OVDeviceCPU:
 		if !openVINOCPUAllowed(devicePref) {
-			return openVINOPlan{}, false
+			return openVINOPlan{}, false, ovReasonCPUUnsupported
 		}
 		device = inference.OVDeviceCPU
 	default: // "auto" or ""
@@ -67,7 +82,7 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 		case openVINOCPUAllowed(devicePref):
 			device = inference.OVDeviceCPU
 		default:
-			return openVINOPlan{}, false
+			return openVINOPlan{}, false, ovReasonNoDevice
 		}
 	}
 
@@ -75,7 +90,7 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 		device:      device,
 		outputIndex: outputIndex,
 		precision:   openVINOPrecisionFor(modelID, device),
-	}, true
+	}, true, ""
 }
 
 // openVINOPrecisionFor returns the INFERENCE_PRECISION_HINT for a (model, device)
@@ -129,9 +144,9 @@ func openVINOGPUAvailable(libraryPath string) bool {
 // OpenVINO path in the Perch ModelInstance (perch_onnx.go), never through this
 // primary path. The plan carries the device (CPU/GPU), logits output index, and
 // the precision hint (f32 on the GPU for BirdNET v2.4; see openVINOPrecisionFor).
-func (bn *BirdNET) openVINOPlan() (openVINOPlan, bool) {
+func (bn *BirdNET) openVINOPlan() (plan openVINOPlan, ok bool, reason string) {
 	if bn.ModelInfo.ID != DefaultModelVersion {
-		return openVINOPlan{}, false
+		return openVINOPlan{}, false, ovReasonNotBirdNETv24
 	}
 	return openVINOPlanFor(
 		bn.Settings.BirdNET.Backend,
@@ -142,14 +157,49 @@ func (bn *BirdNET) openVINOPlan() (openVINOPlan, bool) {
 	)
 }
 
-// shouldTryOpenVINO reports whether the OpenVINO backend should be attempted for
-// the primary classifier before falling back to ORT. True only when built with
-// the openvino tag, the model is the BirdNET v2.4 identity, config does not opt
-// out, and a supported device is available (ARM A76 f16 CPU, or the Intel iGPU at
-// f32; see openVINOPrecisionFor for why BirdNET v2.4 uses f32 on the GPU).
+// shouldTryOpenVINO reports whether the OpenVINO backend is eligible for the
+// primary classifier: the boolean form of openVINOPlan, dropping the plan and the
+// decline reason. True only when built with the openvino tag, the model is the
+// BirdNET v2.4 identity, config does not opt out, and a supported device is
+// available (ARM A76 f16 CPU, or the Intel iGPU at f32; see openVINOPrecisionFor
+// for why BirdNET v2.4 uses f32 on the GPU). initializeModel calls openVINOPlan
+// directly so it can also log the decline reason; this predicate keeps the
+// eligibility gate independently assertable in tests.
 func (bn *BirdNET) shouldTryOpenVINO() bool {
-	_, ok := bn.openVINOPlan()
+	_, ok, _ := bn.openVINOPlan()
 	return ok
+}
+
+// openVINOPrecisionLabel renders an OpenVINO precision hint for logging. An empty
+// hint means the backend default, which is f16 (see openVINOPrecisionFor).
+func openVINOPrecisionLabel(precision string) string {
+	if precision == "" {
+		return "f16"
+	}
+	return precision
+}
+
+// logOpenVINODeclined logs, once at model init, that the OpenVINO backend was not
+// used and why. It logs at WARN when the user explicitly set backend=openvino
+// (they asked for it and did not get it) and at INFO on the auto path (a normal,
+// expected outcome). In a standard build that cannot use OpenVINO at all, the auto
+// path is suppressed entirely so it does not add a line to every startup; an
+// explicit opt-in on such a build still warns.
+func logOpenVINODeclined(model, backendPref, reason string) {
+	explicit := backendPref == conf.BackendPrefOpenVINO
+	if !openvinoBackendAvailable && !explicit {
+		return
+	}
+	fields := []logger.Field{
+		logger.String("model", model),
+		logger.String("reason", reason),
+	}
+	log := GetLogger()
+	if explicit {
+		log.Warn("OpenVINO requested but not used; using ONNX Runtime", fields...)
+		return
+	}
+	log.Info("OpenVINO not used; using ONNX Runtime", fields...)
 }
 
 // initializeOpenVINOModel loads the FP32 ONNX classifier via the OpenVINO
@@ -161,11 +211,12 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	log := GetLogger()
 	settings := bn.Settings
 
-	plan, ok := bn.openVINOPlan()
+	plan, ok, reason := bn.openVINOPlan()
 	if !ok {
 		return errors.Newf("OpenVINO is not eligible for this model or host").
 			Category(errors.CategoryModelInit).
-			Context("model_id", bn.ModelInfo.ID).Build()
+			Context("model_id", bn.ModelInfo.ID).
+			Context("reason", reason).Build()
 	}
 
 	modelPath := bn.onnxModelPath()
@@ -207,6 +258,7 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	log.Info("OpenVINO model initialized",
 		logger.String("model", modelPath),
 		logger.String("device", plan.device),
+		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
 		logger.Int("species", classifier.NumSpecies()),
 		logger.String("init_time", time.Since(start).String()))
 	return nil

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -3,12 +3,40 @@
 package classifier
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// newCaptureLogger swaps the process-global logger for one that writes to the
+// returned buffer at debug level, restoring the previous logger on cleanup. It is
+// used to assert which lines logOpenVINODeclined emits. Callers must NOT run in
+// parallel: it mutates global state.
+func newCaptureLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	capture := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	cl, err := logger.NewCentralLogger(
+		&logger.LoggingConfig{
+			Console:      &logger.ConsoleOutput{Enabled: false},
+			FileOutput:   &logger.FileOutput{Enabled: false},
+			DefaultLevel: "debug",
+		},
+		capture,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cl.Close() })
+	prev := logger.Global()
+	logger.SetGlobal(cl)
+	t.Cleanup(func() { logger.SetGlobal(prev) })
+	return &buf
+}
 
 // TestShouldTryOpenVINO_FalseWithoutTag verifies that without the openvino build
 // tag, shouldTryOpenVINO returns false regardless of config or CPU state.
@@ -45,4 +73,46 @@ func TestShouldTryOpenVINO_FalseForAutoWithoutTag(t *testing.T) {
 	bn := &BirdNET{Settings: &conf.Settings{}}
 	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
 	assert.False(t, bn.shouldTryOpenVINO())
+}
+
+// TestOpenVINOPlanReason_NotBuilt verifies that in the default (no-tag) build the
+// planner reports the not-built reason for an otherwise-eligible BirdNET v2.4
+// model, so initializeModel can log why OpenVINO was declined rather than falling
+// back silently.
+func TestOpenVINOPlanReason_NotBuilt(t *testing.T) {
+	t.Parallel()
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.ModelInfo = ModelInfo{ID: DefaultModelVersion, Backend: BackendONNX}
+	_, ok, reason := bn.openVINOPlan()
+	assert.False(t, ok)
+	assert.Equal(t, ovReasonNotBuilt, reason)
+}
+
+// TestOpenVINOPlanReason_WrongModel verifies the wrong-model reason short-circuits
+// before the build-tag check, so a non-v2.4 model is reported as such in any build.
+func TestOpenVINOPlanReason_WrongModel(t *testing.T) {
+	t.Parallel()
+	bn := &BirdNET{Settings: &conf.Settings{}}
+	bn.ModelInfo = ModelInfo{ID: "BirdNET_V2.3", Backend: BackendONNX}
+	_, ok, reason := bn.openVINOPlan()
+	assert.False(t, ok)
+	assert.Equal(t, ovReasonNotBirdNETv24, reason)
+}
+
+// TestLogOpenVINODeclined_StandardBuild verifies the noise-control policy on a
+// non-openvino build: the auto path (the common case) stays silent so it does not
+// add a line to every standard-build startup, while an explicit backend=openvino
+// opt-in still warns at WARN so the user learns their request could not be honored.
+// Not parallel: it swaps the process-global logger.
+func TestLogOpenVINODeclined_StandardBuild(t *testing.T) {
+	buf := newCaptureLogger(t)
+
+	logOpenVINODeclined(DefaultModelVersion, conf.BackendPrefAuto, ovReasonNotBuilt)
+	assert.Empty(t, buf.String(), "auto-path decline must be silent on a non-openvino build")
+
+	logOpenVINODeclined(DefaultModelVersion, conf.BackendPrefOpenVINO, ovReasonNotBuilt)
+	out := buf.String()
+	assert.Contains(t, out, "OpenVINO requested but not used", "explicit opt-in must warn even on a non-openvino build")
+	assert.Contains(t, out, ovReasonNotBuilt)
+	assert.Contains(t, out, "level=WARN")
 }

--- a/internal/classifier/openvino_gating_openvino_test.go
+++ b/internal/classifier/openvino_gating_openvino_test.go
@@ -61,19 +61,23 @@ func TestShouldTryOpenVINO_Tagged_HardwareGateDecides(t *testing.T) {
 // path never enumerates devices, so no libopenvino_c is required.
 func TestOpenVINOPlan_ExplicitCPU(t *testing.T) {
 	t.Parallel()
-	plan, ok := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceCPU, RegistryIDPerchV2, "", perchLogitsOutputIndex)
+	plan, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceCPU, RegistryIDPerchV2, "", perchLogitsOutputIndex)
 	expected := cpuspec.HasNativeF16() || runtime.GOARCH == "amd64"
 	assert.Equal(t, expected, ok, "explicit CPU is allowed on ARM A76 or amd64, not on ARM A72")
 	if ok {
 		assert.Equal(t, inference.OVDeviceCPU, plan.device)
 		assert.Equal(t, perchLogitsOutputIndex, plan.outputIndex)
+		assert.Empty(t, reason, "an accepted plan must not carry a decline reason")
+	} else {
+		assert.Equal(t, ovReasonCPUUnsupported, reason, "explicit CPU on an unsupported host reports the cpu reason")
 	}
 }
 
 // TestOpenVINOPlan_ONNXOptOut verifies Backend=onnx opts out for any model,
-// including Perch, without touching the OpenVINO library.
+// including Perch, without touching the OpenVINO library, and reports the reason.
 func TestOpenVINOPlan_ONNXOptOut(t *testing.T) {
 	t.Parallel()
-	_, ok := openVINOPlanFor(conf.BackendPrefONNX, conf.OVDeviceAuto, RegistryIDPerchV2, "", perchLogitsOutputIndex)
+	_, ok, reason := openVINOPlanFor(conf.BackendPrefONNX, conf.OVDeviceAuto, RegistryIDPerchV2, "", perchLogitsOutputIndex)
 	assert.False(t, ok, "Backend=onnx must opt out of OpenVINO for Perch too")
+	assert.Equal(t, ovReasonBackendONNX, reason)
 }

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -144,10 +144,12 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 // dynamic-rank DFT op).
 func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, string, bool) {
 	if !isPerchNoDFT(cfg.ModelPath) {
+		logOpenVINODeclined(RegistryIDPerchV2, cfg.Backend, ovReasonNotPerchNoDFT)
 		return nil, "", false
 	}
-	plan, ok := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDPerchV2, cfg.OpenVINOPath, perchLogitsOutputIndex)
+	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDPerchV2, cfg.OpenVINOPath, perchLogitsOutputIndex)
 	if !ok {
+		logOpenVINODeclined(RegistryIDPerchV2, cfg.Backend, reason)
 		return nil, "", false
 	}
 
@@ -177,6 +179,7 @@ func tryPerchOpenVINO(cfg *PerchConfig, labels []string) (inference.Classifier, 
 
 	log.Info("Perch v2 model using OpenVINO backend",
 		logger.String("device", plan.device),
+		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
 		logger.Int("species", classifier.NumSpecies()),
 		logger.String("init_time", time.Since(start).String()))
 	return classifier, plan.device, true

--- a/internal/classifier/perch_openvino_functional_test.go
+++ b/internal/classifier/perch_openvino_functional_test.go
@@ -51,7 +51,7 @@ func TestPerchOpenVINO_Functional(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = inference.DestroyOpenVINO() })
 
-	c, ok := tryPerchOpenVINO(&cfg, labels)
+	c, _, ok := tryPerchOpenVINO(&cfg, labels)
 	require.True(t, ok, "Perch OpenVINO classifier must be created for the no_dft model")
 	require.NotNil(t, c)
 	t.Cleanup(func() { c.Close() })

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -28,6 +28,13 @@ func setDefaultConfig() {
 	// Core processing modules
 	setModuleLogDefaults("analysis", true)    // Bird detection analysis
 	setModuleLogDefaults("birdnet", true)     // BirdNET model inference
+	// Mirror the birdnet module to the console so backend selection, model-init,
+	// reload, and bat-scheduler lines are visible in journald/containers and not
+	// only in logs/birdnet.log. This realigns the viper default with the intent in
+	// logger/config.go (applyConfigDefaults), which the generated config was
+	// silently overriding. Console mirroring is filtered at the console level
+	// (info), so the module's debug-level per-inference file logs never reach stdout.
+	viper.SetDefault("logging.modules.birdnet.console_also", true)
 	setModuleLogDefaults("audio", true)       // Audio capture/processing
 	setModuleLogDefaults("datastore", true)   // Database operations
 	setModuleLogDefaults("spectrogram", true) // Spectrogram generation


### PR DESCRIPTION
## Summary

Makes the OpenVINO inference backend visible in the logs. Previously, at default INFO level there was no way to tell whether a model ran on OpenVINO or ONNX Runtime, on what device and precision, or why OpenVINO was declined; the `auto` path that silently fell back to ORT logged nothing at all.

- Thread a human-readable decline reason out of `openVINOPlanFor` / `openVINOPlan` and log it once per model at init: INFO on the `auto` path, WARN when the user explicitly set `backend: openvino` but it could not be honored. The reason is suppressed on standard (non-openvino) builds unless explicitly requested, so it does not add a line to every startup.
- Add the resolved precision (`f16`/`f32`) to both OpenVINO success log lines (BirdNET and Perch).
- Realign the `birdnet` logging module's `console_also` default to `true`. The module already intended to mirror to the console (per `internal/logger/config.go`), but the viper default in `internal/conf/defaults.go` materialized `console_also: false` into config.yaml and won, hiding model-init / backend-selection lines from journald and container stdout. Console mirroring is filtered at the console level (info), so the module's debug-level per-inference file logs do not reach stdout.

This is logging only; which backend is actually selected is unchanged.

Also fixes a stale openvino-tagged functional test that assigned 2 values from `tryPerchOpenVINO`, which returns 3.

Note for upgrades: existing `config.yaml` files keep their stored value, so to surface these lines in `journalctl` on an existing install, set `logging.modules.birdnet.console_also: true`.

## Test Plan

- [x] `golangci-lint run` clean on changed packages, both default and `-tags openvino` builds
- [x] `go test -race ./internal/classifier/ ./internal/conf/ ./internal/logger/` passing
- [x] openvino-tagged gating/reason tests passing (`go test -tags openvino`)
- [x] Validated on an A76 Raspberry Pi 5: BirdNET `BirdNET_v2.4_fp32.onnx` logs `OpenVINO model initialized ... device=CPU precision=f16`; stock Perch logs `OpenVINO not used ... reason="model is not the Perch no_dft variant"`; switching Perch to the no_dft model logs `Perch v2 model using OpenVINO backend ... precision=f16`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced decision-making for alternative inference backend selection with explicit decline reasons.
  * Improved diagnostic logging when the alternative backend cannot be used.

* **Logging**
  * BirdNET classifier logs now also output to console, improving visibility alongside dedicated log files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->