### PR TITLE
docs(wiki): link config reference and document schema regeneration

### DIFF
--- a/doc/wiki/building.md
+++ b/doc/wiki/building.md
@@ -126,3 +126,17 @@ If you prefer local development with automatic rebuilding and restarting on chan
     air
     ```
     `air` will use the configuration in [`.air.toml`](.air.toml) to watch files, recompile Tailwind CSS, rebuild the Go binary, and restart the server on changes.
+
+### 6. Regenerating Generated Documentation
+
+Some files are generated from source and must be regenerated when the underlying code changes:
+
+- `config.schema.json` (repo root) and [`configuration-reference.md`](configuration-reference.md) are generated from the `conf.Settings` struct by `task generate-schema`.
+
+After changing any struct field, `yaml` tag, or doc comment in `internal/conf` or `internal/logger`, run:
+
+```bash
+task generate-schema
+```
+
+and commit the regenerated files. This task is intentionally not part of the default `task build`, so it does not run automatically. The `TestSchemaUpToDate` test fails CI when the committed files are stale. It is skipped on Windows because the upstream comment parser is not reproducible there, so regenerate on Linux or macOS.

--- a/doc/wiki/index.md
+++ b/doc/wiki/index.md
@@ -58,6 +58,7 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 
 ## Reference
 
+- [Configuration Reference](configuration-reference.md) - Complete reference of every `config.yaml` setting with types and descriptions (auto-generated from source)
 - [Command Line Interface](BirdNET‐Go-Guide#command-line-interface) - Available commands and options
 - [Detection Pipeline Flow](BirdNET‐Go-Guide#birdnet-detection-pipeline) - How settings interact and affect detection results
 - [Range Filter Commands](BirdNET‐Go-Guide#inspection-and-debugging) - CLI commands for inspecting range filter results


### PR DESCRIPTION
Follow-up to #3613.

The auto-generated `doc/wiki/configuration-reference.md` from #3613 wasn't linked from anywhere, so users couldn't find it. This wires it up and documents the regeneration step for contributors.

## Changes
- **index.md**: link `configuration-reference.md` from the Reference section so the generated config reference is discoverable.
- **building.md**: add a "Regenerating Generated Documentation" section explaining that `config.schema.json` and `configuration-reference.md` are generated by `task generate-schema` and must be regenerated/committed after changing `internal/conf` or `internal/logger` structs. The task is intentionally not in the default build, and `TestSchemaUpToDate` fails CI on stale output (skipped on Windows, so regenerate on Linux/macOS).

Docs-only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on regenerating generated documentation after changing configuration-related definitions.
  * Clarified that the configuration reference is a complete, auto-generated list of all settings.
  * Added a link to the Configuration Reference in the documentation index.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->