### PR TITLE
feat(imports): BirdNET-Pi import engine (DB-only)

### DIFF
--- a/internal/imports/birdnetpi/source.go
+++ b/internal/imports/birdnetpi/source.go
@@ -1,0 +1,164 @@
+// Package birdnetpi implements the imports.Source interface for BirdNET-Pi SQLite databases.
+package birdnetpi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/imports"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// Source reads detections from a BirdNET-Pi SQLite database.
+type Source struct {
+	path string
+	db   *gorm.DB
+}
+
+// New opens the BirdNET-Pi database at path read-only.
+// Call Close when done.
+func New(path string) (*Source, error) {
+	dsn := fmt.Sprintf("file:%s?mode=ro", path)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		return nil, errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryDatabase).
+			Context("operation", "open").
+			Context("path", path).
+			Build()
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_sql_db").
+			Build()
+	}
+	// Single connection avoids shared-cache locking issues on read-only SQLite.
+	sqlDB.SetMaxOpenConns(1)
+
+	return &Source{path: path, db: db}, nil
+}
+
+// Validate confirms the detections table exists and is readable.
+func (s *Source) Validate(ctx context.Context) error {
+	var count int64
+	err := s.db.WithContext(ctx).Table("detections").Count(&count).Error
+	if err != nil {
+		return errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryValidation).
+			Context("operation", "validate").
+			Context("path", s.path).
+			Build()
+	}
+	return nil
+}
+
+// Count returns the total number of rows in the detections table.
+func (s *Source) Count(ctx context.Context) (int, error) {
+	var count int64
+	err := s.db.WithContext(ctx).Table("detections").Count(&count).Error
+	if err != nil {
+		return 0, errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryDatabase).
+			Context("operation", "count").
+			Build()
+	}
+	return int(count), nil
+}
+
+// Iterate streams rows in batches ordered by Date, Time.
+// fn is called once per batch; returning an error stops iteration.
+func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.SourceDetection) error) error {
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+
+	offset := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// Use raw SQL to get Date/Time as text, avoiding GORM's automatic time.Time conversion
+		var rows []struct {
+			Date       string
+			Time       string
+			SciName    string `gorm:"column:Sci_Name"`
+			ComName    string `gorm:"column:Com_Name"`
+			Confidence float64
+			Lat        float64
+			Lon        float64
+			Cutoff     float64
+			Sens       float64
+			FileName   string `gorm:"column:File_Name"`
+		}
+
+		err := s.db.WithContext(ctx).
+			Select("CAST(Date AS TEXT) as Date, CAST(Time AS TEXT) as Time, Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Sens, File_Name").
+			Table("detections").
+			Order("Date, Time").
+			Limit(batchSize).
+			Offset(offset).
+			Scan(&rows).Error
+		if err != nil {
+			return errors.New(err).
+				Component("imports/birdnetpi").
+				Category(errors.CategoryDatabase).
+				Context("operation", "iterate").
+				Context("offset", fmt.Sprintf("%d", offset)).
+				Build()
+		}
+
+		if len(rows) == 0 {
+			break
+		}
+
+		batch := make([]imports.SourceDetection, len(rows))
+		for i, r := range rows {
+			batch[i] = imports.SourceDetection{
+				Date:           r.Date,
+				Time:           r.Time,
+				ScientificName: r.SciName,
+				CommonName:     r.ComName,
+				Confidence:     r.Confidence,
+				Latitude:       r.Lat,
+				Longitude:      r.Lon,
+				Cutoff:         r.Cutoff,
+				Sensitivity:    r.Sens,
+				FileName:       r.FileName,
+			}
+		}
+
+		fnErr := fn(batch)
+		if fnErr != nil {
+			return fnErr
+		}
+
+		offset += len(rows)
+		if len(rows) < batchSize {
+			break
+		}
+	}
+
+	return nil
+}
+
+// Close releases the database connection.
+func (s *Source) Close() error {
+	sqlDB, err := s.db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
+}

--- a/internal/imports/birdnetpi/source.go
+++ b/internal/imports/birdnetpi/source.go
@@ -3,7 +3,6 @@ package birdnetpi
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -37,6 +36,9 @@ func New(path string) (*Source, error) {
 
 	sqlDB, err := db.DB()
 	if err != nil {
+		// db.DB() failing means the internal connection pool is unavailable.
+		// We cannot retrieve the underlying sql.DB to close it, so the gorm
+		// instance is abandoned. This path is not reachable under normal operation.
 		return nil, errors.New(err).
 			Component("imports/birdnetpi").
 			Category(errors.CategoryDatabase).
@@ -120,7 +122,7 @@ func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.S
 				Component("imports/birdnetpi").
 				Category(errors.CategoryDatabase).
 				Context("operation", "iterate").
-				Context("last_row_id", fmt.Sprintf("%d", lastRowID)).
+				Context("last_row_id", lastRowID).
 				Build()
 		}
 
@@ -165,7 +167,18 @@ func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.S
 func (s *Source) Close() error {
 	sqlDB, err := s.db.DB()
 	if err != nil {
-		return err
+		return errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryDatabase).
+			Context("operation", "close").
+			Build()
 	}
-	return sqlDB.Close()
+	if err := sqlDB.Close(); err != nil {
+		return errors.New(err).
+			Component("imports/birdnetpi").
+			Category(errors.CategoryDatabase).
+			Context("operation", "close").
+			Build()
+	}
+	return nil
 }

--- a/internal/imports/birdnetpi/source.go
+++ b/internal/imports/birdnetpi/source.go
@@ -4,6 +4,7 @@ package birdnetpi
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imports"
@@ -21,7 +22,7 @@ type Source struct {
 // New opens the BirdNET-Pi database at path read-only.
 // Call Close when done.
 func New(path string) (*Source, error) {
-	dsn := fmt.Sprintf("file:%s?mode=ro", path)
+	dsn := "file:" + url.PathEscape(path) + "?mode=ro"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})
@@ -48,10 +49,13 @@ func New(path string) (*Source, error) {
 	return &Source{path: path, db: db}, nil
 }
 
