### PR TITLE
test(ffmpeg): fix write-then-exec ETXTBSY flake in export runtime-failure tests

### DIFF
--- a/internal/audiocore/ffmpeg/export_test.go
+++ b/internal/audiocore/ffmpeg/export_test.go
@@ -343,7 +343,6 @@ func TestExportAudio_ErrorsAreEnhanced(t *testing.T) {
 // cmd.Wait() non-zero-exit and os.Rename finalize branches are exercised
 // deterministically without a real FFmpeg. POSIX-only; skipped on Windows.
 func TestExportAudio_RuntimeFailuresAreEnhanced(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("fake shell-script FFmpeg binaries are POSIX-only")
 	}
@@ -358,10 +357,19 @@ func TestExportAudio_RuntimeFailuresAreEnhanced(t *testing.T) {
 		return p
 	}
 
+	// Build the fake binaries before t.Parallel() so the write file descriptors
+	// are closed before any concurrent test goroutine can call fork+exec. A
+	// forked child inherits all open fds; if one inherits a write fd to a script
+	// that another goroutine then tries to exec, Linux returns ETXTBSY
+	// (write-then-exec-under-concurrent-fork, golang/go#22315). Building here,
+	// in the sequential pre-parallel phase, eliminates that window entirely.
+	//
 	// Drains stdin then exits non-zero -> cmd.Wait() reports a non-zero exit.
 	waitFailBin := writeFakeBin(t, "wait-fail.sh", "#!/bin/sh\ncat > /dev/null\nexit 1\n")
 	// Exits zero but never writes the temp output file -> os.Rename finalize fails.
 	renameFailBin := writeFakeBin(t, "rename-fail.sh", "#!/bin/sh\ncat > /dev/null\nexit 0\n")
+
+	t.Parallel() // safe: write fds are closed; no concurrent fork can race on the scripts above
 
 	tests := []struct {
 		name          string
@@ -476,7 +484,6 @@ func TestExportAudioToBuffer_ErrorsAreEnhanced(t *testing.T) {
 // error paths using a fake POSIX-shell "FFmpeg" binary so the cmd.Wait()
 // non-zero-exit branch is exercised deterministically. POSIX-only.
 func TestExportAudioToBuffer_RuntimeFailuresAreEnhanced(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("fake shell-script FFmpeg binaries are POSIX-only")
 	}
@@ -484,9 +491,16 @@ func TestExportAudioToBuffer_RuntimeFailuresAreEnhanced(t *testing.T) {
 	outDir := t.TempDir()
 	pcm := makePCMSilence(t, 1)
 
+	// Build the fake binary before t.Parallel() so the write file descriptor is
+	// closed before any concurrent test goroutine can call fork+exec. See the
+	// comment in TestExportAudio_RuntimeFailuresAreEnhanced for the full
+	// explanation of the write-then-exec-under-concurrent-fork (ETXTBSY) race.
+	//
 	// Drains stdin, writes nothing to stdout, exits non-zero -> cmd.Wait() error.
 	waitFailBin := filepath.Join(outDir, "wait-fail.sh")
 	require.NoError(t, os.WriteFile(waitFailBin, []byte("#!/bin/sh\ncat > /dev/null\nexit 1\n"), 0o755)) //nolint:gosec // test-only fake binary must be executable
+
+	t.Parallel() // safe: write fd is closed; no concurrent fork can race on waitFailBin above
 
 	buf, err := ffmpeg.ExportAudioToBuffer(t.Context(), pcm, waitFailBin, 48000, 1, 16, []string{"-c:a", "flac", "-f", "flac"})
 	require.Error(t, err)


### PR DESCRIPTION
## Summary

Two tests in `internal/audiocore/ffmpeg/export_test.go` intermittently failed under `-race -shuffle=on` when the full suite ran under CPU load:

```
--- FAIL: TestExportAudioToBuffer_RuntimeFailuresAreEnhanced
    expected: "export_buffer_wait"  actual: "export_buffer_start"
    expected: int(1)                actual: <nil>
```

It is not a data race (no DATA RACE in `-race` output), it is a write-then-exec timing race.

`TestExportAudio_RuntimeFailuresAreEnhanced` and `TestExportAudioToBuffer_RuntimeFailuresAreEnhanced` each wrote a fake POSIX-shell FFmpeg stub with `os.WriteFile(..., 0o755)` and then immediately exec'd it. Both call `t.Parallel()` first, so the write happened while ~15 other parallel tests were running. When another parallel test called `cmd.Start()` (fork+exec), the forked child inherited the briefly-open write fd to the just-written script. When the parent then tried to exec that same script, Linux returned ETXTBSY ("text file busy"), `cmd.Start()` failed, and the production code returned the `export_buffer_start` error instead of reaching `cmd.Wait()`. This is the golang/go#22315 class of race. The production code path is correct; only the test's assumption that `cmd.Start()` always succeeds was wrong.

## Fix

Move `t.Parallel()` to after the `os.WriteFile` calls in both tests. Go's test runner executes each top-level test's pre-`t.Parallel()` phase sequentially, with no other test goroutines running concurrently, so the write fds are guaranteed closed before any fork can inherit them. This eliminates the ETXTBSY window entirely. No production code changed.

## Test Plan

Reproduced the failure on the old code, then confirmed the fix holds:

- [x] Repro (before fix), 32x CPU oversubscription, `-race -count=30 -shuffle=on`: FAIL
- [x] After fix, 32x CPU oversubscription, `-race -count=40 -shuffle=on`, run `TestExportAudio*`: PASS (40/40)
- [x] After fix, `-race -count=20 -shuffle=on`, run `TestExportAudioToBuffer*`: PASS
- [x] Full package: `go test -tags noembed,skipfrontend -race ./internal/audiocore/ffmpeg/`: PASS
- [x] `golangci-lint run ./internal/audiocore/ffmpeg/...`: 0 issues

## Preflight Status

- [x] Single concern: one test flake fix
- [x] Preflight passed: six review passes (reuse, safety, quality, i18n, integration, regression), all clean
- [x] Linters clean: golangci-lint 0 issues
- [x] Tests pass: package passes under -race
- [x] No regression/backward-compat break: test-only change
- [x] No secrets or PII

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of audio export failure handling checks, reducing flaky test behavior around runtime failures.
  * Added safer setup sequencing for parallel test execution to avoid race conditions during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->