### PR TITLE
fix(spectrogram): resample bat/bird clips in the FFmpeg-only fallback

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -1077,14 +1077,9 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 
 	params := c.parseSpectrogramParameters(ctx)
 
-	// Resolve frequency profile from detection's model type
-	modelType, mtErr := c.DS.GetNoteModelType(noteID)
-	if mtErr != nil {
-		c.logWarnIfEnabled("GetNoteModelType failed, defaulting to bird profile",
-			logger.String("note_id", noteID),
-			logger.Error(mtErr))
-	}
-	profileOpt := spectrogram.WithFrequencyProfile(spectrogram.ProfileForModelType(modelType))
+	// Resolve frequency profile from detection's model type (the helper logs a
+	// warning and falls back to the bird profile when the lookup fails).
+	profileOpt := spectrogram.WithFrequencyProfile(c.resolveDetectionFrequencyProfile(noteID))
 
 	if err := c.spectrogramGenerator.GenerateFromFile(ctx.Request().Context(), tmpPath, tmpSpectrogramPath, params.width, params.raw, profileOpt); err != nil {
 		if ctx.Request().Context().Err() != nil {
@@ -1455,16 +1450,11 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 	// Parse query parameters
 	params := c.parseSpectrogramParameters(ctx)
 
-	// Resolve frequency profile from detection's model type. The same profile
-	// drives both the generation effects (profileOpt) and the cache filename
-	// token (freqSuffix) so a bat render never collides with a bird-profile PNG.
-	modelType, err := c.DS.GetNoteModelType(noteID)
-	if err != nil {
-		c.logWarnIfEnabled("GetNoteModelType failed, defaulting to bird profile",
-			logger.String("note_id", noteID),
-			logger.Error(err))
-	}
-	profile := spectrogram.ProfileForModelType(modelType)
+	// Resolve frequency profile from detection's model type. The same profile drives
+	// both the generation effects (profileOpt) and the cache filename token
+	// (freqSuffix) so a bat render never collides with a bird-profile PNG. The helper
+	// logs a warning and falls back to the bird profile when the lookup fails.
+	profile := c.resolveDetectionFrequencyProfile(noteID)
 	profileOpt := spectrogram.WithFrequencyProfile(profile)
 	freqSuffix := spectrogram.ProfileSuffix(profile)
 
@@ -1475,7 +1465,7 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 		logger.Int("width", params.width),
 		logger.Bool("raw", params.raw),
 		logger.String("size_param", params.sizeStr),
-		logger.String("model_type", modelType),
+		logger.String("freq_suffix", freqSuffix),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()))
 

--- a/internal/spectrogram/frequency_profile.go
+++ b/internal/spectrogram/frequency_profile.go
@@ -2,7 +2,7 @@ package spectrogram
 
 // FrequencyProfile controls spectrogram frequency range and resampling per
 // detection. The gate is the detection's model type: bat models are resampled
