### PR TITLE
ci: raise macOS/Windows -race test timeout to 900s for the api/v2 package

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -125,7 +125,11 @@ jobs:
           # noembed,skipfrontend skip model/frontend embedding. -short skips the
           # heavy suites; testcontainer/integration tests need the `integration`
           # build tag (not set) and are excluded. Longer timeout than Linux: the
-          # native runner with -race is slower.
+          # native runner with -race is slower, and api/v2 (the largest package,
+          # ~2000 tests) intermittently exceeded the old 600s per-package ceiling
+          # under runner load (goroutine dump at timeout was idle, i.e. cumulative
+          # race-instrumented work, not a deadlock). 900s adds headroom and stays
+          # under the 20m step cap below.
           #
           # Write the -json stream to a file and take pass/fail from go test's own
           # exit code. We do NOT pipe through gotestfmt: go wraps the macOS cgo
@@ -133,7 +137,7 @@ jobs:
           # -ltensorflowlite_c, so the rpath/library are harmlessly duplicated)
           # into JSON output events whose content crashes gotestfmt's tokenizer.
           # Failed tests are printed below and in the job summary instead.
-          go test -tags noembed,skipfrontend -race -json -v -short -timeout 600s ./... > gotest.log 2>&1
+          go test -tags noembed,skipfrontend -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
           TEST_EXIT_CODE=$?
           grep '"Action":"fail"' gotest.log | jq -r 'select(.Test) | "FAIL  \(.Package)  \(.Test)"' | sort -u || true
 

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -153,8 +153,11 @@ jobs:
           # exit code (no gotestfmt: go can wrap non-JSON build output into JSON
           # events whose content crashes its tokenizer). Failed tests are printed
           # below and in the job summary. Longer timeout than Linux: the native
-          # runner with -race is much slower.
-          go test -tags noembed,skipfrontend -race -json -v -short -timeout 600s ./... > gotest.log 2>&1
+          # runner with -race is much slower, and api/v2 (the largest package,
+          # ~2000 tests) intermittently exceeded the old 600s per-package ceiling
+          # under runner load (cumulative race-instrumented work, not a deadlock).
+          # 900s adds headroom and stays under the 25m step cap below.
+          go test -tags noembed,skipfrontend -race -json -v -short -timeout 900s ./... > gotest.log 2>&1
           TEST_EXIT_CODE=$?
           grep '"Action":"fail"' gotest.log | jq -r 'select(.Test) | "FAIL  \(.Package)  \(.Test)"' | sort -u || true
 


### PR DESCRIPTION
## Summary

The macOS and Windows unit-test jobs run `go test -race` with a 600s per-package timeout. `internal/api/v2` is the largest package (~2000 tests) and intermittently exceeded 600s on these native `-race` runners under load, panicking the whole package with `test timed out after 10m0s`.

I pulled the `test-log-macos` artifact from a failing run and confirmed the root cause:
- The timed-out binary is `internal/api/v2` at `600.196s`.
- 2073 tests completed, the slowest individual test was ~18s; nothing close to a single hang.
- The goroutine dump at the timeout was idle (37 in `select`, a couple in mutex/chan, 1 running), i.e. cumulative race-instrumented work, not a deadlock.

This raises the per-package timeout to 900s on both native `-race` jobs. It stays well under the step caps (`timeout-minutes: 20` macOS, `25` Windows), so a genuine hang still fails with a goroutine dump, just 5 minutes later. Linux keeps its 300s (much faster, never close to the ceiling).

Both macOS and Windows are bumped because they share the same slow-native-`-race` characteristic and the same 600s value; fixing only macOS would leave the identical latent flake on Windows.

## Test Plan

- [x] Root cause confirmed from the failing run's `-json` log (api/v2 = 600.196s, idle goroutine dump).
- [x] `900s` < both step caps (1200s / 1500s), so the Go timeout fires first and preserves the goroutine dump.
- [ ] CI: the macOS + Windows unit-test jobs run on this PR and exercise the new timeout.

Follow-up: the bump is an interim fix; api/v2 will eventually need splitting/sharding so the largest package does not gate the per-package timeout. Tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test workflow configurations to improve testing reliability under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->