### PR TITLE
test(processor): make TestRaceCondition_ProposedSolutionValidation deterministic with synctest

### DIFF
--- a/internal/analysis/processor/race_condition_simple_test.go
+++ b/internal/analysis/processor/race_condition_simple_test.go
@@ -19,6 +19,7 @@ package processor
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -648,53 +649,80 @@ func TestCompositeAction_EdgeCases(t *testing.T) {
 	})
 }
 
-// TestRaceCondition_ProposedSolutionValidation demonstrates how sequential execution would solve the issue
+// Action delays used by TestRaceCondition_ProposedSolutionValidation. Under
+// testing/synctest the fake clock advances by exactly these durations, so the
+// measured wall-clock deltas are deterministic (no scheduling slack).
+const (
+	// proposedSolutionDBDelay is the time the simulated database action spends
+	// "writing" before it completes.
+	proposedSolutionDBDelay = 200 * time.Millisecond
+	// proposedSolutionSSEDelay is the time the simulated SSE action spends
+	// before it completes. It is shorter than the DB delay because SSE only
+	// broadcasts once the database record is ready.
+	proposedSolutionSSEDelay = 50 * time.Millisecond
+)
+
+// TestRaceCondition_ProposedSolutionValidation demonstrates how sequential execution would solve the issue.
+//
+// The test runs inside testing/synctest so the action delays are driven by a
+// virtual clock. This makes the timing assertions exact and deterministic
+// instead of relying on a hardcoded wall-clock ceiling, which previously flaked
+// under CPU contention (issue #1225): a real 50ms timer measured against a
+// 100ms bound left too little scheduling slack and tripped on loaded runners.
 func TestRaceCondition_ProposedSolutionValidation(t *testing.T) {
 	t.Parallel()
 
-	// This test shows how enforcing sequential execution would prevent race conditions
+	synctest.Test(t, func(t *testing.T) { //nolint:thelper // synctest callback, not a test helper
+		// This test shows how enforcing sequential execution would prevent race conditions
 
-	dbAction := &SimpleAction{
-		name:         "Database Action",
-		executeDelay: 200 * time.Millisecond,
-	}
+		dbAction := &SimpleAction{
+			name:         "Database Action",
+			executeDelay: proposedSolutionDBDelay,
+		}
 
-	sseAction := &SimpleAction{
-		name:         "SSE Action",
-		executeDelay: 50 * time.Millisecond,
-	}
+		sseAction := &SimpleAction{
+			name:         "SSE Action",
+			executeDelay: proposedSolutionSSEDelay,
+		}
 
-	detection := createSimpleDetection()
+		detection := createSimpleDetection()
 
-	// Sequential execution (proposed solution)
-	startTime := time.Now()
+		// Sequential execution (proposed solution)
+		startTime := time.Now()
 
-	// Step 1: Execute database action first
-	err1 := dbAction.Execute(t.Context(), detection)
-	dbCompleteTime := time.Now()
+		// Step 1: Execute database action first
+		err1 := dbAction.Execute(t.Context(), detection)
+		dbCompleteTime := time.Now()
 
-	// Step 2: Execute SSE action only after database completes
-	err2 := sseAction.Execute(t.Context(), detection)
-	sseCompleteTime := time.Now()
+		// Step 2: Execute SSE action only after database completes
+		err2 := sseAction.Execute(t.Context(), detection)
+		sseCompleteTime := time.Now()
 
-	require.NoError(t, err1, "Database action failed")
-	require.NoError(t, err2, "SSE action failed")
+		require.NoError(t, err1, "Database action failed")
+		require.NoError(t, err2, "SSE action failed")
 
-	// Analyze sequential timing
-	dbDuration := dbCompleteTime.Sub(startTime)
-	sseDuration := sseCompleteTime.Sub(dbCompleteTime)
-	totalDuration := sseCompleteTime.Sub(startTime)
+		// Analyze sequential timing
+		dbDuration := dbCompleteTime.Sub(startTime)
+		sseDuration := sseCompleteTime.Sub(dbCompleteTime)
+		totalDuration := sseCompleteTime.Sub(startTime)
 
-	t.Logf("Sequential execution results:")
-	t.Logf("  Database action: %v", dbDuration)
-	t.Logf("  SSE action: %v", sseDuration)
-	t.Logf("  Total duration: %v", totalDuration)
+		t.Logf("Sequential execution results:")
+		t.Logf("  Database action: %v", dbDuration)
+		t.Logf("  SSE action: %v", sseDuration)
+		t.Logf("  Total duration: %v", totalDuration)
 
-	// Verify sequential characteristics
-	assert.GreaterOrEqual(t, dbDuration, 150*time.Millisecond, "Database action completed too quickly")
-	assert.LessOrEqual(t, sseDuration, 100*time.Millisecond, "SSE action took too long (should be fast when DB is ready)")
+		// Verify sequential characteristics. Under synctest the virtual clock
+		// advances by exactly the configured delay for each step, so the
+		// durations are exact: the database action takes its full delay, and the
+		// SSE action only waits its own (shorter) delay. If the SSE action had
+		// blocked on the database work the SSE duration would be larger.
+		assert.Equal(t, proposedSolutionDBDelay, dbDuration, "Database action should take its full configured delay")
+		assert.Equal(t, proposedSolutionSSEDelay, sseDuration, "SSE action should only wait its own delay when DB is already complete")
+		// Explicit ordering: SSE runs strictly after the database action completes.
+		assert.True(t, sseCompleteTime.After(dbCompleteTime), "SSE action should complete after the database action")
 
-	t.Logf("✓ Sequential execution prevents race condition")
-	t.Logf("✓ SSE action executes quickly when database operation is complete")
-	t.Logf("✓ No timeouts or 'note not found' errors would occur")
+		t.Logf("✓ Sequential execution prevents race condition")
+		t.Logf("✓ SSE action executes quickly when database operation is complete")
+		t.Logf("✓ No timeouts or 'note not found' errors would occur")
+	})
 }


