### PR TITLE
refactor(datastore): thread context through notification-history methods

### DIFF
--- a/internal/analysis/processor/detection_event_test.go
+++ b/internal/analysis/processor/detection_event_test.go
@@ -279,11 +279,11 @@ func TestPublishDetectionEvent_SuppressedNewSpecies(t *testing.T) {
 
 	mockDS := mocks.NewMockInterface(t)
 	mockDS.EXPECT().
-		GetActiveNotificationHistory(mock.AnythingOfType("time.Time")).
+		GetActiveNotificationHistory(mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).
 		Maybe()
 	mockDS.EXPECT().
-		SaveNotificationHistory(mock.AnythingOfType("*datastore.NotificationHistory")).
+		SaveNotificationHistory(mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).
 		Maybe()
 

--- a/internal/analysis/processor/integration_test.go
+++ b/internal/analysis/processor/integration_test.go
@@ -29,16 +29,16 @@ func (m *MockDatastoreAdapter) GetSpeciesFirstDetectionInPeriod(ctx context.Cont
 }
 
 // BG-17 fix: Add notification history methods
-func (m *MockDatastoreAdapter) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
-	return m.ds.GetActiveNotificationHistory(after)
+func (m *MockDatastoreAdapter) GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
+	return m.ds.GetActiveNotificationHistory(ctx, after)
 }
 
