### PR TITLE
feat(analytics): seasonal density heatmap (date x time-of-day)

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
@@ -1,0 +1,323 @@
+<!--
+  Seasonal density heatmap: detection count by (date, intra-day slot).
+
+  Brightness (opacity over the theme's primary hue) encodes count, so migration waves and
+  dawn-chorus drift read as bands across the season. The server sends a columnar sparse payload
+  ({ dates, slotResolutionMinutes, cells }) and downsamples the slot resolution on wide ranges;
+  this component renders it as scaleBand x scaleBand rects. On narrow viewports it folds the grid
+  down to 24 hourly rows (toHourlyResolution) so rows stay readable.
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { select, type Selection } from 'd3-selection';
+  import type { AxisDomain, AxisScale } from 'd3-axis';
+
+  import BaseChart from './BaseChart.svelte';
+  import { parseLocalDateString } from '$lib/utils/date';
+  import { createBandScale } from './utils/scales';
+  import { createAxis, styleAxis, addAxisLabel } from './utils/axes';
+  import { ChartTooltip } from './utils/interactions';
+  import { type ChartTheme } from './utils/theme';
+  import {
+    heatmapCells,
+    toHourlyResolution,
+    slotStartLabel,
+    slotsPerDay,
+    maxCellCount,
+    type HeatmapData,
+    type HeatmapCell,
+  } from './utils/heatmap';
+  import { t } from '$lib/i18n';
+
+  interface Props {
+    data: HeatmapData;
+    width?: number;
+    height?: number;
+    ariaLabel?: string;
+  }
+
+  let { data, width = 800, height = 400, ariaLabel }: Props = $props();
+
+  // Layout / style constants.
+  const MARGIN = { top: 30, right: 16, bottom: 48, left: 56 };
+  // Below this inner width the per-slot grid is unreadable, so fold to 24 hourly rows.
+  const COMPACT_WIDTH_THRESHOLD = 480;
+  const CELL_PADDING = 0.04;
+  // Floor so the faintest non-zero cell stays visible against the card background.
+  const MIN_CELL_OPACITY = 0.12;
+  const MINUTES_PER_HOUR = 60;
+  const Y_TICK_EVERY_HOURS = 3; // label the time axis every 3 hours
+  const MAX_X_TICKS = 10;
+  const X_AXIS_LABEL_OFFSET = 38;
+  const Y_AXIS_LABEL_OFFSET = 44;
+  const LEGEND_STEPS = 5;
+  const LEGEND_SWATCH = 14;
+
+  let tooltip: ChartTooltip | null = null;
+  let chartContainer: HTMLDivElement | null = null;
+
+  // Screen-reader summary so the heatmap is not opaque to assistive tech (spec section 7).
+  const summary = $derived.by(() => {
+    const cells = heatmapCells(data);
+    if (cells.length === 0) return '';
+    const total = cells.reduce((sum, c) => sum + c.count, 0);
+    const peak = cells.reduce((best, c) => (c.count > best.count ? c : best), cells[0]);
+    const peakDate = data.dates[peak.dateIndex] ?? '';
+    return t('analytics.advanced.charts.heatmap.summary', {
+      total,
+      days: data.dates.length,
+      time: slotStartLabel(peak.slot, data.slotResolutionMinutes),
+      date: peakDate,
+    });
+  });
+
+  let chartContext = $state<{
+    svg: Selection<SVGSVGElement, unknown, null, undefined>;
+    chartGroup: Selection<globalThis.SVGGElement, unknown, null, undefined>;
+    innerWidth: number;
+    innerHeight: number;
+    theme: ChartTheme;
+  } | null>(null);
+
+  function formatDateTick(dateStr: string): string {
+    const d = parseLocalDateString(dateStr);
+    if (!d || isNaN(d.getTime())) return dateStr;
+    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(d);
+  }
+
+  // Evenly spaced subset of the domain so axis labels never crowd.
+  function sampleTicks(domain: string[], maxTicks: number): string[] {
+    if (domain.length <= maxTicks) return domain;
+    const step = Math.ceil(domain.length / maxTicks);
+    return domain.filter((_, i) => i % step === 0);
+  }
+
+  function drawChart(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight, theme } = context;
+    chartGroup.selectAll('*').remove();
+    if (innerWidth <= 0 || innerHeight <= 0) return;
+
+    // Narrow viewports collapse to a 24-row hourly grid for legibility.
+    const compact = innerWidth < COMPACT_WIDTH_THRESHOLD;
+    const view: HeatmapData = compact ? toHourlyResolution(data) : data;
+    const resolution = view.slotResolutionMinutes;
+    const nSlots = slotsPerDay(resolution);
+    const cells = heatmapCells(view);
+    if (cells.length === 0 || view.dates.length === 0) return;
+
+    const colorMax = Math.max(1, maxCellCount(cells));
+
+    const xScale = createBandScale({
+      domain: view.dates,
+      range: [0, innerWidth],
+      padding: CELL_PADDING,
+    });
+
+    const slotDomain = Array.from({ length: nSlots }, (_, i) => String(i));
+    const yScale = createBandScale({
+      domain: slotDomain,
+      range: [0, innerHeight],
+      padding: CELL_PADDING,
+    });
+
+    // X axis: a sampled subset of dates, formatted "Mon D".
+    // Band scales are valid AxisScales at runtime; widen the type for createAxis.
+    const xAxis = createAxis({
+      scale: xScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'bottom',
+      tickFormat: (d: AxisDomain) => formatDateTick(String(d)),
+    });
+    xAxis.tickValues(sampleTicks(view.dates, MAX_X_TICKS));
+    const xAxisGroup = chartGroup
+      .append('g')
+      .attr('class', 'x-axis')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(xAxis);
+    styleAxis(xAxisGroup, theme.axis);
+
+    // Y axis: every few hours, labelled HH:MM.
+    const slotsPerTick = Math.max(1, (Y_TICK_EVERY_HOURS * MINUTES_PER_HOUR) / resolution);
+    const yTickValues = slotDomain.filter((_, i) => i % slotsPerTick === 0);
+    const yAxis = createAxis({
+      scale: yScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'left',
+      tickFormat: (d: AxisDomain) => slotStartLabel(Number(d), resolution),
+    });
+    yAxis.tickValues(yTickValues);
+    const yAxisGroup = chartGroup.append('g').attr('class', 'y-axis').call(yAxis);
+    styleAxis(yAxisGroup, theme.axis);
+
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t('analytics.advanced.charts.heatmap.axisDate'),
+        orientation: 'bottom',
+        offset: X_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t('analytics.advanced.charts.heatmap.axisTime'),
+        orientation: 'left',
+        offset: Y_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+
+    // Cells: density encoded as opacity over the primary hue (keeps it theme-driven and avoids
+    // parsing CSS color tokens, which can be oklch() under Tailwind v4 and break d3 interpolation).
+    const bandW = xScale.bandwidth();
+    const bandH = yScale.bandwidth();
+    chartGroup
+      .append('g')
+      .attr('class', 'heatmap-cells')
+      .selectAll('rect.heatmap-cell')
+      .data(cells)
+      .enter()
+      .append('rect')
+      .attr('class', 'heatmap-cell')
+      .attr('x', (d: HeatmapCell) => xScale(view.dates[d.dateIndex]) ?? 0)
+      .attr('y', (d: HeatmapCell) => yScale(String(d.slot)) ?? 0)
+      .attr('width', bandW)
+      .attr('height', bandH)
+      .attr('rx', 1)
+      .style('fill', theme.primary)
+      .style(
+        'opacity',
+        (d: HeatmapCell) => MIN_CELL_OPACITY + (1 - MIN_CELL_OPACITY) * (d.count / colorMax)
+      )
+      .on('mouseenter', function (event: MouseEvent, d: HeatmapCell) {
+        select(this).style('stroke', theme.text).style('stroke-width', 1);
+        tooltip?.show({
+          title: data.dates[d.dateIndex] ?? '',
+          items: [
+            {
+              label: t('analytics.advanced.charts.heatmap.tooltipTime'),
+              value: slotStartLabel(d.slot, resolution),
+            },
+            {
+              label: t('analytics.advanced.charts.heatmap.tooltipCount'),
+              value: String(d.count),
+            },
+          ],
+          x: event.clientX,
+          y: event.clientY,
+        });
+      })
+      .on('mouseleave', function () {
+        select(this).style('stroke', 'none');
+        tooltip?.hide();
+      });
+
+    drawLegend(context, colorMax);
+  }
+
+  // Compact gradient legend in the top margin: faint -> solid swatches with min/max labels.
+  function drawLegend(context: NonNullable<typeof chartContext>, colorMax: number): void {
+    const { chartGroup, innerWidth, theme } = context;
+    const legendWidth = LEGEND_STEPS * LEGEND_SWATCH;
+    const legend = chartGroup
+      .append('g')
+      .attr('class', 'heatmap-legend')
+      .attr(
+        'transform',
+        `translate(${Math.max(0, innerWidth - legendWidth)},${-LEGEND_SWATCH - 6})`
+      )
+      .style('pointer-events', 'none');
+
+    for (let i = 0; i < LEGEND_STEPS; i++) {
+      const fraction = (i + 1) / LEGEND_STEPS;
+      legend
+        .append('rect')
+        .attr('x', i * LEGEND_SWATCH)
+        .attr('y', 0)
+        .attr('width', LEGEND_SWATCH)
+        .attr('height', LEGEND_SWATCH)
+        .attr('rx', 1)
+        .style('fill', theme.primary)
+        .style('opacity', MIN_CELL_OPACITY + (1 - MIN_CELL_OPACITY) * fraction);
+    }
+
+    legend
+      .append('text')
+      .attr('x', -6)
+      .attr('y', LEGEND_SWATCH - 3)
+      .attr('text-anchor', 'end')
+      .style('fill', theme.axis.color)
+      .style('font-size', theme.axis.fontSize)
+      .text(t('analytics.advanced.charts.heatmap.legendLess'));
+    legend
+      .append('text')
+      .attr('x', legendWidth + 6)
+      .attr('y', LEGEND_SWATCH - 3)
+      .attr('text-anchor', 'start')
+      .style('fill', theme.axis.color)
+      .style('font-size', theme.axis.fontSize)
+      .text(t('analytics.advanced.charts.heatmap.legendMore', { max: colorMax }));
+  }
+
+  $effect(() => {
+    if (chartContext) {
+      drawChart(chartContext);
+    }
+  });
+
+  onMount(() => {
+    if (chartContainer) {
+      tooltip = new ChartTooltip(chartContainer);
+    }
+  });
+
+  onDestroy(() => {
+    tooltip?.destroy();
+  });
+</script>
+
+<div class="seasonal-heatmap-chart" bind:this={chartContainer}>
+  <BaseChart
+    {width}
+    {height}
+    margin={MARGIN}
+    responsive={true}
+    ariaLabel={ariaLabel ?? t('analytics.advanced.charts.heatmap.ariaLabel')}
+  >
+    {#snippet children(context)}
+      {((chartContext = context), '')}
+    {/snippet}
+  </BaseChart>
+  {#if summary}
+    <p class="sr-only" data-testid="heatmap-summary">{summary}</p>
+  {/if}
+</div>
+
+<style>
+  .seasonal-heatmap-chart {
+    width: 100%;
+    height: 100%;
+    min-height: 400px;
+    /* Narrow viewports fold to 24 hourly rows; allow vertical scroll if they still overflow. */
+    overflow-y: auto;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  :global(.heatmap-cell) {
+    transition: opacity 0.12s ease;
+  }
+</style>

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
@@ -301,20 +301,9 @@
     width: 100%;
     height: 100%;
     min-height: 400px;
+
     /* Narrow viewports fold to 24 hourly rows; allow vertical scroll if they still overflow. */
     overflow-y: auto;
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
   }
 
   :global(.heatmap-cell) {

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.svelte
@@ -79,10 +79,13 @@
     theme: ChartTheme;
   } | null>(null);
 
+  // Cached once: constructing an Intl.DateTimeFormat per tick is costly on frequent redraws.
+  const dateTickFormatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+
   function formatDateTick(dateStr: string): string {
     const d = parseLocalDateString(dateStr);
     if (!d || isNaN(d.getTime())) return dateStr;
-    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(d);
+    return dateTickFormatter.format(d);
   }
 
   // Evenly spaced subset of the domain so axis labels never crowd.
@@ -94,6 +97,9 @@
 
   function drawChart(context: NonNullable<typeof chartContext>): void {
     const { chartGroup, innerWidth, innerHeight, theme } = context;
+    // Hide any active tooltip first: a redraw removes the hovered rect, so its mouseleave
+    // would never fire and the tooltip could otherwise get stuck on screen.
+    tooltip?.hide();
     chartGroup.selectAll('*').remove();
     if (innerWidth <= 0 || innerHeight <= 0) return;
 

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SeasonalHeatmap.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import SeasonalHeatmap from './SeasonalHeatmap.svelte';
+import type { HeatmapData } from './utils/heatmap';
+
+// jsdom has no layout engine; assert on element counts/attributes only.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const sample: HeatmapData = {
+  dates: ['2026-03-01', '2026-03-02'],
+  slotResolutionMinutes: 15,
+  cells: {
+    dateIndex: [0, 0, 1],
+    slot: [0, 1, 95],
+    count: [3, 2, 7],
+  },
+};
+
+const empty: HeatmapData = {
+  dates: ['2026-03-01'],
+  slotResolutionMinutes: 15,
+  cells: { dateIndex: [], slot: [], count: [] },
+};
+
+describe('SeasonalHeatmap', () => {
+  it('renders without throwing for empty cells', () => {
+    expect(() => render(SeasonalHeatmap, { props: { data: empty } })).not.toThrow();
+  });
+
+  it('renders one rect per cell at a wide width', async () => {
+    const { container } = render(SeasonalHeatmap, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelectorAll('rect.heatmap-cell')).toHaveLength(3);
+  });
+
+  it('folds sub-hour slots into hourly rows on narrow widths', async () => {
+    // Two cells in hour 0 (slots 0 and 1 at 15-min resolution) on the same date collapse to one
+    // cell when the chart switches to its 24-row hourly layout.
+    const { container } = render(SeasonalHeatmap, { props: { data: sample, width: 300 } });
+    await Promise.resolve();
+    const cells = container.querySelectorAll('rect.heatmap-cell');
+    // date 0 hour 0 (merged) + date 1 hour 23 = 2 cells, vs 3 at full resolution.
+    expect(cells).toHaveLength(2);
+  });
+
+  it('renders x and y axis groups', async () => {
+    const { container } = render(SeasonalHeatmap, { props: { data: sample } });
+    await Promise.resolve();
+    expect(container.querySelector('.x-axis')).toBeTruthy();
+    expect(container.querySelector('.y-axis')).toBeTruthy();
+  });
+
+  it('encodes higher counts as higher opacity', async () => {
+    const { container } = render(SeasonalHeatmap, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    const opacities = Array.from(container.querySelectorAll('rect.heatmap-cell'), r =>
+      parseFloat((r as SVGRectElement).style.opacity)
+    );
+    // The max-count cell (7) must be fully opaque; the lowest (2) must be fainter.
+    expect(Math.max(...opacities)).toBeCloseTo(1, 5);
+    expect(Math.min(...opacities)).toBeLessThan(1);
+  });
+
+  it('sets an accessible label on the chart container', () => {
+    const { container } = render(SeasonalHeatmap, {
+      props: { data: sample, ariaLabel: 'Seasonal heatmap' },
+    });
+    expect(container.querySelector('[aria-label="Seasonal heatmap"]')).toBeTruthy();
+  });
+
+  it('renders a screen-reader summary when there is data', async () => {
+    const { getByTestId } = render(SeasonalHeatmap, { props: { data: sample } });
+    await Promise.resolve();
+    expect(getByTestId('heatmap-summary')).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/heatmap.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/heatmap.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  heatmapCells,
+  toHourlyResolution,
+  slotStartLabel,
+  slotsPerDay,
+  maxCellCount,
+  type HeatmapData,
+} from '../heatmap';
+
+const sample: HeatmapData = {
+  dates: ['2026-03-01', '2026-03-02'],
+  slotResolutionMinutes: 15,
+  cells: {
+    dateIndex: [0, 0, 1],
+    slot: [0, 1, 95],
+    count: [3, 2, 7],
+  },
+};
+
+describe('heatmapCells', () => {
+  it('zips the parallel columnar arrays into cell objects', () => {
+    expect(heatmapCells(sample)).toEqual([
+      { dateIndex: 0, slot: 0, count: 3 },
+      { dateIndex: 0, slot: 1, count: 2 },
+      { dateIndex: 1, slot: 95, count: 7 },
+    ]);
+  });
+
+  it('returns an empty array when there are no cells', () => {
+    expect(
+      heatmapCells({
+        dates: ['2026-03-01'],
+        slotResolutionMinutes: 15,
+        cells: { dateIndex: [], slot: [], count: [] },
+      })
+    ).toEqual([]);
+  });
+
+  it('truncates to the shortest array when lengths disagree (defensive)', () => {
+    const ragged: HeatmapData = {
+      dates: ['2026-03-01'],
+      slotResolutionMinutes: 15,
+      cells: { dateIndex: [0, 0], slot: [0], count: [5, 6] },
+    };
+    expect(heatmapCells(ragged)).toEqual([{ dateIndex: 0, slot: 0, count: 5 }]);
+  });
+});
+
+describe('toHourlyResolution', () => {
+  it('re-buckets sub-hour slots into 24 hourly slots, summing counts', () => {
+    const hourly = toHourlyResolution(sample);
+    expect(hourly.slotResolutionMinutes).toBe(60);
+    expect(hourly.dates).toEqual(sample.dates);
+    // date 0: slots 0 and 1 both fall in hour 0 -> merged count 5; date 1: slot 95 -> hour 23.
+    expect(heatmapCells(hourly)).toEqual([
+      { dateIndex: 0, slot: 0, count: 5 },
+      { dateIndex: 1, slot: 23, count: 7 },
+    ]);
+  });
+
+  it('is a no-op when already hourly', () => {
+    const alreadyHourly: HeatmapData = {
+      dates: ['2026-03-01'],
+      slotResolutionMinutes: 60,
+      cells: { dateIndex: [0], slot: [13], count: [4] },
+    };
+    expect(toHourlyResolution(alreadyHourly)).toEqual(alreadyHourly);
+  });
+});
+
+describe('slotStartLabel', () => {
+  it('formats the slot start as HH:MM', () => {
+    expect(slotStartLabel(0, 15)).toBe('00:00');
+    expect(slotStartLabel(95, 15)).toBe('23:45');
+    expect(slotStartLabel(1, 30)).toBe('00:30');
+    expect(slotStartLabel(13, 60)).toBe('13:00');
+  });
+});
+
+describe('slotsPerDay', () => {
+  it('returns the number of slots for a resolution', () => {
+    expect(slotsPerDay(15)).toBe(96);
+    expect(slotsPerDay(30)).toBe(48);
+    expect(slotsPerDay(60)).toBe(24);
+  });
+});
+
+describe('maxCellCount', () => {
+  it('returns the largest cell count', () => {
+    expect(maxCellCount(heatmapCells(sample))).toBe(7);
+  });
+
+  it('returns 0 for no cells', () => {
+    expect(maxCellCount([])).toBe(0);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/heatmap.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/heatmap.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure transforms for the seasonal density heatmap.
+ *
+ * The server sends a columnar, sparse payload ({ dates, slotResolutionMinutes, cells }); these
+ * helpers turn it into the row objects the D3 chart draws, fold it down to an hourly grid for the
+ * narrow-viewport fallback, and format slot labels. Kept framework-free so they are unit-tested
+ * directly rather than through the Svelte component.
+ */
+
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * 60;
+const HOURLY_RESOLUTION_MINUTES = 60;
+
+export interface HeatmapData {
+  /** Calendar dates (station-local), ascending; forms the x-axis. */
+  dates: string[];
+  /** Intra-day slot width in minutes (15, 30, or 60). */
+  slotResolutionMinutes: number;
+  /** Parallel sparse cell arrays: cell i is dates[dateIndex[i]] at slot[i] with count[i]. */
+  cells: { dateIndex: number[]; slot: number[]; count: number[] };
+}
+
+export interface HeatmapCell {
+  dateIndex: number;
+  slot: number;
+  count: number;
+}
+
+/**
+ * Zips the parallel columnar arrays into cell objects. Truncates to the shortest array so a
+ * malformed payload can never index past an array's end.
+ */
+export function heatmapCells(data: HeatmapData): HeatmapCell[] {
+  const { dateIndex, slot, count } = data.cells;
+  const n = Math.min(dateIndex.length, slot.length, count.length);
+  const cells: HeatmapCell[] = [];
+  for (let i = 0; i < n; i++) {
+    // eslint-disable-next-line security/detect-object-injection -- i is a bounded loop index over our own arrays
+    cells.push({ dateIndex: dateIndex[i], slot: slot[i], count: count[i] });
+  }
+  return cells;
+}
+
+/** Number of intra-day slots for a resolution (e.g. 15 -> 96, 60 -> 24). */
+export function slotsPerDay(resolutionMinutes: number): number {
+  return Math.floor(MINUTES_PER_DAY / resolutionMinutes);
+}
+
+/**
+ * Folds a payload of any resolution down to 24 hourly slots, summing counts that share an hour.
+ * Used by the narrow-viewport fallback so a year at 15-minute resolution still renders 24 readable
+ * rows. A no-op when the payload is already hourly.
+ */
+export function toHourlyResolution(data: HeatmapData): HeatmapData {
+  if (data.slotResolutionMinutes === HOURLY_RESOLUTION_MINUTES) {
+    return data;
+  }
+
+  const merged = new Map<string, HeatmapCell>();
+  for (const cell of heatmapCells(data)) {
+    const hour = Math.floor((cell.slot * data.slotResolutionMinutes) / MINUTES_PER_HOUR);
+    const key = `${cell.dateIndex}:${hour}`;
+    const existing = merged.get(key);
+    if (existing) {
+      existing.count += cell.count;
+    } else {
+      merged.set(key, { dateIndex: cell.dateIndex, slot: hour, count: cell.count });
+    }
+  }
+
+  // Preserve (dateIndex, slot) ordering for a deterministic, render-friendly result.
+  const ordered = [...merged.values()].sort((a, b) =>
+    a.dateIndex === b.dateIndex ? a.slot - b.slot : a.dateIndex - b.dateIndex
+  );
+
+  return {
+    dates: data.dates,
+    slotResolutionMinutes: HOURLY_RESOLUTION_MINUTES,
+    cells: {
+      dateIndex: ordered.map(c => c.dateIndex),
+      slot: ordered.map(c => c.slot),
+      count: ordered.map(c => c.count),
+    },
+  };
+}
+
+/** Formats a slot's wall-clock start time as HH:MM (e.g. slot 95 at 15-min resolution -> "23:45"). */
+export function slotStartLabel(slot: number, resolutionMinutes: number): string {
+  const startMinutes = slot * resolutionMinutes;
+  const hh = Math.floor(startMinutes / MINUTES_PER_HOUR);
+  const mm = startMinutes % MINUTES_PER_HOUR;
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+}
+
+/** Largest count across the cells, or 0 when there are none. Drives the color scale's domain. */
+export function maxCellCount(cells: HeatmapCell[]): number {
+  let max = 0;
+  for (const cell of cells) {
+    if (cell.count > max) max = cell.count;
+  }
+  return max;
+}

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -15,6 +15,8 @@ import { parseLocalDateString } from '$lib/utils/date';
 import TimeOfDaySpeciesChart from '../components/charts/d3/TimeOfDaySpeciesChart.svelte';
 import DailySpeciesTrendChart from '../components/charts/d3/DailySpeciesTrendChart.svelte';
 import SpeciesDiversityChart from '../components/charts/d3/SpeciesDiversityChart.svelte';
+import SeasonalHeatmap from '../components/charts/d3/SeasonalHeatmap.svelte';
+import type { HeatmapData } from '../components/charts/d3/utils/heatmap';
 import TrendChartOptions from '../components/TrendChartOptions.svelte';
 
 import { formatDateForAPI } from './analyticsParams';
@@ -180,9 +182,80 @@ async function fetchDiversity(
     .filter((item): item is DiversityDatum => item !== null);
 }
 
+/** Keeps only finite numbers from an unknown value; drops anything malformed. */
+function asNumberArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((n): n is number => typeof n === 'number' && Number.isFinite(n))
+    : [];
+}
+
+interface HeatmapResponse {
+  dates?: unknown;
+  slotResolutionMinutes?: unknown;
+  cells?: { dateIndex?: unknown; slot?: unknown; count?: unknown };
+}
+
+const DEFAULT_SLOT_RESOLUTION_MINUTES = 15;
+
+/**
+ * Seasonal density heatmap: detection counts by (date, intra-day slot). Honors an optional
+ * single-species filter (the control bar's first selected species; none means all species).
+ * Returns the server's columnar sparse payload, defensively coerced.
+ */
+async function fetchHeatmap(params: AnalyticsParams, signal?: AbortSignal): Promise<HeatmapData> {
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+  });
+  // The endpoint filters by a single species; use the first selected (none = all species).
+  if (params.species.length > 0) search.append('species', params.species[0]);
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/time/heatmap?${search}`), { signal });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Invalid heatmap response: expected an object');
+  }
+  const body = data as HeatmapResponse;
+  const cells = (body.cells ?? {}) as { dateIndex?: unknown; slot?: unknown; count?: unknown };
+
+  return {
+    dates: Array.isArray(body.dates)
+      ? body.dates.filter((d): d is string => typeof d === 'string')
+      : [],
+    slotResolutionMinutes:
+      typeof body.slotResolutionMinutes === 'number'
+        ? body.slotResolutionMinutes
+        : DEFAULT_SLOT_RESOLUTION_MINUTES,
+    cells: {
+      dateIndex: asNumberArray(cells.dateIndex),
+      slot: asNumberArray(cells.slot),
+      count: asNumberArray(cells.count),
+    },
+  };
+}
+
 // --- Registry --------------------------------------------------------------
 
 export const CHART_REGISTRY: ChartDef[] = [
+  {
+    id: 'seasonal-heatmap',
+    group: 'patterns',
+    titleKey: 'analytics.advanced.charts.heatmap.title',
+    descKey: 'analytics.advanced.charts.heatmap.description',
+    emptyKey: 'analytics.advanced.charts.heatmap.noData',
+    emptyHintKey: 'analytics.advanced.charts.heatmap.noDataHint',
+    component: SeasonalHeatmap,
+    fetch: fetchHeatmap,
+    // The fetch result is the columnar payload (an object), so count its non-zero cells rather
+    // than relying on ChartCard's default array-length count.
+    countDataPoints: data => (data as HeatmapData).cells.count.length,
+    size: 'full',
+    supports: { species: true, source: false },
+    minDataPoints: 20,
+    export: 'csv',
+  },
   {
     id: 'time-of-day-species',
     group: 'patterns',

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -182,13 +182,6 @@ async function fetchDiversity(
     .filter((item): item is DiversityDatum => item !== null);
 }
 
-/** Keeps only finite numbers from an unknown value; drops anything malformed. */
-function asNumberArray(value: unknown): number[] {
-  return Array.isArray(value)
-    ? value.filter((n): n is number => typeof n === 'number' && Number.isFinite(n))
-    : [];
-}
-
 interface HeatmapResponse {
   dates?: unknown;
   slotResolutionMinutes?: unknown;
@@ -196,6 +189,48 @@ interface HeatmapResponse {
 }
 
 const DEFAULT_SLOT_RESOLUTION_MINUTES = 15;
+const VALID_SLOT_RESOLUTIONS = [15, 30, 60];
+
+/**
+ * Coerces the three parallel cell columns in lockstep. dateIndex, slot, and count are parallel
+ * by contract, so a cell is kept only when all three values at that index are finite numbers;
+ * coercing each column independently could drop a value from one column and shift the others
+ * out of alignment, mispairing date/slot/count.
+ */
+function coerceCells(cells: { dateIndex?: unknown; slot?: unknown; count?: unknown }): {
+  dateIndex: number[];
+  slot: number[];
+  count: number[];
+} {
+  const rawDateIndex = Array.isArray(cells.dateIndex) ? cells.dateIndex : [];
+  const rawSlot = Array.isArray(cells.slot) ? cells.slot : [];
+  const rawCount = Array.isArray(cells.count) ? cells.count : [];
+  const n = Math.min(rawDateIndex.length, rawSlot.length, rawCount.length);
+
+  const dateIndex: number[] = [];
+  const slot: number[] = [];
+  const count: number[] = [];
+  /* eslint-disable security/detect-object-injection -- i is a bounded loop index over our own arrays */
+  for (let i = 0; i < n; i++) {
+    const di = rawDateIndex[i];
+    const s = rawSlot[i];
+    const c = rawCount[i];
+    if (
+      typeof di === 'number' &&
+      Number.isFinite(di) &&
+      typeof s === 'number' &&
+      Number.isFinite(s) &&
+      typeof c === 'number' &&
+      Number.isFinite(c)
+    ) {
+      dateIndex.push(di);
+      slot.push(s);
+      count.push(c);
+    }
+  }
+  /* eslint-enable security/detect-object-injection */
+  return { dateIndex, slot, count };
+}
 
 /**
  * Seasonal density heatmap: detection counts by (date, intra-day slot). Honors an optional
@@ -220,19 +255,20 @@ async function fetchHeatmap(params: AnalyticsParams, signal?: AbortSignal): Prom
   const body = data as HeatmapResponse;
   const cells = (body.cells ?? {}) as { dateIndex?: unknown; slot?: unknown; count?: unknown };
 
+  // Restrict the resolution to the values the server can emit so the chart's slot math
+  // (1440 / resolution) and hourly fold stay well-defined.
+  const slotResolutionMinutes =
+    typeof body.slotResolutionMinutes === 'number' &&
+    VALID_SLOT_RESOLUTIONS.includes(body.slotResolutionMinutes)
+      ? body.slotResolutionMinutes
+      : DEFAULT_SLOT_RESOLUTION_MINUTES;
+
   return {
     dates: Array.isArray(body.dates)
       ? body.dates.filter((d): d is string => typeof d === 'string')
       : [],
-    slotResolutionMinutes:
-      typeof body.slotResolutionMinutes === 'number'
-        ? body.slotResolutionMinutes
-        : DEFAULT_SLOT_RESOLUTION_MINUTES,
-    cells: {
-      dateIndex: asNumberArray(cells.dateIndex),
-      slot: asNumberArray(cells.slot),
-      count: asNumberArray(cells.count),
-    },
+    slotResolutionMinutes,
+    cells: coerceCells(cells),
   };
 }
 

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1421,6 +1421,18 @@ export type TranslationKey =
   | 'analytics.advanced.charts.diversity.noDataHint'
   | 'analytics.advanced.charts.diversity.axisDate'
   | 'analytics.advanced.charts.diversity.axisUniqueSpecies'
+  | 'analytics.advanced.charts.heatmap.title'
+  | 'analytics.advanced.charts.heatmap.description'
+  | 'analytics.advanced.charts.heatmap.noData'
+  | 'analytics.advanced.charts.heatmap.noDataHint'
+  | 'analytics.advanced.charts.heatmap.axisDate'
+  | 'analytics.advanced.charts.heatmap.axisTime'
+  | 'analytics.advanced.charts.heatmap.tooltipTime'
+  | 'analytics.advanced.charts.heatmap.tooltipCount'
+  | 'analytics.advanced.charts.heatmap.legendLess'
+  | 'analytics.advanced.charts.heatmap.legendMore' // params: max
+  | 'analytics.advanced.charts.heatmap.ariaLabel'
+  | 'analytics.advanced.charts.heatmap.summary' // params: total, days, time, date
   | 'analytics.advanced.charts.tooltips.date'
   | 'analytics.advanced.charts.tooltips.percentage'
   | 'analytics.advanced.charts.tooltips.detections'
@@ -3925,6 +3937,13 @@ export type TranslationParams = {
   'analytics.hub.card.notEnoughDataHint': { min: string | number };
   'analytics.advanced.speciesSelection': { count: string | number; max: string | number };
   'analytics.advanced.detections': { count: string | number };
+  'analytics.advanced.charts.heatmap.legendMore': { max: string | number };
+  'analytics.advanced.charts.heatmap.summary': {
+    total: string | number;
+    days: string | number;
+    time: string | number;
+    date: string | number;
+  };
   'settings.notFound.message': { section: string | number };
   'settings.main.sections.falsePositiveFilter.detectionCount': {
     count: string | number;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Unikátní druhy"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Procento",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Dato",
           "axisUniqueSpecies": "Unikke arter"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Procentdel",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Einzigartige Arten"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Prozentsatz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Date",
           "axisUniqueSpecies": "Unique Species"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Percentage",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Fecha",
           "axisUniqueSpecies": "Especies únicas"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Fecha",
           "percentage": "Porcentaje",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Päivämäärä",
           "axisUniqueSpecies": "Yksilölliset lajit"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Päivämäärä",
           "percentage": "Prosenttiosuus",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Date",
           "axisUniqueSpecies": "Espèces uniques"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Pourcentage",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Dátum",
           "axisUniqueSpecies": "Egyedi fajok"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Százalék",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Data",
           "axisUniqueSpecies": "Specie uniche"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentuale",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Datums",
           "axisUniqueSpecies": "Unikālās sugas"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Datums",
           "percentage": "Procenti",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Dato",
           "axisUniqueSpecies": "Unike arter"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Prosentandel",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Unieke soorten"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Percentage",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Data",
           "axisUniqueSpecies": "Unikalne gatunki"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Procent",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Data",
           "axisUniqueSpecies": "Espécies únicas"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentagem",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Dátum",
           "axisUniqueSpecies": "Jedinečné druhy"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Percentá",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1831,6 +1831,20 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Unika arter"
         },
+        "heatmap": {
+          "title": "Seasonal Activity Heatmap",
+          "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",
+          "noData": "No activity data available",
+          "noDataHint": "Select a date range to view seasonal activity patterns",
+          "axisDate": "Date",
+          "axisTime": "Time of Day",
+          "tooltipTime": "Time",
+          "tooltipCount": "Detections",
+          "legendLess": "Less",
+          "legendMore": "More ({max})",
+          "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
+          "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Andel",

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -291,6 +291,9 @@ func (m *ActionMockDatastore) GetSpeciesFirstDetectionInPeriod(_ context.Context
 func (m *ActionMockDatastore) GetSpeciesDiversityData(_ context.Context, _, _ string) ([]datastore.DailyAnalyticsData, error) {
 	return nil, nil
 }
+func (m *ActionMockDatastore) GetActivityHeatmap(_ context.Context, _, _, _ string) (datastore.ActivityHeatmapData, error) {
+	return datastore.ActivityHeatmapData{}, nil
+}
 func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -160,6 +160,9 @@ func (m *MockDatastore) GetSpeciesFirstDetectionInPeriod(context.Context, string
 func (m *MockDatastore) GetSpeciesDiversityData(context.Context, string, string) ([]datastore.DailyAnalyticsData, error) {
 	return nil, nil
 }
+func (m *MockDatastore) GetActivityHeatmap(context.Context, string, string, string) (datastore.ActivityHeatmapData, error) {
+	return datastore.ActivityHeatmapData{}, nil
+}
 func (m *MockDatastore) SearchDetections(*datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return make([]datastore.DetectionRecord, 0), 0, nil
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -91,6 +91,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/time/hourly`              | `GetHourlyAnalytics`       | ❌   | Hourly detection patterns          |
 | GET    | `/analytics/time/daily`               | `GetDailyAnalytics`        | ❌   | Daily detection patterns           |
 | GET    | `/analytics/time/distribution/hourly` | `GetTimeOfDayDistribution` | ❌   | Time-of-day detection distribution |
+| GET    | `/analytics/time/heatmap`             | `GetActivityHeatmap`       | ❌   | Seasonal density heatmap (date x intra-day slot; `?format=csv`) |
 
 ### Control Operations (`control.go`)
 

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -1223,7 +1223,9 @@ func (c *Controller) writeActivityHeatmapCSV(ctx echo.Context, data *datastore.A
 	}
 
 	resolution := data.SlotResolutionMinutes
-	for i := range data.CellDateIndex {
+	// Bound by the shortest parallel slice so a malformed payload can never panic on index access.
+	n := min(len(data.CellDateIndex), len(data.CellSlot), len(data.CellCount))
+	for i := range n {
 		date := ""
 		if di := data.CellDateIndex[i]; di >= 0 && di < len(data.Dates) {
 			date = data.Dates[di]

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"context"
+	"encoding/csv"
 	"fmt"
 	"maps"
 	"net/http"
@@ -183,6 +184,7 @@ func (c *Controller) initAnalyticsRoutes() {
 	timeGroup.GET("/daily", c.GetDailyAnalytics)
 	timeGroup.GET("/daily/batch", c.GetBatchDailySpeciesData)         // Batch daily trends for multiple species
 	timeGroup.GET("/distribution/hourly", c.GetTimeOfDayDistribution) // Renamed endpoint for time-of-day distribution
+	timeGroup.GET("/heatmap", c.GetActivityHeatmap)                    // Seasonal density heatmap (date x intra-day slot)
 }
 
 // GetDailySpeciesSummary handles GET /api/v2/analytics/species/daily
@@ -1085,6 +1087,162 @@ func (c *Controller) GetSpeciesDiversity(ctx echo.Context) error {
 	)
 
 	return ctx.JSON(http.StatusOK, response)
+}
+
+// activityHeatmapCells holds the parallel cell arrays for the heatmap wire payload.
+type activityHeatmapCells struct {
+	DateIndex []int `json:"dateIndex"`
+	Slot      []int `json:"slot"`
+	Count     []int `json:"count"`
+}
+
+// activityHeatmapResponse is the columnar, sparse heatmap payload (design spec section 6.1).
+type activityHeatmapResponse struct {
+	Dates                 []string             `json:"dates"`
+	SlotResolutionMinutes int                  `json:"slotResolutionMinutes"`
+	Cells                 activityHeatmapCells `json:"cells"`
+}
+
+// newActivityHeatmapResponse maps the datastore aggregation onto the wire payload, coalescing
+// nil slices to empty ones so the client always receives JSON arrays (never null).
+func newActivityHeatmapResponse(data *datastore.ActivityHeatmapData) activityHeatmapResponse {
+	dates := data.Dates
+	if dates == nil {
+		dates = []string{}
+	}
+	dateIndex := data.CellDateIndex
+	if dateIndex == nil {
+		dateIndex = []int{}
+	}
+	slot := data.CellSlot
+	if slot == nil {
+		slot = []int{}
+	}
+	count := data.CellCount
+	if count == nil {
+		count = []int{}
+	}
+	return activityHeatmapResponse{
+		Dates:                 dates,
+		SlotResolutionMinutes: data.SlotResolutionMinutes,
+		Cells:                 activityHeatmapCells{DateIndex: dateIndex, Slot: slot, Count: count},
+	}
+}
+
+// GetActivityHeatmap handles GET /api/v2/analytics/time/heatmap
+// Returns detection counts bucketed by (station-local date, intra-day slot) over the date range
+// as a columnar sparse payload. With ?format=csv it streams the non-zero cells as CSV instead.
+func (c *Controller) GetActivityHeatmap(ctx echo.Context) error {
+	const operation = "activity heatmap"
+
+	// Validate required parameter
+	if err := c.requireQueryParam(ctx, "start_date", operation); err != nil {
+		return err
+	}
+
+	startDate := ctx.QueryParam("start_date")
+	endDate := ctx.QueryParam("end_date")
+	speciesParam := ctx.QueryParam("species")
+
+	// Validate date formats strictly using regex
+	if err := c.validateDateFormatStrictWithResponse(ctx, startDate, "start_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, endDate, "end_date", operation); err != nil {
+		return err
+	}
+
+	// Validate date values and chronological order
+	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
+		return err
+	}
+
+	// Default the end date to a 30-day window when omitted, matching the other range endpoints.
+	if endDate == "" {
+		startTime, _ := time.Parse(time.DateOnly, startDate) // Regex ensures this parse succeeds
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
+	}
+
+	c.logInfoIfEnabled("Retrieving activity heatmap",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.String("species", speciesParam),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	// Resolve a localized common name to its scientific name so this endpoint matches the
+	// detections/search path and the sibling time endpoints; a scientific name or unresolved
+	// term passes through. Only the datastore query uses the resolved value.
+	querySpecies := speciesParam
+	if resolved, hit := c.resolveSpeciesToScientific(speciesParam); hit {
+		querySpecies = resolved
+	}
+
+	// Add timeout to prevent resource exhaustion
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
+	data, err := c.DS.GetActivityHeatmap(ctxWithTimeout, startDate, endDate, querySpecies)
+	if err != nil {
+		return c.handleAnalyticsQueryError(ctx, err, "Activity heatmap", "Failed to get activity heatmap data",
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("species", speciesParam),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("path", ctx.Request().URL.Path),
+		)
+	}
+
+	if strings.EqualFold(ctx.QueryParam("format"), "csv") {
+		return c.writeActivityHeatmapCSV(ctx, &data)
+	}
+
+	c.logInfoIfEnabled("Activity heatmap retrieved",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.Int("slot_resolution_minutes", data.SlotResolutionMinutes),
+		logger.Int("cell_count", len(data.CellCount)),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	return ctx.JSON(http.StatusOK, newActivityHeatmapResponse(&data))
+}
+
+// writeActivityHeatmapCSV streams the heatmap's non-zero cells as CSV. Each row is one cell:
+// the calendar date, the slot index, the slot's wall-clock start time, and the detection count.
+func (c *Controller) writeActivityHeatmapCSV(ctx echo.Context, data *datastore.ActivityHeatmapData) error {
+	ctx.Response().Header().Set(echo.HeaderContentType, "text/csv; charset=utf-8")
+	ctx.Response().Header().Set(echo.HeaderContentDisposition, `attachment; filename="activity-heatmap.csv"`)
+	ctx.Response().WriteHeader(http.StatusOK)
+
+	w := csv.NewWriter(ctx.Response())
+	if err := w.Write([]string{"date", "slot", "slot_start", "count"}); err != nil {
+		return err
+	}
+
+	resolution := data.SlotResolutionMinutes
+	for i := range data.CellDateIndex {
+		date := ""
+		if di := data.CellDateIndex[i]; di >= 0 && di < len(data.Dates) {
+			date = data.Dates[di]
+		}
+		slot := data.CellSlot[i]
+		startMinutes := slot * resolution
+		row := []string{
+			date,
+			strconv.Itoa(slot),
+			fmt.Sprintf("%02d:%02d", startMinutes/60, startMinutes%60),
+			strconv.Itoa(data.CellCount[i]),
+		}
+		if err := w.Write(row); err != nil {
+			return err
+		}
+	}
+
+	w.Flush()
+	return w.Error()
 }
 
 // GetTimeOfDayDistribution handles GET /api/v2/analytics/time/distribution/hourly

--- a/internal/api/v2/analytics_heatmap_test.go
+++ b/internal/api/v2/analytics_heatmap_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// heatmapJSON mirrors the columnar wire shape from the design spec.
+type heatmapJSON struct {
+	Dates                 []string `json:"dates"`
+	SlotResolutionMinutes int      `json:"slotResolutionMinutes"`
+	Cells                 struct {
+		DateIndex []int `json:"dateIndex"`
+		Slot      []int `json:"slot"`
+		Count     []int `json:"count"`
+	} `json:"cells"`
+}
+
+func sampleHeatmap() datastore.ActivityHeatmapData {
+	return datastore.ActivityHeatmapData{
+		Dates:                 []string{"2026-03-01", "2026-03-02"},
+		SlotResolutionMinutes: 15,
+		CellDateIndex:         []int{0, 1},
+		CellSlot:              []int{0, 95},
+		CellCount:             []int{3, 7},
+	}
+}
+
+func newHeatmapContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/time/heatmap")
+	return c, rec
+}
+
+func TestGetActivityHeatmap_ColumnarShape(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetActivityHeatmap", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return(sampleHeatmap(), nil)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetActivityHeatmap(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp heatmapJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"2026-03-01", "2026-03-02"}, resp.Dates)
+	assert.Equal(t, 15, resp.SlotResolutionMinutes)
+	assert.Equal(t, []int{0, 1}, resp.Cells.DateIndex)
+	assert.Equal(t, []int{0, 95}, resp.Cells.Slot)
+	assert.Equal(t, []int{3, 7}, resp.Cells.Count)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetActivityHeatmap_EmptyArraysNotNull(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// Datastore returns an empty grid (e.g. unknown species) with no cells.
+	mockDS.On("GetActivityHeatmap", mock.Anything, "2026-03-01", "2026-03-02", "Nonexistent species").
+		Return(datastore.ActivityHeatmapData{
+			Dates:                 []string{"2026-03-01", "2026-03-02"},
+			SlotResolutionMinutes: 15,
+		}, nil)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap?start_date=2026-03-01&end_date=2026-03-02&species=Nonexistent+species")
+	require.NoError(t, controller.GetActivityHeatmap(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Cells arrays must serialise as [] not null so the client can read .length safely.
+	assert.Contains(t, rec.Body.String(), `"dateIndex":[]`)
+	assert.NotContains(t, rec.Body.String(), `"cells":null`)
+}
+
+func TestGetActivityHeatmap_DefaultsEndDate(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// With end_date omitted, the handler defaults it to a 30-day window from start_date,
+	// matching the sibling range endpoints. 2026-03-01 + 30d = 2026-03-31.
+	mockDS.On("GetActivityHeatmap", mock.Anything, "2026-03-01", "2026-03-31", "").
+		Return(sampleHeatmap(), nil)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap?start_date=2026-03-01")
+	require.NoError(t, controller.GetActivityHeatmap(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetActivityHeatmap_MissingStartDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap")
+	err := controller.GetActivityHeatmap(c)
+	// The handler writes the error response itself and returns it.
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetActivityHeatmap_InvalidDateFormat(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap?start_date=not-a-date")
+	err := controller.GetActivityHeatmap(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetActivityHeatmap_CSVExport(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetActivityHeatmap", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return(sampleHeatmap(), nil)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap?start_date=2026-03-01&end_date=2026-03-02&format=csv")
+	require.NoError(t, controller.GetActivityHeatmap(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get(echo.HeaderContentType), "text/csv")
+
+	records, err := csv.NewReader(strings.NewReader(rec.Body.String())).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 3) // header + 2 cells
+	assert.Equal(t, []string{"date", "slot", "slot_start", "count"}, records[0])
+	assert.Equal(t, []string{"2026-03-01", "0", "00:00", "3"}, records[1])
+	// slot 95 at 15-minute resolution starts at 23:45.
+	assert.Equal(t, []string{"2026-03-02", "95", "23:45", "7"}, records[2])
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetActivityHeatmap_QueryTimeout(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetActivityHeatmap", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return(datastore.ActivityHeatmapData{}, context.DeadlineExceeded)
+
+	c, rec := newHeatmapContext(e, "/api/v2/analytics/time/heatmap?start_date=2026-03-01&end_date=2026-03-02")
+	// handleAnalyticsQueryError writes the 408 response and returns nil (it does not surface
+	// the error to echo), so assert on the recorded status rather than the returned error.
+	require.NoError(t, controller.GetActivityHeatmap(c))
+	assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+	mockDS.AssertExpectations(t)
+}

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -51,6 +51,22 @@ type HourlyDistributionData struct {
 	Date  string `json:"date,omitempty"` // Optional field, only set when filtering by specific date
 }
 
+// ActivityHeatmapData is the columnar, sparse aggregation behind the seasonal density
+// heatmap: detection counts bucketed by (station-local calendar date, intra-day slot).
+//
+// Dates lists every calendar date in the requested range, ascending, and forms the x-axis;
+// SlotResolutionMinutes is the effective intra-day slot width (15, 30, or 60), downsampled
+// from 15 on wide ranges so the payload stays bounded. The three Cell* slices are parallel
+// and hold only non-zero cells: cell i is Dates[CellDateIndex[i]] at slot CellSlot[i] with
+// CellCount[i] detections. A slot s covers the wall-clock minutes [s*res, (s+1)*res).
+type ActivityHeatmapData struct {
+	Dates                 []string
+	SlotResolutionMinutes int
+	CellDateIndex         []int
+	CellSlot              []int
+	CellCount             []int
+}
+
 // NewSpeciesData represents a species detected for the first time within a period
 type NewSpeciesData struct {
 	ScientificName string `json:"scientific_name"`
@@ -385,6 +401,13 @@ func (ds *DataStore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 	}
 
 	return diversity, nil
+}
+
+// GetActivityHeatmap is a stub on the legacy store. The seasonal density heatmap is a v2only
+// feature; the legacy datastore is deprecated and being removed, so it returns an empty grid
+// rather than implementing the aggregation. See internal/datastore/v2only for the real method.
+func (ds *DataStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (ActivityHeatmapData, error) {
+	return ActivityHeatmapData{}, nil
 }
 
 // GetDetectionTrends calculates the trend in detections over time

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -407,7 +407,15 @@ func (ds *DataStore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 // feature; the legacy datastore is deprecated and being removed, so it returns an empty grid
 // rather than implementing the aggregation. See internal/datastore/v2only for the real method.
 func (ds *DataStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (ActivityHeatmapData, error) {
-	return ActivityHeatmapData{}, nil
+	// Return a structurally valid empty grid (non-nil slices, a real slot resolution) rather
+	// than a zero value, so consumers never see SlotResolutionMinutes == 0.
+	return ActivityHeatmapData{
+		Dates:                 []string{},
+		SlotResolutionMinutes: 15,
+		CellDateIndex:         []int{},
+		CellSlot:              []int{},
+		CellCount:             []int{},
+	}, nil
 }
 
 // GetDetectionTrends calculates the trend in detections over time

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -192,6 +192,9 @@ type Interface interface {
 	GetSpeciesFirstDetectionInPeriod(ctx context.Context, startDate, endDate string, limit, offset int) ([]NewSpeciesData, error)
 	// GetSpeciesDiversityData returns daily unique species counts within the given date range.
 	GetSpeciesDiversityData(ctx context.Context, startDate, endDate string) ([]DailyAnalyticsData, error)
+	// GetActivityHeatmap returns detection counts bucketed by (station-local date, intra-day slot)
+	// over the inclusive date range, as a columnar sparse payload. species is an optional filter.
+	GetActivityHeatmap(ctx context.Context, startDate, endDate, species string) (ActivityHeatmapData, error)
 	// Search functionality
 	SearchDetections(filters *SearchFilters) ([]DetectionRecord, int, error)
 	// Dynamic Threshold methods

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -1020,6 +1020,65 @@ func (_c *MockInterface_GetActiveNotificationHistory_Call) RunAndReturn(run func
 	return _c
 }
 
+// GetActivityHeatmap provides a mock function with given fields: ctx, startDate, endDate, species
+func (_m *MockInterface) GetActivityHeatmap(ctx context.Context, startDate string, endDate string, species string) (datastore.ActivityHeatmapData, error) {
+	ret := _m.Called(ctx, startDate, endDate, species)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetActivityHeatmap")
+	}
+
+	var r0 datastore.ActivityHeatmapData
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (datastore.ActivityHeatmapData, error)); ok {
+		return rf(ctx, startDate, endDate, species)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) datastore.ActivityHeatmapData); ok {
+		r0 = rf(ctx, startDate, endDate, species)
+	} else {
+		r0 = ret.Get(0).(datastore.ActivityHeatmapData)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, startDate, endDate, species)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetActivityHeatmap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActivityHeatmap'
+type MockInterface_GetActivityHeatmap_Call struct {
+	*mock.Call
+}
+
+// GetActivityHeatmap is a helper method to define mock.On call
+//   - ctx context.Context
+//   - startDate string
+//   - endDate string
+//   - species string
+func (_e *MockInterface_Expecter) GetActivityHeatmap(ctx interface{}, startDate interface{}, endDate interface{}, species interface{}) *MockInterface_GetActivityHeatmap_Call {
+	return &MockInterface_GetActivityHeatmap_Call{Call: _e.mock.On("GetActivityHeatmap", ctx, startDate, endDate, species)}
+}
+
+func (_c *MockInterface_GetActivityHeatmap_Call) Run(run func(ctx context.Context, startDate string, endDate string, species string)) *MockInterface_GetActivityHeatmap_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetActivityHeatmap_Call) Return(_a0 datastore.ActivityHeatmapData, _a1 error) *MockInterface_GetActivityHeatmap_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetActivityHeatmap_Call) RunAndReturn(run func(context.Context, string, string, string) (datastore.ActivityHeatmapData, error)) *MockInterface_GetActivityHeatmap_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllComments provides a mock function with no fields
 func (_m *MockInterface) GetAllComments() ([]datastore.NoteComment, error) {
 	ret := _m.Called()

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -757,6 +757,9 @@ func (s *testLegacyInterface) GetSpeciesFirstDetectionInPeriod(_ context.Context
 func (s *testLegacyInterface) GetSpeciesDiversityData(_ context.Context, _, _ string) ([]datastore.DailyAnalyticsData, error) {
 	return nil, nil
 }
+func (s *testLegacyInterface) GetActivityHeatmap(_ context.Context, _, _, _ string) (datastore.ActivityHeatmapData, error) {
+	return datastore.ActivityHeatmapData{}, nil
+}
 func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -242,6 +242,12 @@ type DetectionRepository interface {
 	// that zone rather than the database/OS-local zone. labelID and modelID are optional filters.
 	GetHourlyDistribution(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]HourlyDistributionData, error)
 
+	// GetDetectionTimestamps returns the raw detected_at epochs (seconds) for the half-open
+	// range [start, end), excluding false positives, in no particular order. labelID is an
+	// optional species filter. Callers bucket the timestamps in Go (e.g. the seasonal heatmap),
+	// which keeps the slot/date math out of dialect SQL and correct across DST.
+	GetDetectionTimestamps(ctx context.Context, start, end int64, labelID *uint) ([]int64, error)
+
 	// GetDailyAnalytics returns daily statistics.
 	// tzOffsetSeconds is the configured timezone's UTC offset, applied so detections bucket by
 	// wall-clock date in that zone rather than the database/OS-local zone.

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1579,7 +1579,8 @@ func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, 
 }
 
 // GetDetectionTimestamps returns raw detected_at epochs for [start, end), false positives
-// excluded, ascending. See the interface doc for why bucketing happens in Go, not SQL.
+// excluded, in no particular order. See the interface doc for why bucketing happens in Go,
+// not SQL.
 func (r *detectionRepository) GetDetectionTimestamps(ctx context.Context, start, end int64, labelID *uint) ([]int64, error) {
 	var timestamps []int64
 	// No ORDER BY: the caller buckets timestamps into a map and sorts the resulting cells

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1578,6 +1578,17 @@ func (r *detectionRepository) GetHourlyDistribution(ctx context.Context, start, 
 	return results, err
 }
 
+// GetDetectionTimestamps returns raw detected_at epochs for [start, end), false positives
+// excluded, ascending. See the interface doc for why bucketing happens in Go, not SQL.
+func (r *detectionRepository) GetDetectionTimestamps(ctx context.Context, start, end int64, labelID *uint) ([]int64, error) {
+	var timestamps []int64
+	// No ORDER BY: the caller buckets timestamps into a map and sorts the resulting cells
+	// itself, so ordering (potentially millions of) rows in SQL would be wasted work.
+	err := r.buildAnalyticsBaseQuery(ctx, start, end, labelID, nil).
+		Pluck("d.detected_at", &timestamps).Error
+	return timestamps, err
+}
+
 // GetDailyAnalytics returns daily statistics.
 func (r *detectionRepository) GetDailyAnalytics(ctx context.Context, start, end int64, tzOffsetSeconds int, labelID, modelID *uint) ([]DailyAnalyticsData, error) {
 	var results []DailyAnalyticsData

--- a/internal/datastore/v2/repository/detection_timestamps_test.go
+++ b/internal/datastore/v2/repository/detection_timestamps_test.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDetectionTimestamps(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	labelA := seedLabel(t, db, "Parus major")
+	labelB := seedLabel(t, db, "Turdus merula")
+
+	seedDetection(t, db, labelA, 1000, 0.9) // in range, label A
+	seedDetection(t, db, labelB, 1500, 0.8) // in range, label B
+	seedDetection(t, db, labelA, 2000, 0.7) // in range, label A
+	seedDetection(t, db, labelA, 9000, 0.9) // out of range (>= end)
+	fpID := seedDetection(t, db, labelA, 3000, 0.6)
+	seedFalsePositiveReview(t, db, fpID) // in range but false positive -> excluded
+
+	// The method makes no ordering guarantee (the caller buckets and sorts), so assert on
+	// set membership rather than sequence.
+	t.Run("all species in range, false positives excluded", func(t *testing.T) {
+		got, err := repo.GetDetectionTimestamps(ctx, 500, 5000, nil)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []int64{1000, 1500, 2000}, got)
+	})
+
+	t.Run("species filter", func(t *testing.T) {
+		got, err := repo.GetDetectionTimestamps(ctx, 500, 5000, &labelA)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []int64{1000, 2000}, got)
+	})
+
+	t.Run("end is exclusive", func(t *testing.T) {
+		got, err := repo.GetDetectionTimestamps(ctx, 500, 2000, nil)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []int64{1000, 1500}, got)
+	})
+
+	t.Run("empty range returns no rows without error", func(t *testing.T) {
+		got, err := repo.GetDetectionTimestamps(ctx, 100000, 200000, nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/internal/datastore/v2only/aggregate.go
+++ b/internal/datastore/v2only/aggregate.go
@@ -43,6 +43,14 @@ type cellKey struct {
 	slot      int
 }
 
+// dateKey identifies a calendar day. Keying the date index by this struct (rather than a
+// formatted string) lets the per-timestamp lookup avoid a string allocation on every row.
+type dateKey struct {
+	year  int
+	month time.Month
+	day   int
+}
+
 // buildActivityHeatmap buckets raw detection timestamps (Unix epoch seconds) into a columnar,
 // sparse (date, slot) grid for the seasonal density heatmap.
 //
@@ -76,13 +84,15 @@ func buildActivityHeatmap(timestamps []int64, loc *time.Location, startDate, end
 			Build()
 	}
 
-	// Enumerate every calendar date in the inclusive range and index it for O(1) lookup.
+	// Enumerate every calendar date in the inclusive range and index it for O(1) lookup. The
+	// index is keyed by a (year, month, day) struct so the per-timestamp lookup below allocates
+	// nothing; the human-readable date string is formatted just once per day here.
 	dates := make([]string, 0)
-	dateIndex := make(map[string]int)
+	dateIndex := make(map[dateKey]int)
 	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
-		key := d.Format(time.DateOnly)
-		dateIndex[key] = len(dates)
-		dates = append(dates, key)
+		y, m, day := d.Date()
+		dateIndex[dateKey{year: y, month: m, day: day}] = len(dates)
+		dates = append(dates, d.Format(time.DateOnly))
 	}
 
 	resolution := heatmapSlotResolution(len(dates))
@@ -94,7 +104,8 @@ func buildActivityHeatmap(timestamps []int64, loc *time.Location, startDate, end
 	counts := make(map[cellKey]int)
 	for _, ts := range timestamps {
 		lt := time.Unix(ts, 0).In(loc)
-		idx, ok := dateIndex[lt.Format(time.DateOnly)]
+		y, m, day := lt.Date()
+		idx, ok := dateIndex[dateKey{year: y, month: m, day: day}]
 		if !ok {
 			continue // detection falls outside the requested range in loc
 		}

--- a/internal/datastore/v2only/aggregate.go
+++ b/internal/datastore/v2only/aggregate.go
@@ -1,0 +1,128 @@
+package v2only
+
+import (
+	"maps"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// Slot resolution constants for the seasonal density heatmap. The intra-day slot width is
+// downsampled as the requested range widens so the payload (and the rendered grid) stays
+// bounded: a year at 15-minute resolution would be 365*96 cells, most of them noise.
+const (
+	heatmapMinutesPerDay = 24 * 60 // minutes in a day
+
+	heatmapSlotFine   = 15 // <= heatmapMediumDays
+	heatmapSlotMedium = 30 // (heatmapMediumDays, heatmapCoarseDays]
+	heatmapSlotCoarse = 60 // > heatmapCoarseDays
+
+	heatmapMediumDays = 90  // ~3 months: switch from 15- to 30-minute slots beyond this
+	heatmapCoarseDays = 180 // ~6 months: switch from 30- to 60-minute slots beyond this
+)
+
+// heatmapSlotResolution returns the intra-day slot width in minutes for a range spanning
+// numDays calendar days. Wider ranges use coarser slots to bound payload and render cost.
+func heatmapSlotResolution(numDays int) int {
+	switch {
+	case numDays > heatmapCoarseDays:
+		return heatmapSlotCoarse
+	case numDays > heatmapMediumDays:
+		return heatmapSlotMedium
+	default:
+		return heatmapSlotFine
+	}
+}
+
+// cellKey identifies a heatmap cell by (date index, intra-day slot).
+type cellKey struct {
+	dateIndex int
+	slot      int
+}
+
+// buildActivityHeatmap buckets raw detection timestamps (Unix epoch seconds) into a columnar,
+// sparse (date, slot) grid for the seasonal density heatmap.
+//
+// startDate/endDate are inclusive YYYY-MM-DD bounds interpreted in loc; the returned Dates
+// slice lists every calendar date in [startDate, endDate]. Each timestamp is placed by its
+// wall-clock date and minute-of-day in loc, so bucketing follows the station timezone and is
+// correct across DST transitions (unlike a single-offset SQL expression). The slot width is
+// downsampled for wide ranges (see heatmapSlotResolution). Timestamps whose local date falls
+// outside the range are ignored. Only non-zero cells are emitted, ordered by (dateIndex, slot).
+func buildActivityHeatmap(timestamps []int64, loc *time.Location, startDate, endDate string) (datastore.ActivityHeatmapData, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	start, err := time.ParseInLocation(time.DateOnly, startDate, loc)
+	if err != nil {
+		return datastore.ActivityHeatmapData{}, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "build_activity_heatmap").
+			Context("start_date", startDate).
+			Build()
+	}
+	end, err := time.ParseInLocation(time.DateOnly, endDate, loc)
+	if err != nil {
+		return datastore.ActivityHeatmapData{}, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "build_activity_heatmap").
+			Context("end_date", endDate).
+			Build()
+	}
+
+	// Enumerate every calendar date in the inclusive range and index it for O(1) lookup.
+	dates := make([]string, 0)
+	dateIndex := make(map[string]int)
+	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+		key := d.Format(time.DateOnly)
+		dateIndex[key] = len(dates)
+		dates = append(dates, key)
+	}
+
+	resolution := heatmapSlotResolution(len(dates))
+	slotsPerDay := heatmapMinutesPerDay / resolution
+	lastSlot := slotsPerDay - 1
+
+	// Accumulate counts per (dateIndex, slot); cells are sparse so a map avoids allocating
+	// the full dense grid for ranges where most cells are empty.
+	counts := make(map[cellKey]int)
+	for _, ts := range timestamps {
+		lt := time.Unix(ts, 0).In(loc)
+		idx, ok := dateIndex[lt.Format(time.DateOnly)]
+		if !ok {
+			continue // detection falls outside the requested range in loc
+		}
+		// min guards against any boundary rounding pushing the slot past the last one.
+		slot := min((lt.Hour()*60+lt.Minute())/resolution, lastSlot)
+		counts[cellKey{dateIndex: idx, slot: slot}]++
+	}
+
+	// Emit cells ordered by (dateIndex, slot) for a deterministic, render-friendly payload.
+	keys := slices.Collect(maps.Keys(counts))
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].dateIndex != keys[j].dateIndex {
+			return keys[i].dateIndex < keys[j].dateIndex
+		}
+		return keys[i].slot < keys[j].slot
+	})
+
+	result := datastore.ActivityHeatmapData{
+		Dates:                 dates,
+		SlotResolutionMinutes: resolution,
+		CellDateIndex:         make([]int, 0, len(keys)),
+		CellSlot:              make([]int, 0, len(keys)),
+		CellCount:             make([]int, 0, len(keys)),
+	}
+	for _, k := range keys {
+		result.CellDateIndex = append(result.CellDateIndex, k.dateIndex)
+		result.CellSlot = append(result.CellSlot, k.slot)
+		result.CellCount = append(result.CellCount, counts[k])
+	}
+	return result, nil
+}

--- a/internal/datastore/v2only/aggregate_test.go
+++ b/internal/datastore/v2only/aggregate_test.go
@@ -1,0 +1,167 @@
+package v2only
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// epochAt returns the Unix epoch (seconds) for the given wall-clock time in loc.
+func epochAt(loc *time.Location, year, month, day, hour, minute int) int64 {
+	return time.Date(year, time.Month(month), day, hour, minute, 0, 0, loc).Unix()
+}
+
+func TestHeatmapSlotResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		numDays int
+		want    int
+	}{
+		{"single day stays fine", 1, heatmapSlotFine},
+		{"month stays fine", 30, heatmapSlotFine},
+		{"quarter boundary stays fine", heatmapMediumDays, heatmapSlotFine},
+		{"just over quarter downsamples to medium", heatmapMediumDays + 1, heatmapSlotMedium},
+		{"half year boundary stays medium", heatmapCoarseDays, heatmapSlotMedium},
+		{"just over half year downsamples to coarse", heatmapCoarseDays + 1, heatmapSlotCoarse},
+		{"full year is coarse", 365, heatmapSlotCoarse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, heatmapSlotResolution(tt.numDays))
+		})
+	}
+}
+
+func TestBuildActivityHeatmap_BucketingAndShape(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	timestamps := []int64{
+		epochAt(utc, 2026, 3, 1, 0, 0),   // date 0, slot 0
+		epochAt(utc, 2026, 3, 1, 0, 10),  // date 0, slot 0 (same cell -> count 2)
+		epochAt(utc, 2026, 3, 1, 6, 30),  // date 0, slot 26
+		epochAt(utc, 2026, 3, 2, 23, 59), // date 1, slot 95 (last 15-min slot)
+		epochAt(utc, 2026, 3, 3, 12, 0),  // date 2, slot 48
+	}
+
+	got, err := buildActivityHeatmap(timestamps, utc, "2026-03-01", "2026-03-03")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"2026-03-01", "2026-03-02", "2026-03-03"}, got.Dates)
+	assert.Equal(t, heatmapSlotFine, got.SlotResolutionMinutes)
+
+	// Cells are sparse (only non-zero), parallel, and sorted by (dateIndex, slot).
+	require.Len(t, got.CellDateIndex, 4)
+	require.Len(t, got.CellSlot, len(got.CellDateIndex))
+	require.Len(t, got.CellCount, len(got.CellDateIndex))
+	assert.Equal(t, []int{0, 0, 1, 2}, got.CellDateIndex)
+	assert.Equal(t, []int{0, 26, 95, 48}, got.CellSlot)
+	assert.Equal(t, []int{2, 1, 1, 1}, got.CellCount)
+}
+
+func TestBuildActivityHeatmap_TimezoneOffsetBuckets(t *testing.T) {
+	t.Parallel()
+
+	// Fixed +02:00 zone: a 23:30 UTC detection is 01:30 local the next day, and a
+	// 22:30 UTC detection is 00:30 local two days on (outside a single-day window).
+	loc := time.FixedZone("EET", 2*60*60)
+	timestamps := []int64{
+		time.Date(2026, 2, 28, 23, 30, 0, 0, time.UTC).Unix(), // local 2026-03-01 01:30 -> slot 6
+		time.Date(2026, 3, 1, 22, 30, 0, 0, time.UTC).Unix(),  // local 2026-03-02 00:30 -> out of range
+	}
+
+	got, err := buildActivityHeatmap(timestamps, loc, "2026-03-01", "2026-03-01")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"2026-03-01"}, got.Dates)
+	assert.Equal(t, []int{0}, got.CellDateIndex)
+	assert.Equal(t, []int{6}, got.CellSlot) // 90 minutes / 15 = slot 6
+	assert.Equal(t, []int{1}, got.CellCount)
+}
+
+func TestBuildActivityHeatmap_DSTWallClockBuckets(t *testing.T) {
+	t.Parallel()
+
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	// Both detections are at 13:00 wall-clock local time but on opposite sides of the
+	// DST transition (EDT -04:00 in July, EST -05:00 in January). Per-timestamp
+	// bucketing must place both at the same local slot regardless of the offset; a
+	// single fixed-offset query would mis-bucket one of them.
+	timestamps := []int64{
+		epochAt(loc, 2026, 7, 1, 13, 0),  // summer, EDT
+		epochAt(loc, 2026, 1, 15, 13, 0), // winter, EST
+	}
+
+	got, err := buildActivityHeatmap(timestamps, loc, "2026-01-01", "2026-12-31")
+	require.NoError(t, err)
+	// Full-year range downsamples to hourly slots.
+	require.Equal(t, heatmapSlotCoarse, got.SlotResolutionMinutes)
+
+	// Map each date index to its slot for clear assertions.
+	slotByDate := map[string]int{}
+	for i := range got.CellDateIndex {
+		slotByDate[got.Dates[got.CellDateIndex[i]]] = got.CellSlot[i]
+	}
+	assert.Equal(t, 13, slotByDate["2026-07-01"], "summer 13:00 EDT should bucket to hour 13")
+	assert.Equal(t, 13, slotByDate["2026-01-15"], "winter 13:00 EST should bucket to hour 13")
+}
+
+func TestBuildActivityHeatmap_DownsampleMedium(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	timestamps := []int64{
+		epochAt(utc, 2026, 1, 1, 0, 45), // minute 45 -> slot 1 at 30-min resolution
+		epochAt(utc, 2026, 1, 1, 1, 0),  // minute 60 -> slot 2 at 30-min resolution
+	}
+
+	// ~105 days exceeds the quarter threshold -> 30-minute slots.
+	got, err := buildActivityHeatmap(timestamps, utc, "2026-01-01", "2026-04-15")
+	require.NoError(t, err)
+	assert.Equal(t, heatmapSlotMedium, got.SlotResolutionMinutes)
+	assert.Equal(t, []int{1, 2}, got.CellSlot)
+}
+
+func TestBuildActivityHeatmap_OutOfRangeIgnored(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	timestamps := []int64{
+		epochAt(utc, 2026, 2, 28, 12, 0), // before start
+		epochAt(utc, 2026, 3, 2, 12, 0),  // in range
+		epochAt(utc, 2026, 3, 5, 12, 0),  // after end
+	}
+
+	got, err := buildActivityHeatmap(timestamps, utc, "2026-03-01", "2026-03-03")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1}, got.CellDateIndex) // only the in-range detection
+	assert.Equal(t, []int{1}, got.CellCount)
+}
+
+func TestBuildActivityHeatmap_EmptyRangeHasDatesNoCells(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildActivityHeatmap(nil, time.UTC, "2026-03-01", "2026-03-03")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"2026-03-01", "2026-03-02", "2026-03-03"}, got.Dates)
+	assert.Empty(t, got.CellDateIndex)
+	assert.Empty(t, got.CellSlot)
+	assert.Empty(t, got.CellCount)
+}
+
+func TestBuildActivityHeatmap_InvalidDates(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildActivityHeatmap(nil, time.UTC, "not-a-date", "2026-03-03")
+	require.Error(t, err)
+}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2981,6 +2981,33 @@ func (ds *Datastore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 	return results, nil
 }
 
+// GetActivityHeatmap returns detection counts bucketed by (station-local date, intra-day slot)
+// over [startDate, endDate]. It fetches the raw detection timestamps in range (false positives
+// excluded) and buckets them in Go (buildActivityHeatmap), keeping the slot/date math out of
+// dialect SQL and correct across DST. species is an optional scientific-name filter; an unknown
+// species yields an empty grid that still carries the full date axis.
+func (ds *Datastore) GetActivityHeatmap(ctx context.Context, startDate, endDate, species string) (datastore.ActivityHeatmapData, error) {
+	start, end, err := ds.parseDateRange(startDate, endDate)
+	if err != nil {
+		return datastore.ActivityHeatmapData{}, err
+	}
+
+	labelID, err := ds.resolveLabelID(ctx, species)
+	if err != nil {
+		if errors.Is(err, errNotFound) {
+			return buildActivityHeatmap(nil, ds.timezone, startDate, endDate)
+		}
+		return datastore.ActivityHeatmapData{}, err
+	}
+
+	timestamps, err := ds.detection.GetDetectionTimestamps(ctx, start, end, labelID)
+	if err != nil {
+		return datastore.ActivityHeatmapData{}, err
+	}
+
+	return buildActivityHeatmap(timestamps, ds.timezone, startDate, endDate)
+}
+
 // ============================================================
 // Dynamic Threshold Methods
 // ============================================================

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -293,6 +293,9 @@ func (m *mockStore) GetSpeciesFirstDetectionInPeriod(ctx context.Context, startD
 func (m *mockStore) GetSpeciesDiversityData(_ context.Context, _, _ string) ([]datastore.DailyAnalyticsData, error) {
 	return nil, nil
 }
+func (m *mockStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (datastore.ActivityHeatmapData, error) {
+	return datastore.ActivityHeatmapData{}, nil
+}
 
 // BG-17 fix: Add notification history methods
 func (m *mockStore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {


### PR DESCRIPTION
## Summary

Adds the first new Tier-1 chart to the redesigned analytics hub's **Activity Patterns** tab: a date × time-of-day heatmap where brightness encodes detection count, making migration waves and dawn-chorus drift across the season visible at a glance.

### Backend (additive, v2only only)
- New endpoint `GET /api/v2/analytics/time/heatmap` with an optional `species` filter and a `?format=csv` export branch.
- New `GetActivityHeatmap` datastore interface method, implemented in v2only via a new `GetDetectionTimestamps` repository query (false positives excluded). The legacy `DataStore` is stubbed empty; the generated mock is regenerated.
- Shared Go aggregation buckets timestamps into `(station-local date, 15/30/60-minute slot)` using per-timestamp wall-clock bucketing (correct across DST, unlike a single-offset SQL expression) and downsamples the slot resolution on wide ranges. The response is a columnar, sparse payload: `{ dates, slotResolutionMinutes, cells: { dateIndex, slot, count } }`.

### Frontend
- `SeasonalHeatmap.svelte` (D3, wraps the shared `BaseChart`): `scaleBand` date × slot, count encoded as opacity over the theme hue, a narrow-width fold to a 24-row hourly grid, tooltip, legend, and a screen-reader summary.
- One registry `ChartDef` (group `patterns`, `supports.species`, CSV export, `minDataPoints`) plus a fetcher. New i18n keys added across all 16 locales.

All existing `/api/v2/analytics/*` paths and response shapes are unchanged (additive only).

## Test Plan
- [x] Go: table tests for the bucketing/downsample/timezone/DST logic, the repository query (false-positive exclusion, half-open range), and the handler (columnar shape, empty-arrays-not-null, missing/invalid date, CSV branch, query timeout, end_date defaulting). `go test -race` green.
- [x] `golangci-lint run` clean.
- [x] Frontend: `npm run check:all` (typecheck/lint/ast/prettier) clean; vitest covers the transform helper, the component state matrix, and the narrow-width fallback.
- [ ] Manual: open the hub's Activity Patterns tab on a live instance and verify the heatmap renders, the species filter works, narrow viewports fold to hourly rows, and CSV export downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Seasonal Activity Heatmap to analytics to visualize detection intensity by time of day across the selected date range.
  * Responsive downsampling for narrow layouts, hover tooltips, and a compact legend; supports CSV export.
  * Enhanced accessibility with an ARIA label and a screen-reader summary (total detections and peak time).
* **Documentation**
  * Documented the new `/analytics/time/heatmap` endpoint and its optional `?format=csv` output.
* **Tests**
  * Added chart, utility, and API test coverage (including empty states, tooltip/opacity behavior, and CSV/timeout handling).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->