### PR TITLE
feat(frontend): hide source badge when only one audio source is active

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/SourceBadge.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SourceBadge.svelte
@@ -40,9 +40,11 @@
       : null
   );
 
-  // Only show the source badge when multiple sources are active — with a single
-  // source every detection shares the same origin, so the label adds no value.
-  // Guests never load settings so counts stay 0 and the badge stays hidden.
+  // For the overlay variant (spectrogram cards): suppress when only one source
+  // is active, since every live detection shares the same origin and the label
+  // adds no value. Inline variant always shows — historical views may contain
+  // detections from sources that have since been disabled, and users need the
+  // label to identify the origin. Guests stay hidden: counts stay 0.
   const MULTIPLE_SOURCES_THRESHOLD = 2;
   let hasMultipleSources = $derived(
     ($settingsStore?.formData?.realtime?.audio?.sources?.length ?? 0) +
@@ -51,7 +53,7 @@
   );
 </script>
 
-{#if sourceLabel && hasMultipleSources}
+{#if sourceLabel && (variant !== 'overlay' || hasMultipleSources)}
   <div
     class={cn(variant === 'overlay' ? 'source-badge-overlay' : 'source-badge-inline', className)}
     title={sourceLabel}

--- a/frontend/src/lib/desktop/features/dashboard/components/SourceBadge.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SourceBadge.svelte
@@ -39,9 +39,19 @@
         )
       : null
   );
+
+  // Only show the source badge when multiple sources are active — with a single
+  // source every detection shares the same origin, so the label adds no value.
+  // Guests never load settings so counts stay 0 and the badge stays hidden.
+  const MULTIPLE_SOURCES_THRESHOLD = 2;
+  let hasMultipleSources = $derived(
+    ($settingsStore?.formData?.realtime?.audio?.sources?.length ?? 0) +
+      ($settingsStore?.formData?.realtime?.rtsp?.streams?.filter(s => s.enabled).length ?? 0) >=
+      MULTIPLE_SOURCES_THRESHOLD
+  );
 </script>
 
-{#if sourceLabel}
+{#if sourceLabel && hasMultipleSources}
   <div
     class={cn(variant === 'overlay' ? 'source-badge-overlay' : 'source-badge-inline', className)}
     title={sourceLabel}


### PR DESCRIPTION
The source badge is redundant when all detections come from the same origin. Gate it on hasMultipleSources (audio sources + enabled RTSP streams >= 2) so it only appears when it actually disambiguates.

## Summary
Only display the source badge in the dashboard when multiple audio/RTSP sources are configured and active. When a single source is in use, the badge provides no value since all detections share the same origin.

## Changes
- Added `hasMultipleSources` derived state that counts active audio sources and enabled RTSP streams
- Updated badge visibility condition to require both a valid source label AND multiple sources
- Added explanatory comments noting that guests never load settings (counts stay 0, badge stays hidden)

## Implementation Details
- Uses a threshold constant (`MULTIPLE_SOURCES_THRESHOLD = 2`) for clarity
- Counts enabled RTSP streams via `.filter(s => s.enabled)` to match actual active sources
- Leverages Svelte 5's `$derived` for reactive computation of the multi-source state

https://claude.ai/code/session_01Wn9DmDpiw9eWrunom8cauw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the Source badge behavior to reduce visual clutter by showing it only when multiple audio or RTSP sources are active; overlay mode is now suppressed for single-source setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->