### PR TITLE
feat(classifier): user-editable model catalog JSON seeded from embedded

### DIFF
--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -36,6 +36,12 @@ func (a *BirdNETAnalyzer) Name() string {
 // Start initializes the BirdNET interpreter and builds the species range filter.
 // Model initialization failures are non-retryable (missing files, insufficient resources).
 func (a *BirdNETAnalyzer) Start(_ context.Context) error {
+	// Load the user-editable model catalog before constructing the orchestrator
+	// so every catalog consumer (range-filter setup, the gallery API, the
+	// installed-model scan) sees the same active catalog. Non-fatal: any failure
+	// falls back to the built-in embedded catalog.
+	a.loadModelCatalog()
+
 	bn, err := classifier.NewOrchestrator(a.settings)
 	if err != nil {
 		return errors.New(err).
@@ -102,6 +108,32 @@ func (a *BirdNETAnalyzer) ModelManager() *classifier.ModelManager {
 // initModelManager creates and populates the ModelManager for the model gallery.
 // If the models directory cannot be determined or the manager fails to scan,
 // a warning is logged and the analyzer continues without gallery support.
+// loadModelCatalog loads the user-editable model catalog into the active runtime
+// catalog: seed it on first run, refresh it when a new release ships a changed
+// built-in catalog, and fall back to the embedded catalog on any error. It runs
+// before the orchestrator and model manager so every catalog consumer sees the
+// same active catalog. The catalog file co-locates with config.yaml (the
+// resolved config directory), which is independent of the model-files directory
+// (conf.Settings.ResolveModelsDir); both coincide on a default install but can
+// differ for a system (/etc) or --config install. Failure is non-fatal: the
+// built-in embedded catalog is used and startup continues.
+func (a *BirdNETAnalyzer) loadModelCatalog() {
+	log := GetLogger()
+
+	configDir, err := conf.ResolveConfigDir()
+	if err != nil {
+		log.Warn("could not resolve config directory; using built-in model catalog",
+			logger.String("service", birdNETAnalyzerName),
+			logger.Error(err))
+		return
+	}
+	if err := classifier.LoadCatalog(configDir); err != nil {
+		log.Warn("model catalog could not be fully loaded or persisted; using built-in catalog",
+			logger.String("service", birdNETAnalyzerName),
+			logger.Error(err))
+	}
+}
+
 func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator) {
 	log := GetLogger()
 

--- a/internal/api/v2/models.go
+++ b/internal/api/v2/models.go
@@ -68,15 +68,18 @@ func (c *Controller) ListModels(ctx echo.Context) error {
 	}
 
 	models := make([]ModelListItem, 0, len(enabled))
+
+	// Snapshot the active catalog once (honors a user-edited model-catalog.json).
+	catalog := classifier.ActiveCatalog()
 	for id := range classifier.ModelRegistry {
 		info := classifier.ModelRegistry[id]
 		for _, alias := range info.ConfigAliases {
 			if enabled[strings.ToLower(alias)] {
 				// Determine category from catalog entry (if any), default to "bird".
 				category := "bird"
-				for i := range classifier.EmbeddedCatalog {
-					if classifier.EmbeddedCatalog[i].RegistryID == id {
-						category = classifier.EmbeddedCatalog[i].Category
+				for j := range catalog {
+					if catalog[j].RegistryID == id {
+						category = catalog[j].Category
 						break
 					}
 				}

--- a/internal/classifier/catalog_loader.go
+++ b/internal/classifier/catalog_loader.go
@@ -1,0 +1,330 @@
+// catalog_loader.go loads and persists the user-editable model catalog.
+//
+// The embedded catalog (EmbeddedCatalog, see model_catalog.go) remains the
+// built-in default that ships inside the binary; no extra files are shipped.
+// On first run the catalog is seeded to <config-dir>/model-catalog.json so the
+// user can hand-edit it. On later runs the file is loaded and used.
+//
+// Staleness handling: the on-disk file records a checksum of the embedded
+// catalog it was generated from. When a new binary release ships a changed
+// embedded catalog, a file that the user has NOT edited is automatically
+// refreshed to the new catalog (so the manifest never goes stale on upgrade).
+// A file the user HAS edited is preserved, with a warning telling the user how
+// to regenerate it. Parse or validation errors are non-fatal: the loader logs a
+// warning, falls back to the embedded catalog, and never overwrites the file.
+package classifier
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	// catalogFileName is the on-disk name of the user-editable model catalog,
+	// co-located with config.yaml in the resolved config directory.
+	catalogFileName = "model-catalog.json"
+
+	// catalogSchemaVersion is the current on-disk schema version. It versions
+	// the file format (the wrapper and field shape), independent of the catalog
+	// content fingerprint stored in CatalogChecksum.
+	catalogSchemaVersion = 1
+
+	// catalogFileMode is the permission mode for the catalog file (world-readable
+	// so it can be inspected; owner-writable for hand-editing).
+	catalogFileMode = 0o644
+	// catalogDirMode is the permission mode used when creating the config
+	// directory as a fallback during seeding.
+	catalogDirMode = 0o755
+)
+
+// catalogManifest is the on-disk wrapper for the model catalog. The 2-space
+// indented JSON is meant to be hand-editable.
+type catalogManifest struct {
+	// SchemaVersion is the file-format version (see catalogSchemaVersion).
+	SchemaVersion int `json:"schema_version"`
+	// CatalogChecksum fingerprints the embedded catalog this file was generated
+	// from. It is how an upgrade detects that a pristine file should be refreshed
+	// and that an edited file diverges from its baseline. Hand-edited files may
+	// omit it (empty), which is treated as "edited / unknown baseline".
+	CatalogChecksum string `json:"catalog_checksum"`
+	// Entries is the catalog itself.
+	Entries []CatalogEntry `json:"entries"`
+}
+
+// LoadCatalog initializes the runtime model catalog from configDir. It seeds the
+// file on first run, refreshes a pristine file when the embedded catalog changed
+// (avoiding staleness on upgrade), preserves user edits, and always falls back to
+// the embedded catalog on any error so startup never fails. The returned error is
+// advisory (a seed/refresh write failure); the active catalog is always set.
+func LoadCatalog(configDir string) error {
+	log := GetLogger()
+	path := filepath.Join(configDir, catalogFileName)
+
+	embeddedChecksum, err := catalogChecksum(EmbeddedCatalog)
+	if err != nil {
+		// Should never happen (the embedded catalog always marshals); fall back.
+		setActiveCatalog(EmbeddedCatalog)
+		return errors.New(err).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "checksum_embedded_catalog").
+			Build()
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path derived from the resolved config dir, not user input
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return seedCatalog(log, path, embeddedChecksum)
+		}
+		// Unexpected read error (permissions, etc.): use embedded, surface error.
+		setActiveCatalog(EmbeddedCatalog)
+		return errors.New(err).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "read_model_catalog").
+			Context("path", path).
+			Build()
+	}
+
+	var manifest catalogManifest
+	if uerr := json.Unmarshal(data, &manifest); uerr != nil {
+		log.Warn("model catalog is malformed; using built-in catalog (file left untouched)",
+			logger.String("path", path),
+			logger.Error(uerr))
+		setActiveCatalog(EmbeddedCatalog)
+		return nil
+	}
+
+	if manifest.SchemaVersion != catalogSchemaVersion {
+		log.Warn("model catalog schema version differs from this build; loading best-effort",
+			logger.String("path", path),
+			logger.Int("file_schema_version", manifest.SchemaVersion),
+			logger.Int("app_schema_version", catalogSchemaVersion))
+	}
+
+	if verr := validateCatalog(manifest.Entries); verr != nil {
+		log.Warn("model catalog failed validation; using built-in catalog (file left untouched)",
+			logger.String("path", path),
+			logger.Error(verr))
+		setActiveCatalog(EmbeddedCatalog)
+		return nil
+	}
+
+	// The file's baseline matches the current binary: use it as-is. This honors
+	// any edits the user layered on the current built-in catalog.
+	if manifest.CatalogChecksum == embeddedChecksum {
+		setActiveCatalog(manifest.Entries)
+		log.Info("loaded model catalog",
+			logger.String("path", path),
+			logger.Int("entries", len(manifest.Entries)))
+		return nil
+	}
+
+	// The binary shipped a different embedded catalog than this file's recorded
+	// baseline. Decide whether the file is pristine (safe to refresh) or edited.
+	fileChecksum, err := catalogChecksum(manifest.Entries)
+	if err != nil {
+		// Cannot fingerprint the file; treat as edited and keep it.
+		setActiveCatalog(manifest.Entries)
+		log.Warn("could not fingerprint model catalog; keeping on-disk entries",
+			logger.String("path", path),
+			logger.Error(err))
+		return nil
+	}
+
+	pristine := fileChecksum == manifest.CatalogChecksum
+	if pristine {
+		// User never edited the file: refresh it to the new release so it does
+		// not go stale (e.g. updated checksums, new models). Even if the on-disk
+		// write fails, the in-memory catalog is the fresh embedded one.
+		setActiveCatalog(EmbeddedCatalog)
+		if werr := writeCatalogFileAtomic(path, EmbeddedCatalog, embeddedChecksum); werr != nil {
+			return werr
+		}
+		log.Info("refreshed model catalog to match new release",
+			logger.String("path", path),
+			logger.Int("entries", len(EmbeddedCatalog)))
+		return nil
+	}
+
+	// User edited the file and the built-in catalog also changed. Preserve the
+	// user's edits, but warn that the built-in catalog moved on so the user can
+	// regenerate if they want the new baseline.
+	setActiveCatalog(manifest.Entries)
+	log.Warn("built-in model catalog changed since this file was generated; keeping your edits. "+
+		"Delete the file to regenerate it from the new built-in catalog.",
+		logger.String("path", path),
+		logger.Int("entries", len(manifest.Entries)))
+	return nil
+}
+
+// seedCatalog writes the initial catalog file from the embedded catalog and sets
+// the active catalog to the embedded catalog.
+func seedCatalog(log logger.Logger, path, embeddedChecksum string) error {
+	setActiveCatalog(EmbeddedCatalog)
+	if err := writeCatalogFileAtomic(path, EmbeddedCatalog, embeddedChecksum); err != nil {
+		return err
+	}
+	log.Info("seeded model catalog",
+		logger.String("path", path),
+		logger.Int("entries", len(EmbeddedCatalog)))
+	return nil
+}
+
+// validateCatalog checks that a loaded catalog is well-formed: it has at least
+// one entry, every entry has a unique non-empty id, and every file declares the
+// fields needed to download it (remote_path, local_name, role).
+func validateCatalog(entries []CatalogEntry) error {
+	if len(entries) == 0 {
+		return errors.Newf("model catalog has no entries").
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	seen := make(map[string]struct{}, len(entries))
+	for i := range entries {
+		entry := &entries[i]
+		if entry.ID == "" {
+			return errors.Newf("catalog entry %d has an empty id", i).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
+		}
+		if _, dup := seen[entry.ID]; dup {
+			return errors.Newf("duplicate catalog entry id %q", entry.ID).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
+		}
+		seen[entry.ID] = struct{}{}
+		for j := range entry.Files {
+			f := &entry.Files[j]
+			if f.RemotePath == "" || f.LocalName == "" || f.Role == "" {
+				return errors.Newf("catalog entry %q file %d is missing remote_path, local_name, or role", entry.ID, j).
+					Component("classifier.catalog_loader").
+					Category(errors.CategoryValidation).
+					Build()
+			}
+		}
+	}
+	return nil
+}
+
+// catalogChecksum returns the hex-encoded SHA-256 of the compact JSON encoding
+// of entries. The compact encoding is deterministic (fixed struct field order,
+// ordered slices, no maps), so a pristine file round-trips to the same checksum
+// it was written with, and a changed embedded catalog produces a different one.
+//
+// The checksum is coupled to the Go struct layout and JSON tags, not just the
+// semantic content. Reordering CatalogEntry/CatalogFile fields or renaming a tag
+// shifts every checksum, so after such a refactor existing on-disk files look
+// "changed" and are preserved with a warning (not auto-refreshed) until the user
+// regenerates them. That degradation is benign (the file still loads), but a
+// maintainer making such a change should bump catalogSchemaVersion to signal it.
+func catalogChecksum(entries []CatalogEntry) (string, error) {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return "", errors.New(err).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "marshal_catalog_checksum").
+			Build()
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// writeCatalogFileAtomic writes the catalog manifest to path atomically: it
+// writes a temp file in the same directory, fsyncs it, then renames it into
+// place. A partial write therefore never leaves a corrupt catalog file.
+func writeCatalogFileAtomic(path string, entries []CatalogEntry, checksum string) error {
+	manifest := catalogManifest{
+		SchemaVersion:   catalogSchemaVersion,
+		CatalogChecksum: checksum,
+		Entries:         entries,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return errors.New(err).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "marshal_model_catalog").
+			Build()
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(path)
+	if mkErr := os.MkdirAll(dir, catalogDirMode); mkErr != nil {
+		return errors.New(mkErr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "create_config_dir").
+			Context("path", dir).
+			Build()
+	}
+
+	tmp, err := os.CreateTemp(dir, catalogFileName+".*.tmp")
+	if err != nil {
+		return errors.New(err).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "create_temp_model_catalog").
+			Context("dir", dir).
+			Build()
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup: removes the temp file on any failure path. After a
+	// successful rename the temp file no longer exists and Remove is a no-op.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, werr := tmp.Write(data); werr != nil {
+		_ = tmp.Close()
+		return errors.New(werr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "write_model_catalog").
+			Context("path", tmpName).
+			Build()
+	}
+	if serr := tmp.Sync(); serr != nil {
+		_ = tmp.Close()
+		return errors.New(serr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "sync_model_catalog").
+			Context("path", tmpName).
+			Build()
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return errors.New(cerr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "close_model_catalog").
+			Context("path", tmpName).
+			Build()
+	}
+	if cerr := os.Chmod(tmpName, catalogFileMode); cerr != nil {
+		return errors.New(cerr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "chmod_model_catalog").
+			Context("path", tmpName).
+			Build()
+	}
+	if rerr := os.Rename(tmpName, path); rerr != nil {
+		return errors.New(rerr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "rename_model_catalog").
+			Context("path", path).
+			Build()
+	}
+	return nil
+}

--- a/internal/classifier/catalog_loader.go
+++ b/internal/classifier/catalog_loader.go
@@ -204,6 +204,12 @@ func validateCatalog(entries []CatalogEntry) error {
 				Build()
 		}
 		seen[entry.ID] = struct{}{}
+		if len(entry.Files) == 0 {
+			return errors.Newf("catalog entry %q declares no files", entry.ID).
+				Component("classifier.catalog_loader").
+				Category(errors.CategoryValidation).
+				Build()
+		}
 		for j := range entry.Files {
 			f := &entry.Files[j]
 			if f.RemotePath == "" || f.LocalName == "" || f.Role == "" {

--- a/internal/classifier/catalog_loader.go
+++ b/internal/classifier/catalog_loader.go
@@ -299,6 +299,18 @@ func writeCatalogFileAtomic(path string, entries []CatalogEntry, checksum string
 			Context("path", tmpName).
 			Build()
 	}
+	// Set the final mode on the open descriptor (CreateTemp makes it 0600) rather
+	// than os.Chmod(path) after Close: operating on the fd avoids a TOCTOU window
+	// where the path could be swapped between close and chmod.
+	if cerr := tmp.Chmod(catalogFileMode); cerr != nil {
+		_ = tmp.Close()
+		return errors.New(cerr).
+			Component("classifier.catalog_loader").
+			Category(errors.CategoryFileIO).
+			Context("operation", "chmod_model_catalog").
+			Context("path", tmpName).
+			Build()
+	}
 	if serr := tmp.Sync(); serr != nil {
 		_ = tmp.Close()
 		return errors.New(serr).
@@ -313,14 +325,6 @@ func writeCatalogFileAtomic(path string, entries []CatalogEntry, checksum string
 			Component("classifier.catalog_loader").
 			Category(errors.CategoryFileIO).
 			Context("operation", "close_model_catalog").
-			Context("path", tmpName).
-			Build()
-	}
-	if cerr := os.Chmod(tmpName, catalogFileMode); cerr != nil {
-		return errors.New(cerr).
-			Component("classifier.catalog_loader").
-			Category(errors.CategoryFileIO).
-			Context("operation", "chmod_model_catalog").
 			Context("path", tmpName).
 			Build()
 	}

--- a/internal/classifier/catalog_loader_test.go
+++ b/internal/classifier/catalog_loader_test.go
@@ -153,6 +153,10 @@ func TestLoadCatalog_ValidationFailureFallsBack(t *testing.T) {
 				Files: []CatalogFile{{RemotePath: "m", LocalName: "m"}}, // role empty
 			}},
 		},
+		{
+			name:    "entry with no files",
+			entries: []CatalogEntry{{ID: "no-files"}}, // empty Files
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/classifier/catalog_loader_test.go
+++ b/internal/classifier/catalog_loader_test.go
@@ -1,0 +1,341 @@
+package classifier
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetActiveCatalog restores the package-global catalog to its default (nil =>
+// EmbeddedCatalog) after a test that mutates it. These tests must NOT run in
+// parallel because they share the global activeCatalog.
+func resetActiveCatalog(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { setActiveCatalog(nil) })
+}
+
+// idSet returns the set of entry IDs in a catalog slice.
+func idSet(entries []CatalogEntry) map[string]bool {
+	ids := make(map[string]bool, len(entries))
+	for i := range entries {
+		ids[entries[i].ID] = true
+	}
+	return ids
+}
+
+// customEntry is a minimal, valid catalog entry for tests.
+func customEntry(id string) CatalogEntry {
+	return CatalogEntry{
+		ID:       id,
+		Name:     "Custom " + id,
+		Category: CategoryBird,
+		Version:  "1.0",
+		Files: []CatalogFile{
+			{RemotePath: "model.onnx", LocalName: id + ".onnx", Role: RoleModel},
+		},
+	}
+}
+
+// readManifest reads and unmarshals the catalog file at path.
+func readManifest(t *testing.T, path string) catalogManifest {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	var m catalogManifest
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+// writeManifest writes a manifest file for tests.
+func writeManifest(t *testing.T, path string, m catalogManifest) {
+	t.Helper()
+	data, err := json.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}
+
+func TestLoadCatalog_SeedsWhenAbsent(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	require.NoError(t, LoadCatalog(dir))
+
+	// File is created and round-trips to the embedded catalog.
+	require.FileExists(t, path)
+	m := readManifest(t, path)
+	assert.Equal(t, catalogSchemaVersion, m.SchemaVersion)
+
+	wantChecksum, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+	assert.Equal(t, wantChecksum, m.CatalogChecksum)
+	assert.Equal(t, idSet(EmbeddedCatalog), idSet(m.Entries), "seeded entries must match embedded")
+
+	// The active catalog reflects the embedded catalog.
+	assert.Equal(t, idSet(EmbeddedCatalog), idSet(ActiveCatalog()))
+}
+
+func TestLoadCatalog_LoadsFileWithCustomEntry(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	checksum, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+
+	// A user added a custom entry but left the seed checksum (baseline matches
+	// the current binary), so the file is used as-is.
+	entries := append(slices.Clone(EmbeddedCatalog), customEntry("my-custom-model"))
+	writeManifest(t, path, catalogManifest{
+		SchemaVersion:   catalogSchemaVersion,
+		CatalogChecksum: checksum,
+		Entries:         entries,
+	})
+
+	require.NoError(t, LoadCatalog(dir))
+
+	got, found := GetCatalogEntry("my-custom-model")
+	require.True(t, found, "custom entry must be resolvable")
+	assert.Equal(t, "Custom my-custom-model", got.Name)
+
+	visibleIDs := idSet(VisibleCatalog())
+	assert.True(t, visibleIDs["my-custom-model"], "custom entry must appear in the visible catalog")
+}
+
+func TestLoadCatalog_MalformedJSONFallsBackAndLeavesFileUntouched(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	const bad = "{ this is not valid json"
+	require.NoError(t, os.WriteFile(path, []byte(bad), 0o600))
+
+	require.NoError(t, LoadCatalog(dir))
+
+	// Falls back to embedded; the custom entry is absent.
+	assert.Equal(t, idSet(EmbeddedCatalog), idSet(ActiveCatalog()))
+
+	// The malformed file is left exactly as it was.
+	data, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, bad, string(data), "malformed file must not be overwritten")
+}
+
+func TestLoadCatalog_ValidationFailureFallsBack(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []CatalogEntry
+	}{
+		{
+			name:    "empty entries",
+			entries: []CatalogEntry{},
+		},
+		{
+			name:    "missing id",
+			entries: []CatalogEntry{{Name: "no id", Files: []CatalogFile{{RemotePath: "m", LocalName: "m", Role: RoleModel}}}},
+		},
+		{
+			name:    "duplicate id",
+			entries: []CatalogEntry{customEntry("dup"), customEntry("dup")},
+		},
+		{
+			name: "file missing role",
+			entries: []CatalogEntry{{
+				ID:    "bad-file",
+				Files: []CatalogFile{{RemotePath: "m", LocalName: "m"}}, // role empty
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetActiveCatalog(t)
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, catalogFileName)
+			writeManifest(t, path, catalogManifest{
+				SchemaVersion:   catalogSchemaVersion,
+				CatalogChecksum: "irrelevant",
+				Entries:         tt.entries,
+			})
+			before, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path
+			require.NoError(t, err)
+
+			require.NoError(t, LoadCatalog(dir))
+
+			assert.Equal(t, idSet(EmbeddedCatalog), idSet(ActiveCatalog()), "must fall back to embedded")
+
+			after, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path
+			require.NoError(t, err)
+			assert.Equal(t, before, after, "invalid file must not be overwritten")
+		})
+	}
+}
+
+func TestLoadCatalog_RefreshesPristineFileOnChangedEmbedded(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	// Simulate an older release: a pristine file generated from a catalog that
+	// differs from the current embedded one (here, embedded minus its last entry).
+	require.Greater(t, len(EmbeddedCatalog), 1)
+	oldEntries := slices.Clone(EmbeddedCatalog[:len(EmbeddedCatalog)-1])
+	oldChecksum, err := catalogChecksum(oldEntries)
+	require.NoError(t, err)
+	writeManifest(t, path, catalogManifest{
+		SchemaVersion:   catalogSchemaVersion,
+		CatalogChecksum: oldChecksum, // pristine: matches the (old) entries
+		Entries:         oldEntries,
+	})
+
+	require.NoError(t, LoadCatalog(dir))
+
+	// The file is refreshed to the current embedded catalog.
+	m := readManifest(t, path)
+	embeddedChecksum, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+	assert.Equal(t, embeddedChecksum, m.CatalogChecksum, "checksum must be updated to the new baseline")
+	assert.Equal(t, idSet(EmbeddedCatalog), idSet(m.Entries), "file must be refreshed to the full embedded catalog")
+	assert.Equal(t, idSet(EmbeddedCatalog), idSet(ActiveCatalog()))
+}
+
+func TestLoadCatalog_PreservesEditedFileOnChangedEmbedded(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	// An edited file: entries include a custom model, and the stored checksum is
+	// an old baseline that matches neither the current embedded catalog nor the
+	// file's own entries (so the file is detected as edited, not pristine).
+	staleBaseline, err := catalogChecksum([]CatalogEntry{EmbeddedCatalog[0]})
+	require.NoError(t, err)
+	entries := append(slices.Clone(EmbeddedCatalog), customEntry("user-pinned"))
+	writeManifest(t, path, catalogManifest{
+		SchemaVersion:   catalogSchemaVersion,
+		CatalogChecksum: staleBaseline,
+		Entries:         entries,
+	})
+	before, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	require.NoError(t, LoadCatalog(dir))
+
+	// User edits are preserved in memory and the file is left untouched.
+	_, found := GetCatalogEntry("user-pinned")
+	assert.True(t, found, "user edits must be preserved")
+
+	after, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "edited file must not be overwritten")
+}
+
+func TestLoadCatalog_SchemaVersionMismatchStillLoads(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, catalogFileName)
+
+	checksum, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+	entries := append(slices.Clone(EmbeddedCatalog), customEntry("future-entry"))
+	writeManifest(t, path, catalogManifest{
+		SchemaVersion:   catalogSchemaVersion + 999, // unknown/newer format
+		CatalogChecksum: checksum,
+		Entries:         entries,
+	})
+
+	require.NoError(t, LoadCatalog(dir))
+
+	_, found := GetCatalogEntry("future-entry")
+	assert.True(t, found, "best-effort load must still apply a valid file with an unknown schema version")
+}
+
+func TestLoadCatalog_AtomicWriteLeavesNoTempFile(t *testing.T) {
+	resetActiveCatalog(t)
+
+	dir := t.TempDir()
+	require.NoError(t, LoadCatalog(dir))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "no temporary file should remain after an atomic write")
+	}
+	// Exactly the catalog file should exist.
+	require.Len(t, entries, 1)
+	assert.Equal(t, catalogFileName, entries[0].Name())
+}
+
+func TestLoadCatalog_WriteFailureFallsBackToEmbedded(t *testing.T) {
+	resetActiveCatalog(t)
+
+	// Use a path whose parent is a regular file, so MkdirAll/CreateTemp fails.
+	dir := t.TempDir()
+	notADir := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o600))
+	configDir := filepath.Join(notADir, "config") // child of a file: cannot be created
+
+	err := LoadCatalog(configDir)
+	require.Error(t, err, "seed write into an invalid directory must surface an error")
+
+	// Despite the write failure, the active catalog is the embedded fallback.
+	assert.Equal(t, idSet(EmbeddedCatalog), idSet(ActiveCatalog()))
+}
+
+func TestAccessorsReadActiveCatalog(t *testing.T) {
+	resetActiveCatalog(t)
+
+	custom := []CatalogEntry{
+		customEntry("only-entry"),
+		func() CatalogEntry { e := customEntry("hidden-entry"); e.Hidden = true; return e }(),
+	}
+	setActiveCatalog(custom)
+
+	// ActiveCatalog returns all entries; VisibleCatalog excludes hidden ones.
+	assert.Equal(t, map[string]bool{"only-entry": true, "hidden-entry": true}, idSet(ActiveCatalog()))
+	assert.Equal(t, map[string]bool{"only-entry": true}, idSet(VisibleCatalog()))
+
+	_, found := GetCatalogEntry("only-entry")
+	assert.True(t, found)
+	_, missing := GetCatalogEntry("birdnet-v3.0")
+	assert.False(t, missing, "embedded entries must not leak when activeCatalog is set")
+}
+
+func TestCatalogChecksum_DeterministicAndRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	a, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+	b, err := catalogChecksum(EmbeddedCatalog)
+	require.NoError(t, err)
+	assert.Equal(t, a, b, "checksum must be deterministic")
+
+	// Marshal -> unmarshal -> checksum must equal the original checksum.
+	data, err := json.Marshal(EmbeddedCatalog)
+	require.NoError(t, err)
+	var roundTripped []CatalogEntry
+	require.NoError(t, json.Unmarshal(data, &roundTripped))
+	c, err := catalogChecksum(roundTripped)
+	require.NoError(t, err)
+	assert.Equal(t, a, c, "checksum must survive a JSON round-trip")
+
+	// Order sensitivity: reordering entries must change the checksum. This is the
+	// property that lets pristine-vs-edited detection notice content changes.
+	require.GreaterOrEqual(t, len(EmbeddedCatalog), 2)
+	reordered := slices.Clone(EmbeddedCatalog)
+	reordered[0], reordered[1] = reordered[1], reordered[0]
+	d, err := catalogChecksum(reordered)
+	require.NoError(t, err)
+	assert.NotEqual(t, a, d, "reordering entries must change the checksum")
+}

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -5,6 +5,7 @@ package classifier
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -29,34 +30,40 @@ const (
 )
 
 // CatalogEntry describes a downloadable model available in the model gallery.