-// Validate confirms the detections table exists and is readable.
+// Validate confirms the detections table exists and has the expected schema.
+// It issues a LIMIT 0 query selecting all columns that the adapter reads,
+// so a missing column causes a clear error before any data is processed.
 func (s *Source) Validate(ctx context.Context) error {
-	var count int64
-	err := s.db.WithContext(ctx).Table("detections").Count(&count).Error
+	err := s.db.WithContext(ctx).
+		Raw("SELECT Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Sens, Time, Date, File_Name FROM detections LIMIT 0").
+		Scan(nil).Error
 	if err != nil {
 		return errors.New(err).
 			Component("imports/birdnetpi").
@@ -77,21 +81,25 @@ func (s *Source) Count(ctx context.Context) (int, error) {
 	return int(count), nil
 }
 
-// Iterate streams rows in batches ordered by Date, Time.
+// Iterate streams rows in batches using rowid cursor pagination.
+// Cursor pagination on the implicit rowid is O(N) total and avoids the skip/duplicate
+// hazard of offset-based paging on non-unique (Date, Time) ordering.
 // fn is called once per batch; returning an error stops iteration.
 func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.SourceDetection) error) error {
 	if batchSize <= 0 {
 		batchSize = 500
 	}
 
-	offset := 0
+	var lastRowID int64
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		// Use raw SQL to get Date/Time as text, avoiding GORM's automatic time.Time conversion
+		// Use raw SQL to get Date/Time as text, avoiding GORM's automatic time.Time conversion.
+		// Cursor on rowid ensures O(N) total scan with no duplicates or skips.
 		var rows []struct {
+			RowID      int64 `gorm:"column:row_id"`
 			Date       string
 			Time       string
 			SciName    string `gorm:"column:Sci_Name"`
@@ -105,18 +113,14 @@ func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.S
 		}
 
 		err := s.db.WithContext(ctx).
-			Select("CAST(Date AS TEXT) as Date, CAST(Time AS TEXT) as Time, Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Sens, File_Name").
-			Table("detections").
-			Order("Date, Time").
-			Limit(batchSize).
-			Offset(offset).
+			Raw("SELECT rowid AS row_id, CAST(Date AS TEXT) AS Date, CAST(Time AS TEXT) AS Time, Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Sens, File_Name FROM detections WHERE rowid > ? ORDER BY rowid LIMIT ?", lastRowID, batchSize).
 			Scan(&rows).Error
 		if err != nil {
 			return errors.New(err).
 				Component("imports/birdnetpi").
 				Category(errors.CategoryDatabase).
 				Context("operation", "iterate").
-				Context("offset", fmt.Sprintf("%d", offset)).
+				Context("last_row_id", fmt.Sprintf("%d", lastRowID)).
 				Build()
 		}
 
@@ -125,7 +129,8 @@ func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.S
 		}
 
 		batch := make([]imports.SourceDetection, len(rows))
