### PR TITLE
fix(container): grant read perms to model .txt label and .bin data files

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -98,9 +98,11 @@ fi
 
 # Set read permissions for model files (only when running as root)
 if [ "$RUNNING_AS_ROOT" = true ]; then
-    find /data/models -type f \( -name '*.tflite' -o -name '*.onnx' -o -name '*.csv' \) -exec chmod a+r {} + 2>/dev/null || true
-    # Ensure directory is executable (browsable)
-    chmod a+x /data/models 2>/dev/null || true
+    find /data/models -type f \( -iname '*.tflite' -o -iname '*.onnx' -o -iname '*.csv' -o -iname '*.txt' -o -iname '*.bin' \) -exec chmod a+r {} + 2>/dev/null || true
+    # Ensure directories are browsable. Models live in per-model and shared/
+    # subdirectories, so make every directory (not just the top level)
+    # traversable, otherwise a non-root user cannot reach files in subdirs.
+    find /data/models -type d -exec chmod a+rx {} + 2>/dev/null || true
 fi
 
 # Check if user has custom model path configured via environment variable

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -98,11 +98,13 @@ fi
 
 # Set read permissions for model files (only when running as root)
 if [ "$RUNNING_AS_ROOT" = true ]; then
-    find /data/models -type f \( -iname '*.tflite' -o -iname '*.onnx' -o -iname '*.csv' -o -iname '*.txt' -o -iname '*.bin' \) -exec chmod a+r {} + 2>/dev/null || true
+    # Only chmod entries that actually lack the bits (the ! -perm guards), so a
+    # restart does not rewrite every model file on slow/NFS/read-only mounts.
+    find /data/models -type f \( -iname '*.tflite' -o -iname '*.onnx' -o -iname '*.csv' -o -iname '*.txt' -o -iname '*.bin' \) ! -perm -a+r -exec chmod a+r {} + 2>/dev/null || true
     # Ensure directories are browsable. Models live in per-model and shared/
     # subdirectories, so make every directory (not just the top level)
     # traversable, otherwise a non-root user cannot reach files in subdirs.
-    find /data/models -type d -exec chmod a+rx {} + 2>/dev/null || true
+    find /data/models -type d ! -perm -a+rx -exec chmod a+rx {} + 2>/dev/null || true
 fi
 
 # Check if user has custom model path configured via environment variable

--- a/Podman/entrypoint-podman.sh
+++ b/Podman/entrypoint-podman.sh
@@ -88,9 +88,11 @@ fi
 
 # Set read permissions for model files (only when running as root)
 if [ "$RUNNING_AS_ROOT" = true ]; then
-    find /data/models -type f \( -name '*.tflite' -o -name '*.onnx' -o -name '*.csv' \) -exec chmod a+r {} + 2>/dev/null || true
-    # Ensure directory is executable (browsable)
-    chmod a+x /data/models 2>/dev/null || true
+    find /data/models -type f \( -iname '*.tflite' -o -iname '*.onnx' -o -iname '*.csv' -o -iname '*.txt' -o -iname '*.bin' \) -exec chmod a+r {} + 2>/dev/null || true
+    # Ensure directories are browsable. Models live in per-model and shared/
+    # subdirectories, so make every directory (not just the top level)
+    # traversable, otherwise a non-root user cannot reach files in subdirs.
+    find /data/models -type d -exec chmod a+rx {} + 2>/dev/null || true
 fi
 
 # Check if user has custom model path configured via environment variable

--- a/Podman/entrypoint-podman.sh
+++ b/Podman/entrypoint-podman.sh
@@ -88,11 +88,13 @@ fi
 
 # Set read permissions for model files (only when running as root)
 if [ "$RUNNING_AS_ROOT" = true ]; then
-    find /data/models -type f \( -iname '*.tflite' -o -iname '*.onnx' -o -iname '*.csv' -o -iname '*.txt' -o -iname '*.bin' \) -exec chmod a+r {} + 2>/dev/null || true
+    # Only chmod entries that actually lack the bits (the ! -perm guards), so a
+    # restart does not rewrite every model file on slow/NFS/read-only mounts.
+    find /data/models -type f \( -iname '*.tflite' -o -iname '*.onnx' -o -iname '*.csv' -o -iname '*.txt' -o -iname '*.bin' \) ! -perm -a+r -exec chmod a+r {} + 2>/dev/null || true
     # Ensure directories are browsable. Models live in per-model and shared/
     # subdirectories, so make every directory (not just the top level)
     # traversable, otherwise a non-root user cannot reach files in subdirs.
-    find /data/models -type d -exec chmod a+rx {} + 2>/dev/null || true
+    find /data/models -type d ! -perm -a+rx -exec chmod a+rx {} + 2>/dev/null || true
 fi
 
 # Check if user has custom model path configured via environment variable


### PR DESCRIPTION
## What

The container entrypoints make downloaded model files world-readable so a non-root container (arbitrary UID, K8s `runAsNonRoot`, Podman rootless) can read them. The `find ... -exec chmod a+r` only covered `.tflite`, `.onnx`, and `.csv`, missing the companion `.txt` labels file and `.bin` data files.

Models that ship a `.txt` labels file (Perch v2, BirdNET v3.0, BSG Finland, BattyBirdNET) then crash-loop on startup with "permission denied" when the classifier reads its label file via `os.ReadFile` during model init. This was most visible on arm64 containers running Perch.

## Fix

Add `*.txt` (RoleLabels) and `*.bin` (RoleData) to the `find` pattern in both `Docker/entrypoint.sh` and `Podman/entrypoint-podman.sh`.

## Testing

- `bash -n` and `shellcheck -S warning` clean on both scripts.
- Confirmed these are the only two sites with this chmod pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model file access during startup by ensuring additional file types are readable in container environments.
  * Files with `.txt` and `.bin` extensions in the model directory are now included alongside existing supported formats.
  * Updated directory permissions under `/data/models` to ensure non-root users can traverse subdirectories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->