### PR TITLE
fix(inference): report lifetime max latency on model cards

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -352,11 +352,15 @@ func (c *Controller) buildPerModelInferenceProvider() func() []checks.ModelInfer
 func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, infoMap map[string]*classifier.ModelInfo) []checks.ModelInferenceInfo {
 	result := make([]checks.ModelInferenceInfo, 0, len(snapshots))
 	for modelID, s := range snapshots {
-		var avgMS, p99MS, windowMS float64
+		var avgMS, maxMS, windowMS float64
 		if s.InvokeCount > 0 {
 			avgMS = float64(s.InvokeTotalUs) / float64(s.InvokeCount) / 1000.0
 		}
-		p99MS = float64(s.InvokeMaxUs) / 1000.0
+		// Use the windowed max (since the last collector tick), not the lifetime
+		// max, so a single slow warm-up inference does not permanently latch the
+		// latency health check into Warning/Critical. The model card uses the
+		// lifetime max instead (see buildModelStatus).
+		maxMS = float64(s.InvokeMaxUs) / 1000.0
 		name := modelID
 		if mi, ok := infoMap[modelID]; ok {
 			name = mi.DisplayName()
@@ -369,7 +373,7 @@ func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, inf
 			ModelID:   modelID,
 			ModelName: name,
 			AvgMS:     avgMS,
-			P99MS:     p99MS,
+			MaxMS:     maxMS,
 			WindowMS:  windowMS,
 		})
 	}

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -4,9 +4,11 @@ package api
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -351,7 +353,10 @@ func (c *Controller) buildPerModelInferenceProvider() func() []checks.ModelInfer
 // dropping a model from the inference chart.
 func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, infoMap map[string]*classifier.ModelInfo) []checks.ModelInferenceInfo {
 	result := make([]checks.ModelInferenceInfo, 0, len(snapshots))
-	for modelID, s := range snapshots {
+	// Iterate in sorted model-ID order so the returned slice (and the health
+	// results derived from it) is deterministic; map iteration order is random.
+	for _, modelID := range slices.Sorted(maps.Keys(snapshots)) {
+		s := snapshots[modelID]
 		var avgMS, maxMS, windowMS float64
 		if s.InvokeCount > 0 {
 			avgMS = float64(s.InvokeTotalUs) / float64(s.InvokeCount) / 1000.0

--- a/internal/api/v2/diagnostics_test.go
+++ b/internal/api/v2/diagnostics_test.go
@@ -45,11 +45,39 @@ func TestMapInferenceSnapshotsKeepsUnmappedModel(t *testing.T) {
 	// Mapped model uses DisplayName ("Google Perch v2 (TFLite)").
 	assert.Equal(t, "Google Perch v2 (TFLite)", byID["Perch_V2"].ModelName)
 
-	// Avg and p99 are computed correctly for the mapped model.
+	// Avg and max are computed correctly for the mapped model.
 	assert.InDelta(t, 1.0, byID["Perch_V2"].AvgMS, 0.001, "avg = 4000us / 4 / 1000 = 1ms")
-	assert.InDelta(t, 1.5, byID["Perch_V2"].P99MS, 0.001, "p99 = 1500us / 1000 = 1.5ms")
+	assert.InDelta(t, 1.5, byID["Perch_V2"].MaxMS, 0.001, "max = 1500us / 1000 = 1.5ms")
 
-	// Avg and p99 computed for unmapped model too.
+	// Avg and max computed for unmapped model too.
 	assert.InDelta(t, 1.0, byID["Ghost_Model"].AvgMS, 0.001, "avg = 2000us / 2 / 1000 = 1ms")
-	assert.InDelta(t, 1.2, byID["Ghost_Model"].P99MS, 0.001, "p99 = 1200us / 1000 = 1.2ms")
+	assert.InDelta(t, 1.2, byID["Ghost_Model"].MaxMS, 0.001, "max = 1200us / 1000 = 1.2ms")
+}
+
+// TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime guards the latency
+// health-check path against a regression where a one-time warm-up spike
+// permanently latches the check into Warning/Critical. mapInferenceSnapshots
+// must derive MaxMS from the windowed max (InvokeMaxUs, reset every collector
+// tick), NOT from the never-reset lifetime max (InvokeMaxUsLifetime). The model
+// card uses the lifetime max; the health check must not.
+func TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime(t *testing.T) {
+	t.Parallel()
+	// A model whose all-time peak was a slow 2s warm-up, but whose recent
+	// (windowed) peak is a healthy 250ms.
+	snaps := map[string]inferencestats.PeekSnapshot{
+		"Perch_V2": {
+			InvokeCount:         10,
+			InvokeTotalUs:       2_500_000,
+			InvokeMaxUs:         250_000,   // windowed: recent steady-state peak
+			InvokeMaxUsLifetime: 2_000_000, // lifetime: one-time warm-up spike
+		},
+	}
+
+	out := mapInferenceSnapshots(snaps, map[string]*classifier.ModelInfo{})
+	require.Len(t, out, 1)
+
+	// MaxMS must reflect the windowed max (250ms), not the lifetime spike (2000ms),
+	// so the latency health check clears once the warm-up falls out of the window.
+	assert.InDelta(t, 250.0, out[0].MaxMS, 0.001,
+		"health check must use windowed max, not the lifetime warm-up spike")
 }

--- a/internal/api/v2/diagnostics_test.go
+++ b/internal/api/v2/diagnostics_test.go
@@ -81,3 +81,23 @@ func TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime(t *testing.T) {
 	assert.InDelta(t, 250.0, out[0].MaxMS, 0.001,
 		"health check must use windowed max, not the lifetime warm-up spike")
 }
+
+// TestMapInferenceSnapshotsDeterministicOrder verifies the output is sorted by
+// ModelID regardless of map iteration order, so the derived health results and
+// logs are stable rather than reordering randomly between runs.
+func TestMapInferenceSnapshotsDeterministicOrder(t *testing.T) {
+	t.Parallel()
+	snaps := map[string]inferencestats.PeekSnapshot{
+		"Zebra_Model": {InvokeCount: 1, InvokeTotalUs: 1000, InvokeMaxUs: 1000},
+		"Alpha_Model": {InvokeCount: 1, InvokeTotalUs: 1000, InvokeMaxUs: 1000},
+		"Mango_Model": {InvokeCount: 1, InvokeTotalUs: 1000, InvokeMaxUs: 1000},
+	}
+
+	out := mapInferenceSnapshots(snaps, map[string]*classifier.ModelInfo{})
+	ids := make([]string, len(out))
+	for i, r := range out {
+		ids[i] = r.ModelID
+	}
+	assert.Equal(t, []string{"Alpha_Model", "Mango_Model", "Zebra_Model"}, ids,
+		"models must be returned in sorted ModelID order")
+}

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -107,9 +107,10 @@ type ModelSpecInfo struct {
 }
 
 // ModelStats holds invocation counts and latency for a single model.
-// AvgMs is the lifetime average; MaxMs is the peak since the last metrics
-// collection tick (a recent-window peak, since the collector resets it every
-// interval); RTF is nil when there have been no invocations.
+// AvgMs is the lifetime average and MaxMs is the lifetime peak (both since
+// startup), so MaxMs is always >= AvgMs; RTF is nil when there have been no
+// invocations. MaxMs comes from the never-reset PeekSnapshot.InvokeMaxUsLifetime,
+// not the collector's reset-on-read windowed max.
 //
 // RTF is the lifetime cumulative-average real-time factor: (avgMs / 1000) / clipSec.
 // This differs from the per-model ring-buffer series at MetricKeys.RTF, which is
@@ -216,7 +217,7 @@ func buildModelStatus(info *classifier.ModelInfo, snap inferencestats.PeekSnapsh
 	if snap.InvokeCount > 0 {
 		avgMs = float64(snap.InvokeTotalUs) / float64(snap.InvokeCount) / 1000.0
 	}
-	maxMs := float64(snap.InvokeMaxUs) / 1000.0
+	maxMs := float64(snap.InvokeMaxUsLifetime) / 1000.0
 
 	var rtf *float64
 	if snap.InvokeCount > 0 && clipSec > 0 {

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -141,7 +141,8 @@ func TestBuildModelStatus(t *testing.T) {
 		NumSpecies:   6522,
 		Spec:         classifier.ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
 	}
-	snap := inferencestats.PeekSnapshot{InvokeCount: 1000, InvokeTotalUs: 47_200_000, InvokeMaxUs: 130_000}
+	// MaxMs is sourced from the lifetime max (the model card uses the all-time peak).
+	snap := inferencestats.PeekSnapshot{InvokeCount: 1000, InvokeTotalUs: 47_200_000, InvokeMaxUsLifetime: 130_000}
 	rss := map[string]int64{"BirdNET_V2.4": rssVal}
 
 	got := buildModelStatus(&info, snap, rss, nil, nil, nil)

--- a/internal/classifier/inferencestats/counters.go
+++ b/internal/classifier/inferencestats/counters.go
@@ -15,8 +15,14 @@ import (
 type Counters struct {
 	InvokeCount   atomic.Int64 // total invocations since startup
 	InvokeTotalUs atomic.Int64 // cumulative invoke duration in microseconds
-	InvokeMaxUs   atomic.Int64 // max single invoke duration since last snapshot
-	InvokeErrors  atomic.Int64 // total invocation errors since startup
+	// InvokeMaxUs is the windowed peak: max single invoke duration since the last
+	// Snapshot read, reset-on-read so the collector can emit per-interval maxima.
+	InvokeMaxUs atomic.Int64
+	// InvokeMaxUsLifetime is the all-time peak single invoke duration since
+	// startup. It is never reset on read, so non-destructive status/health views
+	// (PeekAll) report a max that is always >= the lifetime average.
+	InvokeMaxUsLifetime atomic.Int64
+	InvokeErrors        atomic.Int64 // total invocation errors since startup
 }
 
 // RecordInvoke records a single model invocation duration in microseconds.
@@ -24,6 +30,7 @@ func (c *Counters) RecordInvoke(durationUs int64) {
 	c.InvokeCount.Add(1)
 	c.InvokeTotalUs.Add(durationUs)
 	updateAtomicMax(&c.InvokeMaxUs, durationUs)
+	updateAtomicMax(&c.InvokeMaxUsLifetime, durationUs)
 }
 
 // RecordError increments the cumulative error counter by one.
@@ -138,27 +145,35 @@ func (m *CounterMap) SnapshotAll() map[string]Snapshot {
 	return result
 }
 
-// PeekSnapshot is a non-destructive point-in-time view of a model's counters.
-// Unlike Snapshot, it does not reset InvokeMaxUs on read.
+// PeekSnapshot is a non-destructive point-in-time view of a model's counters,
+// used by status and health views. It carries both maxima so each consumer
+// reads the one that fits: InvokeMaxUs is the windowed peak (max since the last
+// collector tick, matching Snapshot.InvokeMaxUs) for recency-sensitive checks
+// like the latency health check, while InvokeMaxUsLifetime is the all-time peak
+// for the model card, where reporting the lifetime peak keeps the displayed max
+// latency >= the lifetime average latency. PeekAll never resets either counter.
 type PeekSnapshot struct {
-	InvokeCount   int64
-	InvokeTotalUs int64
-	InvokeMaxUs   int64
-	InvokeErrors  int64 // cumulative error count; not reset on read
+	InvokeCount         int64
+	InvokeTotalUs       int64
+	InvokeMaxUs         int64 // windowed max since last collector tick; not reset by Peek
+	InvokeMaxUsLifetime int64 // all-time max single invoke duration; never reset
+	InvokeErrors        int64 // cumulative error count; not reset on read
 }
 
-// PeekAll returns a non-destructive snapshot of all per-model counters.
-// Unlike SnapshotAll, it uses Load() instead of Swap(0) for InvokeMaxUs,
-// so the metrics collector's data is not affected.
+// PeekAll returns a non-destructive snapshot of all per-model counters. Unlike
+// SnapshotAll, it never resets any counter (it Loads instead of Swap(0)), so the
+// collector's reset-on-read windowed max is unaffected. It exposes both the
+// windowed max (InvokeMaxUs) and the never-reset lifetime max (InvokeMaxUsLifetime).
 func (m *CounterMap) PeekAll() map[string]PeekSnapshot {
 	result := make(map[string]PeekSnapshot)
 	m.models.Range(func(key, value any) bool {
 		c := value.(*Counters)
 		result[key.(string)] = PeekSnapshot{
-			InvokeCount:   c.InvokeCount.Load(),
-			InvokeTotalUs: c.InvokeTotalUs.Load(),
-			InvokeMaxUs:   c.InvokeMaxUs.Load(),
-			InvokeErrors:  c.InvokeErrors.Load(),
+			InvokeCount:         c.InvokeCount.Load(),
+			InvokeTotalUs:       c.InvokeTotalUs.Load(),
+			InvokeMaxUs:         c.InvokeMaxUs.Load(),
+			InvokeMaxUsLifetime: c.InvokeMaxUsLifetime.Load(),
+			InvokeErrors:        c.InvokeErrors.Load(),
 		}
 		return true
 	})

--- a/internal/classifier/inferencestats/counters_test.go
+++ b/internal/classifier/inferencestats/counters_test.go
@@ -308,14 +308,55 @@ func TestCounterMap_PeekAll_DoesNotInterfereWithSnapshot(t *testing.T) {
 
 	m.RecordInvoke("model_a", 1000)
 
-	// PeekAll should not affect subsequent SnapshotAll
+	// PeekAll is non-destructive: it does not reset the windowed max that the
+	// collector consumes through SnapshotAll.
 	peek := m.PeekAll()
 	assert.Equal(t, int64(1000), peek["model_a"].InvokeMaxUs)
 
 	snap := m.SnapshotAll()
 	assert.Equal(t, int64(1000), snap["model_a"].InvokeMaxUs)
 
-	// After SnapshotAll resets max, PeekAll should see zero
+	// SnapshotAll resets the windowed max, so PeekAll's windowed InvokeMaxUs is
+	// back to zero, but the lifetime max survives the reset.
 	peek2 := m.PeekAll()
 	assert.Equal(t, int64(0), peek2["model_a"].InvokeMaxUs)
+	assert.Equal(t, int64(1000), peek2["model_a"].InvokeMaxUsLifetime)
+}
+
+// TestCounterMap_PeekAll_LifetimeMaxSurvivesSnapshotReset reproduces the model
+// card "avg latency > max latency" bug: the status endpoint reads the max via
+// PeekAll while the metrics collector resets the windowed max on every tick
+// through SnapshotAll. A slow warm-up invocation inflates the lifetime average,
+// but its peak was wiped by the collector, so the reported max fell below the
+// average. PeekAll must report the lifetime peak so max >= avg always holds.
+func TestCounterMap_PeekAll_LifetimeMaxSurvivesSnapshotReset(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+
+	// A slow warm-up invocation sets the lifetime peak (2s).
+	m.RecordInvoke("model_a", 2_000_000)
+
+	// The collector ticks: SnapshotAll resets the windowed max on read.
+	_ = m.SnapshotAll()
+
+	// Steady-state invocations afterwards are much faster than the warm-up.
+	m.RecordInvoke("model_a", 250_000)
+	m.RecordInvoke("model_a", 260_000)
+
+	peek := m.PeekAll()["model_a"]
+	require.Positive(t, peek.InvokeCount)
+	avgUs := peek.InvokeTotalUs / peek.InvokeCount
+
+	// The lifetime max (used by the model card) survives the collector reset, so
+	// it still reflects the warm-up peak and stays >= the lifetime average.
+	assert.Equal(t, int64(2_000_000), peek.InvokeMaxUsLifetime,
+		"lifetime max must report the warm-up peak, not the since-last-tick peak")
+	assert.GreaterOrEqual(t, peek.InvokeMaxUsLifetime, avgUs,
+		"model-card max latency must never be below average latency")
+
+	// The windowed max (used by the latency health check) was reset by the tick,
+	// so it reflects only the recent steady-state peak, not the warm-up spike.
+	// This is what keeps a one-time warm-up from latching the health check.
+	assert.Equal(t, int64(260_000), peek.InvokeMaxUs,
+		"windowed max must reflect only invocations since the last collector tick")
 }

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -105,7 +105,7 @@ type ModelInferenceInfo struct {
 	ModelID   string
 	ModelName string
 	AvgMS     float64
-	P99MS     float64
+	MaxMS     float64 // recent (windowed) max single-inference latency in ms
 	WindowMS  float64 // model-specific analysis window (BufferInterval in ms)
 }
 
@@ -178,19 +178,19 @@ func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Res
 			continue
 		}
 
-		ratio := s.P99MS / s.WindowMS
+		ratio := s.MaxMS / s.WindowMS
 		status := health.StatusHealthy
-		msg := fmt.Sprintf("%s latency OK (p99=%.1fms, window=%.1fms)", s.ModelName, s.P99MS, s.WindowMS)
+		msg := fmt.Sprintf("%s latency OK (max=%.1fms, window=%.1fms)", s.ModelName, s.MaxMS, s.WindowMS)
 
 		switch {
 		case ratio >= latencyCriticalRatio:
 			status = health.StatusCritical
-			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
-				s.ModelName, s.P99MS, latencyCriticalRatio*100, s.WindowMS)
+			msg = fmt.Sprintf("%s max latency (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
+				s.ModelName, s.MaxMS, latencyCriticalRatio*100, s.WindowMS)
 		case ratio >= latencyWarningRatio:
 			status = health.StatusWarning
-			msg = fmt.Sprintf("%s p99 (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
-				s.ModelName, s.P99MS, latencyWarningRatio*100, s.WindowMS)
+			msg = fmt.Sprintf("%s max latency (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
+				s.ModelName, s.MaxMS, latencyWarningRatio*100, s.WindowMS)
 		}
 
 		results = append(results, health.Result{
@@ -202,7 +202,7 @@ func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Res
 				"model_id":   s.ModelID,
 				"model_name": s.ModelName,
 				"avg_ms":     s.AvgMS,
-				"p99_ms":     s.P99MS,
+				"max_ms":     s.MaxMS,
 				"window_ms":  s.WindowMS,
 			},
 			Timestamp: time.Now(),

--- a/internal/health/checks/analysis_test.go
+++ b/internal/health/checks/analysis_test.go
@@ -100,8 +100,8 @@ func TestPerModelInferenceLatencyCheck_Healthy(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, P99MS: 200, WindowMS: 1500},
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 300, P99MS: 600, WindowMS: 2500},
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, MaxMS: 200, WindowMS: 1500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 300, MaxMS: 600, WindowMS: 2500},
 		}
 	})
 
@@ -116,7 +116,7 @@ func TestPerModelInferenceLatencyCheck_Warning(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, P99MS: 800, WindowMS: 1500},
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, MaxMS: 800, WindowMS: 1500},
 		}
 	})
 
