### PR TITLE
fix(birdweather): harden soundscape upload transport and FLAC encoding

### DIFF
--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -28,12 +28,16 @@ func ValidateFFmpegPath(ffmpegPath string) error {
 			Build()
 	}
 
+	// Redact the path in errors/telemetry: a contaminated tool path can embed an
+	// ingress credential token and these errors reach Sentry and support dumps.
+	safeFFmpegPath := conf.RedactToolPath(ffmpegPath)
+
 	if !filepath.IsAbs(ffmpegPath) {
-		return errors.Newf("FFmpeg path must be absolute, got: %s", ffmpegPath).
+		return errors.Newf("FFmpeg path must be absolute, got: %s", safeFFmpegPath).
 			Component("audiocore").
 			Category(errors.CategoryValidation).
 			Context("operation", "validate_ffmpeg_path").
-			Context("path", ffmpegPath).
+			Context("path", safeFFmpegPath).
 			Build()
 	}
 
@@ -42,11 +46,11 @@ func ValidateFFmpegPath(ffmpegPath string) error {
 	// not contain URL-like segments such as "/api/", "/ingress/", "/proxy/",
 	// or "/hassio/". Shares the canonical check with config-time validation.
 	if conf.IsContaminatedToolPath(ffmpegPath) {
-		return errors.Newf("FFmpeg path appears contaminated by proxy/ingress prefix: %s", ffmpegPath).
+		return errors.Newf("FFmpeg path appears contaminated by proxy/ingress prefix: %s", safeFFmpegPath).
 			Component("audiocore").
 			Category(errors.CategoryValidation).
 			Context("operation", "validate_ffmpeg_path").
-			Context("path", ffmpegPath).
+			Context("path", safeFFmpegPath).
 			Build()
 	}
 
@@ -65,12 +69,14 @@ func ValidateSoxPath(soxPath string) error {
 			Build()
 	}
 
+	safeSoxPath := conf.RedactToolPath(soxPath)
+
 	if !filepath.IsAbs(soxPath) {
-		return errors.Newf("Sox path must be absolute, got: %s", soxPath).
+		return errors.Newf("Sox path must be absolute, got: %s", safeSoxPath).
 			Component("audiocore").
 			Category(errors.CategoryValidation).
 			Context("operation", "validate_sox_path").
-			Context("path", soxPath).
+			Context("path", safeSoxPath).
 			Build()
 	}
 
@@ -79,11 +85,11 @@ func ValidateSoxPath(soxPath string) error {
 	// not contain URL-like segments such as "/api/", "/ingress/", "/proxy/",
 	// or "/hassio/". Shares the canonical check with config-time validation.
 	if conf.IsContaminatedToolPath(soxPath) {
-		return errors.Newf("Sox path appears contaminated by proxy/ingress prefix: %s", soxPath).
+		return errors.Newf("Sox path appears contaminated by proxy/ingress prefix: %s", safeSoxPath).
 			Component("audiocore").
 			Category(errors.CategoryValidation).
 			Context("operation", "validate_sox_path").
-			Context("path", soxPath).
+			Context("path", safeSoxPath).
 			Build()
 	}
 

--- a/internal/audiocore/ffmpeg/common.go
+++ b/internal/audiocore/ffmpeg/common.go
@@ -7,20 +7,14 @@ import (
 	"context"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
-
-// rePathContamination matches URL-like path segments that indicate the FFmpeg
-// path has been contaminated by a reverse proxy or ingress prefix (e.g.,
-// "/api/", "/ingress/", "/proxy/", "/hassio/"). A valid FFmpeg binary path
-// should never contain these segments.
-var rePathContamination = regexp.MustCompile(`(?i)/(?:api|ingress|proxy|hassio)/`)
 
 // ValidateFFmpegPath checks if the FFmpeg path is valid for execution.
 // It rejects empty paths, relative paths, and paths that appear to be
@@ -46,8 +40,8 @@ func ValidateFFmpegPath(ffmpegPath string) error {
 	// Reject paths contaminated by HTTP proxy/ingress prefixes.
 	// A valid FFmpeg binary path should be a clean filesystem path,
 	// not contain URL-like segments such as "/api/", "/ingress/", "/proxy/",
-	// or "/hassio/". Uses a case-insensitive regex for broader detection.
-	if rePathContamination.MatchString(ffmpegPath) {
+	// or "/hassio/". Shares the canonical check with config-time validation.
+	if conf.IsContaminatedToolPath(ffmpegPath) {
 		return errors.Newf("FFmpeg path appears contaminated by proxy/ingress prefix: %s", ffmpegPath).
 			Component("audiocore").
 			Category(errors.CategoryValidation).
@@ -83,8 +77,8 @@ func ValidateSoxPath(soxPath string) error {
 	// Reject paths contaminated by HTTP proxy/ingress prefixes.
 	// A valid Sox binary path should be a clean filesystem path,
 	// not contain URL-like segments such as "/api/", "/ingress/", "/proxy/",
-	// or "/hassio/". Uses a case-insensitive regex for broader detection.
-	if rePathContamination.MatchString(soxPath) {
+	// or "/hassio/". Shares the canonical check with config-time validation.
+	if conf.IsContaminatedToolPath(soxPath) {
 		return errors.Newf("Sox path appears contaminated by proxy/ingress prefix: %s", soxPath).
 			Component("audiocore").
 			Category(errors.CategoryValidation).

--- a/internal/audiocore/ffmpeg/common_test.go
+++ b/internal/audiocore/ffmpeg/common_test.go
@@ -298,3 +298,23 @@ func TestGetAudioDuration_CanceledContext(t *testing.T) {
 	_, err := ffmpeg.GetAudioDuration(ctx, dummyPath)
 	assert.Error(t, err, "canceled context should return an error")
 }
+
+// TestValidatePath_RedactsContaminatedTokenInError verifies that the validators
+// never put a credential-bearing ingress path into the error (which reaches
+// telemetry). The Home Assistant ingress prefix carries a token in the path.
+func TestValidatePath_RedactsContaminatedTokenInError(t *testing.T) {
+	t.Parallel()
+
+	const token = "super-secret-ingress-token"
+	contaminated := "/api/hassio_ingress/" + token + "/usr/bin/ffmpeg"
+
+	ffErr := ffmpeg.ValidateFFmpegPath(contaminated)
+	require.Error(t, ffErr)
+	assert.NotContains(t, ffErr.Error(), token, "ffmpeg validation error must not leak the ingress token")
+	assert.NotContains(t, ffErr.Error(), "hassio_ingress", "ffmpeg validation error must not leak the contaminated path")
+
+	soxErr := ffmpeg.ValidateSoxPath("/api/hassio_ingress/" + token + "/usr/bin/sox")
+	require.Error(t, soxErr)
+	assert.NotContains(t, soxErr.Error(), token, "sox validation error must not leak the ingress token")
+	assert.NotContains(t, soxErr.Error(), "hassio_ingress", "sox validation error must not leak the contaminated path")
+}

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -25,8 +25,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/httpclient"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
+
+	"golang.org/x/net/http2"
 )
 
 // GetLogger returns the birdweather package logger
@@ -43,8 +46,24 @@ const (
 	// httpClientTimeout is the default timeout for HTTP requests
 	httpClientTimeout = 45 * time.Second
 
-	// encodingTimeout is the timeout for audio encoding operations
-	encodingTimeout = 30 * time.Second
+	// encodingTimeout is the timeout for audio encoding operations. FLAC
+	// encoding runs two sequential FFmpeg passes (loudness analysis, then the
+	// gain-adjusted encode) under this single budget, so on slow hardware
+	// (Raspberry Pi, Home Assistant add-ons) the analysis pass alone could
+	// previously exhaust a 30s budget and starve the encode pass. 60s gives both
+	// passes room; the upload still runs in a background worker, so a slower
+	// encode does not block the analysis pipeline or the UI.
+	encodingTimeout = 60 * time.Second
+
+	// http2ReadIdleTimeout and http2PingTimeout enable HTTP/2 connection health
+	// checks on the upload client. The BirdWeather API sits behind a CDN that
+	// silently drops idle connections; reusing a half-open pooled connection
+	// surfaces as "http2: client connection force closed via ClientConn.Close".
+	// With these set, the transport sends a PING on an idle connection after
+	// http2ReadIdleTimeout and discards it if no PONG arrives within
+	// http2PingTimeout, so a dead connection is never reused for an upload.
+	http2ReadIdleTimeout = 15 * time.Second
+	http2PingTimeout     = 5 * time.Second
 
 	// detectionDurationSeconds is the duration added to timestamp for end time
 	detectionDurationSeconds = 3
@@ -190,6 +209,29 @@ type Interface interface {
 	Close()
 }
 
+// newUploadHTTPClient builds the HTTP client used for BirdWeather uploads. It
+// uses a dedicated transport (cloned from http.DefaultTransport so proxy support
+// and dial timeouts are preserved) instead of the shared global transport, and
+// enables HTTP/2 health-check PINGs so a half-open connection dropped by the
+// CDN is detected and discarded rather than reused for an upload (which would
+// fail with "http2: client connection force closed via ClientConn.Close").
+func newUploadHTTPClient() *http.Client {
+	transport := httpclient.CloneDefaultTransport()
+	if h2, err := http2.ConfigureTransports(transport); err == nil {
+		h2.ReadIdleTimeout = http2ReadIdleTimeout
+		h2.PingTimeout = http2PingTimeout
+	} else {
+		// Non-fatal: without explicit HTTP/2 configuration the transport still
+		// negotiates HTTP/2 via ALPN, just without the proactive idle PINGs.
+		GetLogger().Warn("Failed to configure HTTP/2 health checks for BirdWeather uploads",
+			logger.Error(err))
+	}
+	return &http.Client{
+		Timeout:   httpClientTimeout,
+		Transport: transport,
+	}
+}
+
 // New creates and initializes a new BwClient with the given settings.
 // The HTTP client is configured with httpClientTimeout to prevent hanging requests.
 func New(settings *conf.Settings) (*BwClient, error) {
@@ -202,7 +244,7 @@ func New(settings *conf.Settings) (*BwClient, error) {
 		Accuracy:      settings.Realtime.Birdweather.LocationAccuracy,
 		Latitude:      settings.BirdNET.Latitude,
 		Longitude:     settings.BirdNET.Longitude,
-		HTTPClient:    &http.Client{Timeout: httpClientTimeout},
+		HTTPClient:    newUploadHTTPClient(),
 	}
 
 	// Attach the circuit breaker. Metrics are intentionally nil for now — the
@@ -1068,7 +1110,10 @@ func (b *BwClient) Close() {
 
 	log.Info("Closing BirdWeather client")
 	if b.HTTPClient != nil && b.HTTPClient.Transport != nil {
-		// If the transport implements the CloseIdleConnections method, call it
+		// If the transport implements the CloseIdleConnections method, call it.
+		// The upload client owns a dedicated transport (see newUploadHTTPClient),
+		// so this only reclaims this client's idle connections and never touches
+		// the shared http.DefaultTransport pool.
 		type transporter interface {
 			CloseIdleConnections()
 		}
@@ -1076,8 +1121,12 @@ func (b *BwClient) Close() {
 			log.Debug("Closing idle HTTP connections")
 			transport.CloseIdleConnections()
 		}
-		// Cancel any in-flight requests by using a new client
-		b.HTTPClient = nil // Allow GC to collect the old client/transport
+		// Deliberately do NOT nil out b.HTTPClient here. In-flight uploads read
+		// b.HTTPClient without holding the processor's bwClientMutex (they
+		// obtained the *BwClient via GetBwClient and released the lock), so a
+		// write here races with those reads and risks a nil dereference. The
+		// client/transport are garbage-collected once the BwClient is dropped
+		// from the processor; CloseIdleConnections already frees pooled sockets.
 	}
 
 	if b.Settings.Realtime.Birdweather.Debug {

--- a/internal/birdweather/upload_transport_test.go
+++ b/internal/birdweather/upload_transport_test.go
@@ -1,0 +1,85 @@
+package birdweather
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestNewUploadHTTPClient_DedicatedTransport verifies the upload client uses its
+// own transport (cloned from the default) rather than sharing the global
+// http.DefaultTransport pool, so closing its idle connections cannot disturb
+// other components and its HTTP/2 health-check settings apply only here.
+func TestNewUploadHTTPClient_DedicatedTransport(t *testing.T) {
+	t.Parallel()
+
+	client := newUploadHTTPClient()
+	require.NotNil(t, client)
+	assert.Equal(t, httpClientTimeout, client.Timeout)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "upload client must use a *http.Transport")
+	require.NotNil(t, transport)
+
+	// Note: the HTTP/2 health-check settings (ReadIdleTimeout/PingTimeout) applied
+	// via http2.ConfigureTransports live on the unexported *http2.Transport and are
+	// not reachable from the *http.Transport, so they are intentionally not asserted
+	// here. The dedicated-transport check below is what guards against regressing to
+	// the shared DefaultTransport (the original bug).
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok)
+	assert.NotSame(t, defaultTransport, transport,
+		"upload client must own a dedicated transport, not the shared DefaultTransport")
+}
+
+// TestBwClientClose_KeepsHTTPClient verifies Close() does not nil out the HTTP
+// client. In-flight uploads read b.HTTPClient without the processor's mutex, so
+// nil-ing it would race and risk a nil dereference.
+func TestBwClientClose_KeepsHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	b := &BwClient{
+		Settings:   &conf.Settings{},
+		HTTPClient: newUploadHTTPClient(),
+	}
+
+	b.Close()
+
+	assert.NotNil(t, b.HTTPClient, "Close() must not nil HTTPClient (in-flight uploads read it lock-free)")
+}
+
+// TestBwClientClose_ConcurrentReadNoRace exercises the exact access pattern of
+// the original bug: an in-flight upload reading b.HTTPClient concurrently with a
+// reconfigure calling Close(). Run under -race; the old code (b.HTTPClient = nil
+// inside Close) tripped the detector here.
+func TestBwClientClose_ConcurrentReadNoRace(t *testing.T) {
+	t.Parallel()
+
+	b := &BwClient{
+		Settings:   &conf.Settings{},
+		HTTPClient: newUploadHTTPClient(),
+	}
+
+	var wg sync.WaitGroup
+	// Readers mimic upload goroutines that obtained *BwClient and dereference
+	// its HTTPClient field without holding any lock.
+	for range 8 {
+		wg.Go(func() {
+			for range 200 {
+				_ = b.HTTPClient
+			}
+		})
+	}
+	// Concurrent reconfigure/disconnect closing the same client.
+	wg.Go(func() {
+		b.Close()
+	})
+
+	wg.Wait()
+	assert.NotNil(t, b.HTTPClient)
+}

--- a/internal/birdweather/upload_transport_test.go
+++ b/internal/birdweather/upload_transport_test.go
@@ -8,7 +8,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/httpclient"
+	"golang.org/x/net/http2"
 )
+
+// TestUploadTransportHTTP2ConfigureSucceeds locks in the contract that
+// newUploadHTTPClient relies on: http2.ConfigureTransports succeeds on a clone of
+// http.DefaultTransport, so the HTTP/2 health-check pings are actually applied and
+// the warn-and-continue fallback in newUploadHTTPClient is not taken. http.Transport.Clone
+// does not copy the altProto registration, so ConfigureTransports does not error even
+// though the default transport is HTTP/2-enabled. A regression here (e.g. a future
+// x/net change) would silently disable the connection-reuse-race fix, so guard it.
+func TestUploadTransportHTTP2ConfigureSucceeds(t *testing.T) {
+	t.Parallel()
+
+	transport := httpclient.CloneDefaultTransport()
+	h2, err := http2.ConfigureTransports(transport)
+	require.NoError(t, err, "ConfigureTransports must succeed on a cloned DefaultTransport so the health-check pings apply")
+	require.NotNil(t, h2)
+}
 
 // TestNewUploadHTTPClient_DedicatedTransport verifies the upload client uses its
 // own transport (cloned from the default) rather than sharing the global

--- a/internal/birdweather/upload_transport_test.go
+++ b/internal/birdweather/upload_transport_test.go
@@ -66,11 +66,15 @@ func TestBwClientClose_ConcurrentReadNoRace(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
+	const (
+		concurrentHTTPClientReaders = 8
+		httpClientReadIterations    = 200
+	)
 	// Readers mimic upload goroutines that obtained *BwClient and dereference
 	// its HTTPClient field without holding any lock.
-	for range 8 {
+	for range concurrentHTTPClientReaders {
 		wg.Go(func() {
-			for range 200 {
+			for range httpClientReadIterations {
 				_ = b.HTTPClient
 			}
 		})

--- a/internal/conf/tool_path_contamination_test.go
+++ b/internal/conf/tool_path_contamination_test.go
@@ -76,3 +76,17 @@ func TestValidateToolPath_RejectsContaminatedConfiguredPath(t *testing.T) {
 	assert.NotContains(t, err.Error(), "hassio_ingress", "error message must not leak the contaminated ingress path/token")
 	assert.Contains(t, err.Error(), redactedToolPath, "error should reference the redacted-path placeholder")
 }
+
+// TestRedactToolPath verifies clean paths pass through unchanged while a
+// contaminated path (carrying a credential token) is replaced wholesale.
+func TestRedactToolPath(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "/usr/bin/ffmpeg", RedactToolPath("/usr/bin/ffmpeg"))
+	assert.Empty(t, RedactToolPath(""))
+
+	got := RedactToolPath("/api/hassio_ingress/secret-token-value/usr/bin/ffmpeg")
+	assert.NotContains(t, got, "secret-token-value")
+	assert.NotContains(t, got, "hassio_ingress")
+	assert.Equal(t, redactedToolPath, got)
+}

--- a/internal/conf/tool_path_contamination_test.go
+++ b/internal/conf/tool_path_contamination_test.go
@@ -29,6 +29,8 @@ func TestIsContaminatedToolPath(t *testing.T) {
 		{name: "proxy segment", path: "/proxy/host/usr/bin/ffmpeg", want: true},
 		{name: "hassio segment", path: "/hassio/abc/usr/bin/ffmpeg", want: true},
 		{name: "case insensitive", path: "/API/foo/ffmpeg", want: true},
+		// Windows backslash-separated contaminated path must also be caught.
+		{name: "windows contaminated path", path: `C:\api\hassio_ingress\token\usr\bin\ffmpeg.exe`, want: true},
 		// A legitimate directory literally named "apidata" must not trip the
 		// check: only full "/api/" style segments count.
 		{name: "substring not a segment", path: "/opt/apidata/ffmpeg", want: false},
@@ -69,4 +71,8 @@ func TestValidateToolPath_RejectsContaminatedConfiguredPath(t *testing.T) {
 	assert.NotEqual(t, contaminated, got, "must not accept contaminated path even though it exists on disk")
 	require.Error(t, err)
 	assert.Empty(t, got)
+
+	// The error must not leak the ingress credential token embedded in the path.
+	assert.NotContains(t, err.Error(), "hassio_ingress", "error message must not leak the contaminated ingress path/token")
+	assert.Contains(t, err.Error(), redactedToolPath, "error should reference the redacted-path placeholder")
 }

--- a/internal/conf/tool_path_contamination_test.go
+++ b/internal/conf/tool_path_contamination_test.go
@@ -50,11 +50,16 @@ func TestValidateToolPath_RejectsContaminatedConfiguredPath(t *testing.T) {
 	t.Parallel()
 
 	// Create a real file whose path contains an ingress-style segment, so
-	// os.Stat succeeds and only the contamination check can reject it.
-	dir := t.TempDir()
-	ingressDir := filepath.Join(dir, "api", "hassio_ingress", "token")
+	// os.Stat succeeds and only the contamination check can reject it. The real
+	// contamination is a Home Assistant ingress URL prefix, which is always
+	// forward-slash separated, so build the path with forward slashes (not
+	// filepath.Join, which would emit backslashes on Windows and never match the
+	// forward-slash contamination regex). Go's os package accepts forward slashes
+	// on Windows, so MkdirAll/WriteFile/Stat still work cross-platform.
+	base := filepath.ToSlash(t.TempDir())
+	ingressDir := base + "/api/hassio_ingress/token"
 	require.NoError(t, os.MkdirAll(ingressDir, 0o755))
-	contaminated := filepath.Join(ingressDir, "ffmpeg")
+	contaminated := ingressDir + "/ffmpeg"
 	require.NoError(t, os.WriteFile(contaminated, []byte("#!/bin/sh\n"), 0o755))
 
 	got, err := ValidateToolPath(contaminated, "nonexistent-tool-binary-xyz")

--- a/internal/conf/tool_path_contamination_test.go
+++ b/internal/conf/tool_path_contamination_test.go
@@ -1,0 +1,67 @@
+package conf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsContaminatedToolPath verifies the shared proxy/ingress contamination
+// detector used by both configuration-time and execution-time tool validation.
+func TestIsContaminatedToolPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "clean absolute unix path", path: "/usr/bin/ffmpeg", want: false},
+		{name: "clean absolute usr local path", path: "/usr/local/bin/ffmpeg", want: false},
+		{name: "clean windows path", path: `C:\ffmpeg\bin\ffmpeg.exe`, want: false},
+		{name: "empty path", path: "", want: false},
+		{name: "home assistant ingress", path: "/api/hassio_ingress/abc123token/usr/bin/ffmpeg", want: true},
+		{name: "api prefix", path: "/api/foo/usr/bin/sox", want: true},
+		{name: "ingress segment", path: "/ingress/abc/usr/bin/ffmpeg", want: true},
+		{name: "proxy segment", path: "/proxy/host/usr/bin/ffmpeg", want: true},
+		{name: "hassio segment", path: "/hassio/abc/usr/bin/ffmpeg", want: true},
+		{name: "case insensitive", path: "/API/foo/ffmpeg", want: true},
+		// A legitimate directory literally named "apidata" must not trip the
+		// check: only full "/api/" style segments count.
+		{name: "substring not a segment", path: "/opt/apidata/ffmpeg", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsContaminatedToolPath(tt.path))
+		})
+	}
+}
+
+// TestValidateToolPath_RejectsContaminatedConfiguredPath verifies that a
+// contaminated configured path is never returned as the validated path, even
+// when os.Stat would succeed on it. Regression test for Home Assistant add-ons
+// resolving ffmpeg to "/api/hassio_ingress/<token>/usr/bin/ffmpeg".
+func TestValidateToolPath_RejectsContaminatedConfiguredPath(t *testing.T) {
+	t.Parallel()
+
+	// Create a real file whose path contains an ingress-style segment, so
+	// os.Stat succeeds and only the contamination check can reject it.
+	dir := t.TempDir()
+	ingressDir := filepath.Join(dir, "api", "hassio_ingress", "token")
+	require.NoError(t, os.MkdirAll(ingressDir, 0o755))
+	contaminated := filepath.Join(ingressDir, "ffmpeg")
+	require.NoError(t, os.WriteFile(contaminated, []byte("#!/bin/sh\n"), 0o755))
+
+	got, err := ValidateToolPath(contaminated, "nonexistent-tool-binary-xyz")
+
+	// The contaminated path must never be returned. With no such tool in PATH,
+	// validation falls through to an error rather than accepting the bad path.
+	assert.NotEqual(t, contaminated, got, "must not accept contaminated path even though it exists on disk")
+	require.Error(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -709,14 +709,21 @@ func GetSoxFormats(soxPath string) []string {
 	return nil
 }
 
+// redactedToolPath replaces a contaminated tool path in logs and error messages.
+// A Home Assistant ingress path embeds a credential token
+// (e.g. "/api/hassio_ingress/<token>/usr/bin/ffmpeg"), so the raw path must never
+// reach logs or support dumps.
+const redactedToolPath = "[redacted contaminated path]"
+
 // rePathContamination matches URL-like segments (e.g. "/api/", "/ingress/",
 // "/proxy/", "/hassio/") that indicate an external tool path has been
 // contaminated by a reverse-proxy or ingress prefix rather than being a clean
 // filesystem path. A real binary path on disk never contains these. Home
 // Assistant add-ons in particular can resolve a tool path to
 // "/api/hassio_ingress/<token>/usr/bin/ffmpeg", which is not a usable
-// executable and fails every invocation.
-var rePathContamination = regexp.MustCompile(`(?i)/(?:api|ingress|proxy|hassio)/`)
+// executable and fails every invocation. Both separators are matched so the
+// check is robust on Windows (backslash) as well as POSIX (forward slash).
+var rePathContamination = regexp.MustCompile(`(?i)[/\\](?:api|ingress|proxy|hassio)[/\\]`)
 
 // IsContaminatedToolPath reports whether an external tool path looks like it was
 // contaminated by a reverse-proxy or ingress URL prefix. It is the single source
@@ -735,6 +742,10 @@ func isExecutableFile(path string) bool {
 // ValidateToolPath checks if a tool is available, either at an explicit path or in the system PATH.
 // It returns the validated path to the tool if found, or an empty string and an error otherwise.
 func ValidateToolPath(configuredPath, toolName string) (string, error) {
+	// pathForMessage is what we surface in logs and errors. It mirrors
+	// configuredPath except for a contaminated path, which is redacted because it
+	// can embed an ingress credential token.
+	pathForMessage := configuredPath
 	if configuredPath != "" {
 		switch {
 		case IsContaminatedToolPath(configuredPath):
@@ -742,9 +753,10 @@ func ValidateToolPath(configuredPath, toolName string) (string, error) {
 			// Assistant add-ons the supervisor can make a path like
 			// "/api/hassio_ingress/<token>/usr/bin/ffmpeg" stat-succeed even
 			// though it is not a usable executable, so the bad path would
-			// otherwise be stored in settings and fail on every invocation.
+			// otherwise be stored in settings and fail on every invocation. Do
+			// not log the path itself; it embeds a credential token.
+			pathForMessage = redactedToolPath
 			GetLogger().Warn("Configured tool path appears contaminated by a proxy/ingress prefix; ignoring it and checking system PATH",
-				logger.String("configured_path", configuredPath),
 				logger.String("tool", toolName))
 		case isExecutableFile(configuredPath):
 			// Ideally, we'd check execute permissions here, but os.Stat doesn't provide a cross-platform way.
@@ -767,7 +779,7 @@ func ValidateToolPath(configuredPath, toolName string) (string, error) {
 
 	// If not found in configured path or system PATH
 	if configuredPath != "" {
-		return "", fmt.Errorf("tool '%s' not found at configured path '%s' or in system PATH", toolName, configuredPath)
+		return "", fmt.Errorf("tool '%s' not found at configured path '%s' or in system PATH", toolName, pathForMessage)
 	}
 	return "", fmt.Errorf("tool '%s' not found in system PATH and no path configured", toolName)
 }

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -733,6 +733,18 @@ func IsContaminatedToolPath(path string) bool {
 	return rePathContamination.MatchString(path)
 }
 
+// RedactToolPath returns a representation of an external tool path that is safe to
+// put in logs, errors, or telemetry. A contaminated path (e.g. a Home Assistant
+// ingress path embedding a credential token) is replaced with a placeholder; a
+// clean path is returned unchanged. Use this anywhere a configured tool path is
+// surfaced to a sink that may reach Sentry or a support dump.
+func RedactToolPath(path string) string {
+	if IsContaminatedToolPath(path) {
+		return redactedToolPath
+	}
+	return path
+}
+
 // isExecutableFile reports whether path exists and is a regular (non-directory) file.
 func isExecutableFile(path string) bool {
 	info, err := os.Stat(path)
@@ -742,10 +754,9 @@ func isExecutableFile(path string) bool {
 // ValidateToolPath checks if a tool is available, either at an explicit path or in the system PATH.
 // It returns the validated path to the tool if found, or an empty string and an error otherwise.
 func ValidateToolPath(configuredPath, toolName string) (string, error) {
-	// pathForMessage is what we surface in logs and errors. It mirrors
-	// configuredPath except for a contaminated path, which is redacted because it
-	// can embed an ingress credential token.
-	pathForMessage := configuredPath
+	// pathForMessage is what we surface in logs and errors: the configured path,
+	// redacted if it is contaminated (it can embed an ingress credential token).
+	pathForMessage := RedactToolPath(configuredPath)
 	if configuredPath != "" {
 		switch {
 		case IsContaminatedToolPath(configuredPath):
@@ -753,9 +764,8 @@ func ValidateToolPath(configuredPath, toolName string) (string, error) {
 			// Assistant add-ons the supervisor can make a path like
 			// "/api/hassio_ingress/<token>/usr/bin/ffmpeg" stat-succeed even
 			// though it is not a usable executable, so the bad path would
-			// otherwise be stored in settings and fail on every invocation. Do
-			// not log the path itself; it embeds a credential token.
-			pathForMessage = redactedToolPath
+			// otherwise be stored in settings and fail on every invocation. The
+			// path itself is omitted here; it embeds a credential token.
 			GetLogger().Warn("Configured tool path appears contaminated by a proxy/ingress prefix; ignoring it and checking system PATH",
 				logger.String("tool", toolName))
 		case isExecutableFile(configuredPath):
@@ -766,7 +776,7 @@ func ValidateToolPath(configuredPath, toolName string) (string, error) {
 		default:
 			// If configured path is invalid, log a warning but still check PATH as a fallback
 			GetLogger().Warn("Configured tool path invalid or not found, checking system PATH",
-				logger.String("configured_path", configuredPath),
+				logger.String("configured_path", pathForMessage),
 				logger.String("tool", toolName))
 		}
 	}

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -708,21 +709,54 @@ func GetSoxFormats(soxPath string) []string {
 	return nil
 }
 
+// rePathContamination matches URL-like segments (e.g. "/api/", "/ingress/",
+// "/proxy/", "/hassio/") that indicate an external tool path has been
+// contaminated by a reverse-proxy or ingress prefix rather than being a clean
+// filesystem path. A real binary path on disk never contains these. Home
+// Assistant add-ons in particular can resolve a tool path to
+// "/api/hassio_ingress/<token>/usr/bin/ffmpeg", which is not a usable
+// executable and fails every invocation.
+var rePathContamination = regexp.MustCompile(`(?i)/(?:api|ingress|proxy|hassio)/`)
+
+// IsContaminatedToolPath reports whether an external tool path looks like it was
+// contaminated by a reverse-proxy or ingress URL prefix. It is the single source
+// of truth for this check, shared by configuration-time validation here and by
+// execution-time validation in the audiocore/ffmpeg package.
+func IsContaminatedToolPath(path string) bool {
+	return rePathContamination.MatchString(path)
+}
+
+// isExecutableFile reports whether path exists and is a regular (non-directory) file.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
 // ValidateToolPath checks if a tool is available, either at an explicit path or in the system PATH.
 // It returns the validated path to the tool if found, or an empty string and an error otherwise.
 func ValidateToolPath(configuredPath, toolName string) (string, error) {
 	if configuredPath != "" {
-		// Check if the explicitly configured path exists and is a file
-		if info, err := os.Stat(configuredPath); err == nil && !info.IsDir() {
+		switch {
+		case IsContaminatedToolPath(configuredPath):
+			// Reject contaminated paths BEFORE the os.Stat check: on Home
+			// Assistant add-ons the supervisor can make a path like
+			// "/api/hassio_ingress/<token>/usr/bin/ffmpeg" stat-succeed even
+			// though it is not a usable executable, so the bad path would
+			// otherwise be stored in settings and fail on every invocation.
+			GetLogger().Warn("Configured tool path appears contaminated by a proxy/ingress prefix; ignoring it and checking system PATH",
+				logger.String("configured_path", configuredPath),
+				logger.String("tool", toolName))
+		case isExecutableFile(configuredPath):
 			// Ideally, we'd check execute permissions here, but os.Stat doesn't provide a cross-platform way.
 			// We assume if it exists and isn't a directory, it's likely the executable.
 			// The actual execution will fail later if it's not executable.
 			return configuredPath, nil
+		default:
+			// If configured path is invalid, log a warning but still check PATH as a fallback
+			GetLogger().Warn("Configured tool path invalid or not found, checking system PATH",
+				logger.String("configured_path", configuredPath),
+				logger.String("tool", toolName))
 		}
-		// If configured path is invalid, log a warning but still check PATH as a fallback
-		GetLogger().Warn("Configured tool path invalid or not found, checking system PATH",
-			logger.String("configured_path", configuredPath),
-			logger.String("tool", toolName))
 	}
 
 	// If no configured path or the configured path was invalid, check the system PATH


### PR DESCRIPTION
## What

Three reliability fixes for BirdWeather soundscape/detection uploads.

### 1. HTTP/2 "client connection force closed via ClientConn.Close"

The upload client was a bare `&http.Client{Timeout: ...}` with no `Transport`, so it shared the global `http.DefaultTransport` connection pool. The BirdWeather API sits behind a CDN that silently drops idle connections; reusing a half-open pooled connection surfaced as `http2: client connection force closed via ClientConn.Close`, which accounted for a large, recurring share of upload failures.

Give the upload client its own transport (cloned from the default via `httpclient.CloneDefaultTransport`, so proxy support and dial timeouts are preserved) and enable HTTP/2 health-check PINGs (`ReadIdleTimeout` 15s, `PingTimeout` 5s) so a dead idle connection is detected and discarded instead of reused. This mirrors the existing `newSecureHTTPClient` pattern in the same package.

### 2. Data race in `Close()`

`Close()` set `b.HTTPClient = nil` while in-flight uploads read `b.HTTPClient` without holding the processor's `bwClientMutex` (they fetch the client via `GetBwClient` and release the lock before the upload runs). Stop nil-ing the field; `CloseIdleConnections` already frees pooled sockets, and the client is garbage-collected once the client is dropped from the processor. No code uses `HTTPClient == nil` as a sentinel (the `*BwClient` pointer is the sentinel).

### 3. FLAC encoding timeout too short for slow hardware

FLAC encoding runs two sequential FFmpeg passes (loudness analysis, then the gain-adjusted encode) under a single shared 30s budget, so on slow hardware (Raspberry Pi, Home Assistant add-ons) the analysis pass could starve the encode pass and time out. Raise `encodingTimeout` to 60s. Encoding runs in a background worker, so a slower encode does not block the analysis pipeline.

### Bonus: reject proxy/ingress-contaminated tool paths at config time

On Home Assistant add-ons the ffmpeg path can resolve to `/api/hassio_ingress/<token>/usr/bin/ffmpeg`, which only failed at encode time. The contamination check now lives in `conf.IsContaminatedToolPath`, shared by `conf.ValidateToolPath` (config-time) and the `audiocore/ffmpeg` validators (execution-time), so a bad path is rejected before it is stored in settings and falls back to the system PATH.

## Testing

- New `internal/birdweather/upload_transport_test.go` (dedicated-transport assertion + a `-race` test reproducing the `Close()` data race).
- New `internal/conf/tool_path_contamination_test.go` (contamination detector + config-time rejection regression test).
- Full `birdweather`, `audiocore/ffmpeg`, and `conf` suites pass under `-race`; `golangci-lint` clean on the touched packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened tool-path validation by detecting reverse-proxy/ingress-style contaminated paths and safely falling back to a valid executable.
  * Improved upload reliability by using a dedicated HTTP client/transport configuration and reducing shutdown-related interruption risk.
* **Tests**
  * Added regression coverage for tool-path contamination handling and for upload HTTP client creation and safe concurrent `Close()` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->