### PR TITLE
feat(analytics): confidence distribution per species

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -483,6 +483,70 @@ async function fetchNocturnal(
   return { hourly, sun };
 }
 
+// Top-N species the confidence histogram requests; mirrors the chart's maxSpecies cap. BINS matches
+// the server default; MAX_CONFIDENCE_BINS bounds the coerced density array defensively (the server
+// clamps bins to 50).
+const CONFIDENCE_DISTRIBUTION_LIMIT = 5;
+const CONFIDENCE_DISTRIBUTION_BINS = 20;
+const MAX_CONFIDENCE_BINS = 50;
+
+interface ConfidenceDistributionDatum {
+  scientificName: string;
+  density: number[];
+  total: number;
+}
+
+/**
+ * Confidence distribution per species: the top-N species by detection volume, each with a normalized
+ * histogram of detection confidence scores (bins over 0..1). Like the who-sings-when ridgeline
+ * (#1159) it always requests the top-N and does not honor the species filter, so the chart compares
+ * several species' confidence shapes rather than collapsing to a single ridge; the server ranks and
+ * normalizes. Defensively coerces the array payload, keeping the server's (variable) bin count.
+ */
+async function fetchConfidenceDistribution(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<ConfidenceDistributionDatum[]> {
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+    limit: String(CONFIDENCE_DISTRIBUTION_LIMIT),
+    bins: String(CONFIDENCE_DISTRIBUTION_BINS),
+  });
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/confidence/distribution?${search}`), {
+    signal,
+  });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid confidence distribution response: expected an array');
+  }
+
+  return data
+    .map(raw => {
+      if (!raw || typeof raw !== 'object') return null;
+      const item = raw as { scientificName?: unknown; bins?: unknown; total?: unknown };
+      const scientificName = typeof item.scientificName === 'string' ? item.scientificName : '';
+      if (!scientificName) return null;
+      // Coerce every bin to a finite number; keep the server's bin count (variable, unlike the
+      // hourly ridgeline's fixed 24) but cap the length defensively so a malformed payload cannot
+      // allocate an unreasonable density array.
+      const rawBins = Array.isArray(item.bins) ? item.bins : [];
+      const binCount = Math.min(rawBins.length, MAX_CONFIDENCE_BINS);
+      const density: number[] = [];
+      for (let i = 0; i < binCount; i++) {
+        // eslint-disable-next-line security/detect-object-injection -- i is a bounded loop index
+        const b = rawBins[i];
+        density.push(typeof b === 'number' && Number.isFinite(b) ? b : 0);
+      }
+      const total = typeof item.total === 'number' && Number.isFinite(item.total) ? item.total : 0;
+      return { scientificName, density, total };
+    })
+    .filter((d): d is ConfidenceDistributionDatum => d !== null);
+}
+
 // --- Registry --------------------------------------------------------------
 
 export const CHART_REGISTRY: ChartDef[] = [
@@ -632,6 +696,52 @@ export const CHART_REGISTRY: ChartDef[] = [
     }),
     size: 'full',
     supports: { species: false, source: false },
+  },
+  {
+    id: 'confidence-distribution',
+    group: 'quality',
+    titleKey: 'analytics.advanced.charts.confidence.title',
+    descKey: 'analytics.advanced.charts.confidence.description',
+    emptyKey: 'analytics.advanced.charts.confidence.noData',
+    emptyHintKey: 'analytics.advanced.charts.confidence.noDataHint',
+    component: SpeciesRidgeline,
+    fetch: fetchConfidenceDistribution,
+    // Reuses the ridgeline: each species' confidence histogram becomes a density row, with a
+    // confidence-bin x-tick formatter (label each bin's left-edge confidence as a percentage) and
+    // this chart's own i18n keys. The endpoint is always top-N by detection volume and never filters
+    // by species, so supports.species is false: this is the only chart in the quality tab, so a
+    // species selector there would be an inert control (the note states the chart shows the top N).
+    mapProps: (data, _params, ctx) => {
+      const rows = data as ConfidenceDistributionDatum[];
+      // All species share the server's bin count; fall back to the requested default for an empty
+      // result so the formatter's divisor is never zero.
+      const firstLen = rows[0]?.density.length ?? 0;
+      const binCount = firstLen > 0 ? firstLen : CONFIDENCE_DISTRIBUTION_BINS;
+      return {
+        series: rows.map(d => ({
+          scientificName: d.scientificName,
+          commonName: ctx.speciesNames.get(d.scientificName) ?? d.scientificName,
+          density: d.density,
+          total: d.total,
+        })),
+        // Label bin index i by the confidence at its left edge (i / binCount) as a percentage, so a
+        // 20-bin histogram reads 0% / 25% / 50% / 75% at step binCount/4.
+        xTickFormat: (index: number) => `${Math.round((index / binCount) * 100)}%`,
+        xTickStep: Math.max(1, Math.round(binCount / 4)),
+        ariaLabelKey: 'analytics.advanced.charts.confidence.ariaLabel',
+        axisLabelKey: 'analytics.advanced.charts.confidence.axisLabel',
+        summaryKey: 'analytics.advanced.charts.confidence.summary',
+        noteKey: 'analytics.advanced.charts.confidence.note',
+        totalLabelKey: 'analytics.advanced.charts.confidence.tooltipCount',
+        peakLabelKey: 'analytics.advanced.charts.confidence.tooltipPeak',
+      };
+    },
+    size: 'full',
+    supports: { species: false, source: false },
+    // A ridgeline needs at least a couple of species to read as a comparison; one lonely ridge does
+    // not tell the user which species are shakier than others.
+    minDataPoints: 2,
+    maxSpecies: CONFIDENCE_DISTRIBUTION_LIMIT,
   },
 ];
 

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -534,13 +534,9 @@ async function fetchConfidenceDistribution(
       // hourly ridgeline's fixed 24) but cap the length defensively so a malformed payload cannot
       // allocate an unreasonable density array.
       const rawBins = Array.isArray(item.bins) ? item.bins : [];
-      const binCount = Math.min(rawBins.length, MAX_CONFIDENCE_BINS);
-      const density: number[] = [];
-      for (let i = 0; i < binCount; i++) {
-        // eslint-disable-next-line security/detect-object-injection -- i is a bounded loop index
-        const b = rawBins[i];
-        density.push(typeof b === 'number' && Number.isFinite(b) ? b : 0);
-      }
+      const density = rawBins
+        .slice(0, MAX_CONFIDENCE_BINS)
+        .map(b => (typeof b === 'number' && Number.isFinite(b) ? b : 0));
       const total = typeof item.total === 'number' && Number.isFinite(item.total) ? item.total : 0;
       return { scientificName, density, total };
     })

--- a/frontend/src/lib/desktop/features/analytics/registry/confidenceDistribution.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/confidenceDistribution.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+
+import { CHART_REGISTRY } from './charts';
+import type { AnalyticsParams, ChartPropsContext } from './types';
+import SpeciesRidgeline from '../components/charts/d3/SpeciesRidgeline.svelte';
+import type { RidgelineSeries } from '../components/charts/d3/utils/ridgeline';
+
+// Verifies the confidence-distribution registry entry reuses the SpeciesRidgeline component with
+// confidence-specific props: series mapping (common-name resolution), the bins x-tick formatter,
+// empty/sparse handling, and the a11y summary. jsdom has no layout engine; assert on element
+// counts/attributes only.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const def = CHART_REGISTRY.find(c => c.id === 'confidence-distribution');
+// Guard at module scope so the rest of the file sees a defined def + mapProps without non-null
+// assertions (forbidden by lint); a missing entry fails every test with a clear message.
+if (!def?.mapProps) {
+  throw new Error('confidence-distribution chart def with mapProps is required');
+}
+const mapProps = def.mapProps;
+
+function makeCtx(names: [string, string][] = []): ChartPropsContext {
+  return {
+    options: {},
+    onParamsChange: vi.fn(),
+    speciesNames: new Map(names),
+  };
+}
+
+// mapProps for this chart ignores params (always top-N); an empty object is enough.
+const params = {} as AnalyticsParams;
+
+/** A 20-length density with a single peak bin, mimicking the server's normalized confidence bins. */
+function bins(peak: number): number[] {
+  return Array.from({ length: 20 }, (_, i) => (i === peak ? 1 : 0));
+}
+
+const sample = [
+  { scientificName: 'Turdus merula', density: bins(16), total: 40 },
+  { scientificName: 'Erithacus rubecula', density: bins(10), total: 12 },
+];
+
+describe('confidence-distribution chart def', () => {
+  it('is registered in the quality group reusing the ridgeline component', () => {
+    expect(def.group).toBe('quality');
+    expect(def.component).toBe(SpeciesRidgeline);
+    // Always top-N by volume; never filters by species, so the (sole) quality tab shows no species selector.
+    expect(def.supports.species).toBe(false);
+    expect(def.supports.source).toBe(false);
+    expect(def.maxSpecies).toBe(5);
+    expect(def.minDataPoints).toBe(2);
+  });
+
+  it('maps confidence data to ridgeline series, resolving common names from the hub map', () => {
+    const props = mapProps(sample, params, makeCtx([['Turdus merula', 'Eurasian Blackbird']]));
+    const series = props.series as Array<{
+      scientificName: string;
+      commonName: string;
+      density: number[];
+      total: number;
+    }>;
+    expect(series).toHaveLength(2);
+    expect(series[0].scientificName).toBe('Turdus merula');
+    expect(series[0].commonName).toBe('Eurasian Blackbird');
+    // No mapping entry -> falls back to the scientific name.
+    expect(series[1].commonName).toBe('Erithacus rubecula');
+    expect(series[0].density).toHaveLength(20);
+    expect(series[0].total).toBe(40);
+  });
+
+  it('labels confidence bins as left-edge percentages (0/25/50/75% for 20 bins)', () => {
+    const props = mapProps(sample, params, makeCtx());
+    const fmt = props.xTickFormat as (_i: number) => string;
+    expect(fmt(0)).toBe('0%');
+    expect(fmt(5)).toBe('25%');
+    expect(fmt(10)).toBe('50%');
+    expect(fmt(15)).toBe('75%');
+    expect(props.xTickStep).toBe(5);
+  });
+
+  it('keeps the formatter divisor safe on an empty result (bin-count fallback)', () => {
+    const props = mapProps([], params, makeCtx());
+    expect(props.series).toHaveLength(0);
+    const fmt = props.xTickFormat as (_i: number) => string;
+    // Falls back to the default 20 bins, so 5/20 = 25% rather than a divide-by-zero.
+    expect(fmt(5)).toBe('25%');
+  });
+
+  it('wires this chart-specific i18n keys into the shared component', () => {
+    const props = mapProps(sample, params, makeCtx());
+    expect(props.ariaLabelKey).toBe('analytics.advanced.charts.confidence.ariaLabel');
+    expect(props.axisLabelKey).toBe('analytics.advanced.charts.confidence.axisLabel');
+    expect(props.summaryKey).toBe('analytics.advanced.charts.confidence.summary');
+    expect(props.noteKey).toBe('analytics.advanced.charts.confidence.note');
+    expect(props.totalLabelKey).toBe('analytics.advanced.charts.confidence.tooltipCount');
+    expect(props.peakLabelKey).toBe('analytics.advanced.charts.confidence.tooltipPeak');
+  });
+
+  it('renders one ridge per species through the shared component, with an a11y summary', async () => {
+    const series = mapProps(sample, params, makeCtx()).series as RidgelineSeries[];
+    const { container } = render(SpeciesRidgeline, { props: { series, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelectorAll('path.ridge-area')).toHaveLength(2);
+    expect(container.querySelector('[data-testid="ridgeline-summary"]')).toBeTruthy();
+  });
+
+  it('renders without throwing for an empty (sparse) result', () => {
+    const series = mapProps([], params, makeCtx()).series as RidgelineSeries[];
+    expect(() => render(SpeciesRidgeline, { props: { series } })).not.toThrow();
+  });
+});

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1469,6 +1469,16 @@ export type TranslationKey =
   | 'analytics.advanced.charts.nocturnal.legendDay'
   | 'analytics.advanced.charts.nocturnal.legendTwilight'
   | 'analytics.advanced.charts.nocturnal.legendNight'
+  | 'analytics.advanced.charts.confidence.title'
+  | 'analytics.advanced.charts.confidence.description'
+  | 'analytics.advanced.charts.confidence.noData'
+  | 'analytics.advanced.charts.confidence.noDataHint'
+  | 'analytics.advanced.charts.confidence.ariaLabel'
+  | 'analytics.advanced.charts.confidence.axisLabel'
+  | 'analytics.advanced.charts.confidence.note' // params: count
+  | 'analytics.advanced.charts.confidence.tooltipCount'
+  | 'analytics.advanced.charts.confidence.tooltipPeak'
+  | 'analytics.advanced.charts.confidence.summary' // params: count, species, time
   | 'analytics.advanced.charts.tooltips.date'
   | 'analytics.advanced.charts.tooltips.percentage'
   | 'analytics.advanced.charts.tooltips.detections'
@@ -3997,6 +4007,12 @@ export type TranslationParams = {
     end: string | number;
   };
   'analytics.advanced.charts.nocturnal.summary': { total: string | number; peak: string | number };
+  'analytics.advanced.charts.confidence.note': { count: string | number };
+  'analytics.advanced.charts.confidence.summary': {
+    count: string | number;
+    species: string | number;
+    time: string | number;
+  };
   'settings.notFound.message': { section: string | number };
   'settings.main.sections.falsePositiveFilter.detectionCount': {
     count: string | number;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Procento",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Procentdel",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Prozentsatz",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Percentage",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Fecha",
           "percentage": "Porcentaje",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Päivämäärä",
           "percentage": "Prosenttiosuus",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Date",
           "percentage": "Pourcentage",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Százalék",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentuale",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Datums",
           "percentage": "Procenti",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Dato",
           "percentage": "Prosentandel",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Percentage",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Procent",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Data",
           "percentage": "Percentagem",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Dátum",
           "percentage": "Percentá",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1887,6 +1887,18 @@
           "legendTwilight": "Twilight",
           "legendNight": "Night"
         },
+        "confidence": {
+          "title": "Confidence Distribution",
+          "description": "How confident the model is per species, so you can spot the birds it most often second-guesses",
+          "noData": "No confidence data available",
+          "noDataHint": "Select a wider date range to compare how confident the model is across species",
+          "ariaLabel": "Confidence distribution: per-species histogram of detection confidence scores",
+          "axisLabel": "Confidence",
+          "note": "Showing the top {count} species by detection volume",
+          "tooltipCount": "Detections",
+          "tooltipPeak": "Peak confidence",
+          "summary": "Detection-confidence distribution for {count} species. {species} clusters around {time} confidence."
+        },
         "tooltips": {
           "date": "Datum",
           "percentage": "Andel",

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -300,6 +300,10 @@ func (m *ActionMockDatastore) GetHourlyDistributionBySpecies(_ context.Context, 
 func (m *ActionMockDatastore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]datastore.DailyActivityOnset, error) {
 	return []datastore.DailyActivityOnset{}, nil
 }
+
+func (m *ActionMockDatastore) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]datastore.SpeciesConfidenceHistogram, error) {
+	return []datastore.SpeciesConfidenceHistogram{}, nil
+}
 func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -169,6 +169,10 @@ func (m *MockDatastore) GetHourlyDistributionBySpecies(context.Context, string, 
 func (m *MockDatastore) GetDailyActivityOnset(context.Context, string, string, string) ([]datastore.DailyActivityOnset, error) {
 	return []datastore.DailyActivityOnset{}, nil
 }
+
+func (m *MockDatastore) GetConfidenceHistogram(context.Context, string, string, string, int, int) ([]datastore.SpeciesConfidenceHistogram, error) {
+	return []datastore.SpeciesConfidenceHistogram{}, nil
+}
 func (m *MockDatastore) SearchDetections(*datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return make([]datastore.DetectionRecord, 0), 0, nil
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -95,6 +95,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/time/heatmap`             | `GetActivityHeatmap`       | ❌   | Seasonal density heatmap (date x intra-day slot; `?format=csv`) |
 | GET    | `/analytics/time/dawn-onset`          | `GetDawnChorusOnset`       | ❌   | Dawn-chorus onset tracker: per-day onset relative to civil dawn (minutes; negative = before civil dawn). `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `species` optional |
 | GET    | `/analytics/sun`                      | `GetAnalyticsSun`          | ❌   | Sun times for the nocturnal activity clock's day/night shading: sunrise/sunset/civil-dawn/civil-dusk as minute-of-day in server-local time. `date` for a single day, or `start_date`/`end_date` for a range (collapsed to its midpoint); defaults to today. Returns `available:false` (not an error) on polar day/night or when SunCalc is unconfigured |
+| GET    | `/analytics/confidence/distribution`  | `GetConfidenceDistribution` | ❌  | Confidence distribution per species: per-species normalized histogram of detection confidence scores (Review & Accuracy tab). `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `species` optional (single species filter; default is the top-N species by volume); `bins` optional (default 20, clamped to 5-50); `limit` optional (default 5, max 8) |
 
 ### Control Operations (`control.go`)
 

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -32,6 +32,14 @@ const (
 	defaultNewSpeciesLimit     = 100              // Default pagination limit for new species queries
 	analyticsQueryTimeout      = 30 * time.Second // Timeout for analytics database queries
 
+	// Confidence distribution bin bounds (design spec section 6.5). The histogram bins span [0,1];
+	// the default of 20 equal bins (width 0.05) aligns with the round confidence thresholds users
+	// reason about (e.g. 0.80). The range is clamped so a malformed or extreme bins param can neither
+	// break the binning nor produce an unreadably fine or coarse histogram.
+	defaultConfidenceBins = 20
+	minConfidenceBins     = 5
+	maxConfidenceBins     = 50
+
 	// Species ridgeline (who-sings-when) top-N bounds. The default matches the chart's maxSpecies
 	// cap; the max keeps the ridgeline readable (more than ~8 overlapping ridges are unreadable).
 	defaultSpeciesRidgelineLimit = 5
@@ -192,6 +200,10 @@ func (c *Controller) initAnalyticsRoutes() {
 	timeGroup.GET("/distribution/species", c.GetSpeciesHourlyDistribution) // Who-sings-when ridgeline (top-N species hour-of-day)
 	timeGroup.GET("/heatmap", c.GetActivityHeatmap)                        // Seasonal density heatmap (date x intra-day slot)
 	timeGroup.GET("/dawn-onset", c.GetDawnChorusOnset)                     // Dawn-chorus onset tracker (daily onset vs civil dawn)
+
+	// Confidence analytics routes
+	confidenceGroup := analyticsGroup.Group("/confidence")
+	confidenceGroup.GET("/distribution", c.GetConfidenceDistribution) // Confidence distribution per species (Review & Accuracy)
 
 	// Sun times for the nocturnal activity clock's day/night shading. Additive: the clock's counts
 	// come from the existing /time/distribution/hourly endpoint (unchanged); only this sun endpoint
@@ -1620,6 +1632,135 @@ func (c *Controller) GetSpeciesHourlyDistribution(ctx echo.Context) error {
 	)
 
 	return ctx.JSON(http.StatusOK, newSpeciesHourlyDistributionResponse(data))
+}
+
+// confidenceDistributionItem is one species' row in the confidence-distribution wire payload: its
+// scientific-name key, its normalized confidence bins (each the fraction of the species' detections
+// in that bin, summing to ~1.0), and the raw detection count. The localized common name is resolved
+// client-side (the v2 label schema stores no common name), matching the sibling species charts.
+type confidenceDistributionItem struct {
+	ScientificName string    `json:"scientificName"`
+	Bins           []float64 `json:"bins"`
+	Total          int       `json:"total"`
+}
+
+// newConfidenceDistributionResponse maps the datastore aggregation onto the wire payload as a JSON
+// array (never null), preserving the descending-volume order. Each species' Bins is emitted as a
+// non-nil array so the client can read it without a null guard.
+func newConfidenceDistributionResponse(data []datastore.SpeciesConfidenceHistogram) []confidenceDistributionItem {
+	items := make([]confidenceDistributionItem, 0, len(data))
+	for i := range data {
+		bins := data[i].Bins
+		if bins == nil {
+			bins = []float64{}
+		}
+		items = append(items, confidenceDistributionItem{
+			ScientificName: data[i].ScientificName,
+			Bins:           bins,
+			Total:          data[i].Total,
+		})
+	}
+	return items
+}
+
+// clampConfidenceBins parses the optional bins query param, falling back to the default and clamping
+// to [minConfidenceBins, maxConfidenceBins] so a malformed or extreme value can neither break the
+// binning nor produce an unreadably fine or coarse histogram.
+func clampConfidenceBins(value string) int {
+	bins, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultConfidenceBins
+	}
+	if bins < minConfidenceBins {
+		return minConfidenceBins
+	}
+	if bins > maxConfidenceBins {
+		return maxConfidenceBins
+	}
+	return bins
+}
+
+// GetConfidenceDistribution handles GET /api/v2/analytics/confidence/distribution
+// Returns the per-species confidence-score distribution, powering the confidence distribution chart
+// in the Review & Accuracy tab (design spec section 6.5). The datastore method is named
+// GetConfidenceHistogram (it computes a per-species histogram); this endpoint and the chart present
+// it as a distribution, hence the route/handler naming.
+func (c *Controller) GetConfidenceDistribution(ctx echo.Context) error {
+	const operation = "confidence distribution"
+
+	// Validate required parameter
+	if err := c.requireQueryParam(ctx, "start_date", operation); err != nil {
+		return err
+	}
+
+	startDate := ctx.QueryParam("start_date")
+	endDate := ctx.QueryParam("end_date")
+	speciesParam := ctx.QueryParam("species")
+
+	// Validate date formats strictly using regex
+	if err := c.validateDateFormatStrictWithResponse(ctx, startDate, "start_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, endDate, "end_date", operation); err != nil {
+		return err
+	}
+
+	// Validate date values and chronological order
+	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
+		return err
+	}
+
+	// Default the end date to a 30-day window when omitted, matching the other range endpoints.
+	if endDate == "" {
+		startTime, _ := time.Parse(time.DateOnly, startDate) // Regex ensures this parse succeeds
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
+	}
+
+	// Resolve a localized common name to its scientific name so the optional species filter matches
+	// the detections/search path and the sibling time endpoints; a scientific name or unresolved term
+	// passes through unchanged. Only the datastore query uses the resolved value.
+	querySpecies := speciesParam
+	if resolved, hit := c.resolveSpeciesToScientific(speciesParam); hit {
+		querySpecies = resolved
+	}
+
+	bins := clampConfidenceBins(ctx.QueryParam("bins"))
+	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesRidgelineLimit, maxSpeciesRidgelineLimit)
+
+	c.logInfoIfEnabled("Retrieving confidence distribution",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.String("species", speciesParam),
+		logger.Int("bins", bins),
+		logger.Int("limit", limit),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	// Add timeout to prevent resource exhaustion
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
+	data, err := c.DS.GetConfidenceHistogram(ctxWithTimeout, startDate, endDate, querySpecies, bins, limit)
+	if err != nil {
+		return c.handleAnalyticsQueryError(ctx, err, "Confidence distribution", "Failed to get confidence distribution",
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("species", speciesParam),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("path", ctx.Request().URL.Path),
+		)
+	}
+
+	c.logInfoIfEnabled("Confidence distribution retrieved",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.Int("species_count", len(data)),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	return ctx.JSON(http.StatusOK, newConfidenceDistributionResponse(data))
 }
 
 // GetTimeOfDayDistribution handles GET /api/v2/analytics/time/distribution/hourly

--- a/internal/api/v2/analytics_confidence_distribution_test.go
+++ b/internal/api/v2/analytics_confidence_distribution_test.go
@@ -75,6 +75,7 @@ func TestGetConfidenceDistribution_EmptyArrayNotNull(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.NotNil(t, resp)
 	assert.Empty(t, resp)
+	mockDS.AssertExpectations(t)
 }
 
 func TestGetConfidenceDistribution_DefaultsEndDate(t *testing.T) {

--- a/internal/api/v2/analytics_confidence_distribution_test.go
+++ b/internal/api/v2/analytics_confidence_distribution_test.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// confidenceDistributionJSON mirrors the confidence-distribution wire shape (design spec section 6.5).
+type confidenceDistributionJSON struct {
+	ScientificName string    `json:"scientificName"`
+	Bins           []float64 `json:"bins"`
+	Total          int       `json:"total"`
+}
+
+func sampleConfidenceDistribution() []datastore.SpeciesConfidenceHistogram {
+	return []datastore.SpeciesConfidenceHistogram{
+		{ScientificName: "Turdus merula", Bins: []float64{0.1, 0.2, 0.3, 0.4}, Total: 40},
+		{ScientificName: "Erithacus rubecula", Bins: []float64{0.25, 0.25, 0.25, 0.25}, Total: 12},
+	}
+}
+
+func newConfidenceDistributionContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/confidence/distribution")
+	return c, rec
+}
+
+func TestGetConfidenceDistribution_Shape(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// Defaults: no species filter ("" passed through), bins 20, top-5 limit.
+	mockDS.On("GetConfidenceHistogram", mock.Anything, "2026-03-01", "2026-03-02", "", 20, 5).
+		Return(sampleConfidenceDistribution(), nil)
+
+	c, rec := newConfidenceDistributionContext(e, "/api/v2/analytics/confidence/distribution?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetConfidenceDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []confidenceDistributionJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 2)
+	assert.Equal(t, "Turdus merula", resp[0].ScientificName)
+	assert.Equal(t, 40, resp[0].Total)
+	require.Len(t, resp[0].Bins, 4)
+	assert.InDelta(t, 0.4, resp[0].Bins[3], 1e-9)
+	assert.Equal(t, "Erithacus rubecula", resp[1].ScientificName)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetConfidenceDistribution_EmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetConfidenceHistogram", mock.Anything, "2026-03-01", "2026-03-02", "", 20, 5).
+		Return([]datastore.SpeciesConfidenceHistogram{}, nil)
+
+	c, rec := newConfidenceDistributionContext(e, "/api/v2/analytics/confidence/distribution?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetConfidenceDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	// Empty result must serialize as [] (not null) so the client can read .length safely.
+	var resp []confidenceDistributionJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp)
+	assert.Empty(t, resp)
+}
+
+func TestGetConfidenceDistribution_DefaultsEndDate(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// With end_date omitted the handler defaults it to a 30-day window: 2026-03-01 + 30d = 2026-03-31.
+	mockDS.On("GetConfidenceHistogram", mock.Anything, "2026-03-01", "2026-03-31", "", 20, 5).
+		Return(sampleConfidenceDistribution(), nil)
+
+	c, rec := newConfidenceDistributionContext(e, "/api/v2/analytics/confidence/distribution?start_date=2026-03-01")
+	require.NoError(t, controller.GetConfidenceDistribution(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetConfidenceDistribution_ClampsBins(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		binsParm string
+		wantBins int
+	}{
+		{"valid in range passes through", "30", 30},
+		{"below min clamps up", "3", minConfidenceBins},
+		{"above max clamps down", "999", maxConfidenceBins},
+		{"non-numeric falls back to default", "abc", defaultConfidenceBins},
+		{"empty falls back to default", "", defaultConfidenceBins},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+			mockDS.On("GetConfidenceHistogram", mock.Anything, "2026-03-01", "2026-03-02", "", tt.wantBins, 5).
+				Return(sampleConfidenceDistribution(), nil)
+
+			target := "/api/v2/analytics/confidence/distribution?start_date=2026-03-01&end_date=2026-03-02"
+			if tt.binsParm != "" {
+				target += "&bins=" + tt.binsParm
+			}
+			c, rec := newConfidenceDistributionContext(e, target)
+			require.NoError(t, controller.GetConfidenceDistribution(c))
+			require.Equal(t, http.StatusOK, rec.Code)
+			mockDS.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetConfidenceDistribution_ClampsLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		limitParm string
+		wantLimit int
+	}{
+		{"valid in range passes through", "3", 3},
+		{"max allowed passes through", "8", 8},
+		{"over max falls back to default", "99", defaultSpeciesRidgelineLimit},
+		{"zero falls back to default", "0", defaultSpeciesRidgelineLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+			mockDS.On("GetConfidenceHistogram", mock.Anything, "2026-03-01", "2026-03-02", "", 20, tt.wantLimit).
+				Return(sampleConfidenceDistribution(), nil)
+
+			c, rec := newConfidenceDistributionContext(e,
+				"/api/v2/analytics/confidence/distribution?start_date=2026-03-01&end_date=2026-03-02&limit="+tt.limitParm)
+			require.NoError(t, controller.GetConfidenceDistribution(c))
+			require.Equal(t, http.StatusOK, rec.Code)
+			mockDS.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetConfidenceDistribution_MissingStartDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newConfidenceDistributionContext(e, "/api/v2/analytics/confidence/distribution")
+	err := controller.GetConfidenceDistribution(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetConfidenceDistribution_InvalidDateFormat(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newConfidenceDistributionContext(e, "/api/v2/analytics/confidence/distribution?start_date=not-a-date")
+	err := controller.GetConfidenceDistribution(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetConfidenceDistribution_QueryTimeout(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetConfidenceHistogram", mock.Anything, "2026-03-01", "2026-03-02", "", 20, 5).
+		Return([]datastore.SpeciesConfidenceHistogram(nil), context.DeadlineExceeded)
+
+	c, rec := newConfidenceDistributionContext(e, "/api/v2/analytics/confidence/distribution?start_date=2026-03-01&end_date=2026-03-02")
+	// handleAnalyticsQueryError writes the 408 response and returns nil.
+	require.NoError(t, controller.GetConfidenceDistribution(c))
+	assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+	mockDS.AssertExpectations(t)
+}

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -98,6 +98,19 @@ type DailyActivityOnset struct {
 	DetectionCount  int
 }
 
+// SpeciesConfidenceHistogram is one species' confidence-score distribution, behind the confidence
+// distribution chart (design spec section 6.5). Bins holds the normalized fraction of the species'
+// detections that fall into each equal-width confidence bin over [0,1] (Bins sums to ~1.0), so the
+// distribution shape is comparable across species regardless of detection volume. Total is the
+// species' detection count over the range (false positives excluded), shown in the tooltip.
+// ScientificName is the stable key; the localized common name is resolved client-side (the v2 label
+// schema stores no common name), matching the sibling species charts.
+type SpeciesConfidenceHistogram struct {
+	ScientificName string
+	Bins           []float64
+	Total          int
+}
+
 // NewSpeciesData represents a species detected for the first time within a period
 type NewSpeciesData struct {
 	ScientificName string `json:"scientific_name"`
@@ -462,6 +475,14 @@ func (ds *DataStore) GetHourlyDistributionBySpecies(_ context.Context, _, _ stri
 // slice rather than implementing the aggregation. See internal/datastore/v2only for the real method.
 func (ds *DataStore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]DailyActivityOnset, error) {
 	return []DailyActivityOnset{}, nil
+}
+
+// GetConfidenceHistogram is a stub on the legacy store. The confidence distribution chart is a
+// v2only feature; the legacy datastore is deprecated and being removed, so it returns an empty
+// (non-nil) slice rather than implementing the aggregation. See internal/datastore/v2only for the
+// real method.
+func (ds *DataStore) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]SpeciesConfidenceHistogram, error) {
+	return []SpeciesConfidenceHistogram{}, nil
 }
 
 // GetDetectionTrends calculates the trend in detections over time

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -203,6 +203,10 @@ type Interface interface {
 	// onset relative to civil dawn (false positives excluded). species is an optional scientific-name
 	// filter. Powers the dawn-chorus onset tracker.
 	GetDailyActivityOnset(ctx context.Context, startDate, endDate, species string) ([]DailyActivityOnset, error)
+	// GetConfidenceHistogram returns the per-species confidence-score distribution over the date range,
+	// powering the confidence distribution chart. With no species filter it covers the top `limit`
+	// species by detection volume; with a species filter it covers just that species.
+	GetConfidenceHistogram(ctx context.Context, startDate, endDate, species string, bins, limit int) ([]SpeciesConfidenceHistogram, error)
 	// Search functionality
 	SearchDetections(filters *SearchFilters) ([]DetectionRecord, int, error)
 	// Dynamic Threshold methods

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -1844,6 +1844,69 @@ func (_c *MockInterface_GetCommentsBatch_Call) RunAndReturn(run func(uint, int) 
 	return _c
 }
 
+// GetConfidenceHistogram provides a mock function with given fields: ctx, startDate, endDate, species, bins, limit
+func (_m *MockInterface) GetConfidenceHistogram(ctx context.Context, startDate string, endDate string, species string, bins int, limit int) ([]datastore.SpeciesConfidenceHistogram, error) {
+	ret := _m.Called(ctx, startDate, endDate, species, bins, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConfidenceHistogram")
+	}
+
+	var r0 []datastore.SpeciesConfidenceHistogram
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int, int) ([]datastore.SpeciesConfidenceHistogram, error)); ok {
+		return rf(ctx, startDate, endDate, species, bins, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int, int) []datastore.SpeciesConfidenceHistogram); ok {
+		r0 = rf(ctx, startDate, endDate, species, bins, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.SpeciesConfidenceHistogram)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, int, int) error); ok {
+		r1 = rf(ctx, startDate, endDate, species, bins, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetConfidenceHistogram_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfidenceHistogram'
+type MockInterface_GetConfidenceHistogram_Call struct {
+	*mock.Call
+}
+
+// GetConfidenceHistogram is a helper method to define mock.On call
+//   - ctx context.Context
+//   - startDate string
+//   - endDate string
+//   - species string
+//   - bins int
+//   - limit int
+func (_e *MockInterface_Expecter) GetConfidenceHistogram(ctx interface{}, startDate interface{}, endDate interface{}, species interface{}, bins interface{}, limit interface{}) *MockInterface_GetConfidenceHistogram_Call {
+	return &MockInterface_GetConfidenceHistogram_Call{Call: _e.mock.On("GetConfidenceHistogram", ctx, startDate, endDate, species, bins, limit)}
+}
+
+func (_c *MockInterface_GetConfidenceHistogram_Call) Run(run func(ctx context.Context, startDate string, endDate string, species string, bins int, limit int)) *MockInterface_GetConfidenceHistogram_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(int), args[5].(int))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetConfidenceHistogram_Call) Return(_a0 []datastore.SpeciesConfidenceHistogram, _a1 error) *MockInterface_GetConfidenceHistogram_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetConfidenceHistogram_Call) RunAndReturn(run func(context.Context, string, string, string, int, int) ([]datastore.SpeciesConfidenceHistogram, error)) *MockInterface_GetConfidenceHistogram_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDailyActivityOnset provides a mock function with given fields: ctx, startDate, endDate, species
 func (_m *MockInterface) GetDailyActivityOnset(ctx context.Context, startDate string, endDate string, species string) ([]datastore.DailyActivityOnset, error) {
 	ret := _m.Called(ctx, startDate, endDate, species)

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -766,6 +766,10 @@ func (s *testLegacyInterface) GetHourlyDistributionBySpecies(_ context.Context, 
 func (s *testLegacyInterface) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]datastore.DailyActivityOnset, error) {
 	return []datastore.DailyActivityOnset{}, nil
 }
+
+func (s *testLegacyInterface) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]datastore.SpeciesConfidenceHistogram, error) {
+	return []datastore.SpeciesConfidenceHistogram{}, nil
+}
 func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -248,6 +248,13 @@ type DetectionRepository interface {
 	// which keeps the slot/date math out of dialect SQL and correct across DST.
 	GetDetectionTimestamps(ctx context.Context, start, end int64, labelID *uint) ([]int64, error)
 
+	// GetBatchConfidences returns the per-label-ID detection confidences for the given label IDs over
+	// the half-open range [start, end), false positives excluded and filtered by minConfidence. Results
+	// group by label_id so a single query (per chunk) covers many labels; callers that map one species
+	// to multiple model label IDs concatenate the per-label slices themselves. Order within a label is
+	// unspecified (callers bin the values); the confidence distribution chart buckets them in Go.
+	GetBatchConfidences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) (map[uint][]float64, error)
+
 	// GetDailyAnalytics returns daily statistics.
 	// tzOffsetSeconds is the configured timezone's UTC offset, applied so detections bucket by
 	// wall-clock date in that zone rather than the database/OS-local zone.

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -935,6 +935,56 @@ func (r *detectionRepository) GetBatchHourlyOccurrences(ctx context.Context, lab
 	return result, nil
 }
 
+// GetBatchConfidences returns per-label-ID detection confidences for the given label IDs over
+// [start, end), false positives excluded and filtered by minConfidence. It mirrors
+// GetBatchHourlyOccurrences: one query per chunk covers many labels (grouped client-side by
+// label_id), large label sets are chunked to stay within SQL host-parameter limits, and each label
+// ID appears in exactly one chunk so no cross-chunk merge is needed. The raw values are returned
+// (not pre-binned) so the binning math stays in shared, dialect-agnostic Go.
+func (r *detectionRepository) GetBatchConfidences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) (map[uint][]float64, error) {
+	result := make(map[uint][]float64, len(labelIDs))
+
+	// Return empty map for empty input (no query)
+	if len(labelIDs) == 0 {
+		return result, nil
+	}
+
+	type labelConfidence struct {
+		LabelID    uint
+		Confidence float64
+	}
+
+	detTable := r.tableName()
+	revTable := r.reviewsTable()
+
+	// Chunk label IDs to avoid exceeding SQL host-parameter limits on the IN clause.
+	for i := 0; i < len(labelIDs); i += batchQuerySize {
+		// Fail fast between chunks if the caller's context was cancelled.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		chunkEnd := min(i+batchQuerySize, len(labelIDs))
+		chunk := labelIDs[i:chunkEnd]
+
+		var rows []labelConfidence
+		err := r.db.WithContext(ctx).Table(fmt.Sprintf("%s d", detTable)).
+			Joins(fmt.Sprintf("LEFT JOIN %s dr ON d.id = dr.detection_id", revTable)).
+			Select("d.label_id as label_id, d.confidence as confidence").
+			Where("d.label_id IN ? AND d.detected_at >= ? AND d.detected_at < ? AND d.confidence >= ?", chunk, start, end, minConfidence).
+			Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
+			Scan(&rows).Error
+		if err != nil {
+			return nil, fmt.Errorf("batch confidences: %w", err)
+		}
+
+		for _, row := range rows {
+			result[row.LabelID] = append(result[row.LabelID], row.Confidence)
+		}
+	}
+
+	return result, nil
+}
+
 // GetDailyOccurrences returns daily detection counts for a label.
 func (r *detectionRepository) GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64, tzOffsetSeconds int) ([]DailyCount, error) {
 	var results []DailyCount

--- a/internal/datastore/v2only/aggregate.go
+++ b/internal/datastore/v2only/aggregate.go
@@ -66,6 +66,78 @@ func buildSpeciesHourlyDistribution(top []repository.SpeciesCount, hourlyByLabel
 	return result
 }
 
+// minConfidenceHistogramDetections is the per-species floor for the confidence distribution (design
+// spec section 6.5). Below this, a ~20-bin histogram averages under one detection per bin and reads
+// as noise rather than a distribution, so the species is dropped from the top-N set. A single
+// explicitly selected species bypasses this (the caller passes a floor of 1) so a requested species
+// is never silently empty.
+const minConfidenceHistogramDetections = 20
+
+// buildSpeciesConfidenceHistogram bins each species' detection confidences into `bins` equal-width
+// bins over [0,1], then normalizes each species so its bins sum to ~1.0 (the distribution shape is
+// comparable across species regardless of detection volume). Label rows sharing a scientific name
+// (multi-model) merge into one species, preserving the input (descending-volume) order. Species with
+// fewer than minCount detections are dropped as noisy. Total is the species' detection count (false
+// positives already excluded upstream), surfaced in the tooltip. Returns a non-nil empty slice when
+// no species qualifies, or when bins is non-positive.
+func buildSpeciesConfidenceHistogram(species []repository.SpeciesCount, confByLabel map[uint][]float64, bins, minCount int) []datastore.SpeciesConfidenceHistogram {
+	if bins <= 0 {
+		return []datastore.SpeciesConfidenceHistogram{}
+	}
+
+	// Merge label rows sharing a scientific name, preserving first-seen (descending-volume) order.
+	// Each distinct species accumulates the confidences of all its label IDs.
+	order := make([]string, 0, len(species))
+	confByName := make(map[string][]float64, len(species))
+	for i := range species {
+		name := species[i].ScientificName
+		if _, ok := confByName[name]; !ok {
+			order = append(order, name)
+		}
+		confByName[name] = append(confByName[name], confByLabel[species[i].LabelID]...)
+	}
+
+	result := make([]datastore.SpeciesConfidenceHistogram, 0, len(order))
+	for _, name := range order {
+		confs := confByName[name]
+		total := len(confs)
+		// Drop low-volume species (and guard the division below). minCount is always >= 1 from the
+		// caller, so total == 0 is covered too.
+		if total < minCount || total == 0 {
+			continue
+		}
+		counts := make([]int, bins)
+		for _, conf := range confs {
+			counts[confidenceBinIndex(conf, bins)]++
+		}
+		dist := datastore.SpeciesConfidenceHistogram{
+			ScientificName: name,
+			Bins:           make([]float64, bins),
+			Total:          total,
+		}
+		for b, count := range counts {
+			dist.Bins[b] = float64(count) / float64(total)
+		}
+		result = append(result, dist)
+	}
+	return result
+}
+
+// confidenceBinIndex maps a confidence score to its bin index in [0, bins-1] for `bins` equal-width
+// bins over [0,1]. Scores are assumed to be in [0,1]; values are clamped so a confidence of exactly
+// 1.0 lands in the last bin and any out-of-range value is pinned to the nearest edge bin rather than
+// indexing out of bounds. Callers guarantee bins > 0.
+func confidenceBinIndex(conf float64, bins int) int {
+	idx := int(conf * float64(bins))
+	if idx < 0 {
+		return 0
+	}
+	if idx >= bins {
+		return bins - 1
+	}
+	return idx
+}
+
 // Slot resolution constants for the seasonal density heatmap. The intra-day slot width is
 // downsampled as the requested range widens so the payload (and the rendered grid) stays
 // bounded: a year at 15-minute resolution would be 365*96 cells, most of them noise.

--- a/internal/datastore/v2only/aggregate_test.go
+++ b/internal/datastore/v2only/aggregate_test.go
@@ -475,3 +475,181 @@ func TestBuildDailyActivityOnset_InvalidDates(t *testing.T) {
 	_, err := buildDailyActivityOnset(nil, time.UTC, "not-a-date", "2026-03-03", onsetDetectionRank, minOnsetDetections, dawnAt(300))
 	require.Error(t, err)
 }
+
+// --- Confidence distribution (buildSpeciesConfidenceHistogram) -------------
+//
+// These exercise the pure binning/normalization. False-positive exclusion happens upstream in the
+// repository query (GetBatchConfidences), so the confByLabel inputs here are already FP-excluded.
+
+// confidenceBinSum sums a species' normalized bins (should be ~1.0 for any non-empty species).
+func confidenceBinSum(bins []float64) float64 {
+	sum := 0.0
+	for _, v := range bins {
+		sum += v
+	}
+	return sum
+}
+
+func TestConfidenceBinIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		conf float64
+		bins int
+		want int
+	}{
+		{"zero lands in the first bin", 0.0, 20, 0},
+		{"mid lands in the middle bin", 0.5, 20, 10},
+		{"just under one lands in the last bin", 0.999, 20, 19},
+		{"exactly one is clamped into the last bin", 1.0, 20, 19},
+		{"above one is clamped into the last bin", 1.5, 20, 19},
+		{"negative is clamped into the first bin", -0.2, 20, 0},
+		{"five-bin boundary", 0.4, 5, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, confidenceBinIndex(tt.conf, tt.bins))
+		})
+	}
+}
+
+func TestBuildSpeciesConfidenceHistogram_BinsAndNormalizes(t *testing.T) {
+	t.Parallel()
+
+	// Four detections across four equal bins (width 0.25): 0.1->bin0, 0.3->bin1, 0.55->bin2,
+	// 0.9->bin3. Each is 1/4 of the total, so every normalized bin is 0.25.
+	species := []repository.SpeciesCount{{LabelID: 1, ScientificName: "Turdus merula"}}
+	confByLabel := map[uint][]float64{1: {0.1, 0.3, 0.55, 0.9}}
+
+	got := buildSpeciesConfidenceHistogram(species, confByLabel, 4, 1)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Equal(t, 4, got[0].Total)
+	require.Len(t, got[0].Bins, 4)
+	for i, want := range []float64{0.25, 0.25, 0.25, 0.25} {
+		assert.InDelta(t, want, got[0].Bins[i], 1e-9)
+	}
+	assert.InDelta(t, 1.0, confidenceBinSum(got[0].Bins), 1e-9, "normalized bins sum to 1.0")
+}
+
+func TestBuildSpeciesConfidenceHistogram_BinBoundaries(t *testing.T) {
+	t.Parallel()
+
+	// Confidence exactly 0.0 must land in the first bin and exactly 1.0 in the last (clamped, not
+	// overflowing the slice).
+	species := []repository.SpeciesCount{{LabelID: 1, ScientificName: "Strix aluco"}}
+	confByLabel := map[uint][]float64{1: {0.0, 1.0}}
+
+	got := buildSpeciesConfidenceHistogram(species, confByLabel, 5, 1)
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Bins, 5)
+	assert.Equal(t, 2, got[0].Total)
+	assert.InDelta(t, 0.5, got[0].Bins[0], 1e-9) // 0.0 -> bin 0
+	assert.InDelta(t, 0.5, got[0].Bins[4], 1e-9) // 1.0 -> last bin
+}
+
+func TestBuildSpeciesConfidenceHistogram_BinCountParam(t *testing.T) {
+	t.Parallel()
+
+	species := []repository.SpeciesCount{{LabelID: 1, ScientificName: "Turdus merula"}}
+	confByLabel := map[uint][]float64{1: {0.2, 0.4, 0.6, 0.8}}
+
+	for _, bins := range []int{10, 20, 50} {
+		got := buildSpeciesConfidenceHistogram(species, confByLabel, bins, 1)
+		require.Len(t, got, 1)
+		assert.Len(t, got[0].Bins, bins, "bin count param is honored")
+		assert.InDelta(t, 1.0, confidenceBinSum(got[0].Bins), 1e-9)
+	}
+
+	// Non-positive bins yields an empty (non-nil) result rather than panicking.
+	empty := buildSpeciesConfidenceHistogram(species, confByLabel, 0, 1)
+	assert.Empty(t, empty)
+	assert.NotNil(t, empty)
+}
+
+func TestBuildSpeciesConfidenceHistogram_MinCountFilter(t *testing.T) {
+	t.Parallel()
+
+	// Pica pica has only 2 detections, below the floor of 5, so it is dropped as noisy.
+	species := []repository.SpeciesCount{
+		{LabelID: 1, ScientificName: "Turdus merula"},
+		{LabelID: 2, ScientificName: "Pica pica"},
+	}
+	confByLabel := map[uint][]float64{
+		1: {0.5, 0.6, 0.7, 0.8, 0.9},
+		2: {0.5, 0.6},
+	}
+
+	got := buildSpeciesConfidenceHistogram(species, confByLabel, 10, 5)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+}
+
+func TestBuildSpeciesConfidenceHistogram_MergesLabelsSharingName(t *testing.T) {
+	t.Parallel()
+
+	// The same species detected under two model label IDs collapses to one row whose confidences are
+	// the concatenation across both labels (systemic multi-model behavior), preserving order.
+	species := []repository.SpeciesCount{
+		{LabelID: 1, ScientificName: "Turdus merula"},
+		{LabelID: 2, ScientificName: "Turdus merula"},
+		{LabelID: 3, ScientificName: "Erithacus rubecula"},
+	}
+	confByLabel := map[uint][]float64{
+		1: {0.1, 0.2}, // Turdus merula via model A -> bin 0 (width 0.25)
+		2: {0.8, 0.9}, // Turdus merula via model B -> bin 3
+		3: {0.5, 0.5, 0.5},
+	}
+
+	got := buildSpeciesConfidenceHistogram(species, confByLabel, 4, 1)
+	require.Len(t, got, 2) // two distinct species, not three label rows
+
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Equal(t, 4, got[0].Total) // 2 + 2 merged
+	assert.InDelta(t, 0.5, got[0].Bins[0], 1e-9)
+	assert.InDelta(t, 0.5, got[0].Bins[3], 1e-9)
+
+	assert.Equal(t, "Erithacus rubecula", got[1].ScientificName)
+	assert.Equal(t, 3, got[1].Total)
+}
+
+func TestBuildSpeciesConfidenceHistogram_PreservesVolumeOrder(t *testing.T) {
+	t.Parallel()
+
+	species := []repository.SpeciesCount{
+		{LabelID: 1, ScientificName: "Turdus merula"},
+		{LabelID: 2, ScientificName: "Erithacus rubecula"},
+		{LabelID: 3, ScientificName: "Strix aluco"},
+	}
+	confByLabel := map[uint][]float64{
+		1: {0.5, 0.6, 0.7},
+		2: {0.4, 0.5, 0.6},
+		3: {0.7, 0.8, 0.9},
+	}
+
+	got := buildSpeciesConfidenceHistogram(species, confByLabel, 10, 1)
+	require.Len(t, got, 3)
+	assert.Equal(t, "Turdus merula", got[0].ScientificName)
+	assert.Equal(t, "Erithacus rubecula", got[1].ScientificName)
+	assert.Equal(t, "Strix aluco", got[2].ScientificName)
+}
+
+func TestBuildSpeciesConfidenceHistogram_Empty(t *testing.T) {
+	t.Parallel()
+
+	empty := buildSpeciesConfidenceHistogram(nil, nil, 20, 1)
+	assert.Empty(t, empty)
+	assert.NotNil(t, empty)
+
+	// A species ranked in by raw volume but with no FP-excluded confidences drops out, never nil.
+	got := buildSpeciesConfidenceHistogram(
+		[]repository.SpeciesCount{{LabelID: 1, ScientificName: "Turdus merula"}},
+		map[uint][]float64{},
+		20, 1,
+	)
+	assert.Empty(t, got)
+	assert.NotNil(t, got)
+}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3122,16 +3122,24 @@ func (ds *Datastore) GetConfidenceHistogram(ctx context.Context, startDate, endD
 	var speciesSet []repository.SpeciesCount
 	var minCount int
 	if species != "" {
-		labelID, resolveErr := ds.resolveLabelID(ctx, species)
-		if resolveErr != nil {
-			if errors.Is(resolveErr, errNotFound) {
-				return []datastore.SpeciesConfidenceHistogram{}, nil
-			}
-			return nil, resolveErr
+		// Use every label ID that maps to this scientific name (a species can carry one label per
+		// model), so the filtered path merges multi-model detections exactly like the top-N path below;
+		// resolving a single label ID would silently drop other models' detections for the species.
+		labelIDs, labelErr := ds.label.GetLabelIDsByScientificName(ctx, species)
+		if labelErr != nil {
+			return nil, errors.New(labelErr).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "get_confidence_histogram_resolve_species").
+				Build()
 		}
-		// resolveLabelID returns a non-nil ID for a non-empty species that resolves (the empty-species
-		// case never reaches here).
-		speciesSet = []repository.SpeciesCount{{LabelID: *labelID, ScientificName: species}}
+		if len(labelIDs) == 0 {
+			return []datastore.SpeciesConfidenceHistogram{}, nil
+		}
+		speciesSet = make([]repository.SpeciesCount, 0, len(labelIDs))
+		for _, labelID := range labelIDs {
+			speciesSet = append(speciesSet, repository.SpeciesCount{LabelID: labelID, ScientificName: species})
+		}
 		minCount = 1
 	} else {
 		// GetTopSpecies uses an inclusive end (<= end) while GetBatchConfidences uses an exclusive end

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3099,6 +3099,81 @@ func (ds *Datastore) GetDailyActivityOnset(ctx context.Context, startDate, endDa
 	return buildDailyActivityOnset(timestamps, ds.timezone, startDate, endDate, onsetDetectionRank, minOnsetDetections, dawn)
 }
 
+// GetConfidenceHistogram returns the per-species confidence-score distribution over the date range,
+// powering the confidence distribution chart (design spec section 6.5). With no species filter it
+// covers the top `limit` species by raw detection volume; with a species filter it covers just that
+// species (always included if it has any detections). It fetches each species' false-positive-excluded
+// confidences in one batched query (GetBatchConfidences), then bins and normalizes them in a shared,
+// table-tested Go helper (buildSpeciesConfidenceHistogram). minConfidence is 0 so every detection is
+// counted, matching the who-sings-when ridgeline and the other species analytics endpoints.
+func (ds *Datastore) GetConfidenceHistogram(ctx context.Context, startDate, endDate, species string, bins, limit int) ([]datastore.SpeciesConfidenceHistogram, error) {
+	start, end, err := ds.parseDateRange(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	// minConfidence 0 counts every detection (no confidence floor), matching the who-sings-when
+	// ridgeline and the other time-based analytics; named to avoid a bare magic literal below.
+	const noConfidenceFloor = 0.0
+
+	// Select the species set and the per-species detection floor. An explicit species filter yields
+	// just that species (always shown if it has any detections); otherwise the top `limit` species by
+	// raw volume, with low-volume species dropped as noisy.
+	var speciesSet []repository.SpeciesCount
+	var minCount int
+	if species != "" {
+		labelID, resolveErr := ds.resolveLabelID(ctx, species)
+		if resolveErr != nil {
+			if errors.Is(resolveErr, errNotFound) {
+				return []datastore.SpeciesConfidenceHistogram{}, nil
+			}
+			return nil, resolveErr
+		}
+		// resolveLabelID returns a non-nil ID for a non-empty species that resolves (the empty-species
+		// case never reaches here).
+		speciesSet = []repository.SpeciesCount{{LabelID: *labelID, ScientificName: species}}
+		minCount = 1
+	} else {
+		// GetTopSpecies uses an inclusive end (<= end) while GetBatchConfidences uses an exclusive end
+		// (< end); subtract one second so ranking and binned totals cover the exact same range and never
+		// disagree on a detection landing on the end boundary (mirrors GetHourlyDistributionBySpecies).
+		topEnd := end
+		if end != math.MaxInt64 {
+			topEnd--
+		}
+		top, topErr := ds.detection.GetTopSpecies(ctx, start, topEnd, noConfidenceFloor, nil, limit)
+		if topErr != nil {
+			return nil, errors.New(topErr).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "get_confidence_histogram_top").
+				Build()
+		}
+		speciesSet = top
+		minCount = minConfidenceHistogramDetections
+	}
+
+	if len(speciesSet) == 0 {
+		return []datastore.SpeciesConfidenceHistogram{}, nil
+	}
+
+	labelIDs := make([]uint, 0, len(speciesSet))
+	for i := range speciesSet {
+		labelIDs = append(labelIDs, speciesSet[i].LabelID)
+	}
+
+	confByLabel, err := ds.detection.GetBatchConfidences(ctx, labelIDs, start, end, noConfidenceFloor)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_confidence_histogram_confidences").
+			Build()
+	}
+
+	return buildSpeciesConfidenceHistogram(speciesSet, confByLabel, bins, minCount), nil
+}
+
 // civilDawnMinuteLookup returns a civilDawnMinuteLookup closure over the datastore's SunCalc and
 // station timezone. The closure yields civil dawn's station-local minute-of-day for a date, or
 // ok=false when no SunCalc is configured or civil dawn is undefined for the date (polar day/night).

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -303,6 +303,10 @@ func (m *mockStore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]
 	return []datastore.DailyActivityOnset{}, nil
 }
 
