### PR TITLE
feat: map external USB/SD/fileshare media into the container

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       #   sudo mkdir -p /mnt/birdnet-go/external
       #   sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
       #   sudo mount --make-rshared /mnt/birdnet-go/external
+      #   sudo chown -h 1000:1000 /mnt/birdnet-go/external
       # Note: the commands above are NOT persistent across reboots. See the external
       # media wiki page for a persistent systemd unit that runs them on every boot.
       # Then mount media under /mnt/birdnet-go/external/<label> on the host.

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       #   sudo mkdir -p /mnt/birdnet-go/external
       #   sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
       #   sudo mount --make-rshared /mnt/birdnet-go/external
+      # Note: the commands above are NOT persistent across reboots. See the external
+      # media wiki page for a persistent systemd unit that runs them on every boot.
       # Then mount media under /mnt/birdnet-go/external/<label> on the host.
       # - type: bind
       #   source: /mnt/birdnet-go/external

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -41,7 +41,8 @@ services:
       #   sudo mkdir -p /mnt/birdnet-go/external
       #   sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
       #   sudo mount --make-rshared /mnt/birdnet-go/external
-      #   sudo chown -h 1000:1000 /mnt/birdnet-go/external
+      #   sudo chown -h "${BIRDNET_UID:-1000}:${BIRDNET_GID:-1000}" /mnt/birdnet-go/external
+      #   (match BIRDNET_UID:BIRDNET_GID from this file if you override them; default 1000)
       # Note: the commands above are NOT persistent across reboots. See the external
       # media wiki page for a persistent systemd unit that runs them on every boot.
       # Then mount media under /mnt/birdnet-go/external/<label> on the host.

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -36,6 +36,17 @@ services:
     volumes:
       - ./config:/config
       - ./data:/data
+      # External media (import / backup), optional.
+      # The host directory must exist and be a shared mount for hot-plug to work.
+      # One-time host setup: mkdir -p /mnt/birdnet-go/external &&
+      #   mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external &&
+      #   mount --make-rshared /mnt/birdnet-go/external
+      # Then mount USB/SD/fileshares under /mnt/birdnet-go/external/<label> on the host.
+      - type: bind
+        source: /mnt/birdnet-go/external
+        target: /external
+        bind:
+          propagation: rslave
     # Mount HLS stream segment files directory as tmpfs (RAM disk)
     tmpfs:
       - /config/hls:exec,size=50M,uid=${BIRDNET_UID:-1000},gid=${BIRDNET_GID:-1000},mode=0755

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -36,17 +36,17 @@ services:
     volumes:
       - ./config:/config
       - ./data:/data
-      # External media (import / backup), optional.
-      # The host directory must exist and be a shared mount for hot-plug to work.
-      # One-time host setup: mkdir -p /mnt/birdnet-go/external &&
-      #   mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external &&
-      #   mount --make-rshared /mnt/birdnet-go/external
-      # Then mount USB/SD/fileshares under /mnt/birdnet-go/external/<label> on the host.
-      - type: bind
-        source: /mnt/birdnet-go/external
-        target: /external
-        bind:
-          propagation: rslave
+      # External media (USB / SD / fileshare) for Import and Backup. Optional, opt-in.
+      # One-time host setup before uncommenting:
+      #   sudo mkdir -p /mnt/birdnet-go/external
+      #   sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
+      #   sudo mount --make-rshared /mnt/birdnet-go/external
+      # Then mount media under /mnt/birdnet-go/external/<label> on the host.
+      # - type: bind
+      #   source: /mnt/birdnet-go/external
+      #   target: /external
+      #   bind:
+      #     propagation: rslave
     # Mount HLS stream segment files directory as tmpfs (RAM disk)
     tmpfs:
       - /config/hls:exec,size=50M,uid=${BIRDNET_UID:-1000},gid=${BIRDNET_GID:-1000},mode=0755

