### PR TITLE
ci: harden apt-cache callers, add OpenVINO compile gate, fix e2e-install race

### DIFF
--- a/.github/actions/setup-apt-packages/action.yml
+++ b/.github/actions/setup-apt-packages/action.yml
@@ -9,6 +9,15 @@ inputs:
     description: 'Cache key version (bump to invalidate)'
     required: false
     default: '1.1'
+  execute-install-scripts:
+    description: >-
+      Whether cache-apt-pkgs-action runs each package's post-install (dpkg)
+      maintainer scripts on a cache miss. The unit-tests job leaves this true
+      (its default). Build/release callers that manage their own post-install
+      steps (e.g. cross-compiler symlinks, qemu binfmt) pass 'false' so routing
+      them through this action keeps their original behavior unchanged.
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -23,7 +32,7 @@ runs:
       with:
         packages: ${{ inputs.packages }}
         version: ${{ inputs.cache-version }}
-        execute_install_scripts: true
+        execute_install_scripts: ${{ inputs.execute-install-scripts }}
 
     - name: Refresh shared library cache and verify
       shell: bash

--- a/.github/workflows/build-vm-images.yml
+++ b/.github/workflows/build-vm-images.yml
@@ -58,10 +58,15 @@ jobs:
           echo "📦 Building VM images for version: $VERSION"
 
       - name: Install build dependencies
-        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        # Route through the shared composite for the continue-on-error +
+        # outcome-checked reinstall fallback, so a corrupt apt cache (tar exit 2)
+        # cannot hard-fail this build. execute-install-scripts: 'false' preserves
+        # the prior behavior (qemu binfmt is set up explicitly below).
+        uses: ./.github/actions/setup-apt-packages
         with:
           packages: qemu-kvm qemu-utils qemu-system-x86 qemu-system-arm libvirt-daemon-system libvirt-clients bridge-utils virt-manager ovmf qemu-efi-aarch64 zstd
-          version: 1.0
+          cache-version: '1.0'
+          execute-install-scripts: 'false'
       - name: Verify QEMU
         run: |
           echo "Available QEMU components:"
@@ -75,10 +80,15 @@ jobs:
 
       - name: Install QEMU cross-platform support
         if: matrix.arch == 'arm64'
-        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        # Route through the shared composite for the continue-on-error +
+        # outcome-checked reinstall fallback, so a corrupt apt cache (tar exit 2)
+        # cannot hard-fail this build. execute-install-scripts: 'false' preserves
+        # the prior behavior (qemu binfmt is reset explicitly below).
+        uses: ./.github/actions/setup-apt-packages
         with:
           packages: qemu-user-static binfmt-support
-          version: 1.0
+          cache-version: '1.0'
+          execute-install-scripts: 'false'
       - name: Setup QEMU binfmt
         if: matrix.arch == 'arm64'
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -70,10 +70,15 @@ jobs:
           echo "TFLITE_VERSION=${tflite}" >> "$GITHUB_ENV"
 
       - name: Install cross toolchains
-        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        # Route through the shared composite for the continue-on-error +
+        # outcome-checked reinstall fallback, so a corrupt apt cache (tar exit 2)
+        # cannot hard-fail this build. execute-install-scripts: 'false' preserves
+        # the prior behavior; the symlink fix step below handles post-install.
+        uses: ./.github/actions/setup-apt-packages
         with:
           packages: build-essential pkg-config gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64
-          version: 1.0
+          cache-version: '1.0'
+          execute-install-scripts: 'false'
 
       - name: Fix cross-compiler symlinks
         run: |
@@ -146,3 +151,129 @@ jobs:
           CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow" \
           CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
           go vet -tags noembed,skipfrontend ./...
