### PR TITLE
test(notification): stabilize dispatcher forward test under race load

### DIFF
--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -14,6 +14,16 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// forwardWaitTimeout is the upper bound for an end-to-end dispatcher forward to
+// reach a test provider. The real path is sub-millisecond, but it crosses four
+// goroutine hops (broadcast, dispatch loop, dispatch, dispatchEnhanced) with no
+// time-based wait on the success path, so this budget exists only to absorb
+// goroutine scheduling stalls under full-suite `go test -race` CPU contention.
+// A generous ceiling keeps the test deterministic without slowing a healthy
+// run: the select wakes instantly on arrival and only reaches the timeout if
+// forwarding is genuinely broken.
+const forwardWaitTimeout = 5 * time.Second
+
 // fakeProvider implements PushProvider for testing
 type fakeProvider struct {
 	name      string
@@ -115,11 +125,16 @@ func TestPushDispatcher_ForwardsNotification(t *testing.T) {
 	_, err = svc.Create(TypeInfo, PriorityLow, "Hello", "World")
 	require.NoError(t, err, "create notification failed")
 
+	// Wait on the observable result (the forwarded notification) rather than a
+	// tight fixed deadline. The select wakes the instant the notification
+	// arrives; the generous timeout only acts as a ceiling for scheduling
+	// stalls under CI load, so a slow run no longer fails while a genuinely
+	// broken dispatcher still fails fast at the ceiling.
 	select {
 	case n := <-fp.recvCh:
 		assert.Equal(t, "Hello", n.Title)
 		assert.Equal(t, "World", n.Message)
-	case <-time.After(1 * time.Second):
+	case <-time.After(forwardWaitTimeout):
 		require.Fail(t, "timeout waiting for provider to receive notification")
 	}
 }


### PR DESCRIPTION
## Summary

`TestPushDispatcher_ForwardsNotification` fails intermittently under full-suite `go test -race ./...` CPU contention (it passes locally with `-race -count=5` and is not reproducible in isolation, the signature of a scheduling-budget flake rather than a logic bug).

Root cause: the test waits for a forwarded notification on the provider channel with a fixed `1s` `select`/`time.After` upper bound. After `svc.Create`, the notification crosses four goroutine hops before it lands on the provider channel:

1. `broadcast` -> non-blocking send to the subscriber channel
2. `runDispatchLoop` goroutine reads the channel and spawns `go d.dispatch(...)`
3. `dispatch` spawns the per-provider dispatch goroutine
4. `dispatchEnhanced` -> `retryLoop` -> `attemptSend` -> the fake provider's `Send` sends to `recvCh`

There is no time-based wait on the success path (`maxRetries=0`, no retry sleep), so the only thing the `1s` budget gates is goroutine scheduling. Under heavy parallel `-race` load that budget can be exceeded by scheduling stalls alone, tripping `require.Fail`.

## Fix

Replace the magic `1 * time.Second` literal with a named `forwardWaitTimeout` constant set to a generous `5s` ceiling, and keep the idiomatic `select` on the channel. The `select` still wakes the instant the notification arrives, so a healthy run is no slower; the larger ceiling only absorbs CI scheduling stalls, while a genuinely broken dispatcher still fails fast at the timeout. `testing/synctest` is not applicable here: the service spawns a `cleanupLoop` via a real `time.Ticker` and the dispatcher emits events on the global event bus, both outside any synctest bubble, and there is no fakeable time-based wait on this path to begin with.

This is a test-only change. No production code is touched.

## Test Plan

- [x] `go test -race -count=50 ./internal/notification/...` with zero flakes
- [x] `go test -race -shuffle=on` across multiple seeds with zero flakes
- [x] Targeted `-count=30` run under heavy CPU stress with zero flakes
- [x] Sanity check: deliberately breaking forwarding makes the test fail at the timeout (then reverted), confirming the test still validates end-to-end forwarding
- [x] `golangci-lint run` on `internal/notification/...`: 0 issues

## Preflight Status

- [x] Single concern: one test-only fix
- [x] Preflight passed (six review passes + Gemini cross-validation): no actionable findings
- [x] Linters clean for the changed package (0 issues)
- [x] Tests pass under `-race` (50x, shuffle, stress)
- [x] No unrelated changes
- [x] No regression/backward-compat break (test-only, no config/API/DB/CLI surface)
- [x] No secrets or PII

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved notification forwarding test timing to be more reliable in slower environments.
  * Increased the wait window for forwarding checks, reducing false failures caused by tight timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->