--- a/doc/wiki/external-media.md
+++ b/doc/wiki/external-media.md
@@ -1,0 +1,86 @@
+# External Media (USB, SD Card, File Shares)
+
+BirdNET-Go can read from and write to removable or network-attached storage
+mounted on the host. The `/external` directory inside the container maps to
+`/mnt/birdnet-go/external` on the host. Planned uses include importing
+recordings from BirdNET-Pi and other bird detectors, and writing backups.
+
+## How it works
+
+The container bind-mounts `/mnt/birdnet-go/external` with `rslave` propagation.
+Any media the host mounts under that directory after the container is already
+running will appear inside the container at the corresponding path without
+requiring a container restart. For example, a USB drive the host mounts at
+`/mnt/birdnet-go/external/usb1` becomes visible inside the container at
+`/external/usb1` automatically.
+
+## Host setup
+
+### install.sh (systemd) installations
+
+The installer-generated systemd service handles this automatically on every
+container start:
+
+1. Creates `/mnt/birdnet-go/external` (mode 0755) if it does not exist.
+2. Bind-mounts it to itself if it is not already a mount point.
+3. Marks it as a shared mount (`--make-rshared`) so sub-mounts propagate into
+   the container.
+
+No manual steps are needed for install.sh users. Re-running the installer after
+upgrading regenerates the service unit and picks up these steps.
+
+### Docker Compose installations
+
+Docker Compose users need a one-time host setup before starting the container:
+
+```bash
+sudo mkdir -p /mnt/birdnet-go/external
+sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
+sudo mount --make-rshared /mnt/birdnet-go/external
+```
+
+To make this persistent across reboots, add the following to `/etc/fstab`:
+
+```
+/mnt/birdnet-go/external /mnt/birdnet-go/external none bind,x-systemd.after=local-fs.target 0 0
+```
+
+Then add a systemd `ExecStartPre` step or use a one-shot service to run
+`mount --make-rshared /mnt/birdnet-go/external` before the container starts.
+
+Note: if the host root filesystem is already `rshared` (common on modern systemd
+distributions), the bind step may not be strictly required, but doing it
+idempotently does no harm.
+
+## Mounting media on the host
+
+Once the host setup is complete, mount any USB drive, SD card, or file share
+under `/mnt/birdnet-go/external`:
+
+```bash
+# USB drive example (replace /dev/sdb1 and label as appropriate)
+sudo mkdir -p /mnt/birdnet-go/external/usb1
+sudo mount /dev/sdb1 /mnt/birdnet-go/external/usb1
+
+# NFS share example
+sudo mkdir -p /mnt/birdnet-go/external/nfs-backup
+sudo mount -t nfs 192.168.1.10:/exports/birdnet /mnt/birdnet-go/external/nfs-backup
+
+# SMB/CIFS share example
+sudo mkdir -p /mnt/birdnet-go/external/smb-share
+sudo mount -t cifs //192.168.1.10/share /mnt/birdnet-go/external/smb-share \
+    -o username=user,password=pass,uid=1000,gid=1000
+```
+
+The mounted media will appear inside the container at `/external/usb1`,
+`/external/nfs-backup`, etc.
+
+## Notes
+
+- Hot-plug propagation requires the host shared-mount setup described above.
+  It has been verified in configuration but needs testing on a real Docker host
+  with physical media.
+- The `/external` path is read-write inside the container.
+- Writes from the container go to the mounted media on the host. Ensure the
+  media filesystem and mount permissions allow writes by the container user
+  (UID/GID set via `BIRDNET_UID` / `BIRDNET_GID`).

--- a/doc/wiki/external-media.md
+++ b/doc/wiki/external-media.md
@@ -21,7 +21,7 @@ requiring a container restart. For example, a USB drive the host mounts at
 The installer-generated systemd service handles this automatically on every
 container start:
 
-1. Creates `/mnt/birdnet-go/external` (mode 0755) if it does not exist.
+1. Creates `/mnt/birdnet-go/external` if it does not exist.
 2. Bind-mounts it to itself if it is not already a mount point.
 3. Marks it as a shared mount (`--make-rshared`) so sub-mounts propagate into
    the container.
@@ -31,7 +31,11 @@ upgrading regenerates the service unit and picks up these steps.
 
 ### Docker Compose installations
 
-Docker Compose users need a one-time host setup before starting the container:
+The external media volume is commented out in `docker-compose.yml` by default.
+`docker compose up` works without any host setup. To enable it, perform the
+one-time host setup below, then uncomment the bind block in `docker-compose.yml`.
+
+#### One-time manual setup
 
 ```bash
 sudo mkdir -p /mnt/birdnet-go/external
@@ -39,17 +43,44 @@ sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
 sudo mount --make-rshared /mnt/birdnet-go/external
 ```
 
