### PR TITLE
fix(install): re-run-safe config writers and extended reconfigure menu

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,44 @@
+name: Install Script Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'install.sh'
+      - 'scripts/install_test.sh'
+      - 'internal/conf/config.yaml'
+      - '.github/workflows/install-test.yml'
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'scripts/install_test.sh'
+      - 'internal/conf/config.yaml'
+      - '.github/workflows/install-test.yml'
+
+concurrency:
+  group: install-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  install-script-tests:
+    name: install.sh helpers (shellcheck + unit tests)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: ShellCheck install.sh and the test harness
+        # ubuntu-24.04 ships shellcheck preinstalled. Gate on errors only; the existing
+        # SC2155 style warnings in install.sh are tracked separately and not part of this PR.
+        run: |
+          shellcheck --version
+          shellcheck -S error install.sh
+          shellcheck -S warning scripts/install_test.sh
+
+      - name: Run install.sh helper unit tests
+        run: bash scripts/install_test.sh

--- a/install.sh
+++ b/install.sh
@@ -3834,7 +3834,7 @@ configure_location() {
     print_message "3) Skip location configuration (use default: 0.0, 0.0)" "$YELLOW"
     
     while true; do
-        print_message "❓ Select location input method (1-3): " "$YELLOW" "nonewline"
+        print_message "❓ Select location input method (1-3) or 'b' to go back: " "$YELLOW" "nonewline"
         if ! read -r location_choice; then
             print_message "\n⚠️ No input; skipping location configuration (using 0.0, 0.0)." "$YELLOW"
             lat="0.0"; lon="0.0"
@@ -3842,6 +3842,12 @@ configure_location() {
         fi
 
         case $location_choice in
+            b)
+                # Back out without touching the existing coordinates. The caller
+                # (reconfigure menu) treats a non-zero return as "no change".
+                log_message "INFO" "User backed out of location configuration"
+                return 1
+                ;;
             1)
                 while true; do
                     print_message "Enter latitude (-90 to 90) or 'b' to go back: " "$YELLOW" "nonewline"
@@ -3970,7 +3976,13 @@ configure_auth() {
     print_message "Do you want to enable password protection for the settings interface?" "$YELLOW"
     print_message "This is highly recommended if BirdNET-Go will be accessible from the internet." "$YELLOW"
     print_message "❓ Enable password protection? (y/n): " "$YELLOW" "nonewline"
-    read -r enable_auth
+    # EOF guard: a closed stdin (piped or otherwise non-interactive run) must not fall
+    # through to the disable branch and silently turn authentication off. Leave the
+    # existing setting untouched and signal "no change" to the caller.
+    if ! read -r enable_auth; then
+        print_message "\n⚠️ No input; leaving authentication settings unchanged." "$YELLOW"
+        return 1
+    fi
 
     if [[ $enable_auth == "y" ]]; then
         log_message "INFO" "User enabled password protection"
@@ -6178,10 +6190,10 @@ reconfigure_menu() {
             3) configure_metrics_exposure; changed="true" ;;
             4) if configure_sound_card; then changed="true"; fi ;;
             5) configure_audio_format; changed="true" ;;
-            6) configure_auth; changed="true" ;;
+            6) if configure_auth; then changed="true"; fi ;;
             7) configure_timezone; changed="true" ;;
             8) configure_locale; changed="true" ;;
-            9) configure_location; changed="true" ;;
+            9) if configure_location; then changed="true"; fi ;;
             10)
                 trap - INT TERM
                 if [ "$changed" != "true" ]; then

