### PR TITLE
feat(inference): rolling-window p95 latency for the health check

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -357,15 +357,15 @@ func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, inf
 	// results derived from it) is deterministic; map iteration order is random.
 	for _, modelID := range slices.Sorted(maps.Keys(snapshots)) {
 		s := snapshots[modelID]
-		var avgMS, maxMS, windowMS float64
+		var avgMS, p95MS, windowMS float64
 		if s.InvokeCount > 0 {
 			avgMS = float64(s.InvokeTotalUs) / float64(s.InvokeCount) / 1000.0
 		}
-		// Use the windowed max (since the last collector tick), not the lifetime
-		// max, so a single slow warm-up inference does not permanently latch the
-		// latency health check into Warning/Critical. The model card uses the
-		// lifetime max instead (see buildModelStatus).
-		maxMS = float64(s.InvokeMaxUs) / 1000.0
+		// Use the rolling-window p95 latency, not the lifetime max, so a single
+		// slow warm-up inference does not permanently latch the health check into
+		// Warning/Critical, and so an occasional GC pause does not flap it. The
+		// model card uses the lifetime max instead (see buildModelStatus).
+		p95MS = float64(s.RecentP95Us) / 1000.0
 		name := modelID
 		if mi, ok := infoMap[modelID]; ok {
 			name = mi.DisplayName()
@@ -378,7 +378,7 @@ func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, inf
 			ModelID:   modelID,
 			ModelName: name,
 			AvgMS:     avgMS,
-			MaxMS:     maxMS,
+			P95MS:     p95MS,
 			WindowMS:  windowMS,
 		})
 	}