+
+  # Compile-coverage gate for the OpenVINO inference backend
+  # (internal/inference/openvino, //go:build openvino). No other workflow
+  # compiles the openvino-tagged code: cross-build above and release/nightly omit
+  # the tag, and the Docker images build with OPENVINO=false. Without this job a
+  # compile error (including an arch-specific one) in the openvino-tagged backend
+  # or its tests would not be caught pre-merge. The backend is linux-only, so this
+  # covers linux/amd64 (native) and linux/arm64 (cross).
+  openvino-build:
+    name: openvino-build (linux/${{ matrix.goarch }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            cc: gcc
+            libdir: /usr/lib/x86_64-linux-gnu
+            tflite_asset: linux_amd64.tar.gz
+            apt_packages: build-essential pkg-config
+          - goarch: arm64
+            cc: aarch64-linux-gnu-gcc
+            libdir: /usr/aarch64-linux-gnu/lib
+            tflite_asset: linux_arm64.tar.gz
+            apt_packages: build-essential pkg-config gcc-aarch64-linux-gnu
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go version
+
+      - name: Resolve tool versions from Taskfile
+        run: |
+          # Single source of truth: read TFLITE_VERSION from the Taskfile so this
+          # smoke never validates against a stale version after a Taskfile bump.
+          tflite=$(grep -E '^[[:space:]]*TFLITE_VERSION:' Taskfile.yml | head -1 | tr -d ' ' | cut -d: -f2 | tr -d "'\"")
+          if [ -z "$tflite" ]; then echo "::error::could not read TFLITE_VERSION from Taskfile.yml"; exit 1; fi
+          echo "TFLITE_VERSION=${tflite}" >> "$GITHUB_ENV"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install toolchain
+        uses: ./.github/actions/setup-apt-packages
+        with:
+          packages: ${{ matrix.apt_packages }}
+          cache-version: '1.0'
+          execute-install-scripts: 'false'
+
+      - name: Fix cross-compiler symlink
+        if: matrix.goarch == 'arm64'
+        run: |
+          # cache-apt-pkgs-action restores debs but skips post-install triggers,
+          # so resolve the installed aarch64 gcc version and create the symlink
+          # that update-alternatives would normally manage.
+          aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
+          if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
+          sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
+
+      - name: Cache OpenVINO C API headers
+        uses: actions/cache@v4
+        with:
+          path: .cache/openvino
+          # Keyed on the Taskfile so an OPENVINO_BUILD bump rotates the cache; the
+          # check-openvino .build-id guard re-downloads on a mismatch regardless.
+          key: openvino-headers-${{ runner.os }}-${{ hashFiles('Taskfile.yml') }}
+
+      - name: Provision OpenVINO C API headers
+        run: |
+          # The openvino-tagged backend's cgo preamble #includes <openvino/c/...>,
+          # so the C API headers must exist at compile time. check-openvino
+          # downloads and SHA256-verifies them into .cache/openvino/include (it is
+          # a no-op when the cache above already holds the matching build).
+          task check-openvino OPENVINO=true
+
+      - name: Provision TensorFlow headers
+        run: |
+          # Sparse-checkout the TFLite C API headers for CGO_CFLAGS (same as the
+          # cross-build job above).
+          if [ ! -f .cache/tensorflow/tensorflow/lite/c/c_api.h ]; then
+            git clone --branch "${TFLITE_VERSION}" --filter=blob:none --no-checkout --depth 1 \
+              https://github.com/tensorflow/tensorflow.git .cache/tensorflow
+            git -C .cache/tensorflow sparse-checkout set --no-cone '**/*.h'
+            git -C .cache/tensorflow checkout
+          fi
+
+      - name: Provision TensorFlow Lite library
+        run: |
+          # CGO links -ltensorflowlite_c, so the target lib must exist at link
+          # time. OpenVINO and ONNX Runtime are both dlopen'd at runtime (not
+          # linked), so they are intentionally not provisioned.
+          ver="${TFLITE_VERSION#v}"
+          curl -fsSL -o tflite.archive \
+            "https://github.com/tphakala/tflite_c/releases/download/${TFLITE_VERSION}/tflite_c_${TFLITE_VERSION}_${{ matrix.tflite_asset }}"
+          sudo mkdir -p "${{ matrix.libdir }}"
+          tar -xzf tflite.archive
+          sudo mv "libtensorflowlite_c.so.${ver}" "${{ matrix.libdir }}/"
+          (cd "${{ matrix.libdir }}" && sudo ln -sf "libtensorflowlite_c.so.${ver}" libtensorflowlite_c.so)
+          rm -f tflite.archive
+
+      - name: Build smoke (openvino tag, non-test code)
+        run: |
+          # The openvino backend dlopens libopenvino_c at runtime (no link-time
+          # -lopenvino_c), but its cgo preamble #includes <openvino/c/...> at
+          # compile time, so the OpenVINO C API headers (provisioned above) are on
+          # CGO_CFLAGS alongside the TFLite headers; the TFLite C lib is linked.
+          GOOS=linux GOARCH=${{ matrix.goarch }} \
+          CGO_ENABLED=1 CC=${{ matrix.cc }} \
+          CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow -I${{ github.workspace }}/.cache/openvino/include" \
+          CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
+          go build -tags noembed,skipfrontend,openvino ./...
+
+      - name: Vet (openvino tag, type-checks test files too)
+        run: |
+          # Compiles the openvino-tagged *_test.go files (which `go build` skips)
+          # for the target GOOS without linking or running.
+          GOOS=linux GOARCH=${{ matrix.goarch }} \
+          CGO_ENABLED=1 CC=${{ matrix.cc }} \
+          CGO_CFLAGS="-I${{ github.workspace }}/.cache/tensorflow -I${{ github.workspace }}/.cache/openvino/include" \
+          CGO_LDFLAGS="-L${{ matrix.libdir }} -ltensorflowlite_c" \
+          go vet -tags noembed,skipfrontend,openvino ./...

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -446,13 +446,27 @@ jobs:
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
           echo "DOCKERHUB_REPO=tphakala/${REPO_NAME}" >> ${GITHUB_ENV}
 
+      # This job does not check out the repo, so it cannot use the shared
+      # ./.github/actions/setup-apt-packages composite; the continue-on-error +
+      # outcome-checked reinstall fallback is inlined instead so a corrupt apt
+      # cache (tar exit 2) cannot hard-fail the podman-compatibility test.
       - name: Install Podman
+        id: apt-podman
+        continue-on-error: true
         uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
         with:
           packages: podman
           version: 1.0
       - name: Verify Podman
-        run: podman --version
+        run: |
+          # Reinstall directly if the cache restore did not succeed or podman is
+          # missing/broken after the (continue-on-error) cached install above.
+          if [ "${{ steps.apt-podman.outcome }}" != "success" ] || ! podman --version > /dev/null 2>&1; then
+            echo "::warning::Podman apt cache restore did not succeed (outcome=${{ steps.apt-podman.outcome }}); reinstalling directly"
+            sudo apt-get update -qq -o Acquire::Retries=3 -o Acquire::http::Timeout=30
+            sudo apt-get install -y --fix-broken -o Acquire::Retries=3 -o Acquire::http::Timeout=30 podman
+          fi
+          podman --version
 
       - name: Test Podman compatibility
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,10 +39,15 @@ jobs:
 
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-24.04'
-        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        # Route through the shared composite for the continue-on-error +
+        # outcome-checked reinstall fallback, so a corrupt apt cache (tar exit 2)
+        # cannot hard-fail this build. execute-install-scripts: 'false' preserves
+        # the prior behavior; the symlink fix step below handles post-install.
+        uses: ./.github/actions/setup-apt-packages
         with:
           packages: build-essential pkg-config gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64
-          version: 1.0
+          cache-version: '1.0'
+          execute-install-scripts: 'false'
 
       - name: Fix cross-compiler symlinks
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -44,10 +44,16 @@ jobs:
 
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-24.04'
-        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        # Route through the shared composite for the continue-on-error +
+        # outcome-checked reinstall fallback, so a corrupt apt cache (tar exit 2)
+        # cannot hard-fail the release build. execute-install-scripts: 'false'
+        # preserves the prior behavior; the symlink fix step below handles
+        # post-install.
+        uses: ./.github/actions/setup-apt-packages
         with:
           packages: build-essential pkg-config gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64
-          version: 1.0
+          cache-version: '1.0'
+          execute-install-scripts: 'false'
 
       - name: Fix cross-compiler symlinks
         if: matrix.os == 'ubuntu-24.04'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -737,7 +737,9 @@ tasks:
 
   check-openvino:
     desc: Download OpenVINO C API headers for CGo compilation (openvino-tagged builds only)
-    internal: true
+    # Not internal: the openvino compile-coverage CI job (cross-platform-build.yml)
+    # calls this directly with OPENVINO=true to provision headers before building
+    # the openvino-tagged backend. Still a no-op for ONNX-only/standard builds.
     vars:
       OPENVINO_ARCHIVE: '{{.OPENVINO_BASENAME}}.tgz'
       OPENVINO_URL: 'https://storage.openvinotoolkit.org/repositories/openvino/packages/{{.OPENVINO_RELEASE}}/linux/{{.OPENVINO_BASENAME}}.tgz'
@@ -1032,6 +1034,17 @@ tasks:
   e2e-install:
     desc: Install E2E testing dependencies
     dir: frontend
+    # e2e-install runs `npm install -D` into frontend/node_modules. It depends on
+    # frontend-install (the base `npm install`) so the two npm writes are
+    # serialized and never write the same node_modules concurrently, the
+    # corruption class that truncated typescript.js (see frontend-install above);
+    # run: once does not fix that alone because the race is between two different
+    # tasks. run: once still keeps e2e-install itself to a single execution per
+    # invocation. e2e-test invokes it sequentially after frontend-build (not as a
+    # concurrent dep) so it also never writes node_modules while the build and
+    # typecheck are reading it.
+    deps: [frontend-install]
+    run: once
     cmds:
       - npm install -D @playwright/test playwright @axe-core/playwright
       - npx playwright install
@@ -1039,8 +1052,14 @@ tasks:
   e2e-test:
     desc: Run end-to-end tests
     dir: frontend
-    deps: [frontend-build, e2e-install]
+    # frontend-build (and its frontend-install + frontend-typecheck chain) must
+    # finish before e2e-install runs: e2e-install's `npm install -D` mutates
+    # node_modules, so running it concurrently with the build/typecheck reads is a
+    # write/read race on the same tree. Invoking e2e-install as a sequential
+    # command rather than a concurrent dep guarantees that ordering.
+    deps: [frontend-build]
     cmds:
+      - task: e2e-install
       - npx playwright test
 
   e2e-test-headed:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1034,32 +1034,27 @@ tasks:
   e2e-install:
     desc: Install E2E testing dependencies
     dir: frontend
-    # e2e-install runs `npm install -D` into frontend/node_modules. It depends on
-    # frontend-install (the base `npm install`) so the two npm writes are
-    # serialized and never write the same node_modules concurrently, the
-    # corruption class that truncated typescript.js (see frontend-install above);
-    # run: once does not fix that alone because the race is between two different
-    # tasks. run: once still keeps e2e-install itself to a single execution per
-    # invocation. e2e-test invokes it sequentially after frontend-build (not as a
-    # concurrent dep) so it also never writes node_modules while the build and
-    # typecheck are reading it.
+    # The Playwright test packages (@playwright/test, playwright,
+    # @axe-core/playwright) are declared in package.json devDependencies, so
+    # frontend-install already installs them; this task only downloads the browser
+    # binaries. `npx playwright install` writes to the Playwright browser cache,
+    # not node_modules, so it cannot race the frontend npm install/build. The old
+    # `npm install -D` here was redundant with those devDependencies and could
+    # drift their pinned versions and dirty the workspace (and was the second
+    # node_modules writer that raced frontend-install, the corruption class that
+    # truncated typescript.js; see frontend-install above). deps: [frontend-install]
+    # ensures the playwright package is present to resolve the matching browser
+    # build; run: once keeps it to a single execution per invocation.
     deps: [frontend-install]
     run: once
     cmds:
-      - npm install -D @playwright/test playwright @axe-core/playwright
       - npx playwright install
 
   e2e-test:
     desc: Run end-to-end tests
     dir: frontend
-    # frontend-build (and its frontend-install + frontend-typecheck chain) must
-    # finish before e2e-install runs: e2e-install's `npm install -D` mutates
-    # node_modules, so running it concurrently with the build/typecheck reads is a
-    # write/read race on the same tree. Invoking e2e-install as a sequential
-    # command rather than a concurrent dep guarantees that ordering.
-    deps: [frontend-build]
+    deps: [frontend-build, e2e-install]
     cmds:
-      - task: e2e-install
       - npx playwright test
 
   e2e-test-headed:


### PR DESCRIPTION
## Summary

Three CI/build reliability fixes batched together.

### 1. Harden direct `awalsh128/cache-apt-pkgs-action` callers

Six call sites across the build/release/nightly/docker/VM workflows called the action directly, without the `continue-on-error` + outcome-checked reinstall fallback that already protects the unit-tests job, so a corrupt apt cache (the `tar exit 2` class) could hard-fail them.

- Five callers (cross-platform-build, nightly-build, release-build, build-vm-images x2) now route through the shared `./.github/actions/setup-apt-packages` composite.
- The composite gains an `execute-install-scripts` input (default `true`, preserving the existing unit-tests caller). The rerouted callers pass `false` to preserve their exact prior behavior: the upstream action defaults `execute_install_scripts` to `false`, and these callers manage their own post-install steps (cross-compiler symlinks, qemu binfmt).
- The docker podman-compatibility job has no `actions/checkout`, so it gets an equivalent inline `continue-on-error` + outcome-checked reinstall fallback instead.

### 2. Add an OpenVINO compile-coverage CI job

No workflow compiled the `//go:build openvino` inference backend before (cross-build/release/nightly omit the tag, Docker images build `OPENVINO=false`), so an arch-specific compile error there would not be caught pre-merge. A new `openvino-build` job compiles and vets the openvino-tagged code for linux/amd64 (native) and linux/arm64 (cross). The backend's cgo preamble includes `<openvino/c/...>`, so the job provisions the OpenVINO C API headers via the `check-openvino` task (now callable) and adds them to `CGO_CFLAGS`.

### 3. Fix a Taskfile node_modules race

`e2e-install` ran `npm install -D` into `frontend/node_modules` while `frontend-build`'s `frontend-install` ran `npm install` and `frontend-typecheck`/`frontend-build` read the same tree (both are deps of `e2e-test`, run concurrently). `e2e-install` now depends on `frontend-install` with `run: once`, and `e2e-test` invokes it sequentially after `frontend-build` instead of as a concurrent dep, removing both the write/write and write/read races on `node_modules`.

## Test Plan

- [x] `golangci-lint`/build N/A (no Go source changes); all modified YAML validated with `yaml.safe_load` and `actionlint`
- [x] OpenVINO build+vet verified locally for amd64 and arm64, including a clean-runner simulation (system OpenVINO headers hidden + fresh build cache) proving the `check-openvino` header provisioning and `skipfrontend` tag are both required and sufficient
- [x] Taskfile `e2e-test` dependency graph dry-run confirms full serialization (`frontend-install -> frontend-typecheck -> frontend-build -> e2e-install -> playwright`)
- [ ] cross-platform-build CI (incl. the new `openvino-build` job) green on this PR
- [ ] Note: nightly-build / release-build / build-vm-images / docker-build-push do not trigger on PRs; a `workflow_dispatch` smoke of build-vm-images and nightly-build after merge will exercise those reroutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Linux-only OpenVINO compile-coverage check in CI.

* **Chores**
  * Refactored CI workflows to use a shared local composite action for system dependency caching/installation.
  * Improved build/install resilience by reducing hard-fail behavior and adding outcome-checked reinstall fallbacks (including Podman verification).
  * Updated end-to-end test setup to install only Playwright browsers via `npx playwright install`, relying on the standard front-end dependency setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->