### PR TITLE
fix(classifier): publish BirdNET model identity via atomic snapshot

### DIFF
--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -63,7 +63,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 			Category(errors.CategoryAudio).
 			ModelContext(settings.BirdNET.ModelPath, modelID).
 			Context("sample_length", len(sample[0])).
-			Timing("prediction-invoke", time.Since(start)).
+			Timing("prediction-invoke", time.Since(invokeStart)).
 			Build()
 
 		recordPredictionFailure(span, modelID, errTypeInvokeFailed, start, err)

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -23,7 +23,10 @@ type DetectionsMap map[string][]datastore.Results
 // Predict performs inference on a given sample using the classifier backend.
 // Implements ModelInstance.
 func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
-	span, _ := startPredictSpan(ctx, bn.ModelInfo.ID, sample)
+	// Capture the model ID once via the lock-free identity snapshot, reused below, so
+	// this hot path never reads bn.ModelInfo directly (reloadModelInternal writes it).
+	modelID := bn.ModelID()
+	span, _ := startPredictSpan(ctx, modelID, sample)
 	defer span.Finish()
 
 	settings := bn.currentSettings()
@@ -35,7 +38,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		span.markErrored(errTypeEmptySample)
 		return nil, errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
-			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, modelID).
 			Build()
 	}
 
@@ -48,7 +51,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		span.markErrored(errTypeClassifierNil)
 		return nil, errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
-			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, modelID).
 			Build()
 	}
 
@@ -58,12 +61,12 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	if err != nil {
 		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, modelID).
 			Context("sample_length", len(sample[0])).
 			Timing("prediction-invoke", time.Since(start)).
 			Build()
 
-		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeInvokeFailed, start, err)
+		recordPredictionFailure(span, modelID, errTypeInvokeFailed, start, err)
 		return nil, err
 	}
 
@@ -72,7 +75,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 
 	// Record model invoke timing separately
 	if m := getMetrics(); m != nil {
-		m.RecordModelInvoke(bn.ModelInfo.ID, invokeDuration.Seconds())
+		m.RecordModelInvoke(modelID, invokeDuration.Seconds())
 	}
 
 	// Use optimized sigmoid function with buffer reuse
@@ -88,7 +91,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 			Timing("prediction-total", time.Since(start)).
 			Build()
 
-		recordPredictionFailure(span, bn.ModelInfo.ID, errTypeLabelMismatch, start, err)
+		recordPredictionFailure(span, modelID, errTypeLabelMismatch, start, err)
 		return nil, err
 	}
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1500,39 +1500,47 @@ func (bn *BirdNET) publishIdentity() {
 	})
 }
 
-// identitySnapshot returns the published identity, or, before the first publish (a
-// struct-literal instance in tests that bypassed NewBirdNET), a snapshot read
-// directly from the fields. An unpublished instance is never concurrently
-// reloaded, so that direct read is race-free.
-func (bn *BirdNET) identitySnapshot() modelIdentity {
-	if id := bn.identity.Load(); id != nil {
-		return *id
-	}
-	return modelIdentity{id: bn.ModelInfo.ID, name: bn.ModelInfo.Name, version: bn.modelVersion, spec: bn.ModelInfo.Spec}
-}
+// The ModelID/ModelName/ModelVersion/Spec getters read the published identity
+// snapshot lock-free via bn.identity.Load(), reading the wanted field straight off
+// the loaded pointer (no whole-struct copy, matching RuntimeInfo's access
+// pattern). Before the first publish (a struct-literal instance in tests that
+// bypassed NewBirdNET, never concurrently reloaded) the pointer is nil and they
+// fall back to reading the fields directly, which is race-free in that case.
 
 // Spec returns the audio requirements for this BirdNET model.
 // Implements ModelInstance.
 func (bn *BirdNET) Spec() ModelSpec {
-	return bn.identitySnapshot().spec
+	if id := bn.identity.Load(); id != nil {
+		return id.spec
+	}
+	return bn.ModelInfo.Spec
 }
 
 // ModelID returns the unique model identifier.
 // Implements ModelInstance.
 func (bn *BirdNET) ModelID() string {
-	return bn.identitySnapshot().id
+	if id := bn.identity.Load(); id != nil {
+		return id.id
+	}
+	return bn.ModelInfo.ID
 }
 
 // ModelName returns the human-readable model name.
 // Implements ModelInstance.
 func (bn *BirdNET) ModelName() string {
-	return bn.identitySnapshot().name
+	if id := bn.identity.Load(); id != nil {
+		return id.name
+	}
+	return bn.ModelInfo.Name
 }
 
 // ModelVersion returns the model version string.
 // Implements ModelInstance.
 func (bn *BirdNET) ModelVersion() string {
-	return bn.identitySnapshot().version
+	if id := bn.identity.Load(); id != nil {
+		return id.version
+	}
+	return bn.modelVersion
 }
 
 // NumSpecies returns the number of species this model can classify.

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -54,6 +54,19 @@ type runtimeInfo struct {
 	precision string
 }
 
