### PR TITLE
perf(datastore): cheaper species first-seen query + SQLite cold-read pragmas

### DIFF
--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -233,7 +233,7 @@ func (s *SQLiteStore) Open() (retErr error) {
 	// happens to execute the statement gets them; new pool connections
 	// remain at SQLite defaults and miss busy_timeout entirely, leading
 	// to immediate "database is locked" errors under concurrency.
-	dsn := buildSQLiteDSN(dbPath, "_journal_mode=WAL&_busy_timeout=30000&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-4000")
+	dsn := buildSQLiteDSN(dbPath, "_journal_mode=WAL&_busy_timeout=30000&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-16000")
 
 	// Open SQLite database with GORM
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
@@ -271,6 +271,16 @@ func (s *SQLiteStore) Open() (retErr error) {
 			Build()
 	}
 	sqlDB.SetMaxOpenConns(1)
+
+	// Enable memory-mapped I/O for reads. mattn/go-sqlite3 has no _mmap_size DSN
+	// param, so set it per-connection; with SetMaxOpenConns(1) and no connection
+	// expiry there is a single long-lived connection, so this one Exec persists.
+	// mmap maps the main DB file (up to the cap or its size) into the page cache,
+	// avoiding read() syscalls; it is read-only and WAL/durability are unaffected.
+	if err := db.Exec(fmt.Sprintf("PRAGMA mmap_size=%d", sqliteMmapSizeBytes)).Error; err != nil {
+		GetLogger().Warn("Failed to set SQLite mmap_size (continuing without memory-mapped reads)",
+			logger.Error(err))
+	}
 
 	// Clean up connection pool if any subsequent initialization step fails.
 	defer func() {
@@ -352,6 +362,12 @@ func (s *SQLiteStore) Open() (retErr error) {
 
 // integrityCheckInterval is how often PRAGMA quick_check runs (24 hours).
 const integrityCheckInterval = 24 * time.Hour
+
+// sqliteMmapSizeBytes caps SQLite's memory-mapped I/O for the main DB file at
+// 256 MiB. This is a max (SQLite maps at most the file size) and consumes virtual
+// address space, not resident memory, so it is safe on small 64-bit hosts and a
+// large win for cold reads on slow storage (e.g. an SD card).
+const sqliteMmapSizeBytes = 256 * 1024 * 1024
 
 // startIntegrityCheckLoop runs PRAGMA quick_check at startup and every 24 hours.
 // Uses the monitoring context for clean shutdown.

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -31,6 +31,12 @@ const defaultGormSlowThreshold = 1 * time.Second
 // Matches the 30s timeout used by the legacy datastore.
 const sqliteBusyTimeoutMs = 30_000
 
+// sqliteMmapSizeBytes caps SQLite's memory-mapped I/O for the main DB file at
+// 256 MiB. It is a max (SQLite maps at most the file size) and consumes virtual
+// address space, not resident memory, so it is safe on small 64-bit hosts and a
+// large win for cold reads on slow storage. Matches the legacy datastore.
+const sqliteMmapSizeBytes = 256 * 1024 * 1024
+
 // walCheckpointInterval is how often a periodic passive WAL checkpoint runs.
 // SQLite's auto-checkpoint (1000 pages) may not fire reliably with connection
 // pooling because the page counter is per-connection. A 5-minute interval
@@ -232,7 +238,7 @@ func NewSQLiteManager(cfg Config) (*SQLiteManager, error) {
 	// connection created by the pool, not just the first one.
 	// Use safe separator in case dbPath already contains query parameters
 	// (e.g., "file::memory:?cache=shared" in tests).
-	pragmas := fmt.Sprintf("_journal_mode=WAL&_busy_timeout=%d&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-4000", sqliteBusyTimeoutMs)
+	pragmas := fmt.Sprintf("_journal_mode=WAL&_busy_timeout=%d&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-16000", sqliteBusyTimeoutMs)
 	sep := "?"
 	if strings.Contains(dbPath, "?") {
 		sep = "&"
@@ -256,6 +262,16 @@ func NewSQLiteManager(cfg Config) (*SQLiteManager, error) {
 		return nil, fmt.Errorf("failed to get underlying database: %w", err)
 	}
 	sqlDB.SetMaxOpenConns(1)
+
+	// Enable memory-mapped I/O for reads. mattn/go-sqlite3 has no _mmap_size DSN
+	// param, so set it per-connection; with SetMaxOpenConns(1) and no connection
+	// expiry there is a single long-lived connection, so this one Exec persists.
+	// mmap maps the main DB file (up to the cap or its size) into the page cache,
+	// avoiding read() syscalls; it is read-only and WAL/durability are unaffected.
+	if err := db.Exec(fmt.Sprintf("PRAGMA mmap_size=%d", sqliteMmapSizeBytes)).Error; err != nil && cfg.Logger != nil {
+		cfg.Logger.Warn("Failed to set SQLite mmap_size (continuing without memory-mapped reads)",
+			logger.Error(err))
+	}
 
 	return &SQLiteManager{
 		db:     db,

--- a/internal/datastore/v2/manager_test.go
+++ b/internal/datastore/v2/manager_test.go
@@ -25,6 +25,24 @@ func TestNewSQLiteManager(t *testing.T) {
 	assert.False(t, mgr.IsMySQL())
 }
 
+// TestNewSQLiteManager_AppliesPerformancePragmas verifies the cold-read tuning
+// pragmas are actually applied to an opened file database: mmap_size (set via a
+// post-open Exec, since mattn has no DSN param) and the larger cache_size (DSN).
+func TestNewSQLiteManager_AppliesPerformancePragmas(t *testing.T) {
+	mgr, err := NewSQLiteManager(Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() })
+
+	var mmap int64
+	require.NoError(t, mgr.DB().Raw("PRAGMA mmap_size").Scan(&mmap).Error)
+	assert.Equal(t, int64(sqliteMmapSizeBytes), mmap,
+		"mmap_size pragma should be applied (confirms the driver build has mmap enabled)")
+
+	var cacheSize int64
+	require.NoError(t, mgr.DB().Raw("PRAGMA cache_size").Scan(&cacheSize).Error)
+	assert.Equal(t, int64(-16000), cacheSize, "cache_size pragma should reflect the DSN value")
+}
+
 func TestSQLiteManager_Initialize(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1660,29 +1660,27 @@ func (r *detectionRepository) GetNewSpecies(ctx context.Context, start, end int6
 
 // GetSpeciesFirstDetectionInPeriod returns the first detection of each species within a date range.
 // Groups by scientific_name to aggregate across all models for the same species.
-// Uses ROW_NUMBER() window function to correctly identify the detection with the earliest timestamp
-// per species, with id as tie-breaker for deterministic results.
+//
+// It uses a plain GROUP BY + MIN(detected_at) rather than a ROW_NUMBER() window
+// function. The only consumer is the species tracker (yearly/seasonal first-seen
+// loads), which uses just scientific_name + first_detected and discards label_id
+// and detection_id; MIN(detected_at) per scientific_name is exactly that first-seen
+// date, and avoids the window function's full per-period sort (a large cost on the
+// startup load). label_id is reported as MIN(label_id) (a representative, not
+// necessarily the first row's label); detection_id is no longer selected (left zero).
 func (r *detectionRepository) GetSpeciesFirstDetectionInPeriod(ctx context.Context, start, end int64, limit, offset int) ([]SpeciesFirstSeen, error) {
 	var results []SpeciesFirstSeen
 
-	// Use window function to rank detections per species (by scientific_name) by timestamp
-	// This ensures we get the actual detection_id that corresponds to the first_detected time
-	// Partitioning by scientific_name aggregates across all models for the same species
 	rawSQL := fmt.Sprintf(`
-		SELECT label_id, scientific_name, first_detected, detection_id
-		FROM (
-			SELECT
-				d.label_id,
-				l.scientific_name,
-				d.detected_at as first_detected,
-				d.id as detection_id,
-				ROW_NUMBER() OVER (PARTITION BY l.scientific_name ORDER BY d.detected_at ASC, d.id ASC) as rn
-			FROM %s d
-			JOIN %s l ON l.id = d.label_id
-			WHERE d.detected_at >= ? AND d.detected_at < ?
-		) ranked
-		WHERE rn = 1
-		ORDER BY first_detected ASC
+		SELECT
+			MIN(d.label_id) as label_id,
+			l.scientific_name,
+			MIN(d.detected_at) as first_detected
+		FROM %s d
+		JOIN %s l ON l.id = d.label_id
+		WHERE d.detected_at >= ? AND d.detected_at < ?
+		GROUP BY l.scientific_name
+		ORDER BY first_detected ASC, l.scientific_name ASC
 		LIMIT ? OFFSET ?
 	`, r.tableName(), r.labelsTable())
 

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -132,6 +132,57 @@ func TestSearch_QueryAndCommonLabelIDs(t *testing.T) {
 	})
 }
 
+// TestGetSpeciesFirstDetectionInPeriod characterizes the per-species first-detection
+// query: period filtering, aggregation across multiple labels of the same scientific
+// name, MIN(detected_at) selection, and ascending order. It must hold for any
+// implementation (window function or GROUP BY+MIN).
+func TestGetSpeciesFirstDetectionInPeriod(t *testing.T) {
+	db := setupDetectionTestDBWithLabels(t)
+	ctx := t.Context()
+	repo := &detectionRepository{db: db}
+
+	// Two species with a single label, plus one species with two labels (two models)
+	// to verify aggregation across labels by scientific_name.
+	corone := createTestLabel(t, db, "Corvus corone", 1)
+	robin := createTestLabel(t, db, "Erithacus rubecula", 1)
+	merulaM1 := createTestLabel(t, db, "Turdus merula", 1)
+	merulaM2 := createTestLabel(t, db, "Turdus merula", 2)
+
+	const start, end int64 = 2000, 4000
+
+	// Corvus corone: two detections in period -> first is 2000.
+	createDetectionForLabel(t, db, corone.ID, 2000)
+	createDetectionForLabel(t, db, corone.ID, 2500)
+	// Erithacus rubecula: one BEFORE the period (excluded), one inside -> first is 3000.
+	createDetectionForLabel(t, db, robin.ID, 1000)
+	createDetectionForLabel(t, db, robin.ID, 3000)
+	// Turdus merula: detections under two different labels; first across both is 2100.
+	createDetectionForLabel(t, db, merulaM1.ID, 2200)
+	createDetectionForLabel(t, db, merulaM2.ID, 2100)
+	// A detection AFTER the period end is excluded (end is exclusive).
+	createDetectionForLabel(t, db, corone.ID, 5000)
+
+	results, err := repo.GetSpeciesFirstDetectionInPeriod(ctx, start, end, 100, 0)
+	require.NoError(t, err)
+
+	// Build a name->firstDetected map for order-independent value checks.
+	got := make(map[string]int64, len(results))
+	for _, r := range results {
+		got[r.ScientificName] = r.FirstDetected
+	}
+	assert.Equal(t, int64(2000), got["Corvus corone"], "corone first detection in period")
+	assert.Equal(t, int64(3000), got["Erithacus rubecula"], "robin first in-period detection (pre-period excluded)")
+	assert.Equal(t, int64(2100), got["Turdus merula"], "merula first across both labels")
+	assert.Len(t, results, 3, "exactly the three species detected within the period")
+
+	// Results are ordered by first_detected ascending.
+	firsts := make([]int64, len(results))
+	for i, r := range results {
+		firsts[i] = r.FirstDetected
+	}
+	assert.Equal(t, []int64{2000, 2100, 3000}, firsts, "ascending by first_detected")
+}
+
 // TestSearch_ScientificLikeNotTruncated guards against the prior 100-row cap: the scientific
 // LIKE runs in SQL and must return all matches, not a capped subset. See issue #3378.
 func TestSearch_ScientificLikeNotTruncated(t *testing.T) {


### PR DESCRIPTION
## Summary

Two low-risk optimizations for the species tracker's startup database load and cold reads in general.

### 1. Drop the window function for first-seen-in-period

`GetSpeciesFirstDetectionInPeriod` (used only by the species tracker for yearly/seasonal first-seen loads) used a `ROW_NUMBER() OVER (PARTITION BY scientific_name ORDER BY detected_at)` window function to recover the `detection_id` of each species' first detection. The window function forces a full per-period sort, but the only caller discards `detection_id` and `label_id` and needs just the first-seen date. Replaced with `GROUP BY scientific_name + MIN(detected_at)`, which gives exactly that without the sort. This also makes the v2 backend consistent with the legacy `notes`-based query (which already used `GROUP BY + MIN`).

Result set is byte-for-byte equivalent for every consumer (v2only wrapper, `convertToNewSpeciesData`, species tracker) - none reads the dropped fields.

### 2. SQLite cold-read pragmas

On both backends: raise the page cache from 4MB to 16MB (`_cache_size`) and enable memory-mapped reads (`PRAGMA mmap_size=256MB`). On a large database on slow storage (e.g. an SD card) this cuts `read()` syscalls on cold reads. mattn/go-sqlite3 has no `_mmap_size` DSN param, so it is set via a post-open `Exec`; both backends use `SetMaxOpenConns(1)` so the single long-lived connection persists it. mmap maps the main DB file read-only; WAL and durability (`synchronous=NORMAL`) are unaffected. The cache bump is ~12MB resident on the single connection.

## Test plan

- [x] New characterization test for `GetSpeciesFirstDetectionInPeriod` (period filtering, cross-label aggregation, MIN selection, ascending order) - passes on both the old and new query
- [x] New test asserting `mmap_size` and `cache_size` pragmas are actually applied on an opened file DB
- [x] `go test -race` passes for `internal/datastore`, `internal/datastore/v2`, `internal/datastore/v2/repository`, `internal/datastore/v2only`, `internal/analysis/species`
- [x] `golangci-lint run` clean (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Increased SQLite cache size for enhanced read performance.
  * Enabled memory-mapped I/O support (up to 256 MiB) for faster database access.
  * Optimized species detection period queries for improved efficiency.

* **Tests**
  * Added test coverage for database performance optimizations.
  * Added test coverage for species detection query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->