### PR TITLE
feat: OpenVINO acceleration for the bat embedding extractor

### DIFF
--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -21,16 +21,18 @@ type Bat struct {
 	batClassifier      inference.CustomClassifier
 	info               ModelInfo
 	mu                 sync.Mutex
-	// device is the compute device the bat pipeline bound to. Both the embedding
-	// extractor and the classifier run on the ONNX Runtime CPU EP today (there is
-	// no OpenVINO path for the bat model), so this is deviceCPU. Kept as a field
-	// rather than a constant so a future OpenVINO bat path can set the real device
-	// at construction. Reported via Device().
+	// device is the compute device the bat pipeline bound to: the OpenVINO device
+	// (CPU/GPU) when the heavy embedding extractor runs on OpenVINO, otherwise
+	// deviceCPU for the ONNX Runtime CPU EP. The tiny bat classifier head always runs
+	// on ORT CPU, so this reports the embedding extractor's device. Set once at
+	// construction; reported via Device().
 	device string
-	// backend is the live execution backend (BackendONNX today; the bat pipeline is
-	// ONNX-only), and precision is the weight precision detected from the classifier
-	// model filename (empty when no token). Both set once at construction; reported
-	// via Backend()/Precision().
+	// backend is the live execution backend of the embedding extractor
+	// (BackendOpenVINO when it runs on OpenVINO, else BackendONNX), and precision is
+	// the effective runtime precision (FP32 on the OpenVINO path, which the bat
+	// embedding model is forced to; the weight precision detected from the classifier
+	// model filename on the ORT path, empty when no token). Both set once at
+	// construction; reported via Backend()/Precision().
 	backend   string
 	precision string
 }
@@ -43,7 +45,23 @@ type BatModelConfig struct {
 	ClassifierLabelPath string
 	ONNXRuntimePath     string
 	Threads             int
+
+	// OpenVINO opt-in, sourced from BirdNET settings: the bat pipeline reuses the
+	// global BirdNET inference backend / OpenVINO device preference. When the gate
+	// allows it, the heavy embedding extractor runs on OpenVINO (forced f32, since the
+	// embedding head overflows at f16); the tiny bat classifier head always stays on
+	// ORT. Any failure falls back to ORT.
+	Backend        string // BirdNET.Backend ("auto"/"onnx"/"openvino")
+	OpenVINOPath   string // BirdNET.OpenVINOPath (libopenvino_c location)
+	OpenVINODevice string // BirdNET.OpenVINODevice ("auto"/"cpu"/"gpu")
 }
+
+// batEmbeddingOutputIndex is the output port of the bat embedding model
+// (birdnet-v24-embeddings.onnx) that carries the embedding vector; port 0 is the
+// species logits, which the bat pipeline discards. The selected port's element count
+// is validated against the bat classifier's input dimension in tryBatOpenVINO, so a
+// wrong index degrades to ORT rather than feeding a malformed embedding downstream.
+const batEmbeddingOutputIndex = 1
 
 // NewBat creates a new bat detection model instance.
 func NewBat(cfg *BatModelConfig) (*Bat, error) {
@@ -56,37 +74,61 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 			Build()
 	}
 
-	embClassifier, err := inference.NewONNXClassifier(cfg.EmbeddingModelPath, inference.ONNXClassifierOptions{
-		Labels:              cfg.EmbeddingLabels,
-		Threads:             cfg.Threads,
-		SkipLabelValidation: true,
-	})
-	if err != nil {
-		return nil, errors.New(err).
-			Category(errors.CategoryModelInit).
-			Context("embedding_model", cfg.EmbeddingModelPath).
-			Build()
-	}
-
-	embExtractor, ok := embClassifier.(inference.EmbeddingExtractor)
-	if !ok {
-		embClassifier.Close()
-		return nil, errors.Newf("embedding model does not support embedding extraction; ensure it has 2 outputs").
-			Category(errors.CategoryModelInit).
-			Context("embedding_model", cfg.EmbeddingModelPath).
-			Build()
-	}
-
+	// Build the bat classifier head first. It always runs on ONNX Runtime (it is too
+	// small to benefit from OpenVINO), and its input dimension is the embedding size
+	// the upstream extractor must produce, which gates and validates the OpenVINO
+	// embedding path below.
 	batCC, err := inference.NewONNXCustomClassifier(cfg.ClassifierModelPath, inference.ONNXCustomClassifierOptions{
 		LabelsPath: cfg.ClassifierLabelPath,
 		Threads:    cfg.Threads,
 	})
 	if err != nil {
-		embClassifier.Close()
 		return nil, errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("classifier_model", cfg.ClassifierModelPath).
 			Build()
+	}
+
+	// Prefer the OpenVINO backend for the heavy embedding extractor when eligible
+	// (same device gate as BirdNET v2.4), falling back to ORT on any failure.
+	// OpenVINO must never make the bat model fail to load, so tryBatOpenVINO logs and
+	// swallows OV errors and returns ok=false. device records the compute device the
+	// extractor actually bound to (the OpenVINO device on the OV path).
+	embExtractor, device, ok := tryBatOpenVINO(cfg, batCC.InputDim())
+	// The bat embedding model is forced to f32 on every OpenVINO device, so the
+	// effective OV runtime precision is FP32. The ORT path overrides all three below.
+	backend := BackendOpenVINO
+	precision := string(QuantizationFP32)
+	if !ok {
+		embClassifier, cerr := inference.NewONNXClassifier(cfg.EmbeddingModelPath, inference.ONNXClassifierOptions{
+			Labels:              cfg.EmbeddingLabels,
+			Threads:             cfg.Threads,
+			SkipLabelValidation: true,
+		})
+		if cerr != nil {
+			batCC.Close()
+			return nil, errors.New(cerr).
+				Category(errors.CategoryModelInit).
+				Context("embedding_model", cfg.EmbeddingModelPath).
+				Build()
+		}
+
+		ext, isExtractor := embClassifier.(inference.EmbeddingExtractor)
+		if !isExtractor {
+			embClassifier.Close()
+			batCC.Close()
+			return nil, errors.Newf("embedding model does not support embedding extraction; ensure it has 2 outputs").
+				Category(errors.CategoryModelInit).
+				Context("embedding_model", cfg.EmbeddingModelPath).
+				Build()
+		}
+		embExtractor = ext
+		// The embedding extractor and the classifier both run on the ONNX Runtime CPU
+		// EP on this path. Surface the weight precision detected from the classifier
+		// model filename (empty when no token, the common case for the bat model).
+		device = deviceCPU
+		backend = BackendONNX
+		precision = string(detectQuantization(cfg.ClassifierModelPath))
 	}
 
 	batLabels := batCC.Labels()