+// modelIdentity is the immutable identity snapshot the ModelInstance getters and
+// the inference span expose: model ID, human-readable name, version string, and
+// audio spec. Like runtimeInfo it is published behind an atomic pointer so those
+// reads are lock-free and never race reloadModelInternal's writes to bn.ModelInfo
+// / bn.modelVersion, nor block on bn.mu (held by inference for the full native
+// call, issue #3336).
+type modelIdentity struct {
+	id      string
+	name    string
+	version string
+	spec    ModelSpec
+}
+
 // BirdNET struct represents the BirdNET model with interpreters and configuration.
 type BirdNET struct {
 	// classifier and rangeFilter are the native inference backends (TFLite/ONNX).
@@ -82,13 +95,20 @@ type BirdNET struct {
 	// RuntimeInfo() through bn.mu would block the card on an in-flight inference.
 	// The atomic pointer gives a lock-free, always-consistent triplet read instead.
 	runtime atomic.Pointer[runtimeInfo]
+	// identity holds the getter-visible model identity snapshot (ID/Name/Spec and
+	// the version string); see modelIdentity. Like runtime it is published behind an
+	// atomic pointer and kept OFF bn.mu so the ModelInstance getters (ModelID,
+	// ModelName, ModelVersion, Spec) and the inference span read it lock-free without
+	// blocking on an in-flight native call holding bn.mu (issue #3336).
+	identity atomic.Pointer[modelIdentity]
 	// mu guards the inference backends (classifier, rangeFilter, rangeFilterFellBack).
 	// Inference holds mu for the full duration of the native call, not just the field
 	// read: the backends are not goroutine-safe and reload/Delete Close() them under
 	// mu, so dropping mu before the native call would reintroduce the issue #3336
-	// use-after-free segfault. (mu is not a complete guard for ModelInfo, which
-	// reloadModelInternal writes under mu but the Spec/ModelID/ModelName getters read
-	// without it.)
+	// use-after-free segfault. (ModelInfo is written under mu by reloadModelInternal;
+	// the identity fields the getters expose are mirrored into the lock-free identity
+	// snapshot above, and the remaining ModelInfo reads run under mu or before the
+	// instance is shared.)
 	mu               sync.Mutex
 	resultsBuffer    []datastore.Results // Pre-allocated buffer for results to reduce allocations
 	confidenceBuffer []float32           // Pre-allocated buffer for confidence values to reduce allocations
@@ -247,6 +267,10 @@ func NewBirdNET(settings *conf.Settings, modelInfo *ModelInfo) (*BirdNET, error)
 			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
 	}
+
+	// Publish the getter-visible identity now that ModelInfo and modelVersion are
+	// finalized, so ModelID/ModelName/ModelVersion/Spec read it lock-free.
+	bn.publishIdentity()
 
 	constructed = true
 	return bn, nil
@@ -1224,6 +1248,9 @@ func (bn *BirdNET) reloadModelInternal() error {
 		// rather than the failed attempt.
 		bn.runtime.Store(oldRuntime)
 		bn.modelVersion = oldModelVersion
+		// Republish the getter-visible identity from the restored ModelInfo /
+		// modelVersion so ModelID/ModelName/ModelVersion/Spec revert too.
+		bn.publishIdentity()
 		bn.updateSettings(oldSettings)
 		// Degraded-but-recovered: make it explicit in the log that the previous
 		// model was restored, so a failed reload is not mistaken for a dead
@@ -1364,6 +1391,10 @@ func (bn *BirdNET) reloadModelInternal() error {
 	// Clear species cache as model/labels have changed
 	bn.clearSpeciesCache()
 
+	// Republish the getter-visible identity for the new model now that the reload
+	// has committed (ModelInfo and modelVersion are final).
+	bn.publishIdentity()
+
 	bn.Debug("Model reload completed successfully")
 	return nil
 }
@@ -1454,28 +1485,54 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 	return 0.0
 }
 
+// publishIdentity snapshots the current ModelInfo identity and modelVersion into
+// the atomic identity pointer. Call it after every commit point that finalizes
+// those fields: the end of NewBirdNET, a successful reload, and the reload
+// rollback. The caller either holds bn.mu (reload) or runs before the instance is
+// shared (construction), so the bn.ModelInfo / bn.modelVersion reads here are
+// consistent.
+func (bn *BirdNET) publishIdentity() {
+	bn.identity.Store(&modelIdentity{
+		id:      bn.ModelInfo.ID,
+		name:    bn.ModelInfo.Name,
+		version: bn.modelVersion,
+		spec:    bn.ModelInfo.Spec,
+	})
+}
+
+// identitySnapshot returns the published identity, or, before the first publish (a
+// struct-literal instance in tests that bypassed NewBirdNET), a snapshot read
+// directly from the fields. An unpublished instance is never concurrently
+// reloaded, so that direct read is race-free.
+func (bn *BirdNET) identitySnapshot() modelIdentity {
+	if id := bn.identity.Load(); id != nil {
+		return *id
+	}
+	return modelIdentity{id: bn.ModelInfo.ID, name: bn.ModelInfo.Name, version: bn.modelVersion, spec: bn.ModelInfo.Spec}
+}
+
 // Spec returns the audio requirements for this BirdNET model.
 // Implements ModelInstance.
 func (bn *BirdNET) Spec() ModelSpec {
-	return bn.ModelInfo.Spec
+	return bn.identitySnapshot().spec
 }
 
 // ModelID returns the unique model identifier.
 // Implements ModelInstance.
 func (bn *BirdNET) ModelID() string {
-	return bn.ModelInfo.ID
+	return bn.identitySnapshot().id
 }
 
 // ModelName returns the human-readable model name.
 // Implements ModelInstance.
 func (bn *BirdNET) ModelName() string {
-	return bn.ModelInfo.Name
+	return bn.identitySnapshot().name
 }
 
 // ModelVersion returns the model version string.
 // Implements ModelInstance.
 func (bn *BirdNET) ModelVersion() string {
-	return bn.modelVersion
+	return bn.identitySnapshot().version
 }
 
 // NumSpecies returns the number of species this model can classify.

--- a/internal/classifier/model_test.go
+++ b/internal/classifier/model_test.go
@@ -16,6 +16,50 @@ var _ ModelInstance = (*BirdNET)(nil)
 // future edit to one of their methods (e.g. RuntimeInfo) fails fast at build.
 var _ ModelInstance = (*Bat)(nil)
 
+// TestBirdNET_Identity_PublishAndSnapshot verifies the atomic identity snapshot
+// behind ModelID/ModelName/ModelVersion/Spec: an unpublished struct-literal
+// instance falls back to reading the fields directly, publishIdentity captures a
+// snapshot read lock-free, and a subsequent bn.ModelInfo write WITHOUT republish
+// does not change the getters. That last property is the race fix: the lock-free
+// getters only ever observe a committed snapshot, never reloadModelInternal's
+// in-flight write to bn.ModelInfo / bn.modelVersion. Republish (reload commit /
+// rollback) then advances the snapshot.
+func TestBirdNET_Identity_PublishAndSnapshot(t *testing.T) {
+	t.Parallel()
+
+	bn := &BirdNET{
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4", Spec: ModelSpec{SampleRate: 48000}},
+		modelVersion: "v2.4-fp32",
+	}
+
+	// Unpublished struct-literal instance: getters fall back to the fields.
+	assert.Equal(t, "BirdNET_V2.4", bn.ModelID())
+	assert.Equal(t, "BirdNET v2.4", bn.ModelName())
+	assert.Equal(t, "v2.4-fp32", bn.ModelVersion())
+	assert.Equal(t, 48000, bn.Spec().SampleRate)
+
+	// Publish the snapshot; getters now read the published value.
+	bn.publishIdentity()
+	assert.Equal(t, "BirdNET_V2.4", bn.ModelID())
+
+	// A bn.ModelInfo / bn.modelVersion write WITHOUT republish must NOT change the
+	// getters: this is what decouples the lock-free getters from a concurrent
+	// reloadModelInternal write to those fields.
+	bn.ModelInfo = ModelInfo{ID: "OTHER", Name: "Other", Spec: ModelSpec{SampleRate: 32000}}
+	bn.modelVersion = "other"
+	assert.Equal(t, "BirdNET_V2.4", bn.ModelID(), "getter must read the published snapshot, not the unpublished field write")
+	assert.Equal(t, "BirdNET v2.4", bn.ModelName())
+	assert.Equal(t, "v2.4-fp32", bn.ModelVersion())
+	assert.Equal(t, 48000, bn.Spec().SampleRate)
+
+	// Republish picks up the new values (the reload-commit / rollback step).
+	bn.publishIdentity()
+	assert.Equal(t, "OTHER", bn.ModelID())
+	assert.Equal(t, "Other", bn.ModelName())
+	assert.Equal(t, "other", bn.ModelVersion())
+	assert.Equal(t, 32000, bn.Spec().SampleRate)
+}
+
 // TestBirdNET_RuntimeInfo_PublishAndRestore verifies the atomic runtime-triplet
 // mechanism behind RuntimeInfo(): an unpublished instance reports the not-loaded
 // triplet, setRuntimeInfo publishes a self-consistent triplet read lock-free, and


### PR DESCRIPTION
## Summary

Follow-up to #3620. That PR made the runtime device/backend/precision triplet a lock-free atomic snapshot so the inference status card reads it without taking `bn.mu` (which inference holds for the full native call, #3336). The same class of lock-free read existed for the model identity:

- The `ModelInstance` getters `ModelID()`, `ModelName()`, `ModelVersion()`, `Spec()` read `bn.ModelInfo` / `bn.modelVersion` without a lock.
- The inference hot path (`Predict`) read `bn.ModelInfo.ID` lock-free at span start and on error paths.

Meanwhile `reloadModelInternal` rewrites `bn.ModelInfo` / `bn.modelVersion` under `bn.mu`. A getter or `Predict` racing a hot reload is a data race (a torn read of the identity), even though an in-place reload cannot change the model ID.

This applies the same fix as the runtime triplet:

- New immutable `modelIdentity{id, name, version, spec}` published into an `atomic.Pointer[modelIdentity]` at each commit point: end of `NewBirdNET`, a successful `reloadModelInternal`, and the reload rollback.
- The four getters read the snapshot lock-free (with a direct-read fallback for struct-literal test instances that never publish and are never concurrently reloaded).
- `Predict` captures the model ID once via `bn.ModelID()` and reuses it for the span name and all error/metric contexts, instead of reading `bn.ModelInfo.ID` directly on the hot path.

The getters stay off `bn.mu`, so they neither block on an in-flight inference nor race the reload writes. No exported API, JSON, config, or DB surface changes.

## Test Plan

- [x] `golangci-lint` clean
- [x] `go test -race ./internal/classifier/ ./internal/api/v2/` passes
- [x] New unit test `TestBirdNET_Identity_PublishAndSnapshot` asserts the decoupling property: a `bn.ModelInfo` / `bn.modelVersion` write without republish does not change the getters (it would fail if the getters were reverted to direct reads)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency of model metadata (ID, name, version, spec) across prediction and tracing by using a shared, immutable snapshot.
  * Enhanced thread-safety for concurrent reads of model metadata during model reloads and rollbacks.

* **Tests**
  * Added coverage to verify snapshot behavior for model getter values, including republishing after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->