### PR TITLE
fix(audio): use -stimeout for RTSP channel-energy analysis on FFmpeg 4.x

### DIFF
--- a/internal/audiocore/ffmpeg/analyze.go
+++ b/internal/audiocore/ffmpeg/analyze.go
@@ -53,7 +53,7 @@ func AnalyzeChannelEnergy(ctx context.Context, url, ffmpegPath string) (*Channel
 	analysisCtx, cancel := context.WithTimeout(ctx, analysisTimeout)
 	defer cancel()
 
-	args := buildAnalysisArgs(url)
+	args := buildAnalysisArgs(url, resolveFfmpegMajor(ffmpegBinary))
 
 	cmd := exec.CommandContext(analysisCtx, ffmpegBinary, args...) //nolint:gosec // G204: ffmpegBinary validated by exec.LookPath, URL from user config
 	var stdout, stderr bytes.Buffer
@@ -98,17 +98,22 @@ func AnalyzeChannelEnergy(ctx context.Context, url, ffmpegPath string) (*Channel
 	}, nil
 }
 
-func buildAnalysisArgs(url string) []string {
+func buildAnalysisArgs(url string, ffmpegMajor int) []string {
 	args := make([]string, 0, 16)
 
 	lower := strings.ToLower(url)
 	isRTSP := strings.HasPrefix(lower, "rtsp://") || strings.HasPrefix(lower, "rtsps://")
+	// Default to -timeout; RTSP on FFmpeg 4.x needs -stimeout instead, since 4.x
+	// treats -timeout on the RTSP demuxer as a listen timeout and fails to
+	// connect. Mirror the live capture path's flag selection.
+	timeoutFlag := ffmpegTimeoutParam
 	if isRTSP {
 		args = append(args, "-rtsp_transport", "tcp")
+		timeoutFlag = rtspTimeoutParamForMajor(ffmpegMajor)
 	}
 
 	args = append(args,
-		ffmpegTimeoutParam, strconv.FormatInt(defaultTimeoutMicroseconds, 10),
+		timeoutFlag, strconv.FormatInt(defaultTimeoutMicroseconds, 10),
 		"-i", url,
 		"-t", strconv.Itoa(analysisCaptureDuration),
 		"-loglevel", "error",

--- a/internal/audiocore/ffmpeg/analyze.go
+++ b/internal/audiocore/ffmpeg/analyze.go
@@ -50,10 +50,15 @@ func AnalyzeChannelEnergy(ctx context.Context, url, ffmpegPath string) (*Channel
 		}
 	}
 
+	// Resolve the FFmpeg major version before starting the analysis timeout
+	// window, so a cold-cache `ffmpeg -version` probe does not eat into the
+	// time budget for the actual analysis run.
+	ffmpegMajor := resolveFfmpegMajor(ffmpegBinary)
+
 	analysisCtx, cancel := context.WithTimeout(ctx, analysisTimeout)
 	defer cancel()
 
-	args := buildAnalysisArgs(url, resolveFfmpegMajor(ffmpegBinary))
+	args := buildAnalysisArgs(url, ffmpegMajor)
 
 	cmd := exec.CommandContext(analysisCtx, ffmpegBinary, args...) //nolint:gosec // G204: ffmpegBinary validated by exec.LookPath, URL from user config
 	var stdout, stderr bytes.Buffer

--- a/internal/audiocore/ffmpeg/analyze_test.go
+++ b/internal/audiocore/ffmpeg/analyze_test.go
@@ -2,6 +2,7 @@ package ffmpeg
 
 import (
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,4 +110,35 @@ func TestComputeRmsDbfs_KnownValue(t *testing.T) {
 	got := computeRmsDbfs(samples)
 	expected := 20 * math.Log10(100.0/32768.0)
 	assert.InDelta(t, expected, got, 0.01)
+}
+
+func TestBuildAnalysisArgs_TimeoutFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		url           string
+		ffmpegMajor   int
+		wantTransport bool
+		wantFlag      string
+		forbiddenFlag string
+	}{
+		{"rtsp_ffmpeg4_uses_stimeout", "rtsp://cam.example.com/live", 4, true, "-stimeout", "-timeout"},
+		{"rtsps_ffmpeg4_uses_stimeout", "rtsps://cam.example.com/live", 4, true, "-stimeout", "-timeout"},
+		{"rtsp_ffmpeg7_uses_timeout", "rtsp://cam.example.com/live", 7, true, "-timeout", "-stimeout"},
+		{"rtsp_unknown_uses_timeout", "rtsp://cam.example.com/live", 0, true, "-timeout", "-stimeout"},
+		{"http_ffmpeg4_uses_timeout", "http://host.example.com/stream", 4, false, "-timeout", "-stimeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			args := buildAnalysisArgs(tt.url, tt.ffmpegMajor)
+
+			assert.Equal(t, tt.wantTransport, slices.Contains(args, "-rtsp_transport"), "rtsp_transport presence mismatch")
+			assert.Contains(t, args, tt.wantFlag, "expected timeout flag missing")
+			assert.NotContains(t, args, tt.forbiddenFlag, "forbidden timeout flag present")
+		})
+	}
 }