@@ -97,19 +139,67 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 	log.Info("Bat detection model initialized",
 		logger.String("embedding_model", cfg.EmbeddingModelPath),
 		logger.String("classifier_model", cfg.ClassifierModelPath),
+		logger.String("backend", backend),
+		logger.String("device", device),
 		logger.Int("bat_species", len(batLabels)))
 
 	return &Bat{
 		embeddingExtractor: embExtractor,
 		batClassifier:      batCC,
 		info:               info,
-		// The bat embedding + classifier pipeline is ONNX-only (CPU EP) today.
-		device:  deviceCPU,
-		backend: BackendONNX,
-		// Surface the weight precision detected from the classifier model filename
-		// (empty when no token, which is the common case for the bat model).
-		precision: string(detectQuantization(cfg.ClassifierModelPath)),
+		device:             device,
+		backend:            backend,
+		precision:          precision,
 	}, nil
+}
+
+// tryBatOpenVINO attempts to build an OpenVINO embedding extractor for the bat
+// pipeline's heavy embedding model. It returns (extractor, device, true) on success
+// or (nil, "", false) to fall back to ORT, where device is the concrete OpenVINO
+// device the extractor bound to (inference.OVDeviceCPU/OVDeviceGPU). Any failure
+// (gate denied, init/compile/validation error) is logged and swallowed: OpenVINO
+// must never make the bat model fail to load. The device gate matches BirdNET v2.4;
+// the bat embedding model is forced to f32 on every device by
+// openVINOPrecisionFor(RegistryIDBat, ...) because its embedding head overflows at
+// f16. expectedDim is the bat classifier's input dimension, used to reject a wrong
+// output port before any inference.
+func tryBatOpenVINO(cfg *BatModelConfig, expectedDim int) (inference.EmbeddingExtractor, string, bool) {
+	plan, ok, reason := openVINOPlanFor(cfg.Backend, cfg.OpenVINODevice, RegistryIDBat, cfg.OpenVINOPath, batEmbeddingOutputIndex)
+	if !ok {
+		logOpenVINODeclined(RegistryIDBat, cfg.Backend, reason)
+		return nil, "", false
+	}
+
+	log := GetLogger()
+	// InitOpenVINO is idempotent: the auto/GPU plan above may already have loaded the
+	// core to enumerate devices, but the explicit-CPU plan path does not, so init here
+	// to cover it. A load failure means no usable OpenVINO; fall back to ORT.
+	if err := inference.InitOpenVINO(cfg.OpenVINOPath); err != nil {
+		log.Warn("Bat OpenVINO init failed; using ONNX Runtime", logger.Error(err))
+		return nil, "", false
+	}
+
+	start := time.Now()
+	extractor, err := inference.NewOpenVINOEmbeddingExtractor(cfg.EmbeddingModelPath, inference.OpenVINOEmbeddingExtractorOptions{
+		Threads:       cfg.Threads,
+		Device:        plan.device,
+		OutputIndex:   plan.outputIndex,
+		PrecisionHint: plan.precision, // f32 for the bat embedding model on every device
+		ExpectedDim:   expectedDim,
+	})
+	if err != nil {
+		log.Warn("Bat OpenVINO embedding extractor init failed; using ONNX Runtime",
+			logger.String("device", plan.device),
+			logger.Error(err))
+		return nil, "", false
+	}
+
+	log.Info("Bat embedding extractor using OpenVINO backend",
+		logger.String("device", plan.device),
+		logger.String("precision", openVINOPrecisionLabel(plan.precision)),
+		logger.Int("embedding_dim", extractor.NumSpecies()),
+		logger.String("init_time", time.Since(start).String()))
+	return extractor, plan.device, true
 }
 
 // Predict runs the two-stage bat detection pipeline: embedding extraction then bat classification.
@@ -269,19 +359,21 @@ func (b *Bat) Labels() []string {
 	return b.batClassifier.Labels()
 }
 
-// Device returns the compute device the bat pipeline bound to ("CPU" today; the
-// model is ONNX-only). Set once at construction and never mutated, so no lock is
-// needed. Implements ModelInstance.
+// Device returns the compute device the bat pipeline bound to: the OpenVINO device
+// (CPU/GPU) when the embedding extractor runs on OpenVINO, else "CPU" for the ONNX
+// Runtime CPU EP. Set once at construction and never mutated, so no lock is needed.
+// Implements ModelInstance.
 func (b *Bat) Device() string { return b.device }
 
-// Backend returns the live execution backend the bat pipeline bound to
-// (BackendONNX today). Set once at construction and never mutated, so no lock is
-// needed. Implements ModelInstance.
+// Backend returns the live execution backend the bat embedding extractor bound to
+// (BackendOpenVINO on the OV path, else BackendONNX). Set once at construction and
+// never mutated, so no lock is needed. Implements ModelInstance.
 func (b *Bat) Backend() string { return b.backend }
 
