### PR TITLE
fix(analytics): localize time-of-day period labels

### DIFF
--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Nepodařilo se načíst analytická data. Zkuste to prosím znovu."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Noc (0-4)",
+      "dawn5to8": "Svítání (5-8)",
+      "morning9to11": "Ráno (9-11)",
+      "afternoon12to16": "Odpoledne (12-16)",
+      "evening17to19": "Večer (17-19)",
+      "night20to23": "Noc (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Kunne ikke indlæse analysedata. Prøv venligst igen."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Nat (0-4)",
+      "dawn5to8": "Daggry (5-8)",
+      "morning9to11": "Morgen (9-11)",
+      "afternoon12to16": "Eftermiddag (12-16)",
+      "evening17to19": "Aften (17-19)",
+      "night20to23": "Nat (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Analysedaten konnten nicht geladen werden. Bitte versuchen Sie es erneut."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Nacht (0-4)",
+      "dawn5to8": "Morgendämmerung (5-8)",
+      "morning9to11": "Vormittag (9-11)",
+      "afternoon12to16": "Nachmittag (12-16)",
+      "evening17to19": "Abend (17-19)",
+      "night20to23": "Nacht (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Error al cargar los datos de análisis. Por favor, inténtelo de nuevo."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Noche (0-4)",
+      "dawn5to8": "Amanecer (5-8)",
+      "morning9to11": "Mañana (9-11)",
+      "afternoon12to16": "Tarde (12-16)",
+      "evening17to19": "Atardecer (17-19)",
+      "night20to23": "Noche (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Analytiikkatietojen lataaminen epäonnistui. Yritä uudelleen."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Yö (0-4)",
+      "dawn5to8": "Aamunkoitto (5-8)",
+      "morning9to11": "Aamu (9-11)",
+      "afternoon12to16": "Iltapäivä (12-16)",
+      "evening17to19": "Ilta (17-19)",
+      "night20to23": "Yö (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Échec du chargement des données d'analyse. Veuillez réessayer."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Nuit (0-4)",
+      "dawn5to8": "Aube (5-8)",
+      "morning9to11": "Matin (9-11)",
+      "afternoon12to16": "Après-midi (12-16)",
+      "evening17to19": "Soir (17-19)",
+      "night20to23": "Nuit (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Az analitikai adatok betöltése sikertelen. Próbálja újra."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Éjszaka (0-4)",
+      "dawn5to8": "Hajnal (5-8)",
+      "morning9to11": "Délelőtt (9-11)",
+      "afternoon12to16": "Délután (12-16)",
+      "evening17to19": "Este (17-19)",
+      "night20to23": "Éjszaka (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Caricamento dei dati di analisi non riuscito. Riprova."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Notte (0-4)",
+      "dawn5to8": "Alba (5-8)",
+      "morning9to11": "Mattina (9-11)",
+      "afternoon12to16": "Pomeriggio (12-16)",
+      "evening17to19": "Sera (17-19)",
+      "night20to23": "Notte (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Neizdevās ielādēt analītikas datus. Lūdzu, mēģiniet vēlreiz."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Nakts (0-4)",
+      "dawn5to8": "Rītausma (5-8)",
+      "morning9to11": "Rīts (9-11)",
+      "afternoon12to16": "Pēcpusdiena (12-16)",
+      "evening17to19": "Vakars (17-19)",
+      "night20to23": "Nakts (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/nb.json
+++ b/frontend/static/messages/nb.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Innlasting av analysedata mislyktes. Prøv igjen."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Natt (0-4)",
+      "dawn5to8": "Daggry (5-8)",
+      "morning9to11": "Morgen (9-11)",
+      "afternoon12to16": "Ettermiddag (12-16)",
+      "evening17to19": "Kveld (17-19)",
+      "night20to23": "Natt (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Analysegegevens konden niet worden geladen. Probeer het opnieuw."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Nacht (0-4)",
+      "dawn5to8": "Dageraad (5-8)",
+      "morning9to11": "Ochtend (9-11)",
+      "afternoon12to16": "Middag (12-16)",
+      "evening17to19": "Avond (17-19)",
+      "night20to23": "Nacht (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Nie udało się załadować danych analitycznych. Spróbuj ponownie."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Noc (0-4)",
+      "dawn5to8": "Świt (5-8)",
+      "morning9to11": "Rano (9-11)",
+      "afternoon12to16": "Popołudnie (12-16)",
+      "evening17to19": "Wieczór (17-19)",
+      "night20to23": "Noc (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Falha ao carregar os dados de análise. Tente novamente."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Noite (0-4)",
+      "dawn5to8": "Amanhecer (5-8)",
+      "morning9to11": "Manhã (9-11)",
+      "afternoon12to16": "Tarde (12-16)",
+      "evening17to19": "Anoitecer (17-19)",
+      "night20to23": "Noite (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Nepodarilo sa načítať analytické údaje. Skúste to znova."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Noc (0-4)",
+      "dawn5to8": "Úsvit (5-8)",
+      "morning9to11": "Ráno (9-11)",
+      "afternoon12to16": "Popoludnie (12-16)",
+      "evening17to19": "Večer (17-19)",
+      "night20to23": "Noc (20-23)"
     }
   },
   "settings": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -1860,12 +1860,12 @@
       "loadFailed": "Kunde inte ladda analysdata. Försök igen."
     },
     "timeOfDayPeriods": {
-      "night0to4": "Night (0-4)",
-      "dawn5to8": "Dawn (5-8)",
-      "morning9to11": "Morning (9-11)",
-      "afternoon12to16": "Afternoon (12-16)",
-      "evening17to19": "Evening (17-19)",
-      "night20to23": "Night (20-23)"
+      "night0to4": "Natt (0-4)",
+      "dawn5to8": "Gryning (5-8)",
+      "morning9to11": "Morgon (9-11)",
+      "afternoon12to16": "Eftermiddag (12-16)",
+      "evening17to19": "Kväll (17-19)",
+      "night20to23": "Natt (20-23)"
     }
   },
   "settings": {


### PR DESCRIPTION
## What

The **Detections by hour of day** chart rendered hardcoded English period names (Night / Dawn / Morning / Afternoon / Evening / Night) regardless of the active locale — e.g. in Portuguese the bars still read "Night (0-4)", "Dawn (5-8)", etc.

## Root cause

Not a code bug. The render-time wiring in `Analytics.svelte` already maps the buckets to `analytics.timeOfDayPeriods.*` keys and runs them through `t()`. The keys simply held **English placeholder values** (the `i18n:sync` fallback) in every non-English locale, so `t()` returned English.

## Change

Translate the six period names across all **15 non-English locales** (`cs, da, de, es, fi, fr, hu, it, lv, nb, nl, pl, pt, sk, sv`).

- Numeric hour ranges (e.g. `(0-4)`) are language-neutral and stay as-is.
- `en.json` is unchanged.
- No key changes → i18n types unaffected.

Example (pt): `Noite (0-4)`, `Amanhecer (5-8)`, `Manhã (9-11)`, `Tarde (12-16)`, `Anoitecer (17-19)`, `Noite (20-23)`.

## Verify

- `npm run i18n:validate:full` and `i18n:validate:json` pass (exit 0); the period keys no longer appear in the untranslated-warning report.
- Diff is exactly 6 values per file, 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated time-of-day period labels for analytics across 15 languages including Czech, Danish, German, Spanish, Finnish, French, Hungarian, Italian, Latvian, Norwegian, Dutch, Polish, Portuguese, Slovak, and Swedish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->