### PR TITLE
fix(classifier): make inference-status runtime reporting consistent

### DIFF
--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -288,6 +288,15 @@ func buildModelStatus(info *classifier.ModelInfo, snap inferencestats.PeekSnapsh
 	}
 }
 
+// modelRuntime is the live device/backend/precision triplet for one model,
+// resolved atomically from the orchestrator (one GetModelRuntimeInfo call) so the
+// status card never shows a mixed-generation triplet when a reload races a poll.
+type modelRuntime struct {
+	device    string
+	backend   string
+	precision string
+}
+
 // applyRuntimeBackend overrides a model status's static file metadata (Backend,
 // Quantization) with the live values resolved from the loaded instance: the real
 // execution provider and effective runtime precision. An empty live value means
@@ -363,22 +372,21 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 	attachments := buildSourceAttachments(settings, infos, primaryID)
 
 	// Compute per-model device, backend, precision, and schedule status from the
-	// live orchestrator. Backend and precision come from the loaded instance (the
-	// real execution provider and runtime precision) rather than the static
-	// ModelInfo file metadata, so an ONNX model executed on OpenVINO reports
-	// "OpenVINO" and its effective precision. Empty values fall back to the static
-	// metadata in the assembly loop below.
-	devices := make(map[string]string, len(infos))
-	backends := make(map[string]string, len(infos))
-	precisions := make(map[string]string, len(infos))
+	// live orchestrator. The device/backend/precision triplet is read in one
+	// GetModelRuntimeInfo call so a reload completing mid-read cannot yield a mixed
+	// triplet (e.g. old device + new backend). Backend and precision come from the
+	// loaded instance (the real execution provider and runtime precision) rather
+	// than the static ModelInfo file metadata, so an ONNX model executed on
+	// OpenVINO reports "OpenVINO" and its effective precision. Empty values fall
+	// back to the static metadata in the assembly loop below.
+	runtimes := make(map[string]modelRuntime, len(infos))
 	paused := make(map[string]bool, len(infos))
 	scheduleLabels := make(map[string]string, len(infos))
 	if orch != nil {
 		for i := range infos {
 			id := infos[i].ID
-			devices[id] = orch.GetModelDevice(id)
-			backends[id] = orch.GetModelBackend(id)
-			precisions[id] = orch.GetModelPrecision(id)
+			device, backend, precision := orch.GetModelRuntimeInfo(id)
+			runtimes[id] = modelRuntime{device: device, backend: backend, precision: precision}
 			active, reason := orch.ModelScheduleStatus(id)
 			paused[id] = !active
 			scheduleLabels[id] = reason
@@ -446,14 +454,15 @@ func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
 		status := buildModelStatus(&infos[i], counters[id], rss, attachments[id], loadFailures, lastDetections)
 		// Live runtime fields resolved from the orchestrator/processor, kept out of
 		// the pure buildModelStatus so it stays a side-effect-free assembler.
-		status.Device = devices[id]
+		rt := runtimes[id]
+		status.Device = rt.device
 		if status.Device == "" {
 			status.Device = deviceUnknown
 		}
 		// Override the static file metadata with the live backend/precision when the
 		// model is loaded (see applyRuntimeBackend); an empty value means "not loaded
 		// / unknown", so the static ModelInfo values set by buildModelStatus survive.
-		applyRuntimeBackend(&status, backends[id], precisions[id])
+		applyRuntimeBackend(&status, rt.backend, rt.precision)
 		status.Paused = paused[id]
 		status.ScheduleLabel = scheduleLabels[id]
 		status.RecentDetections = recentDetections[id]

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -25,14 +25,14 @@ type Bat struct {
 	// (CPU/GPU) when the heavy embedding extractor runs on OpenVINO, otherwise
 	// deviceCPU for the ONNX Runtime CPU EP. The tiny bat classifier head always runs
 	// on ORT CPU, so this reports the embedding extractor's device. Set once at
-	// construction; reported via Device().
+	// construction; reported via RuntimeInfo().
 	device string
 	// backend is the live execution backend of the embedding extractor
 	// (BackendOpenVINO when it runs on OpenVINO, else BackendONNX), and precision is
 	// the effective runtime precision (FP32 on the OpenVINO path, which the bat
 	// embedding model is forced to; the weight precision detected from the classifier
 	// model filename on the ORT path, empty when no token). Both set once at
-	// construction; reported via Backend()/Precision().
+	// construction; reported via RuntimeInfo().
 	backend   string
 	precision string
 }
@@ -359,22 +359,17 @@ func (b *Bat) Labels() []string {
 	return b.batClassifier.Labels()
 }
 
-// Device returns the compute device the bat pipeline bound to: the OpenVINO device
-// (CPU/GPU) when the embedding extractor runs on OpenVINO, else "CPU" for the ONNX
-// Runtime CPU EP. Set once at construction and never mutated, so no lock is needed.
+// RuntimeInfo returns the device, backend, and effective precision the bat
+// pipeline bound to at construction: the OpenVINO device (CPU/GPU) when the
+// embedding extractor runs on OpenVINO, else "CPU" for the ONNX Runtime CPU EP;
+// BackendOpenVINO on the OV path (else BackendONNX); FP32 on the OV path (which
+// the bat embedding model is forced to), or the weight precision detected from
+// the bat classifier model filename on the ORT path (empty when no token). All
+// three are set once at construction and never mutated, so no lock is needed.
 // Implements ModelInstance.
-func (b *Bat) Device() string { return b.device }
-
-// Backend returns the live execution backend the bat embedding extractor bound to
-// (BackendOpenVINO on the OV path, else BackendONNX). Set once at construction and
-// never mutated, so no lock is needed. Implements ModelInstance.
-func (b *Bat) Backend() string { return b.backend }
-
-// Precision returns the effective runtime precision (FP32 on the OpenVINO path, which
-// the bat embedding model is forced to; the weight precision detected from the bat
-// classifier model filename on the ORT path, empty when no token). Set once at
-// construction and never mutated, so no lock is needed. Implements ModelInstance.
-func (b *Bat) Precision() string { return b.precision }
+func (b *Bat) RuntimeInfo() (device, backend, precision string) {
+	return b.device, b.backend, b.precision
+}
 
 // Close releases resources held by the bat model.
 func (b *Bat) Close() error {

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -42,6 +42,18 @@ type speciesCacheEntry struct {
 	scores map[string]float64 // Species occurrence scores keyed by scientific name
 }
 
+// runtimeInfo is the immutable device/backend/precision triplet describing how a
+// loaded classifier actually executes. It is published as a single value behind
+// an atomic pointer so all three are always read from the same generation (no
+// torn read) without taking bn.mu. device is "CPU" for TFLite/ONNX or the
+// concrete OpenVINO device for the OV path; backend is BackendTFLite/BackendONNX/
+// BackendOpenVINO; precision is "INT8"/"FP16"/"FP32" (empty when unknown).
+type runtimeInfo struct {
+	device    string
+	backend   string
+	precision string
+}
+
 // BirdNET struct represents the BirdNET model with interpreters and configuration.
 type BirdNET struct {
 	// classifier and rangeFilter are the native inference backends (TFLite/ONNX).
@@ -63,19 +75,13 @@ type BirdNET struct {
 	TaxonomyPath        string              // Path to custom taxonomy file, if used
 	modelVersion        string              // Human-readable model version string (per-instance to avoid shared global state)
 	modelsDir           string              // base directory for gallery-installed models (set by Orchestrator)
-	// device is the compute device the classifier backend bound to at load time
-	// ("CPU" for TFLite/ONNX, or the OpenVINO device for the OV path). It is set
-	// by each initialize*Model path and defaults to deviceCPU in NewBirdNET so a
-	// path that forgets to set it still reports a sane value. Reported via Device().
-	device string
-	// backend is the inference execution backend bound to at load time
-	// (BackendTFLite/BackendONNX/BackendOpenVINO), and precision is the effective
-	// runtime precision the model executes at ("INT8"/"FP16"/"FP32"). Both mirror
-	// device: set by each initialize*Model path so the inference status card reports
-	// what is really running rather than the static ModelInfo file metadata.
-	// Reported via Backend()/Precision(); guarded by mu like device.
-	backend   string
-	precision string
+	// runtime holds the live device/backend/precision triplet (see runtimeInfo),
+	// published by each initialize*Model path via setRuntimeInfo and restored by the
+	// reload rollback. It is deliberately kept OFF bn.mu: inference holds bn.mu for
+	// the full native call (issue #3336), and routing the read-only status card's
+	// RuntimeInfo() through bn.mu would block the card on an in-flight inference.
+	// The atomic pointer gives a lock-free, always-consistent triplet read instead.
+	runtime atomic.Pointer[runtimeInfo]
 	// mu guards the inference backends (classifier, rangeFilter, rangeFilterFellBack).
 	// Inference holds mu for the full duration of the native call, not just the field
 	// read: the backends are not goroutine-safe and reload/Delete Close() them under
@@ -116,9 +122,6 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 		TaxonomyPath: "", // Default to embedded taxonomy
 		modelVersion: defaultModelVersionString,
 		speciesCache: make(map[string]*speciesCacheEntry),
-		// Default to CPU; the OpenVINO init path overrides this with the real
-		// device (CPU/GPU) it bound to. TFLite and ONNX paths set it explicitly too.
-		device: deviceCPU,
 	}
 	bn.settingsAtomic.Store(settings)
 
@@ -163,12 +166,11 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 	// ONNX entry so existing arm64 configs keep starting without a TFLite backend.
 	bn.ModelInfo = remapV24ForONNXOnly(&bn.ModelInfo, tfliteBackendAvailable, findModelPathInStandardPaths)
 
-	// Seed backend/precision from the resolved static metadata so a model that
-	// somehow loads without an initialize*Model path still reports a sane value
-	// (mirrors the device default). Each init path overrides these with the real
-	// load-time backend and effective runtime precision.
-	bn.backend = bn.ModelInfo.Backend
-	bn.precision = string(bn.ModelInfo.Quantization)
+	// Seed the runtime triplet from the resolved static metadata so a model that
+	// somehow loads without an initialize*Model path still reports a sane value.
+	// Device defaults to CPU; each init path republishes the real load-time device
+	// (the OV path may bind GPU), backend, and effective runtime precision.
+	bn.setRuntimeInfo(deviceCPU, bn.ModelInfo.Backend, string(bn.ModelInfo.Quantization))
 
 	// Load taxonomy data
 	bn.TaxonomyMap, bn.ScientificIndex, err = LoadTaxonomyData(bn.TaxonomyPath)
@@ -322,12 +324,10 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 	}
 
 	bn.classifier = classifier
-	// TFLite runs on CPU (the optional XNNPACK delegate is still CPU execution).
-	bn.device = deviceCPU
-	// TFLite executes the model file as-is, so the runtime precision is the weight
-	// precision recorded in ModelInfo.Quantization (FP32 for the stock v2.4 model).
-	bn.backend = BackendTFLite
-	bn.precision = string(bn.ModelInfo.Quantization)
+	// TFLite runs on CPU (the optional XNNPACK delegate is still CPU execution) and
+	// executes the model file as-is, so the runtime precision is the weight precision
+	// recorded in ModelInfo.Quantization (FP32 for the stock v2.4 model).
+	bn.setRuntimeInfo(deviceCPU, BackendTFLite, string(bn.ModelInfo.Quantization))
 
 	// Update the human-readable model version string for display when a custom
 	// model path is provided. Model identity (ModelInfo.ID) is never modified
@@ -1196,6 +1196,13 @@ func (bn *BirdNET) reloadModelInternal() error {
 	oldModelInfo := bn.ModelInfo
 	oldTaxonomyMap := bn.TaxonomyMap
 	oldScientificIndex := bn.ScientificIndex
+	// initializeModel republishes the runtime triplet (and modelVersion on the
+	// TFLite custom-path branch) before the later reload steps (meta model,
+	// validation) that can still fail, so snapshot them too; otherwise a
+	// rolled-back reload leaves the status card and ModelVersion() describing the
+	// failed attempt instead of the previous (still-serving) model.
+	oldRuntime := bn.runtime.Load()
+	oldModelVersion := bn.modelVersion
 
 	rollback := func() {
 		if bn.classifier != nil && bn.classifier != oldClassifier {
@@ -1212,6 +1219,11 @@ func (bn *BirdNET) reloadModelInternal() error {
 		bn.ModelInfo = oldModelInfo
 		bn.TaxonomyMap = oldTaxonomyMap
 		bn.ScientificIndex = oldScientificIndex
+		// Restore the runtime triplet and model-version string alongside the
+		// classifier so RuntimeInfo / ModelVersion describe the restored model
+		// rather than the failed attempt.
+		bn.runtime.Store(oldRuntime)
+		bn.modelVersion = oldModelVersion
 		bn.updateSettings(oldSettings)
 		// Degraded-but-recovered: make it explicit in the log that the previous
 		// model was restored, so a failed reload is not mistaken for a dead
@@ -1483,35 +1495,31 @@ func (bn *BirdNET) Labels() []string {
 	return slices.Clone(bn.Settings.BirdNET.Labels)
 }
 
-// Device returns the compute device this model's classifier backend bound to
-// at load time ("CPU" for TFLite/ONNX, or the OpenVINO device for the OV path).
-// Guarded by bn.mu because reloadModelInternal rewrites bn.device under the same
-// lock when re-initializing the backend. Implements ModelInstance.
-func (bn *BirdNET) Device() string {
-	bn.mu.Lock()
-	defer bn.mu.Unlock()
-	return bn.device
+// setRuntimeInfo atomically publishes the live runtime triplet. Called by each
+// initialize*Model path with the real load-time values, by NewBirdNET to seed
+// them, and by the reload rollback to republish the previous (still-serving)
+// triplet. Reload-path writers already hold bn.mu and construction-path writers
+// run before the instance is shared; either way the atomic store is what lets
+// RuntimeInfo() read lock-free.
+func (bn *BirdNET) setRuntimeInfo(device, backend, precision string) {
+	bn.runtime.Store(&runtimeInfo{device: device, backend: backend, precision: precision})
 }
 
-// Backend returns the inference execution backend this model loaded on
-// (BackendTFLite/BackendONNX/BackendOpenVINO). Guarded by bn.mu because
-// reloadModelInternal rewrites bn.backend under the same lock when re-initializing
-// the backend. Implements ModelInstance.
-func (bn *BirdNET) Backend() string {
-	bn.mu.Lock()
-	defer bn.mu.Unlock()
-	return bn.backend
-}
-
-// Precision returns the effective runtime precision this model executes at
-// ("INT8"/"FP16"/"FP32"), which can differ from the weight precision stored in
-// the file (BirdNET v2.4 runs the FP32 ONNX model at FP16 on OpenVINO CPU).
-// Guarded by bn.mu because reloadModelInternal rewrites bn.precision under the
-// same lock. Implements ModelInstance.
-func (bn *BirdNET) Precision() string {
-	bn.mu.Lock()
-	defer bn.mu.Unlock()
-	return bn.precision
+// RuntimeInfo returns this model's device, backend, and effective precision from
+// a single atomic load, so the triplet is always internally consistent (never a
+// torn read mixing two reload generations) and the read never blocks on bn.mu,
+// which inference holds for the full native call (issue #3336). device is "CPU"
+// for TFLite/ONNX or the OpenVINO device for the OV path; backend is
+// BackendTFLite/BackendONNX/BackendOpenVINO; precision is "INT8"/"FP16"/"FP32"
+// (an FP32 ONNX model runs at FP16 on OpenVINO CPU). Returns deviceUnknown with
+// empty backend/precision before the first triplet is published. Implements
+// ModelInstance.
+func (bn *BirdNET) RuntimeInfo() (device, backend, precision string) {
+	ri := bn.runtime.Load()
+	if ri == nil {
+		return deviceUnknown, "", ""
+	}
+	return ri.device, ri.backend, ri.precision
 }
 
 // ReloadSnapshot returns a copy of the model metadata and taxonomy maps safely under bn.mu.

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -31,9 +31,9 @@ func (f *fakeModelInstance) ModelVersion() string { return "" }
 func (f *fakeModelInstance) NumSpecies() int      { return len(f.labels) }
 func (f *fakeModelInstance) Labels() []string     { return f.labels }
 func (f *fakeModelInstance) Close() error         { return nil }
-func (f *fakeModelInstance) Device() string       { return deviceCPU }
-func (f *fakeModelInstance) Backend() string      { return BackendONNX }
-func (f *fakeModelInstance) Precision() string    { return "" }
+func (f *fakeModelInstance) RuntimeInfo() (device, backend, precision string) {
+	return deviceCPU, BackendONNX, ""
+}
 
 func TestShouldAutoSelectV3Geomodel(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/model.go
+++ b/internal/classifier/model.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
-// Device name strings reported by ModelInstance.Device(). CPU-bound backends
+// Device name strings reported by ModelInstance.RuntimeInfo(). CPU-bound backends
 // (TFLite, ONNX Runtime CPU EP) report deviceCPU; OpenVINO-backed instances
 // report the concrete OpenVINO device (inference.OVDeviceCPU/OVDeviceGPU).
 // deviceUnknown is returned by the Orchestrator when a model is not loaded.
@@ -88,27 +88,26 @@ type ModelInstance interface {
 	// Labels returns the full list of species labels.
 	Labels() []string
 
-	// Device returns the compute device (execution provider) the model's
-	// inference actually runs on, resolved from the backend selected at load
-	// time. Returns deviceCPU ("CPU") or, for OpenVINO-backed instances, the
-	// concrete OpenVINO device (inference.OVDeviceCPU/OVDeviceGPU). It is never
-	// inferred from the backend string: the value reflects the real chosen path.
-	Device() string
-
-	// Backend returns the inference execution backend the model actually loaded
-	// on (BackendTFLite/BackendONNX/BackendOpenVINO), resolved at load time. This
-	// is the execution provider, which is distinct from the model file format:
-	// an ONNX model file executed through the OpenVINO runtime reports
-	// BackendOpenVINO, not BackendONNX. Like Device(), it reflects the real chosen
-	// path, never the static ModelInfo.Backend file-type metadata.
-	Backend() string
-
-	// Precision returns the effective runtime precision the model executes at
-	// ("INT8"/"FP16"/"FP32", matching the Quantization constants), which can
-	// differ from the weight precision stored in the file (e.g. an FP32 ONNX model
-	// executed on OpenVINO at FP16). Empty when unknown. Like Device(), it reflects
-	// the real chosen path, not the static ModelInfo.Quantization metadata.
-	Precision() string
+	// RuntimeInfo returns the compute device, execution backend, and effective
+	// runtime precision the model bound to at load time, returned together as one
+	// consistent snapshot so a concurrent reload cannot be observed as a torn
+	// triplet (e.g. device from one generation, backend from another).
+	// Implementations publish the triplet as a unit (BirdNET swaps it via an atomic
+	// pointer; Bat and Perch set it once at construction), so the read takes no lock
+	// and the three values are always from the same generation.
+	//
+	// device is deviceCPU ("CPU") or, for OpenVINO-backed instances, the concrete
+	// OpenVINO device (inference.OVDeviceCPU/OVDeviceGPU). backend is the live
+	// execution provider (BackendTFLite/BackendONNX/BackendOpenVINO), which is
+	// distinct from the model file format: an ONNX model file executed through the
+	// OpenVINO runtime reports BackendOpenVINO, not BackendONNX. precision is the
+	// effective runtime precision ("INT8"/"FP16"/"FP32", matching the Quantization
+	// constants), which can differ from the weight precision stored in the file
+	// (e.g. an FP32 ONNX model executed on OpenVINO at FP16); empty when unknown.
+	//
+	// All three reflect the real chosen path, never the static ModelInfo file-type
+	// metadata.
+	RuntimeInfo() (device, backend, precision string)
 
 	// Close releases resources held by the model.
 	Close() error

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -76,15 +76,12 @@ func (bn *BirdNET) initializeONNXModel() error {
 	}
 
 	bn.classifier = classifier
-	// We ship only the CPU execution provider for ONNX Runtime today. Other ORT
-	// EPs (CUDA, DirectML, CoreML) would set this from the bound provider; until
-	// one is wired in, the runtime path is CPU.
-	bn.device = deviceCPU
+	// We ship only the CPU execution provider for ONNX Runtime today (other ORT
+	// EPs like CUDA/DirectML/CoreML would set the device from the bound provider).
 	// ONNX Runtime executes the model file as-is, so the runtime precision is the
-	// weight precision recorded in ModelInfo.Quantization (e.g. INT8 for the
-	// arm64 int8 variant, FP32 for an fp32 ONNX model).
-	bn.backend = BackendONNX
-	bn.precision = string(bn.ModelInfo.Quantization)
+	// weight precision recorded in ModelInfo.Quantization (e.g. INT8 for the arm64
+	// int8 variant, FP32 for an fp32 ONNX model).
+	bn.setRuntimeInfo(deviceCPU, BackendONNX, string(bn.ModelInfo.Quantization))
 
 	log.Info("ONNX model initialized",
 		logger.String("model", modelPath),

--- a/internal/classifier/model_openvino.go
+++ b/internal/classifier/model_openvino.go
@@ -274,14 +274,12 @@ func (bn *BirdNET) initializeOpenVINOModel() error {
 	}
 
 	bn.classifier = classifier
-	// Record the concrete OpenVINO device (CPU/GPU) the classifier bound to so
-	// Device() reports the real execution provider rather than the backend string.
-	bn.device = plan.device
-	// Record the live backend and effective runtime precision so the status card
-	// reports "OpenVINO" + the real compute precision (FP16 by default, FP32 only
-	// for the BirdNET v2.4 GPU path) instead of the static ONNX file metadata.
-	bn.backend = BackendOpenVINO
-	bn.precision = openVINOEffectivePrecision(plan.precision)
+	// Publish the concrete OpenVINO device (CPU/GPU) the classifier bound to plus
+	// the live backend and effective runtime precision, so the status card reports
+	// "OpenVINO" + the real compute precision (FP16 by default, FP32 only for the
+	// BirdNET v2.4 GPU path) and the real device rather than the static ONNX file
+	// metadata.
+	bn.setRuntimeInfo(plan.device, BackendOpenVINO, openVINOEffectivePrecision(plan.precision))
 	log.Info("OpenVINO model initialized",
 		logger.String("model", modelPath),
 		logger.String("device", plan.device),

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -30,7 +30,7 @@ const (
 // ModelInfo.Backend (the static metadata). BackendOpenVINO is an execution
 // provider, not a file type: OpenVINO executes an ONNX model file through the OV
 // runtime, so it only ever appears as a live, per-instance backend reported by
-// ModelInstance.Backend(), never as a ModelInfo.Backend file-type value.
+// ModelInstance.RuntimeInfo(), never as a ModelInfo.Backend file-type value.
 const (
 	BackendTFLite   = "TFLite"
 	BackendONNX     = "ONNX"

--- a/internal/classifier/model_test.go
+++ b/internal/classifier/model_test.go
@@ -5,10 +5,53 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
 // Compile-time check that BirdNET implements ModelInstance.
 var _ ModelInstance = (*BirdNET)(nil)
+
+// Compile-time check that Bat implements ModelInstance (Perch has its own in
+// perch_onnx_test.go). Keeps the three production implementers symmetric so a
+// future edit to one of their methods (e.g. RuntimeInfo) fails fast at build.
+var _ ModelInstance = (*Bat)(nil)
+
+// TestBirdNET_RuntimeInfo_PublishAndRestore verifies the atomic runtime-triplet
+// mechanism behind RuntimeInfo(): an unpublished instance reports the not-loaded
+// triplet, setRuntimeInfo publishes a self-consistent triplet read lock-free, and
+// storing a snapshotted pointer restores it. The store-snapshot step is exactly
+// what reloadModelInternal's rollback performs on a failed reload, so this covers
+// the rollback restoration without needing a native backend to drive the full
+// reload path.
+func TestBirdNET_RuntimeInfo_PublishAndRestore(t *testing.T) {
+	t.Parallel()
+
+	bn := &BirdNET{}
+
+	// Before the first publish: not-loaded triplet (Unknown device, empty rest).
+	device, backend, precision := bn.RuntimeInfo()
+	assert.Equal(t, deviceUnknown, device)
+	assert.Empty(t, backend)
+	assert.Empty(t, precision)
+
+	// Publish an initial triplet and snapshot the pointer (as the reload does).
+	bn.setRuntimeInfo(deviceCPU, BackendTFLite, string(QuantizationFP32))
+	snapshot := bn.runtime.Load()
+
+	// Republish a new triplet (an OpenVINO/GPU/FP16 reload attempt).
+	bn.setRuntimeInfo(inference.OVDeviceGPU, BackendOpenVINO, string(QuantizationFP16))
+	device, backend, precision = bn.RuntimeInfo()
+	assert.Equal(t, inference.OVDeviceGPU, device)
+	assert.Equal(t, BackendOpenVINO, backend)
+	assert.Equal(t, string(QuantizationFP16), precision)
+
+	// Roll back to the snapshot, exactly as reloadModelInternal does on failure.
+	bn.runtime.Store(snapshot)
+	device, backend, precision = bn.RuntimeInfo()
+	assert.Equal(t, deviceCPU, device, "rollback must restore the previous device")
+	assert.Equal(t, BackendTFLite, backend, "rollback must restore the previous backend")
+	assert.Equal(t, string(QuantizationFP32), precision, "rollback must restore the previous precision")
+}
 
 func TestModelSpecDefaults(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -389,42 +389,25 @@ func (o *Orchestrator) instanceFor(modelID string) ModelInstance {
 	return inst
 }
 
-// GetModelDevice returns the compute device (execution provider) the named
-// model's inference currently runs on, resolved from the live instance's
-// Device() (e.g. "CPU" or "GPU"). It returns deviceUnknown when the model is not
-// loaded or its instance has been torn down.
-func (o *Orchestrator) GetModelDevice(modelID string) string {
+// GetModelRuntimeInfo returns the live compute device, execution backend, and
+// effective runtime precision for the named model, resolved from the live
+// instance's RuntimeInfo() in a single instance lookup. Because RuntimeInfo()
+// returns the triplet from one consistent snapshot, the status card never
+// observes a mixed-generation triplet when a reload completes mid-read.
+//
+// device is the live execution provider ("CPU"/"GPU"), falling back to
+// deviceUnknown when the model is not loaded or its instance has been torn down.
+// backend (BackendTFLite/BackendONNX/BackendOpenVINO) and precision
+// ("INT8"/"FP16"/"FP32") come from the loaded instance, so an ONNX model executed
+// on OpenVINO reports "OpenVINO" and its effective precision; both are "" when the
+// model is not loaded, signalling callers to fall back to the static ModelInfo
+// file metadata.
+func (o *Orchestrator) GetModelRuntimeInfo(modelID string) (device, backend, precision string) {
 	inst := o.instanceFor(modelID)
 	if inst == nil {
-		return deviceUnknown
+		return deviceUnknown, "", ""
 	}
-	return inst.Device()
-}
-
-// GetModelBackend returns the live inference execution backend the named model
-// loaded on (BackendTFLite/BackendONNX/BackendOpenVINO), resolved from the live
-// instance's Backend(). It returns "" when the model is not loaded or its instance
-// has been torn down, signalling callers to fall back to the static
-// ModelInfo.Backend file metadata.
-func (o *Orchestrator) GetModelBackend(modelID string) string {
-	inst := o.instanceFor(modelID)
-	if inst == nil {
-		return ""
-	}
-	return inst.Backend()
-}
-
-// GetModelPrecision returns the effective runtime precision the named model
-// executes at ("INT8"/"FP16"/"FP32"), resolved from the live instance's
-// Precision(). It returns "" when the model is not loaded, its instance has been
-// torn down, or the precision is unknown, signalling callers to fall back to the
-// static ModelInfo.Quantization file metadata.
-func (o *Orchestrator) GetModelPrecision(modelID string) string {
-	inst := o.instanceFor(modelID)
-	if inst == nil {
-		return ""
-	}
-	return inst.Precision()
+	return inst.RuntimeInfo()
 }
 
 // ModelSpecFor returns the ModelSpec for the given model ID.

--- a/internal/classifier/orchestrator_device_test.go
+++ b/internal/classifier/orchestrator_device_test.go
@@ -4,104 +4,53 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/inference"
 )
 
-// TestGetModelDevice covers device resolution for loaded, unloaded, and
-// torn-down instances.
-func TestGetModelDevice(t *testing.T) {
+// TestGetModelRuntimeInfo covers the compound device/backend/precision accessor
+// for loaded and unknown models. The triplet is resolved in a single call so the
+// status card never observes a mixed-generation triplet when a reload races a
+// poll. A loaded model returns its live device, backend, and precision; an
+// unknown model returns the not-loaded triplet (Unknown device, empty
+// backend/precision) so the caller falls back to the static ModelInfo metadata.
+func TestGetModelRuntimeInfo(t *testing.T) {
 	t.Parallel()
 
 	const (
 		cpuModelID = "cpu_model"
-		gpuModelID = "gpu_model"
-	)
-	o := newTestOrchestrator(t,
-		&mockModelInstance{id: cpuModelID, device: deviceCPU},
-		&mockModelInstance{id: gpuModelID, device: "GPU"},
-	)
-
-	t.Run("returns the live instance device", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, deviceCPU, o.GetModelDevice(cpuModelID))
-		assert.Equal(t, "GPU", o.GetModelDevice(gpuModelID))
-	})
-
-	t.Run("unknown model returns Unknown", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, deviceUnknown, o.GetModelDevice("not_loaded"))
-	})
-}
-
-// TestGetModelDevice_NilInstance verifies a torn-down entry reports Unknown.
-func TestGetModelDevice_NilInstance(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{
-		models: map[string]*modelEntry{
-			"closed": {instance: nil},
-		},
-		modelRSS: make(map[string]int64),
-	}
-	assert.Equal(t, deviceUnknown, o.GetModelDevice("closed"))
-}
-
-// TestGetModelBackend covers live-backend resolution for loaded, unloaded, and
-// torn-down instances. Unlike GetModelDevice, a missing/unknown backend returns
-// "" so the caller falls back to the static ModelInfo.Backend file metadata.
-func TestGetModelBackend(t *testing.T) {
-	t.Parallel()
-
-	const (
-		ortModelID = "ort_model"
 		ovModelID  = "ov_model"
 	)
 	o := newTestOrchestrator(t,
-		&mockModelInstance{id: ortModelID, backend: BackendONNX},
-		&mockModelInstance{id: ovModelID, backend: BackendOpenVINO},
+		&mockModelInstance{id: cpuModelID, device: deviceCPU, backend: BackendONNX, precision: string(QuantizationINT8)},
+		&mockModelInstance{id: ovModelID, device: inference.OVDeviceGPU, backend: BackendOpenVINO, precision: string(QuantizationFP16)},
 	)
 
-	t.Run("returns the live instance backend", func(t *testing.T) {
+	t.Run("returns the live instance triplet", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, BackendONNX, o.GetModelBackend(ortModelID))
-		assert.Equal(t, BackendOpenVINO, o.GetModelBackend(ovModelID),
+		device, backend, precision := o.GetModelRuntimeInfo(cpuModelID)
+		assert.Equal(t, deviceCPU, device)
+		assert.Equal(t, BackendONNX, backend)
+		assert.Equal(t, string(QuantizationINT8), precision)
+
+		device, backend, precision = o.GetModelRuntimeInfo(ovModelID)
+		assert.Equal(t, inference.OVDeviceGPU, device)
+		assert.Equal(t, BackendOpenVINO, backend,
 			"an ONNX model executed on OpenVINO must report OpenVINO, not ONNX")
+		assert.Equal(t, string(QuantizationFP16), precision)
 	})
 
-	t.Run("unknown model returns empty for static fallback", func(t *testing.T) {
+	t.Run("unknown model reports Unknown device and empty backend/precision", func(t *testing.T) {
 		t.Parallel()
-		assert.Empty(t, o.GetModelBackend("not_loaded"))
+		device, backend, precision := o.GetModelRuntimeInfo("not_loaded")
+		assert.Equal(t, deviceUnknown, device)
+		assert.Empty(t, backend, "empty backend signals static-metadata fallback")
+		assert.Empty(t, precision, "empty precision signals static-metadata fallback")
 	})
 }
 
-// TestGetModelPrecision covers live effective-precision resolution. A missing or
-// unknown precision returns "" so the caller falls back to the static
-// ModelInfo.Quantization metadata.
-func TestGetModelPrecision(t *testing.T) {
-	t.Parallel()
-
-	const (
-		fp16ModelID = "fp16_model"
-		int8ModelID = "int8_model"
-	)
-	o := newTestOrchestrator(t,
-		&mockModelInstance{id: fp16ModelID, precision: string(QuantizationFP16)},
-		&mockModelInstance{id: int8ModelID, precision: string(QuantizationINT8)},
-	)
-
-	t.Run("returns the live instance precision", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, string(QuantizationFP16), o.GetModelPrecision(fp16ModelID))
-		assert.Equal(t, string(QuantizationINT8), o.GetModelPrecision(int8ModelID))
-	})
-
-	t.Run("unknown model returns empty for static fallback", func(t *testing.T) {
-		t.Parallel()
-		assert.Empty(t, o.GetModelPrecision("not_loaded"))
-	})
-}
-
-// TestGetModelBackendPrecision_NilInstance verifies a torn-down entry reports the
-// empty string for both backend and precision (static-fallback signal).
-func TestGetModelBackendPrecision_NilInstance(t *testing.T) {
+// TestGetModelRuntimeInfo_NilInstance verifies a torn-down entry reports the
+// not-loaded triplet: Unknown device, empty backend/precision (static fallback).
+func TestGetModelRuntimeInfo_NilInstance(t *testing.T) {
 	t.Parallel()
 	o := &Orchestrator{
 		models: map[string]*modelEntry{
@@ -109,8 +58,10 @@ func TestGetModelBackendPrecision_NilInstance(t *testing.T) {
 		},
 		modelRSS: make(map[string]int64),
 	}
-	assert.Empty(t, o.GetModelBackend("closed"))
-	assert.Empty(t, o.GetModelPrecision("closed"))
+	device, backend, precision := o.GetModelRuntimeInfo("closed")
+	assert.Equal(t, deviceUnknown, device)
+	assert.Empty(t, backend)
+	assert.Empty(t, precision)
 }
 
 // TestModelScheduleStatus covers the schedule gating contract: only the bat

--- a/internal/classifier/orchestrator_memory_test.go
+++ b/internal/classifier/orchestrator_memory_test.go
@@ -36,9 +36,9 @@ func (f *fakeInstance) ModelVersion() string { return "test" }
 func (f *fakeInstance) NumSpecies() int      { return 1 }
 func (f *fakeInstance) Labels() []string     { return nil }
 func (f *fakeInstance) Close() error         { return nil }
-func (f *fakeInstance) Device() string       { return deviceCPU }
-func (f *fakeInstance) Backend() string      { return BackendONNX }
-func (f *fakeInstance) Precision() string    { return "" }
+func (f *fakeInstance) RuntimeInfo() (device, backend, precision string) {
+	return deviceCPU, BackendONNX, ""
+}
 
 func TestWarmupAndRecordRSS_RecordsNonNegativeDelta(t *testing.T) {
 	t.Parallel()

--- a/internal/classifier/orchestrator_reload_secondary_test.go
+++ b/internal/classifier/orchestrator_reload_secondary_test.go
@@ -50,9 +50,9 @@ func (m *reloadFakeModel) Close() error {
 	}
 	return nil
 }
-func (m *reloadFakeModel) Device() string    { return deviceCPU }
-func (m *reloadFakeModel) Backend() string   { return BackendONNX }
-func (m *reloadFakeModel) Precision() string { return "" }
+func (m *reloadFakeModel) RuntimeInfo() (device, backend, precision string) {
+	return deviceCPU, BackendONNX, ""
+}
 
 // registerTestSecondaryBuilder adds a builder under id for the duration of the
 // test, restoring the global map on cleanup. The map is a package global, so the

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -20,9 +20,9 @@ type mockModelInstance struct {
 	id        string
 	spec      ModelSpec
 	labels    []string // optional; when nil a single default label is returned
-	device    string   // optional; when empty Device() reports "CPU"
-	backend   string   // optional; reported verbatim by Backend()
-	precision string   // optional; reported verbatim by Precision()
+	device    string   // optional; when empty RuntimeInfo reports "CPU"
+	backend   string   // optional; reported verbatim by RuntimeInfo
+	precision string   // optional; reported verbatim by RuntimeInfo
 	predict   func(ctx context.Context, samples [][]float32) ([]datastore.Results, error)
 }
 
@@ -46,14 +46,13 @@ func (m *mockModelInstance) Labels() []string {
 	}
 	return []string{"Turdus merula_Common Blackbird"}
 }
-func (m *mockModelInstance) Close() error      { return nil }
-func (m *mockModelInstance) Backend() string   { return m.backend }
-func (m *mockModelInstance) Precision() string { return m.precision }
-func (m *mockModelInstance) Device() string {
-	if m.device != "" {
-		return m.device
+func (m *mockModelInstance) Close() error { return nil }
+func (m *mockModelInstance) RuntimeInfo() (device, backend, precision string) {
+	device = m.device
+	if device == "" {
+		device = deviceCPU
 	}
-	return deviceCPU
+	return device, m.backend, m.precision
 }
 
 // newTestOrchestrator creates an Orchestrator with mock models for unit testing.

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -36,13 +36,13 @@ type Perch struct {
 	mu         sync.Mutex
 	// device is the compute device the classifier bound to: the OpenVINO device
 	// (CPU/GPU) when the OV path succeeds, otherwise deviceCPU for the ONNX
-	// Runtime CPU EP. Set once at construction; reported via Device().
+	// Runtime CPU EP. Set once at construction; reported via RuntimeInfo().
 	device string
 	// backend is the live execution backend (BackendOpenVINO on the OV path, else
 	// BackendONNX), and precision is the effective runtime precision (FP16 on the
 	// OV path; the weight precision detected from the model filename on the ORT
 	// path, e.g. INT8 for perch_v2_int8_arm.onnx). Both set once at construction;
-	// reported via Backend()/Precision().
+	// reported via RuntimeInfo().
 	backend   string
 	precision string
 }
@@ -290,21 +290,15 @@ func (p *Perch) Labels() []string {
 	return out
 }
 
-// Device returns the compute device the classifier bound to at construction
-// (the OpenVINO device on the OV path, else "CPU"). Set once and never mutated,
-// so no lock is needed. Implements ModelInstance.
-func (p *Perch) Device() string { return p.device }
-
-// Backend returns the live execution backend the classifier bound to at
-// construction (BackendOpenVINO on the OV path, else BackendONNX). Set once and
-// never mutated, so no lock is needed. Implements ModelInstance.
-func (p *Perch) Backend() string { return p.backend }
-
-// Precision returns the effective runtime precision (FP16 on the OpenVINO path;
-// the weight precision detected from the model filename on the ORT path, e.g.
-// INT8 for perch_v2_int8_arm.onnx, empty when no token). Set once and never
-// mutated, so no lock is needed. Implements ModelInstance.
-func (p *Perch) Precision() string { return p.precision }
+// RuntimeInfo returns the device, backend, and effective precision the Perch
+// classifier bound to at construction: the OpenVINO device on the OV path (else
+// "CPU"); BackendOpenVINO on the OV path (else BackendONNX); FP16 on the OV path
+// or the weight precision detected from the model filename on the ORT path (e.g.
+// INT8 for perch_v2_int8_arm.onnx, empty when no token). All three are set once
+// and never mutated, so no lock is needed. Implements ModelInstance.
+func (p *Perch) RuntimeInfo() (device, backend, precision string) {
+	return p.device, p.backend, p.precision
+}
 
 // Close releases resources held by the Perch model.
 func (p *Perch) Close() error {


### PR DESCRIPTION
## Summary

Follow-up to #3601, which made the inference status card report live `Backend()`/`Precision()` alongside the existing device. Two minor, transient reporting inconsistencies remained on the read-only `/ui/system/inference` diagnostics card. Neither was a data race and neither affected detection; both were cosmetic and self-correcting, but worth tightening.

This PR makes the runtime device/backend/precision reporting fully consistent:

1. **Atomic triplet (no torn read).** The status handler previously read device, backend, and precision through three separate orchestrator accessors, each taking the model lock independently, so a hot-reload completing mid-read could yield a mixed triplet (e.g. old device + new backend). The three `ModelInstance` accessors `Device()`/`Backend()`/`Precision()` are replaced by a single `RuntimeInfo() (device, backend, precision string)`, consumed via a new `Orchestrator.GetModelRuntimeInfo`. This collapses three per-model lock round-trips and three parallel maps into one.

2. **Lock-free read, off the inference lock.** `BirdNET` now stores the triplet behind an `atomic.Pointer`, so `RuntimeInfo()` reads lock-free. Inference holds `bn.mu` for the full native call, so routing the read-only status card through `bn.mu` would block the card on an in-flight inference; the atomic load avoids that while still guaranteeing a consistent, never-torn triplet.

3. **Rollback restores the triplet.** `reloadModelInternal` rewrites device/backend/precision (and `modelVersion`) before the later reload steps that can still fail. On a failed reload that rolls back to the previous still-serving classifier, the rollback closure now snapshots and restores these fields too, so the card no longer briefly mislabels the model that is actually serving.

No API contract change: the `/api/v2/system/inference` JSON shape (`device`, `backend`, `quantization`) is unchanged.

## Test Plan

- [x] `golangci-lint` clean
- [x] `go test -race ./internal/classifier/ ./internal/api/v2/` passes
- [x] New unit test covers the atomic publish, lock-free read, and rollback restore of the runtime triplet
- [x] `TestGetModelRuntimeInfo` covers the compound accessor (loaded triplet, OpenVINO-on-ONNX, unknown model, torn-down instance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal model runtime configuration reporting to consolidate multiple data lookups into a single efficient operation, improving system responsiveness without changes to user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->