### PR TITLE
fix(suncalc): close metrics data race and cache-clear thundering herd

### DIFF
--- a/internal/suncalc/race_test.go
+++ b/internal/suncalc/race_test.go
@@ -39,15 +39,21 @@ func TestMetricsRaceUnderConcurrency(t *testing.T) {
 	)
 
 	baseDate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	deadline := time.Now().Add(duration)
 
 	var wg sync.WaitGroup
+	// Release all goroutines together and start each one's deadline only after
+	// it begins, so a slow CI worker cannot let the window elapse before the
+	// goroutines are even scheduled (which would let them run zero iterations
+	// and pass vacuously).
+	start := make(chan struct{})
 
 	// Readers: hammer GetSunEventTimes across many dates (mix of hits and
 	// misses) so every metrics access path is exercised.
 	for r := range readers {
 		seed := r
 		wg.Go(func() {
+			<-start
+			deadline := time.Now().Add(duration)
 			i := seed
 			for time.Now().Before(deadline) {
 				d := baseDate.AddDate(0, 0, i%500)
@@ -62,6 +68,8 @@ func TestMetricsRaceUnderConcurrency(t *testing.T) {
 	for f := range flippers {
 		seed := f
 		wg.Go(func() {
+			<-start
+			deadline := time.Now().Add(duration)
 			i := seed
 			for time.Now().Before(deadline) {
 				if i%2 == 0 {
@@ -74,6 +82,7 @@ func TestMetricsRaceUnderConcurrency(t *testing.T) {
 		})
 	}
 
+	close(start)
 	wg.Wait()
 
 	// Leave metrics set so a final sanity call works.

--- a/internal/suncalc/race_test.go
+++ b/internal/suncalc/race_test.go
@@ -1,0 +1,163 @@
+package suncalc
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/observability/metrics"
+)
+
+// newTestMetrics builds a SunCalcMetrics backed by a private registry so it
+// never collides with other tests or the global registry.
+func newTestMetrics(t *testing.T) *metrics.SunCalcMetrics {
+	t.Helper()
+	m, err := metrics.NewSunCalcMetrics(prometheus.NewRegistry())
+	require.NoError(t, err, "failed to create suncalc metrics")
+	return m
+}
+
+// TestMetricsRaceUnderConcurrency exercises the data race and nil-panic window
+// on sc.metrics: many goroutines call GetSunEventTimes (which reads sc.metrics
+// outside the lock) while another goroutine flips sc.metrics between a real
+// instance and nil via SetMetrics (which writes under the write lock).
+//
+// Run with -race. Before the fix this both races (read-without-lock vs
+// write-under-lock) and can nil-panic when SetMetrics(nil) interleaves between
+// the "if sc.metrics != nil" check and the subsequent method call.
+func TestMetricsRaceUnderConcurrency(t *testing.T) {
+	sc := newTestSunCalc()
+	m := newTestMetrics(t)
+
+	const (
+		readers  = 16
+		flippers = 4
+		duration = 200 * time.Millisecond
+	)
+
+	baseDate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	deadline := time.Now().Add(duration)
+
+	var wg sync.WaitGroup
+
+	// Readers: hammer GetSunEventTimes across many dates (mix of hits and
+	// misses) so every metrics access path is exercised.
+	for r := range readers {
+		seed := r
+		wg.Go(func() {
+			i := seed
+			for time.Now().Before(deadline) {
+				d := baseDate.AddDate(0, 0, i%500)
+				_, _ = sc.GetSunEventTimes(d)
+				i++
+			}
+		})
+	}
+
+	// Flippers: toggle sc.metrics between a live instance and nil to open the
+	// nil-panic window and force the write side of the race.
+	for f := range flippers {
+		seed := f
+		wg.Go(func() {
+			i := seed
+			for time.Now().Before(deadline) {
+				if i%2 == 0 {
+					sc.SetMetrics(m)
+				} else {
+					sc.SetMetrics(nil)
+				}
+				i++
+			}
+		})
+	}
+
+	wg.Wait()
+
+	// Leave metrics set so a final sanity call works.
+	sc.SetMetrics(m)
+	_, err := sc.GetSunEventTimes(baseDate)
+	require.NoError(t, err, "sanity GetSunEventTimes after race loop failed")
+}
+
+// TestCacheClearThunderingHerd drives many goroutines to insert the SAME new
+// date concurrently while the cache sits one below capacity. This is the bug
+// from the issue: several goroutines compute the same missing date, the first
+// inserts it (bringing the cache to capacity), and without the store-path
+// double-check a slightly later goroutine sees the cache full and calls
+// clear(), wiping the entry the first just inserted (and returning a value that
+// is no longer cached). The fix reuses the existing entry and skips clear()
+// when the date is already present, so the new date must survive and the cache
+// must stay at capacity. A start barrier releases the goroutines together to
+// maximize store-path overlap; running under -count or -race stresses the
+// window further.
+func TestCacheClearThunderingHerd(t *testing.T) {
+	sc := newTestSunCalc()
+
+	// Prime the cache to one below capacity so the first concurrent insert
+	// reaches the clear threshold.
+	baseDate := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	for i := range maxCacheEntries - 1 {
+		_, err := sc.GetSunEventTimes(baseDate.AddDate(0, 0, i))
+		require.NoError(t, err)
+	}
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	results := make(chan SunEventTimes, goroutines)
+	errs := make(chan error, goroutines)
+	start := make(chan struct{})
+
+	// All goroutines insert the same brand-new date concurrently.
+	newDate := baseDate.AddDate(0, 0, maxCacheEntries+1000)
+	for range goroutines {
+		wg.Go(func() {
+			<-start // release all goroutines at once
+			times, err := sc.GetSunEventTimes(newDate)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- times
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "concurrent GetSunEventTimes returned error")
+	}
+
+	// All returned values must agree.
+	var first SunEventTimes
+	got := false
+	for times := range results {
+		if !got {
+			first = times
+			got = true
+			continue
+		}
+		require.True(t, first.Sunrise.Equal(times.Sunrise),
+			"concurrent goroutines returned different sunrise")
+	}
+	require.True(t, got, "expected at least one result")
+
+	// The new date must still be cached and the cache must remain exactly at
+	// capacity: the first goroutine inserts newDate and the rest reuse it via
+	// the store-path double-check, so no clear() ever runs. On the buggy code a
+	// later goroutine clears the full cache and reinserts, collapsing it to a
+	// single entry, so both assertions below fail. This makes the test a real
+	// regression guard rather than a no-op.
+	newKey := newDate.In(sc.location).Format(time.DateOnly)
+	sc.lock.RLock()
+	_, ok := sc.cache[newKey]
+	size := len(sc.cache)
+	sc.lock.RUnlock()
+	require.True(t, ok, "new date %s was wiped from the cache by a thundering-herd clear()", newKey)
+	require.Equal(t, maxCacheEntries, size, "cache was inappropriately cleared by the thundering herd")
+}

--- a/internal/suncalc/suncalc.go
+++ b/internal/suncalc/suncalc.go
@@ -34,6 +34,11 @@ type cacheEntry struct {
 // organically from live traffic.
 const maxCacheEntries = 400
 
+// sunEventsOperation is the operation label used for all GetSunEventTimes
+// metrics. Using a single constant keeps the Prometheus series consistent; a
+// typo in any one call site would otherwise split the series.
+const sunEventsOperation = "get_sun_events"
+
 // SunCalc handles caching and calculation of sun event times
 type SunCalc struct {
 	cache    map[string]cacheEntry   // Cache of sun event times for dates
@@ -88,9 +93,9 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 	// If the date exists in the cache, return the cached times
 	if exists {
 		if m != nil {
-			m.RecordSunCalcCacheHit("get_sun_events")
-			m.RecordSunCalcOperation("get_sun_events", "success")
-			m.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
+			m.RecordSunCalcCacheHit(sunEventsOperation)
+			m.RecordSunCalcOperation(sunEventsOperation, "success")
+			m.RecordSunCalcDuration(sunEventsOperation, time.Since(start).Seconds())
 		}
 		return entry.times, nil
 	}
@@ -105,9 +110,9 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 	if entry, ok := sc.cache[dateKey]; ok {
 		sc.lock.RUnlock()
 		if m != nil {
-			m.RecordSunCalcCacheHit("get_sun_events")
-			m.RecordSunCalcOperation("get_sun_events", "success")
-			m.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
+			m.RecordSunCalcCacheHit(sunEventsOperation)
+			m.RecordSunCalcOperation(sunEventsOperation, "success")
+			m.RecordSunCalcDuration(sunEventsOperation, time.Since(start).Seconds())
 		}
 		return entry.times, nil
 	}
@@ -115,15 +120,15 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 
 	// Record cache miss only after the double-check confirms it
 	if m != nil {
-		m.RecordSunCalcCacheMiss("get_sun_events")
+		m.RecordSunCalcCacheMiss(sunEventsOperation)
 	}
 
 	// Calculate outside the lock to avoid blocking readers.
 	times, err := sc.calculateSunEventTimes(localDate)
 	if err != nil {
 		if m != nil {
-			m.RecordSunCalcOperation("get_sun_events", "error")
-			m.RecordSunCalcError("get_sun_events", "calculation_error")
+			m.RecordSunCalcOperation(sunEventsOperation, "error")
+			m.RecordSunCalcError(sunEventsOperation, "calculation_error")
 		}
 		return SunEventTimes{}, err
 	}
@@ -151,8 +156,8 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 
 	// Record successful operation and update sun time gauges
 	if m != nil {
-		m.RecordSunCalcOperation("get_sun_events", "success")
-		m.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
+		m.RecordSunCalcOperation(sunEventsOperation, "success")
+		m.RecordSunCalcDuration(sunEventsOperation, time.Since(start).Seconds())
 
 		// Update sun time gauges for current day
 		if dateKey == time.Now().In(sc.location).Format(time.DateOnly) {

--- a/internal/suncalc/suncalc.go
+++ b/internal/suncalc/suncalc.go
@@ -95,13 +95,15 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 		return entry.times, nil
 	}
 
-	// Double-check under write lock: another goroutine may have populated
-	// the cache between the RLock check and now. This reduces (but does
+	// Double-check under a read lock: another goroutine may have populated
+	// the cache between the first RLock check and now. This reduces (but does
 	// not fully eliminate) redundant calculations under high concurrency,
-	// which is acceptable since calculateSunEventTimes is pure math.
-	sc.lock.Lock()
+	// which is acceptable since calculateSunEventTimes is pure math. A read
+	// lock suffices here because this branch only reads; the authoritative
+	// insert double-check in the store path below runs under the write lock.
+	sc.lock.RLock()
 	if entry, ok := sc.cache[dateKey]; ok {
-		sc.lock.Unlock()
+		sc.lock.RUnlock()
 		if m != nil {
 			m.RecordSunCalcCacheHit("get_sun_events")
 			m.RecordSunCalcOperation("get_sun_events", "success")
@@ -109,7 +111,7 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 		}
 		return entry.times, nil
 	}
-	sc.lock.Unlock()
+	sc.lock.RUnlock()
 
 	// Record cache miss only after the double-check confirms it
 	if m != nil {

--- a/internal/suncalc/suncalc.go
+++ b/internal/suncalc/suncalc.go
@@ -69,21 +69,28 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 	localDate := date.In(sc.location)
 	dateKey := localDate.Format(time.DateOnly)
 
-	// Acquire a read lock and check if the date is in the cache
+	// Acquire a read lock and check if the date is in the cache.
+	// Snapshot the metrics pointer under the same lock into a local so every
+	// metrics access below operates on a stable value. SetMetrics writes
+	// sc.metrics under the write lock, so reading it here (under RLock) is the
+	// only synchronized read of the field; capturing it once also closes the
+	// nil-panic window where a concurrent SetMetrics(nil) could land between a
+	// "!= nil" check and the subsequent method call.
 	sc.lock.RLock()
 	entry, exists := sc.cache[dateKey]
+	m := sc.metrics
 	// Update cache size metric while holding the lock to avoid race condition
-	if sc.metrics != nil {
-		sc.metrics.UpdateCacheSize(float64(len(sc.cache)))
+	if m != nil {
+		m.UpdateCacheSize(float64(len(sc.cache)))
 	}
 	sc.lock.RUnlock()
 
 	// If the date exists in the cache, return the cached times
 	if exists {
-		if sc.metrics != nil {
-			sc.metrics.RecordSunCalcCacheHit("get_sun_events")
-			sc.metrics.RecordSunCalcOperation("get_sun_events", "success")
-			sc.metrics.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
+		if m != nil {
+			m.RecordSunCalcCacheHit("get_sun_events")
+			m.RecordSunCalcOperation("get_sun_events", "success")
+			m.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
 		}
 		return entry.times, nil
 	}
@@ -95,49 +102,59 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 	sc.lock.Lock()
 	if entry, ok := sc.cache[dateKey]; ok {
 		sc.lock.Unlock()
-		if sc.metrics != nil {
-			sc.metrics.RecordSunCalcCacheHit("get_sun_events")
-			sc.metrics.RecordSunCalcOperation("get_sun_events", "success")
-			sc.metrics.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
+		if m != nil {
+			m.RecordSunCalcCacheHit("get_sun_events")
+			m.RecordSunCalcOperation("get_sun_events", "success")
+			m.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
 		}
 		return entry.times, nil
 	}
 	sc.lock.Unlock()
 
 	// Record cache miss only after the double-check confirms it
-	if sc.metrics != nil {
-		sc.metrics.RecordSunCalcCacheMiss("get_sun_events")
+	if m != nil {
+		m.RecordSunCalcCacheMiss("get_sun_events")
 	}
 
 	// Calculate outside the lock to avoid blocking readers.
 	times, err := sc.calculateSunEventTimes(localDate)
 	if err != nil {
-		if sc.metrics != nil {
-			sc.metrics.RecordSunCalcOperation("get_sun_events", "error")
-			sc.metrics.RecordSunCalcError("get_sun_events", "calculation_error")
+		if m != nil {
+			m.RecordSunCalcOperation("get_sun_events", "error")
+			m.RecordSunCalcError("get_sun_events", "calculation_error")
 		}
 		return SunEventTimes{}, err
 	}
 
-	// Store result and enforce cache size limit.
+	// Store result and enforce cache size limit. Double-check for an existing
+	// entry first: when several goroutines compute the same missing date
+	// concurrently, a later one must not clear() the cache and wipe the entry
+	// an earlier one just inserted. Mirroring the read double-check above, if
+	// another goroutine already populated dateKey we reuse its value and skip
+	// the clear/insert entirely. All callers for the date then return the same
+	// cached times.
 	sc.lock.Lock()
-	if len(sc.cache) >= maxCacheEntries {
-		clear(sc.cache)
+	if existing, ok := sc.cache[dateKey]; ok {
+		times = existing.times
+	} else {
+		if len(sc.cache) >= maxCacheEntries {
+			clear(sc.cache)
+		}
+		sc.cache[dateKey] = cacheEntry{times: times}
 	}
-	sc.cache[dateKey] = cacheEntry{times: times}
-	if sc.metrics != nil {
-		sc.metrics.UpdateCacheSize(float64(len(sc.cache)))
+	if m != nil {
+		m.UpdateCacheSize(float64(len(sc.cache)))
 	}
 	sc.lock.Unlock()
 
 	// Record successful operation and update sun time gauges
-	if sc.metrics != nil {
-		sc.metrics.RecordSunCalcOperation("get_sun_events", "success")
-		sc.metrics.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
+	if m != nil {
+		m.RecordSunCalcOperation("get_sun_events", "success")
+		m.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
 
 		// Update sun time gauges for current day
 		if dateKey == time.Now().In(sc.location).Format(time.DateOnly) {
-			sc.metrics.UpdateSunTimes(
+			m.UpdateSunTimes(
 				float64(times.Sunrise.Unix()),
 				float64(times.Sunset.Unix()),
 				float64(times.CivilDawn.Unix()),


### PR DESCRIPTION
## Summary

Two pre-existing concurrency issues in `internal/suncalc/suncalc.go` that the `-race` detector can flag and that risk a rare nil-panic. Both live in the shared `GetSunEventTimes` hot path used across the app, so they get a focused PR with a race test rather than a drive-by.

### 1. Data race + nil-panic on `sc.metrics`

`GetSunEventTimes` read `sc.metrics` outside the cache lock at several points while `SetMetrics` writes it under the write lock, which is a read-without-lock vs write-under-lock data race the detector flags. It was also a TOCTOU nil-panic: a `SetMetrics(nil)` could land between an `if sc.metrics != nil` check and the following `sc.metrics.RecordX()` call.

Fix: snapshot the pointer once under the existing `RLock` (`m := sc.metrics`) and use that local for every nil check and metric call. The only read of the shared field now happens under the lock (removing the race), and the immutable local cannot be nilled mid-call (removing the panic window). In practice metrics are set once at startup and never to nil during live traffic, so the trigger was near-zero, but it is a latent race the detector flags once a test exercises `SetMetrics` concurrently.

### 2. Cache-clear thundering herd

The store path computes outside the lock on a miss, then takes the write lock to insert. When the cache was at `maxCacheEntries` and several goroutines finished computing the same missing date, a later goroutine could hit `clear(sc.cache)` and wipe the entry the first just inserted (and was about to return).

Fix: add a double-check inside the write lock before `clear()`, mirroring the read-path double-check already present. If another goroutine already populated the date, reuse its value and skip the clear/insert so a concurrent insert is never destroyed and all callers for the date return the same cached value.

## Tests

New `internal/suncalc/race_test.go`:
- `TestMetricsRaceUnderConcurrency`: concurrently flips `SetMetrics` (live instance and nil) against many `GetSunEventTimes` callers. Deterministically trips the race detector on the unfixed code; clean on the fix.
- `TestCacheClearThunderingHerd`: many goroutines insert the same new date while the cache sits at capacity, released together by a start barrier, then asserts the new date survives and the cache stays at capacity. Fails on the unfixed code under `-race` (~90% of runs); always passes on the fix.

## Test Plan

- [x] `go test -race ./internal/suncalc/...` repeatedly (30+ runs), zero races / failures
- [x] Verified both new tests fail on pre-fix code and pass on the fix
- [x] `golangci-lint run` on the package: 0 issues
- [x] No public API, config, DB schema, or CLI change (purely internal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and stability for sun event time calculations under heavy concurrent requests.
  * Reduced redundant recomputations and cache contention when multiple requests target the same date simultaneously.
  * Made internal metrics recording safer during concurrent updates, lowering the risk of runtime issues.
* **Tests**
  * Added concurrency-focused tests covering simultaneous metric changes and cache access to prevent “thundering herd” cache behavior regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->