### PR TITLE
feat(release): publish and maintain a machine-readable release manifest

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -178,13 +178,22 @@ jobs:
       - name: List artifacts
         run: find artifacts -type f
 
+      - name: Generate checksums
+        run: |
+          # SHA-256 of every tarball, keyed by basename so the manifest
+          # generator can map a checksum to a release asset by file name.
+          find artifacts -name '*.tar.gz' -print0 | while IFS= read -r -d '' f; do
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  $(basename "$f")"
+          done | sort > checksums.txt
+          cat checksums.txt
+
       - name: Create GitHub Release
         run: |
           REPO="${{ github.repository }}"
           TAG="${{ steps.get_build_version.outputs.build_version }}"
           # If the tag is poisoned from a previous failed run, append run number
           if ! gh release create "$TAG" \
-            artifacts/**/*.tar.gz \
+            artifacts/**/*.tar.gz checksums.txt \
             --repo "$REPO" \
             --title "Nightly Build $TAG" \
             --notes "Nightly build $TAG" \
@@ -192,7 +201,7 @@ jobs:
             --target main 2>/dev/null; then
             TAG="${TAG}-${{ github.run_number }}"
             gh release create "$TAG" \
-              artifacts/**/*.tar.gz \
+              artifacts/**/*.tar.gz checksums.txt \
               --repo "$REPO" \
               --title "Nightly Build $TAG" \
               --notes "Nightly build $TAG" \
@@ -202,6 +211,13 @@ jobs:
           echo "Created release: $TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  manifest:
+    name: Update release manifest
+    needs: release
+    uses: ./.github/workflows/release-manifest.yml
+    permissions:
+      contents: write
 
   get-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -212,12 +212,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
-  # Regenerate the release manifest after the nightly release (with its tarballs
-  # and checksums.txt) is published. No if-guard: every successful nightly run
-  # should refresh the manifest.
+  # Regenerate the release manifest after the nightly release (its tarballs and
+  # checksums.txt) and the container images are published, so the moving
+  # :nightly tag the manifest advertises already points at this build. No
+  # if-guard: every successful nightly run should refresh the manifest.
   manifest:
     name: Update release manifest
-    needs: release
+    needs: [release, docker]
     uses: ./.github/workflows/release-manifest.yml
     permissions:
       contents: write

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -212,6 +212,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
+  # Regenerate the release manifest after the nightly release (with its tarballs
+  # and checksums.txt) is published. No if-guard: every successful nightly run
+  # should refresh the manifest.
   manifest:
     name: Update release manifest
     needs: release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           # Get the latest release tag
           LATEST_TAG=$(git describe --tags --abbrev=0)
-          echo "LATEST_TAG=${LATEST_TAG}" >> ${GITHUB_ENV}
+          echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
           echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
       
       - name: Add Artifacts to GitHub Release
@@ -169,6 +169,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
+  checksums:
+    if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: birdnet-go-*
+
+      - name: Generate checksums
+        run: |
+          # SHA-256 of every tarball, keyed by basename so the manifest
+          # generator can map a checksum to a release asset by file name.
+          find artifacts -name '*.tar.gz' -print0 | while IFS= read -r -d '' f; do
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  $(basename "$f")"
+          done | sort > checksums.txt
+          cat checksums.txt
+
+      - name: Get latest release tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
+
+      - name: Add checksums to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: checksums.txt
+          # For release events, attach to the triggering release; for
+          # workflow_dispatch, attach to the latest release tag.
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && env.LATEST_TAG || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   get-version:
     if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
@@ -201,3 +242,10 @@ jobs:
       cleanup-old-images: false
       keep-images-count: 14
     secrets: inherit
+
+  manifest:
+    if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+    needs: [build, checksums]
+    uses: ./.github/workflows/release-manifest.yml
+    permissions:
+      contents: write

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -157,7 +157,7 @@ jobs:
           # Get the latest release tag
           LATEST_TAG=$(git describe --tags --abbrev=0)
           echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
-          echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+          echo "latest_tag=${LATEST_TAG}" >> "${GITHUB_OUTPUT}"
       
       - name: Add Artifacts to GitHub Release
         uses: softprops/action-gh-release@v3
@@ -243,6 +243,9 @@ jobs:
       keep-images-count: 14
     secrets: inherit
 
+  # Regenerate the release manifest after the tarballs (build) and checksums.txt
+  # (checksums) are attached, so it never races the asset uploads. The if-guard
+  # mirrors the other jobs and must stay in sync with them.
   manifest:
     if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
     needs: [build, checksums]

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -243,12 +243,13 @@ jobs:
       keep-images-count: 14
     secrets: inherit
 