-To make this persistent across reboots, add the following to `/etc/fstab`:
+An fstab bind entry alone does NOT establish `rshared` propagation and is
+therefore not sufficient for hot-plug to work. Both the self-bind and the
+`make-rshared` step are required.
 
-```
-/mnt/birdnet-go/external /mnt/birdnet-go/external none bind,x-systemd.after=local-fs.target 0 0
+#### Making the setup persistent across reboots
+
+Create a one-shot systemd service that runs both steps in the correct order and
+is guaranteed to complete before the container service starts:
+
+```ini
+# /etc/systemd/system/birdnet-external-media.service
+[Unit]
+Description=Prepare BirdNET-Go external media mount point
+DefaultDependencies=no
+After=local-fs.target
+Before=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/mkdir -p /mnt/birdnet-go/external
+ExecStart=/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
+ExecStart=/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
+
+[Install]
+WantedBy=multi-user.target
+RequiredBy=docker.service
 ```
 
-Then add a systemd `ExecStartPre` step or use a one-shot service to run
-`mount --make-rshared /mnt/birdnet-go/external` before the container starts.
+Enable it with:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now birdnet-external-media.service
+```
 
 Note: if the host root filesystem is already `rshared` (common on modern systemd
-distributions), the bind step may not be strictly required, but doing it
+distributions), the bind step may not be strictly required, but running it
 idempotently does no harm.
 
 ## Mounting media on the host
@@ -78,8 +109,8 @@ The mounted media will appear inside the container at `/external/usb1`,
 ## Notes
 
 - Hot-plug propagation requires the host shared-mount setup described above.
-  It has been verified in configuration but needs testing on a real Docker host
-  with physical media.
+  The wiring is in place, but hot-plug propagation has NOT been tested end to end
+  with physical media and must be validated before relying on it.
 - The `/external` path is read-write inside the container.
 - Writes from the container go to the mounted media on the host. Ensure the
   media filesystem and mount permissions allow writes by the container user

--- a/doc/wiki/external-media.md
+++ b/doc/wiki/external-media.md
@@ -43,6 +43,7 @@ one-time host setup below, then uncomment the bind block in `docker-compose.yml`
 sudo mkdir -p /mnt/birdnet-go/external
 sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
 sudo mount --make-rshared /mnt/birdnet-go/external
+sudo chown -h 1000:1000 /mnt/birdnet-go/external
 ```
 
 An fstab bind entry alone does NOT establish `rshared` propagation and is
@@ -68,6 +69,7 @@ RemainAfterExit=yes
 ExecStart=-/bin/mkdir -p /mnt/birdnet-go/external
 ExecStart=-/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
 ExecStart=-/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
+ExecStart=-/bin/chown -h 1000:1000 /mnt/birdnet-go/external
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/wiki/external-media.md
+++ b/doc/wiki/external-media.md
@@ -12,7 +12,9 @@ Any media the host mounts under that directory after the container is already
 running will appear inside the container at the corresponding path without
 requiring a container restart. For example, a USB drive the host mounts at
 `/mnt/birdnet-go/external/usb1` becomes visible inside the container at
-`/external/usb1` automatically.
+`/external/usb1` automatically. The host directory is made a shared mount
+(`--make-rshared`) and the container bind uses `rslave`, so sub-mounts
+propagate one way: host into container, not the other way around.
 
 ## Host setup
 
@@ -69,8 +71,12 @@ ExecStart=/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
 
 [Install]
 WantedBy=multi-user.target
-RequiredBy=docker.service
 ```
+
+Note: this unit intentionally does NOT use `RequiredBy=docker.service`. It is
+best-effort: if the mount setup fails, docker.service still starts normally.
+Only hot-plug propagation is lost; a hard dependency would take down all
+containers if the mount step failed.
 
 Enable it with:
 
@@ -97,10 +103,14 @@ sudo mount /dev/sdb1 /mnt/birdnet-go/external/usb1
 sudo mkdir -p /mnt/birdnet-go/external/nfs-backup
 sudo mount -t nfs 192.168.1.10:/exports/birdnet /mnt/birdnet-go/external/nfs-backup
 