### PR DESCRIPTION
## Problem

`TestRaceCondition_ProposedSolutionValidation` in `internal/analysis/processor` is flaky. It asserts a hardcoded wall-clock ceiling:

```go
assert.LessOrEqual(t, sseDuration, 100*time.Millisecond, "SSE action took too long ...")
```

on an action that performs a real ~50ms `time.NewTimer` sleep, while the test runs under `t.Parallel()`. The 100ms bound leaves only ~50ms of scheduling slack, so under `-race`, single-core scheduling (`-cpu=1`), and CPU contention the timer wakeup plus goroutine scheduling slips past 100ms (observed 121ms and 169ms locally), producing a spurious FAIL. The test passes in isolation and on idle multi-core runs, so it does not fail on `main` under the usual `go test -race`; it only trips on loaded or slow runners.

This is the same wall-clock-bound anti-pattern as the previously fixed jobqueue and notification timing flakes: the bound measures runner/scheduler overhead, not behavior. No data race is reported, it is purely the timing assertion.

## Fix

Wrap the test body in `testing/synctest` (the project-preferred approach over real sleeps) so the action delays run on a virtual clock. When the only goroutine in the bubble blocks on its timer, time advances by exactly the configured delay, so the measured durations are exact and deterministic:

- database action: exactly 200ms
- SSE action: exactly 50ms

with zero scheduling slack. The flake becomes structurally impossible.

The flaky `LessOrEqual` / `GreaterOrEqual` bounds are replaced with exact `assert.Equal` checks against named delay constants, plus an explicit ordering assertion that the SSE action completes after the database action.

The test stays meaningful: it still validates that sequential execution prevents the race (the SSE action only waits its own delay, not the database chain) and that ordering holds. Confirmed that a behavioral regression still fails the test (changing the SSE action's actual delay to 70ms while the assertion expects 50ms produces `Not equal: expected 50ms actual 70ms`).

## Verification

- Target test x30 under `-cpu=1` with full CPU saturation: zero flakes (previously reproduced 121ms and 169ms failures under the same conditions).
- Both reported shuffle seeds under `-cpu=1` + CPU saturation: pass.
- Full package `go test -race ./internal/analysis/processor/`: green.
- Repeated `-race -shuffle=on -count=2` rounds: all green.
- `go vet` and `golangci-lint run` on the package: 0 issues.

## Preflight Status

- [x] Single concern: one test-only flake fix
- [x] Preflight passed: parallel correctness/quality review plus secondary-model (Gemini 3.1 Pro) cross-validation, no findings requiring changes
- [x] Linters clean: `golangci-lint run` on the package reports 0 issues (full-project run shows only the pre-existing, unrelated `frontend/embed.go` typecheck error from an unbuilt frontend `dist/` in this environment)
- [x] Tests pass: `go test -race ./internal/analysis/processor/` passes
- [x] No unrelated changes: diff is a single test function in one file
- [x] No regression / backward-compat break: test-only change, no production code, config, API, DB, or CLI surface touched
- [x] No secrets or PII

Note: sibling tests in the same file still use real-sleep plus wall-clock bounds but with a much larger 500ms tolerance (lower flake risk). Converting those is out of scope for this fix.