### PR TITLE
feat(api): add BirdNET-Pi import API with SSE progress

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -563,6 +563,15 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 | GET    | `/system/diagnostics/report/:id` | `GetDiagnosticsReport`   | ✅   | Retrieve completed report      |
 | GET    | `/system/diagnostics/errors`     | `GetRecentErrors`        | ✅   | Recent error log entries       |
 
+### Import (`import.go`)
+
+| Method | Route                          | Handler              | Auth | Description                              |
+| ------ | ------------------------------ | -------------------- | ---- | ---------------------------------------- |
+| POST   | `/import/birdnet-pi`           | `StartBirdNETPiImport` | ✅   | Start a BirdNET-Pi DB-only import       |
+| GET    | `/import/jobs/:jobId/progress` | `StreamImportProgress` | ✅   | SSE progress stream for import job      |
+| POST   | `/import/jobs/:jobId/cancel`   | `CancelImport`         | ✅   | Cancel a running import                 |
+| GET    | `/import/status`               | `GetImportStatus`      | ✅   | Get current import status (polling)     |
+
 **GET /api/v2/system/diagnostics/status** - Returns the overall health status and per-category breakdown from the most recent diagnostic run. Returns `{"status": "unknown"}` if no diagnostics have been run yet.
 
 **POST /api/v2/system/diagnostics/run** - Executes all registered health checks in parallel (31 checks across 8 categories: system, audio, analysis, streams, database, network, config, logs). Returns a full `DiagnosticsReport` with per-check results, timing, and summary.

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -185,6 +186,17 @@ type Controller struct {
 	// sysinfo implementations at request time when nil.
 	externalMediaEnv   sysinfo.EnvGetter
 	externalMediaProbe sysinfo.MountProber
+
+	// importMgr manages the one-at-a-time import lifecycle.
+	importMgr *importManager
+
+	// importSourceRoot is the directory under which import source paths must resolve.
+	// Defaults to sysinfo.DefaultExternalMountPath when empty.
+	importSourceRoot string
+
+	// importSourceFactory builds an import Source from a resolved path.
+	// Defaults to a BirdNET-Pi adapter when nil. Overridable in tests.
+	importSourceFactory func(path string) (imports.Source, error)
 }
 
 // SourceRestarterFunc restarts a single audio source identified by sourceID.
@@ -469,6 +481,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		cancel:               cancel,
 		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()),
 		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
+		importMgr:            newImportManager(),
 	}
 	// Publish the initial settings snapshot so controllerSettings() reads it
 	// lock-free. Every save republishes via Settings.Store; see the Settings
