### PR TITLE
ci: resolve aarch64 cross-gcc symlink dynamically in nightly/release builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -56,7 +56,11 @@ jobs:
           # so create the symlinks that update-alternatives would normally manage
           sudo ln -sf /usr/bin/x86_64-w64-mingw32-gcc-posix /usr/bin/x86_64-w64-mingw32-gcc
           sudo ln -sf /usr/bin/x86_64-w64-mingw32-g++-posix /usr/bin/x86_64-w64-mingw32-g++
-          sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc-13 /usr/bin/aarch64-linux-gnu-gcc
+          # Resolve the installed aarch64 gcc version dynamically so a future
+          # runner-image gcc bump does not break the symlink.
+          aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
+          if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
+          sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -62,7 +62,11 @@ jobs:
           # so create the symlinks that update-alternatives would normally manage
           sudo ln -sf /usr/bin/x86_64-w64-mingw32-gcc-posix /usr/bin/x86_64-w64-mingw32-gcc
           sudo ln -sf /usr/bin/x86_64-w64-mingw32-g++-posix /usr/bin/x86_64-w64-mingw32-g++
-          sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc-13 /usr/bin/aarch64-linux-gnu-gcc
+          # Resolve the installed aarch64 gcc version dynamically so a future
+          # runner-image gcc bump does not break the symlink.
+          aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
+          if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
+          sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
## Summary

`nightly-build.yml` and `release-build.yml` hardcoded the cross-compiler symlink to `aarch64-linux-gnu-gcc-13`:

```
sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc-13 /usr/bin/aarch64-linux-gnu-gcc
```

That silently breaks the moment the runner image bumps the aarch64 gcc past 13 (the `gcc-aarch64-linux-gnu` metapackage floats with the distro; on newer Ubuntu it already pulls `gcc-15`). This replaces the pinned line with the dynamic resolution already used in `cross-platform-build.yml`:

```
aarch64_gcc=$(find /usr/bin -maxdepth 1 -name 'aarch64-linux-gnu-gcc-[0-9]*' | sort -V | tail -1)
if [ -z "$aarch64_gcc" ]; then echo "::error::aarch64-linux-gnu-gcc not found"; exit 1; fi
sudo ln -sf "$aarch64_gcc" /usr/bin/aarch64-linux-gnu-gcc
```

The mingw symlinks above it are unchanged.

## Behavior

No change on the current runner: `gcc-aarch64-linux-gnu` installs `aarch64-linux-gnu-gcc-13`, so `find ... | sort -V | tail -1` resolves to exactly `aarch64-linux-gnu-gcc-13` and the resulting symlink is byte-for-byte identical to the old line. The added guard also fails fast with a clear error instead of silently creating a dangling symlink. The glob (`gcc-[0-9]*`) matches only versioned gcc binaries, not `gcc-ar`/`gcc-nm`/`gcc-ranlib`.

## Test Plan

- [x] This is the verbatim snippet already exercised on every PR by the arm64 `cross-build` job (via the `setup-tflite-cross` composite), so the logic is PR-validated.
- [x] `actionlint` clean at the changed lines.
- [ ] Note: `nightly-build.yml`/`release-build.yml` do not run on PRs, so their own runs are first exercised on the next scheduled nightly / release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system reliability by updating cross-compiler setup in continuous integration workflows to dynamically detect compiler versions instead of relying on hard-coded configurations. This enhances flexibility and maintainability of the build process across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->