-		for i, r := range rows {
+		for i := range rows {
+			r := &rows[i]
 			batch[i] = imports.SourceDetection{
 				Date:           r.Date,
 				Time:           r.Time,
@@ -138,6 +143,9 @@ func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.S
 				Sensitivity:    r.Sens,
 				FileName:       r.FileName,
 			}
+			if r.RowID > lastRowID {
+				lastRowID = r.RowID
+			}
 		}
 
 		fnErr := fn(batch)
@@ -145,7 +153,6 @@ func (s *Source) Iterate(ctx context.Context, batchSize int, fn func([]imports.S
 			return fnErr
 		}
 
-		offset += len(rows)
 		if len(rows) < batchSize {
 			break
 		}

--- a/internal/imports/birdnetpi/source.go
+++ b/internal/imports/birdnetpi/source.go
@@ -21,7 +21,9 @@ type Source struct {
 // New opens the BirdNET-Pi database at path read-only.
 // Call Close when done.
 func New(path string) (*Source, error) {
-	dsn := "file:" + url.PathEscape(path) + "?mode=ro"
+	// Build a SQLite file URI that preserves path slashes but escapes URI-special
+	// characters (?, #, %, space). OmitHost keeps the "file:/abs/path" form.
+	dsn := (&url.URL{Scheme: "file", OmitHost: true, Path: path, RawQuery: "mode=ro"}).String()
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -115,9 +115,12 @@ func NewEngine(repo datastore.DetectionRepository) *Engine {
 }
 
 // detectionKey returns a stable composite key for duplicate detection.
-// Components: unix second timestamp, scientific name, confidence rounded to 4 decimal places.
+// Components: wall-clock timestamp (timezone-independent), scientific name, confidence rounded to 4 decimal places.
+// Using the wall-clock representation ensures idempotency even when opts.Location differs
+// from the timezone used during read-back (the datastore reconstructs Timestamp from
+// the stored Date/Time strings in its own timezone).
 func detectionKey(ts time.Time, scientificName string, confidence float64) string {
-	return fmt.Sprintf("%d|%s|%.4f", ts.Unix(), scientificName, confidence)
+	return fmt.Sprintf("%s|%s|%.4f", ts.Format(time.DateTime), scientificName, confidence)
 }
 
 // Run imports all detections from src that are not already present in the store.
@@ -195,6 +198,11 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 
 			result := mapToResult(row, ts, opts.SourceNode)
 			if saveErr := e.repo.Save(ctx, result, nil); saveErr != nil {
+				if ctx.Err() != nil {
+					// Context was cancelled or timed out during Save; propagate
+					// the context error so the caller gets a clean abort signal.
+					return ctx.Err()
+				}
 				e.log.Error("failed to save detection",
 					logger.String("scientific_name", row.ScientificName),
 					logger.Error(saveErr))
@@ -251,12 +259,10 @@ func (e *Engine) loadExistingKeys(ctx context.Context, sourceNode string) (map[s
 			return nil, err
 		}
 
-		filters := &datastore.DetectionFilters{
-			Location:         []string{sourceNode},
-			Limit:            pageSize,
-			MinID:            minID,
-			CursorPagination: true,
-		}
+		filters := datastore.NewDetectionFilters().
+			WithMinID(minID)
+		filters.Location = []string{sourceNode}
+		filters.Limit = pageSize
 
 		results, _, err := e.repo.Search(ctx, filters)
 		if err != nil {

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -1,0 +1,328 @@
+// Package imports provides a transport-agnostic engine for importing detections
+// from external sources into the birdnet-go datastore.
+package imports
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	// DefaultSourceNode is the provenance tag written to SourceNode for imported rows.
+	DefaultSourceNode = "birdnet-pi"
+
+	// defaultBatchSize is the number of source rows read per Iterate call.
+	defaultBatchSize = 500
+)
+
+// SourceDetection holds the raw fields from a source database row.
+// Each adapter maps its native schema to this neutral struct.
+type SourceDetection struct {
+	Date           string
+	Time           string
+	ScientificName string
+	CommonName     string
+	Confidence     float64
+	Latitude       float64
+	Longitude      float64
+	Cutoff         float64
+	Sensitivity    float64
+	FileName       string
+}
+
+// Source is the interface a source adapter must implement.
+type Source interface {
+	// Validate confirms the source is readable and has the expected schema.
+	Validate(ctx context.Context) error
+
+	// Count returns the total number of rows in the source.
+	Count(ctx context.Context) (int, error)
+
+	// Iterate streams rows in batches ordered by Date, Time.
+	// fn is called once per batch; returning an error from fn stops iteration.
+	Iterate(ctx context.Context, batchSize int, fn func([]SourceDetection) error) error
+
+	// Close releases the source's resources.
+	Close() error
+}
+
+// ImportStats tracks progress and outcome of an import run.
+type ImportStats struct {
+	Total     int
+	Processed int
+	Inserted  int
+	Skipped   int
+	Errors    int
+	Phase     string
+}
+
+// ProgressReporter receives periodic ImportStats updates from the engine.
+// A nil reporter is safe; the engine performs a nil check before calling.
+type ProgressReporter interface {
+	Report(ImportStats)
+}
+
+// ImportOptions controls engine behaviour.
+type ImportOptions struct {
+	// SourceNode is the provenance tag written to every imported detection.
+	// Defaults to DefaultSourceNode.
+	SourceNode string
+
+	// Location is the timezone used when parsing Date + Time strings.
+	// Defaults to time.Local.
+	Location *time.Location
+
+	// BatchSize controls how many source rows are read per Iterate call.
+	// Defaults to defaultBatchSize.
+	BatchSize int
+
+	// IncludeAudio is reserved for B2 (audio copy). Ignored in B1.
+	IncludeAudio bool
+}
+
+func (o ImportOptions) withDefaults() ImportOptions {
+	if o.SourceNode == "" {
+		o.SourceNode = DefaultSourceNode
+	}
+	if o.Location == nil {
+		o.Location = time.Local
+	}
+	if o.BatchSize <= 0 {
+		o.BatchSize = defaultBatchSize
+	}
+	return o
+}
+
+// Engine runs an import from a Source into a DetectionRepository.
+type Engine struct {
+	repo datastore.DetectionRepository
+	log  logger.Logger
+}
+
+// NewEngine creates a new Engine.
+// repo is used both for saving new detections and for querying existing ones.
+func NewEngine(repo datastore.DetectionRepository) *Engine {
+	return &Engine{
+		repo: repo,
+		log:  logger.Global().Module("imports"),
+	}
+}
+
+// detectionKey returns a stable composite key for duplicate detection.
+// Components: unix second timestamp, scientific name, confidence rounded to 4 decimal places.
+func detectionKey(ts time.Time, scientificName string, confidence float64) string {
+	return fmt.Sprintf("%d|%s|%.4f", ts.Unix(), scientificName, confidence)
+}
+
+// Run imports all detections from src that are not already present in the store.
+// It returns a final ImportStats summary. Partial results are consistent because
+// the dedup set makes a re-run safe.
+func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, reporter ProgressReporter) (ImportStats, error) {
+	opts = opts.withDefaults()
+
+	stats := ImportStats{Phase: "validate"}
+	e.report(reporter, stats)
+
+	if err := src.Validate(ctx); err != nil {
+		return stats, errors.New(err).
+			Component("imports").
+			Category(errors.CategoryValidation).
+			Context("phase", "validate").
+			Build()
+	}
+
+	total, err := src.Count(ctx)
+	if err != nil {
+		return stats, errors.New(err).
+			Component("imports").
+			Category(errors.CategoryDatabase).
+			Context("phase", "count").
+			Build()
+	}
+	stats.Total = total
+	stats.Phase = "dedup"
+	e.report(reporter, stats)
+
+	// Pre-load existing import-source keys to avoid per-row queries.
+	seen, err := e.loadExistingKeys(ctx, opts.SourceNode)
+	if err != nil {
+		return stats, errors.New(err).
+			Component("imports").
+			Category(errors.CategoryDatabase).
+			Context("phase", "dedup").
+			Context("source_node", opts.SourceNode).
+			Build()
+	}
+
+	e.log.Info("starting import",
+		logger.String("source_node", opts.SourceNode),
+		logger.Int("total_rows", total),
+		logger.Int("existing_keys", len(seen)))
+
+	stats.Phase = "import"
+	e.report(reporter, stats)
+
+	iterErr := src.Iterate(ctx, opts.BatchSize, func(batch []SourceDetection) error {
+		for i := range batch {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			row := &batch[i]
+			ts, parseErr := parseTimestamp(row.Date, row.Time, opts.Location)
+			if parseErr != nil {
+				e.log.Debug("skipping row with unparseable timestamp",
+					logger.String("date", row.Date),
+					logger.String("time", row.Time),
+					logger.Error(parseErr))
+				stats.Errors++
+				stats.Processed++
+				continue
+			}
+
+			key := detectionKey(ts, row.ScientificName, row.Confidence)
+			if seen[key] {
+				stats.Skipped++
+				stats.Processed++
+				continue
+			}
+
+			result := mapToResult(row, ts, opts.SourceNode)
+			if saveErr := e.repo.Save(ctx, result, nil); saveErr != nil {
+				e.log.Error("failed to save detection",
+					logger.String("scientific_name", row.ScientificName),
+					logger.Error(saveErr))
+				stats.Errors++
+				stats.Processed++
+				continue
+			}
+
+			// Mark as seen so within-source duplicates are also deduplicated.
+			seen[key] = true
+			stats.Inserted++
+			stats.Processed++
+		}
+
+		e.report(reporter, stats)
+		return nil
+	})
+
+	if iterErr != nil {
+		if ctx.Err() != nil {
+			e.log.Info("import cancelled",
+				logger.Int("inserted", stats.Inserted),
+				logger.Int("skipped", stats.Skipped))
+			return stats, iterErr
+		}
+		return stats, errors.New(iterErr).
+			Component("imports").
+			Category(errors.CategoryDatabase).
+			Context("phase", "import").
+			Build()
+	}
+
+	stats.Phase = "done"
+	e.report(reporter, stats)
+
+	e.log.Info("import complete",
+		logger.Int("total", stats.Total),
+		logger.Int("inserted", stats.Inserted),
+		logger.Int("skipped", stats.Skipped),
+		logger.Int("errors", stats.Errors))
+
+	return stats, nil
+}
+
+// loadExistingKeys pages through all detections attributed to sourceNode
+// and returns their dedup keys in a set.
+func (e *Engine) loadExistingKeys(ctx context.Context, sourceNode string) (map[string]bool, error) {
+	const pageSize = 1000
+	seen := make(map[string]bool)
+	var minID uint
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		filters := &datastore.DetectionFilters{
+			Location:         []string{sourceNode},
+			Limit:            pageSize,
+			MinID:            minID,
+			CursorPagination: true,
+		}
+
+		results, _, err := e.repo.Search(ctx, filters)
+		if err != nil {
+			return nil, fmt.Errorf("querying existing detections: %w", err)
+		}
+
+		for _, r := range results {
+			key := detectionKey(r.Timestamp, r.Species.ScientificName, r.Confidence)
+			seen[key] = true
+			if r.ID > minID {
+				minID = r.ID
+			}
+		}
+
+		if len(results) < pageSize {
+			break
+		}
+	}
+
+	return seen, nil
+}
+
+// parseTimestamp parses "YYYY-MM-DD HH:MM:SS" in loc.
+func parseTimestamp(date, timeStr string, loc *time.Location) (time.Time, error) {
+	return time.ParseInLocation("2006-01-02 15:04:05", date+" "+timeStr, loc)
+}
+
+// mapToResult converts a SourceDetection to a detection.Result.
+//
+// Field mapping decisions:
+//   - BeginTime and EndTime are left as zero values: BirdNET-Pi stores detections
+//     as point-in-time events without clip offsets, so there is no timing data to map.
+//   - ClipName is left empty in DB-only mode (B1); B2 will set it when audio is copied.
+//     An empty ClipName avoids broken "audio not available" links.
+//   - Model is set to a synthetic marker so imported rows are distinguishable from
+//     live detections in queries or analytics.
+//   - Provenance is carried solely by SourceNode (a persisted column). AudioSource is
+//     gorm:"-" runtime-only and is not persisted on the legacy save path, so it is left
+//     zero rather than used as a provenance marker.
+//   - Week and Overlap from BirdNET-Pi are dropped; birdnet-go does not use them.
+func mapToResult(row *SourceDetection, ts time.Time, sourceNode string) *detection.Result {
+	return &detection.Result{
+		Timestamp:  ts,
+		SourceNode: sourceNode,
+		Species: detection.Species{
+			ScientificName: row.ScientificName,
+			CommonName:     row.CommonName,
+			Code:           "",
+		},
+		Confidence:  row.Confidence,
+		Latitude:    row.Latitude,
+		Longitude:   row.Longitude,
+		Threshold:   row.Cutoff,
+		Sensitivity: row.Sensitivity,
+		Model: detection.ModelInfo{
+			Name:    "BirdNET",
+			Version: "birdnet-pi",
+			Variant: "import",
+		},
+		ClipName: "",
+	}
+}
+
+// report calls reporter.Report if reporter is not nil.
+func (e *Engine) report(reporter ProgressReporter, stats ImportStats) {
+	if reporter != nil {
+		reporter.Report(stats)
+	}
+}

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -44,7 +44,7 @@ type Source interface {
 	// Count returns the total number of rows in the source.
 	Count(ctx context.Context) (int, error)
 
-	// Iterate streams rows in batches ordered by Date, Time.
+	// Iterate streams rows in batches ordered by the source's internal row order.
 	// fn is called once per batch; returning an error from fn stops iteration.
 	Iterate(ctx context.Context, batchSize int, fn func([]SourceDetection) error) error
 
@@ -82,7 +82,8 @@ type ImportOptions struct {
 	// Defaults to defaultBatchSize.
 	BatchSize int
 
-	// IncludeAudio is reserved for B2 (audio copy). Ignored in B1.
+	// IncludeAudio controls whether source audio files are copied alongside detection data.
+	// Not yet implemented; setting it currently has no effect.
 	IncludeAudio bool
 }
 
@@ -190,7 +191,7 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 			}
 
 			key := detectionKey(ts, row.ScientificName, row.Confidence)
-			if seen[key] {
+			if _, ok := seen[key]; ok {
 				stats.Skipped++
 				stats.Processed++
 				continue
@@ -212,7 +213,7 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 			}
 
 			// Mark as seen so within-source duplicates are also deduplicated.
-			seen[key] = true
+			seen[key] = struct{}{}
 			stats.Inserted++
 			stats.Processed++
 		}
@@ -249,9 +250,9 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 
 // loadExistingKeys pages through all detections attributed to sourceNode
 // and returns their dedup keys in a set.
-func (e *Engine) loadExistingKeys(ctx context.Context, sourceNode string) (map[string]bool, error) {
+func (e *Engine) loadExistingKeys(ctx context.Context, sourceNode string) (map[string]struct{}, error) {
 	const pageSize = 1000
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var minID uint
 
 	for {
@@ -260,18 +261,22 @@ func (e *Engine) loadExistingKeys(ctx context.Context, sourceNode string) (map[s
 		}
 
 		filters := datastore.NewDetectionFilters().
-			WithMinID(minID)
+			WithMinID(minID).
+			WithLimit(pageSize)
 		filters.Location = []string{sourceNode}
-		filters.Limit = pageSize
 
 		results, _, err := e.repo.Search(ctx, filters)
 		if err != nil {
-			return nil, fmt.Errorf("querying existing detections: %w", err)
+			return nil, errors.New(err).
+				Component("imports").
+				Category(errors.CategoryDatabase).
+				Context("operation", "load_existing_keys").
+				Build()
 		}
 
 		for _, r := range results {
 			key := detectionKey(r.Timestamp, r.Species.ScientificName, r.Confidence)
-			seen[key] = true
+			seen[key] = struct{}{}
 			if r.ID > minID {
 				minID = r.ID
 			}
@@ -295,8 +300,8 @@ func parseTimestamp(date, timeStr string, loc *time.Location) (time.Time, error)
 // Field mapping decisions:
 //   - BeginTime and EndTime are left as zero values: BirdNET-Pi stores detections
 //     as point-in-time events without clip offsets, so there is no timing data to map.
-//   - ClipName is left empty in DB-only mode (B1); B2 will set it when audio is copied.
-//     An empty ClipName avoids broken "audio not available" links.
+//   - ClipName is left empty in DB-only mode; it will be set once audio copying is
+//     implemented. An empty ClipName avoids broken "audio not available" links.
 //   - Model is set to a synthetic marker so imported rows are distinguishable from
 //     live detections in queries or analytics.
 //   - Provenance is carried solely by SourceNode (a persisted column). AudioSource is

--- a/internal/imports/imports_test.go
+++ b/internal/imports/imports_test.go
@@ -110,7 +110,7 @@ func TestValidate_NoDetectionsTable(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	err = src.Validate(t.Context())
 	assert.Error(t, err, "Validate must fail when detections table is absent")
@@ -125,7 +125,7 @@ func TestCount(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	count, err := src.Count(t.Context())
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestImport_FieldMapping(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	store := newTestStore(t)
 	repo := datastore.NewDetectionRepository(store, time.UTC)
@@ -232,7 +232,7 @@ func TestImport_SkipsUnparseableDate(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	store := newTestStore(t)
 	repo := datastore.NewDetectionRepository(store, time.UTC)
@@ -291,7 +291,7 @@ func TestImport_WithinSourceDuplicate(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	stats, err := engine.Run(t.Context(), src, opts, nil)
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestImport_ContextCancellation(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	_, err = engine.Run(ctx, src, opts, nil)
 	assert.ErrorIs(t, err, context.Canceled, "cancelled import must return context error")
@@ -408,7 +408,7 @@ func TestValidate_MissingColumn(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	err = src.Validate(t.Context())
 	assert.Error(t, err, "Validate must fail when required columns are missing")
@@ -453,7 +453,7 @@ func TestImport_CancelDuringSave(t *testing.T) {
 
 	src, err := birdnetpi.New(path)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = src.Close() })
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
 	engine := imports.NewEngine(repo)
 	opts := imports.ImportOptions{

--- a/internal/imports/imports_test.go
+++ b/internal/imports/imports_test.go
@@ -2,6 +2,7 @@ package imports_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -139,11 +140,6 @@ func TestSimpleSave(t *testing.T) {
 	result := &detection.Result{
 		Timestamp:  now,
 		SourceNode: "birdnet-pi",
-		AudioSource: detection.AudioSource{
-			ID:          "birdnet-pi",
-			SafeString:  "birdnet-pi",
-			DisplayName: "birdnet-pi",
-		},
 		Species: detection.Species{
 			ScientificName: "Dendrocopos major",
 			CommonName:     "Great Spotted Woodpecker",
@@ -339,4 +335,125 @@ func TestImport_ContextCancellation(t *testing.T) {
 
 	_, err = engine.Run(ctx, src, opts, nil)
 	assert.ErrorIs(t, err, context.Canceled, "cancelled import must return context error")
+}
+
+// TestImport_Idempotent_TimezoneMismatch verifies that idempotency holds even when
+// opts.Location differs from the repository's timezone. The datastore reconstructs
+// Timestamp from stored Date/Time wall-clock strings in its own timezone (UTC here),
+// so a detectionKey based on ts.Unix() would differ when opts.Location is non-UTC.
+// The wall-clock key (ts.Format) is timezone-independent and must deduplicate correctly.
+func TestImport_Idempotent_TimezoneMismatch(t *testing.T) {
+	rows := []birdnetPiRow{
+		{
+			Date: "2025-06-01", Time: "12:00:00",
+			SciName: "Sylvia atricapilla", ComName: "Eurasian Blackcap",
+			Confidence: 0.8800, Lat: 60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0,
+			FileName: "blackcap.mp3",
+		},
+	}
+	path := newFixtureDB(t, rows)
+
+	// Repository built with UTC (simulates the repo's read-back timezone).
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+
+	// First run: import with a non-UTC location.
+	nonUTCLoc := time.FixedZone("test", 3*3600)
+	opts := imports.ImportOptions{
+		SourceNode: imports.DefaultSourceNode,
+		Location:   nonUTCLoc,
+	}
+
+	src1, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	engine1 := imports.NewEngine(repo)
+	stats1, err := engine1.Run(t.Context(), src1, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, src1.Close())
+	require.Equal(t, 1, stats1.Inserted, "first run must insert the row")
+
+	// Second run: same non-UTC location. Must skip the already-imported row.
+	src2, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	engine2 := imports.NewEngine(repo)
+	stats2, err := engine2.Run(t.Context(), src2, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, src2.Close())
+	assert.Equal(t, 0, stats2.Inserted, "re-run must insert zero rows even with non-UTC import location")
+	assert.Equal(t, 1, stats2.Skipped, "re-run must skip the already-imported row")
+}
+
+// TestValidate_MissingColumn verifies that Validate rejects a database whose
+// detections table is missing a required column.
+func TestValidate_MissingColumn(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad_schema.db")
+
+	// Create a detections table that is missing Sci_Name and several other columns.
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE detections (
+		Date DATE,
+		Time TIME,
+		Com_Name VARCHAR(100) NOT NULL,
+		Confidence FLOAT
+	)`).Error)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	err = src.Validate(t.Context())
+	assert.Error(t, err, "Validate must fail when required columns are missing")
+}
+
+// TestImport_CancelDuringSave verifies that a context cancellation that occurs after
+// at least one row has been processed causes Run to return a context error without
+// miscounting the cancelled row as a save failure.
+func TestImport_CancelDuringSave(t *testing.T) {
+	// 500 rows, batch size 10, so the context can be cancelled partway through.
+	rows := make([]birdnetPiRow, 0, 500)
+	for i := range 500 {
+		rows = append(rows, birdnetPiRow{
+			Date:       "2025-06-10",
+			Time:       fmt.Sprintf("%02d:00:00", i%24),
+			SciName:    "Phylloscopus trochilus",
+			ComName:    "Willow Warbler",
+			Confidence: float64(i+1) * 0.001,
+			Lat:        60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0,
+			FileName: fmt.Sprintf("warbler_%d.mp3", i),
+		})
+	}
+	path := newFixtureDB(t, rows)
+
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	engine := imports.NewEngine(repo)
+	opts := imports.ImportOptions{
+		SourceNode: imports.DefaultSourceNode,
+		Location:   time.UTC,
+		BatchSize:  10,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Cancel after a short delay so at least one row is processed.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err = engine.Run(ctx, src, opts, nil)
+	assert.ErrorIs(t, err, context.Canceled, "mid-import cancel must return context error, not a save error")
 }

--- a/internal/imports/imports_test.go
+++ b/internal/imports/imports_test.go
@@ -274,6 +274,7 @@ func TestImport_Idempotent(t *testing.T) {
 	require.NoError(t, src2.Close())
 	assert.Equal(t, 0, stats2.Inserted, "re-run must insert zero rows")
 	assert.Equal(t, 1, stats2.Skipped, "re-run must skip the already-imported row")
+	assert.Equal(t, 0, stats2.Errors, "re-run must not produce any errors")
 }
 
 func TestImport_WithinSourceDuplicate(t *testing.T) {
@@ -381,6 +382,7 @@ func TestImport_Idempotent_TimezoneMismatch(t *testing.T) {
 	require.NoError(t, src2.Close())
 	assert.Equal(t, 0, stats2.Inserted, "re-run must insert zero rows even with non-UTC import location")
 	assert.Equal(t, 1, stats2.Skipped, "re-run must skip the already-imported row")
+	assert.Equal(t, 0, stats2.Errors, "re-run must not produce any errors")
 }
 
 // TestValidate_MissingColumn verifies that Validate rejects a database whose
@@ -412,11 +414,26 @@ func TestValidate_MissingColumn(t *testing.T) {
 	assert.Error(t, err, "Validate must fail when required columns are missing")
 }
 
-// TestImport_CancelDuringSave verifies that a context cancellation that occurs after
-// at least one row has been processed causes Run to return a context error without
-// miscounting the cancelled row as a save failure.
+// cancelOnFirstReport is a ProgressReporter that cancels a context on its first
+// report call with stats.Inserted > 0, ensuring cancellation happens after the
+// engine has inserted at least one row.
+type cancelOnFirstReport struct {
+	cancel context.CancelFunc
+	once   bool
+}
+
+func (r *cancelOnFirstReport) Report(stats imports.ImportStats) {
+	if !r.once && stats.Inserted > 0 {
+		r.once = true
+		r.cancel()
+	}
+}
+
+// TestImport_CancelDuringSave verifies that a context cancellation after at least
+// one batch has been saved causes Run to return context.Canceled without
+// miscounting the cancelled row as a save failure (stats.Errors must stay 0).
 func TestImport_CancelDuringSave(t *testing.T) {
-	// 500 rows, batch size 10, so the context can be cancelled partway through.
+	// Use enough rows that the import cannot complete in one batch.
 	rows := make([]birdnetPiRow, 0, 500)
 	for i := range 500 {
 		rows = append(rows, birdnetPiRow{
@@ -448,12 +465,13 @@ func TestImport_CancelDuringSave(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	// Cancel after a short delay so at least one row is processed.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		cancel()
-	}()
+	// reporter cancels the context on its first Report call, which the engine issues
+	// at the end of the first batch. This guarantees at least one batch has been
+	// processed before cancellation - no timing dependency.
+	reporter := &cancelOnFirstReport{cancel: cancel}
 
-	_, err = engine.Run(ctx, src, opts, nil)
-	assert.ErrorIs(t, err, context.Canceled, "mid-import cancel must return context error, not a save error")
+	stats, err := engine.Run(ctx, src, opts, reporter)
+	require.ErrorIs(t, err, context.Canceled, "mid-import cancel must return context.Canceled")
+	assert.GreaterOrEqual(t, stats.Inserted, 1, "at least one row must have been inserted before cancel")
+	assert.Equal(t, 0, stats.Errors, "cancelled row must not be counted as a save error")
 }

--- a/internal/imports/imports_test.go
+++ b/internal/imports/imports_test.go
@@ -1,0 +1,342 @@
+package imports_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/imports"
+	"github.com/tphakala/birdnet-go/internal/imports/birdnetpi"
+)
+
+// --- fixture helpers ---
+
+type birdnetPiRow struct {
+	Date       string
+	Time       string
+	SciName    string
+	ComName    string
+	Confidence float64
+	Lat        float64
+	Lon        float64
+	Cutoff     float64
+	Sens       float64
+	FileName   string
+}
+
+func newFixtureDB(t *testing.T, rows []birdnetPiRow) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "birds.db")
+
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE detections (
+		Date DATE,
+		Time TIME,
+		Sci_Name VARCHAR(100) NOT NULL,
+		Com_Name VARCHAR(100) NOT NULL,
+		Confidence FLOAT,
+		Lat FLOAT,
+		Lon FLOAT,
+		Cutoff FLOAT,
+		Week INT,
+		Sens FLOAT,
+		Overlap FLOAT,
+		File_Name VARCHAR(100) NOT NULL
+	)`).Error)
+
+	for _, r := range rows {
+		require.NoError(t, db.Exec(
+			`INSERT INTO detections (Date, Time, Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Week, Sens, Overlap, File_Name)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0.0, ?)`,
+			r.Date, r.Time, r.SciName, r.ComName, r.Confidence,
+			r.Lat, r.Lon, r.Cutoff, r.Sens, r.FileName,
+		).Error)
+	}
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	return path
+}
+
+func newTestStore(t *testing.T) datastore.Interface {
+	t.Helper()
+	tempDir := t.TempDir()
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = tempDir + "/test.db"
+
+	store := datastore.New(settings)
+	require.NoError(t, store.Open(), "failed to open test datastore")
+
+	t.Cleanup(func() {
+		assert.NoError(t, store.Close(), "failed to close test datastore")
+	})
+
+	return store
+}
+
+// --- tests ---
+
+func TestValidate_NoDetectionsTable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.db")
+
+	// Create an empty SQLite file with no tables.
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	err = src.Validate(t.Context())
+	assert.Error(t, err, "Validate must fail when detections table is absent")
+}
+
+func TestCount(t *testing.T) {
+	rows := []birdnetPiRow{
+		{Date: "2025-03-25", Time: "14:27:32", SciName: "Dendrocopos major", ComName: "Great Spotted Woodpecker", Confidence: 0.74, Lat: 60.75, Lon: 24.77, Cutoff: 0.7, Sens: 1.25, FileName: "a.mp3"},
+		{Date: "2025-03-25", Time: "15:00:00", SciName: "Parus major", ComName: "Great Tit", Confidence: 0.81, Lat: 60.75, Lon: 24.77, Cutoff: 0.5, Sens: 1.0, FileName: "b.mp3"},
+	}
+	path := newFixtureDB(t, rows)
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	count, err := src.Count(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestSimpleSave(t *testing.T) {
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+
+	now := time.Date(2025, 3, 25, 14, 27, 32, 0, time.UTC)
+	result := &detection.Result{
+		Timestamp:  now,
+		SourceNode: "birdnet-pi",
+		AudioSource: detection.AudioSource{
+			ID:          "birdnet-pi",
+			SafeString:  "birdnet-pi",
+			DisplayName: "birdnet-pi",
+		},
+		Species: detection.Species{
+			ScientificName: "Dendrocopos major",
+			CommonName:     "Great Spotted Woodpecker",
+			Code:           "",
+		},
+		Confidence:  0.7357,
+		Latitude:    60.7534,
+		Longitude:   24.7709,
+		Threshold:   0.7,
+		Sensitivity: 1.25,
+		Model: detection.ModelInfo{
+			Name:    "BirdNET",
+			Version: "birdnet-pi",
+			Variant: "import",
+		},
+		ClipName: "",
+	}
+
+	ctx := t.Context()
+	err := repo.Save(ctx, result, nil)
+	require.NoError(t, err, "Save should not error")
+	require.NotZero(t, result.ID, "ID should be assigned")
+
+	t.Logf("Saved with ID: %d", result.ID)
+}
+
+func TestImport_FieldMapping(t *testing.T) {
+	rows := []birdnetPiRow{
+		{
+			Date: "2025-03-25", Time: "14:27:32",
+			SciName: "Dendrocopos major", ComName: "Great Spotted Woodpecker",
+			Confidence: 0.7357, Lat: 60.7534, Lon: 24.7709, Cutoff: 0.7, Sens: 1.25,
+			FileName: "woodpecker.mp3",
+		},
+	}
+	path := newFixtureDB(t, rows)
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode: imports.DefaultSourceNode,
+		Location:   time.UTC,
+		BatchSize:  100,
+	}
+
+	stats, err := engine.Run(t.Context(), src, opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Inserted)
+	assert.Equal(t, 0, stats.Errors)
+
+	results, _, err := repo.Search(t.Context(), &datastore.DetectionFilters{
+		Location: []string{imports.DefaultSourceNode},
+		Limit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, "Dendrocopos major", r.Species.ScientificName)
+	assert.Equal(t, "Great Spotted Woodpecker", r.Species.CommonName)
+	assert.Empty(t, r.Species.Code)
+	assert.InDelta(t, 0.7357, r.Confidence, 0.0001)
+	assert.InDelta(t, 60.7534, r.Latitude, 0.0001)
+	assert.InDelta(t, 24.7709, r.Longitude, 0.0001)
+	assert.InDelta(t, 0.7, r.Threshold, 0.0001)
+	assert.InDelta(t, 1.25, r.Sensitivity, 0.0001)
+	assert.Equal(t, imports.DefaultSourceNode, r.SourceNode)
+	// The synthetic Model marker (Version "birdnet-pi", Variant "import") is set at mapping
+	// time, but the legacy datastore stores Note.Model as gorm:"-" (runtime-only), so only
+	// Name survives the save+read round trip on this path. Assert just the Name here.
+	assert.Equal(t, "BirdNET", r.Model.Name)
+	assert.Empty(t, r.ClipName, "ClipName must be empty in DB-only mode")
+
+	expectedTS := time.Date(2025, 3, 25, 14, 27, 32, 0, time.UTC)
+	assert.Equal(t, expectedTS.UTC(), r.Timestamp.UTC())
+}
+
+func TestImport_SkipsUnparseableDate(t *testing.T) {
+	rows := []birdnetPiRow{
+		{Date: "2025-03-25", Time: "10:00:00", SciName: "Parus major", ComName: "Great Tit", Confidence: 0.85, Lat: 60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0, FileName: "valid.mp3"},
+		{Date: "not-a-date", Time: "08:00:00", SciName: "Erithacus rubecula", ComName: "European Robin", Confidence: 0.90, Lat: 60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0, FileName: "invalid.mp3"},
+	}
+	path := newFixtureDB(t, rows)
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+	engine := imports.NewEngine(repo)
+	opts := imports.ImportOptions{SourceNode: imports.DefaultSourceNode, Location: time.UTC}
+
+	stats, err := engine.Run(t.Context(), src, opts, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, stats.Inserted, "only the row with valid date should be inserted")
+	assert.Equal(t, 1, stats.Errors, "unparseable date row must be counted as error")
+}
+
+func TestImport_Idempotent(t *testing.T) {
+	rows := []birdnetPiRow{
+		{Date: "2025-04-01", Time: "09:00:00", SciName: "Turdus merula", ComName: "Common Blackbird", Confidence: 0.9200, Lat: 60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0, FileName: "blackbird.mp3"},
+	}
+	path := newFixtureDB(t, rows)
+
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+	opts := imports.ImportOptions{SourceNode: imports.DefaultSourceNode, Location: time.UTC}
+
+	// First run.
+	src1, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	engine1 := imports.NewEngine(repo)
+	stats1, err := engine1.Run(t.Context(), src1, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, src1.Close())
+	assert.Equal(t, 1, stats1.Inserted)
+
+	// Second run: fresh engine re-loads keys from DB.
+	src2, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	engine2 := imports.NewEngine(repo)
+	stats2, err := engine2.Run(t.Context(), src2, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, src2.Close())
+	assert.Equal(t, 0, stats2.Inserted, "re-run must insert zero rows")
+	assert.Equal(t, 1, stats2.Skipped, "re-run must skip the already-imported row")
+}
+
+func TestImport_WithinSourceDuplicate(t *testing.T) {
+	dupRows := []birdnetPiRow{
+		{Date: "2025-04-02", Time: "11:00:00", SciName: "Fringilla coelebs", ComName: "Common Chaffinch", Confidence: 0.8800, Lat: 60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0, FileName: "chaffinch.mp3"},
+		{Date: "2025-04-02", Time: "11:00:00", SciName: "Fringilla coelebs", ComName: "Common Chaffinch", Confidence: 0.8800, Lat: 60.0, Lon: 24.0, Cutoff: 0.5, Sens: 1.0, FileName: "chaffinch.mp3"},
+	}
+	path := newFixtureDB(t, dupRows)
+
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+	engine := imports.NewEngine(repo)
+	opts := imports.ImportOptions{SourceNode: imports.DefaultSourceNode, Location: time.UTC}
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	stats, err := engine.Run(t.Context(), src, opts, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, stats.Inserted, "within-source duplicate must be inserted only once")
+	assert.Equal(t, 1, stats.Skipped, "second copy of the duplicate must be skipped")
+}
+
+func TestImport_ContextCancellation(t *testing.T) {
+	manyRows := make([]birdnetPiRow, 0, 200)
+	for i := range 200 {
+		manyRows = append(manyRows, birdnetPiRow{
+			Date:       "2025-05-01",
+			Time:       "10:00:00",
+			SciName:    "Parus major",
+			ComName:    "Great Tit",
+			Confidence: float64(i+1) * 0.001,
+			Lat:        60.0,
+			Lon:        24.0,
+			Cutoff:     0.5,
+			Sens:       1.0,
+			FileName:   "tit.mp3",
+		})
+	}
+	path := newFixtureDB(t, manyRows)
+
+	store := newTestStore(t)
+	repo := datastore.NewDetectionRepository(store, time.UTC)
+	engine := imports.NewEngine(repo)
+	opts := imports.ImportOptions{
+		SourceNode: imports.DefaultSourceNode,
+		Location:   time.UTC,
+		BatchSize:  10,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately.
+
+	src, err := birdnetpi.New(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	_, err = engine.Run(ctx, src, opts, nil)
+	assert.ErrorIs(t, err, context.Canceled, "cancelled import must return context error")
+}


### PR DESCRIPTION
## Summary

Adds a reusable, transport-agnostic engine that imports BirdNET-Pi detection history into BirdNET-Go by reusing the live detection save path. DB-only in this PR; audio copy and the web UI come in follow-ups.

- New `internal/imports` engine with a pluggable `Source` interface. `internal/imports/birdnetpi` reads a BirdNET-Pi `birds.db` read-only, with schema validation and rowid cursor pagination (no O(N^2) offset scan).
- Each source row maps to the domain `detection.Result` and persists via `DetectionRepository.Save`, so detections land wherever the active datastore schema wants them (legacy / v2 / fresh) with no schema-specific code.
- Imported detections are tagged with a synthetic `birdnet-pi` source node for provenance, queryability, and idempotency.
- Idempotent import: a timezone-independent dedup key, pre-loaded from existing import-source detections, means re-running inserts zero duplicates; duplicate rows within the source collapse to one.
- Context-cancellable; rows with unparseable dates are skipped and counted, never fatal.

The engine accepts its dependencies by interface and does not construct the datastore itself, so the HTTP layer (and a possible CLI) can drive it later.

## Test Plan

- [x] `go build ./...`, `go vet`, `gofmt`, `golangci-lint run ./internal/imports/...` (0 issues)
- [x] `go test ./internal/imports/... -race`: field mapping, idempotency (including a timezone-mismatch case), schema validation, unparseable-date skip-and-count, within-source dedup, and a deterministic mid-import cancellation test
- [ ] End-to-end via the import UI (a later PR)

No HTTP or UI wiring in this PR; the engine is a standalone, tested package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only BirdNET-Pi SQLite database import to ingest bird detections from external sources.
  * Introduced a transport-agnostic import engine with source validation, total counting, batched processing, and optional progress reporting.
  * Ensures idempotent imports with deduplication and reliable timestamp reconstruction.
* **Tests**
  * Added a comprehensive automated test suite for validation and schema checks, field mapping, skipping invalid timestamps, idempotency (including timezone mismatches), in-run deduping, and context cancellation (including mid-save).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->