### PR TITLE
refactor(frontend): consolidate detection actions and hydrate species exclusion

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
@@ -26,18 +26,17 @@
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
   import AudioSettingsButton from './AudioSettingsButton.svelte';
   import { cn } from '$lib/utils/cn';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { downloadDetectionAudio } from '$lib/utils/audioDownload';
   import { createSpectrogramLoader } from '$lib/utils/spectrogramLoader.svelte';
   import { DEFAULT_PLAYBACK_SPEED } from '$lib/utils/audio';
   import { get } from 'svelte/store';
   import { dashboardSettings } from '$lib/stores/settings';
+  import { t } from '$lib/i18n';
 
   // Configuration constants - use helper to read current default gain at call time
   // (cards are recycled via keyed {#each}, so a one-time const would go stale)
   const getDefaultAudioGain = () => get(dashboardSettings)?.defaultAudioGain ?? 0;
   const DEFAULT_AUDIO_FILTER_FREQ = 20;
-  const DEFAULT_DOWNLOAD_NAME = 'detection';
-  const AUDIO_FILE_EXTENSION = '.wav';
 
   interface Props {
     detection: Detection;
@@ -127,26 +126,6 @@
     onFreezeEnd?.();
   }
 
-  function handleDownload() {
-    // Create a temporary anchor element to trigger download
-    const link = document.createElement('a');
-    link.href = buildAppUrl(`/api/v2/audio/${detection.id}`);
-    // Use species name and date/time for filename
-    // Sanitize commonName to prevent path traversal (remove characters that aren't alphanumeric, space, dot, underscore, or hyphen)
-    const safeCommonName = (detection.commonName || DEFAULT_DOWNLOAD_NAME).replace(
-      /[^a-zA-Z0-9 ._-]/g,
-      '_'
-    );
-    const dateTime =
-      detection.date && detection.time
-        ? `${detection.date}_${detection.time.replace(/:/g, '-')}`
-        : String(detection.id);
-    link.download = `${safeCommonName}_${dateTime}${AUDIO_FILE_EXTENSION}`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
-
   // eslint-disable-next-line no-undef -- browser global
   let observer: IntersectionObserver | undefined;
 
@@ -188,21 +167,27 @@
           <span class="loading loading-spinner loading-md text-[var(--color-base-content)]/50"
           ></span>
           {#if loader.isQueued}
-            <span class="text-xs text-[var(--color-base-content)]/40 mt-1">Waiting...</span>
+            <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
+              >{t('components.audio.waiting')}</span
+            >
           {:else if loader.isGenerating}
-            <span class="text-xs text-[var(--color-base-content)]/40 mt-1">Generating...</span>
+            <span class="text-xs text-[var(--color-base-content)]/40 mt-1"
+              >{t('components.audio.generating')}</span
+            >
           {/if}
         </div>
       {/if}
 
       {#if loader.error}
         <div class="spectrogram-error">
-          <span class="text-sm text-[var(--color-base-content)]/50">Spectrogram unavailable</span>
+          <span class="text-sm text-[var(--color-base-content)]/50"
+            >{t('components.audio.spectrogramUnavailable')}</span
+          >
         </div>
       {:else if loader.spectrogramUrl}
         <img
           src={loader.spectrogramUrl}
-          alt="Spectrogram for {detection.commonName}"
+          alt={t('components.audio.spectrogramForSpecies', { species: detection.commonName })}
           class="spectrogram-image"
           class:opacity-0={loader.state === 'loading'}
           decoding="async"
@@ -269,7 +254,7 @@
       {onToggleSpecies}
       {onToggleLock}
       {onDelete}
-      onDownload={handleDownload}
+      onDownload={() => downloadDetectionAudio(detection)}
       onMenuOpen={handleMenuOpen}
       onMenuClose={handleMenuClose}
     />

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
@@ -32,6 +32,11 @@
   import { loggers } from '$lib/utils/logger';
   import { cn } from '$lib/utils/cn';
   import { useDetectionActions } from '$lib/desktop/features/detections/composables/useDetectionActions.svelte';
+  import {
+    isExcluded as isSpeciesExcluded,
+    setExcluded,
+    hydrateExcludedSpecies,
+  } from '$lib/stores/excludedSpecies.svelte';
 
   const logger = loggers.ui;
 
@@ -67,25 +72,12 @@
   // svelte-ignore state_referenced_locally
   let selectedLimit = $state(limit);
 
-  // Track excluded species by common name (session-local tracking)
-  let excludedSpecies = $state(new Set<string>());
-
-  function isSpeciesExcluded(commonName: string): boolean {
-    return excludedSpecies.has(commonName);
-  }
-
-  // Shared action handlers (review, delete, lock, ignore species)
+  // Shared action handlers (review, delete, lock, ignore species). Exclusion
+  // state is the shared, server-hydrated excludedSpecies store.
   const actions = useDetectionActions({
     onRefresh: () => onRefresh(),
     isSpeciesExcluded,
-    onToggleExclusion: (name, exclude) => {
-      if (exclude) {
-        excludedSpecies.add(name);
-      } else {
-        excludedSpecies.delete(name);
-      }
-      excludedSpecies = new Set(excludedSpecies);
-    },
+    onToggleExclusion: setExcluded,
   });
 
   // Custom dropdown state
@@ -151,6 +143,7 @@
   }
 
   onMount(() => {
+    void hydrateExcludedSpecies();
     document.addEventListener('click', handleDropdownClickOutside);
     return () => {
       document.removeEventListener('click', handleDropdownClickOutside);
@@ -347,6 +340,12 @@
 
   .limit-dropdown-trigger:focus {
     outline: none;
+  }
+
+  /* Keep a visible focus ring for keyboard users (outline is only removed for mouse focus). */
+  .limit-dropdown-trigger:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   .limit-dropdown-value {

--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -8,53 +8,54 @@
   import PlayOverlay from '$lib/desktop/features/dashboard/components/PlayOverlay.svelte';
   import SpeciesInfoBar from '$lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte';
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
-  import ConfirmModal from '$lib/desktop/components/modals/ConfirmModal.svelte';
   import { cn } from '$lib/utils/cn';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { downloadDetectionAudio } from '$lib/utils/audioDownload';
   import { createSpectrogramLoader } from '$lib/utils/spectrogramLoader.svelte';
   import { DEFAULT_PLAYBACK_SPEED } from '$lib/utils/audio';
   import { get } from 'svelte/store';
   import { dashboardSettings } from '$lib/stores/settings';
-  import { fetchWithCSRF } from '$lib/utils/api';
-  import { toastActions } from '$lib/stores/toast';
-  import { setDetectionVerification } from '$lib/utils/reviewDetection';
   import { navigation } from '$lib/stores/navigation.svelte';
-  import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
-
-  const logger = loggers.ui;
 
   const getDefaultAudioGain = () => get(dashboardSettings)?.defaultAudioGain ?? 0;
   const DEFAULT_AUDIO_FILTER_FREQ = 20;
-  const DEFAULT_DOWNLOAD_NAME = 'detection';
-  const AUDIO_FILE_EXTENSION = '.wav';
 
+  // Presentational card: the parent (DetectionsList) owns the action handlers
+  // and the ConfirmModal via the shared useDetectionActions composable, and
+  // passes them in as callbacks plus the server-hydrated isExcluded state.
   interface Props {
     detection: Detection;
+    isExcluded?: boolean;
     onDetailsClick?: (_id: number) => void;
-    onRefresh?: () => void;
+    onReview?: () => void;
+    onMarkCorrect?: () => void;
+    onMarkFalsePositive?: () => void;
+    onToggleSpecies?: () => void;
+    onToggleLock?: () => void;
+    onDelete?: () => void;
   }
 
-  let { detection, onDetailsClick, onRefresh }: Props = $props();
+  let {
+    detection,
+    isExcluded = false,
+    onDetailsClick,
+    onReview,
+    onMarkCorrect,
+    onMarkFalsePositive,
+    onToggleSpecies,
+    onToggleLock,
+    onDelete,
+  }: Props = $props();
 
   const loader = createSpectrogramLoader({ size: 'md', raw: true });
 
   let cardElement = $state<HTMLElement | undefined>(undefined);
   let isVisible = $state(false);
   let isMenuOpen = $state(false);
-  let isExcluded = $state(false);
 
   let audioGainValue = $state(getDefaultAudioGain());
   let audioFilterFreq = $state(DEFAULT_AUDIO_FILTER_FREQ);
   let audioPlaybackSpeed = $state(DEFAULT_PLAYBACK_SPEED);
-
-  let showConfirmModal = $state(false);
-  let confirmModalConfig = $state({
-    title: '',
-    message: '',
-    confirmLabel: t('common.confirm'),
-    onConfirm: async () => {},
-  });
 
   $effect(() => {
     if (isVisible) {
@@ -72,125 +73,12 @@
     isMenuOpen = false;
   }
 
-  function handleReview() {
-    navigation.navigate(`/ui/detections/${detection.id}?tab=review`);
-  }
-
-  async function handleMarkCorrect() {
-    if (await setDetectionVerification(detection.id, 'correct')) {
-      onRefresh?.();
-    }
-  }
-
-  async function handleMarkFalsePositive() {
-    if (await setDetectionVerification(detection.id, 'false_positive')) {
-      onRefresh?.();
-    }
-  }
-
-  function handleToggleSpecies() {
-    const commonName = detection.commonName;
-    const currentlyExcluded = isExcluded;
-    confirmModalConfig = {
-      title: currentlyExcluded
-        ? t('dashboard.recentDetections.modals.showSpecies', { species: commonName })
-        : t('dashboard.recentDetections.modals.ignoreSpecies', { species: commonName }),
-      message: currentlyExcluded
-        ? t('dashboard.recentDetections.modals.showSpeciesConfirm', { species: commonName })
-        : t('dashboard.recentDetections.modals.ignoreSpeciesConfirm', { species: commonName }),
-      confirmLabel: t('common.confirm'),
-      onConfirm: async () => {
-        try {
-          await fetchWithCSRF('/api/v2/detections/ignore', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ common_name: commonName }),
-          });
-          isExcluded = !currentlyExcluded;
-          onRefresh?.();
-        } catch (error) {
-          toastActions.error(t('dashboard.recentDetections.errors.toggleSpeciesFailed'));
-          logger.error('Error toggling species exclusion:', error);
-        }
-      },
-    };
-    showConfirmModal = true;
-  }
-
-  function handleToggleLock() {
-    const detectionId = detection.id;
-    const isLocked = detection.locked;
-    const commonName = detection.commonName;
-    confirmModalConfig = {
-      title: isLocked
-        ? t('dashboard.recentDetections.modals.unlockDetection')
-        : t('dashboard.recentDetections.modals.lockDetection'),
-      message: isLocked
-        ? t('dashboard.recentDetections.modals.unlockDetectionConfirm', { species: commonName })
-        : t('dashboard.recentDetections.modals.lockDetectionConfirm', { species: commonName }),
-      confirmLabel: t('common.confirm'),
-      onConfirm: async () => {
-        try {
-          await fetchWithCSRF(`/api/v2/detections/${detectionId}/lock`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ locked: !isLocked }),
-          });
-          onRefresh?.();
-        } catch (error) {
-          toastActions.error(t('dashboard.recentDetections.errors.toggleLockFailed'));
-          logger.error('Error toggling lock status:', error);
-        }
-      },
-    };
-    showConfirmModal = true;
-  }
-
-  function handleDelete() {
-    const detectionId = detection.id;
-    const commonName = detection.commonName;
-    confirmModalConfig = {
-      title: t('dashboard.recentDetections.modals.deleteDetection', { species: commonName }),
-      message: t('dashboard.recentDetections.modals.deleteDetectionConfirm', {
-        species: commonName,
-      }),
-      confirmLabel: t('common.delete'),
-      onConfirm: async () => {
-        try {
-          await fetchWithCSRF(`/api/v2/detections/${detectionId}`, { method: 'DELETE' });
-          onRefresh?.();
-        } catch (error) {
-          toastActions.error(t('dashboard.recentDetections.errors.deleteFailed'));
-          logger.error('Error deleting detection:', error);
-        }
-      },
-    };
-    showConfirmModal = true;
-  }
-
   function handleViewDetails() {
     if (onDetailsClick) {
       onDetailsClick(detection.id);
     } else {
       navigation.navigate(`/ui/detections/${detection.id}`);
     }
-  }
-
-  function handleDownload() {
-    const link = document.createElement('a');
-    link.href = buildAppUrl(`/api/v2/audio/${detection.id}`);
-    const safeCommonName = (detection.commonName || DEFAULT_DOWNLOAD_NAME).replace(
-      /[^a-zA-Z0-9 ._-]/g,
-      '_'
-    );
-    const dateTime =
-      detection.date && detection.time
-        ? `${detection.date}_${detection.time.replace(/:/g, '-')}`
-        : String(detection.id);
-    link.download = `${safeCommonName}_${dateTime}${AUDIO_FILE_EXTENSION}`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
   }
 
   // eslint-disable-next-line no-undef -- browser global
@@ -250,7 +138,7 @@
       {:else if loader.spectrogramUrl}
         <img
           src={loader.spectrogramUrl}
-          alt={t('components.audio.spectrogramAlt')}
+          alt={t('components.audio.spectrogramForSpecies', { species: detection.commonName })}
           class="spectrogram-image"
           class:opacity-0={loader.state === 'loading'}
           decoding="async"
@@ -302,31 +190,19 @@
     <ActionMenu
       {detection}
       variant="overlay"
-      onMarkCorrect={handleMarkCorrect}
-      onMarkFalsePositive={handleMarkFalsePositive}
-      onReview={handleReview}
+      {onMarkCorrect}
+      {onMarkFalsePositive}
+      {onReview}
       {isExcluded}
-      onToggleSpecies={handleToggleSpecies}
-      onToggleLock={handleToggleLock}
-      onDelete={handleDelete}
-      onDownload={handleDownload}
+      {onToggleSpecies}
+      {onToggleLock}
+      {onDelete}
+      onDownload={() => downloadDetectionAudio(detection)}
       onMenuOpen={handleMenuOpen}
       onMenuClose={handleMenuClose}
     />
   </div>
 </article>
-
-<ConfirmModal
-  isOpen={showConfirmModal}
-  title={confirmModalConfig.title}
-  message={confirmModalConfig.message}
-  confirmLabel={confirmModalConfig.confirmLabel}
-  onClose={() => (showConfirmModal = false)}
-  onConfirm={async () => {
-    await confirmModalConfig.onConfirm();
-    showConfirmModal = false;
-  }}
-/>
 
 <style>
   .detection-card {

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -14,16 +14,16 @@
   - Confidence circle visualization
   - Status badges (verified, false positive, etc.)
   - Weather condition display
-  - Action menu for review/delete operations
+  - Action menu wired to parent-owned handlers (review/lock/ignore/delete)
   - Thumbnail image support
-  - Modal dialogs for review and confirmation
   - Responsive design
 
   Props:
   - detection: Detection - The detection data object
-  - isExcluded?: boolean - Whether this detection is excluded
+  - isExcluded?: boolean - Whether this detection's species is excluded
   - onDetailsClick?: (id: number) => void - Handler for detail view
-  - onRefresh?: () => void - Handler for data refresh
+  - onReview / onMarkCorrect / onMarkFalsePositive / onToggleSpecies / onToggleLock / onDelete -
+    action callbacks supplied by the parent (DetectionsList) via useDetectionActions
 -->
 <script lang="ts">
   import ConfidenceCircle from '$lib/desktop/components/data/ConfidenceCircle.svelte';
@@ -32,14 +32,10 @@
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
   import SourceBadge from '$lib/desktop/features/dashboard/components/SourceBadge.svelte';
   import SpectrogramPlayer from '$lib/desktop/components/media/SpectrogramPlayer.svelte';
-  import ConfirmModal from '$lib/desktop/components/modals/ConfirmModal.svelte';
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import { t } from '$lib/i18n';
   import type { Detection } from '$lib/types/detection.types';
-  import { toastActions } from '$lib/stores/toast';
-  import { fetchWithCSRF } from '$lib/utils/api';
-  import { setDetectionVerification } from '$lib/utils/reviewDetection';
   import { useImageDelayedLoading } from '$lib/utils/delayedLoading.svelte.js';
   import { loggers } from '$lib/utils/logger';
   import { navigation } from '$lib/stores/navigation.svelte';
@@ -48,38 +44,42 @@
 
   const logger = loggers.ui;
 
+  // Presentational row: the parent (DetectionsList) owns the action handlers
+  // and the ConfirmModal via the shared useDetectionActions composable, and
+  // passes them in as callbacks plus the server-hydrated isExcluded state.
   interface Props {
     detection: Detection;
     isExcluded?: boolean;
     onDetailsClick?: (_id: number) => void;
-    onRefresh?: () => void;
     selectionActive?: boolean;
     selected?: boolean;
     onToggleSelect?: (_id: string, _shiftKey: boolean) => void;
+    onReview?: () => void;
+    onMarkCorrect?: () => void;
+    onMarkFalsePositive?: () => void;
+    onToggleSpecies?: () => void;
+    onToggleLock?: () => void;
+    onDelete?: () => void;
   }
 
   let {
     detection,
     isExcluded = false,
     onDetailsClick,
-    onRefresh,
     selectionActive = false,
     selected = false,
     onToggleSelect,
+    onReview,
+    onMarkCorrect,
+    onMarkFalsePositive,
+    onToggleSpecies,
+    onToggleLock,
+    onDelete,
   }: Props = $props();
 
   // Localized common name for display in the visitor's UI locale. Falls back to
   // the server-provided common name, then the scientific name.
   const displayName = $derived(localizeSpeciesName(detection.scientificName, detection.commonName));
-
-  // Modal states
-  let showConfirmModal = $state(false);
-  let confirmModalConfig = $state({
-    title: '',
-    message: '',
-    confirmLabel: 'Confirm',
-    onConfirm: () => {},
-  });
 
   // Thumbnail loading with delayed spinner and URL failure tracking
   const thumbnailLoader = useImageDelayedLoading({
@@ -101,117 +101,6 @@
       // Default navigation to detection detail page
       navigation.navigate(`/ui/detections/${detection.id}`);
     }
-  }
-
-  // Action handlers
-  function handleReview() {
-    navigation.navigate(`/ui/detections/${detection.id}?tab=review`);
-  }
-
-  function handleToggleSpecies() {
-    confirmModalConfig = {
-      title: isExcluded
-        ? t('dashboard.recentDetections.modals.showSpecies', { species: detection.commonName })
-        : t('dashboard.recentDetections.modals.ignoreSpecies', { species: detection.commonName }),
-      message: isExcluded
-        ? t('dashboard.recentDetections.modals.showSpeciesConfirm', {
-            species: detection.commonName,
-          })
-        : t('dashboard.recentDetections.modals.ignoreSpeciesConfirm', {
-            species: detection.commonName,
-          }),
-      confirmLabel: t('common.confirm'),
-      onConfirm: async () => {
-        try {
-          await fetchWithCSRF('/api/v2/detections/ignore', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              common_name: detection.commonName,
-            }),
-          });
-          onRefresh?.();
-        } catch (error) {
-          toastActions.error(t('dashboard.recentDetections.errors.toggleSpeciesFailed'));
-          logger.error('Error toggling species exclusion:', error);
-        }
-      },
-    };
-    showConfirmModal = true;
-  }
-
-  function handleToggleLock() {
-    confirmModalConfig = {
-      title: detection.locked
-        ? t('dashboard.recentDetections.modals.unlockDetection')
-        : t('dashboard.recentDetections.modals.lockDetection'),
-      message: detection.locked
-        ? t('dashboard.recentDetections.modals.unlockDetectionConfirm', {
-            species: detection.commonName,
-          })
-        : t('dashboard.recentDetections.modals.lockDetectionConfirm', {
-            species: detection.commonName,
-          }),
-      confirmLabel: t('common.confirm'),
-      onConfirm: async () => {
-        try {
-          await fetchWithCSRF(`/api/v2/detections/${detection.id}/lock`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              locked: !detection.locked,
-            }),
-          });
-          onRefresh?.();
-        } catch (error) {
-          toastActions.error(t('dashboard.recentDetections.errors.toggleLockFailed'));
-          logger.error('Error toggling lock status:', error);
-        }
-      },
-    };
-    showConfirmModal = true;
-  }
-
-  async function handleMarkCorrect() {
-    if (await setDetectionVerification(detection.id, 'correct')) {
-      detection.verified = 'correct';
-      onRefresh?.();
-    }
-  }
-
-  async function handleMarkFalsePositive() {
-    if (await setDetectionVerification(detection.id, 'false_positive')) {
-      detection.verified = 'false_positive';
-      onRefresh?.();
-    }
-  }
-
-  function handleDelete() {
-    confirmModalConfig = {
-      title: t('dashboard.recentDetections.modals.deleteDetection', {
-        species: detection.commonName,
-      }),
-      message: t('dashboard.recentDetections.modals.deleteDetectionConfirm', {
-        species: detection.commonName,
-      }),
-      confirmLabel: t('common.delete'),
-      onConfirm: async () => {
-        try {
-          await fetchWithCSRF(`/api/v2/detections/${detection.id}`, {
-            method: 'DELETE',
-          });
-          onRefresh?.();
-        } catch (error) {
-          toastActions.error(t('dashboard.recentDetections.errors.deleteFailed'));
-          logger.error('Error deleting detection:', error);
-        }
-      },
-    };
-    showConfirmModal = true;
   }
 
   // Placeholder function for thumbnail URL. buildAppUrl prepends the
