### PR TITLE
feat(imports): add DB+audio mode for BirdNET-Pi import

### DIFF
--- a/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.svelte
+++ b/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.svelte
@@ -10,7 +10,6 @@
   import LoadingSpinner from '$lib/desktop/components/ui/LoadingSpinner.svelte';
   import ErrorAlert from '$lib/desktop/components/ui/ErrorAlert.svelte';
   import ProgressBar from '$lib/desktop/components/ui/ProgressBar.svelte';
-  import Badge from '$lib/desktop/components/ui/Badge.svelte';
   import TextInput from '$lib/desktop/components/forms/TextInput.svelte';
   import { CheckCircle2, XCircle, AlertTriangle, ArrowLeft, ArrowRight } from '@lucide/svelte';
   import type {
@@ -47,6 +46,9 @@
 
   // Path input (relative to mount root)
   let sourcePath = $state('birdnet-pi/birds.db');
+
+  // Selected import mode
+  let selectedMode = $state<'db-only' | 'db-audio'>('db-only');
 
   // Progress / run state
   let jobId = $state<string | null>(null);
@@ -252,7 +254,7 @@
     errorMessage = null;
 
     const body: StartImportRequest = {
-      mode: 'db-only',
+      mode: selectedMode,
       source_path: sourcePath.trim(),
     };
 
@@ -528,7 +530,14 @@
           <label
             class="flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors border-[var(--color-primary)] bg-[color-mix(in_srgb,var(--color-primary)_5%,transparent)]"
           >
-            <input type="radio" name="import-mode" value="db-only" checked={true} class="mt-1" />
+            <input
+              type="radio"
+              name="import-mode"
+              value="db-only"
+              checked={selectedMode === 'db-only'}
+              onchange={() => (selectedMode = 'db-only')}
+              class="mt-1"
+            />
             <div>
               <span class="font-medium text-[var(--color-base-content)]"
                 >{t('system.importExport.mode.dbOnly.label')}</span
@@ -539,34 +548,26 @@
             </div>
           </label>
 
-          <!-- db-audio option (disabled) -->
+          <!-- db-audio option -->
           <label
-            class="flex items-start gap-3 p-4 rounded-lg border border-[var(--color-base-300)] opacity-60 cursor-not-allowed"
+            class="flex items-start gap-3 p-4 rounded-lg border border-[var(--color-base-300)] cursor-pointer hover:border-[var(--color-primary)] hover:bg-[color-mix(in_srgb,var(--color-primary)_4%,transparent)] transition-colors"
           >
             <input
               type="radio"
               name="import-mode"
               value="db-audio"
-              disabled={true}
-              aria-describedby="db-audio-disabled-reason"
+              checked={selectedMode === 'db-audio'}
+              onchange={() => (selectedMode = 'db-audio')}
               class="mt-1"
             />
             <div>
               <div class="flex items-center gap-2">
-                <span class="font-medium text-[var(--color-base-content)]/70"
+                <span class="font-medium text-[var(--color-base-content)]"
                   >{t('system.importExport.mode.dbAudio.label')}</span
                 >
-                <Badge
-                  variant="warning"
-                  size="xs"
-                  text={t('system.importExport.mode.dbAudio.badge')}
-                />
               </div>
-              <p class="text-sm text-[var(--color-base-content)]/50 mt-0.5">
+              <p class="text-sm text-[var(--color-base-content)]/70 mt-0.5">
                 {t('system.importExport.mode.dbAudio.description')}
-              </p>
-              <p id="db-audio-disabled-reason" class="text-xs text-[var(--color-warning)] mt-1">
-                {t('system.importExport.mode.dbAudio.disabledReason')}
               </p>
             </div>
           </label>
@@ -592,7 +593,9 @@
                 {t('system.importExport.confirm.mode')}:
               </dt>
               <dd class="text-sm text-[var(--color-base-content)]">
-                {t('system.importExport.mode.dbOnly.label')}
+                {selectedMode === 'db-audio'
+                  ? t('system.importExport.mode.dbAudio.label')
+                  : t('system.importExport.mode.dbOnly.label')}
               </dd>
             </div>
             <div class="flex gap-3">

--- a/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.test.ts
@@ -236,7 +236,7 @@ describe('BirdNetPiImportWizard', () => {
 
   // ---- Mode step ----
 
-  it('mode step shows db-only enabled and db-audio disabled with reason', async () => {
+  it('mode step shows both db-only and db-audio radios enabled', async () => {
     render(BirdNetPiImportWizard, { props: { onClose } });
     // Navigate to mode step
     await waitFor(() => {
@@ -251,20 +251,20 @@ describe('BirdNetPiImportWizard', () => {
       expect(screen.getByText('system.importExport.mode.label')).toBeInTheDocument();
     });
 
-    // db-only radio should be enabled
+    // db-only radio should be enabled and selected by default
     const dbOnlyRadio = screen.getByRole('radio', {
       name: /system.importExport.mode.dbOnly.label/,
     });
     expect(dbOnlyRadio).not.toBeDisabled();
 
-    // db-audio radio should be disabled
+    // db-audio radio should also be enabled
     const dbAudioRadio = screen.getByRole('radio', {
       name: /system.importExport.mode.dbAudio.label/,
     });
-    expect(dbAudioRadio).toBeDisabled();
+    expect(dbAudioRadio).not.toBeDisabled();
   });
 
-  it('db-audio disabled reason is visible', async () => {
+  it('db-audio disabled reason is not shown', async () => {
     render(BirdNetPiImportWizard, { props: { onClose } });
     await waitFor(() => {
       expect(
@@ -275,10 +275,13 @@ describe('BirdNetPiImportWizard', () => {
     await fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(
-        screen.getByText('system.importExport.mode.dbAudio.disabledReason')
-      ).toBeInTheDocument();
+      expect(screen.getByText('system.importExport.mode.label')).toBeInTheDocument();
     });
+
+    // The disabled reason must no longer appear since db-audio is now enabled
+    expect(
+      screen.queryByText('system.importExport.mode.dbAudio.disabledReason')
+    ).not.toBeInTheDocument();
   });
 
   // ---- Confirm step ----
@@ -334,6 +337,39 @@ describe('BirdNetPiImportWizard', () => {
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith('/api/v2/import/birdnet-pi', {
         mode: 'db-only',
+        source_path: 'birdnet-pi/birds.db',
+      });
+    });
+  });
+
+  it('selecting db-audio posts mode db-audio to the API', async () => {
+    render(BirdNetPiImportWizard, { props: { onClose } });
+    await waitFor(() => {
+      expect(
+        screen.getByText('system.importExport.sourceAccess.mountDescription')
+      ).toBeInTheDocument();
+    });
+
+    // Navigate to the mode step.
+    await fireEvent.click(screen.getByRole('button', { name: /common.buttons.next/ }));
+    await waitFor(() => screen.getByText('system.importExport.mode.label'));
+
+    // Select the db-audio mode.
+    const dbAudioRadio = screen.getByRole('radio', {
+      name: /system.importExport.mode.dbAudio.label/,
+    });
+    await fireEvent.click(dbAudioRadio);
+
+    // Advance to confirm and start.
+    await fireEvent.click(screen.getByRole('button', { name: /common.buttons.next/ }));
+    await waitFor(() => screen.getByText('system.importExport.confirm.description'));
+    await fireEvent.click(
+      screen.getByRole('button', { name: /system.importExport.confirm.startButton/ })
+    );
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith('/api/v2/import/birdnet-pi', {
+        mode: 'db-audio',
         source_path: 'birdnet-pi/birds.db',
       });
     });

--- a/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.test.ts
+++ b/frontend/src/lib/desktop/features/import-export/components/BirdNetPiImportWizard.test.ts
@@ -256,6 +256,8 @@ describe('BirdNetPiImportWizard', () => {
       name: /system.importExport.mode.dbOnly.label/,
     });
     expect(dbOnlyRadio).not.toBeDisabled();
+    // db-only must be the default selection so a regression in the default mode is caught.
+    expect(dbOnlyRadio).toBeChecked();
 
     // db-audio radio should also be enabled
     const dbAudioRadio = screen.getByRole('radio', {

--- a/frontend/src/lib/desktop/features/import-export/types.ts
+++ b/frontend/src/lib/desktop/features/import-export/types.ts
@@ -17,7 +17,7 @@ export interface ExternalMediaGuidance {
 export type SourceAccessState = 'native' | 'container-mount' | 'container-missing';
 
 export interface StartImportRequest {
-  mode: 'db-only';
+  mode: 'db-only' | 'db-audio';
   source_path: string;
   location?: string;
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -567,7 +567,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 
 | Method | Route                          | Handler              | Auth | Description                              |
 | ------ | ------------------------------ | -------------------- | ---- | ---------------------------------------- |
-| POST   | `/import/birdnet-pi`           | `StartBirdNETPiImport` | ✅   | Start a BirdNET-Pi DB-only import       |
+| POST   | `/import/birdnet-pi`           | `StartBirdNETPiImport` | ✅   | Start a BirdNET-Pi import (`db-only`, or `db-audio` to also copy clips) |
 | GET    | `/import/jobs/:jobId/progress` | `StreamImportProgress` | ✅   | SSE progress stream for import job      |
 | POST   | `/import/jobs/:jobId/cancel`   | `CancelImport`         | ✅   | Cancel a running import                 |
 | GET    | `/import/status`               | `GetImportStatus`      | ✅   | Get current import status (polling)     |

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -22,7 +22,7 @@ import (
 // Import mode constants.
 const (
 	importModeDBOnly  = "db-only"
-	importModeDBaudio = "db-audio" // reserved; not yet available
+	importModeDBaudio = "db-audio"
 )
 
 // Import SSE event type constants.
@@ -222,7 +222,7 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 	case importModeDBOnly:
 		// accepted
 	case importModeDBaudio:
-		return c.HandleError(ctx, nil, "audio import is not available yet", http.StatusBadRequest)
+		// accepted; audio options configured below when building opts
 	default:
 		return c.HandleError(ctx, nil, "unsupported import mode", http.StatusBadRequest)
 	}
@@ -287,6 +287,15 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		SourceNode: imports.DefaultSourceNode,
 		Location:   loc,
 	}
+	if req.Mode == importModeDBaudio {
+		exportPath := ""
+		if settings := c.currentSettings(); settings != nil {
+			exportPath = settings.Realtime.Audio.Export.Path
+		}
+		opts.IncludeAudio = true
+		opts.AudioSourceDir = filepath.Dir(resolvedPath)
+		opts.ClipExportPath = exportPath
+	}
 	eng := imports.NewEngine(c.Repo)
 	c.wg.Go(func() {
 		var stats imports.ImportStats
@@ -304,7 +313,7 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		}()
 		defer jobCancel()
 		defer func() { _ = src.Close() }()
-		stats, runErr = eng.Run(jobCtx, src, opts, job)
+		stats, runErr = eng.Run(jobCtx, src, &opts, job)
 	})
 
 	return ctx.JSON(http.StatusAccepted, startImportResponse{

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -59,7 +59,7 @@ var errInvalidSourcePath = errors.NewStd("invalid source path")
 
 // startImportRequest is the JSON body for POST /import/birdnet-pi.
 type startImportRequest struct {
-	Mode       string `json:"mode"`        // must be "db-only"
+	Mode       string `json:"mode"`        // accepted values: "db-only", "db-audio"
 	SourcePath string `json:"source_path"` // path relative to the external mount root
 	Location   string `json:"location"`    // optional IANA timezone name e.g. "Europe/Helsinki"
 }

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -268,6 +268,19 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "source validation failed", http.StatusBadRequest)
 	}
 
+	// For db-audio mode, resolve the export path before reserving the import slot
+	// so an unconfigured path returns 400 without occupying the slot.
+	var clipExportPath string
+	if req.Mode == importModeDBaudio {
+		if settings := c.currentSettings(); settings != nil {
+			clipExportPath = settings.Realtime.Audio.Export.Path
+		}
+		if clipExportPath == "" {
+			_ = src.Close()
+			return c.HandleError(ctx, nil, "audio export path is not configured; set the audio export path to import audio", http.StatusBadRequest)
+		}
+	}
+
 	// Reserve the single import slot.
 	id := generateCorrelationID()
 	parent := c.ctx
@@ -288,13 +301,9 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		Location:   loc,
 	}
 	if req.Mode == importModeDBaudio {
-		exportPath := ""
-		if settings := c.currentSettings(); settings != nil {
-			exportPath = settings.Realtime.Audio.Export.Path
-		}
 		opts.IncludeAudio = true
 		opts.AudioSourceDir = filepath.Dir(resolvedPath)
-		opts.ClipExportPath = exportPath
+		opts.ClipExportPath = clipExportPath
 	}
 	eng := imports.NewEngine(c.Repo)
 	c.wg.Go(func() {

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -277,12 +277,33 @@ func TestStartBirdNETPiImport_BadJSON_Returns400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-// TestStartBirdNETPiImport_ModeDBAudio_Returns400 verifies audio mode is rejected.
-func TestStartBirdNETPiImport_ModeDBAudio_Returns400(t *testing.T) {
+// TestStartBirdNETPiImport_ModeDBAudio_Returns202 verifies db-audio mode is accepted.
+func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
+
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
-	c.Repo = mocks.NewMockDetectionRepository(t)
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	det := imports.SourceDetection{
+		Date: "2024-01-01", Time: "10:00:00",
+		ScientificName: "Parus major", CommonName: "Great Tit",
+		Confidence: 0.9,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{batches: [][]imports.SourceDetection{{det}}}, nil
+	}
 
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
@@ -297,8 +318,12 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns400(t *testing.T) {
 
 	err := c.StartBirdNETPiImport(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "audio import is not available yet")
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+
+	var resp startImportResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.JobID)
+	assert.Equal(t, importStatusStarted, resp.Status)
 }
 
 // TestStartBirdNETPiImport_UnknownMode_Returns400 verifies unknown modes are rejected.

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -305,6 +305,12 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 		return &fakeSource{batches: [][]imports.SourceDetection{{det}}}, nil
 	}
 
+	// db-audio mode now requires a configured export path; provide one so the
+	// handler accepts the request instead of returning 400.
+	settings := newValidTestSettings()
+	settings.Realtime.Audio.Export.Path = t.TempDir()
+	c.Settings.Store(settings)
+
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
 	c.importSourceRoot = dir
@@ -324,6 +330,61 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.NotEmpty(t, resp.JobID)
 	assert.Equal(t, importStatusStarted, resp.Status)
+}
+
+// TestStartBirdNETPiImport_ModeDBAudio_NoExportPath_Returns400 verifies that db-audio mode
+// is rejected with 400 when the audio export path is not configured. Without this guard the
+// import would start, copy no audio (the engine skips audio when ClipExportPath is empty),
+// and silently produce detections with no clips, masking a misconfiguration.
+func TestStartBirdNETPiImport_ModeDBAudio_NoExportPath_Returns400(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
+
+	_, c := newImportController(t)
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	c.Repo = mocks.NewMockDetectionRepository(t)
+
+	// Settings with an empty export path (newValidTestSettings leaves it unset).
+	c.Settings.Store(newValidTestSettings())
+
+	det := imports.SourceDetection{
+		Date: "2024-01-01", Time: "10:00:00",
+		ScientificName: "Parus major", CommonName: "Great Tit",
+		Confidence: 0.9,
+	}
+	c.importSourceFactory = func(_ string) (imports.Source, error) {
+		return &fakeSource{batches: [][]imports.SourceDetection{{det}}}, nil
+	}
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "birds.db"), []byte{}, 0o600)
+	c.importSourceRoot = dir
+
+	body := `{"mode":"db-audio","source_path":"birds.db"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := c.StartBirdNETPiImport(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "db-audio without an export path must be rejected")
+
+	// No import slot may have been reserved: a subsequent status check must report idle.
+	statusReq := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	statusRec := httptest.NewRecorder()
+	statusCtx := echo.New().NewContext(statusReq, statusRec)
+	require.NoError(t, c.GetImportStatus(statusCtx))
+	var status importStatusResponse
+	require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &status))
+	assert.False(t, status.Running, "rejected db-audio request must not occupy the import slot")
 }
 
 // makeTempDBWithRow creates a temporary BirdNET-Pi SQLite file in dir with a single

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -326,6 +326,139 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 	assert.Equal(t, importStatusStarted, resp.Status)
 }
 
+// makeTempDBWithRow creates a temporary BirdNET-Pi SQLite file in dir with a single
+// detection row using the supplied date, common name, and clip file name. It returns the
+// directory holding the database. Used by the db-audio test so the row's audio path
+// components are known and a matching source clip tree can be created.
+func makeTempDBWithRow(t *testing.T, date, comName, fileName string) (dir string) {
+	t.Helper()
+	dir = t.TempDir()
+	path := filepath.Join(dir, "birds.db")
+
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE detections (
+		Date DATE, Time TIME,
+		Sci_Name VARCHAR(100) NOT NULL, Com_Name VARCHAR(100) NOT NULL,
+		Confidence FLOAT, Lat FLOAT, Lon FLOAT, Cutoff FLOAT,
+		Week INT, Sens FLOAT, Overlap FLOAT,
+		File_Name VARCHAR(100) NOT NULL
+	)`).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO detections (Date, Time, Sci_Name, Com_Name, Confidence, Lat, Lon, Cutoff, Week, Sens, Overlap, File_Name)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0.0, ?)`,
+		date, "10:00:00", "Dendrocopos major", comName,
+		0.74, 60.0, 25.0, 0.7, 1.25, fileName,
+	).Error)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	return dir
+}
+
+// TestStartBirdNETPiImport_ModeDBAudio_CopiesClip verifies that db-audio mode actually
+// exercises the audio copy path end to end: it sets Realtime.Audio.Export.Path so the
+// engine receives a non-empty ClipExportPath, provides a matching source clip in the
+// BirdNET-Pi Extracted/By_Date tree alongside the database, and asserts the clip is
+// copied into the export directory. The previous db-audio test left the export path
+// empty, so the engine skipped audio entirely (IncludeAudio && ClipExportPath != "" was
+// false) and the new path was never covered.
+func TestStartBirdNETPiImport_ModeDBAudio_CopiesClip(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t,
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("runtime.gopark"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		)
+	})
+
+	const (
+		date     = "2024-01-01"
+		comName  = "Great Spotted Woodpecker"
+		fileName = "woodpecker.mp3"
+	)
+	clipContent := []byte("fake source audio content")
+
+	e, c := newImportController(t)
+	c.initImportRoutes()
+	mockDS := mocks.NewMockInterface(t)
+	c.DS = mockDS
+	mockRepo := mocks.NewMockDetectionRepository(t)
+	mockRepo.EXPECT().Search(mock.Anything, mock.Anything).
+		Return(nil, int64(0), nil).Maybe()
+	mockRepo.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	c.Repo = mockRepo
+
+	// Database directory doubles as the BirdNET-Pi audio source root: the handler sets
+	// AudioSourceDir to filepath.Dir(resolvedPath), so the Extracted/By_Date tree must
+	// live next to birds.db.
+	sourceRoot := makeTempDBWithRow(t, date, comName, fileName)
+	c.importSourceRoot = sourceRoot
+
+	clipDir := filepath.Join(sourceRoot, "Extracted", "By_Date", date, comName)
+	require.NoError(t, os.MkdirAll(clipDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(clipDir, fileName), clipContent, 0o644))
+
+	// Configure a real export directory so the engine receives a non-empty
+	// ClipExportPath and the audio path is exercised.
+	exportDir := t.TempDir()
+	settings := newValidTestSettings()
+	settings.Realtime.Audio.Export.Path = exportDir
+	c.Settings.Store(settings)
+
+	// Use the default source factory (birdnetpi.New) by leaving importSourceFactory unset
+	// so the real adapter reads the database created above.
+
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+
+	startResp, err := http.Post(srv.URL+"/api/v2/import/birdnet-pi", //nolint:noctx // test uses simplified HTTP calls without context
+		"application/json", strings.NewReader(`{"mode":"db-audio","source_path":"birds.db"}`))
+	require.NoError(t, err)
+	defer func() { _ = startResp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, startResp.StatusCode)
+
+	var startBody startImportResponse
+	require.NoError(t, json.NewDecoder(startResp.Body).Decode(&startBody))
+	require.NotEmpty(t, startBody.JobID)
+
+	// Poll status until the import reaches a terminal done state.
+	deadline := time.Now().Add(10 * time.Second)
+	var finalStatus importStatusResponse
+	e2 := echo.New()
+	for time.Now().Before(deadline) {
+		statusReq := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		statusRec := httptest.NewRecorder()
+		statusCtx := e2.NewContext(statusReq, statusRec)
+		require.NoError(t, c.GetImportStatus(statusCtx))
+		require.NoError(t, json.Unmarshal(statusRec.Body.Bytes(), &finalStatus))
+		if !finalStatus.Running && finalStatus.Status == importStatusDone {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	require.Equal(t, importStatusDone, finalStatus.Status, "db-audio import must reach done state")
+	assert.Empty(t, finalStatus.Error)
+	require.NotNil(t, finalStatus.Progress)
+	assert.Equal(t, 1, finalStatus.Progress.Inserted)
+
+	// The source clip must have been copied into the export tree. The relative layout
+	// mirrors buildClipPath: YYYY/MM/<sci>_<conf>p_<timestamp>.<ext>. The engine parses
+	// the wall-clock "10:00:00" and formats it directly (no UTC conversion), so the
+	// timestamp segment is 20240101T100000Z regardless of the host timezone.
+	destAbs := filepath.Join(exportDir, "2024", "01", "dendrocopos_major_74p_20240101T100000Z.mp3")
+	copied, readErr := os.ReadFile(destAbs)
+	require.NoError(t, readErr, "db-audio import must copy the source clip to %s", destAbs)
+	assert.Equal(t, clipContent, copied, "copied clip content must match the source")
+}
+
 // TestStartBirdNETPiImport_UnknownMode_Returns400 verifies unknown modes are rejected.
 func TestStartBirdNETPiImport_UnknownMode_Returns400(t *testing.T) {
 	_, c := newImportController(t)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -415,6 +415,7 @@ func init() {
 	RegisterComponent("restart", "restart")
 	RegisterComponent("imports", "imports")
 	RegisterComponent("imports/audio", "imports.audio")
+	RegisterComponent("imports/birdnetpi", "imports.birdnetpi")
 
 	// Analysis package components - use slash-separated paths for subpackages
 	RegisterComponent("analysis", "analysis")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -413,6 +413,8 @@ func init() {
 	RegisterComponent("app", "app")
 	RegisterComponent("api", "api")
 	RegisterComponent("restart", "restart")
+	RegisterComponent("imports", "imports")
+	RegisterComponent("imports/audio", "imports.audio")
 
 	// Analysis package components - use slash-separated paths for subpackages
 	RegisterComponent("analysis", "analysis")

--- a/internal/imports/audio.go
+++ b/internal/imports/audio.go
@@ -22,24 +22,79 @@ import (
 // audioWorkerLimit is the maximum number of concurrent clip-copy goroutines per batch.
 const audioWorkerLimit = 4
 
+// sanitizePathComponent validates that s is a single safe path component.
+// Returns the component and true if safe, or ("", false) if s contains a path separator,
+// is ".", is "..", or is empty. A crafted DB value containing ".." is treated as "not found".
+func sanitizePathComponent(s string) (string, bool) {
+	if s == "" || s == "." || s == ".." {
+		return "", false
+	}
+	if strings.ContainsAny(s, "/\\") {
+		return "", false
+	}
+	base := filepath.Base(filepath.Clean(s))
+	if base == "." || base == ".." || base == "" {
+		return "", false
+	}
+	return base, true
+}
+
+// isWithinDir reports whether target is physically contained within root (both cleaned).
+// Mirrors the isContained helper in internal/api/v2/import.go.
+func isWithinDir(root, target string) bool {
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 // resolveSourceClipPath resolves the path of a source audio clip within the BirdNET-Pi
 // audio tree. It tries the exact CommonName first, then a fallback form with spaces
 // replaced by underscores and apostrophes stripped.
-// Returns the resolved path and true if found, or ("", false) if neither form exists.
+// Returns the resolved path and true if found, or ("", false) if neither form exists
+// or if any DB-derived component contains path traversal sequences.
 func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (string, bool) {
+	// Sanitize all DB-derived path components before joining. A component containing
+	// ".." or a separator is treated as "clip not found" (defense against a crafted DB).
+	safeDate, ok := sanitizePathComponent(date)
+	if !ok {
+		return "", false
+	}
+	safeComName, ok := sanitizePathComponent(comName)
+	if !ok {
+		return "", false
+	}
+	safeFileName, ok := sanitizePathComponent(fileName)
+	if !ok {
+		return "", false
+	}
+
 	// Try exact common name first.
-	exact := filepath.Join(audioSourceDir, "Extracted", "By_Date", date, comName, fileName)
+	exact := filepath.Join(audioSourceDir, "Extracted", "By_Date", safeDate, safeComName, safeFileName)
+	if !isWithinDir(audioSourceDir, exact) {
+		return "", false
+	}
 	if _, err := os.Stat(exact); err == nil {
 		return exact, true
 	}
 
 	// Fallback: replace spaces with underscores, strip apostrophes.
-	fallback := strings.ReplaceAll(comName, " ", "_")
+	fallback := strings.ReplaceAll(safeComName, " ", "_")
 	fallback = strings.ReplaceAll(fallback, "'", "")
-	if fallback == comName {
+	if fallback == safeComName {
 		return "", false
 	}
-	fallbackPath := filepath.Join(audioSourceDir, "Extracted", "By_Date", date, fallback, fileName)
+	// Re-sanitize the transformed fallback name.
+	safeFallback, ok := sanitizePathComponent(fallback)
+	if !ok {
+		return "", false
+	}
+	fallbackPath := filepath.Join(audioSourceDir, "Extracted", "By_Date", safeDate, safeFallback, safeFileName)
+	if !isWithinDir(audioSourceDir, fallbackPath) {
+		return "", false
+	}
 	if _, err := os.Stat(fallbackPath); err == nil {
 		return fallbackPath, true
 	}
@@ -52,10 +107,15 @@ func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (stri
 // Format: "YYYY/MM/<scientificName_lowercased_underscored>_<conf>p_<YYYYMMDDTHHMMSSZ>.<srcExt>"
 func targetClipRelPath(scientificName string, confidence float64, ts time.Time, srcExt string) string {
 	formattedName := strings.ToLower(strings.ReplaceAll(scientificName, " ", "_"))
+	// Strip any residual path separators from a crafted scientificName by keeping only
+	// the last component. filepath.Base("../../evil/name") -> "name".
+	formattedName = filepath.Base(formattedName)
 	formattedConf := fmt.Sprintf("%.0fp", confidence*100)
-	timestamp := ts.UTC().Format("20060102T150405Z")
-	year := ts.UTC().Format("2006")
-	month := ts.UTC().Format("01")
+	// Format ts directly (no .UTC()) to match buildClipPath in processor.go, which
+	// uses the configured-zone time with a literal "Z" suffix rather than converting to UTC.
+	timestamp := ts.Format("20060102T150405Z")
+	year := ts.Format("2006")
+	month := ts.Format("01")
 	filename := formattedName + "_" + formattedConf + "_" + timestamp + "." + srcExt
 	return filepath.ToSlash(filepath.Join(year, month, filename))
 }
@@ -222,6 +282,13 @@ func (e *Engine) copyCandidateClips(
 		wg.Go(func() {
 			defer sem.Release(1)
 
+			// Skip this copy if the context was cancelled between acquire and start.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			srcExt := strings.TrimPrefix(filepath.Ext(capturedRow.FileName), ".")
 			if srcExt == "" {
 				srcExt = "mp3"
@@ -229,8 +296,23 @@ func (e *Engine) copyCandidateClips(
 			relPath := targetClipRelPath(capturedRow.ScientificName, capturedRow.Confidence, capturedTs, srcExt)
 			destAbs := filepath.Join(opts.ClipExportPath, filepath.FromSlash(relPath))
 
+			// Containment check: reject a dest path that escapes ClipExportPath.
+			// targetClipRelPath already sanitizes scientificName via filepath.Base; this
+			// is a defense-in-depth guard against any future path that slips through.
+			if !isWithinDir(opts.ClipExportPath, destAbs) {
+				e.log.Warn("target clip path escapes export root, skipping",
+					logger.String("dest", destAbs),
+					logger.String("export_root", opts.ClipExportPath))
+				mu.Lock()
+				*missCount++
+				mu.Unlock()
+				return
+			}
+
 			// Skip copy if target already exists (idempotency guard).
 			if _, statErr := os.Stat(destAbs); statErr == nil {
+				// clipNames[capturedIdx] needs no mutex: each index is owned by exactly one
+				// worker and is written before wg.Wait() ensures visibility.
 				clipNames[capturedIdx] = relPath
 				return
 			}
@@ -258,6 +340,8 @@ func (e *Engine) copyCandidateClips(
 				return
 			}
 
+			// clipNames[capturedIdx] needs no mutex: each index is owned by exactly one
+			// worker and is written before wg.Wait() ensures visibility.
 			clipNames[capturedIdx] = relPath
 		})
 	}

--- a/internal/imports/audio.go
+++ b/internal/imports/audio.go
@@ -77,6 +77,15 @@ func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (stri
 		return "", false
 	}
 	if _, err := os.Stat(exact); err == nil {
+		if resolved, resolveErr := filepath.EvalSymlinks(exact); resolveErr == nil {
+			srcRoot, rootErr := filepath.EvalSymlinks(audioSourceDir)
+			if rootErr != nil {
+				srcRoot = audioSourceDir
+			}
+			if !isWithinDir(srcRoot, resolved) {
+				return "", false
+			}
+		}
 		return exact, true
 	}
 
@@ -96,6 +105,15 @@ func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (stri
 		return "", false
 	}
 	if _, err := os.Stat(fallbackPath); err == nil {
+		if resolved, resolveErr := filepath.EvalSymlinks(fallbackPath); resolveErr == nil {
+			srcRoot, rootErr := filepath.EvalSymlinks(audioSourceDir)
+			if rootErr != nil {
+				srcRoot = audioSourceDir
+			}
+			if !isWithinDir(srcRoot, resolved) {
+				return "", false
+			}
+		}
 		return fallbackPath, true
 	}
 

--- a/internal/imports/audio.go
+++ b/internal/imports/audio.go
@@ -50,14 +50,22 @@ func isWithinDir(root, target string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-// resolveSourceClipPath resolves the path of a source audio clip within the BirdNET-Pi
-// audio tree. It tries the exact CommonName first, then a fallback form with spaces
-// replaced by underscores and apostrophes stripped.
-// Returns the resolved path and true if found, or ("", false) if neither form exists
-// or if any DB-derived component contains path traversal sequences.
-func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (string, bool) {
+// resolveSourceClipRel resolves the path of a source audio clip within the BirdNET-Pi
+// audio tree, relative to root (a sandboxed *os.Root handle on the audio source directory).
+// It tries the exact CommonName first, then a fallback form with spaces replaced by
+// underscores and apostrophes stripped.
+// Returns the path relative to root and true if found, or ("", false) if neither form
+// exists or if any DB-derived component contains path traversal sequences.
+//
+// Containment is enforced atomically by os.Root: every lookup stays within the audio
+// source directory, and a crafted DB value cannot escape it even via a symlink, because
+// os.Root rejects any reference (including an escaping symlink) that resolves outside the
+// root. This closes the time-of-check/time-of-use window that a separate validate-then-open
+// sequence would leave open.
+func resolveSourceClipRel(root *os.Root, date, comName, fileName string) (string, bool) {
 	// Sanitize all DB-derived path components before joining. A component containing
-	// ".." or a separator is treated as "clip not found" (defense against a crafted DB).
+	// ".." or a separator is treated as "clip not found": this gives clean miss semantics
+	// on top of the os.Root containment guarantee (defense against a crafted DB).
 	safeDate, ok := sanitizePathComponent(date)
 	if !ok {
 		return "", false
@@ -71,21 +79,11 @@ func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (stri
 		return "", false
 	}
 
-	// Try exact common name first.
-	exact := filepath.Join(audioSourceDir, "Extracted", "By_Date", safeDate, safeComName, safeFileName)
-	if !isWithinDir(audioSourceDir, exact) {
-		return "", false
-	}
-	if _, err := os.Stat(exact); err == nil {
-		if resolved, resolveErr := filepath.EvalSymlinks(exact); resolveErr == nil {
-			srcRoot, rootErr := filepath.EvalSymlinks(audioSourceDir)
-			if rootErr != nil {
-				srcRoot = audioSourceDir
-			}
-			if !isWithinDir(srcRoot, resolved) {
-				return "", false
-			}
-		}
+	// Try exact common name first. root.Stat enforces containment within the audio source
+	// directory; an escaping path (or escaping symlink) yields an error and is treated as
+	// not found.
+	exact := filepath.Join("Extracted", "By_Date", safeDate, safeComName, safeFileName)
+	if _, err := root.Stat(exact); err == nil {
 		return exact, true
 	}
 
@@ -100,20 +98,8 @@ func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (stri
 	if !ok {
 		return "", false
 	}
-	fallbackPath := filepath.Join(audioSourceDir, "Extracted", "By_Date", safeDate, safeFallback, safeFileName)
-	if !isWithinDir(audioSourceDir, fallbackPath) {
-		return "", false
-	}
-	if _, err := os.Stat(fallbackPath); err == nil {
-		if resolved, resolveErr := filepath.EvalSymlinks(fallbackPath); resolveErr == nil {
-			srcRoot, rootErr := filepath.EvalSymlinks(audioSourceDir)
-			if rootErr != nil {
-				srcRoot = audioSourceDir
-			}
-			if !isWithinDir(srcRoot, resolved) {
-				return "", false
-			}
-		}
+	fallbackPath := filepath.Join("Extracted", "By_Date", safeDate, safeFallback, safeFileName)
+	if _, err := root.Stat(fallbackPath); err == nil {
 		return fallbackPath, true
 	}
 
@@ -138,9 +124,11 @@ func targetClipRelPath(scientificName string, confidence float64, ts time.Time, 
 	return filepath.ToSlash(filepath.Join(year, month, filename))
 }
 
-// copyClipAtomic copies srcPath to destAbsPath using a unique temp file and atomic rename.
-// It creates the destination directory if needed.
-func copyClipAtomic(srcPath, destAbsPath string) error {
+// copyClipAtomic copies the source clip identified by srcRel within root to destAbsPath
+// using a unique temp file and atomic rename. It creates the destination directory if
+// needed. The source is opened through root (an *os.Root), so the read is contained within
+// the audio source directory and cannot be redirected by a symlink that escapes the root.
+func copyClipAtomic(root *os.Root, srcRel, destAbsPath string) error {
 	if err := os.MkdirAll(filepath.Dir(destAbsPath), 0o755); err != nil {
 		return errors.New(err).
 			Component("imports/audio").
@@ -162,7 +150,7 @@ func copyClipAtomic(srcPath, destAbsPath string) error {
 			Build()
 	}
 
-	srcF, err := os.Open(srcPath)
+	srcF, err := root.Open(srcRel)
 	if err != nil {
 		_ = tmpF.Close()
 		_ = os.Remove(tmpPath)
@@ -170,7 +158,7 @@ func copyClipAtomic(srcPath, destAbsPath string) error {
 			Component("imports/audio").
 			Category(errors.CategoryFileIO).
 			Context("operation", "open_src").
-			Context("path", srcPath).
+			Context("path", srcRel).
 			Build()
 	}
 
@@ -225,17 +213,24 @@ func copyClipAtomic(srcPath, destAbsPath string) error {
 }
 
 // sumSourceClipSizes sums the sizes of all source clips for the given source detections
-// and audio source directory. Missing clips are skipped silently.
+// within the audio source directory. Missing clips (and an unopenable source directory)
+// are skipped silently; this is a best-effort size estimate for the disk-space pre-check.
 func sumSourceClipSizes(audioSourceDir string, rows []SourceDetection) uint64 {
+	root, err := os.OpenRoot(audioSourceDir)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = root.Close() }()
+
 	var total uint64
 	for i := range rows {
 		row := &rows[i]
-		srcPath, ok := resolveSourceClipPath(audioSourceDir, row.Date, row.CommonName, row.FileName)
+		srcRel, ok := resolveSourceClipRel(root, row.Date, row.CommonName, row.FileName)
 		if !ok {
 			continue
 		}
-		info, err := os.Stat(srcPath)
-		if err != nil {
+		info, statErr := root.Stat(srcRel)
+		if statErr != nil {
 			continue
 		}
 		if info.Size() > 0 {
@@ -288,6 +283,22 @@ func (e *Engine) copyCandidateClips(
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
+	// Open the audio source directory as a sandboxed root once for the whole batch.
+	// *os.Root is safe for concurrent use, so all copy workers share it; every source
+	// read is then contained within the audio source directory (no traversal, no escaping
+	// symlink). If the directory cannot be opened, every clip is a miss and the detections
+	// are imported without audio (graceful degradation). No worker has started yet, so the
+	// missCount write needs no lock here.
+	root, rootErr := os.OpenRoot(opts.AudioSourceDir)
+	if rootErr != nil {
+		e.log.Warn("audio source directory unavailable, importing detections without audio",
+			logger.String("audio_source_dir", opts.AudioSourceDir),
+			logger.Error(rootErr))
+		*missCount += len(toImport)
+		return
+	}
+	defer func() { _ = root.Close() }()
+
 	for idx := range toImport {
 		capturedIdx := idx
 		capturedRow := toImport[idx]
@@ -335,7 +346,7 @@ func (e *Engine) copyCandidateClips(
 				return
 			}
 
-			srcPath, found := resolveSourceClipPath(opts.AudioSourceDir, capturedRow.Date, capturedRow.CommonName, capturedRow.FileName)
+			srcRel, found := resolveSourceClipRel(root, capturedRow.Date, capturedRow.CommonName, capturedRow.FileName)
 			if !found {
 				e.log.Warn("source clip not found, importing detection without audio",
 					logger.String("date", capturedRow.Date),
@@ -347,9 +358,9 @@ func (e *Engine) copyCandidateClips(
 				return
 			}
 
-			if copyErr := copyClipAtomic(srcPath, destAbs); copyErr != nil {
+			if copyErr := copyClipAtomic(root, srcRel, destAbs); copyErr != nil {
 				e.log.Warn("failed to copy audio clip, importing detection without audio",
-					logger.String("src", srcPath),
+					logger.String("src", srcRel),
 					logger.String("dest", destAbs),
 					logger.Error(copyErr))
 				mu.Lock()

--- a/internal/imports/audio.go
+++ b/internal/imports/audio.go
@@ -1,0 +1,266 @@
+// Package imports audio.go: audio clip resolution, path construction, and copying.
+package imports
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/audiotemp"
+	"github.com/tphakala/birdnet-go/internal/diskmanager"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// audioWorkerLimit is the maximum number of concurrent clip-copy goroutines per batch.
+const audioWorkerLimit = 4
+
+// resolveSourceClipPath resolves the path of a source audio clip within the BirdNET-Pi
+// audio tree. It tries the exact CommonName first, then a fallback form with spaces
+// replaced by underscores and apostrophes stripped.
+// Returns the resolved path and true if found, or ("", false) if neither form exists.
+func resolveSourceClipPath(audioSourceDir, date, comName, fileName string) (string, bool) {
+	// Try exact common name first.
+	exact := filepath.Join(audioSourceDir, "Extracted", "By_Date", date, comName, fileName)
+	if _, err := os.Stat(exact); err == nil {
+		return exact, true
+	}
+
+	// Fallback: replace spaces with underscores, strip apostrophes.
+	fallback := strings.ReplaceAll(comName, " ", "_")
+	fallback = strings.ReplaceAll(fallback, "'", "")
+	if fallback == comName {
+		return "", false
+	}
+	fallbackPath := filepath.Join(audioSourceDir, "Extracted", "By_Date", date, fallback, fileName)
+	if _, err := os.Stat(fallbackPath); err == nil {
+		return fallbackPath, true
+	}
+
+	return "", false
+}
+
+// targetClipRelPath constructs the relative clip path used in the export store,
+// mirroring the format produced by buildClipPath in internal/analysis/processor/processor.go.
+// Format: "YYYY/MM/<scientificName_lowercased_underscored>_<conf>p_<YYYYMMDDTHHMMSSZ>.<srcExt>"
+func targetClipRelPath(scientificName string, confidence float64, ts time.Time, srcExt string) string {
+	formattedName := strings.ToLower(strings.ReplaceAll(scientificName, " ", "_"))
+	formattedConf := fmt.Sprintf("%.0fp", confidence*100)
+	timestamp := ts.UTC().Format("20060102T150405Z")
+	year := ts.UTC().Format("2006")
+	month := ts.UTC().Format("01")
+	filename := formattedName + "_" + formattedConf + "_" + timestamp + "." + srcExt
+	return filepath.ToSlash(filepath.Join(year, month, filename))
+}
+
+// copyClipAtomic copies srcPath to destAbsPath using a unique temp file and atomic rename.
+// It creates the destination directory if needed.
+func copyClipAtomic(srcPath, destAbsPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destAbsPath), 0o755); err != nil {
+		return errors.New(err).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "mkdir").
+			Context("path", filepath.Dir(destAbsPath)).
+			Build()
+	}
+
+	tmpPath := audiotemp.UniquePath(destAbsPath)
+
+	tmpF, err := os.Create(tmpPath)
+	if err != nil {
+		return errors.New(err).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "create_temp").
+			Context("path", tmpPath).
+			Build()
+	}
+
+	srcF, err := os.Open(srcPath)
+	if err != nil {
+		_ = tmpF.Close()
+		_ = os.Remove(tmpPath)
+		return errors.New(err).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "open_src").
+			Context("path", srcPath).
+			Build()
+	}
+
+	_, copyErr := io.Copy(tmpF, srcF)
+	closeErr := srcF.Close()
+	syncErr := tmpF.Sync()
+	tmpCloseErr := tmpF.Close()
+
+	if copyErr != nil {
+		_ = os.Remove(tmpPath)
+		return errors.New(copyErr).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "copy").
+			Build()
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return errors.New(closeErr).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "close_src").
+			Build()
+	}
+	if syncErr != nil {
+		_ = os.Remove(tmpPath)
+		return errors.New(syncErr).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "sync").
+			Build()
+	}
+	if tmpCloseErr != nil {
+		_ = os.Remove(tmpPath)
+		return errors.New(tmpCloseErr).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "close_temp").
+			Build()
+	}
+
+	if err := audiotemp.Finalize(tmpPath, destAbsPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.New(err).
+			Component("imports/audio").
+			Category(errors.CategoryFileIO).
+			Context("operation", "rename").
+			Build()
+	}
+
+	return nil
+}
+
+// sumSourceClipSizes sums the sizes of all source clips for the given source detections
+// and audio source directory. Missing clips are skipped silently.
+func sumSourceClipSizes(audioSourceDir string, rows []SourceDetection) uint64 {
+	var total uint64
+	for i := range rows {
+		row := &rows[i]
+		srcPath, ok := resolveSourceClipPath(audioSourceDir, row.Date, row.CommonName, row.FileName)
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			continue
+		}
+		if info.Size() > 0 {
+			total += uint64(info.Size())
+		}
+	}
+	return total
+}
+
+// checkDiskSpace returns an error if free space on the export path is less than required bytes.
+// freeSpaceFn defaults to diskmanager.GetAvailableSpace when nil.
+func checkDiskSpace(exportPath string, requiredBytes uint64, freeSpaceFn func(string) (uint64, error)) error {
+	fn := freeSpaceFn
+	if fn == nil {
+		fn = diskmanager.GetAvailableSpace
+	}
+	free, err := fn(exportPath)
+	if err != nil {
+		return errors.New(err).
+			Component("imports/audio").
+			Category(errors.CategoryDiskUsage).
+			Context("operation", "disk_space_check").
+			Context("path", exportPath).
+			Build()
+	}
+	if free < requiredBytes {
+		return errors.Newf("insufficient disk space: need %d bytes, have %d bytes free", requiredBytes, free).
+			Component("imports/audio").
+			Category(errors.CategoryDiskUsage).
+			Context("operation", "disk_space_check").
+			Context("path", exportPath).
+			Build()
+	}
+	return nil
+}
+
+// copyCandidateClips concurrently copies audio clips for a set of to-import detections.
+// clipNames is pre-allocated with length len(toImport); each slot is set by its worker.
+// Missing or failed clips result in an empty string at that slot and increment missCount.
+// All goroutines complete before this function returns.
+func (e *Engine) copyCandidateClips(
+	ctx context.Context,
+	opts *ImportOptions,
+	toImport []SourceDetection,
+	timestamps []time.Time,
+	clipNames []string,
+	missCount *int,
+) {
+	sem := semaphore.NewWeighted(audioWorkerLimit)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for idx := range toImport {
+		capturedIdx := idx
+		capturedRow := toImport[idx]
+		capturedTs := timestamps[idx]
+
+		if acquireErr := sem.Acquire(ctx, 1); acquireErr != nil {
+			break
+		}
+
+		wg.Go(func() {
+			defer sem.Release(1)
+
+			srcExt := strings.TrimPrefix(filepath.Ext(capturedRow.FileName), ".")
+			if srcExt == "" {
+				srcExt = "mp3"
+			}
+			relPath := targetClipRelPath(capturedRow.ScientificName, capturedRow.Confidence, capturedTs, srcExt)
+			destAbs := filepath.Join(opts.ClipExportPath, filepath.FromSlash(relPath))
+
+			// Skip copy if target already exists (idempotency guard).
+			if _, statErr := os.Stat(destAbs); statErr == nil {
+				clipNames[capturedIdx] = relPath
+				return
+			}
+
+			srcPath, found := resolveSourceClipPath(opts.AudioSourceDir, capturedRow.Date, capturedRow.CommonName, capturedRow.FileName)
+			if !found {
+				e.log.Warn("source clip not found, importing detection without audio",
+					logger.String("date", capturedRow.Date),
+					logger.String("common_name", capturedRow.CommonName),
+					logger.String("file_name", capturedRow.FileName))
+				mu.Lock()
+				*missCount++
+				mu.Unlock()
+				return
+			}
+
+			if copyErr := copyClipAtomic(srcPath, destAbs); copyErr != nil {
+				e.log.Warn("failed to copy audio clip, importing detection without audio",
+					logger.String("src", srcPath),
+					logger.String("dest", destAbs),
+					logger.Error(copyErr))
+				mu.Lock()
+				*missCount++
+				mu.Unlock()
+				return
+			}
+
+			clipNames[capturedIdx] = relPath
+		})
+	}
+
+	wg.Wait()
+}

--- a/internal/imports/audio_test.go
+++ b/internal/imports/audio_test.go
@@ -2,6 +2,7 @@ package imports_test
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,16 @@ import (
 	"github.com/tphakala/birdnet-go/internal/imports"
 )
 
+// comGreatTit is the BirdNET-Pi common name reused across several audio tests as the
+// clip directory component. Extracted to a constant to satisfy goconst.
+const comGreatTit = "Great Tit"
+
+// Goroutine-leak verification for these engine audio tests is provided by the
+// package-wide goleak gate in zz_goleak_test.go (TestMain), which runs the entire
+// imports_test package under go.uber.org/goleak. The clip-copy worker pool exercised
+// by TestCopyCandidateClips_ConcurrentPool is therefore checked for leaks there; a
+// per-test gate is unnecessary and a second TestMain would not compile.
+
 // makeAudioTree creates a fake BirdNET-Pi audio tree under root and writes a
 // clip file at root/Extracted/By_Date/<date>/<comName>/<fileName>.
 // Returns the path of the created clip file.
@@ -25,6 +36,36 @@ func makeAudioTree(t *testing.T, root, date, comName, fileName string, content [
 	path := filepath.Join(dir, fileName)
 	require.NoError(t, os.WriteFile(path, content, 0o644))
 	return path
+}
+
+// assertWithinDir fails the test if target is not contained within root.
+// This is the test-package mirror of the package-private isWithinDir helper;
+// it uses filepath.Rel because the unexported helper is not importable here.
+func assertWithinDir(t *testing.T, root, target string) {
+	t.Helper()
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, target)
+	require.NoError(t, err, "filepath.Rel(%q, %q) must not error", root, target)
+	assert.NotEqual(t, "..", rel, "%q must be within %q", target, root)
+	assert.False(t, strings.HasPrefix(rel, ".."+string(filepath.Separator)),
+		"%q must be within %q (rel=%q)", target, root, rel)
+}
+
+// walkFiles returns the absolute paths of every regular file under dir.
+func walkFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	var files []string
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, walkErr)
+	return files
 }
 
 // --- resolveSourceClipPath (exported via test-only accessor) ---
@@ -80,6 +121,15 @@ func TestImport_WithAudio_CopiesClips(t *testing.T) {
 	data, readErr := os.ReadFile(destAbs)
 	require.NoError(t, readErr, "copied clip must exist at %s", destAbs)
 	assert.Equal(t, clipContent, data)
+
+	// T-F6: Load the saved detection and verify ClipName was set to the relative clip path.
+	results, _, searchErr := repo.Search(t.Context(), &datastore.DetectionFilters{
+		Location: []string{imports.DefaultSourceNode},
+		Limit:    10,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, results, 1)
+	assert.Equal(t, relPath, results[0].ClipName, "ClipName must equal the relative clip path")
 }
 
 func TestImport_WithAudio_InsufficientDiskSpace_Aborts(t *testing.T) {
@@ -130,6 +180,10 @@ func TestImport_WithAudio_InsufficientDiskSpace_Aborts(t *testing.T) {
 	destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
 	_, statErr := os.Stat(destAbs)
 	assert.True(t, os.IsNotExist(statErr), "no clip may be written when space is insufficient")
+
+	// T-F8: the export tree must be completely empty, not just missing the one expected clip.
+	files := walkFiles(t, exportDir)
+	assert.Empty(t, files, "export tree must contain no files when the disk-space guard trips")
 }
 
 func TestImport_WithAudio_FallbackComName(t *testing.T) {
@@ -184,13 +238,73 @@ func TestImport_WithAudio_FallbackComName(t *testing.T) {
 	assert.Equal(t, clipContent, data)
 }
 
+// TestImport_WithAudio_FallbackPreference verifies that when BOTH the exact-ComName
+// directory and the underscore-fallback directory exist, resolveSourceClipPath prefers
+// the EXACT form. The two directories hold clips with different content so the copied
+// clip can be unambiguously attributed to one source.
+func TestImport_WithAudio_FallbackPreference(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-04-11"
+	fileName := "thrush.mp3"
+	comName := "Robin's Thrush"
+
+	// Exact directory uses the raw common name (apostrophe preserved).
+	exactContent := []byte("exact-comname audio")
+	exactDir := filepath.Join(audioSrc, "Extracted", "By_Date", date, comName)
+	require.NoError(t, os.MkdirAll(exactDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(exactDir, fileName), exactContent, 0o644))
+
+	// Fallback directory: apostrophe stripped, spaces to underscores.
+	fallbackContent := []byte("fallback-comname audio")
+	fallbackDir := filepath.Join(audioSrc, "Extracted", "By_Date", date, "Robins_Thrush")
+	require.NoError(t, os.MkdirAll(fallbackDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fallbackDir, fileName), fallbackContent, 0o644))
+
+	rows := []birdnetPiRow{
+		{
+			Date: date, Time: "09:30:00",
+			SciName: "Turdus species", ComName: comName,
+			Confidence: 0.80, Lat: 60.0, Lon: 24.0,
+			Cutoff: 0.5, Sens: 1.0, FileName: fileName,
+		},
+	}
+	dbPath := newFixtureDB(t, rows)
+
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Inserted)
+
+	ts := time.Date(2025, 4, 11, 9, 30, 0, 0, time.UTC)
+	relPath := imports.TargetClipRelPathForTest("Turdus species", 0.80, ts, "mp3")
+	destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
+	data, readErr := os.ReadFile(destAbs)
+	require.NoError(t, readErr, "clip must be copied to %s", destAbs)
+	assert.Equal(t, exactContent, data, "the exact-ComName directory must be preferred over the fallback")
+}
+
 func TestImport_WithAudio_MissingClip_ImportsContinues(t *testing.T) {
 	audioSrc := t.TempDir()
 	exportDir := t.TempDir()
 	rows := []birdnetPiRow{
 		{
 			Date: "2025-05-01", Time: "08:00:00",
-			SciName: "Parus major", ComName: "Great Tit",
+			SciName: "Parus major", ComName: comGreatTit,
 			Confidence: 0.85, Lat: 60.0, Lon: 24.0,
 			Cutoff: 0.5, Sens: 1.0,
 			FileName: "missing.mp3",
@@ -259,6 +373,11 @@ func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
 	store := newTestStore(t)
 	repo := newDetectionRepo(t, store)
 
+	// Expected destination of the copied clip.
+	ts := time.Date(2025, 6, 1, 7, 0, 0, 0, time.UTC)
+	relPath := imports.TargetClipRelPathForTest("Turdus merula", 0.92, ts, "mp3")
+	destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
+
 	// First run.
 	src1, err := newBirdNetPiSource(t, dbPath)
 	require.NoError(t, err)
@@ -266,6 +385,14 @@ func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
 	stats1, err := eng1.Run(t.Context(), src1, &opts, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats1.Inserted)
+
+	// T-F7: the clip file must exist after run 1; record its mtime and content.
+	info1, statErr := os.Stat(destAbs)
+	require.NoError(t, statErr, "clip must exist after first run at %s", destAbs)
+	mtime1 := info1.ModTime()
+	data1, readErr := os.ReadFile(destAbs)
+	require.NoError(t, readErr)
+	assert.Equal(t, clipContent, data1)
 
 	// Second run: same detection must be skipped.
 	src2, err := newBirdNetPiSource(t, dbPath)
@@ -275,6 +402,18 @@ func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats2.Inserted)
 	assert.Equal(t, 1, stats2.Skipped)
+
+	// T-F7: the clip must not have been rewritten. Same file, same mtime, same content.
+	info2, statErr := os.Stat(destAbs)
+	require.NoError(t, statErr, "clip must still exist after second run")
+	assert.Equal(t, mtime1, info2.ModTime(), "clip must not be rewritten on the idempotent re-run")
+	data2, readErr := os.ReadFile(destAbs)
+	require.NoError(t, readErr)
+	assert.Equal(t, clipContent, data2, "clip content must be unchanged after the idempotent re-run")
+
+	// Exactly one clip file may exist in the export tree across both runs.
+	files := walkFiles(t, exportDir)
+	assert.Len(t, files, 1, "the idempotent re-run must not create a second clip file")
 }
 
 func TestCheckDiskSpace_Sufficient(t *testing.T) {
@@ -321,7 +460,9 @@ func TestTargetClipRelPath_RoundsConfidence(t *testing.T) {
 }
 
 // TestTargetClipRelPath_TraversalScientificName verifies that a crafted ScientificName
-// with path separators or ".." components does not escape the expected path structure.
+// with path separators, absolute paths, Windows paths, or ".." components cannot escape
+// the expected "YYYY/MM/<file>" path structure. For every case the result must be
+// relative, prefixed by the four-digit year, and free of any ".." path segment.
 func TestTargetClipRelPath_TraversalScientificName(t *testing.T) {
 	ts := time.Date(2025, 6, 1, 8, 0, 0, 0, time.UTC)
 
@@ -332,14 +473,34 @@ func TestTargetClipRelPath_TraversalScientificName(t *testing.T) {
 		{"dot-dot prefix", "../evil"},
 		{"deep dot-dot", "../../etc/passwd"},
 		{"slash in name", "a/b/c"},
+		{"absolute unix path", "/etc/passwd"},
+		{"backslash in name", "evil\\name"},
+		{"empty name", ""},
+		{"single dot", "."},
+		{"double dot", ".."},
+		{"deep traversal", "../../etc/passwd"},
 	}
 
 	for _, tc := range crafted {
 		t.Run(tc.name, func(t *testing.T) {
 			relPath := imports.TargetClipRelPathForTest(tc.sciName, 0.9, ts, "mp3")
-			// The result must not contain ".." components.
-			assert.NotContains(t, relPath, "..", "relPath %q must not contain ..", relPath)
-			// The filename part (last slash-separated segment) must not contain forward slashes.
+
+			// Must be a relative path, never absolute.
+			assert.False(t, filepath.IsAbs(relPath), "relPath %q must not be absolute", relPath)
+
+			// Must be prefixed with the four-digit year of the timestamp.
+			assert.True(t, strings.HasPrefix(relPath, "2025/"),
+				"relPath %q must start with the YYYY/ prefix", relPath)
+
+			// No path segment may be exactly "..".
+			for seg := range strings.SplitSeq(relPath, "/") {
+				assert.NotEqual(t, "..", seg, "relPath %q must contain no .. segment", relPath)
+			}
+
+			// The filename part (last slash-separated segment) must not itself contain the
+			// forward-slash path separator used by the returned relative path. A literal
+			// backslash is intentionally allowed: on the Linux import target it is an ordinary
+			// filename byte, not a separator, so it cannot escape the export directory.
 			parts := strings.Split(relPath, "/")
 			require.NotEmpty(t, parts)
 			last := parts[len(parts)-1]
@@ -349,14 +510,15 @@ func TestTargetClipRelPath_TraversalScientificName(t *testing.T) {
 }
 
 // TestResolveSourceClipPath_TraversalRejected verifies that DB-derived path components
-// containing ".." or path separators cannot escape audioSourceDir. Such detections are
-// treated as a clip miss and the detection is still imported (graceful degradation).
+// containing "..", path separators, absolute paths, or Windows paths cannot escape
+// audioSourceDir. Such detections are treated as a clip miss and the detection is still
+// imported (graceful degradation).
 func TestResolveSourceClipPath_TraversalRejected(t *testing.T) {
 	audioSrc := t.TempDir()
 
 	// A legitimate clip for the non-traversal case.
 	date := "2025-06-01"
-	comName := "Great Tit"
+	comName := comGreatTit
 	fileName := "tit.mp3"
 	makeAudioTree(t, audioSrc, date, comName, fileName, []byte("audio"))
 
@@ -370,6 +532,9 @@ func TestResolveSourceClipPath_TraversalRejected(t *testing.T) {
 		{"dot-dot in fileName", date, comName, "../tit.mp3"},
 		{"slash in comName", date, "a/b", fileName},
 		{"slash in fileName", date, comName, "a/b.mp3"},
+		{"absolute path in comName", date, "/etc/Great Tit", fileName},
+		{"windows path in comName", date, "C:\\clip", fileName},
+		{"dot-dot in both comName and fileName", date, "../Great Tit", "../tit.mp3"},
 	}
 
 	for _, tc := range traversalCases {
@@ -417,7 +582,7 @@ func TestCopyCandidateClips_TraversalDestRejected(t *testing.T) {
 	audioSrc := t.TempDir()
 	exportDir := t.TempDir()
 	date := "2025-07-01"
-	comName := "Great Tit"
+	comName := comGreatTit
 	fileName := "tit.mp3"
 	clipContent := []byte("audio data")
 	makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
@@ -459,4 +624,124 @@ func TestCopyCandidateClips_TraversalDestRejected(t *testing.T) {
 	for _, e := range entries {
 		assert.NotEqual(t, "evil", e.Name(), "traversal must not create 'evil' directory outside export root")
 	}
+
+	// T-F2: positive containment proof. The sanitized sciname
+	// "../../evil/parus major" -> filepath.Base -> "parus major" -> "parus_major",
+	// so exactly one clip file must be present and it must live inside exportDir.
+	files := walkFiles(t, exportDir)
+	require.Len(t, files, 1, "exactly one clip file must be written inside exportDir")
+	for _, f := range files {
+		assertWithinDir(t, exportDir, f)
+	}
+	// The single file must carry the sanitized name component.
+	assert.Contains(t, files[0], "parus_major", "clip must be stored under the sanitized scientific name")
+}
+
+// TestCopyCandidateClips_ConcurrentPool exercises the bounded copy worker pool with more
+// rows than audioWorkerLimit (4). It mixes 5 present clips with 3 missing clips and runs
+// the real engine. Under -race this asserts that:
+//   - all 8 detections are saved,
+//   - exactly the 5 present clips are copied to their expected relative paths inside exportDir,
+//   - exactly 5 saved detections have a non-empty ClipName and 3 have an empty ClipName,
+//   - no clip escapes exportDir.
+func TestCopyCandidateClips_ConcurrentPool(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-08-01"
+	comName := comGreatTit
+	sciName := "Parus major"
+
+	const presentCount = 5
+	const missingCount = 3
+	const totalCount = presentCount + missingCount
+
+	// Build rows with unique timestamps so none are deduplicated against each other.
+	// Rows 0..4 have a backing source clip; rows 5..7 do not.
+	rows := make([]birdnetPiRow, 0, totalCount)
+	expectedRelPaths := make([]string, 0, presentCount)
+	for i := range totalCount {
+		fileName := fmt.Sprintf("clip_%d.mp3", i)
+		// Unique second-of-minute keeps Date+Time distinct per row.
+		timeStr := fmt.Sprintf("08:00:%02d", i)
+		confidence := 0.50 + float64(i)*0.01
+		row := birdnetPiRow{
+			Date: date, Time: timeStr,
+			SciName: sciName, ComName: comName,
+			Confidence: confidence, Lat: 60.0, Lon: 24.0,
+			Cutoff: 0.5, Sens: 1.0, FileName: fileName,
+		}
+		rows = append(rows, row)
+
+		if i < presentCount {
+			content := fmt.Appendf(nil, "audio for clip %d", i)
+			makeAudioTree(t, audioSrc, date, comName, fileName, content)
+
+			ts := time.Date(2025, 8, 1, 8, 0, i, 0, time.UTC)
+			relPath := imports.TargetClipRelPathForTest(sciName, confidence, ts, "mp3")
+			expectedRelPaths = append(expectedRelPaths, relPath)
+		}
+	}
+
+	dbPath := newFixtureDB(t, rows)
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		BatchSize:      100,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	stats, runErr := engine.Run(t.Context(), src, &opts, nil)
+	require.NoError(t, runErr)
+	assert.Equal(t, totalCount, stats.Inserted, "all detections must be saved")
+	assert.Equal(t, 0, stats.Errors, "missing clips are not errors")
+
+	// Each present clip must be copied to its expected relative path inside exportDir.
+	for _, relPath := range expectedRelPaths {
+		destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
+		_, statErr := os.Stat(destAbs)
+		require.NoError(t, statErr, "present clip must be copied to %s", destAbs)
+		assertWithinDir(t, exportDir, destAbs)
+	}
+
+	// Exactly presentCount clip files may exist in the export tree, all inside exportDir.
+	files := walkFiles(t, exportDir)
+	assert.Len(t, files, presentCount, "exactly %d clips must be copied", presentCount)
+	for _, f := range files {
+		assertWithinDir(t, exportDir, f)
+	}
+
+	// Verify per-detection ClipName: exactly presentCount non-empty, missingCount empty.
+	results, _, searchErr := repo.Search(t.Context(), &datastore.DetectionFilters{
+		Location: []string{imports.DefaultSourceNode},
+		Limit:    100,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, results, totalCount, "all detections must be persisted")
+
+	withClip := 0
+	withoutClip := 0
+	expectedSet := make(map[string]struct{}, len(expectedRelPaths))
+	for _, p := range expectedRelPaths {
+		expectedSet[p] = struct{}{}
+	}
+	for i := range results {
+		if results[i].ClipName == "" {
+			withoutClip++
+			continue
+		}
+		withClip++
+		_, ok := expectedSet[results[i].ClipName]
+		assert.True(t, ok, "ClipName %q must be one of the expected relative paths", results[i].ClipName)
+	}
+	assert.Equal(t, presentCount, withClip, "exactly %d detections must carry a ClipName", presentCount)
+	assert.Equal(t, missingCount, withoutClip, "exactly %d detections must have an empty ClipName", missingCount)
 }

--- a/internal/imports/audio_test.go
+++ b/internal/imports/audio_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/imports"
 )
 
@@ -216,6 +218,15 @@ func TestImport_WithAudio_MissingClip_ImportsContinues(t *testing.T) {
 	// Detection must still be imported even though audio is missing.
 	assert.Equal(t, 1, stats.Inserted)
 	assert.Equal(t, 0, stats.Errors)
+
+	// The saved detection must have an empty ClipName (graceful degradation).
+	results, _, searchErr := repo.Search(t.Context(), &datastore.DetectionFilters{
+		Location: []string{imports.DefaultSourceNode},
+		Limit:    10,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].ClipName, "ClipName must be empty when source clip is missing")
 }
 
 func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
@@ -307,4 +318,145 @@ func TestTargetClipRelPath_RoundsConfidence(t *testing.T) {
 	assert.Contains(t, got, "81p")
 	assert.Contains(t, got, "parus_major")
 	assert.Contains(t, got, ".wav")
+}
+
+// TestTargetClipRelPath_TraversalScientificName verifies that a crafted ScientificName
+// with path separators or ".." components does not escape the expected path structure.
+func TestTargetClipRelPath_TraversalScientificName(t *testing.T) {
+	ts := time.Date(2025, 6, 1, 8, 0, 0, 0, time.UTC)
+
+	crafted := []struct {
+		name    string
+		sciName string
+	}{
+		{"dot-dot prefix", "../evil"},
+		{"deep dot-dot", "../../etc/passwd"},
+		{"slash in name", "a/b/c"},
+	}
+
+	for _, tc := range crafted {
+		t.Run(tc.name, func(t *testing.T) {
+			relPath := imports.TargetClipRelPathForTest(tc.sciName, 0.9, ts, "mp3")
+			// The result must not contain ".." components.
+			assert.NotContains(t, relPath, "..", "relPath %q must not contain ..", relPath)
+			// The filename part (last slash-separated segment) must not contain forward slashes.
+			parts := strings.Split(relPath, "/")
+			require.NotEmpty(t, parts)
+			last := parts[len(parts)-1]
+			assert.NotContains(t, last, "/", "filename part must not contain /")
+		})
+	}
+}
+
+// TestResolveSourceClipPath_TraversalRejected verifies that DB-derived path components
+// containing ".." or path separators cannot escape audioSourceDir. Such detections are
+// treated as a clip miss and the detection is still imported (graceful degradation).
+func TestResolveSourceClipPath_TraversalRejected(t *testing.T) {
+	audioSrc := t.TempDir()
+
+	// A legitimate clip for the non-traversal case.
+	date := "2025-06-01"
+	comName := "Great Tit"
+	fileName := "tit.mp3"
+	makeAudioTree(t, audioSrc, date, comName, fileName, []byte("audio"))
+
+	traversalCases := []struct {
+		name     string
+		date     string
+		comName  string
+		fileName string
+	}{
+		{"dot-dot in comName", date, "../Great Tit", fileName},
+		{"dot-dot in fileName", date, comName, "../tit.mp3"},
+		{"slash in comName", date, "a/b", fileName},
+		{"slash in fileName", date, comName, "a/b.mp3"},
+	}
+
+	for _, tc := range traversalCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := []birdnetPiRow{{
+				Date: tc.date, Time: "08:00:00",
+				SciName: "Parus major", ComName: tc.comName,
+				Confidence: 0.85,
+				Cutoff:     0.5, Sens: 1.0, FileName: tc.fileName,
+			}}
+			dbPath := newFixtureDB(t, rows)
+			src, err := newBirdNetPiSource(t, dbPath)
+			require.NoError(t, err)
+
+			exportDir := t.TempDir()
+			store := newTestStore(t)
+			repo := newDetectionRepo(t, store)
+			engine := imports.NewEngine(repo)
+
+			opts := imports.ImportOptions{
+				SourceNode:     imports.DefaultSourceNode,
+				Location:       time.UTC,
+				IncludeAudio:   true,
+				AudioSourceDir: audioSrc,
+				ClipExportPath: exportDir,
+			}
+
+			stats, runErr := engine.Run(t.Context(), src, &opts, nil)
+			require.NoError(t, runErr, "traversal attempt must not cause engine error (treated as miss)")
+			assert.Equal(t, 1, stats.Inserted, "detection must be imported even with traversal in audio path")
+
+			// Verify that nothing was written outside exportDir.
+			// The traversal component is rejected, so the clip is a miss and exportDir stays empty.
+			entries, rdErr := os.ReadDir(exportDir)
+			require.NoError(t, rdErr)
+			assert.Empty(t, entries, "exportDir must be empty: no clip may be written for a traversal attempt")
+		})
+	}
+}
+
+// TestCopyCandidateClips_TraversalDestRejected verifies that a crafted ScientificName
+// cannot cause a clip to be written outside ClipExportPath. With sanitization applied,
+// the clip is placed at a safe path inside ClipExportPath, and the source clip is copied.
+func TestCopyCandidateClips_TraversalDestRejected(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-07-01"
+	comName := "Great Tit"
+	fileName := "tit.mp3"
+	clipContent := []byte("audio data")
+	makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
+
+	// A detection with a crafted ScientificName that would have escaped exportDir
+	// before the filepath.Base sanitization was applied.
+	rows := []birdnetPiRow{{
+		Date: date, Time: "08:00:00",
+		SciName: "../../evil/parus major", ComName: comName,
+		Confidence: 0.85,
+		Cutoff:     0.5, Sens: 1.0, FileName: fileName,
+	}}
+	dbPath := newFixtureDB(t, rows)
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	stats, runErr := engine.Run(t.Context(), src, &opts, nil)
+	require.NoError(t, runErr)
+	// Detection is imported regardless.
+	assert.Equal(t, 1, stats.Inserted)
+
+	// The sanitized clip must be inside exportDir (filepath.Base strips the "../../../" prefix).
+	// Verify no directory named "evil" was created outside exportDir.
+	parent := filepath.Dir(exportDir)
+	entries, rdErr := os.ReadDir(parent)
+	require.NoError(t, rdErr)
+	for _, e := range entries {
+		assert.NotEqual(t, "evil", e.Name(), "traversal must not create 'evil' directory outside export root")
+	}
 }

--- a/internal/imports/audio_test.go
+++ b/internal/imports/audio_test.go
@@ -1,0 +1,310 @@
+package imports_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/imports"
+)
+
+// makeAudioTree creates a fake BirdNET-Pi audio tree under root and writes a
+// clip file at root/Extracted/By_Date/<date>/<comName>/<fileName>.
+// Returns the path of the created clip file.
+func makeAudioTree(t *testing.T, root, date, comName, fileName string, content []byte) string {
+	t.Helper()
+	dir := filepath.Join(root, "Extracted", "By_Date", date, comName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, fileName)
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	return path
+}
+
+// --- resolveSourceClipPath (exported via test-only accessor) ---
+
+// We test the internal helpers indirectly through the Engine/Run integration
+// and through the exported ImportOptions fields. For the helpers that are
+// package-private we use an integration approach.
+
+func TestImport_WithAudio_CopiesClips(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-03-25"
+	comName := "Great Spotted Woodpecker"
+	fileName := "woodpecker.mp3"
+	clipContent := []byte("fake audio content")
+	makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
+
+	rows := []birdnetPiRow{
+		{
+			Date: date, Time: "14:27:32",
+			SciName: "Dendrocopos major", ComName: comName,
+			Confidence: 0.74, Lat: 60.75, Lon: 24.77,
+			Cutoff: 0.7, Sens: 1.25, FileName: fileName,
+		},
+	}
+	dbPath := newFixtureDB(t, rows)
+
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		BatchSize:      100,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Inserted)
+	assert.Equal(t, 0, stats.Errors)
+
+	// The clip must have been copied into exportDir.
+	ts := time.Date(2025, 3, 25, 14, 27, 32, 0, time.UTC)
+	relPath := imports.TargetClipRelPathForTest("Dendrocopos major", 0.74, ts, "mp3")
+	destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
+	data, readErr := os.ReadFile(destAbs)
+	require.NoError(t, readErr, "copied clip must exist at %s", destAbs)
+	assert.Equal(t, clipContent, data)
+}
+
+func TestImport_WithAudio_InsufficientDiskSpace_Aborts(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-03-25"
+	comName := "Great Spotted Woodpecker"
+	fileName := "woodpecker.mp3"
+	clipContent := []byte("fake audio content that occupies some bytes")
+	makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
+
+	rows := []birdnetPiRow{
+		{
+			Date: date, Time: "14:27:32",
+			SciName: "Dendrocopos major", ComName: comName,
+			Confidence: 0.74, Lat: 60.75, Lon: 24.77,
+			Cutoff: 0.7, Sens: 1.25, FileName: fileName,
+		},
+	}
+	dbPath := newFixtureDB(t, rows)
+
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		BatchSize:      100,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+		// Report effectively no free space so the disk-space guard trips before
+		// any clip is copied.
+		DiskSpaceFunc: func(string) (uint64, error) { return 0, nil },
+	}
+
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
+	require.Error(t, err, "import must abort when the export volume lacks space")
+	assert.Equal(t, 0, stats.Inserted, "no detections may be saved when the disk-space guard trips")
+
+	// No clip may have been copied into the export tree.
+	ts := time.Date(2025, 3, 25, 14, 27, 32, 0, time.UTC)
+	relPath := imports.TargetClipRelPathForTest("Dendrocopos major", 0.74, ts, "mp3")
+	destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
+	_, statErr := os.Stat(destAbs)
+	assert.True(t, os.IsNotExist(statErr), "no clip may be written when space is insufficient")
+}
+
+func TestImport_WithAudio_FallbackComName(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-04-10"
+	// resolveSourceClipPath fallback replaces spaces with underscores and strips apostrophes.
+	// "Robin's Thrush" -> strip apostrophe -> "Robins Thrush" -> spaces to _ -> "Robins_Thrush"
+	fallbackDir := "Robins_Thrush"
+	fileName := "thrush.mp3"
+	clipContent := []byte("thrush audio")
+	// Place clip under the fallback directory name
+	dir := filepath.Join(audioSrc, "Extracted", "By_Date", date, fallbackDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), clipContent, 0o644))
+
+	comName := "Robin's Thrush"
+	rows := []birdnetPiRow{
+		{
+			Date: date, Time: "09:00:00",
+			SciName: "Turdus species", ComName: comName,
+			Confidence: 0.80, Lat: 60.0, Lon: 24.0,
+			Cutoff: 0.5, Sens: 1.0, FileName: fileName,
+		},
+	}
+	dbPath := newFixtureDB(t, rows)
+
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Inserted)
+
+	ts := time.Date(2025, 4, 10, 9, 0, 0, 0, time.UTC)
+	relPath := imports.TargetClipRelPathForTest("Turdus species", 0.80, ts, "mp3")
+	destAbs := filepath.Join(exportDir, filepath.FromSlash(relPath))
+	data, readErr := os.ReadFile(destAbs)
+	require.NoError(t, readErr, "clip via fallback name must be copied to %s", destAbs)
+	assert.Equal(t, clipContent, data)
+}
+
+func TestImport_WithAudio_MissingClip_ImportsContinues(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	rows := []birdnetPiRow{
+		{
+			Date: "2025-05-01", Time: "08:00:00",
+			SciName: "Parus major", ComName: "Great Tit",
+			Confidence: 0.85, Lat: 60.0, Lon: 24.0,
+			Cutoff: 0.5, Sens: 1.0,
+			FileName: "missing.mp3",
+		},
+	}
+	dbPath := newFixtureDB(t, rows)
+
+	src, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+	engine := imports.NewEngine(repo)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
+	require.NoError(t, err)
+	// Detection must still be imported even though audio is missing.
+	assert.Equal(t, 1, stats.Inserted)
+	assert.Equal(t, 0, stats.Errors)
+}
+
+func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
+	audioSrc := t.TempDir()
+	exportDir := t.TempDir()
+	date := "2025-06-01"
+	comName := "Common Blackbird"
+	fileName := "blackbird.mp3"
+	clipContent := []byte("blackbird song")
+	makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
+
+	rows := []birdnetPiRow{
+		{
+			Date: date, Time: "07:00:00",
+			SciName: "Turdus merula", ComName: comName,
+			Confidence: 0.92, Lat: 60.0, Lon: 24.0,
+			Cutoff: 0.5, Sens: 1.0, FileName: fileName,
+		},
+	}
+	dbPath := newFixtureDB(t, rows)
+
+	opts := imports.ImportOptions{
+		SourceNode:     imports.DefaultSourceNode,
+		Location:       time.UTC,
+		IncludeAudio:   true,
+		AudioSourceDir: audioSrc,
+		ClipExportPath: exportDir,
+	}
+
+	store := newTestStore(t)
+	repo := newDetectionRepo(t, store)
+
+	// First run.
+	src1, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+	eng1 := imports.NewEngine(repo)
+	stats1, err := eng1.Run(t.Context(), src1, &opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats1.Inserted)
+
+	// Second run: same detection must be skipped.
+	src2, err := newBirdNetPiSource(t, dbPath)
+	require.NoError(t, err)
+	eng2 := imports.NewEngine(repo)
+	stats2, err := eng2.Run(t.Context(), src2, &opts, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats2.Inserted)
+	assert.Equal(t, 1, stats2.Skipped)
+}
+
+func TestCheckDiskSpace_Sufficient(t *testing.T) {
+	called := false
+	freeFn := func(_ string) (uint64, error) {
+		called = true
+		return 1000, nil
+	}
+	err := imports.CheckDiskSpaceForTest("any/path", 500, freeFn)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestCheckDiskSpace_Insufficient(t *testing.T) {
+	freeFn := func(_ string) (uint64, error) {
+		return 100, nil
+	}
+	err := imports.CheckDiskSpaceForTest("any/path", 500, freeFn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient disk space")
+}
+
+func TestCheckDiskSpace_FuncError(t *testing.T) {
+	freeFn := func(_ string) (uint64, error) {
+		return 0, fmt.Errorf("syscall failed")
+	}
+	err := imports.CheckDiskSpaceForTest("any/path", 1, freeFn)
+	require.Error(t, err)
+}
+
+func TestTargetClipRelPath(t *testing.T) {
+	ts := time.Date(2025, 3, 25, 14, 27, 32, 0, time.UTC)
+	got := imports.TargetClipRelPathForTest("Dendrocopos major", 0.74, ts, "mp3")
+	// Expected: 2025/03/dendrocopos_major_74p_20250325T142732Z.mp3
+	assert.Equal(t, "2025/03/dendrocopos_major_74p_20250325T142732Z.mp3", got)
+}
+
+func TestTargetClipRelPath_RoundsConfidence(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	got := imports.TargetClipRelPathForTest("Parus major", 0.81, ts, "wav")
+	assert.Contains(t, got, "81p")
+	assert.Contains(t, got, "parus_major")
+	assert.Contains(t, got, ".wav")
+}

--- a/internal/imports/audio_test.go
+++ b/internal/imports/audio_test.go
@@ -350,7 +350,7 @@ func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
 	comName := "Common Blackbird"
 	fileName := "blackbird.mp3"
 	clipContent := []byte("blackbird song")
-	makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
+	srcClipPath := makeAudioTree(t, audioSrc, date, comName, fileName, clipContent)
 
 	rows := []birdnetPiRow{
 		{
@@ -393,6 +393,12 @@ func TestImport_WithAudio_Idempotent_ClipNotCopiedTwice(t *testing.T) {
 	data1, readErr := os.ReadFile(destAbs)
 	require.NoError(t, readErr)
 	assert.Equal(t, clipContent, data1)
+
+	// Mutate the source clip between runs. If the second run wrongly re-copied the clip,
+	// the destination would now hold this mutated content; the assertions below prove it
+	// does not, catching a silent rewrite even when filesystem mtime granularity is coarse.
+	mutatedContent := []byte("MUTATED blackbird song with a different length")
+	require.NoError(t, os.WriteFile(srcClipPath, mutatedContent, 0o644))
 
 	// Second run: same detection must be skipped.
 	src2, err := newBirdNetPiSource(t, dbPath)

--- a/internal/imports/export_test.go
+++ b/internal/imports/export_test.go
@@ -1,0 +1,15 @@
+// Package imports export_test.go exposes internal helpers for use by tests in
+// the imports_test package. This file is only compiled during testing.
+package imports
+
+import "time"
+
+// TargetClipRelPathForTest exposes targetClipRelPath for black-box tests.
+func TargetClipRelPathForTest(scientificName string, confidence float64, ts time.Time, srcExt string) string {
+	return targetClipRelPath(scientificName, confidence, ts, srcExt)
+}
+
+// CheckDiskSpaceForTest exposes checkDiskSpace for black-box tests.
+func CheckDiskSpaceForTest(exportPath string, requiredBytes uint64, freeSpaceFn func(string) (uint64, error)) error {
+	return checkDiskSpace(exportPath, requiredBytes, freeSpaceFn)
+}

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -151,6 +151,18 @@ func (e *Engine) Run(ctx context.Context, src Source, opts *ImportOptions, repor
 	stats := ImportStats{Phase: "validate"}
 	e.report(reporter, stats)
 
+	// When audio import is requested, both the source directory and the export path must
+	// be configured. Failing fast here turns a misconfiguration into a clear error instead
+	// of silently importing detections without their audio (or reading a path relative to
+	// the working directory).
+	if opts.IncludeAudio && (opts.AudioSourceDir == "" || opts.ClipExportPath == "") {
+		return stats, errors.Newf("audio import requires both an audio source directory and a clip export path").
+			Component("imports").
+			Category(errors.CategoryValidation).
+			Context("phase", "validate").
+			Build()
+	}
+
 	if err := src.Validate(ctx); err != nil {
 		return stats, errors.New(err).
 			Component("imports").

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -5,6 +5,7 @@ package imports
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -139,7 +140,12 @@ func detectionKey(ts time.Time, scientificName string, confidence float64) strin
 // Run imports all detections from src that are not already present in the store.
 // It returns a final ImportStats summary. Partial results are consistent because
 // the dedup set makes a re-run safe.
+// opts may be nil; a nil pointer is replaced with a zero-value ImportOptions so
+// callers are not required to allocate one.
 func (e *Engine) Run(ctx context.Context, src Source, opts *ImportOptions, reporter ProgressReporter) (ImportStats, error) {
+	if opts == nil {
+		opts = &ImportOptions{}
+	}
 	opts.withDefaults()
 
 	stats := ImportStats{Phase: "validate"}
@@ -228,23 +234,8 @@ func (e *Engine) Run(ctx context.Context, src Source, opts *ImportOptions, repor
 				rows[i] = *p.row
 				tss[i] = p.ts
 			}
-
-			// Disk-space guard: ensure the export volume can hold this batch's
-			// clips before copying any of them. Sizing source clips up front and
-			// checking once per batch keeps the import single-pass over the source.
-			requiredBytes := sumSourceClipSizes(opts.AudioSourceDir, rows)
-			if requiredBytes > 0 {
-				if spaceErr := checkDiskSpace(opts.ClipExportPath, requiredBytes, opts.DiskSpaceFunc); spaceErr != nil {
-					return spaceErr
-				}
-			}
-
-			missCount := 0
-			e.copyCandidateClips(ctx, opts, rows, tss, clipNames, &missCount)
-			if missCount > 0 {
-				e.log.Info("some audio clips could not be copied",
-					logger.Int("miss_count", missCount),
-					logger.Int("batch_size", len(pending)))
+			if err := e.copyAudioBatch(ctx, opts, rows, tss, clipNames); err != nil {
+				return err
 			}
 		}
 
@@ -308,6 +299,39 @@ func (e *Engine) Run(ctx context.Context, src Source, opts *ImportOptions, repor
 	return stats, nil
 }
 
+// copyAudioBatch creates the export directory, checks disk space, and copies all
+// audio clips for one pending batch. clipNames is updated in-place.
+func (e *Engine) copyAudioBatch(ctx context.Context, opts *ImportOptions, rows []SourceDetection, tss []time.Time, clipNames []string) error {
+	// Ensure export directory exists before the disk-space check so that
+	// GetAvailableSpace does not error on a freshly configured path.
+	if mkErr := os.MkdirAll(opts.ClipExportPath, 0o755); mkErr != nil {
+		return errors.New(mkErr).
+			Component("imports").
+			Category(errors.CategoryFileIO).
+			Context("operation", "mkdir_export_path").
+			Context("path", opts.ClipExportPath).
+			Build()
+	}
+
+	// Disk-space guard: ensure the export volume can hold this batch's clips
+	// before copying any of them.
+	requiredBytes := sumSourceClipSizes(opts.AudioSourceDir, rows)
+	if requiredBytes > 0 {
+		if spaceErr := checkDiskSpace(opts.ClipExportPath, requiredBytes, opts.DiskSpaceFunc); spaceErr != nil {
+			return spaceErr
+		}
+	}
+
+	missCount := 0
+	e.copyCandidateClips(ctx, opts, rows, tss, clipNames, &missCount)
+	if missCount > 0 {
+		e.log.Info("some audio clips could not be copied",
+			logger.Int("miss_count", missCount),
+			logger.Int("batch_size", len(rows)))
+	}
+	return nil
+}
+
 // loadExistingKeys pages through all detections attributed to sourceNode
 // and returns their dedup keys in a set.
 func (e *Engine) loadExistingKeys(ctx context.Context, sourceNode string) (map[string]struct{}, error) {
@@ -360,8 +384,9 @@ func parseTimestamp(date, timeStr string, loc *time.Location) (time.Time, error)
 // Field mapping decisions:
 //   - BeginTime and EndTime are left as zero values: BirdNET-Pi stores detections
 //     as point-in-time events without clip offsets, so there is no timing data to map.
-//   - ClipName is left empty in DB-only mode; it will be set once audio copying is
-//     implemented. An empty ClipName avoids broken "audio not available" links.
+//   - ClipName: DB-only imports leave ClipName empty; DB+audio imports set it before
+//     Save when a matching source clip is found. An empty ClipName avoids broken
+//     "audio not available" links.
 //   - Model is set to a synthetic marker so imported rows are distinguishable from
 //     live detections in queries or analytics.
 //   - Provenance is carried solely by SourceNode (a persisted column). AudioSource is

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -83,11 +83,24 @@ type ImportOptions struct {
 	BatchSize int
 
 	// IncludeAudio controls whether source audio files are copied alongside detection data.
-	// Not yet implemented; setting it currently has no effect.
+	// When true, audio clips are copied from AudioSourceDir into ClipExportPath alongside detection data.
 	IncludeAudio bool
+
+	// AudioSourceDir is the directory containing the BirdNET-Pi source audio tree.
+	// It must contain an "Extracted/By_Date" subtree. Used only when IncludeAudio is true.
+	AudioSourceDir string
+
+	// ClipExportPath is the root directory where audio clips are written.
+	// Used only when IncludeAudio is true.
+	ClipExportPath string
+
+	// DiskSpaceFunc is called to check available disk space before audio copying.
+	// If nil, diskmanager.GetAvailableSpace is used. Inject in tests to avoid
+	// filesystem dependencies.
+	DiskSpaceFunc func(path string) (uint64, error)
 }
 
-func (o ImportOptions) withDefaults() ImportOptions {
+func (o *ImportOptions) withDefaults() {
 	if o.SourceNode == "" {
 		o.SourceNode = DefaultSourceNode
 	}
@@ -97,7 +110,6 @@ func (o ImportOptions) withDefaults() ImportOptions {
 	if o.BatchSize <= 0 {
 		o.BatchSize = defaultBatchSize
 	}
-	return o
 }
 
 // Engine runs an import from a Source into a DetectionRepository.
@@ -127,8 +139,8 @@ func detectionKey(ts time.Time, scientificName string, confidence float64) strin
 // Run imports all detections from src that are not already present in the store.
 // It returns a final ImportStats summary. Partial results are consistent because
 // the dedup set makes a re-run safe.
-func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, reporter ProgressReporter) (ImportStats, error) {
-	opts = opts.withDefaults()
+func (e *Engine) Run(ctx context.Context, src Source, opts *ImportOptions, reporter ProgressReporter) (ImportStats, error) {
+	opts.withDefaults()
 
 	stats := ImportStats{Phase: "validate"}
 	e.report(reporter, stats)
@@ -173,11 +185,18 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 	e.report(reporter, stats)
 
 	iterErr := src.Iterate(ctx, opts.BatchSize, func(batch []SourceDetection) error {
+		// First pass: classify rows into pending (new) vs. skipped/errored.
+		// Keys are added to seen eagerly so within-batch duplicates are caught here.
+		type pendingRow struct {
+			row *SourceDetection
+			ts  time.Time
+		}
+		pending := make([]pendingRow, 0, len(batch))
+
 		for i := range batch {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-
 			row := &batch[i]
 			ts, parseErr := parseTimestamp(row.Date, row.Time, opts.Location)
 			if parseErr != nil {
@@ -189,15 +208,53 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 				stats.Processed++
 				continue
 			}
-
 			key := detectionKey(ts, row.ScientificName, row.Confidence)
 			if _, ok := seen[key]; ok {
 				stats.Skipped++
 				stats.Processed++
 				continue
 			}
+			// Mark seen eagerly to deduplicate within-batch duplicates.
+			seen[key] = struct{}{}
+			pending = append(pending, pendingRow{row: row, ts: ts})
+		}
 
-			result := mapToResult(row, ts, opts.SourceNode)
+		// Second pass: copy audio clips when requested.
+		clipNames := make([]string, len(pending))
+		if opts.IncludeAudio && opts.ClipExportPath != "" && len(pending) > 0 {
+			rows := make([]SourceDetection, len(pending))
+			tss := make([]time.Time, len(pending))
+			for i, p := range pending {
+				rows[i] = *p.row
+				tss[i] = p.ts
+			}
+
+			// Disk-space guard: ensure the export volume can hold this batch's
+			// clips before copying any of them. Sizing source clips up front and
+			// checking once per batch keeps the import single-pass over the source.
+			requiredBytes := sumSourceClipSizes(opts.AudioSourceDir, rows)
+			if requiredBytes > 0 {
+				if spaceErr := checkDiskSpace(opts.ClipExportPath, requiredBytes, opts.DiskSpaceFunc); spaceErr != nil {
+					return spaceErr
+				}
+			}
+
+			missCount := 0
+			e.copyCandidateClips(ctx, opts, rows, tss, clipNames, &missCount)
+			if missCount > 0 {
+				e.log.Info("some audio clips could not be copied",
+					logger.Int("miss_count", missCount),
+					logger.Int("batch_size", len(pending)))
+			}
+		}
+
+		// Third pass: save detections with clip names resolved above.
+		for i, p := range pending {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			result := mapToResult(p.row, p.ts, opts.SourceNode)
+			result.ClipName = clipNames[i]
 			if saveErr := e.repo.Save(ctx, result, nil); saveErr != nil {
 				if ctx.Err() != nil {
 					// Context was cancelled or timed out during Save; propagate
@@ -205,15 +262,12 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 					return ctx.Err()
 				}
 				e.log.Error("failed to save detection",
-					logger.String("scientific_name", row.ScientificName),
+					logger.String("scientific_name", p.row.ScientificName),
 					logger.Error(saveErr))
 				stats.Errors++
 				stats.Processed++
 				continue
 			}
-
-			// Mark as seen so within-source duplicates are also deduplicated.
-			seen[key] = struct{}{}
 			stats.Inserted++
 			stats.Processed++
 		}
@@ -227,6 +281,12 @@ func (e *Engine) Run(ctx context.Context, src Source, opts ImportOptions, report
 			e.log.Info("import cancelled",
 				logger.Int("inserted", stats.Inserted),
 				logger.Int("skipped", stats.Skipped))
+			return stats, iterErr
+		}
+		// A disk-space failure from the audio pre-check is already a fully built
+		// error with the disk-usage category. Pass it through unchanged rather than
+		// re-wrapping it as a database error, so telemetry and category stay correct.
+		if errors.IsCategory(iterErr, errors.CategoryDiskUsage) {
 			return stats, iterErr
 		}
 		return stats, errors.New(iterErr).

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -336,7 +336,11 @@ func (e *Engine) copyAudioBatch(ctx context.Context, opts *ImportOptions, rows [
 
 	missCount := 0
 	e.copyCandidateClips(ctx, opts, rows, tss, clipNames, &missCount)
-	if missCount > 0 {
+	// Only report the miss count for a batch that ran to completion. On cancellation
+	// copyCandidateClips stops launching copies early and the batch is discarded before
+	// any detection is saved, so a partial miss count would understate reality and
+	// mislead; the separate "import cancelled" log is the accurate signal in that case.
+	if missCount > 0 && ctx.Err() == nil {
 		e.log.Info("some audio clips could not be copied",
 			logger.Int("miss_count", missCount),
 			logger.Int("batch_size", len(rows)))

--- a/internal/imports/imports_test.go
+++ b/internal/imports/imports_test.go
@@ -93,6 +93,23 @@ func newTestStore(t *testing.T) datastore.Interface {
 	return store
 }
 
+// newDetectionRepo wraps a datastore in a DetectionRepository for test use.
+func newDetectionRepo(t *testing.T, store datastore.Interface) datastore.DetectionRepository {
+	t.Helper()
+	return datastore.NewDetectionRepository(store, time.UTC)
+}
+
+// newBirdNetPiSource opens a birdnetpi source from path and registers cleanup.
+func newBirdNetPiSource(t *testing.T, path string) (imports.Source, error) {
+	t.Helper()
+	src, err := birdnetpi.New(path)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() { assert.NoError(t, src.Close()) })
+	return src, nil
+}
+
 // --- tests ---
 
 func TestValidate_NoDetectionsTable(t *testing.T) {
@@ -191,7 +208,7 @@ func TestImport_FieldMapping(t *testing.T) {
 		BatchSize:  100,
 	}
 
-	stats, err := engine.Run(t.Context(), src, opts, nil)
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Inserted)
 	assert.Equal(t, 0, stats.Errors)
@@ -239,7 +256,7 @@ func TestImport_SkipsUnparseableDate(t *testing.T) {
 	engine := imports.NewEngine(repo)
 	opts := imports.ImportOptions{SourceNode: imports.DefaultSourceNode, Location: time.UTC}
 
-	stats, err := engine.Run(t.Context(), src, opts, nil)
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, stats.Inserted, "only the row with valid date should be inserted")
@@ -260,7 +277,7 @@ func TestImport_Idempotent(t *testing.T) {
 	src1, err := birdnetpi.New(path)
 	require.NoError(t, err)
 	engine1 := imports.NewEngine(repo)
-	stats1, err := engine1.Run(t.Context(), src1, opts, nil)
+	stats1, err := engine1.Run(t.Context(), src1, &opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, src1.Close())
 	assert.Equal(t, 1, stats1.Inserted)
@@ -269,7 +286,7 @@ func TestImport_Idempotent(t *testing.T) {
 	src2, err := birdnetpi.New(path)
 	require.NoError(t, err)
 	engine2 := imports.NewEngine(repo)
-	stats2, err := engine2.Run(t.Context(), src2, opts, nil)
+	stats2, err := engine2.Run(t.Context(), src2, &opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, src2.Close())
 	assert.Equal(t, 0, stats2.Inserted, "re-run must insert zero rows")
@@ -293,7 +310,7 @@ func TestImport_WithinSourceDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
-	stats, err := engine.Run(t.Context(), src, opts, nil)
+	stats, err := engine.Run(t.Context(), src, &opts, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, stats.Inserted, "within-source duplicate must be inserted only once")
@@ -334,7 +351,7 @@ func TestImport_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, src.Close()) })
 
-	_, err = engine.Run(ctx, src, opts, nil)
+	_, err = engine.Run(ctx, src, &opts, nil)
 	assert.ErrorIs(t, err, context.Canceled, "cancelled import must return context error")
 }
 
@@ -368,7 +385,7 @@ func TestImport_Idempotent_TimezoneMismatch(t *testing.T) {
 	src1, err := birdnetpi.New(path)
 	require.NoError(t, err)
 	engine1 := imports.NewEngine(repo)
-	stats1, err := engine1.Run(t.Context(), src1, opts, nil)
+	stats1, err := engine1.Run(t.Context(), src1, &opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, src1.Close())
 	require.Equal(t, 1, stats1.Inserted, "first run must insert the row")
@@ -377,7 +394,7 @@ func TestImport_Idempotent_TimezoneMismatch(t *testing.T) {
 	src2, err := birdnetpi.New(path)
 	require.NoError(t, err)
 	engine2 := imports.NewEngine(repo)
-	stats2, err := engine2.Run(t.Context(), src2, opts, nil)
+	stats2, err := engine2.Run(t.Context(), src2, &opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, src2.Close())
 	assert.Equal(t, 0, stats2.Inserted, "re-run must insert zero rows even with non-UTC import location")
@@ -470,7 +487,7 @@ func TestImport_CancelDuringSave(t *testing.T) {
 	// processed before cancellation - no timing dependency.
 	reporter := &cancelOnFirstReport{cancel: cancel}
 
-	stats, err := engine.Run(ctx, src, opts, reporter)
+	stats, err := engine.Run(ctx, src, &opts, reporter)
 	require.ErrorIs(t, err, context.Canceled, "mid-import cancel must return context.Canceled")
 	assert.GreaterOrEqual(t, stats.Inserted, 1, "at least one row must have been inserted before cancel")
 	assert.Equal(t, 0, stats.Errors, "cancelled row must not be counted as a save error")

--- a/internal/imports/zz_goleak_test.go
+++ b/internal/imports/zz_goleak_test.go
@@ -1,0 +1,25 @@
+package imports_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs the whole imports_test package under goleak so the engine audio
+// tests, which drive a bounded clip-copy worker pool (copyCandidateClips), are
+// verified to leave no goroutines behind. A leaked copy goroutine or an
+// un-released semaphore would surface here.
+//
+// Ignores are kept narrowly scoped to known benign background goroutines: the
+// SQLite-backed datastore opens a database/sql connection opener, and the logger
+// uses lumberjack for rotation. Both run for the lifetime of the process.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("testing.(*T).Parallel"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
+	)
+}

--- a/internal/imports/zz_goleak_test.go
+++ b/internal/imports/zz_goleak_test.go
@@ -11,14 +11,14 @@ import (
 // verified to leave no goroutines behind. A leaked copy goroutine or an
 // un-released semaphore would surface here.
 //
-// Ignores are kept narrowly scoped to known benign background goroutines: the
-// SQLite-backed datastore opens a database/sql connection opener, and the logger
-// uses lumberjack for rotation. Both run for the lifetime of the process.
+// Ignores are kept narrowly scoped to the two known benign background goroutines that run
+// for the lifetime of the process: the SQLite-backed datastore's database/sql connection
+// opener and the logger's lumberjack rotation worker. goleak v1.3.0 already filters the
+// test-runner stacks (testing.(*T).Run / testing.(*T).Parallel) via its built-in
+// isTestStack check, and a blanket runtime.gopark ignore would suppress real leaks of any
+// parked goroutine, so neither is listed here.
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("testing.(*T).Parallel"),
-		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
 	)


### PR DESCRIPTION
## Summary

Adds the "Database + audio" mode to the BirdNET-Pi import. When selected, each newly-imported detection's audio clip is copied from the BirdNET-Pi audio tree (`<source>/Extracted/By_Date/<Date>/<CommonName>/<FileName>`) into BirdNET-Go's clip store at `clips/YYYY/MM/<scientific_name>_<conf>p_<timestamp>.<ext>`, and the detection's `ClipName` is set so it plays and renders spectrograms like a native clip.

- Copy-only (clips are never moved from removable media); mp3 is copied as-is (the spectrogram pipeline already handles mp3, so no transcode).
- Bounded worker pool with a WaitGroup: all copies complete before the import is reported done (no fire-and-forget).
- Disk-space pre-check before copying; clear error with required vs available bytes.
- Source clip resolution with a common-name fallback (spaces to underscores, apostrophes stripped) for BirdNET-Pi's directory naming.
- Path components from the source database are sanitized and containment-checked on both the read and write paths to prevent traversal.
- Re-running does not re-copy already-imported clips (idempotent via dedup plus an existing-target guard).
- The API accepts mode `db-audio` (and returns 400 if no audio export path is configured); the System-menu wizard enables the "Database + audio" option.

Known follow-ups: the disk-space check is per-batch rather than a single total pre-pass, and the wizard has no timezone selector (imported timestamps use the server's local timezone).

## Test Plan

- [x] `go build ./...`, `go vet`, `gofmt`, `golangci-lint run ./internal/imports/... ./internal/api/v2/...` (0 issues)
- [x] `go test -race ./internal/imports/... ./internal/api/v2/...`: clip copy to `YYYY/MM/`, the common-name fallback, disk-space abort, idempotency, missing-clip graceful degradation, a concurrent multi-clip copy, and path-traversal rejection on both the read and write paths
- [x] Frontend `npm run check:all`, `npm run test:ci`, `npm run i18n:validate:full`, `npm run build` (wizard db-audio option)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * BirdNET-Pi import wizard now offers selectable modes: database-only and database-with-audio.
  * When using database-with-audio, audio clips are copied into your configured export directory.
  * Import now checks available disk space before copying audio clips.

* **Bug Fixes**
  * Database-with-audio imports are now accepted when an export path is configured, and are rejected early if it’s missing.

* **Documentation**
  * Updated import endpoint documentation to reflect both modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->