### PR TITLE
fix(api): canonicalize Settings-page species exclude list to scientific names

### DIFF
--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1702,18 +1702,13 @@ func (c *Controller) canonicalizeExcludeList(exclude []string) []string {
 			continue
 		}
 		resolved := c.resolveExcludeName(trimmed)
-		// Dedup with EqualFold for exact parity with excludeEntryMatches (both
-		// operands are already resolved here, so no second resolution is needed).
-		// A plain scan over the small, already-canonical slice avoids the per-entry
-		// map a lowercased-key set would allocate.
-		dup := false
-		for _, existing := range canonical {
-			if strings.EqualFold(existing, resolved) {
-				dup = true
-				break
-			}
-		}
-		if dup {
+		// Dedup with EqualFold for parity with excludeEntryMatches (both operands are
+		// already resolved here, so no second resolution is needed). Uses the same
+		// slices.ContainsFunc idiom the exclude-list toggle/add paths use; lists are
+		// small, so the linear scan is fine.
+		if slices.ContainsFunc(canonical, func(existing string) bool {
+			return strings.EqualFold(existing, resolved)
+		}) {
 			continue
 		}
 		canonical = append(canonical, resolved)

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1691,9 +1691,15 @@ func (c *Controller) excludeEntryMatches(entry, target string) bool {
 // detection (rangeFilterSettingsChanged) sees no diff and no spurious range-filter
 // rebuild is triggered. Ambiguous common names shared by multiple species are passed
 // through unchanged by resolveSpeciesToScientific, matching the detection-side paths.
+//
+// An empty result (empty input, or every entry dropped) returns nil rather than a
+// non-nil empty slice, so the stored list has a single canonical empty form. This
+// matters because rangeFilterSettingsChanged compares with reflect.DeepEqual and
+// DeepEqual(nil, []string{}) is false: returning a non-nil empty slice would spuriously
+// differ from a nil stored list and trigger a range-filter rebuild on an empty save.
 func (c *Controller) canonicalizeExcludeList(exclude []string) []string {
 	if len(exclude) == 0 {
-		return exclude
+		return nil
 	}
 	canonical := make([]string, 0, len(exclude))
 	for _, entry := range exclude {
@@ -1712,6 +1718,11 @@ func (c *Controller) canonicalizeExcludeList(exclude []string) []string {
 			continue
 		}
 		canonical = append(canonical, resolved)
+	}
+	if len(canonical) == 0 {
+		// Every entry was whitespace; collapse to nil (see the doc comment) so an
+		// empty result matches a nil stored list under reflect.DeepEqual.
+		return nil
 	}
 	return canonical
 }

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1676,6 +1676,51 @@ func (c *Controller) excludeEntryMatches(entry, target string) bool {
 	return false
 }
 
+// canonicalizeExcludeList returns a copy of the species exclude list with every
+// entry resolved to its scientific name (via resolveExcludeName) and de-duplicated
+// case-insensitively, preserving first-occurrence order. Whitespace-only entries
+// are dropped. Settings-page saves persist the slice verbatim through the generic
+// reflection/JSON merge, so without this a localized or common name typed into the
+// Settings exclude editor would be stored in a non-canonical form; routing it
+// through the same resolution the detection endpoints use keeps the stored list in
+// a single scientific-name form that the per-detection filter (isSpeciesExcluded)
+// and the detection-card toggle both match regardless of the UI locale.
+//
+// It is idempotent: a list that is already canonical (all scientific, de-duplicated,
+// trimmed) is returned with identical contents, so reflect.DeepEqual-based change
+// detection (rangeFilterSettingsChanged) sees no diff and no spurious range-filter
+// rebuild is triggered. Ambiguous common names shared by multiple species are passed
+// through unchanged by resolveSpeciesToScientific, matching the detection-side paths.
+func (c *Controller) canonicalizeExcludeList(exclude []string) []string {
+	if len(exclude) == 0 {
+		return exclude
+	}
+	canonical := make([]string, 0, len(exclude))
+	for _, entry := range exclude {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" {
+			continue
+		}
+		resolved := c.resolveExcludeName(trimmed)
+		// Dedup with EqualFold for exact parity with excludeEntryMatches (both
+		// operands are already resolved here, so no second resolution is needed).
+		// A plain scan over the small, already-canonical slice avoids the per-entry
+		// map a lowercased-key set would allocate.
+		dup := false
+		for _, existing := range canonical {
+			if strings.EqualFold(existing, resolved) {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		canonical = append(canonical, resolved)
+	}
+	return canonical
+}
+
 // addToIgnoredSpecies handles the logic for adding species to the ignore list
 func (c *Controller) addToIgnoredSpecies(verified, ignoreSpecies string) error {
 	if verified == "false_positive" && ignoreSpecies != "" {

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -260,6 +260,12 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		updated.Realtime.Species.Config = conf.NormalizeSpeciesConfigKeys(updated.Realtime.Species.Config)
 	}
 
+	// Canonicalize the species exclude list to scientific names so a localized or
+	// common name typed into the Settings exclude editor is stored in the same form
+	// the per-detection filter and the detection-card toggle match. Idempotent for
+	// an already-canonical list, so this does not spuriously trigger a rebuild.
+	updated.Realtime.Species.Exclude = c.canonicalizeExcludeList(updated.Realtime.Species.Exclude)
+
 	// Ensure LocationConfigured is set when birdnet coordinates are present.
 	// Backward compatibility with older frontends that don't send the flag.
 	if updated.BirdNET.Latitude != 0 || updated.BirdNET.Longitude != 0 {
@@ -683,6 +689,14 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 
 	// Migrate legacy single audio source if a cached frontend sent it.
 	updated.MigrateAudioSourceConfig()
+
+	// Canonicalize the species exclude list to scientific names (see UpdateSettings).
+	// Only the realtime/species sections carry it, so skip other sections: an
+	// unrelated section save must not rewrite the list or trigger a spurious
+	// range-filter rebuild via rangeFilterSettingsChanged.
+	if strings.EqualFold(section, SettingsSectionRealtime) || strings.EqualFold(section, SettingsSectionSpecies) {
+		updated.Realtime.Species.Exclude = c.canonicalizeExcludeList(updated.Realtime.Species.Exclude)
+	}
 
 	// Validate the clone before publishing. No rollback needed on validation
 	// failure: we simply never publish.

--- a/internal/api/v2/settings_exclude_canonicalize_test.go
+++ b/internal/api/v2/settings_exclude_canonicalize_test.go
@@ -84,9 +84,9 @@ func TestCanonicalizeExcludeList(t *testing.T) {
 			want:  nil,
 		},
 		{
-			name:  "empty passthrough",
+			name:  "empty slice normalized to nil",
 			input: []string{},
-			want:  []string{},
+			want:  nil,
 		},
 		{
 			name:  "localized name resolved to scientific",
@@ -109,11 +109,12 @@ func TestCanonicalizeExcludeList(t *testing.T) {
 			want:  []string{"American Crow"},
 		},
 		{
-			// A non-empty input whose entries all drop returns a non-nil empty
-			// slice (distinct from the nil/empty passthrough path above).
-			name:  "all entries dropped yields empty slice",
+			// A non-empty input whose entries all drop collapses to nil, the single
+			// canonical empty form (so an empty save matches a nil stored list under
+			// reflect.DeepEqual and does not spuriously rebuild the range filter).
+			name:  "all entries dropped yields nil",
 			input: []string{"   ", ""},
-			want:  []string{},
+			want:  nil,
 		},
 		{
 			name:  "mixed localized + scientific de-duplicated to one scientific",

--- a/internal/api/v2/settings_exclude_canonicalize_test.go
+++ b/internal/api/v2/settings_exclude_canonicalize_test.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// Shared fixture names so the resolver map and the assertions cannot drift apart:
+// the localized common name resolves to the scientific name.
+const (
+	testExcludeLocalizedName  = "mopsilepakko"
+	testExcludeScientificName = "Barbastella barbastellus"
+)
+
+// installExcludeTestResolver wires a batch-capable fake resolver and rebuilds the
+// controller's common-name map so the localized name resolves to its scientific
+// name, mirroring the detection-side localized-name tests.
+func installExcludeTestResolver(t *testing.T, c *Controller) {
+	t.Helper()
+	c.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
+		testExcludeScientificName: testExcludeLocalizedName,
+	}})
+	c.UpdateCommonNameMap([]string{testExcludeScientificName})
+}
+
+// patchSection drives UpdateSectionSettings for an arbitrary section. It asserts
+// HTTP 200: HandleError returns a nil error after writing a 4xx/5xx body, so a
+// rejected save would otherwise pass require.NoError and surface only as a
+// confusing downstream mismatch.
+func patchSection(t *testing.T, e *echo.Echo, c *Controller, section string, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/"+section, bytes.NewReader(data))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues(section)
+	require.NoError(t, c.UpdateSectionSettings(ctx))
+	require.Equal(t, http.StatusOK, rec.Code, "section save must succeed; body: %s", rec.Body.String())
+	return rec
+}
+
+// putFullSettings drives UpdateSettings (PUT /api/v2/settings) with a full
+// settings snapshot, matching what the frontend settings page sends. Asserts
+// HTTP 200 for the same reason patchSection does.
+func putFullSettings(t *testing.T, e *echo.Echo, c *Controller, s *conf.Settings) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(s)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	require.NoError(t, c.UpdateSettings(e.NewContext(req, rec)))
+	require.Equal(t, http.StatusOK, rec.Code, "full settings save must succeed; body: %s", rec.Body.String())
+	return rec
+}
+
+// TestCanonicalizeExcludeList unit-tests the resolution + dedup + cleanup helper
+// directly, independent of the HTTP save handlers.
+func TestCanonicalizeExcludeList(t *testing.T) {
+	t.Parallel()
+
+	c := &Controller{}
+	installExcludeTestResolver(t, c)
+
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "nil passthrough",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty passthrough",
+			input: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "localized name resolved to scientific",
+			input: []string{testExcludeLocalizedName},
+			want:  []string{testExcludeScientificName},
+		},
+		{
+			name:  "scientific name passes through unchanged",
+			input: []string{testExcludeScientificName},
+			want:  []string{testExcludeScientificName},
+		},
+		{
+			name:  "unknown common name passes through trimmed",
+			input: []string{"  American Crow  "},
+			want:  []string{"American Crow"},
+		},
+		{
+			name:  "whitespace-only entries dropped",
+			input: []string{"   ", "American Crow", ""},
+			want:  []string{"American Crow"},
+		},
+		{
+			// A non-empty input whose entries all drop returns a non-nil empty
+			// slice (distinct from the nil/empty passthrough path above).
+			name:  "all entries dropped yields empty slice",
+			input: []string{"   ", ""},
+			want:  []string{},
+		},
+		{
+			name:  "mixed localized + scientific de-duplicated to one scientific",
+			input: []string{testExcludeLocalizedName, testExcludeScientificName},
+			want:  []string{testExcludeScientificName},
+		},
+		{
+			name:  "case-insensitive dedup of passthrough names keeps first occurrence",
+			input: []string{"American Crow", "american crow"},
+			want:  []string{"American Crow"},
+		},
+		{
+			name:  "order preserved across resolved and passthrough entries",
+			input: []string{"American Crow", testExcludeLocalizedName, "Blue Jay"},
+			want:  []string{"American Crow", testExcludeScientificName, "Blue Jay"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := c.canonicalizeExcludeList(tt.input)
+			assert.Equal(t, tt.want, got)
+
+			// Idempotency: canonicalizing an already-canonical list is a no-op.
+			again := c.canonicalizeExcludeList(got)
+			assert.Equal(t, got, again, "canonicalization must be idempotent")
+		})
+	}
+}
+
+// TestUpdateSectionSettingsCanonicalizesExclude verifies the PATCH
+// /api/v2/settings/realtime path stores scientific names regardless of the form
+// the user typed, and de-duplicates mixed forms.
+func TestUpdateSectionSettingsCanonicalizesExclude(t *testing.T) {
+	e, _, controller := setupTestEnvironment(t)
+	clearExcludedSpeciesList(t, controller.Settings.Load())
+	installExcludeTestResolver(t, controller)
+
+	patchSection(t, e, controller, SettingsSectionRealtime, map[string]any{
+		"species": map[string]any{
+			"exclude": []string{testExcludeLocalizedName, testExcludeScientificName, "  American Crow  ", "  "},
+		},
+	})
+
+	got := controller.Settings.Load().Realtime.Species.Exclude
+	assert.Equal(t, []string{testExcludeScientificName, "American Crow"}, got,
+		"localized entry resolved, scientific dup removed, name trimmed, blank dropped")
+}
+
+// TestUpdateSectionSettingsCanonicalizesExcludeViaSpeciesSection verifies the
+// species section PATCH path is canonicalized too (it also carries the list).
+func TestUpdateSectionSettingsCanonicalizesExcludeViaSpeciesSection(t *testing.T) {
+	e, _, controller := setupTestEnvironment(t)
+	clearExcludedSpeciesList(t, controller.Settings.Load())
+	installExcludeTestResolver(t, controller)
+
+	patchSection(t, e, controller, SettingsSectionSpecies, map[string]any{
+		"exclude": []string{testExcludeLocalizedName},
+	})
+
+	got := controller.Settings.Load().Realtime.Species.Exclude
+	assert.Equal(t, []string{testExcludeScientificName}, got)
+}
+
+// TestUpdateSettingsCanonicalizesExclude verifies the full-settings PUT path (the
+// one the frontend settings page actually uses) canonicalizes the exclude list.
+func TestUpdateSettingsCanonicalizesExclude(t *testing.T) {
+	e, _, controller := setupTestEnvironment(t)
+	clearExcludedSpeciesList(t, controller.Settings.Load())
+	installExcludeTestResolver(t, controller)
+
+	// Send a full snapshot with a localized exclude entry, as the settings page does.
+	s := conf.CloneSettings(controller.Settings.Load())
+	s.Realtime.Species.Exclude = []string{testExcludeLocalizedName, "American Crow"}
+	putFullSettings(t, e, controller, s)
+
+	// Exact assertion (order + dedup + count), matching the section tests.
+	got := controller.Settings.Load().Realtime.Species.Exclude
+	assert.Equal(t, []string{testExcludeScientificName, "American Crow"}, got)
+}
+
+// TestUpdateSectionSettingsSkipsExcludeForUnrelatedSection verifies that saving a
+// section that does not carry the exclude list leaves a legacy (non-canonical)
+// entry untouched, so an unrelated save does not rewrite the list or trigger a
+// spurious range-filter rebuild.
+func TestUpdateSectionSettingsSkipsExcludeForUnrelatedSection(t *testing.T) {
+	e, _, controller := setupTestEnvironment(t)
+	installExcludeTestResolver(t, controller)
+
+	// Simulate a pre-upgrade exclude list stored as a localized common name.
+	controller.Settings.Load().Realtime.Species.Exclude = []string{testExcludeLocalizedName}
+
+	// Saving the audio section must not canonicalize the exclude list (patchSection
+	// asserts the save returned 200, so this also proves the no-op save succeeded).
+	patchSection(t, e, controller, SettingsSectionAudio, map[string]any{})
+
+	got := controller.Settings.Load().Realtime.Species.Exclude
+	assert.Equal(t, []string{testExcludeLocalizedName}, got,
+		"unrelated section save must leave the legacy exclude entry untouched")
+}


### PR DESCRIPTION
## Summary

Follow-up to #3683 (which fixed #3681). That PR made the detection-side write
paths (the "ignore this species" toggle and the false-positive review) store
scientific names in `Realtime.Species.Exclude`, so the per-detection filter
`isSpeciesExcluded` matches regardless of UI locale. The Settings > Species
exclude editor was the one remaining write path that still persisted whatever
the user typed or picked (localized common, English common, or scientific)
verbatim, so the stored list drifted into mixed forms.

Filtering still worked (the range-filter matcher and the detection toggle both
reverse-resolve), so this was a storage-consistency issue, not a functional
filtering bug. This change makes the Settings save path canonical too.

## What changed

- New `Controller.canonicalizeExcludeList` (internal/api/v2/detections.go):
  resolves each entry to its scientific name via the existing
  `resolveExcludeName`, de-duplicates case-insensitively (`EqualFold`, matching
  `excludeEntryMatches`), drops whitespace-only entries, and preserves order.
  It is idempotent, so an already-canonical list produces no spurious
  range-filter rebuild.
- `UpdateSettings` (PUT /api/v2/settings) canonicalizes unconditionally;
  `UpdateSectionSettings` (PATCH /api/v2/settings/:section) only for the
  `realtime`/`species` sections that carry the list, so an unrelated section
  save never rewrites it or triggers a spurious rebuild.

Backend-only: the frontend `SpeciesListCard` already maps stored scientific
names to localized display labels and emits canonical values on add, so no UI
change is needed.

## Hot-reload

Canonicalization runs on the cloned settings snapshot before change detection
and publish, so a genuine exclude change still rebuilds the range filter
without a restart. An already-canonical save is a content no-op
(`rangeFilterSettingsChanged` compares with `reflect.DeepEqual`), so it does not
rebuild.

## Note

Exclude entries now normalize to scientific names on save. If a future BirdNET
model renames a species' scientific name, such an entry could strand. This is a
deliberate tradeoff: scientific names are far more stable than localized common
names, which broke on every UI-locale change.

## Test Plan

- [x] New testify tests: unit coverage of `canonicalizeExcludeList` (resolution,
  case-insensitive dedup, whitespace handling, order, idempotency, nil/empty);
  PUT and PATCH (realtime + species) integration tests assert the stored list is
  canonicalized; a test that an unrelated (audio) section save leaves a legacy
  entry untouched.
- [x] `go test -race ./internal/api/v2/` passes.
- [x] `golangci-lint run ./...` clean (0 issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now normalize excluded species names when saved, keeping entries consistent and removing duplicates or blank values.
  * Partial updates only rewrite the exclusion list when editing the relevant settings sections, avoiding unexpected changes elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->