-# SMB/CIFS share example
+# SMB/CIFS share example (store credentials in a file, not on the command line)
+# A cleartext password= option in the mount command is visible in /proc/mounts,
+# ps output, and the journal. Use a credentials file instead:
+#   sudo sh -c 'printf "username=user\npassword=pass\n" > /etc/birdnet-go-smb.cred'
+#   sudo chmod 600 /etc/birdnet-go-smb.cred
 sudo mkdir -p /mnt/birdnet-go/external/smb-share
 sudo mount -t cifs //192.168.1.10/share /mnt/birdnet-go/external/smb-share \
-    -o username=user,password=pass,uid=1000,gid=1000
+    -o credentials=/etc/birdnet-go-smb.cred,uid=1000,gid=1000
 ```
 
 The mounted media will appear inside the container at `/external/usb1`,
@@ -109,8 +119,9 @@ The mounted media will appear inside the container at `/external/usb1`,
 ## Notes
 
 - Hot-plug propagation requires the host shared-mount setup described above.
-  The wiring is in place, but hot-plug propagation has NOT been tested end to end
-  with physical media and must be validated before relying on it.
+  The wiring has been validated end to end on Docker 29.5 (arm64), but behavior
+  may vary on older Docker versions, so validate on your specific platform before
+  relying on it.
 - The `/external` path is read-write inside the container.
 - Writes from the container go to the mounted media on the host. Ensure the
   media filesystem and mount permissions allow writes by the container user

--- a/doc/wiki/external-media.md
+++ b/doc/wiki/external-media.md
@@ -43,7 +43,8 @@ one-time host setup below, then uncomment the bind block in `docker-compose.yml`
 sudo mkdir -p /mnt/birdnet-go/external
 sudo mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external
 sudo mount --make-rshared /mnt/birdnet-go/external
-sudo chown -h 1000:1000 /mnt/birdnet-go/external
+# Use the same UID:GID as BIRDNET_UID:BIRDNET_GID in docker-compose.yml (default 1000).
+sudo chown -h "${BIRDNET_UID:-1000}:${BIRDNET_GID:-1000}" /mnt/birdnet-go/external
 ```
 
 An fstab bind entry alone does NOT establish `rshared` propagation and is
@@ -69,6 +70,7 @@ RemainAfterExit=yes
 ExecStart=-/bin/mkdir -p /mnt/birdnet-go/external
 ExecStart=-/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
 ExecStart=-/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
+# Adjust 1000:1000 to match BIRDNET_UID:BIRDNET_GID if you override them.
 ExecStart=-/bin/chown -h 1000:1000 /mnt/birdnet-go/external
 
 [Install]

--- a/doc/wiki/external-media.md
+++ b/doc/wiki/external-media.md
@@ -65,9 +65,9 @@ Before=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/mkdir -p /mnt/birdnet-go/external
-ExecStart=/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
-ExecStart=/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
+ExecStart=-/bin/mkdir -p /mnt/birdnet-go/external
+ExecStart=-/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
+ExecStart=-/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
 
 [Install]
 WantedBy=multi-user.target
@@ -106,8 +106,11 @@ sudo mount -t nfs 192.168.1.10:/exports/birdnet /mnt/birdnet-go/external/nfs-bac
 # SMB/CIFS share example (store credentials in a file, not on the command line)
 # A cleartext password= option in the mount command is visible in /proc/mounts,
 # ps output, and the journal. Use a credentials file instead:
-#   sudo sh -c 'printf "username=user\npassword=pass\n" > /etc/birdnet-go-smb.cred'
-#   sudo chmod 600 /etc/birdnet-go-smb.cred
+#   sudo install -m 600 /dev/null /etc/birdnet-go-smb.cred
+#   sudoedit /etc/birdnet-go-smb.cred
+#   # then add these two lines to the file:
+#   #   username=YOUR_USERNAME
+#   #   password=YOUR_PASSWORD
 sudo mkdir -p /mnt/birdnet-go/external/smb-share
 sudo mount -t cifs //192.168.1.10/share /mnt/birdnet-go/external/smb-share \
     -o credentials=/etc/birdnet-go-smb.cred,uid=1000,gid=1000

--- a/doc/wiki/index.md
+++ b/doc/wiki/index.md
@@ -20,6 +20,7 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 
 ## Advanced Features
 
