### PR TITLE
feat(analytics): species accumulation curve (biodiversity)

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.svelte
@@ -57,6 +57,8 @@
   const MAX_DOTS_DAYS = 31;
   // Top headroom so the line and the asymptote label do not sit flush against the chart's top edge.
   const Y_HEADROOM_FRAC = 0.08;
+  // One day in milliseconds, used to pad a single-point x-domain so it is never zero-width.
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
   interface PlottedPoint extends AccumulationPoint {
     dateObj: Date;
@@ -106,7 +108,15 @@
 
     const minDate = points[0].dateObj;
     const maxDate = points[points.length - 1].dateObj;
-    const xScale = createTimeScale({ domain: [minDate, maxDate], range: [0, innerWidth] });
+    // A single in-range day (one point) makes minDate === maxDate, a zero-width domain that D3 maps
+    // to NaN and renders as broken SVG. Since minDataPoints keys on the species count (not the day
+    // count), a single day with 2+ first-seen species reaches here, so pad the domain by a day on
+    // each side to keep the scale well-defined.
+    const xDomain: [Date, Date] =
+      minDate.getTime() === maxDate.getTime()
+        ? [new Date(minDate.getTime() - MS_PER_DAY), new Date(maxDate.getTime() + MS_PER_DAY)]
+        : [minDate, maxDate];
+    const xScale = createTimeScale({ domain: xDomain, range: [0, innerWidth] });
 
     // Count axis always starts at 0; add a little headroom so the asymptote line/label clears the top.
     const yTop = maxCumulative + Math.max(1, Math.ceil(maxCumulative * Y_HEADROOM_FRAC));

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.svelte
@@ -1,0 +1,302 @@
+<!--
+  Species accumulation curve (biodiversity collector's curve).
+
+  Cumulative count of distinct species first seen within the selected range, plotted per calendar day.
+  The backend emits one point per day (a continuous, monotonic non-decreasing series), so the curve
+  rises as new species appear and flattens toward an asymptote once the common species are exhausted.
+  A still-climbing tail means the site is under-sampled; a flat tail means most species have been
+  recorded. "First seen" is windowed (bounded to the selected range), not lifetime.
+
+  Rendered as a filled area under a stroked line (curveMonotoneX) with a dashed reference line at the
+  final/total species count. Per-point dots are only drawn for short ranges; on a wide range hundreds
+  of overlapping dots on a steep line read as muddy, so the line alone carries the shape.
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { select } from 'd3-selection';
+  import { line, area, curveMonotoneX } from 'd3-shape';
+  import type { AxisDomain, AxisScale } from 'd3-axis';
+
+  import BaseChart from './BaseChart.svelte';
+  import { parseLocalDateString } from '$lib/utils/date';
+  import { createTimeScale, createLinearScale } from './utils/scales';
+  import {
+    createAxis,
+    styleAxis,
+    addAxisLabel,
+    createDateAxisFormatter,
+    pickDateRangeBucket,
+  } from './utils/axes';
+  import { ChartTooltip } from './utils/interactions';
+  import { type ChartTheme } from './utils/theme';
+  import {
+    finalCumulative,
+    type AccumulationData,
+    type AccumulationPoint,
+  } from './utils/accumulation';
+  import { t } from '$lib/i18n';
+
+  interface Props {
+    data: AccumulationData;
+    width?: number;
+    height?: number;
+    ariaLabel?: string;
+  }
+
+  let { data, width = 800, height = 400, ariaLabel }: Props = $props();
+
+  // Layout / behavior constants.
+  const MARGIN = { top: 24, right: 18, bottom: 48, left: 60 };
+  const MAX_X_TICKS = 8;
+  const X_AXIS_LABEL_OFFSET = 38;
+  const Y_AXIS_LABEL_OFFSET = 46;
+  const AREA_OPACITY = 0.15;
+  const DOT_RADIUS = 3;
+  const DOT_IDLE_OPACITY = 0.7;
+  // Above this many days, drawing a dot per point clutters a steep line; the stroke alone carries it.
+  const MAX_DOTS_DAYS = 31;
+  // Top headroom so the line and the asymptote label do not sit flush against the chart's top edge.
+  const Y_HEADROOM_FRAC = 0.08;
+
+  interface PlottedPoint extends AccumulationPoint {
+    dateObj: Date;
+  }
+
+  let tooltip: ChartTooltip | null = null;
+  let chartContainer: HTMLDivElement | null = null;
+
+  // Points with a valid parsed date, in input (ascending date) order.
+  const parsedPoints = $derived.by<PlottedPoint[]>(() => {
+    const out: PlottedPoint[] = [];
+    for (const p of data.points) {
+      const d = parseLocalDateString(p.date);
+      if (d && !isNaN(d.getTime())) out.push({ ...p, dateObj: d });
+    }
+    return out;
+  });
+
+  // Screen-reader summary so the chart is not opaque to assistive tech (spec section 7).
+  const summary = $derived.by(() => {
+    if (parsedPoints.length === 0) return '';
+    return t('analytics.advanced.charts.accumulation.summary', {
+      species: finalCumulative(data),
+      days: parsedPoints.length,
+    });
+  });
+
+  let chartContext = $state<{
+    svg: import('d3-selection').Selection<SVGSVGElement, unknown, null, undefined>;
+    chartGroup: import('d3-selection').Selection<globalThis.SVGGElement, unknown, null, undefined>;
+    innerWidth: number;
+    innerHeight: number;
+    theme: ChartTheme;
+  } | null>(null);
+
+  function drawChart(context: NonNullable<typeof chartContext>): void {
+    const { chartGroup, innerWidth, innerHeight, theme } = context;
+    // A redraw removes the hovered dot, so its mouseleave would never fire; hide first.
+    tooltip?.hide();
+    chartGroup.selectAll('*').remove();
+    if (innerWidth <= 0 || innerHeight <= 0) return;
+
+    const points = parsedPoints;
+    const maxCumulative = finalCumulative(data);
+    // ChartCard owns the empty / not-enough-data state; bail before drawing axes on an empty curve.
+    if (points.length === 0 || maxCumulative <= 0) return;
+
+    const minDate = points[0].dateObj;
+    const maxDate = points[points.length - 1].dateObj;
+    const xScale = createTimeScale({ domain: [minDate, maxDate], range: [0, innerWidth] });
+
+    // Count axis always starts at 0; add a little headroom so the asymptote line/label clears the top.
+    const yTop = maxCumulative + Math.max(1, Math.ceil(maxCumulative * Y_HEADROOM_FRAC));
+    const yScale = createLinearScale({ domain: [0, yTop], range: [innerHeight, 0] });
+
+    // X axis: locale-aware date labels, bucketed by the span (week / month / year).
+    const dateFmt = createDateAxisFormatter(pickDateRangeBucket([minDate, maxDate]));
+    const xAxis = createAxis({
+      scale: xScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'bottom',
+      tickCount: MAX_X_TICKS,
+      tickFormat: (d: AxisDomain) => dateFmt(d as Date),
+    });
+    const xAxisGroup = chartGroup
+      .append('g')
+      .attr('class', 'x-axis')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(xAxis);
+    styleAxis(xAxisGroup, theme.axis);
+
+    // Y axis: integer species counts (round so a small domain never shows fractional ticks).
+    const yAxis = createAxis({
+      scale: yScale as unknown as AxisScale<AxisDomain>,
+      orientation: 'left',
+      tickFormat: (d: AxisDomain) => String(Math.round(Number(d))),
+    });
+    const yAxisGroup = chartGroup.append('g').attr('class', 'y-axis').call(yAxis);
+    styleAxis(yAxisGroup, theme.axis);
+
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t('analytics.advanced.charts.accumulation.axisDate'),
+        orientation: 'bottom',
+        offset: X_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+    addAxisLabel(
+      chartGroup,
+      {
+        text: t('analytics.advanced.charts.accumulation.axisSpecies'),
+        orientation: 'left',
+        offset: Y_AXIS_LABEL_OFFSET,
+        width: innerWidth,
+        height: innerHeight,
+      },
+      theme.axis
+    );
+
+    // Filled area under the curve (the "species accumulated so far" volume).
+    const areaGen = area<PlottedPoint>()
+      .x(d => xScale(d.dateObj))
+      .y0(innerHeight)
+      .y1(d => yScale(d.cumulativeSpecies))
+      .curve(curveMonotoneX);
+    chartGroup
+      .append('path')
+      .datum(points)
+      .attr('class', 'accumulation-area')
+      .attr('fill', theme.primary)
+      .attr('fill-opacity', AREA_OPACITY)
+      .attr('stroke', 'none')
+      .attr('d', areaGen);
+
+    // The cumulative line itself.
+    const lineGen = line<PlottedPoint>()
+      .x(d => xScale(d.dateObj))
+      .y(d => yScale(d.cumulativeSpecies))
+      .curve(curveMonotoneX);
+    chartGroup
+      .append('path')
+      .datum(points)
+      .attr('class', 'accumulation-line')
+      .attr('fill', 'none')
+      .attr('stroke', theme.primary)
+      .attr('stroke-width', 2)
+      .attr('d', lineGen);
+
+    // Reference line at the total species count, with an inline label. The flat tail of the curve
+    // approaches this; for a still-climbing curve it marks how many species have been recorded so far.
+    const totalY = yScale(maxCumulative);
+    chartGroup
+      .append('line')
+      .attr('class', 'accumulation-asymptote')
+      .attr('x1', 0)
+      .attr('x2', innerWidth)
+      .attr('y1', totalY)
+      .attr('y2', totalY)
+      .style('stroke', theme.axis.color)
+      .style('stroke-dasharray', '4 3')
+      .style('stroke-width', 1)
+      .style('opacity', 0.7);
+    chartGroup
+      .append('text')
+      .attr('x', innerWidth)
+      .attr('y', totalY - 4)
+      .attr('text-anchor', 'end')
+      .attr('aria-hidden', 'true')
+      .style('fill', theme.axis.color)
+      .style('font-size', theme.axis.fontSize)
+      .text(t('analytics.advanced.charts.accumulation.totalSpecies', { species: maxCumulative }));
+
+    // Per-point dots only on short ranges; on a wide range the dense dots clutter the steep line.
+    if (points.length <= MAX_DOTS_DAYS) {
+      chartGroup
+        .append('g')
+        .attr('class', 'accumulation-dots')
+        .selectAll('circle')
+        .data(points)
+        .enter()
+        .append('circle')
+        .attr('cx', (d: PlottedPoint) => xScale(d.dateObj))
+        .attr('cy', (d: PlottedPoint) => yScale(d.cumulativeSpecies))
+        .attr('r', DOT_RADIUS)
+        .style('fill', theme.primary)
+        .style('opacity', DOT_IDLE_OPACITY)
+        .on('mouseenter', function (event: MouseEvent, d: PlottedPoint) {
+          select(this).style('opacity', 1);
+          showTooltip(event, d);
+        })
+        .on('mouseleave', function () {
+          select(this).style('opacity', DOT_IDLE_OPACITY);
+          tooltip?.hide();
+        });
+    }
+  }
+
+  function showTooltip(event: MouseEvent, d: PlottedPoint): void {
+    tooltip?.show({
+      title: d.date,
+      items: [
+        {
+          label: t('analytics.advanced.charts.accumulation.tooltipCumulative'),
+          value: String(d.cumulativeSpecies),
+        },
+        {
+          label: t('analytics.advanced.charts.accumulation.tooltipNew'),
+          value: String(d.newSpecies),
+        },
+      ],
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }
+
+  $effect(() => {
+    if (chartContext) {
+      drawChart(chartContext);
+    }
+  });
+
+  onMount(() => {
+    if (chartContainer) {
+      tooltip = new ChartTooltip(chartContainer);
+    }
+  });
+
+  onDestroy(() => {
+    tooltip?.destroy();
+  });
+</script>
+
+<div class="accumulation-chart" bind:this={chartContainer}>
+  <BaseChart
+    {width}
+    {height}
+    margin={MARGIN}
+    responsive={true}
+    ariaLabel={ariaLabel ?? t('analytics.advanced.charts.accumulation.ariaLabel')}
+  >
+    {#snippet children(context)}
+      {((chartContext = context), '')}
+    {/snippet}
+  </BaseChart>
+  {#if summary}
+    <p class="sr-only" data-testid="accumulation-summary">{summary}</p>
+  {/if}
+</div>
+
+<style>
+  .accumulation-chart {
+    width: 100%;
+    height: 100%;
+    min-height: 320px;
+  }
+
+  :global(.accumulation-dots circle) {
+    transition: opacity 0.12s ease;
+  }
+</style>

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import SpeciesAccumulationChart from './SpeciesAccumulationChart.svelte';
+import { finalCumulative, type AccumulationData } from './utils/accumulation';
+
+// jsdom has no layout engine; assert on element counts/attributes only.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// A short rising curve: cumulative climbs 1 -> 1 -> 2 -> 3 over four days.
+const sample: AccumulationData = {
+  points: [
+    { date: '2026-03-01', cumulativeSpecies: 1, newSpecies: 1 },
+    { date: '2026-03-02', cumulativeSpecies: 1, newSpecies: 0 },
+    { date: '2026-03-03', cumulativeSpecies: 2, newSpecies: 1 },
+    { date: '2026-03-04', cumulativeSpecies: 3, newSpecies: 1 },
+  ],
+};
+
+const empty: AccumulationData = { points: [] };
+
+// All-zero curve (no species accumulated): the component must bail like the empty state.
+const allZero: AccumulationData = {
+  points: [
+    { date: '2026-03-01', cumulativeSpecies: 0, newSpecies: 0 },
+    { date: '2026-03-02', cumulativeSpecies: 0, newSpecies: 0 },
+  ],
+};
+
+// Format a date `offset` days after a base date as YYYY-MM-DD (local), so a long fixture spans real
+// consecutive calendar days across a month boundary rather than invalid dates like 2026-03-40.
+function isoDay(base: Date, offset: number): string {
+  const d = new Date(base);
+  d.setDate(d.getDate() + offset);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// A long range (40 days > MAX_DOTS_DAYS) so the component drops the per-point dots but still draws
+// the line.
+const longRange: AccumulationData = (() => {
+  const base = new Date('2026-03-01T00:00:00');
+  const points = [];
+  let cum = 0;
+  for (let i = 0; i < 40; i++) {
+    const isNew = i % 3 === 0 ? 1 : 0;
+    cum += isNew;
+    points.push({ date: isoDay(base, i), cumulativeSpecies: cum, newSpecies: isNew });
+  }
+  return { points };
+})();
+
+describe('SpeciesAccumulationChart', () => {
+  it('renders without throwing for empty data', () => {
+    expect(() => render(SpeciesAccumulationChart, { props: { data: empty } })).not.toThrow();
+  });
+
+  it('renders without throwing when no species have accumulated', () => {
+    expect(() => render(SpeciesAccumulationChart, { props: { data: allZero } })).not.toThrow();
+  });
+
+  it('renders the axes, the area, the line, and the total-species reference line', async () => {
+    const { container } = render(SpeciesAccumulationChart, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelector('.x-axis')).toBeTruthy();
+    expect(container.querySelector('.y-axis')).toBeTruthy();
+    expect(container.querySelector('.accumulation-area')).toBeTruthy();
+    expect(container.querySelector('.accumulation-line')).toBeTruthy();
+    expect(container.querySelector('.accumulation-asymptote')).toBeTruthy();
+  });
+
+  it('draws one dot per day on a short range', async () => {
+    const { container } = render(SpeciesAccumulationChart, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    expect(container.querySelectorAll('.accumulation-dots circle')).toHaveLength(4);
+  });
+
+  it('drops the per-point dots on a wide range but still draws the line', async () => {
+    const { container } = render(SpeciesAccumulationChart, {
+      props: { data: longRange, width: 800 },
+    });
+    await Promise.resolve();
+    expect(container.querySelectorAll('.accumulation-dots circle')).toHaveLength(0);
+    expect(container.querySelector('.accumulation-line')).toBeTruthy();
+  });
+
+  it('draws the cumulative line as a single continuous run (monotonic, no breaks)', async () => {
+    const { container } = render(SpeciesAccumulationChart, { props: { data: sample, width: 800 } });
+    await Promise.resolve();
+    const path = container.querySelector('.accumulation-line');
+    expect(path).toBeTruthy();
+    const moveCommands = (path?.getAttribute('d')?.match(/M/g) ?? []).length;
+    expect(moveCommands).toBe(1);
+  });
+
+  it('does not draw axes when no species have accumulated', async () => {
+    const { container } = render(SpeciesAccumulationChart, {
+      props: { data: allZero, width: 800 },
+    });
+    await Promise.resolve();
+    // ChartCard owns the not-enough-data state; the chart itself bails before drawing.
+    expect(container.querySelector('.accumulation-line')).toBeNull();
+  });
+
+  it('sets an accessible label on the chart container', () => {
+    const { container } = render(SpeciesAccumulationChart, {
+      props: { data: sample, ariaLabel: 'Species accumulation' },
+    });
+    expect(container.querySelector('[aria-label="Species accumulation"]')).toBeTruthy();
+  });
+
+  it('renders a screen-reader summary when there is data', async () => {
+    const { getByTestId } = render(SpeciesAccumulationChart, { props: { data: sample } });
+    await Promise.resolve();
+    expect(getByTestId('accumulation-summary')).toBeTruthy();
+  });
+
+  it('finalCumulative returns the asymptote (max) value', () => {
+    expect(finalCumulative(sample)).toBe(3);
+    expect(finalCumulative(empty)).toBe(0);
+    expect(finalCumulative(allZero)).toBe(0);
+  });
+});

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/SpeciesAccumulationChart.test.ts
@@ -67,6 +67,22 @@ describe('SpeciesAccumulationChart', () => {
     expect(() => render(SpeciesAccumulationChart, { props: { data: allZero } })).not.toThrow();
   });
 
+  it('renders a single in-range day (zero-width x-domain) without NaN', async () => {
+    // One day with 2+ first-seen species passes minDataPoints (keyed on the species count) but yields
+    // a single point, so minDate === maxDate. The padded domain must keep the scale well-defined.
+    const singleDay: AccumulationData = {
+      points: [{ date: '2026-03-01', cumulativeSpecies: 3, newSpecies: 3 }],
+    };
+    const { container } = render(SpeciesAccumulationChart, {
+      props: { data: singleDay, width: 800 },
+    });
+    await Promise.resolve();
+    const line = container.querySelector('.accumulation-line');
+    expect(line).toBeTruthy();
+    // A NaN domain produces an "MNaN,..." path; assert the rendered path carries no NaN.
+    expect(line?.getAttribute('d') ?? '').not.toContain('NaN');
+  });
+
   it('renders the axes, the area, the line, and the total-species reference line', async () => {
     const { container } = render(SpeciesAccumulationChart, { props: { data: sample, width: 800 } });
     await Promise.resolve();

--- a/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/accumulation.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/charts/d3/utils/accumulation.ts
@@ -1,0 +1,35 @@
+// Species accumulation curve data + pure helpers.
+//
+// The backend (GET /api/v2/analytics/species/accumulation) returns one entry per calendar day in the
+// requested range. `cumulativeSpecies` is the running count of distinct species first detected within
+// the range on or before that day; `newSpecies` is how many first appeared that day. "First seen" is
+// bounded to the selected window, not lifetime, so the curve shows how fast the species list fills up
+// over the period and flattens toward an asymptote as the common species are exhausted.
+
+export interface AccumulationPoint {
+  /** Station-local calendar day, YYYY-MM-DD. */
+  date: string;
+  /** Running count of distinct species first seen in-period on or before this day. */
+  cumulativeSpecies: number;
+  /** Species first seen on this day (within the selected period). */
+  newSpecies: number;
+}
+
+export interface AccumulationData {
+  points: AccumulationPoint[];
+}
+
+/**
+ * Final cumulative species count (the curve's asymptote value). Drives the registry's
+ * not-enough-data check: a dense per-day payload would otherwise always look like plenty of data, so
+ * the gate keys on how many distinct species actually accumulated. The series is monotonic
+ * non-decreasing by construction, but to stay robust against a malformed payload this returns the
+ * maximum cumulative value rather than blindly trusting the last element. An empty series is 0.
+ */
+export function finalCumulative(data: AccumulationData): number {
+  let max = 0;
+  for (const p of data.points) {
+    if (p.cumulativeSpecies > max) max = p.cumulativeSpecies;
+  }
+  return max;
+}

--- a/frontend/src/lib/desktop/features/analytics/registry/charts.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/charts.ts
@@ -25,6 +25,12 @@ import NocturnalClock from '../components/charts/d3/NocturnalClock.svelte';
 import { hourlyTotal } from '../components/charts/d3/utils/nocturnal';
 import type { NocturnalClockData, SunTimes } from '../components/charts/d3/utils/nocturnal';
 import TrendChartOptions from '../components/TrendChartOptions.svelte';
+import SpeciesAccumulationChart from '../components/charts/d3/SpeciesAccumulationChart.svelte';
+import { finalCumulative } from '../components/charts/d3/utils/accumulation';
+import type {
+  AccumulationData,
+  AccumulationPoint,
+} from '../components/charts/d3/utils/accumulation';
 
 import { formatDateForAPI } from './analyticsParams';
 import type { AnalyticsParams, ChartDef } from './types';
@@ -543,6 +549,54 @@ async function fetchConfidenceDistribution(
     .filter((d): d is ConfidenceDistributionDatum => d !== null);
 }
 
+interface AccumulationResponseItem {
+  date?: unknown;
+  cumulativeSpecies?: unknown;
+  newSpecies?: unknown;
+}
+
+/**
+ * Species accumulation curve: per calendar day, the cumulative count of distinct species first seen
+ * within the range (false positives excluded; "first seen" is windowed, not lifetime). The server
+ * emits one entry per day (a monotonic non-decreasing series). All-species, so the species filter is
+ * never sent. Defensively coerces the array payload into the chart's points shape.
+ */
+async function fetchSpeciesAccumulation(
+  params: AnalyticsParams,
+  signal?: AbortSignal
+): Promise<AccumulationData> {
+  const search = new URLSearchParams({
+    start_date: formatDateForAPI(params.startDate),
+    end_date: formatDateForAPI(params.endDate),
+  });
+
+  const response = await fetch(buildAppUrl(`/api/v2/analytics/species/accumulation?${search}`), {
+    signal,
+  });
+  ensureOk(response);
+
+  const data: unknown = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid species accumulation response: expected an array');
+  }
+
+  const points: AccumulationPoint[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== 'object') continue;
+    const item = raw as AccumulationResponseItem;
+    if (typeof item.date !== 'string') continue;
+    const cumulativeSpecies =
+      typeof item.cumulativeSpecies === 'number' && Number.isFinite(item.cumulativeSpecies)
+        ? item.cumulativeSpecies
+        : 0;
+    const newSpecies =
+      typeof item.newSpecies === 'number' && Number.isFinite(item.newSpecies) ? item.newSpecies : 0;
+    points.push({ date: item.date, cumulativeSpecies, newSpecies });
+  }
+
+  return { points };
+}
+
 // --- Registry --------------------------------------------------------------
 
 export const CHART_REGISTRY: ChartDef[] = [
@@ -692,6 +746,25 @@ export const CHART_REGISTRY: ChartDef[] = [
     }),
     size: 'full',
     supports: { species: false, source: false },
+  },
+  {
+    id: 'species-accumulation',
+    group: 'biodiversity',
+    titleKey: 'analytics.advanced.charts.accumulation.title',
+    descKey: 'analytics.advanced.charts.accumulation.description',
+    emptyKey: 'analytics.advanced.charts.accumulation.noData',
+    emptyHintKey: 'analytics.advanced.charts.accumulation.noDataHint',
+    component: SpeciesAccumulationChart,
+    fetch: fetchSpeciesAccumulation,
+    // The fetch result is an object with a points array (one per day across the whole range), so the
+    // default array-length count would always look like plenty of data. The meaningful count is how
+    // many distinct species actually accumulated; below 2 the curve is a trivial flat step, so
+    // ChartCard shows the not-enough-data state. The metric is all-species, so supports.species is
+    // false (the sibling diversity chart in this tab is also species:false, so no dead selector).
+    countDataPoints: data => finalCumulative(data as AccumulationData),
+    size: 'full',
+    supports: { species: false, source: false },
+    minDataPoints: 2,
   },
   {
     id: 'confidence-distribution',

--- a/frontend/src/lib/desktop/features/analytics/registry/speciesAccumulation.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/speciesAccumulation.test.ts
@@ -31,7 +31,7 @@ function makeParams(): AnalyticsParams {
 
 describe('species-accumulation chart def', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {

--- a/frontend/src/lib/desktop/features/analytics/registry/speciesAccumulation.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/registry/speciesAccumulation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { CHART_REGISTRY } from './charts';
+import type { AnalyticsParams } from './types';
+import { finalCumulative, type AccumulationData } from '../components/charts/d3/utils/accumulation';
+
+// Verifies the species-accumulation registry entry: its placement/flags, the custom countDataPoints
+// (final cumulative species, not per-day length), and the fetcher's defensive coercion of the array
+// payload. jsdom has no layout engine; these assert on data, not rendering.
+
+const def = CHART_REGISTRY.find(c => c.id === 'species-accumulation');
+// Guard at module scope so the rest of the file sees a defined def without non-null assertions
+// (forbidden by lint); a missing entry fails every test with a clear message.
+if (!def) {
+  throw new Error('species-accumulation chart def is required');
+}
+const chartDef = def;
+
+function makeParams(): AnalyticsParams {
+  return {
+    tab: 'biodiversity',
+    range: 'month',
+    start: '2026-03-01',
+    end: '2026-03-31',
+    species: [],
+    source: '',
+    startDate: new Date('2026-03-01T00:00:00'),
+    endDate: new Date('2026-03-31T00:00:00'),
+  };
+}
+
+describe('species-accumulation chart def', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is registered in the biodiversity group as an all-species chart', () => {
+    expect(chartDef.group).toBe('biodiversity');
+    // The curve is inherently all-species; the sibling diversity chart is also species:false, so the
+    // biodiversity tab shows no (dead) species selector.
+    expect(chartDef.supports.species).toBe(false);
+    expect(chartDef.supports.source).toBe(false);
+    expect(chartDef.minDataPoints).toBe(2);
+    expect(chartDef.size).toBe('full');
+  });
+
+  it('counts data points as the final cumulative species, not the per-day length', () => {
+    const data: AccumulationData = {
+      points: [
+        { date: '2026-03-01', cumulativeSpecies: 1, newSpecies: 1 },
+        { date: '2026-03-02', cumulativeSpecies: 3, newSpecies: 2 },
+        { date: '2026-03-03', cumulativeSpecies: 3, newSpecies: 0 },
+      ],
+    };
+    expect(chartDef.countDataPoints?.(data)).toBe(3);
+
+    // A long all-zero curve must count as 0 (not its 30-day length), so ChartCard shows the
+    // not-enough-data state instead of an empty flat line.
+    const flat: AccumulationData = {
+      points: Array.from({ length: 30 }, (_, i) => ({
+        date: `2026-03-${String(i + 1).padStart(2, '0')}`,
+        cumulativeSpecies: 0,
+        newSpecies: 0,
+      })),
+    };
+    expect(chartDef.countDataPoints?.(flat)).toBe(0);
+  });
+
+  it('fetches and coerces the array payload, dropping malformed entries', async () => {
+    const payload = [
+      { date: '2026-03-01', cumulativeSpecies: 1, newSpecies: 1 },
+      { date: '2026-03-02', cumulativeSpecies: 2, newSpecies: 1 },
+      null,
+      { cumulativeSpecies: 5, newSpecies: 1 }, // missing date -> dropped
+      { date: '2026-03-03', cumulativeSpecies: 'x', newSpecies: Number.NaN }, // non-finite -> 0
+    ];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = (await chartDef.fetch(makeParams())) as AccumulationData;
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v2/analytics/species/accumulation');
+    // All-species chart: the species filter is never sent.
+    expect(url).not.toContain('species=');
+
+    expect(result.points).toHaveLength(3);
+    expect(result.points[0]).toEqual({ date: '2026-03-01', cumulativeSpecies: 1, newSpecies: 1 });
+    // Non-finite values coerce to 0 rather than leaking NaN into the chart.
+    expect(result.points[2]).toEqual({ date: '2026-03-03', cumulativeSpecies: 0, newSpecies: 0 });
+    expect(finalCumulative(result)).toBe(2);
+  });
+
+  it('throws when the payload is not an array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({ not: 'an array' }),
+      })
+    );
+    await expect(chartDef.fetch(makeParams())).rejects.toThrow();
+  });
+});

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -1421,6 +1421,17 @@ export type TranslationKey =
   | 'analytics.advanced.charts.diversity.noDataHint'
   | 'analytics.advanced.charts.diversity.axisDate'
   | 'analytics.advanced.charts.diversity.axisUniqueSpecies'
+  | 'analytics.advanced.charts.accumulation.title'
+  | 'analytics.advanced.charts.accumulation.description'
+  | 'analytics.advanced.charts.accumulation.noData'
+  | 'analytics.advanced.charts.accumulation.noDataHint'
+  | 'analytics.advanced.charts.accumulation.ariaLabel'
+  | 'analytics.advanced.charts.accumulation.axisDate'
+  | 'analytics.advanced.charts.accumulation.axisSpecies'
+  | 'analytics.advanced.charts.accumulation.totalSpecies' // params: species
+  | 'analytics.advanced.charts.accumulation.tooltipCumulative'
+  | 'analytics.advanced.charts.accumulation.tooltipNew'
+  | 'analytics.advanced.charts.accumulation.summary' // params: days, species
   | 'analytics.advanced.charts.heatmap.title'
   | 'analytics.advanced.charts.heatmap.description'
   | 'analytics.advanced.charts.heatmap.noData'
@@ -3983,6 +3994,11 @@ export type TranslationParams = {
   'analytics.hub.card.notEnoughDataHint': { min: string | number };
   'analytics.advanced.speciesSelection': { count: string | number; max: string | number };
   'analytics.advanced.detections': { count: string | number };
+  'analytics.advanced.charts.accumulation.totalSpecies': { species: string | number };
+  'analytics.advanced.charts.accumulation.summary': {
+    days: string | number;
+    species: string | number;
+  };
   'analytics.advanced.charts.heatmap.legendMore': { max: string | number };
   'analytics.advanced.charts.heatmap.summary': {
     total: string | number;

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Unikátní druhy"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Dato",
           "axisUniqueSpecies": "Unikke arter"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Einzigartige Arten"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Date",
           "axisUniqueSpecies": "Unique Species"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and levels off once the common ones have been recorded; a still-rising line means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Fecha",
           "axisUniqueSpecies": "Especies únicas"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Päivämäärä",
           "axisUniqueSpecies": "Yksilölliset lajit"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Date",
           "axisUniqueSpecies": "Espèces uniques"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Dátum",
           "axisUniqueSpecies": "Egyedi fajok"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Data",
           "axisUniqueSpecies": "Specie uniche"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Datums",
           "axisUniqueSpecies": "Unikālās sugas"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Dato",
           "axisUniqueSpecies": "Unike arter"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Unieke soorten"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Data",
           "axisUniqueSpecies": "Unikalne gatunki"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Data",
           "axisUniqueSpecies": "Espécies únicas"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Dátum",
           "axisUniqueSpecies": "Jedinečné druhy"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1831,6 +1831,19 @@
           "axisDate": "Datum",
           "axisUniqueSpecies": "Unika arter"
         },
+        "accumulation": {
+          "title": "Species Accumulation Curve",
+          "description": "Cumulative number of distinct species detected within the selected period. The curve climbs as new species appear and flattens toward an asymptote once the common ones have been recorded; a still-rising tail means more species are likely waiting to be found.",
+          "noData": "No species accumulation data available",
+          "noDataHint": "Select a wider date range to watch the species list build up over time",
+          "ariaLabel": "Species accumulation curve: cumulative distinct species detected over the period",
+          "axisDate": "Date",
+          "axisSpecies": "Cumulative species",
+          "totalSpecies": "{species} species",
+          "tooltipCumulative": "Cumulative species",
+          "tooltipNew": "New in period",
+          "summary": "Cumulative species accumulation across {days} days, reaching {species} distinct species by the end of the period."
+        },
         "heatmap": {
           "title": "Seasonal Activity Heatmap",
           "description": "Detection density by date and time of day, revealing migration waves and dawn-chorus drift",

--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -304,6 +304,9 @@ func (m *ActionMockDatastore) GetDailyActivityOnset(_ context.Context, _, _, _ s
 func (m *ActionMockDatastore) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]datastore.SpeciesConfidenceHistogram, error) {
 	return []datastore.SpeciesConfidenceHistogram{}, nil
 }
+func (m *ActionMockDatastore) GetSpeciesAccumulation(_ context.Context, _, _ string) ([]datastore.SpeciesAccumulationPoint, error) {
+	return []datastore.SpeciesAccumulationPoint{}, nil
+}
 func (m *ActionMockDatastore) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -173,6 +173,9 @@ func (m *MockDatastore) GetDailyActivityOnset(context.Context, string, string, s
 func (m *MockDatastore) GetConfidenceHistogram(context.Context, string, string, string, int, int) ([]datastore.SpeciesConfidenceHistogram, error) {
 	return []datastore.SpeciesConfidenceHistogram{}, nil
 }
+func (m *MockDatastore) GetSpeciesAccumulation(context.Context, string, string) ([]datastore.SpeciesAccumulationPoint, error) {
+	return []datastore.SpeciesAccumulationPoint{}, nil
+}
 func (m *MockDatastore) SearchDetections(*datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return make([]datastore.DetectionRecord, 0), 0, nil
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -88,6 +88,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/species/summary`          | `GetSpeciesSummary`        | ❌   | Overall species statistics         |
 | GET    | `/analytics/species/detections/new`   | `GetNewSpeciesDetections`  | ❌   | Recently detected new species      |
 | GET    | `/analytics/species/thumbnails`       | `GetSpeciesThumbnails`     | ❌   | Species thumbnail images           |
+| GET    | `/analytics/species/accumulation`     | `GetSpeciesAccumulation`   | ❌   | Species accumulation curve (biodiversity collector's curve): per calendar day, the cumulative count of distinct species first detected within the range (false positives excluded; "first seen" is bounded to the window, not lifetime). All-species (no species filter). `start_date` required; `end_date` optional (defaults to `start_date` + 30 days) |
 | GET    | `/analytics/time/hourly`              | `GetHourlyAnalytics`       | ❌   | Hourly detection patterns          |
 | GET    | `/analytics/time/daily`               | `GetDailyAnalytics`        | ❌   | Daily detection patterns           |
 | GET    | `/analytics/time/distribution/hourly` | `GetTimeOfDayDistribution` | ❌   | Time-of-day detection distribution |

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -189,6 +189,7 @@ func (c *Controller) initAnalyticsRoutes() {
 	speciesGroup.GET("/detections/new", c.GetNewSpeciesDetections) // Renamed endpoint
 	speciesGroup.GET("/thumbnails", c.GetSpeciesThumbnails)        // Batch thumbnail endpoint
 	speciesGroup.GET("/diversity", c.GetSpeciesDiversity)          // Species diversity over time
+	speciesGroup.GET("/accumulation", c.GetSpeciesAccumulation)    // Species accumulation curve (biodiversity collector's curve)
 
 	// Time analytics routes (can be implemented later)
 	timeGroup := analyticsGroup.Group("/time")
@@ -1761,6 +1762,95 @@ func (c *Controller) GetConfidenceDistribution(ctx echo.Context) error {
 	)
 
 	return ctx.JSON(http.StatusOK, newConfidenceDistributionResponse(data))
+}
+
+// speciesAccumulationItem is one day on the wire payload for the species accumulation curve.
+// scientificName is intentionally absent: the curve is an all-species count, not a per-species series.
+type speciesAccumulationItem struct {
+	Date              string `json:"date"`
+	CumulativeSpecies int    `json:"cumulativeSpecies"`
+	NewSpecies        int    `json:"newSpecies"`
+}
+
+// newSpeciesAccumulationResponse maps the datastore aggregation onto the wire payload as a JSON array
+// (never null), one entry per calendar day in ascending date order.
+func newSpeciesAccumulationResponse(data []datastore.SpeciesAccumulationPoint) []speciesAccumulationItem {
+	items := make([]speciesAccumulationItem, 0, len(data))
+	for i := range data {
+		items = append(items, speciesAccumulationItem{
+			Date:              data[i].Date,
+			CumulativeSpecies: data[i].CumulativeSpecies,
+			NewSpecies:        data[i].NewSpecies,
+		})
+	}
+	return items
+}
+
+// GetSpeciesAccumulation handles GET /api/v2/analytics/species/accumulation
+// Returns the species accumulation curve (the biodiversity collector's curve): per calendar day, the
+// cumulative count of distinct species first detected within the selected range, powering the
+// accumulation chart in the Biodiversity tab. The metric is inherently all-species, so there is no
+// species filter; "first seen" is bounded to the queried window, not lifetime.
+func (c *Controller) GetSpeciesAccumulation(ctx echo.Context) error {
+	const operation = "species accumulation"
+
+	// Validate required parameter
+	if err := c.requireQueryParam(ctx, "start_date", operation); err != nil {
+		return err
+	}
+
+	startDate := ctx.QueryParam("start_date")
+	endDate := ctx.QueryParam("end_date")
+
+	// Validate date formats strictly using regex
+	if err := c.validateDateFormatStrictWithResponse(ctx, startDate, "start_date", operation); err != nil {
+		return err
+	}
+	if err := c.validateDateFormatStrictWithResponse(ctx, endDate, "end_date", operation); err != nil {
+		return err
+	}
+
+	// Validate date values and chronological order
+	if err := c.validateDateRangeWithResponse(ctx, startDate, endDate, operation); err != nil {
+		return err
+	}
+
+	// Default the end date to a 30-day window when omitted, matching the other range endpoints.
+	if endDate == "" {
+		startTime, _ := time.Parse(time.DateOnly, startDate) // Regex ensures this parse succeeds
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
+	}
+
+	c.logInfoIfEnabled("Retrieving species accumulation",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	// Add timeout to prevent resource exhaustion
+	ctxWithTimeout, cancel := withAnalyticsTimeout(ctx)
+	defer cancel()
+
+	data, err := c.DS.GetSpeciesAccumulation(ctxWithTimeout, startDate, endDate)
+	if err != nil {
+		return c.handleAnalyticsQueryError(ctx, err, "Species accumulation", "Failed to get species accumulation",
+			logger.String("start_date", startDate),
+			logger.String("end_date", endDate),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("path", ctx.Request().URL.Path),
+		)
+	}
+
+	c.logInfoIfEnabled("Species accumulation retrieved",
+		logger.String("start_date", startDate),
+		logger.String("end_date", endDate),
+		logger.Int("days", len(data)),
+		logger.String("ip", ctx.RealIP()),
+		logger.String("path", ctx.Request().URL.Path),
+	)
+
+	return ctx.JSON(http.StatusOK, newSpeciesAccumulationResponse(data))
 }
 
 // GetTimeOfDayDistribution handles GET /api/v2/analytics/time/distribution/hourly

--- a/internal/api/v2/analytics_species_accumulation_test.go
+++ b/internal/api/v2/analytics_species_accumulation_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// speciesAccumulationJSON mirrors the species-accumulation wire shape (biodiversity collector's curve).
+type speciesAccumulationJSON struct {
+	Date              string `json:"date"`
+	CumulativeSpecies int    `json:"cumulativeSpecies"`
+	NewSpecies        int    `json:"newSpecies"`
+}
+
+func sampleSpeciesAccumulation() []datastore.SpeciesAccumulationPoint {
+	return []datastore.SpeciesAccumulationPoint{
+		{Date: "2026-03-01", CumulativeSpecies: 1, NewSpecies: 1},
+		{Date: "2026-03-02", CumulativeSpecies: 1, NewSpecies: 0},
+		{Date: "2026-03-03", CumulativeSpecies: 3, NewSpecies: 2},
+	}
+}
+
+func newSpeciesAccumulationContext(e *echo.Echo, target string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/analytics/species/accumulation")
+	return c, rec
+}
+
+func TestGetSpeciesAccumulation_Shape(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetSpeciesAccumulation", mock.Anything, "2026-03-01", "2026-03-03").
+		Return(sampleSpeciesAccumulation(), nil)
+
+	c, rec := newSpeciesAccumulationContext(e, "/api/v2/analytics/species/accumulation?start_date=2026-03-01&end_date=2026-03-03")
+	require.NoError(t, controller.GetSpeciesAccumulation(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []speciesAccumulationJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 3)
+	assert.Equal(t, "2026-03-01", resp[0].Date)
+	assert.Equal(t, 1, resp[0].CumulativeSpecies)
+	assert.Equal(t, 1, resp[0].NewSpecies)
+	// Cumulative is monotonic non-decreasing; the last point carries the total.
+	assert.Equal(t, 3, resp[2].CumulativeSpecies)
+	assert.Equal(t, 2, resp[2].NewSpecies)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetSpeciesAccumulation_EmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetSpeciesAccumulation", mock.Anything, "2026-03-01", "2026-03-02").
+		Return([]datastore.SpeciesAccumulationPoint{}, nil)
+
+	c, rec := newSpeciesAccumulationContext(e, "/api/v2/analytics/species/accumulation?start_date=2026-03-01&end_date=2026-03-02")
+	require.NoError(t, controller.GetSpeciesAccumulation(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	// Empty result must serialize as [] (not null) so the client can read .length safely.
+	var resp []speciesAccumulationJSON
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp)
+	assert.Empty(t, resp)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetSpeciesAccumulation_DefaultsEndDate(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	// With end_date omitted the handler defaults it to a 30-day window: 2026-03-01 + 30d = 2026-03-31.
+	mockDS.On("GetSpeciesAccumulation", mock.Anything, "2026-03-01", "2026-03-31").
+		Return(sampleSpeciesAccumulation(), nil)
+
+	c, rec := newSpeciesAccumulationContext(e, "/api/v2/analytics/species/accumulation?start_date=2026-03-01")
+	require.NoError(t, controller.GetSpeciesAccumulation(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	mockDS.AssertExpectations(t)
+}
+
+func TestGetSpeciesAccumulation_MissingStartDate(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newSpeciesAccumulationContext(e, "/api/v2/analytics/species/accumulation")
+	err := controller.GetSpeciesAccumulation(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetSpeciesAccumulation_InvalidDateFormat(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newSpeciesAccumulationContext(e, "/api/v2/analytics/species/accumulation?start_date=not-a-date")
+	err := controller.GetSpeciesAccumulation(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetSpeciesAccumulation_ReversedRange(t *testing.T) {
+	t.Parallel()
+	e, _, controller := setupAnalyticsTestEnvironment(t)
+
+	c, rec := newSpeciesAccumulationContext(e,
+		"/api/v2/analytics/species/accumulation?start_date=2026-03-05&end_date=2026-03-01")
+	err := controller.GetSpeciesAccumulation(c)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetSpeciesAccumulation_QueryTimeout(t *testing.T) {
+	t.Parallel()
+	e, mockDS, controller := setupAnalyticsTestEnvironment(t)
+
+	mockDS.On("GetSpeciesAccumulation", mock.Anything, "2026-03-01", "2026-03-02").
+		Return([]datastore.SpeciesAccumulationPoint(nil), context.DeadlineExceeded)
+
+	c, rec := newSpeciesAccumulationContext(e, "/api/v2/analytics/species/accumulation?start_date=2026-03-01&end_date=2026-03-02")
+	// handleAnalyticsQueryError writes the 408 response and returns nil.
+	require.NoError(t, controller.GetSpeciesAccumulation(c))
+	assert.Equal(t, http.StatusRequestTimeout, rec.Code)
+	mockDS.AssertExpectations(t)
+}

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -111,6 +111,17 @@ type SpeciesConfidenceHistogram struct {
 	Total          int
 }
 
+// SpeciesAccumulationPoint is one day on the species accumulation curve (the biodiversity collector's
+// curve). Date is the station-local calendar day (YYYY-MM-DD). CumulativeSpecies is the running count
+// of distinct species first detected on or before this day within the selected range; NewSpecies is
+// how many of them first appeared on this day. "First seen" is bounded to the queried window, not
+// lifetime, so the curve answers "how fast is the species list filling up over this period".
+type SpeciesAccumulationPoint struct {
+	Date              string
+	CumulativeSpecies int
+	NewSpecies        int
+}
+
 // NewSpeciesData represents a species detected for the first time within a period
 type NewSpeciesData struct {
 	ScientificName string `json:"scientific_name"`
@@ -483,6 +494,13 @@ func (ds *DataStore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([
 // real method.
 func (ds *DataStore) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]SpeciesConfidenceHistogram, error) {
 	return []SpeciesConfidenceHistogram{}, nil
+}
+
+// GetSpeciesAccumulation is a stub on the legacy store. The species accumulation curve is a v2only
+// feature; the legacy datastore is deprecated and being removed, so it returns an empty (non-nil)
+// slice rather than implementing the aggregation. See internal/datastore/v2only for the real method.
+func (ds *DataStore) GetSpeciesAccumulation(_ context.Context, _, _ string) ([]SpeciesAccumulationPoint, error) {
+	return []SpeciesAccumulationPoint{}, nil
 }
 
 // GetDetectionTrends calculates the trend in detections over time

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -207,6 +207,11 @@ type Interface interface {
 	// powering the confidence distribution chart. With no species filter it covers the top `limit`
 	// species by detection volume; with a species filter it covers just that species.
 	GetConfidenceHistogram(ctx context.Context, startDate, endDate, species string, bins, limit int) ([]SpeciesConfidenceHistogram, error)
+	// GetSpeciesAccumulation returns, per calendar day in the inclusive date range, the cumulative
+	// count of distinct species first detected within that range (false positives excluded). Powers
+	// the species accumulation curve in the Biodiversity tab; "first seen" is bounded to the selected
+	// window, not lifetime.
+	GetSpeciesAccumulation(ctx context.Context, startDate, endDate string) ([]SpeciesAccumulationPoint, error)
 	// Search functionality
 	SearchDetections(filters *SearchFilters) ([]DetectionRecord, int, error)
 	// Dynamic Threshold methods

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -3635,6 +3635,66 @@ func (_c *MockInterface_GetReviewsBatch_Call) RunAndReturn(run func(uint, int) (
 	return _c
 }
 
+// GetSpeciesAccumulation provides a mock function with given fields: ctx, startDate, endDate
+func (_m *MockInterface) GetSpeciesAccumulation(ctx context.Context, startDate string, endDate string) ([]datastore.SpeciesAccumulationPoint, error) {
+	ret := _m.Called(ctx, startDate, endDate)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSpeciesAccumulation")
+	}
+
+	var r0 []datastore.SpeciesAccumulationPoint
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]datastore.SpeciesAccumulationPoint, error)); ok {
+		return rf(ctx, startDate, endDate)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) []datastore.SpeciesAccumulationPoint); ok {
+		r0 = rf(ctx, startDate, endDate)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.SpeciesAccumulationPoint)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, startDate, endDate)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetSpeciesAccumulation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSpeciesAccumulation'
+type MockInterface_GetSpeciesAccumulation_Call struct {
+	*mock.Call
+}
+
+// GetSpeciesAccumulation is a helper method to define mock.On call
+//   - ctx context.Context
+//   - startDate string
+//   - endDate string
+func (_e *MockInterface_Expecter) GetSpeciesAccumulation(ctx interface{}, startDate interface{}, endDate interface{}) *MockInterface_GetSpeciesAccumulation_Call {
+	return &MockInterface_GetSpeciesAccumulation_Call{Call: _e.mock.On("GetSpeciesAccumulation", ctx, startDate, endDate)}
+}
+
+func (_c *MockInterface_GetSpeciesAccumulation_Call) Run(run func(ctx context.Context, startDate string, endDate string)) *MockInterface_GetSpeciesAccumulation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetSpeciesAccumulation_Call) Return(_a0 []datastore.SpeciesAccumulationPoint, _a1 error) *MockInterface_GetSpeciesAccumulation_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetSpeciesAccumulation_Call) RunAndReturn(run func(context.Context, string, string) ([]datastore.SpeciesAccumulationPoint, error)) *MockInterface_GetSpeciesAccumulation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSpeciesDiversityData provides a mock function with given fields: ctx, startDate, endDate
 func (_m *MockInterface) GetSpeciesDiversityData(ctx context.Context, startDate string, endDate string) ([]datastore.DailyAnalyticsData, error) {
 	ret := _m.Called(ctx, startDate, endDate)

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -770,6 +770,9 @@ func (s *testLegacyInterface) GetDailyActivityOnset(_ context.Context, _, _, _ s
 func (s *testLegacyInterface) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]datastore.SpeciesConfidenceHistogram, error) {
 	return []datastore.SpeciesConfidenceHistogram{}, nil
 }
+func (s *testLegacyInterface) GetSpeciesAccumulation(_ context.Context, _, _ string) ([]datastore.SpeciesAccumulationPoint, error) {
+	return []datastore.SpeciesAccumulationPoint{}, nil
+}
 func (s *testLegacyInterface) SearchDetections(_ *datastore.SearchFilters) ([]datastore.DetectionRecord, int, error) {
 	return nil, 0, nil
 }

--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -277,6 +277,13 @@ type DetectionRepository interface {
 	// GetSpeciesFirstDetection (per-species first ever).
 	GetSpeciesFirstDetectionInPeriod(ctx context.Context, start, end int64, limit, offset int) ([]SpeciesFirstSeen, error)
 
+	// GetSpeciesFirstSeenInPeriod returns the first detection (MIN detected_at) of each species
+	// within the half-open range [start, end), false positives excluded, grouped by scientific name
+	// so multi-model labels collapse to one species. Unlike GetSpeciesFirstDetectionInPeriod it
+	// excludes false positives and is not paginated (every species is returned), as required by the
+	// species accumulation analytics. Results are ordered by first-seen ascending.
+	GetSpeciesFirstSeenInPeriod(ctx context.Context, start, end int64) ([]SpeciesFirstSeen, error)
+
 	// === Utilities ===
 
 	// GetClipPath returns the clip path for a detection.

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1750,6 +1750,27 @@ func (r *detectionRepository) GetSpeciesFirstDetectionInPeriod(ctx context.Conte
 	return results, err
 }
 
+// GetSpeciesFirstSeenInPeriod returns the in-period first detection of each species over the
+// half-open range [start, end), false positives excluded, grouped by scientific name so a species
+// with one label per model collapses to a single first-seen. Unlike GetSpeciesFirstDetectionInPeriod
+// (which omits the false-positive exclusion and is paginated for the species tracker), this goes
+// through buildAnalyticsBaseQuery so it shares the analytics false-positive filter, and returns every
+// species (no LIMIT) for the accumulation curve. GROUP BY scientific_name with MIN(detected_at) makes
+// the reviews LEFT JOIN immune to fan-out: duplicate joined rows for one detection collapse under the
+// aggregate. label_id is not selected (it is irrelevant to accumulation and stays zero).
+func (r *detectionRepository) GetSpeciesFirstSeenInPeriod(ctx context.Context, start, end int64) ([]SpeciesFirstSeen, error) {
+	var results []SpeciesFirstSeen
+
+	err := r.buildAnalyticsBaseQuery(ctx, start, end, nil, nil).
+		Joins(fmt.Sprintf("JOIN %s l ON l.id = d.label_id", r.labelsTable())).
+		Select("l.scientific_name as scientific_name, MIN(d.detected_at) as first_detected").
+		Group("l.scientific_name").
+		Order("first_detected ASC, l.scientific_name ASC").
+		Scan(&results).Error
+
+	return results, err
+}
+
 // ============================================================================
 // Utilities
 // ============================================================================

--- a/internal/datastore/v2/repository/species_first_seen_test.go
+++ b/internal/datastore/v2/repository/species_first_seen_test.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSpeciesFirstSeenInPeriod(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	labelA := seedLabel(t, db, "Parus major")
+	labelB := seedLabel(t, db, "Turdus merula")
+
+	// Parus major: earliest in-range detection at 1000 (a later one at 2000 must not move first-seen).
+	seedDetection(t, db, labelA, 2000, 0.8)
+	seedDetection(t, db, labelA, 1000, 0.9)
+	// Turdus merula: earliest in-range at 1500.
+	seedDetection(t, db, labelB, 1500, 0.7)
+
+	t.Run("first-seen is MIN(detected_at) per species, ordered ascending", func(t *testing.T) {
+		got, err := repo.GetSpeciesFirstSeenInPeriod(ctx, 500, 5000)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		// Ordered by first_detected ASC.
+		assert.Equal(t, "Parus major", got[0].ScientificName)
+		assert.Equal(t, int64(1000), got[0].FirstDetected)
+		assert.Equal(t, "Turdus merula", got[1].ScientificName)
+		assert.Equal(t, int64(1500), got[1].FirstDetected)
+	})
+
+	t.Run("end is exclusive", func(t *testing.T) {
+		// With end=1500, Turdus merula's only detection (at 1500) is excluded; Parus major remains.
+		got, err := repo.GetSpeciesFirstSeenInPeriod(ctx, 500, 1500)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "Parus major", got[0].ScientificName)
+		assert.Equal(t, int64(1000), got[0].FirstDetected)
+	})
+
+	t.Run("empty range returns no rows without error", func(t *testing.T) {
+		got, err := repo.GetSpeciesFirstSeenInPeriod(ctx, 100000, 200000)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}
+
+func TestGetSpeciesFirstSeenInPeriod_ExcludesFalsePositives(t *testing.T) {
+	db := setupInsightsTestDB(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	withFP := seedLabel(t, db, "Parus major")
+	allFP := seedLabel(t, db, "Turdus merula")
+
+	// Parus major's earliest detection is a false positive: first-seen must skip it for the next real one.
+	fpID := seedDetection(t, db, withFP, 1000, 0.6)
+	seedFalsePositiveReview(t, db, fpID)
+	seedDetection(t, db, withFP, 1800, 0.9)
+
+	// Turdus merula has only a false-positive detection: it must not appear at all.
+	allFPID := seedDetection(t, db, allFP, 1200, 0.5)
+	seedFalsePositiveReview(t, db, allFPID)
+
+	got, err := repo.GetSpeciesFirstSeenInPeriod(ctx, 500, 5000)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Parus major", got[0].ScientificName)
+	// 1000 was a false positive and is excluded, so the first real detection (1800) is the first-seen.
+	assert.Equal(t, int64(1800), got[0].FirstDetected)
+}
+
+func TestGetSpeciesFirstSeenInPeriod_MergesModels(t *testing.T) {
+	db := setupInsightsTestDBMultiModel(t)
+	repo := NewDetectionRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	// The same species detected under two models collapses to one first-seen: the MIN across labels.
+	labelM1 := seedLabelForModel(t, db, "Parus major", 1)
+	labelM2 := seedLabelForModel(t, db, "Parus major", 2)
+	seedDetectionForModel(t, db, labelM1, 1, 1700, 0.9) // model 1, later
+	seedDetectionForModel(t, db, labelM2, 2, 1200, 0.8) // model 2, earliest
+
+	got, err := repo.GetSpeciesFirstSeenInPeriod(ctx, 500, 5000)
+	require.NoError(t, err)
+	require.Len(t, got, 1) // merged to a single species, not one row per model label
+	assert.Equal(t, "Parus major", got[0].ScientificName)
+	assert.Equal(t, int64(1200), got[0].FirstDetected)
+}

--- a/internal/datastore/v2only/aggregate.go
+++ b/internal/datastore/v2only/aggregate.go
@@ -352,3 +352,72 @@ func buildDailyActivityOnset(timestamps []int64, loc *time.Location, startDate, 
 	}
 	return result, nil
 }
+
+// buildSpeciesAccumulation turns per-species in-period first-seen timestamps into the cumulative
+// species accumulation curve (the biodiversity collector's curve).
+//
+// firstSeen carries each species' first detection (Unix epoch seconds) within the queried window,
+// false positives already excluded upstream. Each timestamp is mapped to its station-local calendar
+// date in loc; the count of species whose first-seen lands on a date is that day's NewSpecies, and
+// CumulativeSpecies is the running total. One point is emitted for every calendar day in the inclusive
+// [startDate, endDate] range so the client gets a continuous date axis whose flat tail reads as the
+// curve's asymptote. First-seen dates outside the enumerated range are ignored (the SQL already bounds
+// them, but a row skewed by loc onto an out-of-range day must never inflate the curve or index past
+// the axis). startDate/endDate are inclusive YYYY-MM-DD bounds; the per-detection bucketing is done
+// in loc (nil -> UTC), while the date axis is enumerated in UTC (see below). The result is always
+// non-nil.
+func buildSpeciesAccumulation(firstSeen []repository.SpeciesFirstSeen, loc *time.Location, startDate, endDate string) ([]datastore.SpeciesAccumulationPoint, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	// Enumerate the date axis in UTC, not loc. We only need the sequence of calendar dates from
+	// startDate to endDate, and UTC has no DST, so AddDate(0,0,1) steps exactly one calendar day every
+	// iteration. Parsing the bounds in a loc whose DST transition skips midnight (clocks jump
+	// 23:59:59 -> 01:00:00, e.g. America/Havana) would normalize the skipped 00:00 forward to 01:00,
+	// drift the loop's wall-clock hour, and drop the final day at the !d.After(end) comparison. The
+	// per-detection bucketing below stays in loc, which is the only place the station timezone matters.
+	start, err := time.Parse(time.DateOnly, startDate)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "build_species_accumulation").
+			Context("start_date", startDate).
+			Build()
+	}
+	end, err := time.Parse(time.DateOnly, endDate)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "build_species_accumulation").
+			Context("end_date", endDate).
+			Build()
+	}
+
+	// Tally how many species are first seen on each station-local calendar date. Dates outside the
+	// enumerated range are never looked up below, so they are ignored without an explicit filter. The
+	// (year, month, day) key is timezone-frame-independent, so the loc-bucketed keys here line up with
+	// the UTC-enumerated lookups below for the same calendar date.
+	newByDate := make(map[dateKey]int, len(firstSeen))
+	for i := range firstSeen {
+		lt := time.Unix(firstSeen[i].FirstDetected, 0).In(loc)
+		y, m, day := lt.Date()
+		newByDate[dateKey{year: y, month: m, day: day}]++
+	}
+
+	result := make([]datastore.SpeciesAccumulationPoint, 0)
+	cumulative := 0
+	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+		y, m, day := d.Date()
+		n := newByDate[dateKey{year: y, month: m, day: day}]
+		cumulative += n
+		result = append(result, datastore.SpeciesAccumulationPoint{
+			Date:              d.Format(time.DateOnly),
+			CumulativeSpecies: cumulative,
+			NewSpecies:        n,
+		})
+	}
+	return result, nil
+}

--- a/internal/datastore/v2only/aggregate_test.go
+++ b/internal/datastore/v2only/aggregate_test.go
@@ -653,3 +653,156 @@ func TestBuildSpeciesConfidenceHistogram_Empty(t *testing.T) {
 	assert.Empty(t, got)
 	assert.NotNil(t, got)
 }
+
+// accumTestZone is a fixed UTC+2 zone for deterministic accumulation date-bucketing tests (no DST
+// jumps), so a timestamp's local calendar date is unambiguous.
+var accumTestZone = time.FixedZone("UTC+2", 2*60*60)
+
+// localUnix returns the Unix epoch (seconds) for the given wall-clock time in loc, for terse first-seen
+// fixtures.
+func localUnix(loc *time.Location, year int, month time.Month, day, hour, minute int) int64 {
+	return time.Date(year, month, day, hour, minute, 0, 0, loc).Unix()
+}
+
+func TestBuildSpeciesAccumulation_Empty(t *testing.T) {
+	t.Parallel()
+
+	// Nil input over a 3-day range: one zero point per day, never nil.
+	got, err := buildSpeciesAccumulation(nil, accumTestZone, "2026-06-01", "2026-06-03")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got, 3)
+	for i := range got {
+		assert.Equal(t, 0, got[i].CumulativeSpecies)
+		assert.Equal(t, 0, got[i].NewSpecies)
+	}
+	assert.Equal(t, "2026-06-01", got[0].Date)
+	assert.Equal(t, "2026-06-03", got[2].Date)
+}
+
+func TestBuildSpeciesAccumulation_CumulativeMonotonic(t *testing.T) {
+	t.Parallel()
+
+	// Three species first seen on day 1, day 2, day 4 of a 5-day window; day 3 and day 5 add none.
+	firstSeen := []repository.SpeciesFirstSeen{
+		{ScientificName: "Turdus merula", FirstDetected: localUnix(accumTestZone, 2026, 6, 1, 5, 30)},
+		{ScientificName: "Erithacus rubecula", FirstDetected: localUnix(accumTestZone, 2026, 6, 2, 6, 0)},
+		{ScientificName: "Strix aluco", FirstDetected: localUnix(accumTestZone, 2026, 6, 4, 23, 0)},
+	}
+
+	got, err := buildSpeciesAccumulation(firstSeen, accumTestZone, "2026-06-01", "2026-06-05")
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+
+	wantCumulative := []int{1, 2, 2, 3, 3}
+	wantNew := []int{1, 1, 0, 1, 0}
+	prev := 0
+	for i := range got {
+		assert.Equalf(t, wantCumulative[i], got[i].CumulativeSpecies, "cumulative on day %d", i+1)
+		assert.Equalf(t, wantNew[i], got[i].NewSpecies, "new on day %d", i+1)
+		assert.GreaterOrEqualf(t, got[i].CumulativeSpecies, prev, "curve must be monotonic non-decreasing")
+		prev = got[i].CumulativeSpecies
+	}
+	// The final cumulative equals the number of distinct in-period species.
+	assert.Equal(t, 3, got[len(got)-1].CumulativeSpecies)
+}
+
+func TestBuildSpeciesAccumulation_SameDayFirsts(t *testing.T) {
+	t.Parallel()
+
+	// Two species first seen on the same day jump the cumulative by two on that day.
+	firstSeen := []repository.SpeciesFirstSeen{
+		{ScientificName: "Turdus merula", FirstDetected: localUnix(accumTestZone, 2026, 6, 2, 4, 0)},
+		{ScientificName: "Erithacus rubecula", FirstDetected: localUnix(accumTestZone, 2026, 6, 2, 7, 0)},
+	}
+
+	got, err := buildSpeciesAccumulation(firstSeen, accumTestZone, "2026-06-01", "2026-06-02")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, 0, got[0].CumulativeSpecies)
+	assert.Equal(t, 0, got[0].NewSpecies)
+	assert.Equal(t, 2, got[1].CumulativeSpecies)
+	assert.Equal(t, 2, got[1].NewSpecies)
+}
+
+func TestBuildSpeciesAccumulation_OutOfRangeIgnored(t *testing.T) {
+	t.Parallel()
+
+	// First-seen dates outside the enumerated range must not be counted (defensive: SQL already
+	// bounds them, but a row skewed by loc onto an out-of-range day must never inflate the curve).
+	firstSeen := []repository.SpeciesFirstSeen{
+		{ScientificName: "Before range", FirstDetected: localUnix(accumTestZone, 2026, 5, 30, 12, 0)},
+		{ScientificName: "In range", FirstDetected: localUnix(accumTestZone, 2026, 6, 2, 12, 0)},
+		{ScientificName: "After range", FirstDetected: localUnix(accumTestZone, 2026, 6, 10, 12, 0)},
+	}
+
+	got, err := buildSpeciesAccumulation(firstSeen, accumTestZone, "2026-06-01", "2026-06-03")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	// Only the single in-range species accumulates.
+	assert.Equal(t, 1, got[len(got)-1].CumulativeSpecies)
+	assert.Equal(t, 1, got[1].NewSpecies)
+}
+
+func TestBuildSpeciesAccumulation_TimezoneDateAssignment(t *testing.T) {
+	t.Parallel()
+
+	// A 23:30 local detection belongs to its local date, not the next UTC day. In UTC+2 this epoch
+	// is 21:30 UTC the same date; bucketing in loc keeps it on 2026-06-01.
+	firstSeen := []repository.SpeciesFirstSeen{
+		{ScientificName: "Late singer", FirstDetected: localUnix(accumTestZone, 2026, 6, 1, 23, 30)},
+	}
+
+	got, err := buildSpeciesAccumulation(firstSeen, accumTestZone, "2026-06-01", "2026-06-02")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, 1, got[0].NewSpecies, "23:30 local must land on its own local date")
+	assert.Equal(t, 1, got[0].CumulativeSpecies)
+	assert.Equal(t, 0, got[1].NewSpecies)
+}
+
+func TestBuildSpeciesAccumulation_MidnightDSTEnumeration(t *testing.T) {
+	t.Parallel()
+
+	// A timezone whose spring-forward DST transition skips midnight (clocks jump 23:59:59 -> 01:00:00)
+	// would drift a loc-based day enumeration and drop the final day. The date axis must still be the
+	// exact inclusive calendar range. Cuba sprang forward at 00:00 local on 2018-03-11. Skip when the
+	// zone is unavailable (minimal images without tzdata), like the heatmap DST test.
+	loc, err := time.LoadLocation("America/Havana")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	got, err := buildSpeciesAccumulation(nil, loc, "2018-03-09", "2018-03-13")
+	require.NoError(t, err)
+
+	wantDates := []string{"2018-03-09", "2018-03-10", "2018-03-11", "2018-03-12", "2018-03-13"}
+	require.Len(t, got, len(wantDates), "every calendar day in the range must be emitted across the DST jump")
+	for i, want := range wantDates {
+		assert.Equalf(t, want, got[i].Date, "day index %d", i)
+		assert.Equal(t, 0, got[i].CumulativeSpecies)
+	}
+}
+
+func TestBuildSpeciesAccumulation_NilLocDefaultsUTC(t *testing.T) {
+	t.Parallel()
+
+	firstSeen := []repository.SpeciesFirstSeen{
+		{ScientificName: "Turdus merula", FirstDetected: localUnix(time.UTC, 2026, 6, 1, 12, 0)},
+	}
+	got, err := buildSpeciesAccumulation(firstSeen, nil, "2026-06-01", "2026-06-01")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, 1, got[0].CumulativeSpecies)
+}
+
+func TestBuildSpeciesAccumulation_InvalidDate(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildSpeciesAccumulation(nil, accumTestZone, "not-a-date", "2026-06-03")
+	require.Error(t, err)
+
+	_, err = buildSpeciesAccumulation(nil, accumTestZone, "2026-06-01", "bad")
+	require.Error(t, err)
+}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -3182,6 +3182,29 @@ func (ds *Datastore) GetConfidenceHistogram(ctx context.Context, startDate, endD
 	return buildSpeciesConfidenceHistogram(speciesSet, confByLabel, bins, minCount), nil
 }
 
+// GetSpeciesAccumulation returns the species accumulation curve over [startDate, endDate]: per
+// calendar day, the cumulative count of distinct species first detected within the range (false
+// positives excluded). It fetches each species' in-period first-seen in one grouped query
+// (GetSpeciesFirstSeenInPeriod), then builds the cumulative per-day curve in a shared, table-tested
+// Go helper (buildSpeciesAccumulation) using the station timezone for date bucketing.
+func (ds *Datastore) GetSpeciesAccumulation(ctx context.Context, startDate, endDate string) ([]datastore.SpeciesAccumulationPoint, error) {
+	start, end, err := ds.parseDateRange(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	firstSeen, err := ds.detection.GetSpeciesFirstSeenInPeriod(ctx, start, end)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_species_accumulation").
+			Build()
+	}
+
+	return buildSpeciesAccumulation(firstSeen, ds.timezone, startDate, endDate)
+}
+
 // civilDawnMinuteLookup returns a civilDawnMinuteLookup closure over the datastore's SunCalc and
 // station timezone. The closure yields civil dawn's station-local minute-of-day for a date, or
 // ok=false when no SunCalc is configured or civil dawn is undefined for the date (polar day/night).

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -306,6 +306,9 @@ func (m *mockStore) GetDailyActivityOnset(_ context.Context, _, _, _ string) ([]
 func (m *mockStore) GetConfidenceHistogram(_ context.Context, _, _, _ string, _, _ int) ([]datastore.SpeciesConfidenceHistogram, error) {
 	return []datastore.SpeciesConfidenceHistogram{}, nil
 }
+func (m *mockStore) GetSpeciesAccumulation(_ context.Context, _, _ string) ([]datastore.SpeciesAccumulationPoint, error) {
+	return []datastore.SpeciesAccumulationPoint{}, nil
+}
 
 // BG-17 fix: Add notification history methods
 func (m *mockStore) GetActiveNotificationHistory(_ context.Context, after time.Time) ([]datastore.NotificationHistory, error) {


### PR DESCRIPTION
## What

Adds the first Tier-2 analytics chart: a **species accumulation curve** (the classic biodiversity collector's curve) in the Biodiversity tab. It plots, per calendar day, the cumulative count of distinct species first detected within the selected range. The curve climbs as new species appear and levels off as the common ones get recorded, so a still-rising tail means the site is under-sampled and a flat tail means most species have been seen.

"First seen" is bounded to the selected window, not lifetime, so the chart answers "how fast is my species list filling up over this period". It builds on the existing analytics hub machinery (chart registry + ChartCard + AnalyticsControlBar + BaseChart), so adding it was one registry entry + a chart component + an endpoint.

## Backend (additive; v2only is the real implementation, legacy stubbed empty)

- New endpoint `GET /api/v2/analytics/species/accumulation?start_date&end_date` (handler `GetSpeciesAccumulation`). No species filter (the metric is inherently all-species). Mirrors the existing analytics validation chain and the 30-day default-end-date behavior.
- New `datastore.Interface` method `GetSpeciesAccumulation` + result struct `SpeciesAccumulationPoint{Date, CumulativeSpecies, NewSpecies}`.
- New false-positive-excluded repository query `GetSpeciesFirstSeenInPeriod` (`GROUP BY scientific_name`, `MIN(detected_at)` over the shared analytics base query). It is intentionally distinct from `GetSpeciesFirstDetectionInPeriod`, which does not exclude false positives and is paginated for the species tracker.
- Shared, table-tested Go aggregation `buildSpeciesAccumulation`: buckets each species' first-seen by station-local calendar date and emits a per-day cumulative curve. The date axis is enumerated in UTC (pure calendar arithmetic, DST-free) while the per-detection bucketing stays in the station timezone, so a timezone whose DST transition skips midnight cannot drop the final day.
- Legacy datastore + the test doubles get empty-return stubs; the generated mock is regenerated.

## Frontend

- `SpeciesAccumulationChart.svelte` (D3 line + filled area + a dashed total-species reference line, wraps `BaseChart`), with a screen-reader text summary and tooltips. Per-point dots are only drawn on short ranges so a year view does not turn into a muddy dot cloud.
- Fetcher + registry `ChartDef` (biodiversity group, `supports.species:false` like the sibling diversity chart, so no dead species selector). A custom `countDataPoints` keys the not-enough-data state on how many distinct species accumulated rather than the per-day length.
- i18n keys for all locales (English authored, others follow the standard fallback flow).

## Tests

- Go: table tests for the aggregation (empty, cumulative monotonicity, same-day firsts, out-of-range ignored, station-timezone assignment, and a midnight-skip-DST enumeration regression test), a repository test proving false-positive exclusion and multi-model merge, and handler tests (validation, default end date, empty-as-`[]`-not-null, shape, timeout).
- Frontend: vitest for the component (axis/area/line/reference-line, dot density by range, single continuous line, accessibility summary), the fetcher's defensive coercion, and the registry `countDataPoints`.

Verified locally: `golangci-lint run` clean, `go test -race` green on the affected packages, `npm run check:all` clean, all new vitest and Go tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Species Accumulation Curve” analytics chart showing cumulative distinct species over a chosen date range, with daily hover tooltips for new vs. cumulative species.
  * Includes an accessible chart summary and an in-chart reference marker for the final total.
* **Documentation**
  * Added localized UI text for the chart (title/description, axis labels, tooltips, and empty-state messaging) across all supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->