### PR TITLE
fix(spectrogram): wait for Sox before reading its stderr buffer on FFmpeg failure

### DIFF
--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -724,6 +724,14 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 	// Run FFmpeg (producer)
 	if err := ffmpegCmd.Run(); err != nil {
 		g.killSoxProcess(soxCmd, soxPid)
+		// Wait for Sox to exit before reading soxOutput below. soxCmd.Stderr is a
+		// *bytes.Buffer, so os/exec runs a background goroutine that copies Sox's
+		// stderr into that buffer until soxCmd.Wait() joins it. Reading the buffer
+		// before Wait() returns races that copier goroutine. Setting soxWaitDone
+		// also stops the deferred cleanup from waiting a second time.
+		soxKillTimeout := computeRemainingTimeout(ctx, soxWaitFallbackTimeout)
+		g.waitWithTimeout(soxCmd, soxKillTimeout)
+		soxWaitDone = true
 		g.log().Warn("FFmpeg|SoX pipeline failed (FFmpeg stage)",
 			logger.String("audio_path", audioPath),
 			logger.Int("width", width),

--- a/internal/spectrogram/helpers_test.go
+++ b/internal/spectrogram/helpers_test.go
@@ -213,6 +213,18 @@ func requireSoxAvailable(t *testing.T) string {
 	return soxPath
 }
 
+// requireFFmpegAvailable checks if FFmpeg is available in PATH.
+// Skips the test if FFmpeg is not found, otherwise returns the FFmpeg path.
+func requireFFmpegAvailable(t *testing.T) string {
+	t.Helper()
+
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("FFmpeg binary not found in PATH; skipping integration test")
+	}
+	return ffmpegPath
+}
+
 // integrationTestEnv extends testEnv with integration-specific fields
 type integrationTestEnv struct {
 	*testEnv

--- a/internal/spectrogram/pipeline_race_test.go
+++ b/internal/spectrogram/pipeline_race_test.go
@@ -1,0 +1,61 @@
+package spectrogram
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// TestFFmpegSoxPipelineFailurePathNoRace exercises the FFmpeg-failure branch of
+// generateWithFFmpegSoxPipeline. The branch reads the soxOutput buffer to build
+// error context. Because soxCmd.Stderr is a *bytes.Buffer, os/exec runs a
+// background goroutine that copies Sox stderr into that buffer until
+// soxCmd.Wait() joins it. Reading soxOutput before Wait() returns is a data
+// race on the bytes.Buffer.
+//
+// The test drives FFmpeg to fail (nonexistent input) while Sox is started and
+// emitting stderr, then runs the path many times. Run with -race to detect the
+// race: with the bug present the race detector flags the concurrent read/write
+// on the buffer; with the fix in place it stays clean.
+func TestFFmpegSoxPipelineFailurePathNoRace(t *testing.T) {
+	soxPath := requireSoxAvailable(t)
+	ffmpegPath := requireFFmpegAvailable(t)
+
+	env := setupTestEnv(t)
+	env.Settings.Realtime.Audio.SoxPath = soxPath
+	env.Settings.Realtime.Audio.FfmpegPath = ffmpegPath
+
+	gen := NewGenerator(env.Settings, env.SFS, logger.Global().Module("spectrogram.test"))
+
+	// A nonexistent input makes FFmpeg exit non-zero, taking the FFmpeg-failure
+	// branch. Sox is started reading from FFmpeg's stdout pipe and writes a
+	// failure message to stderr when the pipe closes, so the os/exec copier
+	// goroutine is actively writing the soxOutput buffer around the time the
+	// failure branch reads it.
+	missingAudio := filepath.Join(env.TempDir, "does-not-exist.wav")
+	outputPath := filepath.Join(env.TempDir, "out.png")
+
+	const (
+		iterations          = 200
+		width               = 800
+		raw                 = false
+		preValidatedSeconds = 1.0
+	)
+	for range iterations {
+		// An error is expected every time (FFmpeg fails). The point of the test
+		// is that the -race detector must not flag a data race on soxOutput.
+		err := gen.generateWithFFmpegSoxPipeline(
+			env.Ctx,
+			env.Settings,
+			missingAudio,
+			outputPath,
+			width,
+			raw,
+			preValidatedSeconds,
+			BirdProfile(),
+		)
+		require.Error(t, err, "FFmpeg should fail for a nonexistent input file")
+	}
+}

--- a/internal/spectrogram/pipeline_race_test.go
+++ b/internal/spectrogram/pipeline_race_test.go
@@ -38,7 +38,11 @@ func TestFFmpegSoxPipelineFailurePathNoRace(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "out.png")
 
 	const (
-		iterations          = 200
+		// The race detector (ThreadSanitizer) flags the first unsynchronized
+		// concurrent access deterministically, so a small iteration count is
+		// enough to catch a reintroduced race while keeping this process-spawning
+		// test fast on CI.
+		iterations          = 20
 		width               = 800
 		raw                 = false
 		preValidatedSeconds = 1.0


### PR DESCRIPTION
## Summary

Fixes a data race in `internal/spectrogram/generator.go`, function `generateWithFFmpegSoxPipeline` (the FFmpeg piped into Sox path, used when Sox cannot read the input audio format directly).

In the FFmpeg-failure branch, the code read the `soxOutput` buffer (`soxCmd.Stderr`, a `*bytes.Buffer`) to build error context immediately after SIGKILLing Sox, without waiting for the process first. Because `soxCmd.Stderr` is a non-`*os.File` writer, `os/exec` spawns a background goroutine that copies Sox's stderr into the buffer, and that goroutine is only joined by `soxCmd.Wait()`. The failure branch only set `soxWaitDone` in the deferred cleanup, so reading `soxOutput.String()` raced the still-active copier goroutine. The Go race detector flags this whenever the FFmpeg stage fails while Sox has emitted stderr.

This is a latent, pre-existing race and a source of `-race` CI flakes; it is not introduced by any recent change.

## Fix

Mirror the success path: after `killSoxProcess`, call `waitWithTimeout` to join the copier goroutine, set `soxWaitDone = true` (which also makes the deferred cleanup a no-op so Sox is not waited on twice), and only then read the buffer. The success path is unchanged and behavior is identical. The wait is near-instant since Sox was just SIGKILLed, and `waitWithTimeout` bounds it with its own timeout and kill+reap fallback.

## Test Plan

- [x] Added `TestFFmpegSoxPipelineFailurePathNoRace`, a `-race` regression test that drives the FFmpeg-failure branch repeatedly. It deterministically fires the race detector on the pre-fix code and stays clean with the fix.
- [x] `go test -race -count=10 ./internal/spectrogram/...` passes with zero races (Sox and FFmpeg present locally).
- [x] `golangci-lint run ./internal/spectrogram/...` reports 0 issues; `gofmt`/`go vet` clean.

## Preflight Status

- [x] Single concern: one race fix plus its regression test
- [x] Linters clean on the package (0 issues)
- [x] Tests pass: `go test -race ./internal/spectrogram/...` (10x) green
- [x] No unrelated changes
- [x] No regression/backward-compat break: no config/API/DB/CLI surface change, error content unchanged, success path untouched
- [x] No secrets or PII

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when spectrogram generation fails during audio processing.
  * Prevented a race condition that could affect error handling and log collection.
  * Added safer cleanup so background processing finishes more consistently before reporting failures.

* **Tests**
  * Added coverage for the failure path to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->