### PR TITLE
refactor(notification): drop dead SetServiceForTesting and stop isolated test service

### DIFF
--- a/internal/notification/manager.go
+++ b/internal/notification/manager.go
@@ -3,8 +3,6 @@ package notification
 import (
 	"sync"
 	"sync/atomic"
-
-	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 var (
@@ -32,20 +30,6 @@ func GetService() *Service {
 	mu.RLock()
 	defer mu.RUnlock()
 	return instance
-}
-
-// SetServiceForTesting allows setting a custom service instance for testing only
-// It returns an error if the service is already initialized in production
-func SetServiceForTesting(service *Service) error {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if instance != nil {
-		return errors.Newf("notification service already initialized").Component("notification").Category(errors.CategoryState).Build()
-	}
-
-	instance = service
-	return nil
 }
 
 // MustGetService returns the service instance or panics if not initialized

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -73,19 +73,29 @@ func newFakeProvider(name string, enabled bool, types ...Type) *fakeProvider {
 }
 
 // installIsolatedService installs svc as the process-global notification service
-// for the duration of the test and restores the previous instance on cleanup.
-// Tests that exercise the dispatcher end to end need their own service because
-// dispatcher.start subscribes to the global singleton (via GetService), yet
-// SetServiceForTesting only sets that singleton when it is nil and never resets
-// it. Without isolation such tests share one service, cross-deliver each other's
+// for the duration of the test, then restores the previous instance and stops svc
+// on cleanup. Tests that exercise the dispatcher end to end need their own service
+// because dispatcher.start subscribes to the global singleton (via GetService).
+// Without isolation such tests share one service, cross-deliver each other's
 // notifications, and accumulate rate-limiter state across runs. Callers must not
 // run in parallel: they mutate the global singleton.
+//
+// Cleanups run in LIFO order, so the pointer is restored before svc is stopped:
+// this closes any window where a concurrent GetService caller could observe a
+// service that is shutting down. The caller owns svc's lifecycle, which is why
+// the previous instance is only swapped back (never stopped) on restore.
 func installIsolatedService(t *testing.T, svc *Service) {
 	t.Helper()
+	// Register svc.Stop first so it runs last (after the pointer is restored),
+	// and so the dispatcher goroutines this test created are torn down rather
+	// than relying on the package goleak gate to tolerate them.
+	t.Cleanup(svc.Stop)
+
 	mu.Lock()
 	prev := instance
 	instance = svc
 	mu.Unlock()
+	// Registered after svc.Stop, so this restore runs first (LIFO).
 	t.Cleanup(func() {
 		mu.Lock()
 		instance = prev


### PR DESCRIPTION
## What

Removes the dead `notification.SetServiceForTesting` helper and hardens the in-package dispatcher test isolation.

`SetServiceForTesting` refused to overwrite an existing global instance and had no reset, so the first test to register a notification service won and later tests silently reused it, ignoring their own config. The api/v2 tests already moved to dependency injection (each test injects an isolated `notification.Service` into the `Controller` via the DI seam and stops it with `t.Cleanup`), which left `SetServiceForTesting` with zero callers anywhere in the repo. It was effectively dead, broken code shipped in the production binary, so this removes it along with its now-unused `internal/errors` import.

The only remaining test that uses the process-global singleton is the in-package `installIsolatedService` helper for the push-dispatcher tests. It already swaps the package-private `instance` pointer directly (the right level of access for an in-package helper, so no exported hook is warranted). This change hardens it to also stop the service it creates, with restore-then-stop LIFO ordering:

- `t.Cleanup(svc.Stop)` is registered first, so it runs last.
- The pointer-restore cleanup is registered second, so it runs first.

The result is that the global pointer is restored before the service shuts down, closing any window where a concurrent `GetService` caller could observe a service that is mid-shutdown, and the dispatcher goroutines are genuinely torn down instead of relying on the package goleak gate to tolerate a leaked `cleanupLoop`.

## Why

The old helper's overwrite-refusal plus missing reset made tests that need distinct configs or clean state order-dependent. The deeper dependency-injection fix already landed for the api/v2 handlers; this finishes the job by removing the obsolete global hook and tightening the remaining test helper.

## No behavior change

`Initialize`, `GetService`, `MustGetService`, `IsInitialized`, and the alert-engine gating are untouched. The production notification singleton behaves identically. `push_dispatcher_test.go` is a test file and never ships in the binary.

## Verification

- `go test -race ./internal/notification/... ./internal/api/v2/...` passes.
- Dispatcher and affected api/v2 tests pass under `-shuffle=on` across multiple seeds and `-count=2`, confirming order-independence.
- `golangci-lint run` reports 0 issues on the touched packages.

## Preflight Status

- [x] Single concern: removes dead test hook and hardens the dispatcher test helper.
- [x] Preflight passed: correctness, quality, integration, and regression reviews all clean.
- [x] Linters clean: `golangci-lint run` 0 issues on touched packages.
- [x] Tests pass: `go test -race` on notification and affected api/v2 tests, including under shuffle.
- [x] No unrelated changes: diff is two files in `internal/notification`.
- [x] No regression/backward-compat break: internal package, zero callers, production API unchanged.
- [x] No secrets or PII.

Note: pre-existing timing flakiness in the `import_test.go` SSE tests is unrelated to this change and reproduces on clean main under heavy `-race` shuffle load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup ordering for notification service isolation, making test behavior more reliable.
  * Clarified internal test expectations around service lifecycle and cleanup sequencing.

* **Refactor**
  * Removed an unused testing helper and streamlined notification service management internals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->