### PR TITLE
fix(test): deflake TestJobCancellation and push dispatcher tests

### DIFF
--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1406,19 +1406,29 @@ func TestJobCancellation(t *testing.T) {
 	}()
 
 	longJobStarted := make(chan struct{})
-	longJobBlocked := make(chan struct{})
 
-	// Create a long-running job
+	// The action blocks until the context is cancelled, then returns the
+	// cancellation error. This honors the Action interface contract that
+	// implementations must respect context cancellation, and it makes the
+	// test deterministic: the job can only finish via cancellation, so the
+	// queue always records it as a failure carrying a cancellation error.
+	//
+	// The previous version returned nil immediately after the context was
+	// cancelled, which left executeJobWithTimeout's select racing between the
+	// success branch (action returned nil) and the cancellation branch
+	// (execCtx.Done()). Go picks a ready select case at random, so the job was
+	// marked Completed or Failed depending on scheduler timing; that raced
+	// reliably on loaded CI runners while passing locally.
 	action := &MockAction{
-		ExecuteFunc: func(data any) error {
+		ExecuteFunc: func(_ any) error {
 			close(longJobStarted)
-			<-longJobBlocked // Block until channel is closed
-			return nil
+			<-ctx.Done()
+			return ctx.Err()
 		},
 	}
 
 	// Enqueue the job
-	job, err := queue.Enqueue(t.Context(), action, &TestData{ID: "cancel-test"}, RetryConfig{Enabled: false})
+	_, err := queue.Enqueue(t.Context(), action, &TestData{ID: "cancel-test"}, RetryConfig{Enabled: false})
 	require.NoError(t, err)
 
 	// Process the job to start it
@@ -1427,60 +1437,34 @@ func TestJobCancellation(t *testing.T) {
 	// Wait for job to start
 	waitForChannelWithLog(t, longJobStarted, 2*time.Second, "Job didn't start in time", "Long job started successfully")
 
-	// Cancel the context
+	// Cancel the context. This unblocks the action and signals the queue's
+	// execution cancellation path simultaneously; both outcomes mark the job
+	// as failed with a cancellation error.
 	cancel()
 
-	// Unblock the job
-	close(longJobBlocked)
-
-	// Give some time for cleanup
-	time.Sleep(500 * time.Millisecond)
-
-	// Check job was cancelled
-	stats := queue.GetStats()
-	assert.Equal(t, 1, stats.TotalJobs, "Total jobs should be 1")
-
-	// Job might be reported as failed rather than cancelled due to context cancelled error
-	// Check if the job has the expected error
-	var jobFailed bool
-	var jobHasCancellationError bool
-
-	queue.mu.Lock()
-	// Check in active jobs
-	for _, j := range queue.jobs {
-		if j.ID == job.ID && j.Status == JobStatusFailed {
-			jobFailed = true
-			if j.LastError != nil && strings.Contains(j.LastError.Error(), "cancel") {
-				jobHasCancellationError = true
-			}
-			break
+	// Poll the queue stats until the job is recorded as failed with a
+	// cancellation error, instead of sleeping for a fixed duration (which was
+	// flaky under CI load). FailedJobs and the per-action LastErrorMessage are
+	// updated atomically under the queue lock in handleJobFailure, so observing
+	// FailedJobs > 0 guarantees the matching error message is also visible. The
+	// per-action LastErrorMessage is the durable signal: the Job pointer is
+	// discarded once cleanupStaleJobs runs.
+	require.Eventually(t, func() bool {
+		stats := queue.GetStats()
+		if stats.FailedJobs == 0 {
+			return false
 		}
-	}
-	queue.mu.Unlock()
-
-	if !jobFailed {
-		// After cleanupStaleJobs runs, the failed job pointer is discarded.
-		// Fall back to the queue-wide counter to observe the failure.
-		postStats := queue.GetStats()
-		if postStats.FailedJobs > 0 {
-			jobFailed = true
-		}
-	}
-	if !jobHasCancellationError {
-		// The dropped Job pointer no longer carries the error after cleanup.
-		// The per-action stats still record LastErrorMessage, which captures
-		// the cancellation error emitted by handleExecutionTimeout.
-		postStats := queue.GetStats()
-		for _, as := range postStats.ActionStats {
+		for _, as := range stats.ActionStats {
 			if strings.Contains(as.LastErrorMessage, "cancel") {
-				jobHasCancellationError = true
-				break
+				return true
 			}
 		}
-	}
+		return false
+	}, 5*time.Second, 10*time.Millisecond,
+		"job should be marked failed with a cancellation error after context cancellation")
 
-	assert.True(t, jobFailed, "Job should be marked as failed after cancellation")
-	assert.True(t, jobHasCancellationError, "Job should have a cancellation error")
+	// Exactly one job should have been tracked.
+	assert.Equal(t, 1, queue.GetStats().TotalJobs, "Total jobs should be 1")
 }
 
 // TestLongRunningJobs tests that short jobs can be processed while a long job is running

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -62,15 +62,36 @@ func newFakeProvider(name string, enabled bool, types ...Type) *fakeProvider {
 	}
 }
 
-func TestPushDispatcher_ForwardsNotification(t *testing.T) {
-	t.Parallel()
+// installIsolatedService installs svc as the process-global notification service
+// for the duration of the test and restores the previous instance on cleanup.
+// Tests that exercise the dispatcher end to end need their own service because
+// dispatcher.start subscribes to the global singleton (via GetService), yet
+// SetServiceForTesting only sets that singleton when it is nil and never resets
+// it. Without isolation such tests share one service, cross-deliver each other's
+// notifications, and accumulate rate-limiter state across runs. Callers must not
+// run in parallel: they mutate the global singleton.
+func installIsolatedService(t *testing.T, svc *Service) {
+	t.Helper()
+	mu.Lock()
+	prev := instance
+	instance = svc
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		instance = prev
+		mu.Unlock()
+	})
+}
 
+func TestPushDispatcher_ForwardsNotification(t *testing.T) {
+	// Not parallel: the dispatcher subscribes to the process-global notification
+	// service singleton (dispatcher.start calls GetService), so this test
+	// installs its own isolated service for the duration of the test. Two such
+	// tests cannot run concurrently without racing on the singleton and
+	// cross-delivering notifications, which would fail the title assertion. Per
+	// the project rule, tests that mutate global state must not run in parallel.
 	svc := NewService(DefaultServiceConfig())
-	err := SetServiceForTesting(svc)
-	if err != nil {
-		svc = GetService()
-		require.NotNil(t, svc, "failed to attach to notification service")
-	}
+	installIsolatedService(t, svc)
 
 	fp := newFakeProvider("fake", true)
 
@@ -83,7 +104,7 @@ func TestPushDispatcher_ForwardsNotification(t *testing.T) {
 		defaultTimeout: 200 * time.Millisecond,
 	}
 
-	err = d.start()
+	err := d.start()
 	require.NoError(t, err, "failed to start dispatcher")
 	defer func() {
 		if d.cancel != nil {
@@ -247,14 +268,13 @@ func TestMatchesProviderFilter_ConfidenceTypes(t *testing.T) {
 }
 
 func TestPushDispatcher_ConcurrencyLimit(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: like TestPushDispatcher_ForwardsNotification, the dispatcher
+	// subscribes to the process-global notification service singleton, so this
+	// test installs its own isolated service and must run in the sequential
+	// phase. See the project rule against parallelizing tests that mutate global
+	// state.
 	svc := NewService(DefaultServiceConfig())
-	err := SetServiceForTesting(svc)
-	if err != nil {
-		svc = GetService()
-		require.NotNil(t, svc, "failed to attach to notification service")
-	}
+	installIsolatedService(t, svc)
 
 	slowProvider := &fakeProvider{
 		name:      "slow",
@@ -274,7 +294,7 @@ func TestPushDispatcher_ConcurrencyLimit(t *testing.T) {
 		concurrencySem: semaphore.NewWeighted(3),
 	}
 
-	err = d.start()
+	err := d.start()
 	require.NoError(t, err, "failed to start dispatcher")
 	defer func() {
 		if d.cancel != nil {


### PR DESCRIPTION
## Summary

Two flaky tests that pass locally but fail intermittently on loaded CI runners are made deterministic. Test-only changes; no production code is touched.

### `TestJobCancellation` (`internal/analysis/jobqueue`)

The mock action returned `nil` (success) at the same instant the context was cancelled, so `executeJobWithTimeout`'s `select` raced between the success branch (action returned `nil`) and the cancellation branch (`execCtx.Done()`). Go picks a ready `select` case at random, so the job was marked Completed or Failed depending on scheduler timing. A fixed `time.Sleep(500ms)` before the assertions made it worse under load.

The action now blocks on `ctx.Done()` and returns `ctx.Err()`, so the job can only finish via cancellation and both `select` branches deterministically yield a cancellation failure. The sleep and the white-box `queue.mu`/`queue.jobs` inspection are replaced with `require.Eventually` polling `GetStats()` (`FailedJobs` and the per-action `LastErrorMessage` are updated atomically under the queue lock in `handleJobFailure`).

### `TestPushDispatcher_ForwardsNotification` / `TestPushDispatcher_ConcurrencyLimit` (`internal/notification`)

Both tests subscribed to and broadcast through the global notification service singleton while running `t.Parallel()`. `SetServiceForTesting` only sets the singleton when it is nil and never resets it, so the two parallel tests shared one service and cross-delivered each other's notifications, failing the title assertion (and accumulating rate-limiter state across runs).

Both tests now install an isolated service (restored on cleanup via a new `installIsolatedService` helper) and run sequentially, per the project rule against parallelizing tests that mutate global state.

## Test Plan

- [x] `go test -race -count=200 -run '^TestJobCancellation$' ./internal/analysis/jobqueue/` (also clean under full 16-core CPU saturation)
- [x] `go test -race -count=20 -run TestPushDispatcher ./internal/notification/`
- [x] Full `internal/notification` and `internal/analysis/jobqueue` packages pass under `-race`
- [x] `golangci-lint run` reports 0 issues on both packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved internal testing infrastructure and reliability for job cancellation handling and notification service isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->