### PR TITLE
fix(api): restore redacted secrets before connection tests

### DIFF
--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -519,6 +519,16 @@ func (c *Controller) TestWeatherConnection(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid weather test request", http.StatusBadRequest)
 	}
 
+	// Restore redacted API keys before validation so the test runs against the
+	// real saved secret. The settings UI returns secrets as a redacted
+	// placeholder (redactedValue); if the user clicks Test without re-entering
+	// the key, the request carries that placeholder instead of the real key.
+	// Restoring here (and not only in the save flow) prevents the test from
+	// failing with a bogus "authentication failed".
+	current := c.currentSettings()
+	restoreRedactedSecret(current.Realtime.Weather.OpenWeather.APIKey, &request.OpenWeather.APIKey)
+	restoreRedactedSecret(current.Realtime.Weather.Wunderground.APIKey, &request.Wunderground.APIKey)
+
 	// Validate provider
 	if request.Provider == "" || request.Provider == "none" {
 		return c.HandleErrorWithKey(ctx, nil, "No weather provider selected", http.StatusBadRequest, notification.MsgErrIntegNoWeatherProvider, nil)
@@ -536,7 +546,7 @@ func (c *Controller) TestWeatherConnection(ctx echo.Context) error {
 	ctx.Response().WriteHeader(http.StatusOK)
 
 	// Clone current settings and override only Weather fields from the request
-	testSettings := conf.CloneSettings(c.currentSettings())
+	testSettings := conf.CloneSettings(current)
 	testSettings.Realtime.Weather = conf.WeatherSettings{
 		Provider:     request.Provider,
 		Debug:        request.Debug,
@@ -814,6 +824,13 @@ func (c *Controller) TestEBirdConnection(ctx echo.Context) error {
 	if err := ctx.Bind(&request); err != nil {
 		return c.HandleError(ctx, err, "Invalid eBird test request", http.StatusBadRequest)
 	}
+
+	// Restore the redacted API key before validation so the test runs against
+	// the real saved secret. The settings UI returns the key as a redacted
+	// placeholder (redactedValue); if the user clicks Test without re-entering
+	// it, the request carries that placeholder instead of the real key, which
+	// would otherwise fail authentication.
+	restoreRedactedSecret(c.currentSettings().Realtime.EBird.APIKey, &request.APIKey)
 
 	if !request.Enabled {
 		return ctx.JSON(http.StatusOK, map[string]any{

--- a/internal/api/v2/integrations_test.go
+++ b/internal/api/v2/integrations_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 // Test constants for integration tests
@@ -743,5 +745,195 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		assert.False(t, result.Connected, "Connected should be false when MQTT connection fails")
 		assert.NotEmpty(t, result.LastError, "LastError should not be empty when connection fails")
 		assert.Contains(t, result.LastError, "error:connection:mqtt_broker", "Error should be properly formatted")
+	})
+}
+
+// redactedSecretPlaceholder is the sentinel the settings UI returns in place of
+// stored secrets; it aliases the production redactedValue constant so the tests
+// and the handlers agree on the exact value a client sends when the user has not
+// re-entered a secret.
+const redactedSecretPlaceholder = redactedValue
+
+// TestRestoreRedactedSecret verifies the canonical single-field restore
+// primitive shared by the settings save flow and the integration
+// test-connection handlers.
+func TestRestoreRedactedSecret(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		current  string
+		incoming string
+		want     string
+	}{
+		{
+			name:     "placeholder is restored to current real secret",
+			current:  "real-saved-key",
+			incoming: redactedSecretPlaceholder,
+			want:     "real-saved-key",
+		},
+		{
+			name:     "real incoming value is left untouched",
+			current:  "real-saved-key",
+			incoming: "user-typed-new-key",
+			want:     "user-typed-new-key",
+		},
+		{
+			name:     "empty incoming stays empty (not a placeholder)",
+			current:  "real-saved-key",
+			incoming: "",
+			want:     "",
+		},
+		{
+			name:     "placeholder with empty current resolves to empty",
+			current:  "",
+			incoming: redactedSecretPlaceholder,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			incoming := tt.incoming
+			restoreRedactedSecret(tt.current, &incoming)
+			assert.Equal(t, tt.want, incoming)
+		})
+	}
+}
+
+// publishWeatherTestSettings sets the saved weather provider config the handler
+// reads via currentSettings() and returns the controller. It re-publishes the
+// settings so currentSettings() (which reads the global snapshot first) observes
+// the saved keys/endpoint.
+func publishWeatherTestSettings(t *testing.T, mutate func(*conf.Settings)) (*echo.Echo, *Controller) {
+	t.Helper()
+	e, _, controller := setupTestEnvironment(t)
+	settings := controller.Settings.Load()
+	mutate(settings)
+	publishTestSettings(t, settings)
+	return e, controller
+}
+
+// TestTestWeatherConnection_RestoresRedactedAPIKey verifies the weather
+// test-connection handler restores redacted API-key placeholders from the saved
+// settings before running the test, fixing the bug where clicking "Test" after
+// saving (without re-entering the key) failed with a bogus authentication error.
+func TestTestWeatherConnection_RestoresRedactedAPIKey(t *testing.T) {
+	// Negative path: a redacted placeholder with NO saved key must restore to
+	// the empty string and fail validation with "API key is required". On the
+	// buggy code (no restore) the non-empty placeholder slips past validation
+	// and the handler proceeds to stream, so this case fails on main.
+	t.Run("placeholder without saved key fails validation", func(t *testing.T) {
+		e, controller := publishWeatherTestSettings(t, func(s *conf.Settings) {
+			s.Realtime.Weather.OpenWeather.APIKey = "" // nothing saved
+		})
+
+		body := fmt.Sprintf(`{"provider":%q,"openWeather":{"apiKey":%q}}`,
+			WeatherProviderOpenWeather, redactedSecretPlaceholder)
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/weather/test",
+			strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := controller.TestWeatherConnection(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code,
+			"placeholder restored to empty key must fail the required-key validation")
+		assert.Contains(t, rec.Body.String(), "API key is required")
+	})
+
+	// Positive path (hermetic): with a real saved key, the handler's restore
+	// sequence must make the OpenWeather authentication stage send the REAL key
+	// (not the placeholder) to the API endpoint. We exercise the exact restore
+	// the handler runs and the production auth stage against a local server.
+	t.Run("placeholder is restored to real saved key at auth stage", func(t *testing.T) {
+		const realKey = "real-openweather-key-123"
+
+		var gotAppID string
+		var gotAppIDOnce sync.Once
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAppIDOnce.Do(func() { gotAppID = r.URL.Query().Get("appid") })
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		_, controller := publishWeatherTestSettings(t, func(s *conf.Settings) {
+			s.Realtime.Weather.OpenWeather.APIKey = realKey
+			s.Realtime.Weather.OpenWeather.Endpoint = server.URL
+		})
+
+		// The client echoes back the saved provider config (endpoint included) but
+		// with the API key as the redacted placeholder, because the user did not
+		// re-type the key on the settings page.
+		request := WeatherTestRequest{
+			Provider: WeatherProviderOpenWeather,
+			OpenWeather: conf.OpenWeatherSettings{
+				APIKey:   redactedSecretPlaceholder,
+				Endpoint: server.URL,
+			},
+		}
+
+		// Reproduce the handler's restore sequence using the production helper.
+		current := controller.currentSettings()
+		restoreRedactedSecret(current.Realtime.Weather.OpenWeather.APIKey, &request.OpenWeather.APIKey)
+		restoreRedactedSecret(current.Realtime.Weather.Wunderground.APIKey, &request.Wunderground.APIKey)
+
+		testSettings := conf.CloneSettings(current)
+		testSettings.Realtime.Weather = conf.WeatherSettings{
+			Provider:     request.Provider,
+			OpenWeather:  request.OpenWeather,
+			Wunderground: request.Wunderground,
+		}
+
+		msg, err := controller.testWeatherAuthentication(t.Context(), testSettings)
+		require.NoError(t, err)
+		assert.Contains(t, msg, "Successfully authenticated")
+		assert.Equal(t, realKey, gotAppID,
+			"auth stage must use the real saved key, not the redacted placeholder")
+		assert.NotEqual(t, redactedSecretPlaceholder, gotAppID)
+	})
+}
+
+// TestTestEBirdConnection_RestoresRedactedAPIKey verifies the eBird
+// test-connection handler restores the redacted API-key placeholder from the
+// saved settings before running the test.
+func TestTestEBirdConnection_RestoresRedactedAPIKey(t *testing.T) {
+	// Negative path: placeholder with NO saved key restores to empty and fails
+	// the required-key validation. On the buggy code the non-empty placeholder
+	// passes validation, so this case fails on main.
+	t.Run("placeholder without saved key fails validation", func(t *testing.T) {
+		e, controller := publishWeatherTestSettings(t, func(s *conf.Settings) {
+			s.Realtime.EBird.APIKey = "" // nothing saved
+		})
+
+		body := fmt.Sprintf(`{"enabled":true,"apiKey":%q,"locale":"en"}`, redactedSecretPlaceholder)
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/ebird/test",
+			strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := controller.TestEBirdConnection(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code,
+			"placeholder restored to empty key must fail the required-key validation")
+		assert.Contains(t, rec.Body.String(), "API key is required")
+	})
+
+	// Positive path: with a real saved key, a placeholder request restores to the
+	// real key so the value handed to the auth stage is the real key.
+	t.Run("placeholder is restored to real saved key", func(t *testing.T) {
+		const realKey = "real-ebird-key-456"
+
+		_, controller := publishWeatherTestSettings(t, func(s *conf.Settings) {
+			s.Realtime.EBird.APIKey = realKey
+		})
+
+		apiKey := redactedSecretPlaceholder
+		restoreRedactedSecret(controller.currentSettings().Realtime.EBird.APIKey, &apiKey)
+		assert.Equal(t, realKey, apiKey,
+			"eBird test must use the real saved key, not the redacted placeholder")
 	})
 }

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1828,6 +1828,9 @@ func sanitizeNotificationSecrets(s *conf.Settings) {
 // handlers, so both paths match the same sentinel against the same private
 // redactedValue constant and cannot drift apart.
 func restoreRedactedSecret(current string, incoming *string) {
+	if incoming == nil {
+		return
+	}
 	if *incoming == redactedValue {
 		*incoming = current
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1821,6 +1821,18 @@ func sanitizeNotificationSecrets(s *conf.Settings) {
 	s.Notification.Push.Providers = providersCopy
 }
 
+// restoreRedactedSecret replaces a single incoming secret value with the
+// current (real) value when the incoming value is the redacted placeholder.
+// It is the canonical single-field restore primitive shared by the settings
+// save flow (restoreRedactedSecrets) and the integration test-connection
+// handlers, so both paths match the same sentinel against the same private
+// redactedValue constant and cannot drift apart.
+func restoreRedactedSecret(current string, incoming *string) {
+	if *incoming == redactedValue {
+		*incoming = current
+	}
+}
+
 // restoreRedactedSecrets replaces redacted placeholder values in the incoming
 // settings with the current (real) values so that an update round-trip
 // (GET → modify → PUT) does not overwrite real secrets with the placeholder.
@@ -1833,9 +1845,7 @@ func sanitizeNotificationSecrets(s *conf.Settings) {
 // error is returned listing all affected fields.
 func restoreRedactedSecrets(current, incoming *conf.Settings) error {
 	restore := func(cur, inc *string) {
-		if *inc == redactedValue {
-			*inc = *cur
-		}
+		restoreRedactedSecret(*cur, inc)
 	}
 
 	// Security — defense-in-depth: restore even though SessionSecret is


### PR DESCRIPTION
## Summary

The Test Connection endpoints ran their test against the request payload, which carries the redacted API-key placeholder (the same sentinel the settings UI returns in place of stored secrets). When a user opened the settings page after saving a key and clicked Test without re-entering it, the placeholder was sent as the key and the test failed with a bogus "authentication failed", even though the saved key was valid and the background weather/eBird service worked fine. This affected OpenWeather, Weather Underground, and eBird.

The save flow already restored real secrets via `restoreRedactedSecrets`; only the test path was missing the restore.

## Changes

- Extract the single-field restore primitive into a shared `restoreRedactedSecret(current string, incoming *string)` helper in `settings.go`, and have `restoreRedactedSecrets` delegate to it so the save flow and the test handlers match the same sentinel against the same constant and cannot drift apart.
- Restore redacted API keys before validation in the affected test handlers:
  - `TestWeatherConnection`: `OpenWeather.APIKey` and `Wunderground.APIKey`
  - `TestEBirdConnection`: `APIKey`

`TestMQTTConnection` and `TestBirdWeatherConnection` are unaffected: MQTT reads the saved settings directly and never binds a request secret, and BirdWeather only binds a non-secret station ID. I audited the other test endpoints (`TestAlertRule`, `CreateTestNewSpeciesNotification`, stream/range tests) and none pass a redacted secret from the request into a test.

## Tests

Added tests that fail on the unfixed handlers and pass after the fix:

- A table-driven unit test for the `restoreRedactedSecret` helper (placeholder restores, real value preserved, empty stays empty, placeholder with empty current resolves to empty).
- Handler-level checks that a placeholder with no saved key is restored to empty and fails the required-key validation. These return 400 after the fix; on the buggy code the non-empty placeholder slips past validation and the handler streams instead, so the tests fail on `main`.
- A hermetic OpenWeather auth-stage test (local `httptest` server) asserting the real saved key, not the placeholder, reaches the provider's `appid` parameter.

## Related Issues

Fixes #3103

## Test Plan

- [x] `go test -race ./internal/api/v2/...` green
- [x] New tests proven to fail on the unfixed handlers, pass after the fix
- [x] `golangci-lint run` clean (0 issues)
- [x] No secret leakage: error paths already scrub via `privacy.WrapError`; the real key flows where the existing scrubbing protects it

## Preflight Status

- [x] Single concern: one fix (restore redacted secrets in test-connection handlers) plus its tests
- [x] Preflight passed: reuse/correctness/safety and quality/integration reviewers returned clean, multi-site claim independently verified
- [x] Linters clean: golangci-lint 0 issues
- [x] Tests pass: full internal/api/v2 race suite green
- [x] No unrelated changes
- [x] No regression / backward-compat break: purely additive internal behavior, no config key, API contract, DB schema, or CLI flag changes
- [x] No secrets or PII in the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Integration connection tests now use the saved real API key instead of a redacted placeholder, so weather and eBird connection checks validate credentials correctly.
  - Redacted secrets in settings are restored more reliably before validation, preventing false failures when testing connections from the UI.
  - Added broader test coverage for placeholder-to-secret restoration, including cases with missing saved values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->