+func (m *mockStore) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]datastore.SpeciesConfidenceHistogram, error) {
+	return []datastore.SpeciesConfidenceHistogram{}, nil
+}
+
 // BG-17 fix: Add notification history methods
 func (m *mockStore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {
 	return []datastore.NotificationHistory{}, nil


### PR DESCRIPTION
## What

Final Tier-1 analytics chart: a per-species histogram of detection confidence scores, in the Review & Accuracy tab. For the top species by detection volume it shows how the model's confidence is distributed, so you can spot the species it is least sure about and prioritize review. This completes the Tier-1 chart rollout (heatmap, who-sings-when ridgeline, dawn-chorus onset, nocturnal clock, and now confidence distribution).

## Backend (additive only; v2only real, legacy stubbed)

- New endpoint `GET /api/v2/analytics/confidence/distribution?start_date&end_date&species&bins&limit`. Covers the top-N species by volume, or a single species filter. `bins` defaults to 20 (clamped 5-50); `limit` defaults to 5, max 8. False positives excluded; each species' bins are normalized to sum to ~1.0 so distribution shapes compare across species regardless of count.
- New `datastore.Interface.GetConfidenceHistogram` + `SpeciesConfidenceHistogram`, a v2only implementation, and a shared, table-tested Go binning helper. New batched repository method `GetBatchConfidences` mirrors `GetBatchHourlyOccurrences` (chunked, false-positive excluded). The legacy datastore returns an empty result (it is deprecated).
- README endpoint table updated.

## Frontend

- Reuses the existing `SpeciesRidgeline` component with a confidence-bin x-tick formatter (each bin labeled by its left-edge confidence as a percentage). New chart registry entry in the `quality` (Review & Accuracy) tab. The chart is always top-N and never filters by species, so it intentionally does not expose a species selector. New i18n keys added across all locales.

## Tests

- Go: table tests for the binning helper (bin boundaries including confidence exactly 1.0, bin-count parameter, min-count filter, multi-model label merge, normalization, ordering) and handler tests (validation, end-date default, bins/limit clamping, empty-not-null, query timeout).
- Frontend: vitest for the ridgeline reuse (series mapping, the bins x-tick formatter, empty/sparse fallback, accessibility summary).

## Verification

`golangci-lint run` clean; `go test -race` on touched packages green; frontend `npm run check:all` green with i18n keys and generated types in sync; the analytics vitest suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Confidence Distribution”** analytics chart to the quality analytics section, showing per-species confidence clusters for a selected date range (top results; confidence binning).
  * Added a v2 analytics endpoint to supply the chart data.
  * Added new localized UI text for the chart (title, descriptions, empty states, axis/tooltip labels, and summaries).
* **Tests**
  * Added backend and frontend tests for endpoint responses and chart rendering, including empty/sparse scenarios and formatting.
* **Documentation**
  * Documented the new v2 analytics endpoint in the API reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->