--- a/install.sh
+++ b/install.sh
@@ -170,6 +170,10 @@ sed_escape_pattern() {
 # escaped via sed_escape_replacement, with '|' as the sed delimiter to match that escaping.
 # Any inline comment on the edited line is dropped. Re-run-safe: matches the current value
 # regardless of what it is. No-op if BLOCK or KEY is absent.
+#
+# set_yaml_value (below) is the path-aware superset of this helper, handling keys nested deeper
+# than a top-level block's direct child. This sed variant is kept separate on purpose: the
+# TLS/port callers rely on its silent-success-on-missing-key contract, so do not merge the two.
 set_config_value() {
     local block="$1"
     local key="$2"
@@ -183,9 +187,67 @@ set_config_value() {
     sed -i -E "/^${block}:/,/^[A-Za-z0-9_]/ s|^([[:space:]]{2}${key}:[[:space:]]*).*|\\1${escaped}|" -- "$file"
 }
 
+# Re-run-safe set of a scalar value at an arbitrary YAML key PATH (dotted, e.g.
+# "security.basicauth.enabled" or "realtime.audio.export.type") in the config file (default
+# $CONFIG_FILE). Generalizes set_config_value to keys nested deeper than a top-level block's
+# direct child: it walks the single known descent path, matching each element at exactly two
+# spaces of indentation per level and popping scope on dedent, so a same-named key in a
+# SIBLING block (e.g. security.allowsubnetbypass.enabled vs security.basicauth.enabled, both
+# at indent 4) is never touched and field order within a block is irrelevant. Only the leaf
+# scalar is rewritten; any inline comment on that line is dropped. PATH elements MUST be
+# literal YAML identifiers from the caller (never user input); VALUE is the only untrusted
+# part and is passed to awk through the environment (not -v), so awk performs no backslash
+# escape processing and sed/regex metacharacters in it need no escaping. Returns non-zero if
+# the leaf key was not found (so callers can warn instead of silently succeeding) or the file
+# is missing. The caller decides quoting: pass a value that already includes surrounding
+# quotes for string scalars that need them (e.g. a password hash).
+set_yaml_value() {
+    local path="$1"
+    local value="$2"
+    local file="${3:-$CONFIG_FILE}"
+    [ -f "$file" ] || return 1
+    if BIRDNET_YAML_VALUE="$value" awk -v path="$path" '
+        BEGIN {
+            n = split(path, p, ".")
+            val = ENVIRON["BIRDNET_YAML_VALUE"]
+            depth = 0       # path ancestors currently matched and still in scope
+            replaced = 0
+        }
+        # Only "key:" lines drive scope tracking. Comments, blank lines and list items
+        # ("- ...") are passed through untouched and never change the descent state.
+        /^[[:space:]]*[A-Za-z0-9_]+:/ {
+            ind = 0
+            while (substr($0, ind + 1, 1) == " ") ind++
+            key = $0
+            sub(/^[[:space:]]*/, "", key)
+            sub(/:.*/, "", key)
+            # Pop ancestors we have dedented out of: a key line at or shallower than the
+            # deepest matched ancestor header indent means that block has ended.
+            while (depth > 0 && ind <= 2 * (depth - 1)) depth--
+            if (depth < n && ind == 2 * depth && key == p[depth + 1]) {
+                if (depth + 1 == n) {
+                    # Leaf reached: rewrite the scalar, preserving the original indentation.
+                    print substr($0, 1, ind) key ": " val
+                    replaced = 1
+                    next
+                }
+                depth++
+            }
+        }
+        { print }
+        END { exit (replaced ? 0 : 1) }
+    ' "$file" > "${file}.tmp"; then
+        cat "${file}.tmp" > "$file"
+        rm -f "${file}.tmp"
+        return 0
+    fi
+    rm -f "${file}.tmp"
+    return 1
+}
+
 # Re-run-safe update of the first audio source's device id and friendly name, scoped to the
 # realtime.audio.sources block (4-space indent) so it works whether the config is pristine
-# ("sysdefault" / "Sound Card 1") or already reconfigured (Forgejo #729). The old code only
+# ("sysdefault" / "Sound Card 1") or already reconfigured. The old code only
 # matched the literal template values and silently no-opped on a re-run. DEVICE and NAME are
 # escaped for sed. Assumes the single-source layout the installer manages.
 set_first_audio_source() {
@@ -3123,7 +3185,7 @@ configure_sound_card() {
 
             # Update the first audio source's device and name. Re-run-safe so it also works
             # when reconfiguring an already-configured install, not just a pristine template
-            # (Forgejo #729). set_first_audio_source handles sed escaping internally and
+            #. set_first_audio_source handles sed escaping internally and
             # returns non-zero when there is no active source line to edit (e.g. the config
             # is currently RTSP-only with the sound-card source commented out).
             if set_first_audio_source "$ALSA_CARD" "$ALSA_CARD"; then
@@ -3149,13 +3211,29 @@ configure_rtsp_in_config() {
     local url="$1"
     local stream_name="${2:-RTSP Stream}"
 
+    # Re-run safety: only populate the stream list when it is still the empty
+    # template default. If streams are already configured (by a prior run or by the user via
+    # the web UI), rewriting the list with sed/awk risks clobbering customizations or
+    # corrupting the YAML, so warn and leave the existing configuration intact. This function
+    # runs only on fresh installs today, where the array is always "[]"; the guard just
+    # prevents silent breakage (or partial commenting of the audio source) if it is ever
+    # reached against an already-configured file.
+    if ! grep -qE '^[[:space:]]{4}streams:[[:space:]]*\[\]' "$CONFIG_FILE"; then
+        log_message "WARN" "rtsp.streams already configured; leaving existing streams untouched"
+        print_message "⚠️ RTSP streams are already configured; leaving them unchanged." "$YELLOW"
+        print_message "   Edit $CONFIG_FILE or use the web interface to change RTSP streams." "$YELLOW"
+        return 0
+    fi
+
     local escaped_url
     escaped_url=$(sed_escape_replacement "$url")
     local escaped_name
     escaped_name=$(sed_escape_replacement "$stream_name")
 
-    # Add stream entry to the rtsp.streams section (replaces empty array)
-    sed -i "s|    streams: \[\].*|    streams:\n      - name: \"${escaped_name}\"\n        url: \"${escaped_url}\"\n        enabled: true\n        type: rtsp\n        transport: tcp|" "$CONFIG_FILE"
+    # Add stream entry to the rtsp.streams section (replaces empty array). Match the same
+    # flexible whitespace the empty-streams guard above accepts, so a config the guard treated
+    # as the empty default is never left silently unpopulated by a stricter pattern.
+    sed -i -E "s|^[[:space:]]{4}streams:[[:space:]]*\[\].*|    streams:\n      - name: \"${escaped_name}\"\n        url: \"${escaped_url}\"\n        enabled: true\n        type: rtsp\n        transport: tcp|" "$CONFIG_FILE"
     log_command_result "sed RTSP stream configuration" $? "adding RTSP stream to config"
 
     # Comment out default sound card source (RTSP replaces local capture)
@@ -3248,7 +3326,9 @@ configure_audio_format() {
             *) log_message "WARN" "Invalid BIRDNET_AUDIO_FORMAT: $format, defaulting to aac"
                format="aac" ;;
         esac
-        sed -i "s|type: wav|type: $format|" "$CONFIG_FILE"
+        # Block-scoped, re-run-safe edit so a re-run can change a format that
+        # was already set away from the "wav" template default.
+        set_yaml_value "realtime.audio.export.type" "$format"
         print_message "🔇 Silent mode: audio format set to $format" "$YELLOW"
         return
     fi
@@ -3283,8 +3363,9 @@ configure_audio_format() {
     print_message "✅ Selected audio format: " "$GREEN" "nonewline"
     print_message "$format"
 
-    # Update config file (format is from hardcoded case, safe)
-    sed -i "s|type: wav|type: $format|" "$CONFIG_FILE"
+    # Update config file with a block-scoped, re-run-safe edit. The format is
+    # from the hardcoded case above; awk writes it literally.
+    set_yaml_value "realtime.audio.export.type" "$format"
 }
 
 # Function to configure locale
@@ -3297,7 +3378,9 @@ configure_locale() {
             log_message "ERROR" "Invalid BIRDNET_LOCALE format: $locale"
             locale="en-uk"
         fi
-        sed -i "s|locale: [a-zA-Z0-9_-]*|locale: ${locale}|" "$CONFIG_FILE"
+        # Scope to birdnet.locale so the loose pattern does not also corrupt the eBird locale
+        # (realtime.ebird.locale: "en" -> locale: fi"en").
+        set_yaml_value "birdnet.locale" "$locale"
         print_message "🔇 Silent mode: locale set to $locale" "$YELLOW"
         return
     fi
@@ -3331,7 +3414,9 @@ configure_locale() {
             print_message "✅ Selected language: " "$GREEN" "nonewline"
             print_message "${locale_names[$((selection-1))]}"
             # Update config file (LOCALE_CODE is from hardcoded array, safe)
-            sed -i "s|locale: [a-zA-Z0-9_-]*|locale: ${LOCALE_CODE}|" "$CONFIG_FILE"
+            # Scope to birdnet.locale so the loose pattern does not also corrupt the eBird
+            # locale (realtime.ebird.locale).
+            set_yaml_value "birdnet.locale" "$LOCALE_CODE"
             break
         else
             print_message "❌ Invalid selection. Please try again." "$RED"
@@ -3750,21 +3835,33 @@ configure_location() {
     
     while true; do
         print_message "❓ Select location input method (1-3): " "$YELLOW" "nonewline"
-        read -r location_choice
+        if ! read -r location_choice; then
+            print_message "\n⚠️ No input; skipping location configuration (using 0.0, 0.0)." "$YELLOW"
+            lat="0.0"; lon="0.0"
+            break
+        fi
 
         case $location_choice in
             1)
                 while true; do
                     print_message "Enter latitude (-90 to 90) or 'b' to go back: " "$YELLOW" "nonewline"
-                    read -r lat
-                    
+                    if ! read -r lat; then
+                        print_message "\n⚠️ No input; skipping location configuration (using 0.0, 0.0)." "$YELLOW"
+                        lat="0.0"; lon="0.0"
+                        break 2
+                    fi
+
                     if [ "$lat" = "b" ]; then
                         break  # Go back to method selection
                     fi
                     
                     print_message "Enter longitude (-180 to 180) or 'b' to go back: " "$YELLOW" "nonewline"
-                    read -r lon
-                    
+                    if ! read -r lon; then
+                        print_message "\n⚠️ No input; skipping location configuration (using 0.0, 0.0)." "$YELLOW"
+                        lat="0.0"; lon="0.0"
+                        break 2
+                    fi
+
                     if [ "$lon" = "b" ]; then
                         break  # Go back to method selection
                     fi
@@ -3784,8 +3881,12 @@ configure_location() {
             2)
                 while true; do
                     print_message "Enter location (e.g., 'Helsinki, Finland', 'New York, US') or 'b' to go back: " "$YELLOW" "nonewline"
-                    read -r location
-                    
+                    if ! read -r location; then
+                        print_message "\n⚠️ No input; skipping location configuration (using 0.0, 0.0)." "$YELLOW"
+                        lat="0.0"; lon="0.0"
+                        break 2
+                    fi
+
                     if [ "$location" = "b" ]; then
                         break  # Go back to method selection
                     fi
@@ -3853,11 +3954,11 @@ configure_auth() {
         if [ -n "$BIRDNET_PASSWORD" ]; then
             local password_hash
             password_hash=$(echo -n "$BIRDNET_PASSWORD" | htpasswd -niB "" | cut -d: -f2)
-            local escaped_hash
-            escaped_hash=$(sed_escape_replacement "$password_hash")
-            sed -i "s|enabled: false    # true to enable basic auth|enabled: true    # true to enable basic auth|" "$CONFIG_FILE"
-            sed -i "s|password: \"\"|password: \"${escaped_hash}\"|" "$CONFIG_FILE"
-            unset BIRDNET_PASSWORD password_hash escaped_hash
+            # Block-scoped, re-run-safe edits: awk writes the value literally,
+            # so the bcrypt hash needs no sed escaping.
+            set_yaml_value "security.basicauth.enabled" "true"
+            set_yaml_value "security.basicauth.password" "\"${password_hash}\""
+            unset BIRDNET_PASSWORD password_hash
             print_message "🔇 Silent mode: password protection enabled" "$YELLOW"
         else
             print_message "🔇 Silent mode: no password set (BIRDNET_PASSWORD not provided)" "$YELLOW"
@@ -3874,26 +3975,41 @@ configure_auth() {
     if [[ $enable_auth == "y" ]]; then
         log_message "INFO" "User enabled password protection"
         while true; do
-            read -s -r -p "Enter password: " password
+            # EOF guard: a closed stdin must not loop forever or silently confirm an empty
+            # password (read returns non-zero and leaves the var empty). Reject empty input
+            # explicitly so auth is never enabled with an empty-string hash.
+            if ! read -s -r -p "Enter password: " password; then
+                printf '\n'
+                print_message "⚠️ No input; password protection not enabled." "$YELLOW"
+                break
+            fi
             printf '\n'
-            read -s -r -p "Confirm password: " password2
+            if ! read -s -r -p "Confirm password: " password2; then
+                printf '\n'
+                print_message "⚠️ No input; password protection not enabled." "$YELLOW"
+                break
+            fi
             printf '\n'
-            
+
+            if [ -z "$password" ]; then
+                print_message "❌ Password cannot be empty. Please try again." "$RED"
+                continue
+            fi
+
             if [ "$password" = "$password2" ]; then
                 log_message "INFO" "Password confirmed, generating hash and updating config"
                 # Generate password hash (using bcrypt)
                 password_hash=$(echo -n "$password" | htpasswd -niB "" | cut -d: -f2)
-                local escaped_hash
-                escaped_hash=$(sed_escape_replacement "$password_hash")
 
-                # Update config file
-                sed -i "s|enabled: false    # true to enable basic auth|enabled: true    # true to enable basic auth|" "$CONFIG_FILE"
-                log_command_result "sed enable auth" $? "enabling authentication"
-                sed -i "s|password: \"\"|password: \"${escaped_hash}\"|" "$CONFIG_FILE"
-                log_command_result "sed password hash" $? "setting password hash"
+                # Update config with block-scoped, re-run-safe edits. awk
+                # writes the value literally, so the bcrypt hash needs no sed escaping.
+                set_yaml_value "security.basicauth.enabled" "true"
+                log_command_result "enable auth" $? "enabling authentication"
+                set_yaml_value "security.basicauth.password" "\"${password_hash}\""
+                log_command_result "set password hash" $? "setting password hash"
 
                 # Clear sensitive variables from shell memory
-                unset password password2 password_hash escaped_hash
+                unset password password2 password_hash
 
                 log_message "INFO" "Password protection configured successfully"
                 print_message "✅ Password protection enabled successfully!" "$GREEN"
@@ -3907,7 +4023,12 @@ configure_auth() {
             fi
         done
     else
+        # Explicitly disable auth so this can turn an existing password off when run from the
+        # reconfigure menu, not just leave it unchanged. Idempotent on a fresh
+        # install (already disabled). Any existing password hash is left in place so it can be
+        # reused if auth is re-enabled later; enabled:false means it is not enforced.
         log_message "INFO" "User disabled password protection"
+        set_yaml_value "security.basicauth.enabled" "false"
     fi
 }
 
@@ -5977,8 +6098,11 @@ apply_reconfiguration() {
 }
 
 # Interactive reconfiguration of an existing systemd install: lets the user change the web
-# port, TLS/access mode, metrics exposure, audio device, timezone, and locale, then
-# regenerates the unit and restarts. Edits the existing config in place (a backup is taken
+# port, TLS/access mode, metrics exposure, audio device, audio export format, web
+# authentication, timezone, locale, and location, then regenerates the unit and restarts.
+# RTSP is intentionally not offered here: rewriting the streams list in place is too brittle
+# to do safely, so RTSP stays a fresh-install-only step for now. Edits the
+# existing config in place (a backup is taken
 # so "discard" fully reverts). The service is stopped during reconfiguration so the chosen
 # web port is not reported as "in use" by BirdNET-Go itself. Returns 1 to return to the
 # caller's menu loop.
@@ -6032,11 +6156,14 @@ reconfigure_menu() {
         print_message "  2) TLS / external access mode" "$YELLOW"
         print_message "  3) Prometheus metrics endpoint" "$YELLOW"
         print_message "  4) Audio capture device (sound card)" "$YELLOW"
-        print_message "  5) Timezone" "$YELLOW"
-        print_message "  6) Locale (species name language)" "$YELLOW"
-        print_message "  7) Apply changes and restart" "$YELLOW"
-        print_message "  8) Discard changes and go back" "$YELLOW"
-        print_message "❓ Select an option (1-8): " "$YELLOW" "nonewline"
+        print_message "  5) Audio export format" "$YELLOW"
+        print_message "  6) Web authentication (password)" "$YELLOW"
+        print_message "  7) Timezone" "$YELLOW"
+        print_message "  8) Locale (species name language)" "$YELLOW"
+        print_message "  9) Location (latitude/longitude)" "$YELLOW"
+        print_message "  10) Apply changes and restart" "$YELLOW"
+        print_message "  11) Discard changes and go back" "$YELLOW"
+        print_message "❓ Select an option (1-11): " "$YELLOW" "nonewline"
         local rc_choice
         if ! read -r rc_choice; then
             trap - INT TERM
@@ -6050,9 +6177,12 @@ reconfigure_menu() {
             2) configure_tls_access; changed="true" ;;
             3) configure_metrics_exposure; changed="true" ;;
             4) if configure_sound_card; then changed="true"; fi ;;
-            5) configure_timezone; changed="true" ;;
-            6) configure_locale; changed="true" ;;
-            7)
+            5) configure_audio_format; changed="true" ;;
+            6) configure_auth; changed="true" ;;
+            7) configure_timezone; changed="true" ;;
+            8) configure_locale; changed="true" ;;
+            9) configure_location; changed="true" ;;
+            10)
                 trap - INT TERM
                 if [ "$changed" != "true" ]; then
                     print_message "ℹ️ No changes made; restarting with the existing configuration." "$YELLOW"
