### PR TITLE
feat(analytics): nocturnal activity clock

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.svelte
@@ -475,5 +475,7 @@
   :global(.clock-radial .hour-bar),
   :global(.clock-linear .hour-bar) {
     transition: opacity 0.12s ease;
+    /* Bars reveal their count on hover but are not clickable; the help cursor signals that. */
+    cursor: help;
   }
 </style>

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.svelte
@@ -475,6 +475,7 @@
   :global(.clock-radial .hour-bar),
   :global(.clock-linear .hour-bar) {
     transition: opacity 0.12s ease;
+
     /* Bars reveal their count on hover but are not clickable; the help cursor signals that. */
     cursor: help;
   }

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.svelte
@@ -1,0 +1,479 @@
+<!--
+  Nocturnal activity clock (design spec section 6.4).
+
+  A 24-hour radial histogram of detection counts (one bar per hour, midnight at the top, clockwise)
+  with the daytime arc shaded by sunrise/sunset so nocturnal activity stands out. On narrow
+  viewports the radial gets too small to read, so it falls back to a linear 24-hour bar layout. Sun
+  times come from a separate endpoint and may be unavailable (polar day/night, or no station
+  coordinates); when so, the bars render without day/night shading.
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { select } from 'd3-selection';
+  import { arc as d3arc } from 'd3-shape';
+  import { scaleBand, scaleLinear } from 'd3-scale';
+  import type { AxisDomain, AxisScale } from 'd3-axis';
+
+  import BaseChart from './BaseChart.svelte';
+  import { createAxis, styleAxis, addAxisLabel, createHourAxisFormatter } from './utils/axes';
+  import { ChartTooltip } from './utils/interactions';
+  import { type ChartTheme } from './utils/theme';
+  import {
+    hourlyTotal,
+    maxHourly,
+    peakHour,
+    minuteToAngle,
+    polarToCartesian,
+    formatMinuteOfDay,
+    arcAngles,
+    dayRegionSegments,
+    HOURS_PER_DAY,
+    MINUTES_PER_HOUR,
+    type NocturnalClockData,
+  } from './utils/nocturnal';
+  import { t } from '$lib/i18n';
+
+  interface Props {
+    data: NocturnalClockData;
+    width?: number;
+    height?: number;
+    ariaLabel?: string;
+  }
+
+  let { data, width = 800, height = 400, ariaLabel }: Props = $props();
+
+  // Layout / behavior constants.
+  const MARGIN = { top: 20, right: 20, bottom: 36, left: 44 };
+  // Below this inner width the radial dial is too cramped to read; fall back to a linear bar chart.
+  const RADIAL_MIN_WIDTH = 360;
+  const RADIAL_INNER_FRACTION = 0.38; // hollow center radius as a fraction of the dial radius
+  const RADIAL_LABEL_PAD = 18; // gap between the dial edge and the hour tick labels
+  const BAR_PAD_ANGLE = 0.01; // small angular gap between adjacent radial bars
+  const DAY_FILL_OPACITY = 0.18;
+  const TWILIGHT_FILL_OPACITY = 0.1;
+  const NIGHT_FILL_OPACITY = 0.06;
+  const BAR_IDLE_OPACITY = 0.85;
+  const HOUR_TICK_STEP = 6; // label the dial every 6 hours (0, 6, 12, 18)
+  const LINEAR_X_TICK_STEP = 3; // label the linear axis every 3 hours
+  const X_AXIS_LABEL_OFFSET = 30;
+
+  let tooltip: ChartTooltip | null = null;
+  let chartContainer: HTMLDivElement | null = null;
+
+  // Bounded, finite hourly counts indexed 0..23 (defensive against a short/ragged payload).
+  const hours = $derived.by<number[]>(() => {
+    const out: number[] = [];
+    for (let h = 0; h < HOURS_PER_DAY; h++) {
+      // eslint-disable-next-line security/detect-object-injection -- h is a bounded loop index
+      const c = data.hourly[h];
+      out.push(Number.isFinite(c) ? c : 0);
+    }
+    return out;
+  });
+
+  // Screen-reader summary so the chart is not opaque to assistive tech (spec section 7).
+  const summary = $derived.by(() => {
+    const total = hourlyTotal(data);
+    if (total === 0) return '';
+    const peak = peakHour(data);
+    return t('analytics.advanced.charts.nocturnal.summary', {
+      total,
+      peak: peak === null ? '-' : formatMinuteOfDay(peak * MINUTES_PER_HOUR),
+    });
+  });
+
+  let chartContext = $state<{
+    svg: import('d3-selection').Selection<SVGSVGElement, unknown, null, undefined>;
+    chartGroup: import('d3-selection').Selection<globalThis.SVGGElement, unknown, null, undefined>;
+    innerWidth: number;
+    innerHeight: number;
+    theme: ChartTheme;
+  } | null>(null);
+
+  function hourLabel(hour: number): string {
+    return formatMinuteOfDay((hour % HOURS_PER_DAY) * MINUTES_PER_HOUR);
+  }
+
+  function showBarTooltip(event: MouseEvent, hour: number, count: number): void {
+    tooltip?.show({
+      title: t('analytics.advanced.charts.nocturnal.tooltipHour', {
+        start: hourLabel(hour),
+        end: hourLabel(hour + 1),
+      }),
+      items: [
+        {
+          label: t('analytics.advanced.charts.nocturnal.tooltipCount'),
+          value: String(count),
+        },
+      ],
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }
+
+  // Draw the radial dial: a night base ring, the shaded day/twilight arcs, the hour bars, and the
+  // perimeter hour ticks. Angles use the clock convention (minute 0 at top, clockwise).
+  function drawRadial(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight, theme } = context;
+    const cx = innerWidth / 2;
+    const cy = innerHeight / 2;
+    const dialRadius = Math.min(innerWidth, innerHeight) / 2 - RADIAL_LABEL_PAD;
+    if (dialRadius <= 0) return;
+    const innerRadius = dialRadius * RADIAL_INNER_FRACTION;
+
+    const root = chartGroup
+      .append('g')
+      .attr('class', 'clock-radial')
+      .attr('transform', `translate(${cx},${cy})`);
+
+    const makeArc = d3arc<{
+      innerRadius: number;
+      outerRadius: number;
+      startAngle: number;
+      endAngle: number;
+    }>()
+      .innerRadius(d => d.innerRadius)
+      .outerRadius(d => d.outerRadius)
+      .startAngle(d => d.startAngle)
+      .endAngle(d => d.endAngle);
+
+    const sun = data.sun;
+    // Night base ring spanning the whole dial; the day/twilight arcs are drawn on top of it.
+    if (sun?.available && sun.sunrise !== null && sun.sunset !== null) {
+      root
+        .append('path')
+        .attr('class', 'night-ring')
+        .attr(
+          'd',
+          makeArc({ innerRadius, outerRadius: dialRadius, startAngle: 0, endAngle: 2 * Math.PI })
+        )
+        .style('fill', theme.secondary)
+        .style('opacity', NIGHT_FILL_OPACITY);
+
+      // Twilight bands (civil dawn -> sunrise, sunset -> civil dusk) when a genuine twilight exists.
+      // arcAngles wraps the sweep forward over midnight so a band whose end lands past 00:00 still
+      // shades the correct side of the dial.
+      if (sun.civilDawn !== null) {
+        root
+          .append('path')
+          .attr('class', 'twilight-arc')
+          .attr(
+            'd',
+            makeArc({
+              innerRadius,
+              outerRadius: dialRadius,
+              ...arcAngles(sun.civilDawn, sun.sunrise),
+            })
+          )
+          .style('fill', theme.warning)
+          .style('opacity', TWILIGHT_FILL_OPACITY);
+      }
+      if (sun.civilDusk !== null) {
+        root
+          .append('path')
+          .attr('class', 'twilight-arc')
+          .attr(
+            'd',
+            makeArc({
+              innerRadius,
+              outerRadius: dialRadius,
+              ...arcAngles(sun.sunset, sun.civilDusk),
+            })
+          )
+          .style('fill', theme.warning)
+          .style('opacity', TWILIGHT_FILL_OPACITY);
+      }
+
+      // Daytime arc (sunrise -> sunset).
+      root
+        .append('path')
+        .attr('class', 'day-arc')
+        .attr(
+          'd',
+          makeArc({ innerRadius, outerRadius: dialRadius, ...arcAngles(sun.sunrise, sun.sunset) })
+        )
+        .style('fill', theme.warning)
+        .style('opacity', DAY_FILL_OPACITY);
+    }
+
+    // Hour bars: each bar grows outward from the inner radius proportional to its count.
+    const rScale = scaleLinear()
+      .domain([0, Math.max(1, maxHourly(data))])
+      .range([innerRadius, dialRadius]);
+    const sliceAngle = (2 * Math.PI) / HOURS_PER_DAY;
+
+    const bars = root.append('g').attr('class', 'hour-bars');
+    hours.forEach((count, hour) => {
+      bars
+        .append('path')
+        .attr('class', 'hour-bar')
+        .attr(
+          'd',
+          makeArc({
+            innerRadius,
+            outerRadius: rScale(count),
+            startAngle: hour * sliceAngle + BAR_PAD_ANGLE,
+            endAngle: (hour + 1) * sliceAngle - BAR_PAD_ANGLE,
+          })
+        )
+        .style('fill', theme.primary)
+        .style('opacity', BAR_IDLE_OPACITY)
+        .on('mouseenter', function (event: MouseEvent) {
+          select(this).style('opacity', 1);
+          showBarTooltip(event, hour, count);
+        })
+        .on('mouseleave', function () {
+          select(this).style('opacity', BAR_IDLE_OPACITY);
+          tooltip?.hide();
+        });
+    });
+
+    // Perimeter hour ticks (every HOUR_TICK_STEP hours).
+    const ticks = root.append('g').attr('class', 'hour-ticks');
+    for (let hour = 0; hour < HOURS_PER_DAY; hour += HOUR_TICK_STEP) {
+      const { x, y } = polarToCartesian(
+        0,
+        0,
+        dialRadius + RADIAL_LABEL_PAD * 0.6,
+        minuteToAngle(hour * MINUTES_PER_HOUR)
+      );
+      ticks
+        .append('text')
+        .attr('class', 'hour-tick')
+        .attr('x', x)
+        .attr('y', y)
+        .attr('text-anchor', 'middle')
+        .attr('dominant-baseline', 'middle')
+        .attr('aria-hidden', 'true')
+        .style('fill', theme.axis.color)
+        .style('font-size', theme.axis.fontSize)
+        .text(hourLabel(hour));
+    }
+  }
+
+  // Draw the linear fallback: a 24-bar histogram with the daytime region shaded behind the bars.
+  function drawLinear(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight, theme } = context;
+
+    const root = chartGroup.append('g').attr('class', 'clock-linear');
+
+    const xScale = scaleBand<number>()
+      .domain(Array.from({ length: HOURS_PER_DAY }, (_, h) => h))
+      .range([0, innerWidth])
+      .padding(0.15);
+    const yScale = scaleLinear()
+      .domain([0, Math.max(1, maxHourly(data))])
+      .range([innerHeight, 0])
+      .nice();
+
+    // Daytime region (sunrise -> sunset) shaded behind the bars; minute-of-day maps to x linearly.
+    // dayRegionSegments splits the band in two when it wraps past midnight so it never collapses.
+    const sun = data.sun;
+    if (sun?.available && sun.sunrise !== null && sun.sunset !== null) {
+      for (const seg of dayRegionSegments(sun.sunrise, sun.sunset, innerWidth)) {
+        if (seg.width <= 0) continue;
+        root
+          .append('rect')
+          .attr('class', 'day-region')
+          .attr('x', seg.x)
+          .attr('y', 0)
+          .attr('width', seg.width)
+          .attr('height', innerHeight)
+          .style('fill', theme.warning)
+          .style('opacity', DAY_FILL_OPACITY);
+      }
+    }
+
+    // Bars.
+    const bars = root.append('g').attr('class', 'hour-bars');
+    hours.forEach((count, hour) => {
+      const x = xScale(hour) ?? 0;
+      bars
+        .append('rect')
+        .attr('class', 'hour-bar')
+        .attr('x', x)
+        .attr('y', yScale(count))
+        .attr('width', xScale.bandwidth())
+        .attr('height', innerHeight - yScale(count))
+        .style('fill', theme.primary)
+        .style('opacity', BAR_IDLE_OPACITY)
+        .on('mouseenter', function (event: MouseEvent) {
+          select(this).style('opacity', 1);
+          showBarTooltip(event, hour, count);
+        })
+        .on('mouseleave', function () {
+          select(this).style('opacity', BAR_IDLE_OPACITY);
+          tooltip?.hide();
+        });
+    });
+
+    // X axis: hour-of-day labels every LINEAR_X_TICK_STEP hours (others blanked to avoid clutter).
+    const hourFmt = createHourAxisFormatter();
+    const xAxis = createAxis({
+      scale: xScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'bottom',
+      tickFormat: (d: AxisDomain) =>
+        Number(d) % LINEAR_X_TICK_STEP === 0 ? hourFmt(Number(d)) : '',
+    });
+    const xAxisGroup = root
+      .append('g')
+      .attr('class', 'x-axis')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(xAxis);
+    styleAxis(xAxisGroup, theme.axis);
+
+    // Y axis: detection counts.
+    const yAxis = createAxis({
+      scale: yScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'left',
+    });
+    const yAxisGroup = root.append('g').attr('class', 'y-axis').call(yAxis);
+    styleAxis(yAxisGroup, theme.axis);
+
+    addAxisLabel(
+      root,
+      {
+        text: t('analytics.advanced.charts.nocturnal.axisHour'),
+        orientation: 'bottom',
+        offset: X_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+  }
+
+  function drawChart(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight } = context;
+    // A redraw removes the hovered bar, so its mouseleave would never fire; hide first.
+    tooltip?.hide();
+    chartGroup.selectAll('*').remove();
+    if (innerWidth <= 0 || innerHeight <= 0) return;
+
+    if (innerWidth < RADIAL_MIN_WIDTH) {
+      drawLinear(context);
+    } else {
+      drawRadial(context);
+    }
+  }
+
+  $effect(() => {
+    if (chartContext) {
+      drawChart(chartContext);
+    }
+  });
+
+  onMount(() => {
+    if (chartContainer) {
+      tooltip = new ChartTooltip(chartContainer);
+    }
+  });
+
+  onDestroy(() => {
+    tooltip?.destroy();
+  });
+</script>
+
+<div class="nocturnal-clock-chart" bind:this={chartContainer}>
+  <div class="chart-area">
+    <BaseChart
+      {width}
+      {height}
+      margin={MARGIN}
+      responsive={true}
+      ariaLabel={ariaLabel ?? t('analytics.advanced.charts.nocturnal.ariaLabel')}
+    >
+      {#snippet children(context)}
+        {((chartContext = context), '')}
+      {/snippet}
+    </BaseChart>
+  </div>
+  <!-- Legend maps the day/night shading to text, so the bands are not conveyed by color alone
+       (matches the seasonal heatmap's legend). Shown only when sun times are available. -->
+  {#if data.sun?.available && data.sun.sunrise !== null && data.sun.sunset !== null}
+    <ul class="nocturnal-legend" data-testid="nocturnal-legend">
+      <li>
+        <span class="swatch swatch-day"></span>{t('analytics.advanced.charts.nocturnal.legendDay')}
+      </li>
+      {#if data.sun.civilDawn !== null || data.sun.civilDusk !== null}
+        <li>
+          <span class="swatch swatch-twilight"></span>{t(
+            'analytics.advanced.charts.nocturnal.legendTwilight'
+          )}
+        </li>
+      {/if}
+      <li>
+        <span class="swatch swatch-night"></span>{t(
+          'analytics.advanced.charts.nocturnal.legendNight'
+        )}
+      </li>
+    </ul>
+  {/if}
+  {#if summary}
+    <p class="sr-only" data-testid="nocturnal-summary">{summary}</p>
+  {/if}
+</div>
+
+<style>
+  .nocturnal-clock-chart {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 320px;
+  }
+
+  /* The chart fills the available height; the legend takes its natural height below it. */
+  .chart-area {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+  }
+
+  .nocturnal-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    padding: 0.25rem 0 0;
+    list-style: none;
+    font-size: 0.75rem;
+    color: var(--color-base-content);
+  }
+
+  .nocturnal-legend li {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .swatch {
+    display: inline-block;
+    flex-shrink: 0;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 2px;
+  }
+
+  .swatch-day {
+    background-color: var(--color-warning);
+    opacity: 0.55;
+  }
+
+  .swatch-twilight {
+    background-color: var(--color-warning);
+    opacity: 0.28;
+  }
+
+  .swatch-night {
+    background-color: var(--color-secondary);
+    opacity: 0.3;
+  }
+
+  :global(.clock-radial .hour-bar),
+  :global(.clock-linear .hour-bar) {
+    transition: opacity 0.12s ease;
+  }
+</style>

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/NocturnalClock.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import NocturnalClock from './NocturnalClock.svelte';
+import type { NocturnalClockData } from './utils/nocturnal';
+
+// jsdom has no layout engine; assert on element counts/attributes only. The radial vs linear mode
+// is driven by the width prop (BaseChart falls back to it because ResizeObserver never fires here).
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// 24 hourly counts with a clear nocturnal peak, plus sun times for the day/night shading.
+const sample: NocturnalClockData = {
+  hourly: [12, 9, 7, 5, 3, 2, 4, 8, 6, 3, 1, 0, 0, 1, 2, 3, 5, 7, 9, 11, 14, 16, 15, 13],
+  sun: {
+    date: '2026-03-16',
+    sunrise: 6 * 60 + 12,
+    sunset: 18 * 60 + 30,
+    civilDawn: 5 * 60 + 44,
+    civilDusk: 19 * 60,
+    available: true,
+  },
+};
+
+const noSun: NocturnalClockData = { ...sample, sun: null };
+
+const empty: NocturnalClockData = { hourly: new Array<number>(24).fill(0), sun: null };
+
+describe('NocturnalClock', () => {
+  it('renders without throwing for empty data', () => {
+    expect(() => render(NocturnalClock, { props: { data: empty } })).not.toThrow();
+  });
+
+  it('renders the radial dial with one bar per hour at desktop width', async () => {
+    const { container } = render(NocturnalClock, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelector('.clock-radial')).toBeTruthy();
+    expect(container.querySelector('.clock-linear')).toBeNull();
+    expect(container.querySelectorAll('.clock-radial .hour-bar')).toHaveLength(24);
+  });
+
+  it('shades the daytime arc when sun times are available', async () => {
+    const { container } = render(NocturnalClock, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelector('.day-arc')).toBeTruthy();
+    // Civil dawn and civil dusk both present -> two twilight bands.
+    expect(container.querySelectorAll('.twilight-arc')).toHaveLength(2);
+  });
+
+  it('omits the day shading when sun times are unavailable', async () => {
+    const { container } = render(NocturnalClock, { props: { data: noSun, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelector('.day-arc')).toBeNull();
+    expect(container.querySelector('.night-ring')).toBeNull();
+    // The hourly bars still render without shading.
+    expect(container.querySelectorAll('.clock-radial .hour-bar')).toHaveLength(24);
+  });
+
+  it('falls back to a linear bar layout on a narrow viewport', async () => {
+    const { container } = render(NocturnalClock, { props: { data: sample, width: 300 } });
+    await Promise.resolve();
+    expect(container.querySelector('.clock-linear')).toBeTruthy();
+    expect(container.querySelector('.clock-radial')).toBeNull();
+    expect(container.querySelectorAll('.clock-linear .hour-bar')).toHaveLength(24);
+    expect(container.querySelector('.x-axis')).toBeTruthy();
+    expect(container.querySelector('.y-axis')).toBeTruthy();
+  });
+
+  it('shades the daytime region in the linear fallback when sun is available', async () => {
+    const { container } = render(NocturnalClock, { props: { data: sample, width: 300 } });
+    await Promise.resolve();
+    expect(container.querySelector('.day-region')).toBeTruthy();
+  });
+
+  it('omits the day region in the linear fallback when sun is unavailable', async () => {
+    const { container } = render(NocturnalClock, { props: { data: noSun, width: 300 } });
+    await Promise.resolve();
+    expect(container.querySelector('.clock-linear')).toBeTruthy();
+    expect(container.querySelector('.day-region')).toBeNull();
+    expect(container.querySelectorAll('.clock-linear .hour-bar')).toHaveLength(24);
+  });
+
+  it('renders a day/twilight/night legend when sun is available', async () => {
+    const { getByTestId } = render(NocturnalClock, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    const legend = getByTestId('nocturnal-legend');
+    expect(legend).toBeTruthy();
+    // Day + Twilight + Night = three entries (sample has genuine civil dawn and dusk).
+    expect(legend.querySelectorAll('li')).toHaveLength(3);
+  });
+
+  it('omits the twilight legend entry when no genuine civil twilight exists', async () => {
+    // White-night style: sun rises/sets but civil dawn/dusk are null.
+    const whiteNight: NocturnalClockData = {
+      hourly: sample.hourly,
+      sun: {
+        date: '2026-06-21',
+        sunrise: 3 * 60 + 48,
+        sunset: 23 * 60 + 3,
+        civilDawn: null,
+        civilDusk: null,
+        available: true,
+      },
+    };
+    const { getByTestId } = render(NocturnalClock, { props: { data: whiteNight, width: 800 } });
+    await Promise.resolve();
+    expect(getByTestId('nocturnal-legend').querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('omits the legend entirely when sun is unavailable', async () => {
+    const { queryByTestId } = render(NocturnalClock, { props: { data: noSun, width: 800 } });
+    await Promise.resolve();
+    expect(queryByTestId('nocturnal-legend')).toBeNull();
+  });
+
+  it('sets an accessible label on the chart container', () => {
+    const { container } = render(NocturnalClock, {
+      props: { data: sample, ariaLabel: 'Nocturnal clock' },
+    });
+    expect(container.querySelector('[aria-label="Nocturnal clock"]')).toBeTruthy();
+  });
+
+  it('renders a screen-reader summary when there is activity', async () => {
+    const { getByTestId } = render(NocturnalClock, { props: { data: sample } });
+    await Promise.resolve();
+    expect(getByTestId('nocturnal-summary')).toBeTruthy();
+  });
+
+  it('omits the summary when there is no activity', async () => {
+    const { queryByTestId } = render(NocturnalClock, { props: { data: empty } });
+    await Promise.resolve();
+    expect(queryByTestId('nocturnal-summary')).toBeNull();
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/nocturnal.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/__tests__/nocturnal.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hourlyTotal,
+  maxHourly,
+  peakHour,
+  minuteToAngle,
+  polarToCartesian,
+  formatMinuteOfDay,
+  arcAngles,
+  dayRegionSegments,
+  MINUTES_PER_DAY,
+  type NocturnalClockData,
+} from '../nocturnal';
+
+function clock(hourly: number[], sun: NocturnalClockData['sun'] = null): NocturnalClockData {
+  return { hourly, sun };
+}
+
+describe('nocturnal utils', () => {
+  describe('hourlyTotal', () => {
+    it('sums all hourly counts', () => {
+      expect(hourlyTotal(clock([1, 2, 3, 4]))).toBe(10);
+    });
+
+    it('ignores non-finite values', () => {
+      expect(hourlyTotal(clock([1, NaN, 2, Infinity]))).toBe(3);
+    });
+
+    it('is 0 for an empty array', () => {
+      expect(hourlyTotal(clock([]))).toBe(0);
+    });
+  });
+
+  describe('maxHourly', () => {
+    it('returns the largest count', () => {
+      expect(maxHourly(clock([0, 5, 2, 9, 1]))).toBe(9);
+    });
+
+    it('is 0 when there is no activity', () => {
+      expect(maxHourly(clock([0, 0, 0]))).toBe(0);
+    });
+
+    it('ignores counts beyond 24 hours', () => {
+      const arr = new Array<number>(26).fill(1);
+      arr[25] = 999; // beyond hour 23, must be ignored
+      expect(maxHourly(clock(arr))).toBe(1);
+    });
+  });
+
+  describe('peakHour', () => {
+    it('returns the hour index of the maximum', () => {
+      expect(peakHour(clock([0, 0, 7, 3]))).toBe(2);
+    });
+
+    it('returns the earliest hour on a tie', () => {
+      expect(peakHour(clock([4, 4, 1]))).toBe(0);
+    });
+
+    it('is null when there is no activity', () => {
+      expect(peakHour(clock([0, 0, 0]))).toBeNull();
+    });
+  });
+
+  describe('minuteToAngle', () => {
+    it('maps midnight to 0 (top of the dial)', () => {
+      expect(minuteToAngle(0)).toBe(0);
+    });
+
+    it('maps noon to PI (bottom of the dial)', () => {
+      expect(minuteToAngle(MINUTES_PER_DAY / 2)).toBeCloseTo(Math.PI, 10);
+    });
+
+    it('maps 06:00 to PI/2 (clockwise quarter turn)', () => {
+      expect(minuteToAngle(6 * 60)).toBeCloseTo(Math.PI / 2, 10);
+    });
+  });
+
+  describe('polarToCartesian', () => {
+    it('places angle 0 at the top (midnight)', () => {
+      const p = polarToCartesian(100, 100, 50, 0);
+      expect(p.x).toBeCloseTo(100, 10);
+      expect(p.y).toBeCloseTo(50, 10);
+    });
+
+    it('places a quarter turn to the right (06:00)', () => {
+      const p = polarToCartesian(100, 100, 50, Math.PI / 2);
+      expect(p.x).toBeCloseTo(150, 10);
+      expect(p.y).toBeCloseTo(100, 10);
+    });
+  });
+
+  describe('formatMinuteOfDay', () => {
+    it('formats a minute-of-day as zero-padded HH:MM', () => {
+      expect(formatMinuteOfDay(372)).toBe('06:12');
+      expect(formatMinuteOfDay(0)).toBe('00:00');
+      expect(formatMinuteOfDay(MINUTES_PER_DAY - 1)).toBe('23:59');
+    });
+
+    it('wraps a full day back to 00:00', () => {
+      expect(formatMinuteOfDay(MINUTES_PER_DAY)).toBe('00:00');
+    });
+  });
+
+  describe('arcAngles', () => {
+    it('returns increasing angles for a normal same-day span', () => {
+      const { startAngle, endAngle } = arcAngles(6 * 60, 18 * 60); // 06:00 -> 18:00
+      expect(startAngle).toBeCloseTo(minuteToAngle(6 * 60), 10);
+      expect(endAngle).toBeCloseTo(minuteToAngle(18 * 60), 10);
+      expect(endAngle).toBeGreaterThan(startAngle);
+    });
+
+    it('wraps the end forward over midnight when it precedes the start', () => {
+      // sunrise 23:00 (1380), sunset 02:00 (120) -> day spans midnight; end must wrap past start.
+      const { startAngle, endAngle } = arcAngles(1380, 120);
+      expect(endAngle).toBeGreaterThan(startAngle);
+      // The swept arc stays under a full turn (a real daytime span never covers the whole dial).
+      expect(endAngle - startAngle).toBeLessThan(2 * Math.PI);
+      expect(endAngle).toBeCloseTo(minuteToAngle(120) + 2 * Math.PI, 10);
+    });
+
+    it('wraps equal start/end to a full turn rather than a zero-width arc', () => {
+      const { startAngle, endAngle } = arcAngles(600, 600);
+      expect(endAngle - startAngle).toBeCloseTo(2 * Math.PI, 10);
+    });
+  });
+
+  describe('dayRegionSegments', () => {
+    it('returns a single segment for a normal same-day span', () => {
+      const segs = dayRegionSegments(6 * 60, 18 * 60, 1440); // width=1440 -> 1px per minute
+      expect(segs).toHaveLength(1);
+      expect(segs[0].x).toBeCloseTo(360, 10);
+      expect(segs[0].width).toBeCloseTo(720, 10);
+    });
+
+    it('splits into two segments when the span wraps past midnight', () => {
+      // sunrise 23:00 (1380), sunset 02:00 (120) at width 1440 -> [0,120] and [1380,1440].
+      const segs = dayRegionSegments(1380, 120, 1440);
+      expect(segs).toHaveLength(2);
+      expect(segs[0]).toEqual({ x: 0, width: 120 });
+      expect(segs[1]).toEqual({ x: 1380, width: 60 });
+    });
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/nocturnal.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/nocturnal.ts
@@ -1,0 +1,133 @@
+// Nocturnal activity clock chart data + pure helpers (design spec section 6.4).
+//
+// The chart overlays two data sources: hourly detection counts from the (unchanged) endpoint
+// GET /api/v2/analytics/time/distribution/hourly, and sun times from GET /api/v2/analytics/sun.
+// Sun event fields are minute-of-day (0..1439) in the server's local timezone, the same frame the
+// hourly counts are bucketed in, so the day/night shading aligns with the hourly bars.
+
+export const HOURS_PER_DAY = 24;
+export const MINUTES_PER_DAY = 1440;
+export const MINUTES_PER_HOUR = 60;
+
+/** Sun times for the representative date, used to shade the clock's day/night arcs. */
+export interface SunTimes {
+  /** Representative date the sun times are for (YYYY-MM-DD, server-local). */
+  date: string;
+  /** Minute-of-day (0..1439) in server-local time; null if the event does not occur. */
+  sunrise: number | null;
+  sunset: number | null;
+  /** Civil dawn/dusk; null unless a genuine civil twilight occurs (omitted at high latitudes). */
+  civilDawn: number | null;
+  civilDusk: number | null;
+  /** false when SunCalc is unconfigured or the sun never rises/sets (polar day/night). */
+  available: boolean;
+}
+
+/** The chart's combined data: hourly counts plus optional sun times for shading. */
+export interface NocturnalClockData {
+  /** Detection counts by hour of day (index 0..23), server-local time. */
+  hourly: number[];
+  /** Sun times for the day arc, or null when unavailable (chart renders without shading). */
+  sun: SunTimes | null;
+}
+
+/** Total detections across all hours; drives the registry's not-enough-data check. */
+export function hourlyTotal(data: NocturnalClockData): number {
+  return data.hourly.reduce((sum, c) => sum + (Number.isFinite(c) ? c : 0), 0);
+}
+
+/** Largest hourly count (0 when there is no data); sizes the radial/linear value scale. */
+export function maxHourly(data: NocturnalClockData): number {
+  let max = 0;
+  for (let h = 0; h < HOURS_PER_DAY && h < data.hourly.length; h++) {
+    // eslint-disable-next-line security/detect-object-injection -- h is a bounded loop index
+    const c = data.hourly[h];
+    if (Number.isFinite(c) && c > max) max = c;
+  }
+  return max;
+}
+
+/** Hour (0..23) with the most detections, or null when there are none. Ties pick the earliest. */
+export function peakHour(data: NocturnalClockData): number | null {
+  let best = 0;
+  let bestHour: number | null = null;
+  for (let h = 0; h < HOURS_PER_DAY && h < data.hourly.length; h++) {
+    // eslint-disable-next-line security/detect-object-injection -- h is a bounded loop index
+    const c = data.hourly[h];
+    if (Number.isFinite(c) && c > best) {
+      best = c;
+      bestHour = h;
+    }
+  }
+  return bestHour;
+}
+
+/**
+ * Angle (radians) for a minute-of-day on the 24h clock dial: midnight (minute 0) at the top
+ * (12 o'clock), advancing clockwise. This matches d3-shape `arc` angle convention (0 = top,
+ * positive = clockwise), so it can be passed directly as startAngle/endAngle.
+ */
+export function minuteToAngle(minute: number): number {
+  return (minute / MINUTES_PER_DAY) * 2 * Math.PI;
+}
+
+/**
+ * Cartesian point on a circle for a clock angle (midnight at top, clockwise) in SVG coordinates
+ * where y grows downward: x = cx + r*sin(theta), y = cy - r*cos(theta). Used to place hour ticks.
+ */
+export function polarToCartesian(
+  cx: number,
+  cy: number,
+  radius: number,
+  angle: number
+): { x: number; y: number } {
+  return { x: cx + radius * Math.sin(angle), y: cy - radius * Math.cos(angle) };
+}
+
+/** Format a minute-of-day as a 24-hour "HH:MM" label (e.g. 372 -> "06:12"). */
+export function formatMinuteOfDay(minute: number): string {
+  const m = ((Math.round(minute) % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+  const hh = Math.floor(m / MINUTES_PER_HOUR);
+  const mm = m % MINUTES_PER_HOUR;
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+}
+
+/**
+ * Start/end angles (radians) for a clock arc spanning [startMinute, endMinute], wrapping forward
+ * over midnight when the end is numerically at or before the start. That wrap happens when an
+ * event's minute-of-day in the server timezone lands on the far side of midnight (a station far
+ * from the server's timezone, e.g. a far-east location on a UTC server). d3-shape `arc` draws the
+ * sweep from startAngle to endAngle, so the wrap is expressed by adding one full turn to endAngle
+ * rather than letting it draw backwards (which would shade the night side instead of the day side).
+ */
+export function arcAngles(
+  startMinute: number,
+  endMinute: number
+): { startAngle: number; endAngle: number } {
+  const startAngle = minuteToAngle(startMinute);
+  let endAngle = minuteToAngle(endMinute);
+  if (endAngle <= startAngle) endAngle += 2 * Math.PI;
+  return { startAngle, endAngle };
+}
+
+/**
+ * X-position segments for shading the daytime span [startMinute, endMinute] on a linear 24h axis of
+ * the given pixel width. Normally one segment; when the span wraps past midnight (end before start)
+ * it splits into two: [0, end] and [start, width], so the daytime band never collapses to nothing.
+ */
+export function dayRegionSegments(
+  startMinute: number,
+  endMinute: number,
+  width: number
+): { x: number; width: number }[] {
+  const toX = (m: number) => (m / MINUTES_PER_DAY) * width;
+  const startX = toX(startMinute);
+  const endX = toX(endMinute);
+  if (endX >= startX) {
+    return [{ x: startX, width: endX - startX }];
+  }
+  return [
+    { x: 0, width: endX },
+    { x: startX, width: width - startX },
+  ];
+}

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -391,6 +391,7 @@ async function fetchDawnOnset(
 }
 
 const HOURS_IN_DAY = 24;
+const MINUTES_IN_DAY = HOURS_IN_DAY * 60;
 
 /** Coerces the hourly-distribution payload ([{hour,count}]) into a dense, bounds-checked number[24]. */
 function coerceHourly(data: unknown): number[] {
@@ -400,7 +401,10 @@ function coerceHourly(data: unknown): number[] {
     if (!raw || typeof raw !== 'object') continue;
     const item = raw as { hour?: unknown; count?: unknown };
     const hour = typeof item.hour === 'number' ? item.hour : -1;
-    const count = typeof item.count === 'number' && Number.isFinite(item.count) ? item.count : 0;
+    // Counts are detection tallies; clamp to >= 0 so a malformed negative never yields a negative
+    // (inverted) bar height.
+    const count =
+      typeof item.count === 'number' && Number.isFinite(item.count) ? Math.max(0, item.count) : 0;
     if (Number.isInteger(hour) && hour >= 0 && hour < HOURS_IN_DAY) {
       // eslint-disable-next-line security/detect-object-injection -- hour is bounds-checked above
       hourly[hour] = count;
@@ -409,9 +413,13 @@ function coerceHourly(data: unknown): number[] {
   return hourly;
 }
 
-/** A finite minute-of-day value, or null (the chart treats null as an undefined sun event). */
+/**
+ * A minute-of-day value (0..1439) or null. Out-of-domain numbers are rejected (null) so a malformed
+ * payload cannot place sun shading off the 24h canvas; the chart treats null as an undefined event.
+ */
 function coerceSunMinute(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value >= 0 && value < MINUTES_IN_DAY ? value : null;
 }
 
 /**
@@ -464,8 +472,12 @@ async function fetchNocturnal(
       civilDusk: coerceSunMinute(body.civilDusk),
       available: body.available === true,
     };
-    // A sun failure must not break the card; fall back to no shading.
-  })().catch(() => null);
+  })().catch((err: unknown) => {
+    // Propagate cancellation so an aborted request rejects (the card ignores aborts) rather than
+    // resolving with partial data; only a genuine sun failure degrades to no shading.
+    if (err instanceof Error && err.name === 'AbortError') throw err;
+    return null;
+  });
 
   const [hourly, sun] = await Promise.all([hourlyPromise, sunPromise]);
   return { hourly, sun };

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -21,6 +21,9 @@ import SpeciesRidgeline from '../components/charts/d3/SpeciesRidgeline.svelte';
 import DawnChorusOnset from '../components/charts/d3/DawnChorusOnset.svelte';
 import { onsetCount } from '../components/charts/d3/utils/dawnOnset';
 import type { DawnOnsetData, DawnOnsetPoint } from '../components/charts/d3/utils/dawnOnset';
+import NocturnalClock from '../components/charts/d3/NocturnalClock.svelte';
+import { hourlyTotal } from '../components/charts/d3/utils/nocturnal';
+import type { NocturnalClockData, SunTimes } from '../components/charts/d3/utils/nocturnal';
 import TrendChartOptions from '../components/TrendChartOptions.svelte';
 
 import { formatDateForAPI } from './analyticsParams';
@@ -387,6 +390,87 @@ async function fetchDawnOnset(
   return { points };
 }
 
+const HOURS_IN_DAY = 24;
+
+/** Coerces the hourly-distribution payload ([{hour,count}]) into a dense, bounds-checked number[24]. */
+function coerceHourly(data: unknown): number[] {
+  const hourly = new Array<number>(HOURS_IN_DAY).fill(0);
+  if (!Array.isArray(data)) return hourly;
+  for (const raw of data) {
+    if (!raw || typeof raw !== 'object') continue;
+    const item = raw as { hour?: unknown; count?: unknown };
+    const hour = typeof item.hour === 'number' ? item.hour : -1;
+    const count = typeof item.count === 'number' && Number.isFinite(item.count) ? item.count : 0;
+    if (Number.isInteger(hour) && hour >= 0 && hour < HOURS_IN_DAY) {
+      // eslint-disable-next-line security/detect-object-injection -- hour is bounds-checked above
+      hourly[hour] = count;
+    }
+  }
+  return hourly;
+}
+
+/** A finite minute-of-day value, or null (the chart treats null as an undefined sun event). */
+function coerceSunMinute(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Nocturnal activity clock: hourly detection counts (reusing the unchanged hourly-distribution
+ * endpoint) plus sun times for the day/night shading (from the separate /analytics/sun endpoint).
+ * The two are fetched in parallel; a sun-fetch failure degrades to no shading rather than failing
+ * the whole card. Honors an optional single-species filter on the counts only (sun is
+ * species-independent). The sun endpoint receives the same range and picks the representative
+ * midpoint date server-side.
+ */
+async function fetchNocturnal(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<NocturnalClockData> {
+  const start = formatDateForAPI(params.startDate);
+  const end = formatDateForAPI(params.endDate);
+
+  const hourlySearch = new URLSearchParams({ start_date: start, end_date: end });
+  // The endpoint filters by a single species; use the first selected (none = all species).
+  if (params.species.length > 0) hourlySearch.append('species', params.species[0]);
+
+  const hourlyPromise = (async (): Promise<number[]> => {
+    const response = await fetch(
+      buildAppUrl(`/api/v2/analytics/time/distribution/hourly?${hourlySearch}`),
+      { signal }
+    );
+    ensureOk(response);
+    return coerceHourly(await response.json());
+  })();
+
+  const sunSearch = new URLSearchParams({ start_date: start, end_date: end });
+  const sunPromise: Promise<SunTimes | null> = (async (): Promise<SunTimes | null> => {
+    const response = await fetch(buildAppUrl(`/api/v2/analytics/sun?${sunSearch}`), { signal });
+    ensureOk(response);
+    const raw: unknown = await response.json();
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const body = raw as {
+      date?: unknown;
+      sunrise?: unknown;
+      sunset?: unknown;
+      civilDawn?: unknown;
+      civilDusk?: unknown;
+      available?: unknown;
+    };
+    return {
+      date: typeof body.date === 'string' ? body.date : '',
+      sunrise: coerceSunMinute(body.sunrise),
+      sunset: coerceSunMinute(body.sunset),
+      civilDawn: coerceSunMinute(body.civilDawn),
+      civilDusk: coerceSunMinute(body.civilDusk),
+      available: body.available === true,
+    };
+    // A sun failure must not break the card; fall back to no shading.
+  })().catch(() => null);
+
+  const [hourly, sun] = await Promise.all([hourlyPromise, sunPromise]);
+  return { hourly, sun };
+}
+
 // --- Registry --------------------------------------------------------------
 
 export const CHART_REGISTRY: ChartDef[] = [
@@ -449,6 +533,23 @@ export const CHART_REGISTRY: ChartDef[] = [
     supports: { species: true, source: false },
     // A handful of days with onsets is the minimum before the scatter + trend read as anything.
     minDataPoints: 3,
+  },
+  {
+    id: 'nocturnal-clock',
+    group: 'patterns',
+    titleKey: 'analytics.advanced.charts.nocturnal.title',
+    descKey: 'analytics.advanced.charts.nocturnal.description',
+    emptyKey: 'analytics.advanced.charts.nocturnal.noData',
+    emptyHintKey: 'analytics.advanced.charts.nocturnal.noDataHint',
+    component: NocturnalClock,
+    fetch: fetchNocturnal,
+    // The fetch result is an object (hourly counts + sun times), so count total detections across
+    // the day rather than relying on ChartCard's default array-length count.
+    countDataPoints: data => hourlyTotal(data as NocturnalClockData),
+    size: 'full',
+    supports: { species: true, source: false },
+    // Below this many detections the 24h dial is too sparse to read as an activity pattern.
+    minDataPoints: 10,
   },
   {
     id: 'time-of-day-species',

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1457,6 +1457,18 @@ export type TranslationKey =
   | 'analytics.advanced.charts.dawnOnset.tooltipOnsetAt'
   | 'analytics.advanced.charts.dawnOnset.tooltipCount'
   | 'analytics.advanced.charts.dawnOnset.summary' // params: days, plotted
+  | 'analytics.advanced.charts.nocturnal.title'
+  | 'analytics.advanced.charts.nocturnal.description'
+  | 'analytics.advanced.charts.nocturnal.noData'
+  | 'analytics.advanced.charts.nocturnal.noDataHint'
+  | 'analytics.advanced.charts.nocturnal.ariaLabel'
+  | 'analytics.advanced.charts.nocturnal.axisHour'
+  | 'analytics.advanced.charts.nocturnal.tooltipHour' // params: start, end
+  | 'analytics.advanced.charts.nocturnal.tooltipCount'
+  | 'analytics.advanced.charts.nocturnal.summary' // params: total, peak
+  | 'analytics.advanced.charts.nocturnal.legendDay'
+  | 'analytics.advanced.charts.nocturnal.legendTwilight'
+  | 'analytics.advanced.charts.nocturnal.legendNight'
   | 'analytics.advanced.charts.tooltips.date'
   | 'analytics.advanced.charts.tooltips.percentage'
   | 'analytics.advanced.charts.tooltips.detections'
@@ -3980,6 +3992,11 @@ export type TranslationParams = {
     days: string | number;
     plotted: string | number;
   };
+  'analytics.advanced.charts.nocturnal.tooltipHour': {
+    start: string | number;
+    end: string | number;
+  };
+  'analytics.advanced.charts.nocturnal.summary': { total: string | number; peak: string | number };
   'settings.notFound.message': { section: string | number };
   'settings.main.sections.falsePositiveFilter.detectionCount': {
     count: string | number;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Procento",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Procentdel",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Prozentsatz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Percentage",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Fecha",
           "percentage": "Porcentaje",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Päivämäärä",
           "percentage": "Prosenttiosuus",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Pourcentage",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Százalék",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentuale",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Datums",
           "percentage": "Procenti",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Prosentandel",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Percentage",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Procent",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentagem",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Percentá",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1873,6 +1873,20 @@
           "tooltipCount": "Detections",
           "summary": "Dawn chorus onset relative to civil dawn across {days} days ({plotted} with a measurable onset)."
         },
+        "nocturnal": {
+          "title": "Nocturnal Activity Clock",
+          "description": "Detections around the 24-hour clock with the daytime hours shaded, making nighttime activity stand out",
+          "noData": "No activity data available",
+          "noDataHint": "Select a wider date range or a more active period to see the daily activity pattern",
+          "ariaLabel": "Nocturnal activity clock: detections by hour of day with daytime shading",
+          "axisHour": "Hour of day",
+          "tooltipHour": "{start} to {end}",
+          "tooltipCount": "Detections",
+          "summary": "Detection activity by hour of day ({total} detections, most active around {peak}). Daytime hours are shaded.",
+          "legendDay": "Day",
+          "legendTwilight": "Twilight",
+          "legendNight": "Night"
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Andel",

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -94,6 +94,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/time/distribution/species` | `GetSpeciesHourlyDistribution` | ❌ | Who-sings-when ridgeline: per-species hour-of-day distribution for the top N species by volume. `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `limit` optional (default 5, max 8) |
 | GET    | `/analytics/time/heatmap`             | `GetActivityHeatmap`       | ❌   | Seasonal density heatmap (date x intra-day slot; `?format=csv`) |
 | GET    | `/analytics/time/dawn-onset`          | `GetDawnChorusOnset`       | ❌   | Dawn-chorus onset tracker: per-day onset relative to civil dawn (minutes; negative = before civil dawn). `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `species` optional |
+| GET    | `/analytics/sun`                      | `GetAnalyticsSun`          | ❌   | Sun times for the nocturnal activity clock's day/night shading: sunrise/sunset/civil-dawn/civil-dusk as minute-of-day in server-local time. `date` for a single day, or `start_date`/`end_date` for a range (collapsed to its midpoint); defaults to today. Returns `available:false` (not an error) on polar day/night or when SunCalc is unconfigured |
 
 ### Control Operations (`control.go`)
 

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -1419,23 +1419,21 @@ func localMinuteOfDay(t time.Time) int {
 
 // resolveSunRepresentativeDate picks the single date the nocturnal clock's sun times represent.
 // A multi-day range collapses to its calendar midpoint (the chart notes this in its tooltip); a
-// single `date` (or a lone `start_date`) is used directly; absent all three, today is used. Dates
-// are parsed in the server's local timezone and the midpoint is computed by calendar-day
-// arithmetic (AddDate), so the result is stable across DST transitions within the range and never
-// drifts onto an adjacent day. Inputs are pre-validated by the handler.
+// single `date` (or a lone `start_date`) is used directly; absent all three, today is used. The
+// range bounds are parsed in UTC so every day is exactly 24h (DST-free), making the day count
+// exact; the midpoint is then a pure calendar offset (AddDate), and only its Y-M-D is used
+// downstream. Inputs are pre-validated by the handler.
 func resolveSunRepresentativeDate(dateParam, startDate, endDate string) string {
 	switch {
 	case dateParam != "":
 		return dateParam
 	case startDate != "" && endDate != "":
-		start, errS := time.ParseInLocation(time.DateOnly, startDate, time.Local)
-		end, errE := time.ParseInLocation(time.DateOnly, endDate, time.Local)
+		start, errS := time.Parse(time.DateOnly, startDate)
+		end, errE := time.Parse(time.DateOnly, endDate)
 		if errS != nil || errE != nil {
 			return startDate // defensive: handler validated both already
 		}
-		// Round the span to whole days so a DST hour inside the range cannot shift the count, then
-		// take half the days forward from the start via calendar arithmetic.
-		days := int((end.Sub(start).Hours() + sunHoursPerDay/2) / sunHoursPerDay)
+		days := int(end.Sub(start).Hours()) / sunHoursPerDay
 		return start.AddDate(0, 0, days/2).Format(time.DateOnly)
 	case startDate != "":
 		return startDate
@@ -1470,6 +1468,21 @@ func (c *Controller) GetAnalyticsSun(ctx echo.Context) error {
 	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
 		return err
 	}
+	// The strict format check is a regex, so a well-formed but impossible date (e.g. 2026-02-31)
+	// slips through; reject it explicitly rather than letting it surface later as a misleading
+	// available:false. (start_date/end_date already get this via validateDateRangeWithResponse.)
+	if dateParam != "" {
+		if _, err := time.Parse(time.DateOnly, dateParam); err != nil {
+			_ = c.HandleError(ctx, err, "Invalid date parameters", http.StatusBadRequest)
+			return ErrResponseHandled
+		}
+	}
+	// A lone end_date has no start to pair with and would otherwise be silently ignored (the result
+	// would default to today), which is misleading; require start_date alongside it.
+	if dateParam == "" && startDate == "" && endDate != "" {
+		_ = c.HandleError(ctx, nil, "start_date is required when end_date is provided", http.StatusBadRequest)
+		return ErrResponseHandled
+	}
 
 	repDate := resolveSunRepresentativeDate(dateParam, startDate, endDate)
 
@@ -1495,7 +1508,9 @@ func (c *Controller) GetAnalyticsSun(ctx echo.Context) error {
 	if err != nil {
 		return ctx.JSON(http.StatusOK, resp)
 	}
-	anchor := repTime.Add(sunNoonHour * time.Hour)
+	// Construct local calendar noon directly (not midnight + 12h, which lands at 11:00/13:00 across a
+	// DST transition) so the anchor is always mid-day on the intended calendar date.
+	anchor := time.Date(repTime.Year(), repTime.Month(), repTime.Day(), sunNoonHour, 0, 0, 0, repTime.Location())
 
 	times, err := c.SunCalc.GetSunEventTimes(anchor)
 	if err != nil {

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -192,6 +192,11 @@ func (c *Controller) initAnalyticsRoutes() {
 	timeGroup.GET("/distribution/species", c.GetSpeciesHourlyDistribution) // Who-sings-when ridgeline (top-N species hour-of-day)
 	timeGroup.GET("/heatmap", c.GetActivityHeatmap)                        // Seasonal density heatmap (date x intra-day slot)
 	timeGroup.GET("/dawn-onset", c.GetDawnChorusOnset)                     // Dawn-chorus onset tracker (daily onset vs civil dawn)
+
+	// Sun times for the nocturnal activity clock's day/night shading. Additive: the clock's counts
+	// come from the existing /time/distribution/hourly endpoint (unchanged); only this sun endpoint
+	// is new (design spec section 6.4).
+	analyticsGroup.GET("/sun", c.GetAnalyticsSun)
 }
 
 // GetDailySpeciesSummary handles GET /api/v2/analytics/species/daily
@@ -1378,6 +1383,159 @@ func (c *Controller) GetDawnChorusOnset(ctx echo.Context) error {
 	)
 
 	return ctx.JSON(http.StatusOK, newDawnChorusOnsetResponse(data))
+}
+
+// Nocturnal activity clock sun endpoint constants (design spec section 6.4).
+const (
+	sunNoonHour       = 12 // anchor a date at local noon before a SunCalc lookup (see GetAnalyticsSun)
+	sunHoursPerDay    = 24 // for the range-midpoint day count
+	sunMinutesPerHour = 60 // minute-of-day conversion
+)
+
+// analyticsSunResponse is the sun-times payload for the nocturnal activity clock (design spec
+// section 6.4). Each event field is the minute-of-day (0..1439) in the server's local timezone,
+// the same frame the hourly-distribution endpoint buckets detections in, so the chart's daytime
+// arc aligns with its hourly bars. A nil field means the event does not occur for the date (polar
+// day/night) or SunCalc is unavailable. CivilDawn/CivilDusk are nil unless a genuine civil
+// twilight occurs (SunCalc substitutes sunrise/sunset when it cannot be computed at high
+// latitudes). Available is false when no sun calculator is configured or the sun never rises/sets
+// on the date, signalling the client to render the bars without day/night shading rather than
+// erroring the card.
+type analyticsSunResponse struct {
+	Date      string `json:"date"`
+	Sunrise   *int   `json:"sunrise"`
+	Sunset    *int   `json:"sunset"`
+	CivilDawn *int   `json:"civilDawn"`
+	CivilDusk *int   `json:"civilDusk"`
+	Available bool   `json:"available"`
+}
+
+// localMinuteOfDay expresses an absolute instant as its minute-of-day (0..1439) in the server's
+// local timezone, matching the frame the hourly-distribution endpoint buckets detections in.
+func localMinuteOfDay(t time.Time) int {
+	lt := t.In(time.Local)
+	return lt.Hour()*sunMinutesPerHour + lt.Minute()
+}
+
+// resolveSunRepresentativeDate picks the single date the nocturnal clock's sun times represent.
+// A multi-day range collapses to its calendar midpoint (the chart notes this in its tooltip); a
+// single `date` (or a lone `start_date`) is used directly; absent all three, today is used. Dates
+// are parsed in the server's local timezone and the midpoint is computed by calendar-day
+// arithmetic (AddDate), so the result is stable across DST transitions within the range and never
+// drifts onto an adjacent day. Inputs are pre-validated by the handler.
+func resolveSunRepresentativeDate(dateParam, startDate, endDate string) string {
+	switch {
+	case dateParam != "":
+		return dateParam
+	case startDate != "" && endDate != "":
+		start, errS := time.ParseInLocation(time.DateOnly, startDate, time.Local)
+		end, errE := time.ParseInLocation(time.DateOnly, endDate, time.Local)
+		if errS != nil || errE != nil {
+			return startDate // defensive: handler validated both already
+		}
+		// Round the span to whole days so a DST hour inside the range cannot shift the count, then
+		// take half the days forward from the start via calendar arithmetic.
+		days := int((end.Sub(start).Hours() + sunHoursPerDay/2) / sunHoursPerDay)
+		return start.AddDate(0, 0, days/2).Format(time.DateOnly)
+	case startDate != "":
+		return startDate
+	default:
+		return time.Now().In(time.Local).Format(time.DateOnly)
+	}
+}
+
+// GetAnalyticsSun handles GET /api/v2/analytics/sun
+// Returns the sunrise/sunset/civil-dawn/civil-dusk times (minute-of-day, server-local) for a
+// representative date, powering the nocturnal activity clock's day/night shading (design spec
+// section 6.4). Accepts ?date for a single day or ?start_date&end_date for a range (collapsed to
+// its midpoint); defaults to today. Sun data is separate from the (unchanged) hourly-distribution
+// endpoint so that endpoint's response shape stays backward compatible.
+func (c *Controller) GetAnalyticsSun(ctx echo.Context) error {
+	const operation = "analytics sun times"
+
+	dateParam := ctx.QueryParam("date")
+	startDate := ctx.QueryParam("start_date")
+	endDate := ctx.QueryParam("end_date")
+
+	// All date params are optional (default is today); validate any that are present.
+	if err := c.validateDateFormatStrictWithResponse(ctx, dateParam, "date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, startDate, "start_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, endDate, "end_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
+		return err
+	}
+
+	repDate := resolveSunRepresentativeDate(dateParam, startDate, endDate)
+
+	c.logInfoIfEnabled("Retrieving analytics sun times",
+		logger.String("date", repDate),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	resp := analyticsSunResponse{Date: repDate}
+
+	// SunCalc may be unconfigured (e.g. not started yet). Degrade gracefully so the clock still
+	// renders its hourly bars without day/night shading rather than erroring the whole card.
+	if c.SunCalc == nil {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	// Anchor the date at local noon before the lookup: SunCalc re-derives the calendar day in its
+	// own coordinate-derived zone, so passing midnight could land on the adjacent day. Noon keeps
+	// the intended calendar day for any real timezone offset (same approach as the dawn-onset
+	// tracker). repDate is validated/derived above, so a parse failure is treated as no sun data.
+	repTime, err := time.ParseInLocation(time.DateOnly, repDate, time.Local)
+	if err != nil {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+	anchor := repTime.Add(sunNoonHour * time.Hour)
+
+	times, err := c.SunCalc.GetSunEventTimes(anchor)
+	if err != nil {
+		// Polar day/night: the sun never rises/sets, so there is no daytime arc to shade. Return
+		// available:false (not 500) so the client renders the bars without shading.
+		c.logInfoIfEnabled("Sun times unavailable for date (polar day/night)",
+			logger.String("date", repDate),
+			logger.String("ip", ctx.RealIP()),
+		)
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	sunrise := localMinuteOfDay(times.Sunrise)
+	sunset := localMinuteOfDay(times.Sunset)
+	resp.Sunrise = &sunrise
+	resp.Sunset = &sunset
+	resp.Available = true
+
+	// Civil dawn/dusk only when a genuine civil twilight occurs. SunCalc substitutes sunrise/sunset
+	// (exact equality) when civil twilight cannot be computed at high latitudes (white nights), so a
+	// genuine dawn is strictly before sunrise and a genuine dusk strictly after sunset; the equality
+	// fallback is omitted. Both read the already-fetched times (no second SunCalc lookup), and the
+	// dawn check mirrors suncalc.GetCivilDawn's own genuine-twilight test.
+	if times.CivilDawn.Before(times.Sunrise) {
+		civilDawn := localMinuteOfDay(times.CivilDawn)
+		resp.CivilDawn = &civilDawn
+	}
+	if times.CivilDusk.After(times.Sunset) {
+		civilDusk := localMinuteOfDay(times.CivilDusk)
+		resp.CivilDusk = &civilDusk
+	}
+
+	c.logInfoIfEnabled("Analytics sun times retrieved",
+		logger.String("date", repDate),
+		logger.Bool("available", resp.Available),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 // GetSpeciesHourlyDistribution handles GET /api/v2/analytics/time/distribution/species

--- a/internal/api/v2/analytics_sun_test.go
+++ b/internal/api/v2/analytics_sun_test.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// sunJSON mirrors the analytics sun-times wire shape. Event fields are pointers so an undefined
+// event (polar day/night, or SunCalc unavailable) round-trips as JSON null rather than 0.
+type sunJSON struct {
+	Date      string `json:"date"`
+	Sunrise   *int   `json:"sunrise"`
+	Sunset    *int   `json:"sunset"`
+	CivilDawn *int   `json:"civilDawn"`
+	CivilDusk *int   `json:"civilDusk"`
+	Available bool   `json:"available"`
+}
+
+// minutesInDay bounds a valid minute-of-day value (0..1439).
+const minutesInDay = 24 * 60
+
+func newSunContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/sun")
+	return c, rec
+}
+
+func decodeSun(t *testing.T, rec *httptest.ResponseRecorder) sunJSON {
+	t.Helper()
+	var resp sunJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+func TestGetAnalyticsSun_SingleDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	// Helsinki always has a sunrise and a sunset on a spring date, so events are defined.
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?date=2026-03-20")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeSun(t, rec)
+	assert.Equal(t, "2026-03-20", resp.Date)
+	assert.True(t, resp.Available)
+	require.NotNil(t, resp.Sunrise)
+	require.NotNil(t, resp.Sunset)
+	// Events are minute-of-day in local time, and on a spring day sunrise precedes sunset.
+	assert.GreaterOrEqual(t, *resp.Sunrise, 0)
+	assert.Less(t, *resp.Sunset, minutesInDay)
+	assert.Less(t, *resp.Sunrise, *resp.Sunset)
+	// A genuine civil dawn precedes sunrise; a genuine civil dusk follows sunset.
+	require.NotNil(t, resp.CivilDawn)
+	require.NotNil(t, resp.CivilDusk)
+	assert.Less(t, *resp.CivilDawn, *resp.Sunrise)
+	assert.Greater(t, *resp.CivilDusk, *resp.Sunset)
+}
+
+func TestGetAnalyticsSun_RangeUsesMidpoint(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	// 2026-03-01 .. 2026-03-31 -> calendar midpoint 2026-03-16. The midpoint is computed by
+	// calendar-day arithmetic so it is stable across the end-of-March DST transition.
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?start_date=2026-03-01&end_date=2026-03-31")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeSun(t, rec)
+	assert.Equal(t, "2026-03-16", resp.Date)
+	assert.True(t, resp.Available)
+	require.NotNil(t, resp.Sunrise)
+	require.NotNil(t, resp.Sunset)
+}
+
+func TestGetAnalyticsSun_LoneStartDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	// With only start_date, that date is used directly (no range to collapse).
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?start_date=2026-03-20")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "2026-03-20", decodeSun(t, rec).Date)
+}
+
+func TestGetAnalyticsSun_PolarDayUnavailable(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	// Ny-Ålesund, Svalbard (78.9N): on the summer solstice the sun never sets, so SunCalc cannot
+	// compute sunrise/sunset and the endpoint reports the day as unavailable rather than erroring.
+	controller.SunCalc = suncalc.NewSunCalc(78.9, 11.9)
+
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?date=2026-06-21")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeSun(t, rec)
+	assert.Equal(t, "2026-06-21", resp.Date)
+	assert.False(t, resp.Available)
+	assert.Nil(t, resp.Sunrise)
+	assert.Nil(t, resp.Sunset)
+	assert.Nil(t, resp.CivilDawn)
+	assert.Nil(t, resp.CivilDusk)
+}
+
+func TestGetAnalyticsSun_WhiteNightOmitsCivilTwilight(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	// At ~61N on the summer solstice the sun still rises and sets, but never descends to civil
+	// twilight (white nights), so SunCalc substitutes sunrise/sunset for civil dawn/dusk. The
+	// handler must report available:true with sunrise/sunset set but civilDawn/civilDusk nil
+	// (not the sunrise/sunset fallback values masquerading as a twilight band).
+	controller.SunCalc = suncalc.NewSunCalc(61.0, 24.0)
+
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?date=2026-06-21")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeSun(t, rec)
+	assert.True(t, resp.Available)
+	require.NotNil(t, resp.Sunrise)
+	require.NotNil(t, resp.Sunset)
+	assert.Less(t, *resp.Sunrise, *resp.Sunset)
+	assert.Nil(t, resp.CivilDawn, "civil dawn must be omitted when no genuine civil twilight occurs")
+	assert.Nil(t, resp.CivilDusk, "civil dusk must be omitted when no genuine civil twilight occurs")
+}
+
+func TestGetAnalyticsSun_SunCalcUnavailable(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	// SunCalc not configured: the endpoint degrades gracefully (200, available:false) so the clock
+	// still renders its hourly bars without day/night shading.
+	controller.SunCalc = nil
+
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?date=2026-03-20")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeSun(t, rec)
+	assert.Equal(t, "2026-03-20", resp.Date)
+	assert.False(t, resp.Available)
+	assert.Nil(t, resp.Sunrise)
+	assert.Nil(t, resp.Sunset)
+}
+
+func TestGetAnalyticsSun_DefaultsToToday(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	// No date params: the handler uses today. Helsinki always has a sunrise/sunset, so available.
+	c, rec := newSunContext(e, "/api/v2/analytics/sun")
+	require.NoError(t, controller.GetAnalyticsSun(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	resp := decodeSun(t, rec)
+	assert.NotEmpty(t, resp.Date)
+	assert.True(t, resp.Available)
+}
+
+func TestGetAnalyticsSun_InvalidDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?date=not-a-date")
+	err := controller.GetAnalyticsSun(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetAnalyticsSun_InvalidRangeOrder(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?start_date=2026-03-31&end_date=2026-03-01")
+	err := controller.GetAnalyticsSun(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHourlyDistribution_BackCompatUnchanged guards the API backward-compatibility constraint for
+// the nocturnal activity clock (Forgejo #1161): the clock reuses the existing hourly-distribution
+// endpoint, which must keep returning a 24-element [{hour, count}] array. This fails if a future
+// change alters that shape.
+func TestHourlyDistribution_BackCompatUnchanged(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetHourlyDistribution", mock.Anything, "2026-03-01", "2026-03-02", "").
+		Return([]datastore.HourlyDistributionData{{Hour: 8, Count: 5}, {Hour: 20, Count: 3}}, nil)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v2/analytics/time/distribution/hourly?start_date=2026-03-01&end_date=2026-03-02", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/time/distribution/hourly")
+
+	require.NoError(t, controller.GetTimeOfDayDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []HourlyDistribution
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// The unchanged shape is one entry per hour of day, ordered 0..23.
+	require.Len(t, resp, 24)
+	for hour := range resp {
+		assert.Equal(t, hour, resp[hour].Hour)
+	}
+	assert.Equal(t, 5, resp[8].Count)
+	assert.Equal(t, 3, resp[20].Count)
+	mockDS.AssertExpectations(t)
+}

--- a/internal/api/v2/analytics_sun_test.go
+++ b/internal/api/v2/analytics_sun_test.go
@@ -29,6 +29,14 @@ type sunJSON struct {
 // minutesInDay bounds a valid minute-of-day value (0..1439).
 const minutesInDay = 24 * 60
 
+// forwardMinutes is the clockwise distance from one minute-of-day to another, wrapping past
+// midnight. Sun events are emitted as server-local minute-of-day, so on a test host whose timezone
+// differs from the station coordinates an event pair can straddle midnight and invert a plain
+// a<b comparison; the forward distance is timezone-independent. >0 means "b is ahead of a".
+func forwardMinutes(from, to int) int {
+	return (to - from + minutesInDay) % minutesInDay
+}
+
 func newSunContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
 	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
 	rec := httptest.NewRecorder()
@@ -59,15 +67,17 @@ func TestGetAnalyticsSun_SingleDate(t *testing.T) {
 	assert.True(t, resp.Available)
 	require.NotNil(t, resp.Sunrise)
 	require.NotNil(t, resp.Sunset)
-	// Events are minute-of-day in local time, and on a spring day sunrise precedes sunset.
+	// Events are minute-of-day in local time; assert ordering circularly so the test is independent
+	// of the host timezone (sunrise -> sunset spans the daytime, civil dawn -> sunrise the morning
+	// twilight, sunset -> civil dusk the evening twilight; each is a positive forward span).
 	assert.GreaterOrEqual(t, *resp.Sunrise, 0)
 	assert.Less(t, *resp.Sunset, minutesInDay)
-	assert.Less(t, *resp.Sunrise, *resp.Sunset)
+	assert.Positive(t, forwardMinutes(*resp.Sunrise, *resp.Sunset))
 	// A genuine civil dawn precedes sunrise; a genuine civil dusk follows sunset.
 	require.NotNil(t, resp.CivilDawn)
 	require.NotNil(t, resp.CivilDusk)
-	assert.Less(t, *resp.CivilDawn, *resp.Sunrise)
-	assert.Greater(t, *resp.CivilDusk, *resp.Sunset)
+	assert.Positive(t, forwardMinutes(*resp.CivilDawn, *resp.Sunrise))
+	assert.Positive(t, forwardMinutes(*resp.Sunset, *resp.CivilDusk))
 }
 
 func TestGetAnalyticsSun_RangeUsesMidpoint(t *testing.T) {
@@ -137,7 +147,7 @@ func TestGetAnalyticsSun_WhiteNightOmitsCivilTwilight(t *testing.T) {
 	assert.True(t, resp.Available)
 	require.NotNil(t, resp.Sunrise)
 	require.NotNil(t, resp.Sunset)
-	assert.Less(t, *resp.Sunrise, *resp.Sunset)
+	assert.Positive(t, forwardMinutes(*resp.Sunrise, *resp.Sunset))
 	assert.Nil(t, resp.CivilDawn, "civil dawn must be omitted when no genuine civil twilight occurs")
 	assert.Nil(t, resp.CivilDusk, "civil dusk must be omitted when no genuine civil twilight occurs")
 }
@@ -192,6 +202,32 @@ func TestGetAnalyticsSun_InvalidRangeOrder(t *testing.T) {
 	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
 
 	c, rec := newSunContext(e, "/api/v2/analytics/sun?start_date=2026-03-31&end_date=2026-03-01")
+	err := controller.GetAnalyticsSun(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetAnalyticsSun_ImpossibleDateRejected(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	// A well-formed but impossible date passes the regex but is rejected explicitly with 400,
+	// rather than surfacing later as a misleading available:false.
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?date=2026-02-31")
+	err := controller.GetAnalyticsSun(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetAnalyticsSun_LoneEndDateRejected(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+	controller.SunCalc = suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+
+	// end_date with no start_date has nothing to pair with; reject it rather than silently
+	// defaulting to today.
+	c, rec := newSunContext(e, "/api/v2/analytics/sun?end_date=2026-03-20")
 	err := controller.GetAnalyticsSun(c)
 	require.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)


### PR DESCRIPTION
## Summary

Adds the Tier-1 **nocturnal activity clock** to the analytics hub's Activity Patterns tab: a 24-hour radial histogram of detection counts with the daytime arc shaded by sunrise/sunset so nighttime activity stands out. On narrow viewports it falls back to a linear 24h bar layout.

## Backend (additive only)

- New endpoint `GET /api/v2/analytics/sun` returning sunrise, sunset, civil dawn and civil dusk as **minute-of-day in the server-local timezone**, the same frame the existing hourly-distribution endpoint buckets detections in, so the day/night shading lines up with the bars.
  - Accepts `?date` (single day) or `?start_date&end_date` (a range collapsed to its calendar midpoint; the midpoint is DST-safe). Defaults to today.
  - Returns `available:false` (HTTP 200, not an error) on polar day/night or when no station coordinates are configured, so the chart degrades to "bars without shading" rather than failing the card.
  - Civil dawn/dusk are omitted when no genuine civil twilight occurs (high-latitude white nights), detected from the already-fetched sun times.
- The existing `GET /api/v2/analytics/time/distribution/hourly` endpoint is **reused unchanged**; a guard test pins its 24-element `[{hour,count}]` response shape so a future change can't silently break it.
- No datastore or interface change.

## Frontend

- `NocturnalClock.svelte` (D3, wraps `BaseChart`): radial dial of hourly counts with shaded day, twilight and night arcs, a day/twilight/night legend (so the shading isn't conveyed by color alone), perimeter hour ticks, and a screen-reader summary. Linear fallback below ~360px.
- One registry entry; sun and hourly data are fetched in parallel and a sun-fetch failure degrades to no shading. Sun-event arcs wrap correctly past midnight for stations far from the server timezone.

## Test plan

- [x] Go: `GET /api/v2/analytics/sun` handler (single date, range midpoint, white-night fallback, polar-day fallback, unconfigured SunCalc, invalid date / range order, default-to-today) plus the hourly back-compat guard.
- [x] Vitest: component (radial render, linear fallback, day-arc + legend shading, a11y summary) and the pure clock/geometry helpers (incl. cross-midnight wrap).
- [x] i18n keys added across all 16 locales; types regenerated.
- [x] `golangci-lint run` (0 issues), `go test -race ./internal/api/v2/ ./internal/suncalc/`, frontend `npm run check:all`, full analytics vitest suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **Nocturnal Activity Clock** to advanced analytics, visualizing hourly activity across a 24-hour cycle.
  * Delivers a **responsive desktop radial layout** with a **linear fallback** on narrower screens.
  * **Day/twilight/night shading** appears when sun timing is available and is omitted when it isn’t.
  * Includes **tooltips**, an **accessible summary** (total and peak hour), and a **legend** for shaded regions.
  * **Localized** across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->