-  # Regenerate the release manifest after the tarballs (build) and checksums.txt
-  # (checksums) are attached, so it never races the asset uploads. The if-guard
-  # mirrors the other jobs and must stay in sync with them.
+  # Regenerate the release manifest after the tarballs (build), checksums.txt
+  # (checksums), and container images (docker) are all published, so it never
+  # races the asset uploads or advertises image tags before they are pushed.
+  # The if-guard mirrors the other jobs and must stay in sync with them.
   manifest:
     if: ${{ !contains(github.ref, 'nightly') && (github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
-    needs: [build, checksums]
+    needs: [build, checksums, docker]
     uses: ./.github/workflows/release-manifest.yml
     permissions:
       contents: write

--- a/.github/workflows/release-manifest.yml
+++ b/.github/workflows/release-manifest.yml
@@ -43,14 +43,24 @@ jobs:
           check-latest: true
 
       - name: Generate manifest.json
+        id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           go run ./tools/release-manifest \
             -repo "${{ github.repository }}" \
             -output manifest.json
+          # The generator skips writing the file when no release matches a
+          # channel (e.g. a fresh fork); treat that as a no-op, not a failure.
+          if [ -f manifest.json ]; then
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+            echo "No manifest generated (no matching releases); skipping publish."
+          fi
 
       - name: Validate manifest.json
+        if: steps.generate.outputs.generated == 'true'
         run: |
           # Fail fast if the generated file is not the shape we expect.
           jq -e '.schema_version and (.channels | length > 0)' manifest.json > /dev/null
@@ -58,6 +68,7 @@ jobs:
           jq -r '.channels | keys[]' manifest.json
 
       - name: Publish manifest to dedicated release
+        if: steps.generate.outputs.generated == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/release-manifest.yml
+++ b/.github/workflows/release-manifest.yml
@@ -1,0 +1,78 @@
+name: Update Release Manifest
+
+# Generates manifest.json describing the latest release on each distribution
+# channel (stable, nightly, beta) and publishes it to a dedicated, never-deleted
+# "manifest" release. The stable URL
+#   https://github.com/<owner>/<repo>/releases/download/manifest/manifest.json
+# always resolves to the current manifest, and is consumed by the in-app update
+# checker.
+#
+# Triggers:
+#   - workflow_call:  invoked as the final job of release-build.yml and
+#     nightly-build.yml, after all release assets (tarballs + checksums) exist,
+#     so the manifest never races asset uploads.
+#   - workflow_dispatch:  manual regeneration.
+#   - schedule:  daily self-heal in case a release pipeline failed to update it.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * *'
+
+permissions:
+  contents: write
+
+# Serialise manifest updates so two pipelines never clobber the asset at once.
+concurrency:
+  group: release-manifest
+  cancel-in-progress: false
+
+jobs:
+  manifest:
+    name: Generate and publish manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Generate manifest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go run ./tools/release-manifest \
+            -repo "${{ github.repository }}" \
+            -output manifest.json
+
+      - name: Validate manifest.json
+        run: |
+          # Fail fast if the generated file is not the shape we expect.
+          jq -e '.schema_version and (.channels | length > 0)' manifest.json > /dev/null
+          echo "Manifest channels:"
+          jq -r '.channels | keys[]' manifest.json
+
+      - name: Publish manifest to dedicated release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG=manifest
+          # The manifest release is marked prerelease so it never occupies the
+          # "Latest" slot or the /releases/latest endpoint, which must keep
+          # pointing at the newest stable release.
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$REPO" \
+              --title "Release Manifest" \
+              --notes "Auto-generated, machine-readable manifest of the latest BirdNET-Go release on each channel (stable, nightly, beta). Do not delete; consumed by the in-app update checker. Stable URL: https://github.com/$REPO/releases/download/manifest/manifest.json" \
+              --prerelease \
+              --target main
+          fi
+          gh release upload "$TAG" manifest.json --repo "$REPO" --clobber
+          echo "Published manifest.json to release '$TAG'."

--- a/.github/workflows/release-manifest.yml
+++ b/.github/workflows/release-manifest.yml
@@ -83,7 +83,7 @@ jobs:
               --title "Release Manifest" \
               --notes "Auto-generated, machine-readable manifest of the latest BirdNET-Go release on each channel (stable, nightly, beta). Do not delete; consumed by the in-app update checker. Stable URL: https://github.com/$REPO/releases/download/manifest/manifest.json" \
               --prerelease \
-              --target main
+              --target "$GITHUB_SHA"
           fi
           gh release upload "$TAG" manifest.json --repo "$REPO" --clobber
           echo "Published manifest.json to release '$TAG'."

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -9,7 +9,7 @@ and any external tooling that needs to know what the current builds are.
 The manifest is a single JSON asset on a dedicated, never-deleted `manifest`
 GitHub release. The stable URL always resolves to the current manifest:
 
-```
+```text
 https://github.com/tphakala/birdnet-go/releases/download/manifest/manifest.json
 ```
 

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -1,0 +1,128 @@
+# Release Manifest
+
+BirdNET-Go publishes a machine-readable manifest describing the latest release on
+each distribution channel. It is the data source for the in-app update checker
+and any external tooling that needs to know what the current builds are.
+
+## Where it lives
+
+The manifest is a single JSON asset on a dedicated, never-deleted `manifest`
+GitHub release. The stable URL always resolves to the current manifest:
+
+```
+https://github.com/tphakala/birdnet-go/releases/download/manifest/manifest.json
+```
+
+The `manifest` release is marked as a pre-release so it never occupies the
+"Latest" slot; `/releases/latest` keeps pointing at the newest stable release.
+
+## How it is maintained
+
+`tools/release-manifest` (a small Go CLI) queries the GitHub Releases API, picks
+the newest release on each channel, reads each release's `checksums.txt`, and
+writes `manifest.json`. It runs in CI:
+
+- as the final job of `release-build.yml` and `nightly-build.yml`, after all
+  release assets exist (so the manifest never races asset uploads),
+- on manual `workflow_dispatch`,
+- on a daily schedule as a self-heal.
+
+See `.github/workflows/release-manifest.yml`.
+
+## Channels
+
+| Channel   | Tag pattern                            | Moving Docker tag |
+| --------- | -------------------------------------- | ----------------- |
+| `stable`  | `vX.Y.Z`                               | `:latest`         |
+| `nightly` | `nightly-YYYYMMDD`                     | `:nightly`        |
+| `beta`    | `vX.Y.Z-beta.N` / `-rc.N` / `-alpha.N` | `:beta`           |
+
+A channel with no releases yet is omitted from `channels`.
+
+## Schema
+
+`schema_version` is `1`. Consumers MUST check `schema_version` and tolerate
+unknown fields so additive changes do not break older clients. The Go types in
+`internal/update/manifest/manifest.go` are the authoritative definition.
+
+| Field            | Type          | Notes                                 |
+| ---------------- | ------------- | ------------------------------------- |
+| `schema_version` | int           | Manifest schema version.              |
+| `generated_at`   | RFC 3339 time | When the manifest was produced (UTC). |
+| `repo`           | string        | `owner/repo` the releases come from.  |
+| `channels`       | map           | Channel name to channel object.       |
+
+Each channel object:
+
+| Field              | Type          | Notes                                                         |
+| ------------------ | ------------- | ------------------------------------------------------------- |
+| `version`          | string        | Same string baked into the binary (`settings.Version`).       |
+| `tag`              | string        | Git tag (usually equal to `version`).                         |
+| `name`             | string        | Release title.                                                |
+| `released_at`      | RFC 3339 time | Publication time (UTC).                                       |
+| `prerelease`       | bool          | GitHub pre-release flag.                                      |
+| `critical`         | bool          | Security-critical release (see markers below).                |
+| `min_upgrade_from` | string        | Lowest version that may upgrade directly; empty for none.     |
+| `release_url`      | string        | Human-facing release page.                                    |
+| `notes`            | string        | Release body / changelog (length-bounded).                    |
+| `docker`           | object        | `ghcr`, `dockerhub` (version-pinned), `channel_tag` (moving). |
+| `assets`           | array         | Native binary tarballs, one per platform/arch.                |
+
+Each asset:
+
+| Field      | Type   | Notes                                                                    |
+| ---------- | ------ | ------------------------------------------------------------------------ |
+| `platform` | string | `linux`, `windows`, `darwin`.                                            |
+| `arch`     | string | `amd64`, `arm64`.                                                        |
+| `filename` | string | Asset file name.                                                         |
+| `url`      | string | Direct download URL.                                                     |
+| `size`     | int    | Bytes.                                                                   |
+| `sha256`   | string | Lowercase hex SHA-256; empty for releases predating checksum publishing. |
+
+## Release-note markers
+
+Release authors can annotate a GitHub release body to influence the manifest:
+
+- `<!-- manifest:critical -->` sets `critical: true` on that channel, signalling
+  an urgent or security update.
+- `<!-- manifest:min-upgrade-from=vX.Y.Z -->` sets `min_upgrade_from`.
+
+## Example
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-22T14:41:28Z",
+  "repo": "tphakala/birdnet-go",
+  "channels": {
+    "stable": {
+      "version": "v0.6.4",
+      "tag": "v0.6.4",
+      "name": "March 15th, 2025 release",
+      "released_at": "2025-03-15T10:36:58Z",
+      "prerelease": false,
+      "critical": false,
+      "release_url": "https://github.com/tphakala/birdnet-go/releases/tag/v0.6.4",
+      "notes": "...",
+      "docker": {
+        "ghcr": "ghcr.io/tphakala/birdnet-go:v0.6.4",
+        "dockerhub": "tphakala/birdnet-go:v0.6.4",
+        "channel_tag": "ghcr.io/tphakala/birdnet-go:latest"
+      },
+      "assets": [
+        {
+          "platform": "linux",
+          "arch": "amd64",
+          "filename": "birdnet-go-linux-amd64-v0.6.4.tar.gz",
+          "url": "https://github.com/tphakala/birdnet-go/releases/download/v0.6.4/birdnet-go-linux-amd64-v0.6.4.tar.gz",
+          "size": 82091332,
+          "sha256": "5f3a..."
+        }
+      ]
+    },
+    "nightly": {
+      "...": "same shape, channel_tag ghcr.io/tphakala/birdnet-go:nightly"
+    }
+  }
+}
+```

--- a/docs/release-manifest.md
+++ b/docs/release-manifest.md
@@ -31,13 +31,22 @@ See `.github/workflows/release-manifest.yml`.
 
 ## Channels
 
-| Channel   | Tag pattern                            | Moving Docker tag |
-| --------- | -------------------------------------- | ----------------- |
-| `stable`  | `vX.Y.Z`                               | `:latest`         |
-| `nightly` | `nightly-YYYYMMDD`                     | `:nightly`        |
-| `beta`    | `vX.Y.Z-beta.N` / `-rc.N` / `-alpha.N` | `:beta`           |
+| Channel   | Tag pattern                                         | Moving Docker tag |
+| --------- | --------------------------------------------------- | ----------------- |
+| `stable`  | `vX.Y.Z`                                            | `:latest`         |
+| `nightly` | `nightly-YYYYMMDD` (build/git-describe suffixes ok) | `:nightly`        |
+| `beta`    | `vX.Y.Z-` with an `alpha`/`beta`/`rc` pre-release   | `:beta`           |
 
-A channel with no releases yet is omitted from `channels`.
+The beta pattern accepts any SemVer pre-release identifier beginning with
+`alpha`, `beta`, or `rc`, with or without a numeric or dotted suffix
+(`v1.2.3-beta`, `v1.2.3-rc2`, `v1.2.3-beta.1`, `v1.2.3-rc.1.2`). A version-like
+release that matches no channel is skipped with a warning rather than silently
+dropped. A channel with no releases yet is omitted from `channels`.
+
+For the `nightly` channel only the moving `channel_tag` (`:nightly`) is
+published; no version-pinned Docker ref is advertised, because the nightly
+dated image tag can drift from the GitHub release tag on a build retry. The
+`stable` and `beta` channels carry version-pinned `ghcr`/`dockerhub` refs.
 
 ## Schema
 

--- a/internal/update/manifest/manifest.go
+++ b/internal/update/manifest/manifest.go
@@ -1,0 +1,234 @@
+// Package manifest defines the schema for the BirdNET-Go release manifest: a
+// machine-readable description of the most recent release on each distribution
+// channel (stable, nightly, beta).
+//
+// The manifest is generated in CI by tools/release-manifest and published as an
+// asset on a dedicated, never-deleted "manifest" GitHub release. The stable URL
+//
+//	https://github.com/tphakala/birdnet-go/releases/download/manifest/manifest.json
+//
+// always resolves to the latest manifest. The in-app update checker (a future
+// feature) consumes this file to decide whether a newer build is available.
+//
+// This package intentionally depends only on the standard library so that both
+// the CI generator and the future in-app client can import it without pulling
+// in any application internals. The Go types here are the single source of
+// truth for the manifest contract.
+package manifest
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// SchemaVersion is the current manifest schema version. Consumers MUST check
+// this field and tolerate unknown fields so that additive changes (a new field,
+// a new channel) do not break older clients. The version is only incremented on
+// a breaking change to the existing fields.
+const SchemaVersion = 1
+
+// Channel names. A running build maps to exactly one channel based on its
+// version string (see ClassifyTag).
+const (
+	ChannelStable  = "stable"
+	ChannelNightly = "nightly"
+	ChannelBeta    = "beta"
+)
+
+// CriticalMarker is the token a release author places in the GitHub release body
+// to flag a release as security-critical. The generator copies this into the
+// Channel.Critical field so the update checker can surface an urgent prompt.
+const CriticalMarker = "<!-- manifest:critical -->"
+
+// Manifest is the top-level document published as manifest.json.
+type Manifest struct {
+	// SchemaVersion is the schema version this document conforms to.
+	SchemaVersion int `json:"schema_version"`
+	// GeneratedAt is when the manifest was produced (UTC).
+	GeneratedAt time.Time `json:"generated_at"`
+	// Repo is the "owner/repo" the releases come from.
+	Repo string `json:"repo"`
+	// Channels maps a channel name (stable, nightly, beta) to its latest
+	// release. A channel with no releases yet is omitted entirely.
+	Channels map[string]*Channel `json:"channels"`
+}
+
+// Channel describes the most recent release on a single distribution channel.
+type Channel struct {
+	// Version is the release version string, identical to the value baked into
+	// the binary at build time (e.g. "v0.6.4" or "nightly-20260622").
+	Version string `json:"version"`
+	// Tag is the underlying git tag of the release. Usually equal to Version,
+	// but can differ for nightlies whose tag was suffixed after a retry.
+	Tag string `json:"tag"`
+	// Name is the human-readable release title.
+	Name string `json:"name,omitempty"`
+	// ReleasedAt is the release publication time (UTC).
+	ReleasedAt time.Time `json:"released_at"`
+	// Prerelease reports whether GitHub marks this release as a pre-release.
+	Prerelease bool `json:"prerelease"`
+	// Critical flags a security-critical release (see CriticalMarker).
+	Critical bool `json:"critical"`
+	// MinUpgradeFrom, when set, names the lowest version that may upgrade
+	// directly to this release; older installs must first move to an
+	// intermediate version. Empty means no constraint. Sourced from a
+	// "<!-- manifest:min-upgrade-from=vX.Y.Z -->" marker in the release body.
+	MinUpgradeFrom string `json:"min_upgrade_from,omitempty"`
+	// ReleaseURL is the human-facing GitHub release page.
+	ReleaseURL string `json:"release_url"`
+	// Notes is the release body (changelog), trimmed and length-bounded.
+	Notes string `json:"notes,omitempty"`
+	// Docker holds the container image references for this release.
+	Docker *Docker `json:"docker,omitempty"`
+	// Assets lists the downloadable native binary tarballs, one per platform
+	// and architecture, sorted deterministically.
+	Assets []Asset `json:"assets"`
+}
+
+// Docker holds container image references for a channel.
+type Docker struct {
+	// GHCR is the version-pinned GitHub Container Registry reference,
+	// e.g. "ghcr.io/tphakala/birdnet-go:v0.6.4".
+	GHCR string `json:"ghcr,omitempty"`
+	// DockerHub is the version-pinned Docker Hub reference,
+	// e.g. "tphakala/birdnet-go:v0.6.4".
+	DockerHub string `json:"dockerhub,omitempty"`
+	// ChannelTag is the moving tag a user pulls to track this channel,
+	// e.g. "ghcr.io/tphakala/birdnet-go:latest" or ":nightly". This is the
+	// authoritative reference for Docker-based installs.
+	ChannelTag string `json:"channel_tag,omitempty"`
+}
+
+// Asset is a single downloadable native binary tarball.
+type Asset struct {
+	// Platform is the target OS: "linux", "windows" or "darwin".
+	Platform string `json:"platform"`
+	// Arch is the target architecture: "amd64" or "arm64".
+	Arch string `json:"arch"`
+	// Filename is the asset's file name as attached to the release.
+	Filename string `json:"filename"`
+	// URL is the direct download URL for the tarball.
+	URL string `json:"url"`
+	// Size is the tarball size in bytes.
+	Size int64 `json:"size"`
+	// SHA256 is the lowercase hex SHA-256 of the tarball, sourced from the
+	// release's checksums.txt. Empty if the release predates checksum publishing.
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+var (
+	stableTagRe  = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	betaTagRe    = regexp.MustCompile(`^v\d+\.\d+\.\d+-(?:alpha|beta|rc)(?:[.-]?\d+)?$`)
+	nightlyTagRe = regexp.MustCompile(`^nightly-\d{8}`)
+	// assetNameRe matches both the stable filename form
+	// "birdnet-go-linux-amd64-v0.6.4.tar.gz" and the nightly form
+	// "birdnet-go-linux-amd64.tar.gz" (no version suffix).
+	assetNameRe  = regexp.MustCompile(`^birdnet-go-(linux|windows|darwin)-(amd64|arm64)(?:-.+)?\.tar\.gz$`)
+	minUpgradeRe = regexp.MustCompile(`(?i)<!--\s*manifest:min-upgrade-from=([^\s>]+)\s*-->`)
+)
+
+// ClassifyTag maps a git tag to its distribution channel. It returns false for
+// tags that belong to no channel (for example the "manifest" release's own tag),
+// which the generator skips.
+func ClassifyTag(tag string) (channel string, ok bool) {
+	switch {
+	case nightlyTagRe.MatchString(tag):
+		return ChannelNightly, true
+	case betaTagRe.MatchString(tag):
+		return ChannelBeta, true
+	case stableTagRe.MatchString(tag):
+		return ChannelStable, true
+	default:
+		return "", false
+	}
+}
+
+// ParseAssetName extracts the platform and architecture from a release tarball
+// file name. It returns false for names that are not recognised binary tarballs
+// (READMEs, checksum files, etc.).
+func ParseAssetName(name string) (platform, arch string, ok bool) {
+	m := assetNameRe.FindStringSubmatch(name)
+	if m == nil {
+		return "", "", false
+	}
+	return m[1], m[2], true
+}
+
+// ParseChecksums parses the content of a checksums.txt file in the standard
+// "sha256sum" format ("<hex>  <filename>") into a map of file name to hash.
+// Malformed lines are skipped.
+func ParseChecksums(data []byte) map[string]string {
+	out := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
+		if len(fields) != 2 {
+			continue
+		}
+		out[fields[1]] = strings.ToLower(fields[0])
+	}
+	return out
+}
+
+// ExtractCritical reports whether a release body flags the release as critical.
+func ExtractCritical(body string) bool {
+	return strings.Contains(body, CriticalMarker)
+}
+
+// ExtractMinUpgradeFrom returns the minimum upgrade-from version declared in a
+// release body, or the empty string if no marker is present.
+func ExtractMinUpgradeFrom(body string) string {
+	m := minUpgradeRe.FindStringSubmatch(body)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// Validate performs structural validation of a manifest. It deliberately does
+// not require per-asset checksums so that releases predating checksum publishing
+// remain representable; the generator logs warnings for missing hashes instead.
+func (m *Manifest) Validate() error {
+	if m.SchemaVersion == 0 {
+		return errors.New("schema_version is required")
+	}
+	if len(m.Channels) == 0 {
+		return errors.New("at least one channel is required")
+	}
+	for name, ch := range m.Channels {
+		if ch == nil {
+			return fmt.Errorf("channel %q: entry is nil", name)
+		}
+		if ch.Version == "" {
+			return fmt.Errorf("channel %q: version is required", name)
+		}
+		if ch.Tag == "" {
+			return fmt.Errorf("channel %q: tag is required", name)
+		}
+	}
+	return nil
+}
+
+// JSON marshals the manifest to indented JSON with a trailing newline.
+func (m *Manifest) JSON() ([]byte, error) {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+// Parse decodes a manifest from its JSON representation.
+func Parse(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest: %w", err)
+	}
+	return &m, nil
+}

--- a/internal/update/manifest/manifest.go
+++ b/internal/update/manifest/manifest.go
@@ -123,14 +123,25 @@ type Asset struct {
 }
 
 var (
-	stableTagRe  = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
-	betaTagRe    = regexp.MustCompile(`^v\d+\.\d+\.\d+-(?:alpha|beta|rc)(?:[.-]?\d+)?$`)
+	stableTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	// betaTagRe accepts any SemVer pre-release identifier beginning with
+	// alpha/beta/rc, with or without a separator and with multi-segment
+	// suffixes: v1.2.3-beta, v1.2.3-rc2, v1.2.3-beta.1, v1.2.3-rc.1.2.
+	betaTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+-(?:alpha|beta|rc)(?:[.-]?[0-9A-Za-z.-]+)?$`)
+	// nightlyTagRe matches nightly tags by prefix and is intentionally
+	// unanchored at the end: real nightly tags carry build-retry and
+	// git-describe suffixes (nightly-20260622-414, nightly-20251025-1-gec0f78e)
+	// that an end-anchored pattern would reject.
 	nightlyTagRe = regexp.MustCompile(`^nightly-\d{8}`)
 	// assetNameRe matches both the stable filename form
 	// "birdnet-go-linux-amd64-v0.6.4.tar.gz" and the nightly form
 	// "birdnet-go-linux-amd64.tar.gz" (no version suffix).
 	assetNameRe  = regexp.MustCompile(`^birdnet-go-(linux|windows|darwin)-(amd64|arm64)(?:-.+)?\.tar\.gz$`)
 	minUpgradeRe = regexp.MustCompile(`(?i)<!--\s*manifest:min-upgrade-from=([^\s>]+)\s*-->`)
+	// criticalRe tolerates whitespace variations around the critical marker,
+	// mirroring minUpgradeRe so a stray missing space does not silently drop
+	// the flag.
+	criticalRe = regexp.MustCompile(`(?i)<!--\s*manifest:critical\s*-->`)
 )
 
 // ClassifyTag maps a git tag to its distribution channel. It returns false for
@@ -171,14 +182,18 @@ func ParseChecksums(data []byte) map[string]string {
 		if len(fields) != 2 {
 			continue
 		}
-		out[fields[1]] = strings.ToLower(fields[0])
+		// GNU coreutils prefixes the filename with "*" in binary mode
+		// (sha256sum -b); strip it so the key matches the asset name.
+		name := strings.TrimPrefix(fields[1], "*")
+		out[name] = strings.ToLower(fields[0])
 	}
 	return out
 }
 
 // ExtractCritical reports whether a release body flags the release as critical.
+// It tolerates whitespace variations of CriticalMarker.
 func ExtractCritical(body string) bool {
-	return strings.Contains(body, CriticalMarker)
+	return criticalRe.MatchString(body)
 }
 
 // ExtractMinUpgradeFrom returns the minimum upgrade-from version declared in a

--- a/internal/update/manifest/manifest.go
+++ b/internal/update/manifest/manifest.go
@@ -210,8 +210,8 @@ func ExtractMinUpgradeFrom(body string) string {
 // not require per-asset checksums so that releases predating checksum publishing
 // remain representable; the generator logs warnings for missing hashes instead.
 func (m *Manifest) Validate() error {
-	if m.SchemaVersion == 0 {
-		return errors.New("schema_version is required")
+	if m.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schema_version %d is not the supported version %d", m.SchemaVersion, SchemaVersion)
 	}
 	if len(m.Channels) == 0 {
 		return errors.New("at least one channel is required")

--- a/internal/update/manifest/manifest_test.go
+++ b/internal/update/manifest/manifest_test.go
@@ -220,7 +220,12 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "missing schema version",
 			m:       &Manifest{Channels: map[string]*Channel{ChannelStable: {Version: "v1", Tag: "v1"}}},
-			wantErr: "schema_version is required",
+			wantErr: "is not the supported version",
+		},
+		{
+			name:    "wrong schema version",
+			m:       &Manifest{SchemaVersion: 99, Channels: map[string]*Channel{ChannelStable: {Version: "v1", Tag: "v1"}}},
+			wantErr: "is not the supported version",
 		},
 		{
 			name:    "no channels",

--- a/internal/update/manifest/manifest_test.go
+++ b/internal/update/manifest/manifest_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -19,12 +20,21 @@ func TestClassifyTag(t *testing.T) {
 		{name: "stable semver", tag: "v0.6.4", wantChannel: ChannelStable, wantOK: true},
 		{name: "stable two digit", tag: "v1.10.0", wantChannel: ChannelStable, wantOK: true},
 		{name: "beta suffix", tag: "v0.7.0-beta.1", wantChannel: ChannelBeta, wantOK: true},
-		{name: "rc suffix", tag: "v0.7.0-rc2", wantChannel: ChannelBeta, wantOK: true},
+		{name: "rc suffix no dot", tag: "v0.7.0-rc2", wantChannel: ChannelBeta, wantOK: true},
 		{name: "alpha suffix", tag: "v0.7.0-alpha.3", wantChannel: ChannelBeta, wantOK: true},
+		{name: "beta no number", tag: "v1.2.3-beta", wantChannel: ChannelBeta, wantOK: true},
+		{name: "beta multi segment", tag: "v1.2.3-beta.1.2", wantChannel: ChannelBeta, wantOK: true},
 		{name: "nightly dated", tag: "nightly-20260622", wantChannel: ChannelNightly, wantOK: true},
 		{name: "nightly suffixed retry", tag: "nightly-20260622-414", wantChannel: ChannelNightly, wantOK: true},
+		{name: "nightly git-describe suffix", tag: "nightly-20251025-1-gec0f78e", wantChannel: ChannelNightly, wantOK: true},
 		{name: "manifest tag ignored", tag: "manifest", wantChannel: "", wantOK: false},
 		{name: "plain date tag ignored", tag: "20240215", wantChannel: "", wantOK: false},
+		{name: "two-part version rejected", tag: "v1.2", wantChannel: "", wantOK: false},
+		{name: "four-part version rejected", tag: "v1.2.3.4", wantChannel: "", wantOK: false},
+		{name: "nightly too short rejected", tag: "nightly-2026", wantChannel: "", wantOK: false},
+		{name: "uppercase nightly rejected", tag: "NIGHTLY-20260622", wantChannel: "", wantOK: false},
+		{name: "leading whitespace rejected", tag: " v0.6.4", wantChannel: "", wantOK: false},
+		{name: "trailing whitespace rejected", tag: "v0.6.4 ", wantChannel: "", wantOK: false},
 		{name: "empty ignored", tag: "", wantChannel: "", wantOK: false},
 	}
 	for _, tt := range tests {
@@ -53,6 +63,10 @@ func TestParseAssetName(t *testing.T) {
 		{name: "checksums file rejected", filename: "checksums.txt", wantOK: false},
 		{name: "readme rejected", filename: "README.md", wantOK: false},
 		{name: "unknown arch rejected", filename: "birdnet-go-linux-riscv64.tar.gz", wantOK: false},
+		{name: "uppercase rejected", filename: "BIRDNET-GO-LINUX-AMD64.TAR.GZ", wantOK: false},
+		{name: "signature file rejected", filename: "birdnet-go-linux-amd64.tar.gz.sig", wantOK: false},
+		{name: "prefixed junk rejected", filename: "prefix-birdnet-go-linux-amd64.tar.gz", wantOK: false},
+		{name: "empty rejected", filename: "", wantOK: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,28 +81,133 @@ func TestParseAssetName(t *testing.T) {
 
 func TestParseChecksums(t *testing.T) {
 	t.Parallel()
-	data := []byte(
-		"ABCDEF0123456789  birdnet-go-linux-amd64-v0.6.4.tar.gz\n" +
-			"  \n" + // blank line skipped
-			"deadbeef  birdnet-go-linux-arm64-v0.6.4.tar.gz\n" +
-			"malformed-single-field\n", // skipped
-	)
-	got := ParseChecksums(data)
-	require.Len(t, got, 2)
-	assert.Equal(t, "abcdef0123456789", got["birdnet-go-linux-amd64-v0.6.4.tar.gz"], "hash lowercased")
-	assert.Equal(t, "deadbeef", got["birdnet-go-linux-arm64-v0.6.4.tar.gz"])
+	tests := []struct {
+		name string
+		data string
+		want map[string]string
+	}{
+		{
+			name: "gnu text and lowercasing",
+			data: "ABCDEF0123456789  file-a.tar.gz\n  \ndeadbeef  file-b.tar.gz\nmalformed-single-field\n",
+			want: map[string]string{"file-a.tar.gz": "abcdef0123456789", "file-b.tar.gz": "deadbeef"},
+		},
+		{
+			name: "binary marker stripped",
+			data: "abc123 *file.tar.gz\n",
+			want: map[string]string{"file.tar.gz": "abc123"},
+		},
+		{
+			name: "crlf line endings",
+			data: "abc123  file.tar.gz\r\n",
+			want: map[string]string{"file.tar.gz": "abc123"},
+		},
+		{
+			name: "tab separated",
+			data: "abc123\tfile.tar.gz\n",
+			want: map[string]string{"file.tar.gz": "abc123"},
+		},
+		{
+			name: "bsd style skipped",
+			data: "SHA256 (file.tar.gz) = abc123\n",
+			want: map[string]string{},
+		},
+		{name: "empty input", data: "", want: map[string]string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ParseChecksums([]byte(tt.data)))
+		})
+	}
 }
 
 func TestExtractCritical(t *testing.T) {
 	t.Parallel()
-	assert.True(t, ExtractCritical("Security fix.\n"+CriticalMarker+"\nDetails."))
-	assert.False(t, ExtractCritical("Normal release notes."))
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "canonical marker", body: "Security fix.\n" + CriticalMarker + "\nDetails.", want: true},
+		{name: "no spaces", body: "x\n<!--manifest:critical-->\ny", want: true},
+		{name: "extra spaces", body: "<!--   manifest:critical   -->", want: true},
+		{name: "uppercase", body: "<!-- MANIFEST:CRITICAL -->", want: true},
+		{name: "absent", body: "Normal release notes.", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ExtractCritical(tt.body))
+		})
+	}
 }
 
 func TestExtractMinUpgradeFrom(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "v0.5.0", ExtractMinUpgradeFrom("Notes\n<!-- manifest:min-upgrade-from=v0.5.0 -->\nmore"))
-	assert.Empty(t, ExtractMinUpgradeFrom("No marker here"))
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "basic", body: "Notes\n<!-- manifest:min-upgrade-from=v0.5.0 -->\nmore", want: "v0.5.0"},
+		{name: "no spaces", body: "<!--manifest:min-upgrade-from=v1.0.0-->", want: "v1.0.0"},
+		{name: "uppercase marker", body: "<!-- MANIFEST:MIN-UPGRADE-FROM=v2.0.0 -->", want: "v2.0.0"},
+		{name: "first wins", body: "<!-- manifest:min-upgrade-from=v1.0.0 -->\n<!-- manifest:min-upgrade-from=v2.0.0 -->", want: "v1.0.0"},
+		{name: "empty value not matched", body: "<!-- manifest:min-upgrade-from= -->", want: ""},
+		{name: "absent", body: "No marker here", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ExtractMinUpgradeFrom(tt.body))
+		})
+	}
+}
+
+// Fuzz targets assert structural invariants over arbitrary input, catching
+// edge cases that example tables miss (a known escaped-defect class for the
+// repo's parsers).
+
+func FuzzClassifyTag(f *testing.F) {
+	for _, s := range []string{"v0.6.4", "nightly-20260622", "v0.7.0-beta.1", "manifest", "", "v1.2.3-beta"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, tag string) {
+		channel, ok := ClassifyTag(tag) // must never panic
+		if ok {
+			assert.Contains(t, []string{ChannelStable, ChannelNightly, ChannelBeta}, channel)
+		} else {
+			assert.Empty(t, channel, "ok=false must yield an empty channel")
+		}
+	})
+}
+
+func FuzzParseAssetName(f *testing.F) {
+	for _, s := range []string{"birdnet-go-linux-amd64-v0.6.4.tar.gz", "birdnet-go-darwin-arm64.tar.gz", "checksums.txt", ""} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, name string) {
+		platform, arch, ok := ParseAssetName(name) // must never panic
+		if ok {
+			assert.Contains(t, []string{"linux", "windows", "darwin"}, platform)
+			assert.Contains(t, []string{"amd64", "arm64"}, arch)
+		} else {
+			assert.Empty(t, platform)
+			assert.Empty(t, arch)
+		}
+	})
+}
+
+func FuzzParseChecksums(f *testing.F) {
+	f.Add("abc  file.tar.gz\n")
+	f.Add("abc *file.tar.gz\nSHA256 (x) = y\n")
+	f.Fuzz(func(t *testing.T, s string) {
+		m := ParseChecksums([]byte(s)) // must never panic
+		for _, v := range m {
+			assert.NotEmpty(t, v, "hash value must be non-empty")
+			assert.Equal(t, strings.ToLower(v), v, "hash must be lowercased")
+		}
+	})
 }
 
 func TestValidate(t *testing.T) {

--- a/internal/update/manifest/manifest_test.go
+++ b/internal/update/manifest/manifest_test.go
@@ -1,0 +1,169 @@
+package manifest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyTag(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		tag         string
+		wantChannel string
+		wantOK      bool
+	}{
+		{name: "stable semver", tag: "v0.6.4", wantChannel: ChannelStable, wantOK: true},
+		{name: "stable two digit", tag: "v1.10.0", wantChannel: ChannelStable, wantOK: true},
+		{name: "beta suffix", tag: "v0.7.0-beta.1", wantChannel: ChannelBeta, wantOK: true},
+		{name: "rc suffix", tag: "v0.7.0-rc2", wantChannel: ChannelBeta, wantOK: true},
+		{name: "alpha suffix", tag: "v0.7.0-alpha.3", wantChannel: ChannelBeta, wantOK: true},
+		{name: "nightly dated", tag: "nightly-20260622", wantChannel: ChannelNightly, wantOK: true},
+		{name: "nightly suffixed retry", tag: "nightly-20260622-414", wantChannel: ChannelNightly, wantOK: true},
+		{name: "manifest tag ignored", tag: "manifest", wantChannel: "", wantOK: false},
+		{name: "plain date tag ignored", tag: "20240215", wantChannel: "", wantOK: false},
+		{name: "empty ignored", tag: "", wantChannel: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotChannel, gotOK := ClassifyTag(tt.tag)
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantChannel, gotChannel)
+		})
+	}
+}
+
+func TestParseAssetName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		filename     string
+		wantPlatform string
+		wantArch     string
+		wantOK       bool
+	}{
+		{name: "stable with version", filename: "birdnet-go-linux-amd64-v0.6.4.tar.gz", wantPlatform: "linux", wantArch: "amd64", wantOK: true},
+		{name: "nightly without version", filename: "birdnet-go-linux-arm64.tar.gz", wantPlatform: "linux", wantArch: "arm64", wantOK: true},
+		{name: "windows amd64", filename: "birdnet-go-windows-amd64-v0.6.4.tar.gz", wantPlatform: "windows", wantArch: "amd64", wantOK: true},
+		{name: "darwin arm64", filename: "birdnet-go-darwin-arm64.tar.gz", wantPlatform: "darwin", wantArch: "arm64", wantOK: true},
+		{name: "checksums file rejected", filename: "checksums.txt", wantOK: false},
+		{name: "readme rejected", filename: "README.md", wantOK: false},
+		{name: "unknown arch rejected", filename: "birdnet-go-linux-riscv64.tar.gz", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			platform, arch, ok := ParseAssetName(tt.filename)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantPlatform, platform)
+			assert.Equal(t, tt.wantArch, arch)
+		})
+	}
+}
+
+func TestParseChecksums(t *testing.T) {
+	t.Parallel()
+	data := []byte(
+		"ABCDEF0123456789  birdnet-go-linux-amd64-v0.6.4.tar.gz\n" +
+			"  \n" + // blank line skipped
+			"deadbeef  birdnet-go-linux-arm64-v0.6.4.tar.gz\n" +
+			"malformed-single-field\n", // skipped
+	)
+	got := ParseChecksums(data)
+	require.Len(t, got, 2)
+	assert.Equal(t, "abcdef0123456789", got["birdnet-go-linux-amd64-v0.6.4.tar.gz"], "hash lowercased")
+	assert.Equal(t, "deadbeef", got["birdnet-go-linux-arm64-v0.6.4.tar.gz"])
+}
+
+func TestExtractCritical(t *testing.T) {
+	t.Parallel()
+	assert.True(t, ExtractCritical("Security fix.\n"+CriticalMarker+"\nDetails."))
+	assert.False(t, ExtractCritical("Normal release notes."))
+}
+
+func TestExtractMinUpgradeFrom(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "v0.5.0", ExtractMinUpgradeFrom("Notes\n<!-- manifest:min-upgrade-from=v0.5.0 -->\nmore"))
+	assert.Empty(t, ExtractMinUpgradeFrom("No marker here"))
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		m       *Manifest
+		wantErr string
+	}{
+		{
+			name:    "missing schema version",
+			m:       &Manifest{Channels: map[string]*Channel{ChannelStable: {Version: "v1", Tag: "v1"}}},
+			wantErr: "schema_version is required",
+		},
+		{
+			name:    "no channels",
+			m:       &Manifest{SchemaVersion: SchemaVersion, Channels: map[string]*Channel{}},
+			wantErr: "at least one channel is required",
+		},
+		{
+			name:    "nil channel",
+			m:       &Manifest{SchemaVersion: SchemaVersion, Channels: map[string]*Channel{ChannelStable: nil}},
+			wantErr: "entry is nil",
+		},
+		{
+			name:    "missing version",
+			m:       &Manifest{SchemaVersion: SchemaVersion, Channels: map[string]*Channel{ChannelStable: {Tag: "v1"}}},
+			wantErr: "version is required",
+		},
+		{
+			name:    "valid",
+			m:       &Manifest{SchemaVersion: SchemaVersion, Channels: map[string]*Channel{ChannelStable: {Version: "v1", Tag: "v1"}}},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.m.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	original := &Manifest{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC),
+		Repo:          "tphakala/birdnet-go",
+		Channels: map[string]*Channel{
+			ChannelStable: {
+				Version:    "v0.6.4",
+				Tag:        "v0.6.4",
+				Name:       "BirdNET-Go v0.6.4",
+				ReleasedAt: time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC),
+				ReleaseURL: "https://github.com/tphakala/birdnet-go/releases/tag/v0.6.4",
+				Docker:     &Docker{ChannelTag: "ghcr.io/tphakala/birdnet-go:latest"},
+				Assets: []Asset{
+					{Platform: "linux", Arch: "amd64", Filename: "birdnet-go-linux-amd64-v0.6.4.tar.gz", URL: "https://example/a", Size: 100, SHA256: "abc"},
+				},
+			},
+		},
+	}
+	data, err := original.JSON()
+	require.NoError(t, err)
+	assert.Equal(t, byte('\n'), data[len(data)-1], "trailing newline")
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+	assert.Equal(t, original, parsed)
+	require.NoError(t, parsed.Validate())
+}

--- a/tools/release-manifest/assemble.go
+++ b/tools/release-manifest/assemble.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/update/manifest"
+)
+
+// checksumsFilename is the name of the aggregated checksum asset attached to
+// every release by the build workflows.
+const checksumsFilename = "checksums.txt"
+
+// buildOptions configures manifest generation.
+type buildOptions struct {
+	Repo           string    // owner/repo
+	GHCRImage      string    // e.g. ghcr.io/tphakala/birdnet-go
+	DockerHubImage string    // e.g. tphakala/birdnet-go
+	GeneratedAt    time.Time // stamped into the manifest
+	MaxNotesLen    int       // 0 means unbounded
+}
+
+// buildManifest fetches releases via src, picks the newest release on each
+// channel, and assembles the manifest. It returns any non-fatal warnings (for
+// example a release missing checksums) alongside the manifest so the caller can
+// surface them without failing the build.
+func buildManifest(ctx context.Context, src releaseSource, opts *buildOptions) (*manifest.Manifest, []string, error) {
+	releases, err := src.ListReleases(ctx, opts.Repo)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list releases: %w", err)
+	}
+
+	latest := latestPerChannel(releases)
+	if len(latest) == 0 {
+		return nil, nil, fmt.Errorf("no releases matched a known channel in %s", opts.Repo)
+	}
+
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.SchemaVersion,
+		GeneratedAt:   opts.GeneratedAt.UTC(),
+		Repo:          opts.Repo,
+		Channels:      make(map[string]*manifest.Channel, len(latest)),
+	}
+
+	var warnings []string
+	// Iterate channels in a stable order so warnings are deterministic.
+	for _, name := range sortedKeys(latest) {
+		release := latest[name]
+		channel, w := buildChannel(ctx, src, opts, name, &release)
+		m.Channels[name] = channel
+		warnings = append(warnings, w...)
+	}
+
+	if err := m.Validate(); err != nil {
+		return nil, warnings, fmt.Errorf("validate manifest: %w", err)
+	}
+	return m, warnings, nil
+}
+
+// latestPerChannel selects, for each channel, the published release with the
+// most recent publication time. Drafts and releases belonging to no channel
+// (e.g. the "manifest" release itself) are ignored.
+func latestPerChannel(releases []ghRelease) map[string]ghRelease {
+	latest := make(map[string]ghRelease)
+	for _, r := range releases {
+		if r.Draft {
+			continue
+		}
+		channel, ok := manifest.ClassifyTag(r.TagName)
+		if !ok {
+			continue
+		}
+		if cur, exists := latest[channel]; !exists || r.PublishedAt.After(cur.PublishedAt) {
+			latest[channel] = r
+		}
+	}
+	return latest
+}
+
+// buildChannel converts a single GitHub release into a manifest Channel.
+func buildChannel(ctx context.Context, src releaseSource, opts *buildOptions, channelName string, r *ghRelease) (channel *manifest.Channel, warnings []string) {
+	notes := strings.TrimSpace(r.Body)
+	if opts.MaxNotesLen > 0 && len(notes) > opts.MaxNotesLen {
+		notes = notes[:opts.MaxNotesLen]
+	}
+
+	channel = &manifest.Channel{
+		Version:        r.TagName,
+		Tag:            r.TagName,
+		Name:           r.Name,
+		ReleasedAt:     r.PublishedAt.UTC(),
+		Prerelease:     r.Prerelease,
+		Critical:       manifest.ExtractCritical(r.Body),
+		MinUpgradeFrom: manifest.ExtractMinUpgradeFrom(r.Body),
+		ReleaseURL:     r.HTMLURL,
+		Notes:          notes,
+		Docker:         dockerRefs(opts, channelName, r.TagName),
+	}
+
+	checksums := map[string]string{}
+	for i := range r.Assets {
+		if r.Assets[i].Name != checksumsFilename {
+			continue
+		}
+		data, err := src.Download(ctx, r.Assets[i].BrowserDownloadURL)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: download %s: %v", channelName, checksumsFilename, err))
+			break
+		}
+		checksums = manifest.ParseChecksums(data)
+		break
+	}
+
+	for i := range r.Assets {
+		platform, arch, ok := manifest.ParseAssetName(r.Assets[i].Name)
+		if !ok {
+			continue
+		}
+		sha := checksums[r.Assets[i].Name]
+		if sha == "" {
+			warnings = append(warnings, fmt.Sprintf("%s: no checksum for %s", channelName, r.Assets[i].Name))
+		}
+		channel.Assets = append(channel.Assets, manifest.Asset{
+			Platform: platform,
+			Arch:     arch,
+			Filename: r.Assets[i].Name,
+			URL:      r.Assets[i].BrowserDownloadURL,
+			Size:     r.Assets[i].Size,
+			SHA256:   sha,
+		})
+	}
+	sortAssets(channel.Assets)
+
+	if len(channel.Assets) == 0 {
+		warnings = append(warnings, fmt.Sprintf("%s: release %s has no recognised binary assets", channelName, r.TagName))
+	}
+	return channel, warnings
+}
+
+// dockerRefs builds the container image references for a channel.
+func dockerRefs(opts *buildOptions, channelName, version string) *manifest.Docker {
+	if opts.GHCRImage == "" && opts.DockerHubImage == "" {
+		return nil
+	}
+	d := &manifest.Docker{}
+	if opts.GHCRImage != "" {
+		d.GHCR = opts.GHCRImage + ":" + version
+		d.ChannelTag = opts.GHCRImage + ":" + channelMovingTag(channelName)
+	}
+	if opts.DockerHubImage != "" {
+		d.DockerHub = opts.DockerHubImage + ":" + version
+	}
+	return d
+}
+
+// channelMovingTag returns the moving Docker tag users pull to track a channel.
+func channelMovingTag(channelName string) string {
+	switch channelName {
+	case manifest.ChannelStable:
+		return "latest"
+	case manifest.ChannelNightly:
+		return "nightly"
+	case manifest.ChannelBeta:
+		return "beta"
+	default:
+		return channelName
+	}
+}
+
+func sortAssets(assets []manifest.Asset) {
+	slices.SortFunc(assets, func(a, b manifest.Asset) int {
+		if a.Platform != b.Platform {
+			return strings.Compare(a.Platform, b.Platform)
+		}
+		return strings.Compare(a.Arch, b.Arch)
+	})
+}
+
+func sortedKeys(m map[string]ghRelease) []string {
+	keys := slices.Collect(maps.Keys(m))
+	slices.Sort(keys)
+	return keys
+}

--- a/tools/release-manifest/assemble.go
+++ b/tools/release-manifest/assemble.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -14,6 +15,19 @@ import (
 // checksumsFilename is the name of the aggregated checksum asset attached to
 // every release by the build workflows.
 const checksumsFilename = "checksums.txt"
+
+// Moving Docker tags users pull to track a channel.
+const (
+	dockerTagLatest  = "latest"
+	dockerTagNightly = "nightly"
+	dockerTagBeta    = "beta"
+)
+
+// errNoChannels is returned when no published release matched any channel. The
+// CLI treats it as a soft, non-fatal condition (nothing to publish) so a
+// transient empty-release state cannot fail an otherwise-successful release
+// pipeline.
+var errNoChannels = errors.New("no releases matched a known channel")
 
 // buildOptions configures manifest generation.
 type buildOptions struct {
@@ -34,9 +48,13 @@ func buildManifest(ctx context.Context, src releaseSource, opts *buildOptions) (
 		return nil, nil, fmt.Errorf("list releases: %w", err)
 	}
 
+	// Surface version-like releases that matched no channel, so a mis-tagged
+	// release does not vanish from the manifest with zero diagnostics.
+	warnings := unclassifiedWarnings(releases)
+
 	latest := latestPerChannel(releases)
 	if len(latest) == 0 {
-		return nil, nil, fmt.Errorf("no releases matched a known channel in %s", opts.Repo)
+		return nil, warnings, fmt.Errorf("%w in %s", errNoChannels, opts.Repo)
 	}
 
 	m := &manifest.Manifest{
@@ -46,7 +64,6 @@ func buildManifest(ctx context.Context, src releaseSource, opts *buildOptions) (
 		Channels:      make(map[string]*manifest.Channel, len(latest)),
 	}
 
-	var warnings []string
 	// Iterate channels in a stable order so warnings are deterministic.
 	for _, name := range sortedKeys(latest) {
 		release := latest[name]
@@ -74,18 +91,47 @@ func latestPerChannel(releases []ghRelease) map[string]ghRelease {
 		if !ok {
 			continue
 		}
-		if cur, exists := latest[channel]; !exists || r.PublishedAt.After(cur.PublishedAt) {
+		// Deterministic selection: newest by publish time, and on an exact
+		// timestamp tie prefer the lexicographically greater tag so the result
+		// does not depend on the API's (undocumented) tie ordering.
+		cur, exists := latest[channel]
+		if !exists || r.PublishedAt.After(cur.PublishedAt) ||
+			(r.PublishedAt.Equal(cur.PublishedAt) && r.TagName > cur.TagName) {
 			latest[channel] = r
 		}
 	}
 	return latest
 }
 
+// unclassifiedWarnings reports non-draft releases whose tag looks like a version
+// (starts with "v" or "nightly-") but matched no channel, e.g. a beta tagged
+// with an unsupported pre-release form.
+func unclassifiedWarnings(releases []ghRelease) []string {
+	var warnings []string
+	for i := range releases {
+		r := releases[i]
+		if r.Draft {
+			continue
+		}
+		if _, ok := manifest.ClassifyTag(r.TagName); ok {
+			continue
+		}
+		if strings.HasPrefix(r.TagName, "v") || strings.HasPrefix(r.TagName, "nightly-") {
+			warnings = append(warnings, fmt.Sprintf("release %q matched no channel and was skipped", r.TagName))
+		}
+	}
+	return warnings
+}
+
 // buildChannel converts a single GitHub release into a manifest Channel.
 func buildChannel(ctx context.Context, src releaseSource, opts *buildOptions, channelName string, r *ghRelease) (channel *manifest.Channel, warnings []string) {
 	notes := strings.TrimSpace(r.Body)
-	if opts.MaxNotesLen > 0 && len(notes) > opts.MaxNotesLen {
-		notes = notes[:opts.MaxNotesLen]
+	// Bound the notes by rune count, not bytes, so truncation never splits a
+	// multi-byte character and produces invalid UTF-8.
+	if opts.MaxNotesLen > 0 {
+		if runes := []rune(notes); len(runes) > opts.MaxNotesLen {
+			notes = string(runes[:opts.MaxNotesLen])
+		}
 	}
 
 	channel = &manifest.Channel{
@@ -101,7 +147,7 @@ func buildChannel(ctx context.Context, src releaseSource, opts *buildOptions, ch
 		Docker:         dockerRefs(opts, channelName, r.TagName),
 	}
 
-	checksums := map[string]string{}
+	var checksums map[string]string
 	for i := range r.Assets {
 		if r.Assets[i].Name != checksumsFilename {
 			continue
@@ -146,12 +192,20 @@ func dockerRefs(opts *buildOptions, channelName, version string) *manifest.Docke
 	if opts.GHCRImage == "" && opts.DockerHubImage == "" {
 		return nil
 	}
+	// The nightly dated image tag is derived from the build version, which can
+	// drift from the GitHub release tag on a retry (the release tag gains a
+	// "-<run_number>" suffix the image never gets). Only advertise a
+	// version-pinned ref for channels whose release tag is guaranteed to match
+	// the pushed image tag; nightly installs track the moving channel tag.
+	pinned := channelName != manifest.ChannelNightly
 	d := &manifest.Docker{}
 	if opts.GHCRImage != "" {
-		d.GHCR = opts.GHCRImage + ":" + version
 		d.ChannelTag = opts.GHCRImage + ":" + channelMovingTag(channelName)
+		if pinned {
+			d.GHCR = opts.GHCRImage + ":" + version
+		}
 	}
-	if opts.DockerHubImage != "" {
+	if opts.DockerHubImage != "" && pinned {
 		d.DockerHub = opts.DockerHubImage + ":" + version
 	}
 	return d
@@ -161,11 +215,11 @@ func dockerRefs(opts *buildOptions, channelName, version string) *manifest.Docke
 func channelMovingTag(channelName string) string {
 	switch channelName {
 	case manifest.ChannelStable:
-		return "latest"
+		return dockerTagLatest
 	case manifest.ChannelNightly:
-		return "nightly"
+		return dockerTagNightly
 	case manifest.ChannelBeta:
-		return "beta"
+		return dockerTagBeta
 	default:
 		return channelName
 	}

--- a/tools/release-manifest/assemble_test.go
+++ b/tools/release-manifest/assemble_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/update/manifest"
+)
+
+// fakeSource is an in-memory releaseSource for tests.
+type fakeSource struct {
+	releases  []ghRelease
+	downloads map[string][]byte
+	listErr   error
+}
+
+func (f *fakeSource) ListReleases(_ context.Context, _ string) ([]ghRelease, error) {
+	return f.releases, f.listErr
+}
+
+func (f *fakeSource) Download(_ context.Context, url string) ([]byte, error) {
+	if data, ok := f.downloads[url]; ok {
+		return data, nil
+	}
+	return nil, assert.AnError
+}
+
+func tarball(name, url string, size int64) ghAsset {
+	return ghAsset{Name: name, Size: size, BrowserDownloadURL: url}
+}
+
+func defaultOpts() *buildOptions {
+	return &buildOptions{
+		Repo:           "tphakala/birdnet-go",
+		GHCRImage:      "ghcr.io/tphakala/birdnet-go",
+		DockerHubImage: "tphakala/birdnet-go",
+		GeneratedAt:    time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC),
+		MaxNotesLen:    50000,
+	}
+}
+
+func TestBuildManifest_AllChannels(t *testing.T) {
+	t.Parallel()
+
+	stableChecksumsURL := "https://dl/stable/checksums.txt"
+	nightlyChecksumsURL := "https://dl/nightly/checksums.txt"
+	betaChecksumsURL := "https://dl/beta/checksums.txt"
+
+	src := &fakeSource{
+		releases: []ghRelease{
+			// Newer stable should win over the older one.
+			{
+				TagName: "v0.6.3", PublishedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+				Assets: []ghAsset{tarball("birdnet-go-linux-amd64-v0.6.3.tar.gz", "https://dl/old", 1)},
+			},
+			{
+				TagName: "v0.6.4", Name: "BirdNET-Go v0.6.4",
+				Body:        "Stable notes.\n" + manifest.CriticalMarker + "\n<!-- manifest:min-upgrade-from=v0.5.0 -->",
+				PublishedAt: time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC),
+				HTMLURL:     "https://github.com/tphakala/birdnet-go/releases/tag/v0.6.4",
+				Assets: []ghAsset{
+					tarball("birdnet-go-linux-arm64-v0.6.4.tar.gz", "https://dl/s-arm", 200),
+					tarball("birdnet-go-linux-amd64-v0.6.4.tar.gz", "https://dl/s-amd", 100),
+					{Name: "checksums.txt", BrowserDownloadURL: stableChecksumsURL},
+					{Name: "README.md", BrowserDownloadURL: "https://dl/readme"},
+				},
+			},
+			// Beta.
+			{
+				TagName: "v0.7.0-beta.1", Prerelease: true,
+				PublishedAt: time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC),
+				Assets: []ghAsset{
+					tarball("birdnet-go-linux-amd64-v0.7.0-beta.1.tar.gz", "https://dl/beta", 50),
+					{Name: "checksums.txt", BrowserDownloadURL: betaChecksumsURL},
+				},
+			},
+			// Nightly (no version suffix in asset names).
+			{
+				TagName: "nightly-20260622", Prerelease: true,
+				PublishedAt: time.Date(2026, 6, 22, 1, 0, 0, 0, time.UTC),
+				Assets: []ghAsset{
+					tarball("birdnet-go-linux-amd64.tar.gz", "https://dl/n-amd", 300),
+					{Name: "checksums.txt", BrowserDownloadURL: nightlyChecksumsURL},
+				},
+			},
+			// The manifest release itself must be ignored.
+			{TagName: "manifest", PublishedAt: time.Date(2026, 6, 22, 2, 0, 0, 0, time.UTC)},
+			// A draft must be ignored even if newer.
+			{TagName: "v0.6.5", Draft: true, PublishedAt: time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)},
+		},
+		downloads: map[string][]byte{
+			stableChecksumsURL: []byte(
+				"aaa111  birdnet-go-linux-amd64-v0.6.4.tar.gz\n" +
+					"bbb222  birdnet-go-linux-arm64-v0.6.4.tar.gz\n"),
+			nightlyChecksumsURL: []byte("ccc333  birdnet-go-linux-amd64.tar.gz\n"),
+			betaChecksumsURL:    []byte("ddd444  birdnet-go-linux-amd64-v0.7.0-beta.1.tar.gz\n"),
+		},
+	}
+
+	m, warnings, err := buildManifest(t.Context(), src, defaultOpts())
+	require.NoError(t, err)
+	require.NoError(t, m.Validate())
+	assert.Empty(t, warnings, "all assets have checksums")
+
+	require.Len(t, m.Channels, 3)
+	assert.Equal(t, manifest.SchemaVersion, m.SchemaVersion)
+	assert.Equal(t, "tphakala/birdnet-go", m.Repo)
+
+	// Stable: newest wins, critical + min-upgrade parsed, assets sorted, hashes mapped.
+	stable := m.Channels[manifest.ChannelStable]
+	require.NotNil(t, stable)
+	assert.Equal(t, "v0.6.4", stable.Version)
+	assert.True(t, stable.Critical)
+	assert.Equal(t, "v0.5.0", stable.MinUpgradeFrom)
+	require.Len(t, stable.Assets, 2, "README and checksums excluded")
+	assert.Equal(t, "amd64", stable.Assets[0].Arch, "sorted: amd64 before arm64")
+	assert.Equal(t, "aaa111", stable.Assets[0].SHA256)
+	assert.Equal(t, "bbb222", stable.Assets[1].SHA256)
+	require.NotNil(t, stable.Docker)
+	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:latest", stable.Docker.ChannelTag)
+	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:v0.6.4", stable.Docker.GHCR)
+	assert.Equal(t, "tphakala/birdnet-go:v0.6.4", stable.Docker.DockerHub)
+
+	// Beta.
+	beta := m.Channels[manifest.ChannelBeta]
+	require.NotNil(t, beta)
+	assert.Equal(t, "v0.7.0-beta.1", beta.Version)
+	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:beta", beta.Docker.ChannelTag)
+
+	// Nightly.
+	nightly := m.Channels[manifest.ChannelNightly]
+	require.NotNil(t, nightly)
+	assert.Equal(t, "nightly-20260622", nightly.Version)
+	require.Len(t, nightly.Assets, 1)
+	assert.Equal(t, "ccc333", nightly.Assets[0].SHA256)
+	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:nightly", nightly.Docker.ChannelTag)
+}
+
+func TestBuildManifest_MissingChecksumsWarns(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{
+		releases: []ghRelease{
+			{
+				TagName:     "v0.6.4",
+				PublishedAt: time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+				Assets:      []ghAsset{tarball("birdnet-go-linux-amd64-v0.6.4.tar.gz", "https://dl/amd", 100)},
+			},
+		},
+	}
+	m, warnings, err := buildManifest(t.Context(), src, defaultOpts())
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "no checksum")
+	assert.Empty(t, m.Channels[manifest.ChannelStable].Assets[0].SHA256)
+}
+
+func TestBuildManifest_NoMatchingReleases(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{releases: []ghRelease{{TagName: "manifest"}, {TagName: "random"}}}
+	_, _, err := buildManifest(t.Context(), src, defaultOpts())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no releases matched")
+}
+
+func TestBuildManifest_DockerOmittedWhenImagesEmpty(t *testing.T) {
+	t.Parallel()
+	opts := defaultOpts()
+	opts.GHCRImage = ""
+	opts.DockerHubImage = ""
+	src := &fakeSource{
+		releases: []ghRelease{
+			{TagName: "v0.6.4", PublishedAt: time.Now(), Assets: []ghAsset{tarball("birdnet-go-linux-amd64-v0.6.4.tar.gz", "https://dl/amd", 100)}},
+		},
+	}
+	m, _, err := buildManifest(t.Context(), src, opts)
+	require.NoError(t, err)
+	assert.Nil(t, m.Channels[manifest.ChannelStable].Docker)
+}

--- a/tools/release-manifest/assemble_test.go
+++ b/tools/release-manifest/assemble_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -120,6 +121,7 @@ func TestBuildManifest_AllChannels(t *testing.T) {
 	assert.Equal(t, "amd64", stable.Assets[0].Arch, "sorted: amd64 before arm64")
 	assert.Equal(t, "aaa111", stable.Assets[0].SHA256)
 	assert.Equal(t, "bbb222", stable.Assets[1].SHA256)
+	assert.False(t, stable.Prerelease)
 	require.NotNil(t, stable.Docker)
 	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:latest", stable.Docker.ChannelTag)
 	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:v0.6.4", stable.Docker.GHCR)
@@ -129,15 +131,81 @@ func TestBuildManifest_AllChannels(t *testing.T) {
 	beta := m.Channels[manifest.ChannelBeta]
 	require.NotNil(t, beta)
 	assert.Equal(t, "v0.7.0-beta.1", beta.Version)
+	assert.True(t, beta.Prerelease)
 	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:beta", beta.Docker.ChannelTag)
 
-	// Nightly.
+	// Nightly: moving channel tag only, no version-pinned Docker ref.
 	nightly := m.Channels[manifest.ChannelNightly]
 	require.NotNil(t, nightly)
 	assert.Equal(t, "nightly-20260622", nightly.Version)
+	assert.True(t, nightly.Prerelease)
 	require.Len(t, nightly.Assets, 1)
 	assert.Equal(t, "ccc333", nightly.Assets[0].SHA256)
 	assert.Equal(t, "ghcr.io/tphakala/birdnet-go:nightly", nightly.Docker.ChannelTag)
+	assert.Empty(t, nightly.Docker.GHCR, "nightly must not advertise a version-pinned image")
+	assert.Empty(t, nightly.Docker.DockerHub)
+}
+
+func TestBuildManifest_ChecksumDownloadErrorWarns(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{
+		releases: []ghRelease{{
+			TagName:     "v0.6.4",
+			PublishedAt: time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+			Assets: []ghAsset{
+				tarball("birdnet-go-linux-amd64-v0.6.4.tar.gz", "https://dl/amd", 100),
+				{Name: "checksums.txt", BrowserDownloadURL: "https://dl/missing"}, // absent from downloads -> error
+			},
+		}},
+		downloads: map[string][]byte{},
+	}
+	m, warnings, err := buildManifest(t.Context(), src, defaultOpts())
+	require.NoError(t, err)
+	assert.Contains(t, strings.Join(warnings, "|"), "download checksums.txt")
+	assert.Empty(t, m.Channels[manifest.ChannelStable].Assets[0].SHA256)
+}
+
+func TestBuildManifest_NoBinaryAssetsWarns(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{
+		releases: []ghRelease{{
+			TagName:     "v0.6.4",
+			PublishedAt: time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+			Assets:      []ghAsset{{Name: "README.md", BrowserDownloadURL: "https://dl/readme"}},
+		}},
+	}
+	m, warnings, err := buildManifest(t.Context(), src, defaultOpts())
+	require.NoError(t, err)
+	stable := m.Channels[manifest.ChannelStable]
+	require.NotNil(t, stable)
+	assert.Empty(t, stable.Assets)
+	assert.Equal(t, "v0.6.4", stable.Version, "channel still populated despite no binary assets")
+	assert.Contains(t, strings.Join(warnings, "|"), "no recognised binary assets")
+}
+
+func TestBuildManifest_NoChannelsIsSoftError(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{releases: []ghRelease{
+		{TagName: "manifest"},
+		{TagName: "v1.2"}, // version-like but unclassified -> warning
+	}}
+	_, warnings, err := buildManifest(t.Context(), src, defaultOpts())
+	require.ErrorIs(t, err, errNoChannels)
+	assert.Contains(t, strings.Join(warnings, "|"), "matched no channel")
+}
+
+func TestLatestPerChannel_TieBreaksOnTag(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	// Same instant, listed lower-then-higher and higher-then-lower; the greater
+	// tag must win either way for determinism.
+	for _, order := range [][]string{{"v0.6.4", "v0.6.5"}, {"v0.6.5", "v0.6.4"}} {
+		got := latestPerChannel([]ghRelease{
+			{TagName: order[0], PublishedAt: ts},
+			{TagName: order[1], PublishedAt: ts},
+		})
+		assert.Equal(t, "v0.6.5", got[manifest.ChannelStable].TagName, "order %v", order)
+	}
 }
 
 func TestBuildManifest_MissingChecksumsWarns(t *testing.T) {
@@ -156,14 +224,6 @@ func TestBuildManifest_MissingChecksumsWarns(t *testing.T) {
 	require.Len(t, warnings, 1)
 	assert.Contains(t, warnings[0], "no checksum")
 	assert.Empty(t, m.Channels[manifest.ChannelStable].Assets[0].SHA256)
-}
-
-func TestBuildManifest_NoMatchingReleases(t *testing.T) {
-	t.Parallel()
-	src := &fakeSource{releases: []ghRelease{{TagName: "manifest"}, {TagName: "random"}}}
-	_, _, err := buildManifest(t.Context(), src, defaultOpts())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no releases matched")
 }
 
 func TestBuildManifest_DockerOmittedWhenImagesEmpty(t *testing.T) {

--- a/tools/release-manifest/github.go
+++ b/tools/release-manifest/github.go
@@ -48,6 +48,10 @@ const (
 	apiAcceptHeader = "application/vnd.github+json"
 	apiVersion      = "2022-11-28"
 	maxAssetBytes   = 1 << 20 // 1 MiB cap for checksum file downloads
+	maxReleasesBody = 8 << 20 // 8 MiB cap for the releases listing response
+	// userAgent is sent on every request; the GitHub REST API requires a
+	// User-Agent header and returns 403 without one.
+	userAgent = "birdnet-go-release-manifest"
 )
 
 func newGitHubClient(baseURL, token string) *githubClient {
@@ -65,12 +69,18 @@ func (c *githubClient) newRequest(ctx context.Context, url string) (*http.Reques
 	}
 	req.Header.Set("Accept", apiAcceptHeader)
 	req.Header.Set("X-GitHub-Api-Version", apiVersion)
+	req.Header.Set("User-Agent", userAgent)
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 	return req, nil
 }
 
+// ListReleases fetches the first page (up to 100) of releases. GitHub returns
+// releases newest-first, and the manifest only needs the latest release on each
+// channel, so a single page is sufficient as long as fewer than 100 releases
+// are newer than each channel's latest (always true while nightlies are pruned
+// to 14). Pagination is intentionally omitted.
 func (c *githubClient) ListReleases(ctx context.Context, repo string) ([]ghRelease, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases?per_page=100", c.baseURL, repo)
 	req, err := c.newRequest(ctx, url)
@@ -87,7 +97,7 @@ func (c *githubClient) ListReleases(ctx context.Context, repo string) ([]ghRelea
 		return nil, fmt.Errorf("list releases: unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 	var releases []ghRelease
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxReleasesBody)).Decode(&releases); err != nil {
 		return nil, fmt.Errorf("decode releases: %w", err)
 	}
 	return releases, nil

--- a/tools/release-manifest/github.go
+++ b/tools/release-manifest/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -57,8 +58,10 @@ const (
 func newGitHubClient(baseURL, token string) *githubClient {
 	return &githubClient{
 		httpClient: &http.Client{Timeout: 30 * time.Second},
-		baseURL:    baseURL,
-		token:      token,
+		// Trim a trailing slash so a base URL like "https://api.github.com/"
+		// does not produce a double slash when paths are appended.
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
 	}
 }
 
@@ -118,9 +121,14 @@ func (c *githubClient) Download(ctx context.Context, url string) ([]byte, error)
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download %s: unexpected status %d", url, resp.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAssetBytes))
+	// Read one byte past the cap so an oversized asset is detected and errors
+	// rather than silently truncating into a partial checksum map.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAssetBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	if len(data) > maxAssetBytes {
+		return nil, fmt.Errorf("download %s: asset exceeds %d byte limit", url, maxAssetBytes)
 	}
 	return data, nil
 }

--- a/tools/release-manifest/github.go
+++ b/tools/release-manifest/github.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ghRelease is the subset of the GitHub Releases API response we consume.
+type ghRelease struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Body        string    `json:"body"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	PublishedAt time.Time `json:"published_at"`
+	HTMLURL     string    `json:"html_url"`
+	Assets      []ghAsset `json:"assets"`
+}
+
+// ghAsset is a single release asset.
+type ghAsset struct {
+	Name               string `json:"name"`
+	Size               int64  `json:"size"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// releaseSource abstracts the GitHub API so the assembly logic can be tested
+// against a fake.
+type releaseSource interface {
+	// ListReleases returns the most recent releases for a repo, newest first.
+	ListReleases(ctx context.Context, repo string) ([]ghRelease, error)
+	// Download fetches the raw bytes of an asset URL.
+	Download(ctx context.Context, url string) ([]byte, error)
+}
+
+// githubClient talks to the GitHub REST API over HTTP.
+type githubClient struct {
+	httpClient *http.Client
+	baseURL    string // e.g. https://api.github.com
+	token      string // optional; raises the rate limit and reads private repos
+}
+
+const (
+	apiAcceptHeader = "application/vnd.github+json"
+	apiVersion      = "2022-11-28"
+	maxAssetBytes   = 1 << 20 // 1 MiB cap for checksum file downloads
+)
+
+func newGitHubClient(baseURL, token string) *githubClient {
+	return &githubClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    baseURL,
+		token:      token,
+	}
+}
+
+func (c *githubClient) newRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", apiAcceptHeader)
+	req.Header.Set("X-GitHub-Api-Version", apiVersion)
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	return req, nil
+}
+
+func (c *githubClient) ListReleases(ctx context.Context, repo string) ([]ghRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases?per_page=100", c.baseURL, repo)
+	req, err := c.newRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list releases: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxAssetBytes))
+		return nil, fmt.Errorf("list releases: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	var releases []ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("decode releases: %w", err)
+	}
+	return releases, nil
+}
+
+func (c *githubClient) Download(ctx context.Context, url string) ([]byte, error) {
+	req, err := c.newRequest(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	// Asset download URLs serve the raw bytes; octet-stream is the documented Accept.
+	req.Header.Set("Accept", "application/octet-stream")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download %s: unexpected status %d", url, resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAssetBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	return data, nil
+}

--- a/tools/release-manifest/github_test.go
+++ b/tools/release-manifest/github_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGitHubClient_TrimsTrailingSlash(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{name: "no slash", baseURL: "https://api.github.com", want: "https://api.github.com"},
+		{name: "one trailing slash", baseURL: "https://api.github.com/", want: "https://api.github.com"},
+		{name: "multiple trailing slashes", baseURL: "https://api.github.com///", want: "https://api.github.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, newGitHubClient(tt.baseURL, "").baseURL)
+		})
+	}
+}
+
+func TestGitHubClient_DownloadOK(t *testing.T) {
+	t.Parallel()
+	const body = "abc123  birdnet-go-linux-amd64.tar.gz\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	data, err := newGitHubClient(srv.URL, "").Download(t.Context(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(data))
+}
+
+func TestGitHubClient_DownloadRejectsOversized(t *testing.T) {
+	t.Parallel()
+	big := bytes.Repeat([]byte("a"), maxAssetBytes+10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(big)
+	}))
+	defer srv.Close()
+
+	_, err := newGitHubClient(srv.URL, "").Download(t.Context(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}

--- a/tools/release-manifest/main.go
+++ b/tools/release-manifest/main.go
@@ -46,6 +46,9 @@ func run(repo, output, apiURL, ghcrImage, dockerHubImage string, maxNotesLen int
 	if !repoRe.MatchString(repo) {
 		return fmt.Errorf("invalid -repo %q: want owner/name", repo)
 	}
+	if maxNotesLen < 0 {
+		return fmt.Errorf("invalid -max-notes-len %d: must be >= 0 (0 means unbounded)", maxNotesLen)
+	}
 	// Default the image repositories to the GitHub repo so the manifest is
 	// correct on forks and renames instead of advertising a hardcoded upstream.
 	if ghcrImage == "" {
@@ -86,8 +89,15 @@ func run(repo, output, apiURL, ghcrImage, dockerHubImage string, maxNotesLen int
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(output, data, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", output, err)
+	// Write atomically: a temp file in the same directory, then rename, so a
+	// reader (or the workflow's publish step) never observes a partial file.
+	tmp := output + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, output); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s -> %s: %w", tmp, output, err)
 	}
 
 	fmt.Fprintf(os.Stderr, "wrote %s (%d channel(s), %d warning(s))\n", output, len(m.Channels), len(warnings))

--- a/tools/release-manifest/main.go
+++ b/tools/release-manifest/main.go
@@ -1,0 +1,89 @@
+// Command release-manifest generates the BirdNET-Go release manifest
+// (manifest.json) by querying the GitHub Releases API for the latest release on
+// each distribution channel (stable, nightly, beta). It is run in CI as the
+// final step of the release and nightly build pipelines, and on a daily
+// schedule as a self-heal; the produced file is published as an asset on the
+// dedicated "manifest" release.
+//
+// Usage:
+//
+//	GITHUB_TOKEN=... go run ./tools/release-manifest -repo tphakala/birdnet-go -output manifest.json
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/update/manifest"
+)
+
+func main() {
+	repo := flag.String("repo", "tphakala/birdnet-go", "GitHub repository in owner/repo form")
+	output := flag.String("output", "manifest.json", "path to write the manifest JSON to")
+	apiURL := flag.String("api-url", "https://api.github.com", "GitHub REST API base URL")
+	ghcrImage := flag.String("ghcr-image", "ghcr.io/tphakala/birdnet-go", "GHCR image repository (without tag); empty to omit")
+	dockerHubImage := flag.String("dockerhub-image", "tphakala/birdnet-go", "Docker Hub image repository (without tag); empty to omit")
+	maxNotesLen := flag.Int("max-notes-len", 50000, "maximum release-notes length in bytes; 0 for unbounded")
+	flag.Parse()
+
+	if err := run(*repo, *output, *apiURL, *ghcrImage, *dockerHubImage, *maxNotesLen); err != nil {
+		fmt.Fprintln(os.Stderr, "release-manifest:", err)
+		os.Exit(1)
+	}
+}
+
+func run(repo, output, apiURL, ghcrImage, dockerHubImage string, maxNotesLen int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	client := newGitHubClient(apiURL, os.Getenv("GITHUB_TOKEN"))
+	opts := &buildOptions{
+		Repo:           repo,
+		GHCRImage:      ghcrImage,
+		DockerHubImage: dockerHubImage,
+		GeneratedAt:    time.Now().UTC(),
+		MaxNotesLen:    maxNotesLen,
+	}
+
+	m, warnings, err := buildManifest(ctx, client, opts)
+	for _, w := range warnings {
+		fmt.Fprintln(os.Stderr, "warning:", w)
+	}
+	if err != nil {
+		return err
+	}
+
+	data, err := m.JSON()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(output, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", output, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "wrote %s (%d channel(s), %d warning(s))\n", output, len(m.Channels), len(warnings))
+	for _, name := range sortedChannelNames(m) {
+		fmt.Fprintf(os.Stderr, "  %-8s %s (%d asset(s))\n", name, m.Channels[name].Version, len(m.Channels[name].Assets))
+	}
+	return nil
+}
+
+func sortedChannelNames(m *manifest.Manifest) []string {
+	order := []string{manifest.ChannelStable, manifest.ChannelBeta, manifest.ChannelNightly}
+	var names []string
+	for _, name := range order {
+		if _, ok := m.Channels[name]; ok {
+			names = append(names, name)
+		}
+	}
+	// Append any channel not in the preferred order (future-proofing).
+	for name := range m.Channels {
+		if name != manifest.ChannelStable && name != manifest.ChannelBeta && name != manifest.ChannelNightly {
+			names = append(names, name)
+		}
+	}
+	return names
+}

--- a/tools/release-manifest/main.go
+++ b/tools/release-manifest/main.go
@@ -12,20 +12,27 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/update/manifest"
 )
 
+// repoRe validates the owner/name form of -repo before it is interpolated into
+// an API URL.
+var repoRe = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+
 func main() {
 	repo := flag.String("repo", "tphakala/birdnet-go", "GitHub repository in owner/repo form")
 	output := flag.String("output", "manifest.json", "path to write the manifest JSON to")
 	apiURL := flag.String("api-url", "https://api.github.com", "GitHub REST API base URL")
-	ghcrImage := flag.String("ghcr-image", "ghcr.io/tphakala/birdnet-go", "GHCR image repository (without tag); empty to omit")
-	dockerHubImage := flag.String("dockerhub-image", "tphakala/birdnet-go", "Docker Hub image repository (without tag); empty to omit")
+	ghcrImage := flag.String("ghcr-image", "", "GHCR image repository (without tag); defaults to ghcr.io/<repo>")
+	dockerHubImage := flag.String("dockerhub-image", "", "Docker Hub image repository (without tag); defaults to <repo>")
 	maxNotesLen := flag.Int("max-notes-len", 50000, "maximum release-notes length in bytes; 0 for unbounded")
 	flag.Parse()
 
@@ -36,6 +43,18 @@ func main() {
 }
 
 func run(repo, output, apiURL, ghcrImage, dockerHubImage string, maxNotesLen int) error {
+	if !repoRe.MatchString(repo) {
+		return fmt.Errorf("invalid -repo %q: want owner/name", repo)
+	}
+	// Default the image repositories to the GitHub repo so the manifest is
+	// correct on forks and renames instead of advertising a hardcoded upstream.
+	if ghcrImage == "" {
+		ghcrImage = "ghcr.io/" + strings.ToLower(repo)
+	}
+	if dockerHubImage == "" {
+		dockerHubImage = strings.ToLower(repo)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
@@ -53,6 +72,13 @@ func run(repo, output, apiURL, ghcrImage, dockerHubImage string, maxNotesLen int
 		fmt.Fprintln(os.Stderr, "warning:", w)
 	}
 	if err != nil {
+		// No matching releases (e.g. a fresh fork) is not a pipeline failure:
+		// log and skip publishing rather than failing an otherwise-successful
+		// release run.
+		if errors.Is(err, errNoChannels) {
+			fmt.Fprintln(os.Stderr, "release-manifest:", err, "- nothing to publish, skipping")
+			return nil
+		}
 		return err
 	}
 

--- a/tools/release-manifest/main.go
+++ b/tools/release-manifest/main.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -115,11 +116,15 @@ func sortedChannelNames(m *manifest.Manifest) []string {
 			names = append(names, name)
 		}
 	}
-	// Append any channel not in the preferred order (future-proofing).
+	// Append any channel not in the preferred order (future-proofing), sorted
+	// so the output is deterministic regardless of map iteration order.
+	var extra []string
 	for name := range m.Channels {
 		if name != manifest.ChannelStable && name != manifest.ChannelBeta && name != manifest.ChannelNightly {
-			names = append(names, name)
+			extra = append(extra, name)
 		}
 	}
+	slices.Sort(extra)
+	names = append(names, extra...)
 	return names
 }


### PR DESCRIPTION
## What this does

Adds a machine-readable **release manifest** that describes the latest BirdNET-Go build on each distribution channel (stable, nightly, beta), published as a single JSON asset on a dedicated `manifest` GitHub release. One stable URL always resolves to the current manifest:

```
https://github.com/tphakala/birdnet-go/releases/download/manifest/manifest.json
```

It carries, per channel: version, release date, notes, the Docker tags to pull, and the native binary tarballs with their SHA-256 checksums. CI keeps it current automatically.

This is **groundwork only**. It is the data source a future in-app update checker needs to answer "is there a newer version, and what changed?" without hammering the GitHub API from every install. No in-app UI or self-update behaviour is added in this PR.

## Why / related requests

Several people have asked for the app to be aware of updates instead of requiring a manual `install.sh` re-run or `docker pull`:

- Discussion #3295 - "In-App GUI Update Button and Optional Auto-Updates" (the canonical request: a "new version available" indicator, a Check/Update button, optional auto-update)
- Discussion #3008 - asking whether updates can be done from the dashboard or happen automatically
- Discussion #3548 - "How do I determine what has changed in Nightly Build image?" (the release-awareness half: knowing what a build contains without installing it)

This manifest is the foundation those features build on. It does not close any of them; it is the first phase.

## What's included

- `internal/update/manifest` - the stdlib-only schema package (types + parsing/validation). This is the contract a future in-app updater imports directly.
- `tools/release-manifest` - a small Go CLI that queries the GitHub Releases API, picks the newest release per channel, maps SHA-256 checksums onto assets, and writes `manifest.json`.
- `.github/workflows/release-manifest.yml` - reusable workflow that generates, validates, and publishes the manifest. Runs as the final job of the release and nightly pipelines (after all assets exist, so it never races uploads), plus `workflow_dispatch` and a daily self-heal.
- `release-build.yml` / `nightly-build.yml` - now also emit a `checksums.txt` and call the manifest workflow.
- `docs/release-manifest.md` - the format and hosting documentation.

## Notes

- The `manifest` release is marked as a pre-release, so it never occupies the "Latest" slot; `/releases/latest` keeps pointing at the newest stable release.
- Existing releases predate checksum publishing, so their `sha256` fields stay empty until new releases are cut; this is expected and non-fatal.
- Release authors can flag a release with `<!-- manifest:critical -->` or `<!-- manifest:min-upgrade-from=vX.Y.Z -->` markers in the release body.

## Out of scope (future phases)

- In-app update check (backend fetch + a "new version available" banner) - directly addresses #3295 / #3008.
- Self-update (docker pull / binary swap).
- Manifest signing for authenticity beyond integrity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated, machine-readable release manifest (`manifest.json`) for in-app updates and external tooling, published as a dedicated prerelease.
  * Nightly and release builds now ship deterministic `checksums.txt` (SHA-256, sorted) alongside archive assets.
  * The manifest is refreshed automatically after release assets are ready (including a daily self-heal), with safe, serialized publishing.
* **Documentation**
  * Added/updated documentation detailing the manifest schema, supported channels, tag behavior, and a full JSON example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->