### PR TITLE
feat(api): add external media detection endpoint

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/securefs"
 	"github.com/tphakala/birdnet-go/internal/spectrogram"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
 // Tunnel provider constant for unknown providers
@@ -178,6 +179,12 @@ type Controller struct {
 	// sourceRestarter restarts a single audio source by ID. Set during
 	// pipeline Start() and called by the restart-source control endpoint.
 	sourceRestarter atomic.Pointer[SourceRestarterFunc]
+
+	// externalMediaEnv and externalMediaProbe are injectable dependencies for
+	// the GET /api/v2/system/external-media endpoint. Both default to the real
+	// sysinfo implementations at request time when nil.
+	externalMediaEnv   sysinfo.EnvGetter
+	externalMediaProbe sysinfo.MountProber
 }
 
 // SourceRestarterFunc restarts a single audio source identified by sourceID.

--- a/internal/api/v2/external_media.go
+++ b/internal/api/v2/external_media.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -58,7 +59,7 @@ func (c *Controller) GetExternalMedia(ctx echo.Context) error {
 	prober := c.externalMediaProbe
 	probe := sysinfo.ProbeExternalMount(sysinfo.DefaultExternalMountPath, prober)
 
-	mountPresent := containerized && probe.Exists && probe.IsMountpoint
+	mountPresent := containerized && probe.Exists && probe.IsMountpoint && probe.Readable
 
 	var guidance *ExternalMediaGuidance
 	if containerized && !mountPresent {
@@ -103,7 +104,8 @@ func buildGuidance(envType string) *ExternalMediaGuidance {
 
 	switch envType {
 	case sysinfo.EnvDocker:
-		steps := append(hostSetup,
+		steps := slices.Clone(hostSetup)
+		steps = append(steps,
 			"# Add to your docker run command:",
 			"-v "+hostDir+":"+containerDir+":rslave",
 			"# Or in docker-compose.yml under the birdnet-go service volumes:",
@@ -121,7 +123,8 @@ func buildGuidance(envType string) *ExternalMediaGuidance {
 			Steps:       steps,
 		}
 	case sysinfo.EnvPodman:
-		steps := append(hostSetup,
+		steps := slices.Clone(hostSetup)
+		steps = append(steps,
 			"# Add to your podman run command or quadlet file:",
 			"-v "+hostDir+":"+containerDir+":rslave",
 			"# If you used install.sh, simply re-run the installer to wire this automatically.",
@@ -134,7 +137,8 @@ func buildGuidance(envType string) *ExternalMediaGuidance {
 	default:
 		// Generic container guidance covers LXC, systemd-nspawn, and any
 		// other container runtime the environment detection recognises.
-		steps := append(hostSetup,
+		steps := slices.Clone(hostSetup)
+		steps = append(steps,
 			"# Mount the host directory into the container using your runtime's volume mechanism.",
 			"# Or re-run the BirdNET-Go installer (install.sh) to configure the mount automatically.",
 		)

--- a/internal/api/v2/external_media.go
+++ b/internal/api/v2/external_media.go
@@ -28,14 +28,12 @@ type ExternalMediaResponse struct {
 	// Containerized is true when the app is running inside a known container runtime.
 	Containerized bool `json:"containerized"`
 	// MountPath is the path inside the container that should be bind-mounted from the host.
-	MountPath string `json:"mountPath"`
-	// MountConfigured is true when the mount path exists and is a real mountpoint.
-	MountConfigured bool `json:"mountConfigured"`
+	MountPath string `json:"mount_path"`
 	// MountPresent is true when the mount path exists and is a real mountpoint.
 	// It is always false for native (non-containerized) environments because
 	// there is no bind-mount concept; the frontend should use Containerized to
 	// decide whether to show mount-related UI.
-	MountPresent bool `json:"mountPresent"`
+	MountPresent bool `json:"mount_present"`
 	// Guidance is populated only when Containerized is true and MountPresent is
 	// false. It provides copy-pasteable setup steps keyed to the detected runtime.
 	// null when no setup action is needed.
@@ -53,19 +51,14 @@ func (c *Controller) GetExternalMedia(ctx echo.Context) error {
 	if envGetter == nil {
 		envGetter = sysinfo.GetEnvironment
 	}
-	prober := c.externalMediaProbe
-	if prober == nil {
-		prober = func(path string) sysinfo.MountProbeResult {
-			return sysinfo.ProbeExternalMount(path, envGetter, nil)
-		}
-	}
 
 	envType, _ := envGetter()
 	containerized := sysinfo.IsContainerEnv(envType)
-	probe := prober(sysinfo.DefaultExternalMountPath)
+
+	prober := c.externalMediaProbe
+	probe := sysinfo.ProbeExternalMount(sysinfo.DefaultExternalMountPath, prober)
 
 	mountPresent := containerized && probe.Exists && probe.IsMountpoint
-	mountConfigured := mountPresent
 
 	var guidance *ExternalMediaGuidance
 	if containerized && !mountPresent {
@@ -73,12 +66,11 @@ func (c *Controller) GetExternalMedia(ctx echo.Context) error {
 	}
 
 	resp := ExternalMediaResponse{
-		Environment:     envType,
-		Containerized:   containerized,
-		MountPath:       sysinfo.DefaultExternalMountPath,
-		MountConfigured: mountConfigured,
-		MountPresent:    mountPresent,
-		Guidance:        guidance,
+		Environment:   envType,
+		Containerized: containerized,
+		MountPath:     sysinfo.DefaultExternalMountPath,
+		MountPresent:  mountPresent,
+		Guidance:      guidance,
 	}
 
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "External media status retrieved",
@@ -98,46 +90,56 @@ func buildGuidance(envType string) *ExternalMediaGuidance {
 	const (
 		hostDir      = "/mnt/birdnet-go/external"
 		containerDir = "/external"
-		containerUID = "1000"
 	)
+
+	// Common host-side setup steps required for all container runtimes.
+	hostSetup := []string{
+		"sudo mkdir -p " + hostDir,
+		"sudo mount --bind " + hostDir + " " + hostDir,
+		"sudo mount --make-rshared " + hostDir,
+		`sudo chown -h "${BIRDNET_UID:-1000}:${BIRDNET_GID:-1000}" ` + hostDir,
+	}
 
 	switch envType {
 	case "Docker":
+		steps := append(hostSetup,
+			"# Add to your docker run command:",
+			"-v "+hostDir+":"+containerDir+":rslave",
+			"# Or in docker-compose.yml under the birdnet-go service volumes:",
+			"volumes:",
+			"  - type: bind",
+			"    source: "+hostDir,
+			"    target: "+containerDir,
+			"    bind:",
+			"      propagation: rslave",
+			"# If you used install.sh, simply re-run the installer to wire this automatically.",
+			"# Then restart the container.",
+		)
 		return &ExternalMediaGuidance{
 			Environment: envType,
-			Steps: []string{
-				"sudo mkdir -p " + hostDir,
-				"sudo chown " + containerUID + ":" + containerUID + " " + hostDir,
-				"# Add the following volume to your docker run command or compose file:",
-				"-v " + hostDir + ":" + containerDir + ":rslave",
-				"# Or in docker-compose.yml under the birdnet-go service volumes:",
-				"- " + hostDir + ":" + containerDir + ":rslave",
-				"# Then restart the container.",
-			},
+			Steps:       steps,
 		}
 	case "Podman":
+		steps := append(hostSetup,
+			"# Add to your podman run command or quadlet file:",
+			"-v "+hostDir+":"+containerDir+":rslave",
+			"# If you used install.sh, simply re-run the installer to wire this automatically.",
+			"# Then restart the container.",
+		)
 		return &ExternalMediaGuidance{
 			Environment: envType,
-			Steps: []string{
-				"sudo mkdir -p " + hostDir,
-				"sudo chown " + containerUID + ":" + containerUID + " " + hostDir,
-				"# Add the following volume to your podman run command or quadlet file:",
-				"-v " + hostDir + ":" + containerDir + ":rslave",
-				"# Then restart the container.",
-			},
+			Steps:       steps,
 		}
 	default:
 		// Generic container guidance covers LXC, systemd-nspawn, and any
 		// other container runtime the environment detection recognises.
+		steps := append(hostSetup,
+			"# Mount the host directory into the container using your runtime's volume mechanism.",
+			"# Or re-run the BirdNET-Go installer (install.sh) to configure the mount automatically.",
+		)
 		return &ExternalMediaGuidance{
 			Environment: envType,
-			Steps: []string{
-				"sudo mkdir -p " + hostDir,
-				"sudo chown " + containerUID + ":" + containerUID + " " + hostDir,
-				"sudo mount --bind " + hostDir + " " + containerDir,
-				"sudo mount --make-rshared " + containerDir,
-				"# Or re-run the BirdNET-Go installer (install.sh) to configure the mount automatically.",
-			},
+			Steps:       steps,
 		}
 	}
 }

--- a/internal/api/v2/external_media.go
+++ b/internal/api/v2/external_media.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+// ExternalMediaGuidance contains deployment-specific, copy-pasteable setup
+// instructions returned when the external-media mount is absent. It is
+// structured as machine-readable data so the frontend can render and localize it.
+type ExternalMediaGuidance struct {
+	// Environment is the detected container runtime (e.g. "Docker", "Podman").
+	Environment string `json:"environment"`
+	// Steps is an ordered list of setup steps. Each step is a plain string
+	// (shell command or brief instruction) that is language-neutral and safe
+	// to display verbatim or used as a key for frontend localization.
+	Steps []string `json:"steps"`
+}
+
+// ExternalMediaResponse is the JSON body for GET /api/v2/system/external-media.
+type ExternalMediaResponse struct {
+	// Environment is the runtime environment type as returned by sysinfo.GetEnvironment
+	// (e.g. "Docker", "Podman", "Bare Metal", "WSL2").
+	Environment string `json:"environment"`
+	// Containerized is true when the app is running inside a known container runtime.
+	Containerized bool `json:"containerized"`
+	// MountPath is the path inside the container that should be bind-mounted from the host.
+	MountPath string `json:"mountPath"`
+	// MountConfigured is true when the mount path exists and is a real mountpoint.
+	MountConfigured bool `json:"mountConfigured"`
+	// MountPresent is true when the mount path exists and is a real mountpoint.
+	// It is always false for native (non-containerized) environments because
+	// there is no bind-mount concept; the frontend should use Containerized to
+	// decide whether to show mount-related UI.
+	MountPresent bool `json:"mountPresent"`
+	// Guidance is populated only when Containerized is true and MountPresent is
+	// false. It provides copy-pasteable setup steps keyed to the detected runtime.
+	// null when no setup action is needed.
+	Guidance *ExternalMediaGuidance `json:"guidance"`
+}
+
+// GetExternalMedia handles GET /api/v2/system/external-media.
+// It reports whether the external-media bind-mount is reachable from the
+// running application, and when it is not, provides deployment-specific setup
+// instructions for the detected container runtime.
+func (c *Controller) GetExternalMedia(ctx echo.Context) error {
+	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting external media status")
+
+	envGetter := c.externalMediaEnv
+	if envGetter == nil {
+		envGetter = sysinfo.GetEnvironment
+	}
+	prober := c.externalMediaProbe
+	if prober == nil {
+		prober = func(path string) sysinfo.MountProbeResult {
+			return sysinfo.ProbeExternalMount(path, envGetter, nil)
+		}
+	}
+
+	envType, _ := envGetter()
+	containerized := sysinfo.IsContainerEnv(envType)
+	probe := prober(sysinfo.DefaultExternalMountPath)
+
+	mountPresent := containerized && probe.Exists && probe.IsMountpoint
+	mountConfigured := mountPresent
+
+	var guidance *ExternalMediaGuidance
+	if containerized && !mountPresent {
+		guidance = buildGuidance(envType)
+	}
+
+	resp := ExternalMediaResponse{
+		Environment:     envType,
+		Containerized:   containerized,
+		MountPath:       sysinfo.DefaultExternalMountPath,
+		MountConfigured: mountConfigured,
+		MountPresent:    mountPresent,
+		Guidance:        guidance,
+	}
+
+	c.logAPIRequest(ctx, logger.LogLevelInfo, "External media status retrieved",
+		logger.String("environment", envType),
+		logger.Bool("containerized", containerized),
+		logger.Bool("mountPresent", mountPresent),
+	)
+
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// buildGuidance returns copy-pasteable setup instructions for the given
+// container runtime. Commands match the A1 contract: host dir
+// /mnt/birdnet-go/external, rslave bind-mount, chown to container UID, and
+// runtime-specific volume flags.
+func buildGuidance(envType string) *ExternalMediaGuidance {
+	const (
+		hostDir      = "/mnt/birdnet-go/external"
+		containerDir = "/external"
+		containerUID = "1000"
+	)
+
+	switch envType {
+	case "Docker":
+		return &ExternalMediaGuidance{
+			Environment: envType,
+			Steps: []string{
+				"sudo mkdir -p " + hostDir,
+				"sudo chown " + containerUID + ":" + containerUID + " " + hostDir,
+				"# Add the following volume to your docker run command or compose file:",
+				"-v " + hostDir + ":" + containerDir + ":rslave",
+				"# Or in docker-compose.yml under the birdnet-go service volumes:",
+				"- " + hostDir + ":" + containerDir + ":rslave",
+				"# Then restart the container.",
+			},
+		}
+	case "Podman":
+		return &ExternalMediaGuidance{
+			Environment: envType,
+			Steps: []string{
+				"sudo mkdir -p " + hostDir,
+				"sudo chown " + containerUID + ":" + containerUID + " " + hostDir,
+				"# Add the following volume to your podman run command or quadlet file:",
+				"-v " + hostDir + ":" + containerDir + ":rslave",
+				"# Then restart the container.",
+			},
+		}
+	default:
+		// Generic container guidance covers LXC, systemd-nspawn, and any
+		// other container runtime the environment detection recognises.
+		return &ExternalMediaGuidance{
+			Environment: envType,
+			Steps: []string{
+				"sudo mkdir -p " + hostDir,
+				"sudo chown " + containerUID + ":" + containerUID + " " + hostDir,
+				"sudo mount --bind " + hostDir + " " + containerDir,
+				"sudo mount --make-rshared " + containerDir,
+				"# Or re-run the BirdNET-Go installer (install.sh) to configure the mount automatically.",
+			},
+		}
+	}
+}

--- a/internal/api/v2/external_media.go
+++ b/internal/api/v2/external_media.go
@@ -83,9 +83,10 @@ func (c *Controller) GetExternalMedia(ctx echo.Context) error {
 }
 
 // buildGuidance returns copy-pasteable setup instructions for the given
-// container runtime. Commands match the A1 contract: host dir
-// /mnt/birdnet-go/external, rslave bind-mount, chown to container UID, and
-// runtime-specific volume flags.
+// container runtime. The commands set up the host mount: host dir
+// /mnt/birdnet-go/external, a self bind-mount made rshared so sub-mounts
+// propagate into the container, a chown to the container UID, and the
+// runtime-specific volume flag.
 func buildGuidance(envType string) *ExternalMediaGuidance {
 	const (
 		hostDir      = "/mnt/birdnet-go/external"
@@ -101,7 +102,7 @@ func buildGuidance(envType string) *ExternalMediaGuidance {
 	}
 
 	switch envType {
-	case "Docker":
+	case sysinfo.EnvDocker:
 		steps := append(hostSetup,
 			"# Add to your docker run command:",
 			"-v "+hostDir+":"+containerDir+":rslave",
@@ -119,7 +120,7 @@ func buildGuidance(envType string) *ExternalMediaGuidance {
 			Environment: envType,
 			Steps:       steps,
 		}
-	case "Podman":
+	case sysinfo.EnvPodman:
 		steps := append(hostSetup,
 			"# Add to your podman run command or quadlet file:",
 			"-v "+hostDir+":"+containerDir+":rslave",

--- a/internal/api/v2/external_media_test.go
+++ b/internal/api/v2/external_media_test.go
@@ -34,7 +34,7 @@ func newExternalMediaController(
 
 // callExternalMediaEndpoint fires the GET /api/v2/system/external-media handler
 // and returns the parsed response.
-func callExternalMediaEndpoint(t *testing.T, ctrl *Controller) (ExternalMediaResponse, int) {
+func callExternalMediaEndpoint(t *testing.T, ctrl *Controller) (resp ExternalMediaResponse, statusCode int) {
 	t.Helper()
 	e := ctrl.Echo
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/external-media", http.NoBody)
@@ -44,7 +44,6 @@ func callExternalMediaEndpoint(t *testing.T, ctrl *Controller) (ExternalMediaRes
 	err := ctrl.GetExternalMedia(ctx)
 	require.NoError(t, err)
 
-	var resp ExternalMediaResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	return resp, rec.Code
 }
@@ -83,7 +82,7 @@ func TestGetExternalMedia_ContainerMountPresent(t *testing.T) {
 
 	_, ctrl := newExternalMediaController(
 		t,
-		func() (string, string) { return "Docker", "" },
+		func() (string, string) { return sysinfo.EnvDocker, "" },
 		func(_ string) sysinfo.MountProbeResult {
 			return sysinfo.MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
 		},
@@ -92,10 +91,34 @@ func TestGetExternalMedia_ContainerMountPresent(t *testing.T) {
 	resp, code := callExternalMediaEndpoint(t, ctrl)
 
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "Docker", resp.Environment)
+	assert.Equal(t, sysinfo.EnvDocker, resp.Environment)
 	assert.True(t, resp.Containerized)
 	assert.True(t, resp.MountPresent)
 	assert.Nil(t, resp.Guidance, "guidance should be nil when mount is present")
+}
+
+// TestGetExternalMedia_ContainerMountUnreadable verifies that a mounted but
+// unreadable path is reported as not present, with guidance populated.
+func TestGetExternalMedia_ContainerMountUnreadable(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return sysinfo.EnvDocker, "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: true, IsMountpoint: true, Readable: false}
+		},
+	)
+
+	resp, code := callExternalMediaEndpoint(t, ctrl)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.True(t, resp.Containerized)
+	assert.False(t, resp.MountPresent, "an unreadable mount must not be reported as present")
+	require.NotNil(t, resp.Guidance, "guidance must be populated when the mount is not usable")
 }
 
 // TestGetExternalMedia_ContainerMountAbsent tests state 3: container without
@@ -108,7 +131,7 @@ func TestGetExternalMedia_ContainerMountAbsent(t *testing.T) {
 
 	_, ctrl := newExternalMediaController(
 		t,
-		func() (string, string) { return "Docker", "" },
+		func() (string, string) { return sysinfo.EnvDocker, "" },
 		func(_ string) sysinfo.MountProbeResult {
 			return sysinfo.MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
 		},
@@ -117,7 +140,7 @@ func TestGetExternalMedia_ContainerMountAbsent(t *testing.T) {
 	resp, code := callExternalMediaEndpoint(t, ctrl)
 
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "Docker", resp.Environment)
+	assert.Equal(t, sysinfo.EnvDocker, resp.Environment)
 	assert.True(t, resp.Containerized)
 	assert.False(t, resp.MountPresent)
 	require.NotNil(t, resp.Guidance, "guidance must be populated when mount is absent in a container")
@@ -198,7 +221,7 @@ func TestGetExternalMedia_ResponseShape(t *testing.T) {
 
 	_, ctrl := newExternalMediaController(
 		t,
-		func() (string, string) { return "Docker", "" },
+		func() (string, string) { return sysinfo.EnvDocker, "" },
 		func(_ string) sysinfo.MountProbeResult {
 			return sysinfo.MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
 		},

--- a/internal/api/v2/external_media_test.go
+++ b/internal/api/v2/external_media_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+// newExternalMediaController builds a minimal Controller suitable for
+// external-media endpoint tests, with the given environment getter and prober
+// injected.
+func newExternalMediaController(
+	t *testing.T,
+	envGetter sysinfo.EnvGetter,
+	prober sysinfo.MountProber,
+) (*echo.Echo, *Controller) {
+	t.Helper()
+	e := echo.New()
+	c := &Controller{
+		Echo:               e,
+		Group:              e.Group("/api/v2"),
+		externalMediaEnv:   envGetter,
+		externalMediaProbe: prober,
+	}
+	return e, c
+}
+
+// callExternalMediaEndpoint fires the GET /api/v2/system/external-media handler
+// and returns the parsed response.
+func callExternalMediaEndpoint(t *testing.T, ctrl *Controller) (ExternalMediaResponse, int) {
+	t.Helper()
+	e := ctrl.Echo
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/external-media", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := ctrl.GetExternalMedia(ctx)
+	require.NoError(t, err)
+
+	var resp ExternalMediaResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp, rec.Code
+}
+
+// TestGetExternalMedia_Native tests state 1: running on bare metal (not containerized).
+func TestGetExternalMedia_Native(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return "Bare Metal", "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
+		},
+	)
+
+	resp, code := callExternalMediaEndpoint(t, ctrl)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "Bare Metal", resp.Environment)
+	assert.False(t, resp.Containerized)
+	assert.Equal(t, sysinfo.DefaultExternalMountPath, resp.MountPath)
+	assert.Nil(t, resp.Guidance, "guidance should be nil for native environments")
+}
+
+// TestGetExternalMedia_ContainerMountPresent tests state 2: container with the
+// bind-mount wired up and accessible.
+func TestGetExternalMedia_ContainerMountPresent(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return "Docker", "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
+		},
+	)
+
+	resp, code := callExternalMediaEndpoint(t, ctrl)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "Docker", resp.Environment)
+	assert.True(t, resp.Containerized)
+	assert.True(t, resp.MountConfigured)
+	assert.True(t, resp.MountPresent)
+	assert.Nil(t, resp.Guidance, "guidance should be nil when mount is present")
+}
+
+// TestGetExternalMedia_ContainerMountAbsent tests state 3: container without
+// the bind-mount (guidance must be populated).
+func TestGetExternalMedia_ContainerMountAbsent(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return "Docker", "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
+		},
+	)
+
+	resp, code := callExternalMediaEndpoint(t, ctrl)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "Docker", resp.Environment)
+	assert.True(t, resp.Containerized)
+	assert.False(t, resp.MountPresent)
+	require.NotNil(t, resp.Guidance, "guidance must be populated when mount is absent in a container")
+	assert.NotEmpty(t, resp.Guidance.Environment, "guidance.environment should identify the runtime")
+	assert.NotEmpty(t, resp.Guidance.Steps, "guidance.steps should contain setup instructions")
+}
+
+// TestGetExternalMedia_PodmanMountAbsent tests the Podman-specific guidance path.
+func TestGetExternalMedia_PodmanMountAbsent(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return "Podman", "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
+		},
+	)
+
+	resp, code := callExternalMediaEndpoint(t, ctrl)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.True(t, resp.Containerized)
+	assert.False(t, resp.MountPresent)
+	require.NotNil(t, resp.Guidance)
+	assert.Equal(t, "Podman", resp.Guidance.Environment)
+	assert.NotEmpty(t, resp.Guidance.Steps)
+}
+
+// TestGetExternalMedia_ResponseShape verifies the JSON field names.
+func TestGetExternalMedia_ResponseShape(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return "Docker", "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
+		},
+	)
+
+	e := ctrl.Echo
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/external-media", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	require.NoError(t, ctrl.GetExternalMedia(ctx))
+
+	// Decode into a raw map to verify JSON key names.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+
+	assert.Contains(t, raw, "environment")
+	assert.Contains(t, raw, "containerized")
+	assert.Contains(t, raw, "mountPath")
+	assert.Contains(t, raw, "mountConfigured")
+	assert.Contains(t, raw, "mountPresent")
+	assert.Contains(t, raw, "guidance")
+}

--- a/internal/api/v2/external_media_test.go
+++ b/internal/api/v2/external_media_test.go
@@ -157,6 +157,38 @@ func TestGetExternalMedia_PodmanMountAbsent(t *testing.T) {
 	assert.NotEmpty(t, resp.Guidance.Steps)
 }
 
+// TestGetExternalMedia_GenericContainerMountAbsent tests the default (generic)
+// guidance branch for container runtimes other than Docker/Podman (e.g. LXC,
+// systemd-nspawn).
+func TestGetExternalMedia_GenericContainerMountAbsent(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "external-media")
+
+	_, ctrl := newExternalMediaController(
+		t,
+		func() (string, string) { return "LXC", "" },
+		func(_ string) sysinfo.MountProbeResult {
+			return sysinfo.MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
+		},
+	)
+
+	resp, code := callExternalMediaEndpoint(t, ctrl)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.True(t, resp.Containerized)
+	assert.False(t, resp.MountPresent)
+	require.NotNil(t, resp.Guidance, "generic container must still receive guidance")
+	assert.Equal(t, "LXC", resp.Guidance.Environment)
+	// The generic branch still includes the common host setup commands.
+	steps := strings.Join(resp.Guidance.Steps, "\n")
+	assert.Contains(t, steps, "mkdir -p /mnt/birdnet-go/external")
+	assert.Contains(t, steps, "mount --bind")
+	assert.Contains(t, steps, "make-rshared")
+	assert.Contains(t, steps, `chown -h "${BIRDNET_UID:-1000}:${BIRDNET_GID:-1000}"`)
+}
+
 // TestGetExternalMedia_ResponseShape verifies the JSON field names.
 func TestGetExternalMedia_ResponseShape(t *testing.T) {
 	t.Parallel()

--- a/internal/api/v2/external_media_test.go
+++ b/internal/api/v2/external_media_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -93,7 +94,6 @@ func TestGetExternalMedia_ContainerMountPresent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "Docker", resp.Environment)
 	assert.True(t, resp.Containerized)
-	assert.True(t, resp.MountConfigured)
 	assert.True(t, resp.MountPresent)
 	assert.Nil(t, resp.Guidance, "guidance should be nil when mount is present")
 }
@@ -123,6 +123,13 @@ func TestGetExternalMedia_ContainerMountAbsent(t *testing.T) {
 	require.NotNil(t, resp.Guidance, "guidance must be populated when mount is absent in a container")
 	assert.NotEmpty(t, resp.Guidance.Environment, "guidance.environment should identify the runtime")
 	assert.NotEmpty(t, resp.Guidance.Steps, "guidance.steps should contain setup instructions")
+	// Verify the guidance steps contain required setup commands.
+	steps := strings.Join(resp.Guidance.Steps, "\n")
+	assert.Contains(t, steps, "mkdir -p /mnt/birdnet-go/external", "guidance must include mkdir step")
+	assert.Contains(t, steps, "mount --bind", "guidance must include bind mount step")
+	assert.Contains(t, steps, "make-rshared", "guidance must include make-rshared step")
+	assert.Contains(t, steps, `chown -h "${BIRDNET_UID:-1000}:${BIRDNET_GID:-1000}"`, "guidance must include chown step with env vars")
+	assert.Contains(t, steps, "-v /mnt/birdnet-go/external:/external:rslave", "guidance must include volume flag")
 }
 
 // TestGetExternalMedia_PodmanMountAbsent tests the Podman-specific guidance path.
@@ -177,8 +184,7 @@ func TestGetExternalMedia_ResponseShape(t *testing.T) {
 
 	assert.Contains(t, raw, "environment")
 	assert.Contains(t, raw, "containerized")
-	assert.Contains(t, raw, "mountPath")
-	assert.Contains(t, raw, "mountConfigured")
-	assert.Contains(t, raw, "mountPresent")
+	assert.Contains(t, raw, "mount_path")
+	assert.Contains(t, raw, "mount_present")
 	assert.Contains(t, raw, "guidance")
 }

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -405,6 +405,7 @@ func (c *Controller) initSystemRoutes() {
 	protectedGroup.GET("/restart-status", c.GetRestartStatus)
 	protectedGroup.GET("/models", c.GetActiveModels)
 	protectedGroup.GET("/inference", c.GetInferenceStatus)
+	protectedGroup.GET("/external-media", c.GetExternalMedia)
 
 	// Audio device routes (all protected)
 	audioGroup := protectedGroup.Group("/audio")

--- a/internal/sysinfo/environment.go
+++ b/internal/sysinfo/environment.go
@@ -16,11 +16,11 @@ import (
 // Common string constants to avoid repetition.
 const (
 	armFallback     = "arm"
-	envDocker       = "Docker"
-	envPodman       = "Podman"
-	envLXC          = "LXC"
-	envNspawn       = "systemd-nspawn"
-	envContainerGen = "Container"
+	EnvDocker       = "Docker"
+	EnvPodman       = "Podman"
+	EnvLXC          = "LXC"
+	EnvNspawn       = "systemd-nspawn"
+	EnvContainerGen = "Container"
 )
 
 // Cached detection results — environment never changes at runtime.
@@ -120,12 +120,7 @@ func DetectEnvironment(rootPath string) (envType, detail string) {
 // (Docker, Podman, LXC, systemd-nspawn, or generic container).
 func IsContainer() bool {
 	envType, _ := GetEnvironment()
-	switch envType {
-	case envDocker, envPodman, envLXC, envNspawn, envContainerGen:
-		return true
-	default:
-		return false
-	}
+	return IsContainerEnv(envType)
 }
 
 // GetEnvironment returns the cached environment detection result.
@@ -142,10 +137,10 @@ func GetEnvironment() (envType, detail string) {
 func detectLinuxEnvironment(root string) (envType, detail string) {
 	// 1. Container detection — sentinel files
 	if fileExists(filepath.Join(root, ".dockerenv")) {
-		return envDocker, ""
+		return EnvDocker, ""
 	}
 	if fileExists(filepath.Join(root, "run", ".containerenv")) {
-		return envPodman, ""
+		return EnvPodman, ""
 	}
 
 	// 2. Container detection — environment variable (only in production mode,
@@ -188,15 +183,15 @@ func detectLinuxEnvironment(root string) (envType, detail string) {
 func mapContainerEnvVar(value string) (envType, detail string) {
 	switch strings.ToLower(value) {
 	case "docker":
-		return envDocker, ""
+		return EnvDocker, ""
 	case "podman":
-		return envPodman, ""
+		return EnvPodman, ""
 	case "lxc":
-		return envLXC, ""
-	case envNspawn:
-		return envNspawn, ""
+		return EnvLXC, ""
+	case EnvNspawn:
+		return EnvNspawn, ""
 	default:
-		return envContainerGen, value
+		return EnvContainerGen, value
 	}
 }
 
@@ -212,13 +207,13 @@ func detectFromCgroup(path string) string {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, "docker") {
-			return envDocker
+			return EnvDocker
 		}
 		if strings.Contains(line, "podman") {
-			return envPodman
+			return EnvPodman
 		}
 		if strings.Contains(line, "lxc") {
-			return envLXC
+			return EnvLXC
 		}
 	}
 	return ""

--- a/internal/sysinfo/externalmedia.go
+++ b/internal/sysinfo/externalmedia.go
@@ -2,11 +2,6 @@
 // and provides CPU architecture and model information.
 package sysinfo
 
-import (
-	"os"
-	"syscall"
-)
-
 // DefaultExternalMountPath is the container path where the host external-media
 // directory is expected to be bind-mounted (see install.sh / compose / systemd).
 const DefaultExternalMountPath = "/external"
@@ -31,58 +26,13 @@ type EnvGetter func() (envType, detail string)
 type MountProber func(path string) MountProbeResult
 
 // ProbeExternalMount checks whether the external-media directory at path is
-// present and mounted. envGetter and prober are injectable for testing; pass
-// nil to use the production defaults.
-func ProbeExternalMount(path string, envGetter EnvGetter, prober MountProber) MountProbeResult {
-	if envGetter == nil {
-		envGetter = GetEnvironment
-	}
+// present and mounted. prober is injectable for testing; pass nil to use the
+// production default.
+func ProbeExternalMount(path string, prober MountProber) MountProbeResult {
 	if prober == nil {
 		prober = realMountProber
 	}
 	return prober(path)
-}
-
-// realMountProber is the production implementation of MountProber.
-func realMountProber(path string) MountProbeResult {
-	result := MountProbeResult{}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return result
-	}
-	result.Exists = true
-
-	if !info.IsDir() {
-		return result
-	}
-
-	// Check if path is a mountpoint by comparing its device ID to its parent.
-	// A bind-mount or separate filesystem will have a different Dev value.
-	var statPath, statParent syscall.Stat_t
-	if err := syscall.Stat(path, &statPath); err != nil {
-		return result
-	}
-
-	parent := path + "/.."
-	if err := syscall.Stat(parent, &statParent); err != nil {
-		return result
-	}
-
-	result.IsMountpoint = statPath.Dev != statParent.Dev
-
-	// Check readability by opening the directory.
-	f, err := os.Open(path) //nolint:gosec // path is a fixed constant, not user input
-	if err != nil {
-		return result
-	}
-	defer func() { _ = f.Close() }()
-
-	_, err = f.Readdirnames(1)
-	// io.EOF means the directory is empty but readable; nil means we got entries.
-	result.Readable = err == nil || isEOF(err)
-
-	return result
 }
 
 // IsContainerEnv reports whether the given envType string indicates a container
@@ -96,12 +46,4 @@ func IsContainerEnv(envType string) bool {
 	default:
 		return false
 	}
-}
-
-// isEOF reports whether err is io.EOF (directory is empty but readable).
-func isEOF(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err.Error() == "EOF"
 }

--- a/internal/sysinfo/externalmedia.go
+++ b/internal/sysinfo/externalmedia.go
@@ -1,0 +1,107 @@
+// Package sysinfo detects the runtime environment (container, VM, bare metal)
+// and provides CPU architecture and model information.
+package sysinfo
+
+import (
+	"os"
+	"syscall"
+)
+
+// DefaultExternalMountPath is the container path where the host external-media
+// directory is expected to be bind-mounted (see install.sh / compose / systemd).
+const DefaultExternalMountPath = "/external"
+
+// MountProbeResult holds the result of probing a directory for mount status.
+type MountProbeResult struct {
+	// Exists reports whether the path exists (os.Stat succeeded).
+	Exists bool
+	// IsMountpoint reports whether the path is a distinct mount from its parent.
+	// Determined by comparing device IDs; only meaningful when Exists is true.
+	IsMountpoint bool
+	// Readable reports whether the process can read directory entries.
+	Readable bool
+}
+
+// EnvGetter returns (envType, detail) for the current runtime environment.
+// The default implementation is sysinfo.GetEnvironment.
+type EnvGetter func() (envType, detail string)
+
+// MountProber probes a filesystem path and returns a MountProbeResult.
+// The default implementation uses the real filesystem.
+type MountProber func(path string) MountProbeResult
+
+// ProbeExternalMount checks whether the external-media directory at path is
+// present and mounted. envGetter and prober are injectable for testing; pass
+// nil to use the production defaults.
+func ProbeExternalMount(path string, envGetter EnvGetter, prober MountProber) MountProbeResult {
+	if envGetter == nil {
+		envGetter = GetEnvironment
+	}
+	if prober == nil {
+		prober = realMountProber
+	}
+	return prober(path)
+}
+
+// realMountProber is the production implementation of MountProber.
+func realMountProber(path string) MountProbeResult {
+	result := MountProbeResult{}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return result
+	}
+	result.Exists = true
+
+	if !info.IsDir() {
+		return result
+	}
+
+	// Check if path is a mountpoint by comparing its device ID to its parent.
+	// A bind-mount or separate filesystem will have a different Dev value.
+	var statPath, statParent syscall.Stat_t
+	if err := syscall.Stat(path, &statPath); err != nil {
+		return result
+	}
+
+	parent := path + "/.."
+	if err := syscall.Stat(parent, &statParent); err != nil {
+		return result
+	}
+
+	result.IsMountpoint = statPath.Dev != statParent.Dev
+
+	// Check readability by opening the directory.
+	f, err := os.Open(path) //nolint:gosec // path is a fixed constant, not user input
+	if err != nil {
+		return result
+	}
+	defer func() { _ = f.Close() }()
+
+	_, err = f.Readdirnames(1)
+	// io.EOF means the directory is empty but readable; nil means we got entries.
+	result.Readable = err == nil || isEOF(err)
+
+	return result
+}
+
+// IsContainerEnv reports whether the given envType string indicates a container
+// runtime. It accepts the envType value returned by GetEnvironment or
+// DetectEnvironment and mirrors the logic in IsContainer without requiring a
+// live call to the cached singleton.
+func IsContainerEnv(envType string) bool {
+	switch envType {
+	case envDocker, envPodman, envLXC, envNspawn, envContainerGen:
+		return true
+	default:
+		return false
+	}
+}
+
+// isEOF reports whether err is io.EOF (directory is empty but readable).
+func isEOF(err error) bool {
+	if err == nil {
+		return false
+	}
+	return err.Error() == "EOF"
+}

--- a/internal/sysinfo/externalmedia.go
+++ b/internal/sysinfo/externalmedia.go
@@ -41,7 +41,7 @@ func ProbeExternalMount(path string, prober MountProber) MountProbeResult {
 // live call to the cached singleton.
 func IsContainerEnv(envType string) bool {
 	switch envType {
-	case envDocker, envPodman, envLXC, envNspawn, envContainerGen:
+	case EnvDocker, EnvPodman, EnvLXC, EnvNspawn, EnvContainerGen:
 		return true
 	default:
 		return false

--- a/internal/sysinfo/externalmedia_test.go
+++ b/internal/sysinfo/externalmedia_test.go
@@ -13,19 +13,12 @@ func fakeMountProber(result MountProbeResult) MountProber {
 	}
 }
 
-// fakeEnvGetter returns an EnvGetter that always returns the supplied values.
-func fakeEnvGetter(envType, detail string) EnvGetter {
-	return func() (string, string) {
-		return envType, detail
-	}
-}
-
-// TestProbeExternalMount_NilDefaultsDoNotPanic ensures that nil dependencies
-// fall back to the real implementations without panicking.
+// TestProbeExternalMount_NilDefaultsDoNotPanic ensures that nil prober
+// falls back to the real implementation without panicking.
 func TestProbeExternalMount_NilDefaultsDoNotPanic(t *testing.T) {
 	t.Parallel()
 	// Use a path that definitely does not exist to keep the test host-agnostic.
-	result := ProbeExternalMount("/nonexistent-path-birdnet-test", nil, nil)
+	result := ProbeExternalMount("/nonexistent-path-birdnet-test", nil)
 	// The path should not exist on a test host.
 	assert.False(t, result.Exists, "nonexistent path should report Exists=false")
 }
@@ -62,7 +55,6 @@ func TestProbeExternalMount_NativeNotContainerized(t *testing.T) {
 			t.Parallel()
 			result := ProbeExternalMount(
 				DefaultExternalMountPath,
-				fakeEnvGetter(tt.envType, ""),
 				fakeMountProber(tt.probe),
 			)
 			assert.Equal(t, tt.want, result)
@@ -77,7 +69,6 @@ func TestProbeExternalMount_ContainerMountPresent(t *testing.T) {
 	probe := MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
 	result := ProbeExternalMount(
 		DefaultExternalMountPath,
-		fakeEnvGetter("Docker", ""),
 		fakeMountProber(probe),
 	)
 
@@ -93,7 +84,6 @@ func TestProbeExternalMount_ContainerMountAbsent(t *testing.T) {
 	probe := MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
 	result := ProbeExternalMount(
 		DefaultExternalMountPath,
-		fakeEnvGetter("Docker", ""),
 		fakeMountProber(probe),
 	)
 
@@ -109,7 +99,6 @@ func TestProbeExternalMount_PodmanMountAbsent(t *testing.T) {
 	probe := MountProbeResult{Exists: true, IsMountpoint: false, Readable: false}
 	result := ProbeExternalMount(
 		DefaultExternalMountPath,
-		fakeEnvGetter("Podman", ""),
 		fakeMountProber(probe),
 	)
 
@@ -129,6 +118,6 @@ func TestProbeExternalMount_CustomPath(t *testing.T) {
 	}
 
 	customPath := "/custom/media"
-	ProbeExternalMount(customPath, fakeEnvGetter("Docker", ""), prober)
+	ProbeExternalMount(customPath, prober)
 	assert.Equal(t, customPath, capturedPath, "prober should receive the custom path")
 }

--- a/internal/sysinfo/externalmedia_test.go
+++ b/internal/sysinfo/externalmedia_test.go
@@ -1,0 +1,134 @@
+package sysinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeMountProber returns a MountProber that always returns the supplied result.
+func fakeMountProber(result MountProbeResult) MountProber {
+	return func(_ string) MountProbeResult {
+		return result
+	}
+}
+
+// fakeEnvGetter returns an EnvGetter that always returns the supplied values.
+func fakeEnvGetter(envType, detail string) EnvGetter {
+	return func() (string, string) {
+		return envType, detail
+	}
+}
+
+// TestProbeExternalMount_NilDefaultsDoNotPanic ensures that nil dependencies
+// fall back to the real implementations without panicking.
+func TestProbeExternalMount_NilDefaultsDoNotPanic(t *testing.T) {
+	t.Parallel()
+	// Use a path that definitely does not exist to keep the test host-agnostic.
+	result := ProbeExternalMount("/nonexistent-path-birdnet-test", nil, nil)
+	// The path should not exist on a test host.
+	assert.False(t, result.Exists, "nonexistent path should report Exists=false")
+}
+
+// TestProbeExternalMount_NativeNotContainerized tests the native (non-container) state.
+// In native mode the mount prober still runs; the endpoint handler decides how to
+// interpret the result based on environment. Here we verify the probe result
+// is returned faithfully.
+func TestProbeExternalMount_NativeNotContainerized(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		envType string
+		probe   MountProbeResult
+		want    MountProbeResult
+	}{
+		{
+			name:    "native, path absent",
+			envType: "Bare Metal",
+			probe:   MountProbeResult{Exists: false, IsMountpoint: false, Readable: false},
+			want:    MountProbeResult{Exists: false, IsMountpoint: false, Readable: false},
+		},
+		{
+			name:    "native, path present but not mountpoint",
+			envType: "Bare Metal",
+			probe:   MountProbeResult{Exists: true, IsMountpoint: false, Readable: true},
+			want:    MountProbeResult{Exists: true, IsMountpoint: false, Readable: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ProbeExternalMount(
+				DefaultExternalMountPath,
+				fakeEnvGetter(tt.envType, ""),
+				fakeMountProber(tt.probe),
+			)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+// TestProbeExternalMount_ContainerMountPresent tests the container + mount-present state.
+func TestProbeExternalMount_ContainerMountPresent(t *testing.T) {
+	t.Parallel()
+
+	probe := MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
+	result := ProbeExternalMount(
+		DefaultExternalMountPath,
+		fakeEnvGetter("Docker", ""),
+		fakeMountProber(probe),
+	)
+
+	assert.True(t, result.Exists, "mount should exist")
+	assert.True(t, result.IsMountpoint, "should be a mountpoint")
+	assert.True(t, result.Readable, "should be readable")
+}
+
+// TestProbeExternalMount_ContainerMountAbsent tests the container + mount-absent state.
+func TestProbeExternalMount_ContainerMountAbsent(t *testing.T) {
+	t.Parallel()
+
+	probe := MountProbeResult{Exists: false, IsMountpoint: false, Readable: false}
+	result := ProbeExternalMount(
+		DefaultExternalMountPath,
+		fakeEnvGetter("Docker", ""),
+		fakeMountProber(probe),
+	)
+
+	assert.False(t, result.Exists, "mount should not exist")
+	assert.False(t, result.IsMountpoint, "should not be a mountpoint")
+	assert.False(t, result.Readable, "should not be readable")
+}
+
+// TestProbeExternalMount_PodmanMountAbsent tests the Podman container + mount-absent state.
+func TestProbeExternalMount_PodmanMountAbsent(t *testing.T) {
+	t.Parallel()
+
+	probe := MountProbeResult{Exists: true, IsMountpoint: false, Readable: false}
+	result := ProbeExternalMount(
+		DefaultExternalMountPath,
+		fakeEnvGetter("Podman", ""),
+		fakeMountProber(probe),
+	)
+
+	// Path exists but is not a proper mountpoint.
+	assert.True(t, result.Exists, "path exists")
+	assert.False(t, result.IsMountpoint, "should not be a mountpoint")
+}
+
+// TestProbeExternalMount_CustomPath tests that the path argument is forwarded.
+func TestProbeExternalMount_CustomPath(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+	prober := func(path string) MountProbeResult {
+		capturedPath = path
+		return MountProbeResult{Exists: true, IsMountpoint: true, Readable: true}
+	}
+
+	customPath := "/custom/media"
+	ProbeExternalMount(customPath, fakeEnvGetter("Docker", ""), prober)
+	assert.Equal(t, customPath, capturedPath, "prober should receive the custom path")
+}

--- a/internal/sysinfo/externalmedia_test.go
+++ b/internal/sysinfo/externalmedia_test.go
@@ -1,6 +1,7 @@
 package sysinfo
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,9 +18,10 @@ func fakeMountProber(result MountProbeResult) MountProber {
 // falls back to the real implementation without panicking.
 func TestProbeExternalMount_NilDefaultsDoNotPanic(t *testing.T) {
 	t.Parallel()
-	// Use a path that definitely does not exist to keep the test host-agnostic.
-	result := ProbeExternalMount("/nonexistent-path-birdnet-test", nil)
-	// The path should not exist on a test host.
+	// Use a child under TempDir that we intentionally do not create, so the
+	// path is guaranteed not to exist regardless of host.
+	missingPath := filepath.Join(t.TempDir(), "missing")
+	result := ProbeExternalMount(missingPath, nil)
 	assert.False(t, result.Exists, "nonexistent path should report Exists=false")
 }
 

--- a/internal/sysinfo/externalmedia_unix.go
+++ b/internal/sysinfo/externalmedia_unix.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+package sysinfo
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// realMountProber is the production implementation of MountProber for POSIX systems.
+// It compares device IDs of path and its parent to detect mountpoints.
+func realMountProber(path string) MountProbeResult {
+	result := MountProbeResult{}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return result
+	}
+	result.Exists = true
+
+	if !info.IsDir() {
+		return result
+	}
+
+	// Check if path is a mountpoint by comparing its device ID to its parent.
+	// A bind-mount or separate filesystem will have a different Dev value.
+	var statPath, statParent syscall.Stat_t
+	if err := syscall.Stat(path, &statPath); err != nil {
+		return result
+	}
+
+	parent := filepath.Dir(filepath.Clean(path))
+	if err := syscall.Stat(parent, &statParent); err != nil {
+		return result
+	}
+
+	result.IsMountpoint = statPath.Dev != statParent.Dev
+
+	// Check readability by opening the directory.
+	f, err := os.Open(path) //nolint:gosec // path is a fixed constant, not user input
+	if err != nil {
+		return result
+	}
+	defer func() { _ = f.Close() }()
+
+	_, err = f.Readdirnames(1)
+	// io.EOF means the directory is empty but readable; nil means we got entries.
+	result.Readable = err == nil || errors.Is(err, io.EOF)
+
+	return result
+}

--- a/internal/sysinfo/externalmedia_unix.go
+++ b/internal/sysinfo/externalmedia_unix.go
@@ -32,7 +32,16 @@ func realMountProber(path string) MountProbeResult {
 		return result
 	}
 
-	parent := filepath.Dir(filepath.Clean(path))
+	// Resolve to an absolute, symlink-free path so the parent comparison is
+	// correct for relative paths and symlinked mountpoints.
+	resolved := path
+	if abs, absErr := filepath.Abs(path); absErr == nil {
+		resolved = abs
+	}
+	if linkResolved, symErr := filepath.EvalSymlinks(resolved); symErr == nil {
+		resolved = linkResolved
+	}
+	parent := filepath.Dir(resolved)
 	if err := syscall.Stat(parent, &statParent); err != nil {
 		return result
 	}

--- a/internal/sysinfo/externalmedia_windows.go
+++ b/internal/sysinfo/externalmedia_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package sysinfo
+
+import "os"
+
+// realMountProber is the Windows stub of MountProber. On Windows there is no
+// bind-mount concept, so IsMountpoint is always false. Exists and Readable are
+// still probed via the standard library.
+func realMountProber(path string) MountProbeResult {
+	result := MountProbeResult{}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return result
+	}
+	result.Exists = true
+
+	if !info.IsDir() {
+		return result
+	}
+
+	// IsMountpoint is always false on Windows (no bind-mount concept).
+	result.IsMountpoint = false
+
+	// Check readability by opening the directory.
+	f, err := os.Open(path) //nolint:gosec // path is a fixed constant, not user input
+	if err != nil {
+		return result
+	}
+	defer func() { _ = f.Close() }()
+
+	_, readErr := f.Readdirnames(1)
+	result.Readable = readErr == nil
+	return result
+}

--- a/internal/sysinfo/externalmedia_windows.go
+++ b/internal/sysinfo/externalmedia_windows.go
@@ -2,7 +2,11 @@
 
 package sysinfo
 
-import "os"
+import (
+	"errors"
+	"io"
+	"os"
+)
 
 // realMountProber is the Windows stub of MountProber. On Windows there is no
 // bind-mount concept, so IsMountpoint is always false. Exists and Readable are
@@ -20,8 +24,7 @@ func realMountProber(path string) MountProbeResult {
 		return result
 	}
 
-	// IsMountpoint is always false on Windows (no bind-mount concept).
-	result.IsMountpoint = false
+	// IsMountpoint stays false on Windows (zero value; see the file-level note).
 
 	// Check readability by opening the directory.
 	f, err := os.Open(path) //nolint:gosec // path is a fixed constant, not user input
@@ -31,6 +34,7 @@ func realMountProber(path string) MountProbeResult {
 	defer func() { _ = f.Close() }()
 
 	_, readErr := f.Readdirnames(1)
-	result.Readable = readErr == nil
+	// An empty directory yields io.EOF from Readdirnames but is still readable.
+	result.Readable = readErr == nil || errors.Is(readErr, io.EOF)
 	return result
 }


### PR DESCRIPTION
## Summary

Adds `GET /api/v2/system/external-media`, a backend endpoint that reports whether external media (the host bind-mount that maps to `/external` in the container) is reachable from the running application, and when it is not, returns deployment-specific setup guidance for the detected container runtime. This is the backend that the upcoming BirdNET-Pi import wizard uses to drive its source-access step.

- New `sysinfo.ProbeExternalMount` mount-probe helper with injectable dependencies for deterministic, host-independent testing. Mountpoint detection is build-tagged: a POSIX `st_dev` comparison on unix, a stub on windows.
- Reuses the existing `sysinfo` container/environment detection. `IsContainer` now delegates to a shared `IsContainerEnv` so the runtime switch lives in one place, and the runtime-name constants are exported so the API guidance builder references them instead of raw string literals.
- Three states: native (not containerized, no guidance), container with the mount present (no guidance), and container with the mount absent (guidance populated). The guidance steps match the host mount setup: `mkdir`, a self bind-mount made `rshared`, a `chown` to the container UID, and the runtime-specific volume flag.
- Response uses snake_case JSON tags, consistent with sibling `/api/v2/system` endpoints.

## Test Plan

- [x] `go build ./...` and `go vet` clean; `GOOS=windows go build ./internal/sysinfo/...` passes (mountpoint detection is build-tagged)
- [x] Unit tests cover all three states with mocked environment and mount prober (native, container+present, container+absent, podman, generic/LXC), plus a JSON field-name contract test
- [x] gofmt clean

No frontend in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/v2/system/external-media` to report the external mount path, whether it’s in a container, and whether the mount is present and readable.
  * When missing in a container, returns copy-pasteable host setup guidance for Docker, Podman, LXC, and other supported runtimes.

* **Tests**
  * Added unit tests for mount probing (existence, mountpoint detection, readability, custom paths).
  * Added endpoint tests covering native and container scenarios, including response shape validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->