### PR TITLE
ci: extract setup-tflite-cross composite to de-dup cross-platform-build provisioning

### DIFF
--- a/.github/actions/setup-tflite-cross/action.yml
+++ b/.github/actions/setup-tflite-cross/action.yml
@@ -51,7 +51,9 @@ runs:
         # bump. An explicit tflite-version input overrides the lookup.
         tflite="${TFLITE_VERSION_INPUT}"
         if [ -z "$tflite" ]; then
-          tflite=$(grep -E '^[[:space:]]*TFLITE_VERSION:' Taskfile.yml | head -1 | tr -d ' ' | cut -d: -f2 | tr -d "'\"")
+          # tr also strips \r so a CRLF-checkout Taskfile does not leave a
+          # trailing carriage return that breaks the clone URL / curl downstream.
+          tflite=$(grep -E '^[[:space:]]*TFLITE_VERSION:' Taskfile.yml | head -1 | tr -d ' ' | cut -d: -f2 | tr -d "'\"\r")
         fi
         if [ -z "$tflite" ]; then echo "::error::could not read TFLITE_VERSION from Taskfile.yml"; exit 1; fi
         echo "TFLITE_VERSION=${tflite}" >> "$GITHUB_ENV"

--- a/.github/actions/setup-tflite-cross/action.yml
+++ b/.github/actions/setup-tflite-cross/action.yml
@@ -1,0 +1,112 @@
+name: 'Setup TFLite (cross-compile)'
+description: >-
+  Provision the TensorFlow Lite C API headers and the cross-target
+  libtensorflowlite_c for a CGO cross-compile, with an optional aarch64
+  cross-compiler symlink fix. Shared by the cross-build and openvino-build jobs
+  so the version resolution, header sparse-checkout, and lib download stay in
+  one place instead of drifting across near-identical job steps.
+
+inputs:
+  tflite-asset:
+    description: >-
+      tflite_c release asset suffix to download, e.g. linux_arm64.tar.gz,
+      linux_amd64.tar.gz, or windows_amd64.zip. A .zip asset is treated as the
+      Windows DLL; anything else is treated as a Linux .so tarball.
+    required: true
+  libdir:
+    description: >-
+      Target sysroot lib directory to install the tflite library into, e.g.
+      /usr/aarch64-linux-gnu/lib. This is the path the cross linker resolves
+      -ltensorflowlite_c against (pass it as -L on CGO_LDFLAGS).
+    required: true
+  tflite-version:
+    description: >-
+      TFLite version tag (e.g. v2.17.1). Defaults to reading TFLITE_VERSION from
+      Taskfile.yml so the smoke never validates against a stale version after a
+      Taskfile bump. The resolved value is always exported to GITHUB_ENV as
+      TFLITE_VERSION (including when this input is set), where the header and
+      library steps below consume it.
+    required: false
+    default: ''
+  fix-arm64-cc-symlink:
+    description: >-
+      When 'true', resolve the installed aarch64-linux-gnu-gcc-N and symlink it
+      to aarch64-linux-gnu-gcc. cache-apt-pkgs-action restores debs but skips
+      post-install triggers, so the symlink update-alternatives would normally
+      manage is missing. Leave 'false' for native or mingw targets that do not
+      use the aarch64 cross gcc.
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve TFLITE_VERSION
+      shell: bash
+      env:
+        TFLITE_VERSION_INPUT: ${{ inputs.tflite-version }}
+      run: |
+        # Single source of truth: read TFLITE_VERSION from the Taskfile so the
+        # cross-compile never validates against a stale version after a Taskfile
+        # bump. An explicit tflite-version input overrides the lookup.
+        tflite="${TFLITE_VERSION_INPUT}"
+        if [ -z "$tflite" ]; then
+          tflite=$(grep -E '^[[:space:]]*TFLITE_VERSION:' Taskfile.yml | head -1 | tr -d ' ' | cut -d: -f2 | tr -d "'\"")
+        fi
+        if [ -z "$tflite" ]; then echo "::error::could not read TFLITE_VERSION from Taskfile.yml"; exit 1; fi
+        echo "TFLITE_VERSION=${tflite}" >> "$GITHUB_ENV"
+
+    - name: Fix aarch64 cross-compiler symlink
+      if: inputs.fix-arm64-cc-symlink == 'true'
+      shell: bash
+      run: |
+        # cache-apt-pkgs-action restores debs but skips post-install triggers,
+        # so create the symlink that update-alternatives would normally manage.
+        # Resolve the installed aarch64 gcc version dynamically so a future
+        # runner-image gcc bump does not break the symlink.
+        aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
+        if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
+        sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
+
+    - name: Provision TensorFlow headers
+      shell: bash
+      run: |
+        # Sparse-checkout the TFLite C API headers (same as the check-tensorflow
+        # task) for CGO_CFLAGS. Scripted inline to keep this a Go-only compile
+        # smoke: `task <target>` would drag in the frontend-build (npm) chain,
+        # which is platform-independent and adds no cross-platform signal.
+        if [ ! -f .cache/tensorflow/tensorflow/lite/c/c_api.h ]; then
+          git clone --branch "${TFLITE_VERSION}" --filter=blob:none --no-checkout --depth 1 \
+            https://github.com/tensorflow/tensorflow.git .cache/tensorflow
+          git -C .cache/tensorflow sparse-checkout set --no-cone '**/*.h'
+          git -C .cache/tensorflow checkout
+        fi
+
+    - name: Provision TensorFlow Lite library
+      shell: bash
+      env:
+        TFLITE_ASSET: ${{ inputs.tflite-asset }}
+        LIBDIR: ${{ inputs.libdir }}
+      run: |
+        # CGO links -ltensorflowlite_c, so the target lib must exist at link
+        # time. Place it in the cross sysroot lib dir under the symlink name the
+        # linker resolves (mirrors the download-tflite task). ONNX Runtime and
+        # OpenVINO are both dlopen'd at runtime, not linked, so they are
+        # intentionally not provisioned here.
+        ver="${TFLITE_VERSION#v}"
+        curl -fsSL -o tflite.archive \
+          "https://github.com/tphakala/tflite_c/releases/download/${TFLITE_VERSION}/tflite_c_${TFLITE_VERSION}_${TFLITE_ASSET}"
+        sudo mkdir -p "${LIBDIR}"
+        case "${TFLITE_ASSET}" in
+          *.zip)
+            unzip -o tflite.archive
+            sudo mv "tensorflowlite_c-${ver}.dll" "${LIBDIR}/"
+            (cd "${LIBDIR}" && sudo ln -sf "tensorflowlite_c-${ver}.dll" tensorflowlite_c.dll)
+            ;;
+          *)
+            tar -xzf tflite.archive
+            sudo mv "libtensorflowlite_c.so.${ver}" "${LIBDIR}/"
+            (cd "${LIBDIR}" && sudo ln -sf "libtensorflowlite_c.so.${ver}" libtensorflowlite_c.so)
+            ;;
+        esac
+        rm -f tflite.archive

