### PR TITLE
fix(analytics): localize chart date axis labels to active locale

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/axes.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/axes.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { getLocale } from '$lib/i18n';
 import { select } from 'd3-selection';
 import { scaleLinear } from 'd3-scale';
 import { timeFormatDefaultLocale } from 'd3-time-format';
@@ -169,6 +170,18 @@ describe('createDateAxisFormatter', () => {
 
     expect(formatter(testDate)).toBe('Jan 15');
     expect(formatter(anotherDate)).toBe('Dec 25');
+  });
+
+  it('should localize weekday/month names to the active locale', () => {
+    // testDate is a Monday in January; Portuguese should not say "Mon"/"Jan".
+    vi.mocked(getLocale).mockReturnValueOnce('pt');
+    expect(createDateAxisFormatter('week')(testDate)).toBe('seg. 15');
+
+    vi.mocked(getLocale).mockReturnValueOnce('pt');
+    expect(createDateAxisFormatter('month')(testDate)).toBe('jan. 15');
+
+    vi.mocked(getLocale).mockReturnValueOnce('pt');
+    expect(createDateAxisFormatter('year')(testDate)).toBe('jan. 2024');
   });
 });
 

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/axes.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/axes.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getLocale } from '$lib/i18n';
 import { select } from 'd3-selection';
 import { scaleLinear } from 'd3-scale';