--- a/internal/audiocore/ffmpeg/process.go
+++ b/internal/audiocore/ffmpeg/process.go
@@ -45,13 +45,22 @@ var ffmpegMajorCache sync.Map
 // `ffmpeg -version` process instead of one per stream.
 var ffmpegMajorGroup singleflight.Group
 
-// timeoutParamForSource returns the correct FFmpeg timeout flag for the given source type.
-func timeoutParamForSource(st audiocore.SourceType, ffmpegMajor int) string {
-	if st == audiocore.SourceTypeRTSP && ffmpegMajor > 0 && ffmpegMajor < ffmpegStimeoutMaxMajor {
+// rtspTimeoutParamForMajor returns the RTSP connection-timeout flag for the
+// given FFmpeg major version: -stimeout below 5 (FFmpeg 4.x), -timeout on 5.x+
+// and unknown versions. This is the single source of truth shared by the live
+// capture path (timeoutParamForSource) and the channel-energy analysis path
+// (buildAnalysisArgs), so both stay in lockstep.
+func rtspTimeoutParamForMajor(ffmpegMajor int) string {
+	if ffmpegMajor > 0 && ffmpegMajor < ffmpegStimeoutMaxMajor {
 		return ffmpegLegacyRTSPTimeoutParam
 	}
+	return ffmpegRTSPTimeoutParam
+}
+
+// timeoutParamForSource returns the correct FFmpeg timeout flag for the given source type.
+func timeoutParamForSource(st audiocore.SourceType, ffmpegMajor int) string {
 	if st == audiocore.SourceTypeRTSP {
-		return ffmpegRTSPTimeoutParam
+		return rtspTimeoutParamForMajor(ffmpegMajor)
 	}
 	return ffmpegTimeoutParam
 }


### PR DESCRIPTION
## Summary

Follow-up to #3560. That PR made the live RTSP capture path select `-stimeout` vs `-timeout` by FFmpeg major version, but the channel-energy analysis path (the "test stream / pick channel" feature in audio settings) still emitted `-timeout` unconditionally for RTSP. On FFmpeg 4.x that puts the RTSP demuxer in listen mode and the analysis fails to connect, the same root cause #3331 fixed for capture. So a Debian 12 / FFmpeg 4.x user who just got RTSP capture working would still hit "Unable to open RTSP for listening" when using the channel picker.

## Changes

- Extract `rtspTimeoutParamForMajor` as the single source of truth for the RTSP connection-timeout flag, and reuse it in both `timeoutParamForSource` (capture) and `buildAnalysisArgs` (analysis), so the two paths can't drift.
- `AnalyzeChannelEnergy` resolves the FFmpeg major version from the binary it is about to run, via the same cached, bounded, singleflight-coalesced probe the capture path uses.
- Add table coverage for the analysis-path flag selection (RTSP@4 -> -stimeout, RTSP@7/unknown -> -timeout, HTTP -> -timeout).

## Related Issues

Relates to #3331

## Test Plan

- [x] `go build`, `go vet`, `golangci-lint run` clean on the package
- [x] `go test -race ./internal/audiocore/ffmpeg/...` passes (incl. new `TestBuildAnalysisArgs_TimeoutFlag`)
- [x] Capture-path flag selection unchanged (`TestTimeoutParamForSource` still green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved RTSP audio stream capture by automatically adapting timeout flag handling to the installed FFmpeg version, reducing connection/stream failures and improving stability across FFmpeg 4.x vs 5.x and newer setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->