### PR TITLE
fix(imageprovider): prevent stale cache store from clobbering fresh background refresh

### DIFF
--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -1388,6 +1388,14 @@ func (c *BirdImageCache) handleDBCacheHit(scientificName string, dbImage *BirdIm
 		return c.handleNegativeDBEntry(scientificName, dbImage)
 	}
 
+	// Store the (possibly stale) DB entry in memory BEFORE spawning any background
+	// refresh. The go statement is a happens-before edge for the goroutine's start,
+	// so a refresh goroutine spawned afterwards is guaranteed to run its own
+	// dataMap.Store(fresh) AFTER this store. Storing here first prevents this stale
+	// store from racing the refresh and clobbering the fresh value back to stale in
+	// memory while the DB already holds the fresh entry.
+	c.dataMap.Store(scientificName, dbImage)
+
 	// Regular positive entry - check staleness
 	if isCacheEntryStale(dbImage.CachedAt, false) {
 		log.Debug("DB cache entry is stale, returning stale data and triggering background refresh",
@@ -1399,7 +1407,6 @@ func (c *BirdImageCache) handleDBCacheHit(scientificName string, dbImage *BirdIm
 		log.Debug("Image loaded from DB cache")
 	}
 
-	c.dataMap.Store(scientificName, dbImage)
 	if c.metrics != nil {
 		c.metrics.IncrementCacheMisses()
 	}

--- a/internal/imageprovider/provider_policy_test.go
+++ b/internal/imageprovider/provider_policy_test.go
@@ -330,11 +330,22 @@ func TestRefreshEntryFallbackToDBCache(t *testing.T) {
 	require.NoError(t, err, "Get should return stale data without error")
 	assert.Equal(t, "http://old.example.com/redpoll.jpg", img.URL, "Should return stale data initially")
 
-	// Poll for background refresh to complete (replaces fixed time.Sleep which was flaky in CI)
+	// Poll for the background refresh to land the DB write, which is the actual
+	// observable the assertions below check. The refresh goroutine updates the
+	// in-memory cache (dataMap.Store) BEFORE writing the DB (saveToDB), so polling
+	// primaryCache.Get() (an in-memory read) would unblock before saveToDB runs and
+	// race the DB assertions on a loaded runner. Polling the DB here guarantees both
+	// writes have completed once the condition is met, because the DB write is the
+	// last write in the refresh goroutine's fallback branch.
 	require.Eventually(t, func() bool {
-		img2, err := primaryCache.Get(species)
-		return err == nil && img2.URL == "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg"
-	}, 5*time.Second, 50*time.Millisecond, "Background refresh should update cache with wikimedia fallback URL")
+		dbEntry, err := store.GetImageCache(datastore.ImageCacheQuery{
+			ScientificName: species,
+			ProviderName:   providerAvicommons,
+		})
+		return err == nil && dbEntry != nil &&
+			dbEntry.URL == "https://upload.wikimedia.org/Carduelis_flammea_CT6.jpg" &&
+			dbEntry.CachedAt.After(staleTime)
+	}, 5*time.Second, 50*time.Millisecond, "Background refresh should persist wikimedia fallback URL to DB")
 
 	// Verify full attribution after refresh
 	img2, err := primaryCache.Get(species)


### PR DESCRIPTION
## Summary

Fixes a flaky test in `internal/imageprovider` (`TestRefreshEntryFallbackToDBCache`) that failed intermittently under the full-suite `-race` run on loaded CI runners, and the underlying production race it exposed.

## Root cause

`handleDBCacheHit` serves a stale DB entry, spawns a background refresh, and then stores the stale entry into the in-memory `dataMap` AFTER spawning the goroutine:

```go
if isCacheEntryStale(dbImage.CachedAt, false) {
    c.tryGo(func() { c.refreshEntry(scientificName) })  // (A) spawn refresh
}
c.dataMap.Store(scientificName, dbImage)                // (B) store STALE, after spawn
```

The refresh goroutine (A) writes the fresh fallback image to `dataMap` and then to the DB. There is no ordering between (A) and (B). On a loaded runner the refresh can run fully (fresh in memory and DB) before (B) executes, so (B) overwrites the in-memory cache back to stale while the DB keeps the fresh value. The in-memory cache ends up stale.

The test compounded this: its `require.Eventually` polled the in-memory cache via `Get()` (which reads `dataMap`), then asserted on the DB. The refresh updates memory before writing the DB, so `Eventually` could unblock before `saveToDB` ran, letting the DB assertions race the still-pending write.

## Fix

- **Production:** store the stale entry into `dataMap` BEFORE spawning the background refresh. The `go` statement is a happens-before edge for the goroutine's start, so the refresh's later `dataMap.Store(fresh)` is guaranteed to run after this stale store and win. Serving stale immediately to the caller is unchanged.
- **Test:** poll the DB (the actual observable the assertions check) in `require.Eventually` instead of the in-memory cache. The DB write is the last write in the refresh's fallback branch, so once it lands both writes are complete.

## Verification

- `go test -race -count` over 1700+ focused iterations under heavy CPU pressure (`GOMAXPROCS=2`/`4`, oversubscribed cores, `-shuffle`): zero failures. The original test failed intermittently under the same harness; the fixed version did not.
- Full `internal/imageprovider` package green with `-race -shuffle`.
- `golangci-lint run` on the package: 0 issues.
- `go build ./...`: clean.

## Preflight Status

- [x] Single concern: one flaky-test fix plus the production race it exposed
- [x] Linters clean (package scope; the unrelated `frontend/embed.go` typecheck warning is the missing `frontend/dist` build artifact, generated in CI)
- [x] Tests pass with `-race`
- [x] No unrelated changes
- [x] No API/config/DB/CLI surface changed; internal cache ordering only