### PR TITLE
fix(api): fail closed on missing auth middleware for import routes

### DIFF
--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -176,16 +176,24 @@ func isContained(root, target string) bool {
 }
 
 // initImportRoutes registers all import-related API routes.
+//
+// These endpoints start, cancel, and inspect a database import, so the group
+// must fail closed. c.authMiddleware is non-nil in every real deployment: the
+// server always injects it via WithAuthMiddleware, and that middleware itself
+// enforces or passes through based on the auth configuration. It can only be nil
+// in unit tests or a misconfiguration; in that case install a middleware that
+// denies access with 401 rather than registering the routes unprotected (Echo's
+// applyMiddleware would also panic on a literal nil entry).
 func (c *Controller) initImportRoutes() {
-	var mw []echo.MiddlewareFunc
-	// Echo's applyMiddleware invokes every middleware entry, so a nil auth middleware
-	// would panic at registration. Append it only when present (it is nil in tests and
-	// when auth is not configured); the routes are still gated by the global private-mode
-	// middleware on c.Group in that case.
-	if c.authMiddleware != nil {
-		mw = append(mw, c.authMiddleware)
+	authMiddleware := c.authMiddleware
+	if authMiddleware == nil {
+		authMiddleware = func(echo.HandlerFunc) echo.HandlerFunc {
+			return func(ctx echo.Context) error {
+				return c.HandleError(ctx, nil, "authentication is not configured", http.StatusUnauthorized)
+			}
+		}
 	}
-	g := c.Group.Group("/import", mw...)
+	g := c.Group.Group("/import", authMiddleware)
 	g.POST("/birdnet-pi", c.StartBirdNETPiImport)
 	g.GET("/jobs/:jobId/progress", c.StreamImportProgress)
 	g.POST("/jobs/:jobId/cancel", c.CancelImport)

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -105,6 +105,10 @@ func newImportController(t *testing.T) (*echo.Echo, *Controller) {
 		importMgr: newImportManager(),
 		ctx:       ctx,
 		cancel:    cancel,
+		// Pass-through auth middleware, mirroring production where the server always
+		// injects a non-nil middleware (it enforces or passes based on auth config).
+		// Tests that exercise the fail-closed nil case set authMiddleware to nil.
+		authMiddleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next },
 	}
 	c.Settings.Store(newValidTestSettings())
 	t.Cleanup(func() {
@@ -809,7 +813,8 @@ func TestImportRoutes_Registered(t *testing.T) {
 // with no auth middleware configured it denies access with 401 rather than
 // registering the state-changing endpoints unprotected.
 func TestImportRoutes_FailClosedWhenNoAuth(t *testing.T) {
-	e, c := newImportController(t) // newImportController leaves authMiddleware nil
+	e, c := newImportController(t)
+	c.authMiddleware = nil // exercise the fail-closed path: no auth middleware configured
 	c.initImportRoutes()
 
 	req := httptest.NewRequest(http.MethodGet, apiV2Prefix+"/import/status", http.NoBody)

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -805,6 +805,20 @@ func TestImportRoutes_Registered(t *testing.T) {
 	assertRoutesRegistered(t, e, expected)
 }
 
+// TestImportRoutes_FailClosedWhenNoAuth verifies the import group fails closed:
+// with no auth middleware configured it denies access with 401 rather than
+// registering the state-changing endpoints unprotected.
+func TestImportRoutes_FailClosedWhenNoAuth(t *testing.T) {
+	e, c := newImportController(t) // newImportController leaves authMiddleware nil
+	c.initImportRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, apiV2Prefix+"/import/status", http.NoBody)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
 // TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd verifies the full pipeline with a real SQLite file.
 func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

Follow-up to #3660. The import route group registered its auth middleware only when `c.authMiddleware` was non-nil, which meant that if the middleware were ever absent the state-changing import endpoints (start / cancel / status) would register unprotected (gated only by global private-mode). These endpoints should fail closed.

This installs a fallback middleware that returns 401 when `c.authMiddleware` is nil, so the group is never registered without auth protection.

In practice `c.authMiddleware` is always injected by the server (and itself enforces or passes based on the auth configuration), so this changes behavior only in the nil case (unit tests or a misconfiguration), turning a silent fail-open into a fail-closed 401. It also avoids the panic that passing a literal nil middleware to Echo would cause.

## Test Plan

- [x] New `TestImportRoutes_FailClosedWhenNoAuth`: with no auth middleware configured, `GET /api/v2/import/status` returns 401.
- [x] `TestImportRoutes_Registered` still passes (routes register).
- [x] `go build`, `go vet`, `gofmt`, `golangci-lint run ./internal/api/v2/...` (0 issues), `go test -race ./internal/api/v2/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for import operations by enforcing fail-closed authentication on `/import` endpoints. If authentication is not configured, import-related requests are now consistently rejected with **401 Unauthorized**, preventing access to import functionality without proper authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->