### PR TITLE
feat(analytics): who-sings-when species ridgeline

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -15,6 +15,7 @@
   import { select, type Selection } from 'd3-selection';
   import { area as d3Area, curveBasis } from 'd3-shape';
   import { scaleLinear } from 'd3-scale';
+  import { color as d3Color } from 'd3-color';
   import type { AxisDomain, AxisScale } from 'd3-axis';
 
   import { t } from '$lib/i18n';
@@ -119,11 +120,14 @@
     return label.length > LABEL_MAX_CHARS ? `${label.slice(0, LABEL_MAX_CHARS - 1)}…` : label;
   }
 
-  // Force an rgba palette color to full opacity for the crisp ridge top line; the fill keeps the
-  // translucent original so overlaps blend. Falls back to the input for non-rgba strings.
+  // Force a palette color to full opacity for the crisp ridge top line; the fill keeps the
+  // translucent original so overlaps blend. d3-color robustly parses the rgba palette strings and
+  // returns null for anything it can't (e.g. oklch theme tokens), in which case we keep the input.
   function opaqueStroke(color: string): string {
-    const m = /rgba\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*[\d.]+\s*\)/.exec(color);
-    return m ? `rgb(${m[1]}, ${m[2]}, ${m[3]})` : color;
+    const parsed = d3Color(color);
+    if (!parsed) return color;
+    parsed.opacity = 1;
+    return parsed.formatRgb();
   }
 
   function showRowTooltip(event: MouseEvent, row: (typeof rows)[number], color: string): void {

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -24,7 +24,7 @@
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import { generateSpeciesColors, type ChartTheme } from './utils/theme';
-  import { ridgelineLayout, peakIndex, type RidgelineSeries } from './utils/ridgeline';
+  import { ridgelineLayout, peakIndex, RIDGE_OVERLAP, type RidgelineSeries } from './utils/ridgeline';
 
   interface Props {
     /** One row per species: { scientificName, commonName, density[], total? }. */
@@ -65,7 +65,7 @@
 
   // Layout / style constants.
   const MARGIN = { top: 24, right: 16, bottom: 44, left: 120 };
-  const RIDGE_OVERLAP = 2; // a full-amplitude ridge spans this many row-steps
+  // RIDGE_OVERLAP is imported from utils/ridgeline so the rendering and the layout math stay in sync.
   const RIDGE_FILL_OPACITY = 0.55; // translucent so overlapping ridges blend
   const RIDGE_STROKE_WIDTH = 1.5;
   const RIDGE_STROKE_WIDTH_HOVER = 2.5;

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -1,0 +1,286 @@
+<!--
+  Species ridgeline (joyplot): one overlapping area row per species showing a normalized
+  per-index distribution. Built generically so it is reused across per-species distribution charts:
+  the who-sings-when hour-of-day ridgeline (#1159) and the confidence distribution (#1162). The
+  index meaning (hour 0..23 vs confidence bin) is supplied by the caller via xTickFormat / axisLabel.
+
+  Each ridge is a d3-shape area with curveBasis; a shared amplitude scale maps the global-max
+  density to a fixed pixel height, so a species with concentrated activity rises taller than an
+  all-day one. Species color comes from theme.ts generateSpeciesColors (rgba, so it is never fed to
+  a d3 color interpolator). The scientific name is the stable D3 key; the localized common name is
+  the row label (re-localized here so it tracks the visitor's locale, matching the sibling charts).
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { select, type Selection } from 'd3-selection';
+  import { area as d3Area, curveBasis } from 'd3-shape';
+  import { scaleLinear } from 'd3-scale';
+  import type { AxisDomain, AxisScale } from 'd3-axis';
+
+  import { t } from '$lib/i18n';
+  import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
+  import BaseChart from './BaseChart.svelte';
+  import { createLinearScale } from './utils/scales';
+  import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
+  import { ChartTooltip } from './utils/interactions';
+  import { generateSpeciesColors, type ChartTheme } from './utils/theme';
+  import { ridgelineLayout, peakIndex, type RidgelineSeries } from './utils/ridgeline';
+
+  interface Props {
+    /** One row per species: { scientificName, commonName, density[], total? }. */
+    series: RidgelineSeries[];
+    width?: number;
+    height?: number;
+    /** i18n key for the chart's accessible label. */
+    ariaLabelKey?: string;
+    /** i18n key for the x-axis title. */
+    axisLabelKey?: string;
+    /** Maps a density index to its x-tick / peak label (e.g. hour -> "6:00"). Defaults to "{i}:00". */
+    xTickFormat?: (_index: number) => string;
+    /** Label every Nth x index (default 3, suitable for a 24-hour axis). */
+    xTickStep?: number;
+    /** Optional i18n key for a caption above the plot; receives { count } = number of ridges. */
+    noteKey?: string;
+    /** i18n key for the tooltip's detection-count label. */
+    totalLabelKey?: string;
+    /** i18n key for the tooltip's peak-position label. */
+    peakLabelKey?: string;
+    /** i18n key for the screen-reader summary; receives { count, species, time }. */
+    summaryKey?: string;
+  }
+
+  let {
+    series,
+    width = 800,
+    height = 400,
+    ariaLabelKey = 'analytics.advanced.charts.ridgeline.ariaLabel',
+    axisLabelKey = 'analytics.advanced.charts.ridgeline.axisTime',
+    xTickFormat,
+    xTickStep = 3,
+    noteKey,
+    totalLabelKey = 'analytics.advanced.charts.ridgeline.tooltipDetections',
+    peakLabelKey = 'analytics.advanced.charts.ridgeline.tooltipPeak',
+    summaryKey = 'analytics.advanced.charts.ridgeline.summary',
+  }: Props = $props();
+
+  // Layout / style constants.
+  const MARGIN = { top: 24, right: 16, bottom: 44, left: 120 };
+  const RIDGE_OVERLAP = 2; // a full-amplitude ridge spans this many row-steps
+  const RIDGE_FILL_OPACITY = 0.55; // translucent so overlapping ridges blend
+  const RIDGE_STROKE_WIDTH = 1.5;
+  const RIDGE_STROKE_WIDTH_HOVER = 2.5;
+  const LABEL_MAX_CHARS = 18;
+  const LABEL_GAP = 10; // px between the left edge and a row label
+  const X_AXIS_LABEL_OFFSET = 34;
+  const MIN_DENSITY_DOMAIN = 1e-6; // floor so an all-zero set never yields a degenerate amp domain
+
+  let tooltip: ChartTooltip | null = null;
+  let chartContainer: HTMLDivElement | null = null;
+
+  // Default x-axis tick formatter: station-local hour-of-day, zero-padded ("06:00"), via the shared
+  // hour formatter so labels match the sibling time-of-day chart. This is the #1159 use; the
+  // confidence-distribution reuse (#1162) passes its own xTickFormat for bin labels.
+  const defaultHourFormat = createHourAxisFormatter();
+  const tickFmt = $derived(xTickFormat ?? defaultHourFormat);
+
+  // Localized rows. Computed in a $derived (not in the parent mapProps) so the draw $effect re-runs
+  // when the per-visitor dictionary loads or the UI locale switches; the scientific name stays the
+  // stable key, only the label changes.
+  const rows = $derived(
+    series.map(s => ({
+      scientificName: s.scientificName,
+      label: localizeSpeciesName(s.scientificName, s.commonName),
+      density: s.density,
+      total: s.total ?? 0,
+    }))
+  );
+
+  // Screen-reader summary so the ridgeline is not opaque to assistive tech (spec section 7).
+  const summary = $derived.by(() => {
+    if (rows.length === 0) return '';
+    const top = rows[0];
+    const pk = peakIndex(top.density);
+    return t(summaryKey, {
+      count: rows.length,
+      species: top.label,
+      time: pk >= 0 ? tickFmt(pk) : '',
+    });
+  });
+
+  let chartContext = $state<{
+    svg: Selection<SVGSVGElement, unknown, null, undefined>;
+    chartGroup: Selection<globalThis.SVGGElement, unknown, null, undefined>;
+    innerWidth: number;
+    innerHeight: number;
+    theme: ChartTheme;
+  } | null>(null);
+
+  function truncateLabel(label: string): string {
+    return label.length > LABEL_MAX_CHARS ? `${label.slice(0, LABEL_MAX_CHARS - 1)}…` : label;
+  }
+
+  // Force an rgba palette color to full opacity for the crisp ridge top line; the fill keeps the
+  // translucent original so overlaps blend. Falls back to the input for non-rgba strings.
+  function opaqueStroke(color: string): string {
+    const m = /rgba\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*[\d.]+\s*\)/.exec(color);
+    return m ? `rgb(${m[1]}, ${m[2]}, ${m[3]})` : color;
+  }
+
+  function showRowTooltip(event: MouseEvent, row: (typeof rows)[number], color: string): void {
+    const pk = peakIndex(row.density);
+    const items = [{ label: t(totalLabelKey), value: String(row.total), color }];
+    if (pk >= 0) {
+      items.push({ label: t(peakLabelKey), value: tickFmt(pk), color });
+    }
+    tooltip?.show({ title: row.label, items, x: event.clientX, y: event.clientY });
+  }
+
+  function drawChart(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight, theme } = context;
+    // A redraw removes the hovered path, so its mouseleave would never fire; hide first.
+    tooltip?.hide();
+    chartGroup.selectAll('*').remove();
+    if (innerWidth <= 0 || innerHeight <= 0 || rows.length === 0) return;
+
+    // layout.rows[i] aligns with rows[i]: both derive from `series` in order (rows is a 1:1
+    // localized map of series), so layoutRow.index indexes `rows`, `colors`, and `series` alike.
+    const layout = ridgelineLayout(series, innerHeight, RIDGE_OVERLAP);
+    const colors = generateSpeciesColors(rows.length, theme);
+
+    // x: density index -> px. All series share the same length (24 hours / N bins); use the widest.
+    const xLen = Math.max(1, ...rows.map(r => r.density.length));
+    const xScale = createLinearScale({ domain: [0, xLen - 1], range: [0, innerWidth] });
+
+    // Shared amplitude scale: global-max density -> layout.amplitude px above the baseline.
+    const ampScale = scaleLinear()
+      .domain([0, Math.max(MIN_DENSITY_DOMAIN, layout.maxDensity)])
+      .range([0, layout.amplitude]);
+
+    // X axis: sampled hour/bin ticks along the bottom.
+    const xAxis = createAxis({
+      scale: xScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'bottom',
+      tickFormat: (d: AxisDomain) => tickFmt(Number(d)),
+    });
+    const step = Math.max(1, xTickStep);
+    xAxis.tickValues(Array.from({ length: Math.ceil(xLen / step) }, (_, i) => i * step));
+    const xAxisGroup = chartGroup
+      .append('g')
+      .attr('class', 'x-axis')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(xAxis);
+    styleAxis(xAxisGroup, theme.axis);
+
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t(axisLabelKey),
+        orientation: 'bottom',
+        offset: X_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+
+    // Ridges, drawn top row first so lower (front) ridges overlap onto the ones above them.
+    for (const layoutRow of layout.rows) {
+      const row = rows[layoutRow.index];
+      const color = colors[layoutRow.index] ?? theme.primary;
+      const baseline = layoutRow.baseline;
+
+      const gen = d3Area<number>()
+        .x((_d, j) => xScale(j))
+        .y0(baseline)
+        .y1(d => baseline - ampScale(d))
+        .curve(curveBasis);
+
+      const group = chartGroup
+        .append('g')
+        .attr('class', 'ridge')
+        .attr('data-species', row.scientificName);
+
+      group
+        .append('path')
+        .attr('class', 'ridge-area')
+        .attr('d', gen(row.density) ?? '')
+        .style('fill', color)
+        .style('fill-opacity', RIDGE_FILL_OPACITY)
+        .style('stroke', opaqueStroke(color))
+        .style('stroke-width', RIDGE_STROKE_WIDTH)
+        .on('mouseenter', function (event: MouseEvent) {
+          select(this).style('stroke-width', RIDGE_STROKE_WIDTH_HOVER);
+          showRowTooltip(event, row, color);
+        })
+        .on('mousemove', function (event: MouseEvent) {
+          showRowTooltip(event, row, color);
+        })
+        .on('mouseleave', function () {
+          select(this).style('stroke-width', RIDGE_STROKE_WIDTH);
+          tooltip?.hide();
+        });
+
+      // Row label in the left margin, anchored at the baseline; full name in a native <title>.
+      const labelText = group
+        .append('text')
+        .attr('class', 'ridge-label')
+        .attr('x', -LABEL_GAP)
+        .attr('y', baseline)
+        .attr('text-anchor', 'end')
+        .attr('dominant-baseline', 'middle')
+        .style('fill', theme.text)
+        .style('font-size', theme.axis.fontSize)
+        .style('font-family', theme.axis.fontFamily)
+        .text(truncateLabel(row.label));
+      labelText.append('title').text(row.label);
+    }
+  }
+
+  $effect(() => {
+    if (chartContext) {
+      drawChart(chartContext);
+    }
+  });
+
+  onMount(() => {
+    if (chartContainer) {
+      tooltip = new ChartTooltip(chartContainer);
+    }
+  });
+
+  onDestroy(() => {
+    tooltip?.destroy();
+  });
+</script>
+
+<div class="species-ridgeline-chart" bind:this={chartContainer}>
+  {#if noteKey && rows.length > 0}
+    <p class="ridgeline-note">{t(noteKey, { count: rows.length })}</p>
+  {/if}
+  <BaseChart {width} {height} margin={MARGIN} responsive={true} ariaLabel={t(ariaLabelKey)}>
+    {#snippet children(context)}
+      {((chartContext = context), '')}
+    {/snippet}
+  </BaseChart>
+  {#if summary}
+    <p class="sr-only" data-testid="ridgeline-summary">{summary}</p>
+  {/if}
+</div>
+
+<style>
+  .species-ridgeline-chart {
+    width: 100%;
+    height: 100%;
+    min-height: 400px;
+  }
+
+  .ridgeline-note {
+    margin: 0 0 0.25rem;
+    font-size: 0.75rem;
+    color: var(--text-muted, rgba(0, 0, 0, 0.6));
+  }
+
+  :global(.ridge-area) {
+    transition: stroke-width 0.12s ease;
+  }
+</style>

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import SpeciesRidgeline from './SpeciesRidgeline.svelte';
+import type { RidgelineSeries } from './utils/ridgeline';
+
+// jsdom has no layout engine; assert on element counts/attributes only.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Builds a 24-length hourly density array from (hour, value) pairs. */
+function hourly(pairs: [number, number][]): number[] {
+  const byHour = new Map(pairs);
+  return Array.from({ length: 24 }, (_, i) => byHour.get(i) ?? 0);
+}
+
+const sample: RidgelineSeries[] = [
+  {
+    scientificName: 'Turdus merula',
+    commonName: 'Eurasian Blackbird',
+    density: hourly([
+      [6, 0.6],
+      [18, 0.4],
+    ]),
+    total: 40,
+  },
+  {
+    scientificName: 'Erithacus rubecula',
+    commonName: 'European Robin',
+    density: hourly([[12, 1]]),
+    total: 12,
+  },
+];
+
+describe('SpeciesRidgeline', () => {
+  it('renders without throwing for an empty series', () => {
+    expect(() => render(SpeciesRidgeline, { props: { series: [] } })).not.toThrow();
+  });
+
+  it('renders one ridge area path per species', async () => {
+    const { container } = render(SpeciesRidgeline, { props: { series: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelectorAll('path.ridge-area')).toHaveLength(2);
+  });
+
+  it('renders one row label per species', async () => {
+    const { container } = render(SpeciesRidgeline, { props: { series: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelectorAll('text.ridge-label')).toHaveLength(2);
+  });
+
+  it('keys each ridge by the stable scientific name', async () => {
+    const { container } = render(SpeciesRidgeline, { props: { series: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelector('.ridge[data-species="Turdus merula"]')).toBeTruthy();
+    expect(container.querySelector('.ridge[data-species="Erithacus rubecula"]')).toBeTruthy();
+  });
+
+  it('renders an x axis group', async () => {
+    const { container } = render(SpeciesRidgeline, { props: { series: sample } });
+    await Promise.resolve();
+    expect(container.querySelector('.x-axis')).toBeTruthy();
+  });
+
+  it('sets an accessible label on the chart', () => {
+    const { container } = render(SpeciesRidgeline, {
+      props: { series: sample, ariaLabelKey: 'my.aria.key' },
+    });
+    // t is mocked to return the key, so the aria-label is the key itself.
+    expect(container.querySelector('[aria-label="my.aria.key"]')).toBeTruthy();
+  });
+
+  it('renders a screen-reader summary when there is data', async () => {
+    const { getByTestId } = render(SpeciesRidgeline, { props: { series: sample } });
+    await Promise.resolve();
+    expect(getByTestId('ridgeline-summary')).toBeTruthy();
+  });
+
+  it('renders the optional note caption when a noteKey is given', async () => {
+    const { container } = render(SpeciesRidgeline, {
+      props: { series: sample, noteKey: 'my.note.key' },
+    });
+    await Promise.resolve();
+    expect(container.querySelector('.ridgeline-note')).toBeTruthy();
+  });
+
+  it('omits the note caption when the series is empty', () => {
+    const { container } = render(SpeciesRidgeline, {
+      props: { series: [], noteKey: 'my.note.key' },
+    });
+    expect(container.querySelector('.ridgeline-note')).toBeNull();
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/ridgeline.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/ridgeline.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  maxDensity,
+  ridgelineLayout,
+  peakIndex,
+  RIDGE_OVERLAP,
+  type RidgelineSeries,
+} from '../ridgeline';
+
+function series(scientificName: string, density: number[]): RidgelineSeries {
+  return { scientificName, commonName: scientificName, density };
+}
+
+describe('maxDensity', () => {
+  it('returns the largest value across all series', () => {
+    expect(
+      maxDensity([series('A', [0.1, 0.6, 0.3]), series('B', [0.2, 0.2, 0.2]), series('C', [0.9])])
+    ).toBe(0.9);
+  });
+
+  it('returns 0 for no series or all-empty densities', () => {
+    expect(maxDensity([])).toBe(0);
+    expect(maxDensity([series('A', []), series('B', [])])).toBe(0);
+  });
+});
+
+describe('ridgelineLayout', () => {
+  it('returns an empty layout for no rows or non-positive height', () => {
+    expect(ridgelineLayout([], 400).rows).toHaveLength(0);
+    expect(ridgelineLayout([series('A', [1])], 0).rows).toHaveLength(0);
+  });
+
+  it('places a single row so its baseline is at the bottom and its peak touches the top', () => {
+    const innerHeight = 300;
+    const { rows, amplitude } = ridgelineLayout([series('A', [1])], innerHeight);
+    expect(rows).toHaveLength(1);
+    // n=1: rowStep = H / overlap, amplitude = overlap * rowStep = H, baseline = amplitude = H.
+    expect(amplitude).toBeCloseTo(innerHeight, 9);
+    expect(rows[0].baseline).toBeCloseTo(innerHeight, 9);
+    // Full-amplitude peak (baseline - amplitude) sits exactly at the plot top.
+    expect(rows[0].baseline - amplitude).toBeCloseTo(0, 9);
+  });
+
+  it('spaces multiple rows so the top peak touches y=0 and the bottom baseline is at innerHeight', () => {
+    const innerHeight = 300;
+    const input = [series('A', [1]), series('B', [1]), series('C', [1])];
+    const { rows, amplitude } = ridgelineLayout(input, innerHeight, RIDGE_OVERLAP);
+    expect(rows).toHaveLength(3);
+
+    // Baselines strictly increase down the stack.
+    expect(rows[0].baseline).toBeLessThan(rows[1].baseline);
+    expect(rows[1].baseline).toBeLessThan(rows[2].baseline);
+
+    // Top row's full-amplitude peak reaches the plot top; bottom baseline reaches the bottom.
+    expect(rows[0].baseline - amplitude).toBeCloseTo(0, 9);
+    expect(rows[rows.length - 1].baseline).toBeCloseTo(innerHeight, 9);
+
+    // amplitude exceeds the row step (so ridges overlap) for overlap > 1.
+    const rowStep = rows[1].baseline - rows[0].baseline;
+    expect(amplitude).toBeGreaterThan(rowStep);
+  });
+
+  it('preserves input order and indices', () => {
+    const input = [series('First', [1]), series('Second', [1])];
+    const { rows } = ridgelineLayout(input, 200);
+    expect(rows.map(r => r.series.scientificName)).toEqual(['First', 'Second']);
+    expect(rows.map(r => r.index)).toEqual([0, 1]);
+  });
+});
+
+describe('peakIndex', () => {
+  it('returns the index of the largest bucket', () => {
+    expect(peakIndex([0.1, 0.2, 0.7, 0.0])).toBe(2);
+  });
+
+  it('returns -1 for empty or all-zero densities', () => {
+    expect(peakIndex([])).toBe(-1);
+    expect(peakIndex([0, 0, 0])).toBe(-1);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/ridgeline.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/ridgeline.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure transforms for the species ridgeline (joyplot).
+ *
+ * A ridgeline draws one overlapping area row per species. These helpers compute the per-row
+ * vertical layout (baselines plus the shared amplitude that maps a density value to pixels) and
+ * pick a species' peak bucket for tooltips. Kept framework-free so they are unit-tested directly
+ * rather than through the Svelte component.
+ *
+ * The component is reused across charts that express a per-species distribution: the who-sings-when
+ * hour-of-day ridgeline (#1159) and the confidence distribution (#1162). Density semantics differ
+ * (24 hours vs N confidence bins); these helpers are agnostic to what an index means.
+ */
+
+/** A full-amplitude ridge spans this many row-steps, so adjacent ridges overlap. */
+export const RIDGE_OVERLAP = 2;
+
+/** One species' row in a ridgeline. */
+export interface RidgelineSeries {
+  /** Stable identity: the D3 key and color-assignment seed (scientific name). */
+  scientificName: string;
+  /** Server-provided common name; re-localized per visitor locale in the component. */
+  commonName: string;
+  /** Normalized density along the x-axis (e.g. 24 hourly values that sum to ~1). */
+  density: number[];
+  /** Raw detection count for the tooltip. */
+  total?: number;
+}
+
+/** Vertical placement of one ridge. */
+export interface RidgelineRow {
+  series: RidgelineSeries;
+  /** Position in the stack (0 = top). */
+  index: number;
+  /** y of the row's baseline (the area's y0), in chart-group coordinates. */
+  baseline: number;
+}
+
+/** Computed layout for an entire ridgeline. */
+export interface RidgelineLayout {
+  rows: RidgelineRow[];
+  /** Pixels that the global-max density occupies above a baseline (the amplitude-scale range max). */
+  amplitude: number;
+  /** Largest density across all series (the amplitude-scale domain max). */
+  maxDensity: number;
+}
+
+/** Largest density value across all series, or 0 when there is none. */
+export function maxDensity(series: RidgelineSeries[]): number {
+  let m = 0;
+  for (const s of series) {
+    for (const v of s.density) {
+      if (v > m) m = v;
+    }
+  }
+  return m;
+}
+
+/**
+ * Computes the vertical layout for `series.length` rows within `innerHeight`.
+ *
+ * Baselines are spaced so the top row's full-amplitude peak touches y=0 and the bottom row's
+ * baseline sits at innerHeight: with `n` rows and overlap `o`,
+ *   rowStep      = innerHeight / (n - 1 + o)
+ *   amplitude    = o * rowStep
+ *   baseline[i]  = amplitude + i * rowStep
+ * so non-adjacent ridges can still overlap (amplitude > rowStep when o > 1) without the tallest
+ * ridge clipping above the plot. Returns an empty layout for no rows or a non-positive height.
+ */
+export function ridgelineLayout(
+  series: RidgelineSeries[],
+  innerHeight: number,
+  overlap: number = RIDGE_OVERLAP
+): RidgelineLayout {
+  const n = series.length;
+  if (n === 0 || innerHeight <= 0) {
+    return { rows: [], amplitude: 0, maxDensity: 0 };
+  }
+  const rowStep = innerHeight / (n - 1 + overlap);
+  const amplitude = overlap * rowStep;
+  const rows: RidgelineRow[] = [];
+  for (const [index, s] of series.entries()) {
+    rows.push({ series: s, index, baseline: amplitude + index * rowStep });
+  }
+  return { rows, amplitude, maxDensity: maxDensity(series) };
+}
+
+/**
+ * Index of a species' largest density bucket (its peak activity), or -1 when the density is empty
+ * or all zero. Used to label the tooltip with the peak time / bin.
+ */
+export function peakIndex(density: number[]): number {
+  let idx = -1;
+  let best = 0;
+  for (const [i, v] of density.entries()) {
+    if (v > best) {
+      best = v;
+      idx = i;
+    }
+  }
+  return idx;
+}

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/ridgeline.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/ridgeline.ts
@@ -72,7 +72,9 @@ export function ridgelineLayout(
   overlap: number = RIDGE_OVERLAP
 ): RidgelineLayout {
   const n = series.length;
-  if (n === 0 || innerHeight <= 0) {
+  // Guard the overlap too: a non-positive or non-finite value would make rowStep/amplitude NaN or
+  // Infinity (and divide by zero when n === 1), so fall back to the same safe empty layout.
+  if (n === 0 || innerHeight <= 0 || !Number.isFinite(overlap) || overlap <= 0) {
     return { rows: [], amplitude: 0, maxDensity: 0 };
   }
   const rowStep = innerHeight / (n - 1 + overlap);

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -17,6 +17,7 @@ import DailySpeciesTrendChart from '../components/charts/d3/DailySpeciesTrendCha
 import SpeciesDiversityChart from '../components/charts/d3/SpeciesDiversityChart.svelte';
 import SeasonalHeatmap from '../components/charts/d3/SeasonalHeatmap.svelte';
 import type { HeatmapData } from '../components/charts/d3/utils/heatmap';
+import SpeciesRidgeline from '../components/charts/d3/SpeciesRidgeline.svelte';
 import TrendChartOptions from '../components/TrendChartOptions.svelte';
 
 import { formatDateForAPI } from './analyticsParams';
@@ -272,6 +273,63 @@ async function fetchHeatmap(params: AnalyticsParams, signal?: AbortSignal): Prom
   };
 }
 
+// Top-N species the ridgeline requests; mirrors the chart's maxSpecies cap and the server default.
+const SPECIES_RIDGELINE_LIMIT = 5;
+const SPECIES_DISTRIBUTION_BUCKETS = 24;
+
+interface SpeciesDistributionDatum {
+  scientificName: string;
+  density: number[];
+  total: number;
+}
+
+/**
+ * Who-sings-when ridgeline: the top-N species by detection volume in range, each with a normalized
+ * 24-bucket hour-of-day distribution. Server-ranked and server-normalized; this defensively coerces
+ * the array payload. Common names are resolved later (registry mapProps) from the hub's species map.
+ */
+async function fetchSpeciesDistribution(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<SpeciesDistributionDatum[]> {
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+    limit: String(SPECIES_RIDGELINE_LIMIT),
+  });
+
+  const response = await fetch(
+    buildAppUrl(`/api/v2/analytics/time/distribution/species?${search}`),
+    { signal }
+  );
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid species distribution response: expected an array');
+  }
+
+  return data
+    .map(raw => {
+      if (!raw || typeof raw !== 'object') return null;
+      const item = raw as { scientificName?: unknown; buckets?: unknown; total?: unknown };
+      const scientificName = typeof item.scientificName === 'string' ? item.scientificName : '';
+      if (!scientificName) return null;
+      // Coerce every bucket to a finite number; pad/truncate defensively to 24 so the chart's
+      // hour axis stays well-defined even on a malformed payload.
+      const rawBuckets = Array.isArray(item.buckets) ? item.buckets : [];
+      const density: number[] = [];
+      for (let i = 0; i < SPECIES_DISTRIBUTION_BUCKETS; i++) {
+        // eslint-disable-next-line security/detect-object-injection -- i is a bounded loop index
+        const b = rawBuckets[i];
+        density.push(typeof b === 'number' && Number.isFinite(b) ? b : 0);
+      }
+      const total = typeof item.total === 'number' && Number.isFinite(item.total) ? item.total : 0;
+      return { scientificName, density, total };
+    })
+    .filter((d): d is SpeciesDistributionDatum => d !== null);
+}
+
 // --- Registry --------------------------------------------------------------
 
 export const CHART_REGISTRY: ChartDef[] = [
@@ -291,6 +349,32 @@ export const CHART_REGISTRY: ChartDef[] = [
     supports: { species: true, source: false },
     minDataPoints: 20,
     export: 'csv',
+  },
+  {
+    id: 'species-ridgeline',
+    group: 'patterns',
+    titleKey: 'analytics.advanced.charts.ridgeline.title',
+    descKey: 'analytics.advanced.charts.ridgeline.description',
+    emptyKey: 'analytics.advanced.charts.ridgeline.noData',
+    emptyHintKey: 'analytics.advanced.charts.ridgeline.noDataHint',
+    component: SpeciesRidgeline,
+    fetch: fetchSpeciesDistribution,
+    // The endpoint is always top-N by volume; supports.species lets the patterns tab's species
+    // auto-select run, and the chart notes that it shows the top N regardless of selection.
+    mapProps: (data, _params, ctx) => ({
+      series: (data as SpeciesDistributionDatum[]).map(d => ({
+        scientificName: d.scientificName,
+        commonName: ctx.speciesNames.get(d.scientificName) ?? d.scientificName,
+        density: d.density,
+        total: d.total,
+      })),
+      noteKey: 'analytics.advanced.charts.ridgeline.note',
+    }),
+    size: 'full',
+    supports: { species: true, source: false },
+    // A ridgeline needs at least a couple of species to read as one; one lonely ridge is not useful.
+    minDataPoints: 2,
+    maxSpecies: SPECIES_RIDGELINE_LIMIT,
   },
   {
     id: 'time-of-day-species',

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1433,6 +1433,16 @@ export type TranslationKey =
   | 'analytics.advanced.charts.heatmap.legendMore' // params: max
   | 'analytics.advanced.charts.heatmap.ariaLabel'
   | 'analytics.advanced.charts.heatmap.summary' // params: total, days, time, date
+  | 'analytics.advanced.charts.ridgeline.title'
+  | 'analytics.advanced.charts.ridgeline.description'
+  | 'analytics.advanced.charts.ridgeline.noData'
+  | 'analytics.advanced.charts.ridgeline.noDataHint'
+  | 'analytics.advanced.charts.ridgeline.ariaLabel'
+  | 'analytics.advanced.charts.ridgeline.axisTime'
+  | 'analytics.advanced.charts.ridgeline.note' // params: count
+  | 'analytics.advanced.charts.ridgeline.tooltipDetections'
+  | 'analytics.advanced.charts.ridgeline.tooltipPeak'
+  | 'analytics.advanced.charts.ridgeline.summary' // params: count, species, time
   | 'analytics.advanced.charts.tooltips.date'
   | 'analytics.advanced.charts.tooltips.percentage'
   | 'analytics.advanced.charts.tooltips.detections'
@@ -3943,6 +3953,12 @@ export type TranslationParams = {
     days: string | number;
     time: string | number;
     date: string | number;
+  };
+  'analytics.advanced.charts.ridgeline.note': { count: string | number };
+  'analytics.advanced.charts.ridgeline.summary': {
+    count: string | number;
+    species: string | number;
+    time: string | number;
   };
   'settings.notFound.message': { section: string | number };
   'settings.main.sections.falsePositiveFilter.detectionCount': {

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Procento",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Procentdel",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Prozentsatz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Percentage",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Fecha",
           "percentage": "Porcentaje",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Päivämäärä",
           "percentage": "Prosenttiosuus",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Pourcentage",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Százalék",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentuale",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Datums",
           "percentage": "Procenti",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Prosentandel",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Percentage",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Procent",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentagem",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Percentá",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1845,6 +1845,18 @@
           "ariaLabel": "Seasonal activity heatmap: detection density by date and time of day",
           "summary": "{total} detections across {days} days. Busiest around {time} on {date}."
         },
+        "ridgeline": {
+          "title": "Who Sings When",
+          "description": "Hour-of-day activity for the most-detected species, sorting dawn singers from all-day and nocturnal birds",
+          "noData": "No species activity data available",
+          "noDataHint": "Select a wider date range to compare species activity patterns",
+          "ariaLabel": "Who-sings-when ridgeline: hour-of-day activity distribution per species",
+          "axisTime": "Time of Day",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipDetections": "Detections",
+          "tooltipPeak": "Peak",
+          "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Andel",

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -295,7 +295,7 @@ func (m *ActionMockDatastore) GetActivityHeatmap(_ context.Context, _, _, _ stri
 	return datastore.ActivityHeatmapData{}, nil
 }
 func (m *ActionMockDatastore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
-	return nil, nil
+	return []datastore.SpeciesHourlyDistribution{}, nil
 }
 func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -294,6 +294,9 @@ func (m *ActionMockDatastore) GetSpeciesDiversityData(_ context.Context, _, _ st
 func (m *ActionMockDatastore) GetActivityHeatmap(_ context.Context, _, _, _ string) (datastore.ActivityHeatmapData, error) {
 	return datastore.ActivityHeatmapData{}, nil
 }
+func (m *ActionMockDatastore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
+	return nil, nil
+}
 func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -163,6 +163,9 @@ func (m *MockDatastore) GetSpeciesDiversityData(context.Context, string, string)
 func (m *MockDatastore) GetActivityHeatmap(context.Context, string, string, string) (datastore.ActivityHeatmapData, error) {
 	return datastore.ActivityHeatmapData{}, nil
 }
+func (m *MockDatastore) GetHourlyDistributionBySpecies(context.Context, string, string, int) ([]datastore.SpeciesHourlyDistribution, error) {
+	return nil, nil
+}
 func (m *MockDatastore) SearchDetections(*datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return make([]datastore.DetectionRecord, 0), 0, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -164,7 +164,7 @@ func (m *MockDatastore) GetActivityHeatmap(context.Context, string, string, stri
 	return datastore.ActivityHeatmapData{}, nil
 }
 func (m *MockDatastore) GetHourlyDistributionBySpecies(context.Context, string, string, int) ([]datastore.SpeciesHourlyDistribution, error) {
-	return nil, nil
+	return []datastore.SpeciesHourlyDistribution{}, nil
 }
 func (m *MockDatastore) SearchDetections(*datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return make([]datastore.DetectionRecord, 0), 0, nil

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -91,7 +91,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/time/hourly`              | `GetHourlyAnalytics`       | ❌   | Hourly detection patterns          |
 | GET    | `/analytics/time/daily`               | `GetDailyAnalytics`        | ❌   | Daily detection patterns           |
 | GET    | `/analytics/time/distribution/hourly` | `GetTimeOfDayDistribution` | ❌   | Time-of-day detection distribution |
-| GET    | `/analytics/time/distribution/species` | `GetSpeciesHourlyDistribution` | ❌ | Who-sings-when ridgeline: per-species hour-of-day distribution for the top N species by volume (`?start_date&end_date&limit`) |
+| GET    | `/analytics/time/distribution/species` | `GetSpeciesHourlyDistribution` | ❌ | Who-sings-when ridgeline: per-species hour-of-day distribution for the top N species by volume. `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `limit` optional (default 5, max 8) |
 | GET    | `/analytics/time/heatmap`             | `GetActivityHeatmap`       | ❌   | Seasonal density heatmap (date x intra-day slot; `?format=csv`) |
 
 ### Control Operations (`control.go`)

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -91,6 +91,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/time/hourly`              | `GetHourlyAnalytics`       | ❌   | Hourly detection patterns          |
 | GET    | `/analytics/time/daily`               | `GetDailyAnalytics`        | ❌   | Daily detection patterns           |
 | GET    | `/analytics/time/distribution/hourly` | `GetTimeOfDayDistribution` | ❌   | Time-of-day detection distribution |
+| GET    | `/analytics/time/distribution/species` | `GetSpeciesHourlyDistribution` | ❌ | Who-sings-when ridgeline: per-species hour-of-day distribution for the top N species by volume (`?start_date&end_date&limit`) |
 | GET    | `/analytics/time/heatmap`             | `GetActivityHeatmap`       | ❌   | Seasonal density heatmap (date x intra-day slot; `?format=csv`) |
 
 ### Control Operations (`control.go`)

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -31,6 +31,11 @@ const (
 	defaultAnalyticsDays       = 30               // Default number of days for analytics queries
 	defaultNewSpeciesLimit     = 100              // Default pagination limit for new species queries
 	analyticsQueryTimeout      = 30 * time.Second // Timeout for analytics database queries
+
+	// Species ridgeline (who-sings-when) top-N bounds. The default matches the chart's maxSpecies
+	// cap; the max keeps the ridgeline readable (more than ~8 overlapping ridges are unreadable).
+	defaultSpeciesRidgelineLimit = 5
+	maxSpeciesRidgelineLimit     = 8
 )
 
 // msgQueryTimeout is the user-facing message returned when an analytics query
@@ -182,9 +187,10 @@ func (c *Controller) initAnalyticsRoutes() {
 	timeGroup.GET("/hourly", c.GetHourlyAnalytics)
 	timeGroup.GET("/hourly/batch", c.GetBatchHourlySpeciesData) // Batch hourly data for multiple species
 	timeGroup.GET("/daily", c.GetDailyAnalytics)
-	timeGroup.GET("/daily/batch", c.GetBatchDailySpeciesData)         // Batch daily trends for multiple species
-	timeGroup.GET("/distribution/hourly", c.GetTimeOfDayDistribution) // Renamed endpoint for time-of-day distribution
-	timeGroup.GET("/heatmap", c.GetActivityHeatmap)                    // Seasonal density heatmap (date x intra-day slot)
+	timeGroup.GET("/daily/batch", c.GetBatchDailySpeciesData)              // Batch daily trends for multiple species
+	timeGroup.GET("/distribution/hourly", c.GetTimeOfDayDistribution)      // Renamed endpoint for time-of-day distribution
+	timeGroup.GET("/distribution/species", c.GetSpeciesHourlyDistribution) // Who-sings-when ridgeline (top-N species hour-of-day)
+	timeGroup.GET("/heatmap", c.GetActivityHeatmap)                        // Seasonal density heatmap (date x intra-day slot)
 }
 
 // GetDailySpeciesSummary handles GET /api/v2/analytics/species/daily
@@ -1245,6 +1251,99 @@ func (c *Controller) writeActivityHeatmapCSV(ctx echo.Context, data *datastore.A
 
 	w.Flush()
 	return w.Error()
+}
+
+// speciesHourlyDistributionItem is one species' row in the ridgeline wire payload: the stable
+// scientific-name key, its 24 normalized hour-of-day buckets (index = station-local hour 0..23,
+// summing to 1.0), and the raw detection count. The localized common name is resolved client-side
+// (the v2 label schema stores no common name), matching the sibling species charts.
+type speciesHourlyDistributionItem struct {
+	ScientificName string      `json:"scientificName"`
+	Buckets        [24]float64 `json:"buckets"`
+	Total          int         `json:"total"`
+}
+
+// newSpeciesHourlyDistributionResponse maps the datastore aggregation onto the wire payload as a
+// JSON array (never null), preserving the descending-volume order.
+func newSpeciesHourlyDistributionResponse(data []datastore.SpeciesHourlyDistribution) []speciesHourlyDistributionItem {
+	items := make([]speciesHourlyDistributionItem, 0, len(data))
+	for i := range data {
+		items = append(items, speciesHourlyDistributionItem{
+			ScientificName: data[i].ScientificName,
+			Buckets:        data[i].Buckets,
+			Total:          data[i].Total,
+		})
+	}
+	return items
+}
+
+// GetSpeciesHourlyDistribution handles GET /api/v2/analytics/time/distribution/species
+// Returns the normalized hour-of-day activity distribution for the top N species by detection
+// volume over the date range, powering the who-sings-when ridgeline (design spec section 6.2).
+func (c *Controller) GetSpeciesHourlyDistribution(ctx echo.Context) error {
+	const operation = "species hourly distribution"
+
+	// Validate required parameter
+	if err := c.requireQueryParam(ctx, "start_date", operation); err != nil {
+		return err
+	}
+
+	startDate := ctx.QueryParam("start_date")
+	endDate := ctx.QueryParam("end_date")
+
+	// Validate date formats strictly using regex
+	if err := c.validateDateFormatStrictWithResponse(ctx, startDate, "start_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, endDate, "end_date", operation); err != nil {
+		return err
+	}
+
+	// Validate date values and chronological order
+	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
+		return err
+	}
+
+	// Default the end date to a 30-day window when omitted, matching the other range endpoints.
+	if endDate == "" {
+		startTime, _ := time.Parse(time.DateOnly, startDate) // Regex ensures this parse succeeds
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
+	}
+
+	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesRidgelineLimit, maxSpeciesRidgelineLimit)
+
+	c.logInfoIfEnabled("Retrieving species hourly distribution",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.Int("limit", limit),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	// Add timeout to prevent resource exhaustion
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
+	data, err := c.DS.GetHourlyDistributionBySpecies(ctxWithTimeout, startDate, endDate, limit)
+	if err != nil {
+		return c.handleAnalyticsQueryError(ctx, err, "Species hourly distribution", "Failed to get species hourly distribution",
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.Int("limit", limit),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("path", ctx.Request().URL.Path),
+		)
+	}
+
+	c.logInfoIfEnabled("Species hourly distribution retrieved",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.Int("species_count", len(data)),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	return ctx.JSON(http.StatusOK, newSpeciesHourlyDistributionResponse(data))
 }
 
 // GetTimeOfDayDistribution handles GET /api/v2/analytics/time/distribution/hourly

--- a/internal/api/v2/analytics_species_distribution_test.go
+++ b/internal/api/v2/analytics_species_distribution_test.go
@@ -75,8 +75,12 @@ func TestGetSpeciesHourlyDistribution_EmptyArrayNotNull(t *testing.T) {
 	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species?start_date=2026-03-01&end_date=2026-03-02")
 	require.NoError(t, controller.GetSpeciesHourlyDistribution(c))
 	require.Equal(t, http.StatusOK, rec.Code)
-	// Empty result must serialise as [] not null so the client can read .length safely.
-	assert.Equal(t, "[]\n", rec.Body.String())
+	// Empty result must serialize as [] (not null) so the client can read .length safely. Assert
+	// JSON semantics rather than the raw body to avoid coupling to Echo's newline formatting.
+	var resp []speciesDistributionJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp)
+	assert.Empty(t, resp)
 }
 
 func TestGetSpeciesHourlyDistribution_DefaultsEndDate(t *testing.T) {

--- a/internal/api/v2/analytics_species_distribution_test.go
+++ b/internal/api/v2/analytics_species_distribution_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// speciesDistributionJSON mirrors the ridgeline wire shape from the design spec (section 6.2).
+type speciesDistributionJSON struct {
+	ScientificName string      `json:"scientificName"`
+	Buckets        [24]float64 `json:"buckets"`
+	Total          int         `json:"total"`
+}
+
+func sampleSpeciesDistribution() []datastore.SpeciesHourlyDistribution {
+	var blackbird, robin [24]float64
+	blackbird[6] = 0.75
+	blackbird[18] = 0.25
+	robin[12] = 1.0
+	return []datastore.SpeciesHourlyDistribution{
+		{ScientificName: "Turdus merula", Buckets: blackbird, Total: 40},
+		{ScientificName: "Erithacus rubecula", Buckets: robin, Total: 12},
+	}
+}
+
+func newSpeciesDistributionContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/time/distribution/species")
+	return c, rec
+}
+
+func TestGetSpeciesHourlyDistribution_Shape(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// Default limit (no ?limit) is the ridgeline's top-5.
+	mockDS.On("GetHourlyDistributionBySpecies", mock.Anything, "2026-03-01", "2026-03-02", 5).
+		Return(sampleSpeciesDistribution(), nil)
+
+	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetSpeciesHourlyDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []speciesDistributionJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 2)
+	assert.Equal(t, "Turdus merula", resp[0].ScientificName)
+	assert.Equal(t, 40, resp[0].Total)
+	assert.InDelta(t, 0.75, resp[0].Buckets[6], 1e-9)
+	assert.InDelta(t, 0.25, resp[0].Buckets[18], 1e-9)
+	assert.Equal(t, "Erithacus rubecula", resp[1].ScientificName)
+	assert.InDelta(t, 1.0, resp[1].Buckets[12], 1e-9)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetSpeciesHourlyDistribution_EmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetHourlyDistributionBySpecies", mock.Anything, "2026-03-01", "2026-03-02", 5).
+		Return([]datastore.SpeciesHourlyDistribution{}, nil)
+
+	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetSpeciesHourlyDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	// Empty result must serialise as [] not null so the client can read .length safely.
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestGetSpeciesHourlyDistribution_DefaultsEndDate(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// With end_date omitted the handler defaults it to a 30-day window: 2026-03-01 + 30d = 2026-03-31.
+	mockDS.On("GetHourlyDistributionBySpecies", mock.Anything, "2026-03-01", "2026-03-31", 5).
+		Return(sampleSpeciesDistribution(), nil)
+
+	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species?start_date=2026-03-01")
+	require.NoError(t, controller.GetSpeciesHourlyDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetSpeciesHourlyDistribution_ClampsLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		limitParm string
+		wantLimit int
+	}{
+		{"valid in range passes through", "3", 3},
+		{"max allowed passes through", "8", 8},
+		{"over max falls back to default", "99", defaultSpeciesRidgelineLimit},
+		{"zero falls back to default", "0", defaultSpeciesRidgelineLimit},
+		{"non-numeric falls back to default", "abc", defaultSpeciesRidgelineLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+			mockDS.On("GetHourlyDistributionBySpecies", mock.Anything, "2026-03-01", "2026-03-02", tt.wantLimit).
+				Return(sampleSpeciesDistribution(), nil)
+
+			c, rec := newSpeciesDistributionContext(e,
+				"/api/v2/analytics/time/distribution/species?start_date=2026-03-01&end_date=2026-03-02&limit="+tt.limitParm)
+			require.NoError(t, controller.GetSpeciesHourlyDistribution(c))
+			require.Equal(t, http.StatusOK, rec.Code)
+			mockDS.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetSpeciesHourlyDistribution_MissingStartDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species")
+	err := controller.GetSpeciesHourlyDistribution(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetSpeciesHourlyDistribution_InvalidDateFormat(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species?start_date=not-a-date")
+	err := controller.GetSpeciesHourlyDistribution(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetSpeciesHourlyDistribution_QueryTimeout(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetHourlyDistributionBySpecies", mock.Anything, "2026-03-01", "2026-03-02", 5).
+		Return([]datastore.SpeciesHourlyDistribution(nil), context.DeadlineExceeded)
+
+	c, rec := newSpeciesDistributionContext(e, "/api/v2/analytics/time/distribution/species?start_date=2026-03-01&end_date=2026-03-02")
+	// handleAnalyticsQueryError writes the 408 response and returns nil.
+	require.NoError(t, controller.GetSpeciesHourlyDistribution(c))
+	assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+	mockDS.AssertExpectations(t)
+}

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -67,6 +67,20 @@ type ActivityHeatmapData struct {
 	CellCount             []int
 }
 
+// SpeciesHourlyDistribution is one species' normalized hour-of-day activity distribution,
+// behind the "who sings when" ridgeline (design spec section 6.2).
+//
+// Buckets holds 24 values (index = hour 0..23, station-local) that sum to 1.0 for a species
+// with any detections in range, so each species' shape is comparable regardless of its raw
+// volume. Total is the species' detection count over the range (false positives excluded),
+// used to rank species by volume and shown in the tooltip. ScientificName is the stable key;
+// the localized common name is resolved client-side (the v2 label schema stores no common name).
+type SpeciesHourlyDistribution struct {
+	ScientificName string
+	Buckets        [24]float64
+	Total          int
+}
+
 // NewSpeciesData represents a species detected for the first time within a period
 type NewSpeciesData struct {
 	ScientificName string `json:"scientific_name"`
@@ -416,6 +430,14 @@ func (ds *DataStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (Acti
 		CellSlot:              []int{},
 		CellCount:             []int{},
 	}, nil
+}
+
+// GetHourlyDistributionBySpecies is a stub on the legacy store. The who-sings-when ridgeline is a
+// v2only feature; the legacy datastore is deprecated and being removed, so it returns an empty
+// (non-nil) slice rather than implementing the aggregation. See internal/datastore/v2only for the
+// real method.
+func (ds *DataStore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]SpeciesHourlyDistribution, error) {
+	return []SpeciesHourlyDistribution{}, nil
 }
 
 // GetDetectionTrends calculates the trend in detections over time

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -195,6 +195,10 @@ type Interface interface {
 	// GetActivityHeatmap returns detection counts bucketed by (station-local date, intra-day slot)
 	// over the inclusive date range, as a columnar sparse payload. species is an optional filter.
 	GetActivityHeatmap(ctx context.Context, startDate, endDate, species string) (ActivityHeatmapData, error)
+	// GetHourlyDistributionBySpecies returns the normalized hour-of-day activity distribution for
+	// the top `limit` species by detection volume over the inclusive date range (false positives
+	// excluded), ordered by descending volume. Powers the who-sings-when ridgeline.
+	GetHourlyDistributionBySpecies(ctx context.Context, startDate, endDate string, limit int) ([]SpeciesHourlyDistribution, error)
 	// Search functionality
 	SearchDetections(filters *SearchFilters) ([]DetectionRecord, int, error)
 	// Dynamic Threshold methods

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -2399,6 +2399,67 @@ func (_c *MockInterface_GetHourlyDistribution_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// GetHourlyDistributionBySpecies provides a mock function with given fields: ctx, startDate, endDate, limit
+func (_m *MockInterface) GetHourlyDistributionBySpecies(ctx context.Context, startDate string, endDate string, limit int) ([]datastore.SpeciesHourlyDistribution, error) {
+	ret := _m.Called(ctx, startDate, endDate, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetHourlyDistributionBySpecies")
+	}
+
+	var r0 []datastore.SpeciesHourlyDistribution
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) ([]datastore.SpeciesHourlyDistribution, error)); ok {
+		return rf(ctx, startDate, endDate, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) []datastore.SpeciesHourlyDistribution); ok {
+		r0 = rf(ctx, startDate, endDate, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.SpeciesHourlyDistribution)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int) error); ok {
+		r1 = rf(ctx, startDate, endDate, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetHourlyDistributionBySpecies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetHourlyDistributionBySpecies'
+type MockInterface_GetHourlyDistributionBySpecies_Call struct {
+	*mock.Call
+}
+
+// GetHourlyDistributionBySpecies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - startDate string
+//   - endDate string
+//   - limit int
+func (_e *MockInterface_Expecter) GetHourlyDistributionBySpecies(ctx interface{}, startDate interface{}, endDate interface{}, limit interface{}) *MockInterface_GetHourlyDistributionBySpecies_Call {
+	return &MockInterface_GetHourlyDistributionBySpecies_Call{Call: _e.mock.On("GetHourlyDistributionBySpecies", ctx, startDate, endDate, limit)}
+}
+
+func (_c *MockInterface_GetHourlyDistributionBySpecies_Call) Run(run func(ctx context.Context, startDate string, endDate string, limit int)) *MockInterface_GetHourlyDistributionBySpecies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(int))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetHourlyDistributionBySpecies_Call) Return(_a0 []datastore.SpeciesHourlyDistribution, _a1 error) *MockInterface_GetHourlyDistributionBySpecies_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetHourlyDistributionBySpecies_Call) RunAndReturn(run func(context.Context, string, string, int) ([]datastore.SpeciesHourlyDistribution, error)) *MockInterface_GetHourlyDistributionBySpecies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetHourlyWeather provides a mock function with given fields: date
 func (_m *MockInterface) GetHourlyWeather(date string) ([]datastore.HourlyWeather, error) {
 	ret := _m.Called(date)

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -760,6 +760,9 @@ func (s *testLegacyInterface) GetSpeciesDiversityData(_ context.Context, _, _ st
 func (s *testLegacyInterface) GetActivityHeatmap(_ context.Context, _, _, _ string) (datastore.ActivityHeatmapData, error) {
 	return datastore.ActivityHeatmapData{}, nil
 }
+func (s *testLegacyInterface) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
+	return nil, nil
+}
 func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -761,7 +761,7 @@ func (s *testLegacyInterface) GetActivityHeatmap(_ context.Context, _, _, _ stri
 	return datastore.ActivityHeatmapData{}, nil
 }
 func (s *testLegacyInterface) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
-	return nil, nil
+	return []datastore.SpeciesHourlyDistribution{}, nil
 }
 func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil

--- a/internal/datastore/v2only/aggregate.go
+++ b/internal/datastore/v2only/aggregate.go
@@ -7,8 +7,64 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
+
+// hoursPerDay is the number of hour-of-day buckets in a species distribution (0..23).
+const hoursPerDay = 24
+
+// buildSpeciesHourlyDistribution turns per-label hourly counts into per-species normalized
+// hour-of-day distributions for the who-sings-when ridgeline.
+//
+// top is the top-N species by volume from GetTopSpecies, in descending-volume order; each row is
+// one label ID. hourlyByLabel maps a label ID to its [24]int false-positive-excluded hourly counts.
+// Label IDs that resolve to the same scientific name (one per model) are merged into a single ridge
+// whose buckets are the summed counts, preserving the first-seen volume order. Each species' 24
+// buckets are then normalized to sum to 1.0 so timing shape is comparable across species regardless
+// of raw volume; Total carries the unnormalized count for the tooltip.
+//
+// A species whose merged FP-excluded total is zero is dropped: GetTopSpecies ranks by raw volume
+// without excluding false positives, so an all-false-positive species can rank into the top-N yet
+// contribute no real detections; rendering it as an empty "0 detections" ridge would be misleading.
+// The result is always non-nil.
+func buildSpeciesHourlyDistribution(top []repository.SpeciesCount, hourlyByLabel map[uint][24]int) []datastore.SpeciesHourlyDistribution {
+	// Merge label rows that share a scientific name, preserving first-seen (descending-volume)
+	// order. Each distinct species accumulates the hourly counts of all its label IDs.
+	order := make([]string, 0, len(top))
+	countsByName := make(map[string]*[hoursPerDay]int, len(top))
+	for i := range top {
+		name := top[i].ScientificName
+		acc, ok := countsByName[name]
+		if !ok {
+			acc = &[hoursPerDay]int{}
+			countsByName[name] = acc
+			order = append(order, name)
+		}
+		hours := hourlyByLabel[top[i].LabelID] // zero [24]int when the label has no detections
+		for h := range hoursPerDay {
+			acc[h] += hours[h]
+		}
+	}
+
+	result := make([]datastore.SpeciesHourlyDistribution, 0, len(order))
+	for _, name := range order {
+		acc := countsByName[name]
+		total := 0
+		for h := range hoursPerDay {
+			total += acc[h]
+		}
+		if total == 0 {
+			continue // ranked by raw volume but no FP-excluded detections; skip the empty ridge
+		}
+		dist := datastore.SpeciesHourlyDistribution{ScientificName: name, Total: total}
+		for h := range hoursPerDay {
+			dist.Buckets[h] = float64(acc[h]) / float64(total)
+		}
+		result = append(result, dist)
+	}
+	return result
+}
 
 // Slot resolution constants for the seasonal density heatmap. The intra-day slot width is
 // downsampled as the requested range widens so the payload (and the rendered grid) stays

--- a/internal/datastore/v2only/aggregate_test.go
+++ b/internal/datastore/v2only/aggregate_test.go
@@ -20,7 +20,8 @@ func hours(pairs ...[2]int) [24]int {
 }
 
 // bucketSum sums a species' normalized buckets (should be ~1.0 for any non-empty species).
-func bucketSum(b [24]float64) float64 {
+// Takes a pointer to avoid copying the 192-byte array (gocritic hugeParam).
+func bucketSum(b *[24]float64) float64 {
 	sum := 0.0
 	for _, v := range b {
 		sum += v
@@ -56,8 +57,8 @@ func TestBuildSpeciesHourlyDistribution_NormalizesAndOrders(t *testing.T) {
 	assert.Equal(t, 1, got[2].Total)
 
 	// Each species' buckets are a probability distribution (sum to 1.0).
-	for _, d := range got {
-		assert.InDelta(t, 1.0, bucketSum(d.Buckets), 1e-9, "species %s buckets must sum to 1.0", d.ScientificName)
+	for i := range got {
+		assert.InDelta(t, 1.0, bucketSum(&got[i].Buckets), 1e-9, "species %s buckets must sum to 1.0", got[i].ScientificName)
 	}
 
 	// Spot-check normalized values for the first species.

--- a/internal/datastore/v2only/aggregate_test.go
+++ b/internal/datastore/v2only/aggregate_test.go
@@ -6,7 +6,126 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 )
+
+// hours builds a [24]int from (hour, count) pairs for terse test fixtures.
+func hours(pairs ...[2]int) [24]int {
+	var h [24]int
+	for _, p := range pairs {
+		h[p[0]] = p[1]
+	}
+	return h
+}
+
+// bucketSum sums a species' normalized buckets (should be ~1.0 for any non-empty species).
+func bucketSum(b [24]float64) float64 {
+	sum := 0.0
+	for _, v := range b {
+		sum += v
+	}
+	return sum
+}
+
+func TestBuildSpeciesHourlyDistribution_NormalizesAndOrders(t *testing.T) {
+	t.Parallel()
+
+	top := []repository.SpeciesCount{
+		{LabelID: 1, ScientificName: "Turdus merula", Count: 100},
+		{LabelID: 2, ScientificName: "Erithacus rubecula", Count: 50},
+		{LabelID: 3, ScientificName: "Strix aluco", Count: 10},
+	}
+	hourlyByLabel := map[uint][24]int{
+		1: hours([2]int{0, 2}, [2]int{12, 6}, [2]int{18, 2}), // total 10
+		2: hours([2]int{6, 4}, [2]int{7, 1}),                 // total 5
+		3: hours([2]int{23, 1}),                              // total 1
+	}
+
+	got := buildSpeciesHourlyDistribution(top, hourlyByLabel)
+	require.Len(t, got, 3)
+
+	// Order preserved (descending volume from GetTopSpecies).
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Equal(t, "Erithacus rubecula", got[1].ScientificName)
+	assert.Equal(t, "Strix aluco", got[2].ScientificName)
+
+	// Totals are the FP-excluded hourly counts that drive the tooltip.
+	assert.Equal(t, 10, got[0].Total)
+	assert.Equal(t, 5, got[1].Total)
+	assert.Equal(t, 1, got[2].Total)
+
+	// Each species' buckets are a probability distribution (sum to 1.0).
+	for _, d := range got {
+		assert.InDelta(t, 1.0, bucketSum(d.Buckets), 1e-9, "species %s buckets must sum to 1.0", d.ScientificName)
+	}
+
+	// Spot-check normalized values for the first species.
+	assert.InDelta(t, 0.2, got[0].Buckets[0], 1e-9)
+	assert.InDelta(t, 0.6, got[0].Buckets[12], 1e-9)
+	assert.InDelta(t, 0.2, got[0].Buckets[18], 1e-9)
+}
+
+func TestBuildSpeciesHourlyDistribution_MergesLabelsSharingName(t *testing.T) {
+	t.Parallel()
+
+	// The same species detected under two model label IDs must collapse to one ridge whose
+	// buckets are the summed counts across both labels (systemic multi-model behavior).
+	top := []repository.SpeciesCount{
+		{LabelID: 1, ScientificName: "Turdus merula", Count: 60},
+		{LabelID: 2, ScientificName: "Turdus merula", Count: 40},
+		{LabelID: 3, ScientificName: "Erithacus rubecula", Count: 30},
+	}
+	hourlyByLabel := map[uint][24]int{
+		1: hours([2]int{6, 3}),  // Turdus merula via model A
+		2: hours([2]int{18, 1}), // Turdus merula via model B
+		3: hours([2]int{12, 2}), // Erithacus rubecula
+	}
+
+	got := buildSpeciesHourlyDistribution(top, hourlyByLabel)
+	require.Len(t, got, 2) // two distinct species, not three label rows
+
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Equal(t, 4, got[0].Total) // 3 + 1 merged
+	assert.InDelta(t, 0.75, got[0].Buckets[6], 1e-9)
+	assert.InDelta(t, 0.25, got[0].Buckets[18], 1e-9)
+
+	assert.Equal(t, "Erithacus rubecula", got[1].ScientificName)
+	assert.Equal(t, 2, got[1].Total)
+}
+
+func TestBuildSpeciesHourlyDistribution_DropsZeroTotalSpecies(t *testing.T) {
+	t.Parallel()
+
+	// A species ranked into the top-N by raw volume (GetTopSpecies does not exclude false
+	// positives) but with no FP-excluded hourly detections must be dropped rather than rendered
+	// as an empty ridge with "0 detections".
+	top := []repository.SpeciesCount{
+		{LabelID: 1, ScientificName: "Turdus merula", Count: 5},
+		{LabelID: 2, ScientificName: "Pica pica", Count: 3}, // all false positives -> absent from hourly
+	}
+	hourlyByLabel := map[uint][24]int{
+		1: hours([2]int{8, 5}),
+	}
+
+	got := buildSpeciesHourlyDistribution(top, hourlyByLabel)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+}
+
+func TestBuildSpeciesHourlyDistribution_Empty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, buildSpeciesHourlyDistribution(nil, nil))
+
+	// Non-empty top but no hourly data -> every species drops out, never nil.
+	got := buildSpeciesHourlyDistribution(
+		[]repository.SpeciesCount{{LabelID: 1, ScientificName: "Turdus merula", Count: 5}},
+		map[uint][24]int{},
+	)
+	assert.Empty(t, got)
+	assert.NotNil(t, got)
+}
 
 // epochAt returns the Unix epoch (seconds) for the given wall-clock time in loc.
 func epochAt(loc *time.Location, year, month, day, hour, minute int) int64 {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3024,8 +3024,15 @@ func (ds *Datastore) GetHourlyDistributionBySpecies(ctx context.Context, startDa
 	// other time-based analytics; named to avoid a bare magic literal at the two call sites.
 	const noConfidenceFloor = 0.0
 
-	// Top-N species by raw detection volume across all models (modelID nil).
-	top, err := ds.detection.GetTopSpecies(ctx, start, end, noConfidenceFloor, nil, limit)
+	// Top-N species by raw detection volume across all models (modelID nil). GetTopSpecies uses an
+	// inclusive end (<= end) while GetBatchHourlyOccurrences below uses an exclusive end (< end), so
+	// subtract one second to cover the exact same range; otherwise ranking and bucket totals could
+	// disagree on a detection landing exactly on the end boundary.
+	topEnd := end
+	if end != math.MaxInt64 {
+		topEnd--
+	}
+	top, err := ds.detection.GetTopSpecies(ctx, start, topEnd, noConfidenceFloor, nil, limit)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("datastore").

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3008,6 +3008,54 @@ func (ds *Datastore) GetActivityHeatmap(ctx context.Context, startDate, endDate,
 	return buildActivityHeatmap(timestamps, ds.timezone, startDate, endDate)
 }
 
+// GetHourlyDistributionBySpecies returns the normalized hour-of-day activity distribution for the
+// top `limit` species by detection volume over [startDate, endDate], ordered by descending volume.
+// It selects the top-N label IDs by volume (GetTopSpecies), fetches their false-positive-excluded
+// per-hour counts in a single batched (label_id, hour) group-by (GetBatchHourlyOccurrences), then
+// merges and normalizes per species in Go (buildSpeciesHourlyDistribution). minConfidence is 0 so it
+// counts every detection, matching the heatmap and the other time-based analytics endpoints.
+func (ds *Datastore) GetHourlyDistributionBySpecies(ctx context.Context, startDate, endDate string, limit int) ([]datastore.SpeciesHourlyDistribution, error) {
+	start, end, err := ds.parseDateRange(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	// minConfidence 0 counts every detection (no confidence floor), matching the heatmap and the
+	// other time-based analytics; named to avoid a bare magic literal at the two call sites.
+	const noConfidenceFloor = 0.0
+
+	// Top-N species by raw detection volume across all models (modelID nil).
+	top, err := ds.detection.GetTopSpecies(ctx, start, end, noConfidenceFloor, nil, limit)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_hourly_distribution_by_species_top").
+			Build()
+	}
+	if len(top) == 0 {
+		return []datastore.SpeciesHourlyDistribution{}, nil
+	}
+
+	// One label ID per top row; fetch their false-positive-excluded hourly counts in a single
+	// batched query (chunked internally for large label sets).
+	labelIDs := make([]uint, 0, len(top))
+	for i := range top {
+		labelIDs = append(labelIDs, top[i].LabelID)
+	}
+
+	hourlyByLabel, err := ds.detection.GetBatchHourlyOccurrences(ctx, labelIDs, start, end, ds.zoneOffsetSeconds(start), noConfidenceFloor)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_hourly_distribution_by_species_hourly").
+			Build()
+	}
+
+	return buildSpeciesHourlyDistribution(top, hourlyByLabel), nil
+}
+
 // ============================================================
 // Dynamic Threshold Methods
 // ============================================================

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -296,6 +296,9 @@ func (m *mockStore) GetSpeciesDiversityData(_ context.Context, _, _ string) ([]d
 func (m *mockStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (datastore.ActivityHeatmapData, error) {
 	return datastore.ActivityHeatmapData{}, nil
 }
+func (m *mockStore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
+	return nil, nil
+}
 
 // BG-17 fix: Add notification history methods
 func (m *mockStore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -297,7 +297,7 @@ func (m *mockStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (datas
 	return datastore.ActivityHeatmapData{}, nil
 }
 func (m *mockStore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
-	return nil, nil
+	return []datastore.SpeciesHourlyDistribution{}, nil
 }
 
 // BG-17 fix: Add notification history methods


### PR DESCRIPTION
## Summary

Adds the per-species hour-of-day **ridgeline** (joyplot) to the analytics hub's Activity Patterns tab. One overlapping area ridge per species shows its activity distribution across the day, sorting dawn singers from all-day and nocturnal birds.

- **New additive endpoint** `GET /api/v2/analytics/time/distribution/species?start_date&end_date&limit` (v2only). Returns the top-N species by detection volume, each with a normalized 24-bucket hour-of-day distribution: `[{ scientificName, buckets: number[24], total }]`. Existing analytics endpoints, paths, and response shapes are unchanged.
- **Backend reuses existing repository methods** `GetTopSpecies` (top-N label rows by volume) and `GetBatchHourlyOccurrences` (a single batched `(labelID, hour)` group-by, false positives excluded), so it runs exactly two queries with no N+1. A shared, table-tested Go helper merges multi-model label IDs that share a scientific name, drops all-false-positive species, and normalizes each species' buckets to sum to 1.0. The legacy datastore returns an empty result; the generated mock and the hand-rolled test implementers are updated for the new interface method.
- **New reusable D3 `SpeciesRidgeline` component** wraps the shared `BaseChart`: `d3-shape` areas with `curveBasis`, a shared amplitude scale so concentrated activity rises taller, species colors from the shared palette, scientific name as the stable key and the localized common name as the row label. It is built generically (injectable x-axis formatter and i18n keys) so the upcoming confidence-distribution chart can reuse it. The chart carries an `aria-label` and a screen-reader text summary.
- i18n keys added for all locales; common names are resolved client-side (the v2 label schema stores no common name), consistent with the sibling species charts.

## Test Plan

- [x] `go test -race ./internal/datastore/v2only/ ./internal/api/v2/` (aggregation table tests + handler tests: shape, empty-array-not-null, end-date default, limit clamping, 400/408 paths)
- [x] `golangci-lint run` on the affected packages, `gofmt` clean
- [x] Frontend `npm run typecheck`, `eslint`, `lint:css` (stylelint), and `npx vitest run` (ridgeline util + component tests)
- [ ] Manual: open the analytics hub Activity Patterns tab and confirm the ridgeline renders the top species, with a readable hover tooltip and the top-N note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Who Sings When” ridgeline chart to analytics, visualizing hour-by-hour patterns for top species with tooltips, peak details, and screen-reader accessible summaries.
  * Added a new public endpoint to retrieve species hour-of-day distribution data by date range and limit.
* **Localization**
  * Added ridgeline chart translation strings across supported languages.
* **Tests**
  * Added comprehensive chart, utility, and API endpoint test coverage (including edge cases and empty-state behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->