### PR TITLE
test(api/v2): snapshot goroutines so goleak tolerates cross-test transport dials

### DIFF
--- a/internal/api/v2/api_goroutine_test.go
+++ b/internal/api/v2/api_goroutine_test.go
@@ -23,8 +23,8 @@ func TestControllerShutdownCleansUpGoroutines(t *testing.T) {
 	// Snapshot existing goroutines now (test start) and verify no leaks at the
 	// end. Captured here so a leftover transport-dial goroutine from a
 	// previously-run test (shuffle order) is ignored, not attributed to this
-	// test; see deferNoLeaks for the full rationale.
-	deferNoLeaks(t,
+	// test; see verifyNoLeaks for the full rationale.
+	verifyNoLeaks(t,
 		// Ignore goroutines from testing framework and other standard libraries
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
@@ -139,10 +139,10 @@ func TestSendReconfigActionsRecoverOnClosedChannel(t *testing.T) {
 // TestGoroutineCleanupWithoutRoutes verifies that creating a controller without
 // routes doesn't start unnecessary goroutines
 func TestGoroutineCleanupWithoutRoutes(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		// Ignore goroutines from testing framework and other standard libraries
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),

--- a/internal/api/v2/api_goroutine_test.go
+++ b/internal/api/v2/api_goroutine_test.go
@@ -20,8 +20,11 @@ import (
 // TestControllerShutdownCleansUpGoroutines verifies that background goroutines
 // are properly cleaned up when the controller is shut down
 func TestControllerShutdownCleansUpGoroutines(t *testing.T) {
-	// Defer goleak check to verify no goroutines leak after test
-	defer goleak.VerifyNone(t,
+	// Snapshot existing goroutines now (test start) and verify no leaks at the
+	// end. Captured here so a leftover transport-dial goroutine from a
+	// previously-run test (shuffle order) is ignored, not attributed to this
+	// test; see deferNoLeaks for the full rationale.
+	deferNoLeaks(t,
 		// Ignore goroutines from testing framework and other standard libraries
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
@@ -136,19 +139,19 @@ func TestSendReconfigActionsRecoverOnClosedChannel(t *testing.T) {
 // TestGoroutineCleanupWithoutRoutes verifies that creating a controller without
 // routes doesn't start unnecessary goroutines
 func TestGoroutineCleanupWithoutRoutes(t *testing.T) {
-	// Register cleanup with goleak at the beginning
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			// Ignore goroutines from testing framework and other standard libraries
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("sync.runtime_notifyListWait"),
-			// Ignore the go-cache janitor which we can't control
-			goleak.IgnoreTopFunction("github.com/patrickmn/go-cache.(*janitor).Run"),
-			// Ignore lumberjack logger goroutines
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		// Ignore goroutines from testing framework and other standard libraries
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("sync.runtime_notifyListWait"),
+		// Ignore the go-cache janitor which we can't control
+		goleak.IgnoreTopFunction("github.com/patrickmn/go-cache.(*janitor).Run"),
+		// Ignore lumberjack logger goroutines
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	// Setup test environment (which uses NewWithOptions with initializeRoutes=false)
 	_, _, controller := setupTestEnvironment(t)

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -279,13 +279,14 @@ func TestStartBirdNETPiImport_BadJSON_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_ModeDBAudio_Returns202 verifies db-audio mode is accepted.
 func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
@@ -337,13 +338,14 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 // import would start, copy no audio (the engine skips audio when ClipExportPath is empty),
 // and silently produce detections with no clips, masking a misconfiguration.
 func TestStartBirdNETPiImport_ModeDBAudio_NoExportPath_Returns400(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
@@ -431,13 +433,14 @@ func makeTempDBWithRow(t *testing.T, date, comName, fileName string) (dir string
 // empty, so the engine skipped audio entirely (IncludeAudio && ClipExportPath != "" was
 // false) and the new path was never covered.
 func TestStartBirdNETPiImport_ModeDBAudio_CopiesClip(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	const (
 		date     = "2024-01-01"
@@ -657,13 +660,14 @@ func TestStartBirdNETPiImport_FakeValidationFailure_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_GoodFakeSource_Returns202 verifies 202 on a valid request.
 func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
@@ -705,13 +709,14 @@ func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
 
 // TestStartBirdNETPiImport_ConflictWhileRunning_Returns409 verifies 409 on concurrent starts.
 func TestStartBirdNETPiImport_ConflictWhileRunning_Returns409(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
@@ -883,13 +888,14 @@ func TestCancelImport_JobNotFound_Returns404(t *testing.T) {
 
 // TestCancelImport_RunningJob_Returns200Cancelling verifies cancel returns 200 with cancelling status.
 func TestCancelImport_RunningJob_Returns200Cancelling(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 	_, c := newImportController(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
@@ -1045,13 +1051,14 @@ func TestImportRoutes_FailClosedWhenNoAuth(t *testing.T) {
 
 // TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd verifies the full pipeline with a real SQLite file.
 func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	const rowCount = 3
 
@@ -1145,13 +1152,14 @@ func (p *panicIterateSource) Iterate(_ context.Context, _ int, fn func([]imports
 // TestStreamImportProgress_LiveStreaming verifies that a connected SSE client receives
 // multiple strictly-increasing progress events followed by a terminal complete event.
 func TestStreamImportProgress_LiveStreaming(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	e, c := newImportController(t)
 	c.initImportRoutes()
@@ -1280,13 +1288,14 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 // TestStreamImportProgress_CancelEmitsCancelledEvent verifies that cancelling a
 // running import results in a terminal cancelled SSE event on any connected stream.
 func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	e, c := newImportController(t)
 	c.initImportRoutes()
@@ -1376,13 +1385,14 @@ func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
 // panic in the import engine is recovered, the job reaches a terminal error state,
 // and the last-reported progress is preserved (not zeroed).
 func TestStartBirdNETPiImport_PanicInEngine_RecoverAndPreserveStats(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			goleak.IgnoreTopFunction("testing.(*T).Run"),
-			goleak.IgnoreTopFunction("runtime.gopark"),
-			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
-		)
-	})
+	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// leftover transport-dial goroutine from a previously-run test under
+	// -shuffle is ignored rather than wrongly attributed here.
+	deferNoLeaks(t,
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("runtime.gopark"),
+		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+	)
 
 	e, c := newImportController(t)
 	c.initImportRoutes()

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -279,10 +279,10 @@ func TestStartBirdNETPiImport_BadJSON_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_ModeDBAudio_Returns202 verifies db-audio mode is accepted.
 func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -338,10 +338,10 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 // import would start, copy no audio (the engine skips audio when ClipExportPath is empty),
 // and silently produce detections with no clips, masking a misconfiguration.
 func TestStartBirdNETPiImport_ModeDBAudio_NoExportPath_Returns400(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -433,10 +433,10 @@ func makeTempDBWithRow(t *testing.T, date, comName, fileName string) (dir string
 // empty, so the engine skipped audio entirely (IncludeAudio && ClipExportPath != "" was
 // false) and the new path was never covered.
 func TestStartBirdNETPiImport_ModeDBAudio_CopiesClip(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -660,10 +660,10 @@ func TestStartBirdNETPiImport_FakeValidationFailure_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_GoodFakeSource_Returns202 verifies 202 on a valid request.
 func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -709,10 +709,10 @@ func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
 
 // TestStartBirdNETPiImport_ConflictWhileRunning_Returns409 verifies 409 on concurrent starts.
 func TestStartBirdNETPiImport_ConflictWhileRunning_Returns409(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -888,10 +888,10 @@ func TestCancelImport_JobNotFound_Returns404(t *testing.T) {
 
 // TestCancelImport_RunningJob_Returns200Cancelling verifies cancel returns 200 with cancelling status.
 func TestCancelImport_RunningJob_Returns200Cancelling(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -1051,10 +1051,10 @@ func TestImportRoutes_FailClosedWhenNoAuth(t *testing.T) {
 
 // TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd verifies the full pipeline with a real SQLite file.
 func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -1152,10 +1152,10 @@ func (p *panicIterateSource) Iterate(_ context.Context, _ int, fn func([]imports
 // TestStreamImportProgress_LiveStreaming verifies that a connected SSE client receives
 // multiple strictly-increasing progress events followed by a terminal complete event.
 func TestStreamImportProgress_LiveStreaming(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -1288,10 +1288,10 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 // TestStreamImportProgress_CancelEmitsCancelledEvent verifies that cancelling a
 // running import results in a terminal cancelled SSE event on any connected stream.
 func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
@@ -1385,10 +1385,10 @@ func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
 // panic in the import engine is recovered, the job reaches a terminal error state,
 // and the last-reported progress is preserved (not zeroed).
 func TestStartBirdNETPiImport_PanicInEngine_RecoverAndPreserveStats(t *testing.T) {
-	// Snapshot existing goroutines at test start (see deferNoLeaks) so a
+	// Snapshot existing goroutines at test start (see verifyNoLeaks) so a
 	// leftover transport-dial goroutine from a previously-run test under
 	// -shuffle is ignored rather than wrongly attributed here.
-	deferNoLeaks(t,
+	verifyNoLeaks(t,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),

--- a/internal/api/v2/leakcheck_test.go
+++ b/internal/api/v2/leakcheck_test.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-// deferNoLeaks registers a goroutine-leak check that runs when the test ends.
+// verifyNoLeaks registers a goroutine-leak check that runs when the test ends.
 //
 // It snapshots the goroutines alive at the moment it is called (via
 // goleak.IgnoreCurrent) and ignores them, so a leftover goroutine from a
@@ -19,11 +19,14 @@ import (
 // checks flake under `go test -race -shuffle=on` depending on which test ran
 // first.
 //
-// Because the snapshot is taken when deferNoLeaks is called, callers must call
-// it at the START of the test, before constructing the component under test or
-// doing any work that starts goroutines. Goroutines spawned afterwards are not
-// in the snapshot, so a real leak (a goroutine started during the test and
-// never stopped) still fails the check.
+// Because the snapshot is taken when verifyNoLeaks is called, callers must call
+// it directly (NOT with defer) at the START of the test, before constructing
+// the component under test or doing any work that starts goroutines. Calling it
+// with defer would take the snapshot at the end of the test and silently mask
+// every leak it is meant to catch. The VerifyNone itself is scheduled via
+// t.Cleanup, so no defer is needed at the callsite. Goroutines spawned after
+// the snapshot are not in it, so a real leak (a goroutine started during the
+// test and never stopped) still fails the check.
 //
 // extra options are appended after the snapshot, for per-test ignores such as
 // goleak.IgnoreTopFunction for known process-lifetime workers.
@@ -33,9 +36,9 @@ import (
 // it runs once after all tests, when no other test's goroutines are in flight.
 //
 // These tests run sequentially; do not add t.Parallel() to a test that calls
-// deferNoLeaks, as a process-wide leak check cannot coexist with goroutines
+// verifyNoLeaks, as a process-wide leak check cannot coexist with goroutines
 // from other tests running concurrently.
-func deferNoLeaks(t *testing.T, extra ...goleak.Option) {
+func verifyNoLeaks(t *testing.T, extra ...goleak.Option) {
 	t.Helper()
 	opts := make([]goleak.Option, 0, len(extra)+1)
 	opts = append(opts, goleak.IgnoreCurrent())

--- a/internal/api/v2/leakcheck_test.go
+++ b/internal/api/v2/leakcheck_test.go
@@ -1,0 +1,46 @@
+// leakcheck_test.go: shared goroutine-leak helper for api/v2 tests.
+
+package api
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// deferNoLeaks registers a goroutine-leak check that runs when the test ends.
+//
+// It snapshots the goroutines alive at the moment it is called (via
+// goleak.IgnoreCurrent) and ignores them, so a leftover goroutine from a
+// previously-run test, most often a net/http.(*Transport).dialConn still
+// connecting after another test opened an outbound HTTP connection, is not
+// wrongly attributed to this test. goleak inspects every goroutine in the
+// process, not just the ones this test spawned, so without the snapshot these
+// checks flake under `go test -race -shuffle=on` depending on which test ran
+// first.
+//
+// Because the snapshot is taken when deferNoLeaks is called, callers must call
+// it at the START of the test, before constructing the component under test or
+// doing any work that starts goroutines. Goroutines spawned afterwards are not
+// in the snapshot, so a real leak (a goroutine started during the test and
+// never stopped) still fails the check.
+//
+// extra options are appended after the snapshot, for per-test ignores such as
+// goleak.IgnoreTopFunction for known process-lifetime workers.
+//
+// This helper is for per-test checks. The package-wide gate in TestMain
+// (settings_test_setup_test.go) deliberately does NOT use IgnoreCurrent because
+// it runs once after all tests, when no other test's goroutines are in flight.
+//
+// These tests run sequentially; do not add t.Parallel() to a test that calls
+// deferNoLeaks, as a process-wide leak check cannot coexist with goroutines
+// from other tests running concurrently.
+func deferNoLeaks(t *testing.T, extra ...goleak.Option) {
+	t.Helper()
+	opts := make([]goleak.Option, 0, len(extra)+1)
+	opts = append(opts, goleak.IgnoreCurrent())
+	opts = append(opts, extra...)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, opts...)
+	})
+}


### PR DESCRIPTION
## What

Fixes a flaky goroutine-leak check in `internal/api/v2` tests under `go test -race -shuffle=on`.

Several api/v2 tests call `goleak.VerifyNone` in a `defer` or `t.Cleanup`. goleak inspects every goroutine in the process, not just the ones the current test spawned. Under `-shuffle`, a test that opens an outbound HTTP connection (an httptest SSE client, the BirdNET-Pi import fake-source probe, an ntfy probe dial) can leave a `net/http.(*Transport).dialConn` goroutine still connecting when the next test's `VerifyNone` runs. goleak then wrongly attributes that goroutine to the goroutine-cleanup test and fails it.

This reproduces on `main`: `go test -race -shuffle=on ./internal/api/v2/` flakes (for example `TestGoroutineCleanupWithoutRoutes` and `TestStartBirdNETPiImport_GoodFakeSource_Returns202` both fail blaming a `dialConn` goroutine), while the no-shuffle CI run (`go test -race`) passes reliably.

## Fix

Add a small shared test helper, `deferNoLeaks`, that captures `goleak.IgnoreCurrent()` at the moment it is called (test start) and registers the `VerifyNone` cleanup with that snapshot plus any per-test ignores. `IgnoreCurrent` records the live goroutine set when called, so a leftover transport-dial goroutine from a previously-run test is snapshotted and ignored, while any goroutine spawned by this test afterwards is not in the snapshot and still fails the check.

All twelve per-test checks (two in `api_goroutine_test.go`, ten in `import_test.go`) now route through the helper, so the "snapshot at test start" invariant is structural rather than something each callsite has to get right. The existing `IgnoreTopFunction` options are preserved, so real leak detection is intact: a goroutine started during the test and never stopped is still caught (verified with a temporary deliberate-leak test).

The package-wide goleak gate in `TestMain` is intentionally left unchanged: it runs once after all tests, when no other test's goroutines are in flight, so it must not use `IgnoreCurrent`.

This is a test-only change. No production code is touched.

## Verification

- Reproduced the flake on the base binary under `-shuffle` (failures blaming `net/http.(*Transport).dialConn`).
- After the fix: 20+ `go test -race -shuffle=<seed>` runs across varied seeds with zero failures on the affected tests, and a mutation watch confirmed the flake did not shift to `readLoop`/`writeLoop`.
- `go test -race ./internal/api/v2/` (CI mode, no shuffle) passes.
- A temporary deliberate-leak test confirmed the leak check still fires on a real post-snapshot goroutine leak.
- `golangci-lint run` on the package: 0 issues.

## Preflight Status

- Single concern: test-only flake fix in one package.
- Linters clean: `golangci-lint run` 0 issues; `go vet` clean.
- Tests pass: `go test -race ./internal/api/v2/` green; 20+ shuffle seeds green.
- No regression/backward-compat break: test-only, no API/config/DB/CLI/i18n surface.
- No secrets or PII.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved goroutine leak checks across API tests by capturing a baseline at the start of each test to reduce false positives.
  * Standardized goroutine leak verification using a shared helper across shutdown, import, cancellation/panic recovery, and SSE streaming scenarios.
  * Updated test cleanup behavior and comments to better reflect when goroutine snapshots are taken and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->