+//
+// The snake_case JSON tags define the on-disk schema for the user-editable
+// model-catalog.json file (see catalog_loader.go). They are intentionally
+// stable and readable for hand-editing. The model-gallery API does NOT
+// serialize this struct directly; it maps to a separate camelCase response
+// type (see internal/api/v2/models.go), so these tags do not affect the API.
 type CatalogEntry struct {
-	ID              string        // unique catalog identifier (e.g., "battybirdnet-eu")
-	Name            string        // user-facing display name
-	Description     string        // short description of the model
-	Author          string        // model author or organization
-	License         string        // license identifier (e.g., "Apache-2.0")
-	CommercialUse   bool          // whether commercial use is permitted
-	Category        string        // "wildlife", "bird", "bat", or "geomodel"
-	Region          string        // geographic region, or empty for global models
-	SpeciesCount    int           // number of species the model can identify
-	Version         string        // model version string
-	GeomodelVersion string        // geomodel range filter version (e.g., "v3"); empty if no geomodel
-	RegistryID      string        // maps to a ModelRegistry key; empty if loader not yet implemented
-	Hidden          bool          // if true, entry is excluded from the gallery UI
-	RequiresONNX    bool          // if true, model needs ONNX Runtime (not just TFLite)
-	UpstreamURL     string        // URL to the upstream project repository
-	HuggingFaceRepo string        // HuggingFace repository path
-	Files           []CatalogFile // files to download for this model
+	ID              string        `json:"id"`                // unique catalog identifier (e.g., "battybirdnet-eu")
+	Name            string        `json:"name"`              // user-facing display name
+	Description     string        `json:"description"`       // short description of the model
+	Author          string        `json:"author"`            // model author or organization
+	License         string        `json:"license"`           // license identifier (e.g., "Apache-2.0")
+	CommercialUse   bool          `json:"commercial_use"`    // whether commercial use is permitted
+	Category        string        `json:"category"`          // "wildlife", "bird", "bat", or "geomodel"
+	Region          string        `json:"region"`            // geographic region, or empty for global models
+	SpeciesCount    int           `json:"species_count"`     // number of species the model can identify
+	Version         string        `json:"version"`           // model version string
+	GeomodelVersion string        `json:"geomodel_version"`  // geomodel range filter version (e.g., "v3"); empty if no geomodel
+	RegistryID      string        `json:"registry_id"`       // maps to a ModelRegistry key; empty if loader not yet implemented
+	Hidden          bool          `json:"hidden"`            // if true, entry is excluded from the gallery UI
+	RequiresONNX    bool          `json:"requires_onnx"`     // if true, model needs ONNX Runtime (not just TFLite)
+	UpstreamURL     string        `json:"upstream_url"`      // URL to the upstream project repository
+	HuggingFaceRepo string        `json:"hugging_face_repo"` // HuggingFace repository path
+	Files           []CatalogFile `json:"files"`             // files to download for this model
 }
 
 // CatalogFile describes a single file within a model's HuggingFace repository.
 type CatalogFile struct {
-	RemotePath      string // path within the HuggingFace repo
-	LocalName       string // filename to use on disk
-	Role            string // file role: "model", "labels", "embeddings", "geomodel_model", "geomodel_labels", or "data"
-	SHA256          string // hex-encoded SHA-256 checksum
-	SizeBytes       int64  // file size in bytes
-	HuggingFaceRepo string // override entry-level HuggingFace repo for this file (empty = use entry repo)
+	RemotePath      string `json:"remote_path"`       // path within the HuggingFace repo
+	LocalName       string `json:"local_name"`        // filename to use on disk
+	Role            string `json:"role"`              // file role: "model", "labels", "embeddings", "geomodel_model", "geomodel_labels", or "data"
+	SHA256          string `json:"sha256"`            // hex-encoded SHA-256 checksum
+	SizeBytes       int64  `json:"size_bytes"`        // file size in bytes
+	HuggingFaceRepo string `json:"hugging_face_repo"` // override entry-level HuggingFace repo for this file (empty = use entry repo)
 }
 
 // EmbeddedCatalog is the built-in list of models available for download.