@@ -130,7 +130,7 @@ func TestPerModelInferenceLatencyCheck_Critical(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, P99MS: 2300, WindowMS: 2500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, MaxMS: 2300, WindowMS: 2500},
 		}
 	})
 
@@ -144,8 +144,8 @@ func TestPerModelInferenceLatencyCheck_MixedStatus(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 50, P99MS: 100, WindowMS: 1500},
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, P99MS: 2300, WindowMS: 2500},
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 50, MaxMS: 100, WindowMS: 1500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, MaxMS: 2300, WindowMS: 2500},
 		}
 	})
 
@@ -181,7 +181,7 @@ func TestPerModelInferenceLatencyCheck_ZeroWindow(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "Test", ModelName: "Test Model", AvgMS: 100, P99MS: 200, WindowMS: 0},
+			{ModelID: "Test", ModelName: "Test Model", AvgMS: 100, MaxMS: 200, WindowMS: 0},
 		}
 	})
 
@@ -195,11 +195,11 @@ func TestPerModelInferenceLatencyCheck_CorrectWindowPerModel(t *testing.T) {
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
 			// BirdNET v2.4: 3s clips, 50% overlap -> 1500ms window
-			// 800ms p99 / 1500ms = 53% -> Warning
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 400, P99MS: 800, WindowMS: 1500},
+			// 800ms max / 1500ms = 53% -> Warning
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 400, MaxMS: 800, WindowMS: 1500},
 			// Perch V2: 5s clips, 50% overlap -> 2500ms window