@@ -341,7 +230,7 @@
                 d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
               />
             </svg>
-            <span class="sr-only">Image failed to load</span>
+            <span class="sr-only">{t('detections.row.imageFailedToLoad')}</span>
           </div>
         {:else if !thumbnailLoader.hasUrlFailed(getThumbnailUrl(detection.scientificName))}
           <!-- Only render img element if URL hasn't failed before -->
@@ -402,27 +291,14 @@
   <ActionMenu
     {detection}
     {isExcluded}
-    onMarkCorrect={handleMarkCorrect}
-    onMarkFalsePositive={handleMarkFalsePositive}
-    onReview={handleReview}
-    onToggleSpecies={handleToggleSpecies}
-    onToggleLock={handleToggleLock}
-    onDelete={handleDelete}
+    {onMarkCorrect}
+    {onMarkFalsePositive}
+    {onReview}
+    {onToggleSpecies}
+    {onToggleLock}
+    {onDelete}
   />
 </td>
-
-<!-- Modals -->
-<ConfirmModal
-  isOpen={showConfirmModal}
-  title={confirmModalConfig.title}
-  message={confirmModalConfig.message}
-  confirmLabel={confirmModalConfig.confirmLabel}
-  onClose={() => (showConfirmModal = false)}
-  onConfirm={async () => {
-    await confirmModalConfig.onConfirm();
-    showConfirmModal = false;
-  }}
-/>
 
 <style>
   /* Thumbnail wrapper - responsive width */

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
@@ -83,4 +83,27 @@ describe('DetectionRow action callbacks', () => {
 
     expect(onToggleSpecies).toHaveBeenCalledTimes(1);
   });