+- [External Media (USB, SD, File Shares)](external-media.md) - Mounting removable and network storage for import and backup
 - [Detection Pipeline Architecture](detection-pipeline.md) - How audio flows through multi-model inference, filtering, and action dispatch
 - [BirdNET Detection Pipeline](BirdNET‐Go-Guide#birdnet-detection-pipeline) - Understanding how settings affect detections
 - [BirdNET Range Filter](BirdNET‐Go-Guide#birdnet-range-filter) - Location and time-based species filtering

--- a/install.sh
+++ b/install.sh
@@ -4060,6 +4060,10 @@ generate_systemd_service_content() {
         thermal_volume_line="-v /sys/class/thermal:/sys/class/thermal"
     fi
 
+    # External media mount: host /mnt/birdnet-go/external -> container /external (rslave, rw)
+    # Enables hot-plug of USB/SD/fileshare media mounted under the host directory.
+    local external_media_line="-v /mnt/birdnet-go/external:/external:rslave"
+
     # Check if running on Raspberry Pi and add WiFi power save disable script
     local wifi_power_save_script=""
     if is_raspberry_pi; then
@@ -4083,6 +4087,11 @@ ExecStartPre=-/usr/bin/docker rm -f birdnet-go
 ExecStartPre=/bin/mkdir -p ${CONFIG_DIR}/hls
 # Mount tmpfs, the '|| true' ensures it doesn't fail if already mounted
 ExecStartPre=/bin/sh -c 'mount -t tmpfs -o size=50M,mode=0755,uid=${HOST_UID},gid=${HOST_GID},noexec,nosuid,nodev tmpfs ${CONFIG_DIR}/hls || true'
+# Prepare external media mount point and ensure shared propagation for hot-plug
+ExecStartPre=/bin/mkdir -p /mnt/birdnet-go/external
+ExecStartPre=/bin/chmod 755 /mnt/birdnet-go/external
+ExecStartPre=/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
+ExecStartPre=/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external || true'
 ${wifi_power_save_script:+${wifi_power_save_script}
 }ExecStart=/usr/bin/docker run --rm \\
     --name birdnet-go \\
@@ -4097,7 +4106,8 @@ ${audio_env_line:+    ${audio_env_line} \\
 }    -v ${CONFIG_DIR}:/config \\
     -v ${DATA_DIR}:/data \\
 ${thermal_volume_line:+    ${thermal_volume_line} \\
-}    ${BIRDNET_GO_IMAGE}
+}    ${external_media_line} \\
+    ${BIRDNET_GO_IMAGE}
 # Cleanup tasks on stop
 ExecStopPost=/bin/sh -c 'umount -f ${CONFIG_DIR}/hls || true'
 ExecStopPost=-/usr/bin/docker rm -f birdnet-go

--- a/install.sh
+++ b/install.sh
@@ -4096,6 +4096,10 @@ ExecStartPre=/bin/sh -c 'mount -t tmpfs -o size=50M,mode=0755,uid=${HOST_UID},gi
 ExecStartPre=-/bin/mkdir -p /mnt/birdnet-go/external
 ExecStartPre=-/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
 ExecStartPre=-/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
+# Make the mount point writable by the container user so the app and the
+# upcoming backup feature can write to external media. -h avoids dereferencing
+# a symlink. Best-effort like the steps above.
+ExecStartPre=-/bin/chown -h ${HOST_UID}:${HOST_GID} /mnt/birdnet-go/external
 ${wifi_power_save_script:+${wifi_power_save_script}
 }ExecStart=/usr/bin/docker run --rm \\
     --name birdnet-go \\

--- a/install.sh
+++ b/install.sh
@@ -4088,10 +4088,9 @@ ExecStartPre=/bin/mkdir -p ${CONFIG_DIR}/hls
 # Mount tmpfs, the '|| true' ensures it doesn't fail if already mounted
 ExecStartPre=/bin/sh -c 'mount -t tmpfs -o size=50M,mode=0755,uid=${HOST_UID},gid=${HOST_GID},noexec,nosuid,nodev tmpfs ${CONFIG_DIR}/hls || true'
 # Prepare external media mount point and ensure shared propagation for hot-plug
-ExecStartPre=/bin/mkdir -p /mnt/birdnet-go/external
-ExecStartPre=/bin/chmod 755 /mnt/birdnet-go/external
-ExecStartPre=/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
-ExecStartPre=/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external || true'
+ExecStartPre=-/bin/mkdir -p /mnt/birdnet-go/external
+ExecStartPre=-/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
+ExecStartPre=-/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'
 ${wifi_power_save_script:+${wifi_power_save_script}
 }ExecStart=/usr/bin/docker run --rm \\
     --name birdnet-go \\

--- a/install.sh
+++ b/install.sh
@@ -4060,7 +4060,8 @@ generate_systemd_service_content() {
         thermal_volume_line="-v /sys/class/thermal:/sys/class/thermal"
     fi
 
-    # External media mount: host /mnt/birdnet-go/external -> container /external (rslave, rw)
+    # External media mount: host /mnt/birdnet-go/external -> container /external
+    # Uses rslave propagation; read-write is the Docker default and not specified explicitly.
     # Enables hot-plug of USB/SD/fileshare media mounted under the host directory.
     local external_media_line="-v /mnt/birdnet-go/external:/external:rslave"
 
@@ -4087,7 +4088,11 @@ ExecStartPre=-/usr/bin/docker rm -f birdnet-go
 ExecStartPre=/bin/mkdir -p ${CONFIG_DIR}/hls
 # Mount tmpfs, the '|| true' ensures it doesn't fail if already mounted
 ExecStartPre=/bin/sh -c 'mount -t tmpfs -o size=50M,mode=0755,uid=${HOST_UID},gid=${HOST_GID},noexec,nosuid,nodev tmpfs ${CONFIG_DIR}/hls || true'
-# Prepare external media mount point and ensure shared propagation for hot-plug
+# Prepare external media mount point and ensure shared propagation for hot-plug.
+# These steps are best-effort (prefixed with '-'): the service still starts if
+# they fail; only hot-plug sub-mount propagation is affected.
+# The external mount is always added to the docker run command so the app can
+# detect and guide the user when external media is present or absent.
 ExecStartPre=-/bin/mkdir -p /mnt/birdnet-go/external
 ExecStartPre=-/bin/sh -c 'mountpoint -q /mnt/birdnet-go/external || mount --bind /mnt/birdnet-go/external /mnt/birdnet-go/external'
 ExecStartPre=-/bin/sh -c 'mount --make-rshared /mnt/birdnet-go/external'


### PR DESCRIPTION
## Summary

Adds a controlled, hot-plug-capable mount for external media (USB drives, SD cards, network file shares) into the BirdNET-Go container. This is the foundation for upcoming data import and backup features that need to read from or write to removable media.

- **install.sh / systemd**: provisions a dedicated host directory `/mnt/birdnet-go/external` and maps it to `/external` in the container with `rslave` mount propagation. Media the host mounts under that directory after the container is already running becomes visible inside the container without a restart. The generated systemd unit creates the directory and establishes shared propagation via best-effort `ExecStartPre` steps, which are failure-tolerant so they can never block the service from starting.
- **Docker Compose**: an opt-in (commented-out) bind-mount block with inline one-time host-setup instructions. The default `docker compose up` is unchanged for users who do not use external media (Compose does not auto-create bind-mount source directories, so an active bind would otherwise break startup).
- **Docs**: a new wiki page covering host setup for both install.sh and Compose deployments, a persistent systemd unit example for Compose users, and how to mount USB / NFS / CIFS media under the directory.

The container mount is read-write (backup needs write access); the import feature treats its source as read-only at the application level.

## Notes

- Hot-plug propagation was validated end to end on Docker 29.5 (arm64); behavior may vary on older Docker versions, so the docs advise validating on your platform.
- No application code changes. This PR is deployment wiring and documentation only.

## Test Plan

- [x] `bash -n install.sh` passes
- [x] `docker-compose.yml` parses; default `docker compose up` unaffected (external mount is opt-in / commented)
- [x] On a Docker host, media mounted under `/mnt/birdnet-go/external` after container start is visible at `/external` with no restart
- [ ] Validate across additional Docker versions and host platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mounting host external storage into the container at `/external` (USB/SD and network shares) for streamlined import and backup workflows.

* **Documentation**
  * Added a new “External Media (USB, SD, File Shares)” wiki page with host setup, hot-plug guidance, and in-container path details, linked from the wiki index.

* **Configuration**
  * Updated installation to automatically provide the `/external` mount with the required propagation/host preparation steps, and added an opt-in commented Docker Compose example template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->