--- a/.github/workflows/cross-platform-build.yml
+++ b/.github/workflows/cross-platform-build.yml
@@ -61,73 +61,34 @@ jobs:
           cache: true
       - run: go version
 
-      - name: Resolve tool versions from Taskfile
-        run: |
-          # Single source of truth: read TFLITE_VERSION from the Taskfile so this
-          # smoke never validates against a stale version after a Taskfile bump.
-          tflite=$(grep -E '^[[:space:]]*TFLITE_VERSION:' Taskfile.yml | head -1 | tr -d ' ' | cut -d: -f2 | tr -d "'\"")
-          if [ -z "$tflite" ]; then echo "::error::could not read TFLITE_VERSION from Taskfile.yml"; exit 1; fi
-          echo "TFLITE_VERSION=${tflite}" >> "$GITHUB_ENV"
-
       - name: Install cross toolchains
         # Route through the shared composite for the continue-on-error +
         # outcome-checked reinstall fallback, so a corrupt apt cache (tar exit 2)
         # cannot hard-fail this build. execute-install-scripts: 'false' preserves
-        # the prior behavior; the symlink fix step below handles post-install.
+        # the prior behavior; the mingw symlink step and the setup-tflite-cross
+        # step below recreate the symlinks the skipped post-install would manage.
         uses: ./.github/actions/setup-apt-packages
         with:
           packages: build-essential pkg-config gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64
           cache-version: '1.0'
           execute-install-scripts: 'false'
 
-      - name: Fix cross-compiler symlinks
+      - name: Fix mingw cross-compiler symlinks
+        if: matrix.goos == 'windows'
         run: |
           # cache-apt-pkgs-action restores debs but skips post-install triggers,
