### PR TITLE
test(analytics): pass reactive state to filter form tests

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/forms/FilterForm.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/forms/FilterForm.test.ts
@@ -9,14 +9,17 @@ vi.mock('$lib/i18n', () => ({
   t: createI18nMock(analyticsI18nTranslations),
 }));
 
-// Wrapped in reactiveState so the bound `filters.*` props are reactive proxies,
-// matching how the app passes a $state object via bind:filters (see
+// Plain fixture values. defaultFilters and the variants below wrap a fresh copy
+// in reactiveState so the bound `filters.*` props are reactive proxies, matching
+// how the app passes a $state object via bind:filters (see
 // reactive-state.svelte.ts).
-const defaultFilters = reactiveState({
+const defaultFilterValues = {
   timePeriod: 'all' as const,
   startDate: '',
   endDate: '',
-});
+};
+
+const defaultFilters = reactiveState({ ...defaultFilterValues });
 
 describe('FilterForm', () => {
   it('renders with basic props', () => {
@@ -49,7 +52,7 @@ describe('FilterForm', () => {
 
   it('shows custom date fields when custom time period is selected', () => {
     const customFilters = reactiveState({
-      ...defaultFilters,
+      ...defaultFilterValues,
       timePeriod: 'custom' as const,
     });
 
@@ -164,7 +167,7 @@ describe('FilterForm', () => {
   });
 
   it('handles time period change correctly', async () => {
-    const filters = reactiveState({ ...defaultFilters });
+    const filters = reactiveState({ ...defaultFilterValues });
 
     render(FilterForm, {
       props: {

--- a/frontend/src/lib/desktop/features/analytics/components/forms/FilterForm.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/forms/FilterForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { createI18nMock, analyticsI18nTranslations } from '../../../../../../test/render-helpers';
+import { reactiveState } from '../../../../../../test/reactive-state.svelte';
 import FilterForm from './FilterForm.svelte';
 
 // Mock i18n translations using shared translation constants
@@ -8,11 +9,14 @@ vi.mock('$lib/i18n', () => ({
   t: createI18nMock(analyticsI18nTranslations),
 }));
 
-const defaultFilters = {
+// Wrapped in reactiveState so the bound `filters.*` props are reactive proxies,
+// matching how the app passes a $state object via bind:filters (see
+// reactive-state.svelte.ts).
+const defaultFilters = reactiveState({
   timePeriod: 'all' as const,
   startDate: '',
   endDate: '',
-};
+});
 
 describe('FilterForm', () => {
   it('renders with basic props', () => {
@@ -44,10 +48,10 @@ describe('FilterForm', () => {
   });
 
   it('shows custom date fields when custom time period is selected', () => {
-    const customFilters = {
+    const customFilters = reactiveState({
       ...defaultFilters,
       timePeriod: 'custom' as const,
-    };
+    });
 
     render(FilterForm, {
       props: {
@@ -160,7 +164,7 @@ describe('FilterForm', () => {
   });
 
   it('handles time period change correctly', async () => {
-    const filters = { ...defaultFilters };
+    const filters = reactiveState({ ...defaultFilters });
 
     render(FilterForm, {
       props: {

--- a/frontend/src/lib/desktop/features/analytics/components/forms/FilterForm.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/forms/FilterForm.test.ts
@@ -9,23 +9,23 @@ vi.mock('$lib/i18n', () => ({
   t: createI18nMock(analyticsI18nTranslations),
 }));
 
-// Plain fixture values. defaultFilters and the variants below wrap a fresh copy
-// in reactiveState so the bound `filters.*` props are reactive proxies, matching
-// how the app passes a $state object via bind:filters (see
-// reactive-state.svelte.ts).
+// Plain fixture values. createDefaultFilters() and the variants below wrap a
+// fresh copy in reactiveState so the bound `filters.*` props are reactive
+// proxies, matching how the app passes a $state object via bind:filters (see
+// reactive-state.svelte.ts). A fresh copy per render keeps test state isolated.
 const defaultFilterValues = {
   timePeriod: 'all' as const,
   startDate: '',
   endDate: '',
 };
 
-const defaultFilters = reactiveState({ ...defaultFilterValues });
+const createDefaultFilters = () => reactiveState({ ...defaultFilterValues });
 
 describe('FilterForm', () => {
   it('renders with basic props', () => {
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit: vi.fn(),
         onReset: vi.fn(),
       },
@@ -39,7 +39,7 @@ describe('FilterForm', () => {
   it('displays time period options', () => {
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit: vi.fn(),
         onReset: vi.fn(),
       },
@@ -71,7 +71,7 @@ describe('FilterForm', () => {
   it('hides custom date fields when other time period is selected', () => {
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit: vi.fn(),
         onReset: vi.fn(),
       },
@@ -86,7 +86,7 @@ describe('FilterForm', () => {
 
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit,
         onReset: vi.fn(),
       },
@@ -104,7 +104,7 @@ describe('FilterForm', () => {
 
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit: vi.fn(),
         onReset,
       },
@@ -119,7 +119,7 @@ describe('FilterForm', () => {
   it('disables buttons when loading', () => {
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         isLoading: true,
         onSubmit: vi.fn(),
         onReset: vi.fn(),
@@ -133,7 +133,7 @@ describe('FilterForm', () => {
   it('shows loading spinner when loading', () => {
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         isLoading: true,
         onSubmit: vi.fn(),
         onReset: vi.fn(),
@@ -150,7 +150,7 @@ describe('FilterForm', () => {
 
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit,
         onReset: vi.fn(),
       },
@@ -167,7 +167,7 @@ describe('FilterForm', () => {
   });
 
   it('handles time period change correctly', async () => {
-    const filters = reactiveState({ ...defaultFilterValues });
+    const filters = createDefaultFilters();
 
     render(FilterForm, {
       props: {
@@ -188,7 +188,7 @@ describe('FilterForm', () => {
   it('renders with proper form structure', () => {
     render(FilterForm, {
       props: {
-        filters: defaultFilters,
+        filters: createDefaultFilters(),
         onSubmit: vi.fn(),
         onReset: vi.fn(),
       },

--- a/frontend/src/lib/desktop/features/analytics/components/forms/SpeciesFilterForm.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/forms/SpeciesFilterForm.test.ts
@@ -9,17 +9,19 @@ vi.mock('$lib/i18n', () => ({
   t: createI18nMock(analyticsI18nTranslations),
 }));
 
-// Wrapped in reactiveState so the bound `filters.*` props are reactive proxies,
-// matching how the app passes a $state object via bind:filters (see
+// Plain fixture values. createDefaultFilters() and the variants below wrap a
+// fresh copy in reactiveState so the bound `filters.*` props are reactive
+// proxies, matching how the app passes a $state object via bind:filters (see
 // reactive-state.svelte.ts).
-const createDefaultFilters = () =>
-  reactiveState({
-    timePeriod: 'all' as const,
-    startDate: '',
-    endDate: '',
-    sortOrder: 'count_desc' as const,
-    searchTerm: '',
-  });
+const defaultFilterValues = {
+  timePeriod: 'all' as const,
+  startDate: '',
+  endDate: '',
+  sortOrder: 'count_desc' as const,
+  searchTerm: '',
+};
+
+const createDefaultFilters = () => reactiveState({ ...defaultFilterValues });
 
 describe('SpeciesFilterForm', () => {
   beforeEach(() => {
@@ -87,7 +89,7 @@ describe('SpeciesFilterForm', () => {
 
   it('shows custom date fields when custom time period is selected', () => {
     const customFilters = reactiveState({
-      ...createDefaultFilters(),
+      ...defaultFilterValues,
       timePeriod: 'custom' as const,
     });
 
@@ -256,7 +258,7 @@ describe('SpeciesFilterForm', () => {
 
   it('shows filtered indicator when search term is present', () => {
     const searchFilters = reactiveState({
-      ...createDefaultFilters(),
+      ...defaultFilterValues,
       searchTerm: 'robin',
     });
 
@@ -360,7 +362,7 @@ describe('SpeciesFilterForm', () => {
   });
 
   it('updates filter values correctly', async () => {
-    const filters = reactiveState({ ...createDefaultFilters() });
+    const filters = createDefaultFilters();
 
     render(SpeciesFilterForm, {
       props: {

--- a/frontend/src/lib/desktop/features/analytics/components/forms/SpeciesFilterForm.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/components/forms/SpeciesFilterForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { createI18nMock, analyticsI18nTranslations } from '../../../../../../test/render-helpers';
+import { reactiveState } from '../../../../../../test/reactive-state.svelte';
 import SpeciesFilterForm from './SpeciesFilterForm.svelte';
 
 // Mock i18n translations using shared translation constants
@@ -8,13 +9,17 @@ vi.mock('$lib/i18n', () => ({
   t: createI18nMock(analyticsI18nTranslations),
 }));
 
-const createDefaultFilters = () => ({
-  timePeriod: 'all' as const,
-  startDate: '',
-  endDate: '',
-  sortOrder: 'count_desc' as const,
-  searchTerm: '',
-});
+// Wrapped in reactiveState so the bound `filters.*` props are reactive proxies,
+// matching how the app passes a $state object via bind:filters (see
+// reactive-state.svelte.ts).
+const createDefaultFilters = () =>
+  reactiveState({
+    timePeriod: 'all' as const,
+    startDate: '',
+    endDate: '',
+    sortOrder: 'count_desc' as const,
+    searchTerm: '',
+  });
 
 describe('SpeciesFilterForm', () => {
   beforeEach(() => {
@@ -81,10 +86,10 @@ describe('SpeciesFilterForm', () => {
   });
 
   it('shows custom date fields when custom time period is selected', () => {
-    const customFilters = {
+    const customFilters = reactiveState({
       ...createDefaultFilters(),
       timePeriod: 'custom' as const,
-    };
+    });
 
     render(SpeciesFilterForm, {
       props: {
@@ -250,10 +255,10 @@ describe('SpeciesFilterForm', () => {
   });
 
   it('shows filtered indicator when search term is present', () => {
-    const searchFilters = {
+    const searchFilters = reactiveState({
       ...createDefaultFilters(),
       searchTerm: 'robin',
-    };
+    });
 
     render(SpeciesFilterForm, {
       props: {
@@ -355,7 +360,7 @@ describe('SpeciesFilterForm', () => {
   });
 
   it('updates filter values correctly', async () => {
-    const filters = { ...createDefaultFilters() };
+    const filters = reactiveState({ ...createDefaultFilters() });
 
     render(SpeciesFilterForm, {
       props: {

--- a/frontend/src/test/reactive-state.svelte.ts
+++ b/frontend/src/test/reactive-state.svelte.ts
@@ -1,0 +1,16 @@
+/**
+ * Wrap a plain object in a Svelte `$state` proxy so component tests can pass
+ * reactive props.
+ *
+ * Components such as FilterForm/SpeciesFilterForm declare `filters = $bindable()`
+ * and `bind:value={filters.x}` on child inputs. In dev mode Svelte injects a
+ * runtime reactivity check that emits `binding_property_non_reactive` when the
+ * bound object is not a reactive `$state` proxy. The real app always passes a
+ * `$state` object through `bind:filters`, so it never warns; tests that render
+ * with a plain object do. Wrapping the prop here matches real usage and clears
+ * the warning without suppressing the check in production code.
+ */
+export function reactiveState<T>(initial: T): T {
+  const state = $state(initial);
+  return state;
+}


### PR DESCRIPTION
## Summary

`FilterForm` and `SpeciesFilterForm` declare `filters = $bindable()` and bind `bind:value={filters.x}` on child inputs. In dev mode Svelte injects a runtime reactivity check that emits `binding_property_non_reactive` when the bound object is not a reactive `$state` proxy.

The app always passes a `$state` object via `bind:filters` (see `Species.svelte`), so it never warns in production. The unit tests, however, rendered the forms with plain objects, producing **8 dev-mode warnings** during the test run.

This fixes the warnings at their source (the tests), not by suppressing the check in the production components:

- Adds a small `reactiveState()` test helper (`src/test/reactive-state.svelte.ts`) that wraps a fixture in a `$state` proxy.
- Uses it for the filter fixtures in both form tests so the tests match real usage.

`FilterForm.svelte` has no app render site today (only its test); `SpeciesFilterForm.svelte` is used once in `Species.svelte` with `bind:filters` + `$state`. Both are correctly designed, so the warnings were purely test artifacts.

## Test Plan

- [x] `npm run test:ci`: 154 files / 2419 tests pass
- [x] 0 `binding_property_non_reactive` warnings (was 8)
- [x] `npm run check:all` clean (prettier, eslint, stylelint, svelte-check, ast-grep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test helper to wrap input values in Svelte reactive state, matching real component bindings.
  * Updated analytics filter form tests to use reactive filter fixtures for default, custom time-period, and search-term scenarios.
  * Refreshed default filter creation to ensure each test gets its own reactive state, improving consistency and reducing Svelte dev warnings related to non-reactive bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->