### PR TITLE
fix(inference): report live runtime backend and precision on model cards

### DIFF
--- a/frontend/src/lib/desktop/features/system/inference.types.ts
+++ b/frontend/src/lib/desktop/features/system/inference.types.ts
@@ -95,9 +95,20 @@ export interface InferenceLastDetection {
 export interface InferenceModel {
   id: string;
   name: string;
+  /**
+   * Inference execution backend the model is actually running on ("TFLite",
+   * "ONNX", or "OpenVINO"), resolved from the live instance, not the model file
+   * type. An ONNX model executed through the OpenVINO runtime reports "OpenVINO".
+   * Falls back to the static file type when the model is not loaded.
+   */
   backend: string;
   detectionName?: string;
   detectionVersion?: string;
+  /**
+   * Effective runtime precision ("INT8"/"FP16"/"FP32"), which can differ from the
+   * weight precision in the file (e.g. an FP32 ONNX model executed on OpenVINO at
+   * FP16). Absent when unknown.
+   */
   quantization?: string;
   isStock: boolean;
   spec: ModelSpec;

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -287,6 +287,22 @@ func buildModelStatus(info *classifier.ModelInfo, snap inferencestats.PeekSnapsh
 	}
 }
 
+// applyRuntimeBackend overrides a model status's static file metadata (Backend,
+// Quantization) with the live values resolved from the loaded instance: the real
+// execution provider and effective runtime precision. An empty live value means
+// the model is not loaded or the value is unknown, so the static ModelInfo values
+// set by buildModelStatus are kept as the fallback. This is what makes an ONNX
+// model executed on the OpenVINO runtime report "OpenVINO" with its FP16/FP32
+// compute precision instead of the static "ONNX" file type.
+func applyRuntimeBackend(status *InferenceModelStatus, backend, precision string) {
+	if backend != "" {
+		status.Backend = backend
+	}
+	if precision != "" {
+		status.Quantization = precision
+	}
+}
+
 // GetInferenceStatus handles GET /api/v2/system/inference. It returns a
 // read-only snapshot of the inference subsystem: hardware, backends, loaded
 // models with per-model stats and memory, source attachment, and audio pipeline
@@ -345,14 +361,23 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 	counters := classifier.GetInferenceCounters().PeekAll()
 	attachments := buildSourceAttachments(settings, infos, primaryID)
 
-	// Compute per-model device and schedule status from the live orchestrator.
+	// Compute per-model device, backend, precision, and schedule status from the
+	// live orchestrator. Backend and precision come from the loaded instance (the
+	// real execution provider and runtime precision) rather than the static
+	// ModelInfo file metadata, so an ONNX model executed on OpenVINO reports
+	// "OpenVINO" and its effective precision. Empty values fall back to the static
+	// metadata in the assembly loop below.
 	devices := make(map[string]string, len(infos))
+	backends := make(map[string]string, len(infos))
+	precisions := make(map[string]string, len(infos))
 	paused := make(map[string]bool, len(infos))
 	scheduleLabels := make(map[string]string, len(infos))
 	if orch != nil {
 		for i := range infos {
 			id := infos[i].ID
 			devices[id] = orch.GetModelDevice(id)
+			backends[id] = orch.GetModelBackend(id)
+			precisions[id] = orch.GetModelPrecision(id)
 			active, reason := orch.ModelScheduleStatus(id)
 			paused[id] = !active
 			scheduleLabels[id] = reason
@@ -424,6 +449,10 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 		if status.Device == "" {
 			status.Device = deviceUnknown
 		}
+		// Override the static file metadata with the live backend/precision when the
+		// model is loaded (see applyRuntimeBackend); an empty value means "not loaded
+		// / unknown", so the static ModelInfo values set by buildModelStatus survive.
+		applyRuntimeBackend(&status, backends[id], precisions[id])
 		status.Paused = paused[id]
 		status.ScheduleLabel = scheduleLabels[id]
 		status.RecentDetections = recentDetections[id]

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -167,6 +167,42 @@ func TestBuildModelStatus_ZeroInvocations(t *testing.T) {
 	assert.True(t, got.Memory.Approximate, "memory.approximate must always be true")
 }
 
+// TestApplyRuntimeBackend verifies that live backend/precision values override the
+// static file metadata, while empty live values preserve the static fallback that
+// buildModelStatus set. This is the core of the runtime-sourced fix: an ONNX model
+// executed on OpenVINO must report "OpenVINO" with its FP16 compute precision, but
+// a model that is not loaded (empty live values) must keep its static metadata.
+func TestApplyRuntimeBackend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("live values override static file metadata", func(t *testing.T) {
+		t.Parallel()
+		// Static metadata says ONNX/FP32 (the file), live says OpenVINO/FP16 (running).
+		status := InferenceModelStatus{Backend: classifier.BackendONNX, Quantization: string(classifier.QuantizationFP32)}
+		applyRuntimeBackend(&status, classifier.BackendOpenVINO, string(classifier.QuantizationFP16))
+		assert.Equal(t, classifier.BackendOpenVINO, status.Backend, "live backend must win over static ONNX")
+		assert.Equal(t, string(classifier.QuantizationFP16), status.Quantization, "live precision must win over static FP32")
+	})
+
+	t.Run("live precision fills an empty static quantization", func(t *testing.T) {
+		t.Parallel()
+		// Perch has no static quantization; the live INT8 (from the int8_arm filename)
+		// must surface on the card.
+		status := InferenceModelStatus{Backend: classifier.BackendONNX, Quantization: ""}
+		applyRuntimeBackend(&status, classifier.BackendONNX, string(classifier.QuantizationINT8))
+		assert.Equal(t, string(classifier.QuantizationINT8), status.Quantization, "live INT8 must surface for perch_v2_int8_arm")
+	})
+
+	t.Run("empty live values preserve the static fallback", func(t *testing.T) {
+		t.Parallel()
+		// Model not loaded: live values are empty, so the static metadata is kept.
+		status := InferenceModelStatus{Backend: classifier.BackendTFLite, Quantization: string(classifier.QuantizationFP32)}
+		applyRuntimeBackend(&status, "", "")
+		assert.Equal(t, classifier.BackendTFLite, status.Backend, "empty live backend must keep the static value")
+		assert.Equal(t, string(classifier.QuantizationFP32), status.Quantization, "empty live precision must keep the static value")
+	})
+}
+
 // TestGetInferenceStatus_HTTP200 verifies that GetInferenceStatus returns HTTP
 // 200 and a valid InferenceStatusResponse with TFLite marked available. It uses
 // the shared setupTestEnvironment harness (minimalController + Echo) to exercise

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -27,6 +27,12 @@ type Bat struct {
 	// rather than a constant so a future OpenVINO bat path can set the real device
 	// at construction. Reported via Device().
 	device string
+	// backend is the live execution backend (BackendONNX today; the bat pipeline is
+	// ONNX-only), and precision is the weight precision detected from the classifier
+	// model filename (empty when no token). Both set once at construction; reported
+	// via Backend()/Precision().
+	backend   string
+	precision string
 }
 
 // BatModelConfig holds configuration for creating a Bat model instance.
@@ -98,7 +104,11 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 		batClassifier:      batCC,
 		info:               info,
 		// The bat embedding + classifier pipeline is ONNX-only (CPU EP) today.
-		device: deviceCPU,
+		device:  deviceCPU,
+		backend: BackendONNX,
+		// Surface the weight precision detected from the classifier model filename
+		// (empty when no token, which is the common case for the bat model).
+		precision: string(detectQuantization(cfg.ClassifierModelPath)),
 	}, nil
 }
 
