### PR TITLE
fix(audio): populate sample-rate dropdown when adding a new audio source

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.deviceProbe.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.deviceProbe.test.ts
@@ -46,7 +46,9 @@ function ratesFor(deviceId: string): RateOption[] {
   return deviceId === DEV2 ? [RATE_48K, RATE_192K, RATE_384K] : [RATE_48K, RATE_96K];
 }
 
-vi.mock('$lib/utils/audio/sampleRate', () => ({
+// Keep the real helpers (coerceSupportedRate, etc.); only stub the network probe.
+vi.mock('$lib/utils/audio/sampleRate', async importActual => ({
+  ...(await importActual<typeof import('$lib/utils/audio/sampleRate')>()),
   fetchDeviceCapabilities: vi.fn((deviceId: string, signal?: AbortSignal) =>
     makeAbortableProbe(signal, ratesFor(deviceId))
   ),

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.deviceProbe.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.deviceProbe.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import { renderTyped } from '../../../../test/render-helpers';
+import SoundCardCard from './SoundCardCard.svelte';
+import type { AudioSourceConfig } from '$lib/stores/settings';
+
+// Functional stand-in for SelectDropdown so we can drive the device dropdown and
+// read the probed sample-rate options as real <option> elements.
+vi.mock('./SelectDropdown.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockSelectDropdown.svelte')).default,
+}));
+vi.mock('./InlineSlider.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('./ModelCheckboxList.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('./QuietHoursEditor.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('$lib/desktop/features/settings/components/AudioEqualizerSettings.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('$lib/stores/models.svelte', () => ({
+  DEFAULT_MODEL_ID: 'birdnet',
+}));
+
+// Per-device probe results, so we can tell which device's capabilities landed in
+// the dropdown. Mirrors the real utility's contract: it honours the AbortSignal
+// and only surfaces AbortError to the caller.
+function ratesFor(deviceId: string) {
+  if (deviceId === 'dev2') {
+    return [
+      { value: '48000', label: '48 kHz' },
+      { value: '192000', label: '192 kHz' },
+      { value: '384000', label: '384 kHz' },
+    ];
+  }
+  // dev1
+  return [
+    { value: '48000', label: '48 kHz' },
+    { value: '96000', label: '96 kHz' },
+  ];
+}
+
+vi.mock('$lib/utils/audio/sampleRate', () => ({
+  fetchDeviceCapabilities: vi.fn(
+    (deviceId: string, signal?: AbortSignal) =>
+      new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        const timer = setTimeout(() => {
+          signal?.removeEventListener('abort', onAbort);
+          resolve({ options: ratesFor(deviceId), verified: true });
+        }, 0);
+        function onAbort() {
+          clearTimeout(timer);
+          signal?.removeEventListener('abort', onAbort);
+          reject(new DOMException('Aborted', 'AbortError'));
+        }
+        signal?.addEventListener('abort', onAbort);
+      })
+  ),
+}));
+
+describe('SoundCardCard device capability probe (issue #3593, edit form)', () => {
+  const audioDevices = [
+    { index: 0, name: 'Mic One', id: 'dev1' },
+    { index: 1, name: 'Mic Two', id: 'dev2' },
+  ];
+  const modelOptions = [{ value: 'birdnet', label: 'BirdNET' }];
+  const availableModels = [{ id: 'birdnet', name: 'BirdNET', category: 'bird' }];
+
+  function renderCard() {
+    const source: AudioSourceConfig = {
+      name: 'Living room',
+      device: 'dev1',
+      sampleRate: 48000,
+      gain: 0,
+      models: ['birdnet'],
+    };
+    return renderTyped(SoundCardCard, {
+      props: {
+        source,
+        index: 0,
+        sources: [source],
+        audioDevices,
+        modelOptions,
+        availableModels,
+        disabled: false,
+        onUpdate: vi.fn(() => true),
+        onDelete: vi.fn(),
+      },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function rateSelect() {
+    return screen.getByTestId('select-settings.audio.soundCards.sampleRateLabel');
+  }
+
+  async function openEdit() {
+    await fireEvent.click(screen.getByRole('button', { name: 'common.edit' }));
+  }
+
+  it('probes the current device when the edit form opens', async () => {
+    renderCard();
+    await openEdit();
+
+    // dev1 supports 96 kHz; opening edit must surface it (the documented workaround).
+    await waitFor(() => {
+      expect(rateSelect().querySelector('option[value="96000"]')).not.toBeNull();
+    });
+  });
+
+  it('replaces the sample-rate options when changing device while editing', async () => {
+    renderCard();
+    await openEdit();
+    // Wait for dev1's probe to land first so the switch is a genuine replacement.
+    await waitFor(() => {
+      expect(rateSelect().querySelector('option[value="96000"]')).not.toBeNull();
+    });
+
+    const deviceSelect = screen.getByTestId('select-settings.audio.soundCards.deviceLabel');
+    await fireEvent.change(deviceSelect, { target: { value: 'dev2' } });
+
+    // dev2's rates must replace dev1's: the new rates appear and dev1's exclusive
+    // 96 kHz is gone (wholesale replacement, not a merge).
+    await waitFor(() => {
+      expect(rateSelect().querySelector('option[value="192000"]')).not.toBeNull();
+    });
+    expect(rateSelect().querySelector('option[value="384000"]')).not.toBeNull();
+    expect(rateSelect().querySelector('option[value="96000"]')).toBeNull();
+  });
+});

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.deviceProbe.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.deviceProbe.test.ts
@@ -3,6 +3,18 @@ import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
 import { renderTyped } from '../../../../test/render-helpers';
 import SoundCardCard from './SoundCardCard.svelte';
 import type { AudioSourceConfig } from '$lib/stores/settings';
+import {
+  DEFAULT_MODEL,
+  DEVICE_SELECT_TESTID,
+  EDIT_BUTTON_NAME,
+  SAMPLE_RATE_SELECT_TESTID,
+  RATE_48K,
+  RATE_96K,
+  RATE_192K,
+  RATE_384K,
+  makeAbortableProbe,
+  type RateOption,
+} from '../../../../test/fixtures/soundCardProbeTest';
 
 // Functional stand-in for SelectDropdown so we can drive the device dropdown and
 // read the probed sample-rate options as real <option> elements.
@@ -25,61 +37,36 @@ vi.mock('$lib/stores/models.svelte', () => ({
   DEFAULT_MODEL_ID: 'birdnet',
 }));
 
-// Per-device probe results, so we can tell which device's capabilities landed in
-// the dropdown. Mirrors the real utility's contract: it honours the AbortSignal
-// and only surfaces AbortError to the caller.
-function ratesFor(deviceId: string) {
-  if (deviceId === 'dev2') {
-    return [
-      { value: '48000', label: '48 kHz' },
-      { value: '192000', label: '192 kHz' },
-      { value: '384000', label: '384 kHz' },
-    ];
-  }
-  // dev1
-  return [
-    { value: '48000', label: '48 kHz' },
-    { value: '96000', label: '96 kHz' },
-  ];
+const DEV1 = 'dev1';
+const DEV2 = 'dev2';
+
+// dev1 supports 96 kHz, dev2 does not (but supports 192/384 kHz), so we can tell
+// which device's capabilities landed and exercise the unsupported-rate reset.
+function ratesFor(deviceId: string): RateOption[] {
+  return deviceId === DEV2 ? [RATE_48K, RATE_192K, RATE_384K] : [RATE_48K, RATE_96K];
 }
 
 vi.mock('$lib/utils/audio/sampleRate', () => ({
-  fetchDeviceCapabilities: vi.fn(
-    (deviceId: string, signal?: AbortSignal) =>
-      new Promise((resolve, reject) => {
-        if (signal?.aborted) {
-          reject(new DOMException('Aborted', 'AbortError'));
-          return;
-        }
-        const timer = setTimeout(() => {
-          signal?.removeEventListener('abort', onAbort);
-          resolve({ options: ratesFor(deviceId), verified: true });
-        }, 0);
-        function onAbort() {
-          clearTimeout(timer);
-          signal?.removeEventListener('abort', onAbort);
-          reject(new DOMException('Aborted', 'AbortError'));
-        }
-        signal?.addEventListener('abort', onAbort);
-      })
+  fetchDeviceCapabilities: vi.fn((deviceId: string, signal?: AbortSignal) =>
+    makeAbortableProbe(signal, ratesFor(deviceId))
   ),
 }));
 
 describe('SoundCardCard device capability probe (issue #3593, edit form)', () => {
   const audioDevices = [
-    { index: 0, name: 'Mic One', id: 'dev1' },
-    { index: 1, name: 'Mic Two', id: 'dev2' },
+    { index: 0, name: 'Mic One', id: DEV1 },
+    { index: 1, name: 'Mic Two', id: DEV2 },
   ];
-  const modelOptions = [{ value: 'birdnet', label: 'BirdNET' }];
-  const availableModels = [{ id: 'birdnet', name: 'BirdNET', category: 'bird' }];
+  const modelOptions = [{ value: DEFAULT_MODEL, label: 'BirdNET' }];
+  const availableModels = [{ id: DEFAULT_MODEL, name: 'BirdNET', category: 'bird' }];
 
-  function renderCard() {
+  function renderCard(sampleRate = Number(RATE_48K.value)) {
     const source: AudioSourceConfig = {
       name: 'Living room',
-      device: 'dev1',
-      sampleRate: 48000,
+      device: DEV1,
+      sampleRate,
       gain: 0,
-      models: ['birdnet'],
+      models: [DEFAULT_MODEL],
     };
     return renderTyped(SoundCardCard, {
       props: {
@@ -105,11 +92,15 @@ describe('SoundCardCard device capability probe (issue #3593, edit form)', () =>
   });
 
   function rateSelect() {
-    return screen.getByTestId('select-settings.audio.soundCards.sampleRateLabel');
+    return screen.getByTestId(SAMPLE_RATE_SELECT_TESTID) as HTMLSelectElement;
+  }
+
+  function hasRate(value: string) {
+    return rateSelect().querySelector(`option[value="${value}"]`) !== null;
   }
 
   async function openEdit() {
-    await fireEvent.click(screen.getByRole('button', { name: 'common.edit' }));
+    await fireEvent.click(screen.getByRole('button', { name: EDIT_BUTTON_NAME }));
   }
 
   it('probes the current device when the edit form opens', async () => {
@@ -117,28 +108,36 @@ describe('SoundCardCard device capability probe (issue #3593, edit form)', () =>
     await openEdit();
 
     // dev1 supports 96 kHz; opening edit must surface it (the documented workaround).
-    await waitFor(() => {
-      expect(rateSelect().querySelector('option[value="96000"]')).not.toBeNull();
-    });
+    await waitFor(() => expect(hasRate(RATE_96K.value)).toBe(true));
   });
 
   it('replaces the sample-rate options when changing device while editing', async () => {
     renderCard();
     await openEdit();
     // Wait for dev1's probe to land first so the switch is a genuine replacement.
-    await waitFor(() => {
-      expect(rateSelect().querySelector('option[value="96000"]')).not.toBeNull();
-    });
+    await waitFor(() => expect(hasRate(RATE_96K.value)).toBe(true));
 
-    const deviceSelect = screen.getByTestId('select-settings.audio.soundCards.deviceLabel');
-    await fireEvent.change(deviceSelect, { target: { value: 'dev2' } });
+    const deviceSelect = screen.getByTestId(DEVICE_SELECT_TESTID);
+    await fireEvent.change(deviceSelect, { target: { value: DEV2 } });
 
     // dev2's rates must replace dev1's: the new rates appear and dev1's exclusive
     // 96 kHz is gone (wholesale replacement, not a merge).
-    await waitFor(() => {
-      expect(rateSelect().querySelector('option[value="192000"]')).not.toBeNull();
-    });
-    expect(rateSelect().querySelector('option[value="384000"]')).not.toBeNull();
-    expect(rateSelect().querySelector('option[value="96000"]')).toBeNull();
+    await waitFor(() => expect(hasRate(RATE_192K.value)).toBe(true));
+    expect(hasRate(RATE_384K.value)).toBe(true);
+    expect(hasRate(RATE_96K.value)).toBe(false);
+  });
+
+  it('resets a selected rate the new device cannot honor back to 48 kHz', async () => {
+    // Source saved at 96 kHz, which dev1 supports but dev2 does not.
+    renderCard(Number(RATE_96K.value));
+    await openEdit();
+    await waitFor(() => expect(rateSelect().value).toBe(RATE_96K.value));
+
+    const deviceSelect = screen.getByTestId(DEVICE_SELECT_TESTID);
+    await fireEvent.change(deviceSelect, { target: { value: DEV2 } });
+
+    // dev2 lacks 96 kHz, so the selection must fall back to 48 kHz rather than
+    // persist an unsupported rate.
+    await waitFor(() => expect(rateSelect().value).toBe(RATE_48K.value));
   });
 });

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -244,6 +244,10 @@
     const controller = new AbortController();
     fetchController = controller;
     sampleRateLoading = true;
+    // Drop the previous device's probed rates so a slower probe cannot leave
+    // stale, unverified options on screen while the new one is in flight.
+    sampleRateOptions = [{ value: '48000', label: '48 kHz' }];
+    sampleRateVerified = true;
     try {
       const result = await fetchCapabilities(deviceId, controller.signal);
       // Ignore a superseded probe: a newer device selection has replaced this
@@ -252,6 +256,11 @@
       if (fetchController !== controller) return;
       sampleRateOptions = result.options;
       sampleRateVerified = result.verified;
+      // Drop a selection the new device cannot honor so an unsupported rate is
+      // never persisted.
+      if (!result.options.some(opt => Number(opt.value) === editSampleRate)) {
+        editSampleRate = 48000;
+      }
     } catch {
       // Only AbortError reaches here (utility handles all other failures internally)
     } finally {

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -34,7 +34,10 @@
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
   import { loggers } from '$lib/utils/logger';
-  import { fetchDeviceCapabilities as fetchCapabilities } from '$lib/utils/audio/sampleRate';
+  import {
+    fetchDeviceCapabilities as fetchCapabilities,
+    coerceSupportedRate,
+  } from '$lib/utils/audio/sampleRate';
   import { DEFAULT_MODEL_ID } from '$lib/stores/models.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
   import InlineSlider from './InlineSlider.svelte';
@@ -256,11 +259,9 @@
       if (fetchController !== controller) return;
       sampleRateOptions = result.options;
       sampleRateVerified = result.verified;
-      // Drop a selection the new device cannot honor so an unsupported rate is
-      // never persisted.
-      if (!result.options.some(opt => Number(opt.value) === editSampleRate)) {
-        editSampleRate = 48000;
-      }
+      // Coerce the selection to a rate the new device actually supports so an
+      // unsupported rate is never persisted.
+      editSampleRate = coerceSupportedRate(result.options, editSampleRate);
     } catch {
       // Only AbortError reaches here (utility handles all other failures internally)
     } finally {

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -117,7 +117,12 @@
   ]);
   let sampleRateVerified = $state(true);
   let sampleRateLoading = $state(false);
-  let fetchController: AbortController | null = $state(null);
+  // Plain (non-reactive) ref: the probe effect both reads (abort) and writes this
+  // controller in its synchronous prefix. As $state that read/write would register
+  // the controller as a dependency of the effect and immediately re-run it, whose
+  // cleanup then aborts the brand-new in-flight probe (issue #3593). It is only
+  // used imperatively for abort(), never in markup, so it must not be reactive.
+  let fetchController: AbortController | null = null;
 
   // Device display name lookup
   let deviceDisplayName = $derived(
@@ -236,16 +241,23 @@
   async function fetchDeviceCapabilities(deviceId: string) {
     if (!deviceId) return;
     fetchController?.abort();
-    fetchController = new AbortController();
+    const controller = new AbortController();
+    fetchController = controller;
     sampleRateLoading = true;
     try {
-      const result = await fetchCapabilities(deviceId, fetchController.signal);
+      const result = await fetchCapabilities(deviceId, controller.signal);
+      // Ignore a superseded probe: a newer device selection has replaced this
+      // controller, so applying these results (or clearing the loading flag)
+      // would clobber the newer probe's state.
+      if (fetchController !== controller) return;
       sampleRateOptions = result.options;
       sampleRateVerified = result.verified;
     } catch {
       // Only AbortError reaches here (utility handles all other failures internally)
     } finally {
-      sampleRateLoading = false;
+      if (fetchController === controller) {
+        sampleRateLoading = false;
+      }
     }
   }
 
@@ -255,8 +267,13 @@
       prevEditDevice = editDevice;
       fetchDeviceCapabilities(editDevice);
     }
+    // Capture the controller this run started so the cleanup only aborts that
+    // probe. startEdit() starts a probe directly and then flips isEditing, which
+    // re-runs this effect; without the capture the cleanup would abort that
+    // just-started probe and the edit form would open stuck at 48 kHz (issue #3593).
+    const controllerToAbort = fetchController;
     return () => {
-      fetchController?.abort();
+      controllerToAbort?.abort();
     };
   });
 </script>

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -261,6 +261,10 @@
     const controller = new AbortController();
     newFetchController = controller;
     newSampleRateLoading = true;
+    // Drop the previous device's probed rates so a slower probe cannot leave
+    // stale, unverified options on screen while the new one is in flight.
+    newSampleRateOptions = [{ value: '48000', label: '48 kHz' }];
+    newSampleRateVerified = true;
     try {
       const result = await fetchCapabilities(deviceId, controller.signal);
       // Ignore a superseded probe: a newer device selection has replaced this
@@ -269,6 +273,11 @@
       if (newFetchController !== controller) return;
       newSampleRateOptions = result.options;
       newSampleRateVerified = result.verified;
+      // Drop a selection the new device cannot honor so an unsupported rate is
+      // never persisted.
+      if (!result.options.some(opt => Number(opt.value) === newSampleRate)) {
+        newSampleRate = 48000;
+      }
     } catch {
       // Only AbortError reaches here (utility handles all other failures internally)
     } finally {

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -19,7 +19,10 @@
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { generateId } from '$lib/utils/uuid';
-  import { fetchDeviceCapabilities as fetchCapabilities } from '$lib/utils/audio/sampleRate';
+  import {
+    fetchDeviceCapabilities as fetchCapabilities,
+    coerceSupportedRate,
+  } from '$lib/utils/audio/sampleRate';
   import { toastActions } from '$lib/stores/toast';
   import { cn } from '$lib/utils/cn';
   import { getAvailableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
@@ -273,11 +276,9 @@
       if (newFetchController !== controller) return;
       newSampleRateOptions = result.options;
       newSampleRateVerified = result.verified;
-      // Drop a selection the new device cannot honor so an unsupported rate is
-      // never persisted.
-      if (!result.options.some(opt => Number(opt.value) === newSampleRate)) {
-        newSampleRate = 48000;
-      }
+      // Coerce the selection to a rate the new device actually supports so an
+      // unsupported rate is never persisted.
+      newSampleRate = coerceSupportedRate(result.options, newSampleRate);
     } catch {
       // Only AbortError reaches here (utility handles all other failures internally)
     } finally {

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -99,7 +99,12 @@
   ]);
   let newSampleRateVerified = $state(true);
   let newSampleRateLoading = $state(false);
-  let newFetchController: AbortController | null = $state(null);
+  // Plain (non-reactive) ref: the probe effect both reads (abort) and writes this
+  // controller in its synchronous prefix. As $state that read/write would register
+  // the controller as a dependency of the effect and immediately re-run it, whose
+  // cleanup then aborts the brand-new in-flight probe (issue #3593). It is only
+  // used imperatively for abort(), never in markup, so it must not be reactive.
+  let newFetchController: AbortController | null = null;
   let newModels = $state<string[]>([]);
   let newEqualizer = $state<LocalEqualizerSettings>({ enabled: false, filters: [] });
   let newQuietHours = $state<QuietHoursConfig>({ ...defaultQuietHoursConfig });
@@ -253,16 +258,23 @@
   async function fetchNewDeviceCapabilities(deviceId: string) {
     if (!deviceId) return;
     newFetchController?.abort();
-    newFetchController = new AbortController();
+    const controller = new AbortController();
+    newFetchController = controller;
     newSampleRateLoading = true;
     try {
-      const result = await fetchCapabilities(deviceId, newFetchController.signal);
+      const result = await fetchCapabilities(deviceId, controller.signal);
+      // Ignore a superseded probe: a newer device selection has replaced this
+      // controller, so applying these results (or clearing the loading flag)
+      // would clobber the newer probe's state.
+      if (newFetchController !== controller) return;
       newSampleRateOptions = result.options;
       newSampleRateVerified = result.verified;
     } catch {
       // Only AbortError reaches here (utility handles all other failures internally)
     } finally {
-      newSampleRateLoading = false;
+      if (newFetchController === controller) {
+        newSampleRateLoading = false;
+      }
     }
   }
 
@@ -272,8 +284,12 @@
       prevNewDevice = newDevice;
       fetchNewDeviceCapabilities(newDevice);
     }
+    // Capture the controller this run started so the cleanup only aborts that
+    // probe. A later re-run for an unrelated reason must not abort a probe it
+    // did not start (issue #3593).
+    const controllerToAbort = newFetchController;
     return () => {
-      newFetchController?.abort();
+      controllerToAbort?.abort();
     };
   });
 </script>

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import { renderTyped } from '../../../../test/render-helpers';
+import SoundCardManager from './SoundCardManager.svelte';
+import type { AudioSourceConfig } from '$lib/stores/settings';
+
+// Functional stand-in for SelectDropdown: renders a native <select> wired to the
+// same `onChange` prop and exposes `options` as real <option> elements. This lets
+// us drive device selection and assert on the probed sample-rate options without
+// driving the real portal-based dropdown UI.
+vi.mock('./SelectDropdown.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockSelectDropdown.svelte')).default,
+}));
+
+// Heavy children irrelevant to this flow are replaced with inert components.
+vi.mock('./TextInput.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('./InlineSlider.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('./ModelCheckboxList.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('./QuietHoursEditor.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+vi.mock('$lib/desktop/features/settings/components/AudioEqualizerSettings.svelte', async () => ({
+  default: (await import('../../../../test/fixtures/MockEmpty.svelte')).default,
+}));
+
+// Avoid the models store touching the network during mount.
+vi.mock('$lib/stores/models.svelte', () => ({
+  getAvailableModels: vi.fn(() => []),
+  DEFAULT_MODEL_ID: 'birdnet',
+  fetchModels: vi.fn(() => () => {}),
+}));
+
+const ABORT = () => new DOMException('Aborted', 'AbortError');
+
+// Per-device probe behaviour, mirroring the real utility's contract (only
+// AbortError is surfaced to the caller; everything else returns options).
+//  - 'fast-dev' resolves immediately and honours abort.
+//  - 'slow-dev' resolves late and IGNORES abort, simulating a response that was
+//    already in flight when its controller was aborted (the stale-result race).
+//  - default device resolves immediately with the full rate set and honours abort.
+function probeFor(deviceId: string, signal: AbortSignal | undefined) {
+  if (deviceId === 'slow-dev') {
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(ABORT());
+        return;
+      }
+      // Deliberately ignores the abort signal and resolves later than fast-dev.
+      setTimeout(
+        () => resolve({ options: [{ value: '48000', label: '48 kHz' }], verified: true }),
+        40
+      );
+    });
+  }
+  if (deviceId === 'fast-dev') {
+    return makeAbortableProbe(signal, [
+      { value: '48000', label: '48 kHz' },
+      { value: '96000', label: '96 kHz' },
+    ]);
+  }
+  return makeAbortableProbe(signal, [
+    { value: '48000', label: '48 kHz' },
+    { value: '96000', label: '96 kHz' },
+    { value: '192000', label: '192 kHz' },
+  ]);
+}
+
+function makeAbortableProbe(
+  signal: AbortSignal | undefined,
+  options: { value: string; label: string }[]
+) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(ABORT());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve({ options, verified: true });
+    }, 0);
+    function onAbort() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      reject(ABORT());
+    }
+    signal?.addEventListener('abort', onAbort);
+  });
+}
+
+vi.mock('$lib/utils/audio/sampleRate', () => ({
+  fetchDeviceCapabilities: vi.fn((deviceId: string, signal?: AbortSignal) =>
+    probeFor(deviceId, signal)
+  ),
+}));
+
+const settle = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('SoundCardManager sample rate probe (issue #3593)', () => {
+  function renderManager(audioDevices: Array<{ index: number; name: string; id: string }>) {
+    return renderTyped(SoundCardManager, {
+      props: {
+        sources: [] as AudioSourceConfig[],
+        audioDevices,
+        audioDevicesLoading: false,
+        disabled: false,
+        onUpdateSources: vi.fn(),
+        onRefreshDevices: vi.fn(),
+      },
+    });
+  }
+
+  async function openAddForm() {
+    await fireEvent.click(screen.getByText('settings.audio.soundCards.addSource'));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('populates the sample-rate dropdown after selecting a device for a new source', async () => {
+    renderManager([{ index: 0, name: 'USB Mic', id: 'usb-mic' }]);
+    await openAddForm();
+
+    const deviceSelect = await screen.findByTestId('select-settings.audio.soundCards.deviceLabel');
+    await fireEvent.change(deviceSelect, { target: { value: 'usb-mic' } });
+
+    const rateSelect = screen.getByTestId('select-settings.audio.soundCards.sampleRateLabel');
+
+    // The probed rates beyond the 48 kHz default must become selectable.
+    await waitFor(() => {
+      expect(rateSelect.querySelector('option[value="96000"]')).not.toBeNull();
+    });
+    expect(rateSelect.querySelector('option[value="192000"]')).not.toBeNull();
+  });
+
+  it('ignores a stale probe that resolves after a newer device was selected', async () => {
+    renderManager([
+      { index: 0, name: 'Slow Mic', id: 'slow-dev' },
+      { index: 1, name: 'Fast Mic', id: 'fast-dev' },
+    ]);
+    await openAddForm();
+
+    const deviceSelect = await screen.findByTestId('select-settings.audio.soundCards.deviceLabel');
+    // Select the slow device, then immediately switch to the fast one. The slow
+    // probe resolves later and ignores its abort, so without the supersession
+    // guard it would clobber the fast device's options.
+    await fireEvent.change(deviceSelect, { target: { value: 'slow-dev' } });
+    await fireEvent.change(deviceSelect, { target: { value: 'fast-dev' } });
+
+    const rateSelect = screen.getByTestId('select-settings.audio.soundCards.sampleRateLabel');
+    await waitFor(() => {
+      expect(rateSelect.querySelector('option[value="96000"]')).not.toBeNull();
+    });
+
+    // Let the stale slow-dev probe resolve; the fast device's options must survive.
+    await settle(80);
+    expect(rateSelect.querySelector('option[value="96000"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
@@ -75,7 +75,9 @@ function probeFor(deviceId: string, signal: AbortSignal | undefined) {
   return makeAbortableProbe(signal, [RATE_48K, RATE_96K, RATE_192K]);
 }
 
-vi.mock('$lib/utils/audio/sampleRate', () => ({
+// Keep the real helpers (coerceSupportedRate, etc.); only stub the network probe.
+vi.mock('$lib/utils/audio/sampleRate', async importActual => ({
+  ...(await importActual<typeof import('$lib/utils/audio/sampleRate')>()),
   fetchDeviceCapabilities: vi.fn((deviceId: string, signal?: AbortSignal) =>
     probeFor(deviceId, signal)
   ),

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
@@ -3,6 +3,18 @@ import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
 import { renderTyped } from '../../../../test/render-helpers';
 import SoundCardManager from './SoundCardManager.svelte';
 import type { AudioSourceConfig } from '$lib/stores/settings';
+import {
+  ADD_SOURCE_KEY,
+  ABORT_ERROR,
+  DEVICE_SELECT_TESTID,
+  SAMPLE_RATE_SELECT_TESTID,
+  RATE_48K,
+  RATE_96K,
+  RATE_192K,
+  makeAbortableProbe,
+  settle,
+  type RateOption,
+} from '../../../../test/fixtures/soundCardProbeTest';
 
 // Functional stand-in for SelectDropdown: renders a native <select> wired to the
 // same `onChange` prop and exposes `options` as real <option> elements. This lets
@@ -36,61 +48,31 @@ vi.mock('$lib/stores/models.svelte', () => ({
   fetchModels: vi.fn(() => () => {}),
 }));
 
-const ABORT = () => new DOMException('Aborted', 'AbortError');
+const USB_MIC = 'usb-mic';
+const SLOW_DEV = 'slow-dev';
+const FAST_DEV = 'fast-dev';
 
-// Per-device probe behaviour, mirroring the real utility's contract (only
-// AbortError is surfaced to the caller; everything else returns options).
-//  - 'fast-dev' resolves immediately and honours abort.
-//  - 'slow-dev' resolves late and IGNORES abort, simulating a response that was
-//    already in flight when its controller was aborted (the stale-result race).
-//  - default device resolves immediately with the full rate set and honours abort.
+// The slow probe resolves later than the fast one and IGNORES its abort,
+// simulating a response that was already in flight when its controller was
+// aborted (the stale-result race the supersession guard defends against).
+const SLOW_PROBE_MS = 40;
+const STALE_SETTLE_MS = 80;
+
+// Per-device probe behaviour, mirroring the real utility's contract.
 function probeFor(deviceId: string, signal: AbortSignal | undefined) {
-  if (deviceId === 'slow-dev') {
-    return new Promise((resolve, reject) => {
+  if (deviceId === SLOW_DEV) {
+    return new Promise<{ options: RateOption[]; verified: boolean }>((resolve, reject) => {
       if (signal?.aborted) {
-        reject(ABORT());
+        reject(ABORT_ERROR());
         return;
       }
-      // Deliberately ignores the abort signal and resolves later than fast-dev.
-      setTimeout(
-        () => resolve({ options: [{ value: '48000', label: '48 kHz' }], verified: true }),
-        40
-      );
+      setTimeout(() => resolve({ options: [RATE_48K], verified: true }), SLOW_PROBE_MS);
     });
   }
-  if (deviceId === 'fast-dev') {
-    return makeAbortableProbe(signal, [
-      { value: '48000', label: '48 kHz' },
-      { value: '96000', label: '96 kHz' },
-    ]);
+  if (deviceId === FAST_DEV) {
+    return makeAbortableProbe(signal, [RATE_48K, RATE_96K]);
   }
-  return makeAbortableProbe(signal, [
-    { value: '48000', label: '48 kHz' },
-    { value: '96000', label: '96 kHz' },
-    { value: '192000', label: '192 kHz' },
-  ]);
-}
-
-function makeAbortableProbe(
-  signal: AbortSignal | undefined,
-  options: { value: string; label: string }[]
-) {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(ABORT());
-      return;
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve({ options, verified: true });
-    }, 0);
-    function onAbort() {
-      clearTimeout(timer);
-      signal?.removeEventListener('abort', onAbort);
-      reject(ABORT());
-    }
-    signal?.addEventListener('abort', onAbort);
-  });
+  return makeAbortableProbe(signal, [RATE_48K, RATE_96K, RATE_192K]);
 }
 
 vi.mock('$lib/utils/audio/sampleRate', () => ({
@@ -98,8 +80,6 @@ vi.mock('$lib/utils/audio/sampleRate', () => ({
     probeFor(deviceId, signal)
   ),
 }));
-
-const settle = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 describe('SoundCardManager sample rate probe (issue #3593)', () => {
   function renderManager(audioDevices: Array<{ index: number; name: string; id: string }>) {
@@ -116,7 +96,11 @@ describe('SoundCardManager sample rate probe (issue #3593)', () => {
   }
 
   async function openAddForm() {
-    await fireEvent.click(screen.getByText('settings.audio.soundCards.addSource'));
+    await fireEvent.click(screen.getByText(ADD_SOURCE_KEY));
+  }
+
+  function rateSelect() {
+    return screen.getByTestId(SAMPLE_RATE_SELECT_TESTID);
   }
 
   beforeEach(() => {
@@ -128,42 +112,39 @@ describe('SoundCardManager sample rate probe (issue #3593)', () => {
   });
 
   it('populates the sample-rate dropdown after selecting a device for a new source', async () => {
-    renderManager([{ index: 0, name: 'USB Mic', id: 'usb-mic' }]);
+    renderManager([{ index: 0, name: 'USB Mic', id: USB_MIC }]);
     await openAddForm();
 
-    const deviceSelect = await screen.findByTestId('select-settings.audio.soundCards.deviceLabel');
-    await fireEvent.change(deviceSelect, { target: { value: 'usb-mic' } });
-
-    const rateSelect = screen.getByTestId('select-settings.audio.soundCards.sampleRateLabel');
+    const deviceSelect = await screen.findByTestId(DEVICE_SELECT_TESTID);
+    await fireEvent.change(deviceSelect, { target: { value: USB_MIC } });
 
     // The probed rates beyond the 48 kHz default must become selectable.
     await waitFor(() => {
-      expect(rateSelect.querySelector('option[value="96000"]')).not.toBeNull();
+      expect(rateSelect().querySelector(`option[value="${RATE_96K.value}"]`)).not.toBeNull();
     });
-    expect(rateSelect.querySelector('option[value="192000"]')).not.toBeNull();
+    expect(rateSelect().querySelector(`option[value="${RATE_192K.value}"]`)).not.toBeNull();
   });
 
   it('ignores a stale probe that resolves after a newer device was selected', async () => {
     renderManager([
-      { index: 0, name: 'Slow Mic', id: 'slow-dev' },
-      { index: 1, name: 'Fast Mic', id: 'fast-dev' },
+      { index: 0, name: 'Slow Mic', id: SLOW_DEV },
+      { index: 1, name: 'Fast Mic', id: FAST_DEV },
     ]);
     await openAddForm();
 
-    const deviceSelect = await screen.findByTestId('select-settings.audio.soundCards.deviceLabel');
+    const deviceSelect = await screen.findByTestId(DEVICE_SELECT_TESTID);
     // Select the slow device, then immediately switch to the fast one. The slow
     // probe resolves later and ignores its abort, so without the supersession
     // guard it would clobber the fast device's options.
-    await fireEvent.change(deviceSelect, { target: { value: 'slow-dev' } });
-    await fireEvent.change(deviceSelect, { target: { value: 'fast-dev' } });
+    await fireEvent.change(deviceSelect, { target: { value: SLOW_DEV } });
+    await fireEvent.change(deviceSelect, { target: { value: FAST_DEV } });
 
-    const rateSelect = screen.getByTestId('select-settings.audio.soundCards.sampleRateLabel');
     await waitFor(() => {
-      expect(rateSelect.querySelector('option[value="96000"]')).not.toBeNull();
+      expect(rateSelect().querySelector(`option[value="${RATE_96K.value}"]`)).not.toBeNull();
     });
 
     // Let the stale slow-dev probe resolve; the fast device's options must survive.
-    await settle(80);
-    expect(rateSelect.querySelector('option[value="96000"]')).not.toBeNull();
+    await settle(STALE_SETTLE_MS);
+    expect(rateSelect().querySelector(`option[value="${RATE_96K.value}"]`)).not.toBeNull();
   });
 });

--- a/frontend/src/lib/utils/audio/sampleRate.test.ts
+++ b/frontend/src/lib/utils/audio/sampleRate.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { coerceSupportedRate, DEFAULT_SAMPLE_RATE, type SampleRateOption } from './sampleRate';
+
+const opt = (rate: number): SampleRateOption => ({
+  value: String(rate),
+  label: `${rate / 1000} kHz`,
+});
+
+describe('coerceSupportedRate', () => {
+  it('keeps the current rate when the device supports it', () => {
+    const options = [opt(48000), opt(96000), opt(192000)];
+    expect(coerceSupportedRate(options, 96000)).toBe(96000);
+  });
+
+  it('falls back to 48 kHz when the current rate is unsupported but 48 kHz is offered', () => {
+    const options = [opt(48000), opt(192000), opt(384000)];
+    expect(coerceSupportedRate(options, 96000)).toBe(48000);
+  });
+
+  it('falls back to the first supported rate when 48 kHz is not offered', () => {
+    // A specialised interface that only supports 96 kHz and up.
+    const options = [opt(96000), opt(192000)];
+    expect(coerceSupportedRate(options, 48000)).toBe(96000);
+  });
+
+  it('returns the default when the option list is empty', () => {
+    expect(coerceSupportedRate([], 192000)).toBe(DEFAULT_SAMPLE_RATE);
+  });
+});

--- a/frontend/src/lib/utils/audio/sampleRate.ts
+++ b/frontend/src/lib/utils/audio/sampleRate.ts
@@ -4,6 +4,9 @@
 
 export const CANDIDATE_SAMPLE_RATES = [48000, 96000, 192000, 256000, 384000] as const;
 
+/** Conventional default capture rate, supported by virtually every device. */
+export const DEFAULT_SAMPLE_RATE = 48000;
+
 export type SampleRateOption = { value: string; label: string };
 
 export interface DeviceCapabilitiesResult {
@@ -79,4 +82,24 @@ export async function fetchDeviceCapabilities(
     if (error instanceof Error && error.name === 'AbortError') throw error;
     return { options: fallbackOptions(), verified: false };
   }
+}
+
+/**
+ * Choose a sample rate that the device actually supports.
+ *
+ * Returns `current` when it is among `options`. Otherwise it falls back to the
+ * conventional 48 kHz default when the device offers it, and to the first
+ * supported rate when it does not (e.g. a specialised interface that only
+ * supports 96 kHz and up), so an unsupported rate is never selected. An empty
+ * option list yields the default.
+ */
+export function coerceSupportedRate(options: SampleRateOption[], current: number): number {
+  if (options.length === 0) {
+    return DEFAULT_SAMPLE_RATE;
+  }
+  if (options.some(opt => Number(opt.value) === current)) {
+    return current;
+  }
+  const preferred = options.find(opt => Number(opt.value) === DEFAULT_SAMPLE_RATE) ?? options[0];
+  return Number(preferred.value);
 }

--- a/frontend/src/test/fixtures/MockEmpty.svelte
+++ b/frontend/src/test/fixtures/MockEmpty.svelte
@@ -1,0 +1,9 @@
+<!--
+  Test fixture: inert Svelte 5 component that renders nothing.
+
+  Used to stand in for heavy child components that are irrelevant to the unit
+  under test, while remaining a real (mountable) Svelte 5 component so the
+  parent renders without errors. Ignores all props.
+
+  @component
+-->

--- a/frontend/src/test/fixtures/MockSelectDropdown.svelte
+++ b/frontend/src/test/fixtures/MockSelectDropdown.svelte
@@ -11,6 +11,10 @@
   @component
 -->
 <script lang="ts">
+  // Tests query the rendered control by `data-testid={SELECT_TESTID_PREFIX + label}`.
+  // Keep this in sync with the prefix in soundCardProbeTest.ts.
+  const SELECT_TESTID_PREFIX = 'select-';
+
   interface Option {
     value: string;
     label: string;
@@ -34,7 +38,7 @@
 </script>
 
 <select
-  data-testid={`select-${label}`}
+  data-testid={`${SELECT_TESTID_PREFIX}${label}`}
   value={selected}
   {disabled}
   onchange={e => onChange?.((e.currentTarget as HTMLSelectElement).value)}

--- a/frontend/src/test/fixtures/MockSelectDropdown.svelte
+++ b/frontend/src/test/fixtures/MockSelectDropdown.svelte
@@ -1,0 +1,45 @@
+<!--
+  Test fixture: a functional stand-in for SelectDropdown.svelte.
+
+  The real SelectDropdown is a portal-based custom widget that is awkward to
+  drive in jsdom. This mock renders a plain native <select> wired to the same
+  `onChange` prop and exposes the passed `options` as real <option> elements so
+  tests can both drive selection (fireEvent.change) and assert on the available
+  options without opening a popup. The `data-testid` is derived from `label`
+  so multiple dropdowns in the same form can be addressed individually.
+
+  @component
+-->
+<script lang="ts">
+  interface Option {
+    value: string;
+    label: string;
+  }
+
+  let {
+    value = '',
+    label = '',
+    options = [],
+    disabled = false,
+    onChange,
+  }: {
+    value?: string | string[];
+    label?: string;
+    options?: Option[];
+    disabled?: boolean;
+    onChange?: (_value: string | string[]) => void;
+  } = $props();
+
+  const selected = $derived(Array.isArray(value) ? (value[0] ?? '') : value);
+</script>
+
+<select
+  data-testid={`select-${label}`}
+  value={selected}
+  {disabled}
+  onchange={e => onChange?.((e.currentTarget as HTMLSelectElement).value)}
+>
+  {#each options as opt (opt.value)}
+    <option value={opt.value}>{opt.label}</option>
+  {/each}
+</select>

--- a/frontend/src/test/fixtures/soundCardProbeTest.ts
+++ b/frontend/src/test/fixtures/soundCardProbeTest.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared constants for the SoundCard sample-rate probe tests, so device IDs,
+ * sample-rate option fixtures, probe timings, and the testid/i18n-key selectors
+ * are declared once instead of repeated as magic literals across the suites.
+ */
+// Must match the prefix MockSelectDropdown.svelte builds its data-testid from.
+const SELECT_TESTID_PREFIX = 'select-';
+
+// i18n keys: the test i18n mock returns the key verbatim for unmapped keys, so
+// these double as the rendered selector text.
+const DEVICE_LABEL_KEY = 'settings.audio.soundCards.deviceLabel';
+const SAMPLE_RATE_LABEL_KEY = 'settings.audio.soundCards.sampleRateLabel';
+export const ADD_SOURCE_KEY = 'settings.audio.soundCards.addSource';
+export const EDIT_BUTTON_NAME = 'common.edit';
+
+// MockSelectDropdown derives its testid from `SELECT_TESTID_PREFIX + label`.
+export const DEVICE_SELECT_TESTID = `${SELECT_TESTID_PREFIX}${DEVICE_LABEL_KEY}`;
+export const SAMPLE_RATE_SELECT_TESTID = `${SELECT_TESTID_PREFIX}${SAMPLE_RATE_LABEL_KEY}`;
+
+export type RateOption = { value: string; label: string };
+
+export const RATE_48K: RateOption = { value: '48000', label: '48 kHz' };
+export const RATE_96K: RateOption = { value: '96000', label: '96 kHz' };
+export const RATE_192K: RateOption = { value: '192000', label: '192 kHz' };
+export const RATE_384K: RateOption = { value: '384000', label: '384 kHz' };
+
+export const DEFAULT_MODEL = 'birdnet';
+
+export const ABORT_ERROR = () => new DOMException('Aborted', 'AbortError');
+
+/**
+ * A probe that resolves on the next macrotask with the given options and honours
+ * the AbortSignal, mirroring the real fetchDeviceCapabilities contract (only
+ * AbortError is surfaced to the caller).
+ */
+export function makeAbortableProbe(signal: AbortSignal | undefined, options: RateOption[]) {
+  return new Promise<{ options: RateOption[]; verified: boolean }>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(ABORT_ERROR());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve({ options, verified: true });
+    }, 0);
+    function onAbort() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      reject(ABORT_ERROR());
+    }
+    signal?.addEventListener('abort', onAbort);
+  });
+}
+
+/** Resolve after `ms`, used to let a deliberately-slow stale probe settle. */
+export const settle = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary

When adding a new audio source, the sample-rate dropdown was stuck showing only 48 kHz. You had to save the source with 48 kHz, then re-edit it before other rates appeared.

The root cause is a Svelte 5 reactivity trap. The `AbortController` used to cancel the device-capability probe was declared `$state(null)`. The probe function reads it (`controller?.abort()`) and then writes it (`controller = new AbortController()`) synchronously inside the `$effect` that watches the selected device. The read registered the controller as a reactive dependency of the effect, and the write re-triggered the effect, whose cleanup then aborted the brand-new probe before it could populate the dropdown. The edit form had the same latent pattern, which is why the documented workaround (save, then re-edit) appeared to work but changing the device while editing did not.

## Changes

Applied to both the add form (`SoundCardManager.svelte`) and the edit form (`SoundCardCard.svelte`):

- Make the probe's `AbortController` a plain non-reactive `let` so reading and writing it no longer feeds the effect's dependency graph (kills the self-invalidation loop). The controller is only used imperatively for `abort()`, never in markup.
- Capture the controller per effect run so the cleanup aborts only the probe that run started, not one a later, unrelated re-run created. A plain `let` alone would otherwise regress the edit form: `startEdit()` starts a probe and then flips `isEditing`, re-running the effect whose closure cleanup would abort the just-started probe and leave the form opening stuck at 48 kHz.
- Guard the probe's result write and the loading flag with an identity check (`if (fetchController !== controller) return;`) so a superseded probe cannot clobber a newer device's options or toggle the loading indicator off while a newer probe is still in flight.

## Related Issues

Fixes #3593

## Test Plan

- [x] New regression tests render the real components, drive device selection through a functional `SelectDropdown` stand-in, and assert the probed sample rates populate the dropdown.
- [x] Verified the add-form and device-switch tests fail on the unfixed code and pass after the fix.
- [x] The edit-open test additionally guards against a plain-`let`-only fix that would regress opening the edit form.
- [x] A stale-probe test verifies the supersession guard (fails without it).
- [x] `npm run check:all` (prettier, eslint, stylelint, svelte-check, ast-grep) passes.
- [x] Forms + audio-settings suite: 408 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale device capability probe results from overwriting the currently selected device’s sample-rate options during quick device switches (including both add and edit flows).
  * Updated sample-rate selection so it reliably remains valid for the newly selected device, with correct fallback when the previous rate isn’t supported.
* **Tests**
  * Added/expanded Vitest + Svelte Testing Library coverage for sample-rate probing race conditions, including realistic dropdown option rendering and abort scenarios.
  * Introduced lightweight test fixtures/helpers to streamline UI testing.
* **Chores**
  * Added unit tests for sample-rate coercion logic to ensure consistent fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->