-          # so create the symlinks that update-alternatives would normally manage
+          # so create the mingw symlinks update-alternatives would normally
+          # manage. The aarch64 cross gcc symlink is handled by the
+          # setup-tflite-cross step below via fix-arm64-cc-symlink.
           sudo ln -sf /usr/bin/x86_64-w64-mingw32-gcc-posix /usr/bin/x86_64-w64-mingw32-gcc
           sudo ln -sf /usr/bin/x86_64-w64-mingw32-g++-posix /usr/bin/x86_64-w64-mingw32-g++
-          # Resolve the installed aarch64 gcc version dynamically so a future
-          # runner-image gcc bump does not break the symlink.
-          aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
-          if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
-          sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
 
-      - name: Provision TensorFlow headers
-        run: |
-          # Sparse-checkout the TFLite C API headers (same as the check-tensorflow
-          # task) for CGO_CFLAGS. Scripted inline to keep this a Go-only compile
-          # smoke: `task <target>` would drag in the frontend-build (npm) chain,
-          # which is platform-independent and adds no cross-platform signal.
-          if [ ! -f .cache/tensorflow/tensorflow/lite/c/c_api.h ]; then
-            git clone --branch "${TFLITE_VERSION}" --filter=blob:none --no-checkout --depth 1 \
-              https://github.com/tensorflow/tensorflow.git .cache/tensorflow
-            git -C .cache/tensorflow sparse-checkout set --no-cone '**/*.h'
-            git -C .cache/tensorflow checkout
-          fi
-
-      - name: Provision TensorFlow Lite library
-        run: |
-          # CGO links -ltensorflowlite_c, so the target lib must exist at link
-          # time. Place it in the cross sysroot lib dir under the symlink name the
-          # linker resolves (mirrors the download-tflite task). ONNX Runtime is
-          # dlopen'd at runtime, not linked, so it is intentionally not provisioned.
-          ver="${TFLITE_VERSION#v}"
-          curl -fsSL -o tflite.archive \
-            "https://github.com/tphakala/tflite_c/releases/download/${TFLITE_VERSION}/tflite_c_${TFLITE_VERSION}_${{ matrix.tflite_asset }}"
-          sudo mkdir -p "${{ matrix.libdir }}"
-          case "${{ matrix.tflite_asset }}" in
-            *.zip)
-              unzip -o tflite.archive
-              sudo mv "tensorflowlite_c-${ver}.dll" "${{ matrix.libdir }}/"
-              (cd "${{ matrix.libdir }}" && sudo ln -sf "tensorflowlite_c-${ver}.dll" tensorflowlite_c.dll)
-              ;;
-            *)
-              tar -xzf tflite.archive
-              sudo mv "libtensorflowlite_c.so.${ver}" "${{ matrix.libdir }}/"
-              (cd "${{ matrix.libdir }}" && sudo ln -sf "libtensorflowlite_c.so.${ver}" libtensorflowlite_c.so)
-              ;;
-          esac
-          rm -f tflite.archive
+      - name: Provision TensorFlow Lite (headers + cross lib)
+        uses: ./.github/actions/setup-tflite-cross
+        with:
+          tflite-asset: ${{ matrix.tflite_asset }}
+          libdir: ${{ matrix.libdir }}
+          fix-arm64-cc-symlink: ${{ matrix.goarch == 'arm64' }}
 
       - name: Build smoke (cross-compile, non-test code)
         run: |
@@ -184,14 +145,6 @@ jobs:
           cache: true
       - run: go version
 
-      - name: Resolve tool versions from Taskfile
-        run: |
-          # Single source of truth: read TFLITE_VERSION from the Taskfile so this
-          # smoke never validates against a stale version after a Taskfile bump.
-          tflite=$(grep -E '^[[:space:]]*TFLITE_VERSION:' Taskfile.yml | head -1 | tr -d ' ' | cut -d: -f2 | tr -d "'\"")
-          if [ -z "$tflite" ]; then echo "::error::could not read TFLITE_VERSION from Taskfile.yml"; exit 1; fi
-          echo "TFLITE_VERSION=${tflite}" >> "$GITHUB_ENV"
-
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
@@ -204,16 +157,6 @@ jobs:
           packages: ${{ matrix.apt_packages }}
           cache-version: '1.0'
           execute-install-scripts: 'false'
-
-      - name: Fix cross-compiler symlink
-        if: matrix.goarch == 'arm64'
-        run: |
-          # cache-apt-pkgs-action restores debs but skips post-install triggers,
-          # so resolve the installed aarch64 gcc version and create the symlink
-          # that update-alternatives would normally manage.
-          aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
-          if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
-          sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
 
       - name: Cache OpenVINO C API headers
         uses: actions/cache@v4