-import { timeFormatDefaultLocale } from 'd3-time-format';
 import {
   createHourAxisFormatter,
   createDateAxisFormatter,
@@ -92,45 +91,9 @@ describe('createHourAxisFormatter', () => {
 });
 
 describe('createDateAxisFormatter', () => {
-  // Set fixed English locale for deterministic date formatting
-  beforeAll(() => {
-    timeFormatDefaultLocale({
-      dateTime: '%x, %X',
-      date: '%-m/%-d/%Y',
-      time: '%-I:%M:%S %p',
-      periods: ['AM', 'PM'],
-      days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-      shortDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-      months: [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December',
-      ],
-      shortMonths: [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec',
-      ],
-    });
-  });
+  // Date formatting is locale-driven via Intl.DateTimeFormat; the shared test
+  // setup mocks getLocale() to 'en', so the English expectations below are
+  // deterministic without configuring d3-time-format.
 
   // Fixed dates for deterministic testing
   const testDate = new Date('2024-01-15T14:30:00');

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
@@ -158,8 +158,8 @@ const YEAR_THRESHOLD = 365;
  * Pick the appropriate date-axis bucket for a daily-granularity time domain.
  *
  * NOTE: This intentionally NEVER returns 'day'. The 'day' bucket maps to a
- * clock-time format (%H:%M) via createDateAxisFormatter, which is only correct
- * for intra-day (hourly) data. The analytics charts that use this helper plot
+ * clock-time (hour:minute) format via createDateAxisFormatter, which is only
+ * correct for intra-day (hourly) data. The analytics charts that use this helper plot
  * one point per calendar day, so a short (<= 7 day) span must still show date
  * labels, not "00:00 00:00 ...". A 7-day or shorter span therefore uses 'week'
  * (weekday + day), longer spans use 'month', and spans over a year use 'year'.
@@ -194,11 +194,15 @@ export function createDateAxisFormatter(
 
   switch (range) {
     case 'day': {
-      // Clock time (e.g. "14:30" or "02:30 PM"), locale-aware.
+      // Clock time (e.g. "14:30" or "02:30 PM"), locale-aware. An explicit
+      // hourCycle keeps parity with the previous D3 '%H:%M' / '%I:%M %p' tokens:
+      // h23 renders midnight as "00:00" (never "24:00"), h12 renders 12-hour
+      // with the AM/PM marker. This avoids depending on each locale's default
+      // 24-hour cycle, which can be h24 for some locales.
       const time = new Intl.DateTimeFormat(locale, {
         hour: '2-digit',
         minute: '2-digit',
-        hour12: !use24Hour,
+        hourCycle: use24Hour ? 'h23' : 'h12',
       });
       return (d: Date) => time.format(d);
     }

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/axes.ts
@@ -1,6 +1,6 @@
 // D3 axis utilities for analytics charts
 import { axisBottom, axisLeft, axisRight, axisTop } from 'd3-axis';
-import { timeFormat } from 'd3-time-format';
+import { getLocale } from '$lib/i18n';
 import type { Axis, AxisDomain, AxisScale } from 'd3-axis';
 import type { ScaleLinear, ScaleTime } from 'd3-scale';
 import type { Selection } from 'd3-selection';
@@ -171,26 +171,53 @@ export function pickDateRangeBucket(domain: [Date, Date]): 'day' | 'week' | 'mon
   return 'year';
 }
 
+// Two-digit zero-padded day-of-month, matching the previous D3 '%d' token.
+function padDay(d: Date): string {
+  return d.getDate().toString().padStart(2, '0');
+}
+
 /**
- * Create date axis formatter for different time ranges
+ * Create date axis formatter for different time ranges.
+ *
+ * Weekday and month names are localized to the active app locale via
+ * Intl.DateTimeFormat (e.g. "Sun 24" -> "Dom 24" in Portuguese). The
+ * weekday-/month-first ordering and zero-padded day of the original D3
+ * '%a %d' / '%b %d' / '%b %Y' formats are preserved by composing the parts
+ * manually, so only the translated names change, not the layout.
  */
 export function createDateAxisFormatter(
   range: 'day' | 'week' | 'month' | 'year',
   opts: { use24Hour?: boolean } = {}
 ): (d: Date) => string {
   const use24Hour = opts.use24Hour ?? true;
+  const locale = getLocale();
 
   switch (range) {
-    case 'day':
-      return (d: Date) => timeFormat(use24Hour ? '%H:%M' : '%I:%M %p')(d);
-    case 'week':
-      return (d: Date) => timeFormat('%a %d')(d);
+    case 'day': {
+      // Clock time (e.g. "14:30" or "02:30 PM"), locale-aware.
+      const time = new Intl.DateTimeFormat(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: !use24Hour,
+      });
+      return (d: Date) => time.format(d);
+    }
+    case 'week': {
+      // Localized weekday abbreviation + day (e.g. "Sun 24" / "Dom 24").
+      const weekday = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+      return (d: Date) => `${weekday.format(d)} ${padDay(d)}`;
+    }
+    case 'year': {
+      // Localized month abbreviation + year (e.g. "Oct 2025").
+      const month = new Intl.DateTimeFormat(locale, { month: 'short' });
+      return (d: Date) => `${month.format(d)} ${d.getFullYear()}`;
+    }
     case 'month':
-      return (d: Date) => timeFormat('%b %d')(d);
-    case 'year':
-      return (d: Date) => timeFormat('%b %Y')(d);
-    default:
-      return (d: Date) => timeFormat('%b %d')(d);
+    default: {
+      // Localized month abbreviation + day (e.g. "Oct 01").
+      const month = new Intl.DateTimeFormat(locale, { month: 'short' });
+      return (d: Date) => `${month.format(d)} ${padDay(d)}`;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Analytics chart date/time axis labels were always rendered in **English**, regardless of the app locale. `createDateAxisFormatter` used d3's `timeFormat`, which formats against d3's *global default* locale — and the app never configures it. So a Portuguese user still saw `Mon 15` / `Jan 2024` on their charts.

## Fix

Replace `d3 timeFormat` with `Intl.DateTimeFormat` driven by `getLocale()`. Weekday and month names now follow the active app locale (e.g. `Mon 15` → `seg. 15`, `Jan 2024` → `jan. 2024` in Portuguese).

The original `%a %d` / `%b %d` / `%b %Y` layout — weekday/month first, zero-padded day — is preserved by composing the parts manually (`padDay` helper), so only the translated names change, not the column layout. The `Intl.DateTimeFormat` instances are built once per formatter, not per tick.

## Scope

- `createDateAxisFormatter` only (`day`/`week`/`month`/`year` buckets).
- No new translation keys — `Intl` supplies localized names, so no `*.json` changes needed.

## Testing

- Added a test asserting Portuguese output (`seg. 15`, `jan. 15`, `jan. 2024`) via the mocked `getLocale`.
- `npm run check:all` clean: prettier, eslint, stylelint, `svelte-check` (0 errors/warnings), ast-grep rules.
- Full `axes.test.ts` suite passes (28 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Chart date axis labels now respect your app’s active locale, displaying localized month and weekday abbreviations for daily, weekly, monthly, and yearly chart views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->