### PR TITLE
fix(test): flaky TestCheckAndUpdateSpecies near midnight

### DIFF
--- a/internal/analysis/species/species_tracker_comprehensive_test.go
+++ b/internal/analysis/species/species_tracker_comprehensive_test.go
@@ -273,8 +273,13 @@ func TestCheckAndUpdateSpecies(t *testing.T) {
 	err := tracker.InitFromDatabase()
 	require.NoError(t, err)
 
-	// Use a fixed time at noon to avoid flakiness when tests run near midnight.
-	currentTime := time.Now().Truncate(24 * time.Hour).Add(12 * time.Hour)
+	// Pin to local calendar noon so the +1h "same day" assertion never crosses a
+	// day boundary, regardless of the runner's timezone. time.Now().Truncate(24h)
+	// snaps to UTC midnight (Truncate works on absolute time), so it still lands at
+	// 23:xx local in UTC+11, where +1h rolls into the next day. calculateDaysSince
+	// reads the local .Date(), so the fix has to anchor on local noon.
+	now := time.Now()
+	currentTime := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
 
 	// First detection
 	isNew, daysSince := tracker.CheckAndUpdateSpecies("Parus major", currentTime)

--- a/internal/analysis/species/species_tracker_comprehensive_test.go
+++ b/internal/analysis/species/species_tracker_comprehensive_test.go
@@ -273,7 +273,8 @@ func TestCheckAndUpdateSpecies(t *testing.T) {
 	err := tracker.InitFromDatabase()
 	require.NoError(t, err)
 
-	currentTime := time.Now()
+	// Use a fixed time at noon to avoid flakiness when tests run near midnight.
+	currentTime := time.Now().Truncate(24 * time.Hour).Add(12 * time.Hour)
 
 	// First detection
 	isNew, daysSince := tracker.CheckAndUpdateSpecies("Parus major", currentTime)


### PR DESCRIPTION
I had a few tests fail that were not near anything I touched. It's always dealing with how humans think about time, man. We do some checks that species detections are within the same day, which breaks when it's close to midnight and the clock rolls over. I think the behavior here is reasonable to test so this should just make the test more stable.

clanker generated pr desc below

---


## Summary

- Pin `TestCheckAndUpdateSpecies` base time to noon instead of `time.Now()` so that adding 1 hour never crosses a calendar day boundary
- Fixes flaky CI failures that occur when tests run after 23:00 in the local timezone (the +1h detection lands on the next day, making `daysSince` = 1 instead of 0)

## Evidence of flakiness

This test failed on **all three platforms** in [PR #3613](https://github.com/tphakala/birdnet-go/pull/3613) CI (run at ~23:39 UTC on 2026-06-21):

- **Linux**: [unit-tests](https://github.com/tphakala/birdnet-go/actions/runs/27921157240/job/82615002666) — `TestCheckAndUpdateSpecies` FAIL
- **macOS**: [unit-tests (macos-arm64)](https://github.com/tphakala/birdnet-go/actions/runs/27921157230/job/82615002656) — `TestCheckAndUpdateSpecies` FAIL
- **Windows**: [unit-tests (windows-amd64)](https://github.com/tphakala/birdnet-go/actions/runs/27921157256/job/82615002552) — `TestCheckAndUpdateSpecies` FAIL

Error message (identical on all platforms):
```
species_tracker_comprehensive_test.go:286:
    Error Trace: species_tracker_comprehensive_test.go:286
    Error:       Not equal:
                 expected: 0
                 actual  : 1
    Test:        TestCheckAndUpdateSpecies
    Messages:    Days since should still be 0 on same day
```

## Root cause

`currentTime := time.Now()` followed by `currentTime.Add(time.Hour)` crosses a calendar day boundary when the test runs after 23:00 local time. `calculateDaysSince` uses `.Date()` (local timezone) to extract the calendar date, so the two timestamps resolve to different days and `daysSince` = 1.

## Fix

Replace `time.Now()` with `time.Now().Truncate(24 * time.Hour).Add(12 * time.Hour)` — this pins the base time to noon of the current day, so +1h always stays within the same calendar day.

## Test plan

- [x] `go test -run TestCheckAndUpdateSpecies -count=5` passes consistently
- [ ] CI should pass on all platforms (Linux, macOS, Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using deterministic, fixed timestamps instead of current system time, reducing timing-dependent flakiness around calendar boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->