@@ -6066,7 +6196,7 @@ reconfigure_menu() {
                 rm -f "$rc_backup" "$service_backup"
                 return 1
                 ;;
-            8)
+            11)
                 trap - INT TERM
                 print_message "↩️ Discarding changes and restarting with the previous configuration..." "$YELLOW"
                 _reconfigure_rollback "$rc_backup" "$service_backup" "$has_service_backup"
@@ -6075,7 +6205,7 @@ reconfigure_menu() {
                 return 1
                 ;;
             *)
-                print_message "❌ Invalid selection. Please choose a number between 1 and 8." "$RED"
+                print_message "❌ Invalid selection. Please choose a number between 1 and 11." "$RED"
                 ;;
         esac
     done
@@ -6100,7 +6230,7 @@ display_menu() {
         print_message "3) Fresh installation" "$YELLOW"
         print_message "4) Uninstall BirdNET-Go, remove data" "$YELLOW"
         print_message "5) Uninstall BirdNET-Go, preserve data" "$YELLOW"
-        print_message "6) Reconfigure settings (port, TLS, metrics, audio, timezone, locale)" "$YELLOW"
+        print_message "6) Reconfigure settings (port, TLS, metrics, audio, auth, timezone, locale, location)" "$YELLOW"
         print_message "7) Exit" "$YELLOW"
         print_message "❓ Select an option (1-7): " "$YELLOW" "nonewline"
         return 7  # Return number of options

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the configuration helper functions in install.sh.
+#
+# install.sh edits a 2-space-indent YAML config and parses/regenerates a systemd unit with
+# sed/awk. Those helpers have no other coverage, and several were converted to re-run-safe
+# forms where a wrong indentation anchor or field-order assumption silently
+# corrupts a real user config. This harness extracts the pure helpers from install.sh (the
+# script has no source guard, so it cannot be sourced wholesale) and exercises them against
+# the real config template, asserting both the intended change and that sibling keys are left
+# untouched.
+#
+# Run: scripts/install_test.sh   (exit 0 = all pass). No external dependencies beyond awk/sed.
+
+# Many globals here (colors, CONFIG_FILE, SILENT_MODE, the load_existing_service_config output
+# vars, BIRDNET_AUDIO_FORMAT) are consumed only inside the eval'd functions extracted from
+# install.sh, which shellcheck cannot see, so it flags them as unused. They are not.
+# shellcheck disable=SC2034
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_SH="${REPO_ROOT}/install.sh"
+CONFIG_TEMPLATE="${REPO_ROOT}/internal/conf/config.yaml"
+
+if [ ! -f "$INSTALL_SH" ]; then
+    echo "FATAL: install.sh not found at $INSTALL_SH" >&2
+    exit 2
+fi
+if [ ! -f "$CONFIG_TEMPLATE" ]; then
+    echo "FATAL: config template not found at $CONFIG_TEMPLATE" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Test framework (minimal, dependency-free)
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+CURRENT_TEST=""
+
+it() { CURRENT_TEST="$1"; }
+
+assert_eq() { # description expected actual
+    if [ "$2" = "$3" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        printf 'FAIL [%s] %s\n' "$CURRENT_TEST" "$1" >&2
+        printf '       expected: [%s]\n' "$2" >&2
+        printf '       actual:   [%s]\n' "$3" >&2
+    fi
+}
+
+assert_ok() { # description ; uses $? of previous command via explicit arg
+    if [ "$2" -eq 0 ]; then PASS=$((PASS + 1)); else
+        FAIL=$((FAIL + 1)); printf 'FAIL [%s] %s (rc=%s, expected 0)\n' "$CURRENT_TEST" "$1" "$2" >&2
+    fi
+}
+
+assert_nonzero() { # description rc
+    if [ "$2" -ne 0 ]; then PASS=$((PASS + 1)); else
+        FAIL=$((FAIL + 1)); printf 'FAIL [%s] %s (rc=0, expected non-zero)\n' "$CURRENT_TEST" "$1" >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Extract a single top-level function (name() { ... } closing at column 0) from
+# install.sh and define it in this shell. install.sh formats every top-level
+# function close as a bare "}" at column 0; inner braces are indented, so the
+# first "^}$" after the header is the function's own close. (A here-doc emitting a
+# column-0 "}" would break this assumption; none of the loaded functions do today.)
+# ---------------------------------------------------------------------------
+load_fn() {
+    local fn="$1"
+    local body
+    body="$(awk -v fn="$fn" '
+        $0 ~ "^"fn"\\(\\) \\{" { printing = 1 }
+        printing { print }
+        printing && /^\}$/ { exit }
+    ' "$INSTALL_SH")"
+    if [ -z "$body" ]; then
+        echo "FATAL: could not extract function '$fn' from install.sh" >&2
+        exit 2
+    fi
+    eval "$body"
+}
+
+# Stubs for the side-effecting helpers the extracted functions call.
+print_message() { :; }
+log_message() { :; }
+log_command_result() { :; }
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+# Globals the extracted functions reference (install.sh defines these at the top; the harness
+# only pulls function bodies, so under set -u they must exist here).
+RED=""; GREEN=""; YELLOW=""; NC=""; GRAY=""
+CONFIG_FILE=""
+SILENT_MODE=""
+
+# Load the helpers under test (order matters: callees before callers).
+for fn in \
+    sed_escape_replacement \
+    sed_escape_pattern \
+    set_config_value \
+    set_yaml_value \
+    set_first_audio_source \
+    _extract_bind_addr \
+    load_existing_service_config \
+    apply_tls_settings \
+    ensure_internal_port_8080 \
+    configure_rtsp_in_config \
+    configure_audio_format \
+    configure_locale \
+    rewrite_migrated_config_paths
+do
+    load_fn "$fn"
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fresh_config() { # -> path to a fresh copy of the template
+    local p="${WORK}/cfg.$RANDOM.$RANDOM.yaml"
+    cp "$CONFIG_TEMPLATE" "$p"
+    printf '%s' "$p"
+}
+
+# yaml_scalar FILE INDENT PARENT_REGEX KEY -> value of the first KEY at INDENT spaces after
+# PARENT_REGEX matches. Used to read back what the helpers wrote.
+yaml_after() { # file parent_regex indent key
+    awk -v parent="$2" -v ind="$3" -v key="$4" '
+        $0 ~ parent { f = 1; next }
+        f && $0 ~ ("^ {" ind "}" key ":") {
+            line = $0
+            sub(/^[[:space:]]*[A-Za-z0-9_]+:[[:space:]]*/, "", line)
+            sub(/[[:space:]]+#.*$/, "", line)   # drop an inline comment
+            sub(/[[:space:]]+$/, "", line)      # drop trailing whitespace
+            print line
+            exit
+        }
+    ' "$1"
+}
+
+# ===========================================================================
+# set_yaml_value
+# ===========================================================================
+it "set_yaml_value"
+
+cfg="$(fresh_config)"
+set_yaml_value "security.basicauth.enabled" "true" "$cfg"
+assert_eq "basicauth.enabled set to true" "true" "$(yaml_after "$cfg" '^[[:space:]]{2}basicauth:' 4 enabled)"
+# The sibling sub-blocks that ALSO have enabled: at indent 4 must be untouched.
+assert_eq "allowsubnetbypass.enabled untouched" "false" "$(yaml_after "$cfg" '^[[:space:]]{2}allowsubnetbypass:' 4 enabled)"
+assert_eq "googleAuth.enabled untouched" "false" "$(yaml_after "$cfg" '^[[:space:]]{2}googleAuth:' 4 enabled)"
+
+# Quoted value with sed metacharacters must be written literally (no sed escaping needed).
+set_yaml_value "security.basicauth.password" '"$2b$10$ab/CD.ef&gh|ij"' "$cfg"
+assert_eq "password written literally with metachars" '"$2b$10$ab/CD.ef&gh|ij"' "$(yaml_after "$cfg" '^[[:space:]]{2}basicauth:' 4 password)"
+
+# Deeply nested leaf (indent 6) that appears after sibling scalars and before a sub-block.
+cfg="$(fresh_config)"
+set_yaml_value "realtime.audio.export.type" "aac" "$cfg"
+assert_eq "export.type set to aac" "aac" "$(yaml_after "$cfg" '^[[:space:]]{4}export:' 6 type)"
+assert_eq "export.enabled untouched (true)" "true" "$(yaml_after "$cfg" '^[[:space:]]{4}export:' 6 enabled)"
+# The equalizer list item '- type: HighPass' (indent 8, list element) must be untouched.
+hp="$(awk '/^[[:space:]]{4}equalizer:/{f=1} f&&/^[[:space:]]{8}-[[:space:]]+type:/{print $3; exit}' "$cfg")"
+assert_eq "equalizer filter '- type:' untouched" "HighPass" "$hp"
+
+# Re-run safety: changing a value that is no longer the template default.
+set_yaml_value "realtime.audio.export.type" "opus" "$cfg"
+assert_eq "export.type re-changed aac->opus" "opus" "$(yaml_after "$cfg" '^[[:space:]]{4}export:' 6 type)"
+
+# Missing leaf returns non-zero so callers can warn.
+cfg="$(fresh_config)"
+set_yaml_value "security.basicauth.nope" "x" "$cfg"; rc=$?
+assert_nonzero "missing leaf returns non-zero" "$rc"
+
+# 2-space direct child (same scope set_config_value handles).
+set_yaml_value "webserver.port" '"9000"' "$cfg"
+assert_eq "webserver.port set" '"9000"' "$(yaml_after "$cfg" '^webserver:' 2 port)"
+
+# ===========================================================================
+# set_config_value
+# ===========================================================================
+it "set_config_value"
+
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+set_config_value security host "birdnet.example.com"
+assert_eq "security.host set" "birdnet.example.com" "$(yaml_after "$cfg" '^security:' 2 host)"
+# Re-run: change the already-set value.
+set_config_value security host "other.example.com"
+assert_eq "security.host re-changed" "other.example.com" "$(yaml_after "$cfg" '^security:' 2 host)"
+# A nested grandchild with a same name must NOT be reachable by set_config_value (it only
+# anchors to a 2-space child), so basicauth.enabled stays false.
+set_config_value security enabled "true"
+assert_eq "set_config_value does not reach grandchild basicauth.enabled" "false" "$(yaml_after "$cfg" '^[[:space:]]{2}basicauth:' 4 enabled)"
+
+# ===========================================================================
+# set_first_audio_source
+# ===========================================================================
+it "set_first_audio_source"
+
+# Pristine template: name-first then device.
+cfg="$(fresh_config)"
+set_first_audio_source "hw:1,0" "USB Mic" "$cfg"; rc=$?
+assert_ok "pristine source edit succeeds" "$rc"
+dev="$(awk '/^[[:space:]]{4}sources:/{f=1} f&&/^[[:space:]]+(-[[:space:]]+)?device:/{sub(/^[[:space:]]*(-[[:space:]]+)?device:[[:space:]]*/,"");print;exit}' "$cfg")"
+nm="$(awk '/^[[:space:]]{4}sources:/{f=1} f&&/^[[:space:]]+-[[:space:]]+name:/{sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/,"");print;exit}' "$cfg")"
+assert_eq "device set" '"hw:1,0"' "$dev"
+assert_eq "name set" '"USB Mic"' "$nm"
+
+# Reverse field order (device before name) must also work.
+cat > "$cfg" <<'EOF'
+realtime:
+  audio:
+    sources:
+      - device: "sysdefault"
+        name: "Sound Card 1"
+        gain: 0
+    soundlevel:
+      enabled: false
+EOF
+set_first_audio_source "hw:2,0" "Other Mic" "$cfg"; rc=$?
+assert_ok "reverse-order source edit succeeds" "$rc"
+dev="$(awk '/^[[:space:]]{4}sources:/{f=1} f&&/^[[:space:]]+(-[[:space:]]+)?device:/{sub(/^[[:space:]]*(-[[:space:]]+)?device:[[:space:]]*/,"");print;exit}' "$cfg")"
+assert_eq "device set (reverse order)" '"hw:2,0"' "$dev"
+
+# Multi-source: only the FIRST item is edited.
+cat > "$cfg" <<'EOF'
+realtime:
+  audio:
+    sources:
+      - name: "Sound Card 1"
+        device: "sysdefault"
+        gain: 0
+      - name: "Second"
+        device: "hw:9,0"
+        gain: 0
+    soundlevel:
+      enabled: false
+EOF
+set_first_audio_source "hw:1,0" "First" "$cfg"
+second_dev="$(awk '/- name: "Second"/{f=1} f&&/device:/{print;exit}' "$cfg")"
+assert_eq "second source device untouched" '        device: "hw:9,0"' "$second_dev"
+
+# No active source line (sound card commented out, RTSP-only) returns non-zero.
+cat > "$cfg" <<'EOF'
+realtime:
+  audio:
+    sources:
+# - name: "Sound Card 1"
+#   device: "sysdefault"
+    soundlevel:
+      enabled: false
+EOF
+set_first_audio_source "hw:1,0" "x" "$cfg"; rc=$?
+assert_nonzero "no active source returns non-zero" "$rc"
+
+# ===========================================================================
+# load_existing_service_config
+# ===========================================================================
+it "load_existing_service_config"
+
+unit="${WORK}/birdnet-go.service"
+cat > "$unit" <<'EOF'
+[Service]
+ExecStart=/usr/bin/docker run --rm \
+    --name birdnet-go \
+    -p 127.0.0.1:9000:8080 \
+    -p 443:443 \
+    -p 8090:8090 \
+    --env TZ="Europe/Helsinki" \
+    -v /home/pi/birdnet-go-app/config:/config \
+    ghcr.io/tphakala/birdnet-go:nightly
+EOF
+WEB_PORT=""; WEB_PORT_BIND_ADDR=""; BIND_TLS_PORTS="false"; TLS_BIND_ADDR=""
+BIND_METRICS_PORT="false"; METRICS_BIND_ADDR=""; CONFIGURED_TZ=""
+load_existing_service_config "$unit"
+assert_eq "restored web port" "9000" "$WEB_PORT"
+assert_eq "restored web bind addr" "127.0.0.1" "$WEB_PORT_BIND_ADDR"
+assert_eq "restored TLS binding" "true" "$BIND_TLS_PORTS"
+assert_eq "restored metrics binding" "true" "$BIND_METRICS_PORT"
+assert_eq "restored timezone" "Europe/Helsinki" "$CONFIGURED_TZ"
+
+# A unit with only the web port (no 80/443, no 8090) leaves TLS/metrics off.
+cat > "$unit" <<'EOF'
+[Service]
+ExecStart=/usr/bin/docker run --rm \
+    -p 8080:8080 \
+    --env TZ="UTC" \
+    ghcr.io/tphakala/birdnet-go:nightly
+EOF
+WEB_PORT=""; BIND_TLS_PORTS="false"; BIND_METRICS_PORT="false"; CONFIGURED_TZ=""
+load_existing_service_config "$unit"
+assert_eq "web-only: port restored" "8080" "$WEB_PORT"
+assert_eq "web-only: TLS stays off" "false" "$BIND_TLS_PORTS"
+assert_eq "web-only: metrics stays off" "false" "$BIND_METRICS_PORT"
+
+# ===========================================================================
+# apply_tls_settings (full slate; mode switch must clear stale host)
+# ===========================================================================
+it "apply_tls_settings"
+
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+apply_tls_settings autotls "birdnet.example.com" ""
+assert_eq "autotls: host set" "birdnet.example.com" "$(yaml_after "$cfg" '^security:' 2 host)"
+assert_eq "autotls: autoTls true" "true" "$(yaml_after "$cfg" '^security:' 2 autoTls)"
+# Switch to direct: the stale host must be cleared (the ledger regression).
+apply_tls_settings direct "" ""
+assert_eq "direct: host cleared" "" "$(yaml_after "$cfg" '^security:' 2 host)"
+assert_eq "direct: autoTls false" "false" "$(yaml_after "$cfg" '^security:' 2 autoTls)"
+
+# ===========================================================================
+# configure_rtsp_in_config (populate empty default; guard a populated list)
+# ===========================================================================
+it "configure_rtsp_in_config"
+
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+configure_rtsp_in_config "rtsp://user:pass@cam.local:554/stream1" "Front Door"
+got_url="$(awk '/^[[:space:]]{4}streams:/{f=1} f&&/url:/{sub(/^[[:space:]]*url:[[:space:]]*/,"");print;exit}' "$cfg")"
+assert_eq "fresh: stream url written" '"rtsp://user:pass@cam.local:554/stream1"' "$got_url"
+sc_commented="$(grep -c '^# .*device: "sysdefault"' "$cfg")"
+assert_eq "fresh: default sound card source commented out" "1" "$sc_commented"
+
+# Re-run against the now-populated config: guard must leave it unchanged (no second stream,
+# no double-commenting).
+before="$(sha256sum "$cfg" | cut -d' ' -f1)"
+configure_rtsp_in_config "rtsp://other/stream2" "Backyard"; rc=$?
+after="$(sha256sum "$cfg" | cut -d' ' -f1)"
+assert_ok "re-run returns success" "$rc"
+assert_eq "re-run leaves populated config byte-identical" "$before" "$after"
+
+# Stronger guard test: the byte-identical case above is coincidentally idempotent because the
+# first populate already commented the source. Build the realistic "RTSP added via the web UI"
+# shape, streams populated but the sound-card source still ACTIVE (uncommented). Without the
+# guard, the source-commenting seds would comment the live source; the guard must skip. This
+# case goes RED if the guard is removed.
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+sed -i 's|^    streams: \[\].*|    streams:\n      - name: "Existing"\n        url: "rtsp://existing/s"\n        enabled: true\n        type: rtsp\n        transport: tcp|' "$cfg"
+before="$(sha256sum "$cfg" | cut -d' ' -f1)"
+configure_rtsp_in_config "rtsp://new/stream" "New"; rc=$?
+after="$(sha256sum "$cfg" | cut -d' ' -f1)"
+assert_ok "guard: re-run on populated config returns success" "$rc"
+assert_eq "guard: populated config with ACTIVE source left byte-identical" "$before" "$after"
+active="$(grep -c '^      - name: "Sound Card 1"' "$cfg")"
+assert_eq "guard: sound-card source still active (uncommented)" "1" "$active"
+
+# ===========================================================================
+# configure_audio_format (silent re-run safety)
+# ===========================================================================
+it "configure_audio_format"
+
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+SILENT_MODE="true"; BIRDNET_AUDIO_FORMAT="flac"
+configure_audio_format
+assert_eq "silent: format set to flac" "flac" "$(yaml_after "$cfg" '^[[:space:]]{4}export:' 6 type)"
+BIRDNET_AUDIO_FORMAT="opus"
+configure_audio_format
+assert_eq "silent re-run: format changed flac->opus" "opus" "$(yaml_after "$cfg" '^[[:space:]]{4}export:' 6 type)"
+SILENT_MODE=""
+
+# ===========================================================================
+# rewrite_migrated_config_paths
+# ===========================================================================
+it "rewrite_migrated_config_paths"
+
+cfg="${WORK}/migrate.yaml"
+cat > "$cfg" <<'EOF'
+realtime:
+  audio:
+    export:
+      path: /root/birdnet-go-app/data/clips
+monitoring:
+  disk:
+    paths: /root/.config/birdnet-go
+unrelated: /root/some-other-dir
+EOF
+rewrite_migrated_config_paths "$cfg" "/root" "/home/pi"
+assert_eq "birdnet-go-app path rewritten" "/home/pi/birdnet-go-app/data/clips" "$(awk '/path:/{sub(/^[[:space:]]*path:[[:space:]]*/,"");print;exit}' "$cfg")"
+assert_eq ".config path rewritten" "/home/pi/.config/birdnet-go" "$(awk '/paths:/{sub(/^[[:space:]]*paths:[[:space:]]*/,"");print;exit}' "$cfg")"
+assert_eq "unrelated /root path untouched" "/root/some-other-dir" "$(awk '/unrelated:/{sub(/^[[:space:]]*unrelated:[[:space:]]*/,"");print;exit}' "$cfg")"
+
+# Same old/new home is a no-op.
+cp "$CONFIG_TEMPLATE" "${WORK}/noop.yaml"
+before="$(sha256sum "${WORK}/noop.yaml" | cut -d' ' -f1)"
+rewrite_migrated_config_paths "${WORK}/noop.yaml" "/home/pi" "/home/pi"
+after="$(sha256sum "${WORK}/noop.yaml" | cut -d' ' -f1)"
+assert_eq "same home is a no-op" "$before" "$after"
+
+# ===========================================================================
+# configure_locale (silent; must not corrupt the eBird locale)
+# ===========================================================================
+it "configure_locale"
+
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+SILENT_MODE="true"; BIRDNET_LOCALE="fi"
+configure_locale
+assert_eq "silent: birdnet.locale set to fi" "fi" "$(yaml_after "$cfg" '^birdnet:' 2 locale)"
+# The eBird locale (realtime.ebird.locale: "en") must NOT be corrupted to fi"en" by the
+# birdnet-locale edit (the pre-existing double-locale bug).
+ebird_locale="$(yaml_after "$cfg" '^[[:space:]]{2}ebird:' 4 locale)"
+assert_eq "silent: eBird locale untouched" '"en"' "$ebird_locale"
+SILENT_MODE=""
+
+# ===========================================================================
+# ensure_internal_port_8080 (normalize a custom webserver.port back to 8080)
+# ===========================================================================
+it "ensure_internal_port_8080"
+
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+set_config_value webserver port '"9000"'
+ensure_internal_port_8080
+assert_eq "custom internal port normalized to 8080" '"8080"' "$(yaml_after "$cfg" '^webserver:' 2 port)"
+ensure_internal_port_8080
+assert_eq "already-8080 stays 8080 (idempotent)" '"8080"' "$(yaml_after "$cfg" '^webserver:' 2 port)"
+
+# ===========================================================================
+# Result
+# ===========================================================================
+echo "------------------------------------------------------------"
+echo "install.sh helper tests: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -97,6 +97,7 @@ command_exists() { command -v "$1" >/dev/null 2>&1; }
 RED=""; GREEN=""; YELLOW=""; NC=""; GRAY=""
 CONFIG_FILE=""
 SILENT_MODE=""
+BIRDNET_PASSWORD=""
 
 # Load the helpers under test (order matters: callees before callers).
 for fn in \
@@ -112,6 +113,7 @@ for fn in \
     configure_rtsp_in_config \
     configure_audio_format \
     configure_locale \
+    configure_auth \
     rewrite_migrated_config_paths
 do
     load_fn "$fn"
@@ -407,6 +409,24 @@ assert_eq "silent: birdnet.locale set to fi" "fi" "$(yaml_after "$cfg" '^birdnet
 # birdnet-locale edit (the pre-existing double-locale bug).
 ebird_locale="$(yaml_after "$cfg" '^[[:space:]]{2}ebird:' 4 locale)"
 assert_eq "silent: eBird locale untouched" '"en"' "$ebird_locale"
+SILENT_MODE=""
+
+# ===========================================================================
+# configure_auth (interactive EOF guard: a closed stdin must not disable auth)
+# ===========================================================================
+it "configure_auth"
+
+# Pre-enable auth, then drive the interactive path with stdin closed. The gating
+# "Enable password protection? (y/n)" read hits EOF; before the guard this fell through
+# to the disable branch and silently set basicauth.enabled false. The guard must instead
+# return non-zero and leave the existing setting untouched.
+cfg="$(fresh_config)"
+CONFIG_FILE="$cfg"
+SILENT_MODE="false"
+set_yaml_value "security.basicauth.enabled" "true" "$cfg"
+configure_auth </dev/null
+assert_nonzero "EOF on enable prompt returns non-zero (no change)" "$?"
+assert_eq "EOF must not disable existing auth" "true" "$(yaml_after "$cfg" '^[[:space:]]{2}basicauth:' 4 enabled)"
 SILENT_MODE=""
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Follow-up to #3675. That PR made the installer re-runnable end to end, but a few of the config writers it touched still used literal-template `sed` calls that silently no-op (or worse, corrupt the file) when run against an already-configured `config.yaml`. This PR makes those writers safe to re-run, then wires the safe ones into the interactive reconfigure menu.

The core of the change is a new `set_yaml_value` helper: a path-aware, indentation-scoped YAML scalar setter. It walks a dotted key path matching each element at its exact indentation depth, so a same-named key in a sibling block is never touched (for example `security.basicauth.enabled` vs `security.allowsubnetbypass.enabled`, both at the same indent). Values pass through the environment rather than `awk -v`, so no escaping is needed and a bcrypt hash full of `$` and `/` goes in literally.

## What changed

- **New `set_yaml_value`** path-aware re-run-safe YAML scalar setter; scopes edits to an exact key path by indentation and rewrites only the leaf, preserving inode and permissions.
- **`configure_auth` and `configure_audio_format`** converted off literal-template `sed` to `set_yaml_value`, so a re-run can change an already-set value instead of silently doing nothing.
- **`configure_rtsp_in_config` guarded**: only populates the empty-streams default; warns and skips a populated list rather than risking YAML corruption. RTSP stays fresh-install-only.
- **`configure_locale` fixed**: the loose `locale:` `sed` also rewrote the eBird locale (`locale: "en"` became `locale: fi"en"`); it is now scoped to `birdnet.locale`.
- **`reconfigure_menu` extended** with audio export format, web authentication, and location; Apply/Discard renumbered.
- **Read-loop hardening**: EOF guards on the `configure_auth` and `configure_location` interactive reads, reject an empty password, and let `n` disable auth from the menu.

## Test plan

- New `scripts/install_test.sh`: a dependency-free bash harness that extracts the pure helpers and runs 49 assertions covering `set_yaml_value` (sibling isolation, deep nesting, re-run, missing-leaf, metacharacters), `set_config_value`, `configure_rtsp_in_config` (guard verified against a populated list), `configure_audio_format`, `configure_locale` (eBird locale untouched), and the migration path helpers. All pass.
- New `.github/workflows/install-test.yml`: runs `shellcheck` on `install.sh` and the harness, then the harness, on `ubuntu-24.04` for any change to the installer, the harness, the config template, or the workflow.
- `shellcheck -S error install.sh` and `bash -n install.sh` are clean locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the installer’s reconfiguration menu with additional options (audio export format, web/basicauth, timezone, locale, and location) and added a “Reconfigure settings” entry to the main install flow.
* **Bug Fixes**
  * Improved idempotent configuration editing so repeated runs update only the intended YAML values.
  * Added safeguards to prevent overwriting already-configured RTSP streams.
  * Hardened interactive flows for EOF/missing input during location and authentication (including rejecting empty passwords).
* **Tests**
  * Added an automated GitHub Actions workflow to run ShellCheck and installer script tests.
  * Added/extended a Bash test harness covering configuration updates and re-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->