-// Precision returns the weight precision detected from the bat classifier model
-// filename (empty when no token). Set once at construction and never mutated, so
-// no lock is needed. Implements ModelInstance.
+// Precision returns the effective runtime precision (FP32 on the OpenVINO path, which
+// the bat embedding model is forced to; the weight precision detected from the bat
+// classifier model filename on the ORT path, empty when no token). Set once at
+// construction and never mutated, so no lock is needed. Implements ModelInstance.
 func (b *Bat) Precision() string { return b.precision }
 
 // Close releases resources held by the bat model.

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -102,9 +102,18 @@ func openVINOPlanFor(backendPref, devicePref, modelID, libraryPath string, outpu
 // ~0.8, wrong top-1, confidences fall to ~0) while a loud single-species clip
 // survives by luck; f32 is bit-exact with ORT (~6e-6) and still ~4.6x faster than
 // ORT CPU. CPU f16 (incl. ARM A76) and Perch v2 f16-GPU are unaffected, so the
-// override is scoped to BirdNET-on-GPU. Do NOT widen it to f16 without re-running
-// the inference/openvino_parity_functional_test.go soundscape parity check.
+// BirdNET-v2.4 override is scoped to its GPU path. Do NOT widen it to f16 without
+// re-running the inference/openvino_parity_functional_test.go soundscape parity check.
+//
+// The bat embedding model is the exception that is forced to f32 on EVERY device:
+// its embedding head overflows at f16 on genuine f16 hardware (the A76 CPU's f16 NEON
+// and the Intel iGPU), corrupting the raw embedding the bat classifier consumes and
+// flipping detections. Unlike BirdNET v2.4 this is not GPU-only. Do NOT relax it to
+// f16 without re-running the bat embedding parity check.
 func openVINOPrecisionFor(modelID, device string) string {
+	if modelID == RegistryIDBat {
+		return inference.OVPrecisionF32
+	}
 	if device == inference.OVDeviceGPU && modelID == DefaultModelVersion {
 		return inference.OVPrecisionF32
 	}

--- a/internal/classifier/openvino_dispatch_test.go
+++ b/internal/classifier/openvino_dispatch_test.go
@@ -99,6 +99,33 @@ func TestOpenVINOPlanReason_WrongModel(t *testing.T) {
 	assert.Equal(t, ovReasonNotBirdNETv24, reason)
 }
 
+// TestTryBatOpenVINO_FallsBackWithoutTag verifies that without the openvino build
+// tag, tryBatOpenVINO declines (returns a nil extractor and ok=false) so NewBat uses
+// the ORT embedding path. This pins the "OpenVINO must never make the bat model fail
+// to load" contract at the gate level, and the explicit nil return guards against the
+// typed-nil interface trap. It is the observable behavior in a CI (no-tag) build.
+func TestTryBatOpenVINO_FallsBackWithoutTag(t *testing.T) {
+	t.Parallel()
+	cfg := &BatModelConfig{
+		Backend:        conf.BackendPrefOpenVINO,
+		OpenVINODevice: conf.OVDeviceGPU,
+	}
+	ext, device, ok := tryBatOpenVINO(cfg, 1024)
+	assert.False(t, ok, "without the openvino tag, the bat OV path must decline")
+	assert.Nil(t, ext, "a declined OV path must return a nil extractor (no typed-nil trap)")
+	assert.Empty(t, device)
+}
+
+// TestOpenVINOPlanForBat_NotBuilt verifies that in the default (no-tag) build the
+// planner reports the not-built reason for the bat embedding model, so tryBatOpenVINO
+// logs why OpenVINO was declined rather than falling back silently.
+func TestOpenVINOPlanForBat_NotBuilt(t *testing.T) {
+	t.Parallel()
+	_, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceGPU, RegistryIDBat, "", batEmbeddingOutputIndex)
+	assert.False(t, ok)
+	assert.Equal(t, ovReasonNotBuilt, reason)
+}
+
 // TestLogOpenVINODeclined_StandardBuild verifies the noise-control policy on a
 // non-openvino build: the auto path (the common case) stays silent so it does not
 // add a line to every standard-build startup, while an explicit backend=openvino

--- a/internal/classifier/openvino_gating_openvino_test.go
+++ b/internal/classifier/openvino_gating_openvino_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
+// archAMD64 is the GOARCH value for 64-bit x86, used by the explicit-CPU gate
+// assertions: the x86 OpenVINO CPU plugin is SIGILL-safe, so explicit CPU is allowed
+// there even without ARM native f16.
+const archAMD64 = "amd64"
+
 // TestShouldTryOpenVINO_Tagged_OptOut verifies Backend="onnx" opts out even when the
 // openvino backend is compiled in.
 func TestShouldTryOpenVINO_Tagged_OptOut(t *testing.T) {
@@ -62,7 +67,7 @@ func TestShouldTryOpenVINO_Tagged_HardwareGateDecides(t *testing.T) {
 func TestOpenVINOPlan_ExplicitCPU(t *testing.T) {
 	t.Parallel()
 	plan, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceCPU, RegistryIDPerchV2, "", perchLogitsOutputIndex)
-	expected := cpuspec.HasNativeF16() || runtime.GOARCH == "amd64"
+	expected := cpuspec.HasNativeF16() || runtime.GOARCH == archAMD64
 	assert.Equal(t, expected, ok, "explicit CPU is allowed on ARM A76 or amd64, not on ARM A72")
 	if ok {
 		assert.Equal(t, inference.OVDeviceCPU, plan.device)
@@ -70,6 +75,28 @@ func TestOpenVINOPlan_ExplicitCPU(t *testing.T) {
 		assert.Empty(t, reason, "an accepted plan must not carry a decline reason")
 	} else {
 		assert.Equal(t, ovReasonCPUUnsupported, reason, "explicit CPU on an unsupported host reports the cpu reason")
+	}
+}
+
+// TestOpenVINOPlan_Bat_ForcesF32 verifies the bat embedding model's plan carries f32
+// precision on whatever device the gate selects (explicit CPU here), unlike BirdNET
+// v2.4 which is f32 only on the GPU. The explicit-CPU path never enumerates devices,
+// so no libopenvino_c is required. On a host where CPU is not allowed (ARM A72) the
+// plan is declined, which the else branch covers. This pins the bat-specific
+// "f32 everywhere" deviation at the plan level, where compilation actually reads it.
+func TestOpenVINOPlan_Bat_ForcesF32(t *testing.T) {
+	t.Parallel()
+	plan, ok, reason := openVINOPlanFor(conf.BackendPrefOpenVINO, conf.OVDeviceCPU, RegistryIDBat, "", batEmbeddingOutputIndex)
+	expected := cpuspec.HasNativeF16() || runtime.GOARCH == archAMD64
+	assert.Equal(t, expected, ok, "explicit CPU is allowed on ARM A76 or amd64, not on ARM A72")
+	if ok {
+		assert.Equal(t, inference.OVDeviceCPU, plan.device)
+		assert.Equal(t, batEmbeddingOutputIndex, plan.outputIndex)
+		assert.Equal(t, inference.OVPrecisionF32, plan.precision,
+			"the bat embedding model must run at f32 on the CPU too (f16 overflows the embedding head)")
+		assert.Empty(t, reason, "an accepted plan must not carry a decline reason")
+	} else {
+		assert.Equal(t, ovReasonCPUUnsupported, reason)
 	}
 }
 

--- a/internal/classifier/openvino_precision_test.go
+++ b/internal/classifier/openvino_precision_test.go
@@ -26,6 +26,12 @@ func TestOpenVINOPrecisionFor(t *testing.T) {
 		"Perch on the GPU keeps f16 (validated parity with f32)")
 	assert.Empty(t, openVINOPrecisionFor(RegistryIDPerchV2, inference.OVDeviceCPU),
 		"Perch on CPU keeps the f16 default")
+	// The bat embedding model overflows at f16 on every device, so it must be forced
+	// to f32 on BOTH GPU and CPU (unlike BirdNET v2.4, which is f32 on GPU only).
+	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(RegistryIDBat, inference.OVDeviceGPU),
+		"bat embedding model on the GPU must be forced to f32")
+	assert.Equal(t, inference.OVPrecisionF32, openVINOPrecisionFor(RegistryIDBat, inference.OVDeviceCPU),
+		"bat embedding model on CPU must be forced to f32 (f16 overflows the embedding head)")
 }
 
 // TestOpenVINOEffectivePrecision verifies the mapping from an OpenVINO

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1279,9 +1279,9 @@ func secondaryTripletFor(settings *conf.Settings) secondaryBackendKey {
 	}
 }
 