--- a/internal/api/v2/diagnostics_test.go
+++ b/internal/api/v2/diagnostics_test.go
@@ -17,8 +17,8 @@ import (
 func TestMapInferenceSnapshotsKeepsUnmappedModel(t *testing.T) {
 	t.Parallel()
 	snaps := map[string]inferencestats.PeekSnapshot{
-		"Perch_V2":    {InvokeCount: 4, InvokeTotalUs: 4000, InvokeMaxUs: 1500},
-		"Ghost_Model": {InvokeCount: 2, InvokeTotalUs: 2000, InvokeMaxUs: 1200},
+		"Perch_V2":    {InvokeCount: 4, InvokeTotalUs: 4000, RecentP95Us: 1500},
+		"Ghost_Model": {InvokeCount: 2, InvokeTotalUs: 2000, RecentP95Us: 1200},
 	}
 	infoMap := map[string]*classifier.ModelInfo{
 		"Perch_V2": {
@@ -45,30 +45,30 @@ func TestMapInferenceSnapshotsKeepsUnmappedModel(t *testing.T) {
 	// Mapped model uses DisplayName ("Google Perch v2 (TFLite)").
 	assert.Equal(t, "Google Perch v2 (TFLite)", byID["Perch_V2"].ModelName)
 
-	// Avg and max are computed correctly for the mapped model.
+	// Avg and p95 are computed correctly for the mapped model.
 	assert.InDelta(t, 1.0, byID["Perch_V2"].AvgMS, 0.001, "avg = 4000us / 4 / 1000 = 1ms")
-	assert.InDelta(t, 1.5, byID["Perch_V2"].MaxMS, 0.001, "max = 1500us / 1000 = 1.5ms")
+	assert.InDelta(t, 1.5, byID["Perch_V2"].P95MS, 0.001, "p95 = 1500us / 1000 = 1.5ms")
 
-	// Avg and max computed for unmapped model too.
+	// Avg and p95 computed for unmapped model too.
 	assert.InDelta(t, 1.0, byID["Ghost_Model"].AvgMS, 0.001, "avg = 2000us / 2 / 1000 = 1ms")
-	assert.InDelta(t, 1.2, byID["Ghost_Model"].MaxMS, 0.001, "max = 1200us / 1000 = 1.2ms")
+	assert.InDelta(t, 1.2, byID["Ghost_Model"].P95MS, 0.001, "p95 = 1200us / 1000 = 1.2ms")
 }
 
-// TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime guards the latency
-// health-check path against a regression where a one-time warm-up spike
-// permanently latches the check into Warning/Critical. mapInferenceSnapshots
-// must derive MaxMS from the windowed max (InvokeMaxUs, reset every collector
-// tick), NOT from the never-reset lifetime max (InvokeMaxUsLifetime). The model
-// card uses the lifetime max; the health check must not.
-func TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime(t *testing.T) {
+// TestMapInferenceSnapshotsUsesP95NotLifetime guards the latency health-check
+// path against a regression where a one-time warm-up spike permanently latches
+// the check into Warning/Critical. mapInferenceSnapshots must derive P95MS from
+// the rolling-window p95 (RecentP95Us), NOT from the never-reset lifetime max
+// (InvokeMaxUsLifetime). The model card uses the lifetime max; the health check
+// must not.
+func TestMapInferenceSnapshotsUsesP95NotLifetime(t *testing.T) {
 	t.Parallel()
-	// A model whose all-time peak was a slow 2s warm-up, but whose recent
-	// (windowed) peak is a healthy 250ms.
+	// A model whose all-time peak was a slow 2s warm-up, but whose rolling p95
+	// is a healthy 250ms.
 	snaps := map[string]inferencestats.PeekSnapshot{
 		"Perch_V2": {
 			InvokeCount:         10,
 			InvokeTotalUs:       2_500_000,
-			InvokeMaxUs:         250_000,   // windowed: recent steady-state peak
+			RecentP95Us:         250_000,   // rolling-window p95: recent steady state
 			InvokeMaxUsLifetime: 2_000_000, // lifetime: one-time warm-up spike
 		},
 	}
@@ -76,10 +76,10 @@ func TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime(t *testing.T) {
 	out := mapInferenceSnapshots(snaps, map[string]*classifier.ModelInfo{})
 	require.Len(t, out, 1)
 
-	// MaxMS must reflect the windowed max (250ms), not the lifetime spike (2000ms),
+	// P95MS must reflect the rolling p95 (250ms), not the lifetime spike (2000ms),
 	// so the latency health check clears once the warm-up falls out of the window.
-	assert.InDelta(t, 250.0, out[0].MaxMS, 0.001,
-		"health check must use windowed max, not the lifetime warm-up spike")
+	assert.InDelta(t, 250.0, out[0].P95MS, 0.001,
+		"health check must use the rolling p95, not the lifetime warm-up spike")
 }
 
 // TestMapInferenceSnapshotsDeterministicOrder verifies the output is sorted by
@@ -88,9 +88,9 @@ func TestMapInferenceSnapshotsUsesWindowedMaxNotLifetime(t *testing.T) {
 func TestMapInferenceSnapshotsDeterministicOrder(t *testing.T) {
 	t.Parallel()
 	snaps := map[string]inferencestats.PeekSnapshot{
-		"Zebra_Model": {InvokeCount: 1, InvokeTotalUs: 1000, InvokeMaxUs: 1000},
-		"Alpha_Model": {InvokeCount: 1, InvokeTotalUs: 1000, InvokeMaxUs: 1000},
-		"Mango_Model": {InvokeCount: 1, InvokeTotalUs: 1000, InvokeMaxUs: 1000},
+		"Zebra_Model": {InvokeCount: 1, InvokeTotalUs: 1000, RecentP95Us: 1000},
+		"Alpha_Model": {InvokeCount: 1, InvokeTotalUs: 1000, RecentP95Us: 1000},
+		"Mango_Model": {InvokeCount: 1, InvokeTotalUs: 1000, RecentP95Us: 1000},
 	}
 
 	out := mapInferenceSnapshots(snaps, map[string]*classifier.ModelInfo{})

--- a/internal/classifier/inferencestats/counters.go
+++ b/internal/classifier/inferencestats/counters.go
@@ -1,14 +1,31 @@
-// Package inferencestats provides lock-free atomic counters for tracking
-// BirdNET model inference timing. Designed for the hot analysis path where
-// contention-free recording is critical.
+// Package inferencestats tracks BirdNET model inference timing on the hot
+// analysis path. Count, total, and max are lock-free atomics; a small
+// low-contention mutex additionally guards a per-model ring buffer of recent
+// durations used to compute a rolling-window p95 latency for health checks.
+// Inference is rate-limited by audio clip cadence, so the lock is effectively
+// uncontended.
 package inferencestats
 
 import (
+	"math"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 )
+
+// latencyWindowSize is the number of recent inference durations retained per
+// model for rolling-window percentile computation. 1024 int64 samples is 8 KiB
+// per model and keeps a meaningful window (~30s) even under heavy multi-stream
+// load, while sorting it on read stays well under a millisecond.
+const latencyWindowSize = 1024
+
+// healthLatencyPercentile is the percentile of recent inference latency reported
+// to the latency health check. p95 forgives the occasional GC pause or scheduling
+// hiccup (the slowest ~5% of inferences) so the check does not flap, while still
+// catching a sustained inability to keep up with real time.
+const healthLatencyPercentile = 0.95
 
 // Counters tracks BirdNET inference timing using lock-free atomic operations.
 // Safe for concurrent use from the hot analysis path.
@@ -16,13 +33,26 @@ type Counters struct {
 	InvokeCount   atomic.Int64 // total invocations since startup
 	InvokeTotalUs atomic.Int64 // cumulative invoke duration in microseconds
 	// InvokeMaxUs is the windowed peak: max single invoke duration since the last
-	// Snapshot read, reset-on-read so the collector can emit per-interval maxima.
+	// Snapshot read, reset-on-read. It exists so the metrics collector's Snapshot
+	// path can expose a per-interval maximum, mirroring dbstats; no collector
+	// metric currently consumes it (the live consumers are the lifetime max and
+	// the p95 ring below), so it is retained as windowed-max infrastructure only.
 	InvokeMaxUs atomic.Int64
 	// InvokeMaxUsLifetime is the all-time peak single invoke duration since
 	// startup. It is never reset on read, so non-destructive status/health views
 	// (PeekAll) report a max that is always >= the lifetime average.
 	InvokeMaxUsLifetime atomic.Int64
 	InvokeErrors        atomic.Int64 // total invocation errors since startup
+
+	// latMu guards the rolling-window latency ring below. It is held only for the
+	// O(1) ring write in RecordInvoke and the O(window) copy in recentPercentileUs;
+	// the atomic counters above stay lock-free.
+	latMu sync.Mutex
+	// latRing holds the most recent inference durations (microseconds) as a
+	// circular buffer. latLen samples are valid; latPos is the next write index.
+	latRing [latencyWindowSize]int64
+	latPos  int
+	latLen  int
 }
 
 // RecordInvoke records a single model invocation duration in microseconds.
@@ -31,6 +61,36 @@ func (c *Counters) RecordInvoke(durationUs int64) {
 	c.InvokeTotalUs.Add(durationUs)
 	updateAtomicMax(&c.InvokeMaxUs, durationUs)
 	updateAtomicMax(&c.InvokeMaxUsLifetime, durationUs)
+
+	c.latMu.Lock()
+	c.latRing[c.latPos] = durationUs
+	c.latPos = (c.latPos + 1) % latencyWindowSize
+	if c.latLen < latencyWindowSize {
+		c.latLen++
+	}
+	c.latMu.Unlock()
+}
+
+// recentPercentileUs returns the nearest-rank p-th percentile (p in [0,1]) of the
+// retained recent inference durations in microseconds, or 0 when no samples have
+// been recorded. The ring contents are copied under the lock and sorted on read;
+// sample order does not affect the result.
+func (c *Counters) recentPercentileUs(p float64) int64 {
+	c.latMu.Lock()
+	n := c.latLen
+	if n == 0 {
+		c.latMu.Unlock()
+		return 0
+	}
+	samples := make([]int64, n)
+	copy(samples, c.latRing[:n])
+	c.latMu.Unlock()
+
+	slices.Sort(samples)
+	idx := int(math.Ceil(p*float64(n))) - 1
+	idx = max(idx, 0)
+	idx = min(idx, n-1)
+	return samples[idx]
 }
 
 // RecordError increments the cumulative error counter by one.
@@ -146,24 +206,24 @@ func (m *CounterMap) SnapshotAll() map[string]Snapshot {
 }
 
 // PeekSnapshot is a non-destructive point-in-time view of a model's counters,
-// used by status and health views. It carries both maxima so each consumer
-// reads the one that fits: InvokeMaxUs is the windowed peak (max since the last
-// collector tick, matching Snapshot.InvokeMaxUs) for recency-sensitive checks
-// like the latency health check, while InvokeMaxUsLifetime is the all-time peak
-// for the model card, where reporting the lifetime peak keeps the displayed max
-// latency >= the lifetime average latency. PeekAll never resets either counter.
+// used by status and health views. InvokeMaxUsLifetime is the all-time peak for
+// the model card, where reporting the lifetime peak keeps the displayed max
+// latency >= the lifetime average. RecentP95Us is the rolling-window 95th
+// percentile latency for the health check: a recency-sensitive signal that is
+// robust to one-off warm-up or GC spikes and independent of the collector's
+// reset-on-read cycle. PeekAll never resets any counter.
 type PeekSnapshot struct {
 	InvokeCount         int64
 	InvokeTotalUs       int64
-	InvokeMaxUs         int64 // windowed max since last collector tick; not reset by Peek
 	InvokeMaxUsLifetime int64 // all-time max single invoke duration; never reset
+	RecentP95Us         int64 // rolling-window p95 latency over recent invocations
 	InvokeErrors        int64 // cumulative error count; not reset on read
 }
 
 // PeekAll returns a non-destructive snapshot of all per-model counters. Unlike
 // SnapshotAll, it never resets any counter (it Loads instead of Swap(0)), so the
-// collector's reset-on-read windowed max is unaffected. It exposes both the
-// windowed max (InvokeMaxUs) and the never-reset lifetime max (InvokeMaxUsLifetime).
+// collector's reset-on-read windowed max is unaffected. It reports the never-reset
+// lifetime max for the model card and the rolling-window p95 for the health check.
 func (m *CounterMap) PeekAll() map[string]PeekSnapshot {
 	result := make(map[string]PeekSnapshot)
 	m.models.Range(func(key, value any) bool {
@@ -171,8 +231,8 @@ func (m *CounterMap) PeekAll() map[string]PeekSnapshot {
 		result[key.(string)] = PeekSnapshot{
 			InvokeCount:         c.InvokeCount.Load(),
 			InvokeTotalUs:       c.InvokeTotalUs.Load(),
-			InvokeMaxUs:         c.InvokeMaxUs.Load(),
 			InvokeMaxUsLifetime: c.InvokeMaxUsLifetime.Load(),
+			RecentP95Us:         c.recentPercentileUs(healthLatencyPercentile),
 			InvokeErrors:        c.InvokeErrors.Load(),
 		}
 		return true

--- a/internal/classifier/inferencestats/counters_test.go
+++ b/internal/classifier/inferencestats/counters_test.go
@@ -1,6 +1,8 @@
 package inferencestats
 
 import (
+	"math"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -156,17 +158,17 @@ func TestCounterMap_PeekAll_NonDestructive(t *testing.T) {
 	a := peek1["model_a"]
 	assert.Equal(t, int64(2), a.InvokeCount)
 	assert.Equal(t, int64(1700), a.InvokeTotalUs)
-	assert.Equal(t, int64(1200), a.InvokeMaxUs)
+	assert.Equal(t, int64(1200), a.InvokeMaxUsLifetime)
 
 	b := peek1["model_b"]
 	assert.Equal(t, int64(1), b.InvokeCount)
 	assert.Equal(t, int64(300), b.InvokeTotalUs)
-	assert.Equal(t, int64(300), b.InvokeMaxUs)
+	assert.Equal(t, int64(300), b.InvokeMaxUsLifetime)
 
-	// PeekAll must NOT reset InvokeMaxUs
+	// PeekAll must NOT reset the lifetime max
 	peek2 := m.PeekAll()
-	assert.Equal(t, int64(1200), peek2["model_a"].InvokeMaxUs)
-	assert.Equal(t, int64(300), peek2["model_b"].InvokeMaxUs)
+	assert.Equal(t, int64(1200), peek2["model_a"].InvokeMaxUsLifetime)
+	assert.Equal(t, int64(300), peek2["model_b"].InvokeMaxUsLifetime)
 }
 
 func TestCounterMap_PeekAll_Empty(t *testing.T) {
@@ -174,6 +176,129 @@ func TestCounterMap_PeekAll_Empty(t *testing.T) {
 	m := &CounterMap{}
 	peek := m.PeekAll()
 	assert.Empty(t, peek)
+}
+
+func TestCounterMap_PeekAll_RecentP95(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+	// 100 samples with durations 1000, 2000, ... 100000 us.
+	for k := int64(1); k <= 100; k++ {
+		m.RecordInvoke("model_a", k*1000)
+	}
+	peek := m.PeekAll()["model_a"]
+	// Nearest-rank p95 over 100 samples: idx = ceil(0.95*100)-1 = 94 (0-based),
+	// which is the 95th smallest value = 95000 us.
+	assert.Equal(t, int64(95_000), peek.RecentP95Us, "p95 of 1..100 (x1000) is the 95th value")
+}
+
+func TestCounterMap_PeekAll_RecentP95_Empty(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+	m.RecordError("model_a") // no RecordInvoke, so no latency samples
+	peek := m.PeekAll()["model_a"]
+	assert.Equal(t, int64(0), peek.RecentP95Us, "p95 is zero with no recorded invocations")
+}
+
+func TestCounterMap_PeekAll_RecentP95_IgnoresOutliers(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+	// 96 fast inferences plus 4 very slow ones (4% outliers, below the p95 cut).
+	for range 96 {
+		m.RecordInvoke("model_a", 1_000)
+	}
+	for range 4 {
+		m.RecordInvoke("model_a", 8_000_000)
+	}
+	peek := m.PeekAll()["model_a"]
+	// p95 (index 94 of 100) falls in the fast bucket, so the outliers do not move it.
+	assert.Equal(t, int64(1_000), peek.RecentP95Us, "p95 ignores the slowest 5% of samples")
+	// The lifetime max still captures the outlier for the model card.
+	assert.Equal(t, int64(8_000_000), peek.InvokeMaxUsLifetime, "lifetime max still captures the outlier")
+}
+
+func TestCounterMap_PeekAll_RecentP95_EvictsOldSamples(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+	// Fill the ring with slow samples, then overwrite the whole window with fast ones.
+	for range latencyWindowSize {
+		m.RecordInvoke("model_a", 9_000_000)
+	}
+	for range latencyWindowSize {
+		m.RecordInvoke("model_a", 1_000)
+	}
+	peek := m.PeekAll()["model_a"]
+	// Every slow sample has been evicted, so the rolling p95 reflects only the
+	// recent fast window, not the all-time history.
+	assert.Equal(t, int64(1_000), peek.RecentP95Us, "old slow samples must be evicted from the rolling window")
+}
+
+func TestRecentPercentileUs_Boundaries(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		samples []int64
+		p       float64
+		want    int64
+	}{
+		{name: "empty returns zero", samples: nil, p: 0.95, want: 0},
+		{name: "single sample", samples: []int64{42}, p: 0.95, want: 42},
+		// ceil(0.95*7) = ceil(6.65) = 7 -> idx 6 -> the largest of 7.
+		{name: "odd count nearest-rank", samples: []int64{10, 20, 30, 40, 50, 60, 70}, p: 0.95, want: 70},
+		// ceil(1.0*4) = 4 -> idx 3 (upper clamp boundary) -> the largest.
+		{name: "p100 upper boundary", samples: []int64{1, 2, 3, 4}, p: 1.0, want: 4},
+		// ceil(0.5*5) = 3 -> idx 2 -> the median.
+		{name: "median", samples: []int64{10, 20, 30, 40, 50}, p: 0.5, want: 30},
+		// ceil(0.0*3) = 0 -> idx -1 -> clamped to 0 -> the smallest.
+		{name: "p0 lower clamp", samples: []int64{5, 6, 7}, p: 0.0, want: 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &Counters{}
+			for _, s := range tt.samples {
+				c.RecordInvoke(s)
+			}
+			assert.Equal(t, tt.want, c.recentPercentileUs(tt.p))
+		})
+	}
+}
+
+// referencePercentile is an independent nearest-rank implementation (mirroring
+// the ring's last-latencyWindowSize retention) used to cross-check
+// recentPercentileUs in the fuzz test below.
+func referencePercentile(durations []int64, p float64) int64 {
+	samples := slices.Clone(durations)
+	if len(samples) > latencyWindowSize {
+		samples = samples[len(samples)-latencyWindowSize:]
+	}
+	if len(samples) == 0 {
+		return 0
+	}
+	slices.Sort(samples)
+	n := len(samples)
+	idx := int(math.Ceil(p*float64(n))) - 1
+	idx = max(idx, 0)
+	idx = min(idx, n-1)
+	return samples[idx]
+}
+
+func FuzzRecentPercentileUs(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1})
+	f.Add([]byte{5, 1, 9, 3, 7})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		c := &Counters{}
+		durations := make([]int64, len(data))
+		for i, b := range data {
+			// Map bytes to durations 1..256 so every sample is positive and distinct
+			// values are possible; the ring keeps only the most recent samples.
+			durations[i] = int64(b) + 1
+			c.RecordInvoke(durations[i])
+		}
+		got := c.recentPercentileUs(healthLatencyPercentile)
+		want := referencePercentile(durations, healthLatencyPercentile)
+		require.Equal(t, want, got, "recentPercentileUs must match the nearest-rank reference")
+	})
 }
 
 func TestRTFMetricKey(t *testing.T) {
@@ -308,19 +433,20 @@ func TestCounterMap_PeekAll_DoesNotInterfereWithSnapshot(t *testing.T) {
 
 	m.RecordInvoke("model_a", 1000)
 
-	// PeekAll is non-destructive: it does not reset the windowed max that the
-	// collector consumes through SnapshotAll.
+	// PeekAll never reads or resets the collector's windowed max, so SnapshotAll
+	// still sees the full windowed value.
 	peek := m.PeekAll()
-	assert.Equal(t, int64(1000), peek["model_a"].InvokeMaxUs)
+	assert.Equal(t, int64(1000), peek["model_a"].InvokeMaxUsLifetime)
 
 	snap := m.SnapshotAll()
 	assert.Equal(t, int64(1000), snap["model_a"].InvokeMaxUs)
 
-	// SnapshotAll resets the windowed max, so PeekAll's windowed InvokeMaxUs is
-	// back to zero, but the lifetime max survives the reset.
+	// SnapshotAll reset the collector's windowed max, but PeekAll's lifetime max
+	// is never reset.
 	peek2 := m.PeekAll()
-	assert.Equal(t, int64(0), peek2["model_a"].InvokeMaxUs)
 	assert.Equal(t, int64(1000), peek2["model_a"].InvokeMaxUsLifetime)
+	snap2 := m.SnapshotAll()
+	assert.Equal(t, int64(0), snap2["model_a"].InvokeMaxUs)
 }
 
 // TestCounterMap_PeekAll_LifetimeMaxSurvivesSnapshotReset reproduces the model
@@ -353,10 +479,4 @@ func TestCounterMap_PeekAll_LifetimeMaxSurvivesSnapshotReset(t *testing.T) {
 		"lifetime max must report the warm-up peak, not the since-last-tick peak")
 	assert.GreaterOrEqual(t, peek.InvokeMaxUsLifetime, avgUs,
 		"model-card max latency must never be below average latency")
-
-	// The windowed max (used by the latency health check) was reset by the tick,
-	// so it reflects only the recent steady-state peak, not the warm-up spike.
-	// This is what keeps a one-time warm-up from latching the health check.
-	assert.Equal(t, int64(260_000), peek.InvokeMaxUs,
-		"windowed max must reflect only invocations since the last collector tick")
 }

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -105,7 +105,7 @@ type ModelInferenceInfo struct {
 	ModelID   string
 	ModelName string
 	AvgMS     float64
-	MaxMS     float64 // recent (windowed) max single-inference latency in ms
+	P95MS     float64 // rolling-window p95 single-inference latency in ms
 	WindowMS  float64 // model-specific analysis window (BufferInterval in ms)
 }
 
@@ -178,19 +178,19 @@ func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Res
 			continue
 		}
 
-		ratio := s.MaxMS / s.WindowMS
+		ratio := s.P95MS / s.WindowMS
 		status := health.StatusHealthy
-		msg := fmt.Sprintf("%s latency OK (max=%.1fms, window=%.1fms)", s.ModelName, s.MaxMS, s.WindowMS)
+		msg := fmt.Sprintf("%s latency OK (p95=%.1fms, window=%.1fms)", s.ModelName, s.P95MS, s.WindowMS)
 
 		switch {
 		case ratio >= latencyCriticalRatio:
 			status = health.StatusCritical
-			msg = fmt.Sprintf("%s max latency (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
-				s.ModelName, s.MaxMS, latencyCriticalRatio*100, s.WindowMS)
+			msg = fmt.Sprintf("%s p95 latency (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
+				s.ModelName, s.P95MS, latencyCriticalRatio*100, s.WindowMS)
 		case ratio >= latencyWarningRatio:
 			status = health.StatusWarning
-			msg = fmt.Sprintf("%s max latency (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
-				s.ModelName, s.MaxMS, latencyWarningRatio*100, s.WindowMS)
+			msg = fmt.Sprintf("%s p95 latency (%.1fms) exceeds %.0f%% of analysis window (%.1fms)",
+				s.ModelName, s.P95MS, latencyWarningRatio*100, s.WindowMS)
 		}
 
 		results = append(results, health.Result{
@@ -202,7 +202,7 @@ func (c *PerModelInferenceLatencyCheck) RunMulti(_ context.Context) []health.Res
 				"model_id":   s.ModelID,
 				"model_name": s.ModelName,
 				"avg_ms":     s.AvgMS,
-				"max_ms":     s.MaxMS,
+				"p95_ms":     s.P95MS,
 				"window_ms":  s.WindowMS,
 			},
 			Timestamp: time.Now(),

--- a/internal/health/checks/analysis_test.go
+++ b/internal/health/checks/analysis_test.go
@@ -100,8 +100,8 @@ func TestPerModelInferenceLatencyCheck_Healthy(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, MaxMS: 200, WindowMS: 1500},
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 300, MaxMS: 600, WindowMS: 2500},
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, P95MS: 200, WindowMS: 1500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 300, P95MS: 600, WindowMS: 2500},
 		}
 	})
 
@@ -116,7 +116,7 @@ func TestPerModelInferenceLatencyCheck_Warning(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, MaxMS: 800, WindowMS: 1500},
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 100, P95MS: 800, WindowMS: 1500},
 		}
 	})
 
