### PR TITLE
fix(observability): deterministic clock for collector tick to fix Windows test flake

### DIFF
--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -27,6 +27,14 @@ type Collector struct {
 	interval time.Duration
 	cpuFunc  CPUUsageFunc
 
+	// now is the clock used to timestamp each collection tick. A single tick
+	// timestamp is shared by every delta-based collector (disk I/O, database,
+	// inference, and health counters) so all rates and recorded timestamps in one
+	// collect() reference the same instant. Defaults to time.Now; tests inject a
+	// deterministic clock to avoid depending on wall-clock resolution (which is
+	// coarse on Windows and made TestCollector_InferenceThroughput flaky).
+	now func() time.Time
+
 	// Internal state for disk I/O delta computation
 	prevDiskIO   map[string]disk.IOCountersStat
 	prevDiskTime time.Time
@@ -82,6 +90,7 @@ func NewCollector(store MetricsStore, interval time.Duration, cpuFunc CPUUsageFu
 		store:        store,
 		interval:     interval,
 		cpuFunc:      cpuFunc,
+		now:          time.Now,
 		prevDiskIO:   make(map[string]disk.IOCountersStat),
 		loggedErrors: make(map[string]bool),
 	}
@@ -138,12 +147,19 @@ func inferenceMetricKey(modelID string) string {
 func (c *Collector) collect() {
 	points := make(map[string]float64, expectedMetricCount)
 
+	// Single authoritative timestamp for this tick. Every delta-based collector
+	// computes its delta against this instant and the previous tick's instant
+	// (a rate for disk I/O/database/inference, a recorded count for health
+	// counters), so they stay mutually consistent and the timing is fully
+	// controllable in tests.
+	tick := c.now()
+
 	c.collectCPU(points)
 	c.collectMemory(points)
 	c.collectTemperature(points)
-	c.collectDisk(points)
-	c.collectDatabase(points)
-	c.collectInference(points)
+	c.collectDisk(points, tick)
+	c.collectDatabase(points, tick)
+	c.collectInference(points, tick)
 	c.collectAudio(points)
 
 	if len(points) > 0 {
@@ -152,7 +168,7 @@ func (c *Collector) collect() {
 
 	c.collectModelRSS()
 	c.pruneInferenceGauges()
-	c.collectHealthCounters()
+	c.collectHealthCounters(tick)
 }
 
 // collectCPU reads CPU usage from the injected function.
@@ -182,9 +198,9 @@ func (c *Collector) collectTemperature(points map[string]float64) {
 }
 
 // collectDisk reads disk usage and I/O statistics via gopsutil.
-func (c *Collector) collectDisk(points map[string]float64) {
+func (c *Collector) collectDisk(points map[string]float64, tick time.Time) {
 	c.collectDiskUsage(points)
-	c.collectDiskIO(points)
+	c.collectDiskIO(points, tick)
 }
 
 // collectDiskUsage reads disk usage percentages for each partition.
@@ -211,16 +227,15 @@ func (c *Collector) collectDiskUsage(points map[string]float64) {
 }
 
 // collectDiskIO computes disk I/O rates (bytes/sec) as deltas between ticks.
-func (c *Collector) collectDiskIO(points map[string]float64) {
+func (c *Collector) collectDiskIO(points map[string]float64, tick time.Time) {
 	counters, err := disk.IOCounters()
 	if err != nil {
 		c.logOnce("disk_io", "failed to read disk I/O counters: %v", err)
 		return
 	}
 
-	now := time.Now()
 	if !c.prevDiskTime.IsZero() {
-		elapsed := now.Sub(c.prevDiskTime).Seconds()
+		elapsed := tick.Sub(c.prevDiskTime).Seconds()
 		if elapsed > 0 {
 			for device := range counters {
 				counter := counters[device]
@@ -244,7 +259,7 @@ func (c *Collector) collectDiskIO(points map[string]float64) {
 	}
 
 	c.prevDiskIO = counters
-	c.prevDiskTime = now
+	c.prevDiskTime = tick
 }
 
 // SetDBCounters sets the database atomic counters for latency tracking.
@@ -261,12 +276,15 @@ const usPerSecond = 1_000_000.0
 
 // collectDatabase computes database latency and throughput metrics from
 // atomic counter snapshots. Requires two consecutive snapshots for deltas.
-func (c *Collector) collectDatabase(points map[string]float64) {
+func (c *Collector) collectDatabase(points map[string]float64, tick time.Time) {
 	if c.dbCounters == nil {
 		return
 	}
 
 	snap := c.dbCounters.Snapshot()
+	// Use the shared tick timestamp for delta math and as the stored reference
+	// for the next tick, rather than the snapshot's own time.Now().
+	snap.CollectedAt = tick
 
 	// Max values are reset-on-read from Snapshot(), always record them
 	// (even on the first tick when prevDBSnap is nil)
@@ -371,7 +389,7 @@ func (c *Collector) SetHealthEvents(buf *HealthEventBuffer) {
 	c.healthEvents = buf
 }
 
-func (c *Collector) collectInference(points map[string]float64) {
+func (c *Collector) collectInference(points map[string]float64, tick time.Time) {
 	if c.inferenceCounters == nil {
 		return
 	}
@@ -382,6 +400,14 @@ func (c *Collector) collectInference(points map[string]float64) {
 	}
 
 	snaps := c.inferenceCounters.SnapshotAll()
+	// Stamp every snapshot with the shared tick timestamp so throughput deltas
+	// (and the previous-snapshot references stored below) use one consistent,
+	// test-controllable clock instead of each Snapshot's own time.Now().
+	for modelID := range snaps {
+		s := snaps[modelID]
+		s.CollectedAt = tick
+		snaps[modelID] = s
+	}
 
 	if c.prevInferenceSnaps == nil {
 		c.prevInferenceSnaps = make(map[string]*inferencestats.Snapshot, len(snaps))
@@ -566,13 +592,12 @@ func (c *Collector) collectAudio(points map[string]float64) {
 // collectHealthCounters samples cumulative audio and stream counters,
 // computes deltas from the previous snapshot, and records them into the
 // dedicated HealthMetricsStore. Follows the same delta pattern as collectDiskIO.
-func (c *Collector) collectHealthCounters() {
+func (c *Collector) collectHealthCounters(tick time.Time) {
 	if c.healthStore == nil {
 		return
 	}
-	now := time.Now()
-	c.collectAudioHealthCounters(now)
-	c.collectStreamHealthCounters(now)
+	c.collectAudioHealthCounters(tick)
+	c.collectStreamHealthCounters(tick)
 }
 
 // collectAudioHealthCounters computes deltas for audio drops and overruns and

--- a/internal/observability/collector_health_test.go
+++ b/internal/observability/collector_health_test.go
@@ -30,7 +30,7 @@ func TestCollector_AudioHealthDelta(t *testing.T) {
 		}
 	})
 
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src1"))
 
 	c.SetAudioRouter(func() []AudioRouterSnapshot {
@@ -38,7 +38,7 @@ func TestCollector_AudioHealthDelta(t *testing.T) {
 			{SourceID: "src1", Drops: 15, Errors: 5},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 	assert.Equal(t, int64(5), healthStore.LifetimeTotal("audio.drops.src1"))
 	assert.Equal(t, int64(3), healthStore.LifetimeTotal("audio.overruns.src1"))
 
@@ -57,8 +57,8 @@ func TestCollector_AudioHealthZeroDeltaSkip(t *testing.T) {
 		}
 	})
 
-	c.collectHealthCounters()
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
+	c.collectHealthCounters(time.Now())
 
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src1"))
 	assert.Empty(t, healthEvents.RecentAll(10))
@@ -73,14 +73,14 @@ func TestCollector_AudioHealthCounterReset(t *testing.T) {
 			{SourceID: "src1", Drops: 100, Errors: 0},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	c.SetAudioRouter(func() []AudioRouterSnapshot {
 		return []AudioRouterSnapshot{
 			{SourceID: "src1", Drops: 5, Errors: 0},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	assert.Equal(t, int64(5), healthStore.LifetimeTotal("audio.drops.src1"))
 }
@@ -94,14 +94,14 @@ func TestCollector_StreamHealthDelta(t *testing.T) {
 			{SourceID: "stream_abc123", RestartCount: 2},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	c.SetStreamHealth(func() []StreamHealthSnapshot {
 		return []StreamHealthSnapshot{
 			{SourceID: "stream_abc123", RestartCount: 5},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	assert.Equal(t, int64(3), healthStore.LifetimeTotal("stream.restarts.stream_abc123"))
 
@@ -120,7 +120,7 @@ func TestCollector_MultiSourceAudio(t *testing.T) {
 			{SourceID: "src2", Drops: 0},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	c.SetAudioRouter(func() []AudioRouterSnapshot {
 		return []AudioRouterSnapshot{
@@ -128,7 +128,7 @@ func TestCollector_MultiSourceAudio(t *testing.T) {
 			{SourceID: "src2", Drops: 20},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	assert.Equal(t, int64(10), healthStore.LifetimeTotal("audio.drops.src1"))
 	assert.Equal(t, int64(20), healthStore.LifetimeTotal("audio.drops.src2"))
@@ -144,14 +144,14 @@ func TestCollector_SourceRemoval(t *testing.T) {
 			{SourceID: "src2", Drops: 5},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	c.SetAudioRouter(func() []AudioRouterSnapshot {
 		return []AudioRouterSnapshot{
 			{SourceID: "src1", Drops: 15},
 		}
 	})
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	assert.Equal(t, int64(5), healthStore.LifetimeTotal("audio.drops.src1"))
 	assert.Equal(t, int64(0), healthStore.LifetimeTotal("audio.drops.src2"))
@@ -172,7 +172,7 @@ func TestCollector_SeedsKeysOnFirstTick(t *testing.T) {
 		}
 	})
 
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 
 	assert.Contains(t, healthStore.KeysWithPrefix(MetricPrefixAudioDrops),
 		MetricPrefixAudioDrops+"src1")
@@ -197,5 +197,5 @@ func TestCollector_NoHealthStoreSkips(t *testing.T) {
 		return []AudioRouterSnapshot{{SourceID: "src1", Drops: 10}}
 	})
 
-	c.collectHealthCounters()
+	c.collectHealthCounters(time.Now())
 }

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -344,6 +344,14 @@ func TestCollector_InferenceThroughput(t *testing.T) {
 	store := NewMemoryStore(10)
 	collector := NewCollector(store, time.Second, func() float64 { return 0 })
 
+	// Deterministic clock: the collector stamps every tick from collector.now, so
+	// the elapsed interval is exactly what the test sets. This replaces the old
+	// approach of bracketing wall-clock reads, whose resolution is coarse on
+	// Windows: both collect() calls could land in the same clock quantum, yielding
+	// elapsed 0 -> throughput 0 -> a spurious failure. See Forgejo #1181.
+	clock := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	collector.now = func() time.Time { return clock }
+
 	counters := &inferencestats.CounterMap{}
 	counters.RecordInvoke("ModelA", 10_000) // 10 ms
 	counters.RecordInvoke("ModelA", 10_000)
@@ -353,62 +361,28 @@ func TestCollector_InferenceThroughput(t *testing.T) {
 	throughputKey := inferencestats.ThroughputMetricKey("ModelA")
 
 	// First tick: seeds the previous snapshot; no throughput recorded yet.
-	// Record wall-clock time around the first collect so we can bracket
-	// the Snapshot CollectedAt that the collector stores internally.
-	tick1Before := time.Now()
 	collector.collect()
-	tick1After := time.Now()
 	pts := store.Get(throughputKey, 10)
 	assert.Nil(t, pts, "throughput must not be recorded on the seeding tick")
 
-	// Record two more invocations before the second tick.
-	const deltaInvokes = 2
+	// Advance the clock by a known interval, then record two more invocations.
+	const (
+		deltaInvokes = 2
+		interval     = 2 * time.Second
+	)
+	clock = clock.Add(interval)
 	counters.RecordInvoke("ModelA", 10_000)
 	counters.RecordInvoke("ModelA", 10_000)
 
-	// Second tick: delta = 2 invocations over elapsed time.
-	tick2Before := time.Now()
+	// Second tick: 2 invocations over a 2s interval => exactly 1.0 inv/sec.
 	collector.collect()
-	tick2After := time.Now()
 
 	pts = store.Get(throughputKey, 10)
 	require.Len(t, pts, 1, "throughput must be recorded after second tick")
 
-	// The collector computes throughput as float64(deltaInvokes) / elapsedSeconds,
-	// where elapsedSeconds = snap2.CollectedAt - snap1.CollectedAt. Both CollectedAt
-	// values are set to time.Now() inside the respective Snapshot() calls, so the
-	// actual elapsed lies in [tick2Before - tick1After, tick2After - tick1Before].
-	//
-	// Recover the actual elapsed that the collector used (collector: throughput = delta / elapsed,
-	// so elapsed = delta / throughput) and assert it falls within the bracketed range.
-	// Also verify the formula itself: throughput * elapsed_recovered = deltaInvokes.
 	got := pts[0].Value
-	require.Greater(t, got, 0.0, "throughput must be positive when invocations occurred")
-
-	// Recovered elapsed seconds used by the collector.
-	recoveredElapsed := float64(deltaInvokes) / got
-
-	// The actual Snapshot CollectedAt values fall between tick1Before..tick1After
-	// and tick2Before..tick2After respectively. The elapsed is in the range
-	// [tick2Before - tick1After, tick2After - tick1Before]. Guard against
-	// negative lower bound (can occur on very fast machines where tick2Before < tick1After).
-	lowerElapsed := tick2Before.Sub(tick1After).Seconds()
-	upperElapsed := tick2After.Sub(tick1Before).Seconds()
-	if lowerElapsed < 0 {
-		lowerElapsed = 0
-	}
-
-	// The formula throughput = deltaInvokes / elapsed must hold: recovered elapsed
-	// should be consistent with the measured wall-clock range.
-	require.GreaterOrEqual(t, recoveredElapsed, lowerElapsed,
-		"recovered elapsed must be >= lower wall-clock bound")
-	require.LessOrEqual(t, recoveredElapsed, upperElapsed+time.Millisecond.Seconds(),
-		"recovered elapsed must be <= upper wall-clock bound (with 1ms slack)")
-
-	// Also verify via InDelta: expected throughput using the recovered elapsed equals the
-	// recorded value within floating-point rounding error.
-	expectedThroughput := float64(deltaInvokes) / recoveredElapsed
-	require.InDelta(t, expectedThroughput, got, 1e-9, "throughput must equal deltaInvokes/elapsed")
+	want := float64(deltaInvokes) / interval.Seconds()
+	require.InDelta(t, want, got, 1e-9, "throughput must equal deltaInvokes/elapsedSeconds")
 }
 
 // TestCollector_InferenceThroughputZeroWhenIdle verifies that throughput is
@@ -417,6 +391,11 @@ func TestCollector_InferenceThroughputZeroWhenIdle(t *testing.T) {
 	t.Parallel()
 	store := NewMemoryStore(10)
 	collector := NewCollector(store, time.Second, func() float64 { return 0 })
+
+	// Deterministic clock with a real interval between ticks, so the idle zero
+	// comes from a zero invocation delta and not from a zero elapsed interval.
+	clock := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	collector.now = func() time.Time { return clock }
 
 	counters := &inferencestats.CounterMap{}
 	counters.RecordInvoke("ModelB", 5_000)
@@ -427,7 +406,8 @@ func TestCollector_InferenceThroughputZeroWhenIdle(t *testing.T) {
 	// First tick: seeding.
 	collector.collect()
 
-	// Second tick: no new invocations since the first tick.
+	// Second tick: clock advances but no new invocations since the first tick.
+	clock = clock.Add(time.Second)
 	collector.collect()
 
 	pts := store.Get(throughputKey, 10)
@@ -531,6 +511,14 @@ func TestCollector_InferenceErrorRateCounterReset(t *testing.T) {
 	store := NewMemoryStore(10)
 	collector := NewCollector(store, time.Second, func() float64 { return 0 })
 
+	// Deterministic clock so the second tick always observes a positive elapsed
+	// interval. The two collect() calls otherwise run back-to-back, and on coarse
+	// monotonic-clock platforms (e.g. Windows) both snapshots could read an
+	// identical timestamp, yielding elapsed == 0 and a throughput of 0 that fails
+	// the assertion below.
+	clock := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	collector.now = func() time.Time { return clock }
+
 	// Tick 1: seed with high absolute values (10 invocations, 3 errors).
 	counters1 := &inferencestats.CounterMap{}
 	for range 10 {
@@ -542,15 +530,8 @@ func TestCollector_InferenceErrorRateCounterReset(t *testing.T) {
 	collector.SetInferenceCounters(counters1)
 	collector.collect() // seeding tick; nothing written to store
 
-	// Backdate the seeded snapshot so the second tick observes a positive elapsed
-	// interval. The two collect() calls run back-to-back, and on platforms with
-	// coarse monotonic-clock granularity (e.g. Windows) both snapshots can read an
-	// identical timestamp, yielding elapsed == 0 and a throughput of 0 that fails
-	// the assertion below. Subtracting a full second is robust regardless of clock
-	// resolution; Add preserves the monotonic reading so the delta stays positive.
-	if prev, ok := collector.prevInferenceSnaps["ModelF"]; ok {
-		prev.CollectedAt = prev.CollectedAt.Add(-time.Second)
-	}
+	// Advance the clock so the second tick sees a one-second interval.
+	clock = clock.Add(time.Second)
 
 	// Tick 2: inject a fresh CounterMap with lower absolute values so that
 	// current < previous on both InvokeCount and InvokeErrors. This simulates


### PR DESCRIPTION
## Summary

`TestCollector_InferenceThroughput` in `internal/observability` is flaky on the `windows-amd64` unit-tests job. It bracketed two back-to-back `collect()` calls with wall-clock `time.Now()` reads and asserted the recovered elapsed within 1ms of slack. Windows' clock resolution (~15.6ms) lets both `Counters.Snapshot()` timestamps land in the same quantum, so the computed elapsed can be 0, throughput is recorded as 0, and the positive-value assertion fails. It passes on Linux/macOS and passes on rerun, which is the classic signature of a wall-clock-resolution flake.

## Fix

Give the `Collector` an injectable clock (`now func() time.Time`, defaulting to `time.Now`) and capture a single authoritative tick timestamp per `collect()`. All delta-based collectors (disk I/O, database, inference throughput, and health counters) now compute their deltas against that one instant and the previous tick's instant, instead of each `Counters.Snapshot()` calling `time.Now()` independently.

Tests inject a deterministic clock and assert an exact rate (2 invocations over a 2s interval = 1.0 inv/sec), which removes the wall-clock dependency entirely while still exercising the real throughput path (seeding tick then delta tick). `TestCollector_InferenceErrorRateCounterReset` is migrated off its `CollectedAt`-backdating workaround for the same flake class.

This is also marginally more accurate in production: a single per-tick timestamp means rates no longer fold each tick's variable disk-read latency into the denominator. Metric keys, semantics, and the ~5s production tick interval are unchanged, so dashboards and alerts see no behavioral change.

## Test Plan

- [x] `go test -race ./internal/observability/`
- [x] Inference tests 300x and health tests 50x with no failures
- [x] `golangci-lint run` clean (0 issues, full project)
- [x] Whole project builds

## Preflight Status

- Single concern: one test-flakiness fix
- Reviewed across correctness/safety, quality/patterns, integration/wiring, regression/backward-compat, reuse/efficiency: no Critical/High findings; the two low items raised (comment scope + a sibling backdate-hack test) are addressed in this PR
- No config/API/DB-schema/CLI surface changes; no i18n strings; no regression
- No secrets or PII in the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Metrics collection now uses synchronized timestamps across all monitoring subsystems to ensure consistent timing boundaries between collection cycles, improving reliability of throughput and rate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->