@@ -724,6 +737,7 @@ func (c *Controller) initRoutes() {
 		{"model routes", c.initModelRoutes},
 		{"insights routes", c.initInsightsRoutes},
 		{"tls routes", c.initTLSRoutes},
+		{"import routes", c.initImportRoutes},
 	}
 
 	for _, initializer := range routeInitializers {

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -1,0 +1,460 @@
+// Package api provides the HTTP API for BirdNET-Go.
+package api
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/imports"
+	"github.com/tphakala/birdnet-go/internal/imports/birdnetpi"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+// Import mode constants.
+const (
+	importModeDBOnly  = "db-only"
+	importModeDBaudio = "db-audio" // reserved; not yet available
+)
+
+// Import SSE event type constants.
+const (
+	importEventProgress  = "progress"
+	importEventComplete  = "complete"
+	importEventCancelled = "cancelled"
+	importEventError     = "error"
+	importEventHeartbeat = "heartbeat"
+)
+
+// Import status constants.
+const (
+	importStatusStarted    = "started"
+	importStatusRunning    = "running"
+	importStatusCancelling = "cancelling"
+	importStatusDone       = "done"
+	importStatusIdle       = "idle"
+)
+
+// ErrImportInProgress is returned when a second start is attempted while one is running.
+var ErrImportInProgress = fmt.Errorf("import already in progress")
+
+// ErrInvalidSourcePath is returned when the source path fails containment validation.
+var ErrInvalidSourcePath = fmt.Errorf("invalid source path")
+
+// startImportRequest is the JSON body for POST /import/birdnet-pi.
+type startImportRequest struct {
+	Mode       string `json:"mode"`        // must be "db-only"
+	SourcePath string `json:"source_path"` // path relative to the external mount root
+	Location   string `json:"location"`    // optional IANA timezone name e.g. "Europe/Helsinki"
+}
+
+// startImportResponse is the 202 Accepted reply body.
+type startImportResponse struct {
+	JobID  string `json:"job_id"`
+	Status string `json:"status"`
+}
+
+// cancelImportResponse is the reply body for the cancel endpoint.
+type cancelImportResponse struct {
+	Status string `json:"status"`
+}
+
+// importProgress is the SSE payload carrying live import stats.
+type importProgress struct {
+	Total     int    `json:"total"`
+	Processed int    `json:"processed"`
+	Inserted  int    `json:"inserted"`
+	Skipped   int    `json:"skipped"`
+	Errors    int    `json:"errors"`
+	Phase     string `json:"phase"`
+}
+
+// importErrorPayload is the SSE payload for the error terminal event.
+type importErrorPayload struct {
+	Message   string `json:"message"`
+	Total     int    `json:"total"`
+	Processed int    `json:"processed"`
+	Inserted  int    `json:"inserted"`
+	Skipped   int    `json:"skipped"`
+	Errors    int    `json:"errors"`
+	Phase     string `json:"phase"`
+}
+
+// importStatusResponse is the JSON body for GET /import/status.
+type importStatusResponse struct {
+	Running  bool            `json:"running"`
+	JobID    string          `json:"job_id,omitempty"`
+	Status   string          `json:"status"`
+	Progress *importProgress `json:"progress,omitempty"`
+	Error    string          `json:"error,omitempty"`
+}
+
+// toImportProgress converts engine stats to the API DTO.
+func toImportProgress(s imports.ImportStats) importProgress {
+	return importProgress{
+		Total:     s.Total,
+		Processed: s.Processed,
+		Inserted:  s.Inserted,
+		Skipped:   s.Skipped,
+		Errors:    s.Errors,
+		Phase:     s.Phase,
+	}
+}
+
+// resolveImportSourcePath resolves userPath under root with traversal and symlink-escape protection.
+// userPath must be a relative path. Returns the resolved absolute path on success.
+func resolveImportSourcePath(root, userPath string) (string, error) {
+	if userPath == "" {
+		return "", ErrInvalidSourcePath
+	}
+	cleaned := filepath.Clean(userPath)
+	if filepath.IsAbs(cleaned) {
+		return "", ErrInvalidSourcePath
+	}
+	full := filepath.Join(root, cleaned)
+	rel, err := filepath.Rel(root, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", ErrInvalidSourcePath
+	}
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		rootResolved = root
+	}
+	// Defense in depth: resolve symlinks and re-check physical containment.
+	resolved, err := filepath.EvalSymlinks(full)
+	if err != nil {
+		if !stderrors.Is(err, fs.ErrNotExist) {
+			return "", ErrInvalidSourcePath
+		}
+		// The target file does not exist yet. Validate the deepest existing
+		// ancestor instead so a symlinked parent that escapes root is still
+		// rejected, then let the handler's os.Stat report the missing file.
+		// This closes the TOCTOU window where an attacker creates the file
+		// after a bypassed containment check.
+		dir, base := filepath.Split(full)
+		resolvedDir, dirErr := filepath.EvalSymlinks(filepath.Clean(dir))
+		if dirErr != nil {
+			// Parent directory does not resolve either; treat as not found.
+			return full, nil //nolint:nilerr // intentional: caller's os.Stat reports the missing file
+		}
+		if !isContained(rootResolved, resolvedDir) {
+			return "", ErrInvalidSourcePath
+		}
+		return filepath.Join(resolvedDir, base), nil
+	}
+	if !isContained(rootResolved, resolved) {
+		return "", ErrInvalidSourcePath
+	}
+	return resolved, nil
+}
+
+// isContained reports whether target resides within root after both have been
+// resolved to their physical (symlink-free) forms.
+func isContained(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// initImportRoutes registers all import-related API routes.
+func (c *Controller) initImportRoutes() {
+	var mw []echo.MiddlewareFunc
+	if c.authMiddleware != nil {
+		mw = append(mw, c.authMiddleware)
+	}
+	g := c.Group.Group("/import", mw...)
+	g.POST("/birdnet-pi", c.StartBirdNETPiImport)
+	g.GET("/jobs/:jobId/progress", c.StreamImportProgress)
+	g.POST("/jobs/:jobId/cancel", c.CancelImport)
+	g.GET("/status", c.GetImportStatus)
+}
+
+// StartBirdNETPiImport validates a BirdNET-Pi SQLite source and starts a DB-only import.
+// Returns 202 Accepted with a job_id on success.
+func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
+	// Verify datastore is available.
+	if err := c.requireDatastore(ctx); err != nil {
+		return err
+	}
+	if c.Repo == nil {
+		return c.HandleError(ctx, ErrImportInProgress, "datastore not available", http.StatusServiceUnavailable)
+	}
+
+	// Parse and bind request body.
+	var req startImportRequest
+	if err := ctx.Bind(&req); err != nil {
+		return c.HandleError(ctx, err, "invalid request body", http.StatusBadRequest)
+	}
+
+	// Validate import mode.
+	switch req.Mode {
+	case importModeDBOnly:
+		// accepted
+	case importModeDBaudio:
+		return c.HandleError(ctx, nil, "audio import is not available yet", http.StatusBadRequest)
+	default:
+		return c.HandleError(ctx, nil, "unsupported import mode", http.StatusBadRequest)
+	}
+
+	// Resolve and validate source path.
+	root := c.importSourceRoot
+	if root == "" {
+		root = sysinfo.DefaultExternalMountPath
+	}
+	resolvedPath, err := resolveImportSourcePath(root, req.SourcePath)
+	if err != nil {
+		return c.HandleError(ctx, err, "invalid source path", http.StatusBadRequest)
+	}
+	info, statErr := os.Stat(resolvedPath)
+	if statErr != nil || !info.Mode().IsRegular() {
+		return c.HandleError(ctx, statErr, "source file not found or not a regular file", http.StatusBadRequest)
+	}
+
+	// Parse optional timezone.
+	var loc *time.Location
+	if req.Location != "" {
+		loc, err = time.LoadLocation(req.Location)
+		if err != nil {
+			return c.HandleError(ctx, err, "invalid location", http.StatusBadRequest)
+		}
+	}
+
+	// Build source using the injectable factory (defaults to birdnetpi.New).
+	factory := c.importSourceFactory
+	if factory == nil {
+		factory = func(p string) (imports.Source, error) {
+			return birdnetpi.New(p)
+		}
+	}
+	src, err := factory(resolvedPath)
+	if err != nil {
+		return c.HandleError(ctx, err, "failed to open source", http.StatusBadRequest)
+	}
+
+	// Validate source synchronously for an immediate error response.
+	if err := src.Validate(ctx.Request().Context()); err != nil {
+		_ = src.Close()
+		return c.HandleError(ctx, err, "source validation failed", http.StatusBadRequest)
+	}
+
+	// Reserve the single import slot.
+	id := generateCorrelationID()
+	parent := c.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	jobCtx, jobCancel := context.WithCancel(parent)
+	job := newImportJob(id, jobCancel)
+	if !c.importMgr.start(job) {
+		jobCancel()
+		_ = src.Close()
+		return c.HandleError(ctx, ErrImportInProgress, "an import is already in progress", http.StatusConflict)
+	}
+
+	// Run the engine in a goroutine tracked by the controller WaitGroup.
+	opts := imports.ImportOptions{
+		SourceNode: imports.DefaultSourceNode,
+		Location:   loc,
+	}
+	eng := imports.NewEngine(c.Repo)
+	c.wg.Go(func() {
+		defer jobCancel()
+		defer func() { _ = src.Close() }()
+		var stats imports.ImportStats
+		var runErr error
+		// Always drive the job to a terminal state, even if eng.Run panics, so
+		// the single import slot is released and any SSE streams unblock instead
+		// of hanging until their deadline.
+		defer func() {
+			if r := recover(); r != nil {
+				runErr = fmt.Errorf("import panicked: %v", r)
+			}
+			job.finish(stats, runErr)
+		}()
+		stats, runErr = eng.Run(jobCtx, src, opts, job)
+	})
+
+	return ctx.JSON(http.StatusAccepted, startImportResponse{
+		JobID:  id,
+		Status: importStatusStarted,
+	})
+}
+
+// StreamImportProgress streams import progress as Server-Sent Events.
+// Closing the SSE connection does NOT cancel the import; use the cancel endpoint.
+func (c *Controller) StreamImportProgress(ctx echo.Context) error {
+	id := ctx.Param("jobId")
+	job := c.importMgr.get(id)
+	if job == nil {
+		return c.HandleError(ctx, nil, "import job not found", http.StatusNotFound)
+	}
+
+	setSSEHeaders(ctx)
+
+	// Bound the stream lifetime independently of the import itself.
+	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), maxSSEStreamDuration)
+	defer cancel()
+
+	// Send initial snapshot before entering the event loop. If the job already
+	// finished, emit only the terminal event so the latest sequence number is
+	// not reused for both a progress and a terminal event (event ids stay unique).
+	stats, seq, done, changed, runErr := job.snapshot()
+	if done {
+		_ = c.sendImportTerminal(ctx, seq, stats, runErr)
+		return nil
+	}
+	if err := c.sendImportEvent(ctx, seq, importEventProgress, toImportProgress(stats)); err != nil {
+		return nil
+	}
+
+	hb := time.NewTicker(sseHeartbeatInterval)
+	defer hb.Stop()
+
+	// Capture shutdown channel defensively; c.ctx may be nil in isolated unit tests.
+	var shutdown <-chan struct{}
+	if c.ctx != nil {
+		shutdown = c.ctx.Done()
+	} else {
+		neverClose := make(chan struct{})
+		shutdown = neverClose
+	}
+
+	for {
+		select {
+		case <-reqCtx.Done():
+			return nil
+		case <-shutdown:
+			return nil
+		case <-hb.C:
+			if err := c.sendImportHeartbeat(ctx); err != nil {
+				return nil
+			}
+		case <-changed:
+			stats, seq, done, changed, runErr = job.snapshot()
+			// On the terminal transition emit only the terminal event so the
+			// sequence number is not reused for both a progress and a terminal
+			// event (event ids stay unique even when updates coalesce).
+			if done {
+				_ = c.sendImportTerminal(ctx, seq, stats, runErr)
+				return nil
+			}
+			if err := c.sendImportEvent(ctx, seq, importEventProgress, toImportProgress(stats)); err != nil {
+				return nil
+			}
+		}
+	}
+}
+
+// CancelImport requests cancellation of a running import job.
+// Returns 200 with status "cancelling" (or "done" if already finished).
+func (c *Controller) CancelImport(ctx echo.Context) error {
+	id := ctx.Param("jobId")
+	job := c.importMgr.get(id)
+	if job == nil {
+		return c.HandleError(ctx, nil, "import job not found", http.StatusNotFound)
+	}
+	job.cancel()
+	status := importStatusCancelling
+	if job.isDone() {
+		status = importStatusDone
+	}
+	return ctx.JSON(http.StatusOK, cancelImportResponse{Status: status})
+}
+
+// GetImportStatus returns the current import state for polling UIs.
+func (c *Controller) GetImportStatus(ctx echo.Context) error {
+	job := c.importMgr.active()
+	if job == nil {
+		return ctx.JSON(http.StatusOK, importStatusResponse{
+			Running: false,
+			Status:  importStatusIdle,
+		})
+	}
+	stats, _, done, _, runErr := job.snapshot()
+	prog := toImportProgress(stats)
+	if done {
+		resp := importStatusResponse{
+			Running:  false,
+			JobID:    job.id,
+			Status:   importStatusDone,
+			Progress: &prog,
+		}
+		if runErr != nil {
+			resp.Error = "import failed"
+		}
+		return ctx.JSON(http.StatusOK, resp)
+	}
+	return ctx.JSON(http.StatusOK, importStatusResponse{
+		Running:  true,
+		JobID:    job.id,
+		Status:   importStatusRunning,
+		Progress: &prog,
+	})
+}
+
+// sendImportEvent sends a single SSE event with a monotonic id field.
+func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, data any) error {
+	payload, err := c.safeMarshalJSON(event, data)
+	if err != nil {
+		return fmt.Errorf("marshal import event: %w", err)
+	}
+	msg := fmt.Sprintf("id: %d\nevent: %s\ndata: %s\n\n", id, event, payload)
+	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
+		_ = conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+	}
+	if _, err := ctx.Response().Write([]byte(msg)); err != nil {
+		return fmt.Errorf("write import event: %w", err)
+	}
+	if f, ok := ctx.Response().Writer.(http.Flusher); ok {
+		f.Flush()
+	}
+	return nil
+}
+
+// sendImportHeartbeat sends a lightweight SSE event to keep the connection alive.
+func (c *Controller) sendImportHeartbeat(ctx echo.Context) error {
+	payload, err := c.safeMarshalJSON(importEventHeartbeat, map[string]int64{"ts": time.Now().Unix()})
+	if err != nil {
+		return fmt.Errorf("marshal heartbeat: %w", err)
+	}
+	msg := fmt.Sprintf("event: %s\ndata: %s\n\n", importEventHeartbeat, payload)
+	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
+		_ = conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+	}
+	if _, err := ctx.Response().Write([]byte(msg)); err != nil {
+		return fmt.Errorf("write heartbeat: %w", err)
+	}
+	if f, ok := ctx.Response().Writer.(http.Flusher); ok {
+		f.Flush()
+	}
+	return nil
+}
+
+// sendImportTerminal sends the final SSE event based on the import outcome.
+func (c *Controller) sendImportTerminal(ctx echo.Context, seq uint64, stats imports.ImportStats, runErr error) error {
+	switch {
+	case runErr == nil:
+		return c.sendImportEvent(ctx, seq, importEventComplete, toImportProgress(stats))
+	case stderrors.Is(runErr, context.Canceled) || stderrors.Is(runErr, context.DeadlineExceeded):
+		return c.sendImportEvent(ctx, seq, importEventCancelled, toImportProgress(stats))
+	default:
+		return c.sendImportEvent(ctx, seq, importEventError, importErrorPayload{
+			Message:   "import failed",
+			Total:     stats.Total,
+			Processed: stats.Processed,
+			Inserted:  stats.Inserted,
+			Skipped:   stats.Skipped,
+			Errors:    stats.Errors,
+			Phase:     stats.Phase,
+		})
+	}
+}

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/imports/birdnetpi"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
@@ -46,6 +47,9 @@ const (
 // Progress events with this phase are suppressed; the terminal complete/cancelled/error
 // event is the authoritative completion signal.
 const importEnginePhaseDone = "done"
+
+// importErrorMessage is the generic, non-leaking message reported when an import fails.
+const importErrorMessage = "import failed"
 
 // errImportInProgress is returned when a second start is attempted while one is running.
 var errImportInProgress = errors.NewStd("import already in progress")
@@ -82,14 +86,11 @@ type importProgress struct {
 }
 
 // importErrorPayload is the SSE payload for the error terminal event.
+// importProgress is embedded so the wire format is identical to the progress event
+// (flattened snake_case fields), with an additional "message" field prepended.
 type importErrorPayload struct {
-	Message   string `json:"message"`
-	Total     int    `json:"total"`
-	Processed int    `json:"processed"`
-	Inserted  int    `json:"inserted"`
-	Skipped   int    `json:"skipped"`
-	Errors    int    `json:"errors"`
-	Phase     string `json:"phase"`
+	Message string `json:"message"`
+	importProgress
 }
 
 // importStatusResponse is the JSON body for GET /import/status.
@@ -130,6 +131,9 @@ func resolveImportSourcePath(root, userPath string) (string, error) {
 	}
 	rootResolved, err := filepath.EvalSymlinks(root)
 	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", errInvalidSourcePath
+		}
 		rootResolved = root
 	}
 	// Find the deepest existing ancestor of full, resolving symlinks, and verify it
