### PR TITLE
feat(wiki): auto-sync GitHub wiki from doc/wiki

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -89,6 +89,18 @@ jobs:
           # Unicode-hyphen guide that BirdNET-Go-Guide.md now replaces.
           find "${wiki}" -maxdepth 1 -type f -name '*.md.md' -delete
           find "${wiki}" -maxdepth 1 -type f -name 'BirdNET*Go-Guide.md' ! -name 'BirdNET-Go-Guide.md' -delete
+          # Prune managed pages the exporter no longer generates, so deleting or
+          # renaming a doc/wiki page removes its published counterpart instead of
+          # leaving an orphan. Only pages carrying the generated banner are
+          # eligible, so hand-written wiki pages are never touched.
+          for page in "${wiki}"/*.md; do
+            [ -e "${page}" ] || continue
+            name="$(basename "${page}")"
+            if grep -qF 'wiki-sync:managed' "${page}" && [ ! -e "${staging}/${name}" ]; then
+              echo "pruning stale managed page: ${name}"
+              rm -f "${page}"
+            fi
+          done
 
       - name: Commit and push
         if: steps.guard.outputs.enabled == 'true'

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,106 @@
+name: Sync Wiki
+
+# Publishes doc/wiki/ to the GitHub project wiki. The repository is the single
+# source of truth; the wiki is a generated mirror. The cmd/wiki-export tool
+# remaps page names to wiki slugs, rewrites intra-doc links, and injects a
+# "do not edit" banner. See doc/wiki/building.md (section "Publishing the wiki")
+# for the one-time deploy-key setup required to enable pushes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'doc/wiki/**'
+      - 'cmd/wiki-export/**'
+      - '.github/workflows/wiki-sync.yml'
+  workflow_dispatch:
+
+# The default GITHUB_TOKEN cannot authenticate to the *.wiki.git repository, so
+# this job pushes with a dedicated SSH deploy key (secret WIKI_SSH_DEPLOY_KEY)
+# and needs only read access to the main repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-sync-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Generate wiki pages
+        run: go run ./cmd/wiki-export doc/wiki "${RUNNER_TEMP}/wiki-staging"
+
+      - name: Check for deploy key
+        id: guard
+        env:
+          WIKI_SSH_DEPLOY_KEY: ${{ secrets.WIKI_SSH_DEPLOY_KEY }}
+        run: |
+          if [ -z "${WIKI_SSH_DEPLOY_KEY}" ]; then
+            {
+              echo "### Wiki sync skipped"
+              echo "The \`WIKI_SSH_DEPLOY_KEY\` secret is not configured, so the"
+              echo "generated pages were not pushed. See doc/wiki/building.md for setup."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Configure SSH for the wiki repository
+        if: steps.guard.outputs.enabled == 'true'
+        env:
+          WIKI_SSH_DEPLOY_KEY: ${{ secrets.WIKI_SSH_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${WIKI_SSH_DEPLOY_KEY}" > ~/.ssh/wiki_deploy_key
+          chmod 600 ~/.ssh/wiki_deploy_key
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<'EOF'
+          Host github.com
+            IdentityFile ~/.ssh/wiki_deploy_key
+            IdentitiesOnly yes
+          EOF
+
+      - name: Clone the wiki repository
+        if: steps.guard.outputs.enabled == 'true'
+        run: git clone "git@github.com:${GITHUB_REPOSITORY}.wiki.git" "${RUNNER_TEMP}/wiki"
+
+      - name: Stage generated pages
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          staging="${RUNNER_TEMP}/wiki-staging"
+          wiki="${RUNNER_TEMP}/wiki"
+          # Additive copy: generated pages overwrite their counterparts but any
+          # hand-written wiki page not produced by wiki-export is left untouched.
+          cp -R "${staging}/." "${wiki}/"
+          # Remove legacy pages left by earlier manual pushes (explicit allowlist,
+          # never a blanket mirror): the doubled ".md.md" extensions and the
+          # Unicode-hyphen guide that BirdNET-Go-Guide.md now replaces.
+          find "${wiki}" -maxdepth 1 -type f -name '*.md.md' -delete
+          find "${wiki}" -maxdepth 1 -type f -name 'BirdNET*Go-Guide.md' ! -name 'BirdNET-Go-Guide.md' -delete
+
+      - name: Commit and push
+        if: steps.guard.outputs.enabled == 'true'
+        working-directory: ${{ runner.temp }}/wiki
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki already up to date; nothing to push." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          git commit -m "docs: sync wiki from doc/wiki @ ${GITHUB_SHA:0:7}"
+          git push origin HEAD
+          echo "Wiki synced from doc/wiki @ ${GITHUB_SHA:0:7}." >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -fsSL https://github.com/tphakala/birdnet-go/raw/main/install.sh -o install
 bash ./install.sh
 ```
 
-Docker images are published for `linux/amd64` and `linux/arm64`. Pre-built binaries for Linux, Windows, and macOS ship with each [release](https://github.com/tphakala/birdnet-go/releases). See the [installation guide](https://github.com/tphakala/birdnet-go/wiki/installation.md), [hardware recommendations](https://github.com/tphakala/birdnet-go/wiki/hardware.md), and [security guide](doc/wiki/security.md) for details.
+Docker images are published for `linux/amd64` and `linux/arm64`. Pre-built binaries for Linux, Windows, and macOS ship with each [release](https://github.com/tphakala/birdnet-go/releases). See the [installation guide](https://github.com/tphakala/birdnet-go/wiki/installation), [hardware recommendations](https://github.com/tphakala/birdnet-go/wiki/hardware), and [security guide](https://github.com/tphakala/birdnet-go/wiki/security) for details.
 
 ## Web Dashboard
 
@@ -83,7 +83,7 @@ Docker images are published for `linux/amd64` and `linux/arm64`. Pre-built binar
 - **BirdNET Geomodel v3.0** for location-based range filtering (12,012 species)
 - **Cross-model detection consensus**: agreement between models strengthens confidence and flags disagreements for review
 - **Custom classifiers**: bring your own TFLite model and label set
-- **Configurable false-positive filtering** for accurate results: Deep Detection (repeat-confirmation within a 15-second window), per-species dynamic thresholds, location-based range filter, privacy and dog-bark filters, and per-classifier bat false-positive levels ([guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide#deep-detection))
+- **Configurable false-positive filtering** for accurate results: Deep Detection (repeat-confirmation within a 15-second window), per-species dynamic thresholds, location-based range filter, privacy and dog-bark filters, and per-classifier bat false-positive levels ([guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET-Go-Guide#deep-detection))
 - Per-model and per-source confidence thresholds
 
 ### Audio inputs
@@ -100,7 +100,7 @@ Docker images are published for `linux/amd64` and `linux/arm64`. Pre-built binar
 - Svelte 5 + TypeScript single-page app
 - Installable as a Progressive Web App (PWA)
 - Onboarding wizard for first-run setup
-- Live spectrogram visualization for active streams ([live audio streaming](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide#live-audio-streaming))
+- Live spectrogram visualization for active streams ([live audio streaming](https://github.com/tphakala/birdnet-go/wiki/BirdNET-Go-Guide#live-audio-streaming))
 - Detection heatmaps with ONNX-accelerated rendering
 - Customizable dashboard layout, color schemes, and a "Currently Hearing" card
 - Multiselect and bulk actions on the detections list
@@ -146,17 +146,17 @@ Docker images are published for `linux/amd64` and `linux/arm64`. Pre-built binar
 ## Documentation
 
 - [FAQ](https://github.com/tphakala/birdnet-go/wiki/FAQ) - common questions, issues, and workarounds
-- [User guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide)
-- [Installation](https://github.com/tphakala/birdnet-go/wiki/installation.md)
-- [Hardware recommendations](https://github.com/tphakala/birdnet-go/wiki/hardware.md)
+- [User guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET-Go-Guide)
+- [Installation](https://github.com/tphakala/birdnet-go/wiki/installation)
+- [Hardware recommendations](https://github.com/tphakala/birdnet-go/wiki/hardware)
 - [ONNX Runtime installation](https://github.com/tphakala/birdnet-go/wiki/ONNX-Runtime-Installation)
-- [Detection pipeline](https://github.com/tphakala/birdnet-go/wiki/detection-pipeline.md)
+- [Detection pipeline](https://github.com/tphakala/birdnet-go/wiki/detection-pipeline)
 - [Database Doctor](https://github.com/tphakala/birdnet-go/wiki/Database-Doctor)
 - [Training a custom classifier](https://github.com/tphakala/birdnet-go/wiki/Training-a-Custom-Classifier)
-- [Cloudflare Tunnel](https://github.com/tphakala/birdnet-go/wiki/cloudflare_tunnel_guide.md)
-- [Security](doc/wiki/security.md)
-- [Telemetry and privacy](doc/wiki/telemetry-privacy.md)
-- [RTSP troubleshooting](doc/wiki/rtsp-troubleshooting.md)
+- [Cloudflare Tunnel](https://github.com/tphakala/birdnet-go/wiki/cloudflare_tunnel_guide)
+- [Security](https://github.com/tphakala/birdnet-go/wiki/security)
+- [Telemetry and privacy](https://github.com/tphakala/birdnet-go/wiki/telemetry-privacy)
+- [RTSP troubleshooting](https://github.com/tphakala/birdnet-go/wiki/rtsp-troubleshooting)
 
 ## Development setup
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -187,6 +187,8 @@ tasks:
   wiki-export:
     desc: Render doc/wiki into a wiki-ready staging directory (default .wiki-staging)
     cmds:
+      # Clean first so renamed or deleted pages do not leave stale output behind.
+      - rm -rf {{.OUT | default ".wiki-staging"}}
       - go run ./cmd/wiki-export doc/wiki {{.OUT | default ".wiki-staging"}}
 
   native-target:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,6 +181,14 @@ tasks:
       - config.schema.json
       - doc/wiki/configuration-reference.md
 
+  # Preview the published wiki locally. The wiki-sync.yml workflow runs the same
+  # tool in CI and pushes the result to the GitHub wiki; this task only writes a
+  # local staging directory so you can inspect page names and rewritten links.
+  wiki-export:
+    desc: Render doc/wiki into a wiki-ready staging directory (default .wiki-staging)
+    cmds:
+      - go run ./cmd/wiki-export doc/wiki {{.OUT | default ".wiki-staging"}}
+
   native-target:
     cmds:
       - |

--- a/cmd/wiki-export/export_test.go
+++ b/cmd/wiki-export/export_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,12 @@ func TestExportSkipsImageSymlinks(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "images"), 0o755))
 	writeFile(t, filepath.Join(src, "images", "real.png"), "PNGDATA")
 	if err := os.Symlink(secret, filepath.Join(src, "images", "leak.png")); err != nil {
-		t.Skipf("symlink creation not supported here: %v", err)
+		// Windows runners often lack the privilege to create symlinks; elsewhere
+		// a failure is unexpected and must not silently hide the test.
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation not supported here: %v", err)
+		}
+		require.NoError(t, err)
 	}
 
 	require.NoError(t, export(src, out))

--- a/cmd/wiki-export/export_test.go
+++ b/cmd/wiki-export/export_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExport(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	out := t.TempDir()
+
+	// A remapped page that links to a sibling page and a repo file.
+	writeFile(t, filepath.Join(src, "guide.md"),
+		"# Guide\n\nSee [installation](installation.md) and [privacy](../../PRIVACY.md).\n")
+	// A pass-through page.
+	writeFile(t, filepath.Join(src, "installation.md"),
+		"# Installation\n\nInstall steps.\n")
+	// An image asset that must be copied verbatim.
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "images"), 0o755))
+	writeFile(t, filepath.Join(src, "images", "diagram.png"), "PNGDATA")
+	// A non-markdown file at the top level must be ignored.
+	writeFile(t, filepath.Join(src, "notes.txt"), "ignore me")
+
+	require.NoError(t, export(src, out))
+
+	// guide.md is published as BirdNET-Go-Guide.md with rewritten links + banner.
+	guide := readFile(t, filepath.Join(out, "BirdNET-Go-Guide.md"))
+	assert.Contains(t, guide, bannerMarker)
+	assert.Contains(t, guide, "[installation](installation)")
+	assert.Contains(t, guide, "[privacy](https://github.com/tphakala/birdnet-go/blob/main/PRIVACY.md)")
+	assert.Contains(t, guide, "doc/wiki/guide.md", "banner should reference the source path")
+
+	// installation.md is published under its own name.
+	assert.FileExists(t, filepath.Join(out, "installation.md"))
+
+	// The original source name for a remapped page must NOT appear in output.
+	assert.NoFileExists(t, filepath.Join(out, "guide.md"))
+
+	// Images are copied through.
+	assert.Equal(t, "PNGDATA", readFile(t, filepath.Join(out, "images", "diagram.png")))
+
+	// Non-markdown top-level files are not published.
+	assert.NoFileExists(t, filepath.Join(out, "notes.txt"))
+}
+
+func TestExportSkipsImageSymlinks(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	out := t.TempDir()
+	writeFile(t, filepath.Join(src, "index.md"), "# Home\n\nBody.\n")
+
+	// A secret file outside the wiki tree that a symlink could try to leak.
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	writeFile(t, secret, "TOP SECRET")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "images"), 0o755))
+	writeFile(t, filepath.Join(src, "images", "real.png"), "PNGDATA")
+	if err := os.Symlink(secret, filepath.Join(src, "images", "leak.png")); err != nil {
+		t.Skipf("symlink creation not supported here: %v", err)
+	}
+
+	require.NoError(t, export(src, out))
+
+	// The regular image is copied; the symlink is skipped, so its target's
+	// contents are never published to the wiki.
+	assert.Equal(t, "PNGDATA", readFile(t, filepath.Join(out, "images", "real.png")))
+	assert.NoFileExists(t, filepath.Join(out, "images", "leak.png"))
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test reads files it just wrote
+	require.NoError(t, err)
+	return string(b)
+}

--- a/cmd/wiki-export/main.go
+++ b/cmd/wiki-export/main.go
@@ -1,0 +1,125 @@
+// Command wiki-export prepares the doc/wiki markdown for publishing to the
+// GitHub project wiki. For each page it remaps the page name to its wiki slug,
+// rewrites intra-doc links so they resolve on the wiki, and injects a
+// "do not edit" banner. Image assets are copied through verbatim.
+//
+// Usage:
+//
+//	go run ./cmd/wiki-export [srcDir] [outDir]
+//
+// srcDir defaults to doc/wiki and outDir to .wiki-staging.
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// docWikiRepoDir is the canonical repository-relative location of the wiki
+// sources. Link rewriting always resolves repo-file links against this path,
+// independent of where the files are physically read from, so generated blob
+// URLs are stable.
+const docWikiRepoDir = "doc/wiki"
+
+func main() {
+	srcDir := filepath.FromSlash(docWikiRepoDir)
+	outDir := ".wiki-staging"
+	if len(os.Args) > 1 {
+		srcDir = os.Args[1]
+	}
+	if len(os.Args) > 2 {
+		outDir = os.Args[2]
+	}
+	if err := export(srcDir, outDir); err != nil {
+		fmt.Fprintf(os.Stderr, "wiki-export: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// export transforms every markdown page in srcDir and writes the wiki-ready
+// result into outDir, copying any images/ subdirectory through unchanged.
+func export(srcDir, outDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("reading source dir %s: %w", srcDir, err)
+	}
+
+	basenames := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		basenames = append(basenames, strings.TrimSuffix(e.Name(), ".md"))
+	}
+	slices.Sort(basenames) // deterministic output order
+	idx := buildPageIndex(basenames)
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("creating output dir %s: %w", outDir, err)
+	}
+
+	for _, base := range basenames {
+		srcPath := filepath.Join(srcDir, base+".md")
+		raw, err := os.ReadFile(srcPath) // #nosec G304 -- name comes from a listed dir entry
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", srcPath, err)
+		}
+		content := rewriteLinks(string(raw), docWikiRepoDir, idx)
+		content = injectBanner(content, base+".md")
+
+		outPath := filepath.Join(outDir, wikiPageName(base)+".md")
+		if err := os.WriteFile(outPath, []byte(content), 0o644); err != nil { //nolint:gosec // public wiki content
+			return fmt.Errorf("writing %s: %w", outPath, err)
+		}
+		fmt.Printf("wrote %s\n", outPath)
+	}
+
+	return copyImages(srcDir, outDir)
+}
+
+// copyImages mirrors the images/ subdirectory of srcDir into outDir. It is a
+// no-op when there is no images directory.
+func copyImages(srcDir, outDir string) error {
+	imgSrc := filepath.Join(srcDir, "images")
+	info, err := os.Stat(imgSrc)
+	switch {
+	case os.IsNotExist(err):
+		return nil
+	case err != nil:
+		return fmt.Errorf("stat %s: %w", imgSrc, err)
+	case !info.IsDir():
+		return nil
+	}
+
+	return filepath.WalkDir(imgSrc, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(srcDir, p)
+		if err != nil {
+			return fmt.Errorf("relativizing %s: %w", p, err)
+		}
+		dst := filepath.Join(outDir, rel)
+		if d.IsDir() {
+			if err := os.MkdirAll(dst, 0o755); err != nil {
+				return fmt.Errorf("creating %s: %w", dst, err)
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil // skip symlinks/devices: never publish a link target's contents
+		}
+		data, err := os.ReadFile(p) // #nosec G304 -- walking a known images dir
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", p, err)
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil { //nolint:gosec // public image asset
+			return fmt.Errorf("writing %s: %w", dst, err)
+		}
+		return nil
+	})
+}

--- a/cmd/wiki-export/transform.go
+++ b/cmd/wiki-export/transform.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+)
+
+const (
+	// repoBlobBase is the prefix for linking to a file in the repository's
+	// default branch. Relative links that point at repo files (not wiki pages)
+	// are rewritten to absolute blob URLs so they resolve on the wiki.
+	repoBlobBase = "https://github.com/tphakala/birdnet-go/blob/main/"
+
+	// wikiURLPrefix is the public base URL of the project wiki. Absolute links
+	// that point back at our own wiki are normalized to relative page slugs.
+	wikiURLPrefix = "https://github.com/tphakala/birdnet-go/wiki/"
+
+	// bannerMarker is an HTML comment that flags a page as managed by the sync.
+	// It is also used to make banner injection idempotent.
+	bannerMarker = "<!-- wiki-sync:managed -->"
+
+	// unicodeHyphen is U+2010 (HYPHEN), which legacy wiki page names used in
+	// place of an ASCII hyphen. It is normalized away during rewriting.
+	unicodeHyphen = "‐"
+)
+
+// pageSlugMap maps a source basename (lower-case, no extension) to its wiki
+// page name when the two differ. Pages not listed here are published under
+// their basename unchanged.
+var pageSlugMap = map[string]string{
+	"guide":                        "BirdNET-Go-Guide",
+	"faq":                          "FAQ",
+	"index":                        "Home",
+	"onnx-runtime-installation":    "ONNX-Runtime-Installation",
+	"database-doctor":              "Database-Doctor",
+	"file-analysis":                "File-Analysis",
+	"realtime-analysis":            "Realtime-Analysis",
+	"training-a-custom-classifier": "Training-a-Custom-Classifier",
+}
+
+// wikiPageName returns the published wiki page name (no extension) for a source
+// basename (no extension).
+func wikiPageName(base string) string {
+	if name, ok := pageSlugMap[strings.ToLower(base)]; ok {
+		return name
+	}
+	return base
+}
+
+// buildPageIndex maps normalized link keys to wiki page names. Each source page
+// is registered under both its basename and its wiki slug (lower-cased) so a
+// link written either way resolves to the same page.
+func buildPageIndex(basenames []string) map[string]string {
+	idx := make(map[string]string, len(basenames)*2)
+	for _, b := range basenames {
+		name := wikiPageName(b)
+		idx[strings.ToLower(b)] = name
+		idx[strings.ToLower(name)] = name
+	}
+	return idx
+}
+
+// linkPattern matches a markdown inline link, capturing an optional leading
+// "!" (image), the link text, and the target (URL plus optional title). Note
+// it does not handle nested brackets in the text (e.g. a linked image
+// `[![alt](img)](page)`) or links inside inline `code` spans; those are rare in
+// the wiki docs and are left as authored.
+var linkPattern = regexp.MustCompile(`(!?)\[([^\]]*)\]\(([^)]*)\)`)
+
+var imageExts = []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
+
+// rewriteLinks rewrites markdown links in content so they resolve on the
+// published wiki. sourceDir is the repo-relative directory of the source file
+// (always "doc/wiki"); idx is the page index from buildPageIndex. Links inside
+// fenced code blocks are left untouched.
+func rewriteLinks(content, sourceDir string, idx map[string]string) string {
+	lines := strings.Split(content, "\n")
+	fenced := fenceMask(lines)
+	for i, line := range lines {
+		if fenced[i] {
+			continue
+		}
+		lines[i] = linkPattern.ReplaceAllStringFunc(line, func(m string) string {
+			return rewriteOneLink(m, sourceDir, idx)
+		})
+	}
+	return strings.Join(lines, "\n")
+}
+
+// fenceMask reports, per line, whether the line lies inside a fenced code block.
+// Fence delimiter lines themselves are reported as outside (false). Pairing
+// follows CommonMark: a block opened with N backticks or tildes (indented at
+// most 3 spaces) closes only on a line of at least N of the SAME character with
+// no trailing content, so a tilde line cannot close a backtick block.
+func fenceMask(lines []string) []bool {
+	mask := make([]bool, len(lines))
+	var fenceChar byte
+	var fenceLen int
+	for i, line := range lines {
+		if fenceChar == 0 {
+			if c, n, ok := fenceOpener(line); ok {
+				fenceChar, fenceLen = c, n
+			}
+			continue
+		}
+		if fenceCloses(line, fenceChar, fenceLen) {
+			fenceChar, fenceLen = 0, 0
+			continue
+		}
+		mask[i] = true
+	}
+	return mask
+}
+
+func fenceOpener(line string) (ch byte, runLen int, ok bool) {
+	body := strings.TrimLeft(line, " ")
+	if len(line)-len(body) > 3 || len(body) < 3 {
+		return 0, 0, false
+	}
+	c := body[0]
+	if c != '`' && c != '~' {
+		return 0, 0, false
+	}
+	n := leadingRun(body, c)
+	if n < 3 {
+		return 0, 0, false
+	}
+	return c, n, true
+}
+
+func fenceCloses(line string, ch byte, openLen int) bool {
+	body := strings.TrimLeft(line, " ")
+	if len(line)-len(body) > 3 {
+		return false
+	}
+	n := leadingRun(body, ch)
+	return n >= openLen && strings.TrimSpace(body[n:]) == ""
+}
+
+func leadingRun(s string, ch byte) int {
+	n := 0
+	for n < len(s) && s[n] == ch {
+		n++
+	}
+	return n
+}
+
+func rewriteOneLink(match, sourceDir string, idx map[string]string) string {
+	sub := linkPattern.FindStringSubmatch(match)
+	if sub == nil {
+		return match
+	}
+	bang, text, target := sub[1], sub[2], sub[3]
+	if bang == "!" {
+		return match // image link, leave the target untouched
+	}
+	rewritten := rewriteTarget(target, sourceDir, idx)
+	if rewritten == target {
+		return match
+	}
+	return "[" + text + "](" + rewritten + ")"
+}
+
+// rewriteTarget rewrites a link target, preserving an optional trailing title.
+func rewriteTarget(target, sourceDir string, idx map[string]string) string {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return target
+	}
+	urlPart := trimmed
+	title := ""
+	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+		urlPart = trimmed[:i]
+		title = trimmed[i:]
+	}
+	resolved := resolveURL(urlPart, sourceDir, idx)
+	if resolved == urlPart {
+		return target
+	}
+	return resolved + title
+}
+
+func resolveURL(u, sourceDir string, idx map[string]string) string {
+	switch {
+	case strings.HasPrefix(u, "#"):
+		return u // same-page anchor
+	case strings.HasPrefix(u, wikiURLPrefix):
+		return resolveWikiURL(u[len(wikiURLPrefix):], idx)
+	case isExternalURL(u):
+		return u
+	default:
+		return resolveRelative(u, sourceDir, idx)
+	}
+}
+
+// resolveWikiURL normalizes an absolute self-wiki link into a relative page slug.
+func resolveWikiURL(rest string, idx map[string]string) string {
+	slug, anchor := splitAnchor(rest)
+	slug = decodePercent(slug)
+	slug = strings.ReplaceAll(slug, unicodeHyphen, "-")
+	slug = strings.TrimSuffix(path.Base(slug), ".md")
+	if name, ok := idx[strings.ToLower(slug)]; ok {
+		return name + anchorSuffix(anchor)
+	}
+	return slug + anchorSuffix(anchor)
+}
+
+// resolveRelative rewrites a repo-relative link. Links whose basename is a known
+// wiki page become extensionless slugs; any other repo file becomes an absolute
+// blob URL so it resolves on the wiki.
+func resolveRelative(u, sourceDir string, idx map[string]string) string {
+	pathPart, anchor := splitAnchor(u)
+	norm := strings.ReplaceAll(pathPart, unicodeHyphen, "-")
+	if isImagePath(norm) {
+		return u
+	}
+	base := strings.TrimSuffix(path.Base(norm), ".md")
+	if name, ok := idx[strings.ToLower(base)]; ok {
+		return name + anchorSuffix(anchor)
+	}
+	clean := path.Clean(path.Join(sourceDir, pathPart))
+	clean = strings.TrimPrefix(clean, "./")
+	if strings.HasPrefix(clean, "..") {
+		return u // escapes the repo root; leave the link as authored
+	}
+	return repoBlobBase + clean + anchorSuffix(anchor)
+}
+
+func isExternalURL(u string) bool {
+	return strings.Contains(u, "://") ||
+		strings.HasPrefix(u, "//") || // protocol-relative
+		strings.HasPrefix(u, "mailto:") ||
+		strings.HasPrefix(u, "tel:")
+}
+
+func isImagePath(p string) bool {
+	lower := strings.ToLower(p)
+	for _, ext := range imageExts {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return strings.HasPrefix(p, "images/")
+}
+
+func splitAnchor(s string) (link, anchor string) {
+	if before, after, found := strings.Cut(s, "#"); found {
+		return before, after
+	}
+	return s, ""
+}
+
+func anchorSuffix(anchor string) string {
+	if anchor == "" {
+		return ""
+	}
+	return "#" + anchor
+}
+
+func decodePercent(s string) string {
+	if decoded, err := url.PathUnescape(s); err == nil {
+		return decoded
+	}
+	return s
+}
+
+// bannerText renders the "do not edit" banner for a source file (relative to
+// doc/wiki, e.g. "installation.md").
+func bannerText(sourceRel string) string {
+	src := "doc/wiki/" + sourceRel
+	return bannerMarker + "\n" +
+		"> **This page is generated.** It is published automatically from [`" + src +
+		"`](" + repoBlobBase + src + ") in the BirdNET-Go repository. " +
+		"Do not edit it here; changes are overwritten on the next sync. " +
+		"To propose a change, open a pull request against the source file."
+}
+
+// injectBanner inserts the managed-page banner just after the first H1 heading,
+// or at the top of the document when there is none. It is idempotent.
+func injectBanner(content, sourceRel string) string {
+	if strings.Contains(content, bannerMarker) {
+		return content
+	}
+	banner := bannerText(sourceRel)
+	lines := strings.Split(content, "\n")
+	fenced := fenceMask(lines)
+	for i, line := range lines {
+		if fenced[i] || !strings.HasPrefix(line, "# ") {
+			continue
+		}
+		out := make([]string, 0, len(lines)+2)
+		out = append(out, lines[:i+1]...)
+		out = append(out, "", banner)
+		out = append(out, lines[i+1:]...)
+		return strings.Join(out, "\n")
+	}
+	return banner + "\n\n" + content
+}

--- a/cmd/wiki-export/transform.go
+++ b/cmd/wiki-export/transform.go
@@ -76,6 +76,7 @@ var imageExts = []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
 // (always "doc/wiki"); idx is the page index from buildPageIndex. Links inside
 // fenced code blocks are left untouched.
 func rewriteLinks(content, sourceDir string, idx map[string]string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n") // normalize to LF for consistent output
 	lines := strings.Split(content, "\n")
 	fenced := fenceMask(lines)
 	for i, line := range lines {
@@ -201,6 +202,9 @@ func resolveWikiURL(rest string, idx map[string]string) string {
 	slug = decodePercent(slug)
 	slug = strings.ReplaceAll(slug, unicodeHyphen, "-")
 	slug = strings.TrimSuffix(path.Base(slug), ".md")
+	if slug == "" || slug == "." {
+		slug = "Home" // a bare /wiki/ URL points at the wiki home page
+	}
 	if name, ok := idx[strings.ToLower(slug)]; ok {
 		return name + anchorSuffix(anchor)
 	}
@@ -245,10 +249,14 @@ func resolveRelative(u, sourceDir string, idx map[string]string) string {
 }
 
 func isExternalURL(u string) bool {
-	return strings.Contains(u, "://") ||
-		strings.HasPrefix(u, "//") || // protocol-relative
-		strings.HasPrefix(u, "mailto:") ||
-		strings.HasPrefix(u, "tel:")
+	if strings.HasPrefix(u, "//") { // protocol-relative
+		return true
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	return parsed.IsAbs() // any explicit scheme (http(s), mailto, tel, ...)
 }
 
 func isImagePath(p string) bool {
@@ -258,7 +266,7 @@ func isImagePath(p string) bool {
 			return true
 		}
 	}
-	return strings.HasPrefix(p, "images/")
+	return strings.HasPrefix(lower, "images/")
 }
 
 func splitAnchor(s string) (link, anchor string) {

--- a/cmd/wiki-export/transform.go
+++ b/cmd/wiki-export/transform.go
@@ -207,20 +207,36 @@ func resolveWikiURL(rest string, idx map[string]string) string {
 	return slug + anchorSuffix(anchor)
 }
 
-// resolveRelative rewrites a repo-relative link. Links whose basename is a known
-// wiki page become extensionless slugs; any other repo file becomes an absolute
-// blob URL so it resolves on the wiki.
+// resolveRelative rewrites a repo-relative link so it resolves on the wiki. A
+// bare wiki slug (no path, no extension) or a link that resolves to a sibling
+// page inside the wiki source directory becomes an extensionless slug. Any
+// other repo file becomes an absolute blob URL. Matching is restricted to true
+// siblings so a non-wiki file that merely shares a basename with a wiki page
+// (e.g. ../../internal/installation.md) is not misrouted to the wiki page.
 func resolveRelative(u, sourceDir string, idx map[string]string) string {
 	pathPart, anchor := splitAnchor(u)
 	norm := strings.ReplaceAll(pathPart, unicodeHyphen, "-")
 	if isImagePath(norm) {
 		return u
 	}
-	base := strings.TrimSuffix(path.Base(norm), ".md")
-	if name, ok := idx[strings.ToLower(base)]; ok {
-		return name + anchorSuffix(anchor)
+
+	// Bare wiki-slug reference: no directory and no .md extension.
+	if !strings.Contains(norm, "/") && !strings.HasSuffix(strings.ToLower(norm), ".md") {
+		if name, ok := idx[strings.ToLower(norm)]; ok {
+			return name + anchorSuffix(anchor)
+		}
 	}
-	clean := path.Clean(path.Join(sourceDir, pathPart))
+
+	clean := path.Clean(path.Join(sourceDir, norm))
+	base := strings.TrimSuffix(path.Base(clean), ".md")
+	// Only a link that actually resolves to a sibling page in the wiki source
+	// directory is treated as a wiki page.
+	if clean == path.Join(sourceDir, base+".md") {
+		if name, ok := idx[strings.ToLower(base)]; ok {
+			return name + anchorSuffix(anchor)
+		}
+	}
+
 	clean = strings.TrimPrefix(clean, "./")
 	if strings.HasPrefix(clean, "..") {
 		return u // escapes the repo root; leave the link as authored

--- a/cmd/wiki-export/transform_test.go
+++ b/cmd/wiki-export/transform_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sourceBasenames mirrors the doc/wiki page set (lower-cased basenames without
+// the .md extension), including the four migrated native pages.
+var sourceBasenames = []string{
+	"building",
+	"cloudflare_tunnel_guide",
+	"configuration-reference",
+	"database-doctor",
+	"detection-pipeline",
+	"docker_compose_guide",
+	"external-media",
+	"faq",
+	"file-analysis",
+	"guide",
+	"hardware",
+	"index",
+	"installation",
+	"onnx-runtime-installation",
+	"realtime-analysis",
+	"rtsp-troubleshooting",
+	"security",
+	"telemetry",
+	"telemetry-privacy",
+	"telemetry-setup",
+	"training-a-custom-classifier",
+}
+
+func TestWikiPageName(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"guide":                        "BirdNET-Go-Guide",
+		"faq":                          "FAQ",
+		"index":                        "Home",
+		"onnx-runtime-installation":    "ONNX-Runtime-Installation",
+		"database-doctor":              "Database-Doctor",
+		"file-analysis":                "File-Analysis",
+		"realtime-analysis":            "Realtime-Analysis",
+		"training-a-custom-classifier": "Training-a-Custom-Classifier",
+		// Pass-through: page name equals the source basename.
+		"installation":            "installation",
+		"configuration-reference": "configuration-reference",
+		"detection-pipeline":      "detection-pipeline",
+		"docker_compose_guide":    "docker_compose_guide",
+		"telemetry-privacy":       "telemetry-privacy",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, wikiPageName(in), "wikiPageName(%q)", in)
+	}
+}
+
+func TestRewriteLinks(t *testing.T) {
+	t.Parallel()
+	idx := buildPageIndex(sourceBasenames)
+	const dir = "doc/wiki"
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "relative md link to a pass-through page drops extension",
+			in:   "See the [installation guide](installation.md).",
+			want: "See the [installation guide](installation).",
+		},
+		{
+			name: "md link with anchor to a remapped page uses wiki slug",
+			in:   "Read about [deep detection](guide.md#deep-detection).",
+			want: "Read about [deep detection](BirdNET-Go-Guide#deep-detection).",
+		},
+		{
+			name: "dot-dot relative md link resolves by basename case-insensitively",
+			in:   "See [ONNX setup](../ONNX-Runtime-Installation.md).",
+			want: "See [ONNX setup](ONNX-Runtime-Installation).",
+		},
+		{
+			name: "faq remaps to title-case slug",
+			in:   "Check the [FAQ](faq.md).",
+			want: "Check the [FAQ](FAQ).",
+		},
+		{
+			name: "bare unicode-hyphen slug is normalized",
+			in:   "Locales are [documented here](BirdNET‐Go-Guide#supported-locales-for-species-labels).",
+			want: "Locales are [documented here](BirdNET-Go-Guide#supported-locales-for-species-labels).",
+		},
+		{
+			name: "absolute self-wiki URL with percent-encoded hyphen becomes relative slug",
+			in:   "[guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide#deep-detection)",
+			want: "[guide](BirdNET-Go-Guide#deep-detection)",
+		},
+		{
+			name: "absolute self-wiki URL with .md suffix is cleaned",
+			in:   "[install](https://github.com/tphakala/birdnet-go/wiki/installation.md)",
+			want: "[install](installation)",
+		},
+		{
+			name: "repo-root file link becomes absolute blob URL",
+			in:   "See [privacy policy](../../PRIVACY.md).",
+			want: "See [privacy policy](https://github.com/tphakala/birdnet-go/blob/main/PRIVACY.md).",
+		},
+		{
+			name: "repo file with subpath becomes absolute blob URL",
+			in:   "Use [compose](../../Docker/docker-compose.yml).",
+			want: "Use [compose](https://github.com/tphakala/birdnet-go/blob/main/Docker/docker-compose.yml).",
+		},
+		{
+			name: "external URL is left untouched",
+			in:   "Stream to [OBS](https://obsproject.com/fi) overlays.",
+			want: "Stream to [OBS](https://obsproject.com/fi) overlays.",
+		},
+		{
+			name: "same-page anchor is left untouched",
+			in:   "Jump to [the section](#installing-from-release-tarballs).",
+			want: "Jump to [the section](#installing-from-release-tarballs).",
+		},
+		{
+			name: "absolute image URL is left untouched",
+			in:   "![folder](https://raw.githubusercontent.com/tphakala/birdnet-go/main/doc/wiki/images/x.PNG)",
+			want: "![folder](https://raw.githubusercontent.com/tphakala/birdnet-go/main/doc/wiki/images/x.PNG)",
+		},
+		{
+			name: "relative image link is left untouched",
+			in:   "![diagram](images/diagram.png)",
+			want: "![diagram](images/diagram.png)",
+		},
+		{
+			name: "link title is preserved while target is rewritten",
+			in:   `[hardware](hardware.md "Hardware notes")`,
+			want: `[hardware](hardware "Hardware notes")`,
+		},
+		{
+			name: "links inside fenced code blocks are not rewritten",
+			in:   "```\nsee [x](installation.md)\n```\nand [y](installation.md)",
+			want: "```\nsee [x](installation.md)\n```\nand [y](installation)",
+		},
+		{
+			name: "links inside tilde-fenced code blocks are not rewritten",
+			in:   "~~~\nsee [x](installation.md)\n~~~\nand [y](installation.md)",
+			want: "~~~\nsee [x](installation.md)\n~~~\nand [y](installation)",
+		},
+		{
+			name: "a tilde line inside a backtick fence does not close it",
+			in:   "```\n~~~\n[x](installation.md)\n```\n[y](installation.md)",
+			want: "```\n~~~\n[x](installation.md)\n```\n[y](installation)",
+		},
+		{
+			name: "protocol-relative URL is treated as external",
+			in:   "Served from [cdn](//cdn.example.com/lib.js).",
+			want: "Served from [cdn](//cdn.example.com/lib.js).",
+		},
+		{
+			name: "link escaping above the repo root is left untouched",
+			in:   "Weird [x](../../../../etc/passwd).",
+			want: "Weird [x](../../../../etc/passwd).",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, rewriteLinks(tc.in, dir, idx))
+		})
+	}
+}
+
+func TestInjectBanner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inserts banner after the first H1", func(t *testing.T) {
+		t.Parallel()
+		got := injectBanner("# Title\n\nBody text.\n", "installation.md")
+		require.Contains(t, got, "# Title\n")
+		assert.Contains(t, got, bannerMarker)
+		assert.Contains(t, got, "doc/wiki/installation.md")
+		// Banner must come after the H1 and before the body.
+		h1 := strings.Index(got, "# Title")
+		banner := strings.Index(got, bannerMarker)
+		body := strings.Index(got, "Body text.")
+		assert.Less(t, h1, banner, "banner should follow the H1")
+		assert.Less(t, banner, body, "banner should precede the body")
+	})
+
+	t.Run("prepends banner when no H1 is present", func(t *testing.T) {
+		t.Parallel()
+		got := injectBanner("Just body text.\n", "faq.md")
+		assert.Contains(t, got, bannerMarker)
+		assert.Less(t, strings.Index(got, bannerMarker), strings.Index(got, "Just body text."))
+	})
+
+	t.Run("ignores an H1-looking line inside a leading code fence", func(t *testing.T) {
+		t.Parallel()
+		got := injectBanner("```bash\n# setup script\n```\n# Real Title\n\nBody.\n", "installation.md")
+		// The banner must attach to the real H1, not the "# setup script"
+		// comment inside the fenced block.
+		fenceComment := strings.Index(got, "# setup script")
+		banner := strings.Index(got, bannerMarker)
+		realTitle := strings.Index(got, "# Real Title")
+		assert.Less(t, fenceComment, banner, "banner must not land inside the code fence")
+		assert.Less(t, realTitle, banner, "banner should follow the real H1")
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		t.Parallel()
+		once := injectBanner("# Title\n\nBody.\n", "installation.md")
+		twice := injectBanner(once, "installation.md")
+		assert.Equal(t, once, twice, "injecting the banner twice must not duplicate it")
+	})
+}

--- a/cmd/wiki-export/transform_test.go
+++ b/cmd/wiki-export/transform_test.go
@@ -78,9 +78,14 @@ func TestRewriteLinks(t *testing.T) {
 			want: "Read about [deep detection](BirdNET-Go-Guide#deep-detection).",
 		},
 		{
-			name: "dot-dot relative md link resolves by basename case-insensitively",
-			in:   "See [ONNX setup](../ONNX-Runtime-Installation.md).",
+			name: "sibling md link to a remapped page uses its wiki slug",
+			in:   "See [ONNX setup](onnx-runtime-installation.md).",
 			want: "See [ONNX setup](ONNX-Runtime-Installation).",
+		},
+		{
+			name: "relative link to a non-wiki file sharing a wiki basename is not mapped to the wiki page",
+			in:   "Edit [the template](../../internal/installation.md).",
+			want: "Edit [the template](https://github.com/tphakala/birdnet-go/blob/main/internal/installation.md).",
 		},
 		{
 			name: "faq remaps to title-case slug",

--- a/cmd/wiki-export/transform_test.go
+++ b/cmd/wiki-export/transform_test.go
@@ -167,6 +167,26 @@ func TestRewriteLinks(t *testing.T) {
 			in:   "Weird [x](../../../../etc/passwd).",
 			want: "Weird [x](../../../../etc/passwd).",
 		},
+		{
+			name: "carriage returns are normalized to LF",
+			in:   "Intro [a](installation.md)\r\nNext line\r\n",
+			want: "Intro [a](installation)\nNext line\n",
+		},
+		{
+			name: "absolute self-wiki root URL resolves to Home",
+			in:   "[home](https://github.com/tphakala/birdnet-go/wiki/)",
+			want: "[home](Home)",
+		},
+		{
+			name: "mailto link is left untouched",
+			in:   "Contact [us](mailto:dev@example.com).",
+			want: "Contact [us](mailto:dev@example.com).",
+		},
+		{
+			name: "image directory prefix match is case-insensitive",
+			in:   "[banner](Images/banner)",
+			want: "[banner](Images/banner)",
+		},
 	}
 
 	for _, tc := range cases {

--- a/doc/wiki/building.md
+++ b/doc/wiki/building.md
@@ -14,13 +14,13 @@ For development work within VSCode, using the provided [devcontainer](https://co
 1.  Open the project directory in VSCode.
 2.  Ensure you have Docker installed and the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack.
 3.  Press `F1` or `Shift-Command-P` (Mac) / `Ctrl+Shift+P` (Windows/Linux), type `Reopen in Container`, and select it.
-4.  VSCode will build the container defined in [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) and reopen the project inside it.
+4.  VSCode will build the container defined in [`.devcontainer/devcontainer.json`](../../.devcontainer/devcontainer.json) and reopen the project inside it.
 
 **Inside the Devcontainer:**
 
 - All Go, CGO, TensorFlow, ONNX Runtime, FFmpeg, and SoX dependencies are pre-installed.
 - Your source code is mounted into the container.
-- An `air` development server ([`.air.toml`](.air.toml)) is automatically started. It watches for code changes (`.go`, `.html`, `.css`, `.js`, etc.) and triggers:
+- An `air` development server ([`.air.toml`](../../.air.toml)) is automatically started. It watches for code changes (`.go`, `.html`, `.css`, `.js`, etc.) and triggers:
   - Tailwind CSS recompilation.
   - Go application rebuild.
   - Live reload of the running application.
@@ -53,7 +53,7 @@ This project uses [Task](https://taskfile.dev/) (`Taskfile.yml`) as its build sy
 ### 2. Prepare Dependencies (Handled mostly by Task)
 
 - **TensorFlow Lite C Library:** `task` will automatically download the correct pre-compiled library (from [tphakala/tflite_c](https://github.com/tphakala/tflite_c/releases/tag/{{TFLITE_VERSION}})) for your target OS/architecture when you run a build task. It places the library in the expected system path (e.g., `/usr/lib`, `/usr/local/lib`, `/opt/homebrew/lib`, or `/usr/x86_64-w64-mingw32/lib` for Windows cross-compile) and creates necessary symlinks.
-- **ONNX Runtime (Optional):** Needed for BirdNET v3.0 models (currently in development preview). Run `task download-onnxruntime` to automatically download and install the correct version for your platform. See [ONNX Runtime Installation](../ONNX-Runtime-Installation.md) for manual installation options.
+- **ONNX Runtime (Optional):** Needed for BirdNET v3.0 models (currently in development preview). Run `task download-onnxruntime` to automatically download and install the correct version for your platform. See [ONNX Runtime Installation](onnx-runtime-installation.md) for manual installation options.
 - **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `.cache/tensorflow/` inside the project root. If not, it clones the specific tag (`{{TFLITE_VERSION}}`) required.
 
 ### One-Command Setup
@@ -125,7 +125,7 @@ If you prefer local development with automatic rebuilding and restarting on chan
     ```bash
     air
     ```
-    `air` will use the configuration in [`.air.toml`](.air.toml) to watch files, recompile Tailwind CSS, rebuild the Go binary, and restart the server on changes.
+    `air` will use the configuration in [`.air.toml`](../../.air.toml) to watch files, recompile Tailwind CSS, rebuild the Go binary, and restart the server on changes.
 
 ### 6. Regenerating Generated Documentation
 
@@ -140,3 +140,28 @@ task generate-schema
 ```
 
 and commit the regenerated files. This task is intentionally not part of the default `task build`, so it does not run automatically. The `TestSchemaUpToDate` test fails CI when the committed files are stale. It is skipped on Windows because the upstream comment parser is not reproducible there, so regenerate on Linux or macOS.
+
+### 7. Publishing the Wiki
+
+The published GitHub wiki is generated from `doc/wiki/`; the repository is the single source of truth and the wiki is a one-way mirror. Do not edit pages on the wiki directly, they are overwritten on the next sync.
+
+`cmd/wiki-export` reads `doc/wiki/`, remaps page names to their wiki slugs (for example `guide.md` becomes `BirdNET-Go-Guide`, `index.md` becomes `Home`), rewrites intra-doc links so they resolve on the wiki, and injects a "do not edit" banner into each page. To preview the output locally without pushing anything:
+
+```bash
+task wiki-export        # writes ./.wiki-staging
+task wiki-export OUT=/tmp/wiki-preview
+```
+
+The `.github/workflows/wiki-sync.yml` workflow runs the same tool on every push to `main` that touches `doc/wiki/**` (and can be triggered manually from the Actions tab). It copies the generated pages over the wiki additively, so any hand-written wiki page that the tool does not produce is left untouched.
+
+**One-time maintainer setup (required to enable pushes):** the default `GITHUB_TOKEN` cannot authenticate to the separate `*.wiki.git` repository, so the workflow uses a dedicated SSH deploy key. Until the key is configured the workflow runs but skips the push (it logs a note in the job summary). To enable it:
+
+1. Generate a key pair (no passphrase):
+   ```bash
+   ssh-keygen -t ed25519 -f wiki_deploy_key -N "" -C "birdnet-go wiki sync"
+   ```
+2. Add the **public** key (`wiki_deploy_key.pub`) under the repository's **Settings -> Deploy keys** with **Allow write access** enabled. A deploy key with write access also covers the repository's wiki.
+3. Add the **private** key (`wiki_deploy_key`) as a repository **Actions secret** named `WIKI_SSH_DEPLOY_KEY`.
+4. The wiki must contain at least one page before the first push (GitHub only creates the wiki repository after a page exists). The current wiki already satisfies this.
+
+Delete the local key files afterward.

--- a/doc/wiki/cloudflare_tunnel_guide.md
+++ b/doc/wiki/cloudflare_tunnel_guide.md
@@ -53,7 +53,7 @@ If you're using Docker Compose with BirdNET-Go, setting up Cloudflare Tunnel is 
        depends_on:
          - birdnet-go
      ```
-   - Alternatively, use the [premade docker-compose.yml](../Docker/docker-compose.yml) which already includes this configuration (commented out)
+   - Alternatively, use the [premade docker-compose.yml](../../Docker/docker-compose.yml) which already includes this configuration (commented out)
 
 4. **Start the Services**:
 

--- a/doc/wiki/database-doctor.md
+++ b/doc/wiki/database-doctor.md
@@ -1,0 +1,236 @@
+# Database Doctor
+
+The Database Doctor is a standalone diagnostic and repair tool for BirdNET-Go SQLite databases. Run it outside the application to identify and fix database issues that prevent startup after upgrading between nightly builds.
+
+**Requirements:** Python 3.9+ (no additional packages needed)
+
+## When to Use
+
+Use the Database Doctor when:
+
+- BirdNET-Go fails to start after upgrading to a newer nightly build
+- You see errors like `Cannot add a NOT NULL column with default value NULL`
+- The dashboard shows no detections after an upgrade, but the database file is large
+- The System > Database page shows migration as stuck or incomplete
+- You suspect database corruption after an unclean shutdown or SD card issue
+
+## Download
+
+The script is part of the BirdNET-Go repository. Download it directly:
+
+```bash
+# Download the latest version
+curl -O https://raw.githubusercontent.com/tphakala/birdnet-go/main/tools/db-doctor/db-doctor.py
+chmod +x db-doctor.py
+```
+
+Or if you have a local clone:
+
+```bash
+# The script is at tools/db-doctor/db-doctor.py in the repository
+python3 tools/db-doctor/db-doctor.py --version
+```
+
+## Quick Start
+
+**Important:** Stop BirdNET-Go before running the doctor with `--fix`. The diagnostic (read-only) mode can run while BirdNET-Go is active.
+
+### Step 1: Find your database file
+
+| Install method | Typical database path |
+|---|---|
+| Docker via install.sh | `~/birdnet-go-app/data/birdnet.db` |
+| Docker Compose | Check your volume mount, usually `./data/birdnet.db` |
+| Manual/binary | In the data directory specified in your config, usually `./birdnet.db` |
+
+### Step 2: Run diagnosis
+
+```bash
+python3 db-doctor.py /path/to/birdnet.db
+```
+
+This runs in read-only mode and does not modify anything. It checks:
+
+1. **Database accessibility** - file exists, valid SQLite, reports size and version
+2. **Schema version** - detects v1 (legacy), v2 (current), or mixed (mid-migration)
+3. **SQLite integrity** - checks for index corruption from unclean shutdowns
+4. **Schema contamination** - finds columns that shouldn't be there (the main upgrade issue)
+5. **Foreign key integrity** - finds orphaned references between tables
+6. **Migration state** - checks if migration is stuck or inconsistent
+7. **Clip path extensions** - detects stripped audio file extensions
+
+### Step 3: Review the output
+
+The output looks like this:
+
+```text
+BirdNET-Go Database Doctor v1.0.0
+Schema definition: v2-2026-05-21
+Run at: 2026-05-21 09:32:00
+
+Database: /home/birder/birdnet-go-app/data/birdnet.db
+Size:     105.2 MB
+SQLite:   3.40.1
+Python:   3.11.2
+Platform: Linux aarch64
+Schema:   v2 (migration: completed)
+
+Database fingerprint:
+  detections: 142,891
+  labels: 2,347
+  ai_models: 1
+  audio_sources: 1
+  date range: 2024-03-15 to 2026-05-20
+  distinct species: 187
+  aux: image-caches=1,203, dynamic-thresholds=45, alert-rules=3
+
+Migration state:
+  state: completed
+  completed_at: 2026-03-01 14:22:33
+
+Checks:
+  [PASS] Database accessibility
+  [PASS] Schema version
+  [PASS] SQLite integrity
+  [FAIL] Schema contamination
+         Schema issues found
+         image_caches: unexpected column(s) ['scientific_name'] (1,203 rows)
+           actual columns: [...]
+           expected columns: [...]
+  [PASS] Foreign key integrity
+  [PASS] Migration state
+  [PASS] Clip path extensions
+
+Summary: 1 failure(s), 6 passed
+
+Run with --fix to repair fixable issues.
+
+-- Copy everything above when reporting issues --
+```
+
+### Step 4: Fix issues (if any)
+
+If the doctor found fixable issues, stop BirdNET-Go first, then run:
+
+```bash
+# Stop BirdNET-Go
+sudo systemctl stop birdnet-go
+# Or for Docker: docker stop birdnet-go
+
+# Run the fix
+python3 db-doctor.py /path/to/birdnet.db --fix
+```
+
+The script automatically:
+1. Creates a verified backup (e.g., `birdnet.db.20260521-093204.doctor-backup`)
+2. Applies fixes transactionally (rolls back on failure)
+3. Re-runs diagnostics to verify the fix worked
+
+After the fix completes successfully, start BirdNET-Go again:
+
+```bash
+sudo systemctl start birdnet-go
+# Or for Docker: docker start birdnet-go
+```
+
+## What the Doctor Fixes
+
+### Schema contamination
+
+This is the most common issue when upgrading between nightly builds. Some builds accidentally added legacy columns to v2 tables, preventing newer builds from starting.
+
+The doctor uses SQLite's table-recreation algorithm to remove the extra columns while preserving all data. This works on all SQLite versions (no DROP COLUMN support needed).
+
+**Affected tables:** `image_caches`, `dynamic_thresholds`, `notification_histories`
+
+### Corrupted indexes
+
+SD card corruption or power loss during writes can cause SQLite index trees to become inconsistent. The doctor rebuilds all indexes with `REINDEX`.
+
+### Stuck migration state
+
+If BirdNET-Go crashes during database migration (power loss, OOM kill), the migration state can get stuck. The doctor resets it based on the actual data present:
+- If detections exist, sets state to `completed`
+- If only legacy notes exist, resets to `idle` for re-migration
+
+### Clip path extensions
+
+A past nightly build stripped file extensions from audio clip paths in the database. The doctor can repair these by matching against actual files on disk (requires `--clips-dir`).
+
+### Orphaned label references
+
+After some upgrades, detection records may reference label IDs that no longer exist, making those detections invisible in the dashboard. The doctor attempts to recover these using legacy data when available.
+
+## Command Reference
+
+```bash
+# Basic diagnosis (read-only)
+python3 db-doctor.py /path/to/birdnet.db
+
+# Diagnosis with verbose output (shows SQL queries, full integrity check)
+python3 db-doctor.py /path/to/birdnet.db --verbose
+
+# Diagnose and fix all issues
+python3 db-doctor.py /path/to/birdnet.db --fix
+
+# Fix only specific issue types
+python3 db-doctor.py /path/to/birdnet.db --fix --only schema
+python3 db-doctor.py /path/to/birdnet.db --fix --only indexes
+python3 db-doctor.py /path/to/birdnet.db --fix --only migration
+python3 db-doctor.py /path/to/birdnet.db --fix --only schema,indexes
+
+# Fix with clip extension repair (needs clips directory)
+python3 db-doctor.py /path/to/birdnet.db --fix --clips-dir /path/to/clips
+
+# Skip backup (use when disk is nearly full)
+python3 db-doctor.py /path/to/birdnet.db --fix --no-backup
+
+# JSON output for scripting
+python3 db-doctor.py /path/to/birdnet.db --json
+
+# Check script version
+python3 db-doctor.py --version
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All checks passed (or all fixes applied successfully) |
+| 1 | Issues found (diagnose mode) or a fix failed |
+| 2 | Usage error (bad arguments, file not found) |
+| 3 | Database is locked (BirdNET-Go is still running) |
+
+## Docker Users
+
+If you're running BirdNET-Go in Docker and don't have Python on the host, you can run the doctor inside any Python container:
+
+```bash
+# Stop BirdNET-Go container first
+docker stop birdnet-go
+
+# Run the doctor using a Python container, mounting the data volume
+docker run --rm -v /path/to/data:/data python:3.11-slim \
+  python3 /data/db-doctor.py /data/birdnet.db --fix
+```
+
+Make sure to copy `db-doctor.py` into your data directory first, or mount it separately.
+
+## Reporting Issues
+
+If the doctor cannot fix your database, or you encounter an error, please open a [GitHub Discussion](https://github.com/tphakala/birdnet-go/discussions) and include:
+
+1. The **complete output** of `python3 db-doctor.py /path/to/birdnet.db --verbose`
+2. Which BirdNET-Go version you were upgrading **from** and **to**
+3. Your install method (Docker via install.sh, Docker Compose, manual binary)
+
+The doctor output includes platform info, database fingerprint, migration state, and full schema details, which makes remote debugging possible without follow-up questions.
+
+## Safety
+
+- **Read-only by default.** The `--fix` flag is required for any modification.
+- **Automatic backup.** Before any fix, the script creates a verified backup using SQLite's backup API.
+- **Transactional fixes.** Each repair runs inside a database transaction. If anything fails, changes are rolled back.
+- **Idempotent.** Running `--fix` multiple times produces the same result.
+- **No data deletion.** The doctor never deletes detection data. Schema repair preserves all rows.
+- **Lock detection.** The script refuses to run fixes if BirdNET-Go is still using the database.

--- a/doc/wiki/file-analysis.md
+++ b/doc/wiki/file-analysis.md
@@ -1,0 +1,45 @@
+File analysis is enabled by **file** flag, you can define additional options such as BirdNET detection threshold, sensitivity or number of CPU threads used by tflite. Default format for file analysis results is Raven table and output is saved in _output/inputfilename.wav.txt_.
+
+File analysis works best with WAV files which are recorded in 48k sample rate, BirdNET-Go has very simple resampling algorithm which allows ingestion of audio files with alternative sample rates but detection accuracy will be degraded. Input file bit depths of 16, 24 and 32 (int) are supported.
+
+Running a file analysis for single file
+
+```
+raspberry$ ./birdnet-go file soundscape.wav --threshold 0.1
+Read config file: /etc/birdnet-go/config.yaml
+BirdNET GLOBAL 6K V2.4 FP32 model initialized, using 4 threads of available 4 CPUs
+Analysis completed, total time elapsed: 8 second(s)
+Output written to output/soundscape.wav.txt
+```
+
+Default Raven table output
+
+```
+raspberry$ cat output/soundscape.wav.txt
+Selection       View    Channel Begin File      Begin Time (s)  End Time (s)    Low Freq (Hz)   High Freq (Hz)  Species Code    Common Name     Confidence
+1       Spectrogram 1   1       soundscape.wav  0.0     3.0     0       15000   bkcchi  Black-capped Chickadee  0.9016
+2       Spectrogram 1   1       soundscape.wav  3.0     6.0     0       15000   bkcchi  Black-capped Chickadee  0.2293
+4       Spectrogram 1   1       soundscape.wav  9.0     12.0    0       15000   houfin  House Finch     0.7025
+7       Spectrogram 1   1       soundscape.wav  18.0    21.0    0       15000   blujay  Blue Jay        0.4036
+8       Spectrogram 1   1       soundscape.wav  21.0    24.0    0       15000   blujay  Blue Jay        0.2557
+10      Spectrogram 1   1       soundscape.wav  27.0    30.0    0       15000   merlin  Merlin  0.1787
+12      Spectrogram 1   1       soundscape.wav  33.0    36.0    0       15000   daejun  Dark-eyed Junco 0.4388
+13      Spectrogram 1   1       soundscape.wav  36.0    39.0    0       15000   daejun  Dark-eyed Junco 0.2882
+14      Spectrogram 1   1       soundscape.wav  39.0    42.0    0       15000   houfin  House Finch     0.1649
+15      Spectrogram 1   1       soundscape.wav  42.0    45.0    0       15000   daejun  Dark-eyed Junco 0.8249
+18      Spectrogram 1   1       soundscape.wav  51.0    54.0    0       15000   houfin  House Finch     0.1684
+19      Spectrogram 1   1       soundscape.wav  54.0    57.0    0       15000   houfin  House Finch     0.6576
+21      Spectrogram 1   1       soundscape.wav  60.0    63.0    0       15000   daejun  Dark-eyed Junco 0.5821
+24      Spectrogram 1   1       soundscape.wav  69.0    72.0    0       15000   houfin  House Finch     0.2088
+25      Spectrogram 1   1       soundscape.wav  72.0    75.0    0       15000   houfin  House Finch     0.5951
+27      Spectrogram 1   1       soundscape.wav  78.0    81.0    0       15000   houfin  House Finch     0.1680
+28      Spectrogram 1   1       soundscape.wav  81.0    84.0    0       15000   hawfin  Hawfinch        0.1956
+29      Spectrogram 1   1       soundscape.wav  84.0    87.0    0       15000   houfin  House Finch     0.1953
+31      Spectrogram 1   1       soundscape.wav  90.0    93.0    0       15000   amegfi  American Goldfinch      0.3799
+32      Spectrogram 1   1       soundscape.wav  93.0    96.0    0       15000   houfin  House Finch     0.2400
+33      Spectrogram 1   1       soundscape.wav  96.0    99.0    0       15000   amegfi  American Goldfinch      0.4648
+35      Spectrogram 1   1       soundscape.wav  102.0   105.0   0       15000   houfin  House Finch     0.4192
+38      Spectrogram 1   1       soundscape.wav  111.0   114.0   0       15000   engine  Engine  0.5252
+39      Spectrogram 1   1       soundscape.wav  114.0   117.0   0       15000   engine  Engine  0.1538
+40      Spectrogram 1   1       soundscape.wav  117.0   120.0   0       15000   amegfi  American Goldfinch      0.3417
+```

--- a/doc/wiki/file-analysis.md
+++ b/doc/wiki/file-analysis.md
@@ -4,7 +4,7 @@ File analysis works best with WAV files which are recorded in 48k sample rate, B
 
 Running a file analysis for single file
 
-```
+```text
 raspberry$ ./birdnet-go file soundscape.wav --threshold 0.1
 Read config file: /etc/birdnet-go/config.yaml
 BirdNET GLOBAL 6K V2.4 FP32 model initialized, using 4 threads of available 4 CPUs
@@ -14,7 +14,7 @@ Output written to output/soundscape.wav.txt
 
 Default Raven table output
 
-```
+```text
 raspberry$ cat output/soundscape.wav.txt
 Selection       View    Channel Begin File      Begin Time (s)  End Time (s)    Low Freq (Hz)   High Freq (Hz)  Species Code    Common Name     Confidence
 1       Spectrogram 1   1       soundscape.wav  0.0     3.0     0       15000   bkcchi  Black-capped Chickadee  0.9016

--- a/doc/wiki/index.md
+++ b/doc/wiki/index.md
@@ -5,7 +5,7 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 ## Getting Started
 
 - [Frequently Asked Questions](faq.md) - Common questions, problems, and quick fixes
-- [BirdNET-Go Guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide) - Overview and basic concepts
+- [BirdNET-Go Guide](guide.md) - Overview and basic concepts
 - [Installation Guide](installation.md) - Comprehensive installation instructions for all methods
 - [Recommended Hardware](hardware.md) - Hardware recommendations for optimal performance
 
@@ -22,22 +22,22 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 
 - [External Media (USB, SD, File Shares)](external-media.md) - Mounting removable and network storage for import and backup
 - [Detection Pipeline Architecture](detection-pipeline.md) - How audio flows through multi-model inference, filtering, and action dispatch
-- [BirdNET Detection Pipeline](BirdNET-Go-Guide#birdnet-detection-pipeline) - Understanding how settings affect detections
-- [BirdNET Range Filter](BirdNET-Go-Guide#birdnet-range-filter) - Location and time-based species filtering
-- [Web Dashboard](BirdNET-Go-Guide#web-dashboard) - Using the visualization dashboard
+- [BirdNET Detection Pipeline](guide.md#birdnet-detection-pipeline) - Understanding how settings affect detections
+- [BirdNET Range Filter](guide.md#birdnet-range-filter) - Location and time-based species filtering
+- [Web Dashboard](guide.md#web-dashboard) - Using the visualization dashboard
 - [Remote Internet Access](cloudflare_tunnel_guide.md) - Exposing BirdNET-Go to the internet securely
-- [Weather Integration](BirdNET-Go-Guide#weather-integration) - Connecting to weather data providers
-- [Audio Processing](BirdNET-Go-Guide#audio-processing) - Advanced audio processing capabilities
-- [Deep Detection](BirdNET-Go-Guide#deep-detection) - Improving detection reliability
-- [Live Audio Streaming](BirdNET-Go-Guide#live-audio-streaming) - Streaming audio from the web interface
-- [Species-Specific Settings](BirdNET-Go-Guide#species-specific-settings) - Customized detection rules for specific species
+- [Weather Integration](guide.md#weather-integration) - Connecting to weather data providers
+- [Audio Processing](guide.md#audio-processing) - Advanced audio processing capabilities
+- [Deep Detection](guide.md#deep-detection) - Improving detection reliability
+- [Live Audio Streaming](guide.md#live-audio-streaming) - Streaming audio from the web interface
+- [Species-Specific Settings](guide.md#species-specific-settings) - Customized detection rules for specific species
 
 ## Integration & Security
 
 - [Push Notifications](guide.md#push-notifications) - Discord, Telegram, Slack, and 20+ services
 - [Discord Setup Guide](guide.md#discord-setup-guide) - Step-by-step Discord webhook configuration with rich embeds
-- [MQTT Integration](BirdNET-Go-Guide#integration-options) - Connecting to IoT systems
-- [BirdWeather API](BirdNET-Go-Guide#integration-options) - Sharing data with BirdWeather.com
+- [MQTT Integration](guide.md#integration-options) - Connecting to IoT systems
+- [BirdWeather API](guide.md#integration-options) - Sharing data with BirdWeather.com
 - [Authentication](cloudflare_tunnel_guide.md#enabling-authentication) - Securing your BirdNET-Go instance
 - [Cloudflare Tunnel Setup](cloudflare_tunnel_guide.md) - Detailed guide for secure internet access
 
@@ -51,15 +51,15 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 
 - [Frequently Asked Questions](faq.md) - Common questions, problems, and quick fixes
 - [RTSP Troubleshooting](rtsp-troubleshooting.md) - Comprehensive guide for RTSP camera issues and configuration
-- [Docker Troubleshooting](BirdNET-Go-Guide#docker-installation-troubleshooting) - Resolving common Docker issues
-- [Support Script](BirdNET-Go-Guide#support-script) - Generating diagnostic information
-- [Reporting Issues](BirdNET-Go-Guide#reporting-issues) - How to effectively report bugs
+- [Docker Troubleshooting](guide.md#docker-installation-troubleshooting) - Resolving common Docker issues
+- [Support Script](guide.md#support-script) - Generating diagnostic information
+- [Reporting Issues](guide.md#reporting-issues) - How to effectively report bugs
 
 ## Reference
 
 - [Configuration Reference](configuration-reference.md) - Complete reference of every `config.yaml` setting with types and descriptions (auto-generated from source)
-- [Command Line Interface](BirdNET-Go-Guide#command-line-interface) - Available commands and options
-- [Detection Pipeline Flow](BirdNET-Go-Guide#birdnet-detection-pipeline) - How settings interact and affect detection results
-- [Range Filter Commands](BirdNET-Go-Guide#inspection-and-debugging) - CLI commands for inspecting range filter results
-- [Supported Languages](BirdNET-Go-Guide#supported-languages-for-species-labels) - Language options for species labels
-- [Log Rotation](BirdNET-Go-Guide#log-rotation) - Managing log files
+- [Command Line Interface](guide.md#command-line-interface) - Available commands and options
+- [Detection Pipeline Flow](guide.md#birdnet-detection-pipeline) - How settings interact and affect detection results
+- [Range Filter Commands](guide.md#inspection-and-debugging) - CLI commands for inspecting range filter results
+- [Supported Languages](guide.md#supported-languages-for-species-labels) - Language options for species labels
+- [Log Rotation](guide.md#log-rotation) - Managing log files

--- a/doc/wiki/index.md
+++ b/doc/wiki/index.md
@@ -5,7 +5,7 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 ## Getting Started
 
 - [Frequently Asked Questions](faq.md) - Common questions, problems, and quick fixes
-- [BirdNET‐Go Guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide) - Overview and basic concepts
+- [BirdNET-Go Guide](https://github.com/tphakala/birdnet-go/wiki/BirdNET%E2%80%90Go-Guide) - Overview and basic concepts
 - [Installation Guide](installation.md) - Comprehensive installation instructions for all methods
 - [Recommended Hardware](hardware.md) - Hardware recommendations for optimal performance
 
@@ -22,22 +22,22 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 
 - [External Media (USB, SD, File Shares)](external-media.md) - Mounting removable and network storage for import and backup
 - [Detection Pipeline Architecture](detection-pipeline.md) - How audio flows through multi-model inference, filtering, and action dispatch
-- [BirdNET Detection Pipeline](BirdNET‐Go-Guide#birdnet-detection-pipeline) - Understanding how settings affect detections
-- [BirdNET Range Filter](BirdNET‐Go-Guide#birdnet-range-filter) - Location and time-based species filtering
-- [Web Dashboard](BirdNET‐Go-Guide#web-dashboard) - Using the visualization dashboard
+- [BirdNET Detection Pipeline](BirdNET-Go-Guide#birdnet-detection-pipeline) - Understanding how settings affect detections
+- [BirdNET Range Filter](BirdNET-Go-Guide#birdnet-range-filter) - Location and time-based species filtering
+- [Web Dashboard](BirdNET-Go-Guide#web-dashboard) - Using the visualization dashboard
 - [Remote Internet Access](cloudflare_tunnel_guide.md) - Exposing BirdNET-Go to the internet securely
-- [Weather Integration](BirdNET‐Go-Guide#weather-integration) - Connecting to weather data providers
-- [Audio Processing](BirdNET‐Go-Guide#audio-processing) - Advanced audio processing capabilities
-- [Deep Detection](BirdNET‐Go-Guide#deep-detection) - Improving detection reliability
-- [Live Audio Streaming](BirdNET‐Go-Guide#live-audio-streaming) - Streaming audio from the web interface
-- [Species-Specific Settings](BirdNET‐Go-Guide#species-specific-settings) - Customized detection rules for specific species
+- [Weather Integration](BirdNET-Go-Guide#weather-integration) - Connecting to weather data providers
+- [Audio Processing](BirdNET-Go-Guide#audio-processing) - Advanced audio processing capabilities
+- [Deep Detection](BirdNET-Go-Guide#deep-detection) - Improving detection reliability
+- [Live Audio Streaming](BirdNET-Go-Guide#live-audio-streaming) - Streaming audio from the web interface
+- [Species-Specific Settings](BirdNET-Go-Guide#species-specific-settings) - Customized detection rules for specific species
 
 ## Integration & Security
 
 - [Push Notifications](guide.md#push-notifications) - Discord, Telegram, Slack, and 20+ services
 - [Discord Setup Guide](guide.md#discord-setup-guide) - Step-by-step Discord webhook configuration with rich embeds
-- [MQTT Integration](BirdNET‐Go-Guide#integration-options) - Connecting to IoT systems
-- [BirdWeather API](BirdNET‐Go-Guide#integration-options) - Sharing data with BirdWeather.com
+- [MQTT Integration](BirdNET-Go-Guide#integration-options) - Connecting to IoT systems
+- [BirdWeather API](BirdNET-Go-Guide#integration-options) - Sharing data with BirdWeather.com
 - [Authentication](cloudflare_tunnel_guide.md#enabling-authentication) - Securing your BirdNET-Go instance
 - [Cloudflare Tunnel Setup](cloudflare_tunnel_guide.md) - Detailed guide for secure internet access
 
@@ -46,21 +46,20 @@ Welcome to the BirdNET-Go documentation. This index will help you navigate throu
 - [Error Tracking & Telemetry](telemetry.md) - Optional privacy-first error tracking system
 - [Privacy & Data Collection](telemetry-privacy.md) - Detailed privacy information and data protection
 - [Telemetry Setup Guide](telemetry-setup.md) - Step-by-step configuration instructions
-- [Telemetry Troubleshooting](telemetry-troubleshooting.md) - Resolving telemetry-related issues
 
 ## Troubleshooting & Support
 
 - [Frequently Asked Questions](faq.md) - Common questions, problems, and quick fixes
 - [RTSP Troubleshooting](rtsp-troubleshooting.md) - Comprehensive guide for RTSP camera issues and configuration
-- [Docker Troubleshooting](BirdNET‐Go-Guide#docker-installation-troubleshooting) - Resolving common Docker issues
-- [Support Script](BirdNET‐Go-Guide#support-script) - Generating diagnostic information
-- [Reporting Issues](BirdNET‐Go-Guide#reporting-issues) - How to effectively report bugs
+- [Docker Troubleshooting](BirdNET-Go-Guide#docker-installation-troubleshooting) - Resolving common Docker issues
+- [Support Script](BirdNET-Go-Guide#support-script) - Generating diagnostic information
+- [Reporting Issues](BirdNET-Go-Guide#reporting-issues) - How to effectively report bugs
 
 ## Reference
 
 - [Configuration Reference](configuration-reference.md) - Complete reference of every `config.yaml` setting with types and descriptions (auto-generated from source)
-- [Command Line Interface](BirdNET‐Go-Guide#command-line-interface) - Available commands and options
-- [Detection Pipeline Flow](BirdNET‐Go-Guide#birdnet-detection-pipeline) - How settings interact and affect detection results
-- [Range Filter Commands](BirdNET‐Go-Guide#inspection-and-debugging) - CLI commands for inspecting range filter results
-- [Supported Languages](BirdNET‐Go-Guide#supported-languages-for-species-labels) - Language options for species labels
-- [Log Rotation](BirdNET‐Go-Guide#log-rotation) - Managing log files
+- [Command Line Interface](BirdNET-Go-Guide#command-line-interface) - Available commands and options
+- [Detection Pipeline Flow](BirdNET-Go-Guide#birdnet-detection-pipeline) - How settings interact and affect detection results
+- [Range Filter Commands](BirdNET-Go-Guide#inspection-and-debugging) - CLI commands for inspecting range filter results
+- [Supported Languages](BirdNET-Go-Guide#supported-languages-for-species-labels) - Language options for species labels
+- [Log Rotation](BirdNET-Go-Guide#log-rotation) - Managing log files

--- a/doc/wiki/installation.md
+++ b/doc/wiki/installation.md
@@ -68,7 +68,7 @@ This script streamlines the installation process on compatible Linux systems (De
   - Restart service: `sudo systemctl restart birdnet-go.service`
   - View logs: `journalctl -u birdnet-go.service -f`
 
-_(See [Systemd Service Details](#systemd-service-details) below for more information on the service configuration)_.
+_(See [Systemd Service Details](#systemd-service-details-installsh-method) below for more information on the service configuration)_.
 
 **Updating an `install.sh` Installation:**
 
@@ -166,7 +166,7 @@ This method does not use Docker but requires manual dependency installation.
 
 1.  **Download Binary:** Go to the [BirdNET-Go Releases page](https://github.com/tphakala/birdnet-go/releases) and download the pre-compiled binary suitable for your operating system (Linux, macOS, Windows) and architecture.
 2.  **Download TFLite Library:** Download the corresponding TensorFlow Lite C library from [tphakala/tflite_c Releases](https://github.com/tphakala/tflite_c/releases). Follow the installation instructions there (copying the `.so`, `.dylib`, or `.dll` file to the correct system path or the BirdNET-Go executable directory). Version `v2.17.1` or newer is recommended for best performance (XNNPACK support).
-3.  **(Optional) Install ONNX Runtime:** Required for BirdNET v3.0 models (currently in development preview). The release tarballs bundle the library. See the [ONNX Runtime Installation Guide](../ONNX-Runtime-Installation.md) for platform-specific instructions.
+3.  **(Optional) Install ONNX Runtime:** Required for BirdNET v3.0 models (currently in development preview). The release tarballs bundle the library. See the [ONNX Runtime Installation Guide](onnx-runtime-installation.md) for platform-specific instructions.
 4.  **Install Dependencies:**
     - **FFmpeg:** Required for RTSP stream capture, audio export to formats other than WAV (MP3, AAC, FLAC, Opus), and the [Live Audio Streaming](guide.md#live-audio-streaming) feature. Install using your system's package manager (e.g., `sudo apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on macOS).
     - **SoX:** Required for rendering spectrograms in the web interface. Install using your system's package manager (e.g., `sudo apt install sox` on Debian/Ubuntu, `brew install sox` on macOS).

--- a/doc/wiki/onnx-runtime-installation.md
+++ b/doc/wiki/onnx-runtime-installation.md
@@ -1,0 +1,318 @@
+# ONNX Runtime Installation Guide
+
+ONNX Runtime is a shared library required by BirdNET-Go for neural network inference. It powers the BirdNET v2.4 classifier, Perch v2 embeddings, BattyBirdNET bat detection, range filtering, and BirdNET Geomodel features.
+
+> **Note:** ONNX Runtime will become the sole inference backend in a future release. TensorFlow Lite support is being phased out. If you are setting up a new installation, only ONNX Runtime is needed going forward.
+
+## Do You Need This Guide?
+
+**Docker / container installs (`install.sh`):** ONNX Runtime is baked into the container image. No action needed.
+
+**Release tarballs (`.tar.gz` from GitHub Releases):** The ONNX Runtime library is bundled in every tarball. You just need to install it to the right location on your system. See the [Installing from Release Tarballs](#installing-from-release-tarballs) section.
+
+**Building from source:** You need to download ONNX Runtime yourself. See [Manual Download](#manual-download).
+
+## Required Version
+
+BirdNET-Go requires **ONNX Runtime 1.25.x**. The Go bindings (`onnxruntime_go`) are compiled against `ORT_API_VERSION 25`, which only exists in the 1.25.x series. Older versions (1.24.x and below) and newer major versions will fail to load.
+
+## Installing from Release Tarballs
+
+Every release tarball includes the ONNX Runtime library for the target platform. After extracting the archive, install the library to a system path so the dynamic linker can find it.
+
+### Linux
+
+```bash
+# Extract the tarball
+tar xzf birdnet-go-linux-amd64-*.tar.gz
+
+# Install the library system-wide
+sudo cp libonnxruntime.so /usr/lib/
+sudo ldconfig
+
+# Verify
+ldconfig -p | grep onnxruntime
+```
+
+Expected output:
+
+```text
+libonnxruntime.so (libc6,x86-64) => /usr/lib/libonnxruntime.so
+```
+
+If you don't have root access, use `LD_LIBRARY_PATH` instead:
+
+```bash
+export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH"
+./birdnet-go
+```
+
+Add the export to your `~/.bashrc` or `~/.profile` to make it persistent.
+
+### macOS
+
+```bash
+# Extract the tarball
+tar xzf birdnet-go-darwin-arm64-*.tar.gz
+
+# Install the library
+sudo mkdir -p /usr/local/lib
+sudo cp libonnxruntime.dylib /usr/local/lib/
+
+# Remove quarantine attribute (macOS Gatekeeper)
+xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime.dylib
+
+# Verify
+ls -la /usr/local/lib/libonnxruntime.dylib
+```
+
+macOS does not use `ldconfig`. The dynamic linker searches `/usr/local/lib/` by default.
+
+If you prefer not to copy system-wide:
+
+```bash
+export DYLD_LIBRARY_PATH="$(pwd):$DYLD_LIBRARY_PATH"
+./birdnet-go
+```
+
+Note: macOS System Integrity Protection strips `DYLD_LIBRARY_PATH` when launching through `sudo` or `launchd`. Use the `/usr/local/lib/` method for service installations.
+
+### Windows
+
+After extracting the archive, keep `onnxruntime.dll` in the **same directory** as `birdnet-go.exe`. Windows loads DLLs from the application directory automatically, so no additional installation is needed.
+
+```text
+C:\BirdNET-Go\
+  birdnet-go.exe
+  onnxruntime.dll
+```
+
+If you want to run `birdnet-go.exe` from any directory, copy the DLL to a location in your system PATH:
+
+```powershell
+copy onnxruntime.dll C:\Windows\System32\
+```
+
+This requires Administrator privileges.
+
+## Manual Download
+
+If you are building from source or need to install ONNX Runtime separately, download it from the official Microsoft releases.
+
+### Linux (x86_64 / amd64)
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-x64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+
+mkdir -p onnxruntime-tmp
+tar xzf onnxruntime.tgz -C onnxruntime-tmp --strip-components=1
+sudo cp onnxruntime-tmp/lib/libonnxruntime*.so* /usr/lib/
+sudo ldconfig
+rm -rf onnxruntime.tgz onnxruntime-tmp
+```
+
+### Linux (aarch64 / arm64)
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-aarch64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+
+mkdir -p onnxruntime-tmp
+tar xzf onnxruntime.tgz -C onnxruntime-tmp --strip-components=1
+sudo cp onnxruntime-tmp/lib/libonnxruntime*.so* /usr/lib/
+sudo ldconfig
+rm -rf onnxruntime.tgz onnxruntime-tmp
+```
+
+This covers Raspberry Pi 4/5 (64-bit OS), NVIDIA Jetson, and other ARM64 single-board computers.
+
+### macOS (Apple Silicon / arm64)
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-osx-arm64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+
+# Extract (BSD tar needs special handling)
+mkdir -p onnxruntime-tmp
+tar xzf onnxruntime.tgz -C onnxruntime-tmp
+sudo cp -P onnxruntime-tmp/onnxruntime-*/lib/libonnxruntime*.dylib /usr/local/lib/
+sudo xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime*.dylib 2>/dev/null || true
+rm -rf onnxruntime.tgz onnxruntime-tmp
+```
+
+For Intel Macs (x86_64), replace `arm64` with `x86_64` in the download URL:
+
+```bash
+VERSION=1.25.1
+
+curl -fsSL "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-osx-x86_64-${VERSION}.tgz" \
+  -o onnxruntime.tgz
+```
+
+Note: BirdNET-Go does not currently publish pre-built binaries for Intel Macs. You would need to build from source.
+
+### Windows (x86_64 / amd64)
+
+Download from a browser or PowerShell:
+
+```powershell
+$VERSION = "1.25.1"
+
+Invoke-WebRequest `
+  -Uri "https://github.com/microsoft/onnxruntime/releases/download/v$VERSION/onnxruntime-win-x64-$VERSION.zip" `
+  -OutFile onnxruntime.zip
+
+Expand-Archive onnxruntime.zip -DestinationPath onnxruntime-tmp
+Copy-Item onnxruntime-tmp\onnxruntime-*\lib\onnxruntime.dll -Destination .
+Remove-Item -Recurse onnxruntime.zip, onnxruntime-tmp
+```
+
+Place `onnxruntime.dll` in the same directory as `birdnet-go.exe`.
+
+### Using the Taskfile (Build from Source)
+
+If you have the BirdNET-Go source tree and [Task](https://taskfile.dev) installed:
+
+```bash
+task download-onnxruntime
+```
+
+This automatically detects your platform, downloads the correct archive, and installs the library to the appropriate system path. It requires `sudo` on Linux.
+
+## Platform Support Matrix
+
+| Platform | Architecture | Release Tarball | Manual Download | Docker |
+|----------|-------------|:-:|:-:|:-:|
+| Linux | x86_64 (amd64) | Yes | Yes | Yes |
+| Linux | aarch64 (arm64) | Yes | Yes | Yes |
+| macOS | Apple Silicon (arm64) | Yes | Yes | - |
+| macOS | Intel (x86_64) | - | Yes | - |
+| Windows | x86_64 (amd64) | Yes | Yes | - |
+
+Platforms marked with "-" are not officially supported but may work with manual setup.
+
+## Verification
+
+### Linux
+
+```bash
+# Check the library is in the linker cache
+ldconfig -p | grep onnxruntime
+
+# Check the library version
+readelf -d /usr/lib/libonnxruntime.so | grep SONAME
+```
+
+### macOS
+
+```bash
+# Check the library exists
+ls -la /usr/local/lib/libonnxruntime*.dylib
+
+# Check the library can be loaded
+otool -L /usr/local/lib/libonnxruntime.dylib
+```
+
+### Windows
+
+```powershell
+# Check the DLL exists alongside the binary
+dir C:\BirdNET-Go\onnxruntime.dll
+
+# Or check system-wide
+where.exe onnxruntime.dll
+```
+
+### BirdNET-Go Startup Check
+
+When BirdNET-Go starts, it logs the ONNX Runtime version it loaded. Look for a line like:
+
+```text
+ONNX Runtime initialized (version 1.25.1)
+```
+
+If the library is missing, you will see an error like:
+
+```text
+error while loading shared libraries: libonnxruntime.so: cannot open shared object file
+```
+
+## Troubleshooting
+
+### "error while loading shared libraries: libonnxruntime.so"
+
+**Linux:** The library is not in the dynamic linker search path.
+
+```bash
+# Option 1: Install system-wide
+sudo cp libonnxruntime.so /usr/lib/
+sudo ldconfig
+
+# Option 2: Set library path for current session
+export LD_LIBRARY_PATH="/path/to/library:$LD_LIBRARY_PATH"
+```
+
+### "dyld: Library not loaded: libonnxruntime.dylib"
+
+**macOS:** The library is not in `/usr/local/lib/` or not in `DYLD_LIBRARY_PATH`.
+
+```bash
+sudo cp libonnxruntime.dylib /usr/local/lib/
+```
+
+If you get a Gatekeeper block, remove the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine /usr/local/lib/libonnxruntime.dylib
+```
+
+### "onnxruntime.dll was not found"
+
+**Windows:** The DLL is not in the same directory as `birdnet-go.exe` and not in the system PATH.
+
+Move `onnxruntime.dll` to the same folder as the executable.
+
+### Wrong ONNX Runtime version
+
+If BirdNET-Go reports version incompatibility errors, download the exact version listed at the top of this guide (currently 1.25.1). Newer major versions may introduce breaking API changes.
+
+### Permission denied errors
+
+**Linux:** Ensure the library file is readable:
+
+```bash
+sudo chmod 644 /usr/lib/libonnxruntime.so
+sudo ldconfig
+```
+
+**macOS:** Same approach:
+
+```bash
+sudo chmod 644 /usr/local/lib/libonnxruntime.dylib
+```
+
+### Raspberry Pi / ARM SBC
+
+Use the Linux aarch64 package. Make sure you are running a **64-bit OS**. The 32-bit (armhf) architecture is not supported by ONNX Runtime.
+
+Check your architecture with:
+
+```bash
+uname -m
+# Should show: aarch64
+```
+
+If it shows `armv7l`, you are running a 32-bit OS and need to switch to a 64-bit image (e.g., Raspberry Pi OS 64-bit).
+
+## Further Reading
+
+- [ONNX Runtime GitHub](https://github.com/microsoft/onnxruntime) - official releases and documentation
+- [BirdNET-Go documentation](https://birdnet-go.dev)
+- [BirdNET-Go GitHub](https://github.com/tphakala/birdnet-go) - issues and discussions

--- a/doc/wiki/onnx-runtime-installation.md
+++ b/doc/wiki/onnx-runtime-installation.md
@@ -87,13 +87,14 @@ C:\BirdNET-Go\
   onnxruntime.dll
 ```
 
-If you want to run `birdnet-go.exe` from any directory, copy the DLL to a location in your system PATH:
+If you want to run `birdnet-go.exe` from any directory, keep the DLL in a dedicated folder and add that folder to your user `PATH`. Avoid copying the DLL into `C:\Windows\System32`: that is a global, system-wide install that affects every application and is easy to get wrong.
 
 ```powershell
-copy onnxruntime.dll C:\Windows\System32\
+# Example: keep onnxruntime.dll in C:\BirdNET-Go and add that folder to PATH
+[Environment]::SetEnvironmentVariable("PATH", "$env:PATH;C:\BirdNET-Go", "User")
 ```
 
-This requires Administrator privileges.
+This updates your user `PATH` only and does not require Administrator privileges. Open a new terminal afterwards for the change to take effect.
 
 ## Manual Download
 

--- a/doc/wiki/realtime-analysis.md
+++ b/doc/wiki/realtime-analysis.md
@@ -27,7 +27,7 @@ For Linux users, the PulseAudio backend is recommended. Additionally, Linux dist
 
 Make sure Pulse Audio is installed on your system and set Pulse Audio to output 16bit 48000 hz audio by editing **/etc/pulse/daemon.conf** to contain following
 
-```
+```ini
 default-sample-format = s16le
 default-sample-rate = 48000
 ```
@@ -40,7 +40,7 @@ Make sure that recording device is set to 16 bit 48000 Hz mode, 2 channel source
 
 ## Node and BirdNET settings
 
-```
+```yaml
 node:
   name: BirdNET-Go
   locale: en
@@ -56,7 +56,7 @@ Setting (**node threads**) controls the number of CPU threads used by the Tensor
 
 Setting (**node timeas24h: true**) ensures that output timestamps are in the 24-hour format. Setting it to false is intended to use the 12-hour format, but this feature is not yet implemented.
 
-```
+```yaml
 birdnet:
   sensitivity: 1.0
   threshold: 0.75
@@ -77,7 +77,7 @@ The (**birdnet latitude**) and (**birdnet longitude**) settings enable location-
 
 Configuration file has few settings which controls output of real-time detection results
 
-```
+```yaml
 realtime:
   interval: 15
   processingtime: false
@@ -98,7 +98,7 @@ Setting (**audioexport enabled: true**) allows 3-second audio clips containing i
 
 Setting (**log enabled: true**) saves the timestamp and common name of identified birds to a log file, which can be used as a chat log overlay in OBS. 
 
-```
+```yaml
 output:
   file:
     enabled: false
@@ -126,7 +126,7 @@ BirdNET-Go supports BirdWeather API for uploading captured audio clips and BirdN
 
 For Birdweather API access you need a token which can be requested by email from tim@birdweather.com. You can use following template for token request
 
-```
+```text
 Hi, Tim, and thank you so much for BirdWeather.com!
 
 Below is the information I would like to use to request a BirdWeather ID

--- a/doc/wiki/realtime-analysis.md
+++ b/doc/wiki/realtime-analysis.md
@@ -1,0 +1,147 @@
+Real-time analysis requires an audio capture device from which audio is ingested for analysis. The input audio format should be 16-bit, 48000 Hz. Stereo input is acceptable, as it is downmixed to one channel within BirdNET-Go. Mismatching capture settings may reduce the accuracy of the analysis.
+
+Real-time analysis is conducted by loading PCM audio into a memory buffer. This buffer is then accessed every 1.5 seconds by a dedicated thread, which continues until there are 3 seconds of unprocessed audio accumulated. These 3-second audio segments are subsequently fed into the BirdNET model for analysis. This process repeats continuously until the application is terminated.
+
+Results of real-time analysis can be saved to a log file and to SQLite or MySQL databases. The log file format is suitable for use as a chat log overlay in [Open Broadcaster Software](https://obsproject.com/fi) for wildlife streams and similar applications. The database format is suitable for a BirdNET-Pi-like interface, allowing for the visualization of bird observations.
+
+## Setting up audio device
+
+BirdNET-Go uses miniaudio library for audio device access, supported audio backends for miniaudio are 
+
+### Linux
+* ALSA
+* Pulse Audio
+* JACK
+
+### Windows
+* WASAPI
+* DirectSound
+* WinMM
+
+### macOS
+* Core Audio
+
+For Linux users, the PulseAudio backend is recommended. Additionally, Linux distributions that use PipeWire, specifically with the 'Pipewire-pulse' and 'libpulse' components, have also been tested and confirmed to work.
+
+### Configuring Pulse Audio on Linux
+
+Make sure Pulse Audio is installed on your system and set Pulse Audio to output 16bit 48000 hz audio by editing **/etc/pulse/daemon.conf** to contain following
+
+```
+default-sample-format = s16le
+default-sample-rate = 48000
+```
+
+### Configuring Recording device properties on Windows
+
+Make sure that recording device is set to 16 bit 48000 Hz mode, 2 channel source is downmixed to 1 channel internally in BirdNET-Go. I also recommend unchecking "Allow applications to take exclusive control of this device" especially if you plan to run OBS on same system.
+
+![windows_recording_properties](https://github.com/tphakala/birdnet-go/assets/7030001/f994f01a-7614-428d-b7e5-eca274261889)
+
+## Node and BirdNET settings
+
+```
+node:
+  name: BirdNET-Go
+  locale: en
+  threads: 0
+  timeas24h: true
+```
+
+Value of (**node name**) is saved in database for each detection which allows identifying source node in multi node setups sharing same database.
+
+Setting (**node locale**) controls which translations are used for common names of birds in output. Valid locales are documented here [Supported Languages](guide.md#supported-languages-for-species-labels)
+
+Setting (**node threads**) controls the number of CPU threads used by the TensorFlow Lite runtime. A setting of 0 utilizes all available CPU threads. Valid values range from 1 to the number of CPU cores on the system. If the value exceeds the number of CPU cores available on the system, it is capped at the system's CPU count.
+
+Setting (**node timeas24h: true**) ensures that output timestamps are in the 24-hour format. Setting it to false is intended to use the 12-hour format, but this feature is not yet implemented.
+
+```
+birdnet:
+  sensitivity: 1.0
+  threshold: 0.75
+  overlap: 0.0
+  latitude: 00.000
+  longitude: 00.000
+```
+
+Setting (**birdnet sensitivity**) controls sigmoid sensitivity of prediction in BirdNET model, valid values are from 0.0 to 1.5, higher value makes model more sensitive.
+
+Setting (**birdnet threshold**) controls minimum confidence of prediction result to be recorded for output, valid values are from 0.0 to 1.0. Low value may cause lot of incorrect detections, high value may cause model to miss many detections.
+
+Setting (**birdnet overlap**) is not used for real-time detection.
+
+The (**birdnet latitude**) and (**birdnet longitude**) settings enable location-based species occurrence filtering. This feature helps to exclude non-native species from your region in the results, thereby reducing incorrect detections. Setting these values to 00.000 disables location-based filtering. Valid values for these settings are required if Birdweather uploads are enabled.
+
+## Configuring output
+
+Configuration file has few settings which controls output of real-time detection results
+
+```
+realtime:
+  interval: 15
+  processingtime: false
+  audioexport:
+    enabled: true
+    path: clips/
+    type: wav
+  log:
+    enabled: true
+    path: birdnet.txt
+```
+
+Interval setting reduces log flooding by setting a minimum interval, in seconds, for a repeating bird call to be logged. This flood filter also applies to SQL output.
+
+Setting (**processingtime: true**) prints the time it took for BirdNET analysis to process a 3-second audio chunk. These values should range from 50ms to 550ms, depending on the hardware you are running BirdNET-Go on. As long as the processingtime is less than 1500ms, audio is processed quickly enough to keep up with real-time capture and analysis.
+
+Setting (**audioexport enabled: true**) allows 3-second audio clips containing identified bird calls to be saved to disk. Only WAV audio format type is supported for now. The default path for audio clip exports is **clips**, which is relative to the directory where BirdNET-Go is executed.
+
+Setting (**log enabled: true**) saves the timestamp and common name of identified birds to a log file, which can be used as a chat log overlay in OBS. 
+
+```
+output:
+  file:
+    enabled: false
+  sqlite:
+    enabled: true
+    path: birdnet.db
+  mysql:
+    enabled: false
+    username: birdnet
+    password: secret
+    database: birdnet
+    host: localhost
+    port: 3306
+```
+
+Setting (**output file enabled**) does not apply to real-time detection.
+
+Enabling the SQLite option (**sqlite enabled: true**) allows real-time detection results to be stored in a SQLite database. The (**sqlite path**) setting determines the location of the SQLite database. By default, the location is birdnet.db in the directory where BirdNET-Go is executed.
+
+Enabling the MySQL option (**mysql enabled: true**) allows real-time detection results to be stored in a MySQL database. Please note that if both SQLite and MySQL are set to enabled, only the SQLite output will be used.
+
+## BirdWeather support
+
+BirdNET-Go supports BirdWeather API for uploading captured audio clips and BirdNET results to birdweather.com. BirdNET-Go uploads 3 second audio clips to BirdWeather
+
+For Birdweather API access you need a token which can be requested by email from tim@birdweather.com. You can use following template for token request
+
+```
+Hi, Tim, and thank you so much for BirdWeather.com!
+
+Below is the information I would like to use to request a BirdWeather ID
+
+Latitude=
+Longitude=
+City= [ City ]
+State= [ State ]
+Country= [ Country ]
+
+
+Thank you so much!
+[ Your Name ]
+
+Disclaimer: By requesting this BirdWeather ID, I acknowledge that my location
+and recording data will be made public.
+```
+

--- a/doc/wiki/telemetry-setup.md
+++ b/doc/wiki/telemetry-setup.md
@@ -250,7 +250,7 @@ You can test the system by temporarily causing a harmless error:
 
 ## Troubleshooting
 
-For telemetry-specific issues, see the [Troubleshooting Guide](telemetry-troubleshooting.md).
+For telemetry-specific issues, see the [telemetry FAQ](telemetry.md#frequently-asked-questions) or the general [FAQ](faq.md).
 
 ---
 

--- a/doc/wiki/telemetry.md
+++ b/doc/wiki/telemetry.md
@@ -164,7 +164,6 @@ The same sensitive data always produces the same anonymized identifier, allowing
 - **[Privacy Statement](../../PRIVACY.md)** - **⭐ COMPREHENSIVE** privacy information covering all data collection and external integrations
 - **[Privacy & Data Collection](telemetry-privacy.md)** - Detailed privacy information and data handling (telemetry-specific)
 - **[Setup & Configuration](telemetry-setup.md)** - Step-by-step configuration guide
-- **[Troubleshooting](telemetry-troubleshooting.md)** - Common issues and solutions
 
 **Important**: The main [Privacy Statement](../../PRIVACY.md) contains complete information about all external services including BirdWeather, MQTT, backup services, weather APIs, and image services in addition to telemetry.
 


### PR DESCRIPTION
## What this does

Makes `doc/wiki/` the single source of truth for the published GitHub wiki and adds a one-way `repo -> wiki` sync, so the auto-generated configuration reference (and every other in-repo doc) actually reaches readers on the wiki instead of going stale.

Previously nothing synced the wiki from the repo. The published wiki had drifted into an inconsistent state from past manual pushes: doubled `.md.md` page names (`installation.md.md`), a Unicode-hyphen guide slug (`BirdNET‐Go-Guide`), and a mix of hand-written pages that lived only on the wiki. README links mixed three conventions accordingly.

## Changes

- **`cmd/wiki-export`** (new, tested): renders `doc/wiki/*.md` into wiki-ready pages. It remaps page names to their wiki slugs (`guide.md` -> `BirdNET-Go-Guide`, `index.md` -> `Home`, `faq.md` -> `FAQ`, etc.), rewrites intra-doc links so they resolve on the wiki (relative `.md` links become extensionless slugs, absolute self-wiki URLs become relative slugs, other repo files become `blob/main` URLs, external/anchor/image and code-fenced links are left untouched), and injects a "do not edit, edit the repo" banner into every page.
- **`.github/workflows/wiki-sync.yml`** (new): on push to `main` touching `doc/wiki/**` (and via manual dispatch), runs the exporter and publishes the result to the wiki. The copy is additive (it never mirror-deletes); it removes only an explicit legacy allowlist (the `*.md.md` pages and the old Unicode-hyphen guide). It skips cleanly when the deploy key is not yet configured.
- **Migrated the native-only wiki pages into the repo** so the repo owns 100% of wiki content: `database-doctor.md`, `file-analysis.md`, `realtime-analysis.md`, `onnx-runtime-installation.md`.
- **Normalized inconsistent doc links** and fixed a few mis-based repo-file links so they resolve both in the repo browser and on the wiki. Removed three dead links to a `telemetry-troubleshooting` page that never existed.
- **Fixed README documentation links** to one consistent convention (clean wiki slugs).
- **`task wiki-export`** to preview the generated wiki locally without pushing.

## One-time setup required to activate the sync

The default `GITHUB_TOKEN` cannot authenticate to the separate `*.wiki.git` repository, so the workflow pushes with a dedicated SSH deploy key. Until the key is configured, the workflow runs but skips the push (it logs a note in the job summary). The setup steps (generate a key, add the public half as a write-enabled Deploy key, add the private half as the `WIKI_SSH_DEPLOY_KEY` Actions secret) are documented in `doc/wiki/building.md` under "Publishing the Wiki".

Note: a few README links now point to pages that only appear on the wiki after the first successful sync (for example `wiki/security`, `wiki/telemetry-privacy`). They go live once the deploy key is configured and the workflow runs.

## Acceptance criteria

- Generated `configuration-reference.md` is published to the wiki and updates automatically when regenerated. ✅ (synced on every `doc/wiki/**` change)
- One canonical source (the repo); no hand-editing of published pages. ✅ (banner on every page; one-way sync)
- No accidental deletion of existing wiki content during rollout. ✅ (additive copy; deletions limited to an explicit legacy allowlist)
- README doc links are consistent and correct. ✅

## Testing

- `go test -race ./cmd/wiki-export/` (unit tests for the page mapping, link rewriting across all edge cases, banner injection, and end-to-end export)
- `golangci-lint run ./cmd/wiki-export/...` clean
- `actionlint .github/workflows/wiki-sync.yml` clean
- Ran the exporter against the real `doc/wiki/` and verified every page gets a banner, all links resolve (no stray `.md` targets, no leftover relative paths, no Unicode/encoded hyphens), and the generated slugs match the README links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a wiki publishing workflow to automatically sync `doc/wiki` to the GitHub wiki.
  * Added a local wiki export task/command to generate publish-ready wiki content (with link rewriting and an auto-generated “do not edit” banner).
* **Documentation**
  * Added new wiki pages for real-time analysis, file analysis, ONNX Runtime setup, and Database Doctor.
  * Updated multiple wiki links/anchors, refined build/publishing instructions, and refreshed the documentation index.
* **Tests**
  * Added unit and integration-style tests covering wiki export, link rewriting, and banner injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->