@@ -130,7 +130,7 @@ func TestPerModelInferenceLatencyCheck_Critical(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, MaxMS: 2300, WindowMS: 2500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, P95MS: 2300, WindowMS: 2500},
 		}
 	})
 
@@ -144,8 +144,8 @@ func TestPerModelInferenceLatencyCheck_MixedStatus(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 50, MaxMS: 100, WindowMS: 1500},
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, MaxMS: 2300, WindowMS: 2500},
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 50, P95MS: 100, WindowMS: 1500},
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 500, P95MS: 2300, WindowMS: 2500},
 		}
 	})
 
@@ -181,7 +181,7 @@ func TestPerModelInferenceLatencyCheck_ZeroWindow(t *testing.T) {
 	t.Parallel()
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
-			{ModelID: "Test", ModelName: "Test Model", AvgMS: 100, MaxMS: 200, WindowMS: 0},
+			{ModelID: "Test", ModelName: "Test Model", AvgMS: 100, P95MS: 200, WindowMS: 0},
 		}
 	})
 
@@ -195,11 +195,11 @@ func TestPerModelInferenceLatencyCheck_CorrectWindowPerModel(t *testing.T) {
 	check := NewPerModelInferenceLatencyCheck(func() []ModelInferenceInfo {
 		return []ModelInferenceInfo{
 			// BirdNET v2.4: 3s clips, 50% overlap -> 1500ms window
-			// 800ms max / 1500ms = 53% -> Warning
-			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 400, MaxMS: 800, WindowMS: 1500},
+			// 800ms p95 / 1500ms = 53% -> Warning
+			{ModelID: "BirdNET_V2.4", ModelName: "BirdNET v2.4", AvgMS: 400, P95MS: 800, WindowMS: 1500},
 			// Perch V2: 5s clips, 50% overlap -> 2500ms window
-			// 800ms max / 2500ms = 32% -> Healthy
-			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 400, MaxMS: 800, WindowMS: 2500},
+			// 800ms p95 / 2500ms = 32% -> Healthy
+			{ModelID: "Perch_V2", ModelName: "Perch V2", AvgMS: 400, P95MS: 800, WindowMS: 2500},
 		}
 	})
 