@@ -174,6 +178,10 @@ func isContained(root, target string) bool {
 // initImportRoutes registers all import-related API routes.
 func (c *Controller) initImportRoutes() {
 	var mw []echo.MiddlewareFunc
+	// Echo's applyMiddleware invokes every middleware entry, so a nil auth middleware
+	// would panic at registration. Append it only when present (it is nil in tests and
+	// when auth is not configured); the routes are still gated by the global private-mode
+	// middleware on c.Group in that case.
 	if c.authMiddleware != nil {
 		mw = append(mw, c.authMiddleware)
 	}
@@ -273,22 +281,21 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 	}
 	eng := imports.NewEngine(c.Repo)
 	c.wg.Go(func() {
-		defer jobCancel()
-		defer func() { _ = src.Close() }()
 		var stats imports.ImportStats
 		var runErr error
-		// Always drive the job to a terminal state, even if eng.Run panics, so
-		// the single import slot is released and any SSE streams unblock instead
-		// of hanging until their deadline.
+		// Registered first so it runs last: it recovers panics from eng.Run AND from
+		// the cleanup defers below, and always drives the job to a terminal state so the
+		// single import slot is released and SSE streams unblock.
 		defer func() {
 			if r := recover(); r != nil {
 				runErr = errors.Newf("import panicked: %v", r).Component("api").Category(errors.CategoryGeneric).Build()
-				// Preserve the last reported progress; the local stats var is still zero
-				// because the panicking eng.Run call never returned its stats.
+				// The local stats var is stale on panic; recover the last reported progress.
 				stats, _, _, _, _ = job.snapshot()
 			}
 			job.finish(stats, runErr)
 		}()
+		defer jobCancel()
+		defer func() { _ = src.Close() }()
 		stats, runErr = eng.Run(jobCtx, src, opts, job)
 	})
 
@@ -402,7 +409,7 @@ func (c *Controller) GetImportStatus(ctx echo.Context) error {
 			Progress: &prog,
 		}
 		if runErr != nil {
-			resp.Error = "import failed"
+			resp.Error = importErrorMessage
 		}
 		return ctx.JSON(http.StatusOK, resp)
 	}
@@ -422,7 +429,11 @@ func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, 
 	}
 	msg := fmt.Sprintf("id: %d\nevent: %s\ndata: %s\n\n", id, event, payload)
 	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
-		_ = conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
+		if err := conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline)); err != nil {
+			// Best-effort: not all response writers support deadlines; log and proceed,
+			// matching sendSSEMessage in sse.go.
+			c.logDebugIfEnabled("Failed to set write deadline for import SSE event", logger.Error(err))
+		}
 	}
 	if _, err := ctx.Response().Write([]byte(msg)); err != nil {
 		return fmt.Errorf("write import event: %w", err)
@@ -435,21 +446,7 @@ func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, 
 
 // sendImportHeartbeat sends a lightweight SSE event to keep the connection alive.
 func (c *Controller) sendImportHeartbeat(ctx echo.Context) error {
-	payload, err := c.safeMarshalJSON(importEventHeartbeat, map[string]int64{"ts": time.Now().Unix()})
-	if err != nil {
-		return fmt.Errorf("marshal heartbeat: %w", err)
-	}
-	msg := fmt.Sprintf("event: %s\ndata: %s\n\n", importEventHeartbeat, payload)
-	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
-		_ = conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline))
-	}
-	if _, err := ctx.Response().Write([]byte(msg)); err != nil {
-		return fmt.Errorf("write heartbeat: %w", err)
-	}
-	if f, ok := ctx.Response().Writer.(http.Flusher); ok {
-		f.Flush()
-	}
-	return nil
+	return c.sendSSEMessage(ctx, importEventHeartbeat, map[string]int64{"ts": time.Now().Unix()})
 }
 
 // sendImportTerminal sends the final SSE event based on the import outcome.
@@ -461,13 +458,8 @@ func (c *Controller) sendImportTerminal(ctx echo.Context, seq uint64, stats impo
 		return c.sendImportEvent(ctx, seq, importEventCancelled, toImportProgress(stats))
 	default:
 		return c.sendImportEvent(ctx, seq, importEventError, importErrorPayload{
-			Message:   "import failed",
-			Total:     stats.Total,
-			Processed: stats.Processed,
-			Inserted:  stats.Inserted,
-			Skipped:   stats.Skipped,
-			Errors:    stats.Errors,
-			Phase:     stats.Phase,
+			Message:        importErrorMessage,
+			importProgress: toImportProgress(stats),
 		})
 	}
 }

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/imports/birdnetpi"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
@@ -42,11 +42,16 @@ const (
 	importStatusIdle       = "idle"
 )
 
-// ErrImportInProgress is returned when a second start is attempted while one is running.
-var ErrImportInProgress = fmt.Errorf("import already in progress")
+// importEnginePhaseDone matches the engine's terminal phase string.
+// Progress events with this phase are suppressed; the terminal complete/cancelled/error
+// event is the authoritative completion signal.
+const importEnginePhaseDone = "done"
 
-// ErrInvalidSourcePath is returned when the source path fails containment validation.
-var ErrInvalidSourcePath = fmt.Errorf("invalid source path")
+// errImportInProgress is returned when a second start is attempted while one is running.
+var errImportInProgress = errors.NewStd("import already in progress")
+
+// errInvalidSourcePath is returned when the source path fails containment validation.
+var errInvalidSourcePath = errors.NewStd("invalid source path")
 
 // startImportRequest is the JSON body for POST /import/birdnet-pi.
 type startImportRequest struct {
@@ -112,47 +117,48 @@ func toImportProgress(s imports.ImportStats) importProgress {
 // userPath must be a relative path. Returns the resolved absolute path on success.
 func resolveImportSourcePath(root, userPath string) (string, error) {
 	if userPath == "" {
-		return "", ErrInvalidSourcePath
+		return "", errInvalidSourcePath
 	}
 	cleaned := filepath.Clean(userPath)
 	if filepath.IsAbs(cleaned) {
-		return "", ErrInvalidSourcePath
+		return "", errInvalidSourcePath
 	}
 	full := filepath.Join(root, cleaned)
 	rel, err := filepath.Rel(root, full)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", ErrInvalidSourcePath
+		return "", errInvalidSourcePath
 	}
 	rootResolved, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		rootResolved = root
 	}
-	// Defense in depth: resolve symlinks and re-check physical containment.
-	resolved, err := filepath.EvalSymlinks(full)
-	if err != nil {
-		if !stderrors.Is(err, fs.ErrNotExist) {
-			return "", ErrInvalidSourcePath
+	// Find the deepest existing ancestor of full, resolving symlinks, and verify it
+	// is physically contained within root. This rejects a symlinked ancestor that
+	// escapes root even when the target (or several intermediate dirs) do not yet
+	// exist, closing the TOCTOU window at any depth.
+	ancestor := full
+	for {
+		resolved, evalErr := filepath.EvalSymlinks(ancestor)
+		if evalErr == nil {
+			if !isContained(rootResolved, resolved) {
+				return "", errInvalidSourcePath
+			}
+			suffix, relErr := filepath.Rel(ancestor, full)
+			if relErr != nil {
+				return "", errInvalidSourcePath
+			}
+			return filepath.Join(resolved, suffix), nil
 		}
-		// The target file does not exist yet. Validate the deepest existing
-		// ancestor instead so a symlinked parent that escapes root is still
-		// rejected, then let the handler's os.Stat report the missing file.
-		// This closes the TOCTOU window where an attacker creates the file
-		// after a bypassed containment check.
-		dir, base := filepath.Split(full)
-		resolvedDir, dirErr := filepath.EvalSymlinks(filepath.Clean(dir))
-		if dirErr != nil {
-			// Parent directory does not resolve either; treat as not found.
-			return full, nil //nolint:nilerr // intentional: caller's os.Stat reports the missing file
+		if !errors.Is(evalErr, fs.ErrNotExist) {
+			return "", errInvalidSourcePath
 		}
-		if !isContained(rootResolved, resolvedDir) {
-			return "", ErrInvalidSourcePath
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			// Reached the filesystem root without finding an existing ancestor.
+			return "", errInvalidSourcePath
 		}
-		return filepath.Join(resolvedDir, base), nil
+		ancestor = parent
 	}
-	if !isContained(rootResolved, resolved) {
-		return "", ErrInvalidSourcePath
-	}
-	return resolved, nil
 }
 
 // isContained reports whether target resides within root after both have been
@@ -186,7 +192,7 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		return err
 	}
 	if c.Repo == nil {
-		return c.HandleError(ctx, ErrImportInProgress, "datastore not available", http.StatusServiceUnavailable)
+		return c.HandleError(ctx, errDatastoreUnavailable, "datastore is not available", http.StatusServiceUnavailable)
 	}
 
 	// Parse and bind request body.
@@ -257,7 +263,7 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 	if !c.importMgr.start(job) {
 		jobCancel()
 		_ = src.Close()
-		return c.HandleError(ctx, ErrImportInProgress, "an import is already in progress", http.StatusConflict)
+		return c.HandleError(ctx, errImportInProgress, "an import is already in progress", http.StatusConflict)
 	}
 
 	// Run the engine in a goroutine tracked by the controller WaitGroup.
@@ -276,7 +282,10 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		// of hanging until their deadline.
 		defer func() {
 			if r := recover(); r != nil {
-				runErr = fmt.Errorf("import panicked: %v", r)
+				runErr = errors.Newf("import panicked: %v", r).Component("api").Category(errors.CategoryGeneric).Build()
+				// Preserve the last reported progress; the local stats var is still zero
+				// because the panicking eng.Run call never returned its stats.
+				stats, _, _, _, _ = job.snapshot()
 			}
 			job.finish(stats, runErr)
 		}()
@@ -312,8 +321,10 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 		_ = c.sendImportTerminal(ctx, seq, stats, runErr)
 		return nil
 	}
-	if err := c.sendImportEvent(ctx, seq, importEventProgress, toImportProgress(stats)); err != nil {
-		return nil
+	if stats.Phase != importEnginePhaseDone {
+		if err := c.sendImportEvent(ctx, seq, importEventProgress, toImportProgress(stats)); err != nil {
+			return nil
+		}
 	}
 
 	hb := time.NewTicker(sseHeartbeatInterval)
@@ -347,8 +358,10 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 				_ = c.sendImportTerminal(ctx, seq, stats, runErr)
 				return nil
 			}
-			if err := c.sendImportEvent(ctx, seq, importEventProgress, toImportProgress(stats)); err != nil {
-				return nil
+			if stats.Phase != importEnginePhaseDone {
+				if err := c.sendImportEvent(ctx, seq, importEventProgress, toImportProgress(stats)); err != nil {
+					return nil
+				}
 			}
 		}
 	}