-// to batResampleHz (Nyquist = 128 kHz) so the fixed 0–128 kHz axis in the UI
+// to batResampleHz (Nyquist = 128 kHz) so the fixed 0-128 kHz axis in the UI
 // is always accurate regardless of the original capture rate; everything else
 // gets bird defaults (resample to birdResampleHz).
 type FrequencyProfile struct {
@@ -12,7 +12,7 @@ type FrequencyProfile struct {
 
 const (
 	birdResampleHz  = 24000
-	batResampleHz   = 256000 // Nyquist = 128 kHz; matches the fixed 0–128 kHz overlay axis
+	batResampleHz   = 256000 // Nyquist = 128 kHz; matches the fixed 0-128 kHz overlay axis
 	modelTypeBatStr = "bat"
 )
 
@@ -25,7 +25,7 @@ func BirdProfile() FrequencyProfile {
 
 // BatProfile returns the frequency profile for bat detections. The audio is
 // resampled to batResampleHz (256 kHz, Nyquist = 128 kHz) so the spectrogram
-// always spans the full 0–128 kHz range that the UI axis hardcodes,
+// always spans the full 0-128 kHz range that the UI axis hardcodes,
 // regardless of the original capture rate (192/256/384 kHz are all supported).
 func BatProfile() FrequencyProfile {
 	return FrequencyProfile{

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -90,8 +90,8 @@ func WithDuration(seconds float64) GenerateOption {
 }
 
 // WithFrequencyProfile sets the frequency profile for spectrogram generation.
-// BatProfile() keeps the native sample rate with no resampling or high-pass;
-// BirdProfile() resamples to 24 kHz. When not set, defaults to BirdProfile().
+// BatProfile() resamples to 256 kHz (0-128 kHz axis); BirdProfile() resamples to
+// 24 kHz (0-12 kHz axis). When not set, defaults to BirdProfile().
 func WithFrequencyProfile(fp FrequencyProfile) GenerateOption {
 	return func(o *generateOptions) {
 		o.freqProfile = &fp
@@ -826,9 +826,8 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 		"-n", // No audio output (null output)
 	}
 
-	// Frequency-dependent effects: resample for bird detections. Bat detections
-	// keep the native sample rate with no resampling so the full recorded band is
-	// rendered.
+	// Frequency-dependent effects: resample to the profile's rate (bird 24 kHz,
+	// bat 256 kHz) so the spectrogram's frequency axis matches the fixed UI overlay.
 	if profile.ResampleRate > 0 {
 		args = append(args, "rate", strconv.Itoa(profile.ResampleRate))
 	}
@@ -894,6 +893,37 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 	return nil
 }
 
+// buildFFmpegSpectrogramFilter builds the -lavfi filtergraph for the FFmpeg-only
+// fallback. The showspectrumpic stage uses a style-aware color mode so the fallback
+// visually matches the Sox primary path (without it the fallback always renders the
+// default colorful style, causing intermittent mismatches when Sox fails under load).
+// When the frequency profile sets a resample rate, an aresample stage is prepended so
+// the rendered frequency axis matches the Sox paths (which apply the same rate) and the
+// fixed UI overlay: bird clips resample to 24 kHz (0-12 kHz axis) and bat clips to
+// 256 kHz (0-128 kHz axis) regardless of capture rate. Without it the fallback renders
+// to the native Nyquist and that axis-mismatched image gets cached under the profile
+// filename.
+func buildFFmpegSpectrogramFilter(width int, raw bool, style string, profile FrequencyProfile) string {
+	height := fftFriendlyHeight(width)
+	colorMode := getFFmpegColorMode(style)
+
+	legendFlag := 1
+	if raw {
+		legendFlag = 0
+	}
+
+	// Match the Sox "rate" effect so both backends produce the same frequency axis:
+	// an aresample stage sets showspectrumpic's input rate, so the axis tops out at
+	// its Nyquist (rate/2). Built as a single Sprintf to avoid a throwaway alloc.
+	resamplePrefix := ""
+	if profile.ResampleRate > 0 {
+		resamplePrefix = fmt.Sprintf("aresample=%d,", profile.ResampleRate)
+	}
+
+	return fmt.Sprintf("%sshowspectrumpic=s=%dx%d:legend=%d:gain=%s:drange=%s:color=%s",
+		resamplePrefix, width, height, legendFlag, ffmpegGain, ffmpegDrange, colorMode)
+}
+
 // generateWithFFmpeg generates a spectrogram using only FFmpeg (no Sox).
 // This is a fallback when Sox is not available or fails.
 func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, profile FrequencyProfile) error {
@@ -908,21 +938,8 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Setti
 			Build()
 	}
 
-	height := fftFriendlyHeight(width)
-
-	// Apply style-aware color mode so FFmpeg fallback matches the Sox primary style.
-	// Without this, the FFmpeg fallback always produces the default colorful style,
-	// causing intermittent style mismatches when Sox fails under resource pressure.
 	style := settings.Realtime.Dashboard.Spectrogram.Style
-	colorMode := getFFmpegColorMode(style)
-
-	legendFlag := 1
-	if raw {
-		legendFlag = 0
-	}
-
-	filterStr := fmt.Sprintf("showspectrumpic=s=%dx%d:legend=%d:gain=%s:drange=%s:color=%s",
-		width, height, legendFlag, ffmpegGain, ffmpegDrange, colorMode)
+	filterStr := buildFFmpegSpectrogramFilter(width, raw, style, profile)
 
 	ffmpegArgs := []string{
 		"-hide_banner",
@@ -993,8 +1010,8 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Se
 	heightStr := strconv.Itoa(fftFriendlyHeight(width))
 	widthStr := strconv.Itoa(width)
 
-	// Build base args: resample for bird detections. Bat detections keep the native
-	// sample rate (no resampling) so the full recorded band is rendered.
+	// Build base args: resample to the profile's rate (bird 24 kHz, bat 256 kHz) so
+	// the spectrogram's frequency axis matches the fixed UI overlay.
 	var args []string
 	if profile.ResampleRate > 0 {
 		args = []string{"-n", "rate", strconv.Itoa(profile.ResampleRate), "spectrogram", "-x", widthStr, "-y", heightStr}

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -363,6 +364,45 @@ func TestAudioDurationCache_EvictsOldestEntries(t *testing.T) {
 
 	// Old entry should have been evicted (it was the oldest)
 	assert.False(t, HasCacheEntry(oldFile), "Old cache entry should have been evicted but was still present")
+}
+
+// TestBuildFFmpegSpectrogramFilter_ResamplesPerProfile verifies the FFmpeg-only
+// fallback honors the frequency profile's resample rate, just like the Sox paths.
+// Without an aresample stage the fallback renders to the native Nyquist, so a bat
+// clip captured at 192/384 kHz would disagree with the fixed 0-128 kHz UI axis (and
+// that mismatched image would be cached under the "-bat" filename).
+func TestBuildFFmpegSpectrogramFilter_ResamplesPerProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		profile            FrequencyProfile
+		wantResamplePrefix string // expected leading "aresample=<rate>," stage, or "" for none
+	}{
+		{"bird profile resamples to 24 kHz", BirdProfile(), "aresample=24000,"},
+		{"bat profile resamples to 256 kHz", BatProfile(), "aresample=256000,"},
+		{"native profile keeps the source rate", FrequencyProfile{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildFFmpegSpectrogramFilter(1026, false, "", tt.profile)
+
+			// The showspectrumpic stage must always be present.
+			assert.Contains(t, got, "showspectrumpic=", "filter must always include showspectrumpic")
+
+			if tt.wantResamplePrefix == "" {
+				assert.NotContains(t, got, "aresample", "native profile must not add a resample stage")
+				assert.True(t, strings.HasPrefix(got, "showspectrumpic="),
+					"native filter should start with showspectrumpic, got %q", got)
+			} else {
+				assert.True(t, strings.HasPrefix(got, tt.wantResamplePrefix),
+					"filter should start with %q, got %q", tt.wantResamplePrefix, got)
+			}
+		})
+	}
 }
 
 // TestFFmpegFallback_GetsFreshContext tests that FFmpeg fallback gets adequate time


### PR DESCRIPTION
## Summary

Follow-up to #3529. The Sox-failure **FFmpeg-only fallback** (`generateWithFFmpeg`) rendered spectrograms at the clip's native sample rate, ignoring the frequency profile. The Sox paths resample (bird to 24 kHz, bat to 256 kHz) so the spectrogram's frequency axis matches the fixed UI overlay (0-12 kHz for bird, 0-128 kHz for bat); the FFmpeg-only fallback did not.

Consequence: a bat clip captured at 192/384 kHz that fell back to FFmpeg rendered up to its native Nyquist while the player labelled the axis 0-128 kHz, and that axis-mismatched image was then cached permanently under the `-bat` filename and served from the fast path. This broke the "always 0-128 kHz regardless of capture rate" contract introduced in #3529. The bird profile had the same latent gap on this path (a 48 kHz clip rendered 0-24 kHz under a 0-12 kHz axis).

The fallback only triggers when Sox is unavailable or fails, so working-Sox setups (the common case) were never affected.

## Changes

- **`generator.go`**: extract `buildFFmpegSpectrogramFilter` and prepend an `aresample=<rate>` stage to the `showspectrumpic` filtergraph when the profile sets a resample rate, so the FFmpeg backend produces the same frequency axis as the Sox `rate` effect (aresample sets the input rate, so the axis tops out at its Nyquist = rate/2).
- **`generator_test.go`**: table test covering the bird (24 kHz), bat (256 kHz), and native (no resample) cases.
- **`media.go`**: route `ProcessedSpectrogramByID` and `ServeSpectrogramByID` through the existing `resolveDetectionFrequencyProfile` helper, dropping two inline copies of the `GetNoteModelType` + warn-log + `ProfileForModelType` block.
- Refresh stale comments that still claimed bat detections keep their native rate (`BatProfile` resamples to 256 kHz since the bat profile was re-enabled in #3529), and an en-dash to hyphen sweep in `frequency_profile.go`.

## Test Plan

- [x] `go test ./internal/spectrogram/ -race -count=1` passes (new test included)
- [x] `go test ./internal/api/v2/ -race -count=1` (spectrogram/detection subset) passes
- [x] `golangci-lint run` (full project) reports 0 issues
- [ ] Manual: render a bat detection's spectrogram with Sox disabled and confirm the 0-128 kHz axis matches the rendered content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spectrogram generation so the displayed frequency range now stays consistent across processing paths, reducing mismatches between different spectrogram outputs.
  * Updated spectrogram frequency handling for better alignment with the selected profile, helping results render more reliably for bird and bat audio.

* **Style**
  * Standardized spectrogram axis documentation text for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->