### PR TITLE
fix(audio): match USB sound cards by stable hardware id (#3651)

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -19,6 +19,12 @@
 <script lang="ts">
   import { generateId } from '$lib/utils/uuid';
   import {
+    deviceValue,
+    deviceMatches,
+    deviceLabel,
+    type AudioDevice,
+  } from '$lib/utils/audioDevices';
+  import {
     Settings,
     Trash2,
     Check,
@@ -78,7 +84,7 @@
     source: AudioSourceConfig;
     index: number;
     sources: AudioSourceConfig[];
-    audioDevices: Array<{ index: number; name: string; id: string }>;
+    audioDevices: AudioDevice[];
     modelOptions: Array<{ value: string; label: string }>;
     availableModels: Array<{
       id: string;
@@ -127,9 +133,9 @@
   // used imperatively for abort(), never in markup, so it must not be reactive.
   let fetchController: AbortController | null = null;
 
-  // Device display name lookup
+  // Device display name lookup (matches a saved stable token or legacy ALSA id)
   let deviceDisplayName = $derived(
-    audioDevices.find(d => d.id === source.device)?.name ?? source.device
+    audioDevices.find(d => deviceMatches(d, source.device))?.name ?? source.device
   );
 
   // Model display names (comma-separated for multiple)
@@ -139,11 +145,19 @@
       : (modelOptions[0]?.label ?? '')
   );
 
-  // Device dropdown options — show current source's device + devices not used by other sources
+  // Device dropdown options: the current source's device plus devices not used by
+  // other sources. The currently-configured device keeps its saved value (which
+  // may be a legacy ALSA id) so the dropdown pre-selects it; other devices use the
+  // reboot-stable token so a new pick persists the stable form (GH #3651).
   let deviceOptions = $derived(
     audioDevices
-      .filter(d => d.id === source.device || !sources.some(s => s.device === d.id))
-      .map(d => ({ value: d.id, label: d.name }))
+      .filter(
+        d => deviceMatches(d, source.device) || !sources.some(s => deviceMatches(d, s.device))
+      )
+      .map(d => ({
+        value: deviceMatches(d, source.device) ? source.device : deviceValue(d),
+        label: deviceLabel(d, audioDevices),
+      }))
   );
 
   // Edit mode functions

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -25,6 +25,12 @@
   } from '$lib/utils/audio/sampleRate';
   import { toastActions } from '$lib/stores/toast';
   import { cn } from '$lib/utils/cn';
+  import {
+    deviceValue,
+    deviceMatches,
+    deviceLabel,
+    type AudioDevice,
+  } from '$lib/utils/audioDevices';
   import { getAvailableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
   import SoundCardCard from './SoundCardCard.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
@@ -75,7 +81,7 @@
 
   interface Props {
     sources: AudioSourceConfig[];
-    audioDevices: Array<{ index: number; name: string; id: string }>;
+    audioDevices: AudioDevice[];
     audioDevicesLoading: boolean;
     disabled?: boolean;
     onUpdateSources: (_sources: AudioSourceConfig[]) => void;
@@ -115,11 +121,14 @@
   let nameError = $state<string | null>(null);
   let deviceError = $state<string | null>(null);
 
-  // Device dropdown options — filter out devices already configured as sources
+  // Device dropdown options. New selections persist the reboot-stable USB token
+  // so they survive reboots (GH #3651); the label disambiguates identical device
+  // names with the bus path only when needed. Filter out devices already
+  // configured as a source by either identifier form.
   let deviceOptions = $derived(
     audioDevices
-      .filter(d => !sources.some(s => s.device === d.id))
-      .map(d => ({ value: d.id, label: d.name }))
+      .filter(d => !sources.some(s => deviceMatches(d, s.device)))
+      .map(d => ({ value: deviceValue(d), label: deviceLabel(d, audioDevices) }))
   );
 
   // Clear form errors

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.test.ts
@@ -84,10 +84,19 @@ vi.mock('$lib/utils/audio/sampleRate', async importActual => ({
 }));
 
 describe('SoundCardManager sample rate probe (issue #3593)', () => {
-  function renderManager(audioDevices: Array<{ index: number; name: string; id: string }>) {
+  function renderManager(
+    audioDevices: Array<{
+      index: number;
+      name: string;
+      id: string;
+      stableId?: string;
+      busPath?: string;
+    }>,
+    sources: AudioSourceConfig[] = []
+  ) {
     return renderTyped(SoundCardManager, {
       props: {
-        sources: [] as AudioSourceConfig[],
+        sources,
         audioDevices,
         audioDevicesLoading: false,
         disabled: false,
@@ -125,6 +134,85 @@ describe('SoundCardManager sample rate probe (issue #3593)', () => {
       expect(rateSelect().querySelector(`option[value="${RATE_96K.value}"]`)).not.toBeNull();
     });
     expect(rateSelect().querySelector(`option[value="${RATE_192K.value}"]`)).not.toBeNull();
+  });
+
+  it('persists the stable USB token, not the unstable ALSA index (GH #3651)', async () => {
+    renderManager([
+      {
+        index: 0,
+        name: 'USB Audio Device',
+        id: ':1,0',
+        stableId: 'usb-path:usb-xhci-hcd.0-1',
+        busPath: 'usb-xhci-hcd.0-1',
+      },
+    ]);
+    await openAddForm();
+
+    const deviceSelect = await screen.findByTestId(DEVICE_SELECT_TESTID);
+    // The option value must be the reboot-stable token, not the unstable :1,0 index.
+    const opt = deviceSelect.querySelector('option[value="usb-path:usb-xhci-hcd.0-1"]');
+    expect(opt).not.toBeNull();
+    expect(deviceSelect.querySelector('option[value=":1,0"]')).toBeNull();
+    // A single uniquely-named device shows just its name, not the bus path jargon.
+    expect(opt?.textContent).toContain('USB Audio Device');
+    expect(opt?.textContent).not.toContain('usb-xhci-hcd.0-1');
+  });
+
+  it('appends the bus path only to disambiguate identical device names', async () => {
+    renderManager([
+      {
+        index: 0,
+        name: 'USB Audio Device',
+        id: ':1,0',
+        stableId: 'usb-path:portA',
+        busPath: 'portA',
+      },
+      {
+        index: 1,
+        name: 'USB Audio Device',
+        id: ':2,0',
+        stableId: 'usb-path:portB',
+        busPath: 'portB',
+      },
+    ]);
+    await openAddForm();
+
+    const deviceSelect = await screen.findByTestId(DEVICE_SELECT_TESTID);
+    const optA = deviceSelect.querySelector('option[value="usb-path:portA"]');
+    const optB = deviceSelect.querySelector('option[value="usb-path:portB"]');
+    expect(optA?.textContent).toContain('(portA)');
+    expect(optB?.textContent).toContain('(portB)');
+  });
+
+  it('hides a device already configured by either its legacy id or stable token', async () => {
+    renderManager(
+      [
+        {
+          index: 0,
+          name: 'USB Audio A',
+          id: ':1,0',
+          stableId: 'usb-path:portA',
+          busPath: 'portA',
+        },
+        {
+          index: 1,
+          name: 'USB Audio B',
+          id: ':2,0',
+          stableId: 'usb-path:portB',
+          busPath: 'portB',
+        },
+      ],
+      // A is configured under its legacy index; B is unconfigured.
+      [{ name: 'mic-a', device: ':1,0', gain: 1, models: [] } as AudioSourceConfig]
+    );
+    await openAddForm();
+
+    const deviceSelect = await screen.findByTestId(DEVICE_SELECT_TESTID);
+    // Device A is fully excluded under BOTH identifier forms (it must not reappear
+    // as its legacy id either), while the unconfigured B remains selectable.
+    expect(deviceSelect.querySelector('option[value="usb-path:portA"]')).toBeNull();
+    expect(deviceSelect.querySelector('option[value=":1,0"]')).toBeNull();
+    expect(deviceSelect.querySelector('option[value="usb-path:portB"]')).not.toBeNull();
   });
 
   it('ignores a stale probe that resolves after a newer device was selected', async () => {

--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
@@ -69,6 +69,7 @@
     Info,
   } from '@lucide/svelte';
   import { api } from '$lib/utils/api';
+  import { type AudioDevice } from '$lib/utils/audioDevices';
   import { normalizeForLookup } from '$lib/utils/speciesNames';
   import { localizeSpeciesName } from '$lib/utils/speciesDisplay';
 
@@ -282,8 +283,8 @@
   }
 
   // Audio source options - map to actual device names
-  // Note: v2 API returns lowercase field names (index, name, id)
-  let audioDevices = $state<ApiState<Array<{ index: number; name: string; id: string }>>>({
+  // Note: v2 API returns lowercase field names (index, name, id, stableId, busPath)
+  let audioDevices = $state<ApiState<AudioDevice[]>>({
     loading: true,
     error: null,
     data: [],
@@ -299,11 +300,6 @@
     audioDevices.error = null;
 
     try {
-      interface AudioDevice {
-        index: number;
-        name: string;
-        id: string;
-      }
       const data = await api.get<AudioDevice[]>('/api/v2/system/audio/devices');
       audioDevices.data = data || [];
     } catch (error) {

--- a/frontend/src/lib/utils/audioDevices.test.ts
+++ b/frontend/src/lib/utils/audioDevices.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { deviceValue, deviceMatches, deviceLabel, type AudioDevice } from './audioDevices';
+
+const usbA: AudioDevice = {
+  index: 0,
+  name: 'USB Audio Device',
+  id: ':1,0',
+  stableId: 'usb-path:usb-xhci-hcd.0-1',
+  busPath: 'usb-xhci-hcd.0-1',
+};
+const usbB: AudioDevice = {
+  index: 1,
+  name: 'USB Audio Device',
+  id: ':2,0',
+  stableId: 'usb-path:usb-xhci-hcd.0-2',
+  busPath: 'usb-xhci-hcd.0-2',
+};
+const builtin: AudioDevice = { index: 2, name: 'HDA Intel PCH', id: ':0,0' };
+
+describe('deviceValue', () => {
+  it('prefers the stable USB token', () => {
+    expect(deviceValue(usbA)).toBe('usb-path:usb-xhci-hcd.0-1');
+  });
+  it('falls back to the ALSA id when no stable token', () => {
+    expect(deviceValue(builtin)).toBe(':0,0');
+  });
+});
+
+describe('deviceMatches', () => {
+  it('matches a saved stable token', () => {
+    expect(deviceMatches(usbA, 'usb-path:usb-xhci-hcd.0-1')).toBe(true);
+  });
+  it('matches a saved legacy ALSA id (existing config)', () => {
+    expect(deviceMatches(usbA, ':1,0')).toBe(true);
+  });
+  it('does not match a different device', () => {
+    expect(deviceMatches(usbA, ':2,0')).toBe(false);
+    expect(deviceMatches(usbA, 'usb-path:usb-xhci-hcd.0-2')).toBe(false);
+  });
+  it('matches a device without a stable token by id only', () => {
+    expect(deviceMatches(builtin, ':0,0')).toBe(true);
+    expect(deviceMatches(builtin, '')).toBe(false);
+  });
+});
+
+describe('deviceLabel', () => {
+  it('shows only the name when the device name is unique', () => {
+    expect(deviceLabel(usbA, [usbA, builtin])).toBe('USB Audio Device');
+  });
+  it('appends the bus path only when names collide', () => {
+    expect(deviceLabel(usbA, [usbA, usbB])).toBe('USB Audio Device (usb-xhci-hcd.0-1)');
+    expect(deviceLabel(usbB, [usbA, usbB])).toBe('USB Audio Device (usb-xhci-hcd.0-2)');
+  });
+  it('shows just the name when names collide but no bus path is available', () => {
+    const noPathA: AudioDevice = { index: 0, name: 'Mic', id: ':1,0' };
+    const noPathB: AudioDevice = { index: 1, name: 'Mic', id: ':2,0' };
+    expect(deviceLabel(noPathA, [noPathA, noPathB])).toBe('Mic');
+  });
+});

--- a/frontend/src/lib/utils/audioDevices.ts
+++ b/frontend/src/lib/utils/audioDevices.ts
@@ -1,0 +1,45 @@
+/**
+ * Helpers for presenting and persisting audio capture device selections.
+ *
+ * A device is persisted in `realtime.audio.sources[].device`. Historically this
+ * was the ALSA card index (":1,0"), which is unstable across reboots for USB
+ * devices (GH #3651). The backend now also reports a reboot-stable USB token
+ * (`stableId`, e.g. "usb-path:usb-xhci-hcd.0-1"); new selections persist that
+ * token while existing ":1,0"/name configs keep working via the backend's
+ * legacy match tiers.
+ */
+
+export interface AudioDevice {
+  index: number;
+  name: string;
+  id: string;
+  /** Reboot-stable USB token to persist in preference to `id` (GH #3651). */
+  stableId?: string;
+  /** USB bus path for display; present only for USB devices on Linux. */
+  busPath?: string;
+}
+
+/** The identifier to persist for a device: the stable USB token when available. */
+export function deviceValue(device: AudioDevice): string {
+  // stableId is omitted (undefined) when no stable identity exists; it is never
+  // an empty string, so ?? correctly falls back to the legacy id.
+  return device.stableId ?? device.id;
+}
+
+/**
+ * Whether a saved `device` string refers to this device, matching either the
+ * stable token (new configs) or the legacy ALSA id (existing configs).
+ */
+export function deviceMatches(device: AudioDevice, saved: string): boolean {
+  return device.id === saved || (!!device.stableId && device.stableId === saved);
+}
+
+/**
+ * Dropdown label for a device: its name, with the USB bus path appended only
+ * when another enumerated device shares the same name. Identical USB cards are
+ * thus distinguishable without showing a kernel bus path to every user.
+ */
+export function deviceLabel(device: AudioDevice, all: AudioDevice[]): string {
+  const ambiguous = all.filter(d => d.name === device.name).length > 1;
+  return ambiguous && device.busPath ? `${device.name} (${device.busPath})` : device.name;
+}

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -116,6 +116,17 @@ type AudioDeviceInfo struct {
 	Index int    `json:"index"`
 	Name  string `json:"name"`
 	ID    string `json:"id"`
+	// StableID is the reboot-stable identifier to persist for this device
+	// ("usb-path:..." / "usb-id:..."), empty when no stable USB identity exists.
+	// Clients should save this in preference to ID so the selection survives
+	// reboots (GH #3651).
+	StableID string `json:"stableId,omitempty"`
+	// BusPath is the USB bus path for display (e.g. "usb-0000:00:14.0-3"),
+	// empty for non-USB devices and non-Linux platforms.
+	BusPath string `json:"busPath,omitempty"`
+	// VendorID and ProductID are the 4-hex-digit USB ids, empty when unavailable.
+	VendorID  string `json:"vendorId,omitempty"`
+	ProductID string `json:"productId,omitempty"`
 }
 
 // ActiveAudioDevice represents the currently active audio device
@@ -858,9 +869,13 @@ func (c *Controller) GetAudioDevices(ctx echo.Context) error {
 	apiDevices := make([]AudioDeviceInfo, len(devices))
 	for i, device := range devices {
 		apiDevices[i] = AudioDeviceInfo{
-			Index: device.Index,
-			Name:  device.Name,
-			ID:    device.ID,
+			Index:     device.Index,
+			Name:      device.Name,
+			ID:        device.ID,
+			StableID:  device.StableID,
+			BusPath:   device.BusPath,
+			VendorID:  device.VendorID,
+			ProductID: device.ProductID,
 		}
 	}
 

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -76,6 +76,12 @@ func ProbeAllDeviceCapabilities(log logger.Logger) {
 		}
 		capabilitiesCacheMu.Lock()
 		capabilitiesCache[dev.ID] = caps
+		// Also key by the stable USB token so a config persisted as "usb-path:..."
+		// hits this startup cache instead of falling through to a live exclusive-mode
+		// probe that contends with capture already holding the device (GH #3651).
+		if dev.StableID != "" {
+			capabilitiesCache[dev.StableID] = caps
+		}
 		capabilitiesCacheMu.Unlock()
 		log.Info("cached device capabilities",
 			logger.String("device", dev.Name),
@@ -101,9 +107,10 @@ func GetCachedCapabilities(deviceName string) *DeviceCapabilities {
 // probes the device live. The cache is populated at startup; live probing is
 // the fallback for devices plugged in after startup.
 func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabilities, error) {
-	// Check cache first (covers devices probed at startup).
-	// Direct lookup by ID, then iterate for name/substring match
-	// (same matching logic as matchesDevice in capture.go).
+	// Check cache first (covers devices probed at startup). The cache is keyed by
+	// both the decoded ALSA id and the stable USB token, so a direct lookup hits
+	// for a "usb-path:"/"usb-id:" config; the name-substring scan is a legacy
+	// fallback for name-based configs.
 	capabilitiesCacheMu.RLock()
 	if caps, ok := capabilitiesCache[deviceID]; ok {
 		capabilitiesCacheMu.RUnlock()
@@ -159,6 +166,13 @@ func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCap
 	var selectedInfo *malgo.DeviceInfo
 	var deviceName string
 
+	// Only a stable USB token needs the resolved USB identity to match; legacy
+	// id/name configs match without it. Parse the cards map once when needed.
+	needIdent := isUSBDeviceToken(deviceID)
+	var cards map[int]procCardEntry
+	if needIdent {
+		cards = readProcAsoundCards(defaultProcRoot)
+	}
 	for i := range infos {
 		decodedID, decErr := hexToASCII(infos[i].ID.String())
 		if decErr != nil {
@@ -167,7 +181,11 @@ func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCap
 				logger.Error(decErr))
 			continue
 		}
-		if matchesDevice(decodedID, &infos[i], deviceID) {
+		var ident usbIdentity
+		if needIdent {
+			ident = usbIdentityForCard(parseALSACardNumber(decodedID), cards, defaultProcRoot)
+		}
+		if matchesDevice(decodedID, ident, infos[i].Name(), infos[i].IsDefault == 1, deviceID) {
 			selectedInfo = &infos[i]
 			deviceName = infos[i].Name()
 			break

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -147,7 +147,7 @@ func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCap
 			Component("audiocore.capabilities").
 			Category(errors.CategoryAudioSource).
 			Context("operation", "probe_context_init").
-			Context("device_id", deviceID).
+			Context("device_id", redactDeviceID(deviceID)).
 			Build()
 	}
 	defer uninitAndFreeContext(malgoCtx, log)
@@ -158,7 +158,7 @@ func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCap
 			Component("audiocore.capabilities").
 			Category(errors.CategoryAudioSource).
 			Context("operation", "probe_enumerate_devices").
-			Context("device_id", deviceID).
+			Context("device_id", redactDeviceID(deviceID)).
 			Build()
 	}
 
@@ -204,7 +204,7 @@ func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCap
 
 	if len(rates) > 0 && runtime.GOOS != captureOSLinux {
 		log.Debug("device capabilities from native formats",
-			logger.String("device_id", deviceID),
+			logger.String("device_id", redactDeviceID(deviceID)),
 			logger.String("device_name", deviceName),
 			logger.Any("sample_rates", rates))
 		return &DeviceCapabilities{
@@ -219,7 +219,7 @@ func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCap
 	// On other platforms, this is the fallback when formats are all zero.
 	if runtime.GOOS == captureOSLinux {
 		log.Info("probing device by init (ALSA zero-rate formats)",
-			logger.String("device_id", deviceID),
+			logger.String("device_id", redactDeviceID(deviceID)),
 			logger.String("device_name", deviceName))
 		rates = probeByInit(malgoCtx, selectedInfo, log)
 		if len(rates) > 0 {

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -108,6 +108,10 @@ func listDevices(log logger.Logger) ([]DeviceInfo, error) {
 	devices := make([]DeviceInfo, 0, len(infos))
 	seenNames := make(map[string]bool, len(infos))
 
+	// Parse /proc/asound/cards once for the whole enumeration; usbIdentityForCard
+	// then resolves each device against the shared map (nil on non-Linux).
+	cards := readProcAsoundCards(defaultProcRoot)
+
 	for i := range infos {
 		name := infos[i].Name()
 		if strings.Contains(name, "Discard all samples") {
@@ -131,10 +135,16 @@ func listDevices(log logger.Logger) ([]DeviceInfo, error) {
 		}
 		seenNames[name] = true
 
+		ident := usbIdentityForCard(parseALSACardNumber(decodedID), cards, defaultProcRoot)
 		devices = append(devices, DeviceInfo{
-			Index: i,
-			Name:  name,
-			ID:    decodedID,
+			Index:     i,
+			Name:      name,
+			ID:        decodedID,
+			BusPath:   ident.BusPath,
+			VendorID:  ident.VendorID,
+			ProductID: ident.ProductID,
+			Serial:    ident.Serial,
+			StableID:  ident.stableToken(),
 		})
 	}
 
@@ -147,18 +157,33 @@ func isDefaultDeviceToken(deviceID string) bool {
 	return deviceID == DeviceIDSysDefault || deviceID == DeviceIDDefault
 }
 
-// matchesDevice reports whether the device identified by (decodedID, info)
-// should be selected for the requested deviceID string.
+// matchesDevice reports whether the live device identified by (decodedID, ident,
+// deviceName, isDefault) should be selected for the requested deviceID string,
+// in priority order:
 //
-// On Windows and macOS the DeviceIDDefault / DeviceIDSysDefault token selects
-// the system default device. Otherwise, either a substring of the name or an
-// exact ID match is accepted.
-func matchesDevice(decodedID string, info *malgo.DeviceInfo, deviceID string) bool {
+//  1. Windows/macOS default token -> the platform default device.
+//  2. A persisted "usb-path:" token -> the device's stable USB bus path. Matches
+//     regardless of the current ALSA index, so the selection survives reboots.
+//  3. A persisted "usb-id:" token -> the device's vendor:product:serial.
+//  4. Exact decoded id match (legacy ":X,Y" configs).
+//  5. Device-name substring match (legacy name configs).
+//
+// ident carries the live device's resolved USB identity (zero on non-USB /
+// non-Linux). The USB tiers only add matching ability; tiers 4 and 5 preserve
+// the previous behavior exactly, so existing configurations are unaffected.
+func matchesDevice(decodedID string, ident usbIdentity, deviceName string, isDefault bool, deviceID string) bool {
 	if (runtime.GOOS == captureOSWindows || runtime.GOOS == captureOSDarwin) &&
 		isDefaultDeviceToken(deviceID) {
-		return info.IsDefault == 1
+		return isDefault
 	}
-	return decodedID == deviceID || strings.Contains(info.Name(), deviceID)
+	if path, ok := strings.CutPrefix(deviceID, usbPathTokenPrefix); ok {
+		return path != "" && path == ident.BusPath
+	}
+	if _, ok := strings.CutPrefix(deviceID, usbIDTokenPrefix); ok {
+		token := ident.hwIDToken()
+		return token != "" && deviceID == token
+	}
+	return decodedID == deviceID || strings.Contains(deviceName, deviceID)
 }
 
 // uninitAndFreeContext performs the two-step malgo context teardown:
@@ -169,6 +194,58 @@ func uninitAndFreeContext(ctx *malgo.AllocatedContext, log logger.Logger) {
 		log.Error("failed to uninitialize malgo context", logger.Error(uninitErr))
 	}
 	ctx.Free()
+}
+
+// selectCaptureDevice returns the enumerated device matching deviceID, as both
+// its malgo info pointer and a populated DeviceInfo carrying the matched device's
+// resolved USB identity. The returned bool is false when no device matches.
+//
+// Only a stable USB token needs the resolved USB identity to match, so for the
+// common legacy id/name configs the per-candidate proc/sysfs reads are skipped
+// and a single resolve is done for the matched device. The cards map is parsed
+// once per enumeration when needed.
+func selectCaptureDevice(infos []malgo.DeviceInfo, deviceID string, log logger.Logger) (selected *malgo.DeviceInfo, info DeviceInfo, found bool) {
+	needIdent := isUSBDeviceToken(deviceID)
+	var cards map[int]procCardEntry
+	if needIdent {
+		cards = readProcAsoundCards(defaultProcRoot)
+	}
+	for i := range infos {
+		decodedID, decErr := hexToASCII(infos[i].ID.String())
+		if decErr != nil {
+			log.Warn("failed to decode device ID",
+				logger.Int("device_index", i),
+				logger.Error(decErr))
+			continue
+		}
+		log.Debug("found capture device",
+			logger.Int("index", i),
+			logger.String("name", infos[i].Name()),
+			logger.String("decoded_id", decodedID))
+		var ident usbIdentity
+		if needIdent {
+			ident = usbIdentityForCard(parseALSACardNumber(decodedID), cards, defaultProcRoot)
+		}
+		if !matchesDevice(decodedID, ident, infos[i].Name(), infos[i].IsDefault == 1, deviceID) {
+			continue
+		}
+		// Record the matched device's stable identity. For a legacy/name match we
+		// did not resolve above, so resolve once here for the single selected device.
+		if !needIdent {
+			ident = resolveUSBIdentity(decodedID, defaultProcRoot)
+		}
+		return &infos[i], DeviceInfo{
+			Index:     i,
+			Name:      infos[i].Name(),
+			ID:        decodedID,
+			BusPath:   ident.BusPath,
+			VendorID:  ident.VendorID,
+			ProductID: ident.ProductID,
+			Serial:    ident.Serial,
+			StableID:  ident.stableToken(),
+		}, true
+	}
+	return nil, DeviceInfo{}, false
 }
 
 // startCapture locates the requested device, initialises a malgo context and
@@ -216,36 +293,13 @@ func startCapture(
 	}
 
 	// Find the device matching deviceID.
-	var selectedInfo *malgo.DeviceInfo
-	var selectedDevInfo DeviceInfo
 	log.Info("enumerating capture devices",
 		logger.String("source_id", sourceID),
 		logger.String("requested_device", deviceID),
 		logger.Int("device_count", len(infos)))
-	for i := range infos {
-		decodedID, decErr := hexToASCII(infos[i].ID.String())
-		if decErr != nil {
-			log.Warn("failed to decode device ID",
-				logger.Int("device_index", i),
-				logger.Error(decErr))
-			continue
-		}
-		log.Debug("found capture device",
-			logger.Int("index", i),
-			logger.String("name", infos[i].Name()),
-			logger.String("decoded_id", decodedID))
-		if matchesDevice(decodedID, &infos[i], deviceID) {
-			selectedInfo = &infos[i]
-			selectedDevInfo = DeviceInfo{
-				Index: i,
-				Name:  infos[i].Name(),
-				ID:    decodedID,
-			}
-			break
-		}
-	}
+	selectedInfo, selectedDevInfo, found := selectCaptureDevice(infos, deviceID, log)
 
-	if selectedInfo == nil {
+	if !found {
 		uninitAndFreeContext(malgoCtx, log)
 		return DeviceInfo{}, nil, errors.Newf("no device found matching %q", deviceID).
 			Component("audiocore.capture").

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -136,7 +136,7 @@ func listDevices(log logger.Logger) ([]DeviceInfo, error) {
 		// per card so the several pseudo-devices of one card collapse to a single
 		// entry, while two physically distinct cards that share a display name
 		// (e.g. two identical USB mics) are BOTH listed and selectable.
-		seenKey := deviceDedupKey(name, cardNumber, ident)
+		seenKey := deviceDedupKey(name, ident)
 		if seenNames[seenKey] {
 			continue
 		}

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -129,13 +129,19 @@ func listDevices(log logger.Logger) ([]DeviceInfo, error) {
 			continue
 		}
 
-		// ALSA enumerates multiple pseudo-devices per card; deduplicate by name.
-		if seenNames[name] {
+		cardNumber := parseALSACardNumber(decodedID)
+		ident := usbIdentityForCard(cardNumber, cards, defaultProcRoot)
+
+		// ALSA enumerates multiple pseudo-devices per physical card; deduplicate
+		// per card so the several pseudo-devices of one card collapse to a single
+		// entry, while two physically distinct cards that share a display name
+		// (e.g. two identical USB mics) are BOTH listed and selectable.
+		seenKey := deviceDedupKey(name, cardNumber, ident)
+		if seenNames[seenKey] {
 			continue
 		}
-		seenNames[name] = true
+		seenNames[seenKey] = true
 
-		ident := usbIdentityForCard(parseALSACardNumber(decodedID), cards, defaultProcRoot)
 		devices = append(devices, DeviceInfo{
 			Index:     i,
 			Name:      name,
@@ -295,7 +301,7 @@ func startCapture(
 	// Find the device matching deviceID.
 	log.Info("enumerating capture devices",
 		logger.String("source_id", sourceID),
-		logger.String("requested_device", deviceID),
+		logger.String("requested_device", redactDeviceID(deviceID)),
 		logger.Int("device_count", len(infos)))
 	selectedInfo, selectedDevInfo, found := selectCaptureDevice(infos, deviceID, log)
 
@@ -306,7 +312,7 @@ func startCapture(
 			Category(errors.CategoryAudioSource).
 			Context("operation", "find_device").
 			Context("source_id", sourceID).
-			Context("device_id", deviceID).
+			Context("device_id", redactDeviceID(deviceID)).
 			Build()
 	}
 

--- a/internal/audiocore/device.go
+++ b/internal/audiocore/device.go
@@ -175,7 +175,7 @@ func (dm *DeviceManager) StartCapture(sourceID, deviceID string, cfg DeviceConfi
 	dm.log.Info("capture started",
 		logger.String("source_id", sourceID),
 		logger.String("device", info.Name),
-		logger.String("device_id", deviceID))
+		logger.String("device_id", redactDeviceID(deviceID)))
 
 	return nil
 }

--- a/internal/audiocore/device.go
+++ b/internal/audiocore/device.go
@@ -25,8 +25,27 @@ type DeviceInfo struct {
 	// Name is the human-readable device name (e.g., "HDA Intel PCH: ALC3202 Analog").
 	Name string
 
-	// ID is the decoded device identifier (e.g., ":0,0" on ALSA).
+	// ID is the decoded device identifier (e.g., ":0,0" on ALSA). This is the
+	// unstable ALSA card index; it can change across reboots for USB devices.
 	ID string
+
+	// BusPath is the stable USB topology path (e.g. "usb-0000:00:14.0-3"), empty
+	// for non-USB devices and non-Linux platforms. Stable across reboots while
+	// the device stays in the same physical port.
+	BusPath string
+
+	// VendorID and ProductID are the 4-hex-digit USB ids, empty when unavailable.
+	VendorID  string
+	ProductID string
+
+	// Serial is the USB serial number, empty when the device reports none.
+	Serial string
+
+	// StableID is the reboot-stable identifier to persist for this device
+	// ("usb-path:..." or "usb-id:..."), or "" when no stable USB identity is
+	// available (non-USB, non-Linux). Prefer this over ID when configuring a
+	// device so the selection survives reboots (GH #3651).
+	StableID string
 }
 
 // DeviceConfig carries the capture parameters for a device.

--- a/internal/audiocore/usb.go
+++ b/internal/audiocore/usb.go
@@ -1,0 +1,188 @@
+// Package audiocore provides the core audio infrastructure for BirdNET-Go.
+// usb.go - stable USB hardware identity for ALSA capture devices.
+//
+// Linux assigns ALSA card indices in USB enumeration order at boot, so the same
+// physical USB sound card can be ":1,0" on one boot and ":3,0" on the next. A
+// configuration that stores the decoded ALSA index therefore breaks after a
+// reboot (GH #3651). Matching on a stable USB identifier (the kernel USB bus
+// path, or vendor:product:serial) instead keeps the saved selection valid.
+//
+// This file holds the platform-independent parsing/token logic so it can be
+// unit-tested everywhere. The actual proc/sysfs reads live in usb_linux.go.
+package audiocore
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Stable token prefixes persisted in conf.AudioSourceConfig.Device. A device
+// string carrying one of these prefixes is matched against a live device's
+// resolved USB identity rather than its (unstable) ALSA index.
+const (
+	usbPathTokenPrefix = "usb-path:"
+	usbIDTokenPrefix   = "usb-id:"
+)
+
+// defaultProcRoot is the production filesystem root for the proc/sysfs reads in
+// resolveUSBIdentity. Tests pass a fake root instead.
+const defaultProcRoot = "/"
+
+// usbIdentity holds the stable USB hardware identity of an audio capture device.
+// All fields are empty on non-Linux platforms or for non-USB devices.
+type usbIdentity struct {
+	// BusPath is the kernel USB topology path (e.g. "usb-0000:00:14.0-3" on x86,
+	// "usb-xhci-hcd.0-1" on a Pi). It is stable across reboots as long as the
+	// device stays in the same physical port.
+	BusPath string
+
+	// VendorID is the 4-hex-digit USB vendor id (e.g. "0d8c").
+	VendorID string
+
+	// ProductID is the 4-hex-digit USB product id (e.g. "0014").
+	ProductID string
+
+	// Serial is the USB serial number, or "" when the device reports none
+	// (common on inexpensive USB audio adapters).
+	Serial string
+}
+
+// hasStableID reports whether this identity yields a reboot-stable token.
+func (u usbIdentity) hasStableID() bool {
+	return u.BusPath != "" || (u.VendorID != "" && u.ProductID != "")
+}
+
+// isUSBDeviceToken reports whether a persisted device string is a stable USB
+// token (rather than a legacy ALSA index or device name). Used to skip the
+// proc/sysfs resolution work entirely for the common legacy configurations.
+func isUSBDeviceToken(deviceID string) bool {
+	return strings.HasPrefix(deviceID, usbPathTokenPrefix) ||
+		strings.HasPrefix(deviceID, usbIDTokenPrefix)
+}
+
+// stableToken returns the preferred persisted identifier for this device, or ""
+// when no stable USB identity is available. The bus path is preferred because it
+// disambiguates multiple identical devices (same vendor:product, no serial) by
+// physical port, which vendor:product:serial alone cannot.
+func (u usbIdentity) stableToken() string {
+	if u.BusPath != "" {
+		return usbPathTokenPrefix + u.BusPath
+	}
+	return u.hwIDToken()
+}
+
+// hwIDToken returns the "usb-id:vendor:product:serial" token, or "" when the
+// vendor or product id is unknown.
+func (u usbIdentity) hwIDToken() string {
+	if u.VendorID == "" || u.ProductID == "" {
+		return ""
+	}
+	return usbIDTokenPrefix + u.VendorID + ":" + u.ProductID + ":" + u.Serial
+}
+
+// parseALSACardNumber extracts the ALSA card index from a decoded device id.
+// It accepts the forms malgo produces and a few defensive variants: ":3,0",
+// "hw:3,0", "3,0", "3". Returns -1 when no leading card integer is present
+// (e.g. "default", "sysdefault", "pcmC0D0c", "").
+func parseALSACardNumber(decodedID string) int {
+	s := strings.TrimPrefix(decodedID, "hw")
+	s = strings.TrimPrefix(s, ":")
+	// The card number is the run of digits up to the first ',' (or end).
+	if comma := strings.IndexByte(s, ','); comma >= 0 {
+		s = s[:comma]
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return -1
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return -1
+	}
+	return n
+}
+
+// procCardEntry is one card parsed from /proc/asound/cards.
+type procCardEntry struct {
+	// busPath is the USB bus path ("usb-..."), empty for non-USB cards.
+	busPath string
+	// isUSB is true when the card is a USB-Audio device.
+	isUSB bool
+}
+
+// procCardHeaderRe matches a card header line in /proc/asound/cards, e.g.
+// " 0 [Device         ]: USB-Audio - USB Audio Device". Capture group 1 is the
+// card index.
+var procCardHeaderRe = regexp.MustCompile(`^\s*(\d+)\s+\[`)
+
+// parseProcAsoundCards parses the contents of /proc/asound/cards into a map of
+// card index -> entry. Each card spans a header line and a detail line:
+//
+//	0 [Device         ]: USB-Audio - USB Audio Device
+//	                     C-Media ... USB Audio Device at usb-xhci-hcd.0-1, full speed
+//
+// The bus path is the token between " at " and the next "," on the detail line;
+// only paths beginning with "usb-" are recorded (and mark the card as USB).
+func parseProcAsoundCards(content string) map[int]procCardEntry {
+	result := make(map[int]procCardEntry)
+	curCard := -1
+	for line := range strings.Lines(content) {
+		if m := procCardHeaderRe.FindStringSubmatch(line); m != nil {
+			n, err := strconv.Atoi(m[1])
+			if err != nil {
+				curCard = -1
+				continue
+			}
+			curCard = n
+			result[n] = procCardEntry{isUSB: strings.Contains(line, "USB-Audio")}
+			continue
+		}
+		if curCard < 0 {
+			continue
+		}
+		if bp := extractBusPathFromDetail(line); strings.HasPrefix(bp, "usb-") {
+			e := result[curCard]
+			e.busPath = bp
+			e.isUSB = true
+			result[curCard] = e
+		}
+	}
+	return result
+}
+
+// extractBusPathFromDetail returns the bus path from a /proc/asound/cards detail
+// line such as "... at usb-0000:00:14.0-3, high speed" -> "usb-0000:00:14.0-3".
+// Returns "" when the line has no " at <path>," segment. It anchors on the LAST
+// " at " so a device name that itself contains " at " does not mis-split the
+// trailing bus-path segment.
+func extractBusPathFromDetail(line string) string {
+	const sep = " at "
+	idx := strings.LastIndex(line, sep)
+	if idx < 0 {
+		return ""
+	}
+	rest := line[idx+len(sep):]
+	if comma := strings.IndexByte(rest, ','); comma >= 0 {
+		rest = rest[:comma]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// hex4Re matches exactly four hexadecimal digits (a USB vid/pid).
+var hex4Re = regexp.MustCompile(`^[0-9a-fA-F]{4}$`)
+
+// parseUSBID parses the contents of /proc/asound/cardN/usbid ("VVVV:PPPP") into
+// vendor and product ids. Returns empty strings when the content is malformed.
+func parseUSBID(content string) (vendor, product string) {
+	v, p, found := strings.Cut(strings.TrimSpace(content), ":")
+	if !found {
+		return "", ""
+	}
+	v = strings.TrimSpace(v)
+	p = strings.TrimSpace(p)
+	if !hex4Re.MatchString(v) || !hex4Re.MatchString(p) {
+		return "", ""
+	}
+	return v, p
+}

--- a/internal/audiocore/usb.go
+++ b/internal/audiocore/usb.go
@@ -62,20 +62,18 @@ func isUSBDeviceToken(deviceID string) bool {
 }
 
 // deviceDedupKey returns the key used to collapse the several ALSA pseudo-devices
-// that one physical card enumerates as, while keeping two physically distinct
-// cards that share a display name separate (e.g. two identical USB mics). It
-// prefers the stable USB token, then the ALSA card number, then the bare name.
-// A name-only key would hide the second identical device, the exact case the
-// stable-id selection exists to fix.
-func deviceDedupKey(name string, cardNumber int, ident usbIdentity) string {
-	switch {
-	case ident.stableToken() != "":
-		return name + "\x00" + ident.stableToken()
-	case cardNumber >= 0:
-		return name + "\x00card:" + strconv.Itoa(cardNumber)
-	default:
-		return name
+// that one physical card enumerates as. A USB card's pseudo-devices all share its
+// stable USB token, so keying on the token alone collapses them to one entry
+// (even if ALSA reports slightly different names) while two physically distinct
+// cards stay separate even when they share a display name, e.g. two identical USB
+// mics. Without a stable token (non-USB or legacy) it falls back to the display
+// name, preserving the original name-based dedup so distinctly-named capture
+// devices that a user can still select by ALSA id or name are not merged away.
+func deviceDedupKey(name string, ident usbIdentity) string {
+	if token := ident.stableToken(); token != "" {
+		return token
 	}
+	return name
 }
 
 // redactDeviceID returns a log-safe form of a configured device identifier. A

--- a/internal/audiocore/usb.go
+++ b/internal/audiocore/usb.go
@@ -61,6 +61,44 @@ func isUSBDeviceToken(deviceID string) bool {
 		strings.HasPrefix(deviceID, usbIDTokenPrefix)
 }
 
+// deviceDedupKey returns the key used to collapse the several ALSA pseudo-devices
+// that one physical card enumerates as, while keeping two physically distinct
+// cards that share a display name separate (e.g. two identical USB mics). It
+// prefers the stable USB token, then the ALSA card number, then the bare name.
+// A name-only key would hide the second identical device, the exact case the
+// stable-id selection exists to fix.
+func deviceDedupKey(name string, cardNumber int, ident usbIdentity) string {
+	switch {
+	case ident.stableToken() != "":
+		return name + "\x00" + ident.stableToken()
+	case cardNumber >= 0:
+		return name + "\x00card:" + strconv.Itoa(cardNumber)
+	default:
+		return name
+	}
+}
+
+// redactDeviceID returns a log-safe form of a configured device identifier. A
+// usb-id token embeds the USB serial number, a persistent per-unit hardware
+// identifier, so the serial is masked before the value reaches logs, error
+// context, or support bundles. Bus-path and legacy ALSA/name identifiers carry
+// no such per-unit id and are returned unchanged.
+func redactDeviceID(deviceID string) string {
+	rest, ok := strings.CutPrefix(deviceID, usbIDTokenPrefix)
+	if !ok {
+		return deviceID
+	}
+	vendor, after, found := strings.Cut(rest, ":")
+	if !found {
+		return deviceID
+	}
+	product, serial, found := strings.Cut(after, ":")
+	if !found || serial == "" {
+		return deviceID
+	}
+	return usbIDTokenPrefix + vendor + ":" + product + ":<redacted>"
+}
+
 // stableToken returns the preferred persisted identifier for this device, or ""
 // when no stable USB identity is available. The bus path is preferred because it
 // disambiguates multiple identical devices (same vendor:product, no serial) by

--- a/internal/audiocore/usb_linux.go
+++ b/internal/audiocore/usb_linux.go
@@ -82,8 +82,10 @@ func readUSBSerial(root string, card int) string {
 	}
 	dir := target
 	for range maxUSBSysfsWalkDepth {
-		// Stay within the sysfs subtree; if symlink resolution escaped it, stop.
-		if dir != sysRoot && !strings.HasPrefix(dir, sysRoot+string(os.PathSeparator)) {
+		// Stay strictly below the sysfs root: the USB device node is always a
+		// descendant of <root>/sys, so stop at sysRoot itself or anything that
+		// symlink resolution placed outside the subtree.
+		if dir == sysRoot || !strings.HasPrefix(dir, sysRoot+string(os.PathSeparator)) {
 			break
 		}
 		if _, statErr := os.Stat(filepath.Join(dir, "idVendor")); statErr == nil {

--- a/internal/audiocore/usb_linux.go
+++ b/internal/audiocore/usb_linux.go
@@ -76,6 +76,13 @@ func usbIdentityForCard(card int, cards map[int]procCardEntry, root string) usbI
 // do not report one.
 func readUSBSerial(root string, card int) string {
 	sysRoot := filepath.Join(root, "sys")
+	// Resolve sysRoot the same way as target below; otherwise a symlinked element
+	// in root (a test temp dir, or a path like macOS /var -> /private/var) would
+	// leave the resolved target without the literal sysRoot prefix and the walk
+	// would stop immediately.
+	if resolved, symErr := filepath.EvalSymlinks(sysRoot); symErr == nil {
+		sysRoot = resolved
+	}
 	target, err := filepath.EvalSymlinks(filepath.Join(sysRoot, "class", "sound", "card"+strconv.Itoa(card)))
 	if err != nil {
 		return ""

--- a/internal/audiocore/usb_linux.go
+++ b/internal/audiocore/usb_linux.go
@@ -1,0 +1,104 @@
+//go:build linux
+
+package audiocore
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// maxUSBSysfsWalkDepth bounds the upward sysfs walk in readUSBSerial; the USB
+// device node is normally only 3-4 levels above the card directory, so this is a
+// generous cap that simply guarantees termination.
+const maxUSBSysfsWalkDepth = 12
+
+// resolveUSBIdentity maps an ALSA decoded id (":3,0") to the USB identity of its
+// card. It is a thin wrapper over usbIdentityForCard that reads/parses
+// /proc/asound/cards for the single lookup. Callers enumerating many devices
+// should read the cards map once with readProcAsoundCards and call
+// usbIdentityForCard per card to avoid re-reading the global file.
+//
+// It returns a zero usbIdentity (never an error) on any failure, so device
+// matching falls back to the legacy id/name tiers and capture is never broken by
+// a probing failure. Bus path and USB detection come from /proc/asound/cards and
+// vendor:product from /proc/asound/cardN/usbid (regular files, available even in
+// Docker containers using --device /dev/snd). The serial is a best-effort sysfs
+// read that is often empty. A persisted usb-path:/usb-id: token therefore depends
+// on /proc/asound being readable; when it is not, the token matches nothing and
+// capture reports the device as missing rather than risking a wrong-device match.
+func resolveUSBIdentity(decodedID, root string) usbIdentity {
+	card := parseALSACardNumber(decodedID)
+	if card < 0 {
+		return usbIdentity{}
+	}
+	return usbIdentityForCard(card, readProcAsoundCards(root), root)
+}
+
+// readProcAsoundCards reads and parses <root>/proc/asound/cards into a card-index
+// map. Returns nil on any read error (callers treat nil as "no USB cards").
+func readProcAsoundCards(root string) map[int]procCardEntry {
+	data, err := os.ReadFile(filepath.Join(root, "proc", "asound", "cards"))
+	if err != nil {
+		return nil
+	}
+	return parseProcAsoundCards(string(data))
+}
+
+// usbIdentityForCard resolves the USB identity of a single ALSA card from an
+// already-parsed cards map. Returns a zero usbIdentity for a non-USB card or an
+// absent entry.
+func usbIdentityForCard(card int, cards map[int]procCardEntry, root string) usbIdentity {
+	entry, ok := cards[card]
+	if !ok || !entry.isUSB {
+		return usbIdentity{}
+	}
+	ident := usbIdentity{BusPath: entry.busPath}
+
+	cardDir := "card" + strconv.Itoa(card)
+	if usbid, err := os.ReadFile(filepath.Join(root, "proc", "asound", cardDir, "usbid")); err == nil {
+		ident.VendorID, ident.ProductID = parseUSBID(string(usbid))
+	}
+
+	ident.Serial = readUSBSerial(root, card)
+	return ident
+}
+
+// readUSBSerial walks up from <root>/sys/class/sound/cardN to the USB device node
+// and returns that device's serial, or "" when the device reports none. The
+// device node is the first ancestor exposing an "idVendor" file; the serial (when
+// present) lives alongside it. The walk stops there so a parent hub or host
+// controller's serial (e.g. "xhci-hcd.0" on a root hub) is never mistaken for the
+// device's, and is bounded to the <root>/sys subtree so a symlink that resolves
+// outside sysfs cannot send it wandering into unrelated system directories.
+// Returns "" on any failure; the USB serial is optional and many audio adapters
+// do not report one.
+func readUSBSerial(root string, card int) string {
+	sysRoot := filepath.Join(root, "sys")
+	target, err := filepath.EvalSymlinks(filepath.Join(sysRoot, "class", "sound", "card"+strconv.Itoa(card)))
+	if err != nil {
+		return ""
+	}
+	dir := target
+	for range maxUSBSysfsWalkDepth {
+		// Stay within the sysfs subtree; if symlink resolution escaped it, stop.
+		if dir != sysRoot && !strings.HasPrefix(dir, sysRoot+string(os.PathSeparator)) {
+			break
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, "idVendor")); statErr == nil {
+			// Reached the USB device node. Its serial is optional.
+			data, readErr := os.ReadFile(filepath.Join(dir, "serial"))
+			if readErr != nil {
+				return ""
+			}
+			return strings.TrimSpace(string(data))
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}

--- a/internal/audiocore/usb_linux_test.go
+++ b/internal/audiocore/usb_linux_test.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package audiocore
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFakeProc builds a fake <root>/proc/asound tree for resolveUSBIdentity to
+// read: the cards listing plus an optional usbid file per card.
+func writeFakeProc(t *testing.T, cards string, usbids map[int]string) string {
+	t.Helper()
+	root := t.TempDir()
+	asound := filepath.Join(root, "proc", "asound")
+	require.NoError(t, os.MkdirAll(asound, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(asound, "cards"), []byte(cards), 0o644))
+	for card, id := range usbids {
+		dir := filepath.Join(asound, "card"+strconv.Itoa(card))
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "usbid"), []byte(id), 0o644))
+	}
+	return root
+}
+
+func TestResolveUSBIdentity_AMD64(t *testing.T) {
+	t.Parallel()
+	root := writeFakeProc(t, procCardsAMD64, map[int]string{1: "0b33:0024\n"})
+
+	// Card 1 is the ZOOM AMS-24 USB interface.
+	ident := resolveUSBIdentity(":1,0", root)
+	assert.Equal(t, "usb-0000:00:14.0-3", ident.BusPath)
+	assert.Equal(t, "0b33", ident.VendorID)
+	assert.Equal(t, "0024", ident.ProductID)
+	assert.Empty(t, ident.Serial, "no sysfs serial in fake tree")
+	assert.Equal(t, "usb-path:usb-0000:00:14.0-3", ident.stableToken())
+}
+
+func TestResolveUSBIdentity_RPi5(t *testing.T) {
+	t.Parallel()
+	root := writeFakeProc(t, procCardsRPi5, map[int]string{0: "0d8c:0014\n"})
+
+	// Card 0 is the C-Media USB Audio Device.
+	ident := resolveUSBIdentity(":0,0", root)
+	assert.Equal(t, "usb-xhci-hcd.0-1", ident.BusPath)
+	assert.Equal(t, "0d8c", ident.VendorID)
+	assert.Equal(t, "0014", ident.ProductID)
+	assert.Equal(t, "usb-path:usb-xhci-hcd.0-1", ident.stableToken())
+}
+
+func TestResolveUSBIdentity_NonUSBCardYieldsZero(t *testing.T) {
+	t.Parallel()
+	root := writeFakeProc(t, procCardsAMD64, nil)
+
+	// Card 0 is the snd-aloop Loopback (not USB).
+	ident := resolveUSBIdentity(":0,0", root)
+	assert.Empty(t, ident.BusPath)
+	assert.Empty(t, ident.VendorID)
+	assert.False(t, ident.hasStableID())
+	assert.Empty(t, ident.stableToken())
+}
+
+func TestResolveUSBIdentity_MissingCardYieldsZero(t *testing.T) {
+	t.Parallel()
+	root := writeFakeProc(t, procCardsRPi5, nil)
+
+	assert.False(t, resolveUSBIdentity(":9,0", root).hasStableID(), "absent card")
+	assert.False(t, resolveUSBIdentity("default", root).hasStableID(), "unparseable id")
+}
+
+func TestResolveUSBIdentity_MissingUsbidStillHasBusPath(t *testing.T) {
+	t.Parallel()
+	// USB card present in cards listing but no usbid file: bus path still resolves,
+	// vid/pid stay empty, and the bus-path token is still usable.
+	root := writeFakeProc(t, procCardsRPi5, nil)
+
+	ident := resolveUSBIdentity(":0,0", root)
+	assert.Equal(t, "usb-xhci-hcd.0-1", ident.BusPath)
+	assert.Empty(t, ident.VendorID)
+	assert.Equal(t, "usb-path:usb-xhci-hcd.0-1", ident.stableToken())
+}
+
+func TestResolveUSBIdentity_MissingProcYieldsZero(t *testing.T) {
+	t.Parallel()
+	// An empty root (no /proc/asound) must never error, just yield a zero identity.
+	ident := resolveUSBIdentity(":0,0", t.TempDir())
+	assert.False(t, ident.hasStableID())
+}
+
+func TestReadUSBSerial_AbsentSysfsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	// No /sys tree in the fake root -> best-effort serial read returns "".
+	assert.Empty(t, readUSBSerial(t.TempDir(), 0))
+}
+
+// TestReadUSBSerial_StopsAtDeviceNode reproduces a real-hardware bug found on a
+// Raspberry Pi 5: a serial-less C-Media card sits under a root hub whose own
+// "serial" file reads "xhci-hcd.0". The walk must stop at the device node (the
+// idVendor-bearing dir) and never pick up the hub/controller serial.
+func TestReadUSBSerial_StopsAtDeviceNode(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	hub := filepath.Join(root, "sys", "devices", "platform", "xhci-hcd.0", "usb1")
+	dev := filepath.Join(hub, "1-1")
+	cardDir := filepath.Join(dev, "1-1:1.0", "sound", "card0")
+	require.NoError(t, os.MkdirAll(cardDir, 0o755))
+	// Root hub: has its own idVendor and a serial that must NOT be selected.
+	require.NoError(t, os.WriteFile(filepath.Join(hub, "idVendor"), []byte("1d6b\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(hub, "serial"), []byte("xhci-hcd.0\n"), 0o644))
+	// USB device node: has idVendor but (initially) no serial.
+	require.NoError(t, os.WriteFile(filepath.Join(dev, "idVendor"), []byte("0d8c\n"), 0o644))
+
+	classDir := filepath.Join(root, "sys", "class", "sound")
+	require.NoError(t, os.MkdirAll(classDir, 0o755))
+	require.NoError(t, os.Symlink(cardDir, filepath.Join(classDir, "card0")))
+
+	// Device reports no serial: must return "" rather than the hub's "xhci-hcd.0".
+	assert.Empty(t, readUSBSerial(root, 0))
+
+	// Device that does report a serial: that value is returned.
+	require.NoError(t, os.WriteFile(filepath.Join(dev, "serial"), []byte("DEVICE123\n"), 0o644))
+	assert.Equal(t, "DEVICE123", readUSBSerial(root, 0))
+}

--- a/internal/audiocore/usb_other.go
+++ b/internal/audiocore/usb_other.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+package audiocore
+
+// resolveUSBIdentity is a no-op on non-Linux platforms. Stable USB identity is a
+// Linux ALSA concern (the ALSA index instability described in GH #3651 does not
+// apply to the WASAPI/CoreAudio backends), so this returns a zero usbIdentity and
+// device matching uses the legacy id/name tiers.
+func resolveUSBIdentity(decodedID, root string) usbIdentity {
+	_ = decodedID
+	_ = root
+	return usbIdentity{}
+}
+
+// readProcAsoundCards has no meaning off Linux; it returns nil so batch callers
+// (listDevices) resolve every device to a zero usbIdentity.
+func readProcAsoundCards(root string) map[int]procCardEntry {
+	_ = root
+	return nil
+}
+
+// usbIdentityForCard is a no-op on non-Linux platforms.
+func usbIdentityForCard(card int, cards map[int]procCardEntry, root string) usbIdentity {
+	_ = card
+	_ = cards
+	_ = root
+	return usbIdentity{}
+}

--- a/internal/audiocore/usb_test.go
+++ b/internal/audiocore/usb_test.go
@@ -157,19 +157,19 @@ func TestDeviceDedupKey(t *testing.T) {
 	usbB := usbIdentity{BusPath: "usb-0000:00:14.0-2"}
 	none := usbIdentity{}
 
-	// USB cards key on name + stable token, so two identical-named cards on
-	// different ports get DISTINCT keys and both survive deduplication, while one
-	// card's pseudo-devices (same token) collapse to a single key.
-	assert.Equal(t, "USB Mic\x00usb-path:usb-0000:00:14.0-1", deviceDedupKey("USB Mic", 1, usbA))
-	assert.Equal(t, "USB Mic\x00usb-path:usb-0000:00:14.0-2", deviceDedupKey("USB Mic", 2, usbB))
+	// A USB card's pseudo-devices share its token, so they collapse to one key
+	// even if ALSA reports slightly different names for them.
+	assert.Equal(t, "usb-path:usb-0000:00:14.0-1", deviceDedupKey("USB Mic", usbA))
+	assert.Equal(t, "usb-path:usb-0000:00:14.0-1", deviceDedupKey("USB Mic (alt)", usbA))
 
-	// Non-USB cards (no stable id) fall back to name + card number, so two
-	// same-named cards still separate while one card's pseudo-devices collapse.
-	assert.Equal(t, "HDMI\x00card:1", deviceDedupKey("HDMI", 1, none))
-	assert.Equal(t, "HDMI\x00card:2", deviceDedupKey("HDMI", 2, none))
+	// Two identical-named USB cards on different ports stay distinct and both
+	// survive deduplication (the bug the stable-id selection fixes).
+	assert.NotEqual(t, deviceDedupKey("USB Mic", usbA), deviceDedupKey("USB Mic", usbB))
 
-	// No identity and no card number falls back to the bare name.
-	assert.Equal(t, "Default Audio Device", deviceDedupKey("Default Audio Device", -1, none))
+	// Without a stable token, fall back to the display name (the original
+	// behavior), so distinctly-named non-USB capture devices are not merged.
+	assert.Equal(t, "HDMI 0", deviceDedupKey("HDMI 0", none))
+	assert.NotEqual(t, deviceDedupKey("Line In", none), deviceDedupKey("Mic In", none))
 }
 
 func TestRedactDeviceID(t *testing.T) {

--- a/internal/audiocore/usb_test.go
+++ b/internal/audiocore/usb_test.go
@@ -151,6 +151,50 @@ func TestParseUSBID(t *testing.T) {
 	}
 }
 
+func TestDeviceDedupKey(t *testing.T) {
+	t.Parallel()
+	usbA := usbIdentity{BusPath: "usb-0000:00:14.0-1"}
+	usbB := usbIdentity{BusPath: "usb-0000:00:14.0-2"}
+	none := usbIdentity{}
+
+	// USB cards key on name + stable token, so two identical-named cards on
+	// different ports get DISTINCT keys and both survive deduplication, while one
+	// card's pseudo-devices (same token) collapse to a single key.
+	assert.Equal(t, "USB Mic\x00usb-path:usb-0000:00:14.0-1", deviceDedupKey("USB Mic", 1, usbA))
+	assert.Equal(t, "USB Mic\x00usb-path:usb-0000:00:14.0-2", deviceDedupKey("USB Mic", 2, usbB))
+
+	// Non-USB cards (no stable id) fall back to name + card number, so two
+	// same-named cards still separate while one card's pseudo-devices collapse.
+	assert.Equal(t, "HDMI\x00card:1", deviceDedupKey("HDMI", 1, none))
+	assert.Equal(t, "HDMI\x00card:2", deviceDedupKey("HDMI", 2, none))
+
+	// No identity and no card number falls back to the bare name.
+	assert.Equal(t, "Default Audio Device", deviceDedupKey("Default Audio Device", -1, none))
+}
+
+func TestRedactDeviceID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"usb-id with serial is masked", "usb-id:0b33:0024:ABC123", "usb-id:0b33:0024:<redacted>"},
+		{"usb-id with empty serial is unchanged", "usb-id:0d8c:0014:", "usb-id:0d8c:0014:"},
+		{"usb-path is unchanged", "usb-path:usb-xhci-hcd.0-1", "usb-path:usb-xhci-hcd.0-1"},
+		{"legacy alsa id is unchanged", ":1,0", ":1,0"},
+		{"device name is unchanged", "USB Audio Device", "USB Audio Device"},
+		{"malformed usb-id is unchanged", "usb-id:onlyone", "usb-id:onlyone"},
+		{"empty is unchanged", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, redactDeviceID(tt.in))
+		})
+	}
+}
+
 func TestMatchesDevice(t *testing.T) {
 	t.Parallel()
 	// A live USB device with a known identity (as resolved from /proc).

--- a/internal/audiocore/usb_test.go
+++ b/internal/audiocore/usb_test.go
@@ -1,0 +1,233 @@
+package audiocore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Real /proc/asound/cards fixtures captured from the project test hosts.
+const (
+	// amd64 dev host: a snd-aloop Loopback (card 0) and a ZOOM AMS-24 USB
+	// interface (card 1).
+	procCardsAMD64 = ` 0 [Loopback       ]: Loopback - Loopback
+                      Loopback 1
+ 1 [AMS24          ]: USB-Audio - AMS-24
+                      ZOOM Corporation AMS-24 at usb-0000:00:14.0-3, high speed
+`
+	// arm64 Raspberry Pi 5: a C-Media USB Audio Device (card 0) and two HDMI
+	// outputs (cards 1 and 2).
+	procCardsRPi5 = ` 0 [Device         ]: USB-Audio - USB Audio Device
+                      C-Media Electronics Inc. USB Audio Device at usb-xhci-hcd.0-1, full speed
+ 1 [vc4hdmi0       ]: vc4-hdmi - vc4-hdmi-0
+                      vc4-hdmi-0
+ 2 [vc4hdmi1       ]: vc4-hdmi - vc4-hdmi-1
+                      vc4-hdmi-1
+`
+)
+
+func TestParseALSACardNumber(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"colon card,device", ":3,0", 3},
+		{"colon card 0", ":0,0", 0},
+		{"double digit", ":10,0", 10},
+		{"hw prefix", "hw:2,0", 2},
+		{"bare card,device", "5,0", 5},
+		{"bare card", "7", 7},
+		{"default token", "default", -1},
+		{"sysdefault token", "sysdefault", -1},
+		{"pcm node form", "pcmC0D0c", -1},
+		{"empty", "", -1},
+		{"colon only", ":", -1},
+		{"negative is rejected", ":-1,0", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseALSACardNumber(tt.in))
+		})
+	}
+}
+
+func TestParseProcAsoundCards_AMD64(t *testing.T) {
+	t.Parallel()
+	cards := parseProcAsoundCards(procCardsAMD64)
+
+	// Loopback (card 0) is not USB.
+	loop, ok := cards[0]
+	require.True(t, ok)
+	assert.False(t, loop.isUSB)
+	assert.Empty(t, loop.busPath)
+
+	// AMS-24 (card 1) is USB with the x86-style bus path.
+	ams, ok := cards[1]
+	require.True(t, ok)
+	assert.True(t, ams.isUSB)
+	assert.Equal(t, "usb-0000:00:14.0-3", ams.busPath)
+}
+
+func TestParseProcAsoundCards_RPi5(t *testing.T) {
+	t.Parallel()
+	cards := parseProcAsoundCards(procCardsRPi5)
+
+	// C-Media (card 0) is USB with the Pi-style bus path.
+	dev, ok := cards[0]
+	require.True(t, ok)
+	assert.True(t, dev.isUSB)
+	assert.Equal(t, "usb-xhci-hcd.0-1", dev.busPath)
+
+	// HDMI outputs (cards 1, 2) are not USB.
+	for _, idx := range []int{1, 2} {
+		hdmi, found := cards[idx]
+		require.True(t, found)
+		assert.False(t, hdmi.isUSB)
+		assert.Empty(t, hdmi.busPath)
+	}
+}
+
+func TestParseProcAsoundCards_EdgeCases(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, parseProcAsoundCards(""), "empty input yields no cards")
+
+	// A detail line with " at " for a non-USB reason must not be taken as a bus path.
+	const pci = ` 0 [PCH            ]: HDA-Intel - HDA Intel PCH
+                      HDA Intel PCH at 0xf0440000 irq 145
+`
+	cards := parseProcAsoundCards(pci)
+	entry, ok := cards[0]
+	require.True(t, ok)
+	assert.False(t, entry.isUSB, "PCI card is not USB")
+	assert.Empty(t, entry.busPath, "non usb- bus path is ignored")
+}
+
+func TestExtractBusPathFromDetail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"x86", "ZOOM Corporation AMS-24 at usb-0000:00:14.0-3, high speed", "usb-0000:00:14.0-3"},
+		{"pi", "C-Media ... USB Audio Device at usb-xhci-hcd.0-1, full speed", "usb-xhci-hcd.0-1"},
+		{"no at segment", "Loopback 1", ""},
+		{"at without comma", "thing at usb-0000:00:14.0-3", "usb-0000:00:14.0-3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, extractBusPathFromDetail(tt.in))
+		})
+	}
+}
+
+func TestParseUSBID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		in              string
+		vendor, product string
+	}{
+		{"c-media", "0d8c:0014\n", "0d8c", "0014"},
+		{"zoom", "0b33:0024", "0b33", "0024"},
+		{"no newline", "1234:abcd", "1234", "abcd"},
+		{"malformed no colon", "0d8c0014", "", ""},
+		{"too short", "d8c:14", "", ""},
+		{"not hex", "zzzz:0014", "", ""},
+		{"empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			v, p := parseUSBID(tt.in)
+			assert.Equal(t, tt.vendor, v)
+			assert.Equal(t, tt.product, p)
+		})
+	}
+}
+
+func TestMatchesDevice(t *testing.T) {
+	t.Parallel()
+	// A live USB device with a known identity (as resolved from /proc).
+	usbDev := usbIdentity{BusPath: "usb-xhci-hcd.0-1", VendorID: "0d8c", ProductID: "0014"}
+	const decodedID = ":1,0"
+	const name = "USB Audio Device"
+
+	tests := []struct {
+		name     string
+		ident    usbIdentity
+		devName  string
+		deviceID string
+		want     bool
+	}{
+		// USB bus-path token: matches the resolved bus path regardless of the
+		// current ALSA index (the core reboot-survival case).
+		{"usb-path matches", usbDev, name, "usb-path:usb-xhci-hcd.0-1", true},
+		{"usb-path mismatch", usbDev, name, "usb-path:usb-0000:00:14.0-3", false},
+		{"usb-path against non-usb device", usbIdentity{}, name, "usb-path:usb-xhci-hcd.0-1", false},
+		{"empty usb-path never matches", usbIdentity{}, name, "usb-path:", false},
+		// USB hw-id token: vendor:product:serial.
+		{"usb-id matches", usbDev, name, "usb-id:0d8c:0014:", true},
+		{"usb-id mismatch product", usbDev, name, "usb-id:0d8c:9999:", false},
+		{"usb-id against non-usb device", usbIdentity{}, name, "usb-id:0d8c:0014:", false},
+		// Legacy tiers preserved.
+		{"legacy exact id", usbDev, name, ":1,0", true},
+		{"legacy wrong id (the bug: index shifted)", usbDev, name, ":3,0", false},
+		{"legacy name substring", usbDev, name, "USB Audio", true},
+		{"legacy name miss", usbDev, name, "Webcam", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchesDevice(decodedID, tt.ident, tt.devName, false, tt.deviceID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUSBIdentity_StableToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		ident usbIdentity
+		want  string
+	}{
+		{
+			name:  "bus path preferred over vid:pid",
+			ident: usbIdentity{BusPath: "usb-xhci-hcd.0-1", VendorID: "0d8c", ProductID: "0014"},
+			want:  "usb-path:usb-xhci-hcd.0-1",
+		},
+		{
+			name:  "vid:pid:serial when no bus path",
+			ident: usbIdentity{VendorID: "0b33", ProductID: "0024", Serial: "ABC123"},
+			want:  "usb-id:0b33:0024:ABC123",
+		},
+		{
+			name:  "vid:pid with empty serial",
+			ident: usbIdentity{VendorID: "0d8c", ProductID: "0014"},
+			want:  "usb-id:0d8c:0014:",
+		},
+		{
+			name:  "no identity yields empty token",
+			ident: usbIdentity{},
+			want:  "",
+		},
+		{
+			name:  "vendor without product yields empty token",
+			ident: usbIdentity{VendorID: "0d8c"},
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.ident.stableToken())
+			assert.Equal(t, tt.want != "", tt.ident.hasStableID())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3651. On Linux the configured local sound card is persisted as the ALSA card index (`:1,0`), which the kernel assigns in USB enumeration order at boot. The same physical USB device can therefore come up as `:1,0` on one boot and `:3,0` on the next, so after a reboot the saved index no longer matches any device and capture fails ("no device found matching ...") until the user reopens Settings and re-selects the same card. This is the most-reported audio issue (also #3307, #3424, #3639).

The fix matches the configured device on a stable, reboot-invariant USB hardware identifier instead of the volatile ALSA index.

## What changed

- **USB-identity resolver** (`internal/audiocore/usb*.go`, Linux only): maps an ALSA card index to its USB bus path (e.g. `usb-0000:00:14.0-3`) and vendor:product:serial by reading `/proc/asound/cards` and `/proc/asound/cardN/usbid`, with a best-effort sysfs serial. The bus path is stable per physical port across reboots. The resolver degrades to a zero identity on any read/parse failure, so a probing error never breaks capture; non-Linux builds get a no-op stub.
- **`matchesDevice` priority match**: `usb-path:` token, then `usb-id:` token (vendor:product:serial), then the legacy exact ALSA id, then device-name substring. The legacy tiers are preserved byte-for-byte, so existing `:X,Y` and name configs behave exactly as before.
- **API + settings UI**: the audio-devices endpoint now reports `stableId`/`busPath`/`vendorId`/`productId`, and the sound-card dropdowns persist the stable token (falling back to the legacy id), showing the USB bus path only when needed to tell identical device names apart. New selections survive reboots; existing configs keep working and self-heal to the stable token on the next re-select. Both the add form and the per-source edit card were updated, so a token-configured device shows its friendly name and pre-selects correctly.
- **Capability cache** is now keyed by the stable token too, so a token config hits the startup cache instead of contending for a live exclusive-mode probe.

Stable-USB matching is Linux-specific (the WASAPI/CoreAudio backends are unaffected). Auto-migrating an already-broken `:X,Y` config without a user re-select is deferred (it needs the engine to update a running source's connection string to avoid a capture restart).

## Test plan

- **Unit (Go, testify):** `parseALSACardNumber`, the `/proc/asound/cards` parser (real fixtures from an x86 ZOOM AMS-24 and an arm64 Pi 5 C-Media adapter, plus non-USB and malformed cases), `parseUSBID`, `stableToken` precedence, all five `matchesDevice` tiers with hit and miss cases, and the resolver against a faked `/proc`+sysfs tree, including a regression test for a real bug where the sysfs walk picked up a root hub's serial.
- **Unit (frontend, vitest):** the device token/label/match helpers, and the dropdown integration (persists the stable token, hides a configured device under either identifier, appends the bus path only on a name collision).
- **Lint:** `golangci-lint` 0 issues; frontend `npm run check:all` clean.
- **Real hardware:** verified the resolver on both an x86 host and an arm64 Raspberry Pi 5, including an actual reboot: the stable token is byte-identical before and after, a config saved with the pre-reboot token still matches the live device, and a deliberately-wrong legacy index fails (the bug the token avoids).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio input device selections now persist more reliably across reboots, especially for USB devices, using stable identity tokens.
  * Device dropdowns and labels are improved, including clearer disambiguation (e.g., adding bus-path details when device names match).

* **Bug Fixes**
  * Fixed device selection so the currently chosen audio source continues to be recognized after hardware reordering.
  * Already configured devices are now hidden from selection lists using both legacy identifiers and stable tokens, reducing duplicate/incorrect picks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->