-			// 800ms p99 / 2500ms = 32% -> Healthy
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 400, P99MS: 800, WindowMS: 2500},
+			// 800ms max / 2500ms = 32% -> Healthy
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 400, MaxMS: 800, WindowMS: 2500},
 		}
 	})
 


### PR DESCRIPTION
## Summary

The AI Models page (`/ui/system/inference`) could display a model's **average latency above its max latency** (e.g. avg 305.6 ms, max 269.6 ms), which is impossible for a single dataset.

**Root cause:** a window mismatch in `buildModelStatus`. `avgMs` is computed from the cumulative `InvokeTotalUs / InvokeCount` counters (a lifetime average), but `maxMs` came from `InvokeMaxUs`, which the metrics collector resets to zero on every tick via `Snapshot().Swap(0)`. The status endpoint reads through `PeekAll()`, so by the time it read the max it only reflected the peak since the last collector tick (~5s), not the lifetime peak. With a slow warm-up inference baked into the lifetime average but a recent-window-only max, the average could exceed the max.

## Fix

The two `PeekAll()` consumers want different things, so the counter now exposes both maxima:

- A never-reset `InvokeMaxUsLifetime` counter is maintained alongside the windowed `InvokeMaxUs` in `RecordInvoke`; `PeekSnapshot` carries both.
- **Model card** (`buildModelStatus` -> `stats.maxMs`) reads the lifetime max, so `maxMs >= avgMs` always holds.
- **Latency health check** (`mapInferenceSnapshots` -> `PerModelInferenceLatencyCheck`) keeps reading the windowed max. Using the lifetime max there would let a single slow warm-up inference permanently latch a model into Warning/Critical (the all-time peak never decreases). The windowed max self-clears every collector tick, preserving prior behavior.
- The collector's reset-on-read `InvokeMaxUs` on `Snapshot`/`SnapshotAll` is unchanged, so the Prometheus `avg_ms`/`rtf`/`throughput` series are unaffected.

Also renamed the health check's `ModelInferenceInfo.P99MS` to `MaxMS` (plus the `p99_ms` detail key and message text), since the value was always a raw max, never a computed percentile. The misleading label predates this change; corrected here to keep the health output honest.

## Test Plan

- [x] New counter-level regression test: `PeekAll` reports the lifetime peak (survives a collector tick) while the windowed max reflects only recent invocations, asserting max >= avg.
- [x] New api-level test: the health check derives its max from the windowed value, not the lifetime spike.
- [x] `go test -race` green for `inferencestats`, `api/v2`, and `health/checks`.
- [x] `golangci-lint` clean; full `go build ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Per-model inference latency health checks now use the maximum latency within the current collection window instead of p99, reducing the impact of slow warm-up invocations on ongoing assessments.
  * In inference status/diagnostics, latency reporting now distinguishes windowed maximum from lifetime peak maximum for clearer context over time.
  * Diagnostics output is now returned in a stable, deterministic order by model ID.
* **Tests**
  * Updated and added tests to cover deterministic ordering and correct windowed-vs-lifetime max behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->