### PR TITLE
test(api/v2): trim slow real-wait tests via injectable timeouts

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -197,6 +197,18 @@ type Controller struct {
 	// importSourceFactory builds an import Source from a resolved path.
 	// Defaults to a BirdNET-Pi adapter when nil. Overridable in tests.
 	importSourceFactory func(path string) (imports.Source, error)
+
+	// ntfyCheckTimeoutOverride overrides the per-scheme ntfy connectivity probe
+	// timeout used by CheckNtfyServer. Zero in production, where the probe uses
+	// ntfyServerCheckTimeout. Tests set a short timeout so the unreachable-host
+	// path returns quickly instead of waiting the full default for each scheme.
+	ntfyCheckTimeoutOverride time.Duration
+
+	// audioWaitTimeoutOverride overrides the server-side wait for an in-progress
+	// audio encoding used by waitForAudioFile. Zero in production, where the wait
+	// uses audioWaitTimeout. Tests set a short timeout to exercise the
+	// 503-after-timeout path without waiting the full default.
+	audioWaitTimeoutOverride time.Duration
 }
 
 // SourceRestarterFunc restarts a single audio source identified by sourceID.

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -436,7 +436,14 @@ func (c *Controller) handleAudioNotReady(ctx echo.Context) error {
 // This reduces 503 responses by waiting server-side instead of requiring
 // the client to retry.
 func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath, tempPath string) bool {
-	waitCtx, cancel := context.WithTimeout(ctx.Request().Context(), audioWaitTimeout)
+	// Resolve the wait timeout. Production leaves the override at zero and uses the
+	// default constant; tests inject a short timeout to exercise the
+	// 503-after-timeout path without waiting the full default.
+	timeout := audioWaitTimeout
+	if c.audioWaitTimeoutOverride > 0 {
+		timeout = c.audioWaitTimeoutOverride
+	}
+	waitCtx, cancel := context.WithTimeout(ctx.Request().Context(), timeout)
 	defer cancel()
 
 	ticker := time.NewTicker(audioWaitPollInterval)

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -1428,6 +1428,12 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 func TestServeAudioClipReturns503AfterTimeout(t *testing.T) {
 	e, controller, tempDir := setupMediaTestEnvironment(t)
 
+	// Inject a short server-side wait so the 503-after-timeout path is exercised
+	// quickly. The final file never appears, so the wait deterministically expires
+	// regardless of the timeout value; the override only bounds the wait (default
+	// would be audioWaitTimeout).
+	controller.audioWaitTimeoutOverride = testFailFastTimeout
+
 	audioFilename := "slow-encoding.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
 	// Mirror the per-export unique temp name "<clip>.<pid>.<seq>.temp" the real
@@ -1435,7 +1441,7 @@ func TestServeAudioClipReturns503AfterTimeout(t *testing.T) {
 	// isAudioBeingEncoded rather than a fixed name that production never produces.
 	tempFilePath := audioFilePath + ".99999.1" + ffmpeg.TempExt
 
-	// Create only the temp file — final file never appears
+	// Create only the temp file; the final file never appears.
 	err := os.WriteFile(tempFilePath, []byte("temp encoding data"), 0o600)
 	require.NoError(t, err)
 

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -251,7 +251,15 @@ func (c *Controller) CheckNtfyServer(ctx echo.Context) error {
 		return c.HandleErrorWithKey(ctx, nil, "invalid host parameter", http.StatusBadRequest, notification.MsgErrNotifInvalidHost, nil)
 	}
 
-	resp := probeNtfyServer(ctx.Request().Context(), host)
+	// Resolve the per-scheme probe timeout. Production leaves the override at zero
+	// and uses the default constant; tests inject a short timeout so the
+	// unreachable-host path does not wait the full default for each scheme.
+	timeout := ntfyServerCheckTimeout
+	if c.ntfyCheckTimeoutOverride > 0 {
+		timeout = c.ntfyCheckTimeoutOverride
+	}
+
+	resp := probeNtfyServer(ctx.Request().Context(), host, timeout)
 	return ctx.JSON(http.StatusOK, resp)
 }
 
@@ -339,7 +347,8 @@ func isNtfyHealthResponse(r *http.Response) bool {
 // It validates the response is from an ntfy server by checking for the
 // /v1/health JSON response with a "healthy" key, preventing false positives
 // from unrelated HTTP servers running on the same host/port.
-func probeNtfyServer(ctx context.Context, host string) NtfyServerCheckResponse {
+// timeout is the per-scheme client timeout applied to each probe attempt.
+func probeNtfyServer(ctx context.Context, host string, timeout time.Duration) NtfyServerCheckResponse {
 	resp := NtfyServerCheckResponse{Recommended: "unreachable"}
 
 	// Normalize bare IPv6 addresses (e.g. ::1 → [::1]) for RFC 3986 URL compliance.
@@ -352,8 +361,8 @@ func probeNtfyServer(ctx context.Context, host string) NtfyServerCheckResponse {
 	}
 
 	client := &http.Client{
-		Timeout: ntfyServerCheckTimeout,
-		// Don't follow redirects — ntfy health endpoint does not redirect
+		Timeout: timeout,
+		// Don't follow redirects: the ntfy health endpoint does not redirect
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/internal/api/v2/notifications_ntfy_check_test.go
+++ b/internal/api/v2/notifications_ntfy_check_test.go
@@ -57,6 +57,11 @@ func TestCheckNtfyServer_InvalidHost_Unreachable(t *testing.T) {
 	e := echo.New()
 	ctrl := &Controller{}
 	ctrl.Settings.Store(newValidTestSettings())
+	// Inject a short per-scheme probe timeout so the unreachable-host path returns
+	// quickly. 192.0.2.1 never responds, so the result is deterministically
+	// "unreachable" regardless of the timeout; the override only bounds the wait
+	// (default would be ntfyServerCheckTimeout for HTTPS plus HTTP).
+	ctrl.ntfyCheckTimeoutOverride = testFailFastTimeout
 	// Use a reserved/invalid IP that will not respond (TEST-NET-1, RFC 5737)
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=192.0.2.1", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/ntfy_integration_test.go
+++ b/internal/api/v2/ntfy_integration_test.go
@@ -33,7 +33,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 	host := container.GetHost(ctx)
 
 	t.Run("http_reachable", func(t *testing.T) {
-		resp := probeNtfyServer(context.Background(), host)
+		resp := probeNtfyServer(context.Background(), host, ntfyServerCheckTimeout)
 
 		assert.Equal(t, "http", resp.Recommended, "container should be reachable via HTTP")
 		assert.True(t, resp.HTTP, "HTTP should be true")
@@ -46,7 +46,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 		require.NoError(t, err, "should parse host:port")
 
 		unreachableHost := fmt.Sprintf("%s:1", hostPart)
-		resp := probeNtfyServer(context.Background(), unreachableHost)
+		resp := probeNtfyServer(context.Background(), unreachableHost, ntfyServerCheckTimeout)
 
 		assert.Equal(t, "unreachable", resp.Recommended, "port 1 should be unreachable")
 	})

--- a/internal/api/v2/sse_connection_test.go
+++ b/internal/api/v2/sse_connection_test.go
@@ -86,7 +86,10 @@ func attemptSSEConnection(t *testing.T, serverURL, endpoint string, connID int, 
 	for eventCount < maxSSEReadLines && scanner.Scan() {
 		eventCount++
 	}
-	return true
+	// Report success only if the full connected event was read. Returning true
+	// unconditionally would count a connection that got HTTP 200 but never
+	// delivered the handshake (e.g. the stream closed early) as established.
+	return eventCount == maxSSEReadLines
 }
 
 // Common test configurations for different SSE endpoints

--- a/internal/api/v2/sse_connection_test.go
+++ b/internal/api/v2/sse_connection_test.go
@@ -44,6 +44,14 @@ type SSETestConfig struct {
 	connectionTimeout time.Duration
 }
 
+// maxSSEReadLines is the number of lines attemptSSEConnection reads from an SSE
+// stream before returning. The initial connected event is exactly this many
+// lines ("event: ...", "data: ...", and the trailing blank line from the
+// "\n\n" terminator), so reading this many confirms the connection was
+// established without blocking on the next event, which only arrives at the
+// heartbeat interval.
+const maxSSEReadLines = 3
+
 // attemptSSEConnection attempts to establish an SSE connection and read events.
 // Returns true if connection was established and events were read.
 func attemptSSEConnection(t *testing.T, serverURL, endpoint string, connID int, timeout time.Duration) bool {
@@ -68,10 +76,14 @@ func attemptSSEConnection(t *testing.T, serverURL, endpoint string, connID int, 
 		return false
 	}
 
-	// Read a few events
+	// Read the initial connected event's lines, then stop. The line-count check
+	// must come before scanner.Scan() so that once we have read the connected
+	// event (exactly maxSSEReadLines lines) we never issue another Scan. A Scan
+	// after the connected event would block until the next heartbeat or the
+	// client timeout, burning the full timeout per connection for no benefit.
 	scanner := bufio.NewScanner(resp.Body)
 	eventCount := 0
-	for scanner.Scan() && eventCount < 3 {
+	for eventCount < maxSSEReadLines && scanner.Scan() {
 		eventCount++
 	}
 	return true

--- a/internal/api/v2/test_helpers_test.go
+++ b/internal/api/v2/test_helpers_test.go
@@ -23,6 +23,12 @@ const (
 	testControlChanBuffer     = 10               // Buffer size for control channel in tests
 	testNewYorkLongitude      = -74.0060         // New York City longitude for test data
 	testResponseHeaderTimeout = 30 * time.Second // HTTP response header timeout for tests
+	// testFailFastTimeout is a short timeout injected into deliberate-failure
+	// waits (unreachable ntfy host, audio file that never appears) so those
+	// tests reach the expected timeout state quickly instead of waiting the full
+	// production defaults. It is intentionally well above any local/CI dial or
+	// scheduling latency while staying far below the production timeouts.
+	testFailFastTimeout = 200 * time.Millisecond
 )
 
 // getTestController creates a test controller with disabled saving


### PR DESCRIPTION
## Summary

Trims the three slowest real-wait tests in `internal/api/v2`, which are the dominant contributors to that package's `-race` wall time. No production behavior changes: the production timeout defaults are byte-for-byte unchanged, and only tests inject shorter values.

Measured per-test wall time (local, no race):

| Test | Before | After |
| --- | --- | --- |
| `TestCheckNtfyServer_InvalidHost_Unreachable` | 10.0s | 0.4s |
| `TestServeAudioClipReturns503AfterTimeout` | 6.3s | 1.2s |
| `TestSSEConnectionCleanup` (per endpoint subtest) | 7.1s | 1.2s |

## How

1. **ntfy connectivity probe (`CheckNtfyServer` / `probeNtfyServer`).** The probe tried HTTPS then HTTP, each with a 5s client timeout, so an unreachable host waited the full 10s. Added a zero-default `Controller.ntfyCheckTimeoutOverride`; production keeps using the existing `ntfyServerCheckTimeout` constant, the test injects a short timeout. The test still drives the full handler and still asserts the `unreachable` result against the reserved TEST-NET-1 address.

2. **Audio clip 503-after-timeout (`waitForAudioFile`).** The server-side wait used the 5s `audioWaitTimeout`. Added a zero-default `Controller.audioWaitTimeoutOverride`; production keeps the default, the test injects a short timeout. The test still asserts the 503 status and `Retry-After` header.

3. **SSE connection cleanup (`attemptSSEConnection` helper).** Fixed an off-by-one in the test read loop: `for scanner.Scan() && eventCount < 3` issued one extra blocking `Scan` after the initial connected event (exactly 3 lines), which then blocked until the client timeout (5s). Reordered to `for eventCount < maxSSEReadLines && scanner.Scan()` so it stops after the connected event without the extra blocking read. The connection-established assertion is unchanged. Test-only change.

The two timeout overrides follow the Controller's existing test-injection idiom (`probeStreamInfo`, `externalMediaProbe`, etc.): unexported fields, zero in production, fall back to the named default constants. A shared `testFailFastTimeout` constant is used for the injected values.

Native-runner CI sharding (the optional part of this work) was intentionally deferred: the test trims deliver the timeout relief on their own, and sharding adds CI-config risk better handled in a later change.

## Verification

- `go build ./...` and `go vet ./internal/api/v2/` clean (also `go vet -tags integration`).
- `go test -race ./internal/api/v2/...` green.
- `golangci-lint run ./internal/api/v2/...` reports 0 issues.

## Preflight Status

- [x] Single concern: test-timing trim only
- [x] Preflight passed (correctness, quality, integration-wiring, regression reviews); one finding (integration-tagged test still calling the old `probeNtfyServer` signature) fixed
- [x] Linters clean
- [x] Tests pass under `-race`
- [x] No production behavior change: default timeout constants unchanged, no production code sets the overrides
- [x] No API/config/DB/CLI changes