### PR TITLE
fix(spectrogram): version the bat cache token to drop stale wrong-axis renders

### DIFF
--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1353,7 +1353,7 @@ func (c *Controller) removeDetectionFiles(clipName string) {
 
 	// Remove all associated spectrogram files. buildSpectrogramPaths names them
 	// <basename>_<width>px<suffix>.png, where <suffix> encodes the visual style,
-	// dynamic range, frequency profile (e.g. "-bat") and legend/raw variant - and a
+	// dynamic range, frequency profile (e.g. "-bat-v2") and legend/raw variant - and a
 	// single clip can accumulate several of these as those settings change over time.
 	// Rather than enumerate every combination (and miss renders from styles no longer
 	// configured), scan the directory and remove any PNG whose name matches this

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -1056,10 +1056,13 @@ func TestDeleteDetectionRemovesFiles(t *testing.T) {
 		baseName + "_258px.png",
 		baseName + "_1026px.png",
 		baseName + "_1026px-legend.png",
-		// Bat frequency-profile renders carry a "-bat" token; they must be removed
-		// too (regression test for orphaned bat spectrograms on detection delete).
+		// Bat frequency-profile renders carry a versioned "-bat-v2" token; legacy
+		// "-bat" files from before the cache-version bump may still be on disk. Both
+		// must be removed (regression test for orphaned bat spectrograms on delete).
 		baseName + "_1026px-bat.png",
 		baseName + "_1026px-bat-legend.png",
+		baseName + "_1026px-bat-v2.png",
+		baseName + "_1026px-bat-v2-legend.png",
 		// Non-default visual style / dynamic-range / combined suffixes must also be
 		// removed (regression test for orphaned styled spectrograms on delete).
 		baseName + "_1026px-scientific_dark.png",

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -2012,7 +2012,7 @@ func buildSpectrogramPaths(relAudioPath string, width int, raw bool, style, dyna
 	// produce no suffix for backward compatibility with existing cached spectrograms.
 	styleSuffix := buildStyleSuffix(style, dynamicRange)
 
-	// Append the frequency-profile token (e.g. "bat") so renders made with a
+	// Append the frequency-profile token (e.g. "bat-v2") so renders made with a
 	// non-default profile get a distinct filename and do not collide with an
 	// existing bird-profile PNG. Bird (empty token) keeps the legacy filename.
 	if freqSuffix != "" {

--- a/internal/spectrogram/frequency_profile.go
+++ b/internal/spectrogram/frequency_profile.go
@@ -13,7 +13,22 @@ type FrequencyProfile struct {
 const (
 	birdResampleHz  = 24000
 	batResampleHz   = 256000 // Nyquist = 128 kHz; matches the fixed 0-128 kHz overlay axis
-	modelTypeBatStr = "bat"
+	modelTypeBatStr = "bat"  // ai_models.model_type value that selects the bat profile
+
+	// batCacheSuffix is the cache-filename token for bat spectrograms (e.g.
+	// "<clip>_1026px-bat-v2.png"). It is intentionally separate from
+	// modelTypeBatStr (the stored model-type value) and carries a version marker:
+	// bumping it changes the on-disk filename, so a corrected render lands at a new
+	// path instead of colliding with a stale bat image cached by an older generator.
+	// Bumped to "-v2" alongside the FFmpeg-only fallback resample fix (#3689): bat
+	// clips rendered via the Sox-failure fallback before that fix carry a frequency
+	// axis that disagrees with the 0-128 kHz overlay, and would otherwise be served
+	// from cache indefinitely. Only bat files carry a suffix, so this invalidates
+	// just bat spectrograms; bird renders (empty suffix) are untouched. Pre-bump
+	// "-bat.png" files are left on disk (lazily superseded by the new "-bat-v2"
+	// render) and reaped when the detection is deleted (the delete scan matches any
+	// "<base>_<width>px-" prefix), so the only cost is a tiny transient orphan.
+	batCacheSuffix = "bat-v2"
 )
 
 // BirdProfile returns the default frequency profile for bird detections.
@@ -30,7 +45,7 @@ func BirdProfile() FrequencyProfile {
 func BatProfile() FrequencyProfile {
 	return FrequencyProfile{
 		ResampleRate: batResampleHz,
-		suffix:       modelTypeBatStr,
+		suffix:       batCacheSuffix,
 	}
 }
 

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -370,7 +370,7 @@ func TestAudioDurationCache_EvictsOldestEntries(t *testing.T) {
 // fallback honors the frequency profile's resample rate, just like the Sox paths.
 // Without an aresample stage the fallback renders to the native Nyquist, so a bat
 // clip captured at 192/384 kHz would disagree with the fixed 0-128 kHz UI axis (and
-// that mismatched image would be cached under the "-bat" filename).
+// that mismatched image would be cached under the "-bat-v2" filename).
 func TestBuildFFmpegSpectrogramFilter_ResamplesPerProfile(t *testing.T) {
 	t.Parallel()
 
@@ -932,7 +932,7 @@ func TestProfileForModelType(t *testing.T) {
 		wantSuffix   string
 	}{
 		{"bird model", "bird", 24000, ""},
-		{"bat model uses bat profile", "bat", 256000, "bat"},
+		{"bat model uses bat profile", "bat", 256000, "bat-v2"},
 		{"multi model defaults to bird", "multi", 24000, ""},
 		{"empty defaults to bird", "", 24000, ""},
 	}
@@ -947,14 +947,15 @@ func TestProfileForModelType(t *testing.T) {
 }
 
 // TestProfileSuffix verifies the cache-key token derived from a frequency profile:
-// bat profiles get a "bat" token; bird defaults stay empty for backward
-// compatibility with existing cached spectrogram filenames.
+// bat profiles get a versioned "bat-v2" token (bumped with the FFmpeg-fallback
+// resample fix so stale bat renders are not served from cache); bird defaults stay
+// empty for backward compatibility with existing cached spectrogram filenames.
 func TestProfileSuffix(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "bat", ProfileSuffix(BatProfile()), "bat profile should map to the bat token")
+	assert.Equal(t, "bat-v2", ProfileSuffix(BatProfile()), "bat profile should map to the versioned bat token")
 	assert.Empty(t, ProfileSuffix(BirdProfile()), "bird profile should map to an empty token")
-	assert.Equal(t, "bat", ProfileSuffix(ProfileForModelType("bat")))
+	assert.Equal(t, "bat-v2", ProfileSuffix(ProfileForModelType("bat")))
 	assert.Empty(t, ProfileSuffix(ProfileForModelType("bird")))
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3689. That PR fixed the FFmpeg-only fallback to resample bat clips, but bat spectrograms cached by the *old* fallback (wrong frequency axis) reuse the same filename (`<clip>_<width>px-bat.png`), so the serve fast-path would keep returning the stale wrong image until the file was otherwise regenerated.

This bumps the bat cache token to `bat-v2` so corrected renders land at a new path (`<clip>_<width>px-bat-v2.png`) and the stale `-bat.png` is no longer served. The token is a new `batCacheSuffix` constant, kept **separate** from `modelTypeBatStr = "bat"` (which still matches the stored `ai_models.model_type`, so bat detections continue resolving to the bat profile).

## Why this scope

- **Bat-only invalidation, no global flush.** Only bat renders carry a suffix; bird renders use the empty suffix and keep their legacy filenames untouched. So the one-time regeneration is limited to the niche bat feature, not every spectrogram on every install (which would be costly on Raspberry Pi).
- **Legacy orphans self-clean.** Pre-bump `-bat.png` files are lazily superseded and reaped on detection delete (the delete scan matches any `<base>_<width>px-` prefix).

## A second follow-up was investigated and found NOT to be a bug

The prerenderer writes a different filename scheme (`<base>.png`, no width/style/profile token) than the by-ID serving API (`<base>_<width>px[-bat-v2].png`). I traced it: the frontend requests spectrograms exclusively via the by-ID API, which resolves the bat profile correctly and drives the 0-128 kHz axis. Nothing in `internal/api/v2/` serves the prerenderer's `<base>.png`, so there is no wrong-axis path there. The prerender/serve filename mismatch is a pre-existing, profile-agnostic concern unrelated to the bat work and is left untouched here (tracked separately).

## Changes

- `frequency_profile.go`: add `batCacheSuffix = "bat-v2"`; `BatProfile().suffix` uses it; document the cache-versioning rationale and the bounded-orphan tradeoff.
- `generator_test.go`, `detections_test.go`: assert the `bat-v2` token; the delete test now covers both legacy `-bat` and new `-bat-v2` variants.
- `media.go`, `detections.go`: refresh the example token in the cache-path / delete-scan comments.

## Test Plan

- [x] `go test ./internal/spectrogram/ ./internal/api/v2/ -race -count=1` passes
- [x] `golangci-lint run` (full project) reports 0 issues
- [x] Pre-push gate (6 review agents + Gemini) clean: no correctness/regression issues; bat-only invalidation confirmed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bat spectrogram file naming to use a versioned suffix, reducing conflicts with older cached files.
  * Detection removal now cleans up both legacy and versioned bat spectrogram variants.
  * Test coverage was refreshed to match the new bat spectrogram naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->