@@ -263,6 +273,16 @@ func (b *Bat) Labels() []string {
 // model is ONNX-only). Set once at construction and never mutated, so no lock is
 // needed. Implements ModelInstance.
 func (b *Bat) Device() string { return b.device }
+
+// Backend returns the live execution backend the bat pipeline bound to
+// (BackendONNX today). Set once at construction and never mutated, so no lock is
+// needed. Implements ModelInstance.
+func (b *Bat) Backend() string { return b.backend }
+
+// Precision returns the weight precision detected from the bat classifier model
+// filename (empty when no token). Set once at construction and never mutated, so
+// no lock is needed. Implements ModelInstance.
+func (b *Bat) Precision() string { return b.precision }
 
 // Close releases resources held by the bat model.
 func (b *Bat) Close() error {

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -68,6 +68,14 @@ type BirdNET struct {
 	// by each initialize*Model path and defaults to deviceCPU in NewBirdNET so a
 	// path that forgets to set it still reports a sane value. Reported via Device().
 	device string
+	// backend is the inference execution backend bound to at load time
+	// (BackendTFLite/BackendONNX/BackendOpenVINO), and precision is the effective
+	// runtime precision the model executes at ("INT8"/"FP16"/"FP32"). Both mirror
+	// device: set by each initialize*Model path so the inference status card reports
+	// what is really running rather than the static ModelInfo file metadata.
+	// Reported via Backend()/Precision(); guarded by mu like device.
+	backend   string
+	precision string
 	// mu guards the inference backends (classifier, rangeFilter, rangeFilterFellBack).
 	// Inference holds mu for the full duration of the native call, not just the field
 	// read: the backends are not goroutine-safe and reload/Delete Close() them under
@@ -154,6 +162,13 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 	// resolved v2.4 TFLite model (from version:"2.4" or the default) to the INT8
 	// ONNX entry so existing arm64 configs keep starting without a TFLite backend.
 	bn.ModelInfo = remapV24ForONNXOnly(&bn.ModelInfo, tfliteBackendAvailable, findModelPathInStandardPaths)
+
+	// Seed backend/precision from the resolved static metadata so a model that
+	// somehow loads without an initialize*Model path still reports a sane value
+	// (mirrors the device default). Each init path overrides these with the real
+	// load-time backend and effective runtime precision.
+	bn.backend = bn.ModelInfo.Backend
+	bn.precision = string(bn.ModelInfo.Quantization)
 
 	// Load taxonomy data
 	bn.TaxonomyMap, bn.ScientificIndex, err = LoadTaxonomyData(bn.TaxonomyPath)
@@ -309,6 +324,10 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 	bn.classifier = classifier
 	// TFLite runs on CPU (the optional XNNPACK delegate is still CPU execution).
 	bn.device = deviceCPU
+	// TFLite executes the model file as-is, so the runtime precision is the weight
+	// precision recorded in ModelInfo.Quantization (FP32 for the stock v2.4 model).
+	bn.backend = BackendTFLite
+	bn.precision = string(bn.ModelInfo.Quantization)
 
 	// Update the human-readable model version string for display when a custom
 	// model path is provided. Model identity (ModelInfo.ID) is never modified
@@ -1472,6 +1491,27 @@ func (bn *BirdNET) Device() string {
 	bn.mu.Lock()
 	defer bn.mu.Unlock()
 	return bn.device
+}
+
+// Backend returns the inference execution backend this model loaded on
+// (BackendTFLite/BackendONNX/BackendOpenVINO). Guarded by bn.mu because
+// reloadModelInternal rewrites bn.backend under the same lock when re-initializing
+// the backend. Implements ModelInstance.
+func (bn *BirdNET) Backend() string {
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+	return bn.backend
+}
+
+// Precision returns the effective runtime precision this model executes at
+// ("INT8"/"FP16"/"FP32"), which can differ from the weight precision stored in
+// the file (BirdNET v2.4 runs the FP32 ONNX model at FP16 on OpenVINO CPU).
+// Guarded by bn.mu because reloadModelInternal rewrites bn.precision under the
+// same lock. Implements ModelInstance.
+func (bn *BirdNET) Precision() string {
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+	return bn.precision
 }
 
 // ReloadSnapshot returns a copy of the model metadata and taxonomy maps safely under bn.mu.

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -32,6 +32,8 @@ func (f *fakeModelInstance) NumSpecies() int      { return len(f.labels) }
 func (f *fakeModelInstance) Labels() []string     { return f.labels }
 func (f *fakeModelInstance) Close() error         { return nil }
 func (f *fakeModelInstance) Device() string       { return deviceCPU }
+func (f *fakeModelInstance) Backend() string      { return BackendONNX }
+func (f *fakeModelInstance) Precision() string    { return "" }
 
 func TestShouldAutoSelectV3Geomodel(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/model.go
+++ b/internal/classifier/model.go
@@ -95,6 +95,21 @@ type ModelInstance interface {
 	// inferred from the backend string: the value reflects the real chosen path.
 	Device() string
 
+	// Backend returns the inference execution backend the model actually loaded
+	// on (BackendTFLite/BackendONNX/BackendOpenVINO), resolved at load time. This
+	// is the execution provider, which is distinct from the model file format:
+	// an ONNX model file executed through the OpenVINO runtime reports
+	// BackendOpenVINO, not BackendONNX. Like Device(), it reflects the real chosen
+	// path, never the static ModelInfo.Backend file-type metadata.
+	Backend() string
+
+	// Precision returns the effective runtime precision the model executes at
+	// ("INT8"/"FP16"/"FP32", matching the Quantization constants), which can
+	// differ from the weight precision stored in the file (e.g. an FP32 ONNX model
+	// executed on OpenVINO at FP16). Empty when unknown. Like Device(), it reflects
+	// the real chosen path, not the static ModelInfo.Quantization metadata.
+	Precision() string
+
 	// Close releases resources held by the model.
 	Close() error
 }

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -80,6 +80,11 @@ func (bn *BirdNET) initializeONNXModel() error {
 	// EPs (CUDA, DirectML, CoreML) would set this from the bound provider; until
 	// one is wired in, the runtime path is CPU.
 	bn.device = deviceCPU
+	// ONNX Runtime executes the model file as-is, so the runtime precision is the
+	// weight precision recorded in ModelInfo.Quantization (e.g. INT8 for the
+	// arm64 int8 variant, FP32 for an fp32 ONNX model).
+	bn.backend = BackendONNX
+	bn.precision = string(bn.ModelInfo.Quantization)
 
 	log.Info("ONNX model initialized",
 		logger.String("model", modelPath),

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -179,6 +179,19 @@ func openVINOPrecisionLabel(precision string) string {
 	return precision
 }
 
+// openVINOEffectivePrecision maps an OpenVINO INFERENCE_PRECISION_HINT to the
+// effective runtime precision label shown on the inference status card, using the
+// shared Quantization vocabulary ("FP16"/"FP32"). An empty hint means the backend
+// default, which is f16 (see openVINOPrecisionFor), so it maps to FP16; the only
+// explicit override currently emitted is OVPrecisionF32 (BirdNET v2.4 on the GPU),
+// which maps to FP32.
+func openVINOEffectivePrecision(precisionHint string) string {
+	if precisionHint == inference.OVPrecisionF32 {
+		return string(QuantizationFP32)
+	}
+	return string(QuantizationFP16)
+}
+
 // logOpenVINODeclined logs, once at model init, that the OpenVINO backend was not
 // used and why. It logs at WARN when the user explicitly set backend=openvino
 // (they asked for it and did not get it) and at INFO on the auto path (a normal,
@@ -255,6 +268,11 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	// Record the concrete OpenVINO device (CPU/GPU) the classifier bound to so
 	// Device() reports the real execution provider rather than the backend string.
 	bn.device = plan.device
+	// Record the live backend and effective runtime precision so the status card
+	// reports "OpenVINO" + the real compute precision (FP16 by default, FP32 only
+	// for the BirdNET v2.4 GPU path) instead of the static ONNX file metadata.
+	bn.backend = BackendOpenVINO
+	bn.precision = openVINOEffectivePrecision(plan.precision)
 	log.Info("OpenVINO model initialized",
 		logger.String("model", modelPath),
 		logger.String("device", plan.device),

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -25,9 +25,16 @@ const (
 )
 
 // Inference backend identifiers.
+//
+// BackendTFLite and BackendONNX double as the model file-type stored in
+// ModelInfo.Backend (the static metadata). BackendOpenVINO is an execution
+// provider, not a file type: OpenVINO executes an ONNX model file through the OV
+// runtime, so it only ever appears as a live, per-instance backend reported by
+// ModelInstance.Backend(), never as a ModelInfo.Backend file-type value.
 const (
-	BackendTFLite = "TFLite"
-	BackendONNX   = "ONNX"
+	BackendTFLite   = "TFLite"
+	BackendONNX     = "ONNX"
+	BackendOpenVINO = "OpenVINO"
 )
 
 // Model file extensions (lowercase, including the leading dot).

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -27,3 +27,16 @@ func TestOpenVINOPrecisionFor(t *testing.T) {
 	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceCPU),
 		"Perch on CPU keeps the f16 default")
 }
+
+// TestOpenVINOEffectivePrecision verifies the mapping from an OpenVINO
+// INFERENCE_PRECISION_HINT to the display precision shown on the inference status
+// card. The empty default hint (f16) maps to FP16, and the only explicit override
+// emitted (OVPrecisionF32, the BirdNET v2.4 GPU path) maps to FP32. Tag-agnostic
+// like openVINOEffectivePrecision itself, so it runs in the default suite.
+func TestOpenVINOEffectivePrecision(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, string(QuantizationFP16), openVINOEffectivePrecision(""),
+		"empty hint is the backend f16 default, shown as FP16")
+	assert.Equal(t, string(QuantizationFP32), openVINOEffectivePrecision(inference.OVPrecisionF32),
+		"the f32 hint (BirdNET v2.4 GPU) is shown as FP32")
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -368,29 +368,63 @@ func (o *Orchestrator) ModelScheduleStatus(modelID string) (active bool, reason 
 	return false, scheduleReasonNight
 }
 
-// GetModelDevice returns the compute device (execution provider) the named
-// model's inference currently runs on, resolved from the live instance's
-// Device() (e.g. "CPU" or "GPU"). It returns deviceUnknown when the model is not
-// loaded or its instance has been torn down. Locking mirrors ModelInfos /
-// PredictModel: o.mu.RLock to find the entry, then entry.mu to read the instance.
-func (o *Orchestrator) GetModelDevice(modelID string) string {
+// instanceFor returns the live ModelInstance for modelID, or nil when the model
+// is not loaded or its instance has been torn down. Locking mirrors ModelInfos /
+// PredictModel: o.mu.RLock to find the entry, then entry.mu only briefly to
+// capture the instance pointer. The pointer is captured under entry.mu and the
+// lock released before the caller invokes any instance method, because those
+// methods may take their own per-model lock (BirdNET locks bn.mu), and holding
+// entry.mu across such a call would stall PredictModel, which needs entry.mu only
+// briefly on the inference hot path.
+func (o *Orchestrator) instanceFor(modelID string) ModelInstance {
 	o.mu.RLock()
 	entry, ok := o.models[modelID]
 	o.mu.RUnlock()
 	if !ok {
-		return deviceUnknown
+		return nil
 	}
-	// Capture the instance pointer under entry.mu, then release it before calling
-	// Device(): a model's Device() may take its own per-model lock (BirdNET locks
-	// bn.mu), and holding entry.mu across that call would stall PredictModel, which
-	// needs entry.mu only briefly on the inference hot path. Mirrors PredictModel.
 	entry.mu.Lock()
 	inst := entry.instance
 	entry.mu.Unlock()
+	return inst
+}
+
+// GetModelDevice returns the compute device (execution provider) the named
+// model's inference currently runs on, resolved from the live instance's
+// Device() (e.g. "CPU" or "GPU"). It returns deviceUnknown when the model is not
+// loaded or its instance has been torn down.
+func (o *Orchestrator) GetModelDevice(modelID string) string {
+	inst := o.instanceFor(modelID)
 	if inst == nil {
 		return deviceUnknown
 	}
 	return inst.Device()
+}
+
+// GetModelBackend returns the live inference execution backend the named model
+// loaded on (BackendTFLite/BackendONNX/BackendOpenVINO), resolved from the live
+// instance's Backend(). It returns "" when the model is not loaded or its instance
+// has been torn down, signalling callers to fall back to the static
+// ModelInfo.Backend file metadata.
+func (o *Orchestrator) GetModelBackend(modelID string) string {
+	inst := o.instanceFor(modelID)
+	if inst == nil {
+		return ""
+	}
+	return inst.Backend()
+}
+
+// GetModelPrecision returns the effective runtime precision the named model
+// executes at ("INT8"/"FP16"/"FP32"), resolved from the live instance's
+// Precision(). It returns "" when the model is not loaded, its instance has been
+// torn down, or the precision is unknown, signalling callers to fall back to the
+// static ModelInfo.Quantization file metadata.
+func (o *Orchestrator) GetModelPrecision(modelID string) string {
+	inst := o.instanceFor(modelID)
+	if inst == nil {
+		return ""
+	}
+	return inst.Precision()
 }
 
 // ModelSpecFor returns the ModelSpec for the given model ID.

--- a/internal/classifier/orchestrator_device_test.go
+++ b/internal/classifier/orchestrator_device_test.go
@@ -44,6 +44,75 @@ func TestGetModelDevice_NilInstance(t *testing.T) {
 	assert.Equal(t, deviceUnknown, o.GetModelDevice("closed"))
 }
 
+// TestGetModelBackend covers live-backend resolution for loaded, unloaded, and
+// torn-down instances. Unlike GetModelDevice, a missing/unknown backend returns
+// "" so the caller falls back to the static ModelInfo.Backend file metadata.
+func TestGetModelBackend(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ortModelID = "ort_model"
+		ovModelID  = "ov_model"
+	)
+	o := newTestOrchestrator(t,
+		&mockModelInstance{id: ortModelID, backend: BackendONNX},
+		&mockModelInstance{id: ovModelID, backend: BackendOpenVINO},
+	)
+
+	t.Run("returns the live instance backend", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, BackendONNX, o.GetModelBackend(ortModelID))
+		assert.Equal(t, BackendOpenVINO, o.GetModelBackend(ovModelID),
+			"an ONNX model executed on OpenVINO must report OpenVINO, not ONNX")
+	})
+
+	t.Run("unknown model returns empty for static fallback", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, o.GetModelBackend("not_loaded"))
+	})
+}
+
+// TestGetModelPrecision covers live effective-precision resolution. A missing or
+// unknown precision returns "" so the caller falls back to the static
+// ModelInfo.Quantization metadata.
+func TestGetModelPrecision(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fp16ModelID = "fp16_model"
+		int8ModelID = "int8_model"
+	)
+	o := newTestOrchestrator(t,
+		&mockModelInstance{id: fp16ModelID, precision: string(QuantizationFP16)},
+		&mockModelInstance{id: int8ModelID, precision: string(QuantizationINT8)},
+	)
+
+	t.Run("returns the live instance precision", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, string(QuantizationFP16), o.GetModelPrecision(fp16ModelID))
+		assert.Equal(t, string(QuantizationINT8), o.GetModelPrecision(int8ModelID))
+	})
+
+	t.Run("unknown model returns empty for static fallback", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, o.GetModelPrecision("not_loaded"))
+	})
+}
+
+// TestGetModelBackendPrecision_NilInstance verifies a torn-down entry reports the
+// empty string for both backend and precision (static-fallback signal).
+func TestGetModelBackendPrecision_NilInstance(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{
+		models: map[string]*modelEntry{
+			"closed": {instance: nil},
+		},
+		modelRSS: make(map[string]int64),
+	}
+	assert.Empty(t, o.GetModelBackend("closed"))
+	assert.Empty(t, o.GetModelPrecision("closed"))
+}
+
 // TestModelScheduleStatus covers the schedule gating contract: only the bat
 // model is gated, and only when its scheduler reports inactive.
 func TestModelScheduleStatus(t *testing.T) {

--- a/internal/classifier/orchestrator_memory_test.go
+++ b/internal/classifier/orchestrator_memory_test.go
@@ -37,6 +37,8 @@ func (f *fakeInstance) NumSpecies() int      { return 1 }
 func (f *fakeInstance) Labels() []string     { return nil }
 func (f *fakeInstance) Close() error         { return nil }
 func (f *fakeInstance) Device() string       { return deviceCPU }
+func (f *fakeInstance) Backend() string      { return BackendONNX }
+func (f *fakeInstance) Precision() string    { return "" }
 
 func TestWarmupAndRecordRSS_RecordsNonNegativeDelta(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -50,7 +50,9 @@ func (m *reloadFakeModel) Close() error {
 	}
 	return nil
 }
-func (m *reloadFakeModel) Device() string { return deviceCPU }
+func (m *reloadFakeModel) Device() string    { return deviceCPU }
+func (m *reloadFakeModel) Backend() string   { return BackendONNX }
+func (m *reloadFakeModel) Precision() string { return "" }
 
 // registerTestSecondaryBuilder adds a builder under id for the duration of the
 // test, restoring the global map on cleanup. The map is a package global, so the

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -17,11 +17,13 @@ import (
 
 // mockModelInstance implements ModelInstance for testing.
 type mockModelInstance struct {
-	id      string
-	spec    ModelSpec
-	labels  []string // optional; when nil a single default label is returned
-	device  string   // optional; when empty Device() reports "CPU"
-	predict func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
+	id        string
+	spec      ModelSpec
+	labels    []string // optional; when nil a single default label is returned
+	device    string   // optional; when empty Device() reports "CPU"
+	backend   string   // optional; reported verbatim by Backend()
+	precision string   // optional; reported verbatim by Precision()
+	predict   func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
 }
 
 func (m *mockModelInstance) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
@@ -44,7 +46,9 @@ func (m *mockModelInstance) Labels() []string {
 	}
 	return []string{"Turdus merula_Common Blackbird"}
 }
-func (m *mockModelInstance) Close() error { return nil }
+func (m *mockModelInstance) Close() error      { return nil }
+func (m *mockModelInstance) Backend() string   { return m.backend }
+func (m *mockModelInstance) Precision() string { return m.precision }
 func (m *mockModelInstance) Device() string {
 	if m.device != "" {
 		return m.device

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -38,6 +38,13 @@ type Perch struct {
 	// (CPU/GPU) when the OV path succeeds, otherwise deviceCPU for the ONNX
 	// Runtime CPU EP. Set once at construction; reported via Device().
 	device string
+	// backend is the live execution backend (BackendOpenVINO on the OV path, else
+	// BackendONNX), and precision is the effective runtime precision (FP16 on the
+	// OV path; the weight precision detected from the model filename on the ORT
+	// path, e.g. INT8 for perch_v2_int8_arm.onnx). Both set once at construction;
+	// reported via Backend()/Precision().
+	backend   string
+	precision string
 }
 
 // PerchConfig holds configuration for creating a Perch model instance.
@@ -88,6 +95,11 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 	// device records the compute device actually bound to (the OpenVINO device on
 	// the OV path, else the ONNX Runtime CPU EP).
 	classifier, device, ok := tryPerchOpenVINO(cfg, labels)
+	// Perch always compiles OpenVINO at the f16 default (openVINOPrecisionFor
+	// returns "" for Perch, never f32), so the effective OV runtime precision is
+	// FP16. The ORT path overrides both below.
+	backend := BackendOpenVINO
+	precision := string(QuantizationFP16)
 	if !ok {
 		// Initialize ONNX Runtime
 		if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
@@ -110,8 +122,12 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 				Context("label_count", len(labels)).
 				Build()
 		}
-		// ONNX Runtime currently runs Perch on the CPU execution provider.
+		// ONNX Runtime currently runs Perch on the CPU execution provider, executing
+		// the model file as-is: surface the weight precision detected from the
+		// filename (e.g. INT8 for perch_v2_int8_arm.onnx; empty when no token).
 		device = deviceCPU
+		backend = BackendONNX
+		precision = string(detectQuantization(cfg.ModelPath))
 	}
 
 	info := ModelInfo{
@@ -131,6 +147,8 @@ func NewPerch(cfg *PerchConfig) (*Perch, error) {
 		labels:     labels,
 		info:       info,
 		device:     device,
+		backend:    backend,
+		precision:  precision,
 	}, nil
 }
 
@@ -276,6 +294,17 @@ func (p *Perch) Labels() []string {
 // (the OpenVINO device on the OV path, else "CPU"). Set once and never mutated,
 // so no lock is needed. Implements ModelInstance.
 func (p *Perch) Device() string { return p.device }
+
+// Backend returns the live execution backend the classifier bound to at
+// construction (BackendOpenVINO on the OV path, else BackendONNX). Set once and
+// never mutated, so no lock is needed. Implements ModelInstance.
+func (p *Perch) Backend() string { return p.backend }
+
+// Precision returns the effective runtime precision (FP16 on the OpenVINO path;
+// the weight precision detected from the model filename on the ORT path, e.g.
+// INT8 for perch_v2_int8_arm.onnx, empty when no token). Set once and never
+// mutated, so no lock is needed. Implements ModelInstance.
+func (p *Perch) Precision() string { return p.precision }
 
 // Close releases resources held by the Perch model.
 func (p *Perch) Close() error {


### PR DESCRIPTION
## Summary

The inference status page (`/ui/system/inference`) derived each model card's **Backend** and **Quantization** from static model-file metadata (file extension plus a filename heuristic) instead of the backend and precision the model actually loaded with. As a result:

- A model executed on the OpenVINO runtime was mislabeled `ONNX` (there was no `OpenVINO` backend value, and the field was never updated when a model loaded on OpenVINO).
- Perch's `perch_v2_int8_arm.onnx` showed no precision at all, because quantization was only detected for the BirdNET v2.4 slot.

**Device** was already correct because it alone was sourced from the live orchestrator instance. This change surfaces backend and precision the same way Device already works.

## What changed

- Add `Backend()` and `Precision()` to the `ModelInstance` interface, implemented by BirdNET, Perch, and Bat. Each records its execution backend and effective runtime precision at load time (BirdNET per init path; Perch per OpenVINO/ORT path; Bat from its classifier filename).
- Add an explicit `OpenVINO` execution-provider backend value, distinct from the ONNX file type (OpenVINO runs an ONNX model through the OV runtime).
- Add orchestrator accessors `GetModelBackend` / `GetModelPrecision` mirroring `GetModelDevice`, returning empty when a model is not loaded so the static `ModelInfo` metadata stays as the fallback. `GetModelDevice` is refactored onto a shared `instanceFor` helper (behavior unchanged).
- In `GetInferenceStatus`, override the static `Backend` / `Quantization` with the live values when the model is loaded.
- Document the runtime-sourced semantics on the frontend `InferenceModel` type.

## Result

- A model loaded on OpenVINO shows backend `OpenVINO` with its effective precision (`FP16`, or `FP32` on the BirdNET v2.4 GPU path).
- `perch_v2_int8_arm.onnx` shows `INT8`.
- Device behavior is unchanged.

## Test Plan

- [x] `go build ./...`
- [x] `golangci-lint run` on changed packages (0 issues)
- [x] `go test -race ./internal/classifier/ ./internal/api/v2/` (green)
- [x] Frontend `typecheck` + `eslint` clean; types file prettier-clean
- New unit tests: orchestrator `GetModelBackend`/`GetModelPrecision` (loaded / unknown / nil-instance), `openVINOEffectivePrecision` mapping, and `applyRuntimeBackend` override-vs-static-fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced inference status API to display the actual runtime backend (TFLite, ONNX, or OpenVINO) and effective runtime precision for each loaded model, providing real-time visibility into the active inference configuration.

* **Tests**
  * Added comprehensive test coverage for runtime backend and precision tracking across model instances and orchestrator operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->