### PR TITLE
feat(analytics): dawn-chorus onset tracker

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/DawnChorusOnset.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/DawnChorusOnset.svelte
@@ -1,0 +1,303 @@
+<!--
+  Dawn-chorus onset tracker (design spec section 6.3).
+
+  Scatter of each day's chorus onset relative to civil dawn (minutes; negative = before civil dawn)
+  with a smoothed trend line and a y=0 reference line marking civil dawn. The backend emits one
+  point per calendar day, so gap days (too few detections / no civil dawn) leave the scatter empty
+  there. The smoothed trend spans short gaps (the moving average still has enough nearby days) but
+  breaks over sustained ones, where the window has too few non-null days to average.
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { select } from 'd3-selection';
+  import { line, curveMonotoneX } from 'd3-shape';
+  import type { AxisDomain, AxisScale } from 'd3-axis';
+
+  import BaseChart from './BaseChart.svelte';
+  import { parseLocalDateString } from '$lib/utils/date';
+  import { createTimeScale, createLinearScale } from './utils/scales';
+  import {
+    createAxis,
+    styleAxis,
+    addAxisLabel,
+    createDateAxisFormatter,
+    pickDateRangeBucket,
+  } from './utils/axes';
+  import { ChartTooltip } from './utils/interactions';
+  import { type ChartTheme } from './utils/theme';
+  import {
+    movingAverageTrend,
+    onsetCount,
+    type DawnOnsetData,
+    type DawnOnsetPoint,
+  } from './utils/dawnOnset';
+  import { t } from '$lib/i18n';
+
+  interface Props {
+    data: DawnOnsetData;
+    width?: number;
+    height?: number;
+    ariaLabel?: string;
+  }
+
+  let { data, width = 800, height = 400, ariaLabel }: Props = $props();
+
+  // Layout / behavior constants.
+  const MARGIN = { top: 24, right: 18, bottom: 48, left: 60 };
+  const TREND_WINDOW_DAYS = 7; // weekly centered moving average
+  const TREND_MIN_SAMPLES = 3; // window needs this many non-null days, else the trend breaks here
+  const DOT_RADIUS = 3;
+  const DOT_IDLE_OPACITY = 0.55;
+  const MAX_X_TICKS = 8;
+  const X_AXIS_LABEL_OFFSET = 38;
+  const Y_AXIS_LABEL_OFFSET = 46;
+  // Pad a collapsed y-domain (all onsets identical) so the chart still renders a band.
+  const FLAT_DOMAIN_PAD_MINUTES = 10;
+
+  interface PlottedPoint extends DawnOnsetPoint {
+    dateObj: Date;
+  }
+
+  let tooltip: ChartTooltip | null = null;
+  let chartContainer: HTMLDivElement | null = null;
+
+  // Points with a valid parsed date, in input (ascending date) order.
+  const parsedPoints = $derived.by<PlottedPoint[]>(() => {
+    const out: PlottedPoint[] = [];
+    for (const p of data.points) {
+      const d = parseLocalDateString(p.date);
+      if (d && !isNaN(d.getTime())) out.push({ ...p, dateObj: d });
+    }
+    return out;
+  });
+
+  // Screen-reader summary so the chart is not opaque to assistive tech (spec section 7).
+  const summary = $derived.by(() => {
+    if (parsedPoints.length === 0) return '';
+    return t('analytics.advanced.charts.dawnOnset.summary', {
+      days: parsedPoints.length,
+      plotted: onsetCount(data),
+    });
+  });
+
+  let chartContext = $state<{
+    svg: import('d3-selection').Selection<SVGSVGElement, unknown, null, undefined>;
+    chartGroup: import('d3-selection').Selection<globalThis.SVGGElement, unknown, null, undefined>;
+    innerWidth: number;
+    innerHeight: number;
+    theme: ChartTheme;
+  } | null>(null);
+
+  // Signed minute label for the y axis (e.g. "+20", "0", "-15").
+  function formatMinutes(value: number): string {
+    const rounded = Math.round(value);
+    return rounded > 0 ? `+${rounded}` : String(rounded);
+  }
+
+  // Human-readable onset for the tooltip, relative to civil dawn.
+  function onsetText(rel: number): string {
+    if (rel > 0) {
+      return t('analytics.advanced.charts.dawnOnset.tooltipOnsetAfter', { minutes: rel });
+    }
+    if (rel < 0) {
+      return t('analytics.advanced.charts.dawnOnset.tooltipOnsetBefore', { minutes: -rel });
+    }
+    return t('analytics.advanced.charts.dawnOnset.tooltipOnsetAt');
+  }
+
+  function drawChart(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight, theme } = context;
+    // A redraw removes the hovered dot, so its mouseleave would never fire; hide first.
+    tooltip?.hide();
+    chartGroup.selectAll('*').remove();
+    if (innerWidth <= 0 || innerHeight <= 0) return;
+
+    const points = parsedPoints;
+    const plotted = points.filter(p => p.onsetRelMinutes !== null);
+    // ChartCard owns the empty / not-enough-data state; bail before drawing axes on an empty series.
+    if (plotted.length === 0) return;
+
+    const minDate = points[0].dateObj;
+    const maxDate = points[points.length - 1].dateObj;
+    const xScale = createTimeScale({ domain: [minDate, maxDate], range: [0, innerWidth] });
+
+    const onsetValues = plotted.map(p => p.onsetRelMinutes as number);
+    // Always include 0 (civil dawn) so the reference line is on-screen.
+    let yLow = Math.min(0, ...onsetValues);
+    let yHigh = Math.max(0, ...onsetValues);
+    if (yLow === yHigh) {
+      yLow -= FLAT_DOMAIN_PAD_MINUTES;
+      yHigh += FLAT_DOMAIN_PAD_MINUTES;
+    }
+    const yScale = createLinearScale({ domain: [yLow, yHigh], range: [innerHeight, 0] });
+
+    // X axis: locale-aware date labels, bucketed by the span (week / month / year).
+    const dateFmt = createDateAxisFormatter(pickDateRangeBucket([minDate, maxDate]));
+    const xAxis = createAxis({
+      scale: xScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'bottom',
+      tickCount: MAX_X_TICKS,
+      tickFormat: (d: AxisDomain) => dateFmt(d as Date),
+    });
+    const xAxisGroup = chartGroup
+      .append('g')
+      .attr('class', 'x-axis')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(xAxis);
+    styleAxis(xAxisGroup, theme.axis);
+
+    // Y axis: signed minutes from civil dawn.
+    const yAxis = createAxis({
+      scale: yScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'left',
+      tickFormat: (d: AxisDomain) => formatMinutes(Number(d)),
+    });
+    const yAxisGroup = chartGroup.append('g').attr('class', 'y-axis').call(yAxis);
+    styleAxis(yAxisGroup, theme.axis);
+
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t('analytics.advanced.charts.dawnOnset.axisDate'),
+        orientation: 'bottom',
+        offset: X_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t('analytics.advanced.charts.dawnOnset.axisOnset'),
+        orientation: 'left',
+        offset: Y_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+
+    // Civil dawn reference line at y=0, with an inline label.
+    const zeroY = yScale(0);
+    chartGroup
+      .append('line')
+      .attr('class', 'civil-dawn-line')
+      .attr('x1', 0)
+      .attr('x2', innerWidth)
+      .attr('y1', zeroY)
+      .attr('y2', zeroY)
+      .style('stroke', theme.axis.color)
+      .style('stroke-dasharray', '4 3')
+      .style('stroke-width', 1)
+      .style('opacity', 0.7);
+    chartGroup
+      .append('text')
+      .attr('x', innerWidth)
+      .attr('y', zeroY - 4)
+      .attr('text-anchor', 'end')
+      .attr('aria-hidden', 'true')
+      .style('fill', theme.axis.color)
+      .style('font-size', theme.axis.fontSize)
+      .text(t('analytics.advanced.charts.dawnOnset.civilDawn'));
+
+    // Smoothed trend line; .defined() breaks it over gaps rather than interpolating to 0.
+    const trend = movingAverageTrend(points, TREND_WINDOW_DAYS, TREND_MIN_SAMPLES);
+    // trend is aligned 1:1 with points; .at() (not bracket indexing) keeps the lint clean.
+    const trendData = points.map((p, i) => ({ dateObj: p.dateObj, value: trend.at(i) ?? null }));
+    const trendLine = line<{ dateObj: Date; value: number | null }>()
+      .defined(d => d.value !== null)
+      .x(d => xScale(d.dateObj))
+      .y(d => yScale(d.value as number))
+      .curve(curveMonotoneX);
+    chartGroup
+      .append('path')
+      .datum(trendData)
+      .attr('class', 'onset-trend')
+      .attr('fill', 'none')
+      .attr('stroke', theme.primary)
+      .attr('stroke-width', 2)
+      .attr('d', trendLine);
+
+    // Scatter dots for the days with a measurable onset.
+    chartGroup
+      .append('g')
+      .attr('class', 'onset-dots')
+      .selectAll('circle')
+      .data(plotted)
+      .enter()
+      .append('circle')
+      .attr('cx', (d: PlottedPoint) => xScale(d.dateObj))
+      .attr('cy', (d: PlottedPoint) => yScale(d.onsetRelMinutes as number))
+      .attr('r', DOT_RADIUS)
+      .style('fill', theme.primary)
+      .style('opacity', DOT_IDLE_OPACITY)
+      .on('mouseenter', function (event: MouseEvent, d: PlottedPoint) {
+        select(this).style('opacity', 1);
+        tooltip?.show({
+          title: d.date,
+          items: [
+            {
+              label: t('analytics.advanced.charts.dawnOnset.tooltipOnset'),
+              value: onsetText(d.onsetRelMinutes as number),
+            },
+            {
+              label: t('analytics.advanced.charts.dawnOnset.tooltipCount'),
+              value: String(d.detectionCount),
+            },
+          ],
+          x: event.clientX,
+          y: event.clientY,
+        });
+      })
+      .on('mouseleave', function () {
+        select(this).style('opacity', DOT_IDLE_OPACITY);
+        tooltip?.hide();
+      });
+  }
+
+  $effect(() => {
+    if (chartContext) {
+      drawChart(chartContext);
+    }
+  });
+
+  onMount(() => {
+    if (chartContainer) {
+      tooltip = new ChartTooltip(chartContainer);
+    }
+  });
+
+  onDestroy(() => {
+    tooltip?.destroy();
+  });
+</script>
+
+<div class="dawn-onset-chart" bind:this={chartContainer}>
+  <BaseChart
+    {width}
+    {height}
+    margin={MARGIN}
+    responsive={true}
+    ariaLabel={ariaLabel ?? t('analytics.advanced.charts.dawnOnset.ariaLabel')}
+  >
+    {#snippet children(context)}
+      {((chartContext = context), '')}
+    {/snippet}
+  </BaseChart>
+  {#if summary}
+    <p class="sr-only" data-testid="dawn-onset-summary">{summary}</p>
+  {/if}
+</div>
+
+<style>
+  .dawn-onset-chart {
+    width: 100%;
+    height: 100%;
+    min-height: 320px;
+  }
+
+  :global(.onset-dots circle) {
+    transition: opacity 0.12s ease;
+  }
+</style>

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/DawnChorusOnset.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/DawnChorusOnset.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import DawnChorusOnset from './DawnChorusOnset.svelte';
+import type { DawnOnsetData, DawnOnsetPoint } from './utils/dawnOnset';
+
+// jsdom has no layout engine; assert on element counts/attributes only.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const sample: DawnOnsetData = {
+  points: [
+    { date: '2026-03-01', onsetRelMinutes: 20, detectionCount: 40 },
+    { date: '2026-03-02', onsetRelMinutes: null, detectionCount: 2 }, // gap day
+    { date: '2026-03-03', onsetRelMinutes: 5, detectionCount: 33 },
+    { date: '2026-03-04', onsetRelMinutes: -10, detectionCount: 50 },
+  ],
+};
+
+const empty: DawnOnsetData = { points: [] };
+
+const allGaps: DawnOnsetData = {
+  points: [{ date: '2026-03-01', onsetRelMinutes: null, detectionCount: 1 }],
+};
+
+// Two clusters of measurable days separated by a long null run, long enough that the centered
+// 7-day trend window goes empty in the middle (so the trend must break, not interpolate across).
+const gappy: DawnOnsetData = (() => {
+  const points: DawnOnsetPoint[] = [];
+  [10, 12, 8, 11].forEach((v, i) =>
+    points.push({ date: `2026-03-0${i + 1}`, onsetRelMinutes: v, detectionCount: 20 })
+  );
+  for (let day = 5; day <= 12; day++) {
+    points.push({
+      date: `2026-03-${String(day).padStart(2, '0')}`,
+      onsetRelMinutes: null,
+      detectionCount: 1,
+    });
+  }
+  [9, 7, 10, 12].forEach((v, i) =>
+    points.push({ date: `2026-03-${13 + i}`, onsetRelMinutes: v, detectionCount: 20 })
+  );
+  return { points };
+})();
+
+describe('DawnChorusOnset', () => {
+  it('renders without throwing for empty data', () => {
+    expect(() => render(DawnChorusOnset, { props: { data: empty } })).not.toThrow();
+  });
+
+  it('renders without throwing when every day is a gap', () => {
+    expect(() => render(DawnChorusOnset, { props: { data: allGaps } })).not.toThrow();
+  });
+
+  it('draws one dot per day with a measurable onset (nulls are gaps)', async () => {
+    const { container } = render(DawnChorusOnset, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    // 3 non-null points -> 3 dots; the null day is skipped.
+    expect(container.querySelectorAll('.onset-dots circle')).toHaveLength(3);
+  });
+
+  it('breaks the trend line over a sustained gap instead of interpolating across it', async () => {
+    const { container } = render(DawnChorusOnset, { props: { data: gappy, width: 800 } });
+    await Promise.resolve();
+    const path = container.querySelector('.onset-trend');
+    expect(path).toBeTruthy();
+    // A segmented path starts each run with a move-to ('M'); interpolation across the gap would
+    // yield a single continuous run with exactly one 'M'.
+    const moveCommands = (path?.getAttribute('d')?.match(/M/g) ?? []).length;
+    expect(moveCommands).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders the axes, the civil-dawn reference line, and a trend line', async () => {
+    const { container } = render(DawnChorusOnset, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelector('.x-axis')).toBeTruthy();
+    expect(container.querySelector('.y-axis')).toBeTruthy();
+    expect(container.querySelector('.civil-dawn-line')).toBeTruthy();
+    expect(container.querySelector('.onset-trend')).toBeTruthy();
+  });
+
+  it('sets an accessible label on the chart container', () => {
+    const { container } = render(DawnChorusOnset, {
+      props: { data: sample, ariaLabel: 'Dawn onset' },
+    });
+    expect(container.querySelector('[aria-label="Dawn onset"]')).toBeTruthy();
+  });
+
+  it('renders a screen-reader summary when there is data', async () => {
+    const { getByTestId } = render(DawnChorusOnset, { props: { data: sample } });
+    await Promise.resolve();
+    expect(getByTestId('dawn-onset-summary')).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesRidgeline.svelte
@@ -25,7 +25,12 @@
   import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
   import { ChartTooltip } from './utils/interactions';
   import { generateSpeciesColors, type ChartTheme } from './utils/theme';
-  import { ridgelineLayout, peakIndex, RIDGE_OVERLAP, type RidgelineSeries } from './utils/ridgeline';
+  import {
+    ridgelineLayout,
+    peakIndex,
+    RIDGE_OVERLAP,
+    type RidgelineSeries,
+  } from './utils/ridgeline';
 
   interface Props {
     /** One row per species: { scientificName, commonName, density[], total? }. */

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/dawnOnset.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/dawnOnset.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+import { movingAverageTrend, onsetCount, type DawnOnsetPoint } from '../dawnOnset';
+
+function pt(date: string, onsetRelMinutes: number | null, detectionCount = 10): DawnOnsetPoint {
+  return { date, onsetRelMinutes, detectionCount };
+}
+
+describe('onsetCount', () => {
+  it('counts only the days with a non-null onset', () => {
+    expect(onsetCount({ points: [pt('a', 1), pt('b', null), pt('c', 3)] })).toBe(2);
+  });
+
+  it('is zero for empty and all-gap data', () => {
+    expect(onsetCount({ points: [] })).toBe(0);
+    expect(onsetCount({ points: [pt('a', null), pt('b', null)] })).toBe(0);
+  });
+});
+
+describe('movingAverageTrend', () => {
+  it('averages the non-null values in a centered window', () => {
+    const points = [pt('1', 10), pt('2', 20), pt('3', 30)];
+    // window 3 (half 1): i0 -> [10,20]=15, i1 -> [10,20,30]=20, i2 -> [20,30]=25.
+    expect(movingAverageTrend(points, 3, 1)).toEqual([15, 20, 25]);
+  });
+
+  it('skips nulls inside the window but averages the values that are present', () => {
+    const points = [pt('1', 10), pt('2', null), pt('3', 30)];
+    // i1 window is [10, null, 30] -> (10 + 30) / 2 = 20.
+    expect(movingAverageTrend(points, 3, 1)[1]).toBe(20);
+  });
+
+  it('returns null where fewer than minSamples non-null values fall in the window', () => {
+    const points = [pt('1', 10), pt('2', null), pt('3', null), pt('4', null), pt('5', 50)];
+    const trend = movingAverageTrend(points, 3, 2);
+    expect(trend[2]).toBeNull(); // window [null,null,null]
+    expect(trend[0]).toBeNull(); // window [10,null] -> only 1 sample
+  });
+
+  it('returns a result aligned 1:1 with the input', () => {
+    expect(movingAverageTrend([pt('1', 10), pt('2', 20)], 7, 1)).toHaveLength(2);
+  });
+
+  it('returns all-null for an all-null series', () => {
+    expect(movingAverageTrend([pt('1', null), pt('2', null)], 3, 1)).toEqual([null, null]);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/dawnOnset.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/dawnOnset.ts
@@ -1,0 +1,50 @@
+// Dawn-chorus onset chart data + pure helpers.
+//
+// The backend (GET /api/v2/analytics/time/dawn-onset) returns one entry per calendar day in the
+// requested range. `onsetRelMinutes` is the day's chorus onset relative to civil dawn (negative =
+// before civil dawn) or null when the day had too few detections or no civil dawn (polar day /
+// night). Emitting every day - including nulls - gives the chart a continuous date axis so its
+// trend line can break over gaps instead of interpolating a misleading line across them.
+
+export interface DawnOnsetPoint {
+  /** Station-local calendar day, YYYY-MM-DD. */
+  date: string;
+  /** Onset minute-of-day minus civil dawn's minute-of-day; null on gap days. */
+  onsetRelMinutes: number | null;
+  /** Day's detection count (false positives excluded), shown in the tooltip. */
+  detectionCount: number;
+}
+
+export interface DawnOnsetData {
+  points: DawnOnsetPoint[];
+}
+
+/** Count of plotted (non-null) onset points; drives the registry's not-enough-data check. */
+export function onsetCount(data: DawnOnsetData): number {
+  return data.points.reduce((n, p) => (p.onsetRelMinutes === null ? n : n + 1), 0);
+}
+
+/**
+ * Centered moving average of `onsetRelMinutes` over a window of `windowDays` consecutive daily
+ * points (the backend emits one point per day). Each window uses only its non-null values; the
+ * result is null when fewer than `minSamples` non-null values fall in the window, so the rendered
+ * trend line breaks over sustained gaps rather than interpolating across them. The returned array
+ * is aligned 1:1 with `points`.
+ */
+export function movingAverageTrend(
+  points: DawnOnsetPoint[],
+  windowDays: number,
+  minSamples: number
+): (number | null)[] {
+  const half = Math.floor(windowDays / 2);
+  return points.map((_, i) => {
+    const lo = Math.max(0, i - half);
+    const hi = Math.min(points.length, i + half + 1);
+    const values = points
+      .slice(lo, hi)
+      .map(p => p.onsetRelMinutes)
+      .filter((v): v is number => v !== null);
+    if (values.length < minSamples) return null;
+    return values.reduce((sum, v) => sum + v, 0) / values.length;
+  });
+}

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -18,6 +18,9 @@ import SpeciesDiversityChart from '../components/charts/d3/SpeciesDiversityChart
 import SeasonalHeatmap from '../components/charts/d3/SeasonalHeatmap.svelte';
 import type { HeatmapData } from '../components/charts/d3/utils/heatmap';
 import SpeciesRidgeline from '../components/charts/d3/SpeciesRidgeline.svelte';
+import DawnChorusOnset from '../components/charts/d3/DawnChorusOnset.svelte';
+import { onsetCount } from '../components/charts/d3/utils/dawnOnset';
+import type { DawnOnsetData, DawnOnsetPoint } from '../components/charts/d3/utils/dawnOnset';
 import TrendChartOptions from '../components/TrendChartOptions.svelte';
 
 import { formatDateForAPI } from './analyticsParams';
@@ -330,6 +333,60 @@ async function fetchSpeciesDistribution(
     .filter((d): d is SpeciesDistributionDatum => d !== null);
 }
 
+interface DawnOnsetResponseItem {
+  date?: unknown;
+  onsetRelMinutes?: unknown;
+  detectionCount?: unknown;
+}
+
+/**
+ * Dawn-chorus onset: per-day chorus onset relative to civil dawn. The server emits one entry per
+ * calendar day in the range (negative = before civil dawn; null on days with too few detections or
+ * no civil dawn). Honors an optional single-species filter (the control bar's first selection).
+ * Defensively coerces the array, preserving nulls so the chart's trend line can break over gaps.
+ */
+async function fetchDawnOnset(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<DawnOnsetData> {
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+  });
+  // The endpoint filters by a single species; use the first selected (none = all species).
+  if (params.species.length > 0) search.append('species', params.species[0]);
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/time/dawn-onset?${search}`), {
+    signal,
+  });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid dawn onset response: expected an array');
+  }
+
+  const points: DawnOnsetPoint[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== 'object') continue;
+    const item = raw as DawnOnsetResponseItem;
+    if (typeof item.date !== 'string') continue;
+    // Keep null distinct from 0: a gap day must stay null so the trend line breaks rather than
+    // dipping to civil dawn.
+    const onsetRelMinutes =
+      typeof item.onsetRelMinutes === 'number' && Number.isFinite(item.onsetRelMinutes)
+        ? item.onsetRelMinutes
+        : null;
+    const detectionCount =
+      typeof item.detectionCount === 'number' && Number.isFinite(item.detectionCount)
+        ? item.detectionCount
+        : 0;
+    points.push({ date: item.date, onsetRelMinutes, detectionCount });
+  }
+
+  return { points };
+}
+
 // --- Registry --------------------------------------------------------------
 
 export const CHART_REGISTRY: ChartDef[] = [
@@ -375,6 +432,23 @@ export const CHART_REGISTRY: ChartDef[] = [
     // A ridgeline needs at least a couple of species to read as one; one lonely ridge is not useful.
     minDataPoints: 2,
     maxSpecies: SPECIES_RIDGELINE_LIMIT,
+  },
+  {
+    id: 'dawn-chorus-onset',
+    group: 'patterns',
+    titleKey: 'analytics.advanced.charts.dawnOnset.title',
+    descKey: 'analytics.advanced.charts.dawnOnset.description',
+    emptyKey: 'analytics.advanced.charts.dawnOnset.noData',
+    emptyHintKey: 'analytics.advanced.charts.dawnOnset.noDataHint',
+    component: DawnChorusOnset,
+    fetch: fetchDawnOnset,
+    // The fetch result is an object with a points array (one per day, including nulls); count only
+    // the days that have a measurable onset rather than the raw array length.
+    countDataPoints: data => onsetCount(data as DawnOnsetData),
+    size: 'full',
+    supports: { species: true, source: false },
+    // A handful of days with onsets is the minimum before the scatter + trend read as anything.
+    minDataPoints: 3,
   },
   {
     id: 'time-of-day-species',

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1443,6 +1443,20 @@ export type TranslationKey =
   | 'analytics.advanced.charts.ridgeline.tooltipDetections'
   | 'analytics.advanced.charts.ridgeline.tooltipPeak'
   | 'analytics.advanced.charts.ridgeline.summary' // params: count, species, time
+  | 'analytics.advanced.charts.dawnOnset.title'
+  | 'analytics.advanced.charts.dawnOnset.description'
+  | 'analytics.advanced.charts.dawnOnset.noData'
+  | 'analytics.advanced.charts.dawnOnset.noDataHint'
+  | 'analytics.advanced.charts.dawnOnset.ariaLabel'
+  | 'analytics.advanced.charts.dawnOnset.axisDate'
+  | 'analytics.advanced.charts.dawnOnset.axisOnset'
+  | 'analytics.advanced.charts.dawnOnset.civilDawn'
+  | 'analytics.advanced.charts.dawnOnset.tooltipOnset'
+  | 'analytics.advanced.charts.dawnOnset.tooltipOnsetAfter' // params: minutes
+  | 'analytics.advanced.charts.dawnOnset.tooltipOnsetBefore' // params: minutes
+  | 'analytics.advanced.charts.dawnOnset.tooltipOnsetAt'
+  | 'analytics.advanced.charts.dawnOnset.tooltipCount'
+  | 'analytics.advanced.charts.dawnOnset.summary' // params: days, plotted
   | 'analytics.advanced.charts.tooltips.date'
   | 'analytics.advanced.charts.tooltips.percentage'
   | 'analytics.advanced.charts.tooltips.detections'
@@ -3959,6 +3973,12 @@ export type TranslationParams = {
     count: string | number;
     species: string | number;
     time: string | number;
+  };
+  'analytics.advanced.charts.dawnOnset.tooltipOnsetAfter': { minutes: string | number };
+  'analytics.advanced.charts.dawnOnset.tooltipOnsetBefore': { minutes: string | number };
+  'analytics.advanced.charts.dawnOnset.summary': {
+    days: string | number;
+    plotted: string | number;
   };
   'settings.notFound.message': { section: string | number };
   'settings.main.sections.falsePositiveFilter.detectionCount': {

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Procento",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Procentdel",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Prozentsatz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Percentage",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Fecha",
           "percentage": "Porcentaje",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Päivämäärä",
           "percentage": "Prosenttiosuus",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Pourcentage",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Százalék",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentuale",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Datums",
           "percentage": "Procenti",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Prosentandel",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Percentage",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Procent",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentagem",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Percentá",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1857,6 +1857,22 @@
           "tooltipPeak": "Peak",
           "summary": "Hour-of-day activity for {count} species. Most active: {species} around {time}."
         },
+        "dawnOnset": {
+          "title": "Dawn Chorus Onset",
+          "description": "When the morning chorus starts each day relative to civil dawn, isolating the seasonal shift from clock time",
+          "noData": "No dawn chorus data available",
+          "noDataHint": "Select a wider date range to track how the dawn chorus shifts across the seasons",
+          "ariaLabel": "Dawn chorus onset tracker: daily chorus onset relative to civil dawn",
+          "axisDate": "Date",
+          "axisOnset": "Minutes from civil dawn",
+          "civilDawn": "Civil dawn",
+          "tooltipOnset": "Onset",
+          "tooltipOnsetAfter": "{minutes} min after civil dawn",
+          "tooltipOnsetBefore": "{minutes} min before civil dawn",
+          "tooltipOnsetAt": "At civil dawn",
+          "tooltipCount": "Detections",
+          "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Andel",

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -297,6 +297,9 @@ func (m *ActionMockDatastore) GetActivityHeatmap(_ context.Context, _, _, _ stri
 func (m *ActionMockDatastore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
 	return []datastore.SpeciesHourlyDistribution{}, nil
 }
+func (m *ActionMockDatastore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]datastore.DailyActivityOnset, error) {
+	return []datastore.DailyActivityOnset{}, nil
+}
 func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -166,6 +166,9 @@ func (m *MockDatastore) GetActivityHeatmap(context.Context, string, string, stri
 func (m *MockDatastore) GetHourlyDistributionBySpecies(context.Context, string, string, int) ([]datastore.SpeciesHourlyDistribution, error) {
 	return []datastore.SpeciesHourlyDistribution{}, nil
 }
+func (m *MockDatastore) GetDailyActivityOnset(context.Context, string, string, string) ([]datastore.DailyActivityOnset, error) {
+	return []datastore.DailyActivityOnset{}, nil
+}
 func (m *MockDatastore) SearchDetections(*datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return make([]datastore.DetectionRecord, 0), 0, nil
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -93,6 +93,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/time/distribution/hourly` | `GetTimeOfDayDistribution` | ❌   | Time-of-day detection distribution |
 | GET    | `/analytics/time/distribution/species` | `GetSpeciesHourlyDistribution` | ❌ | Who-sings-when ridgeline: per-species hour-of-day distribution for the top N species by volume. `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `limit` optional (default 5, max 8) |
 | GET    | `/analytics/time/heatmap`             | `GetActivityHeatmap`       | ❌   | Seasonal density heatmap (date x intra-day slot; `?format=csv`) |
+| GET    | `/analytics/time/dawn-onset`          | `GetDawnChorusOnset`       | ❌   | Dawn-chorus onset tracker: per-day onset relative to civil dawn (minutes; negative = before civil dawn). `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `species` optional |
 
 ### Control Operations (`control.go`)
 

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -191,6 +191,7 @@ func (c *Controller) initAnalyticsRoutes() {
 	timeGroup.GET("/distribution/hourly", c.GetTimeOfDayDistribution)      // Renamed endpoint for time-of-day distribution
 	timeGroup.GET("/distribution/species", c.GetSpeciesHourlyDistribution) // Who-sings-when ridgeline (top-N species hour-of-day)
 	timeGroup.GET("/heatmap", c.GetActivityHeatmap)                        // Seasonal density heatmap (date x intra-day slot)
+	timeGroup.GET("/dawn-onset", c.GetDawnChorusOnset)                     // Dawn-chorus onset tracker (daily onset vs civil dawn)
 }
 
 // GetDailySpeciesSummary handles GET /api/v2/analytics/species/daily
@@ -1275,6 +1276,108 @@ func newSpeciesHourlyDistributionResponse(data []datastore.SpeciesHourlyDistribu
 		})
 	}
 	return items
+}
+
+// dawnChorusOnsetItem is one calendar day's row in the dawn-chorus onset wire payload (design spec
+// section 6.3). OnsetRelMinutes is the onset minute-of-day minus civil dawn's minute-of-day
+// (negative = before civil dawn); it is null when the day had too few detections or civil dawn is
+// undefined for the date, which the client renders as a gap (its trend line breaks over nulls
+// rather than interpolating across them). DetectionCount is the day's detection count, shown in the
+// tooltip.
+type dawnChorusOnsetItem struct {
+	Date            string `json:"date"`
+	OnsetRelMinutes *int   `json:"onsetRelMinutes"`
+	DetectionCount  int    `json:"detectionCount"`
+}
+
+// newDawnChorusOnsetResponse maps the datastore aggregation onto the wire payload as a JSON array
+// (never null), preserving the ascending-date order.
+func newDawnChorusOnsetResponse(data []datastore.DailyActivityOnset) []dawnChorusOnsetItem {
+	items := make([]dawnChorusOnsetItem, 0, len(data))
+	for i := range data {
+		items = append(items, dawnChorusOnsetItem{
+			Date:            data[i].Date,
+			OnsetRelMinutes: data[i].OnsetRelMinutes,
+			DetectionCount:  data[i].DetectionCount,
+		})
+	}
+	return items
+}
+
+// GetDawnChorusOnset handles GET /api/v2/analytics/time/dawn-onset
+// Returns, per calendar day in the range, the dawn-chorus onset relative to civil dawn (in minutes;
+// negative = before civil dawn), powering the dawn-chorus onset tracker (design spec section 6.3).
+func (c *Controller) GetDawnChorusOnset(ctx echo.Context) error {
+	const operation = "dawn chorus onset"
+
+	// Validate required parameter
+	if err := c.requireQueryParam(ctx, "start_date", operation); err != nil {
+		return err
+	}
+
+	startDate := ctx.QueryParam("start_date")
+	endDate := ctx.QueryParam("end_date")
+	speciesParam := ctx.QueryParam("species")
+
+	// Validate date formats strictly using regex
+	if err := c.validateDateFormatStrictWithResponse(ctx, startDate, "start_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, endDate, "end_date", operation); err != nil {
+		return err
+	}
+
+	// Validate date values and chronological order
+	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
+		return err
+	}
+
+	// Default the end date to a 30-day window when omitted, matching the other range endpoints.
+	if endDate == "" {
+		startTime, _ := time.Parse(time.DateOnly, startDate) // Regex ensures this parse succeeds
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
+	}
+
+	// Resolve a localized common name to its scientific name so this endpoint matches the
+	// detections/search path and the sibling time endpoints; a scientific name or unresolved
+	// term passes through. Only the datastore query uses the resolved value.
+	querySpecies := speciesParam
+	if resolved, hit := c.resolveSpeciesToScientific(speciesParam); hit {
+		querySpecies = resolved
+	}
+
+	c.logInfoIfEnabled("Retrieving dawn chorus onset",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.String("species", speciesParam),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	// Add timeout to prevent resource exhaustion
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
+	data, err := c.DS.GetDailyActivityOnset(ctxWithTimeout, startDate, endDate, querySpecies)
+	if err != nil {
+		return c.handleAnalyticsQueryError(ctx, err, "Dawn chorus onset", "Failed to get dawn chorus onset",
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("species", speciesParam),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("path", ctx.Request().URL.Path),
+		)
+	}
+
+	c.logInfoIfEnabled("Dawn chorus onset retrieved",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.Int("day_count", len(data)),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	return ctx.JSON(http.StatusOK, newDawnChorusOnsetResponse(data))
 }
 
 // GetSpeciesHourlyDistribution handles GET /api/v2/analytics/time/distribution/species

--- a/internal/api/v2/analytics_dawn_onset_test.go
+++ b/internal/api/v2/analytics_dawn_onset_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// dawnOnsetJSON mirrors the dawn-chorus onset wire shape. OnsetRelMinutes is a pointer so a null
+// day (too few detections / no civil dawn) round-trips as JSON null rather than 0.
+type dawnOnsetJSON struct {
+	Date            string `json:"date"`
+	OnsetRelMinutes *int   `json:"onsetRelMinutes"`
+	DetectionCount  int    `json:"detectionCount"`
+}
+
+func sampleDawnOnset() []datastore.DailyActivityOnset {
+	return []datastore.DailyActivityOnset{
+		{Date: "2026-03-01", OnsetRelMinutes: new(20), DetectionCount: 42},
+		// A day below the min-count / with no civil dawn: nil onset, rendered as a gap by the client.
+		{Date: "2026-03-02", OnsetRelMinutes: nil, DetectionCount: 3},
+	}
+}
+
+func newDawnOnsetContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/time/dawn-onset")
+	return c, rec
+}
+
+func TestGetDawnChorusOnset_Shape(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetDailyActivityOnset", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return(sampleDawnOnset(), nil)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetDawnChorusOnset(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []dawnOnsetJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 2)
+
+	assert.Equal(t, "2026-03-01", resp[0].Date)
+	require.NotNil(t, resp[0].OnsetRelMinutes)
+	assert.Equal(t, 20, *resp[0].OnsetRelMinutes)
+	assert.Equal(t, 42, resp[0].DetectionCount)
+
+	assert.Equal(t, "2026-03-02", resp[1].Date)
+	assert.Nil(t, resp[1].OnsetRelMinutes)
+	assert.Equal(t, 3, resp[1].DetectionCount)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetDawnChorusOnset_NullOnsetSerialisesAsNull(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetDailyActivityOnset", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return(sampleDawnOnset(), nil)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetDawnChorusOnset(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// A gap day must serialise as null (not 0 or omitted) so the client breaks its trend line there.
+	assert.Contains(t, rec.Body.String(), `"onsetRelMinutes":null`)
+}
+
+func TestGetDawnChorusOnset_EmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetDailyActivityOnset", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return([]datastore.DailyActivityOnset{}, nil)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetDawnChorusOnset(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestGetDawnChorusOnset_DefaultsEndDate(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// With end_date omitted, the handler defaults it to a 30-day window: 2026-03-01 + 30d = 2026-03-31.
+	mockDS.On("GetDailyActivityOnset", mock.Anything, "2026-03-01", "2026-03-31", "").
+		Return(sampleDawnOnset(), nil)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset?start_date=2026-03-01")
+	require.NoError(t, controller.GetDawnChorusOnset(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetDawnChorusOnset_MissingStartDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset")
+	err := controller.GetDawnChorusOnset(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetDawnChorusOnset_InvalidDateFormat(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset?start_date=not-a-date")
+	err := controller.GetDawnChorusOnset(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetDawnChorusOnset_QueryTimeout(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetDailyActivityOnset", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return([]datastore.DailyActivityOnset{}, context.DeadlineExceeded)
+
+	c, rec := newDawnOnsetContext(e, "/api/v2/analytics/time/dawn-onset?start_date=2026-03-01&end_date=2026-03-02")
+	// handleAnalyticsQueryError writes the 408 response and returns nil.
+	require.NoError(t, controller.GetDawnChorusOnset(c))
+	assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+	mockDS.AssertExpectations(t)
+}

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -81,6 +81,23 @@ type SpeciesHourlyDistribution struct {
 	Total          int
 }
 
+// DailyActivityOnset is one calendar day's dawn-chorus onset relative to civil dawn, behind the
+// dawn-chorus onset tracker (design spec section 6.3).
+//
+// Date is the station-local calendar day (YYYY-MM-DD). OnsetRelMinutes is the onset minute-of-day
+// (the time by which the morning chorus has clearly begun) minus civil dawn's minute-of-day, so a
+// negative value means the chorus started before civil dawn. It is nil when the day had too few
+// detections to be meaningful, or when civil dawn is undefined for the date (polar day / white
+// nights / polar night). DetectionCount is the day's false-positive-excluded detection count,
+// surfaced in the tooltip. The aggregation emits one entry per calendar day in the requested range
+// (DetectionCount is 0 on quiet days) so the chart has a continuous date axis and its trend line
+// breaks over gaps rather than interpolating across them.
+type DailyActivityOnset struct {
+	Date            string
+	OnsetRelMinutes *int
+	DetectionCount  int
+}
+
 // NewSpeciesData represents a species detected for the first time within a period
 type NewSpeciesData struct {
 	ScientificName string `json:"scientific_name"`
@@ -438,6 +455,13 @@ func (ds *DataStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (Acti
 // real method.
 func (ds *DataStore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]SpeciesHourlyDistribution, error) {
 	return []SpeciesHourlyDistribution{}, nil
+}
+
+// GetDailyActivityOnset is a stub on the legacy store. The dawn-chorus onset tracker is a v2only
+// feature; the legacy datastore is deprecated and being removed, so it returns an empty (non-nil)
+// slice rather than implementing the aggregation. See internal/datastore/v2only for the real method.
+func (ds *DataStore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]DailyActivityOnset, error) {
+	return []DailyActivityOnset{}, nil
 }
 
 // GetDetectionTrends calculates the trend in detections over time

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -199,6 +199,10 @@ type Interface interface {
 	// the top `limit` species by detection volume over the inclusive date range (false positives
 	// excluded), ordered by descending volume. Powers the who-sings-when ridgeline.
 	GetHourlyDistributionBySpecies(ctx context.Context, startDate, endDate string, limit int) ([]SpeciesHourlyDistribution, error)
+	// GetDailyActivityOnset returns, per calendar day in the inclusive date range, the dawn-chorus
+	// onset relative to civil dawn (false positives excluded). species is an optional scientific-name
+	// filter. Powers the dawn-chorus onset tracker.
+	GetDailyActivityOnset(ctx context.Context, startDate, endDate, species string) ([]DailyActivityOnset, error)
 	// Search functionality
 	SearchDetections(filters *SearchFilters) ([]DetectionRecord, int, error)
 	// Dynamic Threshold methods

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -1844,6 +1844,67 @@ func (_c *MockInterface_GetCommentsBatch_Call) RunAndReturn(run func(uint, int) 
 	return _c
 }
 
+// GetDailyActivityOnset provides a mock function with given fields: ctx, startDate, endDate, species
+func (_m *MockInterface) GetDailyActivityOnset(ctx context.Context, startDate string, endDate string, species string) ([]datastore.DailyActivityOnset, error) {
+	ret := _m.Called(ctx, startDate, endDate, species)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDailyActivityOnset")
+	}
+
+	var r0 []datastore.DailyActivityOnset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]datastore.DailyActivityOnset, error)); ok {
+		return rf(ctx, startDate, endDate, species)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []datastore.DailyActivityOnset); ok {
+		r0 = rf(ctx, startDate, endDate, species)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.DailyActivityOnset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, startDate, endDate, species)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetDailyActivityOnset_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDailyActivityOnset'
+type MockInterface_GetDailyActivityOnset_Call struct {
+	*mock.Call
+}
+
+// GetDailyActivityOnset is a helper method to define mock.On call
+//   - ctx context.Context
+//   - startDate string
+//   - endDate string
+//   - species string
+func (_e *MockInterface_Expecter) GetDailyActivityOnset(ctx interface{}, startDate interface{}, endDate interface{}, species interface{}) *MockInterface_GetDailyActivityOnset_Call {
+	return &MockInterface_GetDailyActivityOnset_Call{Call: _e.mock.On("GetDailyActivityOnset", ctx, startDate, endDate, species)}
+}
+
+func (_c *MockInterface_GetDailyActivityOnset_Call) Run(run func(ctx context.Context, startDate string, endDate string, species string)) *MockInterface_GetDailyActivityOnset_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetDailyActivityOnset_Call) Return(_a0 []datastore.DailyActivityOnset, _a1 error) *MockInterface_GetDailyActivityOnset_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetDailyActivityOnset_Call) RunAndReturn(run func(context.Context, string, string, string) ([]datastore.DailyActivityOnset, error)) *MockInterface_GetDailyActivityOnset_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDailyAnalyticsData provides a mock function with given fields: ctx, startDate, endDate, species
 func (_m *MockInterface) GetDailyAnalyticsData(ctx context.Context, startDate string, endDate string, species string) ([]datastore.DailyAnalyticsData, error) {
 	ret := _m.Called(ctx, startDate, endDate, species)

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -763,6 +763,9 @@ func (s *testLegacyInterface) GetActivityHeatmap(_ context.Context, _, _, _ stri
 func (s *testLegacyInterface) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
 	return []datastore.SpeciesHourlyDistribution{}, nil
 }
+func (s *testLegacyInterface) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]datastore.DailyActivityOnset, error) {
+	return []datastore.DailyActivityOnset{}, nil
+}
 func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/datastore/v2only/aggregate.go
+++ b/internal/datastore/v2only/aggregate.go
@@ -193,3 +193,90 @@ func buildActivityHeatmap(timestamps []int64, loc *time.Location, startDate, end
 	}
 	return result, nil
 }
+
+// Dawn-chorus onset constants (design spec section 6.3).
+//
+// The onset for a day is the minute-of-day of the onsetDetectionRank-th earliest detection. An
+// absolute rank is used deliberately instead of a daily percentile: a percentile of the day's total
+// volume couples the morning onset to unrelated later-in-day activity (a busy afternoon pushes a low
+// percentile index later and fakes a later dawn), and at realistic daily counts a low percentile
+// collapses to the very first detection, giving no false-positive robustness. The Nth-earliest
+// detection is immune to later-in-day volume (adding detections after it never moves it) and rejects
+// up to (rank-1) lone pre-dawn false positives, which is the robustness the spec actually wanted.
+const (
+	onsetDetectionRank = 3 // onset = the 3rd earliest detection of the day (rejects up to 2 stray pre-dawn false positives)
+	minOnsetDetections = 5 // days with fewer detections are too sparse to read a meaningful onset (must be >= onsetDetectionRank)
+)
+
+// civilDawnMinuteLookup returns civil dawn's station-local minute-of-day (0..1439) for the given
+// calendar date and whether civil dawn is defined for it. ok is false when civil dawn cannot be
+// determined (polar day / white nights / polar night, or no sun calculator configured). It is
+// injected into buildDailyActivityOnset so the polar-null and min-count paths are unit-testable
+// without a real SunCalc.
+type civilDawnMinuteLookup func(date time.Time) (minuteOfDay int, ok bool)
+
+// buildDailyActivityOnset buckets false-positive-excluded detection timestamps (Unix epoch seconds)
+// by station-local calendar date and computes, for each date in the inclusive [startDate, endDate]
+// range, the dawn-chorus onset relative to civil dawn.
+//
+// The onset for a day is the minute-of-day of the rank-th earliest detection (see the
+// onsetDetectionRank rationale). OnsetRelMinutes is that onset minus civil dawn's minute-of-day
+// (negative = before civil dawn). It is left nil when the day has fewer than minDetections
+// detections (too sparse) or when dawn reports civil dawn undefined for the date (polar day /
+// night). Every date in the range is emitted with its DetectionCount (0 on quiet days) so the
+// client has a continuous date axis and its trend line breaks over gaps rather than interpolating
+// across them. startDate/endDate are inclusive YYYY-MM-DD bounds interpreted in loc (nil -> UTC);
+// civil dawn is resolved in the same loc frame as the bucketed detections so the subtraction is a
+// true duration. The result is always non-nil.
+func buildDailyActivityOnset(timestamps []int64, loc *time.Location, startDate, endDate string, rank, minDetections int, dawn civilDawnMinuteLookup) ([]datastore.DailyActivityOnset, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	start, err := time.ParseInLocation(time.DateOnly, startDate, loc)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "build_daily_activity_onset").
+			Context("start_date", startDate).
+			Build()
+	}
+	end, err := time.ParseInLocation(time.DateOnly, endDate, loc)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "build_daily_activity_onset").
+			Context("end_date", endDate).
+			Build()
+	}
+
+	// Group each detection's station-local minute-of-day by its local calendar date. Detections
+	// whose local date falls outside the enumerated range simply never get looked up.
+	minutesByDate := make(map[dateKey][]int)
+	for _, ts := range timestamps {
+		lt := time.Unix(ts, 0).In(loc)
+		y, m, day := lt.Date()
+		k := dateKey{year: y, month: m, day: day}
+		minutesByDate[k] = append(minutesByDate[k], lt.Hour()*60+lt.Minute())
+	}
+
+	result := make([]datastore.DailyActivityOnset, 0)
+	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+		y, m, day := d.Date()
+		mins := minutesByDate[dateKey{year: y, month: m, day: day}]
+		item := datastore.DailyActivityOnset{Date: d.Format(time.DateOnly), DetectionCount: len(mins)}
+
+		if rank >= 1 && len(mins) >= minDetections && len(mins) >= rank {
+			slices.Sort(mins)
+			onsetMinute := mins[rank-1]
+			if dawnMinute, ok := dawn(d); ok {
+				rel := onsetMinute - dawnMinute
+				item.OnsetRelMinutes = &rel
+			}
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}

--- a/internal/datastore/v2only/aggregate_test.go
+++ b/internal/datastore/v2only/aggregate_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 )
 
@@ -283,5 +284,194 @@ func TestBuildActivityHeatmap_InvalidDates(t *testing.T) {
 	t.Parallel()
 
 	_, err := buildActivityHeatmap(nil, time.UTC, "not-a-date", "2026-03-03")
+	require.Error(t, err)
+}
+
+// --- Dawn-chorus onset (buildDailyActivityOnset) ---------------------------
+
+// dawnAt returns a civilDawnMinuteLookup that yields a constant civil dawn minute for every date.
+func dawnAt(minute int) civilDawnMinuteLookup {
+	return func(time.Time) (int, bool) { return minute, true }
+}
+
+// noCivilDawn is a civilDawnMinuteLookup that reports civil dawn undefined for every date (polar).
+func noCivilDawn(time.Time) (int, bool) { return 0, false }
+
+// onsetByDate maps the returned days by date string for clear, order-independent assertions.
+func onsetByDate(days []datastore.DailyActivityOnset) map[string]datastore.DailyActivityOnset {
+	m := make(map[string]datastore.DailyActivityOnset, len(days))
+	for _, d := range days {
+		m[d.Date] = d
+	}
+	return m
+}
+
+func TestBuildDailyActivityOnset_RankOnsetRelativeToCivilDawn(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	// Five detections at 05:00..05:40 (minutes 300..340). With rank 3 the onset is the 3rd
+	// earliest = 05:20 (320). Civil dawn is fixed at 05:00 (300), so the relative onset is +20.
+	timestamps := []int64{
+		epochAt(utc, 2026, 3, 1, 5, 0),
+		epochAt(utc, 2026, 3, 1, 5, 10),
+		epochAt(utc, 2026, 3, 1, 5, 20),
+		epochAt(utc, 2026, 3, 1, 5, 30),
+		epochAt(utc, 2026, 3, 1, 5, 40),
+	}
+
+	days, err := buildDailyActivityOnset(timestamps, utc, "2026-03-01", "2026-03-01", onsetDetectionRank, minOnsetDetections, dawnAt(300))
+	require.NoError(t, err)
+	require.Len(t, days, 1)
+	assert.Equal(t, "2026-03-01", days[0].Date)
+	assert.Equal(t, 5, days[0].DetectionCount)
+	require.NotNil(t, days[0].OnsetRelMinutes)
+	assert.Equal(t, 20, *days[0].OnsetRelMinutes)
+}
+
+func TestBuildDailyActivityOnset_TooFewDetectionsNullButCounted(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	// Four detections is below the min of 5: the day is emitted with its count but a nil onset.
+	timestamps := []int64{
+		epochAt(utc, 2026, 3, 1, 5, 0),
+		epochAt(utc, 2026, 3, 1, 5, 10),
+		epochAt(utc, 2026, 3, 1, 5, 20),
+		epochAt(utc, 2026, 3, 1, 5, 30),
+	}
+
+	days, err := buildDailyActivityOnset(timestamps, utc, "2026-03-01", "2026-03-01", onsetDetectionRank, minOnsetDetections, dawnAt(300))
+	require.NoError(t, err)
+	require.Len(t, days, 1)
+	assert.Equal(t, 4, days[0].DetectionCount)
+	assert.Nil(t, days[0].OnsetRelMinutes, "below min-count days keep their count but have no onset")
+}
+
+func TestBuildDailyActivityOnset_PolarDayNull(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	timestamps := []int64{
+		epochAt(utc, 2026, 6, 21, 2, 0),
+		epochAt(utc, 2026, 6, 21, 2, 10),
+		epochAt(utc, 2026, 6, 21, 2, 20),
+		epochAt(utc, 2026, 6, 21, 2, 30),
+		epochAt(utc, 2026, 6, 21, 2, 40),
+	}
+
+	// Civil dawn undefined (polar day): plenty of detections, but the onset is still nil.
+	days, err := buildDailyActivityOnset(timestamps, utc, "2026-06-21", "2026-06-21", onsetDetectionRank, minOnsetDetections, noCivilDawn)
+	require.NoError(t, err)
+	require.Len(t, days, 1)
+	assert.Equal(t, 5, days[0].DetectionCount)
+	assert.Nil(t, days[0].OnsetRelMinutes)
+}
+
+func TestBuildDailyActivityOnset_ImmuneToLaterInDayVolume(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	// Both days share the same five morning detections; day 2 adds a large afternoon burst.
+	// The rank-3 onset (the 3rd earliest detection) must be identical, proving the metric is not
+	// pulled later by unrelated afternoon volume the way a daily percentile would be.
+	timestamps := []int64{
+		// 2026-03-01: morning only.
+		epochAt(utc, 2026, 3, 1, 5, 0),
+		epochAt(utc, 2026, 3, 1, 5, 10),
+		epochAt(utc, 2026, 3, 1, 5, 20),
+		epochAt(utc, 2026, 3, 1, 5, 30),
+		epochAt(utc, 2026, 3, 1, 5, 40),
+		// 2026-03-02: same morning detections...
+		epochAt(utc, 2026, 3, 2, 5, 0),
+		epochAt(utc, 2026, 3, 2, 5, 10),
+		epochAt(utc, 2026, 3, 2, 5, 20),
+		epochAt(utc, 2026, 3, 2, 5, 30),
+		epochAt(utc, 2026, 3, 2, 5, 40),
+		// ...plus a big afternoon burst that must not move the onset.
+		epochAt(utc, 2026, 3, 2, 14, 0),
+		epochAt(utc, 2026, 3, 2, 14, 5),
+		epochAt(utc, 2026, 3, 2, 14, 10),
+		epochAt(utc, 2026, 3, 2, 14, 15),
+		epochAt(utc, 2026, 3, 2, 14, 20),
+		epochAt(utc, 2026, 3, 2, 14, 25),
+	}
+
+	days, err := buildDailyActivityOnset(timestamps, utc, "2026-03-01", "2026-03-02", onsetDetectionRank, minOnsetDetections, dawnAt(300))
+	require.NoError(t, err)
+	byDate := onsetByDate(days)
+
+	require.NotNil(t, byDate["2026-03-01"].OnsetRelMinutes)
+	require.NotNil(t, byDate["2026-03-02"].OnsetRelMinutes)
+	assert.Equal(t, 20, *byDate["2026-03-01"].OnsetRelMinutes)
+	assert.Equal(t, *byDate["2026-03-01"].OnsetRelMinutes, *byDate["2026-03-02"].OnsetRelMinutes,
+		"onset must not shift when later-in-day volume grows")
+	assert.Equal(t, 5, byDate["2026-03-01"].DetectionCount)
+	assert.Equal(t, 11, byDate["2026-03-02"].DetectionCount)
+}
+
+func TestBuildDailyActivityOnset_FullDateAxisWithGaps(t *testing.T) {
+	t.Parallel()
+
+	// No detections: every date in the inclusive range is still emitted (count 0, nil onset) so
+	// the client has a continuous date axis and its trend line can break over the gaps.
+	days, err := buildDailyActivityOnset(nil, time.UTC, "2026-03-01", "2026-03-03", onsetDetectionRank, minOnsetDetections, dawnAt(300))
+	require.NoError(t, err)
+	require.Len(t, days, 3)
+	assert.Equal(t, []string{"2026-03-01", "2026-03-02", "2026-03-03"},
+		[]string{days[0].Date, days[1].Date, days[2].Date})
+	for _, d := range days {
+		assert.Zero(t, d.DetectionCount)
+		assert.Nil(t, d.OnsetRelMinutes)
+	}
+}
+
+func TestBuildDailyActivityOnset_TimezoneBucketing(t *testing.T) {
+	t.Parallel()
+
+	// Fixed +02:00 zone: detections at 03:00..03:40 UTC are 05:00..05:40 local on 2026-03-01, so
+	// they bucket onto the local day and the onset is computed in local minutes (rank-3 = 05:20).
+	loc := time.FixedZone("EET", 2*60*60)
+	base := time.Date(2026, 3, 1, 3, 0, 0, 0, time.UTC)
+	timestamps := []int64{
+		base.Unix(),
+		base.Add(10 * time.Minute).Unix(),
+		base.Add(20 * time.Minute).Unix(),
+		base.Add(30 * time.Minute).Unix(),
+		base.Add(40 * time.Minute).Unix(),
+	}
+
+	days, err := buildDailyActivityOnset(timestamps, loc, "2026-03-01", "2026-03-01", onsetDetectionRank, minOnsetDetections, dawnAt(300))
+	require.NoError(t, err)
+	require.Len(t, days, 1)
+	assert.Equal(t, 5, days[0].DetectionCount)
+	require.NotNil(t, days[0].OnsetRelMinutes)
+	assert.Equal(t, 20, *days[0].OnsetRelMinutes) // local onset 05:20 minus civil dawn 05:00
+}
+
+func TestBuildDailyActivityOnset_OutOfRangeDetectionsIgnored(t *testing.T) {
+	t.Parallel()
+
+	utc := time.UTC
+	// Five detections on 2026-02-28, outside the requested [2026-03-01, 2026-03-01] range.
+	timestamps := []int64{
+		epochAt(utc, 2026, 2, 28, 5, 0),
+		epochAt(utc, 2026, 2, 28, 5, 10),
+		epochAt(utc, 2026, 2, 28, 5, 20),
+		epochAt(utc, 2026, 2, 28, 5, 30),
+		epochAt(utc, 2026, 2, 28, 5, 40),
+	}
+
+	days, err := buildDailyActivityOnset(timestamps, utc, "2026-03-01", "2026-03-01", onsetDetectionRank, minOnsetDetections, dawnAt(300))
+	require.NoError(t, err)
+	require.Len(t, days, 1)
+	assert.Zero(t, days[0].DetectionCount, "detections outside the range are not counted")
+	assert.Nil(t, days[0].OnsetRelMinutes)
+}
+
+func TestBuildDailyActivityOnset_InvalidDates(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildDailyActivityOnset(nil, time.UTC, "not-a-date", "2026-03-03", onsetDetectionRank, minOnsetDetections, dawnAt(300))
 	require.Error(t, err)
 }

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3063,6 +3063,66 @@ func (ds *Datastore) GetHourlyDistributionBySpecies(ctx context.Context, startDa
 	return buildSpeciesHourlyDistribution(top, hourlyByLabel), nil
 }
 
+// GetDailyActivityOnset returns the per-day dawn-chorus onset relative to civil dawn over the
+// inclusive [startDate, endDate] range. It fetches false-positive-excluded detection timestamps
+// once (GetDetectionTimestamps), then buckets and computes the per-day onset in a shared,
+// table-tested Go helper (buildDailyActivityOnset). Civil dawn comes from the configured SunCalc,
+// expressed in the station timezone so it shares the same minute-of-day frame as the bucketed
+// detections; a day with no civil dawn (polar day / night) or too few detections gets a nil onset
+// that the client renders as a gap. species is an optional scientific-name filter; an unknown
+// species yields all-null days that still carry the full date axis (matching the heatmap).
+func (ds *Datastore) GetDailyActivityOnset(ctx context.Context, startDate, endDate, species string) ([]datastore.DailyActivityOnset, error) {
+	start, end, err := ds.parseDateRange(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	dawn := ds.civilDawnMinuteLookup()
+
+	labelID, err := ds.resolveLabelID(ctx, species)
+	if err != nil {
+		if errors.Is(err, errNotFound) {
+			return buildDailyActivityOnset(nil, ds.timezone, startDate, endDate, onsetDetectionRank, minOnsetDetections, dawn)
+		}
+		return nil, err
+	}
+
+	timestamps, err := ds.detection.GetDetectionTimestamps(ctx, start, end, labelID)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_daily_activity_onset").
+			Build()
+	}
+
+	return buildDailyActivityOnset(timestamps, ds.timezone, startDate, endDate, onsetDetectionRank, minOnsetDetections, dawn)
+}
+
+// civilDawnMinuteLookup returns a civilDawnMinuteLookup closure over the datastore's SunCalc and
+// station timezone. The closure yields civil dawn's station-local minute-of-day for a date, or
+// ok=false when no SunCalc is configured or civil dawn is undefined for the date (polar day/night).
+func (ds *Datastore) civilDawnMinuteLookup() civilDawnMinuteLookup {
+	return func(date time.Time) (int, bool) {
+		if ds.suncalc == nil {
+			return 0, false
+		}
+		// Anchor at local noon before the lookup: SunCalc re-derives the calendar date in its own
+		// coordinate-derived zone, so passing midnight could land on the adjacent day (and return
+		// the wrong day's civil dawn) when that zone trails the configured station timezone. Noon
+		// keeps the intended calendar day for any real timezone offset.
+		civilDawn, ok := ds.suncalc.GetCivilDawn(date.Add(12 * time.Hour))
+		if !ok {
+			return 0, false
+		}
+		// Express civil dawn in the station timezone so its minute-of-day matches the frame used to
+		// bucket detections; this stays correct even if SunCalc's coordinate-derived zone differs
+		// from the configured station timezone or across DST.
+		lt := civilDawn.In(ds.timezone)
+		return lt.Hour()*60 + lt.Minute(), true
+	}
+}
+
 // ============================================================
 // Dynamic Threshold Methods
 // ============================================================

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -299,6 +299,9 @@ func (m *mockStore) GetActivityHeatmap(_ context.Context, _, _, _ string) (datas
 func (m *mockStore) GetHourlyDistributionBySpecies(_ context.Context, _, _ string, _ int) ([]datastore.SpeciesHourlyDistribution, error) {
 	return []datastore.SpeciesHourlyDistribution{}, nil
 }
+func (m *mockStore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]datastore.DailyActivityOnset, error) {
+	return []datastore.DailyActivityOnset{}, nil
+}
 
 // BG-17 fix: Add notification history methods
 func (m *mockStore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {

--- a/internal/suncalc/civil_dawn_test.go
+++ b/internal/suncalc/civil_dawn_test.go
@@ -1,0 +1,41 @@
+package suncalc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCivilDawn_DefinedAtMidLatitude verifies that at a mid-latitude location civil dawn is
+// reported as defined and is strictly before sunrise (matching the cached GetSunEventTimes value).
+func TestGetCivilDawn_DefinedAtMidLatitude(t *testing.T) {
+	t.Parallel()
+
+	// London, around the spring equinox: civil dawn is well-defined year-round here.
+	sc := NewSunCalc(51.5074, -0.1278)
+	date := time.Date(2026, 3, 21, 12, 0, 0, 0, time.UTC)
+
+	civilDawn, ok := sc.GetCivilDawn(date)
+	require.True(t, ok, "civil dawn should be defined at mid-latitude")
+
+	events, err := sc.GetSunEventTimes(date)
+	require.NoError(t, err)
+	assert.True(t, civilDawn.Before(events.Sunrise), "civil dawn must precede sunrise")
+	assert.Equal(t, events.CivilDawn, civilDawn, "GetCivilDawn returns the same instant as GetSunEventTimes")
+}
+
+// TestGetCivilDawn_UndefinedDuringPolarDay verifies that during polar day / white nights (when civil
+// twilight does not occur and GetSunEventTimes either errors or substitutes sunrise for civil dawn),
+// GetCivilDawn reports civil dawn as undefined so the dawn-onset analytics can treat it as a gap.
+func TestGetCivilDawn_UndefinedDuringPolarDay(t *testing.T) {
+	t.Parallel()
+
+	// Svalbard at the summer solstice: the sun does not dip to civil twilight (or set at all).
+	sc := NewSunCalc(78.2232, 15.6267)
+	date := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+
+	_, ok := sc.GetCivilDawn(date)
+	assert.False(t, ok, "civil dawn should be undefined during polar day")
+}

--- a/internal/suncalc/suncalc.go
+++ b/internal/suncalc/suncalc.go
@@ -234,3 +234,25 @@ func (sc *SunCalc) GetSunsetTime(date time.Time) (time.Time, error) {
 	}
 	return sunEventTimes.Sunset, nil
 }
+
+// GetCivilDawn returns civil dawn for the given date and whether civil dawn is astronomically
+// defined for it. ok is false when civil dawn does not occur: during polar day / white nights
+// (civil twilight never happens, and GetSunEventTimes substitutes sunrise for civil dawn), or
+// during polar night (the sun does not rise and the underlying calculation errors).
+//
+// Callers that must distinguish a genuine civil dawn from the sunrise fallback (for example the
+// dawn-chorus onset analytics, which treat a day with no civil dawn as a gap) use this instead of
+// reading GetSunEventTimes().CivilDawn directly. It reuses the GetSunEventTimes cache rather than
+// recalculating, and detects the fallback by the fact that a genuine civil dawn is always strictly
+// before sunrise, while GetSunEventTimes assigns CivilDawn = Sunrise (exact equality) when civil
+// twilight cannot be computed.
+func (sc *SunCalc) GetCivilDawn(date time.Time) (time.Time, bool) {
+	times, err := sc.GetSunEventTimes(date)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if !times.CivilDawn.Before(times.Sunrise) {
+		return time.Time{}, false
+	}
+	return times.CivilDawn, true
+}


### PR DESCRIPTION
## Summary

Adds a Tier-1 analytics chart, the dawn-chorus onset tracker. It plots each day's chorus onset relative to civil dawn, isolating the seasonal shift in when the morning chorus starts from clock time. This is the third Tier-1 chart, modeled on the existing seasonal heatmap and who-sings-when ridgeline.

Backend is additive only (v2only). No existing analytics endpoint, response shape, or DB schema changes:

- New `GET /api/v2/analytics/time/dawn-onset` endpoint and a `GetDailyActivityOnset` datastore method; the deprecated legacy datastore is stubbed empty.
- A day's onset is the minute-of-day of the 3rd-earliest detection, measured against civil dawn. I chose an absolute rank over a daily percentile on purpose: a percentile of the day's total volume gets pulled later by afternoon activity (faking a later dawn) and gives no false-positive robustness at realistic counts, whereas the Nth-earliest detection is immune to later-in-day volume and rejects lone pre-dawn false positives.
- Civil dawn comes from a new `suncalc.GetCivilDawn` that reports polar days (no civil dawn) as undefined, so those days render as gaps.
- Date bucketing and onset math live in a table-tested pure Go helper; civil dawn is injected as a function so the polar and min-count paths are unit-testable.

Frontend:

- `DawnChorusOnset.svelte`: a D3 scatter with a smoothed trend line (spans short gaps, breaks over sustained ones) and a y=0 civil-dawn reference line, wrapping the shared BaseChart.
- Registry entry and fetcher; i18n keys added across all locales.

## Test plan

- [x] `go test -race` for the aggregation helper (rank onset, min-count null, polar null, timezone bucketing, afternoon-volume immunity, gaps), the suncalc method, and the handler.
- [x] Frontend vitest for the trend/parse helpers and the chart component (dot count, axes, civil-dawn line, gap-breaking trend, screen-reader summary).
- [x] `golangci-lint run` clean; `npm run check:all` clean.
- [ ] Render the chart in the Activity Patterns tab against a real dataset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Dawn Chorus Onset" analytics chart that tracks when birds begin singing relative to civil dawn, with support for date range selection and optional species filtering.
  * Chart displays daily onset timing, detection counts, trend lines, and multi-language localization across 16 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->