### PR DESCRIPTION
## Summary

Follow-up to #3602. The `inference_latency` health check derived its latency metric from the **collector-windowed max**, which the metrics collector resets to zero every ~5s tick. That made the signal depend on collector tick phase and outlier-sensitive: a single slow inference could trip it, and the effective window was an unstable 0-5s.

This replaces it with a **stable rolling-window p95** computed from recent inference durations.

## Changes

- `Counters` gains a per-model fixed-size ring buffer (1024 samples) of recent durations, written under a small mutex in `RecordInvoke`. The count/total/max atomics stay lock-free; inference is rate-limited by audio clip cadence, so the lock is effectively uncontended. ~8 KiB per model keeps a meaningful window (~30s) even under heavy multi-stream load.
- `recentPercentileUs` computes a nearest-rank percentile (copy under lock, sort on read).
- `PeekSnapshot` drops the now-unused windowed `InvokeMaxUs` and exposes `RecentP95Us` (at the named `healthLatencyPercentile`). The model card still uses the never-reset lifetime max; the collector's reset-on-read `Snapshot.InvokeMaxUs` is untouched.
- `mapInferenceSnapshots` feeds the p95 into the health check. Renamed `ModelInferenceInfo.MaxMS` to `P95MS`, the detail key `max_ms` to `p95_ms`, and the message text to "p95 latency", since the value is now a real percentile.