@@ -444,7 +457,7 @@ func (c *Controller) sendImportTerminal(ctx echo.Context, seq uint64, stats impo
 	switch {
 	case runErr == nil:
 		return c.sendImportEvent(ctx, seq, importEventComplete, toImportProgress(stats))
-	case stderrors.Is(runErr, context.Canceled) || stderrors.Is(runErr, context.DeadlineExceeded):
+	case errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded):
 		return c.sendImportEvent(ctx, seq, importEventCancelled, toImportProgress(stats))
 	default:
 		return c.sendImportEvent(ctx, seq, importEventError, importErrorPayload{

--- a/internal/api/v2/import_manager.go
+++ b/internal/api/v2/import_manager.go
@@ -1,0 +1,108 @@
+// Package api provides the HTTP API for BirdNET-Go.
+package api
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tphakala/birdnet-go/internal/imports"
+)
+
+// importManager ensures only one import runs at a time and retains the most
+// recent job so SSE, cancel, and status endpoints keep working after completion.
+type importManager struct {
+	mu      sync.Mutex
+	current *importJob // nil until first start; may be done
+}
+
+// newImportManager creates a new importManager.
+func newImportManager() *importManager { return &importManager{} }
+
+// start reserves the single import slot.
+// Returns false if an import is already in progress.
+func (m *importManager) start(job *importJob) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.current != nil && !m.current.isDone() {
+		return false
+	}
+	m.current = job
+	return true
+}
+
+// get returns the job whose id matches id, or nil if no such job is current.
+func (m *importManager) get(id string) *importJob {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.current != nil && m.current.id == id {
+		return m.current
+	}
+	return nil
+}
+
+// active returns the current job (may be done or nil) for status reporting.
+func (m *importManager) active() *importJob {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.current
+}
+
+// importJob tracks a single in-flight or completed import.
+type importJob struct {
+	id     string
+	cancel context.CancelFunc
+
+	mu      sync.Mutex
+	stats   imports.ImportStats
+	seq     uint64 // monotonic counter; used as the SSE event id
+	done    bool
+	runErr  error
+	changed chan struct{} // closed and replaced on every update (last-value broadcast)
+}
+
+// newImportJob creates a new importJob with the given id and cancel function.
+func newImportJob(id string, cancel context.CancelFunc) *importJob {
+	return &importJob{id: id, cancel: cancel, changed: make(chan struct{})}
+}
+
+// Report implements imports.ProgressReporter. Called from the engine goroutine.
+func (j *importJob) Report(s imports.ImportStats) {
+	j.mu.Lock()
+	j.stats = s
+	j.seq++
+	j.wakeLocked()
+	j.mu.Unlock()
+}
+
+// finish records the final state and error of a completed or cancelled import.
+func (j *importJob) finish(s imports.ImportStats, err error) {
+	j.mu.Lock()
+	j.stats = s
+	j.runErr = err
+	j.done = true
+	j.seq++
+	j.wakeLocked()
+	j.mu.Unlock()
+}
+
+// wakeLocked closes the current changed channel and replaces it with a new one.
+// Must be called with j.mu held.
+func (j *importJob) wakeLocked() {
+	close(j.changed)
+	j.changed = make(chan struct{})
+}
+
+// isDone reports whether the job has reached a terminal state.
+func (j *importJob) isDone() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.done
+}
+
+// snapshot returns a consistent view of the current state and the wait channel
+// for the next change. The caller waits on changed, then calls snapshot again.
+func (j *importJob) snapshot() (stats imports.ImportStats, seq uint64, done bool, changed <-chan struct{}, runErr error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.stats, j.seq, j.done, j.changed, j.runErr
+}

--- a/internal/api/v2/import_manager.go
+++ b/internal/api/v2/import_manager.go
@@ -68,21 +68,21 @@ func newImportJob(id string, cancel context.CancelFunc) *importJob {
 // Report implements imports.ProgressReporter. Called from the engine goroutine.
 func (j *importJob) Report(s imports.ImportStats) {
 	j.mu.Lock()
+	defer j.mu.Unlock()
 	j.stats = s
 	j.seq++
 	j.wakeLocked()
-	j.mu.Unlock()
 }
 
 // finish records the final state and error of a completed or cancelled import.
 func (j *importJob) finish(s imports.ImportStats, err error) {
 	j.mu.Lock()
+	defer j.mu.Unlock()
 	j.stats = s
 	j.runErr = err
 	j.done = true
 	j.seq++
 	j.wakeLocked()
-	j.mu.Unlock()
 }
 
 // wakeLocked closes the current changed channel and replaces it with a new one.

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -313,19 +313,24 @@ func TestResolveImportSourcePath_SymlinkEscape(t *testing.T) {
 	// A non-existent file under the symlinked parent must be rejected because
 	// its physical parent resolves outside root.
 	_, err := resolveImportSourcePath(root, filepath.Join("escape", "missing.db"))
-	require.ErrorIs(t, err, ErrInvalidSourcePath)
+	require.ErrorIs(t, err, errInvalidSourcePath)
 
 	// An existing file reached through the escaping symlink must also be rejected.
 	existing := filepath.Join(outside, "real.db")
 	require.NoError(t, os.WriteFile(existing, []byte("x"), 0o600))
 	_, err = resolveImportSourcePath(root, filepath.Join("escape", "real.db"))
-	require.ErrorIs(t, err, ErrInvalidSourcePath)
+	require.ErrorIs(t, err, errInvalidSourcePath)
 
 	// A legitimate non-existent file directly under root resolves without error
 	// (the handler's os.Stat reports it missing).
 	resolved, err := resolveImportSourcePath(root, "legit.db")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(root, "legit.db"), resolved)
+
+	// Multi-level: a path under a symlinked ancestor where multiple intermediate
+	// directories do not exist yet must also be rejected.
+	_, err = resolveImportSourcePath(root, filepath.Join("escape", "missingA", "missingB", "x.db"))
+	require.ErrorIs(t, err, errInvalidSourcePath)
 }
 
 // TestStartBirdNETPiImport_MissingFile_Returns400 verifies missing file returns 400.