@@ -369,12 +376,62 @@ func batCatalogEntry(id, name, region string, speciesCount int, fileRegion strin
 	}
 }
 
+// catalogMu guards activeCatalog. activeCatalog is the runtime source of truth
+// for catalog reads. It is nil until LoadCatalog populates it; a nil value means
+// "use EmbeddedCatalog", so behavior is unchanged when LoadCatalog is never
+// called (e.g. in tests). The RWMutex makes a future hot-reload race-safe.
+//
+// A future hot-reload must publish a brand-new slice via setActiveCatalog; it
+// must never mutate an existing entry (or an entry's Files slice) in place,
+// because ActiveCatalog hands out a shallow snapshot that shares those backing
+// arrays with readers.
+var (
+	catalogMu     sync.RWMutex
+	activeCatalog []CatalogEntry
+)
+
+// currentCatalogLocked returns the active runtime catalog, falling back to the
+// built-in EmbeddedCatalog when no catalog has been loaded. Callers must hold
+// catalogMu (read or write).
+func currentCatalogLocked() []CatalogEntry {
+	if activeCatalog == nil {
+		return EmbeddedCatalog
+	}
+	return activeCatalog
+}
+
+// setActiveCatalog replaces the runtime catalog. It is called by LoadCatalog
+// once at startup. Passing EmbeddedCatalog restores the built-in default, and
+// passing nil restores the "use EmbeddedCatalog" sentinel. Test callers that use
+// it to inject a catalog must run serially (no t.Parallel), since it mutates
+// this package-global.
+func setActiveCatalog(entries []CatalogEntry) {
+	catalogMu.Lock()
+	activeCatalog = entries
+	catalogMu.Unlock()
+}
+
+// ActiveCatalog returns a snapshot copy of the active runtime catalog (all
+// entries, including hidden ones). The copy is safe for callers to range over
+// without holding any lock. Entries' Files slices are shared (read-only).
+func ActiveCatalog() []CatalogEntry {
+	catalogMu.RLock()
+	defer catalogMu.RUnlock()
+	cat := currentCatalogLocked()
+	out := make([]CatalogEntry, len(cat))
+	copy(out, cat)
+	return out
+}
+
 // GetCatalogEntry returns the catalog entry with the given ID and true,
 // or a zero value and false if no entry matches.
 func GetCatalogEntry(id string) (CatalogEntry, bool) {
-	for i := range EmbeddedCatalog {
-		if EmbeddedCatalog[i].ID == id {
-			return EmbeddedCatalog[i], true
+	catalogMu.RLock()
+	defer catalogMu.RUnlock()
+	cat := currentCatalogLocked()
+	for i := range cat {
+		if cat[i].ID == id {
+			return cat[i], true
 		}
 	}
 	return CatalogEntry{}, false
@@ -382,10 +439,13 @@ func GetCatalogEntry(id string) (CatalogEntry, bool) {
 
 // VisibleCatalog returns catalog entries that are not hidden.
 func VisibleCatalog() []CatalogEntry {
-	visible := make([]CatalogEntry, 0, len(EmbeddedCatalog))
-	for i := range EmbeddedCatalog {
-		if !EmbeddedCatalog[i].Hidden {
-			visible = append(visible, EmbeddedCatalog[i])
+	catalogMu.RLock()
+	defer catalogMu.RUnlock()
+	cat := currentCatalogLocked()
+	visible := make([]CatalogEntry, 0, len(cat))
+	for i := range cat {
+		if !cat[i].Hidden {
+			visible = append(visible, cat[i])
 		}
 	}
 	return visible

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -136,10 +136,14 @@ func (mm *ModelManager) notifyTopologyChanged() {
 func (mm *ModelManager) ScanInstalled() {
 	log := GetLogger()
 
+	// Snapshot the active catalog (honors a user-edited model-catalog.json)
+	// before taking mm.mu; ActiveCatalog acquires its own lock.
+	catalog := ActiveCatalog()
+
 	// Phase 1: scan the filesystem under mm.mu.
 	mm.mu.Lock()
-	for i := range EmbeddedCatalog {
-		entry := &EmbeddedCatalog[i]
+	for i := range catalog {
+		entry := &catalog[i]
 		subdir := filepath.Join(mm.modelsDir, entry.ID)
 
 		modelFile := ""

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -1081,10 +1081,14 @@ func TestModelManager_Uninstall_GeomodelConfigClearing(t *testing.T) {
 	current := conf.GetSettings()
 	require.Equal(t, "v3", current.BirdNET.RangeFilter.Model, "precondition: install must set model to v3")
 
-	// Add entry to EmbeddedCatalog temporarily so Uninstall can find it.
-	origLen := len(EmbeddedCatalog)
-	EmbeddedCatalog = append(EmbeddedCatalog, entry)
-	t.Cleanup(func() { EmbeddedCatalog = EmbeddedCatalog[:origLen] })
+	// Make the entry resolvable by Uninstall via the active catalog. Setting
+	// activeCatalog (under its lock) instead of mutating the shared
+	// EmbeddedCatalog global keeps the lock-guarded catalog accessors race-free.
+	withEntry := make([]CatalogEntry, len(EmbeddedCatalog), len(EmbeddedCatalog)+1)
+	copy(withEntry, EmbeddedCatalog)
+	withEntry = append(withEntry, entry)
+	setActiveCatalog(withEntry)
+	t.Cleanup(func() { setActiveCatalog(nil) })
 
 	// Uninstall should clear the range filter config.
 	require.NoError(t, mm.Uninstall("test-geo-uninstall-config"))

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -466,8 +466,9 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 			logger.String("registry_id", registryID))
 		return "", "", ""
 	}
-	for i := range EmbeddedCatalog {
-		entry := &EmbeddedCatalog[i]
+	catalog := ActiveCatalog()
+	for i := range catalog {
+		entry := &catalog[i]
 		if entry.RegistryID != registryID {
 			continue
 		}

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -175,6 +175,33 @@ func FindConfigFile() (string, error) {
 		Build()
 }
 
+// ResolveConfigDir returns the directory that contains the active config.yaml.
+// It prefers the directory of the resolved config file (honoring the --config
+// flag and viper's resolved path); when no config file is found yet (e.g. a
+// fresh install before the first save), it falls back to the first default
+// config path. This is the directory where co-located config artifacts such as
+// the user-editable model catalog are read from and written to.
+func ResolveConfigDir() (string, error) {
+	if path, err := FindConfigFile(); err == nil {
+		return filepath.Dir(path), nil
+	}
+
+	configPaths, err := GetDefaultConfigPaths()
+	if err != nil {
+		return "", errors.New(err).
+			Category(errors.CategoryConfiguration).
+			Context("operation", "resolve-config-dir").
+			Build()
+	}
+	if len(configPaths) == 0 {
+		return "", errors.Newf("no config directory could be resolved").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "resolve-config-dir").
+			Build()
+	}
+	return configPaths[0], nil
+}
+
 // GetBasePath expands environment variables in the given path and ensures the resulting path exists.
 // If the path is relative, it's interpreted as relative to the directory of the executing binary.
 func GetBasePath(path string) string {

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -182,6 +182,13 @@ func FindConfigFile() (string, error) {
 // config path. This is the directory where co-located config artifacts such as
 // the user-editable model catalog are read from and written to.
 func ResolveConfigDir() (string, error) {
+	// An explicit --config path wins even when the file does not exist yet (a
+	// fresh install whose config.yaml has not been saved): co-locate artifacts
+	// with the user-specified config rather than the default directory.
+	if ConfigPath != "" {
+		return filepath.Dir(ConfigPath), nil
+	}
+
 	if path, err := FindConfigFile(); err == nil {
 		return filepath.Dir(path), nil
 	}

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -277,6 +277,25 @@ func TestFindConfigFile_EmptyConfigPathFallsThrough(t *testing.T) {
 	}
 }
 
+func TestResolveConfigDir_ExplicitConfigPathHonoredWhenMissing(t *testing.T) {
+	// Save and restore the global ConfigPath after the test.
+	origConfigPath := ConfigPath
+	t.Cleanup(func() {
+		ConfigPath = origConfigPath
+	})
+
+	// An explicit --config path pointing at a file that does not exist yet
+	// (fresh install before the first save) must still resolve to that file's
+	// directory, so co-located artifacts (the model catalog) land next to the
+	// user-specified config rather than in a default directory.
+	tmpDir := t.TempDir()
+	ConfigPath = filepath.Join(tmpDir, "custom-config.yaml")
+
+	dir, err := ResolveConfigDir()
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir, dir, "ResolveConfigDir should return the explicit --config directory even when the file is absent")
+}
+
 func TestGetSoxFormats_WithExplicitPath(t *testing.T) {
 	soxPath, err := exec.LookPath(GetSoxBinaryName())
 	if err != nil {


### PR DESCRIPTION
## Summary

Converts the model catalog from a hardcoded Go slice into a user-editable JSON file at `<config-dir>/model-catalog.json`. The binary still ships only itself; the manifest is created on first run.

On startup:
- **Absent:** the file is seeded from the embedded catalog and written atomically.
- **Present:** it is loaded, validated, and used.
- **Bad JSON / failed validation:** falls back to the embedded catalog and leaves the file untouched (a user typo can never brick startup).

### Staleness handling (no stale manifest on upgrade)

The file records a SHA-256 checksum of the embedded catalog it was generated from. When a new release ships a changed built-in catalog:
- an **unedited (pristine)** file is auto-refreshed to the new catalog, so it never goes stale;
- a **user-edited** file is preserved as-is, with a warning telling the user to delete it to regenerate.

### Changes

- `model_catalog.go`: snake_case JSON tags on `CatalogEntry`/`CatalogFile`; a runtime `activeCatalog` (nil-sentinel meaning "use the embedded catalog") behind a `sync.RWMutex`; `ActiveCatalog`/`setActiveCatalog` plus lock-guarded accessors.
- `catalog_loader.go` (new): `LoadCatalog` (seed / load / refresh / preserve / fallback), `validateCatalog`, `catalogChecksum`, and an atomic temp-file write (write, fsync, chmod 0644, rename).
- Routes the remaining direct `EmbeddedCatalog` reads (`ScanInstalled`, `resolveInstalledPaths`, `ListModels`) through `ActiveCatalog` so user edits are honored everywhere.
- `conf.ResolveConfigDir`; loads the catalog at analyzer startup before the orchestrator so every catalog consumer sees the active catalog.

The model-gallery API is unaffected: it maps `CatalogEntry` to a separate camelCase response type, so the new on-disk tags do not change the API contract.

## Test Plan

- [x] `golangci-lint run` clean on all touched packages
- [x] `go test -race ./internal/classifier/ ./internal/conf/ ./internal/api/v2/` pass
- [x] New `catalog_loader_test.go`: seed, custom-entry load, malformed-JSON fallback (file untouched), validation failures, pristine refresh, edited-file preservation, schema-version mismatch, atomic write, write-failure fallback, accessor reads, checksum determinism + order sensitivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime-customizable model catalog persisted to an on-disk catalog file.
  * Model discovery, installed-model resolution, and model listings now reflect the active (loaded/custom) catalog.
  * Uses a resolved configuration directory for catalog/model-catalog operations.
* **Bug Fixes**
  * Startup and catalog loading are non-blocking; when catalog files are missing/invalid, the system falls back to the built-in catalog.
  * Invalid/malformed catalog files are not overwritten, preserving user edits.
* **Tests**
  * Added comprehensive automated coverage for seeding, validation, checksum/pristine detection, atomic writes, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->