p95 forgives the occasional GC pause or scheduling hiccup (ignoring 1 in 20 slow inferences) so the check does not flap, while still catching a sustained inability to keep up with real time.

## Behavioral notes for existing users

- The analysis-latency health check is now **less noisy**: it uses a rolling p95 instead of a 5s windowed max. A genuinely sustained slowdown still trips it (once it exceeds the slowest 5% of the window); one-off warm-up/GC spikes no longer do.
- The health result `Details` key changed from `max_ms` to `p95_ms`. No frontend consumer reads this key by name (the `*_max_ms` keys in the UI are the unrelated database-latency metrics).

## Test Plan

- [x] Percentile correctness: nearest-rank happy path, empty/no-sample, outlier robustness, ring eviction across the window boundary, a boundary table (single sample, odd count, p0/p100 clamps, median).
- [x] Fuzz target cross-checking the percentile against an independent nearest-rank reference (200k+ execs clean).
- [x] api-level test that the health check reads the rolling p95, not the lifetime max.
- [x] `go test -race` green for `inferencestats`, `api/v2`, `health/checks`; `go vet` (copylocks) clean; `golangci-lint` clean; full `go build ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Inference latency metrics now report 95th percentile (p95) latency instead of maximum windowed latency for more stable and representative performance monitoring.
  * Health checks now evaluate model inference performance based on typical (p95) latency, reducing the impact of occasional spikes or warm-up pauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->