@@ -231,30 +174,12 @@ jobs:
           # a no-op when the cache above already holds the matching build).
           task check-openvino OPENVINO=true
 
-      - name: Provision TensorFlow headers
-        run: |
-          # Sparse-checkout the TFLite C API headers for CGO_CFLAGS (same as the
-          # cross-build job above).
-          if [ ! -f .cache/tensorflow/tensorflow/lite/c/c_api.h ]; then
-            git clone --branch "${TFLITE_VERSION}" --filter=blob:none --no-checkout --depth 1 \
-              https://github.com/tensorflow/tensorflow.git .cache/tensorflow
-            git -C .cache/tensorflow sparse-checkout set --no-cone '**/*.h'
-            git -C .cache/tensorflow checkout
-          fi
-
-      - name: Provision TensorFlow Lite library
-        run: |
-          # CGO links -ltensorflowlite_c, so the target lib must exist at link
-          # time. OpenVINO and ONNX Runtime are both dlopen'd at runtime (not
-          # linked), so they are intentionally not provisioned.
-          ver="${TFLITE_VERSION#v}"
-          curl -fsSL -o tflite.archive \
-            "https://github.com/tphakala/tflite_c/releases/download/${TFLITE_VERSION}/tflite_c_${TFLITE_VERSION}_${{ matrix.tflite_asset }}"
-          sudo mkdir -p "${{ matrix.libdir }}"
-          tar -xzf tflite.archive
-          sudo mv "libtensorflowlite_c.so.${ver}" "${{ matrix.libdir }}/"
-          (cd "${{ matrix.libdir }}" && sudo ln -sf "libtensorflowlite_c.so.${ver}" libtensorflowlite_c.so)
-          rm -f tflite.archive
+      - name: Provision TensorFlow Lite (headers + cross lib)
+        uses: ./.github/actions/setup-tflite-cross
+        with:
+          tflite-asset: ${{ matrix.tflite_asset }}
+          libdir: ${{ matrix.libdir }}
+          fix-arm64-cc-symlink: ${{ matrix.goarch == 'arm64' }}
 
       - name: Build smoke (openvino tag, non-test code)
         run: |


### PR DESCRIPTION
## Summary

The `openvino-build` job in `cross-platform-build.yml` (added in #3630) copied four provisioning steps verbatim from the `cross-build` job in the same file: TFLITE_VERSION resolution, the aarch64 cross-compiler symlink fix, the TensorFlow header sparse-checkout, and the tflite C library download. That mirrored block was the largest duplication in the file and the most likely to drift (a change to the version-read, the download URL pattern, or the header checkout had to be applied in lockstep across both jobs).

This extracts a `setup-tflite-cross` composite action that both jobs call instead of their inline copies.

### What the composite does

`.github/actions/setup-tflite-cross/action.yml`, inputs `tflite-asset` + `libdir` (plus an optional `tflite-version` override and a `fix-arm64-cc-symlink` flag):

- Resolves `TFLITE_VERSION` from the Taskfile (single source of truth), exported to `GITHUB_ENV`.
- Optionally recreates the aarch64 gcc symlink, resolving the installed gcc version dynamically (`find ... | sort -V | tail -1`) so a runner-image gcc bump cannot break it.
- Sparse-checks-out the TF C API headers into `.cache/tensorflow`.
- Downloads the tflite C library into `libdir`, handling both the Windows `.zip` DLL and the Linux `.tar.gz` `.so`.

### Behavior preservation

No functional change. Behavior is preserved across all four matrix entries (cross-build windows/amd64 + linux/arm64, openvino-build amd64 + arm64). The `cross-build` job keeps a windows-only mingw symlink step (mingw is not shared with `openvino-build`). Each previously-unconditional symlink that is now gated was already unused by that entry's build compiler, so gating it off changes nothing observable.

## Test Plan

- [x] `actionlint` clean on the refactored workflow (also validates the local-action input names match the composite).
- [x] Both YAML files parse.
- [ ] CI: this workflow triggers on `.github/actions/**` and on its own path, so the PR run exercises the refactored `cross-build` and `openvino-build` jobs end to end on Ubuntu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new composite GitHub Action to streamline provisioning of TensorFlow Lite C API headers and libraries for cross-compilation in build workflows.

* **Chores**
  * Refactored cross-platform build workflows to reuse the new shared setup step, reducing duplicated logic.
  * Enabled an optional ARM64 toolchain symlink fix as part of the TensorFlow Lite provisioning, improving consistency across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->