+
+  it('invokes onMarkCorrect when the mark-correct menu item is clicked', async () => {
+    const onMarkCorrect = vi.fn();
+    render(DetectionRow, {
+      props: { detection: createMockDetection({ id: 400 }), onMarkCorrect },
+    });
+
+    // Anchored so "Correct" does not also match "Incorrect".
+    await openMenuAndClick(/^Correct$/);
+
+    expect(onMarkCorrect).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onMarkFalsePositive when the mark-false-positive menu item is clicked', async () => {
+    const onMarkFalsePositive = vi.fn();
+    render(DetectionRow, {
+      props: { detection: createMockDetection({ id: 500 }), onMarkFalsePositive },
+    });
+
+    await openMenuAndClick(/^Incorrect$/);
+
+    expect(onMarkFalsePositive).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
 import DetectionRow from './DetectionRow.svelte';
 import type { Detection } from '$lib/types/detection.types';
-import { navigation } from '$lib/stores/navigation.svelte';
-import { fetchWithCSRF } from '$lib/utils/api';
-import { toastActions } from '$lib/stores/toast';
 
-// Mock the navigation store
+// DetectionRow is presentational: opening the action menu and clicking an item
+// must invoke the callback the parent passed (the parent owns the actual
+// API/modal logic via useDetectionActions). These tests assert that wiring.
+
 vi.mock('$lib/stores/navigation.svelte', () => ({
   navigation: {
     currentPath: '/ui/detections',
@@ -15,12 +15,6 @@ vi.mock('$lib/stores/navigation.svelte', () => ({
   },
 }));
 
-// Mock fetchWithCSRF
-vi.mock('$lib/utils/api', () => ({
-  fetchWithCSRF: vi.fn(),
-}));
-
-// Create a mock detection for testing
 function createMockDetection(overrides: Partial<Detection> = {}): Detection {
   return {
     id: 123,
@@ -38,146 +32,55 @@ function createMockDetection(overrides: Partial<Detection> = {}): Detection {
   } as Detection;
 }
 
-describe('DetectionRow navigation tests', () => {
+async function openMenuAndClick(itemName: RegExp) {
+  const menuButton = screen.getByRole('button', { name: /actions menu/i });
+  await fireEvent.click(menuButton);
+  const item = screen.getByRole('menuitem', { name: itemName });
+  await fireEvent.click(item);
+}
+
+describe('DetectionRow action callbacks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
+  it('invokes onReview when the review menu item is clicked', async () => {
+    const onReview = vi.fn();
+    render(DetectionRow, { props: { detection: createMockDetection({ id: 456 }), onReview } });
+
+    await openMenuAndClick(/review detection/i);
+
+    expect(onReview).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates to review tab when review action is clicked', async () => {
-    const detection = createMockDetection({ id: 456 });
+  it('invokes onDelete when the delete menu item is clicked', async () => {
+    const onDelete = vi.fn();
+    render(DetectionRow, { props: { detection: createMockDetection({ id: 100 }), onDelete } });
 
+    await openMenuAndClick(/delete detection/i);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onToggleLock when the lock menu item is clicked', async () => {
+    const onToggleLock = vi.fn();
     render(DetectionRow, {
-      props: {
-        detection,
-      },
+      props: { detection: createMockDetection({ id: 200, locked: false }), onToggleLock },
     });
 
-    // Open the action menu
-    const menuButton = screen.getByRole('button', { name: /actions menu/i });
-    await fireEvent.click(menuButton);
+    await openMenuAndClick(/lock detection/i);
 
-    // Click review action
-    const reviewButton = screen.getByRole('menuitem', { name: /review detection/i });
-    await fireEvent.click(reviewButton);
-
-    // Verify navigation was called with correct URL including query parameter
-    expect(navigation.navigate).toHaveBeenCalledWith('/ui/detections/456?tab=review');
+    expect(onToggleLock).toHaveBeenCalledTimes(1);
   });
 
-  it('provides handleReview callback that navigates with query params', async () => {
-    // This test verifies the pattern: navigation.navigate is called with ?tab=review
-    // which requires the navigation store to properly separate pathname from query
-    const detection = createMockDetection({ id: 999 });
-
+  it('invokes onToggleSpecies when the ignore-species menu item is clicked', async () => {
+    const onToggleSpecies = vi.fn();
     render(DetectionRow, {
-      props: {
-        detection,
-      },
+      props: { detection: createMockDetection({ id: 300 }), onToggleSpecies },
     });
 
-    const menuButton = screen.getByRole('button', { name: /actions menu/i });
-    await fireEvent.click(menuButton);
+    await openMenuAndClick(/ignore species/i);
 
-    const reviewButton = screen.getByRole('menuitem', { name: /review detection/i });
-    await fireEvent.click(reviewButton);
-
-    // The fix ensures query params don't break routing in App.svelte
-    expect(navigation.navigate).toHaveBeenCalledWith('/ui/detections/999?tab=review');
-  });
-
-  it('uses correct detection ID in review navigation', async () => {
-    const detection = createMockDetection({ id: 257651 });
-
-    render(DetectionRow, {
-      props: {
-        detection,
-      },
-    });
-
-    const menuButton = screen.getByRole('button', { name: /actions menu/i });
-    await fireEvent.click(menuButton);
-
-    const reviewButton = screen.getByRole('menuitem', { name: /review detection/i });
-    await fireEvent.click(reviewButton);
-
-    // Verify the exact URL format matches what App.svelte handleRouting expects
-    expect(navigation.navigate).toHaveBeenCalledWith('/ui/detections/257651?tab=review');
-  });
-});
-
-describe('DetectionRow error notification tests', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('shows error toast when delete action fails', async () => {
-    vi.mocked(fetchWithCSRF).mockRejectedValueOnce(new Error('Network error'));
-    const detection = createMockDetection({ id: 100 });
-
-    render(DetectionRow, { props: { detection } });
-
-    // Open action menu and click delete
-    const menuButton = screen.getByRole('button', { name: /actions menu/i });
-    await fireEvent.click(menuButton);
-    const deleteButton = screen.getByRole('menuitem', { name: /delete detection/i });
-    await fireEvent.click(deleteButton);
-
-    // Confirm the modal
-    const confirmButton = await screen.findByRole('button', { name: /delete/i });
-    await fireEvent.click(confirmButton);
-
-    await waitFor(() => {
-      expect(toastActions.error).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('shows error toast when toggle lock fails', async () => {
-    vi.mocked(fetchWithCSRF).mockRejectedValueOnce(new Error('Server error'));
-    const detection = createMockDetection({ id: 200, locked: false });
-
-    render(DetectionRow, { props: { detection } });
-
-    // Open action menu and click lock
-    const menuButton = screen.getByRole('button', { name: /actions menu/i });
-    await fireEvent.click(menuButton);
-    const lockButton = screen.getByRole('menuitem', { name: /lock detection/i });
-    await fireEvent.click(lockButton);
-
-    // Confirm the modal
-    const confirmButton = await screen.findByRole('button', { name: /confirm/i });
-    await fireEvent.click(confirmButton);
-
-    await waitFor(() => {
-      expect(toastActions.error).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('shows error toast when toggle species exclusion fails', async () => {
-    vi.mocked(fetchWithCSRF).mockRejectedValueOnce(new Error('Server error'));
-    const detection = createMockDetection({ id: 300 });
-
-    render(DetectionRow, { props: { detection } });
-
-    // Open action menu and click ignore species
-    const menuButton = screen.getByRole('button', { name: /actions menu/i });
-    await fireEvent.click(menuButton);
-    const ignoreButton = screen.getByRole('menuitem', { name: /ignore species/i });
-    await fireEvent.click(ignoreButton);
-
-    // Confirm the modal
-    const confirmButton = await screen.findByRole('button', { name: /confirm/i });
-    await fireEvent.click(confirmButton);
-
-    await waitFor(() => {
-      expect(toastActions.error).toHaveBeenCalledTimes(1);
-    });
+    expect(onToggleSpecies).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsCardView.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsCardView.svelte
@@ -12,7 +12,7 @@
   import DetectionCard from '$lib/desktop/features/dashboard/components/DetectionCard.svelte';
   import ConfirmModal from '$lib/desktop/components/modals/ConfirmModal.svelte';
   import type { Detection } from '$lib/types/detection.types';
-  import { SvelteSet } from 'svelte/reactivity';
+  import { isExcluded as isSpeciesExcluded, setExcluded } from '$lib/stores/excludedSpecies.svelte';
   import { useDetectionActions } from '../composables/useDetectionActions.svelte';
 
   interface Props {
@@ -22,19 +22,12 @@
 
   let { detections, onRefresh }: Props = $props();
 
-  // Track excluded species locally (session state)
-  let excludedSpecies = new SvelteSet<string>();
-
+  // Exclusion state is the shared, server-hydrated excludedSpecies store
+  // (hydrated by the parent DetectionsList).
   const actions = useDetectionActions({
     onRefresh: () => onRefresh?.(),
-    isSpeciesExcluded: name => excludedSpecies.has(name),
-    onToggleExclusion: (name, exclude) => {
-      if (exclude) {
-        excludedSpecies.add(name);
-      } else {
-        excludedSpecies.delete(name);
-      }
-    },
+    isSpeciesExcluded,
+    onToggleExclusion: setExcluded,
   });
 </script>
 
@@ -42,7 +35,7 @@
   {#each detections as detection (detection.id)}
     <DetectionCard
       {detection}
-      isExcluded={excludedSpecies.has(detection.commonName)}
+      isExcluded={isSpeciesExcluded(detection.commonName)}
       onMarkCorrect={() => actions.handleMarkCorrect(detection)}
       onMarkFalsePositive={() => actions.handleMarkFalsePositive(detection)}
       onReview={() => actions.handleReview(detection)}

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
@@ -56,8 +56,14 @@
     Trash2,
     XCircle,
   } from '@lucide/svelte';
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { useSelectionMode } from '../composables/useSelectionMode.svelte';
+  import { useDetectionActions } from '../composables/useDetectionActions.svelte';
+  import {
+    isExcluded as isSpeciesExcluded,
+    setExcluded,
+    hydrateExcludedSpecies,
+  } from '$lib/stores/excludedSpecies.svelte';
   import DetectionCardMobile from './DetectionCardMobile.svelte';
   import DetectionRow from './DetectionRow.svelte';
   import DetectionsCardView from './DetectionsCardView.svelte';
@@ -233,6 +239,19 @@
   // Selection mode
   let canEdit = $derived(!$auth.security.enabled || $auth.security.accessAllowed);
   const selection = useSelectionMode(() => data?.totalResults ?? 0);
+
+  // Per-detection action handlers (review/correct/false-positive/ignore/lock/
+  // delete) shared by the table rows and mobile cards, backed by the
+  // server-hydrated excludedSpecies store. Distinct from the bulk-action modal.
+  const detectionActions = useDetectionActions({
+    onRefresh: () => onRefresh?.(),
+    isSpeciesExcluded,
+    onToggleExclusion: setExcluded,
+  });
+
+  onMount(() => {
+    void hydrateExcludedSpecies();
+  });
 
   const pageIds = $derived((data?.notes ?? []).map(d => String(d.id)));
 
@@ -618,10 +637,16 @@
                   <DetectionRow
                     {detection}
                     {onDetailsClick}
-                    {onRefresh}
+                    isExcluded={isSpeciesExcluded(detection.commonName)}
                     selectionActive={selection.selectionActive}
                     selected={selection.isSelected(String(detection.id))}
                     onToggleSelect={handleToggleSelect}
+                    onReview={() => detectionActions.handleReview(detection)}
+                    onMarkCorrect={() => detectionActions.handleMarkCorrect(detection)}
+                    onMarkFalsePositive={() => detectionActions.handleMarkFalsePositive(detection)}
+                    onToggleSpecies={() => detectionActions.handleToggleSpecies(detection)}
+                    onToggleLock={() => detectionActions.handleToggleLock(detection)}
+                    onDelete={() => detectionActions.handleDelete(detection)}
                   />
                 </tr>
               {/each}
@@ -635,7 +660,17 @@
       <!-- Mobile: card layout (always mobile cards on small screens) -->
       <div class="md:hidden space-y-2">
         {#each data.notes as detection (detection.id)}
-          <DetectionCardMobile {detection} {onDetailsClick} {onRefresh} />
+          <DetectionCardMobile
+            {detection}
+            {onDetailsClick}
+            isExcluded={isSpeciesExcluded(detection.commonName)}
+            onReview={() => detectionActions.handleReview(detection)}
+            onMarkCorrect={() => detectionActions.handleMarkCorrect(detection)}
+            onMarkFalsePositive={() => detectionActions.handleMarkFalsePositive(detection)}
+            onToggleSpecies={() => detectionActions.handleToggleSpecies(detection)}
+            onToggleLock={() => detectionActions.handleToggleLock(detection)}
+            onDelete={() => detectionActions.handleDelete(detection)}
+          />
         {/each}
       </div>
     {/if}
@@ -664,6 +699,7 @@
     </div>
   {/if}
 
+  <!-- Bulk-action confirmation (select mode) -->
   <ConfirmModal
     isOpen={showBulkConfirmModal}
     title={bulkConfirmConfig.title}
@@ -675,4 +711,16 @@
       showBulkConfirmModal = false;
     }}
   />
+
+  <!-- Per-detection confirmation (review/ignore/lock/delete from a row or card) -->
+  {#if detectionActions.selectedDetection}
+    <ConfirmModal
+      isOpen={detectionActions.showConfirmModal}
+      title={detectionActions.confirmModalConfig.title}
+      message={detectionActions.confirmModalConfig.message}
+      confirmLabel={detectionActions.confirmModalConfig.confirmLabel}
+      onClose={detectionActions.closeModal}
+      onConfirm={detectionActions.confirmModal}
+    />
+  {/if}
 </div>

--- a/frontend/src/lib/desktop/features/detections/composables/useDetectionActions.svelte.ts
+++ b/frontend/src/lib/desktop/features/detections/composables/useDetectionActions.svelte.ts
@@ -2,8 +2,10 @@
  * useDetectionActions.svelte.ts
  *
  * Shared composable for detection card action handlers (review, delete, lock, ignore species).
- * Used by both DetectionCardGrid (dashboard) and DetectionsCardView (detections listing)
- * to eliminate duplicated modal + API logic.
+ * Used by DetectionCardGrid (dashboard), DetectionsCardView (detections card view), and
+ * DetectionsList (table rows + mobile cards) to eliminate duplicated modal + API logic.
+ * Exclusion state is delegated to the shared excludedSpecies store via the
+ * isSpeciesExcluded / onToggleExclusion options.
  *
  * Usage:
  *   const actions = useDetectionActions({ onRefresh, isSpeciesExcluded, onToggleExclusion });
@@ -29,6 +31,13 @@ interface DetectionActionOptions {
   onToggleExclusion: (_commonName: string, _exclude: boolean) => void;
 }
 
+/** Response shape of POST /api/v2/detections/ignore (IgnoreSpeciesResponse). */
+interface IgnoreSpeciesResponse {
+  common_name: string;
+  action: string;
+  is_excluded: boolean;
+}
+
 export function useDetectionActions(options: DetectionActionOptions) {
   let showConfirmModal = $state(false);
   let selectedDetection = $state<Detection | null>(null);
@@ -44,27 +53,35 @@ export function useDetectionActions(options: DetectionActionOptions) {
   }
 
   function handleToggleSpecies(detection: Detection) {
-    const isExcluded = options.isSpeciesExcluded(detection.commonName);
+    // Snapshot at modal-open so the awaited confirm uses a stable value even if
+    // the detection prop is swapped by a background refresh.
+    const commonName = detection.commonName;
+    const wasExcluded = options.isSpeciesExcluded(commonName);
     confirmModalConfig = {
-      title: isExcluded
-        ? t('dashboard.recentDetections.modals.showSpecies', { species: detection.commonName })
-        : t('dashboard.recentDetections.modals.ignoreSpecies', { species: detection.commonName }),
-      message: isExcluded
-        ? t('dashboard.recentDetections.modals.showSpeciesConfirm', {
-            species: detection.commonName,
-          })
-        : t('dashboard.recentDetections.modals.ignoreSpeciesConfirm', {
-            species: detection.commonName,
-          }),
+      title: wasExcluded
+        ? t('dashboard.recentDetections.modals.showSpecies', { species: commonName })
+        : t('dashboard.recentDetections.modals.ignoreSpecies', { species: commonName }),
+      message: wasExcluded
+        ? t('dashboard.recentDetections.modals.showSpeciesConfirm', { species: commonName })
+        : t('dashboard.recentDetections.modals.ignoreSpeciesConfirm', { species: commonName }),
       confirmLabel: t('common.buttons.confirm'),
       onConfirm: async () => {
         try {
-          await fetchWithCSRF('/api/v2/detections/ignore', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ common_name: detection.commonName }),
-          });
-          options.onToggleExclusion(detection.commonName, !isExcluded);
+          const resp = await fetchWithCSRF<IgnoreSpeciesResponse | null>(
+            '/api/v2/detections/ignore',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ common_name: commonName }),
+            }
+          );
+          // Trust the server's authoritative new state, not an optimistic
+          // negation (the endpoint is a blind toggle that returns the result).
+          // Guard against an empty body so a successful toggle still refreshes
+          // the list rather than surfacing a misleading error toast.
+          if (resp) {
+            options.onToggleExclusion(resp.common_name, resp.is_excluded);
+          }
           options.onRefresh?.();
         } catch (err) {
           toastActions.error(t('dashboard.recentDetections.errors.toggleSpeciesFailed'));
@@ -77,24 +94,23 @@ export function useDetectionActions(options: DetectionActionOptions) {
   }
 
   function handleToggleLock(detection: Detection) {
+    const detectionId = detection.id;
+    const commonName = detection.commonName;
+    const wasLocked = detection.locked;
     confirmModalConfig = {
-      title: detection.locked
+      title: wasLocked
         ? t('dashboard.recentDetections.modals.unlockDetection')
         : t('dashboard.recentDetections.modals.lockDetection'),
-      message: detection.locked
-        ? t('dashboard.recentDetections.modals.unlockDetectionConfirm', {
-            species: detection.commonName,
-          })
-        : t('dashboard.recentDetections.modals.lockDetectionConfirm', {
-            species: detection.commonName,
-          }),
+      message: wasLocked
+        ? t('dashboard.recentDetections.modals.unlockDetectionConfirm', { species: commonName })
+        : t('dashboard.recentDetections.modals.lockDetectionConfirm', { species: commonName }),
       confirmLabel: t('common.buttons.confirm'),
       onConfirm: async () => {
         try {
-          await fetchWithCSRF(`/api/v2/detections/${detection.id}/lock`, {
+          await fetchWithCSRF(`/api/v2/detections/${detectionId}/lock`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ locked: !detection.locked }),
+            body: JSON.stringify({ locked: !wasLocked }),
           });
           options.onRefresh?.();
         } catch (err) {
@@ -108,17 +124,17 @@ export function useDetectionActions(options: DetectionActionOptions) {
   }
 
   function handleDelete(detection: Detection) {
+    const detectionId = detection.id;
+    const commonName = detection.commonName;
     confirmModalConfig = {
-      title: t('dashboard.recentDetections.modals.deleteDetection', {
-        species: detection.commonName,
-      }),
+      title: t('dashboard.recentDetections.modals.deleteDetection', { species: commonName }),
       message: t('dashboard.recentDetections.modals.deleteDetectionConfirm', {
-        species: detection.commonName,
+        species: commonName,
       }),
       confirmLabel: t('common.buttons.delete'),
       onConfirm: async () => {
         try {
-          await fetchWithCSRF(`/api/v2/detections/${detection.id}`, {
+          await fetchWithCSRF(`/api/v2/detections/${detectionId}`, {
             method: 'DELETE',
           });
           options.onRefresh?.();

--- a/frontend/src/lib/desktop/features/detections/composables/useDetectionActions.test.ts
+++ b/frontend/src/lib/desktop/features/detections/composables/useDetectionActions.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for useDetectionActions.
+ *
+ * Common mocks (logger, i18n, toast) come from src/test/setup.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/api', () => ({
+  fetchWithCSRF: vi.fn(),
+}));
+vi.mock('$lib/utils/reviewDetection', () => ({
+  setDetectionVerification: vi.fn(),
+}));
+vi.mock('$lib/stores/navigation.svelte', () => ({
+  navigation: { navigate: vi.fn() },
+}));
+
+import { useDetectionActions } from './useDetectionActions.svelte';
+import { fetchWithCSRF } from '$lib/utils/api';
+import { toastActions } from '$lib/stores/toast';
+import type { Detection } from '$lib/types/detection.types';
+
+const mockFetch = vi.mocked(fetchWithCSRF);
+
+function detection(overrides: Partial<Detection>): Detection {
+  return { id: 1, commonName: 'House Sparrow', locked: false, ...overrides } as Detection;
+}
+
+describe('useDetectionActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it('writes the server is_excluded (true) into onToggleExclusion', async () => {
+    const onToggleExclusion = vi.fn();
+    const actions = useDetectionActions({
+      onRefresh: vi.fn(),
+      isSpeciesExcluded: () => false,
+      onToggleExclusion,
+    });
+    mockFetch.mockResolvedValue({
+      common_name: 'House Sparrow',
+      action: 'added',
+      is_excluded: true,
+    });
+
+    actions.handleToggleSpecies(detection({}));
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(onToggleExclusion).toHaveBeenCalledWith('House Sparrow', true);
+  });
+
+  it('trusts the server is_excluded=false even when the optimistic guess would differ', async () => {
+    const onToggleExclusion = vi.fn();
+    const actions = useDetectionActions({
+      onRefresh: vi.fn(),
+      // local view says "not excluded" -> optimistic negation would be true,
+      // but the server reports it ended up not excluded.
+      isSpeciesExcluded: () => false,
+      onToggleExclusion,
+    });
+    mockFetch.mockResolvedValue({
+      common_name: 'House Sparrow',
+      action: 'removed',
+      is_excluded: false,
+    });
+
+    actions.handleToggleSpecies(detection({}));
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(onToggleExclusion).toHaveBeenCalledWith('House Sparrow', false);
+  });
+
+  it('still refreshes without updating the set when the toggle returns an empty body', async () => {
+    const onRefresh = vi.fn();
+    const onToggleExclusion = vi.fn();
+    const actions = useDetectionActions({
+      onRefresh,
+      isSpeciesExcluded: () => false,
+      onToggleExclusion,
+    });
+    // 204 / zero-length responses surface as null from fetchWithCSRF.
+    mockFetch.mockResolvedValue(null);
+
+    actions.handleToggleSpecies(detection({}));
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(onToggleExclusion).not.toHaveBeenCalled();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error toast when the ignore toggle fails', async () => {
+    const actions = useDetectionActions({
+      onRefresh: vi.fn(),
+      isSpeciesExcluded: () => false,
+      onToggleExclusion: vi.fn(),
+    });
+    mockFetch.mockRejectedValue(new Error('network down'));
+
+    actions.handleToggleSpecies(detection({}));
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(toastActions.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('locks using the value snapshotted at modal-open, not the live prop', async () => {
+    const actions = useDetectionActions({
+      onRefresh: vi.fn(),
+      isSpeciesExcluded: () => false,
+      onToggleExclusion: vi.fn(),
+    });
+    mockFetch.mockResolvedValue({});
+    const det = detection({ id: 5, locked: false });
+
+    actions.handleToggleLock(det);
+    // Background refresh swaps the underlying object's locked state.
+    det.locked = true;
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v2/detections/5/lock',
+      expect.objectContaining({ body: JSON.stringify({ locked: true }) })
+    );
+  });
+
+  it('deletes the id snapshotted at modal-open', async () => {
+    const onRefresh = vi.fn();
+    const actions = useDetectionActions({
+      onRefresh,
+      isSpeciesExcluded: () => false,
+      onToggleExclusion: vi.fn(),
+    });
+    mockFetch.mockResolvedValue({});
+    const det = detection({ id: 7 });
+
+    actions.handleDelete(det);
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v2/detections/7',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('shows an error toast when a delete request fails', async () => {
+    const onRefresh = vi.fn();
+    const actions = useDetectionActions({
+      onRefresh,
+      isSpeciesExcluded: () => false,
+      onToggleExclusion: vi.fn(),
+    });
+    mockFetch.mockRejectedValue(new Error('network down'));
+
+    actions.handleDelete(detection({ id: 9 }));
+    await actions.confirmModalConfig.onConfirm();
+
+    expect(toastActions.error).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -755,6 +755,7 @@ export type TranslationKey =
   | 'detections.row.viewDetails' // params: species
   | 'detections.row.play'
   | 'detections.row.playAudio'
+  | 'detections.row.imageFailedToLoad'
   | 'detections.media.title'
   | 'detections.media.clipHint'
   | 'detections.tabs.overview'
@@ -3326,6 +3327,7 @@ export type TranslationKey =
   | 'components.audio.spectrogramLoaded'
   | 'components.audio.spectrogramLoadingAria'
   | 'components.audio.spectrogramAlt'
+  | 'components.audio.spectrogramForSpecies' // params: species
   | 'components.audio.spectrogramGeneratingAria'
   | 'components.audio.generating'
   | 'components.audio.waiting'
@@ -4120,6 +4122,7 @@ export type TranslationParams = {
   'media.audio.nowPlaying': { source: string | number };
   'media.audio.streamTitle': { source: string | number };
   'media.audio.playbackError': { details: string | number };
+  'components.audio.spectrogramForSpecies': { species: string | number };
   'components.audio.queuePosition': { position: string | number };
   'components.forms.numberField.adjustedToMinimum': { value: string | number };
   'components.forms.numberField.adjustedToMaximum': { value: string | number };

--- a/frontend/src/lib/stores/excludedSpecies.svelte.ts
+++ b/frontend/src/lib/stores/excludedSpecies.svelte.ts
@@ -1,0 +1,119 @@
+/**
+ * excludedSpecies.svelte.ts
+ *
+ * Single source of truth for the set of species the user has chosen to ignore
+ * ("exclude") via the detection action menus.
+ *
+ * The set is keyed by the SERVER common name (detection.commonName), NOT the
+ * localized display name from localizeSpeciesName(). The backend stores and
+ * returns exactly this string: POST /api/v2/detections/ignore writes
+ * req.common_name into Realtime.Species.Exclude, and
+ * GET /api/v2/detections/ignored returns that same list. Keying on anything
+ * else (scientificName, a localized name) would silently never match.
+ *
+ * A SvelteSet (not a plain Set) is required: it is shared by reference across
+ * every detection card/row/grid, and SvelteSet.has() reads are tracked, so an
+ * in-place add()/delete() re-evaluates every consumer's isExcluded binding.
+ * A plain Set shared by reference would leave reference-equality consumers
+ * (e.g. DetectionCardGrid) stale.
+ *
+ * Usage:
+ *   import { isExcluded, setExcluded, hydrateExcludedSpecies } from '$lib/stores/excludedSpecies.svelte';
+ *   onMount(() => { void hydrateExcludedSpecies(); });
+ *   // read:  isExcluded(detection.commonName)
+ *   // write: setExcluded(resp.common_name, resp.is_excluded)
+ */
+
+import { SvelteSet } from 'svelte/reactivity';
+import { api } from '$lib/utils/api';
+import { getLogger } from '$lib/utils/logger';
+
+const logger = getLogger('excludedSpecies');
+
+/**
+ * Response shape of GET /api/v2/detections/ignored (ExcludedSpeciesResponse).
+ * `species` is nullable because Go marshals an empty/nil exclude slice as null.
+ */
+interface ExcludedSpeciesResponse {
+  species: string[] | null;
+  count: number;
+}
+
+/** Reactive set of excluded common names. Module-level singleton. */
+const excluded = new SvelteSet<string>();
+
+/** True once a hydration has completed successfully (so we fetch at most once). */
+let hydrated = false;
+/** In-flight hydration promise, shared so concurrent callers await one fetch. */
+let inflight: Promise<void> | null = null;
+/** Monotonic id of the latest hydration run, used to detect a superseded run. */
+let runId = 0;
+
+/** Whether the given species (by server common name) is currently excluded. */
+export function isExcluded(commonName: string): boolean {
+  return excluded.has(commonName);
+}
+
+/**
+ * Reflect a toggle result in the shared set. Pass the authoritative state from
+ * the ignore endpoint's response (resp.is_excluded), never an optimistic guess.
+ */
+export function setExcluded(commonName: string, excludedNow: boolean): void {
+  if (excludedNow) {
+    excluded.add(commonName);
+  } else {
+    excluded.delete(commonName);
+  }
+}
+
+/**
+ * Load the exclude list from the backend into the shared set.
+ *
+ * Fetches at most once per session unless `force` is true. Concurrent callers
+ * share a single in-flight request. A failed fetch is logged and swallowed so
+ * the UI keeps working (the set simply stays as it was), and does not mark the
+ * store hydrated, so a later call can retry.
+ *
+ * @param force - Re-fetch even if already hydrated (e.g. after an external change).
+ */
+export async function hydrateExcludedSpecies(force = false): Promise<void> {
+  if (hydrated && !force) return;
+  // Coalesce concurrent non-forced callers onto the single in-flight fetch.
+  if (inflight && !force) return inflight;
+  // A forced refresh waits for any in-flight fetch to settle first, so the two
+  // requests do not overlap (and the old one cannot clobber the new result).
+  if (inflight) await inflight.catch(() => {});
+
+  const myRunId = ++runId;
+  const run = (async () => {
+    try {
+      const resp = await api.get<ExcludedSpeciesResponse>('/api/v2/detections/ignored');
+      const species = Array.isArray(resp.species) ? resp.species : [];
+      excluded.clear();
+      for (const name of species) {
+        if (typeof name === 'string' && name.length > 0) {
+          excluded.add(name);
+        }
+      }
+      hydrated = true;
+    } catch (err) {
+      logger.error('Failed to load excluded species list:', err);
+    } finally {
+      // Only clear if a newer run has not superseded this one.
+      if (runId === myRunId) inflight = null;
+    }
+  })();
+  inflight = run;
+  return run;
+}
+
+/**
+ * Reset all internal state. Exported ONLY for Vitest. Do not call from app code.
+ * @internal
+ */
+export function resetExcludedSpeciesForTest(): void {
+  excluded.clear();
+  hydrated = false;
+  inflight = null;
+  runId = 0;
+}

--- a/frontend/src/lib/stores/excludedSpecies.test.ts
+++ b/frontend/src/lib/stores/excludedSpecies.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the excludedSpecies store.
+ *
+ * Note: common mocks (logger, i18n, toast) are defined in src/test/setup.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/utils/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+    }
+  },
+}));
+
+import {
+  isExcluded,
+  setExcluded,
+  hydrateExcludedSpecies,
+  resetExcludedSpeciesForTest,
+} from './excludedSpecies.svelte';
+import { api } from '$lib/utils/api';
+
+const mockGet = vi.mocked(api.get);
+
+describe('excludedSpecies store', () => {
+  beforeEach(() => {
+    resetExcludedSpeciesForTest();
+    mockGet.mockReset();
+  });
+
+  it('hydrates the set from GET /api/v2/detections/ignored', async () => {
+    mockGet.mockResolvedValue({ species: ['Eurasian Wren', 'House Sparrow'], count: 2 });
+
+    expect(isExcluded('House Sparrow')).toBe(false);
+
+    await hydrateExcludedSpecies();
+
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/detections/ignored');
+    expect(isExcluded('House Sparrow')).toBe(true);
+    expect(isExcluded('Eurasian Wren')).toBe(true);
+    expect(isExcluded('Common Blackbird')).toBe(false);
+  });
+
+  it('setExcluded toggles membership', () => {
+    expect(isExcluded('Great Tit')).toBe(false);
+    setExcluded('Great Tit', true);
+    expect(isExcluded('Great Tit')).toBe(true);
+    setExcluded('Great Tit', false);
+    expect(isExcluded('Great Tit')).toBe(false);
+  });
+
+  it('does not throw and leaves the set empty when hydration fails', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+
+    await expect(hydrateExcludedSpecies()).resolves.toBeUndefined();
+    expect(isExcluded('anything')).toBe(false);
+  });
+
+  it('hydrates at most once unless forced', async () => {
+    mockGet.mockResolvedValue({ species: ['House Sparrow'], count: 1 });
+
+    await Promise.all([hydrateExcludedSpecies(), hydrateExcludedSpecies()]);
+    await hydrateExcludedSpecies();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    await hydrateExcludedSpecies(true);
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('a forced hydrate during an in-flight fetch triggers a fresh fetch (not coalesced)', async () => {
+    let resolveFirst!: (v: { species: string[]; count: number }) => void;
+    mockGet.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveFirst = resolve;
+      })
+    );
+    mockGet.mockResolvedValueOnce({ species: ['Great Tit'], count: 1 });
+
+    const p1 = hydrateExcludedSpecies(); // fetch #1, left pending
+    const p2 = hydrateExcludedSpecies(true); // forced while #1 in flight
+    resolveFirst({ species: ['House Sparrow'], count: 1 });
+    await Promise.all([p1, p2]);
+
+    // The forced call must not have coalesced onto the in-flight non-forced fetch.
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    // Final state reflects the forced (second) fetch, which replaced the set.
+    expect(isExcluded('Great Tit')).toBe(true);
+    expect(isExcluded('House Sparrow')).toBe(false);
+  });
+
+  it('replaces (not merges) the set contents on re-hydrate', async () => {
+    mockGet.mockResolvedValueOnce({ species: ['House Sparrow'], count: 1 });
+    await hydrateExcludedSpecies();
+    expect(isExcluded('House Sparrow')).toBe(true);
+
+    mockGet.mockResolvedValueOnce({ species: ['Great Tit'], count: 1 });
+    await hydrateExcludedSpecies(true);
+    expect(isExcluded('House Sparrow')).toBe(false);
+    expect(isExcluded('Great Tit')).toBe(true);
+  });
+
+  it('tolerates a malformed response without throwing', async () => {
+    // species missing entirely
+    mockGet.mockResolvedValue({ count: 0 } as unknown as { species: string[]; count: number });
+    await expect(hydrateExcludedSpecies()).resolves.toBeUndefined();
+    expect(isExcluded('anything')).toBe(false);
+  });
+});

--- a/frontend/src/lib/utils/audioDownload.test.ts
+++ b/frontend/src/lib/utils/audioDownload.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildDetectionAudioFilename } from './audioDownload';
+import type { Detection } from '$lib/types/detection.types';
+
+function makeDetection(overrides: Partial<Detection>): Detection {
+  return {
+    id: 42,
+    commonName: 'House Sparrow',
+    scientificName: 'Passer domesticus',
+    date: '2026-06-22',
+    time: '14:30:05',
+    confidence: 0.9,
+    ...overrides,
+  } as Detection;
+}
+
+describe('buildDetectionAudioFilename', () => {
+  it('builds <commonName>_<date>_<time>.wav with colons replaced', () => {
+    expect(buildDetectionAudioFilename(makeDetection({}))).toBe(
+      'House Sparrow_2026-06-22_14-30-05.wav'
+    );
+  });
+
+  it('sanitizes unsafe characters in the common name', () => {
+    expect(
+      buildDetectionAudioFilename(makeDetection({ commonName: 'Anna/..\\Hummingbird?' }))
+    ).toBe('Anna_.._Hummingbird__2026-06-22_14-30-05.wav');
+  });
+
+  it('falls back to the id when date or time is missing', () => {
+    expect(buildDetectionAudioFilename(makeDetection({ date: '', time: '' }))).toBe(
+      'House Sparrow_42.wav'
+    );
+  });
+
+  it('falls back to the default name when commonName is empty', () => {
+    expect(buildDetectionAudioFilename(makeDetection({ commonName: '' }))).toBe(
+      'detection_2026-06-22_14-30-05.wav'
+    );
+  });
+});

--- a/frontend/src/lib/utils/audioDownload.ts
+++ b/frontend/src/lib/utils/audioDownload.ts
@@ -1,0 +1,50 @@
+/**
+ * audioDownload.ts
+ *
+ * Shared helper for downloading a detection's audio clip. Used by the dashboard
+ * DetectionCard and the mobile DetectionCardMobile so the filename logic lives
+ * in one place.
+ *
+ * The actual bytes are served by GET /api/v2/audio/{id}; the `download`
+ * attribute only hints the saved filename, so the sanitization here is for a
+ * sensible filename, not server-side path safety.
+ */
+
+import type { Detection } from '$lib/types/detection.types';
+import { buildAppUrl } from '$lib/utils/urlHelpers';
+
+/** Fallback base name when a detection has no common name. */
+const DEFAULT_DOWNLOAD_NAME = 'detection';
+/** Extension for downloaded clips. */
+const AUDIO_FILE_EXTENSION = '.wav';
+
+/**
+ * Build a safe download filename for a detection's audio clip:
+ * `<common name>_<date>_<time>.wav`, falling back to the id when date/time are
+ * absent. Strips characters that are not alphanumeric, space, dot, underscore,
+ * or hyphen.
+ */
+export function buildDetectionAudioFilename(detection: Detection): string {
+  const safeCommonName = (detection.commonName || DEFAULT_DOWNLOAD_NAME).replace(
+    /[^a-zA-Z0-9 ._-]/g,
+    '_'
+  );
+  const dateTime =
+    detection.date && detection.time
+      ? `${detection.date}_${detection.time.replace(/:/g, '-')}`
+      : String(detection.id);
+  return `${safeCommonName}_${dateTime}${AUDIO_FILE_EXTENSION}`;
+}
+
+/**
+ * Trigger a browser download of the detection's audio clip via a temporary
+ * anchor element.
+ */
+export function downloadDetectionAudio(detection: Detection): void {
+  const link = document.createElement('a');
+  link.href = buildAppUrl(`/api/v2/audio/${detection.id}`);
+  link.download = buildDetectionAudioFilename(detection);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Zobrazit podrobnosti pro {species}",
       "play": "Přehrát",
-      "playAudio": "Přehrát zvuk"
+      "playAudio": "Přehrát zvuk",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram načten",
       "spectrogramLoadingAria": "Načítání spektrogramu",
       "spectrogramAlt": "Zvukový spektrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Generování spektrogramu",
       "generating": "Generování…",
       "waiting": "Waiting...",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Vis detaljer for {species}",
       "play": "Afspil",
-      "playAudio": "Afspil lyd"
+      "playAudio": "Afspil lyd",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Optagelse og spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram indlæst",
       "spectrogramLoadingAria": "Indlæser spektrogram",
       "spectrogramAlt": "Lydspektrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Genererer spektrogram",
       "generating": "Genererer...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Details für {species} anzeigen",
       "play": "Abspielen",
-      "playAudio": "Audio abspielen"
+      "playAudio": "Audio abspielen",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Aufnahme & Spektrogramm",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogramm geladen",
       "spectrogramLoadingAria": "Spektrogramm wird geladen",
       "spectrogramAlt": "Audio-Spektrogramm",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Spektrogramm wird generiert",
       "generating": "Wird generiert...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "View details for {species}",
       "play": "Play",
-      "playAudio": "Play audio"
+      "playAudio": "Play audio",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Recording & Spectrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spectrogram loaded",
       "spectrogramLoadingAria": "Loading spectrogram",
       "spectrogramAlt": "Audio spectrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Generating spectrogram",
       "generating": "Generating...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Ver detalles para {species}",
       "play": "Reproducir",
-      "playAudio": "Reproducir audio"
+      "playAudio": "Reproducir audio",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Grabación y espectrograma",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Espectrograma cargado",
       "spectrogramLoadingAria": "Cargando espectrograma",
       "spectrogramAlt": "Espectrograma de audio",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Generando espectrograma",
       "generating": "Generando...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Näytä {species} tiedot",
       "play": "Toista",
-      "playAudio": "Toista ääni"
+      "playAudio": "Toista ääni",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Tallenne ja spektrogrammi",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogrammi ladattu",
       "spectrogramLoadingAria": "Ladataan spektrogrammia",
       "spectrogramAlt": "Äänispektrogrammi",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Luodaan spektrogrammia",
       "generating": "Luodaan...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Voir les détails pour {species}",
       "play": "Lire",
-      "playAudio": "Lire l'audio"
+      "playAudio": "Lire l'audio",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Enregistrement et spectrogramme",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spectrogramme chargé",
       "spectrogramLoadingAria": "Chargement du spectrogramme",
       "spectrogramAlt": "Spectrogramme audio",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Génération du spectrogramme",
       "generating": "Génération...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "{species} részleteinek megtekintése",
       "play": "Lejátszás",
-      "playAudio": "Hang lejátszása"
+      "playAudio": "Hang lejátszása",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Felvétel és spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram betöltve",
       "spectrogramLoadingAria": "Spektrogram betöltése",
       "spectrogramAlt": "Hang spektrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Spektrogram generálása",
       "generating": "Generálás...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Vedi dettagli per {species}",
       "play": "Riproduci",
-      "playAudio": "Riproduci audio"
+      "playAudio": "Riproduci audio",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Registrazione e Spettrogramma",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spettrogramma caricato",
       "spectrogramLoadingAria": "Caricamento spettrogramma",
       "spectrogramAlt": "Spettrogramma audio",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Generazione spettrogramma",
       "generating": "Generazione...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Skatīt informāciju par sugu {species}",
       "play": "Atskaņot",
-      "playAudio": "Atskaņot audio"
+      "playAudio": "Atskaņot audio",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Ieraksts un spektrogramma",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogramma ielādēta",
       "spectrogramLoadingAria": "Ielādē spektrogrammu",
       "spectrogramAlt": "Audio spektrogramma",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Ģenerē spektrogrammu",
       "generating": "Ģenerē...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Vis detaljer for {species}",
       "play": "Spill av",
-      "playAudio": "Spill av lyd"
+      "playAudio": "Spill av lyd",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Opptak og spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram lastet",
       "spectrogramLoadingAria": "Laster spektrogram",
       "spectrogramAlt": "Lydspektrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Genererer spektrogram",
       "generating": "Genererer...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Bekijk details voor {species}",
       "play": "Afspelen",
-      "playAudio": "Geluid afspelen"
+      "playAudio": "Geluid afspelen",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Geluid opname & Spectrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spectrogram geladen",
       "spectrogramLoadingAria": "Spectrogram laden",
       "spectrogramAlt": "Audiospectogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Spectrogram genereren",
       "generating": "Genereren...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Wyświetl szczegóły dla {species}",
       "play": "Odtwórz",
-      "playAudio": "Odtwórz dźwięk"
+      "playAudio": "Odtwórz dźwięk",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Nagranie i Spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram załadowany",
       "spectrogramLoadingAria": "Ładowanie spektrogramu",
       "spectrogramAlt": "Spektrogram audio",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Generowanie spektrogramu",
       "generating": "Generowanie...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Ver detalhes para {species}",
       "play": "Reproduzir",
-      "playAudio": "Reproduzir áudio"
+      "playAudio": "Reproduzir áudio",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Gravação e espectrograma",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Espectrograma carregado",
       "spectrogramLoadingAria": "Carregando espectrograma",
       "spectrogramAlt": "Espectrograma de áudio",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Gerando espectrograma",
       "generating": "Gerando...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Zobraziť podrobnosti pre {species}",
       "play": "Prehrať",
-      "playAudio": "Prehrať zvuk"
+      "playAudio": "Prehrať zvuk",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram bol načítaný",
       "spectrogramLoadingAria": "Načítava sa spektrogram",
       "spectrogramAlt": "Zvukový spektrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Generuje sa spektrogram",
       "generating": "Generuje sa...",
       "waiting": "Waiting...",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -939,7 +939,8 @@
     "row": {
       "viewDetails": "Visa detaljer för {species}",
       "play": "Spela upp",
-      "playAudio": "Spela upp ljud"
+      "playAudio": "Spela upp ljud",
+      "imageFailedToLoad": "Image failed to load"
     },
     "media": {
       "title": "Inspelning och spektrogram",
@@ -4559,6 +4560,7 @@
       "spectrogramLoaded": "Spektrogram laddat",
       "spectrogramLoadingAria": "Laddar spektrogram",
       "spectrogramAlt": "Ljudspektrogram",
+      "spectrogramForSpecies": "Spectrogram for {species}",
       "spectrogramGeneratingAria": "Genererar spektrogram",
       "generating": "Genererar...",
       "waiting": "Waiting...",


### PR DESCRIPTION
## Summary

Removes the duplicated detection-action logic across the detection-card surface and makes the "ignore species" menu state correct on first load.

- New `src/lib/stores/excludedSpecies.svelte.ts`: a module-singleton `SvelteSet` keyed by common name, hydrated once from `GET /api/v2/detections/ignored`. Single source of truth replacing the empty session-local sets in `DetectionCardGrid` and `DetectionsCardView` (which always started empty, so an already-excluded species wrongly showed "Ignore species"). This also fixes the detections table rows, which never received `isExcluded` and always showed "Ignore species".
- New `src/lib/utils/audioDownload.ts`: shared `downloadDetectionAudio` plus a filename builder, replacing the byte-identical copies in `DetectionCard` and `DetectionCardMobile`.
- `DetectionCardMobile` and `DetectionRow` are now presentational. `DetectionsList` owns one `useDetectionActions` instance plus one per-detection `ConfirmModal` and passes the action callbacks + `isExcluded` down, removing three parallel copies of the same six action handlers.
- `useDetectionActions` trusts the server `is_excluded` from the toggle response instead of an optimistic negation, and snapshots the detection fields at modal-open so a background refresh cannot retarget the confirmed action.
- `DetectionCard` spectrogram strings now route through i18n; the spectrogram alt text is species-specific and localized.

No backend, API, DB, or config changes.

## Test Plan
- [x] `npm run check:all` clean (typecheck, ESLint, stylelint, ast-grep)
- [x] `npm test` green (2384 tests; new specs for the store, download helper, and composable; the DetectionRow spec rewritten for the presentational contract)
- [x] Production build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shared, global “ignore species” behavior so exclusions stay consistent across detection views.
  * Improved detection audio downloads with consistent, sanitized filenames.

* **Accessibility**
  * Improved keyboard focus styling for the species-ignore dropdown.

* **Internationalization**
  * Added localized UI messaging for failed detection image loads.
  * Added species-specific spectrogram labeling via translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->