### PR TITLE
fix(analysis): read primary model identity via o.mu-guarded accessor

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -179,8 +179,9 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	// Set the primary model ID and buffer dimensions on the engine so that
 	// analysis buffers are allocated from the model's spec, not hardcoded
 	// constants. This matches the secondary model allocation path.
-	clipBytes, overlapBytes, readSize := bn.ModelInfo.Spec.BufferDimensions()
-	p.engine.SetPrimaryModel(bn.ModelInfo.ID, clipBytes, overlapBytes, readSize)
+	primaryInfo := bn.PrimaryModelInfo()
+	clipBytes, overlapBytes, readSize := primaryInfo.Spec.BufferDimensions()
+	p.engine.SetPrimaryModel(primaryInfo.ID, clipBytes, overlapBytes, readSize)
 
 	// Register all loaded models in the ai_models database table so they
 	// appear even before any detections are saved.
@@ -895,8 +896,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 	}
 
 	// Primary model fallback targets for sources with no model config.
-	primaryInfo := &p.bnAnalyzer.BirdNET().ModelInfo
-	primaryTargets := []classifier.ModelInfo{*primaryInfo}
+	primaryTargets := []classifier.ModelInfo{p.bnAnalyzer.BirdNET().PrimaryModelInfo()}
 
 	bufMgr := p.engine.BufferManager()
 	currentSettings := conf.Setting()
@@ -1115,7 +1115,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		for i := range modelInfoSlice {
 			loadedModels[modelInfoSlice[i].ID] = modelInfoSlice[i]
 		}
-		primaryModelID = p.bnAnalyzer.BirdNET().ModelInfo.ID
+		primaryModelID = p.bnAnalyzer.BirdNET().PrimaryModelID()
 	}
 	bufMgr := p.engine.BufferManager()
 
@@ -1511,7 +1511,7 @@ func (p *AudioPipelineService) buildMonitorConfigs(sourceModelMap map[string][]s
 		loadedModels[modelInfoSlice[i].ID] = modelInfoSlice[i]
 	}
 
-	primaryInfo := p.bnAnalyzer.BirdNET().ModelInfo
+	primaryInfo := p.bnAnalyzer.BirdNET().PrimaryModelInfo()
 	result := make(map[string][]monitorConfig, len(sourceIDs))
 
 	for _, sid := range sourceIDs {

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -154,7 +154,8 @@ func (m *BufferManager) AddMonitor(source string) error {
 	// Fallback to primary model for backward compatibility when no
 	// models are registered via the orchestrator's model map.
 	if len(configs) == 0 {
-		cfg := buildMonitorConfig(source, &m.bn.ModelInfo)
+		primaryInfo := m.bn.PrimaryModelInfo()
+		cfg := buildMonitorConfig(source, &primaryInfo)
 		configs = []monitorConfig{cfg}
 	}
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -1876,6 +1876,17 @@ func (o *Orchestrator) PrimaryModelID() string {
 	return o.ModelInfo.ID
 }
 
+// PrimaryModelInfo returns a copy of the primary model's live ModelInfo, read
+// under o.mu so callers outside the package get a consistent value instead of
+// racing reloadModelInternal's o.mu-guarded write to o.ModelInfo. The result is
+// a snapshot copy; it does not track subsequent reloads. Returns the zero
+// ModelInfo if no primary is set.
+func (o *Orchestrator) PrimaryModelInfo() ModelInfo {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.ModelInfo
+}
+
 // ModelInfos returns ModelInfo for all registered models. Thread-safe.
 // Used by the pipeline to build ModelTarget lists for buffer fan-out.
 // For the primary model entry, the live o.ModelInfo is returned rather than the

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -69,6 +69,22 @@ func newTestOrchestrator(t *testing.T, mocks ...*mockModelInstance) *Orchestrato
 	}
 }
 
+// TestPrimaryModelInfo covers the o.mu-guarded primary-identity accessors that
+// callers outside the package use instead of reading o.ModelInfo directly.
+func TestPrimaryModelInfo(t *testing.T) {
+	t.Parallel()
+
+	want := ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4", Spec: ModelSpec{SampleRate: 48000}}
+	o := &Orchestrator{ModelInfo: want}
+	assert.Equal(t, want, o.PrimaryModelInfo())
+	assert.Equal(t, want.ID, o.PrimaryModelID())
+
+	// Zero value when no primary is set.
+	empty := &Orchestrator{}
+	assert.Equal(t, ModelInfo{}, empty.PrimaryModelInfo())
+	assert.Empty(t, empty.PrimaryModelID())
+}
+
 func TestNewOrchestrator_SyncsSharedState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`internal/analysis` read `Orchestrator.ModelInfo` (the `o.mu`-guarded copy of the primary model's identity) lock-free via `p.bnAnalyzer.BirdNET().ModelInfo`, while `reloadModelInternal`'s re-sync writes that field under `o.mu.Lock()`. That is a data race: a torn read of the primary `ModelInfo` during a model hot-reload concurrent with pipeline setup/reconfiguration.

This adds `Orchestrator.PrimaryModelInfo()` (the struct-returning sibling of the existing `PrimaryModelID()`), returning a snapshot copy under `o.mu.RLock()`, and routes the six lock-free reads in `internal/analysis` through it / `PrimaryModelID()`:

- `audio_pipeline_service.go`: primary buffer dimensions + ID for `SetPrimaryModel`; the no-config fallback model targets; the model-set reconciliation paths.
- `buffer_manager.go`: the fallback monitor config now builds from a local snapshot copy (`&primaryInfo`) rather than a pointer into the live field.

All affected sites are pipeline setup and reconfiguration paths (not the per-sample inference hot path), so the brief `RLock` + small struct copy is negligible. Behavior is unchanged: each site reads the same value it did before, just consistently under the lock. Internal-only: no API, config, DB, or CLI change.

## Test Plan

- [x] `golangci-lint` clean
- [x] `go test -race ./internal/analysis/ ./internal/classifier/` passes
- [x] New `TestPrimaryModelInfo` covers the accessor (populated + zero-value cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated primary model information retrieval across multiple components to ensure consistent behavior and correct configuration handling.

* **Tests**
  * Added unit test coverage for primary model information access and retrieval validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->