@@ -422,12 +427,13 @@ func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
 
 // TestStartBirdNETPiImport_ConflictWhileRunning_Returns409 verifies 409 on concurrent starts.
 func TestStartBirdNETPiImport_ConflictWhileRunning_Returns409(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("runtime.gopark"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-	)
-
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
@@ -597,12 +603,13 @@ func TestCancelImport_JobNotFound_Returns404(t *testing.T) {
 
 // TestCancelImport_RunningJob_Returns200Cancelling verifies cancel returns 200 with cancelling status.
 func TestCancelImport_RunningJob_Returns200Cancelling(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("runtime.gopark"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-	)
-
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
@@ -795,7 +802,347 @@ func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
 
 	assert.Equal(t, importStatusDone, finalStatus.Status, "import should reach done state")
 	assert.Empty(t, finalStatus.Error)
-	if finalStatus.Progress != nil {
-		assert.Equal(t, rowCount, finalStatus.Progress.Total)
+	require.NotNil(t, finalStatus.Progress)
+	assert.Equal(t, rowCount, finalStatus.Progress.Total)
+	assert.Equal(t, rowCount, finalStatus.Progress.Inserted)
+	assert.Equal(t, 0, finalStatus.Progress.Errors)
+	assert.Equal(t, 0, finalStatus.Progress.Skipped)
+}
+
+// panicIterateSource implements imports.Source. It processes the first panicAfter
+// batches normally (allowing the engine to report progress), then panics on the
+// next batch, simulating a mid-run engine crash.
+type panicIterateSource struct {
+	mu         sync.Mutex
+	batches    [][]imports.SourceDetection
+	panicAfter int
+}
+
+func (p *panicIterateSource) Validate(_ context.Context) error { return nil }
+func (p *panicIterateSource) Close() error                     { return nil }
+func (p *panicIterateSource) Count(_ context.Context) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, b := range p.batches {
+		n += len(b)
 	}
+	return n, nil
+}
+
+func (p *panicIterateSource) Iterate(_ context.Context, _ int, fn func([]imports.SourceDetection) error) error {
+	p.mu.Lock()
+	batches := p.batches
+	p.mu.Unlock()
+	for i, b := range batches {
+		if i >= p.panicAfter {
+			panic("simulated import panic after progress")
+		}
+		if err := fn(b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestStreamImportProgress_LiveStreaming verifies that a connected SSE client receives
+// multiple strictly-increasing progress events followed by a terminal complete event.
+func TestStreamImportProgress_LiveStreaming(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
+
+	e, c := newImportController(t)
+	c.initImportRoutes()
+
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	// readyCh gates the source between batches; close it after the SSE client connects.
+	readyCh := make(chan struct{})
+	det := imports.SourceDetection{
+		Date: "2024-06-01", Time: "08:00:00",
+		ScientificName: "Parus major", CommonName: "Great Tit",
+		Confidence: 0.9,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{
+			batches: [][]imports.SourceDetection{
+				{det},
+				{det},
+				{det},
+			},
+			block: readyCh,
+		}, nil
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600))
+	c.importSourceRoot = dir
+
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+
+	// Start the import.
+	startResp, err := http.Post(srv.URL+"/api/v2/import/birdnet-pi", //nolint:noctx // test uses simplified HTTP calls without context
+		"application/json", strings.NewReader(testDBOnlyBody))
+	require.NoError(t, err)
+	defer func() { _ = startResp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, startResp.StatusCode)
+
+	var startBody startImportResponse
+	require.NoError(t, json.NewDecoder(startResp.Body).Decode(&startBody))
+	jobID := startBody.JobID
+	require.NotEmpty(t, jobID)
+
+	// Connect SSE stream before unblocking so we catch intermediate events.
+	streamResp, err := http.Get(srv.URL + "/api/v2/import/jobs/" + jobID + "/progress") //nolint:noctx // test uses simplified HTTP calls without context
+	require.NoError(t, err)
+	defer func() { _ = streamResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, streamResp.StatusCode)
+
+	// Unblock the import so batches flow through.
+	close(readyCh)
+
+	// Read all SSE events until the stream closes.
+	scanner := bufio.NewScanner(streamResp.Body)
+	var events []importSSEEvent
+	var cur importSSEEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			cur.id = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			cur.event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			cur.data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if cur.event != "" {
+				events = append(events, cur)
+				cur = importSSEEvent{}
+			}
+		}
+	}
+
+	require.NotEmpty(t, events, "should receive at least one SSE event")
+
+	// Validate: strictly increasing ids, snake_case keys, no phase=done in progress,
+	// stream ends with complete.
+	var prevID int64 = -1
+	var progressCount int
+	var lastEvent string
+	for _, ev := range events {
+		if ev.event == importEventHeartbeat {
+			continue
+		}
+		require.NotEmpty(t, ev.id, "event %q must have an id", ev.event)
+		id, parseErr := strconv.ParseInt(ev.id, 10, 64)
+		require.NoError(t, parseErr, "id must be numeric, got %q", ev.id)
+		assert.Greater(t, id, prevID, "ids must be strictly increasing")
+		prevID = id
+		lastEvent = ev.event
+
+		if ev.event == importEventProgress {
+			progressCount++
+			var m map[string]any
+			require.NoError(t, json.Unmarshal([]byte(ev.data), &m))
+			for key := range m {
+				assert.Equal(t, strings.ToLower(key), key, "JSON key %q should be snake_case", key)
+			}
+			phase, _ := m["phase"].(string)
+			assert.NotEqual(t, importEnginePhaseDone, phase, "progress event must not carry phase=done")
+		}
+	}
+
+	assert.GreaterOrEqual(t, progressCount, 1, "should have received at least one progress event")
+	assert.Equal(t, importEventComplete, lastEvent, "stream must end with complete event")
+}
+
+// TestStreamImportProgress_CancelEmitsCancelledEvent verifies that cancelling a
+// running import results in a terminal cancelled SSE event on any connected stream.
+func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
+
+	e, c := newImportController(t)
+	c.initImportRoutes()
+
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	blockCh := make(chan struct{})
+	det := imports.SourceDetection{
+		Date: "2024-06-01", Time: "09:00:00",
+		ScientificName: "Erithacus rubecula", CommonName: "Robin",
+		Confidence: 0.88,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{
+			batches: [][]imports.SourceDetection{{det}},
+			block:   blockCh,
+		}, nil
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600))
+	c.importSourceRoot = dir
+
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+
+	// Start the import.
+	startResp, err := http.Post(srv.URL+"/api/v2/import/birdnet-pi", //nolint:noctx // test uses simplified HTTP calls without context
+		"application/json", strings.NewReader(testDBOnlyBody))
+	require.NoError(t, err)
+	defer func() { _ = startResp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, startResp.StatusCode)
+
+	var startBody startImportResponse
+	require.NoError(t, json.NewDecoder(startResp.Body).Decode(&startBody))
+	jobID := startBody.JobID
+
+	// Connect SSE stream.
+	streamResp, err := http.Get(srv.URL + "/api/v2/import/jobs/" + jobID + "/progress") //nolint:noctx // test uses simplified HTTP calls without context
+	require.NoError(t, err)
+	defer func() { _ = streamResp.Body.Close() }()
+
+	// Cancel the import.
+	cancelResp, err := http.Post(srv.URL+"/api/v2/import/jobs/"+jobID+"/cancel", //nolint:noctx // test uses simplified HTTP calls without context
+		"application/json", http.NoBody)
+	require.NoError(t, err)
+	defer func() { _ = cancelResp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, cancelResp.StatusCode)
+
+	// Unblock so the import goroutine can exit cleanly via context cancellation.
+	close(blockCh)
+
+	// Drain the SSE stream and find the terminal event.
+	scanner := bufio.NewScanner(streamResp.Body)
+	var events []importSSEEvent
+	var cur importSSEEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			cur.id = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			cur.event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			cur.data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if cur.event != "" {
+				events = append(events, cur)
+				cur = importSSEEvent{}
+			}
+		}
+	}
+
+	require.NotEmpty(t, events, "should receive at least one SSE event")
+	lastEvent := events[len(events)-1]
+	assert.Equal(t, importEventCancelled, lastEvent.event, "terminal event must be cancelled")
+}
+
+// TestStartBirdNETPiImport_PanicInEngine_RecoverAndPreserveStats verifies that a
+// panic in the import engine is recovered, the job reaches a terminal error state,
+// and the last-reported progress is preserved (not zeroed).
+func TestStartBirdNETPiImport_PanicInEngine_RecoverAndPreserveStats(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
+
+	e, c := newImportController(t)
+	c.initImportRoutes()
+
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	det := imports.SourceDetection{
+		Date: "2024-06-01", Time: "07:00:00",
+		ScientificName: "Cyanistes caeruleus", CommonName: "Blue Tit",
+		Confidence: 0.75,
+	}
+	// panicIterateSource: processes first batch (engine reports progress), then panics.
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &panicIterateSource{
+			batches:    [][]imports.SourceDetection{{det}, {det}},
+			panicAfter: 1,
+		}, nil
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600))
+	c.importSourceRoot = dir
+
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+
+	// Start the import.
+	startResp, err := http.Post(srv.URL+"/api/v2/import/birdnet-pi", //nolint:noctx // test uses simplified HTTP calls without context
+		"application/json", strings.NewReader(testDBOnlyBody))
+	require.NoError(t, err)
+	defer func() { _ = startResp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, startResp.StatusCode)
+
+	var startBody startImportResponse
+	require.NoError(t, json.NewDecoder(startResp.Body).Decode(&startBody))
+	require.NotEmpty(t, startBody.JobID)
+
+	// Poll status until done.
+	deadline := time.Now().Add(10 * time.Second)
+	var finalStatus importStatusResponse
+	e2 := echo.New()
+	for time.Now().Before(deadline) {
+		statusReq := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		statusRec := httptest.NewRecorder()
+		statusCtx := e2.NewContext(statusReq, statusRec)
+		require.NoError(t, c.GetImportStatus(statusCtx))
+		require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &finalStatus))
+		if !finalStatus.Running && finalStatus.Status == importStatusDone {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	assert.Equal(t, importStatusDone, finalStatus.Status, "job must reach done state after panic")
+	assert.NotEmpty(t, finalStatus.Error, "error must be set after panic")
+	require.NotNil(t, finalStatus.Progress, "progress must be preserved after panic")
+	// The engine reported stats for the first batch before panicking, so Total
+	// must be non-zero rather than the all-zeros default (regression guard for Fix A).
+	assert.Positive(t, finalStatus.Progress.Total, "Total must be non-zero (panic stats preserved)")
+
+	// The slot must be freed: a subsequent start must succeed.
+	startResp2, err := http.Post(srv.URL+"/api/v2/import/birdnet-pi", //nolint:noctx // test uses simplified HTTP calls without context
+		"application/json", strings.NewReader(testDBOnlyBody))
+	require.NoError(t, err)
+	defer func() { _ = startResp2.Body.Close() }()
+	assert.Equal(t, http.StatusAccepted, startResp2.StatusCode, "slot must be freed after panic recovery")
 }

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -1,0 +1,801 @@
+// Package api provides tests for the import API endpoints.
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/imports"
+)
+
+// testDBOnlyBody is the canonical valid db-only import request body used across tests.
+const testDBOnlyBody = `{"mode":"db-only","source_path":"birds.db"}`
+
+// fakeSource implements imports.Source for unit tests.
+type fakeSource struct {
+	mu       sync.Mutex
+	batches  [][]imports.SourceDetection
+	validate error
+	block    chan struct{} // optional: gate between batches for cancel tests
+}
+
+func (f *fakeSource) Validate(_ context.Context) error {
+	return f.validate
+}
+
+func (f *fakeSource) Count(_ context.Context) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, b := range f.batches {
+		n += len(b)
+	}
+	return n, nil
+}
+
+func (f *fakeSource) Iterate(ctx context.Context, _ int, fn func([]imports.SourceDetection) error) error {
+	f.mu.Lock()
+	batches := f.batches
+	block := f.block
+	f.mu.Unlock()
+	for _, b := range batches {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := fn(b); err != nil {
+			return err
+		}
+		if block != nil {
+			select {
+			case <-block:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeSource) Close() error { return nil }
+
+// newImportController creates a lightweight Controller for import tests.
+func newImportController(t *testing.T) (*echo.Echo, *Controller) {
+	t.Helper()
+	e := echo.New()
+	ctx, cancel := context.WithCancel(t.Context())
+	c := &Controller{
+		Group:     e.Group(apiV2Prefix),
+		importMgr: newImportManager(),
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+	c.Settings.Store(newValidTestSettings())
+	t.Cleanup(func() {
+		cancel()
+		c.wg.Wait()
+	})
+	return e, c
+}
+
+// makeTempDB creates a temporary BirdNET-Pi SQLite file with the given number of rows.
+func makeTempDB(t *testing.T, rows int) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, "birds.db")
+
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE detections (
+		Date DATE, Time TIME,
+		Sci_Name VARCHAR(100) NOT NULL, Com_Name VARCHAR(100) NOT NULL,
+		Confidence FLOAT, Lat FLOAT, Lon FLOAT, Cutoff FLOAT,
+		Week INT, Sens FLOAT, Overlap FLOAT,
+		File_Name VARCHAR(100) NOT NULL
+	)`).Error)
+
+	for i := range rows {
+		require.NoError(t, db.Exec(
+			`INSERT INTO detections (Date, Time, Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Week, Sens, Overlap, File_Name)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0.0, ?)`,
+			fmt.Sprintf("2024-01-0%d", (i%9)+1), "10:00:00",
+			fmt.Sprintf("Parus major%d", i), fmt.Sprintf("Great Tit%d", i),
+			0.9+float64(i)*0.001, 60.0, 25.0, 0.1, 1.0,
+			fmt.Sprintf("clip%d.wav", i),
+		).Error)
+	}
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	return dir, path
+}
+
+// importSSEEvent holds parsed fields from a single import SSE event.
+type importSSEEvent struct {
+	id    string
+	event string
+	data  string
+}
+
+// parseImportSSEEvents parses SSE-formatted text into a slice of import events.
+func parseImportSSEEvents(body string) []importSSEEvent {
+	var events []importSSEEvent
+	var cur importSSEEvent
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			cur.id = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			cur.event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			cur.data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if cur.event != "" {
+				events = append(events, cur)
+				cur = importSSEEvent{}
+			}
+		}
+	}
+	return events
+}
+
+// TestImportManager_ConcurrencyGuard verifies the single-slot guard.
+func TestImportManager_ConcurrencyGuard(t *testing.T) {
+	t.Parallel()
+	mgr := newImportManager()
+
+	_, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	job1 := newImportJob("job1", cancel)
+	assert.True(t, mgr.start(job1), "first start should succeed")
+	assert.False(t, mgr.start(newImportJob("job2", func() {})), "second start while running should fail")
+
+	// After job1 finishes, a new start should succeed.
+	job1.finish(imports.ImportStats{Phase: "done"}, nil)
+	assert.True(t, mgr.start(newImportJob("job3", func() {})), "start after completion should succeed")
+}
+
+// TestImportManager_GetByID verifies ID-based job lookup.
+func TestImportManager_GetByID(t *testing.T) {
+	t.Parallel()
+	mgr := newImportManager()
+	job := newImportJob("abc123", func() {})
+	require.True(t, mgr.start(job))
+	assert.Equal(t, job, mgr.get("abc123"))
+	assert.Nil(t, mgr.get("wrong-id"))
+}
+
+// TestStartBirdNETPiImport_NoRepo_Returns503 verifies 503 when no datastore.
+func TestStartBirdNETPiImport_NoRepo_Returns503(t *testing.T) {
+	e := echo.New()
+	c := &Controller{
+		Group:     e.Group(apiV2Prefix),
+		importMgr: newImportManager(),
+	}
+	c.Settings.Store(newValidTestSettings())
+
+	body := testDBOnlyBody
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/import/birdnet-pi", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	// requireDatastore writes the 503 response and returns the sentinel error,
+	// which the handler propagates (matching the established datastore-guard pattern).
+	err := c.StartBirdNETPiImport(ctx)
+	require.ErrorIs(t, err, errDatastoreUnavailable)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestStartBirdNETPiImport_BadJSON_Returns400 verifies 400 on malformed JSON.
+func TestStartBirdNETPiImport_BadJSON_Returns400(t *testing.T) {
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString("{bad json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := c.StartBirdNETPiImport(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestStartBirdNETPiImport_ModeDBAudio_Returns400 verifies audio mode is rejected.
+func TestStartBirdNETPiImport_ModeDBAudio_Returns400(t *testing.T) {
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
+	c.importSourceRoot = dir
+
+	body := `{"mode":"db-audio","source_path":"birds.db"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := c.StartBirdNETPiImport(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "audio import is not available yet")
+}
+
+// TestStartBirdNETPiImport_UnknownMode_Returns400 verifies unknown modes are rejected.
+func TestStartBirdNETPiImport_UnknownMode_Returns400(t *testing.T) {
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+	c.importSourceRoot = t.TempDir()
+
+	for _, mode := range []string{"", "csv", "xml"} {
+		body := fmt.Sprintf(`{"mode":%q,"source_path":"birds.db"}`, mode)
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		require.NoError(t, c.StartBirdNETPiImport(ctx))
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "mode %q should be rejected", mode)
+	}
+}
+
+// TestStartBirdNETPiImport_TraversalPath_Returns400 verifies path traversal is blocked.
+func TestStartBirdNETPiImport_TraversalPath_Returns400(t *testing.T) {
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+	c.importSourceRoot = t.TempDir()
+	c.importSourceFactory = func(_ string) (imports.Source, error) { return &fakeSource{}, nil }
+
+	for _, badPath := range []string{"../etc/passwd", "../../secret", "/etc/passwd"} {
+		body := fmt.Sprintf(`{"mode":"db-only","source_path":%q}`, badPath)
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		require.NoError(t, c.StartBirdNETPiImport(ctx))
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "path %q should be rejected", badPath)
+	}
+}
+
+// TestResolveImportSourcePath_SymlinkEscape verifies that a symlinked parent
+// directory pointing outside the root is rejected, including for files that do
+// not yet exist (the TOCTOU-resistant containment check).
+func TestResolveImportSourcePath_SymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// Create a symlink inside root that points to a directory outside root.
+	escapeLink := filepath.Join(root, "escape")
+	require.NoError(t, os.Symlink(outside, escapeLink))
+
+	// A non-existent file under the symlinked parent must be rejected because
+	// its physical parent resolves outside root.
+	_, err := resolveImportSourcePath(root, filepath.Join("escape", "missing.db"))
+	require.ErrorIs(t, err, ErrInvalidSourcePath)
+
+	// An existing file reached through the escaping symlink must also be rejected.
+	existing := filepath.Join(outside, "real.db")
+	require.NoError(t, os.WriteFile(existing, []byte("x"), 0o600))
+	_, err = resolveImportSourcePath(root, filepath.Join("escape", "real.db"))
+	require.ErrorIs(t, err, ErrInvalidSourcePath)
+
+	// A legitimate non-existent file directly under root resolves without error
+	// (the handler's os.Stat reports it missing).
+	resolved, err := resolveImportSourcePath(root, "legit.db")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "legit.db"), resolved)
+}
+
+// TestStartBirdNETPiImport_MissingFile_Returns400 verifies missing file returns 400.
+func TestStartBirdNETPiImport_MissingFile_Returns400(t *testing.T) {
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+	c.importSourceRoot = t.TempDir()
+	c.importSourceFactory = func(_ string) (imports.Source, error) { return &fakeSource{}, nil }
+
+	body := `{"mode":"db-only","source_path":"nonexistent.db"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(ctx))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestStartBirdNETPiImport_FakeValidationFailure_Returns400 verifies validation errors return 400.
+func TestStartBirdNETPiImport_FakeValidationFailure_Returns400(t *testing.T) {
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
+	c.importSourceRoot = dir
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{validate: fmt.Errorf("bad schema")}, nil
+	}
+
+	body := testDBOnlyBody
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(ctx))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "source validation failed")
+}
+
+// TestStartBirdNETPiImport_GoodFakeSource_Returns202 verifies 202 on a valid request.
+func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
+
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	det := imports.SourceDetection{
+		Date: "2024-01-01", Time: "10:00:00",
+		ScientificName: "Parus major", CommonName: "Great Tit",
+		Confidence: 0.9,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{batches: [][]imports.SourceDetection{{det}}}, nil
+	}
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
+	c.importSourceRoot = dir
+
+	body := testDBOnlyBody
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(ctx))
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	var resp startImportResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.JobID)
+	assert.Equal(t, importStatusStarted, resp.Status)
+}
+
+// TestStartBirdNETPiImport_ConflictWhileRunning_Returns409 verifies 409 on concurrent starts.
+func TestStartBirdNETPiImport_ConflictWhileRunning_Returns409(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
+
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	// Use a blocking source so the import stays running.
+	blockCh := make(chan struct{})
+	det := imports.SourceDetection{
+		Date: "2024-01-01", Time: "10:00:00",
+		ScientificName: "Turdus merula", CommonName: "Blackbird",
+		Confidence: 0.8,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{
+			batches: [][]imports.SourceDetection{{det}},
+			block:   blockCh,
+		}, nil
+	}
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
+	c.importSourceRoot = dir
+
+	body := testDBOnlyBody
+
+	// First start.
+	e := echo.New()
+	req1 := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req1.Header.Set("Content-Type", "application/json")
+	rec1 := httptest.NewRecorder()
+	ctx1 := e.NewContext(req1, rec1)
+	require.NoError(t, c.StartBirdNETPiImport(ctx1))
+	assert.Equal(t, http.StatusAccepted, rec1.Code)
+
+	// Second start while first is still blocked.
+	req2 := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req2.Header.Set("Content-Type", "application/json")
+	rec2 := httptest.NewRecorder()
+	ctx2 := e.NewContext(req2, rec2)
+	require.NoError(t, c.StartBirdNETPiImport(ctx2))
+	assert.Equal(t, http.StatusConflict, rec2.Code)
+
+	// Unblock and let goroutines exit.
+	close(blockCh)
+}
+
+// TestStreamImportProgress_JobNotFound_Returns404 verifies 404 for unknown job.
+func TestStreamImportProgress_JobNotFound_Returns404(t *testing.T) {
+	_, c := newImportController(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/import/jobs/notexist/progress", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("jobId")
+	ctx.SetParamValues("notexist")
+
+	require.NoError(t, c.StreamImportProgress(ctx))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestStreamImportProgress_DoneJob_EmitsCompleteEvent verifies complete event is emitted.
+func TestStreamImportProgress_DoneJob_EmitsCompleteEvent(t *testing.T) {
+	_, c := newImportController(t)
+
+	jobCtx, jobCancel := context.WithCancel(t.Context())
+	jobCancel()
+	job := newImportJob("testjob", jobCancel)
+	require.True(t, c.importMgr.start(job))
+	job.Report(imports.ImportStats{Total: 5, Processed: 5, Inserted: 5, Phase: "import"})
+	job.finish(imports.ImportStats{Total: 5, Processed: 5, Inserted: 5, Phase: "done"}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req = req.WithContext(jobCtx)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("jobId")
+	ctx.SetParamValues("testjob")
+
+	require.NoError(t, c.StreamImportProgress(ctx))
+
+	body := rec.Body.String()
+	events := parseImportSSEEvents(body)
+	require.NotEmpty(t, events, "expected at least one SSE event")
+
+	var found bool
+	for _, ev := range events {
+		if ev.event == importEventComplete {
+			found = true
+			var prog importProgress
+			require.NoError(t, json.Unmarshal([]byte(ev.data), &prog))
+			assert.Equal(t, "done", prog.Phase)
+		}
+	}
+	assert.True(t, found, "expected a complete event")
+}
+
+// TestStreamImportProgress_EventIDsMonotonic verifies SSE event IDs are monotonically increasing.
+func TestStreamImportProgress_EventIDsMonotonic(t *testing.T) {
+	_, c := newImportController(t)
+
+	_, jobCancel := context.WithCancel(t.Context())
+	defer jobCancel()
+	job := newImportJob("monotone", jobCancel)
+	require.True(t, c.importMgr.start(job))
+
+	for i := range 3 {
+		job.Report(imports.ImportStats{Total: 10, Processed: i + 1, Phase: "import"})
+	}
+	job.finish(imports.ImportStats{Total: 10, Processed: 10, Inserted: 10, Phase: "done"}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req = req.WithContext(t.Context())
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("jobId")
+	ctx.SetParamValues("monotone")
+
+	require.NoError(t, c.StreamImportProgress(ctx))
+
+	body := rec.Body.String()
+	events := parseImportSSEEvents(body)
+	require.NotEmpty(t, events)
+
+	var prevID int64 = -1
+	for _, ev := range events {
+		if ev.event == importEventHeartbeat {
+			continue
+		}
+		require.NotEmpty(t, ev.id, "event %q must have an id", ev.event)
+		id, err := strconv.ParseInt(ev.id, 10, 64)
+		require.NoError(t, err, "id must be numeric, got %q", ev.id)
+		assert.Greater(t, id, prevID, "ids must be strictly increasing")
+		prevID = id
+	}
+
+	for _, ev := range events {
+		if ev.event != importEventProgress && ev.event != importEventComplete {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(ev.data), &m))
+		for key := range m {
+			assert.Equal(t, strings.ToLower(key), key, "JSON key %q should be lowercase/snake_case", key)
+		}
+	}
+}
+
+// TestCancelImport_JobNotFound_Returns404 verifies 404 for unknown job.
+func TestCancelImport_JobNotFound_Returns404(t *testing.T) {
+	_, c := newImportController(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("jobId")
+	ctx.SetParamValues("notexist")
+
+	require.NoError(t, c.CancelImport(ctx))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestCancelImport_RunningJob_Returns200Cancelling verifies cancel returns 200 with cancelling status.
+func TestCancelImport_RunningJob_Returns200Cancelling(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
+
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	blockCh := make(chan struct{})
+	det := imports.SourceDetection{
+		Date: "2024-01-01", Time: "10:00:00",
+		ScientificName: "Corvus cornix", CommonName: "Hooded Crow",
+		Confidence: 0.85,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{
+			batches: [][]imports.SourceDetection{{det}},
+			block:   blockCh,
+		}, nil
+	}
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
+	c.importSourceRoot = dir
+
+	body := testDBOnlyBody
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	startCtx := e.NewContext(req, rec)
+	require.NoError(t, c.StartBirdNETPiImport(startCtx))
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	var startResp startImportResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &startResp))
+	jobID := startResp.JobID
+
+	req2 := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	rec2 := httptest.NewRecorder()
+	cancelCtx := e.NewContext(req2, rec2)
+	cancelCtx.SetParamNames("jobId")
+	cancelCtx.SetParamValues(jobID)
+	require.NoError(t, c.CancelImport(cancelCtx))
+	assert.Equal(t, http.StatusOK, rec2.Code)
+
+	var cancelResp cancelImportResponse
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &cancelResp))
+	assert.Contains(t, []string{importStatusCancelling, importStatusDone}, cancelResp.Status)
+
+	close(blockCh)
+}
+
+// TestGetImportStatus_NoJob_ReturnsIdle verifies idle status when no job exists.
+func TestGetImportStatus_NoJob_ReturnsIdle(t *testing.T) {
+	_, c := newImportController(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.GetImportStatus(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp importStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.False(t, resp.Running)
+	assert.Equal(t, importStatusIdle, resp.Status)
+}
+
+// TestGetImportStatus_RunningJob verifies running status with progress.
+func TestGetImportStatus_RunningJob(t *testing.T) {
+	_, c := newImportController(t)
+
+	_, jobCancel := context.WithCancel(t.Context())
+	defer jobCancel()
+	job := newImportJob("running1", jobCancel)
+	require.True(t, c.importMgr.start(job))
+	job.Report(imports.ImportStats{Total: 100, Processed: 50, Phase: "import"})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.GetImportStatus(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp importStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.True(t, resp.Running)
+	assert.Equal(t, importStatusRunning, resp.Status)
+	assert.Equal(t, "running1", resp.JobID)
+	require.NotNil(t, resp.Progress)
+	assert.Equal(t, 100, resp.Progress.Total)
+	assert.Equal(t, 50, resp.Progress.Processed)
+}
+
+// TestGetImportStatus_DoneJob verifies done status after completion.
+func TestGetImportStatus_DoneJob(t *testing.T) {
+	_, c := newImportController(t)
+
+	_, jobCancel := context.WithCancel(t.Context())
+	jobCancel()
+	job := newImportJob("done1", jobCancel)
+	require.True(t, c.importMgr.start(job))
+	job.finish(imports.ImportStats{Total: 10, Processed: 10, Inserted: 8, Skipped: 2, Phase: "done"}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	require.NoError(t, c.GetImportStatus(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp importStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.False(t, resp.Running)
+	assert.Equal(t, importStatusDone, resp.Status)
+	assert.Empty(t, resp.Error)
+}
+
+// TestImportRoutes_Registered verifies all import routes are registered.
+func TestImportRoutes_Registered(t *testing.T) {
+	e, c := newImportController(t)
+	c.initImportRoutes()
+
+	expected := []string{
+		"POST " + apiV2Prefix + "/import/birdnet-pi",
+		"GET " + apiV2Prefix + "/import/jobs/:jobId/progress",
+		"POST " + apiV2Prefix + "/import/jobs/:jobId/cancel",
+		"GET " + apiV2Prefix + "/import/status",
+	}
+	assertRoutesRegistered(t, e, expected)
+}
+
+// TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd verifies the full pipeline with a real SQLite file.
+func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
+
+	const rowCount = 3
+
+	dir, _ := makeTempDB(t, rowCount)
+
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+	c.importSourceRoot = dir
+
+	body := testDBOnlyBody
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	startCtx := e.NewContext(req, rec)
+
+	require.NoError(t, c.StartBirdNETPiImport(startCtx))
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	var startResp startImportResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &startResp))
+	jobID := startResp.JobID
+	assert.NotEmpty(t, jobID)
+
+	// Poll status until done.
+	deadline := time.Now().Add(10 * time.Second)
+	var finalStatus importStatusResponse
+	for time.Now().Before(deadline) {
+		statusReq := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		statusRec := httptest.NewRecorder()
+		statusCtx := e.NewContext(statusReq, statusRec)
+		require.NoError(t, c.GetImportStatus(statusCtx))
+		require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &finalStatus))
+		if !finalStatus.Running && finalStatus.Status == importStatusDone {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	assert.Equal(t, importStatusDone, finalStatus.Status, "import should reach done state")
+	assert.Empty(t, finalStatus.Error)
+	if finalStatus.Progress != nil {
+		assert.Equal(t, rowCount, finalStatus.Progress.Total)
+	}
+}

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -39,6 +39,11 @@ type fakeSource struct {
 	batches  [][]imports.SourceDetection
 	validate error
 	block    chan struct{} // optional: gate between batches for cancel tests
+	// gate, when non-nil, makes Iterate receive one value before producing each
+	// batch. The test sends one token per batch and reads the resulting progress
+	// event before sending the next, so progress updates cannot coalesce. This
+	// gives the live-streaming test a deterministic multi-event stream.
+	gate chan struct{}
 }
 
 func (f *fakeSource) Validate(_ context.Context) error {
@@ -59,8 +64,18 @@ func (f *fakeSource) Iterate(ctx context.Context, _ int, fn func([]imports.Sourc
 	f.mu.Lock()
 	batches := f.batches
 	block := f.block
+	gate := f.gate
 	f.mu.Unlock()
 	for _, b := range batches {
+		if gate != nil {
+			// Wait for the test to release this batch so the SSE reader can
+			// observe each progress event before the next batch is produced.
+			select {
+			case <-gate:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -141,6 +156,30 @@ type importSSEEvent struct {
 	id    string
 	event string
 	data  string
+}
+
+// readImportSSEEvent reads scanner lines until one complete SSE event (terminated
+// by a blank line) has been assembled, then returns it. It returns ok=false when
+// the stream ends before a complete event is read. Used by tests that need to read
+// events incrementally rather than draining the whole stream at once.
+func readImportSSEEvent(scanner *bufio.Scanner) (event importSSEEvent, ok bool) {
+	var cur importSSEEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			cur.id = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			cur.event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			cur.data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if cur.event != "" {
+				return cur, true
+			}
+		}
+	}
+	return importSSEEvent{}, false
 }
 
 // parseImportSSEEvents parses SSE-formatted text into a slice of import events.
@@ -287,7 +326,11 @@ func TestStartBirdNETPiImport_TraversalPath_Returns400(t *testing.T) {
 	c.importSourceRoot = t.TempDir()
 	c.importSourceFactory = func(_ string) (imports.Source, error) { return &fakeSource{}, nil }
 
-	for _, badPath := range []string{"../etc/passwd", "../../secret", "/etc/passwd"} {
+	// filepath.Join(t.TempDir(), ...) is drive-absolute on Windows and outside the
+	// import root on all platforms, so it covers the filepath.IsAbs rejection path
+	// on every OS (unlike "/etc/passwd" which is not absolute on Windows).
+	outsidePath := filepath.Join(t.TempDir(), "outside.db")
+	for _, badPath := range []string{"../etc/passwd", "../../secret", "/etc/passwd", outsidePath} {
 		body := fmt.Sprintf(`{"mode":"db-only","source_path":%q}`, badPath)
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
@@ -381,11 +424,13 @@ func TestStartBirdNETPiImport_FakeValidationFailure_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_GoodFakeSource_Returns202 verifies 202 on a valid request.
 func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("runtime.gopark"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-	)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
 
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
@@ -536,6 +581,8 @@ func TestStreamImportProgress_DoneJob_EmitsCompleteEvent(t *testing.T) {
 }
 
 // TestStreamImportProgress_EventIDsMonotonic verifies SSE event IDs are monotonically increasing.
+// This test covers the connect-after-done path (terminal-only event), complementing
+// TestStreamImportProgress_LiveStreaming which covers the live multi-event path.
 func TestStreamImportProgress_EventIDsMonotonic(t *testing.T) {
 	_, c := newImportController(t)
 
@@ -750,11 +797,13 @@ func TestImportRoutes_Registered(t *testing.T) {
 
 // TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd verifies the full pipeline with a real SQLite file.
 func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("runtime.gopark"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-	)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
 
 	const rowCount = 3
 
@@ -867,8 +916,11 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	c.Repo = mockRepo
 
-	// readyCh gates the source between batches; close it after the SSE client connects.
-	readyCh := make(chan struct{})
+	// gate releases one batch at a time. The test sends one token per batch and
+	// reads the resulting progress event before releasing the next, so progress
+	// updates cannot coalesce. This makes the multi-event assertion deterministic.
+	const batchCount = 3
+	gate := make(chan struct{})
 	det := imports.SourceDetection{
 		Date: "2024-06-01", Time: "08:00:00",
 		ScientificName: "Parus major", CommonName: "Great Tit",
@@ -881,7 +933,7 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 				{det},
 				{det},
 			},
-			block: readyCh,
+			gate: gate,
 		}, nil
 	}
 
@@ -904,35 +956,44 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 	jobID := startBody.JobID
 	require.NotEmpty(t, jobID)
 
-	// Connect SSE stream before unblocking so we catch intermediate events.
+	// Connect SSE stream before releasing any batch so we catch every event.
 	streamResp, err := http.Get(srv.URL + "/api/v2/import/jobs/" + jobID + "/progress") //nolint:noctx // test uses simplified HTTP calls without context
 	require.NoError(t, err)
 	defer func() { _ = streamResp.Body.Close() }()
 	require.Equal(t, http.StatusOK, streamResp.StatusCode)
 
-	// Unblock the import so batches flow through.
-	close(readyCh)
-
-	// Read all SSE events until the stream closes.
 	scanner := bufio.NewScanner(streamResp.Body)
 	var events []importSSEEvent
-	var cur importSSEEvent
-	for scanner.Scan() {
-		line := scanner.Text()
-		switch {
-		case strings.HasPrefix(line, "id: "):
-			cur.id = strings.TrimPrefix(line, "id: ")
-		case strings.HasPrefix(line, "event: "):
-			cur.event = strings.TrimPrefix(line, "event: ")
-		case strings.HasPrefix(line, "data: "):
-			cur.data = strings.TrimPrefix(line, "data: ")
-		case line == "":
-			if cur.event != "" {
-				events = append(events, cur)
-				cur = importSSEEvent{}
+
+	// Release every batch except the last, reading its progress event before
+	// releasing the next. Because the source parks on the next gate token after
+	// reporting, each of these updates is observed individually (no coalesce), so
+	// the stream is guaranteed to carry batchCount-1 distinct progress events.
+	// The final batch is released afterwards; its progress may legitimately
+	// coalesce into the terminal event (finish supersedes a pending progress),
+	// so we do not require a separate progress event for it.
+	for range batchCount - 1 {
+		gate <- struct{}{}
+		for {
+			ev, ok := readImportSSEEvent(scanner)
+			require.True(t, ok, "stream closed before a progress event arrived")
+			events = append(events, ev)
+			if ev.event == importEventProgress {
+				break
 			}
 		}
 	}
+
+	// Release the final batch and drain the remaining events through the terminal.
+	gate <- struct{}{}
+	for {
+		ev, ok := readImportSSEEvent(scanner)
+		if !ok {
+			break
+		}
+		events = append(events, ev)
+	}
+	require.NoError(t, scanner.Err(), "SSE stream must not error during read")
 
 	require.NotEmpty(t, events, "should receive at least one SSE event")
 
@@ -964,7 +1025,7 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 		}
 	}
 
-	assert.GreaterOrEqual(t, progressCount, 1, "should have received at least one progress event")
+	assert.GreaterOrEqual(t, progressCount, 2, "should have received at least two progress events (3-batch source)")
 	assert.Equal(t, importEventComplete, lastEvent, "stream must end with complete event")
 }
 
@@ -1056,6 +1117,7 @@ func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
 			}
 		}
 	}
+	require.NoError(t, scanner.Err(), "SSE stream must not error during read")
 
 	require.NotEmpty(t, events, "should receive at least one SSE event")
 	lastEvent := events[len(events)-1]

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -349,13 +349,29 @@ func TestResolveImportSourcePath_SymlinkEscape(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()
 
-	// Create a symlink inside root that points to a directory outside root.
+	// t.TempDir may itself sit under a symlink (macOS /var -> /private/var), so the
+	// resolver legitimately returns the symlink-resolved root. Compare against that.
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+
+	// A legitimate non-existent file directly under root resolves without error
+	// (the handler's os.Stat reports it missing). Platform-independent, so check it
+	// before the symlink-dependent cases below.
+	resolved, err := resolveImportSourcePath(root, "legit.db")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(resolvedRoot, "legit.db"), resolved)
+
+	// The escape cases need a symlink inside root pointing outside it. Creating a
+	// symlink needs a privilege the Windows CI runner lacks, so skip them when the
+	// symlink cannot be created rather than failing the whole test.
 	escapeLink := filepath.Join(root, "escape")
-	require.NoError(t, os.Symlink(outside, escapeLink))
+	if symErr := os.Symlink(outside, escapeLink); symErr != nil {
+		t.Skipf("skipping symlink-escape cases: cannot create symlink: %v", symErr)
+	}
 
 	// A non-existent file under the symlinked parent must be rejected because
 	// its physical parent resolves outside root.
-	_, err := resolveImportSourcePath(root, filepath.Join("escape", "missing.db"))
+	_, err = resolveImportSourcePath(root, filepath.Join("escape", "missing.db"))
 	require.ErrorIs(t, err, errInvalidSourcePath)
 
 	// An existing file reached through the escaping symlink must also be rejected.
@@ -363,12 +379,6 @@ func TestResolveImportSourcePath_SymlinkEscape(t *testing.T) {
 	require.NoError(t, os.WriteFile(existing, []byte("x"), 0o600))
 	_, err = resolveImportSourcePath(root, filepath.Join("escape", "real.db"))
 	require.ErrorIs(t, err, errInvalidSourcePath)
-
-	// A legitimate non-existent file directly under root resolves without error
-	// (the handler's os.Stat reports it missing).
-	resolved, err := resolveImportSourcePath(root, "legit.db")
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(root, "legit.db"), resolved)
 
 	// Multi-level: a path under a symlinked ancestor where multiple intermediate
 	// directories do not exist yet must also be rejected.


### PR DESCRIPTION
## Summary

Adds an HTTP API that drives the existing BirdNET-Pi import engine (`internal/imports`) from the web layer, so a BirdNET-Pi `birds.db` can be imported into BirdNET-Go with live progress streaming.

New endpoints under `/api/v2/import` (all auth-gated, consistent with other system endpoints):

- `POST /api/v2/import/birdnet-pi`: validate a BirdNET-Pi SQLite source and start a DB-only import in the background; returns 202 with a `job_id`.
- `GET /api/v2/import/jobs/:jobId/progress`: Server-Sent Events stream of progress (`total`, `processed`, `inserted`, `skipped`, `errors`, `phase`) with unique, monotonic event IDs; terminates with a `complete`, `cancelled`, or `error` event.
- `POST /api/v2/import/jobs/:jobId/cancel`: cancel a running import via context cancellation; re-running is safe because the engine deduplicates.
- `GET /api/v2/import/status`: current import state (idle / running / done) for polling clients.

Design notes:

- DB-only. Audio copying is intentionally out of scope and handled separately.
- One import at a time, guarded by a single-slot manager; a second start returns 409.
- Progress uses a last-value broadcast, so the engine never blocks on a slow or absent SSE client and a late or reconnecting client still receives the latest state.
- The import runs under the controller lifetime context and is tracked by the server WaitGroup, so a graceful shutdown aborts and joins it. Closing the SSE connection does not cancel the import.
- Source paths are validated for containment under the external media mount with symlink-escape protection before the read-only SQLite source is opened.
- Source discovery reuses the existing `GET /api/v2/system/external-media` endpoint.

## Test Plan

- [x] `go build ./...`, `go vet`, `gofmt`, `golangci-lint run ./internal/api/v2/...` (0 issues)
- [x] `go test -race ./internal/api/v2/...`: start validation, SSE streaming with monotonic IDs, cancel, status, a real-SQLite end-to-end import, and panic recovery
- [x] 20x repeat run of the import tests with no flakes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented import job endpoints for starting, monitoring, and canceling BirdNET-Pi database imports with progress streaming and status polling capabilities.

* **Documentation**
  * Added API documentation for the new import endpoints.

* **Tests**
  * Added comprehensive test suite covering import functionality, error handling, concurrency, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->