-func (m *MockDatastoreAdapter) SaveNotificationHistory(history *datastore.NotificationHistory) error {
-	return m.ds.SaveNotificationHistory(history)
+func (m *MockDatastoreAdapter) SaveNotificationHistory(ctx context.Context, history *datastore.NotificationHistory) error {
+	return m.ds.SaveNotificationHistory(ctx, history)
 }
 
-func (m *MockDatastoreAdapter) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
-	return m.ds.DeleteExpiredNotificationHistory(before)
+func (m *MockDatastoreAdapter) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
+	return m.ds.DeleteExpiredNotificationHistory(ctx, before)
 }
 
 // setupIntegrationTestDB creates a real SQLite database for integration testing

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -338,16 +338,16 @@ func (m *ActionMockDatastore) DeleteThresholdEvents(_ string) error {
 func (m *ActionMockDatastore) DeleteAllThresholdEvents() (int64, error) {
 	return 0, nil
 }
-func (m *ActionMockDatastore) SaveNotificationHistory(_ *datastore.NotificationHistory) error {
+func (m *ActionMockDatastore) SaveNotificationHistory(_ context.Context, _ *datastore.NotificationHistory) error {
 	return nil
 }
-func (m *ActionMockDatastore) GetNotificationHistory(_, _ string) (*datastore.NotificationHistory, error) {
+func (m *ActionMockDatastore) GetNotificationHistory(_ context.Context, _, _ string) (*datastore.NotificationHistory, error) {
 	return nil, datastore.ErrNotificationHistoryNotFound
 }
-func (m *ActionMockDatastore) GetActiveNotificationHistory(_ time.Time) ([]datastore.NotificationHistory, error) {
+func (m *ActionMockDatastore) GetActiveNotificationHistory(_ context.Context, _ time.Time) ([]datastore.NotificationHistory, error) {
 	return nil, nil
 }
-func (m *ActionMockDatastore) DeleteExpiredNotificationHistory(_ time.Time) (int64, error) {
+func (m *ActionMockDatastore) DeleteExpiredNotificationHistory(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
 }
 func (m *ActionMockDatastore) SchemaVersion() string                           { return datastore.SchemaVersionLegacy }

--- a/internal/analysis/processor/notification_timing_test.go
+++ b/internal/analysis/processor/notification_timing_test.go
@@ -35,13 +35,13 @@ func setupMockDatastore(t *testing.T) *mocks.MockInterface {
 	mockDS := mocks.NewMockInterface(t)
 	mockDS.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	mockDS.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	mockDS.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	mockDS.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	mockDS.On("Save", mock.AnythingOfType("*datastore.Note"), mock.Anything).
 		Return(nil).Maybe()
-	mockDS.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	mockDS.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
 	return mockDS
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -325,22 +325,22 @@ func (m *MockDatastore) DeleteAllThresholdEvents() (int64, error) {
 }
 
 // BG-17 fix: Add notification history methods
-func (m *MockDatastore) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
+func (m *MockDatastore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
 	return []datastore.NotificationHistory{}, nil
 }
 
-func (m *MockDatastore) GetNotificationHistory(scientificName, notificationType string) (*datastore.NotificationHistory, error) {
+func (m *MockDatastore) GetNotificationHistory(_ context.Context, scientificName, notificationType string) (*datastore.NotificationHistory, error) {
 	return nil, errors.Newf("notification history not found").
 		Component("datastore").
 		Category(errors.CategoryNotFound).
 		Build()
 }
 
-func (m *MockDatastore) SaveNotificationHistory(history *datastore.NotificationHistory) error {
+func (m *MockDatastore) SaveNotificationHistory(_ context.Context, history *datastore.NotificationHistory) error {
 	return nil
 }
 
-func (m *MockDatastore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
+func (m *MockDatastore) DeleteExpiredNotificationHistory(_ context.Context, before time.Time) (int64, error) {
 	return 0, nil
 }
 

--- a/internal/analysis/species/database.go
+++ b/internal/analysis/species/database.go
@@ -492,9 +492,9 @@ func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(ctx context.Context
 		return nil
 	}
 
-	// This is the last load step and GetActiveNotificationHistory takes no context,
-	// so honor a cancelled load (shutdown during warm-up) by skipping it here rather
-	// than issuing one more query. Treated as a clean skip, not an error.
+	// This is the last load step. GetActiveNotificationHistory honors ctx, but
+	// short-circuit here on an already-cancelled load (shutdown during warm-up) to
+	// skip issuing one more query. Treated as a clean skip, not an error.
 	select {
 	case <-ctx.Done():
 		getLog().Debug("Notification history load skipped: initialization cancelled")
@@ -511,7 +511,7 @@ func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(ctx context.Context
 		logger.Duration("suppression_window", t.notificationSuppressionWindow))
 
 	// Get notification history from database
-	histories, err := t.ds.GetActiveNotificationHistory(lookbackTime)
+	histories, err := t.ds.GetActiveNotificationHistory(ctx, lookbackTime)
 	if err != nil {
 		return errors.Newf("failed to load notification history from database: %w", err).
 			Component("new-species-tracker").

--- a/internal/analysis/species/maintenance.go
+++ b/internal/analysis/species/maintenance.go
@@ -3,6 +3,7 @@
 package species
 
 import (
+	"context"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -263,14 +264,14 @@ func (t *SpeciesTracker) RecordNotificationSent(scientificName string, sentTime 
 		logger.String("sent_time", sentTime.Format(time.DateTime)))
 
 	// Persist to database asynchronously to avoid blocking (BG-17 fix)
-	// This ensures notification suppression state survives application restarts
-	//
-	// Note: Database methods don't accept context, so timeout cannot be enforced.
-	// However, SQLite is local and GORM has internal timeouts, so hangs are unlikely.
-	// If a goroutine does leak due to database hang, in-memory suppression still works.
-	// TODO(BG-17): Consider adding context.Context parameter to SaveNotificationHistory interface
+	// This ensures notification suppression state survives application restarts.
+	// The write runs under a bounded context so a stuck SQLite write cannot leak
+	// this goroutine; in-memory suppression still works if the persist fails.
 	if t.ds != nil {
 		t.asyncOpsWg.Go(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), notificationPersistTimeout)
+			defer cancel()
+
 			// ExpiresAt = when the suppression ends (sentTime + suppressionWindow)
 			expiresAt := sentTime.Add(t.notificationSuppressionWindow)
 			history := &datastore.NotificationHistory{
@@ -282,7 +283,7 @@ func (t *SpeciesTracker) RecordNotificationSent(scientificName string, sentTime 
 				UpdatedAt:        sentTime,
 			}
 
-			if err := t.ds.SaveNotificationHistory(history); err != nil {
+			if err := t.ds.SaveNotificationHistory(ctx, history); err != nil {
 				getLog().Error("Failed to save notification history to database",
 					logger.String("species", scientificName),
 					logger.Error(err),
@@ -320,15 +321,15 @@ func (t *SpeciesTracker) CleanupOldNotificationRecords(currentTime time.Time) in
 	}
 
 	// Clean up database records asynchronously (BG-17 fix)
-	// Deletes records where ExpiresAt < currentTime (i.e., suppression has expired)
-	//
-	// Note: Database methods don't accept context, so timeout cannot be enforced.
-	// However, SQLite is local and GORM has internal timeouts, so hangs are unlikely.
-	// TODO(BG-17): Consider adding context.Context parameter to DeleteExpiredNotificationHistory interface
+	// Deletes records where ExpiresAt < currentTime (i.e., suppression has expired).
+	// Runs under a bounded context so a stuck delete cannot leak this goroutine.
 	if t.ds != nil {
 		t.asyncOpsWg.Go(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), notificationPersistTimeout)
+			defer cancel()
+
 			// Delete records that have expired (ExpiresAt < now)
-			deletedCount, err := t.ds.DeleteExpiredNotificationHistory(currentTime)
+			deletedCount, err := t.ds.DeleteExpiredNotificationHistory(ctx, currentTime)
 			if err != nil {
 				getLog().Error("Failed to cleanup expired notification history from database",
 					logger.Error(err),

--- a/internal/analysis/species/notification_suppression_test.go
+++ b/internal/analysis/species/notification_suppression_test.go
@@ -23,15 +23,15 @@ func (m *mockSpeciesDatastore) GetSpeciesFirstDetectionInPeriod(ctx context.Cont
 }
 
 // BG-17 fix: Add notification history methods
-func (m *mockSpeciesDatastore) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
+func (m *mockSpeciesDatastore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
 	return []datastore.NotificationHistory{}, nil
 }
 
-func (m *mockSpeciesDatastore) SaveNotificationHistory(history *datastore.NotificationHistory) error {
+func (m *mockSpeciesDatastore) SaveNotificationHistory(_ context.Context, history *datastore.NotificationHistory) error {
 	return nil
 }
 
-func (m *mockSpeciesDatastore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
+func (m *mockSpeciesDatastore) DeleteExpiredNotificationHistory(_ context.Context, before time.Time) (int64, error) {
 	return 0, nil
 }
 

--- a/internal/analysis/species/novelty_test.go
+++ b/internal/analysis/species/novelty_test.go
@@ -224,15 +224,15 @@ func (d *noveltyHistoryDatastore) GetSpeciesFirstDetectionInPeriod(context.Conte
 	return nil, nil
 }
 
-func (d *noveltyHistoryDatastore) GetActiveNotificationHistory(time.Time) ([]datastore.NotificationHistory, error) {
+func (d *noveltyHistoryDatastore) GetActiveNotificationHistory(context.Context, time.Time) ([]datastore.NotificationHistory, error) {
 	return nil, nil
 }
 
-func (d *noveltyHistoryDatastore) SaveNotificationHistory(*datastore.NotificationHistory) error {
+func (d *noveltyHistoryDatastore) SaveNotificationHistory(context.Context, *datastore.NotificationHistory) error {
 	return nil
 }
 
-func (d *noveltyHistoryDatastore) DeleteExpiredNotificationHistory(time.Time) (int64, error) {
+func (d *noveltyHistoryDatastore) DeleteExpiredNotificationHistory(context.Context, time.Time) (int64, error) {
 	return 0, nil
 }
 

--- a/internal/analysis/species/species_tracker.go
+++ b/internal/analysis/species/species_tracker.go
@@ -33,6 +33,11 @@ const (
 	// database or slow storage and briefly flag every species as new.
 	speciesTrackerInitTimeout = 5 * time.Minute
 
+	// notificationPersistTimeout bounds the fire-and-forget notification-history
+	// writes (save/cleanup) so a stuck SQLite write cannot leak a goroutine
+	// indefinitely. These are small local upsert/delete operations.
+	notificationPersistTimeout = 30 * time.Second
+
 	// Time calculations
 	hoursPerDay          = 24
 	seasonBufferDays     = 7 // Days buffer for season comparison
@@ -94,9 +99,9 @@ type SpeciesDatastore interface {
 	GetNewSpeciesDetections(ctx context.Context, startDate, endDate string, limit, offset int) ([]datastore.NewSpeciesData, error)
 	GetSpeciesFirstDetectionInPeriod(ctx context.Context, startDate, endDate string, limit, offset int) ([]datastore.NewSpeciesData, error)
 	// Notification history methods for BG-17 fix
-	GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error)
-	SaveNotificationHistory(history *datastore.NotificationHistory) error
-	DeleteExpiredNotificationHistory(before time.Time) (int64, error)
+	GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]datastore.NotificationHistory, error)
+	SaveNotificationHistory(ctx context.Context, history *datastore.NotificationHistory) error
+	DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error)
 }
 
 type speciesDetectionHistoryDatastore interface {

--- a/internal/analysis/species/species_tracker_additional_test.go
+++ b/internal/analysis/species/species_tracker_additional_test.go
@@ -21,7 +21,7 @@ func TestUpdateSpeciesComprehensive(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -124,7 +124,7 @@ func TestBuildSpeciesStatusLocked(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -340,7 +340,7 @@ func TestConcurrentBatchOperations(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -394,10 +394,10 @@ func TestNotificationSuppressionEdgeCases(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: RecordNotificationSent saves to database (called in subtests)
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
 
 	t.Run("exactly at suppression window boundary", func(t *testing.T) {
@@ -455,13 +455,13 @@ func TestCleanupOldNotificationRecordsLocked(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -509,13 +509,13 @@ func TestEmptySeasonMap(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{

--- a/internal/analysis/species/species_tracker_async_init_test.go
+++ b/internal/analysis/species/species_tracker_async_init_test.go
@@ -58,7 +58,7 @@ func TestInitFromDatabaseAsyncSuppressesNewSpeciesWhileWarming(t *testing.T) {
 		Return([]datastore.NewSpeciesData{
 			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-01"}, // 20 days before detection
 		}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -108,7 +108,7 @@ func TestInitFromDatabaseAsyncGoesLiveOnError(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData(nil), assert.AnError).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	tracker := NewTrackerFromSettings(ds, asyncTestSettings())
@@ -141,7 +141,7 @@ func TestInitFromDatabaseAsyncCloseCancelsLoad(t *testing.T) {
 			}
 		}).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesDetectionDatesInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.SpeciesDetectionDate{}, nil).Maybe()
@@ -178,7 +178,7 @@ func TestInitFromDatabaseAsyncNoRaceUnderConcurrentDetections(t *testing.T) {
 		Return([]datastore.NewSpeciesData{
 			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-01"},
 		}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_business_logic_reliability_test.go
+++ b/internal/analysis/species/species_tracker_business_logic_reliability_test.go
@@ -332,7 +332,7 @@ func TestComputeCurrentSeason_CriticalReliability(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -414,7 +414,7 @@ func TestDateRangeFunctions_CriticalReliability(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_comprehensive_test.go
+++ b/internal/analysis/species/species_tracker_comprehensive_test.go
@@ -153,7 +153,7 @@ func TestDatabaseSyncBug(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(oldData, nil).Once()
 	// BG-17: InitFromDatabase loads notification history (only if NotificationSuppressionHours > 0)
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(oldData, nil).Maybe()
@@ -202,12 +202,12 @@ func TestYearResetLogic(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -299,13 +299,13 @@ func TestNotificationSuppressionSystem(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -345,13 +345,13 @@ func TestNotificationSuppressionWhenDisabled(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -384,13 +384,13 @@ func TestNotificationRecordCleanup(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: RecordNotificationSent saves to database
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
 	// BG-17: CleanupOldNotificationRecords deletes from database
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -740,12 +740,12 @@ func TestLoadYearlyDataError(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(nil, errors.New("yearly data error"))
@@ -776,12 +776,12 @@ func TestLoadSeasonalDataError(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase loads notification history (only if NotificationSuppressionHours > 0)
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	// First call succeeds for yearly, second fails for seasonal
@@ -838,12 +838,12 @@ func TestConcurrentNotificationOperations(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -986,13 +986,13 @@ func TestNotificationSuppressionWithNegativeValue(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{

--- a/internal/analysis/species/species_tracker_coverage_test.go
+++ b/internal/analysis/species/species_tracker_coverage_test.go
@@ -23,12 +23,12 @@ func TestIsNewSpecies(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -69,12 +69,12 @@ func TestGetBatchSpeciesStatus(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -203,12 +203,12 @@ func TestCleanupExpiredCache(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -259,12 +259,12 @@ func TestCleanupExpiredCacheLRU(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -321,12 +321,12 @@ func TestCheckAndUpdateSpeciesAtomic(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -404,12 +404,12 @@ func TestIsSeasonMapInitializedAndCount(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -477,12 +477,12 @@ func TestExpireCacheForTesting(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -523,12 +523,12 @@ func TestClearCacheForTestingMethod(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -573,12 +573,12 @@ func TestShouldSuppressNotificationMethod(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -639,12 +639,12 @@ func TestRecordNotificationSentMethod(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -702,12 +702,12 @@ func TestCleanupOldNotificationRecordsMethod(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -784,12 +784,12 @@ func TestCheckAndResetPeriods(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -915,12 +915,12 @@ func TestPruneOldEntriesComprehensive(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: Notification persistence - async operations
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -1027,15 +1027,15 @@ func TestConcurrentOperationsStress(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: RecordNotificationSent saves to database (called in case 7)
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).Maybe()
 	// BG-17: CleanupOldNotificationRecords deletes from database (called in PruneOldEntries)
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{

--- a/internal/analysis/species/species_tracker_critical_operations_test.go
+++ b/internal/analysis/species/species_tracker_critical_operations_test.go
@@ -181,7 +181,7 @@ func TestUpdateSpecies_CriticalReliability(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase loads notification history (optional - only if suppression enabled)
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -372,7 +372,7 @@ func TestCheckAndResetPeriods_CriticalReliability(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase loads notification history (optional - only if suppression enabled)
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -459,7 +459,7 @@ func TestGetBatchSpeciesStatus_CriticalReliability(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_database_reliability_test.go
+++ b/internal/analysis/species/species_tracker_database_reliability_test.go
@@ -116,7 +116,7 @@ func TestLoadLifetimeDataFromDatabase_CriticalReliability(t *testing.T) {
 			}
 
 			// BG-17: InitFromDatabase requires notification history (optional)
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 			// Mock other required methods (optional based on settings)
@@ -250,7 +250,7 @@ func TestLoadYearlyDataFromDatabase_CriticalReliability(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe() // Lifetime data
 
 			if tt.mockError != nil {
@@ -424,7 +424,7 @@ func TestSyncIfNeeded_CriticalReliability(t *testing.T) {
 			}
 
 			// BG-17: InitFromDatabase requires notification history (optional)
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 			// Always setup for period data calls (optional based on settings)

--- a/internal/analysis/species/species_tracker_fix_validation_test.go
+++ b/internal/analysis/species/species_tracker_fix_validation_test.go
@@ -25,7 +25,7 @@ func TestNegativeDaysFixValidation(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -107,7 +107,7 @@ func TestConcurrentAccessFixValidation(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -195,7 +195,7 @@ func TestPrecisionEdgeCases(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_helper_functions_test.go
+++ b/internal/analysis/species/species_tracker_helper_functions_test.go
@@ -269,7 +269,7 @@ func setupNotificationMock(mockDS *mocks.MockInterface, skipCall bool, histories
 		return
 	}
 	mockDS.EXPECT().
-		GetActiveNotificationHistory(mock.AnythingOfType("time.Time")).
+		GetActiveNotificationHistory(mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(histories, mockErr).
 		Once()
 }

--- a/internal/analysis/species/species_tracker_init_test.go
+++ b/internal/analysis/species/species_tracker_init_test.go
@@ -41,7 +41,7 @@ func TestInitFromDatabase_CriticalReliability(t *testing.T) {
 						{ScientificName: "Lifetime_Species_2", FirstSeenDate: "2024-02-01"},
 					}, nil).Maybe()
 				// BG-17: InitFromDatabase requires notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				// Yearly data
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -101,7 +101,7 @@ func TestInitFromDatabase_CriticalReliability(t *testing.T) {
 				ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()
 				// BG-17: InitFromDatabase now loads notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				// Yearly fails
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -123,7 +123,7 @@ func TestInitFromDatabase_CriticalReliability(t *testing.T) {
 				ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()
 				// BG-17: InitFromDatabase now loads notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				// First season fails
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -144,7 +144,7 @@ func TestInitFromDatabase_CriticalReliability(t *testing.T) {
 				ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()
 				// BG-17: InitFromDatabase now loads notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_integration_test.go
+++ b/internal/analysis/species/species_tracker_integration_test.go
@@ -28,7 +28,7 @@ func TestFullWorkflow_BasicTracking(t *testing.T) {
 	// Setup mock to return empty results for any date range
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// Basic tracking doesn't use yearly/seasonal, so this may not be called
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -107,7 +107,7 @@ func TestFullWorkflow_YearlyTracking(t *testing.T) {
 	// that this species has never been seen before in lifetime tracking
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	// For yearly tracking, return the species data for 2024
@@ -244,7 +244,7 @@ func TestFullWorkflow_CombinedTracking(t *testing.T) {
 	// Setup default mock responses
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 
@@ -386,11 +386,11 @@ func TestFullWorkflow_MemoryManagement(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: PruneOldEntries deletes from database
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).Return(int64(0), nil).Maybe()
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil).Maybe()
 
 	// Verify all mock expectations are met
 	t.Cleanup(func() { ds.AssertExpectations(t) })
@@ -454,13 +454,13 @@ func TestFullWorkflow_NotificationSystem(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: RecordNotificationSent saves to database
-	ds.On("SaveNotificationHistory", mock.AnythingOfType("*datastore.NotificationHistory")).Return(nil).Maybe()
+	ds.On("SaveNotificationHistory", mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).Return(nil).Maybe()
 	// BG-17: CleanupOldNotificationRecords deletes from database
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).Return(int64(0), nil).Maybe()
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).Return(int64(0), nil).Maybe()
 
 	// Verify all mock expectations are met
 	t.Cleanup(func() { ds.AssertExpectations(t) })
@@ -527,7 +527,7 @@ func TestFullWorkflow_PerformanceUnderLoad(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]datastore.NewSpeciesData{}, nil).Maybe()
 

--- a/internal/analysis/species/species_tracker_memory_management_test.go
+++ b/internal/analysis/species/species_tracker_memory_management_test.go
@@ -37,7 +37,7 @@ func createMockTrackerForCache(t *testing.T) *SpeciesTracker {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -218,7 +218,7 @@ func TestCacheLRUEviction_CriticalReliability(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -388,7 +388,7 @@ func TestBuildSpeciesStatusWithBuffer_CriticalReliability(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -490,7 +490,7 @@ func TestConcurrentCacheOperations_CriticalReliability(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_performance_edge_test.go
+++ b/internal/analysis/species/species_tracker_performance_edge_test.go
@@ -232,7 +232,7 @@ func TestCacheEvictionUnderPressure(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_periods_test.go
+++ b/internal/analysis/species/species_tracker_periods_test.go
@@ -28,7 +28,7 @@ func TestSeasonalPeriodInitialization(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -123,7 +123,7 @@ func TestSeasonalTrackingWithNilMaps(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -203,7 +203,7 @@ func TestYearlyTrackingAcrossYearBoundary(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(historicalData, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(historicalData, nil).Maybe()
@@ -281,7 +281,7 @@ func TestSpeciesStatusForDailySummaryCard(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -377,7 +377,7 @@ func TestBatchSpeciesStatusPerformance(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -439,7 +439,7 @@ func BenchmarkBatchSpeciesStatusPerformance(b *testing.B) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -493,7 +493,7 @@ func TestConcurrentSeasonalUpdates(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -557,7 +557,7 @@ func TestSeasonalWindowExpiration(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -624,7 +624,7 @@ func TestSpeciesStatusCaching(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -677,7 +677,7 @@ func TestDefaultSeasonInitialization(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -747,7 +747,7 @@ func TestSeasonMapInitializationOnTransition(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -842,7 +842,7 @@ func TestInitFromDatabaseWithSeasonalTracking(t *testing.T) {
 	ds := mocks.NewMockInterface(t)
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(historicalData, nil).Maybe()
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(historicalData, nil).Maybe()

--- a/internal/analysis/species/species_tracker_race_condition_test.go
+++ b/internal/analysis/species/species_tracker_race_condition_test.go
@@ -31,7 +31,7 @@ func TestRaceConditionInTimeCalculation(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -203,7 +203,7 @@ func TestHighContentionScenario(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_reliability_test.go
+++ b/internal/analysis/species/species_tracker_reliability_test.go
@@ -320,7 +320,7 @@ func TestDatabaseFailureRecovery(t *testing.T) {
 						{ScientificName: "Test_Species", FirstSeenDate: "2024-01-01"},
 					}, nil).Maybe()
 				// BG-17: InitFromDatabase requires notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -329,7 +329,7 @@ func TestDatabaseFailureRecovery(t *testing.T) {
 				ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()
 				// BG-17: InitFromDatabase now loads notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -341,7 +341,7 @@ func TestDatabaseFailureRecovery(t *testing.T) {
 						{ScientificName: "Valid_Species", FirstSeenDate: "2024-01-01"}, // Valid data
 					}, nil).Maybe()
 				// BG-17: InitFromDatabase requires notification history
-				ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+				ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 					Return([]datastore.NotificationHistory{}, nil).Maybe()
 				ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_restart_state_test.go
+++ b/internal/analysis/species/species_tracker_restart_state_test.go
@@ -46,7 +46,7 @@ func TestEmptyTrackerMarksKnownSpeciesAsNew(t *testing.T) {
 			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-25"},
 		}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -100,7 +100,7 @@ func TestCorrectBehaviorWithInitialization(t *testing.T) {
 			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-01"}, // 20 days ago
 		}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -191,7 +191,7 @@ func TestInitFromDatabase_EmptyDatabaseResults(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -302,7 +302,7 @@ func TestLoadLifetimeData_PreservesExistingDataOnEmptyResults(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	// Try to sync - should preserve existing data
@@ -327,7 +327,7 @@ func TestLoadLifetimeData_ReplacesDataOnNewResults(t *testing.T) {
 			{ScientificName: "Species2", FirstSeenDate: "2024-01-02"},
 		}, nil).Once()
 	// BG-17: InitFromDatabase loads notification history (only if NotificationSuppressionHours > 0)
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -378,7 +378,7 @@ func TestRestartScenario_SuccessfulInitialization(t *testing.T) {
 	ds1.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil)
 	// BG-17: InitFromDatabase now loads notification history (only if NotificationSuppressionHours > 0)
-	ds1.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds1.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds1.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -411,7 +411,7 @@ func TestRestartScenario_SuccessfulInitialization(t *testing.T) {
 			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-01"},
 		}, nil)
 	// BG-17: InitFromDatabase now loads notification history (only if NotificationSuppressionHours > 0)
-	ds2.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds2.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds2.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -517,7 +517,7 @@ func TestRecovery_SyncAfterFailedInit(t *testing.T) {
 			{ScientificName: "Branta canadensis", FirstSeenDate: "2024-10-25"},
 		}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -562,7 +562,7 @@ func TestInitFromDatabase_LargeDatasetTimeout(t *testing.T) {
 		}).
 		Return(largeDataset, nil)
 	// BG-17: InitFromDatabase requires notification history (only if NotificationSuppressionHours > 0)
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -614,7 +614,7 @@ func TestInitFromDatabase_LogsSpeciesCount(t *testing.T) {
 			{ScientificName: "Species2", FirstSeenDate: "2024-01-02"},
 		}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_test.go
+++ b/internal/analysis/species/species_tracker_test.go
@@ -43,7 +43,7 @@ func TestSpeciesTracker_NewSpecies(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(historicalData, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	// Create tracker with new species window
@@ -94,7 +94,7 @@ func TestSpeciesTracker_ConcurrentAccess(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -145,7 +145,7 @@ func TestSpeciesTracker_UpdateSpecies(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -196,7 +196,7 @@ func TestSpeciesTracker_EdgeCases(t *testing.T) {
 		ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 			Return(historicalData, nil).Maybe()
 		// BG-17: InitFromDatabase now loads notification history
-		ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+		ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 			Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 		settings := &conf.SpeciesTrackingSettings{
@@ -229,10 +229,10 @@ func TestSpeciesTracker_EdgeCases(t *testing.T) {
 		ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 			Return([]datastore.NewSpeciesData{}, nil).Maybe()
 		// BG-17: InitFromDatabase now loads notification history
-		ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+		ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 			Return([]datastore.NotificationHistory{}, nil).Maybe()
 		// BG-17: CleanupOldNotificationRecords deletes from database
-		ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+		ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 			Return(int64(0), nil).Maybe()
 
 		settings := &conf.SpeciesTrackingSettings{
@@ -278,10 +278,10 @@ func TestSpeciesTracker_PruneOldEntries(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return(historicalData, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// BG-17: CleanupOldNotificationRecords deletes from database
-	ds.On("DeleteExpiredNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("DeleteExpiredNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -323,7 +323,7 @@ func BenchmarkSpeciesTracker_GetSpeciesStatus(b *testing.B) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -366,7 +366,7 @@ func BenchmarkSpeciesTracker_UpdateSpecies(b *testing.B) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -407,7 +407,7 @@ func BenchmarkSpeciesTracker_ConcurrentOperations(b *testing.B) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -460,7 +460,7 @@ func BenchmarkSpeciesTracker_MapMemoryUsage(b *testing.B) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 
 	settings := &conf.SpeciesTrackingSettings{
@@ -510,7 +510,7 @@ func TestNewTrackerFromSettings_BasicConfiguration(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -584,7 +584,7 @@ func TestMultiPeriodTracking_YearlyTracking(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -699,7 +699,7 @@ func TestMultiPeriodTracking_SeasonalTracking(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -799,7 +799,7 @@ func TestMultiPeriodTracking_CrossPeriodScenarios(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -862,7 +862,7 @@ func TestMultiPeriodTracking_SeasonTransition(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	// Mock should return empty data so the test scenario works as expected
 	// The test wants to simulate first detection in spring, then check status in summer
@@ -931,7 +931,7 @@ func TestMultiPeriodTracking_YearReset(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase requires notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/species_tracker_time_edge_test.go
+++ b/internal/analysis/species/species_tracker_time_edge_test.go
@@ -67,7 +67,7 @@ func TestTimeZoneTransitions(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -174,7 +174,7 @@ func TestClockSkewScenarios(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -293,7 +293,7 @@ func TestLeapYearHandling(t *testing.T) {
 			ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
 			// BG-17: InitFromDatabase now loads notification history
-			ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+			ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 				Return([]datastore.NotificationHistory{}, nil).Maybe()
 			ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]datastore.NewSpeciesData{}, nil).Maybe()
@@ -370,7 +370,7 @@ func TestInvalidDetectionTimes(t *testing.T) {
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()
 	// BG-17: InitFromDatabase now loads notification history
-	ds.On("GetActiveNotificationHistory", mock.AnythingOfType("time.Time")).
+	ds.On("GetActiveNotificationHistory", mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).Maybe()
 	ds.On("GetSpeciesFirstDetectionInPeriod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]datastore.NewSpeciesData{}, nil).Maybe()

--- a/internal/analysis/species/test_helpers_test.go
+++ b/internal/analysis/species/test_helpers_test.go
@@ -42,7 +42,7 @@ func createTestTrackerWithMocks(t *testing.T, settings *conf.SpeciesTrackingSett
 
 	// BG-17: InitFromDatabase now loads notification history
 	mockDS.EXPECT().
-		GetActiveNotificationHistory(mock.AnythingOfType("time.Time")).
+		GetActiveNotificationHistory(mock.Anything, mock.AnythingOfType("time.Time")).
 		Return([]datastore.NotificationHistory{}, nil).
 		Maybe() // Conditional - only called if NotificationSuppressionHours > 0
 
@@ -53,12 +53,12 @@ func createTestTrackerWithMocks(t *testing.T, settings *conf.SpeciesTrackingSett
 
 	// BG-17: Notification persistence - async operations called in goroutines
 	mockDS.EXPECT().
-		SaveNotificationHistory(mock.AnythingOfType("*datastore.NotificationHistory")).
+		SaveNotificationHistory(mock.Anything, mock.AnythingOfType("*datastore.NotificationHistory")).
 		Return(nil).
 		Maybe() // Called asynchronously by RecordNotificationSent
 
 	mockDS.EXPECT().
-		DeleteExpiredNotificationHistory(mock.AnythingOfType("time.Time")).
+		DeleteExpiredNotificationHistory(mock.Anything, mock.AnythingOfType("time.Time")).
 		Return(int64(0), nil).
 		Maybe() // Called asynchronously by CleanupOldNotificationRecords
 

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -211,16 +211,10 @@ type Interface interface {
 	DeleteThresholdEvents(speciesName string) error
 	DeleteAllThresholdEvents() (int64, error)
 	// Notification History methods
-	// TODO(BG-17): Add context.Context as first parameter for cancellation/timeout support:
-	//   SaveNotificationHistory(ctx context.Context, history *NotificationHistory) error
-	//   GetNotificationHistory(ctx context.Context, scientificName string, notificationType string) (*NotificationHistory, error)
-	//   GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]NotificationHistory, error)
-	//   DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error)
-	// This requires updating all implementations and call sites (breaking change)
-	SaveNotificationHistory(history *NotificationHistory) error
-	GetNotificationHistory(scientificName string, notificationType string) (*NotificationHistory, error)
-	GetActiveNotificationHistory(after time.Time) ([]NotificationHistory, error)
-	DeleteExpiredNotificationHistory(before time.Time) (int64, error) // Returns count deleted
+	SaveNotificationHistory(ctx context.Context, history *NotificationHistory) error
+	GetNotificationHistory(ctx context.Context, scientificName string, notificationType string) (*NotificationHistory, error)
+	GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]NotificationHistory, error)
+	DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) // Returns count deleted
 	// Database stats method for runtime statistics
 	GetDatabaseStats(ctx context.Context) (*DatabaseStats, error)
 	// PingWithLatency executes a trivial query (SELECT 1) and returns the round-trip time.

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -664,9 +664,9 @@ func (_c *MockInterface_DeleteExpiredDynamicThresholds_Call) RunAndReturn(run fu
 	return _c
 }
 
-// DeleteExpiredNotificationHistory provides a mock function with given fields: before
-func (_m *MockInterface) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
-	ret := _m.Called(before)
+// DeleteExpiredNotificationHistory provides a mock function with given fields: ctx, before
+func (_m *MockInterface) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
+	ret := _m.Called(ctx, before)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteExpiredNotificationHistory")
@@ -674,17 +674,17 @@ func (_m *MockInterface) DeleteExpiredNotificationHistory(before time.Time) (int
 
 	var r0 int64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(time.Time) (int64, error)); ok {
-		return rf(before)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) (int64, error)); ok {
+		return rf(ctx, before)
 	}
-	if rf, ok := ret.Get(0).(func(time.Time) int64); ok {
-		r0 = rf(before)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) int64); ok {
+		r0 = rf(ctx, before)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(time.Time) error); ok {
-		r1 = rf(before)
+	if rf, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
+		r1 = rf(ctx, before)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -698,14 +698,15 @@ type MockInterface_DeleteExpiredNotificationHistory_Call struct {
 }
 
 // DeleteExpiredNotificationHistory is a helper method to define mock.On call
+//   - ctx context.Context
 //   - before time.Time
-func (_e *MockInterface_Expecter) DeleteExpiredNotificationHistory(before interface{}) *MockInterface_DeleteExpiredNotificationHistory_Call {
-	return &MockInterface_DeleteExpiredNotificationHistory_Call{Call: _e.mock.On("DeleteExpiredNotificationHistory", before)}
+func (_e *MockInterface_Expecter) DeleteExpiredNotificationHistory(ctx interface{}, before interface{}) *MockInterface_DeleteExpiredNotificationHistory_Call {
+	return &MockInterface_DeleteExpiredNotificationHistory_Call{Call: _e.mock.On("DeleteExpiredNotificationHistory", ctx, before)}
 }
 
-func (_c *MockInterface_DeleteExpiredNotificationHistory_Call) Run(run func(before time.Time)) *MockInterface_DeleteExpiredNotificationHistory_Call {
+func (_c *MockInterface_DeleteExpiredNotificationHistory_Call) Run(run func(ctx context.Context, before time.Time)) *MockInterface_DeleteExpiredNotificationHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(time.Time))
+		run(args[0].(context.Context), args[1].(time.Time))
 	})
 	return _c
 }
@@ -715,7 +716,7 @@ func (_c *MockInterface_DeleteExpiredNotificationHistory_Call) Return(_a0 int64,
 	return _c
 }
 
-func (_c *MockInterface_DeleteExpiredNotificationHistory_Call) RunAndReturn(run func(time.Time) (int64, error)) *MockInterface_DeleteExpiredNotificationHistory_Call {
+func (_c *MockInterface_DeleteExpiredNotificationHistory_Call) RunAndReturn(run func(context.Context, time.Time) (int64, error)) *MockInterface_DeleteExpiredNotificationHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -960,9 +961,9 @@ func (_c *MockInterface_Get_Call) RunAndReturn(run func(string) (datastore.Note,
 	return _c
 }
 
-// GetActiveNotificationHistory provides a mock function with given fields: after
-func (_m *MockInterface) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
-	ret := _m.Called(after)
+// GetActiveNotificationHistory provides a mock function with given fields: ctx, after
+func (_m *MockInterface) GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
+	ret := _m.Called(ctx, after)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetActiveNotificationHistory")
@@ -970,19 +971,19 @@ func (_m *MockInterface) GetActiveNotificationHistory(after time.Time) ([]datast
 
 	var r0 []datastore.NotificationHistory
 	var r1 error
-	if rf, ok := ret.Get(0).(func(time.Time) ([]datastore.NotificationHistory, error)); ok {
-		return rf(after)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) ([]datastore.NotificationHistory, error)); ok {
+		return rf(ctx, after)
 	}
-	if rf, ok := ret.Get(0).(func(time.Time) []datastore.NotificationHistory); ok {
-		r0 = rf(after)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) []datastore.NotificationHistory); ok {
+		r0 = rf(ctx, after)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]datastore.NotificationHistory)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(time.Time) error); ok {
-		r1 = rf(after)
+	if rf, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
+		r1 = rf(ctx, after)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -996,14 +997,15 @@ type MockInterface_GetActiveNotificationHistory_Call struct {
 }
 
 // GetActiveNotificationHistory is a helper method to define mock.On call
+//   - ctx context.Context
 //   - after time.Time
-func (_e *MockInterface_Expecter) GetActiveNotificationHistory(after interface{}) *MockInterface_GetActiveNotificationHistory_Call {
-	return &MockInterface_GetActiveNotificationHistory_Call{Call: _e.mock.On("GetActiveNotificationHistory", after)}
+func (_e *MockInterface_Expecter) GetActiveNotificationHistory(ctx interface{}, after interface{}) *MockInterface_GetActiveNotificationHistory_Call {
+	return &MockInterface_GetActiveNotificationHistory_Call{Call: _e.mock.On("GetActiveNotificationHistory", ctx, after)}
 }
 
-func (_c *MockInterface_GetActiveNotificationHistory_Call) Run(run func(after time.Time)) *MockInterface_GetActiveNotificationHistory_Call {
+func (_c *MockInterface_GetActiveNotificationHistory_Call) Run(run func(ctx context.Context, after time.Time)) *MockInterface_GetActiveNotificationHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(time.Time))
+		run(args[0].(context.Context), args[1].(time.Time))
 	})
 	return _c
 }
@@ -1013,7 +1015,7 @@ func (_c *MockInterface_GetActiveNotificationHistory_Call) Return(_a0 []datastor
 	return _c
 }
 
-func (_c *MockInterface_GetActiveNotificationHistory_Call) RunAndReturn(run func(time.Time) ([]datastore.NotificationHistory, error)) *MockInterface_GetActiveNotificationHistory_Call {
+func (_c *MockInterface_GetActiveNotificationHistory_Call) RunAndReturn(run func(context.Context, time.Time) ([]datastore.NotificationHistory, error)) *MockInterface_GetActiveNotificationHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3093,9 +3095,9 @@ func (_c *MockInterface_GetNoteReview_Call) RunAndReturn(run func(string) (*data
 	return _c
 }
 
-// GetNotificationHistory provides a mock function with given fields: scientificName, notificationType
-func (_m *MockInterface) GetNotificationHistory(scientificName string, notificationType string) (*datastore.NotificationHistory, error) {
-	ret := _m.Called(scientificName, notificationType)
+// GetNotificationHistory provides a mock function with given fields: ctx, scientificName, notificationType
+func (_m *MockInterface) GetNotificationHistory(ctx context.Context, scientificName string, notificationType string) (*datastore.NotificationHistory, error) {
+	ret := _m.Called(ctx, scientificName, notificationType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetNotificationHistory")
@@ -3103,19 +3105,19 @@ func (_m *MockInterface) GetNotificationHistory(scientificName string, notificat
 
 	var r0 *datastore.NotificationHistory
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*datastore.NotificationHistory, error)); ok {
-		return rf(scientificName, notificationType)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*datastore.NotificationHistory, error)); ok {
+		return rf(ctx, scientificName, notificationType)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) *datastore.NotificationHistory); ok {
-		r0 = rf(scientificName, notificationType)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *datastore.NotificationHistory); ok {
+		r0 = rf(ctx, scientificName, notificationType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*datastore.NotificationHistory)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(scientificName, notificationType)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, scientificName, notificationType)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3129,15 +3131,16 @@ type MockInterface_GetNotificationHistory_Call struct {
 }
 
 // GetNotificationHistory is a helper method to define mock.On call
+//   - ctx context.Context
 //   - scientificName string
 //   - notificationType string
-func (_e *MockInterface_Expecter) GetNotificationHistory(scientificName interface{}, notificationType interface{}) *MockInterface_GetNotificationHistory_Call {
-	return &MockInterface_GetNotificationHistory_Call{Call: _e.mock.On("GetNotificationHistory", scientificName, notificationType)}
+func (_e *MockInterface_Expecter) GetNotificationHistory(ctx interface{}, scientificName interface{}, notificationType interface{}) *MockInterface_GetNotificationHistory_Call {
+	return &MockInterface_GetNotificationHistory_Call{Call: _e.mock.On("GetNotificationHistory", ctx, scientificName, notificationType)}
 }
 
-func (_c *MockInterface_GetNotificationHistory_Call) Run(run func(scientificName string, notificationType string)) *MockInterface_GetNotificationHistory_Call {
+func (_c *MockInterface_GetNotificationHistory_Call) Run(run func(ctx context.Context, scientificName string, notificationType string)) *MockInterface_GetNotificationHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -3147,7 +3150,7 @@ func (_c *MockInterface_GetNotificationHistory_Call) Return(_a0 *datastore.Notif
 	return _c
 }
 
-func (_c *MockInterface_GetNotificationHistory_Call) RunAndReturn(run func(string, string) (*datastore.NotificationHistory, error)) *MockInterface_GetNotificationHistory_Call {
+func (_c *MockInterface_GetNotificationHistory_Call) RunAndReturn(run func(context.Context, string, string) (*datastore.NotificationHistory, error)) *MockInterface_GetNotificationHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4426,17 +4429,17 @@ func (_c *MockInterface_SaveNoteReview_Call) RunAndReturn(run func(*datastore.No
 	return _c
 }
 
-// SaveNotificationHistory provides a mock function with given fields: history
-func (_m *MockInterface) SaveNotificationHistory(history *datastore.NotificationHistory) error {
-	ret := _m.Called(history)
+// SaveNotificationHistory provides a mock function with given fields: ctx, history
+func (_m *MockInterface) SaveNotificationHistory(ctx context.Context, history *datastore.NotificationHistory) error {
+	ret := _m.Called(ctx, history)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SaveNotificationHistory")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*datastore.NotificationHistory) error); ok {
-		r0 = rf(history)
+	if rf, ok := ret.Get(0).(func(context.Context, *datastore.NotificationHistory) error); ok {
+		r0 = rf(ctx, history)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -4450,14 +4453,15 @@ type MockInterface_SaveNotificationHistory_Call struct {
 }
 
 // SaveNotificationHistory is a helper method to define mock.On call
+//   - ctx context.Context
 //   - history *datastore.NotificationHistory
-func (_e *MockInterface_Expecter) SaveNotificationHistory(history interface{}) *MockInterface_SaveNotificationHistory_Call {
-	return &MockInterface_SaveNotificationHistory_Call{Call: _e.mock.On("SaveNotificationHistory", history)}
+func (_e *MockInterface_Expecter) SaveNotificationHistory(ctx interface{}, history interface{}) *MockInterface_SaveNotificationHistory_Call {
+	return &MockInterface_SaveNotificationHistory_Call{Call: _e.mock.On("SaveNotificationHistory", ctx, history)}
 }
 
-func (_c *MockInterface_SaveNotificationHistory_Call) Run(run func(history *datastore.NotificationHistory)) *MockInterface_SaveNotificationHistory_Call {
+func (_c *MockInterface_SaveNotificationHistory_Call) Run(run func(ctx context.Context, history *datastore.NotificationHistory)) *MockInterface_SaveNotificationHistory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*datastore.NotificationHistory))
+		run(args[0].(context.Context), args[1].(*datastore.NotificationHistory))
 	})
 	return _c
 }
@@ -4467,7 +4471,7 @@ func (_c *MockInterface_SaveNotificationHistory_Call) Return(_a0 error) *MockInt
 	return _c
 }
 
-func (_c *MockInterface_SaveNotificationHistory_Call) RunAndReturn(run func(*datastore.NotificationHistory) error) *MockInterface_SaveNotificationHistory_Call {
+func (_c *MockInterface_SaveNotificationHistory_Call) RunAndReturn(run func(context.Context, *datastore.NotificationHistory) error) *MockInterface_SaveNotificationHistory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datastore/notification_history.go
+++ b/internal/datastore/notification_history.go
@@ -22,7 +22,7 @@ import (
 // SaveNotificationHistory saves or updates a notification history record in the database
 // This uses an upsert operation to either create a new record or update an existing one
 // The combination of (ScientificName, NotificationType) is unique
-func (ds *DataStore) SaveNotificationHistory(history *NotificationHistory) error {
+func (ds *DataStore) SaveNotificationHistory(ctx context.Context, history *NotificationHistory) error {
 	if history == nil {
 		return validationError("notification history cannot be nil", "history", nil)
 	}
@@ -39,8 +39,8 @@ func (ds *DataStore) SaveNotificationHistory(history *NotificationHistory) error
 
 	// Upsert: Use GORM's OnConflict clause for efficient upsert
 	// This handles the composite unique index on (scientific_name, notification_type)
-	return RetryOnLock(context.Background(), "save_notification_history", func() error {
-		result := ds.DB.Clauses(clause.OnConflict{
+	return RetryOnLock(ctx, "save_notification_history", func() error {
+		result := ds.DB.WithContext(ctx).Clauses(clause.OnConflict{
 			Columns: []clause.Column{
 				{Name: "scientific_name"},
 				{Name: "notification_type"},
@@ -65,7 +65,7 @@ func (ds *DataStore) SaveNotificationHistory(history *NotificationHistory) error
 }
 
 // GetNotificationHistory retrieves a notification history record for a specific species and type
-func (ds *DataStore) GetNotificationHistory(scientificName, notificationType string) (*NotificationHistory, error) {
+func (ds *DataStore) GetNotificationHistory(ctx context.Context, scientificName, notificationType string) (*NotificationHistory, error) {
 	if scientificName == "" {
 		return nil, validationError("scientific name cannot be empty", "scientific_name", "")
 	}
@@ -74,7 +74,7 @@ func (ds *DataStore) GetNotificationHistory(scientificName, notificationType str
 	}
 
 	var history NotificationHistory
-	err := ds.DB.Where("scientific_name = ? AND notification_type = ?", scientificName, notificationType).
+	err := ds.DB.WithContext(ctx).Where("scientific_name = ? AND notification_type = ?", scientificName, notificationType).
 		First(&history).Error
 
 	if err != nil {
@@ -94,12 +94,12 @@ func (ds *DataStore) GetNotificationHistory(scientificName, notificationType str
 // This is used during initialization to load recent notification history into memory
 // Typical usage: Load notifications from past 2x suppression window (14 days)
 // Currently filters to only "new_species" type as that's the only type consumed by the tracker
-func (ds *DataStore) GetActiveNotificationHistory(after time.Time) ([]NotificationHistory, error) {
+func (ds *DataStore) GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]NotificationHistory, error) {
 	var histories []NotificationHistory
 
 	// Filter by notification_type to reduce data transfer (optimization)
 	// Currently only "new_species" notifications are used by the species tracker
-	err := ds.DB.Where("notification_type = ? AND last_sent >= ?", "new_species", after).
+	err := ds.DB.WithContext(ctx).Where("notification_type = ? AND last_sent >= ?", "new_species", after).
 		Order("last_sent DESC").
 		Find(&histories).Error
 
@@ -116,10 +116,10 @@ func (ds *DataStore) GetActiveNotificationHistory(after time.Time) ([]Notificati
 // DeleteExpiredNotificationHistory removes all notification history records that have expired
 // Returns the count of deleted records
 // This is typically called periodically by a cleanup job
-func (ds *DataStore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
+func (ds *DataStore) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
 	var rowsAffected int64
-	err := RetryOnLock(context.Background(), "delete_expired_notification_history", func() error {
-		result := ds.DB.Where("expires_at < ?", before).Delete(&NotificationHistory{})
+	err := RetryOnLock(ctx, "delete_expired_notification_history", func() error {
+		result := ds.DB.WithContext(ctx).Where("expires_at < ?", before).Delete(&NotificationHistory{})
 		if result.Error != nil {
 			return result.Error
 		}

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -637,7 +637,7 @@ func (s *testLegacyInterface) GetThresholdEvents(speciesName string, limit int) 
 }
 
 // GetActiveNotificationHistory implements datastore.Interface.
-func (s *testLegacyInterface) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
+func (s *testLegacyInterface) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
 	var history []datastore.NotificationHistory
 	err := s.db.Where("expires_at > ?", after).Find(&history).Error
 	return history, err
@@ -782,13 +782,13 @@ func (s *testLegacyInterface) GetRecentThresholdEvents(_ int) ([]datastore.Thres
 }
 func (s *testLegacyInterface) DeleteThresholdEvents(_ string) error     { return nil }
 func (s *testLegacyInterface) DeleteAllThresholdEvents() (int64, error) { return 0, nil }
-func (s *testLegacyInterface) SaveNotificationHistory(_ *datastore.NotificationHistory) error {
+func (s *testLegacyInterface) SaveNotificationHistory(_ context.Context, _ *datastore.NotificationHistory) error {
 	return nil
 }
-func (s *testLegacyInterface) GetNotificationHistory(_, _ string) (*datastore.NotificationHistory, error) {
+func (s *testLegacyInterface) GetNotificationHistory(_ context.Context, _, _ string) (*datastore.NotificationHistory, error) {
 	return nil, nil //nolint:nilnil // stub
 }
-func (s *testLegacyInterface) DeleteExpiredNotificationHistory(_ time.Time) (int64, error) {
+func (s *testLegacyInterface) DeleteExpiredNotificationHistory(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
 }
 func (s *testLegacyInterface) SchemaVersion() string                           { return datastore.SchemaVersionLegacy }

--- a/internal/datastore/v2/migration/worker_auxiliary.go
+++ b/internal/datastore/v2/migration/worker_auxiliary.go
@@ -437,7 +437,7 @@ func (m *AuxiliaryMigrator) migrateNotificationHistory(ctx context.Context, resu
 	}
 
 	// Get active notification history (not expired)
-	legacyHistory, err := m.legacyStore.GetActiveNotificationHistory(time.Now())
+	legacyHistory, err := m.legacyStore.GetActiveNotificationHistory(ctx, time.Now())
 	if err != nil {
 		m.logger.Warn("failed to get legacy notification history", logger.Error(err))
 		result.Notifications.Error = err

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3507,11 +3507,10 @@ func notificationScientificName(h *entities.NotificationHistory) string {
 
 // SaveNotificationHistory saves a notification history entry.
 // Resolves the scientific name to a label ID before saving.
-func (ds *Datastore) SaveNotificationHistory(history *datastore.NotificationHistory) error {
+func (ds *Datastore) SaveNotificationHistory(ctx context.Context, history *datastore.NotificationHistory) error {
 	if ds.notification == nil {
 		return fmt.Errorf("notification repository not configured")
 	}
-	ctx := context.Background()
 
 	// Resolve scientific name to label ID using default model
 	label, err := ds.label.GetOrCreate(ctx, history.ScientificName, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)
@@ -3529,11 +3528,10 @@ func (ds *Datastore) SaveNotificationHistory(history *datastore.NotificationHist
 }
 
 // GetNotificationHistory retrieves a notification history entry.
-func (ds *Datastore) GetNotificationHistory(scientificName, notificationType string) (*datastore.NotificationHistory, error) {
+func (ds *Datastore) GetNotificationHistory(ctx context.Context, scientificName, notificationType string) (*datastore.NotificationHistory, error) {
 	if ds.notification == nil {
 		return nil, datastore.ErrNotificationHistoryNotFound
 	}
-	ctx := context.Background()
 	h, err := ds.notification.GetNotificationHistory(ctx, scientificName, notificationType)
 	if err != nil {
 		return nil, err
@@ -3550,11 +3548,10 @@ func (ds *Datastore) GetNotificationHistory(scientificName, notificationType str
 }
 
 // GetActiveNotificationHistory retrieves active notification history entries.
-func (ds *Datastore) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
+func (ds *Datastore) GetActiveNotificationHistory(ctx context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
 	if ds.notification == nil {
 		return []datastore.NotificationHistory{}, nil
 	}
-	ctx := context.Background()
 	v2Histories, err := ds.notification.GetActiveNotificationHistory(ctx, after)
 	if err != nil {
 		return nil, err
@@ -3576,11 +3573,10 @@ func (ds *Datastore) GetActiveNotificationHistory(after time.Time) ([]datastore.
 }
 
 // DeleteExpiredNotificationHistory deletes expired notification history entries.
-func (ds *Datastore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
+func (ds *Datastore) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
 	if ds.notification == nil {
 		return 0, nil
 	}
-	ctx := context.Background()
 	return ds.notification.DeleteExpiredNotificationHistory(ctx, before)
 }
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3511,6 +3511,9 @@ func (ds *Datastore) SaveNotificationHistory(ctx context.Context, history *datas
 	if ds.notification == nil {
 		return fmt.Errorf("notification repository not configured")
 	}
+	if history == nil {
+		return fmt.Errorf("notification history cannot be nil")
+	}
 
 	// Resolve scientific name to label ID using default model
 	label, err := ds.label.GetOrCreate(ctx, history.ScientificName, ds.defaultModelID, ds.speciesLabelTypeID, ds.avesClassID)

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -848,17 +848,17 @@ func TestV2OnlyDatastore_NotificationHistory(t *testing.T) {
 	}
 
 	// Save history
-	err := ds.SaveNotificationHistory(history)
+	err := ds.SaveNotificationHistory(t.Context(), history)
 	require.NoError(t, err)
 
 	// Get history
-	retrieved, err := ds.GetNotificationHistory("Passer domesticus", "new_species")
+	retrieved, err := ds.GetNotificationHistory(t.Context(), "Passer domesticus", "new_species")
 	require.NoError(t, err)
 	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
 	assert.Equal(t, "new_species", retrieved.NotificationType)
 
 	// Get active history
-	active, err := ds.GetActiveNotificationHistory(time.Now().Add(-1 * time.Hour))
+	active, err := ds.GetActiveNotificationHistory(t.Context(), time.Now().Add(-1*time.Hour))
 	require.NoError(t, err)
 	assert.Len(t, active, 1)
 }

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -295,19 +295,19 @@ func (m *mockStore) GetSpeciesDiversityData(_ context.Context, _, _ string) ([]d
 }
 
 // BG-17 fix: Add notification history methods
-func (m *mockStore) GetActiveNotificationHistory(after time.Time) ([]datastore.NotificationHistory, error) {
+func (m *mockStore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
 	return []datastore.NotificationHistory{}, nil
 }
 
-func (m *mockStore) GetNotificationHistory(scientificName, notificationType string) (*datastore.NotificationHistory, error) {
+func (m *mockStore) GetNotificationHistory(_ context.Context, scientificName, notificationType string) (*datastore.NotificationHistory, error) {
 	return nil, datastore.ErrNotificationHistoryNotFound
 }
 
-func (m *mockStore) SaveNotificationHistory(history *datastore.NotificationHistory) error {
+func (m *mockStore) SaveNotificationHistory(_ context.Context, history *datastore.NotificationHistory) error {
 	return nil
 }
 
-func (m *mockStore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
+func (m *mockStore) DeleteExpiredNotificationHistory(_ context.Context, before time.Time) (int64, error) {
 	return 0, nil
 }
 


### PR DESCRIPTION
## Summary

Completes the long-standing BG-17 plumbing TODO by adding `context.Context` as the first parameter to the four notification-history methods on `datastore.Interface` (`SaveNotificationHistory`, `GetNotificationHistory`, `GetActiveNotificationHistory`, `DeleteExpiredNotificationHistory`) and the `species.SpeciesDatastore` subset. Previously these methods took no context, so the species tracker could not cancel or time-bound them.

## What changed

- **Legacy `DataStore`** threads `ctx` via gorm `WithContext(ctx)` and `RetryOnLock(ctx, ...)`.
- **v2only `Datastore`** uses the caller's `ctx` instead of creating `context.Background()` internally.
- **Species tracker warm-up load** passes its cancellable init context, so a shutdown during warm-up aborts the notification-history query cleanly (clean skip / swallowed non-fatal error) instead of running it to completion.
- **The two fire-and-forget notification writes** (`RecordNotificationSent`, `CleanupOldNotificationRecords`) now run under a 30s bounded context, replacing the previous "goroutine leaks forever on a DB hang" TODO. `RetryOnLock`'s worst-case backoff (~15s) fits comfortably inside the budget.
- Regenerated the datastore mock and updated test mocks/expectations to the new signatures.

Query semantics (WHERE/ORDER/OnConflict) are byte-for-byte unchanged; this is internal interface plumbing only. No DB schema, API, or config change. All methods live under `internal/`, so there are no external consumers of the changed signatures.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)
- [x] `go test -race` passes for `internal/analysis/species`, `internal/analysis/processor`, `internal/imageprovider`, `internal/datastore`, `internal/datastore/v2only`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of notification-history persistence and cleanup by making database operations context-aware for cancellation and timeouts.
  * Added bounded timeouts to asynchronous notification suppression work to reduce the risk of stuck operations and leaked goroutines.
* **Bug Fixes**
  * Prevents extra/unnecessary database calls during shutdown or warm-up cancellation scenarios.
  * Ensures notification-history reads/writes respect the provided request lifecycle for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->