-// ReloadSecondaryModels rebuilds the OV-capable secondary models (currently
-// Perch) when the BirdNET inference backend or OpenVINO device preference
-// changes at runtime, so they move to the new device without a full restart.
+// ReloadSecondaryModels rebuilds the OV-capable secondary models (Perch, and the
+// bat embedding extractor) when the BirdNET inference backend or OpenVINO device
+// preference changes at runtime, so they move to the new device without a full restart.
 // It mirrors the primary reload's transactional safety: each model is built on
 // the new backend BEFORE the old instance is closed, and a build failure leaves
 // the old instance serving (one model failing does not abort the others).
@@ -1547,10 +1547,10 @@ type secondaryModelBuilder func(o *Orchestrator, settings *conf.Settings, thread
 // whose construction honors the BirdNET inference backend / OpenVINO device
 // preference to a builder returning a fresh, unregistered instance.
 // ReloadSecondaryModels rebuilds exactly these models when the backend/device
-// changes at runtime. ORT-only secondaries (e.g. Bat, which consumes only
-// ONNXRuntimePath) are intentionally absent: rebuilding them on a device change
-// would be wasted native work. Giving a new secondary OpenVINO support is a
-// one-line entry here, paired with the OV fields on its loader config.
+// changes at runtime. For Bat, only the heavy embedding extractor honors the
+// preference; the tiny bat classifier head always runs on ORT. Giving a new
+// secondary OpenVINO support is a one-line entry here, paired with the OV fields on
+// its loader config.
 var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 	RegistryIDPerchV2: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
 		// Explicit nil-on-error return avoids the typed-nil interface trap (a
@@ -1560,6 +1560,15 @@ var openvinoCapableSecondaryBuilders = map[string]secondaryModelBuilder{
 			return nil, err
 		}
 		return p, nil
+	},
+	RegistryIDBat: func(o *Orchestrator, settings *conf.Settings, threads int) (ModelInstance, error) {
+		// Explicit nil-on-error return avoids the typed-nil interface trap (a
+		// nil *Bat wrapped in a non-nil ModelInstance).
+		b, err := o.buildBat(settings, threads)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
 	},
 }
 

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -1,22 +1,20 @@
 package classifier
 
 import (
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// loadBat creates and registers a bat detection model instance from settings.
-// o.mu.Lock() is held by the caller.
-func (o *Orchestrator) loadBat(threads int) error {
-	log := GetLogger()
-	before := o.captureRSSBefore()
-
-	// Read the live published settings snapshot once (mirroring loadPerch) rather
-	// than the deprecated o.Settings pointer, so an out-of-band LoadModel after a
-	// hot-reload builds against the same configuration the rest of the orchestrator
-	// sees instead of a possibly-staler pointer.
-	settings := o.currentSettings()
-
+// buildBat constructs a Bat model instance from the given settings snapshot WITHOUT
+// registering it in o.models. loadBat uses it for the initial registration; the
+// hot-reload path (ReloadSecondaryModels) uses it directly so it can build the new
+// instance on the new backend/device before transactionally swapping it into the
+// existing modelEntry.
+//
+// The settings snapshot is passed in (rather than read inside) so the caller builds
+// with the exact settings it gated the reload decision on.
+func (o *Orchestrator) buildBat(settings *conf.Settings, threads int) (*Bat, error) {
 	classifierModel := settings.Bat.ClassifierModel
 	labelPath := settings.Bat.LabelPath
 	embeddingModel := settings.Bat.EmbeddingModel
@@ -35,7 +33,7 @@ func (o *Orchestrator) loadBat(threads int) error {
 	}
 
 	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
-		return errors.Newf("bat model files not installed or configured").
+		return nil, errors.Newf("bat model files not installed or configured").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBat).
@@ -43,7 +41,7 @@ func (o *Orchestrator) loadBat(threads int) error {
 	}
 
 	if err := checkORTOrFail(settings.BirdNET.ONNXRuntimePath, "Bat model", RegistryIDBat, "classifier.orchestrator"); err != nil {
-		return err
+		return nil, err
 	}
 
 	cfg := BatModelConfig{
@@ -53,25 +51,50 @@ func (o *Orchestrator) loadBat(threads int) error {
 		ClassifierLabelPath: labelPath,
 		ONNXRuntimePath:     settings.BirdNET.ONNXRuntimePath,
 		Threads:             threads,
+		Backend:             settings.BirdNET.Backend,
+		OpenVINOPath:        settings.BirdNET.OpenVINOPath,
+		OpenVINODevice:      settings.BirdNET.OpenVINODevice,
 	}
 
 	bat, err := NewBat(&cfg)
 	if err != nil {
-		return errors.New(err).
+		return nil, errors.New(err).
 			Component("classifier.orchestrator").
 			Category(errors.CategoryModelInit).
 			Context("model", RegistryIDBat).
 			Build()
 	}
 
-	o.models[bat.ModelID()] = &modelEntry{instance: bat}
+	return bat, nil
+}
+
+// loadBat creates and registers a bat detection model instance from settings.
+// o.mu.Lock() is held by the caller.
+func (o *Orchestrator) loadBat(threads int) error {
+	// Capture the settings snapshot once so the recorded backend triplet matches the
+	// exact configuration the instance was built against (mirroring loadPerch). This
+	// is what makes an out-of-band runtime install (LoadModel) reconcile correctly:
+	// the entry records its own triplet, so a later ReloadSecondaryModels rebuilds it
+	// only when the backend/device actually changes.
+	settings := o.currentSettings()
+	before := o.captureRSSBefore()
+
+	bat, err := o.buildBat(settings, threads)
+	if err != nil {
+		return err
+	}
+
+	o.models[bat.ModelID()] = &modelEntry{
+		instance: bat,
+		backend:  secondaryTripletFor(settings),
+	}
 	// Defer the warm-up + RSS measurement until the caller releases o.mu, so the
 	// warm-up inference runs via the serialized inference path instead of stalling
 	// live inference on o.mu. The entry is registered above first
 	// so the drainer can find it by key.
 	o.deferWarmup(bat.ModelID(), before)
 
-	log.Info("Bat model loaded into Orchestrator",
+	GetLogger().Info("Bat model loaded into Orchestrator",
 		logger.String("model_id", bat.ModelID()),
 		logger.Int("species", bat.NumSpecies()))
 

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -213,17 +213,30 @@ func TestReloadSecondaryModels_KeepsOldOnBuildFailure(t *testing.T) {
 func TestReloadSecondaryModels_SkipsNonOVCapableSecondary(t *testing.T) {
 	setGlobalBackend(t, "openvino", "gpu", "")
 
-	// A non-OV-capable secondary (no builder registered, e.g. ORT-only Bat) must
-	// not be touched by the reload.
-	batLike := &reloadFakeModel{id: RegistryIDBat}
+	// A secondary with no registered OV builder must not be touched by the reload.
+	// (Bat used to be the example here, but it is now OV-capable, so use a synthetic
+	// ID that is genuinely absent from openvinoCapableSecondaryBuilders.)
+	const ortOnlyID = "ORTOnlySecondary"
+	ortOnly := &reloadFakeModel{id: ortOnlyID}
 	o := newTestOrchestrator(t, &mockModelInstance{id: permanentRegistryID})
 	o.ModelInfo.ID = permanentRegistryID
-	o.models[RegistryIDBat] = &modelEntry{instance: batLike}
+	o.models[ortOnlyID] = &modelEntry{instance: ortOnly}
 
 	require.NoError(t, o.ReloadSecondaryModels())
 
-	assert.Same(t, ModelInstance(batLike), o.models[RegistryIDBat].instance, "non-OV secondary must be untouched")
-	assert.Equal(t, int32(0), batLike.closes.Load(), "non-OV secondary must not be closed")
+	assert.Same(t, ModelInstance(ortOnly), o.models[ortOnlyID].instance, "non-OV secondary must be untouched")
+	assert.Equal(t, int32(0), ortOnly.closes.Load(), "non-OV secondary must not be closed")
+}
+
+// TestBatRegisteredAsOVCapableSecondary pins that the bat model is wired as an
+// OpenVINO-capable secondary, so ReloadSecondaryModels rebuilds it on a backend or
+// device change (only its heavy embedding extractor honors the preference; the bat
+// head stays on ORT). The rebuild/swap/triplet mechanics are covered by the
+// synthetic-ID reload tests above.
+func TestBatRegisteredAsOVCapableSecondary(t *testing.T) {
+	t.Parallel()
+	_, ok := openvinoCapableSecondaryBuilders[RegistryIDBat]
+	assert.True(t, ok, "bat must be registered as an OpenVINO-capable secondary")
 }
 
 func TestReloadSecondaryModels_OrphanedEntrySkipsSwapAndClosesNew(t *testing.T) {

--- a/internal/classifier/prediction_telemetry_test.go
+++ b/internal/classifier/prediction_telemetry_test.go
@@ -248,15 +248,17 @@ func (f *batEmbeddingExtractor) PredictWithEmbeddings(_ []float32) (logits, embe
 
 // batCustomClassifier is a fake inference.CustomClassifier for the Bat tests.
 type batCustomClassifier struct {
-	scores []float32
-	labels []string
-	err    error
+	scores   []float32
+	labels   []string
+	inputDim int
+	err      error
 }
 
 func (f *batCustomClassifier) PredictEmbedding(_ []float32) ([]float32, error) {
 	return f.scores, f.err
 }
 func (f *batCustomClassifier) NumClasses() int  { return len(f.labels) }
+func (f *batCustomClassifier) InputDim() int    { return f.inputDim }
 func (f *batCustomClassifier) Labels() []string { return f.labels }
 func (f *batCustomClassifier) Close()           {}
 

--- a/internal/inference/backend.go
+++ b/internal/inference/backend.go
@@ -38,6 +38,11 @@ type CustomClassifier interface {
 	// NumClasses returns the number of output classes.
 	NumClasses() int
 
+	// InputDim returns the embedding vector length the classifier expects as
+	// input. Used to validate that an upstream embedding extractor produces a
+	// compatible embedding dimension before wiring the two together.
+	InputDim() int
+
 	// Labels returns the classification labels.
 	Labels() []string
 

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -184,6 +184,14 @@ func (c *onnxCustomClassifier) NumClasses() int {
 	return c.classifier.NumClasses()
 }
 
+// InputDim returns the embedding vector length the classifier expects as input.
+func (c *onnxCustomClassifier) InputDim() int {
+	if c.classifier == nil {
+		return 0
+	}
+	return c.classifier.InputDim()
+}
+
 // Labels returns the classification labels.
 func (c *onnxCustomClassifier) Labels() []string {
 	if c.classifier == nil {

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -111,6 +111,111 @@ func (c *openvinoClassifier) Close() {
 	}
 }
 
+// OpenVINOEmbeddingExtractorOptions configures an OpenVINO-backed embedding
+// extractor. Unlike OpenVINOClassifierOptions it carries no label list: the
+// extractor reads a single non-logits output port (the embedding vector) and is
+// validated against the consumer's expected embedding dimension rather than a
+// species label count.
+type OpenVINOEmbeddingExtractorOptions struct {
+	Threads       int    // INFERENCE_NUM_THREADS; 0 = OpenVINO auto-tune (CPU only)
+	PrecisionHint string // INFERENCE_PRECISION_HINT; "" defaults to f16
+	Device        string // ov.DeviceCPU (default) or ov.DeviceGPU
+	OutputIndex   int    // embedding output port index (e.g. 1 for birdnet-v24-embeddings)
+	ExpectedDim   int    // required embedding element count; validated against the model
+}
+
+// openvinoEmbeddingExtractor adapts a single-output ov.Classifier bound to a
+// model's embedding port into an EmbeddingExtractor. The bat pipeline consumes
+// only the embedding vector (the embedding model's logits are discarded), so the
+// underlying classifier is compiled to read just the embedding output port. It is
+// NOT goroutine-safe; callers serialize access.
+type openvinoEmbeddingExtractor struct {
+	c   ov.Classifier
+	dim int
+}
+
+// NewOpenVINOEmbeddingExtractor creates an EmbeddingExtractor backed by the native
+// OpenVINO backend that reads a model's embedding output port (opts.OutputIndex).
+// InitOpenVINO must be called first; if the OpenVINO core is not initialized (or the
+// backend is not compiled in), construction returns ov.ErrOpenVINOUnavailable, which
+// the caller treats as fall back to ORT. The compiled embedding port's element count
+// is validated against opts.ExpectedDim (the consumer's required embedding dimension):
+// a mismatch (a wrong OutputIndex or an unexpected model) is rejected so the caller
+// falls back to ORT rather than feeding a malformed embedding downstream.
+func NewOpenVINOEmbeddingExtractor(modelPath string, opts OpenVINOEmbeddingExtractorOptions) (EmbeddingExtractor, error) {
+	if opts.ExpectedDim <= 0 {
+		return nil, errors.Newf("OpenVINO embedding extractor requires a positive ExpectedDim").
+			Category(errors.CategoryValidation).Build()
+	}
+	prec := opts.PrecisionHint
+	if prec == "" {
+		prec = ov.DefaultPrecisionHint
+	}
+	threads := max(opts.Threads, 0)
+	c, err := ov.NewClassifier(modelPath, ov.Options{
+		PrecisionHint: prec,
+		Threads:       threads,
+		Device:        opts.Device,
+		OutputIndex:   opts.OutputIndex,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Validate the compiled embedding port dimension against the consumer's expected
+	// embedding size (the bat classifier's input dim). The OV backend reports
+	// NumClasses from the selected output port of the compiled model, so a mismatch is
+	// a genuine model/port inconsistency: reject it and let the caller fall back to ORT.
+	if n := c.NumClasses(); n != opts.ExpectedDim {
+		_ = c.Close()
+		return nil, errors.Newf("OpenVINO embedding output dimension %d does not match expected %d", n, opts.ExpectedDim).
+			Category(errors.CategoryValidation).Build()
+	}
+	ovActiveClassifiers.Add(1)
+	return &openvinoEmbeddingExtractor{c: c, dim: c.NumClasses()}, nil
+}
+
+// Predict runs one inference and returns the embedding vector. This extractor binds
+// only the embedding output port (the embedding model's logits port is not compiled
+// in), so Predict returns the embedding rather than logits. The bat pipeline calls
+// PredictWithEmbeddings, not Predict; Predict exists to satisfy the Classifier
+// interface that EmbeddingExtractor embeds.
+func (e *openvinoEmbeddingExtractor) Predict(samples []float32) ([]float32, error) {
+	if e.c == nil {
+		return nil, ov.ErrOpenVINOUnavailable
+	}
+	return e.c.PredictRaw(samples)
+}
+
+// PredictWithEmbeddings runs one inference and returns the embedding vector as the
+// embeddings result with nil logits. The compiled model exposes only the embedding
+// output port (the native backend binds a single output per infer request) and the
+// bat pipeline discards the logits, so logits are intentionally nil.
+func (e *openvinoEmbeddingExtractor) PredictWithEmbeddings(samples []float32) (logits, embeddings []float32, err error) {
+	if e.c == nil {
+		return nil, nil, ov.ErrOpenVINOUnavailable
+	}
+	emb, err := e.c.PredictRaw(samples)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, emb, nil
+}
+
+// NumSpecies returns the embedding element count. The extractor has no species
+// output of its own (its logits port is not compiled in); this reports the embedding
+// dimension so the value is non-zero and stable.
+func (e *openvinoEmbeddingExtractor) NumSpecies() int { return e.dim }
+
+// Close releases the underlying compiled model and decrements the active-classifier
+// count. Idempotent.
+func (e *openvinoEmbeddingExtractor) Close() {
+	if e.c != nil {
+		_ = e.c.Close()
+		e.c = nil
+		ovActiveClassifiers.Add(-1)
+	}
+}
+
 // InitOpenVINO initializes the OpenVINO runtime (loads libopenvino_c and the
 // process-global core). Safe to call repeatedly; retries after failure for
 // hot-reload recovery. Mirrors InitONNXRuntime.

--- a/internal/inference/openvino.go
+++ b/internal/inference/openvino.go
@@ -174,16 +174,15 @@ func NewOpenVINOEmbeddingExtractor(modelPath string, opts OpenVINOEmbeddingExtra
 	return &openvinoEmbeddingExtractor{c: c, dim: c.NumClasses()}, nil
 }
 
-// Predict runs one inference and returns the embedding vector. This extractor binds
-// only the embedding output port (the embedding model's logits port is not compiled
-// in), so Predict returns the embedding rather than logits. The bat pipeline calls
-// PredictWithEmbeddings, not Predict; Predict exists to satisfy the Classifier
-// interface that EmbeddingExtractor embeds.
-func (e *openvinoEmbeddingExtractor) Predict(samples []float32) ([]float32, error) {
-	if e.c == nil {
-		return nil, ov.ErrOpenVINOUnavailable
-	}
-	return e.c.PredictRaw(samples)
+// Predict satisfies the Classifier interface that EmbeddingExtractor embeds, but
+// this extractor compiles only the model's embedding output port and so cannot
+// produce the raw logits Predict is contracted to return. It returns an error rather
+// than silently handing back an embedding vector in place of logits, so a caller
+// using it through a generic Classifier reference fails loudly instead of consuming
+// the wrong tensor. The bat pipeline calls PredictWithEmbeddings, never Predict.
+func (e *openvinoEmbeddingExtractor) Predict(_ []float32) ([]float32, error) {
+	return nil, errors.Newf("openvino embedding extractor does not produce logits; use PredictWithEmbeddings").
+		Category(errors.CategoryValidation).Build()
 }
 
 // PredictWithEmbeddings runs one inference and returns the embedding vector as the

--- a/internal/inference/openvino_notag_test.go
+++ b/internal/inference/openvino_notag_test.go
@@ -26,6 +26,32 @@ func TestNewOpenVINOClassifier_UnavailableWithoutTag(t *testing.T) {
 	assert.ErrorIs(t, err, ov.ErrOpenVINOUnavailable)
 }
 
+// TestNewOpenVINOEmbeddingExtractor_UnavailableWithoutTag verifies that without the
+// openvino build tag, the embedding extractor construction fails with the sentinel so
+// the bat pipeline falls back to its ORT embedding extractor.
+func TestNewOpenVINOEmbeddingExtractor_UnavailableWithoutTag(t *testing.T) {
+	t.Parallel()
+	e, err := NewOpenVINOEmbeddingExtractor("/x.onnx", OpenVINOEmbeddingExtractorOptions{
+		OutputIndex: 1,
+		ExpectedDim: 1024,
+	})
+	assert.Nil(t, e)
+	assert.ErrorIs(t, err, ov.ErrOpenVINOUnavailable)
+}
+
+// TestNewOpenVINOEmbeddingExtractor_RejectsInvalidExpectedDim verifies the guard that
+// rejects a non-positive ExpectedDim before any native call. A missing expected
+// dimension is a caller bug, not a runtime fallback, so it returns a validation error
+// rather than the unavailable sentinel.
+func TestNewOpenVINOEmbeddingExtractor_RejectsInvalidExpectedDim(t *testing.T) {
+	t.Parallel()
+	e, err := NewOpenVINOEmbeddingExtractor("/x.onnx", OpenVINOEmbeddingExtractorOptions{OutputIndex: 1})
+	assert.Nil(t, e)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ov.ErrOpenVINOUnavailable,
+		"a bad ExpectedDim is a validation error, not the unavailable sentinel")
+}
+
 // TestInitOpenVINO_GuardWithoutTag verifies that without the openvino build tag,
 // InitOpenVINO returns an error via the stub and does NOT mark the runtime as
 // initialized, leaving DestroyOpenVINO a safe no-op.

--- a/internal/inference/openvino_parity_functional_test.go
+++ b/internal/inference/openvino_parity_functional_test.go
@@ -225,6 +225,112 @@ func TestOpenVINOPrecisionDivergence_Functional(t *testing.T) {
 	require.LessOrEqual(t, maxConfDiff, maxConfErr, "f16 confidence drift from f32 exceeds tolerance")
 }
 
+// TestOpenVINOBatEmbeddingParity_Functional runs the bat pipeline's heavy embedding
+// model through both ONNX Runtime (the f32 reference) and the OpenVINO embedding
+// extractor on identical input, and compares the embedding vectors element-wise. It
+// is the evidence harness behind enabling the bat embedding extractor on OpenVINO:
+// the bat classifier consumes the raw embedding, so the OV path must reproduce it.
+// The bat embedding model is forced to f32 because f16 overflows its embedding head;
+// this test would blow up if that forcing regressed. Run it on amd64 (iGPU and CPU)
+// and arm64 (A76 CPU) to confirm per-device parity.
+//
+// Skipped unless OV_TEST_BAT_EMB_MODEL is set, so normal CI stays green. Env:
+//
+//   - OV_TEST_BAT_EMB_MODEL:        path to the FP32 bat embedding ONNX
+//     (birdnet-v24-embeddings.onnx, [batch,144000] -> logits + embedding).
+//   - OV_TEST_BAT_EMB_AUDIO:        optional raw little-endian float32 PCM (48 kHz
+//     mono, 3 s = 144000 samples). Zeros if unset, but a real clip is more telling.
+//   - OV_TEST_BAT_EMB_OUTPUT_INDEX: embedding output port (default 1; port 0 is logits).
+//   - OV_TEST_DEVICE:               "cpu", "gpu", or "auto"/"" (defaults to "gpu").
+//   - OV_TEST_LIB / OV_TEST_ORT_LIB: optional libopenvino_c / libonnxruntime paths.
+//   - OV_TEST_BAT_EMB_MAX_ERR:      max allowed |emb_ov - emb_ort| (default 0.05: see
+//     the tolerance note in the body).
+func TestOpenVINOBatEmbeddingParity_Functional(t *testing.T) {
+	modelPath := os.Getenv("OV_TEST_BAT_EMB_MODEL")
+	if modelPath == "" {
+		t.Skip("set OV_TEST_BAT_EMB_MODEL to run the OpenVINO bat embedding parity test")
+	}
+
+	samples := readAudioOrZeros(t, os.Getenv("OV_TEST_BAT_EMB_AUDIO"))
+	device := mapDevice(os.Getenv("OV_TEST_DEVICE"))
+
+	outputIndex := batEmbeddingParityDefaultOutputIndex
+	if v := os.Getenv("OV_TEST_BAT_EMB_OUTPUT_INDEX"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		require.NoError(t, err)
+		outputIndex = parsed
+	}
+	// f32-vs-f32 cross-runtime drift is small but not bit-exact: measured ~0.002 on
+	// the amd64 CPU and ~0.005 on the Iris Xe GPU, because ORT and OpenVINO use
+	// different f32 kernels and FMA ordering. The default tolerance sits an order of
+	// magnitude above that and two orders below the f16-overflow regime (~5.0), so it
+	// catches an f16 regression (which would corrupt the embedding and flip bat
+	// detections) without flagging benign GPU f32 numerics.
+	maxErr := 0.05
+	if v := os.Getenv("OV_TEST_BAT_EMB_MAX_ERR"); v != "" {
+		parsed, err := strconv.ParseFloat(v, 64)
+		require.NoError(t, err)
+		maxErr = parsed
+	}
+
+	// Reference backend: ONNX Runtime (f32) embedding extractor. The label list is
+	// irrelevant to the embedding output, so use a single placeholder with validation
+	// skipped, mirroring how the bat pipeline loads the embedding model.
+	require.NoError(t, InitONNXRuntime(os.Getenv("OV_TEST_ORT_LIB")))
+	t.Cleanup(func() { _ = DestroyONNXRuntime() })
+	ortClassifier, err := NewONNXClassifier(modelPath, ONNXClassifierOptions{
+		Labels:              []string{"placeholder"},
+		Threads:             1,
+		SkipLabelValidation: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(ortClassifier.Close)
+	ortExtractor, ok := ortClassifier.(EmbeddingExtractor)
+	require.True(t, ok, "ORT embedding model must implement EmbeddingExtractor (2 outputs)")
+
+	_, ortEmb, err := ortExtractor.PredictWithEmbeddings(samples)
+	require.NoError(t, err)
+	require.NotEmpty(t, ortEmb, "ORT embedding must be non-empty")
+
+	// Candidate backend: OpenVINO embedding extractor at forced f32 (the bat policy).
+	require.NoError(t, InitOpenVINO(os.Getenv("OV_TEST_LIB")))
+	t.Cleanup(func() { _ = DestroyOpenVINO() })
+	ovExtractor, err := NewOpenVINOEmbeddingExtractor(modelPath, OpenVINOEmbeddingExtractorOptions{
+		Threads:       1,
+		Device:        device,
+		OutputIndex:   outputIndex,
+		PrecisionHint: OVPrecisionF32,
+		ExpectedDim:   len(ortEmb),
+	})
+	require.NoError(t, err)
+	t.Cleanup(ovExtractor.Close)
+
+	require.Equal(t, len(ortEmb), ovExtractor.NumSpecies(),
+		"OV embedding dim must equal the ORT embedding dim")
+
+	_, ovEmb, err := ovExtractor.PredictWithEmbeddings(samples)
+	require.NoError(t, err)
+	require.Len(t, ovEmb, len(ortEmb))
+
+	var maxAbsErr float64
+	for i := range ortEmb {
+		if d := math.Abs(float64(ovEmb[i] - ortEmb[i])); d > maxAbsErr {
+			maxAbsErr = d
+		}
+	}
+	t.Logf("device=%s outputIndex=%d model=%s", device, outputIndex, modelPath)
+	t.Logf("embedding dim = %d", len(ortEmb))
+	t.Logf("max |emb_ov - emb_ort| = %.6g", maxAbsErr)
+
+	require.LessOrEqual(t, maxAbsErr, maxErr,
+		"OpenVINO f32 embedding drift from ORT exceeds tolerance (an f16 regression would blow this up)")
+}
+
+// batEmbeddingParityDefaultOutputIndex is the embedding output port of the bat
+// embedding model (port 0 is the species logits). Kept local to the test to avoid a
+// cross-package dependency on the classifier constant.
+const batEmbeddingParityDefaultOutputIndex = 1
+
 func sigmoid(x float32) float64 { return 1.0 / (1.0 + math.Exp(-float64(x))) }
 
 // mapDevice maps an OV_TEST_DEVICE value to an OpenVINO device string, defaulting


### PR DESCRIPTION
## Summary

Runs the bat model's heavy embedding extractor (`birdnet-v24-embeddings`) on OpenVINO instead of ONNX Runtime, mirroring the existing BirdNET v2.4 and Perch v2 pattern with OV-first and ORT fallback. OpenVINO never makes the bat model fail to load: any gate decline, init, compile, or validation error falls back to ORT. The tiny bat classifier head always stays on ORT (too small to benefit).

The device gate is identical to BirdNET v2.4 (reuses `openVINOPlanFor`): `auto` picks GPU when available, else CPU; `backend=onnx` or no eligible device falls back to ORT. The bat pipeline reuses the global `BirdNET.Backend` / `OpenVINOPath` / `OpenVINODevice` settings, so there is no new user-facing config.

## Precision: FP32 on every device

The one model-specific deviation from BirdNET v2.4 (which uses f16 on CPU, f32 only on GPU) is that the bat embedding model is forced to FP32 on every device. Its embedding head overflows at f16 on genuine f16 hardware (the A76 CPU's f16 NEON and the Intel iGPU), corrupting the raw embedding the bat classifier consumes and flipping detections. At FP32, OpenVINO beats ONNX Runtime on both CPU and GPU, so this is a performance win on whatever device the gate selects.

## Changes

- `NewOpenVINOEmbeddingExtractor` (internal/inference/openvino.go): reads a model's embedding output port and validates its dimension against the consumer's expected embedding size, falling back to ORT on mismatch.
- `InputDim()` added to the `inference.CustomClassifier` interface so the bat head's input dimension gates and validates the OpenVINO embedding path.
- `tryBatOpenVINO` in a reordered `NewBat`: build the ORT head first to read its input dim, then try OpenVINO with ORT fallback.
- `buildBat` / `loadBat` split records the backend triplet, and the bat model is registered as an OpenVINO-capable secondary so a runtime backend or device change rebuilds it via the existing hot-reload path.
- `openVINOPrecisionFor` forces FP32 for the bat model on every device.

## Validation

OpenVINO f32 vs ONNX Runtime f32 embedding parity, max absolute error, on real audio:

| Target | device | max abs error |
|--------|--------|---------------|
| amd64 i7-1260P Iris Xe | GPU | 0.0047 |
| amd64 i7-1260P | CPU | 0.0022 |
| rpi5 (Cortex-A76) | CPU | 0.0025 |

All three sit roughly 1000x below the f16-overflow regime (~5.0), confirming the forced-f32 path reproduces the ORT embedding on every device.

## Test Plan

- [x] `go build` (default and `-tags openvino`)
- [x] `go test -race` for `internal/classifier` and `internal/inference`
- [x] `golangci-lint run` clean (default build)
- [x] New unit tests: bat f32 precision (CPU and GPU), OV-first/ORT-fallback gating, dim-validation guards, hot-reload registration
- [x] New env-gated `-tags openvino` parity test, run on amd64 (GPU and CPU) and arm64 (A76 CPU)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenVINO acceleration for bat embedding extraction, with automatic fallback to ONNX Runtime when OpenVINO isn’t available or can’t compile.

* **Improvements**
  * Bat model runtime settings (backend/device/precision) are now properly detected and recorded, so secondary model reloads update correctly when configuration changes.
  * Bat OpenVINO embedding now consistently uses required f32 precision for matching results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->