### PR TITLE
refactor(api/v2): extract apicore shared core; facade embeds *apicore.Core

### DIFF
--- a/internal/api/v2/alerts.go
+++ b/internal/api/v2/alerts.go
@@ -39,7 +39,7 @@ func (c *Controller) initAlertRoutes() {
 	alerts.GET("/history", c.ListAlertHistory)
 
 	// Protected endpoints
-	protected := alerts.Group("", c.authMiddleware)
+	protected := alerts.Group("", c.AuthMiddleware)
 	protected.GET("/rules/export", c.ExportAlertRules)
 	protected.POST("/rules", c.CreateAlertRule)
 	protected.PUT("/rules/:id", c.UpdateAlertRule)
@@ -155,7 +155,7 @@ func (c *Controller) ListAlertRules(ctx echo.Context) error {
 
 	rules, err := c.alertRuleRepo.ListRules(ctx.Request().Context(), filter)
 	if err != nil {
-		c.logErrorIfEnabled("failed to list alert rules", logger.Error(err))
+		c.LogErrorIfEnabled("failed to list alert rules", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to list alert rules", http.StatusInternalServerError)
 	}
 
@@ -181,7 +181,7 @@ func (c *Controller) GetAlertRule(ctx echo.Context) error {
 		if errors.Is(err, repository.ErrAlertRuleNotFound) {
 			return c.HandleErrorWithKey(ctx, err, "Alert rule not found", http.StatusNotFound, notification.MsgErrAlertNotFound, nil)
 		}
-		c.logErrorIfEnabled("failed to get alert rule", logger.Error(err))
+		c.LogErrorIfEnabled("failed to get alert rule", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to get alert rule", http.StatusInternalServerError)
 	}
 
@@ -202,7 +202,7 @@ func (c *Controller) CreateAlertRule(ctx echo.Context) error {
 	// Prevent duplicate names
 	count, err := c.alertRuleRepo.CountRulesByName(ctx.Request().Context(), rule.Name)
 	if err != nil {
-		c.logErrorIfEnabled("failed to check rule name uniqueness", logger.Error(err))
+		c.LogErrorIfEnabled("failed to check rule name uniqueness", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to create alert rule", http.StatusInternalServerError)
 	}
 	if count > 0 {
@@ -210,14 +210,14 @@ func (c *Controller) CreateAlertRule(ctx echo.Context) error {
 	}
 
 	if err := c.alertRuleRepo.CreateRule(ctx.Request().Context(), rule); err != nil {
-		c.logErrorIfEnabled("failed to create alert rule", logger.Error(err))
+		c.LogErrorIfEnabled("failed to create alert rule", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to create alert rule", http.StatusInternalServerError)
 	}
 
 	// Refresh engine cache if available
 	c.refreshAlertEngine(ctx)
 
-	c.logInfoIfEnabled("alert rule created",
+	c.LogInfoIfEnabled("alert rule created",
 		logger.String("name", rule.Name),
 		logger.Uint64("id", uint64(rule.ID)))
 
@@ -253,7 +253,7 @@ func (c *Controller) UpdateAlertRule(ctx echo.Context) error {
 	rule.CreatedAt = existing.CreatedAt
 
 	if err := c.alertRuleRepo.UpdateRule(ctx.Request().Context(), rule); err != nil {
-		c.logErrorIfEnabled("failed to update alert rule", logger.Error(err))
+		c.LogErrorIfEnabled("failed to update alert rule", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to update alert rule", http.StatusInternalServerError)
 	}
 
@@ -284,7 +284,7 @@ func (c *Controller) ToggleAlertRule(ctx echo.Context) error {
 		if errors.Is(err, repository.ErrAlertRuleNotFound) {
 			return c.HandleErrorWithKey(ctx, err, "Alert rule not found", http.StatusNotFound, notification.MsgErrAlertNotFound, nil)
 		}
-		c.logErrorIfEnabled("failed to toggle alert rule", logger.Error(err))
+		c.LogErrorIfEnabled("failed to toggle alert rule", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to toggle alert rule", http.StatusInternalServerError)
 	}
 
@@ -308,7 +308,7 @@ func (c *Controller) DeleteAlertRule(ctx echo.Context) error {
 		if errors.Is(err, repository.ErrAlertRuleNotFound) {
 			return c.HandleErrorWithKey(ctx, err, "Alert rule not found", http.StatusNotFound, notification.MsgErrAlertNotFound, nil)
 		}
-		c.logErrorIfEnabled("failed to delete alert rule", logger.Error(err))
+		c.LogErrorIfEnabled("failed to delete alert rule", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to delete alert rule", http.StatusInternalServerError)
 	}
 
@@ -354,7 +354,7 @@ func (c *Controller) ResetDefaultAlertRules(ctx echo.Context) error {
 
 	_, err := c.alertRuleRepo.DeleteBuiltInRules(reqCtx)
 	if err != nil {
-		c.logErrorIfEnabled("failed to delete built-in rules", logger.Error(err))
+		c.LogErrorIfEnabled("failed to delete built-in rules", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to reset default rules", http.StatusInternalServerError)
 	}
 
@@ -362,7 +362,7 @@ func (c *Controller) ResetDefaultAlertRules(ctx echo.Context) error {
 	defaults := alerting.DefaultRules()
 	for i := range defaults {
 		if err := c.alertRuleRepo.CreateRule(reqCtx, &defaults[i]); err != nil {
-			c.logErrorIfEnabled("failed to seed default rule",
+			c.LogErrorIfEnabled("failed to seed default rule",
 				logger.String("name", defaults[i].Name), logger.Error(err))
 		}
 	}
@@ -407,7 +407,7 @@ func (c *Controller) ListAlertHistory(ctx echo.Context) error {
 
 	items, total, err := c.alertRuleRepo.ListHistory(ctx.Request().Context(), filter)
 	if err != nil {
-		c.logErrorIfEnabled("failed to list alert history", logger.Error(err))
+		c.LogErrorIfEnabled("failed to list alert history", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to list alert history", http.StatusInternalServerError)
 	}
 
@@ -427,7 +427,7 @@ func (c *Controller) ClearAlertHistory(ctx echo.Context) error {
 
 	deleted, err := c.alertRuleRepo.DeleteHistory(ctx.Request().Context())
 	if err != nil {
-		c.logErrorIfEnabled("failed to clear alert history", logger.Error(err))
+		c.LogErrorIfEnabled("failed to clear alert history", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to clear alert history", http.StatusInternalServerError)
 	}
 
@@ -442,7 +442,7 @@ func (c *Controller) ExportAlertRules(ctx echo.Context) error {
 
 	rules, err := c.alertRuleRepo.ListRules(ctx.Request().Context(), repository.AlertRuleFilter{})
 	if err != nil {
-		c.logErrorIfEnabled("failed to export alert rules", logger.Error(err))
+		c.LogErrorIfEnabled("failed to export alert rules", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to export alert rules", http.StatusInternalServerError)
 	}
 
@@ -483,13 +483,13 @@ func (c *Controller) ImportAlertRules(ctx echo.Context) error {
 		}
 
 		if err := validateEscalationSteps(rule.EscalationSteps); err != nil {
-			c.logErrorIfEnabled("skipping imported rule with invalid escalation steps",
+			c.LogErrorIfEnabled("skipping imported rule with invalid escalation steps",
 				logger.String("name", rule.Name), logger.Error(err))
 			continue
 		}
 
 		if err := c.alertRuleRepo.CreateRule(reqCtx, rule); err != nil {
-			c.logErrorIfEnabled("failed to import rule",
+			c.LogErrorIfEnabled("failed to import rule",
 				logger.String("name", rule.Name), logger.Error(err))
 			continue
 		}
@@ -508,7 +508,7 @@ func (c *Controller) ImportAlertRules(ctx echo.Context) error {
 func (c *Controller) refreshAlertEngine(ctx echo.Context) {
 	if c.alertEngine != nil {
 		if err := c.alertEngine.RefreshRules(ctx.Request().Context()); err != nil {
-			c.logErrorIfEnabled("failed to refresh alert engine rules", logger.Error(err))
+			c.LogErrorIfEnabled("failed to refresh alert engine rules", logger.Error(err))
 		}
 	}
 }

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -85,13 +85,13 @@ func (c *Controller) handleAnalyticsQueryError(ctx echo.Context, err error, opLa
 		// Client disconnected (navigated away / closed the tab). An expected lifecycle
 		// event, not a server error: log at info and return the non-standard
 		// client-closed status, matching the convention in media.go.
-		c.logInfoIfEnabled(opLabel+" query canceled by client", fields...)
+		c.LogInfoIfEnabled(opLabel+" query canceled by client", fields...)
 		return c.HandleError(ctx, err, "Request canceled by client", StatusClientClosedRequest)
 	case errors.Is(err, context.DeadlineExceeded):
-		c.logErrorIfEnabled(opLabel+" query timeout", fields...)
+		c.LogErrorIfEnabled(opLabel+" query timeout", fields...)
 		return c.HandleError(ctx, err, msgQueryTimeout, http.StatusRequestTimeout)
 	default:
-		c.logErrorIfEnabled(opLabel+" query failed", fields...)
+		c.LogErrorIfEnabled(opLabel+" query failed", fields...)
 		return c.HandleError(ctx, err, genericMsg, http.StatusInternalServerError)
 	}
 }
@@ -103,10 +103,10 @@ func (c *Controller) handleAnalyticsQueryError(ctx echo.Context, err error, opLa
 func (c *Controller) logBatchQueryError(msg string, err error, fields ...logger.Field) (canceled bool) {
 	fields = append(fields, logger.Error(err))
 	if errors.Is(err, context.Canceled) {
-		c.logDebugIfEnabled(msg+": client canceled request", fields...)
+		c.LogDebugIfEnabled(msg+": client canceled request", fields...)
 		return true
 	}
-	c.logErrorIfEnabled(msg, fields...)
+	c.LogErrorIfEnabled(msg, fields...)
 	return false
 }
 
@@ -244,7 +244,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 		return err // Return the HTTP error created by the helper
 	}
 
-	c.logInfoIfEnabled("Retrieving daily species summary",
+	c.LogInfoIfEnabled("Retrieving daily species summary",
 		logger.String("date", selectedDate),
 		logger.Float64("min_confidence", minConfidence),
 		logger.Int("limit", limit),
@@ -294,7 +294,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 		return result[i].LatestHeard > result[j].LatestHeard
 	})
 
-	c.logInfoIfEnabled("Daily species summary retrieved",
+	c.LogInfoIfEnabled("Daily species summary retrieved",
 		logger.String("date", selectedDate),
 		logger.Int("count", len(result)),
 		logger.Bool("limit_applied", limit > 0),
@@ -318,7 +318,7 @@ func (c *Controller) GetBatchDailySpeciesSummary(ctx echo.Context) error {
 		return err
 	}
 
-	c.logInfoIfEnabled("Retrieving batch daily species summary",
+	c.LogInfoIfEnabled("Retrieving batch daily species summary",
 		logger.Int("date_count", len(dates)),
 		logger.Float64("min_confidence", minConfidence),
 		logger.Int("limit", limit),
@@ -362,7 +362,7 @@ func (c *Controller) processBatchDates(ctx context.Context, dates []string, minC
 		// Stop cleanly if the client disconnected (request canceled): an expected
 		// lifecycle event, not a processing failure worth recording.
 		if err := ctx.Err(); err != nil {
-			c.logDebugIfEnabled("Batch daily species summary: client canceled request",
+			c.LogDebugIfEnabled("Batch daily species summary: client canceled request",
 				logger.String("date", selectedDate),
 				logger.Error(err),
 				logger.String("ip", ip),
@@ -415,7 +415,7 @@ func (c *Controller) processSingleDateForBatch(ctx context.Context, selectedDate
 	// Build response
 	result, err := c.buildDailySpeciesSummaryResponse(aggregatedData, selectedDate)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to build response for date in batch request",
+		c.LogErrorIfEnabled("Failed to build response for date in batch request",
 			logger.String("date", selectedDate),
 			logger.Error(err),
 			logger.String("ip", ip),
@@ -687,7 +687,7 @@ func (c *Controller) GetSpeciesSummary(ctx echo.Context) error {
 	endDate := ctx.QueryParam("end_date")
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 
-	c.logInfoIfEnabled("Retrieving species summary",
+	c.LogInfoIfEnabled("Retrieving species summary",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("ip", ip),
@@ -700,7 +700,7 @@ func (c *Controller) GetSpeciesSummary(ctx echo.Context) error {
 
 	// Retrieve species summary data from the datastore
 	summaryData, dbDuration, err := c.fetchSpeciesSummaryData(ctx, startDate, endDate)
-	c.logInfoIfEnabled("Database query completed",
+	c.LogInfoIfEnabled("Database query completed",
 		logger.Int64("duration_ms", dbDuration.Milliseconds()),
 		logger.Int("record_count", len(summaryData)),
 		logger.String("ip", ip),
@@ -724,7 +724,7 @@ func (c *Controller) GetSpeciesSummary(ctx echo.Context) error {
 	// Apply limit
 	response, limit := c.applyOptionalLimit(ctx, response, ip, path)
 
-	c.logInfoIfEnabled("Species summary retrieved",
+	c.LogInfoIfEnabled("Species summary retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("count", len(response)),
@@ -761,7 +761,7 @@ func (c *Controller) batchFetchThumbnailsWithLogging(scientificNames []string, i
 		return nil
 	}
 
-	c.logDebugIfEnabled("Fetching cached thumbnails only",
+	c.LogDebugIfEnabled("Fetching cached thumbnails only",
 		logger.Int("count", len(scientificNames)),
 		logger.String("ip", ip),
 		logger.String("path", path),
@@ -769,7 +769,7 @@ func (c *Controller) batchFetchThumbnailsWithLogging(scientificNames []string, i
 	thumbStart := time.Now()
 	thumbnailURLs := cache.GetBatchCachedOnly(scientificNames)
 	thumbDuration := time.Since(thumbStart)
-	c.logInfoIfEnabled("Cached thumbnail fetch completed",
+	c.LogInfoIfEnabled("Cached thumbnail fetch completed",
 		logger.Int64("duration_ms", thumbDuration.Milliseconds()),
 		logger.Int("cached_count", len(thumbnailURLs)),
 		logger.Int("requested_count", len(scientificNames)),
@@ -830,7 +830,7 @@ func (c *Controller) applyOptionalLimit(ctx echo.Context, response []SpeciesSumm
 
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil {
-		c.logWarnIfEnabled("Invalid limit parameter",
+		c.LogWarnIfEnabled("Invalid limit parameter",
 			logger.String("value", limitStr),
 			logger.Error(err),
 			logger.String("ip", ip),
@@ -866,7 +866,7 @@ func (c *Controller) GetHourlyAnalytics(ctx echo.Context) error {
 		return err
 	}
 
-	c.logInfoIfEnabled("Retrieving hourly analytics",
+	c.LogInfoIfEnabled("Retrieving hourly analytics",
 		logger.String("date", date),
 		logger.String("species", speciesParam),
 		logger.String("ip", ctx.RealIP()),
@@ -919,7 +919,7 @@ func (c *Controller) GetHourlyAnalytics(ctx echo.Context) error {
 		"total":   total,
 	}
 
-	c.logInfoIfEnabled("Hourly analytics retrieved",
+	c.LogInfoIfEnabled("Hourly analytics retrieved",
 		logger.String("date", date),
 		logger.String("species", speciesParam),
 		logger.Int("total", total),
@@ -963,7 +963,7 @@ func (c *Controller) GetDailyAnalytics(ctx echo.Context) error {
 		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
-	c.logInfoIfEnabled("Retrieving daily analytics",
+	c.LogInfoIfEnabled("Retrieving daily analytics",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("species", speciesParam),
@@ -1026,7 +1026,7 @@ func (c *Controller) GetDailyAnalytics(ctx echo.Context) error {
 	}
 	response.Total = totalCount
 
-	c.logInfoIfEnabled("Daily analytics retrieved",
+	c.LogInfoIfEnabled("Daily analytics retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("species", speciesParam),
@@ -1071,7 +1071,7 @@ func (c *Controller) GetSpeciesDiversity(ctx echo.Context) error {
 		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
-	c.logInfoIfEnabled("Retrieving species diversity data",
+	c.LogInfoIfEnabled("Retrieving species diversity data",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("ip", ctx.RealIP()),
@@ -1122,7 +1122,7 @@ func (c *Controller) GetSpeciesDiversity(ctx echo.Context) error {
 	}
 	response.MaxDiversity = maxDiversity
 
-	c.logInfoIfEnabled("Species diversity data retrieved",
+	c.LogInfoIfEnabled("Species diversity data retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("data_points", len(response.Data)),
@@ -1208,7 +1208,7 @@ func (c *Controller) GetActivityHeatmap(ctx echo.Context) error {
 		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
-	c.logInfoIfEnabled("Retrieving activity heatmap",
+	c.LogInfoIfEnabled("Retrieving activity heatmap",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("species", speciesParam),
@@ -1243,7 +1243,7 @@ func (c *Controller) GetActivityHeatmap(ctx echo.Context) error {
 		return c.writeActivityHeatmapCSV(ctx, &data)
 	}
 
-	c.logInfoIfEnabled("Activity heatmap retrieved",
+	c.LogInfoIfEnabled("Activity heatmap retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("slot_resolution_minutes", data.SlotResolutionMinutes),
@@ -1384,7 +1384,7 @@ func (c *Controller) GetDawnChorusOnset(ctx echo.Context) error {
 		querySpecies = resolved
 	}
 
-	c.logInfoIfEnabled("Retrieving dawn chorus onset",
+	c.LogInfoIfEnabled("Retrieving dawn chorus onset",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("species", speciesParam),
@@ -1407,7 +1407,7 @@ func (c *Controller) GetDawnChorusOnset(ctx echo.Context) error {
 		)
 	}
 
-	c.logInfoIfEnabled("Dawn chorus onset retrieved",
+	c.LogInfoIfEnabled("Dawn chorus onset retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("day_count", len(data)),
@@ -1519,7 +1519,7 @@ func (c *Controller) GetAnalyticsSun(ctx echo.Context) error {
 
 	repDate := resolveSunRepresentativeDate(dateParam, startDate, endDate)
 
-	c.logInfoIfEnabled("Retrieving analytics sun times",
+	c.LogInfoIfEnabled("Retrieving analytics sun times",
 		logger.String("date", repDate),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -1549,7 +1549,7 @@ func (c *Controller) GetAnalyticsSun(ctx echo.Context) error {
 	if err != nil {
 		// Polar day/night: the sun never rises/sets, so there is no daytime arc to shade. Return
 		// available:false (not 500) so the client renders the bars without shading.
-		c.logInfoIfEnabled("Sun times unavailable for date (polar day/night)",
+		c.LogInfoIfEnabled("Sun times unavailable for date (polar day/night)",
 			logger.String("date", repDate),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -1576,7 +1576,7 @@ func (c *Controller) GetAnalyticsSun(ctx echo.Context) error {
 		resp.CivilDusk = &civilDusk
 	}
 
-	c.logInfoIfEnabled("Analytics sun times retrieved",
+	c.LogInfoIfEnabled("Analytics sun times retrieved",
 		logger.String("date", repDate),
 		logger.Bool("available", resp.Available),
 		logger.String("ip", ctx.RealIP()),
@@ -1629,7 +1629,7 @@ func serveTopNHourlyChart[T any](
 
 	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultLimit, maxLimit)
 
-	c.logInfoIfEnabled("Retrieving "+operation,
+	c.LogInfoIfEnabled("Retrieving "+operation,
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("limit", limit),
@@ -1652,7 +1652,7 @@ func serveTopNHourlyChart[T any](
 		)
 	}
 
-	c.logInfoIfEnabled(operation+" retrieved",
+	c.LogInfoIfEnabled(operation+" retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("species_count", len(data)),
@@ -1806,7 +1806,7 @@ func (c *Controller) GetConfidenceDistribution(ctx echo.Context) error {
 	bins := clampConfidenceBins(ctx.QueryParam("bins"))
 	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesRidgelineLimit, maxSpeciesRidgelineLimit)
 
-	c.logInfoIfEnabled("Retrieving confidence distribution",
+	c.LogInfoIfEnabled("Retrieving confidence distribution",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("species", speciesParam),
@@ -1831,7 +1831,7 @@ func (c *Controller) GetConfidenceDistribution(ctx echo.Context) error {
 		)
 	}
 
-	c.logInfoIfEnabled("Confidence distribution retrieved",
+	c.LogInfoIfEnabled("Confidence distribution retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("species_count", len(data)),
@@ -1899,7 +1899,7 @@ func (c *Controller) GetSpeciesAccumulation(ctx echo.Context) error {
 		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
-	c.logInfoIfEnabled("Retrieving species accumulation",
+	c.LogInfoIfEnabled("Retrieving species accumulation",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("ip", ctx.RealIP()),
@@ -1920,7 +1920,7 @@ func (c *Controller) GetSpeciesAccumulation(ctx echo.Context) error {
 		)
 	}
 
-	c.logInfoIfEnabled("Species accumulation retrieved",
+	c.LogInfoIfEnabled("Species accumulation retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("days", len(data)),
@@ -2016,7 +2016,7 @@ func (c *Controller) GetAnalyticsSources(ctx echo.Context) error {
 		}
 	}
 
-	c.logInfoIfEnabled("Retrieving analytics audio sources",
+	c.LogInfoIfEnabled("Retrieving analytics audio sources",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("ip", ctx.RealIP()),
@@ -2047,7 +2047,7 @@ func (c *Controller) GetAnalyticsSources(ctx echo.Context) error {
 		})
 	}
 
-	c.logInfoIfEnabled("Analytics audio sources retrieved",
+	c.LogInfoIfEnabled("Analytics audio sources retrieved",
 		logger.Int("count", len(resp.Sources)),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -2116,7 +2116,7 @@ func (c *Controller) GetYearOverYear(ctx echo.Context) error {
 		return err
 	}
 
-	c.logInfoIfEnabled("Retrieving year-over-year tracker",
+	c.LogInfoIfEnabled("Retrieving year-over-year tracker",
 		logger.String("date", date),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -2135,7 +2135,7 @@ func (c *Controller) GetYearOverYear(ctx echo.Context) error {
 		)
 	}
 
-	c.logInfoIfEnabled("Year-over-year retrieved",
+	c.LogInfoIfEnabled("Year-over-year retrieved",
 		logger.String("date", date),
 		logger.Int("current_year", data.CurrentYear),
 		logger.Int("days", len(data.Points)),
@@ -2209,7 +2209,7 @@ func (c *Controller) GetSpeciesPhenology(ctx echo.Context) error {
 
 	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesPhenologyLimit, maxSpeciesPhenologyLimit)
 
-	c.logInfoIfEnabled("Retrieving species phenology",
+	c.LogInfoIfEnabled("Retrieving species phenology",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("limit", limit),
@@ -2231,7 +2231,7 @@ func (c *Controller) GetSpeciesPhenology(ctx echo.Context) error {
 		)
 	}
 
-	c.logInfoIfEnabled("Species phenology retrieved",
+	c.LogInfoIfEnabled("Species phenology retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("species_count", len(data)),
@@ -2305,7 +2305,7 @@ func (c *Controller) GetNewSpeciesDetections(ctx echo.Context) error {
 	// Get query parameters with defaults (last 30 days)
 	startDate, endDate := getDefaultDateRange(ctx.QueryParam("start_date"), ctx.QueryParam("end_date"), -30, 0)
 
-	c.logInfoIfEnabled("Retrieving new species detections",
+	c.LogInfoIfEnabled("Retrieving new species detections",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.String("ip", ip),
@@ -2341,7 +2341,7 @@ func (c *Controller) GetNewSpeciesDetections(ctx echo.Context) error {
 	// Build response with thumbnails
 	response := c.convertNewSpeciesToResponse(newSpeciesData)
 
-	c.logInfoIfEnabled("New species detections retrieved",
+	c.LogInfoIfEnabled("New species detections retrieved",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("count", len(response)),
@@ -2550,7 +2550,7 @@ func (c *Controller) GetBatchHourlySpeciesData(ctx echo.Context) error {
 	}
 
 	minConfidence := c.parseOptionalFloat(ctx, "min_confidence", 0.0, PercentageMultiplier)
-	c.logInfoIfEnabled("Retrieving batch hourly species data",
+	c.LogInfoIfEnabled("Retrieving batch hourly species data",
 		logger.String("date", date),
 		logger.Int("species_count", len(speciesParams)),
 		logger.Float64("min_confidence", minConfidence),
@@ -2600,7 +2600,7 @@ func (c *Controller) processHourlyBatchSpecies(ctx echo.Context, speciesParams [
 
 	for _, speciesItem := range speciesParams {
 		if err := reqCtx.Err(); err != nil {
-			c.logDebugIfEnabled("Batch hourly species data: client canceled request",
+			c.LogDebugIfEnabled("Batch hourly species data: client canceled request",
 				logger.String("species", speciesItem),
 				logger.Error(err),
 				logger.String("ip", ip),
@@ -2677,7 +2677,7 @@ func (c *Controller) GetBatchDailySpeciesData(ctx echo.Context) error {
 		return err
 	}
 
-	c.logInfoIfEnabled("Retrieving batch daily species data",
+	c.LogInfoIfEnabled("Retrieving batch daily species data",
 		logger.String("start_date", startDate),
 		logger.String("end_date", endDate),
 		logger.Int("species_requested", len(speciesParams)),
@@ -2736,7 +2736,7 @@ func (c *Controller) processDailyBatchSpecies(ctx echo.Context, uniqueSpecies []
 
 	for _, speciesItem := range uniqueSpecies {
 		if err := reqCtx.Err(); err != nil {
-			c.logDebugIfEnabled("Batch daily species data: client canceled request",
+			c.LogDebugIfEnabled("Batch daily species data: client canceled request",
 				logger.String("species", speciesItem),
 				logger.Error(err),
 				logger.String("ip", ip),
@@ -2795,7 +2795,7 @@ func buildSpeciesDailyData(speciesName, startDate, endDate string, dailyData []d
 // handleBatchDailyResults logs and returns batch daily results
 func (c *Controller) handleBatchDailyResults(ctx echo.Context, results map[string]SpeciesDailyData, processingErrors []string, requestedCount, uniqueCount int, ip, path string) error {
 	if len(processingErrors) > 0 && len(results) > 0 {
-		c.logWarnIfEnabled("Batch daily species data completed with partial failures",
+		c.LogWarnIfEnabled("Batch daily species data completed with partial failures",
 			logger.Int("successful", len(results)),
 			logger.Int("failed", len(processingErrors)),
 			logger.Any("errors", processingErrors),
@@ -2805,7 +2805,7 @@ func (c *Controller) handleBatchDailyResults(ctx echo.Context, results map[strin
 	}
 
 	if len(results) == 0 {
-		c.logErrorIfEnabled("All species in batch daily request failed",
+		c.LogErrorIfEnabled("All species in batch daily request failed",
 			logger.Int("requested_species", requestedCount),
 			logger.Int("unique_species", uniqueCount),
 			logger.Any("errors", processingErrors),
@@ -2815,7 +2815,7 @@ func (c *Controller) handleBatchDailyResults(ctx echo.Context, results map[strin
 		return c.HandleError(ctx, fmt.Errorf("failed to process any requested species"), "Failed to process batch daily request", http.StatusInternalServerError)
 	}
 
-	c.logInfoIfEnabled("Batch daily species data retrieved",
+	c.LogInfoIfEnabled("Batch daily species data retrieved",
 		logger.Int("requested_species", requestedCount),
 		logger.Int("unique_species", uniqueCount),
 		logger.Int("successful_species", len(results)),

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	speciestracker "github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -629,11 +630,7 @@ func TestGetInvalidAnalyticsRequests(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			controller := &Controller{
-				DS:             mockDS,
-				BirdImageCache: mockImageCache,
-				// sunCalc and controlChan might be needed depending on handlers tested
-			}
+			controller := &Controller{Core: &apicore.Core{DS: mockDS, BirdImageCache: mockImageCache}}
 			controller.Settings.Store(appSettings)
 
 			e := echo.New()
@@ -789,10 +786,7 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 	})
 
 	// Create a controller with our mocks
-	controller := &Controller{
-		DS:             mockDS,
-		BirdImageCache: imageCache,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS, BirdImageCache: imageCache}}
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/analytics/species/daily?date=%s", testDate), http.NoBody)
@@ -934,7 +928,7 @@ func TestGetDailySpeciesSummary_LocalizedNonPrimarySpecies(t *testing.T) {
 			sciEurasianBlackbird: blackbirdHourly,
 		}, nil)
 
-	controller := &Controller{DS: mockDS}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS}}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date="+testDate, http.NoBody)
 	rec := httptest.NewRecorder()
@@ -1049,10 +1043,7 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 	imageCache := imageprovider.InitCache("test", mockImageProvider, NewTestMetrics(t), mockDS)
 
 	// Create a controller with our mocks
-	controller := &Controller{
-		DS:             mockDS,
-		BirdImageCache: imageCache,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS, BirdImageCache: imageCache}}
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07", http.NoBody)
@@ -1104,9 +1095,7 @@ func TestGetDailySpeciesSummary_EmptyResult(t *testing.T) {
 	// Expect GetBatchHourlyOccurrences not to be called since there are no birds
 
 	// Create a controller with our mock
-	controller := &Controller{
-		DS: mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS}}
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07", http.NoBody)
@@ -1188,9 +1177,7 @@ func TestGetDailySpeciesSummary_TimeHandling(t *testing.T) {
 	}, nil)
 
 	// Create a controller with our mock
-	controller := &Controller{
-		DS: mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS}}
 
 	// Create a request with the date we want to test
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07", http.NoBody)
@@ -1272,9 +1259,7 @@ func TestGetDailySpeciesSummary_ConfidenceFilter(t *testing.T) {
 	}, nil)
 
 	// Create a controller with our mock
-	controller := &Controller{
-		DS: mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS}}
 
 	// Test with a confidence threshold of "70"
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07&min_confidence=70", http.NoBody)
@@ -1358,9 +1343,7 @@ func TestGetDailySpeciesSummary_LimitParameter(t *testing.T) {
 	}, nil)
 
 	// Create a controller with our mock
-	controller := &Controller{
-		DS: mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS}}
 
 	// Create a request with a limit of 2
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/analytics/species/daily?date=2025-03-07&limit=2", http.NoBody)
@@ -1501,7 +1484,7 @@ func TestAnalytics_ResolvesLocalizedCommonNameToScientific(t *testing.T) {
 	t.Attr("feature", "localized-name-resolution")
 
 	e := echo.New()
-	c := &Controller{Group: e.Group("/api/v2")}
+	c := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2")}}
 	c.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
 		"Barbastella barbastellus": "mopsilepakko",
 	}})

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -2,50 +2,39 @@
 package api
 
 import (
-	"context"
-	"crypto/rand"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/patrickmn/go-cache"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/tphakala/birdnet-go/internal/alerting"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
-	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
-	"github.com/tphakala/birdnet-go/internal/ebird"
-	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
-	"github.com/tphakala/birdnet-go/internal/securefs"
 	"github.com/tphakala/birdnet-go/internal/spectrogram"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
-
-// Tunnel provider constant for unknown providers
-const tunnelProviderUnknown = "unknown"
 
 // apiV2Prefix is the base path prefix for all v2 API routes (the Echo group
 // prefix; see Controller.Group). It is the single source of truth used to
@@ -53,47 +42,31 @@ const tunnelProviderUnknown = "unknown"
 // allow-list in isPrivateModeExempt cannot drift from the registered routes.
 const apiV2Prefix = "/api/v2"
 
-// Controller manages the API routes and handlers
+// Controller manages the API routes and handlers. It embeds the shared
+// substrate *apicore.Core BY POINTER so every exported Core member (deps,
+// settings accessors, error/log helpers, shared middleware, SSE hub and
+// broadcasters) promotes onto *Controller and external callers keep working.
+// Core holds atomic/lock-bearing fields, so it MUST be embedded by pointer and
+// never copied by value; a single Core is constructed once in NewWithOptions
+// and shared by this pointer.
 type Controller struct {
-	Echo  *echo.Echo
-	Group *echo.Group
-	DS    datastore.Interface           // Deprecated: Use Repo for new detection operations
-	Repo  datastore.DetectionRepository // New: Preferred for detection CRUD operations
-	// Settings holds this controller's settings snapshot as a lock-free atomic
-	// pointer (copy-on-write). Update handlers publish a fresh *conf.Settings via
-	// Settings.Store under settingsMutex; every reader Loads it, directly or
-	// through the currentSettings()/controllerSettings() accessors. Storing it
-	// atomically (rather than as a plain *conf.Settings field) is what lets
-	// newErrorResponse read it from HandleError while UpdateSettings holds
-	// settingsMutex.Lock without deadlocking on a non-reentrant RLock. The sibling
-	// engine and audioWatchdog fields use the same atomic-pointer pattern.
-	Settings          atomic.Pointer[conf.Settings]
-	BirdImageCache    *imageprovider.BirdImageCache
-	SunCalc           *suncalc.SunCalc
-	Processor         *processor.Processor
-	EBirdClient       *ebird.Client
-	TaxonomyDB        *classifier.TaxonomyDatabase
-	controlChan       chan string
-	shutdownRequester ShutdownRequester // programmatic shutdown trigger (e.g., for restart)
-	shutdownMu        sync.RWMutex      // protects shutdownRequester
+	*apicore.Core
+
+	controlChan chan string
+
 	// DisableSaveSettings prevents persisting settings changes to disk.
 	// When set to true, all settings modifications remain in memory only.
 	// This is primarily used in testing but can be used in production for read-only mode.
 	// Thread-safe: should be set before controller initialization.
-	DisableSaveSettings  bool         // disables disk persistence of settings
-	isGlobalOwner        bool         // true when this controller owns the global settings singleton
-	settingsMutex        sync.RWMutex // Serializes the read-modify-write in settings update handlers; reads are lock-free via the atomic Settings pointer
-	detectionCache       *cache.Cache // Cache for detection queries
+	DisableSaveSettings bool         // disables disk persistence of settings
+	isGlobalOwner       bool         // true when this controller owns the global settings singleton
+	settingsMutex       sync.RWMutex // Serializes the read-modify-write in settings update handlers; reads are lock-free via the atomic Settings pointer
+
 	startTime            *time.Time
-	SFS                  *securefs.SecureFS     // Add SecureFS instance
-	apiLogger            logger.Logger          // Structured logger for API operations
-	securityLogger       logger.Logger          // Logger scoped to the "security" module for authentication events
-	metrics              *observability.Metrics // Shared metrics instance
 	spectrogramGenerator *spectrogram.Generator // Shared spectrogram generator (initialized after SFS)
 
-	// Auth related fields (injected from server via functional options)
-	authService    auth.Service        // Authentication service (injected from server)
-	authMiddleware echo.MiddlewareFunc // Authentication middleware function (injected from server)
+	// authService is the authentication service injected from server.
+	authService auth.Service
 
 	// notificationService is the notification service this controller uses. It is
 	// nil in production, where getNotificationService() falls back to the
@@ -101,51 +74,6 @@ type Controller struct {
 	// isolated per-test instance via WithNotificationService so each test gets its
 	// own config and store without touching the global singleton.
 	notificationService *notification.Service
-
-	// Metrics history store for sparkline data
-	metricsStore observability.MetricsStore
-
-	// Detection rate cache for database overview endpoint
-	detectionRateCache *datastore.DetectionRateCache
-
-	// SSE related fields
-	sseManager *SSEManager // Manager for Server-Sent Events connections
-
-	// Cleanup related fields
-	ctx    context.Context    // Context for managing goroutines
-	cancel context.CancelFunc // Cancel function for graceful shutdown
-
-	// Goroutine lifecycle management
-	wg sync.WaitGroup // tracks background goroutines for clean shutdown
-
-	// Audio level channel for SSE streaming
-	// TODO: Consider moving to a dedicated audio manager
-	audioLevelChan chan audiocore.AudioLevelData
-
-	// engine provides access to the unified audio subsystem (sources, buffers, routing).
-	// Stored atomically: written once via WithAudioEngine after Controller init,
-	// read concurrently by HTTP handlers.
-	engine atomic.Pointer[engine.AudioEngine]
-
-	// V2Manager provides access to the v2 normalized database for stats and backup
-	V2Manager datastoreV2.Manager
-
-	// Application metadata repository (initialized lazily in initAppRoutes)
-	appMetadataRepo repository.AppMetadataRepository
-
-	// Alerting fields (initialized lazily in initAlertRoutes)
-	alertRuleRepo repository.AlertRuleRepository
-	alertEngine   *alerting.Engine
-
-	// Insights fields (initialized lazily in initInsightsRoutes)
-	insightsRepo repository.InsightsRepository
-	nameMaps     atomic.Value // stores *nameMaps; see internal/api/v2/insights.go
-	// nameResolver is the authoritative localized name source shared with the
-	// classifier orchestrator. Overrides label-derived names in the cached maps.
-	nameResolver atomic.Pointer[datastore.SpeciesNameResolver]
-
-	// Model gallery fields
-	ModelManager *classifier.ModelManager
 
 	// Audio processing fields
 	processingCache     *processingCache
@@ -164,18 +92,6 @@ type Controller struct {
 	// This is primarily used in testing to ensure proper setup before assertions.
 	// Only created when routes are initialized (production mode or specific tests).
 	goroutinesStarted chan struct{} // signals when all background goroutines have started (nil if routes not initialized)
-
-	// audioWatchdog provides liveness state for audio health endpoints.
-	// Stored atomically because it is set during pipeline Start() and read
-	// concurrently by HTTP handlers.
-	audioWatchdog atomic.Pointer[audiocore.LivenessWatchdog]
-
-	// Health check infrastructure for the diagnostics endpoints.
-	healthRegistry     *health.Registry
-	healthReports      *health.ReportStore
-	healthErrors       *health.ErrorRingBuffer
-	healthMetricsStore *observability.HealthMetricsStore
-	healthEvents       *observability.HealthEventBuffer
 
 	// sourceRestarter restarts a single audio source by ID. Set during
 	// pipeline Start() and called by the restart-source control endpoint.
@@ -209,49 +125,39 @@ type Controller struct {
 	// uses audioWaitTimeout. Tests set a short timeout to exercise the
 	// 503-after-timeout path without waiting the full default.
 	audioWaitTimeoutOverride time.Duration
+
+	// Audio level channel for SSE streaming
+	// TODO: Consider moving to a dedicated audio manager
+	audioLevelChan chan audiocore.AudioLevelData
+
+	// Application metadata repository (initialized lazily in initAppRoutes)
+	appMetadataRepo repository.AppMetadataRepository
+
+	// Alerting fields (initialized lazily in initAlertRoutes)
+	alertRuleRepo repository.AlertRuleRepository
+	alertEngine   *alerting.Engine
+
+	// Insights fields (initialized lazily in initInsightsRoutes)
+	insightsRepo repository.InsightsRepository
+	nameMaps     atomic.Value // stores *nameMaps; see internal/api/v2/insights.go
+	// nameResolver is the authoritative localized name source shared with the
+	// classifier orchestrator. Overrides label-derived names in the cached maps.
+	nameResolver atomic.Pointer[datastore.SpeciesNameResolver]
+
+	// Health check infrastructure for the diagnostics endpoints (initialized lazily
+	// in initDiagnosticsRoutes; healthErrors may be injected via WithHealthErrorBuffer).
+	// These stay on the facade: the diagnostics and metrics-history handlers own
+	// them, and HealthMetricsStore()/HealthEventBuffer() expose them to the analysis
+	// pipeline as exported accessor methods (which would collide with exported fields).
+	healthRegistry     *health.Registry
+	healthReports      *health.ReportStore
+	healthErrors       *health.ErrorRingBuffer
+	healthMetricsStore *observability.HealthMetricsStore
+	healthEvents       *observability.HealthEventBuffer
 }
 
 // SourceRestarterFunc restarts a single audio source identified by sourceID.
 type SourceRestarterFunc func(sourceID string) error
-
-// ShutdownRequester allows triggering a programmatic shutdown.
-type ShutdownRequester interface {
-	RequestShutdown()
-}
-
-// currentSettings returns the latest settings snapshot so UI changes
-// take effect in API responses without restarting the service.
-//
-// It resolves the lock-free global atomic snapshot first and only falls back
-// to this controller's own snapshot when no global snapshot has been published
-// (standalone unit-test controllers). Both reads are lock-free (the per-controller
-// fallback is an atomic Load), so the accessor is race-free against the
-// Settings.Store the update handlers perform under c.settingsMutex.
-func (c *Controller) currentSettings() *conf.Settings {
-	if latest := conf.GetSettings(); latest != nil {
-		return latest
-	}
-	return c.Settings.Load()
-}
-
-// controllerSettings returns this controller's own settings snapshot, read
-// lock-free from the atomic Settings pointer that the update handlers publish on
-// every save. Unlike currentSettings(), it deliberately does NOT consult the
-// process-global atomic snapshot: use it for reads whose result is asserted
-// per-controller (e.g. debug-gated response verbosity), where the shared global
-// snapshot would couple otherwise-independent parallel tests.
-//
-// Loading the atomic pointer (rather than reading a plain field under
-// settingsMutex.RLock) is what makes this safe to call from newErrorResponse,
-// which is reached from HandleError while UpdateSettings already holds
-// settingsMutex.Lock: a non-reentrant RLock there would deadlock. The snapshot is
-// published under that same write lock, so the read sees a consistent value. The
-// returned snapshot is immutable (copy-on-write), so callers may dereference its
-// fields freely. Returns nil only on a controller that never stored settings
-// (standalone tests); callers that may hit that path nil-check or fall back.
-func (c *Controller) controllerSettings() *conf.Settings {
-	return c.Settings.Load()
-}
 
 // Option is a functional option for configuring the Controller.
 type Option func(*Controller)
@@ -259,7 +165,7 @@ type Option func(*Controller)
 // WithAuthMiddleware sets the authentication middleware for the controller.
 func WithAuthMiddleware(mw echo.MiddlewareFunc) Option {
 	return func(c *Controller) {
-		c.authMiddleware = mw
+		c.AuthMiddleware = mw
 	}
 }
 
@@ -284,7 +190,7 @@ func WithNotificationService(svc *notification.Service) Option {
 // This enables the metrics history and streaming endpoints.
 func WithMetricsStore(store observability.MetricsStore) Option {
 	return func(c *Controller) {
-		c.metricsStore = store
+		c.MetricsStore = store
 	}
 }
 
@@ -299,7 +205,7 @@ func WithV2Manager(mgr datastoreV2.Manager) Option {
 // WithAudioEngine sets the AudioEngine for audio subsystem access.
 func WithAudioEngine(e *engine.AudioEngine) Option {
 	return func(c *Controller) {
-		c.engine.Store(e)
+		c.Engine.Store(e)
 	}
 }
 
@@ -308,7 +214,7 @@ func WithModelManager(mm *classifier.ModelManager) Option {
 	return func(c *Controller) {
 		c.ModelManager = mm
 		// Wire the topology-changed callback so model add/remove broadcasts over
-		// the metrics SSE stream. The method value binds c; c.metricsStore is read
+		// the metrics SSE stream. The method value binds c; c.MetricsStore is read
 		// lazily at call time, so option ordering is irrelevant.
 		mm.SetTopologyChangedCallback(c.BroadcastInferenceTopologyChanged)
 	}
@@ -320,59 +226,6 @@ func WithModelManager(mm *classifier.ModelManager) Option {
 func WithHealthErrorBuffer(buf *health.ErrorRingBuffer) Option {
 	return func(c *Controller) {
 		c.healthErrors = buf
-	}
-}
-
-// parseIPFromHeader attempts to parse a valid IP from a header value.
-// Returns the IP string if valid, empty string otherwise.
-func parseIPFromHeader(headerValue string) string {
-	if headerValue == "" {
-		return ""
-	}
-	// Strip IPv6 zone ID (e.g., %wlan0) before parsing.
-	// net.ParseIP does not handle zone identifiers, and iOS Safari
-	// commonly connects via IPv6 link-local addresses with zone IDs.
-	if before, _, found := strings.Cut(headerValue, "%"); found {
-		headerValue = before
-	}
-	ip := net.ParseIP(headerValue)
-	if ip != nil {
-		return ip.String()
-	}
-	return ""
-}
-
-// TunnelDetectionMiddleware inspects headers to determine if the request is likely proxied
-// and sets context values for logging.
-func (c *Controller) TunnelDetectionMiddleware() echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(ctx echo.Context) error {
-			req := ctx.Request()
-			tunneled := false
-			provider := tunnelProviderUnknown
-
-			// Only classify the request as tunneled when the IP extractor actually
-			// honored a forwarded header, i.e. the resolved client IP differs from
-			// the immediate connection peer. That happens only for a trusted proxy,
-			// so a directly-connected client cannot spoof a "tunneled" label by
-			// sending forwarded headers from an untrusted address.
-			if peerIP, _ := peerAddrFromRequest(req); peerIP != nil && peerIP.String() != ctx.RealIP() {
-				switch {
-				case req.Header.Get(headerCFConnectingIP) != "":
-					tunneled = true
-					provider = "cloudflare"
-				case req.Header.Get(echo.HeaderXForwardedFor) != "" || req.Header.Get(echo.HeaderXRealIP) != "":
-					// Other proxy headers present: tunneled, but provider is generic.
-					tunneled = true
-					provider = "generic"
-				}
-			}
-
-			ctx.Set("is_tunneled", tunneled)
-			ctx.Set("tunnel_provider", provider)
-
-			return next(ctx)
-		}
 	}
 }
 
@@ -400,56 +253,6 @@ func New(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
 	return c, nil
 }
 
-// resolveAndValidateMediaPath resolves a potentially relative media path and ensures it exists as a directory.
-// Returns the absolute path and any error encountered.
-func resolveAndValidateMediaPath(configPath string) (string, error) {
-	mediaPath := configPath
-	if mediaPath == "" {
-		mediaPath = defaultExportPath
-		GetLogger().Warn("Audio export path is empty, using default",
-			logger.String("default_path", defaultExportPath),
-		)
-	}
-
-	// Resolve relative path to absolute based on working directory
-	if !filepath.IsAbs(mediaPath) {
-		workDir, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("failed to get working directory to resolve relative media path: %w", err)
-		}
-		mediaPath = filepath.Join(workDir, mediaPath)
-		GetLogger().Debug("Resolved relative media export path",
-			logger.String("config_path", configPath),
-			logger.String("absolute_path", mediaPath),
-		)
-	}
-
-	// Ensure directory exists, creating if necessary
-	if err := ensureDirectoryExists(mediaPath); err != nil {
-		return "", err
-	}
-
-	return mediaPath, nil
-}
-
-// ensureDirectoryExists checks that a path exists and is a directory, creating it if needed.
-func ensureDirectoryExists(path string) error {
-	fi, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		if err := os.MkdirAll(path, FilePermExecutable); err != nil {
-			return fmt.Errorf("failed to create directory %q: %w", path, err)
-		}
-		fi, err = os.Stat(path)
-	}
-	if err != nil {
-		return fmt.Errorf("error checking path %q: %w", path, err)
-	}
-	if !fi.IsDir() {
-		return fmt.Errorf("path is not a directory: %q", path)
-	}
-	return nil
-}
-
 // NewWithOptions creates a new API controller with optional route initialization.
 // Set initializeRoutes to false for testing to avoid starting background goroutines.
 func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
@@ -457,76 +260,34 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	controlChan chan string,
 	metrics *observability.Metrics, initializeRoutes bool, opts ...Option) (*Controller, error) {
 
-	// Validate and resolve media export path
-	mediaPath, err := resolveAndValidateMediaPath(settings.Realtime.Audio.Export.Path)
+	// Build the shared core (SecureFS, lifecycle context, IP extractor, loggers,
+	// taxonomy, eBird client, SSE manager). The PrivateMode exempt allow-list is
+	// supplied by the facade so it stays colocated with the domain route-path
+	// constants.
+	core, err := apicore.NewCore(e, ds, settings, birdImageCache, sunCalc, metrics, isPrivateModeExempt)
 	if err != nil {
 		return nil, err
 	}
 
-	sfs, err := securefs.New(mediaPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize secure filesystem for media: %w", err)
-	}
-
-	// Create context for managing goroutines
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Only create DetectionRepository if datastore is available.
-	// This prevents nil pointer dereference when datastore is disabled.
-	var repo datastore.DetectionRepository
-	if ds != nil {
-		repo = datastore.NewDetectionRepository(ds, nil)
-	}
-
 	c := &Controller{
-		Echo:                 e,
-		DS:                   ds,
-		Repo:                 repo, // Bridge to new domain model (nil if datastore disabled)
-		isGlobalOwner:        settings == conf.GetSettings(),
-		BirdImageCache:       birdImageCache,
-		SunCalc:              sunCalc,
-		controlChan:          controlChan,
-		detectionCache:       cache.New(detectionCacheExpiry, detectionCacheCleanup),
-		SFS:                  sfs, // Assign SecureFS instance
-		metrics:              metrics,
-		ctx:                  ctx,
-		cancel:               cancel,
-		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()),
-		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
-		importMgr:            newImportManager(),
+		Core:          core,
+		controlChan:   controlChan,
+		isGlobalOwner: settings == conf.GetSettings(),
+		importMgr:     newImportManager(),
 	}
-	// Publish the initial settings snapshot so controllerSettings() reads it
-	// lock-free. Every save republishes via Settings.Store; see the Settings
-	// field doc and the settings update handlers.
-	c.Settings.Store(settings)
-
-	// Configure the trusted-proxy-gated IP extractor. Forwarded client-IP headers
-	// (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) are honored only when the
-	// connection peer is a trusted proxy (loopback/link-local/private by default,
-	// plus Security.TrustedProxies); otherwise the real peer address is used. It
-	// reads this controller's own settings snapshot per request (published above
-	// and on every save), so it honors the controller's TrustedProxies and
-	// hot-reloads without a restart.
-	e.IPExtractor = newTrustedProxyIPExtractor(c.controllerSettings)
-	GetLogger().Info("Configured trusted-proxy-gated IP extractor (forwarded client IP honored only from trusted proxies)")
-
-	// Propagate the derived FFprobe path from config validation to the
-	// ffmpeg package so executeFFprobe can find it without PATH lookup.
-	// Always set (even if empty) so repeated controller inits clear stale state.
-	ffmpeg.SetFFprobePath(settings.Realtime.Audio.FfprobePath)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
 	c.processingCache = newProcessingCache(cacheDir, processingCacheMaxFiles)
 	c.processingSemaphore = make(chan struct{}, 2)
 
-	// Start cache cleanup goroutine
-	c.wg.Go(func() {
+	// Start cache cleanup goroutine (tracked by the core wait group)
+	c.Go(func() {
 		ticker := time.NewTicker(processingCacheTickerInterval)
 		defer ticker.Stop()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-c.Context().Done():
 				return
 			case <-ticker.C:
 				c.processingCache.cleanExpired()
@@ -534,32 +295,8 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		}
 	})
 
-	// Initialize structured logger for API requests
-	c.apiLogger = logger.Global().Module("api")
-
-	// Authentication events (form login/logout, OAuth callback) log to the
-	// "security" module so they are co-located with the OAuth and provider-init
-	// logging, where admins look when debugging auth.
-	c.securityLogger = logger.Global().Module("security")
-
-	// Load local taxonomy database for fast species lookups
-	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
-	if err != nil {
-		c.logWarnIfEnabled("Failed to load taxonomy database", logger.Error(err))
-		c.logWarnIfEnabled("Species taxonomy lookups will fall back to eBird API")
-		// Continue without taxonomy database - eBird API fallback will be used
-		c.TaxonomyDB = nil
-	} else {
-		c.TaxonomyDB = taxonomyDB
-		stats := taxonomyDB.Stats()
-		c.logInfoIfEnabled("Loaded taxonomy database",
-			logger.Any("genus_count", stats["genus_count"]),
-			logger.Any("family_count", stats["family_count"]),
-			logger.Any("species_count", stats["species_count"]),
-			logger.String("version", taxonomyDB.Version),
-			logger.String("updated_at", taxonomyDB.UpdatedAt),
-		)
-	}
+	// Spectrogram generator (needs the media SecureFS)
+	c.spectrogramGenerator = spectrogram.NewGenerator(settings, c.SFS, getSpectrogramLogger())
 
 	// Apply functional options (auth middleware and service injected from server)
 	for _, opt := range opts {
@@ -568,7 +305,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 
 	// Log auth configuration status
 	log := GetLogger()
-	if c.authMiddleware != nil {
+	if c.AuthMiddleware != nil {
 		log.Info("Auth middleware configured via functional options")
 	} else {
 		log.Warn("Auth middleware not configured")
@@ -577,7 +314,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Create v2 API group
 	c.Group = e.Group(apiV2Prefix)
 
-	// Configure middlewares
+	// Configure middlewares (applied once, in this order)
 	c.Group.Use(middleware.Recover())          // Recover should be early
 	c.Group.Use(c.TunnelDetectionMiddleware()) // Add tunnel detection **before** logging
 	// c.Group.Use(middleware.Logger())        // Removed: Use custom LoggingMiddleware below for structured logging
@@ -585,7 +322,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Removing duplicate CORS here to avoid conflicts with global CORS configuration
 	c.Group.Use(middleware.BodyLimit("1M")) // Limit request body to 1MB to prevent DoS attacks
 	c.Group.Use(c.LoggingMiddleware())      // Use custom structured logging middleware
-	c.Group.Use(c.privateModeAuth)          // Gate all API endpoints behind auth when PrivateMode is enabled
+	c.Group.Use(c.PrivateModeAuth)          // Gate all API endpoints behind auth when PrivateMode is enabled
 
 	// NOTE: CSRF token is provided by the /app/config endpoint using middleware.EnsureCSRFToken()
 	// which handles Echo v4.15.0's Sec-Fetch-Site optimization that may skip token generation
@@ -594,39 +331,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Initialize start time for uptime tracking
 	now := time.Now()
 	c.startTime = &now
-
-	// Initialize SSE manager
-	c.sseManager = NewSSEManager()
-
-	// Initialize eBird client if enabled
-	if settings.Realtime.EBird.Enabled {
-		if settings.Realtime.EBird.APIKey == "" {
-			// Create notification for missing API key
-			// The Build() method automatically publishes to the event bus for notifications
-			_ = errors.Newf("eBird integration enabled but API key not configured").
-				Category(errors.CategoryConfiguration).
-				Context("setting", "realtime.ebird.apikey").
-				Component("ebird").
-				Build()
-			log.Warn("eBird integration enabled but API key not configured")
-		} else {
-			ebirdConfig := ebird.Config{
-				APIKey:   settings.Realtime.EBird.APIKey,
-				CacheTTL: time.Duration(settings.Realtime.EBird.CacheTTL) * time.Hour,
-			}
-			ebirdClient, err := ebird.NewClient(ebirdConfig)
-			if err != nil {
-				// Initialization error - already enhanced by ebird.NewClient
-				log.Warn("Failed to initialize eBird client", logger.Error(err))
-				// Continue without eBird client - it's not critical
-			} else {
-				c.EBirdClient = ebirdClient
-				log.Info("Initialized eBird API client")
-			}
-		}
-	} else {
-		log.Debug("eBird integration disabled")
-	}
 
 	// Initialize routes if requested (skip in tests to avoid starting background goroutines)
 	if initializeRoutes {
@@ -638,69 +342,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	}
 
 	return c, nil // Return controller and nil error
-}
-
-// LoggingMiddleware creates a middleware function that logs API requests
-func (c *Controller) LoggingMiddleware() echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(ctx echo.Context) error {
-			start := time.Now()
-
-			// Process the request
-			err := next(ctx)
-
-			// Skip logging if apiLogger is not initialized
-			if c.apiLogger == nil {
-				return err
-			}
-
-			// Extract request information
-			req := ctx.Request()
-			res := ctx.Response()
-
-			// Determine the actual status code. When a handler returns an
-			// *echo.HTTPError, Echo's centralized error handler has not yet
-			// executed at this point in the middleware chain, so res.Status
-			// is still the default 200. Extract the real code from the error.
-			status := res.Status
-			if err != nil {
-				var he *echo.HTTPError
-				if errors.As(err, &he) {
-					status = he.Code
-				} else if status < http.StatusBadRequest {
-					// Non-HTTP errors (e.g. database errors) won't have a
-					// status set yet; Echo's error handler runs after this
-					// middleware. Default to 500 to avoid logging failures
-					// as successes.
-					status = http.StatusInternalServerError
-				}
-			}
-
-			// Get tunnel info from context
-			isTunneled, _ := ctx.Get("is_tunneled").(bool)
-			tunnelProvider, _ := ctx.Get("tunnel_provider").(string)
-
-			// Log the request with structured data
-			fields := []logger.Field{
-				logger.String("method", req.Method),
-				logger.String("path", req.URL.Path),
-				logger.String("query", req.URL.RawQuery),
-				logger.Int("status", status),
-				logger.String("ip", ctx.RealIP()), // Uses custom extractor
-				logger.Bool("tunneled", isTunneled),
-				logger.String("tunnel_provider", tunnelProvider),
-				logger.String("user_agent", req.UserAgent()),
-				logger.Int64("latency_ms", time.Since(start).Milliseconds()),
-			}
-			if err != nil {
-				fields = append(fields, logger.Error(err))
-			}
-
-			c.apiLogger.Info("API Request", fields...)
-
-			return err
-		}
-	}
 }
 
 // initRoutes registers all API endpoints
@@ -774,38 +415,13 @@ func (c *Controller) initRoutes() {
 	}
 }
 
-// errDatastoreUnavailable is returned by DS-dependent handlers when the controller was
-// constructed without a datastore. NewWithOptions permits a nil datastore ("datastore
-// disabled" mode) and initRoutes skips registering the detection and media route groups
-// in that mode; requireDatastore is defense in depth for any such handler reached anyway.
-var errDatastoreUnavailable = errors.NewStd("datastore is not available")
-
-// requireDatastore writes a 503 Service Unavailable response and returns the non-nil
-// errDatastoreUnavailable when the controller has no datastore, so handlers can guard with:
-//
-//	if err := c.requireDatastore(ctx); err != nil {
-//	    return err
-//	}
-//
-// It returns the sentinel (not HandleError's nil) so the guard actually short-circuits the
-// caller; the 503 body is already written, so echo's error handler skips the committed
-// response. This honors the constructor's advertised "datastore disabled" mode instead of
-// letting a nil c.DS dereference panic.
-func (c *Controller) requireDatastore(ctx echo.Context) error {
-	if c.DS == nil {
-		_ = c.HandleError(ctx, errDatastoreUnavailable, "Datastore is not available", http.StatusServiceUnavailable)
-		return errDatastoreUnavailable
-	}
-	return nil
-}
-
 // HealthCheck handles the API health check endpoint
 func (c *Controller) HealthCheck(ctx echo.Context) error {
 	// Read version/build/debug from this controller's own snapshot (nil-safe for
 	// standalone test controllers).
 	var version, buildDate string
 	debug := false
-	if settings := c.controllerSettings(); settings != nil {
+	if settings := c.ControllerSettings(); settings != nil {
 		version = settings.Version
 		buildDate = settings.BuildDate
 		debug = settings.WebServer.Debug
@@ -903,8 +519,8 @@ func (c *Controller) Shutdown() {
 	// Close all SSE clients first so echo.Shutdown() has no active
 	// connections to wait for. SSE handlers block on request context
 	// which only closes when echo shuts down, creating a circular wait.
-	if c.sseManager != nil {
-		c.sseManager.CloseAllClients()
+	if c.SSEManager != nil {
+		c.SSEManager.CloseAllClients()
 	}
 
 	// Stop alerting engine background goroutines and event bus
@@ -915,13 +531,9 @@ func (c *Controller) Shutdown() {
 		bus.Stop()
 	}
 
-	// Cancel context to stop all goroutines
-	if c.cancel != nil {
-		c.cancel()
-	}
-
-	// Wait for all goroutines to finish
-	c.wg.Wait()
+	// Cancel context to stop all goroutines, then wait for them to finish.
+	c.Cancel()
+	c.Wait()
 
 	// Release the media SecureFS sandbox handle (an open os.Root): otherwise it
 	// leaks across controller restarts, and on Windows the open directory handle
@@ -952,183 +564,11 @@ func (c *Controller) Shutdown() {
 
 	// TODO: The go-cache library's janitor goroutine cannot be stopped.
 	// Consider migrating to a context-aware cache implementation.
-	if c.detectionCache != nil {
-		c.detectionCache.Flush()
+	if c.DetectionCache != nil {
+		c.DetectionCache.Flush()
 	}
 
 	c.Debug("API Controller shutdown complete")
-}
-
-// SetShutdownRequester sets the shutdown requester for programmatic restart.
-// Thread-safe: may be called after the HTTP server starts accepting requests.
-func (c *Controller) SetShutdownRequester(sr ShutdownRequester) {
-	c.shutdownMu.Lock()
-	defer c.shutdownMu.Unlock()
-	c.shutdownRequester = sr
-}
-
-// getShutdownRequester returns the current shutdown requester, or nil.
-func (c *Controller) getShutdownRequester() ShutdownRequester {
-	c.shutdownMu.RLock()
-	defer c.shutdownMu.RUnlock()
-	return c.shutdownRequester
-}
-
-// Error response structure
-type ErrorResponse struct {
-	Error         string         `json:"error"`
-	Message       string         `json:"message"`
-	Code          int            `json:"code"`
-	CorrelationID string         `json:"correlation_id"`         // Unique identifier for tracking this error
-	ErrorKey      string         `json:"error_key,omitempty"`    // i18n translation key for frontend
-	ErrorParams   map[string]any `json:"error_params,omitempty"` // Interpolation parameters for error_key
-}
-
-// newErrorResponse creates a new API error response using the controller's
-// injected settings to decide whether to expose raw error details.
-func (c *Controller) newErrorResponse(err error, message string, code int) *ErrorResponse {
-	// Generate a random correlation ID (8 characters should be sufficient)
-	correlationID := generateCorrelationID()
-
-	// Only expose raw err.Error() in debug mode: it can contain internal
-	// paths, SQL errors, stack traces, etc. In production, use the
-	// sanitized message parameter instead.
-	var errorStr string
-	// Read the controller's own debug flag via the lock-free atomic Settings pointer: this
-	// is reached from HandleError while UpdateSettings holds c.settingsMutex, so
-	// it must not acquire the lock (a non-reentrant RLock would deadlock), and the
-	// flag must remain per-controller (handlers assert debug-gated error verbosity
-	// per controller, not via the shared global snapshot). controllerSettings()
-	// reads the per-controller snapshot published under that same write lock, so
-	// the read is race-free. See controllerSettings.
-	settings := c.controllerSettings()
-	if err != nil && settings != nil && settings.WebServer.Debug {
-		errorStr = err.Error()
-	} else {
-		errorStr = message
-	}
-
-	return &ErrorResponse{
-		Error:         errorStr,
-		Message:       message,
-		Code:          code,
-		CorrelationID: correlationID,
-	}
-}
-
-// generateCorrelationID creates a unique identifier for error tracking using cryptographic randomness
-// for better security and uniqueness guarantees across all platforms
-func generateCorrelationID() string {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	const length = 8
-
-	b := make([]byte, length)
-	if _, err := rand.Read(b); err != nil {
-		// Fall back to a default ID if crypto/rand fails
-		return "ERR-RAND"
-	}
-
-	// Map the random bytes to charset characters
-	for i := range b {
-		b[i] = charset[int(b[i])%len(charset)]
-	}
-	return string(b)
-}
-
-// handleErrorInternal is the shared implementation for HandleError and HandleErrorWithKey.
-func (c *Controller) handleErrorInternal(ctx echo.Context, err error, message string, code int, errorKey string, errorParams map[string]any) error {
-	errorResp := c.newErrorResponse(err, message, code)
-	errorResp.ErrorKey = errorKey
-	errorResp.ErrorParams = errorParams
-
-	// Determine IP to log using the request context
-	ip := ctx.RealIP()
-
-	// Get tunnel info from context
-	isTunneled, _ := ctx.Get("is_tunneled").(bool)
-	tunnelProvider, _ := ctx.Get("tunnel_provider").(string)
-
-	// Build error string for logging
-	var errorStr string
-	if err != nil {
-		errorStr = err.Error()
-	} else {
-		errorStr = message
-	}
-
-	// Build log fields
-	fields := []logger.Field{
-		logger.String("correlation_id", errorResp.CorrelationID),
-		logger.String("message", message),
-		logger.String("error", errorStr),
-		logger.Int("code", code),
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("method", ctx.Request().Method),
-		logger.String("ip", ip),
-		logger.Bool("tunneled", isTunneled),
-		logger.String("tunnel_provider", tunnelProvider),
-	}
-	if errorKey != "" {
-		fields = append(fields, logger.String("error_key", errorKey))
-	}
-
-	c.logErrorIfEnabled("API Error", fields...)
-
-	// Report server-side errors (5xx) to Sentry telemetry.
-	// 4xx errors are client mistakes (bad input, not found), not bugs, and are excluded.
-	if code >= http.StatusInternalServerError {
-		c.reportErrorToTelemetry(ctx, err, message, code)
-	}
-
-	return ctx.JSON(code, errorResp)
-}
-
-// reportErrorToTelemetry reports server-side errors (5xx) to Sentry telemetry.
-// Errors already reported by lower layers (e.g., datastore) are skipped to avoid
-// duplicate Sentry events. Privacy scrubbing and opt-in checks are handled by the
-// internal/errors and internal/telemetry packages.
-func (c *Controller) reportErrorToTelemetry(ctx echo.Context, err error, message string, code int) {
-	// Skip if the underlying error was already reported by a lower layer.
-	if err != nil {
-		var ee *errors.EnhancedError
-		if errors.As(err, &ee) && ee.IsReported() {
-			return
-		}
-	}
-
-	// Client disconnects and request timeouts are not server bugs.
-	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-		return
-	}
-
-	path := ctx.Request().URL.Path
-	method := ctx.Request().Method
-
-	var builder *errors.ErrorBuilder
-	if err != nil {
-		builder = errors.New(err)
-	} else {
-		builder = errors.Newf("%s", message)
-	}
-
-	_ = builder.
-		Component("api").
-		Category(errors.CategoryHTTP).
-		Context("http_status", code).
-		Context("endpoint", path).
-		Context("method", method).
-		Build()
-}
-
-// HandleError constructs and returns an appropriate error response
-func (c *Controller) HandleError(ctx echo.Context, err error, message string, code int) error {
-	return c.handleErrorInternal(ctx, err, message, code, "", nil)
-}
-
-// HandleErrorWithKey constructs and returns an error response with an i18n translation key.
-// The errorKey and errorParams allow the frontend to display translated error messages.
-func (c *Controller) HandleErrorWithKey(ctx echo.Context, err error, message string, code int, errorKey string, errorParams map[string]any) error {
-	return c.handleErrorInternal(ctx, err, message, code, errorKey, errorParams)
 }
 
 // HandleErrorForTest constructs and returns an echo.HTTPError for testing purposes
@@ -1140,61 +580,6 @@ func (c *Controller) HandleErrorForTest(ctx echo.Context, err error, message str
 		fullMessage = fmt.Sprintf("%s: %v", message, err)
 	}
 	return echo.NewHTTPError(code, fullMessage)
-}
-
-// Debug logs debug messages when debug mode is enabled.
-//
-// Reads the debug flag from the process-global snapshot via conf.GetSettings()
-// (a lock-free atomic.Load), so process-wide debug logging follows the latest
-// published global settings. Returns silently when the global snapshot has not
-// been set (e.g. in unit tests with a standalone Controller); the per-controller
-// c.Settings snapshot is deliberately not consulted here.
-func (c *Controller) Debug(format string, v ...any) {
-	settings := conf.GetSettings()
-	if settings == nil {
-		// Skip debug logging when the global snapshot hasn't been set
-		// (e.g. in unit tests with a standalone Controller).
-		return
-	}
-	if settings.WebServer.Debug {
-		msg := fmt.Sprintf(format, v...)
-		c.logDebugIfEnabled(msg)
-	}
-}
-
-// logAPIRequest is a helper to log API requests with common context fields.
-func (c *Controller) logAPIRequest(ctx echo.Context, level logger.LogLevel, msg string, fields ...logger.Field) {
-	if c.apiLogger == nil {
-		return // Do nothing if logger isn't initialized
-	}
-
-	// Extract common context info
-	ip := ctx.RealIP()
-	path := ctx.Request().URL.Path
-
-	// Create base fields with preallocated capacity
-	baseFields := make([]logger.Field, 0, 2+len(fields))
-	baseFields = append(baseFields,
-		logger.String("path", path),
-		logger.String("ip", ip),
-	)
-
-	// Append specific fields to base fields
-	baseFields = append(baseFields, fields...)
-
-	// Log at the specified level
-	c.apiLogger.Log(level, msg, baseFields...)
-}
-
-// GetAuthMiddleware returns the authentication middleware function injected from server.
-// This replaces the previous getEffectiveAuthMiddleware that had fallback logic.
-//
-// Returns nil if no middleware was configured via WithAuthMiddleware option.
-// Callers should be aware that applying nil middleware to Echo routes is a no-op
-// (the routes become unprotected). A warning is logged during initialization
-// if auth middleware is not configured.
-func (c *Controller) GetAuthMiddleware() echo.MiddlewareFunc {
-	return c.authMiddleware
 }
 
 // InitializeAPI creates a new API controller and registers all routes.
@@ -1215,7 +600,7 @@ func InitializeAPI(e *echo.Echo, ds datastore.Interface, settings *conf.Settings
 	apiController.Processor = proc
 
 	// Log initialization
-	apiController.logInfoIfEnabled("API v2 initialized",
+	apiController.LogInfoIfEnabled("API v2 initialized",
 		logger.String("version", settings.Version),
 		logger.String("build_date", settings.BuildDate),
 	)

--- a/internal/api/v2/api_datastore_guard_test.go
+++ b/internal/api/v2/api_datastore_guard_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 )
 
 // TestGetSpectrogramStatusReturns503WhenDatastoreDisabled pins that a DS-dependent
@@ -36,7 +37,7 @@ func TestGetSpectrogramStatusReturns503WhenDatastoreDisabled(t *testing.T) {
 
 	var err error
 	require.NotPanics(t, func() { err = controller.GetSpectrogramStatus(ctx) })
-	require.ErrorIs(t, err, errDatastoreUnavailable,
+	require.ErrorIs(t, err, apicore.ErrDatastoreUnavailable,
 		"DS-dependent handler must short-circuit with the datastore-unavailable sentinel, not panic")
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
 		"DS-dependent handler must return 503 when the datastore is disabled, not panic")
@@ -47,11 +48,7 @@ func TestGetSpectrogramStatusReturns503WhenDatastoreDisabled(t *testing.T) {
 // the datastore-independent media routes (filename serve, species images) still register.
 func TestInitMediaRoutesSkippedWhenDatastoreDisabled(t *testing.T) {
 	e := echo.New()
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-		DS:    nil,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: nil}}
 
 	controller.initMediaRoutes()
 
@@ -80,11 +77,7 @@ func TestInitMediaRoutesSkippedWhenDatastoreDisabled(t *testing.T) {
 // is not registered when the controller has no datastore.
 func TestInitDetectionRoutesSkippedWhenDatastoreDisabled(t *testing.T) {
 	e := echo.New()
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-		DS:    nil,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: nil}}
 
 	controller.initDetectionRoutes()
 
@@ -104,10 +97,7 @@ func TestInitDebugRoutesReadsSettingsNilSafely(t *testing.T) {
 	settings := newValidTestSettings()
 	settings.Debug = false // debug mode off -> initDebugRoutes takes the skip path
 
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	// initDebugRoutes must read settings through the nil-safe controllerSettings()
 	// accessor (an atomic Load), not assume a non-nil snapshot.
 	controller.Settings.Store(settings)

--- a/internal/api/v2/api_debug_race_test.go
+++ b/internal/api/v2/api_debug_race_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 )
@@ -24,7 +25,7 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 		conftest.SetTestSettings(previous)
 	})
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	stopWriter := make(chan struct{})

--- a/internal/api/v2/api_engine_test.go
+++ b/internal/api/v2/api_engine_test.go
@@ -15,13 +15,13 @@ func TestEngineAtomicLoadStore(t *testing.T) {
 	c := getTestController(t, e)
 
 	// Initially nil.
-	assert.Nil(t, c.engine.Load())
+	assert.Nil(t, c.Engine.Load())
 
 	// Store and load back.
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine.Store(eng)
-	require.Same(t, eng, c.engine.Load())
+	c.Engine.Store(eng)
+	require.Same(t, eng, c.Engine.Load())
 }
 
 func TestWithAudioEngineOption(t *testing.T) {
@@ -34,5 +34,5 @@ func TestWithAudioEngineOption(t *testing.T) {
 
 	opt := WithAudioEngine(eng)
 	opt(c)
-	require.Same(t, eng, c.engine.Load())
+	require.Same(t, eng, c.Engine.Load())
 }

--- a/internal/api/v2/api_error_response_race_test.go
+++ b/internal/api/v2/api_error_response_race_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 )
 
 // TestNewErrorResponseConcurrentSettingsPublishIsRaceFree hammers
@@ -25,7 +26,7 @@ import (
 func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
 	withRestoredGlobalSettings(t)
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	testErr := echo.NewHTTPError(http.StatusInternalServerError, "raw internal detail")
@@ -56,7 +57,7 @@ func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
 	for range readers {
 		wg.Go(func() {
 			for range itersPerWorker {
-				_ = controller.newErrorResponse(testErr, "sanitized message", http.StatusInternalServerError)
+				_ = controller.NewErrorResponse(testErr, "sanitized message", http.StatusInternalServerError)
 			}
 		})
 	}

--- a/internal/api/v2/api_goroutine_test.go
+++ b/internal/api/v2/api_goroutine_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -85,12 +86,9 @@ func TestSendReconfigActionsExitsOnShutdown(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	controlChan := make(chan string, 1)
-	c := &Controller{
-		controlChan: controlChan,
-		ctx:         ctx,
-		cancel:      cancel,
-		apiLogger:   logger.Global().Module("api"),
-	}
+	cCore := &apicore.Core{APILogger: logger.Global().Module("api")}
+	cCore.SetTestContext(ctx, cancel)
+	c := &Controller{Core: cCore, controlChan: controlChan}
 
 	actions := []string{"action_one", "action_two", "action_three"}
 
@@ -121,12 +119,9 @@ func TestSendReconfigActionsRecoverOnClosedChannel(t *testing.T) {
 	defer cancel()
 
 	controlChan := make(chan string, 1)
-	c := &Controller{
-		controlChan: controlChan,
-		ctx:         ctx,
-		cancel:      cancel,
-		apiLogger:   logger.Global().Module("api"),
-	}
+	cCore := &apicore.Core{APILogger: logger.Global().Module("api")}
+	cCore.SetTestContext(ctx, cancel)
+	c := &Controller{Core: cCore, controlChan: controlChan}
 
 	close(controlChan)
 

--- a/internal/api/v2/api_test.go
+++ b/internal/api/v2/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
@@ -175,50 +176,19 @@ func TestNewErrorResponseDebugMode(t *testing.T) {
 	testErr := echo.NewHTTPError(http.StatusBadRequest, "Test error")
 
 	// Test 1: Non-debug mode — Error field should use sanitized message
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(&conf.Settings{
 		WebServer: conf.WebServerSettings{Debug: false},
 	})
 
-	resp := c.newErrorResponse(testErr, "Safe message", http.StatusBadRequest)
+	resp := c.NewErrorResponse(testErr, "Safe message", http.StatusBadRequest)
 	assert.Equal(t, "Safe message", resp.Error, "Non-debug mode should use sanitized message")
 	assert.Equal(t, "Safe message", resp.Message)
 
 	// Test 2: Debug mode — Error field should expose raw err.Error()
 	c.Settings.Load().WebServer.Debug = true
 
-	resp = c.newErrorResponse(testErr, "Safe message", http.StatusBadRequest)
+	resp = c.NewErrorResponse(testErr, "Safe message", http.StatusBadRequest)
 	assert.Equal(t, "code=400, message=Test error", resp.Error, "Debug mode should expose raw error")
 	assert.Equal(t, "Safe message", resp.Message)
-}
-
-// TestParseIPFromHeader tests IP parsing with zone ID stripping.
-func TestParseIPFromHeader(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{name: "empty string", input: "", expected: ""},
-		{name: "valid IPv4", input: "192.168.1.1", expected: "192.168.1.1"},
-		{name: "valid IPv6", input: "2001:db8::1", expected: "2001:db8::1"},
-		{name: "IPv6 link-local with zone ID", input: "fe80::1%eth0", expected: "fe80::1"},
-		{name: "IPv6 link-local with wlan zone", input: "fe80::1cb6:63bc:5462:71c5%wlan0", expected: "fe80::1cb6:63bc:5462:71c5"},
-		{name: "IPv4 with spurious percent", input: "192.168.1.1%zone", expected: "192.168.1.1"},
-		{name: "just a percent sign", input: "%", expected: ""},
-		{name: "garbage with percent", input: "not_an_ip%zone", expected: ""},
-		{name: "multiple percent signs", input: "fe80::1%wlan0%extra", expected: "fe80::1"},
-		{name: "invalid IP", input: "999.999.999.999", expected: ""},
-		{name: "IPv6 loopback", input: "::1", expected: "::1"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := parseIPFromHeader(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/internal/api/v2/apicore/core.go
+++ b/internal/api/v2/apicore/core.go
@@ -1,0 +1,376 @@
+package apicore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/patrickmn/go-cache"
+
+	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
+	"github.com/tphakala/birdnet-go/internal/ebird"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/observability"
+	"github.com/tphakala/birdnet-go/internal/securefs"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// Cache tuning constants for the shared detection caches owned by Core.
+const (
+	detectionCacheExpiry  = 5 * time.Minute  // Default detection-query cache expiration
+	detectionCacheCleanup = 10 * time.Minute // Detection-query cache cleanup interval
+	detectionRateCacheTTL = 5 * time.Minute  // Detection-rate cache TTL (database overview)
+)
+
+// Default path and permission constants used while resolving the media export root.
+const (
+	// defaultExportPath is the default audio clip export directory, matching internal/conf/defaults.go.
+	defaultExportPath = "clips/"
+	// mediaDirPerm is the permission used when creating the media export directory.
+	mediaDirPerm = 0o755
+)
+
+// ShutdownRequester allows triggering a programmatic shutdown.
+type ShutdownRequester interface {
+	RequestShutdown()
+}
+
+// Core is the shared substrate of the API v2 controller. The api facade embeds
+// *Core by pointer so every exported Core member promotes onto *api.Controller
+// (and, in later phases, onto each domain handler type). Core holds atomic and
+// lock-bearing fields, so it must NEVER be copied by value: embed *Core, never
+// Core. The single instance is created once in NewCore and shared by pointer.
+type Core struct {
+	Echo  *echo.Echo
+	Group *echo.Group
+	DS    datastore.Interface           // Deprecated: Use Repo for new detection operations
+	Repo  datastore.DetectionRepository // New: Preferred for detection CRUD operations
+	// Settings holds this controller's settings snapshot as a lock-free atomic
+	// pointer (copy-on-write). Update handlers publish a fresh *conf.Settings via
+	// Settings.Store under the facade settings mutex; every reader Loads it, directly or
+	// through the CurrentSettings()/ControllerSettings() accessors. Storing it
+	// atomically (rather than as a plain *conf.Settings field) is what lets
+	// newErrorResponse read it from HandleError while UpdateSettings holds
+	// the settings write lock without deadlocking on a non-reentrant RLock. The sibling
+	// Engine and AudioWatchdog fields use the same atomic-pointer pattern.
+	Settings       atomic.Pointer[conf.Settings]
+	BirdImageCache *imageprovider.BirdImageCache
+	SunCalc        *suncalc.SunCalc
+	Processor      *processor.Processor
+	EBirdClient    *ebird.Client
+	TaxonomyDB     *classifier.TaxonomyDatabase
+	SFS            *securefs.SecureFS     // SecureFS instance for media
+	APILogger      logger.Logger          // Structured logger for API operations
+	Metrics        *observability.Metrics // Shared metrics instance
+
+	// AuthMiddleware is the authentication middleware function (injected from server
+	// via WithAuthMiddleware). Read by PrivateModeAuth, GetAuthMiddleware, and the
+	// per-route protected-group registrations.
+	AuthMiddleware echo.MiddlewareFunc
+
+	// MetricsStore holds the metrics history store for sparkline data and the
+	// inference-topology broadcast (BroadcastInferenceTopologyChanged).
+	MetricsStore observability.MetricsStore
+
+	// DetectionCache caches detection queries.
+	DetectionCache *cache.Cache
+	// DetectionRateCache caches detection rate results for the database overview endpoint.
+	DetectionRateCache *datastore.DetectionRateCache
+
+	// SSEManager manages Server-Sent Events connections.
+	SSEManager *SSEManager
+
+	// V2Manager provides access to the v2 normalized database for stats and backup.
+	V2Manager datastoreV2.Manager
+
+	// ModelManager backs the model gallery operations.
+	ModelManager *classifier.ModelManager
+
+	// Engine provides access to the unified audio subsystem (sources, buffers, routing).
+	// Stored atomically: written once via WithAudioEngine after Core init, read
+	// concurrently by HTTP handlers.
+	Engine atomic.Pointer[engine.AudioEngine]
+
+	// AudioWatchdog provides liveness state for audio health endpoints. Stored
+	// atomically because it is set during pipeline Start() and read concurrently by HTTP handlers.
+	AudioWatchdog atomic.Pointer[audiocore.LivenessWatchdog]
+
+	// securityLogger is scoped to the "security" module for authentication events.
+	securityLogger logger.Logger
+
+	// shutdownRequester is the programmatic shutdown trigger (e.g., for restart).
+	shutdownRequester ShutdownRequester
+	shutdownMu        sync.RWMutex // protects shutdownRequester
+
+	// Goroutine lifecycle management.
+	ctx    context.Context    // Context for managing goroutines
+	cancel context.CancelFunc // Cancel function for graceful shutdown
+	wg     sync.WaitGroup     // tracks background goroutines for clean shutdown
+
+	// privateModeExempt reports whether a (method, path) pair is exempt from the
+	// PrivateMode auth gate. Injected by the facade so the exempt allow-list stays
+	// colocated with the domain route-path constants and registrations.
+	privateModeExempt func(method, path string) bool
+}
+
+// NewCore builds the shared API v2 substrate. It resolves the media export root,
+// creates the SecureFS sandbox and the cancellation context, wires the
+// trusted-proxy IP extractor, loads the taxonomy database, initializes the eBird
+// client (when enabled) and the SSE manager. The functional options (auth
+// middleware, audio engine, etc.) and the echo Group + group middleware are
+// applied by the facade after construction.
+func NewCore(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
+	birdImageCache *imageprovider.BirdImageCache, sunCalc *suncalc.SunCalc,
+	metrics *observability.Metrics,
+	privateModeExempt func(method, path string) bool) (*Core, error) {
+
+	// Validate and resolve media export path
+	mediaPath, err := resolveAndValidateMediaPath(settings.Realtime.Audio.Export.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	sfs, err := securefs.New(mediaPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize secure filesystem for media: %w", err)
+	}
+
+	// Create context for managing goroutines
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Only create DetectionRepository if datastore is available.
+	// This prevents nil pointer dereference when datastore is disabled.
+	var repo datastore.DetectionRepository
+	if ds != nil {
+		repo = datastore.NewDetectionRepository(ds, nil)
+	}
+
+	c := &Core{
+		Echo:               e,
+		DS:                 ds,
+		Repo:               repo, // Bridge to new domain model (nil if datastore disabled)
+		BirdImageCache:     birdImageCache,
+		SunCalc:            sunCalc,
+		DetectionCache:     cache.New(detectionCacheExpiry, detectionCacheCleanup),
+		SFS:                sfs, // Assign SecureFS instance
+		Metrics:            metrics,
+		ctx:                ctx,
+		cancel:             cancel,
+		DetectionRateCache: datastore.NewDetectionRateCache(detectionRateCacheTTL),
+		privateModeExempt:  privateModeExempt,
+	}
+	// Publish the initial settings snapshot so ControllerSettings() reads it
+	// lock-free. Every save republishes via Settings.Store; see the Settings
+	// field doc and the settings update handlers.
+	c.Settings.Store(settings)
+
+	// Configure the trusted-proxy-gated IP extractor. Forwarded client-IP headers
+	// (CF-Connecting-IP, X-Forwarded-For, X-Real-IP) are honored only when the
+	// connection peer is a trusted proxy (loopback/link-local/private by default,
+	// plus Security.TrustedProxies); otherwise the real peer address is used. It
+	// reads this controller's own settings snapshot per request (published above
+	// and on every save), so it honors the controller's TrustedProxies and
+	// hot-reloads without a restart.
+	e.IPExtractor = newTrustedProxyIPExtractor(c.ControllerSettings)
+	GetLogger().Info("Configured trusted-proxy-gated IP extractor (forwarded client IP honored only from trusted proxies)")
+
+	// Propagate the derived FFprobe path from config validation to the
+	// ffmpeg package so executeFFprobe can find it without PATH lookup.
+	// Always set (even if empty) so repeated controller inits clear stale state.
+	ffmpeg.SetFFprobePath(settings.Realtime.Audio.FfprobePath)
+
+	// Initialize structured logger for API requests
+	c.APILogger = logger.Global().Module("api")
+
+	// Authentication events (form login/logout, OAuth callback) log to the
+	// "security" module so they are co-located with the OAuth and provider-init
+	// logging, where admins look when debugging auth.
+	c.securityLogger = logger.Global().Module("security")
+
+	// Load local taxonomy database for fast species lookups
+	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
+	if err != nil {
+		c.LogWarnIfEnabled("Failed to load taxonomy database", logger.Error(err))
+		c.LogWarnIfEnabled("Species taxonomy lookups will fall back to eBird API")
+		// Continue without taxonomy database - eBird API fallback will be used
+		c.TaxonomyDB = nil
+	} else {
+		c.TaxonomyDB = taxonomyDB
+		stats := taxonomyDB.Stats()
+		c.LogInfoIfEnabled("Loaded taxonomy database",
+			logger.Any("genus_count", stats["genus_count"]),
+			logger.Any("family_count", stats["family_count"]),
+			logger.Any("species_count", stats["species_count"]),
+			logger.String("version", taxonomyDB.Version),
+			logger.String("updated_at", taxonomyDB.UpdatedAt),
+		)
+	}
+
+	// Initialize SSE manager
+	c.SSEManager = NewSSEManager()
+
+	// Initialize eBird client if enabled
+	log := GetLogger()
+	if settings.Realtime.EBird.Enabled {
+		if settings.Realtime.EBird.APIKey == "" {
+			// Create notification for missing API key
+			// The Build() method automatically publishes to the event bus for notifications
+			_ = errors.Newf("eBird integration enabled but API key not configured").
+				Category(errors.CategoryConfiguration).
+				Context("setting", "realtime.ebird.apikey").
+				Component("ebird").
+				Build()
+			log.Warn("eBird integration enabled but API key not configured")
+		} else {
+			ebirdConfig := ebird.Config{
+				APIKey:   settings.Realtime.EBird.APIKey,
+				CacheTTL: time.Duration(settings.Realtime.EBird.CacheTTL) * time.Hour,
+			}
+			ebirdClient, err := ebird.NewClient(ebirdConfig)
+			if err != nil {
+				// Initialization error - already enhanced by ebird.NewClient
+				log.Warn("Failed to initialize eBird client", logger.Error(err))
+				// Continue without eBird client - it's not critical
+			} else {
+				c.EBirdClient = ebirdClient
+				log.Info("Initialized eBird API client")
+			}
+		}
+	} else {
+		log.Debug("eBird integration disabled")
+	}
+
+	return c, nil
+}
+
+// resolveAndValidateMediaPath resolves a potentially relative media path and ensures it exists as a directory.
+// Returns the absolute path and any error encountered.
+func resolveAndValidateMediaPath(configPath string) (string, error) {
+	mediaPath := configPath
+	if mediaPath == "" {
+		mediaPath = defaultExportPath
+		GetLogger().Warn("Audio export path is empty, using default",
+			logger.String("default_path", defaultExportPath),
+		)
+	}
+
+	// Resolve relative path to absolute based on working directory
+	if !filepath.IsAbs(mediaPath) {
+		workDir, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get working directory to resolve relative media path: %w", err)
+		}
+		mediaPath = filepath.Join(workDir, mediaPath)
+		GetLogger().Debug("Resolved relative media export path",
+			logger.String("config_path", configPath),
+			logger.String("absolute_path", mediaPath),
+		)
+	}
+
+	// Ensure directory exists, creating if necessary
+	if err := ensureDirectoryExists(mediaPath); err != nil {
+		return "", err
+	}
+
+	return mediaPath, nil
+}
+
+// ensureDirectoryExists checks that a path exists and is a directory, creating it if needed.
+func ensureDirectoryExists(path string) error {
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(path, mediaDirPerm); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", path, err)
+		}
+		fi, err = os.Stat(path)
+	}
+	if err != nil {
+		return fmt.Errorf("error checking path %q: %w", path, err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("path is not a directory: %q", path)
+	}
+	return nil
+}
+
+// Context returns the controller lifecycle context. Background goroutines
+// derive their cancellation from it so they stop on Shutdown.
+func (c *Core) Context() context.Context {
+	return c.ctx
+}
+
+// SetTestContext installs a lifecycle context and cancel function on a Core that
+// was built directly (not via NewCore). It exists solely so tests can drive the
+// context-cancellation paths of handlers that read Context(); production code
+// installs these inside NewCore. A nil cancel is permitted (Cancel becomes a no-op).
+func (c *Core) SetTestContext(ctx context.Context, cancel context.CancelFunc) {
+	c.ctx = ctx
+	c.cancel = cancel
+}
+
+// Go runs fn in a tracked goroutine so Shutdown can wait for it to finish.
+func (c *Core) Go(fn func()) {
+	c.wg.Go(fn)
+}
+
+// Cancel cancels the controller lifecycle context, signalling background
+// goroutines to stop. Safe to call when no context was created.
+func (c *Core) Cancel() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+// Wait blocks until all goroutines started via Go have returned.
+func (c *Core) Wait() {
+	c.wg.Wait()
+}
+
+// Debug logs debug messages when debug mode is enabled.
+//
+// Reads the debug flag from the process-global snapshot via conf.GetSettings()
+// (a lock-free atomic.Load), so process-wide debug logging follows the latest
+// published global settings. Returns silently when the global snapshot has not
+// been set (e.g. in unit tests with a standalone Core); the per-controller
+// Settings snapshot is deliberately not consulted here.
+func (c *Core) Debug(format string, v ...any) {
+	settings := conf.GetSettings()
+	if settings == nil {
+		// Skip debug logging when the global snapshot hasn't been set
+		// (e.g. in unit tests with a standalone Core).
+		return
+	}
+	if settings.WebServer.Debug {
+		msg := fmt.Sprintf(format, v...)
+		c.LogDebugIfEnabled(msg)
+	}
+}
+
+// SetShutdownRequester sets the shutdown requester for programmatic restart.
+// Thread-safe: may be called after the HTTP server starts accepting requests.
+func (c *Core) SetShutdownRequester(sr ShutdownRequester) {
+	c.shutdownMu.Lock()
+	defer c.shutdownMu.Unlock()
+	c.shutdownRequester = sr
+}
+
+// GetShutdownRequester returns the current shutdown requester, or nil.
+func (c *Core) GetShutdownRequester() ShutdownRequester {
+	c.shutdownMu.RLock()
+	defer c.shutdownMu.RUnlock()
+	return c.shutdownRequester
+}

--- a/internal/api/v2/apicore/errors.go
+++ b/internal/api/v2/apicore/errors.go
@@ -1,0 +1,194 @@
+package apicore
+
+import (
+	"context"
+	"crypto/rand"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// ErrorResponse is the API error response structure.
+type ErrorResponse struct {
+	Error         string         `json:"error"`
+	Message       string         `json:"message"`
+	Code          int            `json:"code"`
+	CorrelationID string         `json:"correlation_id"`         // Unique identifier for tracking this error
+	ErrorKey      string         `json:"error_key,omitempty"`    // i18n translation key for frontend
+	ErrorParams   map[string]any `json:"error_params,omitempty"` // Interpolation parameters for error_key
+}
+
+// ErrDatastoreUnavailable is returned by DS-dependent handlers when the controller was
+// constructed without a datastore. NewWithOptions permits a nil datastore ("datastore
+// disabled" mode) and initRoutes skips registering the detection and media route groups
+// in that mode; RequireDatastore is defense in depth for any such handler reached anyway.
+var ErrDatastoreUnavailable = errors.NewStd("datastore is not available")
+
+// NewErrorResponse creates a new API error response using the controller's
+// injected settings to decide whether to expose raw error details.
+func (c *Core) NewErrorResponse(err error, message string, code int) *ErrorResponse {
+	// Generate a random correlation ID (8 characters should be sufficient)
+	correlationID := GenerateCorrelationID()
+
+	// Only expose raw err.Error() in debug mode: it can contain internal
+	// paths, SQL errors, stack traces, etc. In production, use the
+	// sanitized message parameter instead.
+	var errorStr string
+	// Read the controller's own debug flag via the lock-free atomic Settings pointer: this
+	// is reached from HandleError while UpdateSettings holds the settings write lock, so
+	// it must not acquire the lock (a non-reentrant RLock would deadlock), and the
+	// flag must remain per-controller (handlers assert debug-gated error verbosity
+	// per controller, not via the shared global snapshot). ControllerSettings()
+	// reads the per-controller snapshot published under that same write lock, so
+	// the read is race-free. See ControllerSettings.
+	settings := c.ControllerSettings()
+	if err != nil && settings != nil && settings.WebServer.Debug {
+		errorStr = err.Error()
+	} else {
+		errorStr = message
+	}
+
+	return &ErrorResponse{
+		Error:         errorStr,
+		Message:       message,
+		Code:          code,
+		CorrelationID: correlationID,
+	}
+}
+
+// GenerateCorrelationID creates a unique identifier for error tracking using cryptographic randomness
+// for better security and uniqueness guarantees across all platforms.
+func GenerateCorrelationID() string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const length = 8
+
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		// Fall back to a default ID if crypto/rand fails
+		return "ERR-RAND"
+	}
+
+	// Map the random bytes to charset characters
+	for i := range b {
+		b[i] = charset[int(b[i])%len(charset)]
+	}
+	return string(b)
+}
+
+// handleErrorInternal is the shared implementation for HandleError and HandleErrorWithKey.
+func (c *Core) handleErrorInternal(ctx echo.Context, err error, message string, code int, errorKey string, errorParams map[string]any) error {
+	errorResp := c.NewErrorResponse(err, message, code)
+	errorResp.ErrorKey = errorKey
+	errorResp.ErrorParams = errorParams
+
+	// Determine IP to log using the request context
+	ip := ctx.RealIP()
+
+	// Get tunnel info from context
+	isTunneled, _ := ctx.Get(CtxKeyIsTunneled).(bool)
+	tunnelProvider, _ := ctx.Get(CtxKeyTunnelProvider).(string)
+
+	// Build error string for logging
+	var errorStr string
+	if err != nil {
+		errorStr = err.Error()
+	} else {
+		errorStr = message
+	}
+
+	// Build log fields
+	fields := []logger.Field{
+		logger.String("correlation_id", errorResp.CorrelationID),
+		logger.String("message", message),
+		logger.String("error", errorStr),
+		logger.Int("code", code),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("method", ctx.Request().Method),
+		logger.String("ip", ip),
+		logger.Bool("tunneled", isTunneled),
+		logger.String("tunnel_provider", tunnelProvider),
+	}
+	if errorKey != "" {
+		fields = append(fields, logger.String("error_key", errorKey))
+	}
+
+	c.LogErrorIfEnabled("API Error", fields...)
+
+	// Report server-side errors (5xx) to Sentry telemetry.
+	// 4xx errors are client mistakes (bad input, not found), not bugs, and are excluded.
+	if code >= http.StatusInternalServerError {
+		c.reportErrorToTelemetry(ctx, err, message, code)
+	}
+
+	return ctx.JSON(code, errorResp)
+}
+
+// reportErrorToTelemetry reports server-side errors (5xx) to Sentry telemetry.
+// Errors already reported by lower layers (e.g., datastore) are skipped to avoid
+// duplicate Sentry events. Privacy scrubbing and opt-in checks are handled by the
+// internal/errors and internal/telemetry packages.
+func (c *Core) reportErrorToTelemetry(ctx echo.Context, err error, message string, code int) {
+	// Skip if the underlying error was already reported by a lower layer.
+	if err != nil {
+		var ee *errors.EnhancedError
+		if errors.As(err, &ee) && ee.IsReported() {
+			return
+		}
+	}
+
+	// Client disconnects and request timeouts are not server bugs.
+	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		return
+	}
+
+	path := ctx.Request().URL.Path
+	method := ctx.Request().Method
+
+	var builder *errors.ErrorBuilder
+	if err != nil {
+		builder = errors.New(err)
+	} else {
+		builder = errors.Newf("%s", message)
+	}
+
+	_ = builder.
+		Component("api").
+		Category(errors.CategoryHTTP).
+		Context("http_status", code).
+		Context("endpoint", path).
+		Context("method", method).
+		Build()
+}
+
+// HandleError constructs and returns an appropriate error response.
+func (c *Core) HandleError(ctx echo.Context, err error, message string, code int) error {
+	return c.handleErrorInternal(ctx, err, message, code, "", nil)
+}
+
+// HandleErrorWithKey constructs and returns an error response with an i18n translation key.
+// The errorKey and errorParams allow the frontend to display translated error messages.
+func (c *Core) HandleErrorWithKey(ctx echo.Context, err error, message string, code int, errorKey string, errorParams map[string]any) error {
+	return c.handleErrorInternal(ctx, err, message, code, errorKey, errorParams)
+}
+
+// RequireDatastore writes a 503 Service Unavailable response and returns the non-nil
+// errDatastoreUnavailable when the controller has no datastore, so handlers can guard with:
+//
+//	if err := c.RequireDatastore(ctx); err != nil {
+//	    return err
+//	}
+//
+// It returns the sentinel (not HandleError's nil) so the guard actually short-circuits the
+// caller; the 503 body is already written, so echo's error handler skips the committed
+// response. This honors the constructor's advertised "datastore disabled" mode instead of
+// letting a nil c.DS dereference panic.
+func (c *Core) RequireDatastore(ctx echo.Context) error {
+	if c.DS == nil {
+		_ = c.HandleError(ctx, ErrDatastoreUnavailable, "Datastore is not available", http.StatusServiceUnavailable)
+		return ErrDatastoreUnavailable
+	}
+	return nil
+}

--- a/internal/api/v2/apicore/ip_extractor.go
+++ b/internal/api/v2/apicore/ip_extractor.go
@@ -4,7 +4,7 @@
 // X-Forwarded-For, X-Real-IP) when the immediate connection peer is a trusted
 // reverse proxy. On a directly-exposed instance this prevents a client from
 // spoofing its source IP, which feeds rate limiting, ban/allow lists, and logs.
-package api
+package apicore
 
 import (
 	"net"
@@ -32,6 +32,25 @@ var (
 	canonicalXForwardedFor  = http.CanonicalHeaderKey(echo.HeaderXForwardedFor)
 	canonicalXRealIP        = http.CanonicalHeaderKey(echo.HeaderXRealIP)
 )
+
+// parseIPFromHeader attempts to parse a valid IP from a header value.
+// Returns the IP string if valid, empty string otherwise.
+func parseIPFromHeader(headerValue string) string {
+	if headerValue == "" {
+		return ""
+	}
+	// Strip IPv6 zone ID (e.g., %wlan0) before parsing.
+	// net.ParseIP does not handle zone identifiers, and iOS Safari
+	// commonly connects via IPv6 link-local addresses with zone IDs.
+	if before, _, found := strings.Cut(headerValue, "%"); found {
+		headerValue = before
+	}
+	ip := net.ParseIP(headerValue)
+	if ip != nil {
+		return ip.String()
+	}
+	return ""
+}
 
 // cloudflareEdgeCIDRs lists Cloudflare's published proxy IP ranges
 // (https://www.cloudflare.com/ips/). These ranges are stable and change rarely;

--- a/internal/api/v2/apicore/ip_extractor_test.go
+++ b/internal/api/v2/apicore/ip_extractor_test.go
@@ -1,6 +1,6 @@
 // ip_extractor_test.go: tests for the trusted-proxy-gated client IP extractor.
 
-package api
+package apicore
 
 import (
 	"net"
@@ -439,4 +439,35 @@ func mustParseIP(t *testing.T, s string) net.IP {
 	ip := net.ParseIP(s)
 	require.NotNil(t, ip, "test IP %q must parse", s)
 	return ip
+}
+
+// TestParseIPFromHeader tests IP parsing with zone ID stripping.
+func TestParseIPFromHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty string", input: "", expected: ""},
+		{name: "valid IPv4", input: "192.168.1.1", expected: "192.168.1.1"},
+		{name: "valid IPv6", input: "2001:db8::1", expected: "2001:db8::1"},
+		{name: "IPv6 link-local with zone ID", input: "fe80::1%eth0", expected: "fe80::1"},
+		{name: "IPv6 link-local with wlan zone", input: "fe80::1cb6:63bc:5462:71c5%wlan0", expected: "fe80::1cb6:63bc:5462:71c5"},
+		{name: "IPv4 with spurious percent", input: "192.168.1.1%zone", expected: "192.168.1.1"},
+		{name: "just a percent sign", input: "%", expected: ""},
+		{name: "garbage with percent", input: "not_an_ip%zone", expected: ""},
+		{name: "multiple percent signs", input: "fe80::1%wlan0%extra", expected: "fe80::1"},
+		{name: "invalid IP", input: "999.999.999.999", expected: ""},
+		{name: "IPv6 loopback", input: "::1", expected: "::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseIPFromHeader(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/internal/api/v2/apicore/logging.go
+++ b/internal/api/v2/apicore/logging.go
@@ -1,0 +1,139 @@
+// Package apicore holds the shared substrate of the API v2 controller: the
+// cross-cutting dependencies, settings accessors, error/logging helpers, shared
+// middleware, the SSE hub and broadcasters, and the name-map plumbing. Domain
+// handler packages embed *Core so these members promote onto each handler type
+// without re-wiring. apicore depends only on leaf packages; it never imports a
+// domain package or the api facade, so there is no import cycle.
+package apicore
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// GetLogger returns a logger instance for the API v2 package.
+// This provides consistent logging with module identification.
+func GetLogger() logger.Logger {
+	return logger.Global().Module("api")
+}
+
+// CurrentSettings returns the latest settings snapshot so UI changes
+// take effect in API responses without restarting the service.
+//
+// It resolves the lock-free global atomic snapshot first and only falls back
+// to this controller's own snapshot when no global snapshot has been published
+// (standalone unit-test controllers). Both reads are lock-free (the per-controller
+// fallback is an atomic Load), so the accessor is race-free against the
+// Settings.Store the update handlers perform under the settings mutex.
+func (c *Core) CurrentSettings() *conf.Settings {
+	if latest := conf.GetSettings(); latest != nil {
+		return latest
+	}
+	return c.Settings.Load()
+}
+
+// ControllerSettings returns this controller's own settings snapshot, read
+// lock-free from the atomic Settings pointer that the update handlers publish on
+// every save. Unlike CurrentSettings(), it deliberately does NOT consult the
+// process-global atomic snapshot: use it for reads whose result is asserted
+// per-controller (e.g. debug-gated response verbosity), where the shared global
+// snapshot would couple otherwise-independent parallel tests.
+//
+// Loading the atomic pointer (rather than reading a plain field under a mutex)
+// is what makes this safe to call from newErrorResponse, which is reached from
+// HandleError while UpdateSettings already holds the settings write lock: a
+// non-reentrant RLock there would deadlock. The snapshot is published under that
+// same write lock, so the read sees a consistent value. The returned snapshot is
+// immutable (copy-on-write), so callers may dereference its fields freely.
+// Returns nil only on a controller that never stored settings (standalone tests);
+// callers that may hit that path nil-check or fall back.
+func (c *Core) ControllerSettings() *conf.Settings {
+	return c.Settings.Load()
+}
+
+// LogAPIRequest is a helper to log API requests with common context fields.
+func (c *Core) LogAPIRequest(ctx echo.Context, level logger.LogLevel, msg string, fields ...logger.Field) {
+	if c.APILogger == nil {
+		return // Do nothing if logger isn't initialized
+	}
+
+	// Extract common context info
+	ip := ctx.RealIP()
+	path := ctx.Request().URL.Path
+
+	// Create base fields with preallocated capacity
+	baseFields := make([]logger.Field, 0, 2+len(fields))
+	baseFields = append(baseFields,
+		logger.String("path", path),
+		logger.String("ip", ip),
+	)
+
+	// Append specific fields to base fields
+	baseFields = append(baseFields, fields...)
+
+	// Log at the specified level
+	c.APILogger.Log(level, msg, baseFields...)
+}
+
+// LogInfoIfEnabled logs info message if APILogger is enabled
+func (c *Core) LogInfoIfEnabled(msg string, fields ...logger.Field) {
+	if c.APILogger != nil {
+		c.APILogger.Info(msg, fields...)
+	}
+}
+
+// LogErrorIfEnabled logs error message if APILogger is enabled
+func (c *Core) LogErrorIfEnabled(msg string, fields ...logger.Field) {
+	if c.APILogger != nil {
+		c.APILogger.Error(msg, fields...)
+	}
+}
+
+// LogWarnIfEnabled logs warning message if APILogger is enabled
+func (c *Core) LogWarnIfEnabled(msg string, fields ...logger.Field) {
+	if c.APILogger != nil {
+		c.APILogger.Warn(msg, fields...)
+	}
+}
+
+// LogDebugIfEnabled logs debug message if APILogger is enabled
+func (c *Core) LogDebugIfEnabled(msg string, fields ...logger.Field) {
+	if c.APILogger != nil {
+		c.APILogger.Debug(msg, fields...)
+	}
+}
+
+// The LogSecurity* helpers mirror the api-module helpers above but write to the
+// "security" module logger, so authentication events (form login/logout, OAuth
+// callback) are co-located with the OAuth and provider-init logging where
+// admins look when debugging auth.
+
+// LogSecurityInfoIfEnabled logs an info message to the security module if enabled.
+func (c *Core) LogSecurityInfoIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Info(msg, fields...)
+	}
+}
+
+// LogSecurityWarnIfEnabled logs a warning message to the security module if enabled.
+func (c *Core) LogSecurityWarnIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Warn(msg, fields...)
+	}
+}
+
+// LogSecurityErrorIfEnabled logs an error message to the security module if enabled.
+func (c *Core) LogSecurityErrorIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Error(msg, fields...)
+	}
+}
+
+// LogSecurityDebugIfEnabled logs a debug message to the security module if enabled.
+func (c *Core) LogSecurityDebugIfEnabled(msg string, fields ...logger.Field) {
+	if c.securityLogger != nil {
+		c.securityLogger.Debug(msg, fields...)
+	}
+}

--- a/internal/api/v2/apicore/middleware.go
+++ b/internal/api/v2/apicore/middleware.go
@@ -1,0 +1,170 @@
+package apicore
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// tunnelProviderUnknown is the tunnel provider label for unknown providers.
+const tunnelProviderUnknown = "unknown"
+
+// Echo context keys set by TunnelDetectionMiddleware and read by
+// LoggingMiddleware, handleErrorInternal, and domain handlers (e.g. media). They
+// are exported so no package re-literals the string key.
+const (
+	// CtxKeyIsTunneled holds a bool: whether the request was classified as proxied/tunneled.
+	CtxKeyIsTunneled = "is_tunneled"
+	// CtxKeyTunnelProvider holds a string: the detected tunnel provider label.
+	CtxKeyTunnelProvider = "tunnel_provider"
+)
+
+// TunnelDetectionMiddleware inspects headers to determine if the request is likely proxied
+// and sets context values for logging.
+func (c *Core) TunnelDetectionMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			req := ctx.Request()
+			tunneled := false
+			provider := tunnelProviderUnknown
+
+			// Only classify the request as tunneled when the IP extractor actually
+			// honored a forwarded header, i.e. the resolved client IP differs from
+			// the immediate connection peer. That happens only for a trusted proxy,
+			// so a directly-connected client cannot spoof a "tunneled" label by
+			// sending forwarded headers from an untrusted address.
+			if peerIP, _ := peerAddrFromRequest(req); peerIP != nil && peerIP.String() != ctx.RealIP() {
+				switch {
+				case req.Header.Get(headerCFConnectingIP) != "":
+					tunneled = true
+					provider = "cloudflare"
+				case req.Header.Get(echo.HeaderXForwardedFor) != "" || req.Header.Get(echo.HeaderXRealIP) != "":
+					// Other proxy headers present: tunneled, but provider is generic.
+					tunneled = true
+					provider = "generic"
+				}
+			}
+
+			ctx.Set(CtxKeyIsTunneled, tunneled)
+			ctx.Set(CtxKeyTunnelProvider, provider)
+
+			return next(ctx)
+		}
+	}
+}
+
+// LoggingMiddleware creates a middleware function that logs API requests.
+func (c *Core) LoggingMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			start := time.Now()
+
+			// Process the request
+			err := next(ctx)
+
+			// Skip logging if APILogger is not initialized
+			if c.APILogger == nil {
+				return err
+			}
+
+			// Extract request information
+			req := ctx.Request()
+			res := ctx.Response()
+
+			// Determine the actual status code. When a handler returns an
+			// *echo.HTTPError, Echo's centralized error handler has not yet
+			// executed at this point in the middleware chain, so res.Status
+			// is still the default 200. Extract the real code from the error.
+			status := res.Status
+			if err != nil {
+				var he *echo.HTTPError
+				if errors.As(err, &he) {
+					status = he.Code
+				} else if status < http.StatusBadRequest {
+					// Non-HTTP errors (e.g. database errors) won't have a
+					// status set yet; Echo's error handler runs after this
+					// middleware. Default to 500 to avoid logging failures
+					// as successes.
+					status = http.StatusInternalServerError
+				}
+			}
+
+			// Get tunnel info from context
+			isTunneled, _ := ctx.Get(CtxKeyIsTunneled).(bool)
+			tunnelProvider, _ := ctx.Get(CtxKeyTunnelProvider).(string)
+
+			// Log the request with structured data
+			fields := []logger.Field{
+				logger.String("method", req.Method),
+				logger.String("path", req.URL.Path),
+				logger.String("query", req.URL.RawQuery),
+				logger.Int("status", status),
+				logger.String("ip", ctx.RealIP()), // Uses custom extractor
+				logger.Bool("tunneled", isTunneled),
+				logger.String("tunnel_provider", tunnelProvider),
+				logger.String("user_agent", req.UserAgent()),
+				logger.Int64("latency_ms", time.Since(start).Milliseconds()),
+			}
+			if err != nil {
+				fields = append(fields, logger.Error(err))
+			}
+
+			c.APILogger.Info("API Request", fields...)
+
+			return err
+		}
+	}
+}
+
+// PrivateModeAuth gates all API endpoints behind authentication when PrivateMode
+// is enabled. The set of public-exempt routes is supplied by the facade via the
+// injected privateModeExempt function (it composes route-path constants that live
+// with their domain registrations), so the exempt allow-list cannot drift from
+// the registered routes. It is applied once at the API group level by the facade.
+func (c *Core) PrivateModeAuth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		// Read the live global snapshot (race-free, hot-reloading) via
+		// CurrentSettings() to match the sibling publicLiveAudioAuth middleware; the
+		// per-controller snapshot would miss out-of-band StoreSettings republishes.
+		privateMode := c.CurrentSettings().Security.PrivateMode
+
+		if !privateMode {
+			return next(ctx)
+		}
+		// Fail closed: if PrivateMode is requested but no auth middleware
+		// is configured the request must be rejected, not silently allowed.
+		// Auth middleware is always wired up in production; reaching this
+		// branch in a real deployment means the controller is misconfigured.
+		if c.AuthMiddleware == nil {
+			return c.HandleError(
+				ctx,
+				nil,
+				"Private mode is enabled but authentication is not configured",
+				http.StatusServiceUnavailable,
+			)
+		}
+		// Use ctx.Path() (the registered route pattern) rather than the raw
+		// request URL so the match is robust to trailing slashes, ingress
+		// prefixes, and other URL normalisation differences. The method is
+		// matched explicitly so that a future handler bound to the same
+		// path with a different verb does not inherit the public exemption.
+		if c.privateModeExempt != nil && c.privateModeExempt(ctx.Request().Method, ctx.Path()) {
+			return next(ctx)
+		}
+		return c.AuthMiddleware(next)(ctx)
+	}
+}
+
+// GetAuthMiddleware returns the authentication middleware function injected from server.
+//
+// Returns nil if no middleware was configured via WithAuthMiddleware option.
+// Callers should be aware that applying nil middleware to Echo routes is a no-op
+// (the routes become unprotected). A warning is logged during initialization
+// if auth middleware is not configured.
+func (c *Core) GetAuthMiddleware() echo.MiddlewareFunc {
+	return c.AuthMiddleware
+}

--- a/internal/api/v2/apicore/sse.go
+++ b/internal/api/v2/apicore/sse.go
@@ -1,0 +1,469 @@
+package apicore
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore/soundlevel"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// SSE client health monitoring and stream-type constants used by the hub.
+const (
+	// maxConsecutiveDrops auto-disconnects clients after this many consecutive dropped messages.
+	maxConsecutiveDrops = 3
+
+	// Stream types - used to identify what data a client wants to receive.
+	// Note: StreamTypeAll shares a single consecutiveDrops counter across both
+	// streams, meaning drops on one stream affect health tracking for both.
+	StreamTypeDetections  = "detections"
+	StreamTypeSoundLevels = "soundlevels"
+	StreamTypeAll         = "all"
+)
+
+// SSEDetectionData represents the detection data sent via SSE.
+// Uses explicit fields with camelCase JSON tags instead of embedding datastore.Note
+// to avoid exposing internal Go struct layout, sensitive data (filesystem paths,
+// RTSP credentials), and to provide a stable, well-defined API contract.
+type SSEDetectionData struct {
+	// Detection identity and classification
+	ID             uint    `json:"id"`
+	Date           string  `json:"date"` // "2024-01-15"
+	Time           string  `json:"time"` // "14:30:00"
+	ScientificName string  `json:"scientificName"`
+	CommonName     string  `json:"commonName"`
+	SpeciesCode    string  `json:"speciesCode,omitempty"`
+	Confidence     float64 `json:"confidence"` // No omitempty - 0.0 is a valid confidence value
+
+	// Location
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
+
+	// Audio clip (filename only, no path)
+	ClipName string `json:"clipName,omitempty"`
+
+	// Source info (safe fields only, no credentials)
+	Source *SSESourceInfo `json:"source,omitempty"`
+
+	// Time context
+	BeginTime string `json:"beginTime,omitempty"`
+	EndTime   string `json:"endTime,omitempty"`
+
+	// Review status
+	Verified string `json:"verified,omitempty"`
+	Locked   bool   `json:"locked"`
+	Unlikely bool   `json:"unlikely,omitempty"`
+
+	// Bird image with attribution
+	BirdImage SSEBirdImage `json:"birdImage"`
+
+	// SSE event metadata
+	Timestamp time.Time `json:"timestamp"`
+	EventType string    `json:"eventType"`
+
+	// Species tracking metadata
+	IsNewSpecies       bool `json:"isNewSpecies,omitempty"`       // First seen within tracking window
+	DaysSinceFirstSeen int  `json:"daysSinceFirstSeen,omitempty"` // Days since species was first detected
+}
+
+// SSESourceInfo describes the audio source in SSE events.
+// Only exposes safe identifiers, never raw connection strings or credentials.
+type SSESourceInfo struct {
+	ID          string `json:"id"`
+	Type        string `json:"type,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+// SSEBirdImage represents bird image data in SSE events with proper JSON tags.
+type SSEBirdImage struct {
+	URL            string `json:"url"`
+	ScientificName string `json:"scientificName,omitempty"`
+	LicenseName    string `json:"licenseName,omitempty"`
+	LicenseURL     string `json:"licenseURL,omitempty"`
+	AuthorName     string `json:"authorName,omitempty"`
+	AuthorURL      string `json:"authorURL,omitempty"`
+	SourceProvider string `json:"sourceProvider,omitempty"`
+}
+
+// SSESoundLevelData represents sound level data sent via SSE.
+type SSESoundLevelData struct {
+	soundlevel.SoundLevelData
+	EventType string `json:"eventType"`
+}
+
+// safeBaseName returns the filename component of a path, or empty string if the path is empty.
+// Unlike filepath.Base("") which returns ".", this returns "" for empty inputs.
+func safeBaseName(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.Base(path)
+}
+
+// NewSSEDetectionData creates an SSEDetectionData from a datastore.Note and BirdImage.
+// It sanitizes sensitive data: ClipName is stripped to filename only, and Source
+// only includes safe display fields (no raw connection strings or credentials).
+func NewSSEDetectionData(note *datastore.Note, birdImage *imageprovider.BirdImage) SSEDetectionData {
+	det := SSEDetectionData{
+		ID:             note.ID,
+		Date:           note.Date,
+		Time:           note.Time,
+		ScientificName: note.ScientificName,
+		CommonName:     note.CommonName,
+		SpeciesCode:    note.SpeciesCode,
+		Confidence:     note.Confidence,
+		Latitude:       note.Latitude,
+		Longitude:      note.Longitude,
+		ClipName:       safeBaseName(note.ClipName),
+		Verified:       note.Verified,
+		Locked:         note.Locked,
+		Unlikely:       note.Unlikely,
+		Timestamp:      time.Now(),
+		EventType:      "new_detection",
+	}
+
+	// Format time fields as RFC3339 if non-zero
+	if !note.BeginTime.IsZero() {
+		det.BeginTime = note.BeginTime.Format(time.RFC3339)
+	}
+	if !note.EndTime.IsZero() {
+		det.EndTime = note.EndTime.Format(time.RFC3339)
+	}
+
+	// Only expose safe source identifiers, never raw connection strings
+	if note.Source.ID != "" {
+		det.Source = &SSESourceInfo{
+			ID:          note.Source.ID,
+			DisplayName: note.Source.DisplayName,
+		}
+	}
+
+	// Map bird image with proper camelCase tags
+	if birdImage != nil {
+		det.BirdImage = SSEBirdImage{
+			URL:            birdImage.URL,
+			ScientificName: birdImage.ScientificName,
+			LicenseName:    birdImage.LicenseName,
+			LicenseURL:     birdImage.LicenseURL,
+			AuthorName:     birdImage.AuthorName,
+			AuthorURL:      birdImage.AuthorURL,
+			SourceProvider: birdImage.SourceProvider,
+		}
+	}
+
+	return det
+}
+
+// SSEClient represents a connected SSE client.
+type SSEClient struct {
+	ID             string
+	Channel        chan SSEDetectionData
+	SoundLevelChan chan SSESoundLevelData
+	PendingChan    chan any // Channel for pending detection snapshots ([]SSEPendingDetection from processor)
+	Request        *http.Request
+	Response       http.ResponseWriter
+	Done           chan struct{} // Signal-only buffered channel to prevent blocking
+	StreamType     string        // StreamTypeDetections, StreamTypeSoundLevels, or StreamTypeAll
+
+	// Health tracking for auto-disconnect of slow/blocked clients
+	// Uses atomic operations for thread-safe access during concurrent broadcasts
+	consecutiveDrops atomic.Int32 // Count of consecutive failed message sends
+}
+
+// SSEManager manages SSE connections and broadcasts.
+type SSEManager struct {
+	clients      map[string]*SSEClient
+	mutex        sync.RWMutex
+	shuttingDown atomic.Bool // blocks new registrations during shutdown
+}
+
+// NewSSEManager creates a new SSE manager.
+func NewSSEManager() *SSEManager {
+	return &SSEManager{
+		clients: make(map[string]*SSEClient),
+	}
+}
+
+// AddClient adds a new SSE client. Returns false if the manager is
+// shutting down and no new registrations are accepted.
+func (m *SSEManager) AddClient(client *SSEClient) bool {
+	if m.shuttingDown.Load() {
+		return false
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.shuttingDown.Load() {
+		return false
+	}
+	m.clients[client.ID] = client
+	GetLogger().Debug("SSE client connected",
+		logger.String("client_id", client.ID),
+		logger.Int("total_clients", len(m.clients)),
+	)
+	return true
+}
+
+// RemoveClient removes an SSE client.
+func (m *SSEManager) RemoveClient(clientID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if client, exists := m.clients[clientID]; exists {
+		if client.Channel != nil {
+			close(client.Channel)
+		}
+		if client.SoundLevelChan != nil {
+			close(client.SoundLevelChan)
+		}
+		if client.PendingChan != nil {
+			close(client.PendingChan)
+		}
+		close(client.Done)
+		delete(m.clients, clientID)
+		GetLogger().Debug("SSE client disconnected",
+			logger.String("client_id", clientID),
+			logger.Int("total_clients", len(m.clients)),
+		)
+	}
+}
+
+// BroadcastDetection sends detection data to all connected clients.
+// Uses non-blocking send to prevent slow clients from blocking fast clients.
+// Clients are automatically disconnected after maxConsecutiveDrops failed sends.
+func (m *SSEManager) BroadcastDetection(detection *SSEDetectionData) {
+	m.mutex.RLock()
+
+	if len(m.clients) == 0 {
+		m.mutex.RUnlock()
+		return // No clients to broadcast to
+	}
+
+	// Collect blocked client IDs to remove them after releasing the lock
+	var blockedClients []string
+
+	for clientID, client := range m.clients {
+		select {
+		case client.Channel <- *detection:
+			// Successfully sent to client - reset health counter atomically
+			client.consecutiveDrops.Store(0)
+
+		default:
+			// Channel full - drop this update, increment counter atomically
+			drops := client.consecutiveDrops.Add(1)
+
+			// Only log when reaching disconnect threshold to avoid log spam
+			if drops >= maxConsecutiveDrops {
+				GetLogger().Info("SSE client disconnected after consecutive drops",
+					logger.String("client_id", clientID),
+					logger.Int("consecutive_drops", int(drops)),
+				)
+				blockedClients = append(blockedClients, clientID)
+			}
+		}
+	}
+
+	// Release the read lock before removing clients
+	m.mutex.RUnlock()
+
+	// Remove blocked clients synchronously (we're outside the lock and RemoveClient is fast)
+	// Note: Low probability race if client reconnects with same ID between unlock and removal
+	for _, clientID := range blockedClients {
+		m.RemoveClient(clientID)
+	}
+}
+
+// BroadcastSoundLevel sends sound level data to all connected clients.
+// Uses non-blocking send to prevent slow clients from blocking fast clients.
+// Clients are automatically disconnected after maxConsecutiveDrops failed sends.
+func (m *SSEManager) BroadcastSoundLevel(soundLevel *SSESoundLevelData) {
+	m.mutex.RLock()
+
+	if len(m.clients) == 0 {
+		m.mutex.RUnlock()
+		return // No clients to broadcast to
+	}
+
+	// Collect blocked client IDs to remove them after releasing the lock
+	var blockedClients []string
+
+	for clientID, client := range m.clients {
+		// Only send to clients that want sound level data
+		if client.StreamType == StreamTypeSoundLevels || client.StreamType == StreamTypeAll {
+			if client.SoundLevelChan != nil {
+				select {
+				case client.SoundLevelChan <- *soundLevel:
+					// Successfully sent to client - reset health counter atomically
+					client.consecutiveDrops.Store(0)
+
+				default:
+					// Channel full - drop this update, increment counter atomically
+					drops := client.consecutiveDrops.Add(1)
+
+					// Only log when reaching disconnect threshold to avoid log spam
+					if drops >= maxConsecutiveDrops {
+						GetLogger().Info("SSE client disconnected after consecutive drops",
+							logger.String("client_id", clientID),
+							logger.Int("consecutive_drops", int(drops)),
+						)
+						blockedClients = append(blockedClients, clientID)
+					}
+				}
+			}
+		}
+	}
+
+	// Release the read lock before removing clients
+	m.mutex.RUnlock()
+
+	// Remove blocked clients synchronously (we're outside the lock and RemoveClient is fast)
+	// Note: Low probability race if client reconnects with same ID between unlock and removal
+	for _, clientID := range blockedClients {
+		m.RemoveClient(clientID)
+	}
+}
+
+// BroadcastPending sends pending detection data to all connected detection stream clients.
+// Uses non-blocking send to prevent slow clients from blocking the processor.
+// Clients are automatically disconnected after maxConsecutiveDrops failed sends.
+func (m *SSEManager) BroadcastPending(pending any) {
+	m.mutex.RLock()
+
+	if len(m.clients) == 0 {
+		m.mutex.RUnlock()
+		return
+	}
+
+	var blockedClients []string
+
+	for clientID, client := range m.clients {
+		// Only send to clients receiving detection data
+		if client.StreamType != StreamTypeDetections && client.StreamType != StreamTypeAll {
+			continue
+		}
+		if client.PendingChan == nil {
+			continue
+		}
+		select {
+		case client.PendingChan <- pending:
+			client.consecutiveDrops.Store(0)
+		default:
+			drops := client.consecutiveDrops.Add(1)
+			if drops >= maxConsecutiveDrops {
+				GetLogger().Info("SSE client disconnected after consecutive drops",
+					logger.String("client_id", clientID),
+					logger.Int("consecutive_drops", int(drops)),
+				)
+				blockedClients = append(blockedClients, clientID)
+			}
+		}
+	}
+
+	m.mutex.RUnlock()
+
+	for _, clientID := range blockedClients {
+		m.RemoveClient(clientID)
+	}
+}
+
+// CloseAllClients disconnects all SSE clients during shutdown.
+// This must be called before echo.Shutdown() so the HTTP server
+// has no active connections to wait for.
+func (m *SSEManager) CloseAllClients() {
+	m.shuttingDown.Store(true)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	for id, client := range m.clients {
+		if client.Channel != nil {
+			close(client.Channel)
+		}
+		if client.SoundLevelChan != nil {
+			close(client.SoundLevelChan)
+		}
+		if client.PendingChan != nil {
+			close(client.PendingChan)
+		}
+		close(client.Done)
+		delete(m.clients, id)
+	}
+	GetLogger().Info("SSE shutdown: closed all clients",
+		logger.String("operation", "sse_close_all_clients"))
+}
+
+// GetClientCount returns the number of connected clients.
+func (m *SSEManager) GetClientCount() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return len(m.clients)
+}
+
+// BroadcastDetection is a helper method to broadcast detection from the controller.
+// It maps the internal datastore.Note to a sanitized SSEDetectionData struct that
+// only exposes safe fields with proper camelCase JSON tags.
+func (c *Core) BroadcastDetection(note *datastore.Note, birdImage *imageprovider.BirdImage) error {
+	if c.SSEManager == nil {
+		return fmt.Errorf("SSE manager not initialized")
+	}
+
+	// Add nil checks to prevent panic
+	if note == nil {
+		c.LogErrorIfEnabled("SSE broadcast skipped: note is nil")
+		return fmt.Errorf("note is nil")
+	}
+	if birdImage == nil {
+		c.LogErrorIfEnabled("SSE broadcast skipped: birdImage is nil")
+		return fmt.Errorf("birdImage is nil")
+	}
+
+	detection := NewSSEDetectionData(note, birdImage)
+
+	// Add species tracking metadata if processor has tracker.
+	// Compare the detection date with the species' first-seen date so the flag
+	// is true only for the actual first detection, not for every detection of a
+	// recently-first-seen species.
+	// Snapshot processor and tracker to avoid TOCTOU race.
+	if proc := c.Processor; proc != nil {
+		if tracker := proc.GetNewSpeciesTracker(); tracker != nil {
+			status := tracker.GetSpeciesStatus(note.ScientificName, time.Now())
+			detection.IsNewSpecies = !status.FirstSeenTime.IsZero() &&
+				note.Date == status.FirstSeenTime.Format(time.DateOnly)
+			detection.DaysSinceFirstSeen = status.DaysSinceFirst
+		}
+	}
+
+	c.SSEManager.BroadcastDetection(&detection)
+	return nil
+}
+
+// BroadcastSoundLevel is a helper method to broadcast sound level data from the controller.
+func (c *Core) BroadcastSoundLevel(soundLevel *soundlevel.SoundLevelData) error {
+	if c.SSEManager == nil {
+		return fmt.Errorf("SSE manager not initialized")
+	}
+
+	// Add nil check to prevent panic
+	if soundLevel == nil {
+		c.LogErrorIfEnabled("SSE broadcast skipped: soundLevel is nil")
+		return fmt.Errorf("soundLevel is nil")
+	}
+
+	sseData := SSESoundLevelData{
+		SoundLevelData: *soundLevel,
+		EventType:      "sound_level_update",
+	}
+
+	c.SSEManager.BroadcastSoundLevel(&sseData)
+	return nil
+}
+
+// BroadcastPending broadcasts pending detection snapshot from the controller.
+func (c *Core) BroadcastPending(snapshot any) {
+	if c.SSEManager == nil {
+		return
+	}
+	c.SSEManager.BroadcastPending(snapshot)
+}

--- a/internal/api/v2/apicore_bridge.go
+++ b/internal/api/v2/apicore_bridge.go
@@ -1,0 +1,33 @@
+package api
+
+import "github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+
+// Type aliases re-export the shared types that moved to the apicore package so
+// existing handlers and tests in package api keep referring to them by their
+// short names. These are zero-cost aliases (identical types), not wrappers.
+type (
+	// ErrorResponse is the API error response structure (defined in apicore).
+	ErrorResponse = apicore.ErrorResponse
+	// SSEDetectionData is the sanitized detection wire struct sent over SSE.
+	SSEDetectionData = apicore.SSEDetectionData
+	// SSESoundLevelData is the sound-level wire struct sent over SSE.
+	SSESoundLevelData = apicore.SSESoundLevelData
+	// SSESourceInfo describes the audio source in SSE events.
+	SSESourceInfo = apicore.SSESourceInfo
+	// SSEBirdImage is the bird image payload in SSE detection events.
+	SSEBirdImage = apicore.SSEBirdImage
+	// SSEManager manages SSE connections and broadcasts.
+	SSEManager = apicore.SSEManager
+	// SSEClient is a single connected SSE client.
+	SSEClient = apicore.SSEClient
+	// ShutdownRequester triggers a programmatic shutdown.
+	ShutdownRequester = apicore.ShutdownRequester
+)
+
+// Stream-type identifiers re-declared from apicore so the SSE stream handlers in
+// package api keep using the short, unexported names.
+const (
+	streamTypeDetections  = apicore.StreamTypeDetections
+	streamTypeSoundLevels = apicore.StreamTypeSoundLevels
+	streamTypeAll         = apicore.StreamTypeAll
+)

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -142,14 +142,14 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 	// same-origin requests, but this endpoint must always provide a token.
 	csrfToken, err := middleware.EnsureCSRFToken(ctx)
 	if err != nil {
-		c.logWarnIfEnabled("Failed to generate CSRF token", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to generate CSRF token", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to generate CSRF token", http.StatusInternalServerError)
 	}
 
 	// Snapshot the live settings once so the response reflects the latest
 	// published configuration and every read below is race-free against a
 	// concurrent settings save (see currentSettings).
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
 	}
@@ -234,7 +234,7 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 		}
 	}
 
-	c.logDebugIfEnabled("Serving app config",
+	c.LogDebugIfEnabled("Serving app config",
 		logger.Bool("security_enabled", securityEnabled),
 		logger.Bool("access_allowed", accessAllowed),
 		logger.String("ip", ctx.RealIP()),
@@ -264,7 +264,7 @@ func (c *Controller) determineWizardState(ctx context.Context, settings *conf.Se
 
 	lastSeenVersion, err := c.appMetadataRepo.Get(ctx, appMetadataKeyLastSeenVersion)
 	if err != nil {
-		c.logWarnIfEnabled("Failed to read last_seen_version from app_metadata", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to read last_seen_version from app_metadata", logger.Error(err))
 		return false, false, ""
 	}
 
@@ -274,7 +274,7 @@ func (c *Controller) determineWizardState(ctx context.Context, settings *conf.Se
 			// Auto-seed: existing install predates wizard tracking.
 			// Intentional write inside GET handler (idempotent upsert, fires once per install).
 			if err := c.appMetadataRepo.Set(ctx, appMetadataKeyLastSeenVersion, settings.Version); err != nil {
-				c.logWarnIfEnabled("Failed to auto-seed last_seen_version", logger.Error(err))
+				c.LogWarnIfEnabled("Failed to auto-seed last_seen_version", logger.Error(err))
 			}
 			return false, false, settings.Version
 		}
@@ -307,7 +307,7 @@ func (c *Controller) hasZeroDetections(ctx context.Context) bool {
 	err := c.V2Manager.DB().WithContext(ctx).Table(tableName).
 		Select("1").Limit(1).Scan(&exists).Error
 	if err != nil {
-		c.logWarnIfEnabled("Failed to check detections for wizard state", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to check detections for wizard state", logger.Error(err))
 		// On error, assume not a fresh install to avoid showing wizard incorrectly
 		return false
 	}
@@ -350,7 +350,7 @@ func (c *Controller) hasNotes(ctx context.Context) bool {
 	err := c.V2Manager.DB().WithContext(ctx).Table(tableName).
 		Select("1").Limit(1).Scan(&exists).Error
 	if err != nil {
-		c.logWarnIfEnabled("Failed to check notes for wizard state", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to check notes for wizard state", logger.Error(err))
 		return false
 	}
 	return exists != 0
@@ -369,7 +369,7 @@ func (c *Controller) DismissWizard(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "App metadata not available", http.StatusServiceUnavailable)
 	}
 
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
 	}

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -1025,10 +1026,7 @@ func FuzzGetAppConfig_Headers(f *testing.F) {
 			Version: "1.0.0-fuzz",
 		}
 
-		controller := &Controller{
-			DS:          mockDS,
-			authService: nil,
-		}
+		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
@@ -1088,10 +1086,7 @@ func FuzzGetAppConfig_QueryParams(f *testing.F) {
 			Version: "1.0.0-fuzz",
 		}
 
-		controller := &Controller{
-			DS:          mockDS,
-			authService: nil,
-		}
+		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
 
 		// Build URL safely - query string must be URL-encoded
@@ -1153,10 +1148,7 @@ func FuzzGetAppConfig_CSRFToken(f *testing.F) {
 			Version: "1.0.0-fuzz",
 		}
 
-		controller := &Controller{
-			DS:          mockDS,
-			authService: nil,
-		}
+		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
@@ -1219,10 +1211,7 @@ func FuzzGetAppConfig_Version(f *testing.F) {
 			Version: version,
 		}
 
-		controller := &Controller{
-			DS:          mockDS,
-			authService: nil,
-		}
+		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 
@@ -1373,10 +1362,7 @@ func FuzzGetAppConfig_SecurityConfig(f *testing.F) {
 			},
 		}
 
-		controller := &Controller{
-			DS:          mockDS,
-			authService: nil,
-		}
+		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
 		publishTestSettings(t, settings)
 

--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"gorm.io/driver/sqlite"
@@ -221,7 +222,7 @@ func TestDetermineWizardState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c := &Controller{}
+			c := &Controller{Core: &apicore.Core{}}
 			c.Settings.Store(&conf.Settings{Version: tt.version})
 			c.appMetadataRepo = tt.metadataRepo
 			if tt.v2Manager != nil {
@@ -246,9 +247,7 @@ func TestDismissWizard_Success(t *testing.T) {
 	// Not parallel: publishes settings to the process-wide global snapshot.
 	mockRepo := newMockAppMetadataRepo()
 	e := echo.New()
-	c := &Controller{
-		appMetadataRepo: mockRepo,
-	}
+	c := &Controller{Core: &apicore.Core{}, appMetadataRepo: mockRepo}
 	c.Settings.Store(&conf.Settings{Version: "v0.9.0"})
 	publishTestSettings(t, c.Settings.Load())
 
@@ -268,9 +267,7 @@ func TestDismissWizard_NilRepo(t *testing.T) {
 	t.Parallel()
 
 	e := echo.New()
-	c := &Controller{
-		// appMetadataRepo intentionally nil
-	}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(&conf.Settings{
 		Version:   "v0.9.0",
 		WebServer: conf.WebServerSettings{Debug: true},
@@ -294,9 +291,7 @@ func TestDismissWizard_SetError(t *testing.T) {
 	mockRepo.setErr = assert.AnError
 
 	e := echo.New()
-	c := &Controller{
-		appMetadataRepo: mockRepo,
-	}
+	c := &Controller{Core: &apicore.Core{}, appMetadataRepo: mockRepo}
 	c.Settings.Store(&conf.Settings{
 		Version:   "v0.9.0",
 		WebServer: conf.WebServerSettings{Debug: true},

--- a/internal/api/v2/audio_health.go
+++ b/internal/api/v2/audio_health.go
@@ -14,17 +14,17 @@ type AudioHealthResponse struct {
 
 // initAudioHealthRoutes registers the audio liveness health endpoints.
 func (c *Controller) initAudioHealthRoutes() {
-	c.Group.GET("/health/audio", c.GetAudioHealth, c.authMiddleware)
+	c.Group.GET("/health/audio", c.GetAudioHealth, c.AuthMiddleware)
 }
 
 // SetAudioWatchdog injects the liveness watchdog for the health endpoint.
 func (c *Controller) SetAudioWatchdog(w *audiocore.LivenessWatchdog) {
-	c.audioWatchdog.Store(w)
+	c.AudioWatchdog.Store(w)
 }
 
 // GetAudioHealth returns the current liveness state for all monitored audio sources.
 func (c *Controller) GetAudioHealth(ctx echo.Context) error {
-	w := c.audioWatchdog.Load()
+	w := c.AudioWatchdog.Load()
 	if w == nil {
 		return ctx.JSON(http.StatusOK, AudioHealthResponse{
 			Sources: []audiocore.SourceHealthSnapshot{},

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -219,7 +219,7 @@ func hlsPlaylistURL(token string) string {
 // initHLSRoutes registers HLS streaming endpoints
 func (c *Controller) initHLSRoutes() {
 	// Get authentication middleware
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// HLS base group (no auth by default)
 	hlsGroup := c.Group.Group(hlsGroupPath)
@@ -242,7 +242,7 @@ func (c *Controller) initHLSRoutes() {
 
 	// Start the HLS activity sync goroutine (only once across all controller instances)
 	hlsMgr.activitySyncOnce.Do(func() {
-		ctx, cancel := context.WithCancel(c.ctx)
+		ctx, cancel := context.WithCancel(c.Context())
 		hlsMgr.activitySyncCancel = cancel
 		go runHLSActivitySync(ctx)
 	})
@@ -254,53 +254,11 @@ func (c *Controller) initHLSRoutes() {
 // to take effect immediately without a server restart.
 func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		isPublic := c.currentSettings().Security.PublicAccess.LiveAudio
+		isPublic := c.CurrentSettings().Security.PublicAccess.LiveAudio
 		if isPublic {
 			return next(ctx)
 		}
-		return c.authMiddleware(next)(ctx)
-	}
-}
-
-// privateModeAuth is a dynamic middleware applied at the v2 API group level
-// that requires authentication for every endpoint when Security.PrivateMode
-// is enabled. A small set of paths stay public so the frontend can complete
-// the bootstrap and login flow and so the existing PublicAccess.LiveAudio
-// carve-out is preserved (those routes fall through to their own
-// publicLiveAudioAuth middleware which decides based on PublicAccess.LiveAudio).
-// The check runs per-request so the setting hot-reloads without a server
-// restart.
-func (c *Controller) privateModeAuth(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(ctx echo.Context) error {
-		// Read the live global snapshot (race-free, hot-reloading) via
-		// currentSettings() to match the sibling publicLiveAudioAuth middleware; the
-		// per-controller snapshot would miss out-of-band StoreSettings republishes.
-		privateMode := c.currentSettings().Security.PrivateMode
-
-		if !privateMode {
-			return next(ctx)
-		}
-		// Fail closed: if PrivateMode is requested but no auth middleware
-		// is configured the request must be rejected, not silently allowed.
-		// Auth middleware is always wired up in production; reaching this
-		// branch in a real deployment means the controller is misconfigured.
-		if c.authMiddleware == nil {
-			return c.HandleError(
-				ctx,
-				nil,
-				"Private mode is enabled but authentication is not configured",
-				http.StatusServiceUnavailable,
-			)
-		}
-		// Use ctx.Path() (the registered route pattern) rather than the raw
-		// request URL so the match is robust to trailing slashes, ingress
-		// prefixes, and other URL normalisation differences. The method is
-		// matched explicitly so that a future handler bound to the same
-		// path with a different verb does not inherit the public exemption.
-		if isPrivateModeExempt(ctx.Request().Method, ctx.Path()) {
-			return next(ctx)
-		}
-		return c.authMiddleware(next)(ctx)
+		return c.AuthMiddleware(next)(ctx)
 	}
 }
 
@@ -430,13 +388,13 @@ func (c *Controller) StartHLSStream(ctx echo.Context) error {
 		forceRestart = false
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "HLS stream start requested",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "HLS stream start requested",
 		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 		logger.String("client_id", clientID),
 		logger.Bool("force_restart", forceRestart))
 
 	// Verify source exists by checking for a capture buffer
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
@@ -448,7 +406,7 @@ func (c *Controller) StartHLSStream(ctx echo.Context) error {
 	if existingStream := c.getHLSStream(sourceID); existingStream != nil && !forceRestart {
 		// Existing stream found - register client and reuse it
 		c.updateHLSActivity(sourceID, clientID, "stream_join", hlsNewStreamGracePeriod)
-		c.logAPIRequest(ctx, logger.LogLevelInfo, "Reusing existing HLS stream",
+		c.LogAPIRequest(ctx, logger.LogLevelInfo, "Reusing existing HLS stream",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.String("client_id", clientID))
 		return c.buildHLSStreamResponse(ctx, sourceID, existingStream)
@@ -462,7 +420,7 @@ func (c *Controller) StartHLSStream(ctx echo.Context) error {
 		stream, err = c.getOrCreateHLSStream(sourceID)
 	}
 	if err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to create HLS stream",
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to create HLS stream",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to start audio stream", http.StatusInternalServerError)
@@ -504,7 +462,7 @@ func (c *Controller) buildHLSStreamResponse(ctx echo.Context, sourceID string, s
 	status := "starting"
 	if isReady {
 		status = "ready"
-		c.logAPIRequest(ctx, logger.LogLevelInfo, "HLS stream ready",
+		c.LogAPIRequest(ctx, logger.LogLevelInfo, "HLS stream ready",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.String("stream_token", token[:8]+"..."),
 			logger.String("playlist_url", playlistURL))
@@ -576,7 +534,7 @@ func (c *Controller) StopHLSStream(ctx echo.Context) error {
 
 	clientID := c.resolveClientID(ctx, req.SessionID)
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "HLS stream stop requested",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "HLS stream stop requested",
 		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 		logger.String("client_id", clientID))
 
@@ -618,7 +576,7 @@ func (c *Controller) HLSHeartbeat(ctx echo.Context) error {
 	// Validate stream exists
 	if !c.hlsStreamExists(sourceID) {
 		if hlsMgr.verboseLogging {
-			c.logAPIRequest(ctx, logger.LogLevelWarn, "Heartbeat for non-existent stream",
+			c.LogAPIRequest(ctx, logger.LogLevelWarn, "Heartbeat for non-existent stream",
 				logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 		}
 		return ctx.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -1063,7 +1021,7 @@ func (c *Controller) setHLSHeaders(ctx echo.Context) {
 
 // getEffectiveSegmentLength returns the configured segment length with defaults and limits applied
 func (c *Controller) getEffectiveSegmentLength() int {
-	segmentLength := c.currentSettings().WebServer.LiveStream.SegmentLength
+	segmentLength := c.CurrentSettings().WebServer.LiveStream.SegmentLength
 	switch {
 	case segmentLength < hlsMinSegmentLen:
 		return hlsDefaultSegmentLen // Default
@@ -1206,7 +1164,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	// Create stream context from controller's lifecycle context, NOT from HTTP request context.
 	// Using request context would cause the stream to be cleaned up when the /start request completes.
 	// The stream must persist beyond the initial request lifetime.
-	streamCtx, streamCancel := context.WithCancel(c.ctx)
+	streamCtx, streamCancel := context.WithCancel(c.Context())
 
 	// Get HLS directory
 	hlsBaseDir, err := conf.GetHLSDirectory()
@@ -1235,7 +1193,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	}
 
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
-	ffmpegPath := c.currentSettings().Realtime.Audio.FfmpegPath
+	ffmpegPath := c.CurrentSettings().Realtime.Audio.FfmpegPath
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegPath); err != nil {
 		streamCancel()
 		return nil, fmt.Errorf("invalid FFmpeg path: %w", err)
@@ -1433,7 +1391,7 @@ func (c *Controller) setupHLSFFmpeg(ctx context.Context, ffmpegPath, inputSource
 
 // buildFFmpegArgs constructs FFmpeg command line arguments
 func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string) []string {
-	settings := c.currentSettings().WebServer.LiveStream
+	settings := c.CurrentSettings().WebServer.LiveStream
 
 	// Apply defaults and limits
 	bitrate := 128
@@ -1693,7 +1651,7 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	consumerID := fmt.Sprintf("hls_%s_%s", privacy.SanitizeStreamUrl(sourceID), uuid.New().String()[:8])
 	// Use the configured live stream sample rate, falling back to the default HLS sample rate.
 	sampleRate := hlsDefaultSampleRate
-	liveStream := c.currentSettings().WebServer.LiveStream
+	liveStream := c.CurrentSettings().WebServer.LiveStream
 	if liveStream.SampleRate > 0 {
 		sampleRate = liveStream.SampleRate
 	}
@@ -1708,7 +1666,7 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	}
 
 	// Load the engine once for all registry/router operations in this section.
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return nil, nil, fmt.Errorf("audio engine not initialized")
 	}
@@ -2003,7 +1961,7 @@ func (c *Controller) handleHLSDisconnect(ctx echo.Context, sourceID, clientID st
 	if lastTime, exists := hlsMgr.clientActivity[sourceID+":"+clientID]; exists {
 		if time.Since(lastTime) < hlsPrematureDisconnectThreshold {
 			hlsMgr.activityMu.Unlock()
-			c.logAPIRequest(ctx, logger.LogLevelWarn, "Ignoring premature disconnect",
+			c.LogAPIRequest(ctx, logger.LogLevelWarn, "Ignoring premature disconnect",
 				logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 			c.updateHLSActivity(sourceID, clientID, "continued-connection")
 			return ctx.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -2011,7 +1969,7 @@ func (c *Controller) handleHLSDisconnect(ctx echo.Context, sourceID, clientID st
 	}
 	hlsMgr.activityMu.Unlock()
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Client announced disconnection",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Client announced disconnection",
 		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 		logger.String("client_id", clientID))
 

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -525,7 +526,7 @@ func TestResolveClientID(t *testing.T) {
 	const testRemoteAddr = "192.168.1.100:12345"
 
 	t.Run("prefers session ID when provided", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -539,7 +540,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("falls back to generateClientID when no session", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -554,7 +555,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("different sessions from same IP get different IDs", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 
@@ -572,7 +573,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("rejects invalid session ID format", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -98,11 +98,11 @@ var audioLevelMgr = &audioLevelManager{
 // This connects the audio capture system to the SSE endpoint.
 func (c *Controller) SetAudioLevelChan(ch chan audiocore.AudioLevelData) {
 	c.audioLevelChan = ch
-	c.logInfoIfEnabled("Audio level channel connected to API v2 controller")
+	c.LogInfoIfEnabled("Audio level channel connected to API v2 controller")
 
 	// Start the broadcaster goroutine (only once across all controller instances)
 	audioLevelMgr.broadcasterOnce.Do(func() {
-		ctx, cancel := context.WithCancel(c.ctx)
+		ctx, cancel := context.WithCancel(c.Context())
 		audioLevelMgr.broadcasterCancel = cancel
 		go runAudioLevelBroadcaster(ctx, ch)
 	})
@@ -231,7 +231,7 @@ func (c *Controller) initAudioLevelRoutes() {
 func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	// Early nil check for audio level channel
 	if c.audioLevelChan == nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Audio level stream unavailable - channel not configured")
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Audio level stream unavailable - channel not configured")
 		return c.HandleError(ctx, nil, "Audio level stream is not available", http.StatusServiceUnavailable)
 	}
 
@@ -248,7 +248,7 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	}
 	if count >= audioLevelMaxConnectionsPerIP {
 		audioLevelMgr.connectionMu.Unlock()
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Rejected audio level SSE connection - max per IP reached",
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Rejected audio level SSE connection - max per IP reached",
 			logger.String("reason", "max_connections_per_ip"),
 			logger.Int("current_count", int(count)),
 			logger.Int("max_allowed", audioLevelMaxConnectionsPerIP))
@@ -286,9 +286,9 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	atomic.AddInt64(&audioLevelMgr.totalConnections, 1)
 
 	// Track metrics if available
-	if c.metrics != nil && c.metrics.HTTP != nil {
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
 		connectionStartTime := time.Now()
-		c.metrics.HTTP.SSEConnectionStarted(audioLevelStreamEndpoint)
+		c.Metrics.HTTP.SSEConnectionStarted(audioLevelStreamEndpoint)
 		defer func() {
 			duration := time.Since(connectionStartTime).Seconds()
 			closeReason := "closed"
@@ -297,7 +297,7 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 			} else if ctx.Request().Context().Err() == context.Canceled {
 				closeReason = "canceled"
 			}
-			c.metrics.HTTP.SSEConnectionClosed(audioLevelStreamEndpoint, duration, closeReason)
+			c.Metrics.HTTP.SSEConnectionClosed(audioLevelStreamEndpoint, duration, closeReason)
 		}()
 	}
 
@@ -328,7 +328,7 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	}
 
 	// Log connection
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE client connected",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE client connected",
 		logger.Bool("authenticated", isAuthenticated),
 		logger.Int64("total_connections", atomic.LoadInt64(&audioLevelMgr.totalConnections)))
 
@@ -348,20 +348,20 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	// Main event loop - reads from subscriber channel instead of source channel
 	for {
 		select {
-		case <-c.ctx.Done():
+		case <-c.Context().Done():
 			// Controller shutting down
-			c.logAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE connection closed",
+			c.LogAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE connection closed",
 				logger.String("reason", "shutdown"))
 			return nil
 
 		case <-timeoutCtx.Done():
-			c.logAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE connection closed",
+			c.LogAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE connection closed",
 				logger.String("reason", "timeout_or_cancelled"))
 			return nil
 
 		case audioData, ok := <-subscriberChan:
 			if !ok {
-				c.logWarnIfEnabled("Audio level subscriber channel closed")
+				c.LogWarnIfEnabled("Audio level subscriber channel closed")
 				return nil
 			}
 
@@ -378,7 +378,7 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 
 		case <-activityCheck.C:
 			// Prune sources that have been removed/disabled since the session started.
-			eng := c.engine.Load()
+			eng := c.Engine.Load()
 			if eng == nil {
 				continue
 			}
@@ -421,7 +421,7 @@ func createAudioLevelEntry(sourceID, displayName string) audiocore.AudioLevelDat
 // initializeAudioLevels creates the initial levels map with configured sources
 func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audiocore.AudioLevelData {
 	levels := make(map[string]audiocore.AudioLevelData)
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return levels
 	}
@@ -448,7 +448,7 @@ func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audi
 // getAudioCardSources retrieves all configured audio card sources from the registry.
 func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*audiocore.AudioSource {
 	var sources []*audiocore.AudioSource
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return nil
 	}
@@ -466,7 +466,7 @@ func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*
 
 // addStreamSourcesToLevels adds all configured stream sources to the levels map.
 func (c *Controller) addStreamSourcesToLevels(registry *audiocore.SourceRegistry, levels map[string]audiocore.AudioLevelData, isAuthenticated bool) {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return
 	}
@@ -492,7 +492,7 @@ func (c *Controller) updateAudioLevel(
 	isAuthenticated bool,
 ) {
 	now := time.Now()
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	var registry *audiocore.SourceRegistry
 	if eng != nil {
 		registry = eng.Registry()
@@ -664,7 +664,7 @@ func (c *Controller) extractRemoteAddr(ctx echo.Context) string {
 func (c *Controller) resetAudioLevelWriteDeadline(ctx echo.Context, operation string) {
 	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
 		if err := conn.SetWriteDeadline(time.Now().Add(audioLevelWriteDeadline)); err != nil {
-			c.logDebugIfEnabled("Failed to set write deadline for "+operation, logger.Error(err))
+			c.LogDebugIfEnabled("Failed to set write deadline for "+operation, logger.Error(err))
 		}
 	}
 }

--- a/internal/api/v2/audio_level_test.go
+++ b/internal/api/v2/audio_level_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -67,7 +68,7 @@ func TestAudioLevelSSEDataFormat(t *testing.T) {
 // TestIsSourceInactive tests the source inactivity detection logic
 func TestIsSourceInactive(t *testing.T) {
 	// Create a minimal controller for testing
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	t.Run("new source is active", func(t *testing.T) {
@@ -122,7 +123,7 @@ func TestIsSourceInactive(t *testing.T) {
 
 // TestCheckSourceActivity tests the source activity checking for multiple sources
 func TestCheckSourceActivity(t *testing.T) {
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	t.Run("no inactive sources", func(t *testing.T) {
@@ -178,7 +179,7 @@ func TestCheckSourceActivity(t *testing.T) {
 
 // TestGetAnonymizedSourceNameFallback tests the fallback source name anonymization
 func TestGetAnonymizedSourceNameFallback(t *testing.T) {
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	t.Run("audio card source", func(t *testing.T) {

--- a/internal/api/v2/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio_level_write_deadline_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -67,7 +68,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{}
+		controller := &Controller{Core: &apicore.Core{}}
 		controller.Settings.Store(newValidTestSettings())
 
 		// Create test audio level data
@@ -108,7 +109,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		ctx.Response().Writer = mockWriter
 
-		controller := &Controller{}
+		controller := &Controller{Core: &apicore.Core{}}
 		controller.Settings.Store(newValidTestSettings())
 		levels := map[string]audiocore.AudioLevelData{
 			"test_source": {Level: 50, Name: "Test Source", Source: "test_source"},
@@ -141,7 +142,7 @@ func TestSendAudioLevelHeartbeatSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{}
+		controller := &Controller{Core: &apicore.Core{}}
 		controller.Settings.Store(newValidTestSettings())
 
 		// Call sendAudioLevelHeartbeat

--- a/internal/api/v2/audio_sources.go
+++ b/internal/api/v2/audio_sources.go
@@ -51,14 +51,14 @@ func isStreamSourceType(t audiocore.SourceType) bool {
 // source names are replaced with anonymized values for unauthenticated
 // clients, matching the behavior of the audio-level SSE stream.
 func (c *Controller) listSources(ctx echo.Context, label string, filter func(audiocore.SourceType) bool, anonymize bool) error {
-	c.logInfoIfEnabled("Listing "+label,
+	c.LogInfoIfEnabled("Listing "+label,
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	resp := AudioSourceListResponse{Sources: []AudioSourceInfo{}}
 
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return ctx.JSON(http.StatusOK, resp)
 	}
@@ -82,7 +82,7 @@ func (c *Controller) listSources(ctx echo.Context, label string, filter func(aud
 		resp.Sources = append(resp.Sources, info)
 	}
 
-	c.logInfoIfEnabled(label+" listed",
+	c.LogInfoIfEnabled(label+" listed",
 		logger.Int("count", len(resp.Sources)),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),

--- a/internal/api/v2/audio_sources_test.go
+++ b/internal/api/v2/audio_sources_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -37,12 +38,9 @@ func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (
 	}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(&conf.Settings{})
-	controller.engine.Store(eng)
+	controller.Engine.Store(eng)
 	return e, controller
 }
 
@@ -54,10 +52,7 @@ func TestListAudioSources(t *testing.T) {
 
 	t.Run("No engine returns empty list", func(t *testing.T) {
 		e := echo.New()
-		controller := &Controller{
-			Echo:  e,
-			Group: e.Group("/api/v2"),
-		}
+		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 		controller.Settings.Store(&conf.Settings{})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/sources", http.NoBody)
@@ -124,10 +119,7 @@ func TestListStreamSources(t *testing.T) {
 
 	t.Run("No engine returns empty list", func(t *testing.T) {
 		e := echo.New()
-		controller := &Controller{
-			Echo:  e,
-			Group: e.Group("/api/v2"),
-		}
+		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 		controller.Settings.Store(&conf.Settings{})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/sources", http.NoBody)

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -94,7 +94,7 @@ func (c *Controller) initAuthRoutes() {
 		},
 		ErrorHandler: func(ctx echo.Context, err error) error {
 			// Return a user-friendly error message when rate limit is exceeded
-			c.logSecurityWarnIfEnabled("Login rate limit exceeded",
+			c.LogSecurityWarnIfEnabled("Login rate limit exceeded",
 				logger.String("ip", ctx.RealIP()),
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("user_agent", ctx.Request().Header.Get("User-Agent")),
@@ -103,7 +103,7 @@ func (c *Controller) initAuthRoutes() {
 		},
 		DenyHandler: func(ctx echo.Context, identifier string, err error) error {
 			// This is called when the rate limit is exceeded
-			c.logSecurityWarnIfEnabled("Login attempt denied due to rate limit",
+			c.LogSecurityWarnIfEnabled("Login attempt denied due to rate limit",
 				logger.String("identifier", identifier),
 				logger.String("ip", ctx.RealIP()),
 				logger.String("path", ctx.Request().URL.Path),
@@ -120,7 +120,7 @@ func (c *Controller) initAuthRoutes() {
 	authGroup.GET(authCallbackPath, c.OAuthCallback)
 
 	// Routes that require authentication
-	protectedGroup := authGroup.Group("", c.authMiddleware)
+	protectedGroup := authGroup.Group("", c.AuthMiddleware)
 	protectedGroup.POST(authLogoutPath, c.Logout)
 	protectedGroup.GET(authStatusPath, c.GetAuthStatus)
 }
@@ -130,7 +130,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	// Parse login request
 	var req AuthRequest
 	if err := ctx.Bind(&req); err != nil {
-		c.logSecurityErrorIfEnabled("Invalid login request",
+		c.LogSecurityErrorIfEnabled("Invalid login request",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -142,7 +142,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	authService := c.authService
 	if authService == nil {
 		// Handle case where auth might not be configured but login endpoint is hit
-		c.logSecurityErrorIfEnabled("Login attempt but AuthService is nil (auth not configured?)",
+		c.LogSecurityErrorIfEnabled("Login attempt but AuthService is nil (auth not configured?)",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -153,7 +153,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 
 	// If authentication is not required, act as if the login was successful
 	if !authService.IsAuthRequired(ctx) {
-		c.logSecurityInfoIfEnabled("Authentication not required",
+		c.LogSecurityInfoIfEnabled("Authentication not required",
 			logger.Username(req.Username),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -171,7 +171,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 		// Add a short, randomized delay to mitigate timing attacks on username enumeration
 		randomDelay(ctx.Request().Context(), authDelayMinMs, authDelayMaxMs)
 
-		c.logSecurityWarnIfEnabled("Login attempt with missing credentials",
+		c.LogSecurityWarnIfEnabled("Login attempt with missing credentials",
 			logger.Bool("username_present", req.Username != ""),
 			logger.Bool("password_present", req.Password != ""),
 			logger.String("ip", ctx.RealIP()),
@@ -193,7 +193,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 		// Add a short, randomized delay to mitigate brute force/timing attacks
 		randomDelay(ctx.Request().Context(), authDelayMinMs, authDelayMaxMs)
 
-		c.logSecurityWarnIfEnabled("Failed login attempt",
+		c.LogSecurityWarnIfEnabled("Failed login attempt",
 			logger.Username(req.Username),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -215,7 +215,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	}
 
 	// Successful login - auth code has been generated directly (V1 pattern)
-	c.logSecurityInfoIfEnabled("Successful login with auth code",
+	c.LogSecurityInfoIfEnabled("Successful login with auth code",
 		logger.Username(req.Username),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -235,7 +235,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 
 			// Log if redirect was adjusted
 			if finalRedirect != req.RedirectURL {
-				c.logSecurityDebugIfEnabled("Adjusted redirect URL to stay within base path",
+				c.LogSecurityDebugIfEnabled("Adjusted redirect URL to stay within base path",
 					logger.String("requested", req.RedirectURL),
 					logger.String("basePath", basePath),
 					logger.String("final", finalRedirect),
@@ -243,7 +243,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 			}
 		} else {
 			// Invalid redirect - log and use default
-			c.logSecurityWarnIfEnabled("Invalid redirect URL provided, using base path",
+			c.LogSecurityWarnIfEnabled("Invalid redirect URL provided, using base path",
 				logger.String("requested", req.RedirectURL),
 				logger.String("basePath", basePath),
 				logger.String("default", finalRedirect),
@@ -267,7 +267,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 	callbackPath := apiV2Prefix + authGroupPath + authCallbackPath
 	redirectURL := fmt.Sprintf("%s%s?code=%s&redirect=%s", requestBase, callbackPath, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
 
-	c.logSecurityInfoIfEnabled("Returning successful login response with redirect",
+	c.LogSecurityInfoIfEnabled("Returning successful login response with redirect",
 		logger.Username(req.Username),
 		logger.String("redirect_url", redirectURL),
 		logger.String("final_redirect", finalRedirect),
@@ -288,7 +288,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 	// Use the stored auth service instance
 	authService := c.authService
 	if authService == nil {
-		c.logSecurityWarnIfEnabled("Logout requested but AuthService is nil (auth not configured?)",
+		c.LogSecurityWarnIfEnabled("Logout requested but AuthService is nil (auth not configured?)",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -306,7 +306,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 
 	// Try to perform logout via auth service
 	if err := authService.Logout(ctx); err != nil {
-		c.logSecurityErrorIfEnabled("Logout failed",
+		c.LogSecurityErrorIfEnabled("Logout failed",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
@@ -314,7 +314,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Logout failed", http.StatusInternalServerError)
 	}
 
-	c.logSecurityInfoIfEnabled("User logged out",
+	c.LogSecurityInfoIfEnabled("User logged out",
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.Bool("has_provider_logout", providerLogoutURL != ""),
@@ -347,7 +347,7 @@ func (c *Controller) GetAuthStatus(ctx echo.Context) error {
 		Method:        authMethod,
 	}
 
-	c.logSecurityInfoIfEnabled("Auth status check",
+	c.LogSecurityInfoIfEnabled("Auth status check",
 		logger.Bool("authenticated", status.Authenticated),
 		logger.Username(status.Username),
 		logger.String("method", status.Method),
@@ -407,7 +407,7 @@ func stringFromCtx(ctx echo.Context, key, defaultValue string) string {
 func (c *Controller) extractBasePath(ctx echo.Context, req AuthRequest) string {
 	// 1. If explicitly provided and valid, use it
 	if req.BasePath != "" && isValidBasePath(req.BasePath) {
-		c.logDebugIfEnabled("Using explicit base path from request",
+		c.LogDebugIfEnabled("Using explicit base path from request",
 			logger.String("basePath", req.BasePath),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -418,7 +418,7 @@ func (c *Controller) extractBasePath(ctx echo.Context, req AuthRequest) string {
 	referer := ctx.Request().Header.Get("Referer")
 	if referer != "" {
 		if basePath := extractBasePathFromReferer(referer); basePath != "" {
-			c.logDebugIfEnabled("Extracted base path from Referer",
+			c.LogDebugIfEnabled("Extracted base path from Referer",
 				logger.String("basePath", basePath),
 				logger.String("referer", referer),
 				logger.String("ip", ctx.RealIP()),
@@ -430,7 +430,7 @@ func (c *Controller) extractBasePath(ctx echo.Context, req AuthRequest) string {
 	// 3. Default fallback - try to detect common patterns
 	// Check if request is coming from /ui/* path based on API versioning
 	defaultBasePath := "/ui/"
-	c.logDebugIfEnabled("Using default base path",
+	c.LogDebugIfEnabled("Using default base path",
 		logger.String("basePath", defaultBasePath),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -538,7 +538,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	code := ctx.QueryParam("code")
 	redirect := ctx.QueryParam("redirect")
 
-	c.logSecurityInfoIfEnabled("Handling V2 OAuth callback",
+	c.LogSecurityInfoIfEnabled("Handling V2 OAuth callback",
 		logger.String("redirect", redirect),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),
@@ -546,7 +546,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 
 	// 1. Validate code parameter
 	if code == "" {
-		c.logSecurityWarnIfEnabled("Missing authorization code in callback",
+		c.LogSecurityWarnIfEnabled("Missing authorization code in callback",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -555,7 +555,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 
 	// 2. Defensive check: ensure AuthService is available
 	if c.authService == nil {
-		c.logSecurityErrorIfEnabled("AuthService is nil in OAuthCallback - server misconfiguration",
+		c.LogSecurityErrorIfEnabled("AuthService is nil in OAuthCallback - server misconfiguration",
 			logger.String("ip", ctx.RealIP()),
 			logger.String("path", ctx.Request().URL.Path),
 		)
@@ -569,26 +569,26 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	accessToken, err := c.authService.ExchangeAuthCode(exchangeCtx, code)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			c.logSecurityWarnIfEnabled("Timeout exchanging authorization code",
+			c.LogSecurityWarnIfEnabled("Timeout exchanging authorization code",
 				logger.Error(err),
 				logger.String("ip", ctx.RealIP()),
 			)
 			return c.HandleErrorWithKey(ctx, nil, "Login timed out. Please try again.", http.StatusGatewayTimeout, notification.MsgErrAuthTimeout, nil)
 		}
-		c.logSecurityWarnIfEnabled("Failed to exchange authorization code",
+		c.LogSecurityWarnIfEnabled("Failed to exchange authorization code",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 		)
 		return c.HandleErrorWithKey(ctx, nil, "Unable to complete login at this time. Please try again.", http.StatusUnauthorized, notification.MsgErrAuthExchangeFailed, nil)
 	}
 
-	c.logSecurityInfoIfEnabled("Successfully exchanged authorization code for access token",
+	c.LogSecurityInfoIfEnabled("Successfully exchanged authorization code for access token",
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	// 4. Establish session (handles session fixation mitigation)
 	if err := c.authService.EstablishSession(ctx, accessToken); err != nil {
-		c.logSecurityErrorIfEnabled("Failed to establish session",
+		c.LogSecurityErrorIfEnabled("Failed to establish session",
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -598,7 +598,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	// 5. Validate redirect path (prevent open redirects)
 	safeRedirect := validateAndSanitizeRedirect(redirect)
 
-	c.logSecurityInfoIfEnabled("Redirecting user to final destination",
+	c.LogSecurityInfoIfEnabled("Redirecting user to final destination",
 		logger.String("destination", safeRedirect),
 		logger.String("ip", ctx.RealIP()),
 	)

--- a/internal/api/v2/backup.go
+++ b/internal/api/v2/backup.go
@@ -362,7 +362,7 @@ func (c *Controller) initBackupRoutes() {
 		// Scan database directories where backup files are now written,
 		// plus os.TempDir() for files created by older versions.
 		var dbDirs []string
-		settings := c.currentSettings()
+		settings := c.CurrentSettings()
 		if settings != nil && settings.Output.SQLite.Path != "" {
 			dbDirs = append(dbDirs, filepath.Dir(settings.Output.SQLite.Path))
 		}
@@ -376,7 +376,7 @@ func (c *Controller) initBackupRoutes() {
 	backupGroup := c.Group.Group("/system/database/backup/jobs")
 
 	// Get the appropriate auth middleware
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// Create auth-protected group
 	protectedGroup := backupGroup.Group("", authMiddleware)
@@ -458,7 +458,7 @@ func (c *Controller) StartBackupJob(ctx echo.Context) error {
 			notification.MsgErrBackupCreateFailed, nil)
 	}
 
-	c.logInfoIfEnabled("Backup job started",
+	c.LogInfoIfEnabled("Backup job started",
 		logger.String("job_id", job.ID),
 		logger.String("db_type", dbType),
 		logger.Int64("db_size", dbSize))
@@ -553,7 +553,7 @@ func (c *Controller) DownloadBackupFile(ctx echo.Context) error {
 	ctx.Response().Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
 	ctx.Response().Header().Set("Content-Type", "application/octet-stream")
 
-	c.logInfoIfEnabled("Backup download started",
+	c.LogInfoIfEnabled("Backup download started",
 		logger.String("job_id", jobID),
 		logger.String("db_type", job.DBType),
 		logger.String("filename", filename))
@@ -571,7 +571,7 @@ func (c *Controller) CancelBackupJob(ctx echo.Context) error {
 			notification.MsgErrBackupNotFound, nil)
 	}
 
-	c.logInfoIfEnabled("Backup job cancelled",
+	c.LogInfoIfEnabled("Backup job cancelled",
 		logger.String("job_id", jobID))
 
 	return ctx.JSON(http.StatusOK, map[string]string{
@@ -588,7 +588,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 
 	// Retry loop for database lock
 	for attempt := 1; attempt <= backupVacuumRetries; attempt++ {
-		c.logInfoIfEnabled("Backup VACUUM INTO starting",
+		c.LogInfoIfEnabled("Backup VACUUM INTO starting",
 			logger.String("job_id", job.ID),
 			logger.Int("attempt", attempt),
 			logger.String("temp_path", job.tempPath))
@@ -603,7 +603,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 			break // Non-recoverable error
 		}
 
-		c.logWarnIfEnabled("Backup VACUUM INTO database locked, retrying",
+		c.LogWarnIfEnabled("Backup VACUUM INTO database locked, retrying",
 			logger.String("job_id", job.ID),
 			logger.Int("attempt", attempt),
 			logger.Error(lastErr))
@@ -612,7 +612,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 	}
 
 	if lastErr != nil {
-		c.logWarnIfEnabled("Backup VACUUM INTO failed",
+		c.LogWarnIfEnabled("Backup VACUUM INTO failed",
 			logger.String("job_id", job.ID),
 			logger.Error(lastErr))
 		_ = errors.New(lastErr).
@@ -628,7 +628,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 	job.updateProgress()
 	job.setStatus(BackupStatusCompleted, "")
 
-	c.logInfoIfEnabled("Backup job completed",
+	c.LogInfoIfEnabled("Backup job completed",
 		logger.String("job_id", job.ID),
 		logger.String("db_type", job.DBType),
 		logger.Int64("bytes_written", job.BytesWritten))
@@ -637,7 +637,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 // getBackupDBInfo returns the database path and GORM DB for the given type.
 func (c *Controller) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
 	if dbType == dbTypeLegacy {
-		settings := c.currentSettings()
+		settings := c.CurrentSettings()
 		if settings == nil || settings.Output.SQLite.Path == "" {
 			return "", nil, fmt.Errorf("backup only available for SQLite databases")
 		}

--- a/internal/api/v2/constants.go
+++ b/internal/api/v2/constants.go
@@ -128,12 +128,6 @@ const (
 	DefaultCacheDurationMinutes = 30
 )
 
-// Default path constants
-const (
-	// defaultExportPath is the default audio clip export directory, matching internal/conf/defaults.go.
-	defaultExportPath = "clips/"
-)
-
 // File permission constants
 const (
 	// FilePermReadWrite is the permission for read/write files (0o644)

--- a/internal/api/v2/control.go
+++ b/internal/api/v2/control.go
@@ -47,10 +47,10 @@ const (
 
 // initControlRoutes registers all control-related API endpoints
 func (c *Controller) initControlRoutes() {
-	c.logInfoIfEnabled("Initializing control routes")
+	c.LogInfoIfEnabled("Initializing control routes")
 
 	// Create control API group with auth middleware
-	controlGroup := c.Group.Group("/control", c.authMiddleware)
+	controlGroup := c.Group.Group("/control", c.AuthMiddleware)
 
 	// Control routes
 	controlGroup.POST("/restart", c.RestartAnalysis)
@@ -61,13 +61,13 @@ func (c *Controller) initControlRoutes() {
 	controlGroup.POST("/restart-source/:id", c.RestartAudioSource)
 	controlGroup.GET("/actions", c.GetAvailableActions)
 
-	c.logInfoIfEnabled("Control routes initialized successfully")
+	c.LogInfoIfEnabled("Control routes initialized successfully")
 }
 
 // GetAvailableActions handles GET /api/v2/control/actions
 // Returns a list of available control actions
 func (c *Controller) GetAvailableActions(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting available control actions",
+	c.LogInfoIfEnabled("Getting available control actions",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -102,7 +102,7 @@ func (c *Controller) GetAvailableActions(ctx echo.Context) error {
 		})
 	}
 
-	c.logInfoIfEnabled("Retrieved available control actions successfully",
+	c.LogInfoIfEnabled("Retrieved available control actions successfully",
 		logger.Int("action_count", len(actions)),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -121,14 +121,14 @@ func (c *Controller) GetAvailableActions(ctx echo.Context) error {
 //
 // Returns an error if the control channel is nil or if the request times out
 func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMessage, successMessage string) error {
-	c.logInfoIfEnabled(logMessage,
+	c.LogInfoIfEnabled(logMessage,
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	if c.controlChan == nil {
 		err := fmt.Errorf("control channel not initialized")
-		c.logErrorIfEnabled("Control channel not available",
+		c.LogErrorIfEnabled("Control channel not available",
 			logger.Error(err),
 			logger.String("action", action),
 			logger.String("path", ctx.Request().URL.Path),
@@ -144,21 +144,21 @@ func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMe
 	reqCtx := ctx.Request().Context()
 
 	// Send signal with context timeout and shutdown awareness.
-	// The c.ctx.Done() case prevents a send-on-closed-channel panic if shutdown
+	// The c.Context().Done() case prevents a send-on-closed-channel panic if shutdown
 	// closes controlChan while an HTTP request is still in-flight.
 	select {
 	case c.controlChan <- signal:
-		c.logInfoIfEnabled("Control signal sent successfully",
+		c.LogInfoIfEnabled("Control signal sent successfully",
 			logger.String("action", action),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
-	case <-c.ctx.Done():
-		return c.HandleError(ctx, c.ctx.Err(),
+	case <-c.Context().Done():
+		return c.HandleError(ctx, c.Context().Err(),
 			"Server is shutting down", http.StatusServiceUnavailable)
 	case <-reqCtx.Done():
 		err := reqCtx.Err()
-		c.logErrorIfEnabled("Request timeout/cancel while sending control signal",
+		c.LogErrorIfEnabled("Request timeout/cancel while sending control signal",
 			logger.Error(err),
 			logger.String("action", action),
 			logger.String("path", ctx.Request().URL.Path),
@@ -201,7 +201,7 @@ func (c *Controller) RebuildFilter(ctx echo.Context) error {
 // It checks the shutdown requester, applies the CAS flag via setFlag,
 // and schedules an async shutdown after the HTTP response is sent.
 func (c *Controller) handleRestartRequest(ctx echo.Context, action string, setFlag func() bool, successMessage string) error {
-	sr := c.getShutdownRequester()
+	sr := c.GetShutdownRequester()
 	if sr == nil {
 		err := fmt.Errorf("shutdown requester not initialized")
 		return c.HandleError(ctx, err,
@@ -218,7 +218,7 @@ func (c *Controller) handleRestartRequest(ctx echo.Context, action string, setFl
 		})
 	}
 
-	c.logInfoIfEnabled(successMessage,
+	c.LogInfoIfEnabled(successMessage,
 		logger.String("action", action),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -246,7 +246,7 @@ func (c *Controller) handleRestartRequest(ctx echo.Context, action string, setFl
 // RestartServer handles POST /api/v2/control/restart-server
 // Triggers a graceful binary restart.
 func (c *Controller) RestartServer(ctx echo.Context) error {
-	c.logInfoIfEnabled("Received request to restart server",
+	c.LogInfoIfEnabled("Received request to restart server",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -257,7 +257,7 @@ func (c *Controller) RestartServer(ctx echo.Context) error {
 // RestartContainer handles POST /api/v2/control/restart-container
 // Triggers a container restart by exiting the process.
 func (c *Controller) RestartContainer(ctx echo.Context) error {
-	c.logInfoIfEnabled("Received request to restart container",
+	c.LogInfoIfEnabled("Received request to restart container",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -290,13 +290,13 @@ func (c *Controller) RestartAudioSource(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Source ID is required", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Received request to restart audio source",
+	c.LogInfoIfEnabled("Received request to restart audio source",
 		logger.String("source_id", sourceID),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return c.HandleError(ctx, fmt.Errorf("audio engine not initialized"),
 			"Audio engine not available", http.StatusInternalServerError)
@@ -313,7 +313,7 @@ func (c *Controller) RestartAudioSource(ctx echo.Context) error {
 	}
 
 	if err := (*fn)(sourceID); err != nil {
-		c.logErrorIfEnabled("Failed to restart audio source",
+		c.LogErrorIfEnabled("Failed to restart audio source",
 			logger.String("source_id", sourceID),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -322,7 +322,7 @@ func (c *Controller) RestartAudioSource(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to restart audio source", http.StatusInternalServerError)
 	}
 
-	c.logInfoIfEnabled("Audio source restarted successfully",
+	c.LogInfoIfEnabled("Audio source restarted successfully",
 		logger.String("source_id", sourceID),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),

--- a/internal/api/v2/control_restart_source_test.go
+++ b/internal/api/v2/control_restart_source_test.go
@@ -36,7 +36,7 @@ func TestRestartAudioSource_SourceNotFound(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine.Store(eng)
+	c.Engine.Store(eng)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/nonexistent", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -55,7 +55,7 @@ func TestRestartAudioSource_NoPipeline(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine.Store(eng)
+	c.Engine.Store(eng)
 
 	src := &audiocore.SourceConfig{
 		ID:          "test-src",
@@ -82,7 +82,7 @@ func TestRestartAudioSource_Success(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine.Store(eng)
+	c.Engine.Store(eng)
 
 	src := &audiocore.SourceConfig{
 		ID:          "test-src",
@@ -124,7 +124,7 @@ func TestRestartAudioSource_RestartError(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine.Store(eng)
+	c.Engine.Store(eng)
 
 	src := &audiocore.SourceConfig{
 		ID:          "test-src",

--- a/internal/api/v2/database_overview.go
+++ b/internal/api/v2/database_overview.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -38,9 +37,6 @@ var metricsCollectorIntervalSec = metricsCollectorInterval.Seconds()
 // samplesPerHour is how many ring buffer entries cover one hour at the collector interval.
 var samplesPerHour = int(3600 / metricsCollectorIntervalSec)
 
-// detectionRateCacheTTL is how long detection rate query results are cached.
-const detectionRateCacheTTL = 5 * time.Minute
-
 // GetDatabaseOverview handles GET /api/v2/system/database/overview.
 // It assembles engine metadata, table stats, performance metrics, and detection rates
 // into a single response.
@@ -49,7 +45,7 @@ func (c *Controller) GetDatabaseOverview(ctx echo.Context) error {
 	basicStats, err := c.DS.GetDatabaseStats(ctx.Request().Context())
 	if err != nil || basicStats == nil {
 		if err != nil {
-			c.logDebugIfEnabled("Database stats unavailable", logger.Error(err))
+			c.LogDebugIfEnabled("Database stats unavailable", logger.Error(err))
 		}
 		return ctx.JSON(http.StatusOK, &DatabaseOverviewResponse{
 			Status:           dbStatusDisconnected,
@@ -78,7 +74,7 @@ func (c *Controller) GetDatabaseOverview(ctx echo.Context) error {
 	if ok {
 		// Engine details
 		if details, err := inspector.GetEngineDetails(); err != nil {
-			c.logDebugIfEnabled("Failed to get engine details", logger.Error(err))
+			c.LogDebugIfEnabled("Failed to get engine details", logger.Error(err))
 		} else {
 			resp.SQLite = details.SQLite
 			resp.MySQL = details.MySQL
@@ -86,15 +82,15 @@ func (c *Controller) GetDatabaseOverview(ctx echo.Context) error {
 
 		// Table stats
 		if tables, err := inspector.GetTableStats(); err != nil {
-			c.logDebugIfEnabled("Failed to get table stats", logger.Error(err))
+			c.LogDebugIfEnabled("Failed to get table stats", logger.Error(err))
 		} else {
 			resp.Tables = tables
 			resp.TotalTables = len(tables)
 		}
 
 		// Detection rate (24h hourly histogram) — cached to avoid repeated queries
-		if rates, err := c.detectionRateCache.GetHourly(inspector.GetDetectionRate24h); err != nil {
-			c.logDebugIfEnabled("Failed to get detection rate", logger.Error(err))
+		if rates, err := c.DetectionRateCache.GetHourly(inspector.GetDetectionRate24h); err != nil {
+			c.LogDebugIfEnabled("Failed to get detection rate", logger.Error(err))
 		} else {
 			resp.DetectionRate24h = rates
 		}
@@ -111,12 +107,12 @@ func (c *Controller) GetDatabaseOverview(ctx echo.Context) error {
 func (c *Controller) assemblePerformanceStats() datastore.PerformanceStats {
 	stats := datastore.PerformanceStats{}
 
-	if c.metricsStore == nil {
+	if c.MetricsStore == nil {
 		return stats
 	}
 
 	// Current values from latest ring buffer entry
-	latest := c.metricsStore.GetLatest()
+	latest := c.MetricsStore.GetLatest()
 	if latest != nil {
 		if pt, ok := latest["db.read_latency_ms"]; ok {
 			stats.ReadLatencyAvgMs = pt.Value
@@ -136,7 +132,7 @@ func (c *Controller) assemblePerformanceStats() datastore.PerformanceStats {
 	}
 
 	// QueriesLastHour: sum ring buffer entries × collection interval
-	samples := c.metricsStore.Get("db.queries_per_sec", samplesPerHour)
+	samples := c.MetricsStore.Get("db.queries_per_sec", samplesPerHour)
 	if len(samples) > 0 {
 		var total float64
 		for _, s := range samples {
@@ -161,9 +157,9 @@ func (c *Controller) initDatabaseOverviewRoutes() {
 	dbGroup := c.Group.Group("/system/database")
 
 	// Get the appropriate auth middleware
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	dbGroup.GET("/overview", c.GetDatabaseOverview, authMiddleware)
 
-	c.logInfoIfEnabled("Database overview route initialized")
+	c.LogInfoIfEnabled("Database overview route initialized")
 }

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -57,7 +57,7 @@ func (c *Controller) requireDebugMode(next echo.HandlerFunc) echo.HandlerFunc {
 
 // initDebugRoutes registers debug-related routes
 func (c *Controller) initDebugRoutes() {
-	// Only register debug routes if debug mode is enabled. Read via controllerSettings()
+	// Only register debug routes if debug mode is enabled. Read via ControllerSettings()
 	// (a nil-safe atomic Load) to match requireDebugMode; it returns nil when no
 	// snapshot has been stored (standalone/test controllers), which the guard handles.
 	if s := c.ControllerSettings(); s == nil || !s.Debug {

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -48,7 +48,7 @@ type DebugSystemStatus struct {
 // This is defense-in-depth — debug routes are already conditionally registered.
 func (c *Controller) requireDebugMode(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
-		if s := c.controllerSettings(); s == nil || !s.Debug {
+		if s := c.ControllerSettings(); s == nil || !s.Debug {
 			return c.HandleErrorWithKey(ctx, nil, "Debug mode not enabled", http.StatusForbidden, notification.MsgErrDebugNotEnabled, nil)
 		}
 		return next(ctx)
@@ -60,13 +60,13 @@ func (c *Controller) initDebugRoutes() {
 	// Only register debug routes if debug mode is enabled. Read via controllerSettings()
 	// (a nil-safe atomic Load) to match requireDebugMode; it returns nil when no
 	// snapshot has been stored (standalone/test controllers), which the guard handles.
-	if s := c.controllerSettings(); s == nil || !s.Debug {
+	if s := c.ControllerSettings(); s == nil || !s.Debug {
 		GetLogger().Debug("Debug mode not enabled, skipping debug routes")
 		return
 	}
 
 	// Debug endpoints require authentication and debug mode (defense-in-depth)
-	debugGroup := c.Group.Group("/debug", c.authMiddleware, c.requireDebugMode)
+	debugGroup := c.Group.Group("/debug", c.AuthMiddleware, c.requireDebugMode)
 
 	debugGroup.POST("/trigger-error", c.DebugTriggerError)
 	debugGroup.POST("/trigger-notification", c.DebugTriggerNotification)
@@ -112,7 +112,7 @@ func (c *Controller) DebugTriggerError(ctx echo.Context) error {
 	err := testErr.Build()
 
 	// Log the error which will trigger telemetry if enabled
-	c.logErrorIfEnabled("Debug error triggered",
+	c.LogErrorIfEnabled("Debug error triggered",
 		logger.Error(err),
 		logger.String("component", req.Component),
 		logger.String("category", req.Category))
@@ -187,7 +187,7 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 
 // DebugSystemStatus returns current system status for debugging
 func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
-	settings := c.controllerSettings()
+	settings := c.ControllerSettings()
 	debug := false
 	if settings != nil {
 		debug = settings.Debug

--- a/internal/api/v2/debug_test.go
+++ b/internal/api/v2/debug_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -17,9 +18,7 @@ func TestDebugTriggerError(t *testing.T) {
 	t.Parallel()
 
 	e := echo.New()
-	c := &Controller{
-		apiLogger: nil,
-	}
+	c := &Controller{Core: &apicore.Core{APILogger: nil}}
 	c.Settings.Store(&conf.Settings{Debug: true})
 
 	tests := []struct {
@@ -66,9 +65,7 @@ func TestDebugEndpointsRequireDebugMode(t *testing.T) {
 
 	// Create controller with debug disabled
 	e := echo.New()
-	c := &Controller{
-		apiLogger: nil,
-	}
+	c := &Controller{Core: &apicore.Core{APILogger: nil}}
 	c.Settings.Store(&conf.Settings{Debug: false})
 
 	// Table-driven tests for all debug endpoints returning 403 when debug mode is disabled

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -36,12 +36,10 @@ func (e *dateValidationError) Error() string { return e.message }
 
 // Detection constants (file-local)
 const (
-	detectionCacheExpiry  = 5 * time.Minute  // Default cache expiration
-	detectionCacheCleanup = 10 * time.Minute // Cache cleanup interval
-	defaultNumResults     = 100              // Default number of results
-	maxNumResults         = 1000             // Maximum number of results
-	sunEventWindowMinutes = 30               // Minutes before/after sunrise/sunset
-	minHourRangeParts     = 2                // Minimum parts for hour range parsing
+	defaultNumResults     = 100  // Default number of results
+	maxNumResults         = 1000 // Maximum number of results
+	sunEventWindowMinutes = 30   // Minutes before/after sunrise/sunset
+	minHourRangeParts     = 2    // Minimum parts for hour range parsing
 
 	// queryType values for detection queries
 	queryTypeHourly  = "hourly"
@@ -139,7 +137,7 @@ func (c *Controller) initDetectionRoutes() {
 	// mode (NewWithOptions permits a nil datastore) by not registering this route group
 	// when there is no datastore, instead of registering handlers that would panic.
 	if c.DS == nil {
-		c.logWarnIfEnabled("Skipping detection routes: datastore is not available")
+		c.LogWarnIfEnabled("Skipping detection routes: datastore is not available")
 		return
 	}
 
@@ -157,7 +155,7 @@ func (c *Controller) initDetectionRoutes() {
 	c.Group.GET("/detections/:id/time-of-day", c.GetDetectionTimeOfDay)
 
 	// Protected detection management endpoints
-	detectionGroup := c.Group.Group("/detections", c.authMiddleware)
+	detectionGroup := c.Group.Group("/detections", c.AuthMiddleware)
 	detectionGroup.DELETE("/:id", c.DeleteDetection)
 	detectionGroup.POST("/:id/review", c.ReviewDetection)
 	detectionGroup.POST("/:id/lock", c.LockDetection)
@@ -406,7 +404,7 @@ func (c *Controller) validateDateParameters(startDateStr, endDateStr string, ctx
 	// Validate individual date formats
 	for _, dp := range []struct{ value, name string }{{startDateStr, "start_date"}, {endDateStr, "end_date"}} {
 		if err := validateDateParam(dp.value, dp.name); err != nil {
-			c.logErrorIfEnabled("Invalid date parameter",
+			c.LogErrorIfEnabled("Invalid date parameter",
 				logger.String("parameter", dp.name),
 				logger.String("value", dp.value),
 				logger.String("path", ctx.Request().URL.Path),
@@ -417,7 +415,7 @@ func (c *Controller) validateDateParameters(startDateStr, endDateStr string, ctx
 
 	// Check date order
 	if err := validateDateOrder(startDateStr, endDateStr); err != nil {
-		c.logErrorIfEnabled("Invalid date range",
+		c.LogErrorIfEnabled("Invalid date range",
 			logger.String("start_date", startDateStr),
 			logger.String("end_date", endDateStr),
 			logger.String("path", ctx.Request().URL.Path),
@@ -434,12 +432,12 @@ func (c *Controller) parseNumResults(numResultsStr string) (int, error) {
 		return defaultNumResults, nil // Default value
 	}
 
-	c.logDebugIfEnabled("GetDetections: Raw numResults string",
+	c.LogDebugIfEnabled("GetDetections: Raw numResults string",
 		logger.String("value", numResultsStr),
 	)
 	numResults, err := strconv.Atoi(numResultsStr)
 	if err != nil {
-		c.logDebugIfEnabled("GetDetections: Invalid numResults string",
+		c.LogDebugIfEnabled("GetDetections: Invalid numResults string",
 			logger.String("value", numResultsStr),
 			logger.Error(err),
 		)
@@ -454,11 +452,11 @@ func (c *Controller) parseNumResults(numResultsStr string) (int, error) {
 		return 0, fmt.Errorf("Invalid numeric value for numResults: %w", err) //nolint:staticcheck // matches test expectations
 	}
 
-	c.logDebugIfEnabled("GetDetections: Parsed numResults value",
+	c.LogDebugIfEnabled("GetDetections: Parsed numResults value",
 		logger.Int("value", numResults),
 	)
 	if numResults <= 0 {
-		c.logDebugIfEnabled("GetDetections: Zero or negative numResults value",
+		c.LogDebugIfEnabled("GetDetections: Zero or negative numResults value",
 			logger.Int("value", numResults),
 		)
 		// Log the enhanced error for telemetry while returning a simpler error for HTTP response
@@ -473,7 +471,7 @@ func (c *Controller) parseNumResults(numResultsStr string) (int, error) {
 	}
 
 	if numResults > maxNumResults {
-		c.logDebugIfEnabled("GetDetections: Too large numResults value",
+		c.LogDebugIfEnabled("GetDetections: Too large numResults value",
 			logger.Int("value", numResults),
 		)
 		// Log the enhanced error for telemetry while returning a simpler error for HTTP response
@@ -496,12 +494,12 @@ func (c *Controller) parseOffset(offsetStr string) (int, error) {
 		return 0, nil // Default value
 	}
 
-	c.logDebugIfEnabled("GetDetections: Raw offset string",
+	c.LogDebugIfEnabled("GetDetections: Raw offset string",
 		logger.String("value", offsetStr),
 	)
 	offset, err := strconv.Atoi(offsetStr)
 	if err != nil {
-		c.logDebugIfEnabled("GetDetections: Invalid offset string",
+		c.LogDebugIfEnabled("GetDetections: Invalid offset string",
 			logger.String("value", offsetStr),
 			logger.Error(err),
 		)
@@ -515,11 +513,11 @@ func (c *Controller) parseOffset(offsetStr string) (int, error) {
 		return 0, fmt.Errorf("Invalid numeric value for offset: %w", err) //nolint:staticcheck // matches test expectations
 	}
 
-	c.logDebugIfEnabled("GetDetections: Parsed offset value",
+	c.LogDebugIfEnabled("GetDetections: Parsed offset value",
 		logger.Int("value", offset),
 	)
 	if offset < 0 {
-		c.logDebugIfEnabled("GetDetections: Negative offset value",
+		c.LogDebugIfEnabled("GetDetections: Negative offset value",
 			logger.Int("value", offset),
 		)
 		// Log the enhanced error for telemetry
@@ -534,7 +532,7 @@ func (c *Controller) parseOffset(offsetStr string) (int, error) {
 
 	const maxOffset = 1000000
 	if offset > maxOffset {
-		c.logDebugIfEnabled("GetDetections: Too large offset value",
+		c.LogDebugIfEnabled("GetDetections: Too large offset value",
 			logger.Int("value", offset),
 		)
 		// Log the enhanced error for telemetry
@@ -556,7 +554,7 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 	// Parse and validate query parameters
 	params, err := c.parseDetectionQueryParams(ctx)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to parse query parameters",
+		c.LogErrorIfEnabled("Failed to parse query parameters",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -569,7 +567,7 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 	}
 
 	// Log the retrieval attempt
-	c.logInfoIfEnabled("Retrieving detections",
+	c.LogInfoIfEnabled("Retrieving detections",
 		logger.String("queryType", params.QueryType),
 		logger.String("date", params.Date),
 		logger.String("hour", params.Hour),
@@ -587,7 +585,7 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 	// Get notes based on query type
 	notes, totalResults, err := c.getDetectionsByQueryType(params)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to retrieve detections",
+		c.LogErrorIfEnabled("Failed to retrieve detections",
 			logger.String("queryType", params.QueryType),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -604,7 +602,7 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 	response := c.createPaginatedResponse(detections, totalResults, params.NumResults, params.Offset)
 
 	// Log the successful response
-	c.logInfoIfEnabled("Detections retrieved successfully",
+	c.LogInfoIfEnabled("Detections retrieved successfully",
 		logger.String("queryType", params.QueryType),
 		logger.Int("count", len(detections)),
 		logger.Int64("total", response.Total),
@@ -834,7 +832,7 @@ func (c *Controller) populateWeatherData(detection *DetectionResponse, note *dat
 	detectionTimeStr := note.Date + " " + note.Time
 	detectionTime, err := time.ParseInLocation("2006-01-02 15:04:05", detectionTimeStr, time.Local)
 	if err != nil {
-		c.logWarnIfEnabled("Failed to parse detection time for weather data",
+		c.LogWarnIfEnabled("Failed to parse detection time for weather data",
 			logger.String("time_str", detectionTimeStr),
 			logger.Error(err))
 		return
@@ -940,7 +938,7 @@ func (c *Controller) getHourlyDetections(date, hour string, duration, numResults
 	cacheKey := fmt.Sprintf("hourly:%s:%s:%d:%d:%d", date, hour, duration, numResults, offset)
 
 	// Check if data is in cache
-	if cachedData, found := c.detectionCache.Get(cacheKey); found {
+	if cachedData, found := c.DetectionCache.Get(cacheKey); found {
 		cachedResult := cachedData.(struct {
 			Notes []datastore.Note
 			Total int64
@@ -951,7 +949,7 @@ func (c *Controller) getHourlyDetections(date, hour string, duration, numResults
 	// If not in cache, query the database
 	notes, err := c.DS.GetHourlyDetections(date, hour, duration, numResults, offset)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get hourly detections",
+		c.LogErrorIfEnabled("Failed to get hourly detections",
 			logger.String("date", date),
 			logger.String("hour", hour),
 			logger.Int("duration", duration),
@@ -964,7 +962,7 @@ func (c *Controller) getHourlyDetections(date, hour string, duration, numResults
 
 	totalCount, err := c.DS.CountHourlyDetections(date, hour, duration)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to count hourly detections",
+		c.LogErrorIfEnabled("Failed to count hourly detections",
 			logger.String("date", date),
 			logger.String("hour", hour),
 			logger.Int("duration", duration),
@@ -974,12 +972,12 @@ func (c *Controller) getHourlyDetections(date, hour string, duration, numResults
 	}
 
 	// Cache the results
-	c.detectionCache.Set(cacheKey, struct {
+	c.DetectionCache.Set(cacheKey, struct {
 		Notes []datastore.Note
 		Total int64
 	}{notes, totalCount}, cache.DefaultExpiration)
 
-	c.logInfoIfEnabled("Retrieved hourly detections",
+	c.LogInfoIfEnabled("Retrieved hourly detections",
 		logger.String("date", date),
 		logger.String("hour", hour),
 		logger.Int("duration", duration),
@@ -996,7 +994,7 @@ func (c *Controller) getSpeciesDetections(species, date, hour string, duration, 
 	cacheKey := fmt.Sprintf("species:%s:%s:%s:%d:%d:%d", species, date, hour, duration, numResults, offset)
 
 	// Check if data is in cache
-	if cachedData, found := c.detectionCache.Get(cacheKey); found {
+	if cachedData, found := c.DetectionCache.Get(cacheKey); found {
 		cachedResult := cachedData.(struct {
 			Notes []datastore.Note
 			Total int64
@@ -1007,7 +1005,7 @@ func (c *Controller) getSpeciesDetections(species, date, hour string, duration, 
 	// If not in cache, query the database
 	notes, err := c.DS.SpeciesDetections(species, date, hour, duration, false, numResults, offset)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get species detections",
+		c.LogErrorIfEnabled("Failed to get species detections",
 			logger.String("species", species),
 			logger.String("date", date),
 			logger.String("hour", hour),
@@ -1021,7 +1019,7 @@ func (c *Controller) getSpeciesDetections(species, date, hour string, duration, 
 
 	totalCount, err := c.DS.CountSpeciesDetections(species, date, hour, duration)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to count species detections",
+		c.LogErrorIfEnabled("Failed to count species detections",
 			logger.String("species", species),
 			logger.String("date", date),
 			logger.String("hour", hour),
@@ -1032,12 +1030,12 @@ func (c *Controller) getSpeciesDetections(species, date, hour string, duration, 
 	}
 
 	// Cache the results
-	c.detectionCache.Set(cacheKey, struct {
+	c.DetectionCache.Set(cacheKey, struct {
 		Notes []datastore.Note
 		Total int64
 	}{notes, totalCount}, cache.DefaultExpiration)
 
-	c.logInfoIfEnabled("Retrieved species detections",
+	c.LogInfoIfEnabled("Retrieved species detections",
 		logger.String("species", species),
 		logger.String("date", date),
 		logger.String("hour", hour),
@@ -1053,7 +1051,7 @@ func (c *Controller) getSpeciesDetections(species, date, hour string, duration, 
 func (c *Controller) getSearchDetectionsAdvanced(params *detectionQueryParams) ([]datastore.Note, int64, error) {
 	cacheKey := params.advancedSearchCacheKey()
 
-	if cachedData, found := c.detectionCache.Get(cacheKey); found {
+	if cachedData, found := c.DetectionCache.Get(cacheKey); found {
 		cachedResult := cachedData.(struct {
 			Notes []datastore.Note
 			Total int64
@@ -1065,14 +1063,14 @@ func (c *Controller) getSearchDetectionsAdvanced(params *detectionQueryParams) (
 
 	notes, totalCount, err := c.DS.SearchNotesAdvanced(&filters)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to perform advanced search",
+		c.LogErrorIfEnabled("Failed to perform advanced search",
 			logger.String("filters", fmt.Sprintf("%+v", filters)),
 			logger.Error(err),
 		)
 		return nil, 0, err
 	}
 
-	c.detectionCache.Set(cacheKey, struct {
+	c.DetectionCache.Set(cacheKey, struct {
 		Notes []datastore.Note
 		Total int64
 	}{notes, totalCount}, cache.DefaultExpiration)
@@ -1156,7 +1154,7 @@ func (c *Controller) getSearchDetections(search string, numResults, offset int) 
 	cacheKey := fmt.Sprintf("search:%s:%d:%d", search, numResults, offset)
 
 	// Check if data is in cache
-	if cachedData, found := c.detectionCache.Get(cacheKey); found {
+	if cachedData, found := c.DetectionCache.Get(cacheKey); found {
 		cachedResult := cachedData.(struct {
 			Notes []datastore.Note
 			Total int64
@@ -1167,7 +1165,7 @@ func (c *Controller) getSearchDetections(search string, numResults, offset int) 
 	// If not in cache, query the database
 	notes, totalCount, err := c.DS.SearchNotes(search, false, numResults, offset)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to search notes",
+		c.LogErrorIfEnabled("Failed to search notes",
 			logger.String("query", search),
 			logger.Int("limit", numResults),
 			logger.Int("offset", offset),
@@ -1177,12 +1175,12 @@ func (c *Controller) getSearchDetections(search string, numResults, offset int) 
 	}
 
 	// Cache the results
-	c.detectionCache.Set(cacheKey, struct {
+	c.DetectionCache.Set(cacheKey, struct {
 		Notes []datastore.Note
 		Total int64
 	}{notes, totalCount}, cache.DefaultExpiration)
 
-	c.logInfoIfEnabled("Retrieved search results",
+	c.LogInfoIfEnabled("Retrieved search results",
 		logger.String("query", search),
 		logger.Int("count", len(notes)),
 		logger.Int64("total", totalCount),
@@ -1197,7 +1195,7 @@ func (c *Controller) getAllDetections(numResults, offset int) ([]datastore.Note,
 	cacheKey := fmt.Sprintf("all:%d:%d", numResults, offset)
 
 	// Check if data is in cache
-	if cachedData, found := c.detectionCache.Get(cacheKey); found {
+	if cachedData, found := c.DetectionCache.Get(cacheKey); found {
 		cachedResult := cachedData.(struct {
 			Notes []datastore.Note
 			Total int64
@@ -1208,7 +1206,7 @@ func (c *Controller) getAllDetections(numResults, offset int) ([]datastore.Note,
 	// Use the datastore.SearchNotes method with an empty query to get all notes
 	notes, totalResults, err := c.DS.SearchNotes("", false, numResults, offset)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get all detections",
+		c.LogErrorIfEnabled("Failed to get all detections",
 			logger.Int("limit", numResults),
 			logger.Int("offset", offset),
 			logger.Error(err),
@@ -1217,12 +1215,12 @@ func (c *Controller) getAllDetections(numResults, offset int) ([]datastore.Note,
 	}
 
 	// Cache the results
-	c.detectionCache.Set(cacheKey, struct {
+	c.DetectionCache.Set(cacheKey, struct {
 		Notes []datastore.Note
 		Total int64
 	}{notes, totalResults}, cache.DefaultExpiration)
 
-	c.logInfoIfEnabled("Retrieved all detections",
+	c.LogInfoIfEnabled("Retrieved all detections",
 		logger.Int("count", len(notes)),
 		logger.Int64("total", totalResults),
 	)
@@ -1317,10 +1315,10 @@ var spectrogramWidths = []int{
 // are silently ignored, and other errors are logged as warnings without
 // affecting the caller.
 func (c *Controller) removeDetectionFiles(clipName string) {
-	log := c.apiLogger
+	log := c.APILogger
 
 	// Normalize the clip path to get a relative path within SecureFS
-	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
+	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalized := NormalizeClipPath(clipName, clipsPrefix)
 	if normalized == "" {
 		log.Warn("Cannot remove detection files: empty normalized clip path",
@@ -1415,7 +1413,7 @@ func isSpectrogramFileFor(pngName, baseFilename string) bool {
 // operation that modifies detection data.
 func (c *Controller) invalidateDetectionCache() {
 	// Clear all cached detection data to ensure fresh results
-	c.detectionCache.Flush()
+	c.DetectionCache.Flush()
 }
 
 // checkAndHandleLock verifies if a detection is locked and manages lock state
@@ -1501,7 +1499,7 @@ func (c *Controller) ReviewDetection(ctx echo.Context) error {
 
 	// Handle lock/unlock request separately
 	if req.LockDetection != note.Locked {
-		c.logInfoIfEnabled("Updating lock status",
+		c.LogInfoIfEnabled("Updating lock status",
 			logger.String("detection_id", idStr),
 			logger.Bool("current_locked", note.Locked),
 			logger.Bool("new_locked", req.LockDetection),
@@ -1511,7 +1509,7 @@ func (c *Controller) ReviewDetection(ctx echo.Context) error {
 		err = c.AddLock(note.ID, req.LockDetection)
 		if err != nil {
 			// Log the lock operation failure
-			c.logErrorIfEnabled("Failed to update lock status",
+			c.LogErrorIfEnabled("Failed to update lock status",
 				logger.String("detection_id", idStr),
 				logger.Bool("attempted_lock_state", req.LockDetection),
 				logger.Error(err),
@@ -1610,7 +1608,7 @@ func (c *Controller) IgnoreSpecies(ctx echo.Context) error {
 	// Log the action. "species" is the name the user supplied; "stored_species"
 	// is what actually landed in the exclude list, so support can tell the two
 	// apart when a localized name was resolved to a scientific name.
-	c.logInfoIfEnabled("Species exclusion toggled",
+	c.LogInfoIfEnabled("Species exclusion toggled",
 		logger.String("species", req.CommonName),
 		logger.String("stored_species", speciesToIgnore),
 		logger.String("action", action),
@@ -1933,10 +1931,10 @@ func calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTime
 // Returns "imperial" for Fahrenheit or "metric" for Celsius to match frontend expectations.
 func (c *Controller) getWeatherUnits() string {
 	// Use dashboard temperature unit preference for display. Read the live
-	// snapshot (race-free, hot-reloading) via currentSettings() so out-of-band
+	// snapshot (race-free, hot-reloading) via CurrentSettings() so out-of-band
 	// global republishes are picked up, matching the rest of the Dashboard reads.
 	// All temperatures are now stored in Celsius internally.
-	switch c.currentSettings().Realtime.Dashboard.TemperatureUnit {
+	switch c.CurrentSettings().Realtime.Dashboard.TemperatureUnit {
 	case conf.TemperatureUnitFahrenheit:
 		return "imperial"
 	case conf.TemperatureUnitCelsius:

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -141,7 +141,7 @@ func (c *Controller) initDetectionRoutes() {
 		return
 	}
 
-	// detectionCache is already initialized by the constructor (NewWithOptions); do not
+	// DetectionCache is already initialized by the constructor (NewWithOptions); do not
 	// re-create it here, which would orphan the constructor's cache (and its janitor).
 
 	// Detection endpoints - publicly accessible

--- a/internal/api/v2/detections_batch.go
+++ b/internal/api/v2/detections_batch.go
@@ -84,7 +84,7 @@ func (c *Controller) BatchDeleteDetections(ctx echo.Context) error {
 	for _, idStr := range ids {
 		note, err := c.DS.Get(idStr)
 		if err != nil {
-			c.logWarnIfEnabled("Batch delete: failed to get detection",
+			c.LogWarnIfEnabled("Batch delete: failed to get detection",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
@@ -97,7 +97,7 @@ func (c *Controller) BatchDeleteDetections(ctx echo.Context) error {
 
 		clipName := note.ClipName
 		if err := c.DS.Delete(idStr); err != nil {
-			c.logWarnIfEnabled("Batch delete: failed to delete detection",
+			c.LogWarnIfEnabled("Batch delete: failed to delete detection",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
@@ -146,7 +146,7 @@ func (c *Controller) BatchReviewDetections(ctx echo.Context) error {
 	for _, idStr := range ids {
 		note, err := c.DS.Get(idStr)
 		if err != nil {
-			c.logWarnIfEnabled("Batch review: failed to get detection",
+			c.LogWarnIfEnabled("Batch review: failed to get detection",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
@@ -159,7 +159,7 @@ func (c *Controller) BatchReviewDetections(ctx echo.Context) error {
 		}
 
 		if err := c.AddReview(note.ID, verification.Verified); err != nil {
-			c.logWarnIfEnabled("Batch review: failed to set verification",
+			c.LogWarnIfEnabled("Batch review: failed to set verification",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
@@ -197,7 +197,7 @@ func (c *Controller) BatchLockDetections(ctx echo.Context) error {
 	for _, idStr := range ids {
 		note, err := c.DS.Get(idStr)
 		if err != nil {
-			c.logWarnIfEnabled("Batch lock: failed to get detection",
+			c.LogWarnIfEnabled("Batch lock: failed to get detection",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++
@@ -210,7 +210,7 @@ func (c *Controller) BatchLockDetections(ctx echo.Context) error {
 		}
 
 		if err := c.AddLock(note.ID, req.Locked); err != nil {
-			c.logWarnIfEnabled("Batch lock: failed to set lock state",
+			c.LogWarnIfEnabled("Batch lock: failed to set lock state",
 				logger.String("id", idStr),
 				logger.Error(err))
 			skipped++

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
@@ -2545,11 +2546,9 @@ func TestApplySpeciesTrackingMetadata_NoveltyFlags(t *testing.T) {
 	// Seed the tracker: species first seen on 2026-03-20
 	_, _ = tracker.CheckAndUpdateSpecies("Parus major", time.Date(2026, 3, 20, 8, 0, 0, 0, time.Local))
 
-	controller := &Controller{
-		Processor: &processor.Processor{
-			NewSpeciesTracker: tracker,
-		},
-	}
+	controller := &Controller{Core: &apicore.Core{Processor: &processor.Processor{
+		NewSpeciesTracker: tracker,
+	}}}
 
 	tests := []struct {
 		name            string
@@ -2597,7 +2596,7 @@ func TestNoteToDetectionResponse_SourceInfo(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "source-info")
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	tests := []struct {

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -51,7 +51,7 @@ func (c *Controller) initDiagnosticsRoutes() {
 
 	c.registerHealthChecks()
 
-	diagnosticsGroup := c.Group.Group("/system/diagnostics", c.authMiddleware)
+	diagnosticsGroup := c.Group.Group("/system/diagnostics", c.AuthMiddleware)
 	diagnosticsGroup.GET("/status", c.GetDiagnosticsStatus)
 	diagnosticsGroup.POST("/run", c.RunDiagnostics)
 	diagnosticsGroup.GET("/report/:id", c.GetDiagnosticsReport)
@@ -76,7 +76,7 @@ func (c *Controller) HealthEventBuffer() *observability.HealthEventBuffer {
 // registerHealthChecks registers all health checks with dependency injection closures.
 func (c *Controller) registerHealthChecks() {
 	snapshotProvider := func() []audiocore.SourceHealthSnapshot {
-		w := c.audioWatchdog.Load()
+		w := c.AudioWatchdog.Load()
 		if w == nil {
 			return nil
 		}
@@ -135,7 +135,7 @@ func (c *Controller) registerHealthChecks() {
 		}),
 		checks.NewResultsQueueDropCheck(c.healthMetricsStore, c.healthEvents.Recent),
 		checks.NewORTAvailabilityCheck(func() (available, initialized bool, version, libraryPath, errMsg string) {
-			status := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
+			status := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 			return status.Available, status.Initialized, status.Version, status.LibraryPath, status.Error
 		}),
 		checks.NewOpenVINOAvailabilityCheck(func() (supported, active bool) {
@@ -164,14 +164,14 @@ func (c *Controller) registerHealthChecks() {
 
 		// Database checks
 		checks.NewDatabaseSizeCheck(func() string {
-			return c.currentSettings().Output.SQLite.Path
+			return c.CurrentSettings().Output.SQLite.Path
 		}),
 		checks.NewMigrationStatusCheck(func() (bool, string, error) {
 			if c.DS == nil {
 				return false, "", errors.NewStd("datastore unavailable")
 			}
 			dbType := "sqlite"
-			if c.currentSettings().Output.MySQL.Enabled {
+			if c.CurrentSettings().Output.MySQL.Enabled {
 				dbType = "mysql"
 			}
 			return true, dbType + " (auto-migrated at startup)", nil
@@ -197,7 +197,7 @@ func (c *Controller) registerHealthChecks() {
 
 		// Network checks
 		checks.NewMQTTCheck(
-			func() bool { return c.currentSettings().Realtime.MQTT.Enabled },
+			func() bool { return c.CurrentSettings().Realtime.MQTT.Enabled },
 			func() bool {
 				proc := c.Processor
 				if proc == nil {
@@ -211,7 +211,7 @@ func (c *Controller) registerHealthChecks() {
 			},
 		),
 		checks.NewBirdWeatherCheck(
-			func() bool { return c.currentSettings().Realtime.Birdweather.Enabled },
+			func() bool { return c.CurrentSettings().Realtime.Birdweather.Enabled },
 			func() (bool, string) {
 				proc := c.Processor
 				if proc == nil {
@@ -250,7 +250,7 @@ func (c *Controller) registerHealthChecks() {
 		}),
 		checks.NewWeatherCheck(
 			func() bool {
-				p := c.currentSettings().Realtime.Weather.Provider
+				p := c.CurrentSettings().Realtime.Weather.Provider
 				return p != string(conf.WeatherNone)
 			},
 			weather.GetStatus,
@@ -258,7 +258,7 @@ func (c *Controller) registerHealthChecks() {
 
 		// Config checks
 		checks.NewToolAvailabilityCheck(func() []checks.ToolInfo {
-			s := c.currentSettings()
+			s := c.CurrentSettings()
 			return []checks.ToolInfo{
 				{
 					Name:    "FFmpeg",
@@ -272,7 +272,7 @@ func (c *Controller) registerHealthChecks() {
 			}
 		}),
 		checks.NewPathAccessCheck(map[string]string{
-			"data": filepath.Dir(c.currentSettings().Output.SQLite.Path),
+			"data": filepath.Dir(c.CurrentSettings().Output.SQLite.Path),
 		}),
 		checks.NewConfigConsistencyCheck(func() []string { return nil }),
 		checks.NewDiskBudgetCheck(
@@ -390,10 +390,10 @@ var errNoTempSensors = errors.NewStd("no temperature sensors found")
 
 // buildStreamHealthProvider returns a closure that bridges the FFmpegManager's
 // stream health data to the checks.StreamHealthInfo format. The closure
-// atomically loads c.engine at call time because it is set after Controller init.
+// atomically loads c.Engine at call time because it is set after Controller init.
 func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 	return func() []checks.StreamHealthInfo {
-		eng := c.engine.Load()
+		eng := c.Engine.Load()
 		if eng == nil {
 			return nil
 		}
@@ -434,7 +434,7 @@ func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInf
 // audio counter values from the audio router for the health metrics collector.
 func (c *Controller) buildAudioRouterSnapshotProvider() func() []observability.AudioRouterSnapshot {
 	return func() []observability.AudioRouterSnapshot {
-		eng := c.engine.Load()
+		eng := c.Engine.Load()
 		if eng == nil {
 			return nil
 		}
@@ -475,7 +475,7 @@ func (c *Controller) buildAudioRouterSnapshotProvider() func() []observability.A
 // stream restart counts for the health metrics collector.
 func (c *Controller) buildStreamHealthSnapshotProvider() func() []observability.StreamHealthSnapshot {
 	return func() []observability.StreamHealthSnapshot {
-		eng := c.engine.Load()
+		eng := c.Engine.Load()
 		if eng == nil {
 			return nil
 		}
@@ -508,7 +508,7 @@ func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 		}
 
 		// Require engine/router so checks skip cleanly before startup and after teardown.
-		eng := c.engine.Load()
+		eng := c.Engine.Load()
 		if eng == nil {
 			return nil
 		}
@@ -547,7 +547,7 @@ func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 // utilization from the buffer manager.
 func (c *Controller) buildCaptureBufferHealthProvider() func() []checks.CaptureBufferInfo {
 	return func() []checks.CaptureBufferInfo {
-		eng := c.engine.Load()
+		eng := c.Engine.Load()
 		if eng == nil {
 			return nil
 		}
@@ -573,7 +573,7 @@ func (c *Controller) buildCaptureBufferHealthProvider() func() []checks.CaptureB
 
 // getDataPaths returns filesystem paths that should be monitored for disk space.
 func (c *Controller) getDataPaths() []string {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	seen := make(map[string]struct{})
 	var paths []string
 	addPath := func(p string) {

--- a/internal/api/v2/dynamic_thresholds.go
+++ b/internal/api/v2/dynamic_thresholds.go
@@ -127,8 +127,8 @@ func (c *Controller) initDynamicThresholdRoutes() {
 	c.Group.GET("/dynamic-thresholds/:species/events", c.GetThresholdEvents)
 
 	// Protected endpoints for modifying thresholds (require authentication)
-	c.Group.DELETE("/dynamic-thresholds/:species", c.ResetDynamicThreshold, c.authMiddleware)
-	c.Group.DELETE("/dynamic-thresholds", c.ResetAllDynamicThresholds, c.authMiddleware)
+	c.Group.DELETE("/dynamic-thresholds/:species", c.ResetDynamicThreshold, c.AuthMiddleware)
+	c.Group.DELETE("/dynamic-thresholds", c.ResetAllDynamicThresholds, c.AuthMiddleware)
 }
 
 // GetDynamicThresholds returns all dynamic thresholds with optional pagination
@@ -230,7 +230,7 @@ func (c *Controller) addMemoryThresholds(thresholdMap map[string]*DynamicThresho
 		return
 	}
 	memoryData := proc.GetDynamicThresholdData()
-	baseThreshold := c.currentSettings().BirdNET.Threshold
+	baseThreshold := c.CurrentSettings().BirdNET.Threshold
 
 	for _, dt := range memoryData {
 		key := strings.ToLower(dt.ModelName) + ":" + strings.ToLower(dt.SpeciesName)
@@ -281,7 +281,7 @@ func (c *Controller) GetDynamicThresholdStats(ctx echo.Context) error {
 		})
 	}
 
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	return ctx.JSON(http.StatusOK, ThresholdStatsResponse{
 		TotalCount:        totalCount,
 		ActiveCount:       activeCount,

--- a/internal/api/v2/dynamic_thresholds_test.go
+++ b/internal/api/v2/dynamic_thresholds_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -54,10 +55,7 @@ func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	controller := &Controller{
-		DS:        mockDS,
-		Processor: proc,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS, Processor: proc}}
 	controller.Settings.Store(proc.Settings)
 
 	result := controller.getMergedThresholdData()
@@ -106,10 +104,7 @@ func TestGetMergedThresholdData_MemoryOnlySpecies(t *testing.T) {
 		},
 	}
 
-	controller := &Controller{
-		DS:        mockDS,
-		Processor: proc,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS, Processor: proc}}
 	controller.Settings.Store(proc.Settings)
 
 	result := controller.getMergedThresholdData()
@@ -153,10 +148,7 @@ func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
 		DynamicThresholds: map[string]*processor.DynamicThreshold{},
 	}
 
-	controller := &Controller{
-		DS:        mockDS,
-		Processor: proc,
-	}
+	controller := &Controller{Core: &apicore.Core{DS: mockDS, Processor: proc}}
 	controller.Settings.Store(proc.Settings)
 
 	result := controller.getMergedThresholdData()

--- a/internal/api/v2/events.go
+++ b/internal/api/v2/events.go
@@ -241,7 +241,7 @@ func (c *Controller) GetOperationalEvents(ctx echo.Context) error {
 	appLogPath := logger.Global().GetDefaultOutputPath()
 	if appLogPath != "" {
 		if entries, err := readLogSource(appLogPath, targetDate, level, time.Local); err != nil {
-			c.logWarnIfEnabled("Failed to read application log",
+			c.LogWarnIfEnabled("Failed to read application log",
 				logger.Error(err),
 				logger.String("path", appLogPath),
 				logger.String("date", date),
@@ -255,7 +255,7 @@ func (c *Controller) GetOperationalEvents(ctx echo.Context) error {
 	audioLogPath := logger.Global().GetOutputPath("audio")
 	if audioLogPath != "" {
 		if entries, err := readLogSource(audioLogPath, targetDate, level, time.Local); err != nil {
-			c.logWarnIfEnabled("Failed to read audio log",
+			c.LogWarnIfEnabled("Failed to read audio log",
 				logger.Error(err),
 				logger.String("path", audioLogPath),
 				logger.String("date", date),

--- a/internal/api/v2/events_test.go
+++ b/internal/api/v2/events_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/logger/reader"
 )
 
@@ -41,7 +42,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty entries returns empty response", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		result := c.aggregateDetectionEvents(nil, baseTime)
@@ -57,7 +58,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("single approve creates one bucket and one species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -96,7 +97,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple operations same bucket same species accumulate", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -126,7 +127,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple species same bucket grouped correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -143,7 +144,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple buckets separated by hour and sorted newest first", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
@@ -164,7 +165,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pre-filters counted in bucket but not in species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -190,7 +191,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pending count from create_pending_detection hourly array", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -208,7 +209,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species sorting approved first then by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -236,7 +237,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("top discarded species top 3", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -270,7 +271,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("audio clip matching attached to correct species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -303,7 +304,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("peak confidence tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -321,7 +322,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("max match count tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -339,7 +340,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty species name entries are skipped", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -360,7 +361,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("approved per hour metric calculated correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
@@ -381,7 +382,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("timestamps are recorded for approve and discard", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		approveTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
@@ -403,7 +404,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species summary sorted by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Core: &apicore.Core{}}
 		c.Settings.Store(newValidTestSettings())
 
 		entries := []reader.LogEntry{

--- a/internal/api/v2/external_media.go
+++ b/internal/api/v2/external_media.go
@@ -46,7 +46,7 @@ type ExternalMediaResponse struct {
 // running application, and when it is not, provides deployment-specific setup
 // instructions for the detected container runtime.
 func (c *Controller) GetExternalMedia(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting external media status")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting external media status")
 
 	envGetter := c.externalMediaEnv
 	if envGetter == nil {
@@ -74,7 +74,7 @@ func (c *Controller) GetExternalMedia(ctx echo.Context) error {
 		Guidance:      guidance,
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "External media status retrieved",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "External media status retrieved",
 		logger.String("environment", envType),
 		logger.Bool("containerized", containerized),
 		logger.Bool("mountPresent", mountPresent),

--- a/internal/api/v2/external_media_test.go
+++ b/internal/api/v2/external_media_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
@@ -23,12 +24,7 @@ func newExternalMediaController(
 ) (*echo.Echo, *Controller) {
 	t.Helper()
 	e := echo.New()
-	c := &Controller{
-		Echo:               e,
-		Group:              e.Group("/api/v2"),
-		externalMediaEnv:   envGetter,
-		externalMediaProbe: prober,
-	}
+	c := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}, externalMediaEnv: envGetter, externalMediaProbe: prober}
 	return e, c
 }
 

--- a/internal/api/v2/filesystem.go
+++ b/internal/api/v2/filesystem.go
@@ -36,15 +36,15 @@ type BrowseResponse struct {
 
 // initFileSystemRoutes registers all filesystem-related API endpoints
 func (c *Controller) initFileSystemRoutes() {
-	c.logInfoIfEnabled("Initializing filesystem routes")
+	c.LogInfoIfEnabled("Initializing filesystem routes")
 
 	// Create filesystem API group with authentication
-	fsGroup := c.Group.Group("/filesystem", c.authMiddleware)
+	fsGroup := c.Group.Group("/filesystem", c.AuthMiddleware)
 
 	// GET /api/v2/filesystem/browse - Browse files and directories
 	fsGroup.GET("/browse", c.BrowseFileSystem)
 
-	c.logInfoIfEnabled("Filesystem routes initialized")
+	c.LogInfoIfEnabled("Filesystem routes initialized")
 }
 
 // browsePathResult holds validated path information for browsing.
@@ -98,7 +98,7 @@ func (c *Controller) validateBrowsePath(reqPath string) (browsePathResult, error
 func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 	var req BrowseRequest
 	if err := ctx.Bind(&req); err != nil {
-		c.logErrorIfEnabled("Failed to bind browse request",
+		c.LogErrorIfEnabled("Failed to bind browse request",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -115,7 +115,7 @@ func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 		} else if os.IsPermission(err) {
 			status = http.StatusForbidden
 		}
-		c.logWarnIfEnabled("Path validation failed",
+		c.LogWarnIfEnabled("Path validation failed",
 			logger.String("requested_path", req.Path),
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
@@ -126,7 +126,7 @@ func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 	// Read directory contents using SecureFS
 	entries, err := c.SFS.ReadDir(pathResult.browsePath)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to read directory",
+		c.LogErrorIfEnabled("Failed to read directory",
 			logger.String("path", pathResult.browsePath),
 			logger.Error(err),
 			logger.String("ip", ctx.RealIP()),
@@ -139,7 +139,7 @@ func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 	for _, entry := range entries {
 		item, err := c.convertDirEntryToItem(pathResult.browsePath, entry)
 		if err != nil {
-			c.logDebugIfEnabled("Skipping file due to error",
+			c.LogDebugIfEnabled("Skipping file due to error",
 				logger.String("file", entry.Name()),
 				logger.String("directory", pathResult.browsePath),
 				logger.Error(err),
@@ -152,7 +152,7 @@ func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 	// Determine parent path securely using SecureFS
 	parentPath, err := c.SFS.ParentPath(pathResult.browsePath)
 	if err != nil {
-		c.logDebugIfEnabled("Failed to get parent path",
+		c.LogDebugIfEnabled("Failed to get parent path",
 			logger.String("path", pathResult.browsePath),
 			logger.Error(err))
 		parentPath = ""
@@ -170,7 +170,7 @@ func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 		ParentPath:  parentPath,
 	}
 
-	c.logInfoIfEnabled("Successfully browsed directory",
+	c.LogInfoIfEnabled("Successfully browsed directory",
 		logger.String("path", currentPath),
 		logger.Int("item_count", len(items)),
 		logger.String("ip", ctx.RealIP()),

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -442,7 +442,7 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 
 	cached, _, hit := cache.get(cacheKey)
 	if hit {
-		c.logAPIRequest(ctx, logger.LogLevelDebug, "Heatmap cache hit", logger.String("species", params.species))
+		c.LogAPIRequest(ctx, logger.LogLevelDebug, "Heatmap cache hit", logger.String("species", params.species))
 		return ctx.Blob(http.StatusOK, "application/octet-stream", cached)
 	}
 
@@ -499,7 +499,7 @@ func (c *Controller) getHeatmapOptimized(ctx echo.Context, service *classifier.H
 		if result.Err != nil {
 			return c.HandleError(ctx, result.Err, "Failed to compute heatmap grid", http.StatusInternalServerError)
 		}
-		c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed (optimized)",
+		c.LogAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed (optimized)",
 			logger.String("species", params.species),
 			logger.Int("rows", params.rows),
 			logger.Int("cols", params.cols),
@@ -530,7 +530,7 @@ func (c *Controller) getHeatmapFallback(ctx echo.Context, birdnet *classifier.Or
 	encoded := encodeBNHM(params.cols, params.rows, float32(params.south), float32(params.west), float32(params.resolution), data)
 	cache.put(cacheKey, encoded, missGen)
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed (fallback)",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed (fallback)",
 		logger.String("species", params.species),
 		logger.Int("rows", params.rows),
 		logger.Int("cols", params.cols))

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/imports/birdnetpi"
@@ -178,14 +179,14 @@ func isContained(root, target string) bool {
 // initImportRoutes registers all import-related API routes.
 //
 // These endpoints start, cancel, and inspect a database import, so the group
-// must fail closed. c.authMiddleware is non-nil in every real deployment: the
+// must fail closed. c.AuthMiddleware is non-nil in every real deployment: the
 // server always injects it via WithAuthMiddleware, and that middleware itself
 // enforces or passes through based on the auth configuration. It can only be nil
 // in unit tests or a misconfiguration; in that case install a middleware that
 // denies access with 401 rather than registering the routes unprotected (Echo's
 // applyMiddleware would also panic on a literal nil entry).
 func (c *Controller) initImportRoutes() {
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 	if authMiddleware == nil {
 		authMiddleware = func(echo.HandlerFunc) echo.HandlerFunc {
 			return func(ctx echo.Context) error {
@@ -204,11 +205,11 @@ func (c *Controller) initImportRoutes() {
 // Returns 202 Accepted with a job_id on success.
 func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 	// Verify datastore is available.
-	if err := c.requireDatastore(ctx); err != nil {
+	if err := c.RequireDatastore(ctx); err != nil {
 		return err
 	}
 	if c.Repo == nil {
-		return c.HandleError(ctx, errDatastoreUnavailable, "datastore is not available", http.StatusServiceUnavailable)
+		return c.HandleError(ctx, apicore.ErrDatastoreUnavailable, "datastore is not available", http.StatusServiceUnavailable)
 	}
 
 	// Parse and bind request body.
@@ -272,7 +273,7 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 	// so an unconfigured path returns 400 without occupying the slot.
 	var clipExportPath string
 	if req.Mode == importModeDBaudio {
-		if settings := c.currentSettings(); settings != nil {
+		if settings := c.CurrentSettings(); settings != nil {
 			clipExportPath = settings.Realtime.Audio.Export.Path
 		}
 		if clipExportPath == "" {
@@ -282,8 +283,8 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 	}
 
 	// Reserve the single import slot.
-	id := generateCorrelationID()
-	parent := c.ctx
+	id := apicore.GenerateCorrelationID()
+	parent := c.Context()
 	if parent == nil {
 		parent = context.Background()
 	}
@@ -306,16 +307,14 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 		opts.ClipExportPath = clipExportPath
 	}
 	eng := imports.NewEngine(c.Repo)
-	c.wg.Go(func() {
+	c.Go(func() {
 		var stats imports.ImportStats
 		var runErr error
-		// Registered first so it runs last: it recovers panics from eng.Run AND from
-		// the cleanup defers below, and always drives the job to a terminal state so the
-		// single import slot is released and SSE streams unblock.
+
 		defer func() {
 			if r := recover(); r != nil {
 				runErr = errors.Newf("import panicked: %v", r).Component("api").Category(errors.CategoryGeneric).Build()
-				// The local stats var is stale on panic; recover the last reported progress.
+
 				stats, _, _, _, _ = job.snapshot()
 			}
 			job.finish(stats, runErr)
@@ -363,10 +362,10 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 	hb := time.NewTicker(sseHeartbeatInterval)
 	defer hb.Stop()
 
-	// Capture shutdown channel defensively; c.ctx may be nil in isolated unit tests.
+	// Capture shutdown channel defensively; c.Context() may be nil in isolated unit tests.
 	var shutdown <-chan struct{}
-	if c.ctx != nil {
-		shutdown = c.ctx.Done()
+	if c.Context() != nil {
+		shutdown = c.Context().Done()
 	} else {
 		neverClose := make(chan struct{})
 		shutdown = neverClose
@@ -458,7 +457,7 @@ func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, 
 		if err := conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline)); err != nil {
 			// Best-effort: not all response writers support deadlines; log and proceed,
 			// matching sendSSEMessage in sse.go.
-			c.logDebugIfEnabled("Failed to set write deadline for import SSE event", logger.Error(err))
+			c.LogDebugIfEnabled("Failed to set write deadline for import SSE event", logger.Error(err))
 		}
 	}
 	if _, err := ctx.Response().Write([]byte(msg)); err != nil {

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -26,6 +26,7 @@ import (
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imports"
 )
@@ -118,20 +119,13 @@ func newImportController(t *testing.T) (*echo.Echo, *Controller) {
 	t.Helper()
 	e := echo.New()
 	ctx, cancel := context.WithCancel(t.Context())
-	c := &Controller{
-		Group:     e.Group(apiV2Prefix),
-		importMgr: newImportManager(),
-		ctx:       ctx,
-		cancel:    cancel,
-		// Pass-through auth middleware, mirroring production where the server always
-		// injects a non-nil middleware (it enforces or passes based on auth config).
-		// Tests that exercise the fail-closed nil case set authMiddleware to nil.
-		authMiddleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next },
-	}
+	cCore := &apicore.Core{Group: e.Group(apiV2Prefix), AuthMiddleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next }}
+	cCore.SetTestContext(ctx, cancel)
+	c := &Controller{Core: cCore, importMgr: newImportManager()}
 	c.Settings.Store(newValidTestSettings())
 	t.Cleanup(func() {
 		cancel()
-		c.wg.Wait()
+		c.Wait()
 	})
 	return e, c
 }
@@ -258,10 +252,7 @@ func TestImportManager_GetByID(t *testing.T) {
 // TestStartBirdNETPiImport_NoRepo_Returns503 verifies 503 when no datastore.
 func TestStartBirdNETPiImport_NoRepo_Returns503(t *testing.T) {
 	e := echo.New()
-	c := &Controller{
-		Group:     e.Group(apiV2Prefix),
-		importMgr: newImportManager(),
-	}
+	c := &Controller{Core: &apicore.Core{Group: e.Group(apiV2Prefix)}, importMgr: newImportManager()}
 	c.Settings.Store(newValidTestSettings())
 
 	body := testDBOnlyBody
@@ -273,7 +264,7 @@ func TestStartBirdNETPiImport_NoRepo_Returns503(t *testing.T) {
 	// requireDatastore writes the 503 response and returns the sentinel error,
 	// which the handler propagates (matching the established datastore-guard pattern).
 	err := c.StartBirdNETPiImport(ctx)
-	require.ErrorIs(t, err, errDatastoreUnavailable)
+	require.ErrorIs(t, err, apicore.ErrDatastoreUnavailable)
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
@@ -1057,7 +1048,7 @@ func TestImportRoutes_Registered(t *testing.T) {
 // registering the state-changing endpoints unprotected.
 func TestImportRoutes_FailClosedWhenNoAuth(t *testing.T) {
 	e, c := newImportController(t)
-	c.authMiddleware = nil // exercise the fail-closed path: no auth middleware configured
+	c.AuthMiddleware = nil // exercise the fail-closed path: no auth middleware configured
 	c.initImportRoutes()
 
 	req := httptest.NewRequest(http.MethodGet, apiV2Prefix+"/import/status", http.NoBody)

--- a/internal/api/v2/inference_status.go
+++ b/internal/api/v2/inference_status.go
@@ -319,7 +319,7 @@ func applyRuntimeBackend(status *InferenceModelStatus, backend, precision string
 // metrics. The snapshot is assembled from live sources on every request so it
 // reflects hot-reload changes without any caching.
 func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 
 	resp := InferenceStatusResponse{
 		SnapshotAtUnix: time.Now().Unix(),
@@ -533,10 +533,14 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 
 // BroadcastInferenceTopologyChanged signals all metrics-stream SSE clients that
 // the inference topology (models or source attachment) changed so they re-fetch
-// the /api/v2/system/inference snapshot. Safe to call when no metrics store is set.
+// the /api/v2/system/inference snapshot. Safe to call when the controller, its
+// core, or its metrics store is nil. It stays on the facade (rather than moving
+// to apicore with the other broadcasters) to preserve its nil-*Controller-safe
+// contract: promotion of a *Core method would dereference the embedded core on a
+// nil *Controller before the guard could run.
 func (c *Controller) BroadcastInferenceTopologyChanged() {
-	if c == nil || c.metricsStore == nil {
+	if c == nil || c.Core == nil || c.MetricsStore == nil {
 		return
 	}
-	c.metricsStore.BroadcastTopologyChanged()
+	c.MetricsStore.BroadcastTopologyChanged()
 }

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
@@ -238,7 +239,7 @@ func TestBroadcastInferenceTopologyChanged_ReachesConsumer(t *testing.T) {
 	assert.Equal(t, eventInferenceTopologyChangedName, eventInferenceTopologyChanged)
 
 	store := observability.NewMemoryStore(10)
-	controller := &Controller{metricsStore: store}
+	controller := &Controller{Core: &apicore.Core{MetricsStore: store}}
 
 	topoCh, cancel := store.SubscribeTopology()
 	t.Cleanup(cancel)
@@ -261,7 +262,7 @@ func TestBroadcastInferenceTopologyChanged_NilSafe(t *testing.T) {
 	var nilController *Controller
 	assert.NotPanics(t, nilController.BroadcastInferenceTopologyChanged)
 
-	noStore := &Controller{}
+	noStore := &Controller{Core: &apicore.Core{}}
 	assert.NotPanics(t, noStore.BroadcastInferenceTopologyChanged)
 }
 

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -398,7 +398,7 @@ func (c *Controller) initInsightsRoutes() {
 	c.insightsRepo = repository.NewInsightsRepository(db, useV2Prefix, isMySQL)
 
 	// Build both name maps once and cache on Controller
-	if s := c.controllerSettings(); s != nil {
+	if s := c.ControllerSettings(); s != nil {
 		c.UpdateCommonNameMap(s.BirdNET.Labels)
 	}
 
@@ -482,7 +482,7 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 		})
 	}
 
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return ctx.JSON(http.StatusOK, ExpectedTodayRegionalResponse{
 			Species:   []RegionalSpeciesItem{},
@@ -511,7 +511,7 @@ func (c *Controller) getExpectedTodayRegionalImpl(ctx echo.Context) error {
 	yearRanges := buildYearRanges(now, expectedTodayWindowDays)
 	localSpecies, localErr := c.insightsRepo.GetExpectedSpeciesToday(reqCtx, yearRanges, analyticsTZOffset(now), nil)
 	if localErr != nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Failed to query local species for deduplication",
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Failed to query local species for deduplication",
 			logger.Error(localErr))
 	}
 

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 )
@@ -69,10 +70,7 @@ func setupInsightsTestController(t *testing.T, mock *mockInsightsRepo) (*echo.Ec
 			},
 		},
 	}
-	controller := &Controller{
-		Group:        e.Group("/api/v2"),
-		insightsRepo: mock,
-	}
+	controller := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2")}, insightsRepo: mock}
 	controller.Settings.Store(settingsVal)
 	controller.UpdateCommonNameMap(controller.Settings.Load().BirdNET.Labels)
 	return e, controller

--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -214,10 +214,10 @@ type BirdWeatherStatus struct {
 
 // initIntegrationsRoutes registers all integration-related API endpoints
 func (c *Controller) initIntegrationsRoutes() {
-	c.logInfoIfEnabled("Initializing integrations routes")
+	c.LogInfoIfEnabled("Initializing integrations routes")
 
 	// Create integrations API group with auth middleware
-	integrationsGroup := c.Group.Group("/integrations", c.authMiddleware)
+	integrationsGroup := c.Group.Group("/integrations", c.AuthMiddleware)
 
 	// MQTT routes
 	mqttGroup := integrationsGroup.Group("/mqtt")
@@ -226,7 +226,7 @@ func (c *Controller) initIntegrationsRoutes() {
 	mqttGroup.POST("/homeassistant/discovery", c.TriggerHomeAssistantDiscovery)
 
 	// MQTT TLS certificate management
-	mqttTLSGroup := mqttGroup.Group("/tls", c.authMiddleware)
+	mqttTLSGroup := mqttGroup.Group("/tls", c.AuthMiddleware)
 	mqttTLSGroup.GET("/certificate", c.GetMQTTTLSCertificate)
 	mqttTLSGroup.POST("/certificate", c.UploadMQTTTLSCertificate)
 	mqttTLSGroup.DELETE("/certificate", c.DeleteMQTTTLSCertificate)
@@ -244,19 +244,19 @@ func (c *Controller) initIntegrationsRoutes() {
 	ebirdGroup := integrationsGroup.Group("/ebird")
 	ebirdGroup.POST("/test", c.TestEBirdConnection)
 
-	c.logInfoIfEnabled("Integrations routes initialized successfully")
+	c.LogInfoIfEnabled("Integrations routes initialized successfully")
 }
 
 // GetMQTTStatus handles GET /api/v2/integrations/mqtt/status
 func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 	ip := ctx.RealIP()
 	path := ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting MQTT status",
+	c.LogInfoIfEnabled("Getting MQTT status",
 		logger.String("path", path),
 		logger.String("ip", ip))
 
 	// Get MQTT configuration from fresh settings
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	mqttConfig := settings.Realtime.MQTT
 
 	// Prepare status response
@@ -269,14 +269,14 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 
 	// If MQTT is not enabled, return status as-is
 	if !mqttConfig.Enabled {
-		c.logInfoIfEnabled("MQTT is disabled, returning status",
+		c.LogInfoIfEnabled("MQTT is disabled, returning status",
 			logger.String("path", path),
 			logger.String("ip", ip))
 		return ctx.JSON(http.StatusOK, status)
 	}
 
 	// Check connection status using a temporary client
-	c.logDebugIfEnabled("Checking MQTT connection status",
+	c.LogDebugIfEnabled("Checking MQTT connection status",
 		logger.String("path", path),
 		logger.String("ip", ip))
 	connected, checkErr := c.checkMQTTConnectionStatus(ctx.Request().Context(), settings)
@@ -285,7 +285,7 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 		status.LastError = checkErr
 	}
 
-	c.logInfoIfEnabled("Retrieved MQTT status successfully",
+	c.LogInfoIfEnabled("Retrieved MQTT status successfully",
 		logger.Bool("connected", status.Connected),
 		logger.String("broker", status.Broker),
 		logger.String("last_error", status.LastError),
@@ -300,14 +300,14 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 // Returns true if connected, false otherwise, along with any error message encountered.
 func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context, settings *conf.Settings) (connected bool, lastError string) {
 	// Use the injected metrics instance
-	if c.metrics == nil {
-		c.logErrorIfEnabled("Metrics instance not available for MQTT status check")
+	if c.Metrics == nil {
+		c.LogErrorIfEnabled("Metrics instance not available for MQTT status check")
 		return false, "error:metrics:not_initialized"
 	}
 
-	tempClient, err := mqtt.NewClient(settings, c.metrics)
+	tempClient, err := mqtt.NewClient(settings, c.Metrics)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to create temporary MQTT client for status check",
+		c.LogErrorIfEnabled("Failed to create temporary MQTT client for status check",
 			logger.Error(err))
 		return false, fmt.Sprintf("error:client:mqtt_client_creation:%s", err.Error())
 	}
@@ -320,7 +320,7 @@ func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context, settin
 	// Try to connect
 	err = tempClient.Connect(connectCtx)
 	if err != nil {
-		c.logWarnIfEnabled("Temporary MQTT client connection failed during status check",
+		c.LogWarnIfEnabled("Temporary MQTT client connection failed during status check",
 			logger.Error(err),
 			logger.String("broker", settings.Realtime.MQTT.Broker))
 		return false, fmt.Sprintf("error:connection:mqtt_broker:%s", err.Error())
@@ -328,13 +328,13 @@ func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context, settin
 
 	// Check if genuinely connected
 	if !tempClient.IsConnected() {
-		c.logWarnIfEnabled("Temporary MQTT client connected but IsConnected() returned false",
+		c.LogWarnIfEnabled("Temporary MQTT client connected but IsConnected() returned false",
 			logger.String("broker", settings.Realtime.MQTT.Broker))
 		// Consider this a failure for status purposes, though connection might be flapping
 		return false, "error:connection:mqtt_connection_unstable"
 	}
 
-	c.logDebugIfEnabled("Temporary MQTT client connected successfully for status check",
+	c.LogDebugIfEnabled("Temporary MQTT client connected successfully for status check",
 		logger.String("broker", settings.Realtime.MQTT.Broker))
 	return true, "" // Connected successfully
 }
@@ -343,12 +343,12 @@ func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context, settin
 func (c *Controller) GetBirdWeatherStatus(ctx echo.Context) error {
 	ip := ctx.RealIP()
 	path := ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting BirdWeather status",
+	c.LogInfoIfEnabled("Getting BirdWeather status",
 		logger.String("path", path),
 		logger.String("ip", ip))
 
 	// Get BirdWeather configuration from fresh settings
-	bwConfig := c.currentSettings().Realtime.Birdweather
+	bwConfig := c.CurrentSettings().Realtime.Birdweather
 
 	// Prepare status response
 	status := BirdWeatherStatus{
@@ -360,7 +360,7 @@ func (c *Controller) GetBirdWeatherStatus(ctx echo.Context) error {
 
 	// For now, we just return the configuration status
 	// In the future, we could add checks for client status here
-	c.logInfoIfEnabled("Retrieved BirdWeather status successfully",
+	c.LogInfoIfEnabled("Retrieved BirdWeather status successfully",
 		logger.Bool("enabled", status.Enabled),
 		logger.String("station_id", status.StationID),
 		logger.Float64("threshold", status.Threshold),
@@ -374,7 +374,7 @@ func (c *Controller) GetBirdWeatherStatus(ctx echo.Context) error {
 // TestMQTTConnection handles POST /api/v2/integrations/mqtt/test
 func (c *Controller) TestMQTTConnection(ctx echo.Context) error {
 	// Get MQTT configuration from fresh settings
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	mqttConfig := settings.Realtime.MQTT
 
 	if !mqttConfig.Enabled {
@@ -393,7 +393,7 @@ func (c *Controller) TestMQTTConnection(ctx echo.Context) error {
 	}
 
 	// Use the injected metrics instance
-	if c.metrics == nil {
+	if c.Metrics == nil {
 		return ctx.JSON(http.StatusInternalServerError, MQTTTestResult{
 			Success: false,
 			Message: "Metrics instance not available for MQTT test",
@@ -401,7 +401,7 @@ func (c *Controller) TestMQTTConnection(ctx echo.Context) error {
 	}
 
 	// Create test MQTT client with the current configuration
-	client, err := mqtt.NewClient(settings, c.metrics)
+	client, err := mqtt.NewClient(settings, c.Metrics)
 	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, MQTTTestResult{
 			Success: false,
@@ -447,7 +447,7 @@ func (c *Controller) TestBirdWeatherConnection(ctx echo.Context) error {
 	}
 
 	// Clone current settings and override only BirdWeather fields from the request
-	testSettings := conf.CloneSettings(c.currentSettings())
+	testSettings := conf.CloneSettings(c.CurrentSettings())
 	testSettings.Realtime.Birdweather = conf.BirdweatherSettings{
 		Enabled:          request.Enabled,
 		ID:               request.ID,
@@ -525,7 +525,7 @@ func (c *Controller) TestWeatherConnection(ctx echo.Context) error {
 	// the key, the request carries that placeholder instead of the real key.
 	// Restoring here (and not only in the save flow) prevents the test from
 	// failing with a bogus "authentication failed".
-	current := c.currentSettings()
+	current := c.CurrentSettings()
 	restoreRedactedSecret(current.Realtime.Weather.OpenWeather.APIKey, &request.OpenWeather.APIKey)
 	restoreRedactedSecret(current.Realtime.Weather.Wunderground.APIKey, &request.Wunderground.APIKey)
 
@@ -775,7 +775,7 @@ func getProviderDisplayName(provider string) string {
 // TriggerHomeAssistantDiscovery handles POST /api/v2/integrations/mqtt/homeassistant/discovery
 // It manually triggers Home Assistant MQTT discovery message publishing.
 func (c *Controller) TriggerHomeAssistantDiscovery(ctx echo.Context) error {
-	c.logInfoIfEnabled("Triggering Home Assistant discovery",
+	c.LogInfoIfEnabled("Triggering Home Assistant discovery",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()))
 
@@ -790,7 +790,7 @@ func (c *Controller) TriggerHomeAssistantDiscovery(ctx echo.Context) error {
 		return c.HandleErrorWithKey(ctx, err, "Failed to trigger Home Assistant discovery", http.StatusBadRequest, notification.MsgErrIntegDiscoveryFailed, nil)
 	}
 
-	c.logInfoIfEnabled("Home Assistant discovery triggered successfully",
+	c.LogInfoIfEnabled("Home Assistant discovery triggered successfully",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()))
 
@@ -830,7 +830,7 @@ func (c *Controller) TestEBirdConnection(ctx echo.Context) error {
 	// placeholder (redactedValue); if the user clicks Test without re-entering
 	// it, the request carries that placeholder instead of the real key, which
 	// would otherwise fail authentication.
-	restoreRedactedSecret(c.currentSettings().Realtime.EBird.APIKey, &request.APIKey)
+	restoreRedactedSecret(c.CurrentSettings().Realtime.EBird.APIKey, &request.APIKey)
 
 	if !request.Enabled {
 		return ctx.JSON(http.StatusOK, map[string]any{

--- a/internal/api/v2/integrations_test.go
+++ b/internal/api/v2/integrations_test.go
@@ -876,7 +876,7 @@ func TestTestWeatherConnection_RestoresRedactedAPIKey(t *testing.T) {
 		}
 
 		// Reproduce the handler's restore sequence using the production helper.
-		current := controller.currentSettings()
+		current := controller.CurrentSettings()
 		restoreRedactedSecret(current.Realtime.Weather.OpenWeather.APIKey, &request.OpenWeather.APIKey)
 		restoreRedactedSecret(current.Realtime.Weather.Wunderground.APIKey, &request.Wunderground.APIKey)
 
@@ -932,7 +932,7 @@ func TestTestEBirdConnection_RestoresRedactedAPIKey(t *testing.T) {
 		})
 
 		apiKey := redactedSecretPlaceholder
-		restoreRedactedSecret(controller.currentSettings().Realtime.EBird.APIKey, &apiKey)
+		restoreRedactedSecret(controller.CurrentSettings().Realtime.EBird.APIKey, &apiKey)
 		assert.Equal(t, realKey, apiKey,
 			"eBird test must use the real saved key, not the redacted placeholder")
 	})

--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -72,7 +72,7 @@ func (c *Controller) tableExistsMySQL(db *gorm.DB, tableName string) (bool, erro
 	var count int64
 	err := db.Raw(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
-		c.currentSettings().Output.MySQL.Database, tableName,
+		c.CurrentSettings().Output.MySQL.Database, tableName,
 	).Scan(&count).Error
 	if err != nil {
 		return false, err
@@ -139,7 +139,7 @@ func (cs *CleanupStatus) TryStart() bool {
 
 // initLegacyCleanupRoutes registers the legacy cleanup API routes.
 func (c *Controller) initLegacyCleanupRoutes() {
-	c.logInfoIfEnabled("Initializing legacy cleanup routes")
+	c.LogInfoIfEnabled("Initializing legacy cleanup routes")
 
 	// Initialize cleanup status tracker
 	c.cleanupStatus = NewCleanupStatus()
@@ -148,7 +148,7 @@ func (c *Controller) initLegacyCleanupRoutes() {
 	legacyGroup := c.Group.Group("/system/database/legacy")
 
 	// Get the appropriate auth middleware
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// Create auth-protected group
 	protectedGroup := legacyGroup.Group("", authMiddleware)
@@ -157,14 +157,14 @@ func (c *Controller) initLegacyCleanupRoutes() {
 	protectedGroup.GET("/status", c.GetLegacyStatus)
 	protectedGroup.POST("/cleanup", c.StartLegacyCleanup)
 
-	c.logInfoIfEnabled("Legacy cleanup routes initialized successfully")
+	c.LogInfoIfEnabled("Legacy cleanup routes initialized successfully")
 }
 
 // GetLegacyStatus handles GET /api/v2/system/database/legacy/status
 // Returns information about the legacy database for the cleanup UI.
 func (c *Controller) GetLegacyStatus(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting legacy database status", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Getting legacy database status", logger.String("path", path), logger.String("ip", ip))
 
 	response := LegacyStatusResponse{
 		Tables: []LegacyTableInfo{},
@@ -180,7 +180,7 @@ func (c *Controller) GetLegacyStatus(ctx echo.Context) error {
 
 // getLegacyStatusSQLite handles legacy status for SQLite deployments.
 func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacyStatusResponse) error {
-	legacyPath := c.currentSettings().Output.SQLite.Path
+	legacyPath := c.CurrentSettings().Output.SQLite.Path
 	response.Location = legacyPath
 
 	// Check if legacy file exists
@@ -249,7 +249,7 @@ func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacySta
 
 // getLegacyStatusMySQL handles legacy status for MySQL deployments.
 func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStatusResponse) error {
-	response.Location = c.currentSettings().Output.MySQL.Database
+	response.Location = c.CurrentSettings().Output.MySQL.Database
 
 	// Check if we're in v2-only mode (required for cleanup)
 	if !isV2OnlyMode {
@@ -290,10 +290,10 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 			// remaining table query would fail the same way, so stop quietly
 			// instead of logging a warning per table.
 			if reqCtx.Err() != nil {
-				c.logDebugIfEnabled("Legacy status query cancelled by client", logger.Error(reqCtx.Err()))
+				c.LogDebugIfEnabled("Legacy status query cancelled by client", logger.Error(reqCtx.Err()))
 				break
 			}
-			c.logWarnIfEnabled("Legacy cleanup: failed to check table existence",
+			c.LogWarnIfEnabled("Legacy cleanup: failed to check table existence",
 				logger.String("table", tableName),
 				logger.Error(err))
 			continue
@@ -305,7 +305,7 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 		// Get row count
 		err = db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&tableInfo.RowCount).Error
 		if err != nil {
-			c.logWarnIfEnabled("Legacy cleanup: failed to query row count",
+			c.LogWarnIfEnabled("Legacy cleanup: failed to query row count",
 				logger.String("table", tableName),
 				logger.Error(err))
 			tableInfo.RowCount = 0
@@ -318,9 +318,9 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 			SELECT COALESCE(data_length, 0), COALESCE(index_length, 0)
 			FROM information_schema.tables
 			WHERE table_schema = ? AND table_name = ?`,
-			c.currentSettings().Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
+			c.CurrentSettings().Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
 		if err != nil {
-			c.logWarnIfEnabled("Legacy cleanup: failed to query table size",
+			c.LogWarnIfEnabled("Legacy cleanup: failed to query table size",
 				logger.String("table", tableName),
 				logger.Error(err))
 		} else {
@@ -352,7 +352,7 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 // Initiates asynchronous legacy database cleanup.
 func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Starting legacy database cleanup", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Starting legacy database cleanup", logger.String("path", path), logger.String("ip", ip))
 
 	// Check if we're in v2-only mode (check before trying to start)
 	if !isV2OnlyMode {
@@ -381,9 +381,9 @@ func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 	}
 
 	// Start async cleanup using WaitGroup for proper lifecycle management
-	c.wg.Go(func() {
-		// Use controller's shutdown context for graceful cancellation
-		cleanupCtx := c.ctx
+	c.Go(func() {
+
+		cleanupCtx := c.Context()
 		if cleanupCtx == nil {
 			cleanupCtx = context.Background()
 		}
@@ -398,11 +398,11 @@ func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 		}
 
 		if err != nil {
-			c.logErrorIfEnabled("Legacy cleanup failed", logger.Error(err))
+			c.LogErrorIfEnabled("Legacy cleanup failed", logger.Error(err))
 			c.cleanupStatus.Set(CleanupStateFailed, err.Error(), remaining, 0)
 			c.sendCleanupNotification(false, 0, err.Error())
 		} else {
-			c.logInfoIfEnabled("Legacy cleanup completed successfully",
+			c.LogInfoIfEnabled("Legacy cleanup completed successfully",
 				logger.Int64("space_reclaimed_bytes", sizeBytes),
 				logger.String("space_reclaimed", formatBytes(sizeBytes)))
 			c.cleanupStatus.Set(CleanupStateCompleted, "", nil, sizeBytes)
@@ -410,7 +410,7 @@ func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 		}
 	})
 
-	c.logInfoIfEnabled("Legacy cleanup started", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Legacy cleanup started", logger.String("path", path), logger.String("ip", ip))
 
 	return ctx.JSON(http.StatusOK, CleanupActionResponse{
 		Success: true,
@@ -427,33 +427,33 @@ func (c *Controller) cleanupSQLiteLegacy(ctx context.Context) error {
 	default:
 	}
 
-	legacyPath := c.currentSettings().Output.SQLite.Path
+	legacyPath := c.CurrentSettings().Output.SQLite.Path
 
-	c.logInfoIfEnabled("Starting SQLite legacy database cleanup",
+	c.LogInfoIfEnabled("Starting SQLite legacy database cleanup",
 		logger.String("path", legacyPath))
 
 	// CRITICAL SAFETY CHECK: Ensure we're not deleting a V2 database
 	if datastoreV2.CheckSQLiteHasV2Schema(legacyPath) {
-		c.logErrorIfEnabled("Safety check failed: target is a V2 database",
+		c.LogErrorIfEnabled("Safety check failed: target is a V2 database",
 			logger.String("path", legacyPath))
 		return fmt.Errorf("target file appears to be a V2 database - cleanup aborted for safety")
 	}
 
-	c.logInfoIfEnabled("Safety check passed: confirmed legacy database",
+	c.LogInfoIfEnabled("Safety check passed: confirmed legacy database",
 		logger.String("path", legacyPath))
 
 	// Delete main database file
 	if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete legacy database: %w", err)
 	}
-	c.logInfoIfEnabled("Deleted legacy database file",
+	c.LogInfoIfEnabled("Deleted legacy database file",
 		logger.String("file", legacyPath))
 
 	// Delete WAL and SHM files if they exist (ignore errors)
 	walDeleted := os.Remove(legacyPath+"-wal") == nil
 	shmDeleted := os.Remove(legacyPath+"-shm") == nil
 
-	c.logInfoIfEnabled("SQLite legacy cleanup completed",
+	c.LogInfoIfEnabled("SQLite legacy cleanup completed",
 		logger.String("path", legacyPath),
 		logger.Bool("wal_deleted", walDeleted),
 		logger.Bool("shm_deleted", shmDeleted))
@@ -463,7 +463,7 @@ func (c *Controller) cleanupSQLiteLegacy(ctx context.Context) error {
 
 // cleanupMySQLLegacy drops legacy tables from MySQL.
 func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
-	c.logInfoIfEnabled("Starting MySQL legacy tables cleanup",
+	c.LogInfoIfEnabled("Starting MySQL legacy tables cleanup",
 		logger.Int("total_tables", len(legacyTables)))
 
 	dbProvider, ok := c.Repo.(gormDBProvider)
@@ -483,7 +483,7 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 		// Check for cancellation before each table
 		select {
 		case <-ctx.Done():
-			c.logWarnIfEnabled("MySQL cleanup cancelled",
+			c.LogWarnIfEnabled("MySQL cleanup cancelled",
 				logger.Int("tables_dropped", droppedCount),
 				logger.Int("tables_remaining", len(legacyTables)-i))
 			return legacyTables[i:], ctx.Err()
@@ -493,7 +493,7 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 		// Check if table exists first
 		exists, err := c.tableExistsMySQL(db, tableName)
 		if err != nil {
-			c.logWarnIfEnabled("Legacy cleanup: failed to check table existence",
+			c.LogWarnIfEnabled("Legacy cleanup: failed to check table existence",
 				logger.String("table", tableName),
 				logger.Error(err))
 			continue
@@ -505,7 +505,7 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 		// Drop the table
 		err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)).Error
 		if err != nil {
-			c.logErrorIfEnabled("Failed to drop legacy table",
+			c.LogErrorIfEnabled("Failed to drop legacy table",
 				logger.String("table", tableName),
 				logger.Error(err))
 			// Stop on first error, return remaining tables
@@ -514,11 +514,11 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 		}
 
 		droppedCount++
-		c.logInfoIfEnabled("Dropped legacy table",
+		c.LogInfoIfEnabled("Dropped legacy table",
 			logger.String("table", tableName))
 	}
 
-	c.logInfoIfEnabled("MySQL legacy cleanup completed",
+	c.LogInfoIfEnabled("MySQL legacy cleanup completed",
 		logger.Int("tables_dropped", droppedCount))
 
 	return nil, nil
@@ -526,7 +526,7 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 
 // getSQLiteLegacySize returns the total size of SQLite legacy files.
 func (c *Controller) getSQLiteLegacySize() int64 {
-	legacyPath := c.currentSettings().Output.SQLite.Path
+	legacyPath := c.CurrentSettings().Output.SQLite.Path
 	var totalSize int64
 
 	if info, err := os.Stat(legacyPath); err == nil {
@@ -558,10 +558,10 @@ func (c *Controller) getMySQLLegacySize(ctx context.Context) int64 {
 		if err != nil {
 			// Client disconnected: stop quietly instead of warning per table.
 			if ctx.Err() != nil {
-				c.logDebugIfEnabled("Legacy size query cancelled by client", logger.Error(ctx.Err()))
+				c.LogDebugIfEnabled("Legacy size query cancelled by client", logger.Error(ctx.Err()))
 				break
 			}
-			c.logWarnIfEnabled("Legacy cleanup: failed to check table existence",
+			c.LogWarnIfEnabled("Legacy cleanup: failed to check table existence",
 				logger.String("table", tableName),
 				logger.Error(err))
 			continue
@@ -575,9 +575,9 @@ func (c *Controller) getMySQLLegacySize(ctx context.Context) int64 {
 			SELECT COALESCE(data_length, 0), COALESCE(index_length, 0)
 			FROM information_schema.tables
 			WHERE table_schema = ? AND table_name = ?`,
-			c.currentSettings().Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
+			c.CurrentSettings().Output.MySQL.Database, tableName).Row().Scan(&dataLength, &indexLength)
 		if err != nil {
-			c.logWarnIfEnabled("Legacy cleanup: failed to query table size",
+			c.LogWarnIfEnabled("Legacy cleanup: failed to query table size",
 				logger.String("table", tableName),
 				logger.Error(err))
 		} else {
@@ -627,7 +627,7 @@ func (c *Controller) sendCleanupNotification(success bool, spaceReclaimed int64,
 		WithMessageKey(messageKey, messageParams)
 
 	if err := notifService.CreateWithMetadata(notif); err != nil {
-		c.logWarnIfEnabled("Failed to send cleanup notification", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to send cleanup notification", logger.Error(err))
 	}
 }
 

--- a/internal/api/v2/legacy_cleanup_test.go
+++ b/internal/api/v2/legacy_cleanup_test.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/mattn/go-sqlite3" // SQLite driver for safety check test
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -33,10 +34,7 @@ func createLegacyTestController(tb testing.TB, e *echo.Echo, settings *conf.Sett
 	// Handlers read the live snapshot via currentSettings(); publish the test's
 	// settings so the read resolves to them (restored on cleanup).
 	publishTestSettings(tb, settings)
-	c := &Controller{
-		Echo:          e,
-		cleanupStatus: NewCleanupStatus(),
-	}
+	c := &Controller{Core: &apicore.Core{Echo: e}, cleanupStatus: NewCleanupStatus()}
 	c.Settings.Store(settings)
 	return c
 }

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
@@ -172,7 +173,7 @@ type ProcessAudioRequest struct {
 
 // Initialize media routes
 func (c *Controller) initMediaRoutes() {
-	c.logInfoIfEnabled("Initializing media routes")
+	c.LogInfoIfEnabled("Initializing media routes")
 
 	// Datastore-independent media routes serve from SecureFS / BirdImageCache and do
 	// not touch c.DS, so they register regardless of datastore availability.
@@ -194,7 +195,7 @@ func (c *Controller) initMediaRoutes() {
 	// registering handlers that would panic. The datastore-independent routes
 	// above stay available in that mode.
 	if c.DS == nil {
-		c.logWarnIfEnabled("Skipping ID-based media routes: datastore is not available")
+		c.LogWarnIfEnabled("Skipping ID-based media routes: datastore is not available")
 		return
 	}
 
@@ -205,18 +206,18 @@ func (c *Controller) initMediaRoutes() {
 	c.Echo.POST("/api/v2/spectrogram/:id/generate", c.GenerateSpectrogramByID)
 
 	// Clip extraction (requires authentication)
-	c.Echo.POST("/api/v2/audio/:id/clip", c.ExtractAudioClipByID, c.authMiddleware)
+	c.Echo.POST("/api/v2/audio/:id/clip", c.ExtractAudioClipByID, c.AuthMiddleware)
 
 	// Audio processing / preview (requires authentication)
-	c.Echo.POST("/api/v2/audio/:id/process", c.ProcessAudioByID, c.authMiddleware)
+	c.Echo.POST("/api/v2/audio/:id/process", c.ProcessAudioByID, c.AuthMiddleware)
 
 	// Processed spectrogram preview (requires authentication)
-	c.Echo.POST("/api/v2/spectrogram/:id/process", c.ProcessedSpectrogramByID, c.authMiddleware)
+	c.Echo.POST("/api/v2/spectrogram/:id/process", c.ProcessedSpectrogramByID, c.AuthMiddleware)
 
 	// Convenient combined endpoint (redirects to ID-based internally)
 	c.Group.GET("/media/audio", c.ServeAudioByQueryID)
 
-	c.logInfoIfEnabled("Media routes initialized successfully")
+	c.LogInfoIfEnabled("Media routes initialized successfully")
 }
 
 // translateSecureFSError handles SecureFS errors consistently across handler methods.
@@ -229,7 +230,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		ctx.Logger().Debugf("SecureFS httpErr=%d internal=%v msg=%v",
 			httpErr.Code, httpErr.Internal, httpErr.Message)
 		// Log this as an error since it represents a failed request from SFS
-		c.logErrorIfEnabled("SecureFS returned HTTP error",
+		c.LogErrorIfEnabled("SecureFS returned HTTP error",
 			logger.Error(err),
 			logger.Int("status_code", httpErr.Code),
 			logger.String("path", ctx.Request().URL.Path),
@@ -239,13 +240,13 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 	}
 
 	// Get tunnel info for logging
-	isTunneled, _ := ctx.Get("is_tunneled").(bool)
-	tunnelProvider, _ := ctx.Get("tunnel_provider").(string)
+	isTunneled, _ := ctx.Get(apicore.CtxKeyIsTunneled).(bool)
+	tunnelProvider, _ := ctx.Get(apicore.CtxKeyTunnelProvider).(string)
 
 	// Check for specific error types and map to appropriate status codes
 	switch {
 	case errors.Is(err, securefs.ErrPathTraversal) || errors.Is(err, ErrPathTraversalAttempt):
-		c.logWarnIfEnabled("Path traversal attempt detected",
+		c.LogWarnIfEnabled("Path traversal attempt detected",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -254,7 +255,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		)
 		return c.HandleError(ctx, err, "Invalid file path: attempted path traversal", http.StatusBadRequest)
 	case errors.Is(err, securefs.ErrInvalidPath) || errors.Is(err, ErrInvalidAudioPath):
-		c.logWarnIfEnabled("Invalid file path provided",
+		c.LogWarnIfEnabled("Invalid file path provided",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -263,7 +264,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		)
 		return c.HandleError(ctx, err, "Invalid file path specification", http.StatusBadRequest)
 	case errors.Is(err, securefs.ErrAccessDenied):
-		c.logWarnIfEnabled("Access denied to resource",
+		c.LogWarnIfEnabled("Access denied to resource",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -272,7 +273,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		)
 		return c.HandleError(ctx, err, "Access denied to requested resource", http.StatusForbidden)
 	case errors.Is(err, securefs.ErrNotRegularFile):
-		c.logWarnIfEnabled("Requested resource is not a regular file",
+		c.LogWarnIfEnabled("Requested resource is not a regular file",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -281,7 +282,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		)
 		return c.HandleError(ctx, err, "Requested resource is not a regular file", http.StatusForbidden)
 	case errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist) || errors.Is(err, ErrAudioFileNotFound) || errors.Is(err, imageprovider.ErrImageNotFound):
-		c.logInfoIfEnabled("Resource not found", // Info level as 404 is common
+		c.LogInfoIfEnabled("Resource not found", // Info level as 404 is common
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -290,7 +291,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		)
 		return c.HandleError(ctx, err, "Resource not found", http.StatusNotFound)
 	case errors.Is(err, context.DeadlineExceeded):
-		c.logWarnIfEnabled("Request timed out",
+		c.LogWarnIfEnabled("Request timed out",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -299,7 +300,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 		)
 		return c.HandleError(ctx, err, "Request timed out", http.StatusRequestTimeout)
 	case errors.Is(err, context.Canceled):
-		c.logInfoIfEnabled("Request canceled by client",
+		c.LogInfoIfEnabled("Request canceled by client",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -310,7 +311,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 	}
 
 	// For other errors, log as error and use the provided user message with a 500 status
-	c.logErrorIfEnabled("Unhandled SecureFS/media error",
+	c.LogErrorIfEnabled("Unhandled SecureFS/media error",
 		logger.Error(err),
 		logger.String("user_message", userMsg),
 		logger.String("path", ctx.Request().URL.Path),
@@ -525,7 +526,7 @@ func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string
 			if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
 				return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after encoding completed")
 			}
-			c.logInfoIfEnabled("Successfully served audio clip after waiting for encoding", logFields...)
+			c.LogInfoIfEnabled("Successfully served audio clip after waiting for encoding", logFields...)
 			return nil
 		}
 		// Distinguish "still encoding" from "encoder exited/failed".
@@ -543,7 +544,7 @@ func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string
 		if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
 			return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after grace wait")
 		}
-		c.logInfoIfEnabled("Successfully served audio clip after grace wait", logFields...)
+		c.LogInfoIfEnabled("Successfully served audio clip after grace wait", logFields...)
 		return nil
 	}
 
@@ -554,23 +555,23 @@ func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string
 func (c *Controller) ServeAudioClip(ctx echo.Context) error {
 	filename := ctx.Param("filename")
 	if filename == "" {
-		c.logErrorIfEnabled("Missing filename parameter for ServeAudioClip",
+		c.LogErrorIfEnabled("Missing filename parameter for ServeAudioClip",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
 		return c.HandleError(ctx, fmt.Errorf("missing filename"), "Filename parameter is required", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Serving audio clip by filename",
+	c.LogInfoIfEnabled("Serving audio clip by filename",
 		logger.String("filename", filename),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	// Normalize and validate the path using the common helper
-	normalizedFilename, err := c.normalizeAndValidatePathWithLogger(filename, c.apiLogger)
+	normalizedFilename, err := c.normalizeAndValidatePathWithLogger(filename, c.APILogger)
 	if err != nil {
-		c.logWarnIfEnabled("Invalid file path detected",
+		c.LogWarnIfEnabled("Invalid file path detected",
 			logger.String("original_filename", filename),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -599,7 +600,7 @@ func (c *Controller) ServeAudioClip(ctx echo.Context) error {
 		return c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
 	}
 
-	c.logInfoIfEnabled("Successfully served audio clip by filename",
+	c.LogInfoIfEnabled("Successfully served audio clip by filename",
 		logger.String("filename", filename),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -613,7 +614,7 @@ func (c *Controller) ServeAudioClip(ctx echo.Context) error {
 func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
-	if err := c.requireDatastore(ctx); err != nil {
+	if err := c.RequireDatastore(ctx); err != nil {
 		return err
 	}
 
@@ -642,7 +643,7 @@ func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 	}
 
 	// Normalize and validate the path using the common helper
-	normalizedClipPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.apiLogger)
+	normalizedClipPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.APILogger)
 	if err != nil {
 		return c.HandleError(ctx, err, "Invalid clip path", http.StatusBadRequest)
 	}
@@ -710,7 +711,7 @@ func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 func (c *Controller) ExtractAudioClipByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
-	if err := c.requireDatastore(ctx); err != nil {
+	if err := c.RequireDatastore(ctx); err != nil {
 		return err
 	}
 
@@ -764,7 +765,7 @@ func (c *Controller) ExtractAudioClipByID(ctx echo.Context) error {
 	}
 
 	// Normalize and validate path via SecureFS (same pattern as ServeAudioByID)
-	normalizedPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.apiLogger)
+	normalizedPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.APILogger)
 	if err != nil {
 		return c.HandleError(ctx, err, "Invalid clip path", http.StatusBadRequest)
 	}
@@ -806,7 +807,7 @@ func (c *Controller) ExtractAudioClipByID(ctx echo.Context) error {
 		End:        req.End,
 		Format:     req.Format,
 		Filters:    filters,
-		FFmpegPath: c.currentSettings().Realtime.Audio.FfmpegPath,
+		FFmpegPath: c.CurrentSettings().Realtime.Audio.FfmpegPath,
 	})
 	if err != nil {
 		if ctx.Request().Context().Err() != nil {
@@ -864,7 +865,7 @@ func clipFileExtension(format string) string {
 func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
-	if err := c.requireDatastore(ctx); err != nil {
+	if err := c.RequireDatastore(ctx); err != nil {
 		return err
 	}
 
@@ -900,7 +901,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("no audio file found"), "No audio clip available", http.StatusNotFound)
 	}
 
-	normalizedPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.apiLogger)
+	normalizedPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.APILogger)
 	if err != nil {
 		return c.HandleError(ctx, err, "Invalid clip path", http.StatusBadRequest)
 	}
@@ -949,7 +950,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 	defer os.Remove(tmpPath) //nolint:errcheck // best-effort cleanup
 
 	if err := ffmpeg.ProcessAudioToFile(ctx.Request().Context(), absolutePath,
-		c.currentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
+		c.CurrentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
@@ -964,7 +965,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 	// Cache the result (non-fatal on failure)
 	if c.processingCache != nil {
 		if err := c.processingCache.put(cacheKey, wavData); err != nil {
-			c.logAPIRequest(ctx, logger.LogLevelWarn, "Failed to cache processed audio",
+			c.LogAPIRequest(ctx, logger.LogLevelWarn, "Failed to cache processed audio",
 				logger.String("cache_key", cacheKey),
 				logger.Error(err),
 			)
@@ -984,7 +985,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
-	if err := c.requireDatastore(ctx); err != nil {
+	if err := c.RequireDatastore(ctx); err != nil {
 		return err
 	}
 
@@ -1025,7 +1026,7 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("no audio file found"), "No audio clip available", http.StatusNotFound)
 	}
 
-	normalizedPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.apiLogger)
+	normalizedPath, err := c.normalizeAndValidatePathWithLogger(clipPath, c.APILogger)
 	if err != nil {
 		return c.HandleError(ctx, err, "Invalid clip path", http.StatusBadRequest)
 	}
@@ -1066,7 +1067,7 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 	defer func() { _ = os.Remove(tmpPath) }()
 
 	if err := ffmpeg.ProcessAudioToFile(ctx.Request().Context(), absolutePath,
-		c.currentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
+		c.CurrentSettings().Realtime.Audio.FfmpegPath, filters, tmpPath); err != nil {
 		if ctx.Request().Context().Err() != nil {
 			return nil // Client disconnected
 		}
@@ -1165,7 +1166,7 @@ type spectrogramParameters struct {
 // global settings that affect the visual appearance of all spectrograms. Including them
 // in the filename prevents serving stale cached spectrograms when these settings change.
 func (c *Controller) parseSpectrogramParameters(ctx echo.Context) spectrogramParameters {
-	spec := c.currentSettings().Realtime.Dashboard.Spectrogram
+	spec := c.CurrentSettings().Realtime.Dashboard.Spectrogram
 	params := spectrogramParameters{
 		width:        SpectrogramSizeLg, // Default width (lg) - single render size for all contexts
 		sizeStr:      ctx.QueryParam("size"),
@@ -1199,13 +1200,13 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 	// Defense in depth: initMediaRoutes already skips registering the ID-based media
 	// handlers when the datastore is disabled, but guard the c.DS dereference below
 	// anyway.
-	if err = c.requireDatastore(ctx); err != nil {
+	if err = c.RequireDatastore(ctx); err != nil {
 		return
 	}
 
 	noteID = ctx.Param("id")
 	if noteID == "" {
-		c.logErrorIfEnabled("Missing note ID for spectrogram request",
+		c.LogErrorIfEnabled("Missing note ID for spectrogram request",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()))
 		err = fmt.Errorf("missing ID")
@@ -1215,7 +1216,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 
 	// Validate that the ID is numeric to prevent wildcard route collisions
 	if _, parseErr := strconv.ParseUint(noteID, 10, 64); parseErr != nil {
-		c.logErrorIfEnabled("Non-numeric note ID for spectrogram request",
+		c.LogErrorIfEnabled("Non-numeric note ID for spectrogram request",
 			logger.String("note_id", noteID),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()))
@@ -1226,7 +1227,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 
 	clipPath, err = c.DS.GetNoteClipPath(noteID)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get clip path from database",
+		c.LogErrorIfEnabled("Failed to get clip path from database",
 			logger.String("note_id", noteID),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -1240,7 +1241,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 	}
 
 	if clipPath == "" {
-		c.logWarnIfEnabled("Empty clip path for note",
+		c.LogWarnIfEnabled("Empty clip path for note",
 			logger.String("note_id", noteID),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()))
@@ -1256,7 +1257,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 // Returns true if the request was handled (either success or error response sent).
 func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters, freqSuffix string) (bool, error) {
 	// Normalize and validate the audio path
-	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
+	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(clipPath, clipsPrefix)
 	relAudioPath, err := c.SFS.ValidateRelativePath(normalizedPath)
 
@@ -1267,7 +1268,7 @@ func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath 
 		// Check if spectrogram already exists and is non-empty
 		if statInfo, statErr := c.SFS.StatRel(relSpectrogramPath); statErr == nil && statInfo.Size() > 0 {
 			// Spectrogram exists, serve it with cache headers
-			c.logDebugIfEnabled("Serving existing spectrogram in user-requested mode",
+			c.LogDebugIfEnabled("Serving existing spectrogram in user-requested mode",
 				logger.String("note_id", noteID),
 				logger.String("spectrogram_path", relSpectrogramPath),
 				logger.String("path", ctx.Request().URL.Path),
@@ -1286,7 +1287,7 @@ func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath 
 	}
 
 	// Spectrogram doesn't exist in user-requested mode - return 404 with helpful message
-	c.logDebugIfEnabled("Spectrogram not found in user-requested mode",
+	c.LogDebugIfEnabled("Spectrogram not found in user-requested mode",
 		logger.String("note_id", noteID),
 		logger.String("mode", conf.SpectrogramModeUserRequested),
 		logger.String("path", ctx.Request().URL.Path),
@@ -1302,14 +1303,13 @@ func (c *Controller) returnSpectrogramNotGeneratedError(ctx echo.Context) (bool,
 	// Flow: <img> element's onerror handler triggers -> frontend makes fetch() call to same URL
 	// -> this JSON response is parsed by frontend -> mode field triggers UI to show "Generate" button
 	// Note: The <img> element doesn't parse this JSON; the error handler's fetch() call does.
-	errorResp := c.newErrorResponse(
+	errorResp := c.NewErrorResponse(
 		fmt.Errorf("spectrogram not generated"),
 		"Spectrogram has not been generated yet. Click 'Generate Spectrogram' to create it.",
-		http.StatusNotFound,
-	)
+		http.StatusNotFound)
 
 	// Log the error with structured logging
-	c.logErrorIfEnabled("Spectrogram not generated",
+	c.LogErrorIfEnabled("Spectrogram not generated",
 		logger.String("correlation_id", errorResp.CorrelationID),
 		logger.String("mode", conf.SpectrogramModeUserRequested),
 		logger.String("path", ctx.Request().URL.Path),
@@ -1349,15 +1349,15 @@ func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath 
 		// Check if this is an operational error (context canceled, timeout, etc.)
 		if spectrogram.IsOperationalError(err) {
 			// Log at Debug level for expected operational events
-			c.logDebugIfEnabled("Spectrogram generation canceled or interrupted", logFields...)
+			c.LogDebugIfEnabled("Spectrogram generation canceled or interrupted", logFields...)
 		} else {
 			// Log at Error level for unexpected failures
-			c.logErrorIfEnabled("Spectrogram generation failed", logFields...)
+			c.LogErrorIfEnabled("Spectrogram generation failed", logFields...)
 		}
 		return c.spectrogramHTTPError(ctx, err)
 	}
 
-	c.logDebugIfEnabled("Spectrogram path determined",
+	c.LogDebugIfEnabled("Spectrogram path determined",
 		logger.String("note_id", noteID),
 		logger.String("spectrogram_path", spectrogramPath),
 		logger.Int64("duration_ms", generationDuration.Milliseconds()),
@@ -1378,7 +1378,7 @@ func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath 
 		if !ctx.Response().Committed {
 			ctx.Response().Header().Del("Cache-Control")
 		}
-		c.logErrorIfEnabled("Failed to serve spectrogram file",
+		c.LogErrorIfEnabled("Failed to serve spectrogram file",
 			logger.String("note_id", noteID),
 			logger.String("spectrogram_path", spectrogramPath),
 			logger.Error(err),
@@ -1388,7 +1388,7 @@ func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath 
 		return c.translateSecureFSError(ctx, err, "Failed to serve spectrogram image")
 	}
 
-	c.logDebugIfEnabled("Spectrogram served successfully",
+	c.LogDebugIfEnabled("Spectrogram served successfully",
 		logger.String("note_id", noteID),
 		logger.String("spectrogram_path", spectrogramPath),
 		logger.Int64("serve_duration_ms", serveDuration.Milliseconds()),
@@ -1466,7 +1466,7 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 	freqSuffix := spectrogram.ProfileSuffix(profile)
 
 	// Log request details
-	c.logDebugIfEnabled("Spectrogram requested by ID",
+	c.LogDebugIfEnabled("Spectrogram requested by ID",
 		logger.String("note_id", noteID),
 		logger.String("clip_path", clipPath),
 		logger.Int("width", params.width),
@@ -1477,7 +1477,7 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 		logger.String("ip", ctx.RealIP()))
 
 	// Check spectrogram generation mode
-	spectrogramMode := c.currentSettings().Realtime.Dashboard.Spectrogram.GetMode()
+	spectrogramMode := c.CurrentSettings().Realtime.Dashboard.Spectrogram.GetMode()
 
 	// Handle user-requested mode
 	if spectrogramMode == conf.SpectrogramModeUserRequested {
@@ -1544,7 +1544,7 @@ func (c *Controller) ServeSpectrogram(ctx echo.Context) error {
 	raw := parseRawParameter(ctx.QueryParam("raw"))
 
 	// Read style settings for filename generation (prevents serving stale cached spectrograms)
-	spec := c.currentSettings().Realtime.Dashboard.Spectrogram
+	spec := c.CurrentSettings().Realtime.Dashboard.Spectrogram
 	style := spec.Style
 	dynamicRange := spec.DynamicRange
 
@@ -1595,7 +1595,7 @@ func (c *Controller) ServeSpectrogram(ctx echo.Context) error {
 func (c *Controller) GetSpectrogramStatus(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes already skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereferences below anyway.
-	if err := c.requireDatastore(ctx); err != nil {
+	if err := c.RequireDatastore(ctx); err != nil {
 		return err
 	}
 
@@ -1646,7 +1646,7 @@ func (c *Controller) GetSpectrogramStatus(ctx echo.Context) error {
 	// The on-disk file is legitimately path-derived (Export.Path controls where it is
 	// stored), so this resolution uses the live settings snapshot.
 	audioPath := detection.ClipName
-	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
+	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(audioPath, clipsPrefix)
 	relAudioPath, err := c.SFS.ValidateRelativePath(normalizedPath)
 	if err != nil {
@@ -1733,7 +1733,7 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 	params := c.parseSpectrogramParameters(ctx)
 
 	// Log request details
-	c.logDebugIfEnabled("Spectrogram generation requested by user",
+	c.LogDebugIfEnabled("Spectrogram generation requested by user",
 		logger.String("note_id", noteID),
 		logger.String("clip_path", clipPath),
 		logger.Int("width", params.width),
@@ -1744,12 +1744,12 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 
 	// Check if spectrogram already exists (fast path)
 	// Also compute the immutable queue key for status tracking
-	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
+	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(clipPath, clipsPrefix)
 	relAudioPath, err := c.SFS.ValidateRelativePath(normalizedPath)
 	if err != nil {
 		// Path validation failed - return error immediately before spawning goroutine
-		c.logErrorIfEnabled("Invalid audio path for spectrogram generation",
+		c.LogErrorIfEnabled("Invalid audio path for spectrogram generation",
 			logger.String("note_id", noteID),
 			logger.String("clip_path", clipPath),
 			logger.String("normalized_path", normalizedPath),
@@ -1822,43 +1822,35 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 
 	// Start async generation in background with proper cleanup and panic recovery
 	// Track goroutine lifecycle for graceful shutdown
-	c.wg.Go(func() {
-		// Ensure cleanup even if panic occurs (prevents memory leaks)
+	c.Go(func() {
+
 		defer func() {
 			if r := recover(); r != nil {
-				c.logErrorIfEnabled("Panic in async spectrogram generation",
+				c.LogErrorIfEnabled("Panic in async spectrogram generation",
 					logger.String("note_id", noteID),
 					logger.Any("panic", r))
 			}
 		}()
 
-		// Use controller context (respects shutdown signals) with timeout
-		bgCtx, cancel := context.WithTimeout(c.ctx, spectrogramGenerationTimeout)
+		bgCtx, cancel := context.WithTimeout(c.Context(), spectrogramGenerationTimeout)
 		defer cancel()
 
-		// Reuse the frequency profile resolved on the handler thread so the worker's
-		// generation effects and on-disk filename match the queue key computed above.
 		profileOpt := spectrogram.WithFrequencyProfile(profile)
 
-		// Thread both the handler-validated relative audio path (so the worker writes
-		// the on-disk file at the path the handler resolved, even if Export.Path
-		// changed after the handler returned) and the immutable queue key (so the
-		// worker's status updates land on the same entry GetSpectrogramStatus polls).
-		// Re-deriving either here would reopen the queue-key TOCTOU.
 		spectrogramPath, err := c.generateSpectrogramFromRel(bgCtx, relAudioPath, clipPath, queueKey, params.width, params.raw, params.style, params.dynamicRange, freqSuffix, profileOpt)
 
 		if err != nil {
-			// Update queue status so polling clients see the failure
+
 			if queueKey != "" {
 				c.updateQueueStatus(queueKey, spectrogramStatusFailed, 0, "Generation failed")
 			}
 
-			c.logErrorIfEnabled("Async spectrogram generation failed",
+			c.LogErrorIfEnabled("Async spectrogram generation failed",
 				logger.String("note_id", noteID),
 				logger.String("clip_path", clipPath),
 				logger.Error(err))
 		} else {
-			c.logInfoIfEnabled("Async spectrogram generated successfully",
+			c.LogInfoIfEnabled("Async spectrogram generated successfully",
 				logger.String("note_id", noteID),
 				logger.String("spectrogram_path", spectrogramPath))
 		}
@@ -1987,7 +1979,7 @@ func getSpectrogramLogger() logger.Logger {
 func (c *Controller) resolveDetectionFrequencyProfile(noteID string) spectrogram.FrequencyProfile {
 	modelType, err := c.DS.GetNoteModelType(noteID)
 	if err != nil {
-		c.logWarnIfEnabled("GetNoteModelType failed, defaulting to bird profile",
+		c.LogWarnIfEnabled("GetNoteModelType failed, defaulting to bird profile",
 			logger.String("note_id", noteID),
 			logger.Error(err))
 	}
@@ -2187,7 +2179,7 @@ func (c *Controller) validateSpectrogramInputs(ctx context.Context, absAudioPath
 			logger.String("queue_key", queueKey))
 
 		// Track retry metrics
-		c.logInfoIfEnabled("Spectrogram generation deferred - audio not ready",
+		c.LogInfoIfEnabled("Spectrogram generation deferred - audio not ready",
 			logger.String("audio_path", audioPath),
 			logger.Int64("file_size", validationResult.FileSize),
 			logger.Int64("retry_after_ms", validationResult.RetryAfter.Milliseconds()),
@@ -2350,7 +2342,7 @@ func (c *Controller) normalizeAndValidatePath(audioPath string) (string, error) 
 //
 // This reduces duplication across the codebase where this pattern is used.
 func (c *Controller) normalizeAndValidatePathWithLogger(audioPath string, log logger.Logger) (string, error) {
-	clipsPrefix := c.currentSettings().Realtime.Audio.Export.Path
+	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalizedPath := NormalizeClipPath(audioPath, clipsPrefix)
 
 	if log != nil && normalizedPath != audioPath {
@@ -2916,16 +2908,16 @@ func (c *Controller) generateSpectrogramFromRel(ctx context.Context, relAudioPat
 	// Use DoChan so callers can bail out early if their request context is
 	// cancelled (e.g. client disconnect) without blocking the handler goroutine.
 	// The shared work continues in the background using the controller-scoped
-	// context (c.ctx) and the next request will hit the fast path. Coalesce on the
+	// context (c.Context()) and the next request will hit the fast path. Coalesce on the
 	// path-based singleflightKey so requests targeting the same on-disk file share
 	// one generation pass regardless of how each derived its queueKey.
 	resultCh := spectrogramGroup.DoChan(singleflightKey, func() (any, error) {
 		// Use a controller-scoped context with timeout instead of the request-scoped ctx.
 		// Since singleflight shares the result across all concurrent callers, using a
 		// request-scoped context would cause all waiters to fail if the winning request's
-		// client disconnects. The controller context (c.ctx) respects server shutdown
+		// client disconnects. The controller context (c.Context()) respects server shutdown
 		// but is not tied to any individual HTTP request.
-		sharedCtx, sharedCancel := context.WithTimeout(c.ctx, spectrogramGenerationTimeout)
+		sharedCtx, sharedCancel := context.WithTimeout(c.Context(), spectrogramGenerationTimeout)
 		defer sharedCancel()
 
 		// Step 4: Wait for audio file to appear on disk. The detection DB record and
@@ -3160,7 +3152,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 	}
 
 	if cachedPath != "" && fresh {
-		c.logDebugIfEnabled("Serving fresh cached image",
+		c.LogDebugIfEnabled("Serving fresh cached image",
 			logger.String("scientific_name", scientificName),
 			logger.String("path", cachedPath))
 		return c.serveImageFile(ctx, cachedPath, contentType)
@@ -3171,20 +3163,20 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 	if dlErr != nil {
 		// Graceful degradation: serve stale file if available, otherwise redirect
 		if cachedPath != "" {
-			c.logDebugIfEnabled("Download failed, serving stale cached image",
+			c.LogDebugIfEnabled("Download failed, serving stale cached image",
 				logger.String("scientific_name", scientificName),
 				logger.String("path", cachedPath),
 				logger.Error(dlErr))
 			return c.serveImageFile(ctx, cachedPath, contentType)
 		}
-		c.logInfoIfEnabled("File cache download failed, redirecting to external URL",
+		c.LogInfoIfEnabled("File cache download failed, redirecting to external URL",
 			logger.String("scientific_name", scientificName),
 			logger.String("url", birdImage.URL),
 			logger.Error(dlErr))
 		return ctx.Redirect(http.StatusFound, birdImage.URL)
 	}
 
-	c.logDebugIfEnabled("Serving freshly downloaded image",
+	c.LogDebugIfEnabled("Serving freshly downloaded image",
 		logger.String("scientific_name", scientificName),
 		logger.String("path", newPath),
 		logger.String("content_type", newCT))

--- a/internal/api/v2/media_spectrogram_queuekey_test.go
+++ b/internal/api/v2/media_spectrogram_queuekey_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -56,11 +57,9 @@ func TestGetSpectrogramStatusFindsInFlightJobAfterExportPathChange(t *testing.T)
 	// path). An unexpected Get call would fail this test, which is the point.
 	mockDS := mocks.NewMockInterface(t)
 
-	controller := &Controller{
-		SFS: sfs,
-		ctx: t.Context(),
-		DS:  mockDS,
-	}
+	controllerCore := &apicore.Core{SFS: sfs, DS: mockDS}
+	controllerCore.SetTestContext(t.Context(), nil)
+	controller := &Controller{Core: controllerCore}
 	controller.Settings.Store(settings)
 	conftest.SetTestSettings(settings)
 
@@ -116,10 +115,9 @@ func TestGenerateSpectrogramFromRelRetainsFailedStatusForPolling(t *testing.T) {
 	cancel()
 
 	settings := newValidTestSettings()
-	controller := &Controller{
-		SFS: sfs,
-		ctx: ctx,
-	}
+	controllerCore := &apicore.Core{SFS: sfs}
+	controllerCore.SetTestContext(ctx, nil)
+	controller := &Controller{Core: controllerCore}
 	controller.Settings.Store(settings)
 	conftest.SetTestSettings(settings)
 

--- a/internal/api/v2/media_spectrogram_toctou_test.go
+++ b/internal/api/v2/media_spectrogram_toctou_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/securefs"
@@ -41,10 +42,9 @@ func TestGenerateSpectrogramFromRelIgnoresLiveExportPath(t *testing.T) {
 
 	ctx := t.Context()
 
-	controller := &Controller{
-		SFS: sfs,
-		ctx: ctx,
-	}
+	controllerCore := &apicore.Core{SFS: sfs}
+	controllerCore.SetTestContext(ctx, nil)
+	controller := &Controller{Core: controllerCore}
 	controller.Settings.Store(newValidTestSettings())
 
 	const (

--- a/internal/api/v2/metrics_history.go
+++ b/internal/api/v2/metrics_history.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -33,7 +34,7 @@ type MetricsHistoryResponse struct {
 //
 //	GET /api/v2/system/metrics/history?metrics=cpu.total,memory.used_percent&points=60
 func (c *Controller) GetMetricsHistory(ctx echo.Context) error {
-	if c.metricsStore == nil {
+	if c.MetricsStore == nil {
 		return c.HandleError(ctx, nil, "Metrics history not available", http.StatusServiceUnavailable)
 	}
 
@@ -56,15 +57,15 @@ func (c *Controller) GetMetricsHistory(ctx echo.Context) error {
 			if name == "" {
 				continue
 			}
-			if pts := c.metricsStore.Get(name, points); pts != nil {
+			if pts := c.MetricsStore.Get(name, points); pts != nil {
 				result[name] = pts
 			}
 		}
 	} else {
-		result = c.metricsStore.GetAll(points)
+		result = c.MetricsStore.GetAll(points)
 	}
 
-	c.logDebugIfEnabled("Metrics history retrieved",
+	c.LogDebugIfEnabled("Metrics history retrieved",
 		logger.Int("metrics_count", len(result)),
 		logger.Int("points_requested", points),
 	)
@@ -76,7 +77,7 @@ func (c *Controller) GetMetricsHistory(ctx echo.Context) error {
 //
 //	GET /api/v2/system/metrics/stream?metrics=cpu.total,memory.used_percent
 func (c *Controller) StreamMetrics(ctx echo.Context) error {
-	if c.metricsStore == nil {
+	if c.MetricsStore == nil {
 		return c.HandleError(ctx, nil, "Metrics stream not available", http.StatusServiceUnavailable)
 	}
 
@@ -94,19 +95,19 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 	}
 
 	// Subscribe to metric updates
-	ch, cancel := c.metricsStore.Subscribe()
+	ch, cancel := c.MetricsStore.Subscribe()
 	defer cancel()
 
 	// Subscribe to inference topology changes (model add/remove, source
 	// reassignment) so the client re-fetches the inference snapshot.
-	topoCh, topoCancel := c.metricsStore.SubscribeTopology()
+	topoCh, topoCancel := c.MetricsStore.SubscribeTopology()
 	defer topoCancel()
 
 	// Set SSE headers
 	setSSEHeaders(ctx)
 
-	clientID := generateCorrelationID()
-	c.logInfoIfEnabled("Metrics SSE client connected",
+	clientID := apicore.GenerateCorrelationID()
+	c.LogInfoIfEnabled("Metrics SSE client connected",
 		logger.String("client_id", clientID),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -126,14 +127,14 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 
 	for {
 		select {
-		case <-c.ctx.Done():
-			c.logInfoIfEnabled("Metrics SSE client disconnected due to shutdown",
+		case <-c.Context().Done():
+			c.LogInfoIfEnabled("Metrics SSE client disconnected due to shutdown",
 				logger.String("client_id", clientID),
 			)
 			return nil
 
 		case <-reqCtx.Done():
-			c.logInfoIfEnabled("Metrics SSE client disconnected",
+			c.LogInfoIfEnabled("Metrics SSE client disconnected",
 				logger.String("client_id", clientID),
 			)
 			return nil
@@ -156,7 +157,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 
 			if len(data) > 0 {
 				if err := c.sendSSEMessage(ctx, "metrics", data); err != nil {
-					c.logDebugIfEnabled("Metrics SSE send failed, client likely disconnected",
+					c.LogDebugIfEnabled("Metrics SSE send failed, client likely disconnected",
 						logger.String("client_id", clientID),
 						logger.Error(err),
 					)
@@ -168,7 +169,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 			if err := c.sendSSEMessage(ctx, eventInferenceTopologyChanged, map[string]any{
 				"timestamp": time.Now().Unix(),
 			}); err != nil {
-				c.logDebugIfEnabled("Metrics SSE topology-changed send failed, client likely disconnected",
+				c.LogDebugIfEnabled("Metrics SSE topology-changed send failed, client likely disconnected",
 					logger.String("client_id", clientID),
 					logger.Error(err),
 				)
@@ -179,7 +180,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 			if err := c.sendSSEMessage(ctx, "heartbeat", map[string]any{
 				"timestamp": time.Now().Unix(),
 			}); err != nil {
-				c.logDebugIfEnabled("Metrics SSE heartbeat failed",
+				c.LogDebugIfEnabled("Metrics SSE heartbeat failed",
 					logger.String("client_id", clientID),
 					logger.Error(err),
 				)
@@ -191,15 +192,15 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 
 // initMetricsHistoryRoutes registers the metrics history endpoints.
 func (c *Controller) initMetricsHistoryRoutes() {
-	if c.metricsStore == nil {
-		c.logWarnIfEnabled("Metrics store not configured, skipping metrics history routes")
+	if c.MetricsStore == nil {
+		c.LogWarnIfEnabled("Metrics store not configured, skipping metrics history routes")
 		return
 	}
 
-	c.logInfoIfEnabled("Initializing metrics history routes")
+	c.LogInfoIfEnabled("Initializing metrics history routes")
 
 	systemGroup := c.Group.Group("/system")
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// Rate limiter for metrics SSE connections (10 requests per minute per IP)
 	rateLimiterConfig := middleware.RateLimiterConfig{
@@ -227,24 +228,21 @@ func (c *Controller) initMetricsHistoryRoutes() {
 	metricsGroup.GET("/stream", c.StreamMetrics, middleware.RateLimiterWithConfig(rateLimiterConfig))
 
 	// Start the collector background goroutine
-	c.wg.Go(func() {
+	c.Go(func() {
 		collector := observability.NewCollector(
-			c.metricsStore,
+			c.MetricsStore,
 			metricsCollectorInterval,
 			c.getCPUUsageFunc(),
 		)
 
-		// Wire database counters if the datastore supports them
 		if provider, ok := c.DS.(datastore.DBCountersProvider); ok {
 			if counters := provider.GetDBCounters(); counters != nil {
 				collector.SetDBCounters(counters)
 			}
 		}
 
-		// Wire BirdNET inference counters
 		collector.SetInferenceCounters(classifier.GetInferenceCounters())
 
-		// Wire per-model clip length and RSS functions for RTF computation and RSS gauges
 		if c.Processor != nil {
 			if bn := c.Processor.GetBirdNET(); bn != nil {
 				collector.SetModelClipFunc(func() map[string]float64 {
@@ -258,12 +256,11 @@ func (c *Controller) initMetricsHistoryRoutes() {
 				collector.SetModelRSSFunc(bn.ModelRSS)
 			}
 		}
-		if c.metrics != nil && c.metrics.BirdNET != nil {
-			collector.SetInferenceGaugeSetters(c.metrics.BirdNET.SetInferenceRTF, c.metrics.BirdNET.SetModelRSSBytes, c.metrics.BirdNET.DeleteInferenceMetrics)
-			collector.SetAudioGaugeSetters(c.metrics.BirdNET.SetAudioQueueDepth, c.metrics.BirdNET.SetAudioDroppedChunks)
+		if c.Metrics != nil && c.Metrics.BirdNET != nil {
+			collector.SetInferenceGaugeSetters(c.Metrics.BirdNET.SetInferenceRTF, c.Metrics.BirdNET.SetModelRSSBytes, c.Metrics.BirdNET.DeleteInferenceMetrics)
+			collector.SetAudioGaugeSetters(c.Metrics.BirdNET.SetAudioQueueDepth, c.Metrics.BirdNET.SetAudioDroppedChunks)
 		}
 
-		// Wire health counter collection (drops, overruns, stream restarts)
 		if c.healthMetricsStore != nil {
 			collector.SetHealthStore(c.healthMetricsStore)
 			collector.SetHealthEvents(c.healthEvents)
@@ -271,10 +268,10 @@ func (c *Controller) initMetricsHistoryRoutes() {
 			collector.SetStreamHealth(c.buildStreamHealthSnapshotProvider())
 		}
 
-		collector.Start(c.ctx)
+		collector.Start(c.Context())
 	})
 
-	c.logInfoIfEnabled(fmt.Sprintf("Metrics history routes initialized (collector interval: %s)", metricsCollectorInterval))
+	c.LogInfoIfEnabled(fmt.Sprintf("Metrics history routes initialized (collector interval: %s)", metricsCollectorInterval))
 }
 
 // metricsCollectorInterval is the time between metric collection ticks.

--- a/internal/api/v2/migration.go
+++ b/internal/api/v2/migration.go
@@ -174,13 +174,13 @@ func (c *Controller) requireMigrationStateManager(next echo.HandlerFunc) echo.Ha
 
 // initMigrationRoutes registers the migration API routes.
 func (c *Controller) initMigrationRoutes() {
-	c.logInfoIfEnabled("Initializing migration routes")
+	c.LogInfoIfEnabled("Initializing migration routes")
 
 	// Create migration API group under system/database
 	migrationGroup := c.Group.Group("/system/database/migration")
 
 	// Get the appropriate auth middleware
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// Create auth-protected group
 	protectedGroup := migrationGroup.Group("", authMiddleware)
@@ -198,13 +198,13 @@ func (c *Controller) initMigrationRoutes() {
 	smGroup.POST("/cancel", c.CancelMigration)
 	smGroup.POST("/rollback", c.RollbackMigration)
 
-	c.logInfoIfEnabled("Migration routes initialized successfully")
+	c.LogInfoIfEnabled("Migration routes initialized successfully")
 }
 
 // GetMigrationStatus handles GET /api/v2/system/database/migration/status
 func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting migration status", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Getting migration status", logger.String("path", path), logger.String("ip", ip))
 
 	// Snapshot state under lock for thread-safety
 	sm := getStateManager()
@@ -215,7 +215,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 	if sm == nil {
 		// In enhanced database mode, migration is complete and state manager is not needed
 		if v2Only {
-			c.logInfoIfEnabled("Running in enhanced database mode, migration is complete",
+			c.LogInfoIfEnabled("Running in enhanced database mode, migration is complete",
 				logger.String("path", path), logger.String("ip", ip))
 			// Get cleanup state for v2-only mode
 			var cleanupState, cleanupErr string
@@ -245,7 +245,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 				CleanupSpaceReclaimed:  cleanupReclaimed,
 			})
 		}
-		c.logWarnIfEnabled("Migration state manager not available",
+		c.LogWarnIfEnabled("Migration state manager not available",
 			logger.String("path", path), logger.String("ip", ip))
 		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
 			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
@@ -254,7 +254,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 	// Get migration state
 	state, err := sm.GetState()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get migration state",
+		c.LogErrorIfEnabled("Failed to get migration state",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to get migration status", http.StatusInternalServerError)
 	}
@@ -262,7 +262,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 	// Get dirty ID count
 	dirtyCount, err := sm.GetDirtyIDCount()
 	if err != nil {
-		c.logWarnIfEnabled("Failed to get dirty ID count",
+		c.LogWarnIfEnabled("Failed to get dirty ID count",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		dirtyCount = 0
 	}
@@ -355,7 +355,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 		CleanupSpaceReclaimed:  cleanupReclaimed,
 	}
 
-	c.logInfoIfEnabled("Migration status retrieved",
+	c.LogInfoIfEnabled("Migration status retrieved",
 		logger.String("state", response.State),
 		logger.String("phase", response.CurrentPhase),
 		logger.Int("phase_number", response.PhaseNumber),
@@ -372,7 +372,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 // StartMigration handles POST /api/v2/system/database/migration/start
 func (c *Controller) StartMigration(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Starting migration", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Starting migration", logger.String("path", path), logger.String("ip", ip))
 
 	// Snapshot state under lock for thread-safety
 	sm := getStateManager()
@@ -380,7 +380,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 
 	// Run pre-flight checks
 	if err := c.runPreflightChecks(); err != nil {
-		c.logErrorIfEnabled("Pre-flight checks failed",
+		c.LogErrorIfEnabled("Pre-flight checks failed",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleErrorWithKey(ctx, err, "Pre-flight checks failed", http.StatusBadRequest, notification.MsgErrMigrationPreFlight, nil)
 	}
@@ -388,7 +388,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 	// Parse request body
 	var req MigrationStartRequest
 	if err := ctx.Bind(&req); err != nil {
-		c.logErrorIfEnabled("Failed to parse start request",
+		c.LogErrorIfEnabled("Failed to parse start request",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleErrorWithKey(ctx, err, "Invalid request body", http.StatusBadRequest, notification.MsgErrMigrationInvalidBody, nil)
 	}
@@ -398,12 +398,12 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 	// to avoid this slower fallback
 	totalRecords := req.TotalRecords
 	if totalRecords <= 0 {
-		c.logWarnIfEnabled("Total records not provided, counting from database",
+		c.LogWarnIfEnabled("Total records not provided, counting from database",
 			logger.String("path", path), logger.String("ip", ip))
 
 		count, err := c.Repo.CountAll(ctx.Request().Context())
 		if err != nil {
-			c.logErrorIfEnabled("Failed to count legacy records",
+			c.LogErrorIfEnabled("Failed to count legacy records",
 				logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 			return c.HandleErrorWithKey(ctx, err, "Failed to determine total records", http.StatusInternalServerError, notification.MsgErrMigrationRecordCount, nil)
 		}
@@ -412,18 +412,18 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 
 	// Start migration
 	if err := sm.StartMigration(totalRecords); err != nil {
-		c.logErrorIfEnabled("Failed to start migration",
+		c.LogErrorIfEnabled("Failed to start migration",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleErrorWithKey(ctx, err, "Failed to start migration", http.StatusConflict, notification.MsgErrMigrationStartFailed, nil)
 	}
 
 	// Transition to dual-write
 	if err := sm.TransitionToDualWrite(); err != nil {
-		c.logErrorIfEnabled("Failed to transition to dual-write",
+		c.LogErrorIfEnabled("Failed to transition to dual-write",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		// Try to cancel since we couldn't complete initialization
 		if cancelErr := sm.Cancel(); cancelErr != nil {
-			c.logWarnIfEnabled("Failed to cancel after transition failure",
+			c.LogWarnIfEnabled("Failed to cancel after transition failure",
 				logger.Error(cancelErr))
 		}
 		return c.HandleErrorWithKey(ctx, err, "Failed to initialize migration", http.StatusInternalServerError, notification.MsgErrMigrationInitFailed, nil)
@@ -436,13 +436,13 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 		SetMigrationWorkerCancel(workerCancel)
 		if err := worker.Start(workerCtx); err != nil {
 			workerCancel() // Clean up on failure
-			c.logWarnIfEnabled("Failed to start migration worker",
+			c.LogWarnIfEnabled("Failed to start migration worker",
 				logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 			// Migration state is still valid, worker can be started later
 		}
 	}
 
-	c.logInfoIfEnabled("Migration started successfully",
+	c.LogInfoIfEnabled("Migration started successfully",
 		logger.Int64("total_records", totalRecords),
 		logger.String("path", path), logger.String("ip", ip))
 
@@ -464,7 +464,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 			WithMessageKey(notification.MsgMigrationStartedMessage, nil)
 
 		if err := notifService.CreateWithMetadata(notif); err != nil {
-			c.logWarnIfEnabled("Failed to send migration start notification",
+			c.LogWarnIfEnabled("Failed to send migration start notification",
 				logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		}
 	}
@@ -502,7 +502,7 @@ func (c *Controller) PauseMigration(ctx echo.Context) error {
 // ResumeMigration handles POST /api/v2/system/database/migration/resume
 func (c *Controller) ResumeMigration(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Resuming migration", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Resuming migration", logger.String("path", path), logger.String("ip", ip))
 
 	// Snapshot state under lock for thread-safety
 	sm := getStateManager()
@@ -510,7 +510,7 @@ func (c *Controller) ResumeMigration(ctx echo.Context) error {
 
 	// Resume the state
 	if err := sm.Resume(); err != nil {
-		c.logErrorIfEnabled("Failed to resume migration",
+		c.LogErrorIfEnabled("Failed to resume migration",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleErrorWithKey(ctx, err, "Failed to resume migration", http.StatusConflict, notification.MsgErrMigrationResumeFailed, nil)
 	}
@@ -525,7 +525,7 @@ func (c *Controller) ResumeMigration(ctx echo.Context) error {
 			SetMigrationWorkerCancel(workerCancel)
 			if err := worker.Start(workerCtx); err != nil {
 				workerCancel() // Clean up on failure
-				c.logWarnIfEnabled("Failed to restart migration worker",
+				c.LogWarnIfEnabled("Failed to restart migration worker",
 					logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 			}
 		}
@@ -533,11 +533,11 @@ func (c *Controller) ResumeMigration(ctx echo.Context) error {
 
 	// Clear any previous error
 	if err := sm.ClearError(); err != nil {
-		c.logWarnIfEnabled("Failed to clear error message",
+		c.LogWarnIfEnabled("Failed to clear error message",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 	}
 
-	c.logInfoIfEnabled("Migration resumed successfully",
+	c.LogInfoIfEnabled("Migration resumed successfully",
 		logger.String("path", path), logger.String("ip", ip))
 
 	// Get the actual state after resume
@@ -557,14 +557,14 @@ func (c *Controller) ResumeMigration(ctx echo.Context) error {
 // RetryValidation handles POST /api/v2/system/database/migration/retry-validation
 func (c *Controller) RetryValidation(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Retrying migration validation", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Retrying migration validation", logger.String("path", path), logger.String("ip", ip))
 
 	sm := getStateManager()
 	worker := getMigrationWorker()
 
 	// Transition FAILED → VALIDATING
 	if err := sm.RetryValidation(); err != nil {
-		c.logErrorIfEnabled("Failed to retry validation",
+		c.LogErrorIfEnabled("Failed to retry validation",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to retry validation", http.StatusConflict)
 	}
@@ -578,7 +578,7 @@ func (c *Controller) RetryValidation(ctx echo.Context) error {
 			SetMigrationWorkerCancel(workerCancel)
 			if err := worker.Start(workerCtx); err != nil {
 				workerCancel()
-				c.logWarnIfEnabled("Failed to restart migration worker",
+				c.LogWarnIfEnabled("Failed to restart migration worker",
 					logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 			}
 		}
@@ -586,11 +586,11 @@ func (c *Controller) RetryValidation(ctx echo.Context) error {
 
 	// Clear any previous error
 	if err := sm.ClearError(); err != nil {
-		c.logWarnIfEnabled("Failed to clear error message",
+		c.LogWarnIfEnabled("Failed to clear error message",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 	}
 
-	c.logInfoIfEnabled("Migration validation retry initiated",
+	c.LogInfoIfEnabled("Migration validation retry initiated",
 		logger.String("path", path), logger.String("ip", ip))
 
 	return ctx.JSON(http.StatusOK, MigrationActionResponse{
@@ -603,7 +603,7 @@ func (c *Controller) RetryValidation(ctx echo.Context) error {
 // CancelMigration handles POST /api/v2/system/database/migration/cancel
 func (c *Controller) CancelMigration(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Cancelling migration", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Cancelling migration", logger.String("path", path), logger.String("ip", ip))
 
 	// Snapshot state under lock for thread-safety
 	sm := getStateManager()
@@ -623,18 +623,18 @@ func (c *Controller) CancelMigration(ctx echo.Context) error {
 
 	// Cancel the state
 	if err := sm.Cancel(); err != nil {
-		c.logErrorIfEnabled("Failed to cancel migration",
+		c.LogErrorIfEnabled("Failed to cancel migration",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to cancel migration", http.StatusConflict)
 	}
 
 	// Clear dirty IDs since we're cancelling
 	if err := sm.ClearDirtyIDs(); err != nil {
-		c.logWarnIfEnabled("Failed to clear dirty IDs",
+		c.LogWarnIfEnabled("Failed to clear dirty IDs",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 	}
 
-	c.logInfoIfEnabled("Migration cancelled successfully",
+	c.LogInfoIfEnabled("Migration cancelled successfully",
 		logger.String("path", path), logger.String("ip", ip))
 
 	// Report cancellation to telemetry
@@ -655,7 +655,7 @@ func (c *Controller) CancelMigration(ctx echo.Context) error {
 			WithMessageKey(notification.MsgMigrationCancelledMessage, nil)
 
 		if err := notifService.CreateWithMetadata(notif); err != nil {
-			c.logWarnIfEnabled("Failed to send migration cancel notification",
+			c.LogWarnIfEnabled("Failed to send migration cancel notification",
 				logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		}
 	}
@@ -753,7 +753,7 @@ type migrationActionParams struct {
 // All callers are behind the requireMigrationStateManager middleware.
 func (c *Controller) executeMigrationAction(ctx echo.Context, params *migrationActionParams) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled(params.logStart, logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled(params.logStart, logger.String("path", path), logger.String("ip", ip))
 
 	// Perform worker action if worker is running
 	if params.worker != nil && params.worker.IsRunning() {
@@ -762,12 +762,12 @@ func (c *Controller) executeMigrationAction(ctx echo.Context, params *migrationA
 
 	// Perform state action
 	if err := params.stateAction(); err != nil {
-		c.logErrorIfEnabled(params.logFailure,
+		c.LogErrorIfEnabled(params.logFailure,
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, params.logFailure, http.StatusConflict)
 	}
 
-	c.logInfoIfEnabled(params.logSuccess,
+	c.LogInfoIfEnabled(params.logSuccess,
 		logger.String("path", path), logger.String("ip", ip))
 
 	// Send notification if configured
@@ -789,7 +789,7 @@ func (c *Controller) executeMigrationAction(ctx echo.Context, params *migrationA
 			}
 
 			if err := notifService.CreateWithMetadata(notif); err != nil {
-				c.logWarnIfEnabled("Failed to send migration notification",
+				c.LogWarnIfEnabled("Failed to send migration notification",
 					logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 			}
 		}

--- a/internal/api/v2/migration_test.go
+++ b/internal/api/v2/migration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -116,12 +117,7 @@ func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *data
 		db:            db,
 	}
 
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-		DS:    testDS,
-		Repo:  mockRepo,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
 	controller.Settings.Store(getTestSettings(t))
 	publishTestSettings(t, controller.Settings.Load())
 
@@ -573,10 +569,7 @@ func TestGetMigrationStatus_NoStateManager(t *testing.T) {
 	t.Attr("feature", "error-handling")
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(getTestSettings(t))
 
 	// Save and clear the global state manager

--- a/internal/api/v2/models.go
+++ b/internal/api/v2/models.go
@@ -49,9 +49,9 @@ func (c *Controller) initModelRoutes() {
 	c.Group.GET("/models", c.ListModels)
 	c.Group.GET("/models/catalog", c.GetModelCatalog)
 	c.Group.GET("/models/installed", c.GetInstalledModels)
-	c.Group.POST("/models/install/:id", c.InstallModel, c.authMiddleware)
-	c.Group.POST("/models/reinstall/:id", c.ReinstallModel, c.authMiddleware)
-	c.Group.DELETE("/models/installed/:id", c.UninstallModel, c.authMiddleware)
+	c.Group.POST("/models/install/:id", c.InstallModel, c.AuthMiddleware)
+	c.Group.POST("/models/reinstall/:id", c.ReinstallModel, c.AuthMiddleware)
+	c.Group.DELETE("/models/installed/:id", c.UninstallModel, c.AuthMiddleware)
 	c.Group.GET("/models/install/:id/progress", c.StreamInstallProgress)
 }
 
@@ -111,7 +111,7 @@ func (c *Controller) GetModelCatalog(ctx echo.Context) error {
 	catalog := make([]CatalogEntryResponse, 0, len(visible))
 
 	// Check ORT availability once, reuse for all entries that require ONNX.
-	ortStatus := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
+	ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 
 	for i := range visible {
 		entry := &visible[i]
@@ -189,7 +189,7 @@ func (c *Controller) InstallModel(ctx echo.Context) error {
 
 	// Reject installation of ONNX-dependent models when ORT is unavailable.
 	if entry.RequiresONNX {
-		ortStatus := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
+		ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 		if !ortStatus.Available {
 			return c.HandleError(ctx, nil,
 				"model requires ONNX Runtime "+inference.ORTRequiredVersion()+": "+ortStatus.Error,
@@ -199,23 +199,23 @@ func (c *Controller) InstallModel(ctx echo.Context) error {
 
 	// Start async install in a background goroutine.
 	progressChan := make(chan classifier.DownloadState, 16)
-	c.wg.Go(func() {
+	c.Go(func() {
 		defer func() {
 			if r := recover(); r != nil {
-				c.logErrorIfEnabled("Panic during model install",
+				c.LogErrorIfEnabled("Panic during model install",
 					logger.String("catalog_id", catalogID),
 					logger.Any("panic", r),
 				)
 			}
 		}()
-		if err := c.ModelManager.Install(c.ctx, &entry, "", progressChan); err != nil {
-			c.logErrorIfEnabled("Model install failed",
+		if err := c.ModelManager.Install(c.Context(), &entry, "", progressChan); err != nil {
+			c.LogErrorIfEnabled("Model install failed",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err),
 			)
 		}
 		close(progressChan)
-		// Drain remaining progress events so the channel does not leak.
+
 		for range progressChan {
 		}
 	})
@@ -250,7 +250,7 @@ func (c *Controller) ReinstallModel(ctx echo.Context) error {
 
 	// Reject reinstall of ONNX-dependent models when ORT is unavailable.
 	if entry.RequiresONNX {
-		ortStatus := inference.CheckORTAvailability(c.currentSettings().BirdNET.ONNXRuntimePath)
+		ortStatus := inference.CheckORTAvailability(c.CurrentSettings().BirdNET.ONNXRuntimePath)
 		if !ortStatus.Available {
 			return c.HandleError(ctx, nil,
 				"model requires ONNX Runtime "+inference.ORTRequiredVersion()+": "+ortStatus.Error,
@@ -260,23 +260,23 @@ func (c *Controller) ReinstallModel(ctx echo.Context) error {
 
 	// Start async reinstall in a background goroutine.
 	progressChan := make(chan classifier.DownloadState, 16)
-	c.wg.Go(func() {
+	c.Go(func() {
 		defer func() {
 			if r := recover(); r != nil {
-				c.logErrorIfEnabled("Panic during model reinstall",
+				c.LogErrorIfEnabled("Panic during model reinstall",
 					logger.String("catalog_id", catalogID),
 					logger.Any("panic", r),
 				)
 			}
 		}()
-		if err := c.ModelManager.Reinstall(c.ctx, &entry, "", progressChan); err != nil {
-			c.logErrorIfEnabled("Model reinstall failed",
+		if err := c.ModelManager.Reinstall(c.Context(), &entry, "", progressChan); err != nil {
+			c.LogErrorIfEnabled("Model reinstall failed",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err),
 			)
 		}
 		close(progressChan)
-		// Drain remaining progress events so the channel does not leak.
+
 		for range progressChan {
 		}
 	})

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -31,7 +31,7 @@ type MQTTTLSCertificateUpload struct {
 // then falling back to TLSManager's managed directory.
 func (c *Controller) getMQTTCertPath(certType conf.TLSCertificateType) string {
 	// Check settings-configured paths first (covers manually configured certs).
-	// controllerSettings() can be nil on a standalone/test controller that never
+	// ControllerSettings() can be nil on a standalone/test controller that never
 	// stored a snapshot; in that case skip the configured paths and still allow
 	// the TLSManager-managed cert fallback below.
 	var settingsPath string

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -35,7 +35,7 @@ func (c *Controller) getMQTTCertPath(certType conf.TLSCertificateType) string {
 	// stored a snapshot; in that case skip the configured paths and still allow
 	// the TLSManager-managed cert fallback below.
 	var settingsPath string
-	if settings := c.controllerSettings(); settings != nil {
+	if settings := c.ControllerSettings(); settings != nil {
 		mqttTLS := settings.Realtime.MQTT.TLS
 		switch certType {
 		case conf.TLSCertTypeCA:

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -144,7 +144,7 @@ func (c *Controller) executeNotificationAction(ctx echo.Context, action notifica
 		if errors.Is(err, notification.ErrNotificationNotFound) || errors.IsNotFound(err) {
 			return c.HandleErrorWithKey(ctx, err, "Notification not found", http.StatusNotFound, notification.MsgErrNotifNotFound, nil)
 		}
-		c.logErrorIfEnabled(action.errorLogMsg,
+		c.LogErrorIfEnabled(action.errorLogMsg,
 			logger.Error(err),
 			logger.String("id", id))
 		return c.HandleError(ctx, err, action.errorRespMsg, http.StatusInternalServerError)
@@ -194,7 +194,7 @@ func (c *Controller) SetupNotificationRoutes() {
 	// Route priority: Echo matches static path segments before parameter
 	// routes ("/:id"), so /unread/count and /stream always win over the
 	// /:id routes registered in the auth group below. Register these on
-	// the parent c.Group so they are NOT wrapped by c.authMiddleware.
+	// the parent c.Group so they are NOT wrapped by c.AuthMiddleware.
 	// (/check-ntfy-server is intentionally NOT public — see the auth group
 	// registration later in this function, kept authed to prevent SSRF.)
 	c.Group.GET("/notifications", c.GetNotifications, c.requireNotificationService)
@@ -205,7 +205,7 @@ func (c *Controller) SetupNotificationRoutes() {
 	// Auth-protected endpoints: per-item read, mutations, the test-notification
 	// trigger, and the NTFY connectivity probe (kept authed to avoid being
 	// used as an SSRF relay by unauthenticated callers).
-	notificationsGroup := c.Group.Group("/notifications", c.authMiddleware)
+	notificationsGroup := c.Group.Group("/notifications", c.AuthMiddleware)
 
 	notifServiceGroup := notificationsGroup.Group("", c.requireNotificationService)
 	notifServiceGroup.PUT("/read-all", c.MarkAllNotificationsRead)
@@ -401,8 +401,8 @@ func (c *Controller) StreamNotifications(ctx echo.Context) error {
 	connectionStartTime := time.Now()
 
 	// Track active connections using metrics
-	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.SSEConnectionStarted(sseEndpoint)
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.SSEConnectionStarted(sseEndpoint)
 		defer func() {
 			duration := time.Since(connectionStartTime).Seconds()
 			// Determine close reason based on context
@@ -412,7 +412,7 @@ func (c *Controller) StreamNotifications(ctx echo.Context) error {
 			} else if ctx.Request().Context().Err() == context.Canceled {
 				closeReason = metrics.SSECloseReasonCanceled
 			}
-			c.metrics.HTTP.SSEConnectionClosed(sseEndpoint, duration, closeReason)
+			c.Metrics.HTTP.SSEConnectionClosed(sseEndpoint, duration, closeReason)
 		}()
 	}
 
@@ -477,8 +477,8 @@ func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*Notification
 		return nil, nil, err
 	}
 
-	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.RecordSSEMessageSent(sseEndpoint, sseEventConnected)
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.RecordSSEMessageSent(sseEndpoint, sseEventConnected)
 	}
 
 	// Log the connection
@@ -516,9 +516,9 @@ func (c *Controller) runNotificationEventLoop(ctx echo.Context, client *Notifica
 	// Main event loop
 	for {
 		select {
-		case <-c.ctx.Done():
+		case <-c.Context().Done():
 			// Controller shutting down
-			c.logInfoIfEnabled("notification SSE client disconnected due to shutdown",
+			c.LogInfoIfEnabled("notification SSE client disconnected due to shutdown",
 				logger.String("client_id", client.ID),
 			)
 			return nil
@@ -665,13 +665,13 @@ func (c *Controller) logNotificationConnection(clientID, ip, userAgent string, c
 		action = "disconnected"
 	}
 
-	if s := c.currentSettings(); s != nil && s.WebServer.Debug && connected {
-		c.logDebugIfEnabled("notification SSE client "+action,
+	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug && connected {
+		c.LogDebugIfEnabled("notification SSE client "+action,
 			logger.String("clientId", clientID),
 			logger.String("ip", privacy.AnonymizeIP(ip)),
 			logger.String("user_agent", privacy.RedactUserAgent(userAgent)))
 	} else {
-		c.logInfoIfEnabled("notification SSE client "+action,
+		c.LogInfoIfEnabled("notification SSE client "+action,
 			logger.String("clientId", clientID),
 			logger.String("ip", privacy.AnonymizeIP(ip)))
 	}
@@ -679,16 +679,16 @@ func (c *Controller) logNotificationConnection(clientID, ip, userAgent string, c
 
 // logNotificationError logs SSE errors
 func (c *Controller) logNotificationError(message string, err error, clientID string) {
-	c.logErrorIfEnabled(message,
+	c.LogErrorIfEnabled(message,
 		logger.Error(err),
 		logger.String("clientId", clientID))
 }
 
 // logToastSent logs successful toast sending
 func (c *Controller) logToastSent(clientID string, notif *notification.Notification) {
-	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
+	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug {
 		toastType, _ := notif.Metadata["toastType"].(string)
-		c.logDebugIfEnabled("toast sent via SSE",
+		c.LogDebugIfEnabled("toast sent via SSE",
 			logger.String("clientId", clientID),
 			logger.Any("toast_id", notif.Metadata["toastId"]),
 			logger.String("type", toastType),
@@ -698,8 +698,8 @@ func (c *Controller) logToastSent(clientID string, notif *notification.Notificat
 
 // logNotificationSent logs successful notification sending
 func (c *Controller) logNotificationSent(clientID string, notif *notification.Notification) {
-	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
-		c.logDebugIfEnabled("notification sent via SSE",
+	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug {
+		c.LogDebugIfEnabled("notification sent via SSE",
 			logger.String("clientId", clientID),
 			logger.String("notification_id", notif.ID),
 			logger.String("type", string(notif.Type)),
@@ -766,8 +766,8 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 		}
 	}
 
-	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
-		c.logDebugIfEnabled("listing notifications",
+	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug {
+		c.LogDebugIfEnabled("listing notifications",
 			logger.Any("status", filter.Status),
 			logger.Any("types", filter.Types),
 			logger.Any("priorities", filter.Priorities),
@@ -778,7 +778,7 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 	// Get notifications
 	notifications, err := service.List(filter)
 	if err != nil {
-		c.logErrorIfEnabled("failed to list notifications", logger.Error(err))
+		c.LogErrorIfEnabled("failed to list notifications", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to retrieve notifications", http.StatusInternalServerError)
 	}
 
@@ -801,13 +801,13 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 		notifications = filtered
 	}
 
-	if s := c.currentSettings(); s != nil && s.WebServer.Debug {
+	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug {
 		unreadCount, err := service.GetUnreadCount()
 		if err != nil {
-			c.logErrorIfEnabled("failed to get unread count", logger.Error(err))
+			c.LogErrorIfEnabled("failed to get unread count", logger.Error(err))
 			unreadCount = -1 // Indicate error in debug log
 		}
-		c.logDebugIfEnabled("notifications retrieved",
+		c.LogDebugIfEnabled("notifications retrieved",
 			logger.Int("count", len(notifications)),
 			logger.Int("total_unread", unreadCount))
 	}
@@ -833,7 +833,7 @@ func (c *Controller) GetNotification(ctx echo.Context) error {
 		if errors.Is(err, notification.ErrNotificationNotFound) || errors.IsNotFound(err) {
 			return c.HandleErrorWithKey(ctx, err, "Notification not found", http.StatusNotFound, notification.MsgErrNotifNotFound, nil)
 		}
-		c.logErrorIfEnabled("failed to get notification",
+		c.LogErrorIfEnabled("failed to get notification",
 			logger.Error(err),
 			logger.String("id", id))
 		return c.HandleError(ctx, err, "Failed to retrieve notification", http.StatusInternalServerError)
@@ -848,7 +848,7 @@ func (c *Controller) MarkAllNotificationsRead(ctx echo.Context) error {
 
 	count, err := service.MarkAllAsRead()
 	if err != nil {
-		c.logErrorIfEnabled("failed to mark all notifications as read", logger.Error(err))
+		c.LogErrorIfEnabled("failed to mark all notifications as read", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to mark all notifications as read", http.StatusInternalServerError)
 	}
 
@@ -904,7 +904,7 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 			Status: []notification.Status{notification.StatusUnread},
 		})
 		if err != nil {
-			c.logErrorIfEnabled("failed to count detection notifications for guest", logger.Error(err))
+			c.LogErrorIfEnabled("failed to count detection notifications for guest", logger.Error(err))
 			return c.HandleError(ctx, err, "Failed to get unread count", http.StatusInternalServerError)
 		}
 		return ctx.JSON(http.StatusOK, map[string]any{
@@ -914,7 +914,7 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 
 	count, err := service.GetUnreadCount()
 	if err != nil {
-		c.logErrorIfEnabled("failed to get unread count", logger.Error(err))
+		c.LogErrorIfEnabled("failed to get unread count", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to get unread count", http.StatusInternalServerError)
 	}
 
@@ -925,7 +925,7 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 
 // CreateTestNewSpeciesNotification creates a test new species detection notification
 func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)
 	}
@@ -991,12 +991,12 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 
 	// Use CreateWithMetadata to persist and broadcast
 	if err := service.CreateWithMetadata(testNotification); err != nil {
-		c.logErrorIfEnabled("failed to create test notification", logger.Error(err))
+		c.LogErrorIfEnabled("failed to create test notification", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to create test notification", http.StatusInternalServerError)
 	}
 
 	if settings.WebServer.Debug {
-		c.logDebugIfEnabled("test new species notification created",
+		c.LogDebugIfEnabled("test new species notification created",
 			logger.String("notification_id", testNotification.ID),
 			logger.String("species", testTemplateData.CommonName),
 			logger.String("rendered_title", title),

--- a/internal/api/v2/notifications_helpers_test.go
+++ b/internal/api/v2/notifications_helpers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
@@ -44,9 +45,7 @@ func assertNoNilAction(t *testing.T, result, metadata map[string]any) {
 
 // mockController creates a controller with minimal setup for testing
 func mockController() *Controller {
-	c := &Controller{
-		apiLogger: nil, // Will skip logging in tests
-	}
+	c := &Controller{Core: &apicore.Core{APILogger: nil}}
 	c.Settings.Store(&conf.Settings{
 		WebServer: conf.WebServerSettings{
 			Debug: true,
@@ -318,9 +317,7 @@ func TestController_logNotificationConnection(t *testing.T) {
 	t.Parallel()
 
 	// Test with nil logger (should not panic)
-	c := &Controller{
-		apiLogger: nil,
-	}
+	c := &Controller{Core: &apicore.Core{APILogger: nil}}
 	c.Settings.Store(mockController().Settings.Load())
 
 	// These should not panic

--- a/internal/api/v2/notifications_mark_read_test.go
+++ b/internal/api/v2/notifications_mark_read_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
@@ -33,7 +34,7 @@ func newNotificationTestController(t *testing.T) (*Controller, *notification.Ser
 	service := notification.NewService(config)
 	t.Cleanup(service.Stop)
 
-	controller := &Controller{notificationService: service}
+	controller := &Controller{Core: &apicore.Core{}, notificationService: service}
 	controller.Settings.Store(&conf.Settings{})
 
 	return controller, service

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
@@ -34,7 +35,7 @@ func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(&conf.Settings{})
 
 	// Call through middleware to test the guard
@@ -69,7 +70,7 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{notificationService: service}
+	controller := &Controller{Core: &apicore.Core{}, notificationService: service}
 	// Build a minimal settings snapshot with only the fields this test needs,
 	// then publish it once (the empty base matches the original test).
 	settings := &conf.Settings{}

--- a/internal/api/v2/notifications_ntfy_check_test.go
+++ b/internal/api/v2/notifications_ntfy_check_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 )
 
 func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
@@ -22,7 +23,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Core: &apicore.Core{}}
 	ctrl.Settings.Store(newValidTestSettings())
 	// ts.Listener.Addr().String() returns "127.0.0.1:PORT"
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
@@ -42,7 +43,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 
 func TestCheckNtfyServer_MissingHost(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Core: &apicore.Core{}}
 	ctrl.Settings.Store(newValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -55,7 +56,7 @@ func TestCheckNtfyServer_MissingHost(t *testing.T) {
 
 func TestCheckNtfyServer_InvalidHost_Unreachable(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Core: &apicore.Core{}}
 	ctrl.Settings.Store(newValidTestSettings())
 	// Inject a short per-scheme probe timeout so the unreachable-host path returns
 	// quickly. 192.0.2.1 never responds, so the result is deterministically
@@ -87,7 +88,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Core: &apicore.Core{}}
 	ctrl.Settings.Store(newValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
@@ -104,7 +105,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 
 func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Core: &apicore.Core{}}
 	ctrl.Settings.Store(newValidTestSettings())
 	// Slash injection attempt
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=evil.com%2F%40good.com", http.NoBody)
@@ -118,7 +119,7 @@ func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 
 func TestCheckNtfyServer_CloudMetadataBlocked(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Core: &apicore.Core{}}
 	ctrl.Settings.Store(newValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=169.254.169.254", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/ntfy_integration_test.go
+++ b/internal/api/v2/ntfy_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/testutil/containers"
 )
 
@@ -54,7 +55,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 	t.Run("handler_integration", func(t *testing.T) {
 		// Test the full CheckNtfyServer handler via Echo context
 		e := echo.New()
-		ctrl := &Controller{}
+		ctrl := &Controller{Core: &apicore.Core{}}
 		ctrl.Settings.Store(newValidTestSettings())
 
 		req := httptest.NewRequest(http.MethodGet,

--- a/internal/api/v2/prerequisites.go
+++ b/internal/api/v2/prerequisites.go
@@ -84,7 +84,7 @@ const MinMySQLWaitTimeout = 600
 // Returns the status of all prerequisite checks before migration can start.
 func (c *Controller) GetPrerequisites(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Checking migration prerequisites", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Checking migration prerequisites", logger.String("path", path), logger.String("ip", ip))
 
 	criticalFailures := 0
 	warnings := 0
@@ -127,7 +127,7 @@ func (c *Controller) GetPrerequisites(ctx echo.Context) error {
 		CheckedAt:         time.Now(),
 	}
 
-	c.logInfoIfEnabled("Prerequisites check complete",
+	c.LogInfoIfEnabled("Prerequisites check complete",
 		logger.String("path", path),
 		logger.String("ip", ip),
 		logger.Bool("can_start", canStart),
@@ -139,7 +139,7 @@ func (c *Controller) GetPrerequisites(ctx echo.Context) error {
 
 // isUsingMySQL returns true if the application is configured to use MySQL.
 func (c *Controller) isUsingMySQL() bool {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return false
 	}
@@ -212,7 +212,7 @@ func (c *Controller) checkDiskSpace() PrerequisiteCheck {
 	requiredSpace := uint64(MinDiskSpaceBytes)
 	dbSizeInfo := ""
 
-	if settings := c.currentSettings(); settings != nil && !settings.Output.MySQL.Enabled {
+	if settings := c.CurrentSettings(); settings != nil && !settings.Output.MySQL.Enabled {
 		dbPath := settings.Output.SQLite.Path
 		if !filepath.IsAbs(dbPath) {
 			dbPath, _ = filepath.Abs(dbPath)
@@ -254,7 +254,7 @@ func (c *Controller) checkDiskSpace() PrerequisiteCheck {
 // Returns an error if the directory cannot be determined or verified.
 // For MySQL, returns empty string with nil error (disk space check not applicable to remote DB).
 func (c *Controller) getDatabaseDirectoryResolved() (string, error) {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return "", fmt.Errorf("settings not available")
 	}
@@ -597,7 +597,7 @@ func (c *Controller) checkRecordCount() PrerequisiteCheck {
 	}
 
 	// Use context.Background() as fallback if ctx is nil (e.g., in tests)
-	ctx := c.ctx
+	ctx := c.Context()
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/internal/api/v2/prerequisites_test.go
+++ b/internal/api/v2/prerequisites_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 
@@ -152,7 +153,7 @@ func TestCheckLegacyAccessible_NilDS(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{DS: nil}
+	controller := &Controller{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkLegacyAccessible()
 
@@ -184,7 +185,7 @@ func TestCheckRecordCount_NilRepo(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Repo: nil}
+	controller := &Controller{Core: &apicore.Core{Repo: nil}}
 
 	check := controller.checkRecordCount()
 
@@ -215,7 +216,7 @@ func TestCheckSQLiteIntegrity_NilDB(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{DS: nil}
+	controller := &Controller{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkSQLiteIntegrity()
 
@@ -238,7 +239,7 @@ func TestCheckSQLiteIntegrity_V2OnlyMode(t *testing.T) {
 	isV2OnlyMode = true
 	t.Cleanup(func() { isV2OnlyMode = prevV2Only })
 
-	controller := &Controller{DS: nil}
+	controller := &Controller{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkSQLiteIntegrity()
 
@@ -262,7 +263,7 @@ func TestCheckLegacyAccessible_V2OnlyMode(t *testing.T) {
 	isV2OnlyMode = true
 	t.Cleanup(func() { isV2OnlyMode = prevV2Only })
 
-	controller := &Controller{DS: nil}
+	controller := &Controller{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkLegacyAccessible()
 
@@ -286,7 +287,7 @@ func TestCheckRecordCount_V2OnlyMode(t *testing.T) {
 	isV2OnlyMode = true
 	t.Cleanup(func() { isV2OnlyMode = prevV2Only })
 
-	controller := &Controller{Repo: nil}
+	controller := &Controller{Core: &apicore.Core{Repo: nil}}
 
 	check := controller.checkRecordCount()
 
@@ -302,7 +303,7 @@ func TestCheckMemoryAvailable(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	controller.Settings.Store(newValidTestSettings())
 
 	check := controller.checkMemoryAvailable()
@@ -319,7 +320,7 @@ func TestCheckExistingV2Data_NilManager(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{V2Manager: nil}
+	controller := &Controller{Core: &apicore.Core{V2Manager: nil}}
 
 	check := controller.checkExistingV2Data()
 
@@ -373,7 +374,7 @@ func TestCheckExistingV2Data_UsesManagerTablePrefix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := &Controller{V2Manager: newFakeV2ManagerWithTable(t, tt.tableName, tt.prefix, tt.count)}
+			controller := &Controller{Core: &apicore.Core{V2Manager: newFakeV2ManagerWithTable(t, tt.tableName, tt.prefix, tt.count)}}
 
 			check := controller.checkExistingV2Data()
 
@@ -438,7 +439,7 @@ func TestIsUsingMySQL_NilSettings(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 
 	result := controller.isUsingMySQL()
 
@@ -465,7 +466,7 @@ func TestGetDatabaseDirectoryResolved_NilSettings(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{}
+	controller := &Controller{Core: &apicore.Core{}}
 	// Publish a nil global so currentSettings() falls back to the controller's
 	// nil c.Settings and exercises the "settings not available" path.
 	publishTestSettings(t, nil)
@@ -495,7 +496,7 @@ func TestGetLegacyGormDB_NilDS(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{DS: nil}
+	controller := &Controller{Core: &apicore.Core{DS: nil}}
 
 	db := controller.getLegacyGormDB()
 
@@ -576,12 +577,7 @@ func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *
 		db:            db,
 	}
 
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-		DS:    testDS,
-		Repo:  mockRepo,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
 	controller.Settings.Store(getTestSettings(t))
 	publishTestSettings(t, controller.Settings.Load())
 

--- a/internal/api/v2/quiet_hours.go
+++ b/internal/api/v2/quiet_hours.go
@@ -41,11 +41,11 @@ func (c *Controller) initQuietHoursRoutes() {
 // StreamManager settings form) continue to receive the sanitized URL map.
 func (c *Controller) GetQuietHoursStatus(ctx echo.Context) error {
 	// Read the live global snapshot (race-free, hot-reloading) via
-	// currentSettings() so out-of-band republishes are seen and the read never
+	// CurrentSettings() so out-of-band republishes are seen and the read never
 	// races the Settings.Store in UpdateSettings.
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	var scheduler *schedule.QuietHoursScheduler
-	if eng := c.engine.Load(); eng != nil {
+	if eng := c.Engine.Load(); eng != nil {
 		scheduler = eng.Scheduler()
 	}
 

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -79,7 +79,7 @@ func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
 
 // currentLocale returns the BirdNET locale from the current settings.
 func (c *Controller) currentLocale() string {
-	locale := c.currentSettings().BirdNET.Locale
+	locale := c.CurrentSettings().BirdNET.Locale
 	return locale
 }
 
@@ -88,7 +88,7 @@ func (c *Controller) currentLocale() string {
 // current settings with only the test values overridden, so it can be passed
 // directly to GetProbableSpeciesWithSettings without modifying global state.
 func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *conf.Settings {
-	testSnapshot := conf.CloneSettings(c.currentSettings())
+	testSnapshot := conf.CloneSettings(c.CurrentSettings())
 
 	testSnapshot.BirdNET.Latitude = lat
 	testSnapshot.BirdNET.Longitude = lon
@@ -351,7 +351,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 
 	// Read defaults from latest published settings snapshot so UI changes
 	// to coordinates take effect without restart.
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	lat := settings.BirdNET.Latitude
 	lon := settings.BirdNET.Longitude
 	locale := settings.BirdNET.Locale
@@ -418,7 +418,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		},
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelDebug, "Range filter species scores retrieved", logger.Int("species_count", len(speciesList)))
+	c.LogAPIRequest(ctx, logger.LogLevelDebug, "Range filter species scores retrieved", logger.Int("species_count", len(speciesList)))
 	return ctx.JSON(http.StatusOK, response)
 }
 
@@ -431,7 +431,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/count [get]
 func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 
 	// Count the de-duplicated display list so the count matches what
 	// /range/species/list renders (the same collapse of force-include override
@@ -461,7 +461,7 @@ func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/list [get]
 func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	includedSpecies := settings.GetIncludedSpecies()
 
 	birdnetInstance, _ := c.getBirdNETInstance()
@@ -615,7 +615,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 	response.Parameters.InputDate = req.Date
 	response.Parameters.InputWeek = req.Week
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Range filter test completed", logger.Int("species_count", len(speciesList)))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Range filter test completed", logger.Int("species_count", len(speciesList)))
 	return ctx.JSON(http.StatusOK, response)
 }
 
@@ -647,7 +647,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		var testReq RangeFilterTestRequest
 
 		// Read current settings from the lock-free atomic snapshot for defaults
-		defaults := c.currentSettings()
+		defaults := c.CurrentSettings()
 		testReq.Latitude = defaults.BirdNET.Latitude
 		testReq.Longitude = defaults.BirdNET.Longitude
 		testReq.Threshold = defaults.BirdNET.RangeFilter.Threshold
@@ -699,7 +699,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		// full active set via getTestSpeciesList, which also includes always-active
 		// secondary-model species. The settings UI always sends parameters, so it
 		// hits that branch; this branch is the no-argument fallback.
-		settings := c.currentSettings()
+		settings := c.CurrentSettings()
 
 		birdnetInstance, _ := c.getBirdNETInstance()
 		speciesList = dedupeSpeciesForDisplay(convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale))
@@ -727,7 +727,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 	ctx.Response().Header().Set("Pragma", "no-cache")
 	ctx.Response().Header().Set("Expires", "0")
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Range filter species CSV exported", logger.Int("species_count", len(speciesList)))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Range filter species CSV exported", logger.Int("species_count", len(speciesList)))
 	return ctx.Blob(http.StatusOK, "text/csv; charset=utf-8", csvBytes)
 }
 
@@ -878,7 +878,7 @@ func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
 
 	// Read from the latest published snapshot so the just-published rebuild
 	// result is reflected immediately.
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	includedSpecies := settings.GetIncludedSpecies()
 	lastUpdated := settings.BirdNET.RangeFilter.LastUpdated
 
@@ -889,6 +889,6 @@ func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
 		"lastUpdated": lastUpdated,
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Range filter rebuilt successfully", logger.Int("species_count", len(includedSpecies)))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Range filter rebuilt successfully", logger.Int("species_count", len(includedSpecies)))
 	return ctx.JSON(http.StatusOK, response)
 }

--- a/internal/api/v2/routes_enumeration_test.go
+++ b/internal/api/v2/routes_enumeration_test.go
@@ -1,0 +1,363 @@
+package api
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/observability"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// goldenRoutes is the complete, sorted "METHOD PATH" set registered by a fully
+// initialized v2 controller (initializeRoutes=true). It is the regression gate
+// for the internal/api/v2 package split: every phase that moves handlers must
+// keep this set byte-identical. The entries include echo's auto-generated
+// route-not-found stubs for group prefixes, and the greedy GET /api/v2/audio/:id
+// route registered directly on the Echo instance (see internal/api/v2/CLAUDE.md).
+//
+// To regenerate after an INTENTIONAL route change: run the test, take the sorted
+// list it prints on failure, and replace this slice.
+var goldenRoutes = []string{
+	"DELETE /api/v2/detections/:id",
+	"DELETE /api/v2/dynamic-thresholds",
+	"DELETE /api/v2/dynamic-thresholds/:species",
+	"DELETE /api/v2/integrations/mqtt/tls/certificate",
+	"DELETE /api/v2/models/installed/:id",
+	"DELETE /api/v2/notifications/:id",
+	"DELETE /api/v2/system/database/backup/jobs/:id",
+	"DELETE /api/v2/tls/certificate",
+	"GET /api/v2/analytics/confidence/distribution",
+	"GET /api/v2/analytics/sources",
+	"GET /api/v2/analytics/species/accumulation",
+	"GET /api/v2/analytics/species/daily",
+	"GET /api/v2/analytics/species/daily/batch",
+	"GET /api/v2/analytics/species/detections/new",
+	"GET /api/v2/analytics/species/diversity",
+	"GET /api/v2/analytics/species/phenology",
+	"GET /api/v2/analytics/species/summary",
+	"GET /api/v2/analytics/species/thumbnails",
+	"GET /api/v2/analytics/sun",
+	"GET /api/v2/analytics/time/daily",
+	"GET /api/v2/analytics/time/daily/batch",
+	"GET /api/v2/analytics/time/dawn-onset",
+	"GET /api/v2/analytics/time/distribution/hourly",
+	"GET /api/v2/analytics/time/distribution/species",
+	"GET /api/v2/analytics/time/heatmap",
+	"GET /api/v2/analytics/time/hourly",
+	"GET /api/v2/analytics/time/hourly/batch",
+	"GET /api/v2/analytics/time/succession",
+	"GET /api/v2/analytics/time/year-over-year",
+	"GET /api/v2/app/config",
+	"GET /api/v2/audio/:id",
+	"GET /api/v2/auth/callback",
+	"GET /api/v2/auth/status",
+	"GET /api/v2/control/actions",
+	"GET /api/v2/detections",
+	"GET /api/v2/detections/:id",
+	"GET /api/v2/detections/:id/time-of-day",
+	"GET /api/v2/detections/ignored",
+	"GET /api/v2/detections/recent",
+	"GET /api/v2/detections/stream",
+	"GET /api/v2/dynamic-thresholds",
+	"GET /api/v2/dynamic-thresholds/:species",
+	"GET /api/v2/dynamic-thresholds/:species/events",
+	"GET /api/v2/dynamic-thresholds/stats",
+	"GET /api/v2/filesystem/browse",
+	"GET /api/v2/health",
+	"GET /api/v2/health/audio",
+	"GET /api/v2/import/jobs/:jobId/progress",
+	"GET /api/v2/import/status",
+	"GET /api/v2/integrations/birdweather/status",
+	"GET /api/v2/integrations/mqtt/status",
+	"GET /api/v2/integrations/mqtt/tls/certificate",
+	"GET /api/v2/media/audio",
+	"GET /api/v2/media/audio/:filename",
+	"GET /api/v2/media/bird-image/:scientific_name",
+	"GET /api/v2/media/image/:scientific_name",
+	"GET /api/v2/media/species-image",
+	"GET /api/v2/media/species-image/info",
+	"GET /api/v2/media/spectrogram/:filename",
+	"GET /api/v2/models",
+	"GET /api/v2/models/catalog",
+	"GET /api/v2/models/install/:id/progress",
+	"GET /api/v2/models/installed",
+	"GET /api/v2/notifications",
+	"GET /api/v2/notifications/:id",
+	"GET /api/v2/notifications/check-ntfy-server",
+	"GET /api/v2/notifications/stream",
+	"GET /api/v2/notifications/unread/count",
+	"GET /api/v2/ping",
+	"GET /api/v2/range/heatmap",
+	"GET /api/v2/range/species/count",
+	"GET /api/v2/range/species/csv",
+	"GET /api/v2/range/species/list",
+	"GET /api/v2/range/species/scores",
+	"GET /api/v2/range/status",
+	"GET /api/v2/settings",
+	"GET /api/v2/settings/:section",
+	"GET /api/v2/settings/dashboard",
+	"GET /api/v2/settings/imageproviders",
+	"GET /api/v2/settings/locales",
+	"GET /api/v2/settings/systemid",
+	"GET /api/v2/soundlevels/stream",
+	"GET /api/v2/species",
+	"GET /api/v2/species/:code/thumbnail",
+	"GET /api/v2/species/all",
+	"GET /api/v2/species/dictionary/:locale",
+	"GET /api/v2/species/taxonomy",
+	"GET /api/v2/spectrogram/:id",
+	"GET /api/v2/spectrogram/:id/status",
+	"GET /api/v2/sse/status",
+	"GET /api/v2/streams/audio-level",
+	"GET /api/v2/streams/health",
+	"GET /api/v2/streams/health/:url",
+	"GET /api/v2/streams/health/stream",
+	"GET /api/v2/streams/hls/status",
+	"GET /api/v2/streams/hls/t/:streamToken/*",
+	"GET /api/v2/streams/hls/t/:streamToken/playlist.m3u8",
+	"GET /api/v2/streams/quiet-hours/status",
+	"GET /api/v2/streams/sources",
+	"GET /api/v2/streams/status",
+	"GET /api/v2/support/download/:id",
+	"GET /api/v2/support/status",
+	"GET /api/v2/system/audio/active",
+	"GET /api/v2/system/audio/devices",
+	"GET /api/v2/system/audio/devices/capabilities",
+	"GET /api/v2/system/audio/equalizer/config",
+	"GET /api/v2/system/audio/sources",
+	"GET /api/v2/system/database/backup/jobs",
+	"GET /api/v2/system/database/backup/jobs/:id",
+	"GET /api/v2/system/database/backup/jobs/:id/download",
+	"GET /api/v2/system/database/legacy/status",
+	"GET /api/v2/system/database/migration/prerequisites",
+	"GET /api/v2/system/database/migration/status",
+	"GET /api/v2/system/database/overview",
+	"GET /api/v2/system/database/stats",
+	"GET /api/v2/system/database/v2/stats",
+	"GET /api/v2/system/diagnostics/errors",
+	"GET /api/v2/system/diagnostics/report/:id",
+	"GET /api/v2/system/diagnostics/status",
+	"GET /api/v2/system/disks",
+	"GET /api/v2/system/events/detections",
+	"GET /api/v2/system/events/operational",
+	"GET /api/v2/system/external-media",
+	"GET /api/v2/system/inference",
+	"GET /api/v2/system/info",
+	"GET /api/v2/system/jobs",
+	"GET /api/v2/system/models",
+	"GET /api/v2/system/network-interfaces",
+	"GET /api/v2/system/processes",
+	"GET /api/v2/system/resources",
+	"GET /api/v2/system/restart-status",
+	"GET /api/v2/system/temperature/cpu",
+	"GET /api/v2/taxonomy/family/:family",
+	"GET /api/v2/taxonomy/genus/:genus",
+	"GET /api/v2/taxonomy/tree/:scientific_name",
+	"GET /api/v2/terminal/ws",
+	"GET /api/v2/tls/certificate",
+	"GET /api/v2/tls/certificate/download",
+	"GET /api/v2/weather/daily/:date",
+	"GET /api/v2/weather/detection/:id",
+	"GET /api/v2/weather/hourly/:date",
+	"GET /api/v2/weather/hourly/:date/:hour",
+	"GET /api/v2/weather/latest",
+	"GET /api/v2/weather/moon/:date",
+	"GET /api/v2/weather/sun/:date",
+	"PATCH /api/v2/settings/:section",
+	"POST /api/v2/app/wizard/dismiss",
+	"POST /api/v2/audio/:id/clip",
+	"POST /api/v2/audio/:id/process",
+	"POST /api/v2/auth/login",
+	"POST /api/v2/auth/logout",
+	"POST /api/v2/control/rebuild-filter",
+	"POST /api/v2/control/reload",
+	"POST /api/v2/control/restart",
+	"POST /api/v2/control/restart-container",
+	"POST /api/v2/control/restart-server",
+	"POST /api/v2/control/restart-source/:id",
+	"POST /api/v2/detections/:id/lock",
+	"POST /api/v2/detections/:id/review",
+	"POST /api/v2/detections/batch/delete",
+	"POST /api/v2/detections/batch/lock",
+	"POST /api/v2/detections/batch/resolve",
+	"POST /api/v2/detections/batch/review",
+	"POST /api/v2/detections/ignore",
+	"POST /api/v2/import/birdnet-pi",
+	"POST /api/v2/import/jobs/:jobId/cancel",
+	"POST /api/v2/integrations/birdweather/test",
+	"POST /api/v2/integrations/ebird/test",
+	"POST /api/v2/integrations/mqtt/homeassistant/discovery",
+	"POST /api/v2/integrations/mqtt/test",
+	"POST /api/v2/integrations/mqtt/tls/certificate",
+	"POST /api/v2/integrations/weather/test",
+	"POST /api/v2/models/install/:id",
+	"POST /api/v2/models/reinstall/:id",
+	"POST /api/v2/notifications/test/new-species",
+	"POST /api/v2/range/rebuild",
+	"POST /api/v2/range/species/test",
+	"POST /api/v2/search",
+	"POST /api/v2/spectrogram/:id/generate",
+	"POST /api/v2/spectrogram/:id/process",
+	"POST /api/v2/streams/analyze-channels",
+	"POST /api/v2/streams/hls/:sourceID/start",
+	"POST /api/v2/streams/hls/:sourceID/stop",
+	"POST /api/v2/streams/hls/heartbeat",
+	"POST /api/v2/streams/test",
+	"POST /api/v2/support/generate",
+	"POST /api/v2/system/database/backup",
+	"POST /api/v2/system/database/backup/jobs",
+	"POST /api/v2/system/database/legacy/cleanup",
+	"POST /api/v2/system/database/migration/cancel",
+	"POST /api/v2/system/database/migration/pause",
+	"POST /api/v2/system/database/migration/resume",
+	"POST /api/v2/system/database/migration/retry-validation",
+	"POST /api/v2/system/database/migration/rollback",
+	"POST /api/v2/system/database/migration/start",
+	"POST /api/v2/system/diagnostics/run",
+	"POST /api/v2/tls/certificate",
+	"POST /api/v2/tls/certificate/generate",
+	"PUT /api/v2/notifications/:id/acknowledge",
+	"PUT /api/v2/notifications/:id/read",
+	"PUT /api/v2/notifications/read-all",
+	"PUT /api/v2/settings",
+	"echo_route_not_found /api/v2",
+	"echo_route_not_found /api/v2/*",
+	"echo_route_not_found /api/v2/analytics",
+	"echo_route_not_found /api/v2/analytics/*",
+	"echo_route_not_found /api/v2/analytics/confidence",
+	"echo_route_not_found /api/v2/analytics/confidence/*",
+	"echo_route_not_found /api/v2/analytics/species",
+	"echo_route_not_found /api/v2/analytics/species/*",
+	"echo_route_not_found /api/v2/analytics/time",
+	"echo_route_not_found /api/v2/analytics/time/*",
+	"echo_route_not_found /api/v2/auth",
+	"echo_route_not_found /api/v2/auth/*",
+	"echo_route_not_found /api/v2/control",
+	"echo_route_not_found /api/v2/control/*",
+	"echo_route_not_found /api/v2/detections",
+	"echo_route_not_found /api/v2/detections/*",
+	"echo_route_not_found /api/v2/detections/batch",
+	"echo_route_not_found /api/v2/detections/batch/*",
+	"echo_route_not_found /api/v2/filesystem",
+	"echo_route_not_found /api/v2/filesystem/*",
+	"echo_route_not_found /api/v2/import",
+	"echo_route_not_found /api/v2/import/*",
+	"echo_route_not_found /api/v2/integrations",
+	"echo_route_not_found /api/v2/integrations/*",
+	"echo_route_not_found /api/v2/integrations/birdweather",
+	"echo_route_not_found /api/v2/integrations/birdweather/*",
+	"echo_route_not_found /api/v2/integrations/ebird",
+	"echo_route_not_found /api/v2/integrations/ebird/*",
+	"echo_route_not_found /api/v2/integrations/mqtt",
+	"echo_route_not_found /api/v2/integrations/mqtt/*",
+	"echo_route_not_found /api/v2/integrations/mqtt/tls",
+	"echo_route_not_found /api/v2/integrations/mqtt/tls/*",
+	"echo_route_not_found /api/v2/integrations/weather",
+	"echo_route_not_found /api/v2/integrations/weather/*",
+	"echo_route_not_found /api/v2/notifications",
+	"echo_route_not_found /api/v2/notifications/*",
+	"echo_route_not_found /api/v2/settings",
+	"echo_route_not_found /api/v2/settings/*",
+	"echo_route_not_found /api/v2/streams/hls",
+	"echo_route_not_found /api/v2/streams/hls/*",
+	"echo_route_not_found /api/v2/streams/hls/t",
+	"echo_route_not_found /api/v2/streams/hls/t/*",
+	"echo_route_not_found /api/v2/support",
+	"echo_route_not_found /api/v2/support/*",
+	"echo_route_not_found /api/v2/system",
+	"echo_route_not_found /api/v2/system/*",
+	"echo_route_not_found /api/v2/system/audio",
+	"echo_route_not_found /api/v2/system/audio/*",
+	"echo_route_not_found /api/v2/system/database",
+	"echo_route_not_found /api/v2/system/database/*",
+	"echo_route_not_found /api/v2/system/database/backup/jobs",
+	"echo_route_not_found /api/v2/system/database/backup/jobs/*",
+	"echo_route_not_found /api/v2/system/database/legacy",
+	"echo_route_not_found /api/v2/system/database/legacy/*",
+	"echo_route_not_found /api/v2/system/database/migration",
+	"echo_route_not_found /api/v2/system/database/migration/*",
+	"echo_route_not_found /api/v2/system/diagnostics",
+	"echo_route_not_found /api/v2/system/diagnostics/*",
+	"echo_route_not_found /api/v2/system/events",
+	"echo_route_not_found /api/v2/system/events/*",
+	"echo_route_not_found /api/v2/terminal",
+	"echo_route_not_found /api/v2/terminal/*",
+	"echo_route_not_found /api/v2/tls",
+	"echo_route_not_found /api/v2/tls/*",
+	"echo_route_not_found /api/v2/weather",
+	"echo_route_not_found /api/v2/weather/*",
+}
+
+// buildFullyRoutedController constructs a controller with every route registered,
+// mirroring production wiring (NewWithOptions with initializeRoutes=true).
+func buildFullyRoutedController(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+	// Permissive expectations for DS methods that background goroutines started
+	// by initRoutes (e.g. the app-event pruning worker) may call before Shutdown.
+	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
+	settings := newValidTestSettings()
+	settings.Realtime.Audio.Export.Path = t.TempDir()
+	publishTestSettings(t, settings)
+	birdImageCache := &imageprovider.BirdImageCache{}
+	sunCalc := suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+	controlChan := make(chan string, testControlChannelBuf)
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+	c, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, metrics, true)
+	require.NoError(t, err)
+	t.Cleanup(c.Shutdown)
+	return e
+}
+
+func sortedRouteSet(e *echo.Echo) []string {
+	routes := e.Routes()
+	out := make([]string, 0, len(routes))
+	for _, r := range routes {
+		out = append(out, r.Method+" "+r.Path)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestRouteEnumerationMatchesGolden pins the full method+path route set so the
+// API v2 package-split phases cannot silently add, drop, or reorder a route.
+func TestRouteEnumerationMatchesGolden(t *testing.T) {
+	// NOT parallel: publishTestSettings mutates the process-global snapshot.
+	e := buildFullyRoutedController(t)
+	got := sortedRouteSet(e)
+
+	assert.Equal(t, goldenRoutes, got,
+		"registered route set changed; if intentional, regenerate goldenRoutes from the sorted list")
+}
+
+// TestRouteEnumerationIsDeterministic builds the controller twice and asserts the
+// route set is identical, guarding against registration-order nondeterminism.
+func TestRouteEnumerationIsDeterministic(t *testing.T) {
+	// NOT parallel: publishTestSettings mutates the process-global snapshot.
+	first := sortedRouteSet(buildFullyRoutedController(t))
+	second := sortedRouteSet(buildFullyRoutedController(t))
+	assert.Equal(t, first, second)
+}
+
+// TestGreedyAudioRouteRegisteredOnEcho pins that GET /api/v2/audio/:id is
+// registered directly on the Echo instance (not the group), preserving the
+// documented greedy-route behavior that catches all /api/v2/audio/* paths.
+func TestGreedyAudioRouteRegisteredOnEcho(t *testing.T) {
+	// NOT parallel: publishTestSettings mutates the process-global snapshot.
+	e := buildFullyRoutedController(t)
+	found := false
+	for _, r := range e.Routes() {
+		if r.Method == "GET" && r.Path == "/api/v2/audio/:id" {
+			found = true
+		}
+	}
+	assert.True(t, found, "greedy GET /api/v2/audio/:id must be registered")
+}

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -25,12 +25,12 @@ const maxSearchSpeciesScientific = 100
 
 // initSearchRoutes registers the search-related routes
 func (c *Controller) initSearchRoutes() {
-	c.logInfoIfEnabled("Initializing search routes")
+	c.LogInfoIfEnabled("Initializing search routes")
 
 	// Search endpoints - publicly accessible
 	c.Group.POST("/search", c.HandleSearch)
 
-	c.logInfoIfEnabled("Search routes initialized successfully")
+	c.LogInfoIfEnabled("Search routes initialized successfully")
 }
 
 // SearchRequest defines the structure of the search API request
@@ -65,12 +65,12 @@ type SearchResponse struct {
 func (c *Controller) HandleSearch(ctx echo.Context) error {
 	ip := ctx.RealIP()
 	path := ctx.Request().URL.Path
-	c.logInfoIfEnabled("Handling search request", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Handling search request", logger.String("path", path), logger.String("ip", ip))
 
 	// Parse the request
 	var req SearchRequest
 	if err := ctx.Bind(&req); err != nil {
-		c.logErrorIfEnabled("Failed to bind search request", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Failed to bind search request", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Invalid request format", http.StatusBadRequest)
 	}
 
@@ -87,7 +87,7 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 	resolved, hit := c.resolveSpeciesToScientific(req.Species)
 	req.Species = resolved
 	if hit {
-		c.logDebugIfEnabled("Resolved common-name query to scientific name",
+		c.LogDebugIfEnabled("Resolved common-name query to scientific name",
 			logger.String("input", originalSpecies),
 			logger.String("resolved", req.Species),
 			logger.String("path", path),
@@ -97,7 +97,7 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 		// The species term did not map to a known scientific name; the query falls
 		// back to substring/LIKE. Log it so "unresolvable name" is distinguishable
 		// from "resolved but no detections" when triaging an empty result.
-		c.logDebugIfEnabled("Species query did not resolve to a scientific name, using substring search",
+		c.LogDebugIfEnabled("Species query did not resolve to a scientific name, using substring search",
 			logger.String("input", originalSpecies),
 			logger.String("path", path),
 			logger.String("ip", ip),
@@ -113,12 +113,12 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 
 	// Build filters
 	filters := c.buildSearchFilters(&req, ctxTimeout)
-	c.logDebugIfEnabled("Executing search with filters", logger.Any("filters", filters), logger.String("path", path), logger.String("ip", ip))
+	c.LogDebugIfEnabled("Executing search with filters", logger.Any("filters", filters), logger.String("path", path), logger.String("ip", ip))
 
 	// Execute the search
 	results, total, err := c.DS.SearchDetections(&filters)
 	if err != nil {
-		c.logErrorIfEnabled("Search query failed", logger.Error(err), logger.String("filters", fmt.Sprintf("%+v", filters)), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Search query failed", logger.Error(err), logger.String("filters", fmt.Sprintf("%+v", filters)), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Search failed", http.StatusInternalServerError)
 	}
 
@@ -134,7 +134,7 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 
 	// Build and return response
 	resp := c.buildSearchResponse(&req, results, total, filters.PerPage)
-	c.logInfoIfEnabled("Search completed successfully",
+	c.LogInfoIfEnabled("Search completed successfully",
 		logger.Int("total_results", resp.Total),
 		logger.Int("results_returned", len(resp.Results)),
 		logger.Int("total_pages", resp.Pages),
@@ -151,7 +151,7 @@ func (c *Controller) logValidatedRequest(path, ip string, req *SearchRequest) {
 	c.Debug("Validated Search request: Species='%s', DateStart='%s', DateEnd='%s', ConfidenceMin=%f, ConfidenceMax=%f, VerifiedStatus='%s', LockedStatus='%s', TimeOfDay='%s', Page=%d, SortBy='%s'",
 		req.Species, req.DateStart, req.DateEnd, req.ConfidenceMin, req.ConfidenceMax, req.VerifiedStatus,
 		req.LockedStatus, req.TimeOfDay, req.Page, req.SortBy)
-	c.logDebugIfEnabled("Validated search request parameters",
+	c.LogDebugIfEnabled("Validated search request parameters",
 		logger.String("species", req.Species),
 		logger.String("dateStart", req.DateStart),
 		logger.String("dateEnd", req.DateEnd),
@@ -250,7 +250,7 @@ func (c *Controller) validateAndNormalizeSearchRequest(ctx echo.Context, req *Se
 
 	// Validate Page
 	if req.Page < 1 {
-		c.logWarnIfEnabled("Invalid page number requested, defaulting to 1", logger.Int("requested_page", req.Page), logger.String("path", path), logger.String("ip", ip))
+		c.LogWarnIfEnabled("Invalid page number requested, defaulting to 1", logger.Int("requested_page", req.Page), logger.String("path", path), logger.String("ip", ip))
 		req.Page = 1
 	}
 
@@ -286,15 +286,15 @@ func (c *Controller) validateAndNormalizeSearchRequest(ctx echo.Context, req *Se
 // validateSearchDates validates the DateStart and DateEnd parameters.
 func (c *Controller) validateSearchDates(path, ip string, req *SearchRequest) error {
 	if err := validateDateFormat(req.DateStart, "start date"); err != nil {
-		c.logErrorIfEnabled("Invalid start date format", logger.String("dateStart", req.DateStart), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid start date format", logger.String("dateStart", req.DateStart), logger.String("path", path), logger.String("ip", ip))
 		return err
 	}
 	if err := validateDateFormat(req.DateEnd, "end date"); err != nil {
-		c.logErrorIfEnabled("Invalid end date format", logger.String("dateEnd", req.DateEnd), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid end date format", logger.String("dateEnd", req.DateEnd), logger.String("path", path), logger.String("ip", ip))
 		return err
 	}
 	if err := validateDateOrder(req.DateStart, req.DateEnd); err != nil {
-		c.logErrorIfEnabled("Invalid date range", logger.String("dateStart", req.DateStart), logger.String("dateEnd", req.DateEnd), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid date range", logger.String("dateStart", req.DateStart), logger.String("dateEnd", req.DateEnd), logger.String("path", path), logger.String("ip", ip))
 		return fmt.Errorf("'dateStart' (%s) must be earlier than or equal to 'dateEnd' (%s)", req.DateStart, req.DateEnd)
 	}
 	return nil
@@ -311,7 +311,7 @@ func (c *Controller) validateSearchStatusEnums(path, ip string, req *SearchReque
 	if req.VerifiedStatus == "" {
 		req.VerifiedStatus = QueryValueAny
 	} else if !validVerifiedStatus[req.VerifiedStatus] {
-		c.logErrorIfEnabled("Invalid verified status parameter", logger.String("verifiedStatus", req.VerifiedStatus), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid verified status parameter", logger.String("verifiedStatus", req.VerifiedStatus), logger.String("path", path), logger.String("ip", ip))
 		return fmt.Errorf("invalid verified status %q. Use %q, %q, %q, or %q",
 			req.VerifiedStatus,
 			QueryValueAny,
@@ -324,7 +324,7 @@ func (c *Controller) validateSearchStatusEnums(path, ip string, req *SearchReque
 	if req.LockedStatus == "" {
 		req.LockedStatus = QueryValueAny
 	} else if !validLockedStatus[req.LockedStatus] {
-		c.logErrorIfEnabled("Invalid locked status parameter", logger.String("lockedStatus", req.LockedStatus), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid locked status parameter", logger.String("lockedStatus", req.LockedStatus), logger.String("path", path), logger.String("ip", ip))
 		return fmt.Errorf("invalid locked status '%s'. Use 'any', 'locked', or 'unlocked'", req.LockedStatus)
 	}
 	return nil
@@ -336,7 +336,7 @@ func (c *Controller) validateSearchTimeOfDay(path, ip string, req *SearchRequest
 	if req.TimeOfDay == "" {
 		req.TimeOfDay = QueryValueAny
 	} else if !validTimeOfDay[req.TimeOfDay] {
-		c.logErrorIfEnabled("Invalid time of day parameter", logger.String("timeOfDay", req.TimeOfDay), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid time of day parameter", logger.String("timeOfDay", req.TimeOfDay), logger.String("path", path), logger.String("ip", ip))
 		return fmt.Errorf("invalid time of day '%s'. Use 'any', 'day', 'night', 'sunrise', or 'sunset'", req.TimeOfDay)
 	}
 	return nil
@@ -371,7 +371,7 @@ func (c *Controller) normalizeConfidenceMax(minConf, maxConf float64, path, ip s
 		c.logConfidenceAdjustment("confidenceMax", maxConf, 0, path, ip)
 		return 0
 	case maxConf == 0 && minConf == 0:
-		c.logDebugIfEnabled("Confidence range is [0, 0], defaulting ConfidenceMax to 1", logger.String("path", path), logger.String("ip", ip))
+		c.LogDebugIfEnabled("Confidence range is [0, 0], defaulting ConfidenceMax to 1", logger.String("path", path), logger.String("ip", ip))
 		return 1
 	default:
 		return maxConf
@@ -380,12 +380,12 @@ func (c *Controller) normalizeConfidenceMax(minConf, maxConf float64, path, ip s
 
 // logConfidenceAdjustment logs when a confidence value is adjusted
 func (c *Controller) logConfidenceAdjustment(field string, original, adjusted float64, path, ip string) {
-	c.logWarnIfEnabled("Invalid "+field+", adjusted", logger.Float64("original", original), logger.Float64("adjusted", adjusted), logger.String("path", path), logger.String("ip", ip))
+	c.LogWarnIfEnabled("Invalid "+field+", adjusted", logger.Float64("original", original), logger.Float64("adjusted", adjusted), logger.String("path", path), logger.String("ip", ip))
 }
 
 // logConfidenceSwap logs when min/max values are swapped
 func (c *Controller) logConfidenceSwap(minConf, maxConf float64, path, ip string) {
-	c.logWarnIfEnabled("ConfidenceMin > ConfidenceMax after normalization, swapping values",
+	c.LogWarnIfEnabled("ConfidenceMin > ConfidenceMax after normalization, swapping values",
 		logger.Float64("normalizedConfidenceMin", minConf), logger.Float64("normalizedConfidenceMax", maxConf), logger.String("path", path), logger.String("ip", ip))
 }
 
@@ -402,7 +402,7 @@ func (c *Controller) validateSearchSortBy(path, ip string, req *SearchRequest) e
 	}
 	if req.SortBy != "" { // Allow empty string for default sorting (handled by datastore)
 		if _, ok := allowedSortBy[req.SortBy]; !ok {
-			c.logErrorIfEnabled("Invalid sortBy parameter", logger.String("sortBy", req.SortBy), logger.String("path", path), logger.String("ip", ip))
+			c.LogErrorIfEnabled("Invalid sortBy parameter", logger.String("sortBy", req.SortBy), logger.String("path", path), logger.String("ip", ip))
 			// Create a list of allowed sort options for the error message
 			allowedKeys := slices.Collect(maps.Keys(allowedSortBy))
 			return fmt.Errorf("invalid sortBy parameter '%s'. Allowed values: %v", req.SortBy, allowedKeys)

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -29,9 +30,7 @@ var testLabels = []string{
 func setupSearchTestController(t *testing.T, labels []string) *Controller {
 	t.Helper()
 	e := echo.New()
-	c := &Controller{
-		Group: e.Group("/api/v2"),
-	}
+	c := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2")}}
 	c.Settings.Store(&conf.Settings{
 		BirdNET: conf.BirdNETConfig{
 			Labels: labels,
@@ -170,9 +169,7 @@ func TestUpdateCommonNameMap_PopulatesBothMaps(t *testing.T) {
 	t.Parallel()
 
 	e := echo.New()
-	c := &Controller{
-		Group: e.Group("/api/v2"),
-	}
+	c := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2")}}
 
 	labels := []string{
 		"Strix aluco_Tawny Owl",
@@ -260,7 +257,7 @@ func TestBuildNameMaps_MalformedLabels(t *testing.T) {
 func TestLoadNameMaps_CalledBeforeInit(t *testing.T) {
 	t.Parallel()
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	assert.NotNil(t, c.loadCommonNameMap())
 	assert.NotNil(t, c.loadCommonToScientificMap())
 	assert.Empty(t, c.loadCommonNameMap())
@@ -283,10 +280,7 @@ func TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies(t *testing.T) {
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(t)
 
-	controller := &Controller{
-		Group: e.Group("/api/v2"),
-		DS:    mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2"), DS: mockDS}}
 	controller.Settings.Store(newValidTestSettings())
 
 	// Wire a batch-capable resolver so the scientific-only bat label

--- a/internal/api/v2/search_species_scientific_test.go
+++ b/internal/api/v2/search_species_scientific_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 )
 
 func TestSanitizeSpeciesScientific(t *testing.T) {
@@ -41,7 +42,7 @@ func TestSanitizeSpeciesScientific(t *testing.T) {
 func TestBuildSearchFilters_ThreadsSpeciesScientific(t *testing.T) {
 	t.Parallel()
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	req := &SearchRequest{
 		Species:           "Corvus",
 		SpeciesScientific: []string{"Barbastella barbastellus", "Myotis daubentonii"},

--- a/internal/api/v2/security_test.go
+++ b/internal/api/v2/security_test.go
@@ -616,7 +616,7 @@ func TestDDoSProtection(t *testing.T) {
 	e, mockDS, controller := setupTestEnvironment(t)
 
 	// Initialize the detection cache manually since routes aren't initialized in test environment
-	controller.detectionCache = cache.New(5*time.Minute, 10*time.Minute)
+	controller.DetectionCache = cache.New(5*time.Minute, 10*time.Minute)
 
 	// Number of concurrent requests to simulate
 	concurrentRequests := 50

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -48,7 +48,7 @@ type UpdateRequest struct {
 
 // initSettingsRoutes registers all settings-related API endpoints
 func (c *Controller) initSettingsRoutes() {
-	c.logInfoIfEnabled("Initializing settings routes")
+	c.LogInfoIfEnabled("Initializing settings routes")
 
 	// Public read-only endpoint: the Dashboard section contains only
 	// layout/display preferences (no secrets, tokens, or PII) and must be
@@ -62,7 +62,7 @@ func (c *Controller) initSettingsRoutes() {
 	c.Group.GET("/settings/dashboard", c.GetDashboardSettings)
 
 	// Create auth-protected settings API group for everything else.
-	settingsGroup := c.Group.Group("/settings", c.authMiddleware)
+	settingsGroup := c.Group.Group("/settings", c.AuthMiddleware)
 
 	// Routes for settings
 	// GET /api/v2/settings - Retrieves all application settings
@@ -83,23 +83,23 @@ func (c *Controller) initSettingsRoutes() {
 	// (includes /settings/dashboard — writes remain auth-protected).
 	settingsGroup.PATCH("/:section", c.UpdateSectionSettings)
 
-	c.logInfoIfEnabled("Settings routes initialized successfully")
+	c.LogInfoIfEnabled("Settings routes initialized successfully")
 }
 
 // GetAllSettings handles GET /api/v2/settings
 func (c *Controller) GetAllSettings(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting all settings",
+	c.LogInfoIfEnabled("Getting all settings",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	// Read the controller's lock-free settings snapshot.
-	settings := c.controllerSettings()
+	settings := c.ControllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set
 		settings = conf.Setting()
 		if settings == nil {
-			c.logErrorIfEnabled("Settings not initialized when trying to get all settings",
+			c.LogErrorIfEnabled("Settings not initialized when trying to get all settings",
 				logger.String("path", ctx.Request().URL.Path),
 				logger.String("ip", ctx.RealIP()),
 			)
@@ -107,7 +107,7 @@ func (c *Controller) GetAllSettings(ctx echo.Context) error {
 		}
 	}
 
-	c.logInfoIfEnabled("Retrieved all settings successfully",
+	c.LogInfoIfEnabled("Retrieved all settings successfully",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -130,15 +130,15 @@ const dashboardSectionName = "dashboard"
 // to this section are handled by UpdateSectionSettings and remain
 // auth-protected.
 func (c *Controller) GetDashboardSettings(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting public dashboard settings")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting public dashboard settings")
 
 	// Read the controller's lock-free settings snapshot.
-	settings := c.controllerSettings()
+	settings := c.ControllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set.
 		settings = conf.Setting()
 		if settings == nil {
-			c.logAPIRequest(ctx, logger.LogLevelError,
+			c.LogAPIRequest(ctx, logger.LogLevelError,
 				"Settings not initialized when trying to get dashboard settings")
 			return c.HandleError(ctx, fmt.Errorf("settings not initialized"),
 				"Failed to get settings", http.StatusInternalServerError)
@@ -152,7 +152,7 @@ func (c *Controller) GetDashboardSettings(ctx echo.Context) error {
 	sanitized := sanitizeSettingsForAPI(settings)
 	sectionValue, err := getSettingsSection(sanitized, dashboardSectionName)
 	if err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelError,
+		c.LogAPIRequest(ctx, logger.LogLevelError,
 			"Failed to get dashboard settings section", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to get settings section",
 			http.StatusInternalServerError)
@@ -164,20 +164,20 @@ func (c *Controller) GetDashboardSettings(ctx echo.Context) error {
 // GetSectionSettings handles GET /api/v2/settings/:section
 func (c *Controller) GetSectionSettings(ctx echo.Context) error {
 	section := ctx.Param("section")
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting settings for section", logger.String("section", section))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting settings for section", logger.String("section", section))
 
 	if section == "" {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Missing section parameter")
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Missing section parameter")
 		return c.HandleError(ctx, fmt.Errorf("section not specified"), "Section parameter is required", http.StatusBadRequest)
 	}
 
 	// Read the controller's lock-free settings snapshot.
-	settings := c.controllerSettings()
+	settings := c.ControllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set
 		settings = conf.Setting()
 		if settings == nil {
-			c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized when trying to get section settings", logger.String("section", section))
+			c.LogAPIRequest(ctx, logger.LogLevelError, "Settings not initialized when trying to get section settings", logger.String("section", section))
 			return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
 		}
 	}
@@ -186,11 +186,11 @@ func (c *Controller) GetSectionSettings(ctx echo.Context) error {
 	sanitized := sanitizeSettingsForAPI(settings)
 	sectionValue, err := getSettingsSection(sanitized, section)
 	if err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to get settings section", logger.String("section", section), logger.Error(err))
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to get settings section", logger.String("section", section), logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to get settings section", http.StatusNotFound)
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Retrieved settings section successfully", logger.String("section", section))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Retrieved settings section successfully", logger.String("section", section))
 
 	return ctx.JSON(http.StatusOK, sectionValue)
 }
@@ -204,7 +204,7 @@ func (c *Controller) GetSectionSettings(ctx echo.Context) error {
 // the new one, never a torn view. Rollback after a validation or disk-write
 // failure is a republish of the previous snapshot.
 func (c *Controller) UpdateSettings(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Attempting to update settings")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Attempting to update settings")
 	// Serialise concurrent PUT /api/v2/settings calls; each must see the
 	// latest published snapshot as its baseline.
 	c.settingsMutex.Lock()
@@ -216,7 +216,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	// publish below updates both the atomic Settings pointer and conf.settingsInstance.
 	current := c.getSettingsOrFallback()
 	if current == nil {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized during update attempt")
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Settings not initialized during update attempt")
 		return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
 	}
 
@@ -233,7 +233,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	// Parse the request body
 	var updatedSettings conf.Settings
 	if err := ctx.Bind(&updatedSettings); err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to bind request body for settings update", logger.Error(err))
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to bind request body for settings update", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to parse request body", http.StatusBadRequest)
 	}
 
@@ -241,18 +241,18 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	// logic does not overwrite real secrets with the placeholder. Operate on
 	// updated (clone) as the canonical destination, not on current.
 	if err := restoreRedactedSecrets(updated, &updatedSettings); err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Redacted sentinel validation failed", logger.Error(err))
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Redacted sentinel validation failed", logger.Error(err))
 		return c.HandleError(ctx, err, "Cannot save: some secret fields contain the redacted placeholder because their identifying key was changed while the secret was hidden. Re-enter the secret values.", http.StatusBadRequest)
 	}
 
 	// Apply allowed field updates to the clone.
 	skippedFields, err := updateAllowedSettingsWithTracking(updated, &updatedSettings)
 	if err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Error updating allowed settings fields", logger.Error(err), logger.Any("skipped_fields", skippedFields))
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Error updating allowed settings fields", logger.Error(err), logger.Any("skipped_fields", skippedFields))
 		return c.HandleError(ctx, err, "Failed to update settings", http.StatusInternalServerError)
 	}
 	if len(skippedFields) > 0 {
-		c.logAPIRequest(ctx, logger.LogLevelDebug, "Skipped protected fields during settings update", logger.Any("skipped_fields", skippedFields))
+		c.LogAPIRequest(ctx, logger.LogLevelDebug, "Skipped protected fields during settings update", logger.Any("skipped_fields", skippedFields))
 	}
 
 	// Normalize species config keys to lowercase for case-insensitive matching.
@@ -302,7 +302,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 			conf.StoreSettings(current)
 		}
 		c.Settings.Store(current)
-		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to apply settings changes, rolling back", logger.Error(err))
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to apply settings changes, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
@@ -315,7 +315,7 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 			// Rollback in-memory; disk write never happened successfully.
 			conf.StoreSettings(current)
 			c.Settings.Store(current)
-			c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
+			c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
 	}
@@ -333,10 +333,10 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	imageprovider.SetCustomSynonyms(updated.TaxonomySynonyms, updated.BirdNET.Labels)
 
 	if publishGlobal && !c.DisableSaveSettings {
-		c.logAPIRequest(ctx, logger.LogLevelInfo, "Settings updated and saved successfully",
+		c.LogAPIRequest(ctx, logger.LogLevelInfo, "Settings updated and saved successfully",
 			logger.Int("skipped_fields_count", len(skippedFields)))
 	} else {
-		c.logAPIRequest(ctx, logger.LogLevelDebug, "Settings updated (save to disk skipped)",
+		c.LogAPIRequest(ctx, logger.LogLevelDebug, "Settings updated (save to disk skipped)",
 			logger.Bool("publishGlobal", publishGlobal),
 			logger.Bool("disableSaveSettings", c.DisableSaveSettings))
 	}
@@ -675,7 +675,7 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	// does not overwrite real secrets with the placeholder. current is the
 	// source of truth for the pre-update values.
 	if err := restoreRedactedSecrets(current, updated); err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Redacted sentinel validation failed", logger.Error(err))
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Redacted sentinel validation failed", logger.Error(err))
 		return c.HandleError(ctx, err, "Cannot save: some secret fields contain the redacted placeholder because their identifying key was changed while the secret was hidden. Re-enter the secret values.", http.StatusBadRequest)
 	}
 
@@ -732,12 +732,12 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 			c.Settings.Store(current)
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
-		c.logAPIRequest(ctx, logger.LogLevelInfo, "Section settings saved successfully",
+		c.LogAPIRequest(ctx, logger.LogLevelInfo, "Section settings saved successfully",
 			logger.String("section", section))
 	}
 
 	if !publishGlobal || c.DisableSaveSettings {
-		c.logAPIRequest(ctx, logger.LogLevelDebug, "Section settings updated (save to disk skipped)",
+		c.LogAPIRequest(ctx, logger.LogLevelDebug, "Section settings updated (save to disk skipped)",
 			logger.String("section", section),
 			logger.Bool("publishGlobal", publishGlobal),
 			logger.Bool("disableSaveSettings", c.DisableSaveSettings))
@@ -2246,9 +2246,10 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 	// reloads settings (which may be republished by a concurrent update).
 	if len(reconfigActions) > 0 {
 		debugEnabled := currentSettings.WebServer.Debug
-		c.wg.Go(func() {
+		c.Go(func() {
 			c.sendReconfigActions(reconfigActions, debugEnabled)
 		})
+
 	}
 
 	return nil
@@ -2264,23 +2265,23 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 func (c *Controller) sendReconfigActions(actions []string, debugEnabled bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			c.logWarnIfEnabled("Recovered from send on closed controlChan during shutdown",
+			c.LogWarnIfEnabled("Recovered from send on closed controlChan during shutdown",
 				logger.Any("panic", r))
 		}
 	}()
 
 	for _, action := range actions {
 		if debugEnabled {
-			c.logDebugIfEnabled("Asynchronously executing action", logger.String("action", action))
+			c.LogDebugIfEnabled("Asynchronously executing action", logger.String("action", action))
 		}
 		select {
-		case <-c.ctx.Done():
+		case <-c.Context().Done():
 			return
 		case c.controlChan <- action:
 		}
 
 		select {
-		case <-c.ctx.Done():
+		case <-c.Context().Done():
 			return
 		case <-time.After(actionDelay):
 		}
@@ -2672,14 +2673,14 @@ type ImageProviderOption struct {
 
 // GetLocales handles GET /api/v2/settings/locales
 func (c *Controller) GetLocales(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting available locales")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting available locales")
 
 	// Return locales in the same format as v1 for compatibility
 	// This matches the client-side expectation of key-value pairs
 	locales := make(map[string]string)
 	maps.Copy(locales, conf.LocaleCodes)
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Retrieved locales successfully", logger.Int("count", len(locales)))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Retrieved locales successfully", logger.Int("count", len(locales)))
 
 	return ctx.JSON(http.StatusOK, locales)
 }
@@ -2699,13 +2700,13 @@ func (c *Controller) collectImageProviders(ctx echo.Context) (providers []ImageP
 
 	cache := c.BirdImageCache
 	if cache == nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "BirdImageCache is nil, cannot get provider names")
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "BirdImageCache is nil, cannot get provider names")
 		return providers, count
 	}
 
 	registry := cache.GetRegistry()
 	if registry == nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "ImageProviderRegistry is nil, cannot get provider names")
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "ImageProviderRegistry is nil, cannot get provider names")
 		return providers, count
 	}
 
@@ -2726,31 +2727,31 @@ func (c *Controller) collectImageProviders(ctx echo.Context) (providers []ImageP
 
 // GetImageProviders handles GET /api/v2/settings/imageproviders
 func (c *Controller) GetImageProviders(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting available image providers")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting available image providers")
 
 	providers, providerCount := c.collectImageProviders(ctx)
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Retrieved image providers successfully", logger.Int("count", len(providers)), logger.Int("provider_count", providerCount))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Retrieved image providers successfully", logger.Int("count", len(providers)), logger.Int("provider_count", providerCount))
 
 	return ctx.JSON(http.StatusOK, map[string]any{"providers": providers})
 }
 
 // GetSystemID handles GET /api/v2/settings/systemid
 func (c *Controller) GetSystemID(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting system ID")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting system ID")
 
 	// Read the controller's lock-free settings snapshot.
-	settings := c.controllerSettings()
+	settings := c.ControllerSettings()
 	if settings == nil {
 		// Fallback to global settings if controller settings not set
 		settings = conf.Setting()
 		if settings == nil {
-			c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized when trying to get system ID", logger.String("endpoint", "GetSystemID"))
+			c.LogAPIRequest(ctx, logger.LogLevelError, "Settings not initialized when trying to get system ID", logger.String("endpoint", "GetSystemID"))
 			return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
 		}
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Retrieved system ID successfully", logger.String("system_id", settings.SystemID))
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Retrieved system ID successfully", logger.String("system_id", settings.SystemID))
 
 	// Return system ID in the format expected by the frontend
 	response := map[string]string{

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -132,7 +132,7 @@ func equalizerSettingsChanged(oldSettings, newSettings conf.EqualizerSettings) b
 // registered sources (both sound cards and streams). Each source's effective EQ
 // is resolved via Settings.ResolveEQOverride using the registry DisplayName.
 func (c *Controller) handleEqualizerChange(currentSettings *conf.Settings) error {
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return nil
 	}
@@ -264,7 +264,7 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 	// Detect source/stream name changes and sync DisplayName in the registry.
 	// Each function detects renames and updates the registry in a single pass.
 	var registry sourceNameUpdater
-	if eng := c.engine.Load(); eng != nil {
+	if eng := c.Engine.Load(); eng != nil {
 		registry = eng.Registry()
 	}
 	srcNameChanged := syncAudioSourceNames(oldSettings, currentSettings, registry)

--- a/internal/api/v2/settings_concurrent_test.go
+++ b/internal/api/v2/settings_concurrent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 )
 
 // TestConcurrentUpdates verifies the system handles concurrent updates safely
@@ -72,11 +73,7 @@ func TestConcurrentUpdates(t *testing.T) {
 			// Initialize test settings with known values
 
 			e := echo.New()
-			controller := &Controller{
-				Echo:                e,
-				controlChan:         make(chan string, 100),
-				DisableSaveSettings: true,
-			}
+			controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 100), DisableSaveSettings: true}
 			controller.Settings.Store(getTestSettings(t))
 
 			var wg sync.WaitGroup
@@ -331,11 +328,7 @@ func TestRaceConditionScenarios(t *testing.T) {
 			t.Parallel()
 
 			e := echo.New()
-			controller := &Controller{
-				Echo:                e,
-				controlChan:         make(chan string, 100),
-				DisableSaveSettings: true,
-			}
+			controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 100), DisableSaveSettings: true}
 			controller.Settings.Store(getTestSettings(t))
 
 			tt.scenario(t, controller)

--- a/internal/api/v2/settings_eq_roundtrip_test.go
+++ b/internal/api/v2/settings_eq_roundtrip_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -54,11 +55,7 @@ func TestEQFilterRoundTrip_PUT(t *testing.T) {
 	}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
 	controller.Settings.Store(initial)
 
 	eqConfig := map[string]any{
@@ -164,11 +161,7 @@ func TestEQFilterRoundTrip_PUT_PerSource(t *testing.T) {
 	}}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
 	controller.Settings.Store(initial)
 
 	sourceEQ := map[string]any{
@@ -223,11 +216,7 @@ func TestEQFilterRoundTrip_PATCH(t *testing.T) {
 	}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
 	controller.Settings.Store(initial)
 
 	payload := map[string]any{
@@ -305,11 +294,7 @@ func TestEQFilterRoundTrip_PUT_PerStream(t *testing.T) {
 	}}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
 	controller.Settings.Store(initial)
 
 	streamEQ := map[string]any{
@@ -357,11 +342,7 @@ func TestEQFilterRoundTrip_PUT_WithFrontendIDField(t *testing.T) {
 
 	initial := getTestSettings(t)
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
 	controller.Settings.Store(initial)
 
 	eqConfig := map[string]any{

--- a/internal/api/v2/settings_exclude_canonicalize_test.go
+++ b/internal/api/v2/settings_exclude_canonicalize_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -70,7 +71,7 @@ func putFullSettings(t *testing.T, e *echo.Echo, c *Controller, s *conf.Settings
 func TestCanonicalizeExcludeList(t *testing.T) {
 	t.Parallel()
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	installExcludeTestResolver(t, c)
 
 	tests := []struct {

--- a/internal/api/v2/settings_species_test.go
+++ b/internal/api/v2/settings_species_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -162,9 +163,7 @@ func TestSpeciesSettingsUpdate(t *testing.T) {
 			},
 		},
 	}
-	controller := &Controller{
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{}, DisableSaveSettings: true}
 	controller.Settings.Store(settings)
 
 	// Update with zero values
@@ -247,9 +246,7 @@ func TestPartialSpeciesConfigUpdate(t *testing.T) {
 			},
 		},
 	}
-	controller := &Controller{
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{}, DisableSaveSettings: true}
 	controller.Settings.Store(settings)
 
 	// Update only Bird A with zero values, Bird B should remain unchanged
@@ -309,9 +306,7 @@ func TestSpeciesSettingsPatchGetSync(t *testing.T) {
 			},
 		},
 	}
-	controller := &Controller{
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{}, DisableSaveSettings: true}
 	controller.Settings.Store(settings)
 
 	// Step 1: PATCH update with zero values
@@ -432,9 +427,7 @@ func newAPIContext(t *testing.T, e *echo.Echo, method, path string, body any) (e
 		Exclude: []string{},
 		Config:  map[string]conf.SpeciesConfig{},
 	}
-	controller := &Controller{
-		DisableSaveSettings: true, // Disable file save for testing
-	}
+	controller := &Controller{Core: &apicore.Core{}, DisableSaveSettings: true}
 	controller.Settings.Store(settings)
 
 	// Use default values if method or path are empty
@@ -506,9 +499,7 @@ func TestSpeciesConfigNormalizationOnAPIUpdate(t *testing.T) {
 		Exclude: []string{},
 		Config:  make(map[string]conf.SpeciesConfig),
 	}
-	controller := &Controller{
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{}, DisableSaveSettings: true}
 	controller.Settings.Store(settings)
 
 	// Update with mixed-case species names (as UI would send)
@@ -571,9 +562,7 @@ func createTestController(t *testing.T) *Controller {
 		Config:  map[string]conf.SpeciesConfig{},
 	}
 
-	c := &Controller{
-		DisableSaveSettings: true,
-	}
+	c := &Controller{Core: &apicore.Core{}, DisableSaveSettings: true}
 	c.Settings.Store(settings)
 	return c
 }

--- a/internal/api/v2/settings_update_test.go
+++ b/internal/api/v2/settings_update_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -28,11 +29,7 @@ func TestDashboardLayoutWidthPersistence(t *testing.T) {
 	}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Simulate the frontend save: elements without width field (user set to full)
@@ -106,11 +103,7 @@ func TestMergePreservesJSONDashFields(t *testing.T) {
 	initialSettings.BirdNET.Labels = []string{"species1", "species2"}
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// PATCH birdnet section — Labels (json:"-") must survive
@@ -149,11 +142,7 @@ func TestDashboardPartialUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only summary field
@@ -204,11 +193,7 @@ func TestWeatherPartialUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only provider
@@ -254,11 +239,7 @@ func TestMQTTPartialUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only broker
@@ -297,11 +278,7 @@ func TestBirdNETCoordinatesUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only coordinates
@@ -342,11 +319,7 @@ func TestNestedRangeFilterUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only range filter threshold
@@ -386,11 +359,7 @@ func TestAudioExportPartialUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only export type
@@ -441,11 +410,7 @@ func TestSpeciesConfigUpdate(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only threshold
@@ -498,11 +463,7 @@ func TestEmptyUpdatePreservesEverything(t *testing.T) {
 
 	// Create controller with settings
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Send empty update
@@ -565,10 +526,7 @@ func TestValidationErrors(t *testing.T) {
 			t.Parallel()
 
 			e := echo.New()
-			controller := &Controller{
-				Echo:        e,
-				controlChan: make(chan string, 10),
-			}
+			controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10)}
 
 			var body []byte
 			var err error
@@ -609,11 +567,7 @@ func TestDeepNestedUpdates(t *testing.T) {
 	initialTLSEnabled := initialSettings.Realtime.MQTT.TLS.Enabled
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, 10),
-		DisableSaveSettings: true,
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, 10), DisableSaveSettings: true}
 	controller.Settings.Store(initialSettings)
 
 	// Update only one deeply nested field

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -124,14 +124,14 @@ type AllSpeciesResponse struct {
 func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 	ip := ctx.RealIP()
 	path := ctx.Request().URL.Path
-	c.logDebugIfEnabled("Retrieving all BirdNET species labels",
+	c.LogDebugIfEnabled("Retrieving all BirdNET species labels",
 		logger.String("ip", ip),
 		logger.String("path", path),
 	)
 
 	speciesList := buildAllSpeciesList(c.loadCommonNameMap(), c.allModelLabels())
 
-	c.logInfoIfEnabled("All species labels retrieved successfully",
+	c.LogInfoIfEnabled("All species labels retrieved successfully",
 		logger.Int("count", len(speciesList)),
 		logger.String("ip", ip),
 		logger.String("path", path),
@@ -206,7 +206,7 @@ func (c *Controller) allModelLabels() []string {
 			}
 		}
 	}
-	if s := c.controllerSettings(); s != nil {
+	if s := c.ControllerSettings(); s != nil {
 		return s.BirdNET.Labels
 	}
 	return nil
@@ -677,7 +677,7 @@ func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
 	}
 
 	// Log the request if API logger is available
-	c.logDebugIfEnabled("Retrieving thumbnail for species code",
+	c.LogDebugIfEnabled("Retrieving thumbnail for species code",
 		logger.String("species_code", speciesCode),
 		logger.String("ip", ctx.RealIP()),
 		logger.String("path", ctx.Request().URL.Path),

--- a/internal/api/v2/species_dictionary_test.go
+++ b/internal/api/v2/species_dictionary_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/speciesdict"
 )
 
@@ -22,7 +23,7 @@ import (
 func newDictController(t *testing.T) (*echo.Echo, *Controller) {
 	t.Helper()
 	e := echo.New()
-	controller := &Controller{Echo: e, Group: e.Group("/api/v2")}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.initSpeciesRoutes()
 	return e, controller
 }

--- a/internal/api/v2/species_taxonomy_test.go
+++ b/internal/api/v2/species_taxonomy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 )
 
@@ -24,9 +25,7 @@ func TestGetGenusSpecies(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	// Create a minimal controller with taxonomy DB
-	c := &Controller{
-		TaxonomyDB: taxonomyDB,
-	}
+	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
@@ -124,9 +123,7 @@ func TestGetFamilySpecies(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Controller{
-		TaxonomyDB: taxonomyDB,
-	}
+	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
@@ -205,9 +202,7 @@ func TestGetSpeciesTree(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Controller{
-		TaxonomyDB: taxonomyDB,
-	}
+	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
@@ -310,11 +305,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Controller{
-		TaxonomyDB: taxonomyDB,
-		// No EBirdClient - testing local DB only
-		EBirdClient: nil,
-	}
+	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB, EBirdClient: nil}}
 	c.Settings.Store(newValidTestSettings())
 
 	tests := []struct {
@@ -367,11 +358,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
-	c := &Controller{
-		// No TaxonomyDB and no EBirdClient
-		TaxonomyDB:  nil,
-		EBirdClient: nil,
-	}
+	c := &Controller{Core: &apicore.Core{TaxonomyDB: nil, EBirdClient: nil}}
 	c.Settings.Store(newValidTestSettings())
 
 	// This should fail gracefully

--- a/internal/api/v2/species_test.go
+++ b/internal/api/v2/species_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -423,10 +424,7 @@ func TestGetAllSpecies_LocalizedSecondaryModel(t *testing.T) {
 	t.Attr("feature", "localized-name-resolution")
 
 	e := echo.New()
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(&conf.Settings{})
 
 	// Wire a batch-capable resolver so the scientific-only bat label gets a
@@ -512,10 +510,7 @@ func TestGetAllSpecies(t *testing.T) {
 			settings := &conf.Settings{}
 			settings.BirdNET.Labels = tt.labels
 
-			controller := &Controller{
-				Echo:  e,
-				Group: e.Group("/api/v2"),
-			}
+			controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 			controller.Settings.Store(settings)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/species/all", http.NoBody)

--- a/internal/api/v2/sse.go
+++ b/internal/api/v2/sse.go
@@ -6,18 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"runtime/debug"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/tphakala/birdnet-go/internal/audiocore/soundlevel"
-	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
-	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 )
@@ -44,154 +39,11 @@ const (
 	// Rate limits
 	sseRateLimitRequests = 10              // SSE rate limit requests per window
 	sseRateLimitWindow   = 1 * time.Minute // SSE rate limit time window
-
-	// Client health monitoring
-	maxConsecutiveDrops = 3 // Auto-disconnect clients after this many consecutive dropped messages
-
-	// Stream types - used to identify what data a client wants to receive
-	// Note: StreamType="all" shares a single consecutiveDrops counter across both streams,
-	// meaning drops on one stream affect health tracking for both
-	streamTypeDetections  = "detections"
-	streamTypeSoundLevels = "soundlevels"
-	streamTypeAll         = "all"
 )
 
 // WriteDeadlineSetter interface for response writers that support write deadlines
 type WriteDeadlineSetter interface {
 	SetWriteDeadline(time.Time) error
-}
-
-// SSEDetectionData represents the detection data sent via SSE.
-// Uses explicit fields with camelCase JSON tags instead of embedding datastore.Note
-// to avoid exposing internal Go struct layout, sensitive data (filesystem paths,
-// RTSP credentials), and to provide a stable, well-defined API contract.
-type SSEDetectionData struct {
-	// Detection identity and classification
-	ID             uint    `json:"id"`
-	Date           string  `json:"date"` // "2024-01-15"
-	Time           string  `json:"time"` // "14:30:00"
-	ScientificName string  `json:"scientificName"`
-	CommonName     string  `json:"commonName"`
-	SpeciesCode    string  `json:"speciesCode,omitempty"`
-	Confidence     float64 `json:"confidence"` // No omitempty — 0.0 is a valid confidence value
-
-	// Location
-	Latitude  float64 `json:"latitude,omitempty"`
-	Longitude float64 `json:"longitude,omitempty"`
-
-	// Audio clip (filename only, no path)
-	ClipName string `json:"clipName,omitempty"`
-
-	// Source info (safe fields only, no credentials)
-	Source *SSESourceInfo `json:"source,omitempty"`
-
-	// Time context
-	BeginTime string `json:"beginTime,omitempty"`
-	EndTime   string `json:"endTime,omitempty"`
-
-	// Review status
-	Verified string `json:"verified,omitempty"`
-	Locked   bool   `json:"locked"`
-	Unlikely bool   `json:"unlikely,omitempty"`
-
-	// Bird image with attribution
-	BirdImage SSEBirdImage `json:"birdImage"`
-
-	// SSE event metadata
-	Timestamp time.Time `json:"timestamp"`
-	EventType string    `json:"eventType"`
-
-	// Species tracking metadata
-	IsNewSpecies       bool `json:"isNewSpecies,omitempty"`       // First seen within tracking window
-	DaysSinceFirstSeen int  `json:"daysSinceFirstSeen,omitempty"` // Days since species was first detected
-}
-
-// SSESourceInfo describes the audio source in SSE events.
-// Only exposes safe identifiers, never raw connection strings or credentials.
-type SSESourceInfo struct {
-	ID          string `json:"id"`
-	Type        string `json:"type,omitempty"`
-	DisplayName string `json:"displayName,omitempty"`
-}
-
-// SSEBirdImage represents bird image data in SSE events with proper JSON tags.
-type SSEBirdImage struct {
-	URL            string `json:"url"`
-	ScientificName string `json:"scientificName,omitempty"`
-	LicenseName    string `json:"licenseName,omitempty"`
-	LicenseURL     string `json:"licenseURL,omitempty"`
-	AuthorName     string `json:"authorName,omitempty"`
-	AuthorURL      string `json:"authorURL,omitempty"`
-	SourceProvider string `json:"sourceProvider,omitempty"`
-}
-
-// safeBaseName returns the filename component of a path, or empty string if the path is empty.
-// Unlike filepath.Base("") which returns ".", this returns "" for empty inputs.
-func safeBaseName(path string) string {
-	if path == "" {
-		return ""
-	}
-	return filepath.Base(path)
-}
-
-// newSSEDetectionData creates an SSEDetectionData from a datastore.Note and BirdImage.
-// It sanitizes sensitive data: ClipName is stripped to filename only, and Source
-// only includes safe display fields (no raw connection strings or credentials).
-func newSSEDetectionData(note *datastore.Note, birdImage *imageprovider.BirdImage) SSEDetectionData {
-	det := SSEDetectionData{
-		ID:             note.ID,
-		Date:           note.Date,
-		Time:           note.Time,
-		ScientificName: note.ScientificName,
-		CommonName:     note.CommonName,
-		SpeciesCode:    note.SpeciesCode,
-		Confidence:     note.Confidence,
-		Latitude:       note.Latitude,
-		Longitude:      note.Longitude,
-		ClipName:       safeBaseName(note.ClipName),
-		Verified:       note.Verified,
-		Locked:         note.Locked,
-		Unlikely:       note.Unlikely,
-		Timestamp:      time.Now(),
-		EventType:      "new_detection",
-	}
-
-	// Format time fields as RFC3339 if non-zero
-	if !note.BeginTime.IsZero() {
-		det.BeginTime = note.BeginTime.Format(time.RFC3339)
-	}
-	if !note.EndTime.IsZero() {
-		det.EndTime = note.EndTime.Format(time.RFC3339)
-	}
-
-	// Only expose safe source identifiers, never raw connection strings
-	if note.Source.ID != "" {
-		det.Source = &SSESourceInfo{
-			ID:          note.Source.ID,
-			DisplayName: note.Source.DisplayName,
-		}
-	}
-
-	// Map bird image with proper camelCase tags
-	if birdImage != nil {
-		det.BirdImage = SSEBirdImage{
-			URL:            birdImage.URL,
-			ScientificName: birdImage.ScientificName,
-			LicenseName:    birdImage.LicenseName,
-			LicenseURL:     birdImage.LicenseURL,
-			AuthorName:     birdImage.AuthorName,
-			AuthorURL:      birdImage.AuthorURL,
-			SourceProvider: birdImage.SourceProvider,
-		}
-	}
-
-	return det
-}
-
-// SSESoundLevelData represents sound level data sent via SSE
-type SSESoundLevelData struct {
-	soundlevel.SoundLevelData
-	EventType string `json:"eventType"`
 }
 
 // SSEEvent represents a generic SSE event that can contain different data types
@@ -201,252 +53,11 @@ type SSEEvent struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// SSEClient represents a connected SSE client
-type SSEClient struct {
-	ID             string
-	Channel        chan SSEDetectionData
-	SoundLevelChan chan SSESoundLevelData
-	PendingChan    chan any // Channel for pending detection snapshots ([]SSEPendingDetection from processor)
-	Request        *http.Request
-	Response       http.ResponseWriter
-	Done           chan struct{} // Signal-only buffered channel to prevent blocking
-	StreamType     string        // streamTypeDetections, streamTypeSoundLevels, or streamTypeAll
-
-	// Health tracking for auto-disconnect of slow/blocked clients
-	// Uses atomic operations for thread-safe access during concurrent broadcasts
-	consecutiveDrops atomic.Int32 // Count of consecutive failed message sends
-}
-
-// SSEManager manages SSE connections and broadcasts
-type SSEManager struct {
-	clients      map[string]*SSEClient
-	mutex        sync.RWMutex
-	shuttingDown atomic.Bool // blocks new registrations during shutdown
-}
-
-// NewSSEManager creates a new SSE manager
-func NewSSEManager() *SSEManager {
-	return &SSEManager{
-		clients: make(map[string]*SSEClient),
-	}
-}
-
-// AddClient adds a new SSE client. Returns false if the manager is
-// shutting down and no new registrations are accepted.
-func (m *SSEManager) AddClient(client *SSEClient) bool {
-	if m.shuttingDown.Load() {
-		return false
-	}
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	if m.shuttingDown.Load() {
-		return false
-	}
-	m.clients[client.ID] = client
-	GetLogger().Debug("SSE client connected",
-		logger.String("client_id", client.ID),
-		logger.Int("total_clients", len(m.clients)),
-	)
-	return true
-}
-
-// RemoveClient removes an SSE client
-func (m *SSEManager) RemoveClient(clientID string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	if client, exists := m.clients[clientID]; exists {
-		if client.Channel != nil {
-			close(client.Channel)
-		}
-		if client.SoundLevelChan != nil {
-			close(client.SoundLevelChan)
-		}
-		if client.PendingChan != nil {
-			close(client.PendingChan)
-		}
-		close(client.Done)
-		delete(m.clients, clientID)
-		GetLogger().Debug("SSE client disconnected",
-			logger.String("client_id", clientID),
-			logger.Int("total_clients", len(m.clients)),
-		)
-	}
-}
-
-// BroadcastDetection sends detection data to all connected clients
-// Uses non-blocking send to prevent slow clients from blocking fast clients.
-// Clients are automatically disconnected after maxConsecutiveDrops failed sends.
-func (m *SSEManager) BroadcastDetection(detection *SSEDetectionData) {
-	m.mutex.RLock()
-
-	if len(m.clients) == 0 {
-		m.mutex.RUnlock()
-		return // No clients to broadcast to
-	}
-
-	// Collect blocked client IDs to remove them after releasing the lock
-	var blockedClients []string
-
-	for clientID, client := range m.clients {
-		select {
-		case client.Channel <- *detection:
-			// Successfully sent to client - reset health counter atomically
-			client.consecutiveDrops.Store(0)
-
-		default:
-			// Channel full - drop this update, increment counter atomically
-			drops := client.consecutiveDrops.Add(1)
-
-			// Only log when reaching disconnect threshold to avoid log spam
-			if drops >= maxConsecutiveDrops {
-				GetLogger().Info("SSE client disconnected after consecutive drops",
-					logger.String("client_id", clientID),
-					logger.Int("consecutive_drops", int(drops)),
-				)
-				blockedClients = append(blockedClients, clientID)
-			}
-		}
-	}
-
-	// Release the read lock before removing clients
-	m.mutex.RUnlock()
-
-	// Remove blocked clients synchronously (we're outside the lock and RemoveClient is fast)
-	// Note: Low probability race if client reconnects with same ID between unlock and removal
-	for _, clientID := range blockedClients {
-		m.RemoveClient(clientID)
-	}
-}
-
-// BroadcastSoundLevel sends sound level data to all connected clients
-// Uses non-blocking send to prevent slow clients from blocking fast clients.
-// Clients are automatically disconnected after maxConsecutiveDrops failed sends.
-func (m *SSEManager) BroadcastSoundLevel(soundLevel *SSESoundLevelData) {
-	m.mutex.RLock()
-
-	if len(m.clients) == 0 {
-		m.mutex.RUnlock()
-		return // No clients to broadcast to
-	}
-
-	// Collect blocked client IDs to remove them after releasing the lock
-	var blockedClients []string
-
-	for clientID, client := range m.clients {
-		// Only send to clients that want sound level data
-		if client.StreamType == streamTypeSoundLevels || client.StreamType == streamTypeAll {
-			if client.SoundLevelChan != nil {
-				select {
-				case client.SoundLevelChan <- *soundLevel:
-					// Successfully sent to client - reset health counter atomically
-					client.consecutiveDrops.Store(0)
-
-				default:
-					// Channel full - drop this update, increment counter atomically
-					drops := client.consecutiveDrops.Add(1)
-
-					// Only log when reaching disconnect threshold to avoid log spam
-					if drops >= maxConsecutiveDrops {
-						GetLogger().Info("SSE client disconnected after consecutive drops",
-							logger.String("client_id", clientID),
-							logger.Int("consecutive_drops", int(drops)),
-						)
-						blockedClients = append(blockedClients, clientID)
-					}
-				}
-			}
-		}
-	}
-
-	// Release the read lock before removing clients
-	m.mutex.RUnlock()
-
-	// Remove blocked clients synchronously (we're outside the lock and RemoveClient is fast)
-	// Note: Low probability race if client reconnects with same ID between unlock and removal
-	for _, clientID := range blockedClients {
-		m.RemoveClient(clientID)
-	}
-}
-
-// BroadcastPending sends pending detection data to all connected detection stream clients.
-// Uses non-blocking send to prevent slow clients from blocking the processor.
-// Clients are automatically disconnected after maxConsecutiveDrops failed sends.
-func (m *SSEManager) BroadcastPending(pending any) {
-	m.mutex.RLock()
-
-	if len(m.clients) == 0 {
-		m.mutex.RUnlock()
-		return
-	}
-
-	var blockedClients []string
-
-	for clientID, client := range m.clients {
-		// Only send to clients receiving detection data
-		if client.StreamType != streamTypeDetections && client.StreamType != streamTypeAll {
-			continue
-		}
-		if client.PendingChan == nil {
-			continue
-		}
-		select {
-		case client.PendingChan <- pending:
-			client.consecutiveDrops.Store(0)
-		default:
-			drops := client.consecutiveDrops.Add(1)
-			if drops >= maxConsecutiveDrops {
-				GetLogger().Info("SSE client disconnected after consecutive drops",
-					logger.String("client_id", clientID),
-					logger.Int("consecutive_drops", int(drops)),
-				)
-				blockedClients = append(blockedClients, clientID)
-			}
-		}
-	}
-
-	m.mutex.RUnlock()
-
-	for _, clientID := range blockedClients {
-		m.RemoveClient(clientID)
-	}
-}
-
-// CloseAllClients disconnects all SSE clients during shutdown.
-// This must be called before echo.Shutdown() so the HTTP server
-// has no active connections to wait for.
-func (m *SSEManager) CloseAllClients() {
-	m.shuttingDown.Store(true)
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	for id, client := range m.clients {
-		if client.Channel != nil {
-			close(client.Channel)
-		}
-		if client.SoundLevelChan != nil {
-			close(client.SoundLevelChan)
-		}
-		if client.PendingChan != nil {
-			close(client.PendingChan)
-		}
-		close(client.Done)
-		delete(m.clients, id)
-	}
-	GetLogger().Info("SSE shutdown: closed all clients",
-		logger.String("operation", "sse_close_all_clients"))
-}
-
-// GetClientCount returns the number of connected clients
-func (m *SSEManager) GetClientCount() int {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	return len(m.clients)
-}
-
 // initSSERoutes registers SSE-related API endpoints
 func (c *Controller) initSSERoutes() {
 	// Initialize SSE manager if not already done
-	if c.sseManager == nil {
-		c.sseManager = NewSSEManager()
+	if c.SSEManager == nil {
+		c.SSEManager = apicore.NewSSEManager()
 	}
 
 	// Create rate limiter for SSE connections (10 requests per minute per IP)
@@ -519,7 +130,7 @@ func (c *Controller) logSSEConnection(clientID, ip, userAgent, streamType string
 		action = SSEStatusDisconnected
 	}
 
-	c.logInfoIfEnabled(fmt.Sprintf("SSE %s client %s", streamType, action),
+	c.LogInfoIfEnabled(fmt.Sprintf("SSE %s client %s", streamType, action),
 		logger.String("client_id", clientID),
 		logger.String("ip", ip),
 		logger.String("user_agent", userAgent),
@@ -530,14 +141,14 @@ func (c *Controller) logSSEConnection(clientID, ip, userAgent, streamType string
 func (c *Controller) sendSSEHeartbeat(ctx echo.Context, clientID, streamType string) error {
 	data := map[string]any{
 		"timestamp": time.Now().Unix(),
-		"clients":   c.sseManager.GetClientCount(),
+		"clients":   c.SSEManager.GetClientCount(),
 	}
 	if streamType != "" {
 		data["type"] = streamType
 	}
 
 	if err := c.sendSSEMessage(ctx, "heartbeat", data); err != nil {
-		c.logDebugIfEnabled("SSE heartbeat failed, client likely disconnected",
+		c.LogDebugIfEnabled("SSE heartbeat failed, client likely disconnected",
 			logger.String("client_id", clientID),
 			logger.Error(err),
 		)
@@ -560,8 +171,8 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 		endpoint = soundLevelStreamEndpoint
 	}
 
-	if c.metrics != nil && c.metrics.HTTP != nil && endpoint != "" {
-		c.metrics.HTTP.SSEConnectionStarted(endpoint)
+	if c.Metrics != nil && c.Metrics.HTTP != nil && endpoint != "" {
+		c.Metrics.HTTP.SSEConnectionStarted(endpoint)
 		defer func() {
 			duration := time.Since(connectionStartTime).Seconds()
 			closeReason := metrics.SSECloseReasonClosed
@@ -570,7 +181,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 			} else if ctx.Request().Context().Err() == context.Canceled {
 				closeReason = metrics.SSECloseReasonCanceled
 			}
-			c.metrics.HTTP.SSEConnectionClosed(endpoint, duration, closeReason)
+			c.Metrics.HTTP.SSEConnectionClosed(endpoint, duration, closeReason)
 		}()
 	}
 
@@ -586,7 +197,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 	setSSEHeaders(ctx)
 
 	// Generate client ID and create client
-	clientID := generateCorrelationID()
+	clientID := apicore.GenerateCorrelationID()
 	client := createSSEClient(clientID, ctx, streamType)
 
 	// Allow custom setup
@@ -595,7 +206,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 	}
 
 	// Add client to manager (rejected during shutdown)
-	if !c.sseManager.AddClient(client) {
+	if !c.SSEManager.AddClient(client) {
 		return ctx.JSON(http.StatusServiceUnavailable, map[string]string{
 			"error": "Server is shutting down",
 		})
@@ -603,7 +214,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 
 	// Send initial connection message
 	if err := c.sendConnectionMessage(ctx, clientID, message, streamType); err != nil {
-		c.sseManager.RemoveClient(clientID)
+		c.SSEManager.RemoveClient(clientID)
 		return err
 	}
 
@@ -612,7 +223,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 
 	// Handle the SSE connection
 	defer func() {
-		c.sseManager.RemoveClient(clientID)
+		c.SSEManager.RemoveClient(clientID)
 		c.logSSEConnection(clientID, ctx.RealIP(), "", logPrefix, false)
 	}()
 
@@ -663,7 +274,7 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 					return nil
 				}
 				if err := c.sendSSEMessage(ctx, "detection", detection); err != nil {
-					c.logErrorIfEnabled("Failed to send SSE detection",
+					c.LogErrorIfEnabled("Failed to send SSE detection",
 						logger.String("client_id", clientID),
 						logger.String("endpoint", endpoint),
 						logger.Error(err),
@@ -684,7 +295,7 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 						return nil
 					}
 					if err := c.sendSSEMessage(ctx, "pending", pending); err != nil {
-						c.logErrorIfEnabled("Failed to send SSE pending",
+						c.LogErrorIfEnabled("Failed to send SSE pending",
 							logger.String("client_id", clientID),
 							logger.String("endpoint", endpoint),
 							logger.Error(err),
@@ -760,7 +371,7 @@ func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, client
 			// Check for data on the channel (non-blocking)
 			if data, hasData := dataReceiver(); hasData {
 				if err := c.sendSSEMessage(ctx, eventType, data); err != nil {
-					c.logErrorIfEnabled("Failed to send SSE message",
+					c.LogErrorIfEnabled("Failed to send SSE message",
 						logger.String("client_id", clientID),
 						logger.String("endpoint", endpoint),
 						logger.String("event_type", eventType),
@@ -794,7 +405,7 @@ func (c *Controller) sendSSEMessage(ctx echo.Context, event string, data any) er
 		deadline := time.Now().Add(sseWriteDeadline) // Write deadline timeout
 		if err := conn.SetWriteDeadline(deadline); err != nil {
 			// If we can't set deadline, log but continue - not all response writers support this
-			c.logDebugIfEnabled("Failed to set write deadline for SSE message", logger.Error(err))
+			c.LogDebugIfEnabled("Failed to set write deadline for SSE message", logger.Error(err))
 		}
 	}
 
@@ -811,21 +422,13 @@ func (c *Controller) sendSSEMessage(ctx echo.Context, event string, data any) er
 	return nil
 }
 
-// BroadcastPending broadcasts pending detection snapshot from the controller.
-func (c *Controller) BroadcastPending(snapshot any) {
-	if c.sseManager == nil {
-		return
-	}
-	c.sseManager.BroadcastPending(snapshot)
-}
-
 // safeMarshalJSON marshals data to JSON with panic recovery.
 // This protects against panics from concurrent map access or unmarshalable data.
 func (c *Controller) safeMarshalJSON(event string, data any) (jsonData []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("JSON marshal panic: %v", r)
-			c.logErrorIfEnabled("SSE marshal panic recovered",
+			c.LogErrorIfEnabled("SSE marshal panic recovered",
 				logger.String("event", event),
 				logger.Any("panic", r),
 				logger.String("stack", string(debug.Stack())),
@@ -843,7 +446,7 @@ func (c *Controller) safeMarshalJSON(event string, data any) (jsonData []byte, e
 
 // GetSSEStatus returns information about SSE connections
 func (c *Controller) GetSSEStatus(ctx echo.Context) error {
-	if c.sseManager == nil {
+	if c.SSEManager == nil {
 		return ctx.JSON(http.StatusOK, map[string]any{
 			"connected_clients": 0,
 			"status":            "disabled",
@@ -851,66 +454,7 @@ func (c *Controller) GetSSEStatus(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]any{
-		"connected_clients": c.sseManager.GetClientCount(),
+		"connected_clients": c.SSEManager.GetClientCount(),
 		"status":            "active",
 	})
-}
-
-// BroadcastDetection is a helper method to broadcast detection from the controller.
-// It maps the internal datastore.Note to a sanitized SSEDetectionData struct that
-// only exposes safe fields with proper camelCase JSON tags.
-func (c *Controller) BroadcastDetection(note *datastore.Note, birdImage *imageprovider.BirdImage) error {
-	if c.sseManager == nil {
-		return fmt.Errorf("SSE manager not initialized")
-	}
-
-	// Add nil checks to prevent panic
-	if note == nil {
-		c.logErrorIfEnabled("SSE broadcast skipped: note is nil")
-		return fmt.Errorf("note is nil")
-	}
-	if birdImage == nil {
-		c.logErrorIfEnabled("SSE broadcast skipped: birdImage is nil")
-		return fmt.Errorf("birdImage is nil")
-	}
-
-	detection := newSSEDetectionData(note, birdImage)
-
-	// Add species tracking metadata if processor has tracker.
-	// Compare the detection date with the species' first-seen date so the flag
-	// is true only for the actual first detection, not for every detection of a
-	// recently-first-seen species.
-	// Snapshot processor and tracker to avoid TOCTOU race.
-	if proc := c.Processor; proc != nil {
-		if tracker := proc.GetNewSpeciesTracker(); tracker != nil {
-			status := tracker.GetSpeciesStatus(note.ScientificName, time.Now())
-			detection.IsNewSpecies = !status.FirstSeenTime.IsZero() &&
-				note.Date == status.FirstSeenTime.Format(time.DateOnly)
-			detection.DaysSinceFirstSeen = status.DaysSinceFirst
-		}
-	}
-
-	c.sseManager.BroadcastDetection(&detection)
-	return nil
-}
-
-// BroadcastSoundLevel is a helper method to broadcast sound level data from the controller
-func (c *Controller) BroadcastSoundLevel(soundLevel *soundlevel.SoundLevelData) error {
-	if c.sseManager == nil {
-		return fmt.Errorf("SSE manager not initialized")
-	}
-
-	// Add nil check to prevent panic
-	if soundLevel == nil {
-		c.logErrorIfEnabled("SSE broadcast skipped: soundLevel is nil")
-		return fmt.Errorf("soundLevel is nil")
-	}
-
-	sseData := SSESoundLevelData{
-		SoundLevelData: *soundLevel,
-		EventType:      "sound_level_update",
-	}
-
-	c.sseManager.BroadcastSoundLevel(&sseData)
-	return nil
 }

--- a/internal/api/v2/sse_contract_test.go
+++ b/internal/api/v2/sse_contract_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 )
@@ -157,7 +158,7 @@ func createTestBirdImage() imageprovider.BirdImage {
 func createTestSSEDetectionData() SSEDetectionData {
 	note := createTestNoteWithAllFields()
 	birdImage := createTestBirdImage()
-	det := newSSEDetectionData(&note, &birdImage)
+	det := apicore.NewSSEDetectionData(&note, &birdImage)
 	det.IsNewSpecies = true
 	det.DaysSinceFirstSeen = 14
 	return det
@@ -403,7 +404,7 @@ func TestSSEContract_IsNewSpeciesOmittedWhenFalse(t *testing.T) {
 
 	note := createTestNoteWithAllFields()
 	birdImage := createTestBirdImage()
-	detection := newSSEDetectionData(&note, &birdImage)
+	detection := apicore.NewSSEDetectionData(&note, &birdImage)
 	detection.IsNewSpecies = false   // Should be omitted
 	detection.DaysSinceFirstSeen = 0 // Should be omitted
 
@@ -508,7 +509,7 @@ func TestSSEContract_SensitiveDataExcluded(t *testing.T) {
 	}
 
 	birdImage := createTestBirdImage()
-	detection := newSSEDetectionData(&note, &birdImage)
+	detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 	jsonBytes, err := json.Marshal(detection)
 	require.NoError(t, err)
@@ -601,7 +602,7 @@ func TestSSEContract_VerifiedAndLocked_Serialization(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.Verified = "correct"
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -622,7 +623,7 @@ func TestSSEContract_VerifiedAndLocked_Serialization(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.Verified = "" // empty string, omitempty should omit
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -642,7 +643,7 @@ func TestSSEContract_VerifiedAndLocked_Serialization(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.Locked = true
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -663,7 +664,7 @@ func TestSSEContract_VerifiedAndLocked_Serialization(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.Locked = false
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -690,7 +691,7 @@ func TestSSEContract_Source_NestedFields(t *testing.T) {
 
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -718,7 +719,7 @@ func TestSSEContract_Source_NestedFields(t *testing.T) {
 		// so it should be omitted due to omitempty
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -741,7 +742,7 @@ func TestSSEContract_Source_NestedFields(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.Source = datastore.AudioSource{} // empty source
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -766,7 +767,7 @@ func TestSSEContract_BeginTimeEndTime_RFC3339(t *testing.T) {
 
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -813,7 +814,7 @@ func TestSSEContract_BeginTimeEndTime_RFC3339(t *testing.T) {
 		note.BeginTime = time.Time{} // zero value
 		note.EndTime = time.Time{}   // zero value
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -842,7 +843,7 @@ func TestSSEContract_IsNewSpecies_DaysSinceFirstSeen(t *testing.T) {
 
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 		detection.IsNewSpecies = true
 		detection.DaysSinceFirstSeen = 0
 
@@ -869,7 +870,7 @@ func TestSSEContract_IsNewSpecies_DaysSinceFirstSeen(t *testing.T) {
 
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 		detection.IsNewSpecies = false
 		detection.DaysSinceFirstSeen = 42
 
@@ -897,7 +898,7 @@ func TestSSEContract_IsNewSpecies_DaysSinceFirstSeen(t *testing.T) {
 
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 		detection.IsNewSpecies = true
 		detection.DaysSinceFirstSeen = 7
 
@@ -991,7 +992,7 @@ func TestSSEContract_BirdImage_AllSubFields(t *testing.T) {
 		t.Parallel()
 
 		note := createTestNoteWithAllFields()
-		detection := newSSEDetectionData(&note, nil)
+		detection := apicore.NewSSEDetectionData(&note, nil)
 
 		jsonBytes, err := json.Marshal(detection)
 		require.NoError(t, err)
@@ -1024,7 +1025,7 @@ func TestSSEContract_ZeroConfidence_NotOmitted(t *testing.T) {
 	note := createTestNoteWithAllFields()
 	note.Confidence = 0.0 // Zero confidence is valid — must not be omitted
 	birdImage := createTestBirdImage()
-	detection := newSSEDetectionData(&note, &birdImage)
+	detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 	jsonBytes, err := json.Marshal(detection)
 	require.NoError(t, err)
@@ -1047,7 +1048,7 @@ func TestSSEContract_AllFieldValues_RoundTrip(t *testing.T) {
 
 	note := createTestNoteWithAllFields()
 	birdImage := createTestBirdImage()
-	detection := newSSEDetectionData(&note, &birdImage)
+	detection := apicore.NewSSEDetectionData(&note, &birdImage)
 	detection.IsNewSpecies = true
 	detection.DaysSinceFirstSeen = 5
 
@@ -1189,7 +1190,7 @@ func TestSSEContract_OmitemptyFields_Comprehensive(t *testing.T) {
 		// Source.ID: ""       (omitempty on Source pointer)
 	}
 
-	detection := newSSEDetectionData(&note, nil)
+	detection := apicore.NewSSEDetectionData(&note, nil)
 	// IsNewSpecies: false    (omitempty)
 	// DaysSinceFirstSeen: 0  (omitempty)
 
@@ -1339,7 +1340,7 @@ func TestSSEContract_NewSSEDetectionData_Constructor(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.ClipName = "/deeply/nested/path/to/recordings/2024/clip.wav"
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		assert.Equal(t, "clip.wav", detection.ClipName,
 			"ClipName must be stripped to filename only")
@@ -1351,7 +1352,7 @@ func TestSSEContract_NewSSEDetectionData_Constructor(t *testing.T) {
 		note := createTestNoteWithAllFields()
 		note.ClipName = ""
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		assert.Empty(t, detection.ClipName,
 			"Empty ClipName must remain empty, not '.'")
@@ -1362,7 +1363,7 @@ func TestSSEContract_NewSSEDetectionData_Constructor(t *testing.T) {
 
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 
 		assert.Equal(t, "new_detection", detection.EventType,
 			"EventType must always be 'new_detection'")
@@ -1374,7 +1375,7 @@ func TestSSEContract_NewSSEDetectionData_Constructor(t *testing.T) {
 		before := time.Now()
 		note := createTestNoteWithAllFields()
 		birdImage := createTestBirdImage()
-		detection := newSSEDetectionData(&note, &birdImage)
+		detection := apicore.NewSSEDetectionData(&note, &birdImage)
 		after := time.Now()
 
 		assert.False(t, detection.Timestamp.Before(before),

--- a/internal/api/v2/sse_panic_recovery_test.go
+++ b/internal/api/v2/sse_panic_recovery_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -20,9 +21,7 @@ import (
 func TestSendSSEMessagePanicRecovery(t *testing.T) {
 	t.Parallel()
 
-	c := &Controller{
-		apiLogger: nil, // Will skip logging in tests
-	}
+	c := &Controller{Core: &apicore.Core{APILogger: nil}}
 	c.Settings.Store(&conf.Settings{
 		WebServer: conf.WebServerSettings{
 			Debug: true,

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -116,7 +117,7 @@ type StreamSummaryResponse struct {
 // so that if a handler is ever carved out in the future, raw RTSP credentials
 // cannot leak.
 func (c *Controller) initStreamHealthRoutes() {
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// REST endpoints — authenticated
 	c.Group.GET("/streams/health", c.GetAllStreamsHealth, authMiddleware)
@@ -178,7 +179,7 @@ type streamInfo struct {
 // Reads the controller's lock-free settings snapshot, so a hot-reload that
 // republishes settings is visible on the next call.
 func (c *Controller) getStreamInfo(rawURL string) streamInfo {
-	settings := c.controllerSettings()
+	settings := c.ControllerSettings()
 	if settings == nil {
 		return streamInfo{}
 	}
@@ -202,7 +203,7 @@ func (c *Controller) getStreamInfo(rawURL string) streamInfo {
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health [get]
 func (c *Controller) GetAllStreamsHealth(ctx echo.Context) error {
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		// No engine - we cannot report real stream health. Signal the
 		// caller with 503 rather than fabricating misleading zero counts.
@@ -259,7 +260,7 @@ func (c *Controller) GetStreamHealth(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid URL encoding", http.StatusBadRequest)
 	}
 
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		// Match GetAllStreamsHealth / GetStreamsStatusSummary: 503, not
 		// 404. The stream may very well exist in config, we just cannot
@@ -290,7 +291,7 @@ func (c *Controller) GetStreamHealth(ctx echo.Context) error {
 
 	if lookupErr != nil {
 		healthData := ffmpegMgr.AllStreamHealth()
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Stream not found",
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Stream not found",
 			logger.String("requested_url", privacy.SanitizeStreamUrl(decodedURL)),
 			logger.Int("active_streams", len(healthData)))
 		return c.HandleError(ctx, nil, "Stream not found", http.StatusNotFound)
@@ -316,7 +317,7 @@ func (c *Controller) GetStreamHealth(ctx echo.Context) error {
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/status [get]
 func (c *Controller) GetStreamsStatusSummary(ctx echo.Context) error {
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		// Zero counts would be technically accurate but misleading: clients
 		// cannot tell "no streams configured" apart from "audio engine not
@@ -478,7 +479,7 @@ func convertErrorContextToResponse(errCtx *ffmpeg.ErrorContext) *ErrorContextRes
 // handleStreamHealthHeartbeat sends a heartbeat and returns true if client disconnected.
 func (c *Controller) handleStreamHealthHeartbeat(ctx echo.Context, clientID string) error {
 	if err := c.sendSSEHeartbeat(ctx, clientID, "stream_health"); err != nil {
-		c.logDebugIfEnabled("Stream health SSE heartbeat failed, client likely disconnected",
+		c.LogDebugIfEnabled("Stream health SSE heartbeat failed, client likely disconnected",
 			logger.String("client_id", clientID),
 			logger.Error(err))
 		return err
@@ -488,7 +489,7 @@ func (c *Controller) handleStreamHealthHeartbeat(ctx echo.Context, clientID stri
 
 // handleStreamHealthPoll polls for stream health changes and processes updates.
 func (c *Controller) handleStreamHealthPoll(ctx echo.Context, clientID string, previousState map[string]streamHealthSnapshot) error {
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return nil
 	}
@@ -505,7 +506,7 @@ func (c *Controller) handleStreamHealthPoll(ctx echo.Context, clientID string, p
 // This enables real-time bandwidth and bytes display in the UI regardless of state changes.
 // Note: This sends a lightweight payload without history arrays to reduce bandwidth.
 func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) error {
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return nil
 	}
@@ -515,7 +516,7 @@ func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) 
 	for sourceID, fh := range healthData {
 		rawURL := c.resolveSourceURL(registry, sourceID)
 		if err := c.sendStreamStatsUpdate(ctx, rawURL, fh); err != nil {
-			c.logDebugIfEnabled("Failed to send stats update, client disconnected",
+			c.LogDebugIfEnabled("Failed to send stats update, client disconnected",
 				logger.String("url", privacy.SanitizeStreamUrl(rawURL)),
 				logger.String("client_id", clientID),
 				logger.Error(err))
@@ -536,7 +537,7 @@ func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) 
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health/stream [get]
 func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
-	eng := c.engine.Load()
+	eng := c.Engine.Load()
 	if eng == nil {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
@@ -549,7 +550,7 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 	ctx.SetRequest(ctx.Request().WithContext(timeoutCtx))
 
 	setSSEHeaders(ctx)
-	clientID := generateCorrelationID()
+	clientID := apicore.GenerateCorrelationID()
 
 	c.logSSEConnection(clientID, ctx.RealIP(), ctx.Request().UserAgent(), "stream-health", true)
 	defer c.logSSEConnection(clientID, ctx.RealIP(), "", "stream-health", false)
@@ -570,9 +571,9 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 
 	for {
 		select {
-		case <-c.ctx.Done():
+		case <-c.Context().Done():
 			// Controller shutting down
-			c.logInfoIfEnabled("stream health SSE client disconnected due to shutdown",
+			c.LogInfoIfEnabled("stream health SSE client disconnected due to shutdown",
 				logger.String("client_id", clientID),
 			)
 			return nil
@@ -674,7 +675,7 @@ func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID strin
 		if !exists {
 			// New stream detected
 			if err := c.sendStreamHealthUpdate(ctx, rawURL, health, "stream_added"); err != nil {
-				c.logDebugIfEnabled("Failed to send stream_added event, client disconnected",
+				c.LogDebugIfEnabled("Failed to send stream_added event, client disconnected",
 					logger.String("url", privacy.SanitizeStreamUrl(rawURL)),
 					logger.String("client_id", clientID),
 					logger.Error(err))
@@ -684,7 +685,7 @@ func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID strin
 			// Stream health changed
 			eventType := determineEventType(&previousSnapshot, &currentSnapshot)
 			if err := c.sendStreamHealthUpdate(ctx, rawURL, health, eventType); err != nil {
-				c.logDebugIfEnabled("Failed to send health update, client disconnected",
+				c.LogDebugIfEnabled("Failed to send health update, client disconnected",
 					logger.String("url", privacy.SanitizeStreamUrl(rawURL)),
 					logger.String("event_type", eventType),
 					logger.String("client_id", clientID),
@@ -732,7 +733,7 @@ func (c *Controller) processRemovedStreams(ctx echo.Context, clientID string, he
 
 		delete(previousState, prevSourceID)
 
-		c.logInfoIfEnabled("Stream removed",
+		c.LogInfoIfEnabled("Stream removed",
 			logger.String("url", sanitizedURL),
 			logger.String("client_id", clientID))
 	}
@@ -758,7 +759,7 @@ func (c *Controller) sendStreamHealthUpdate(ctx echo.Context, rawURL string, hea
 		return err
 	}
 
-	c.logDebugIfEnabled("Stream health update sent",
+	c.LogDebugIfEnabled("Stream health update sent",
 		logger.String("url", privacy.SanitizeStreamUrl(rawURL)),
 		logger.String("event_type", eventType),
 		logger.Bool("is_healthy", health.IsHealthy),

--- a/internal/api/v2/streams_test_handler.go
+++ b/internal/api/v2/streams_test_handler.go
@@ -63,8 +63,8 @@ type probeStreamInfoFunc func(ctx context.Context, url string) (*ffmpeg.StreamIn
 
 // initStreamTestRoutes registers stream testing endpoints.
 func (c *Controller) initStreamTestRoutes() {
-	c.Group.POST("/streams/test", c.TestStream, c.authMiddleware)
-	c.Group.POST("/streams/analyze-channels", c.AnalyzeChannels, c.authMiddleware)
+	c.Group.POST("/streams/test", c.TestStream, c.AuthMiddleware)
+	c.Group.POST("/streams/analyze-channels", c.AnalyzeChannels, c.AuthMiddleware)
 }
 
 // TestStream tests a stream URL to discover its audio properties.

--- a/internal/api/v2/streams_test_handler_test.go
+++ b/internal/api/v2/streams_test_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -89,7 +90,7 @@ func TestTestStreamHandler_ValidationErrors(t *testing.T) {
 			rec := httptest.NewRecorder()
 			ctx := e.NewContext(req, rec)
 
-			ctrl := &Controller{}
+			ctrl := &Controller{Core: &apicore.Core{}}
 			ctrl.Settings.Store(&conf.Settings{})
 			err := ctrl.TestStream(ctx)
 			require.NoError(t, err)
@@ -113,11 +114,9 @@ func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	ctrl := &Controller{
-		probeStreamInfo: func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
-			return nil, ffmpeg.ErrNoAudioStreamsFound
-		},
-	}
+	ctrl := &Controller{Core: &apicore.Core{}, probeStreamInfo: func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
+		return nil, ffmpeg.ErrNoAudioStreamsFound
+	}}
 	ctrl.Settings.Store(&conf.Settings{})
 	err := ctrl.TestStream(ctx)
 	require.NoError(t, err)

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -28,7 +28,7 @@ const (
 
 // valueContext wraps a cancellation-bearing context while delegating
 // Value lookups to a separate context. This lets the support dump
-// handler use the server lifecycle context (c.ctx) for cancellation
+// handler use the server lifecycle context (c.Context()) for cancellation
 // while still reading trace IDs from the HTTP request context.
 type valueContext struct {
 	context.Context
@@ -75,12 +75,12 @@ func sanitizeGitHubIssueNumber(issueNum string) string {
 
 // GenerateSupportDump handles the generation and optional upload of support dumps
 func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
-	c.logDebugIfEnabled("Support dump generation started")
+	c.LogDebugIfEnabled("Support dump generation started")
 
 	// Use the server lifecycle context for cancellation so the dump
 	// stops on shutdown, but delegate Value lookups to the request
 	// context so trace IDs remain accessible.
-	parentCtx := c.ctx
+	parentCtx := c.Context()
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
@@ -95,7 +95,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	// is 30s, but the dump can take much longer).
 	rc := http.NewResponseController(ctx.Response().Writer)
 	if err := rc.SetWriteDeadline(time.Now().Add(supportDumpTimeout)); err != nil {
-		c.logDebugIfEnabled("Failed to extend write deadline for support dump", logger.Error(err))
+		c.LogDebugIfEnabled("Failed to extend write deadline for support dump", logger.Error(err))
 	}
 
 	// Parse JSON request
@@ -107,7 +107,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	// Sanitize GitHub issue number: must be digits only (frontend strips '#' prefix)
 	req.GitHubIssueNumber = sanitizeGitHubIssueNumber(req.GitHubIssueNumber)
 
-	c.logDebugIfEnabled("Support dump request parsed",
+	c.LogDebugIfEnabled("Support dump request parsed",
 		logger.Bool("include_logs", req.IncludeLogs),
 		logger.Bool("include_config", req.IncludeConfig),
 		logger.Bool("include_system_info", req.IncludeSystemInfo),
@@ -124,13 +124,13 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		req.IncludeSystemInfo = true
 		req.IncludeDatabaseInfo = true
 		req.IncludeAppEvents = true
-		c.logDebugIfEnabled("Set default options for support dump")
+		c.LogDebugIfEnabled("Set default options for support dump")
 	}
 
 	// Read the live global snapshot (race-free, hot-reloading) via
-	// currentSettings() so out-of-band republishes are seen and the read never
+	// CurrentSettings() so out-of-band republishes are seen and the read never
 	// races the Settings.Store in UpdateSettings.
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
 	}
@@ -185,30 +185,30 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	}
 
 	// Collect data
-	c.logDebugIfEnabled("Starting support data collection", logger.String("system_id", settings.SystemID))
+	c.LogDebugIfEnabled("Starting support data collection", logger.String("system_id", settings.SystemID))
 	dump, err := collector.Collect(dumpCtx, opts)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to collect support data",
+		c.LogErrorIfEnabled("Failed to collect support data",
 			logger.Error(err),
 			logger.String("system_id", settings.SystemID),
 			logger.Any("opts", opts),
 		)
 		return c.HandleError(ctx, err, "Failed to collect support data", http.StatusInternalServerError)
 	}
-	c.logDebugIfEnabled("Support data collected successfully", logger.String("dump_id", dump.ID))
+	c.LogDebugIfEnabled("Support data collected successfully", logger.String("dump_id", dump.ID))
 
 	// Create archive
-	c.logDebugIfEnabled("Creating support archive", logger.String("dump_id", dump.ID))
+	c.LogDebugIfEnabled("Creating support archive", logger.String("dump_id", dump.ID))
 	archiveData, err := collector.CreateArchive(dumpCtx, dump, opts)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to create support archive",
+		c.LogErrorIfEnabled("Failed to create support archive",
 			logger.Error(err),
 			logger.String("dump_id", dump.ID),
 			logger.Any("context_err", dumpCtx.Err()),
 		)
 		return c.HandleError(ctx, err, "Failed to create support archive", http.StatusInternalServerError)
 	}
-	c.logDebugIfEnabled("Support archive created successfully",
+	c.LogDebugIfEnabled("Support archive created successfully",
 		logger.String("dump_id", dump.ID),
 		logger.Int("archive_size", len(archiveData)))
 
@@ -223,7 +223,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		// Initialize minimal Sentry if needed
 		if !settings.Sentry.Enabled {
 			if err := telemetry.InitMinimalSentryForSupport(settings.SystemID, settings.Version); err != nil {
-				c.logErrorIfEnabled("Failed to initialize minimal Sentry for support upload",
+				c.LogErrorIfEnabled("Failed to initialize minimal Sentry for support upload",
 					logger.Error(err),
 					logger.String("dump_id", dump.ID),
 				)
@@ -240,7 +240,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 				// the user can still retrieve the dump: builds without a Sentry
 				// DSN (e.g. from-source) have a disabled uploader, and a
 				// transient upload failure should not strand the dump.
-				c.logErrorIfEnabled("Failed to upload support dump to Sentry",
+				c.LogErrorIfEnabled("Failed to upload support dump to Sentry",
 					logger.Error(err),
 					logger.String("dump_id", dump.ID),
 				)
@@ -249,7 +249,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 			} else {
 				response.UploadedAt = time.Now().UTC().Format(time.RFC3339)
 				response.Message = "Support dump generated and uploaded successfully"
-				c.logInfoIfEnabled("Support dump uploaded to Sentry",
+				c.LogInfoIfEnabled("Support dump uploaded to Sentry",
 					logger.String("dump_id", dump.ID),
 					logger.String("system_id", settings.SystemID),
 					logger.Bool("telemetry_enabled", settings.Sentry.Enabled),
@@ -265,7 +265,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		// Store temporarily for download
 		tempFile := filepath.Join(os.TempDir(), fmt.Sprintf("birdnet-go-support-%s.zip", dump.ID))
 		if err := os.WriteFile(tempFile, archiveData, FilePermOwnerOnly); err != nil {
-			c.logErrorIfEnabled("Failed to store temporary file",
+			c.LogErrorIfEnabled("Failed to store temporary file",
 				logger.Error(err),
 				logger.String("path", tempFile),
 			)
@@ -275,7 +275,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	}
 
 	// Log successful generation
-	c.logInfoIfEnabled("Support dump generated",
+	c.LogInfoIfEnabled("Support dump generated",
 		logger.String("dump_id", dump.ID),
 		logger.Int("size", len(archiveData)),
 		logger.Bool("uploaded", response.UploadedAt != ""),
@@ -321,9 +321,9 @@ func (c *Controller) DownloadSupportDump(ctx echo.Context) error {
 // GetSupportStatus returns the current support/telemetry configuration status
 func (c *Controller) GetSupportStatus(ctx echo.Context) error {
 	// Read the live global snapshot (race-free, hot-reloading) via
-	// currentSettings() so out-of-band republishes are seen and the read never
+	// CurrentSettings() so out-of-band republishes are seen and the read never
 	// races the Settings.Store in UpdateSettings.
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
 	}
@@ -340,20 +340,22 @@ func (c *Controller) GetSupportStatus(ctx echo.Context) error {
 // initSupportRoutes registers support-related routes
 func (c *Controller) initSupportRoutes() {
 	// Create protected group for support endpoints (consistent with other route files)
-	supportGroup := c.Group.Group("/support", c.authMiddleware)
+	supportGroup := c.Group.Group("/support", c.AuthMiddleware)
 	supportGroup.POST("/generate", c.GenerateSupportDump)
 	supportGroup.GET("/download/:id", c.DownloadSupportDump)
 	supportGroup.GET("/status", c.GetSupportStatus)
 
 	// Start cleanup goroutine for old support dumps with proper context
 	// Go 1.25: Using WaitGroup.Go() for automatic Add/Done management
-	if c.ctx != nil {
-		c.wg.Go(func() {
-			c.startSupportDumpCleanup(c.ctx)
+	if c.Context() != nil {
+		c.Go(func() {
+			c.startSupportDumpCleanup(c.Context())
 		})
-		c.wg.Go(func() {
-			c.startAppEventPruning(c.ctx)
+
+		c.Go(func() {
+			c.startAppEventPruning(c.Context())
 		})
+
 	}
 }
 
@@ -361,7 +363,7 @@ func (c *Controller) initSupportRoutes() {
 func (c *Controller) startSupportDumpCleanup(ctx context.Context) {
 	// Ensure we have a valid context
 	if ctx == nil {
-		c.logErrorIfEnabled("Cannot start support dump cleanup with nil context")
+		c.LogErrorIfEnabled("Cannot start support dump cleanup with nil context")
 		return
 	}
 
@@ -376,7 +378,7 @@ func (c *Controller) startSupportDumpCleanup(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			// Context cancelled, exit gracefully
-			c.logInfoIfEnabled("Support dump cleanup goroutine stopping due to context cancellation")
+			c.LogInfoIfEnabled("Support dump cleanup goroutine stopping due to context cancellation")
 			return
 		case <-ticker.C:
 			c.cleanupOldSupportDumps()
@@ -391,7 +393,7 @@ func (c *Controller) cleanupOldSupportDumps() {
 
 	files, err := filepath.Glob(pattern)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to list support dump files for cleanup",
+		c.LogErrorIfEnabled("Failed to list support dump files for cleanup",
 			logger.String("pattern", pattern), logger.Error(err))
 		return
 	}
@@ -406,7 +408,7 @@ func (c *Controller) cleanupOldSupportDumps() {
 	}
 
 	if removedCount > 0 {
-		c.logInfoIfEnabled("Cleaned up old support dump files", logger.Int("count", removedCount))
+		c.LogInfoIfEnabled("Cleaned up old support dump files", logger.Int("count", removedCount))
 	}
 }
 
@@ -416,7 +418,7 @@ func (c *Controller) tryRemoveOldFile(file string, cutoff time.Time) bool {
 	info, err := os.Stat(file)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			c.logWarnIfEnabled("Failed to stat support dump file", logger.String("path", file), logger.Error(err))
+			c.LogWarnIfEnabled("Failed to stat support dump file", logger.String("path", file), logger.Error(err))
 		}
 		return false
 	}
@@ -426,7 +428,7 @@ func (c *Controller) tryRemoveOldFile(file string, cutoff time.Time) bool {
 	}
 
 	if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
-		c.logWarnIfEnabled("Failed to remove old support dump file",
+		c.LogWarnIfEnabled("Failed to remove old support dump file",
 			logger.String("path", file), logger.Duration("age", time.Since(info.ModTime())), logger.Error(err))
 		return false
 	}
@@ -471,10 +473,10 @@ func (c *Controller) pruneAppEvents(ctx context.Context) {
 	}
 	pruned, err := c.DS.PruneAppEvents(ctx, appEventRetentionDays)
 	if err != nil {
-		c.logWarnIfEnabled("Failed to prune app events", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to prune app events", logger.Error(err))
 		return
 	}
 	if pruned > 0 {
-		c.logInfoIfEnabled("Pruned old app events", logger.Int64("count", pruned))
+		c.LogInfoIfEnabled("Pruned old app events", logger.Int64("count", pruned))
 	}
 }

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -230,14 +230,14 @@ type JobQueueStats struct {
 
 // GetJobQueueStats returns statistics about the job queue
 func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting job queue statistics",
+	c.LogInfoIfEnabled("Getting job queue statistics",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	proc := c.Processor
 	if proc == nil {
-		c.logErrorIfEnabled("Processor not available for job queue stats",
+		c.LogErrorIfEnabled("Processor not available for job queue stats",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -246,7 +246,7 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 
 	jq := proc.JobQueue
 	if jq == nil {
-		c.logErrorIfEnabled("Job queue not available",
+		c.LogErrorIfEnabled("Job queue not available",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -258,7 +258,7 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 	// Convert to JSON
 	jsonStats, err := stats.ToJSON()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to convert job queue stats to JSON",
+		c.LogErrorIfEnabled("Failed to convert job queue stats to JSON",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -269,7 +269,7 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 	// Parse the JSON string back to a map for proper JSON response
 	var statsMap map[string]any
 	if err := json.Unmarshal([]byte(jsonStats), &statsMap); err != nil {
-		c.logErrorIfEnabled("Failed to parse job queue stats JSON",
+		c.LogErrorIfEnabled("Failed to parse job queue stats JSON",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -277,7 +277,7 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to parse job queue stats JSON", http.StatusInternalServerError)
 	}
 
-	c.logInfoIfEnabled("Job queue statistics retrieved successfully",
+	c.LogInfoIfEnabled("Job queue statistics retrieved successfully",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -296,7 +296,7 @@ type NetworkInterface struct {
 // GetNetworkInterfaces returns the IPv4 network interfaces available for binding.
 // GET /api/v2/system/network-interfaces
 func (c *Controller) GetNetworkInterfaces(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting network interfaces")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting network interfaces")
 
 	interfaces := []NetworkInterface{
 		{Address: "0.0.0.0", Name: "all", Label: "All interfaces", Status: "up"},
@@ -308,11 +308,11 @@ func (c *Controller) GetNetworkInterfaces(ctx echo.Context) error {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		// Log but don't fail — return at least the wildcard and loopback
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Failed to enumerate network interfaces", logger.Error(err))
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Failed to enumerate network interfaces", logger.Error(err))
 		interfaces = append(interfaces, NetworkInterface{
 			Address: "127.0.0.1", Name: "lo", Label: "Loopback", Status: "up",
 		})
-		c.logAPIRequest(ctx, logger.LogLevelInfo, "Network interfaces retrieved (fallback)",
+		c.LogAPIRequest(ctx, logger.LogLevelInfo, "Network interfaces retrieved (fallback)",
 			logger.Int("count", len(interfaces)))
 		return ctx.JSON(http.StatusOK, map[string]any{"interfaces": interfaces})
 	}
@@ -363,14 +363,14 @@ func (c *Controller) GetNetworkInterfaces(ctx echo.Context) error {
 		}
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Network interfaces retrieved successfully",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Network interfaces retrieved successfully",
 		logger.Int("count", len(interfaces)))
 	return ctx.JSON(http.StatusOK, map[string]any{"interfaces": interfaces})
 }
 
 // GetRestartStatus handles GET /api/v2/system/restart-status
 func (c *Controller) GetRestartStatus(ctx echo.Context) error {
-	canRestart := c.getShutdownRequester() != nil
+	canRestart := c.GetShutdownRequester() != nil
 	status := RestartStatus{
 		BinaryRestartAvailable:    canRestart,
 		ContainerRestartAvailable: canRestart && sysinfo.IsContainer(),
@@ -383,21 +383,21 @@ func (c *Controller) GetRestartStatus(ctx echo.Context) error {
 
 // Initialize system routes
 func (c *Controller) initSystemRoutes() {
-	c.logInfoIfEnabled("Initializing system routes")
+	c.LogInfoIfEnabled("Initializing system routes")
 
 	// Start CPU usage monitoring in background with controller's context for controlled shutdown
 	// Go 1.25: Using WaitGroup.Go() for cleaner goroutine management
-	c.wg.Go(func() {
-		UpdateCPUCache(c.ctx)
+	c.Go(func() {
+		UpdateCPUCache(c.Context())
 	})
 
-	c.logInfoIfEnabled("Started CPU usage monitoring")
+	c.LogInfoIfEnabled("Started CPU usage monitoring")
 
 	// Create system API group
 	systemGroup := c.Group.Group("/system")
 
 	// Get the appropriate auth middleware
-	authMiddleware := c.authMiddleware
+	authMiddleware := c.AuthMiddleware
 
 	// Create auth-protected group using the appropriate middleware
 	protectedGroup := systemGroup.Group("", authMiddleware)
@@ -441,17 +441,17 @@ func (c *Controller) initSystemRoutes() {
 	// Initialize legacy cleanup routes
 	c.initLegacyCleanupRoutes()
 
-	c.logInfoIfEnabled("System routes initialized successfully")
+	c.LogInfoIfEnabled("System routes initialized successfully")
 }
 
 // GetSystemInfo handles GET /api/v2/system/info
 func (c *Controller) GetSystemInfo(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting system information", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Getting system information", logger.String("path", path), logger.String("ip", ip))
 
 	hostInfo, err := host.Info()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get host information", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Failed to get host information", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to get host information", http.StatusInternalServerError)
 	}
 
@@ -477,7 +477,7 @@ func (c *Controller) GetSystemInfo(ctx echo.Context) error {
 		Virtualization: envDetail,
 	}
 
-	c.logInfoIfEnabled("System information retrieved successfully", logger.String("os_display", info.OSDisplay), logger.String("arch", info.Architecture), logger.String("hostname", info.Hostname), logger.Any("uptime", info.UpTime), logger.Int64("app_uptime", info.AppUptime), logger.String("timezone", info.TimeZone), logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("System information retrieved successfully", logger.String("os_display", info.OSDisplay), logger.String("arch", info.Architecture), logger.String("hostname", info.Hostname), logger.Any("uptime", info.UpTime), logger.Int64("app_uptime", info.AppUptime), logger.String("timezone", info.TimeZone), logger.String("path", path), logger.String("ip", ip))
 
 	return ctx.JSON(http.StatusOK, info)
 }
@@ -486,7 +486,7 @@ func (c *Controller) GetSystemInfo(ctx echo.Context) error {
 func (c *Controller) getHostnameWithFallback(ip, path string) string {
 	hostname, err := os.Hostname()
 	if err != nil {
-		c.logWarnIfEnabled("Failed to get hostname, using 'unknown'", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogWarnIfEnabled("Failed to get hostname, using 'unknown'", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return ValueUnknown
 	}
 	return hostname
@@ -499,7 +499,7 @@ func (c *Controller) getSystemModelWithLogging(ip, path string) string {
 	}
 	systemModel := getSystemModelFromProc()
 	if systemModel == "" {
-		c.logDebugIfEnabled("Could not determine system model from /proc/cpuinfo", logger.String("path", path), logger.String("ip", ip))
+		c.LogDebugIfEnabled("Could not determine system model from /proc/cpuinfo", logger.String("path", path), logger.String("ip", ip))
 	}
 	return systemModel
 }
@@ -578,7 +578,7 @@ func getSystemModelFromProc() string {
 
 // GetResourceInfo handles GET /api/v2/system/resources
 func (c *Controller) GetResourceInfo(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting system resource information",
+	c.LogInfoIfEnabled("Getting system resource information",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -586,7 +586,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 	// Get memory statistics
 	memInfo, err := mem.VirtualMemory()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get memory information",
+		c.LogErrorIfEnabled("Failed to get memory information",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -597,7 +597,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 	// Get swap statistics
 	swapInfo, err := mem.SwapMemory()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get swap information",
+		c.LogErrorIfEnabled("Failed to get swap information",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -611,7 +611,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 	// Get process information (current process)
 	proc, err := process.NewProcess(int32(os.Getpid())) // #nosec G115 -- PID conversion safe, PIDs are within int32 range
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get process information",
+		c.LogErrorIfEnabled("Failed to get process information",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -622,7 +622,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 	procMem, err := proc.MemoryInfo()
 	if err != nil {
 		c.Debug("Failed to get process memory info: %v", err)
-		c.logWarnIfEnabled("Failed to get process memory info",
+		c.LogWarnIfEnabled("Failed to get process memory info",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -633,7 +633,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 	procCPU, err := proc.CPUPercent()
 	if err != nil {
 		c.Debug("Failed to get process CPU info: %v", err)
-		c.logWarnIfEnabled("Failed to get process CPU info",
+		c.LogWarnIfEnabled("Failed to get process CPU info",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -670,7 +670,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 		resourceInfo.CPUUsage = cpuPercent[0]
 	}
 
-	c.logInfoIfEnabled("System resource information retrieved successfully",
+	c.LogInfoIfEnabled("System resource information retrieved successfully",
 		logger.Float64("cpu_usage", resourceInfo.CPUUsage),
 		logger.Float64("memory_usage", resourceInfo.MemoryUsage),
 		logger.Float64("swap_usage", resourceInfo.SwapUsage),
@@ -685,18 +685,18 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 
 // GetDiskInfo handles GET /api/v2/system/disks
 func (c *Controller) GetDiskInfo(ctx echo.Context) error {
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting disk information")
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting disk information")
 
 	partitions, err := disk.Partitions(false)
 	if err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to get disk partitions",
+		c.LogAPIRequest(ctx, logger.LogLevelError, "Failed to get disk partitions",
 			logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to get disk partitions", http.StatusInternalServerError)
 	}
 
 	ioCounters, err := disk.IOCounters()
 	if err != nil {
-		c.logAPIRequest(ctx, logger.LogLevelWarn, "Failed to get IO counters, continuing without IO metrics",
+		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Failed to get IO counters, continuing without IO metrics",
 			logger.Error(err))
 	}
 	uptimeMs := c.getUptimeMs()
@@ -710,7 +710,7 @@ func (c *Controller) GetDiskInfo(ctx echo.Context) error {
 		disks = append(disks, diskInfo)
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Disk information retrieved successfully",
+	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Disk information retrieved successfully",
 		logger.Int("disk_count", len(disks)))
 	return ctx.JSON(http.StatusOK, disks)
 }
@@ -838,7 +838,7 @@ func isReadOnlyMount(opts []string) bool {
 
 // GetAudioDevices handles GET /api/v2/system/audio/devices
 func (c *Controller) GetAudioDevices(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting audio devices",
+	c.LogInfoIfEnabled("Getting audio devices",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -846,7 +846,7 @@ func (c *Controller) GetAudioDevices(ctx echo.Context) error {
 	// Get audio devices
 	devices, err := audiocore.ListCaptureDevices()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to list audio devices",
+		c.LogErrorIfEnabled("Failed to list audio devices",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -857,7 +857,7 @@ func (c *Controller) GetAudioDevices(ctx echo.Context) error {
 	// Check if no devices were found
 	if len(devices) == 0 {
 		c.Debug("No audio devices found on the system")
-		c.logWarnIfEnabled("No audio devices found on the system",
+		c.LogWarnIfEnabled("No audio devices found on the system",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 			logger.String("os", runtime.GOOS),
@@ -884,7 +884,7 @@ func (c *Controller) GetAudioDevices(ctx echo.Context) error {
 		deviceNames[i] = device.Name
 	}
 
-	c.logInfoIfEnabled("Audio devices retrieved successfully",
+	c.LogInfoIfEnabled("Audio devices retrieved successfully",
 		logger.Int("device_count", len(apiDevices)),
 		logger.String("devices", strings.Join(deviceNames, ", ")),
 		logger.String("path", ctx.Request().URL.Path),
@@ -902,25 +902,25 @@ func (c *Controller) GetDeviceCapabilities(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "deviceId query parameter is required", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Probing device capabilities",
+	c.LogInfoIfEnabled("Probing device capabilities",
 		logger.String("device_id", deviceID),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
-	caps, err := audiocore.ProbeDeviceCapabilities(deviceID, c.apiLogger)
+	caps, err := audiocore.ProbeDeviceCapabilities(deviceID, c.APILogger)
 	if err != nil {
 		if goerrors.Is(err, audiocore.ErrDeviceNotFound) {
 			return c.HandleError(ctx, err, "Device not found", http.StatusNotFound)
 		}
-		c.logErrorIfEnabled("Failed to probe device capabilities",
+		c.LogErrorIfEnabled("Failed to probe device capabilities",
 			logger.Error(err),
 			logger.String("device_id", deviceID),
 		)
 		return c.HandleError(ctx, err, "Failed to probe device capabilities", http.StatusInternalServerError)
 	}
 
-	c.logInfoIfEnabled("Device capabilities retrieved",
+	c.LogInfoIfEnabled("Device capabilities retrieved",
 		logger.String("device_id", caps.DeviceID),
 		logger.String("device_name", caps.DeviceName),
 		logger.Int("rate_count", len(caps.SampleRates)),
@@ -932,21 +932,21 @@ func (c *Controller) GetDeviceCapabilities(ctx echo.Context) error {
 
 // GetActiveAudioDevice handles GET /api/v2/system/audio/active
 func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting active audio device",
+	c.LogInfoIfEnabled("Getting active audio device",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	// Get active audio device from settings (first configured source)
 	var deviceName string
-	settings := c.currentSettings()
+	settings := c.CurrentSettings()
 	if settings != nil && len(settings.Realtime.Audio.Sources) > 0 {
 		deviceName = settings.Realtime.Audio.Sources[0].Device
 	}
 
 	// Check if no device is configured
 	if deviceName == "" {
-		c.logInfoIfEnabled("No audio device currently active",
+		c.LogInfoIfEnabled("No audio device currently active",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -994,7 +994,7 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 			diagnostics["note"] = "On Linux, check if PulseAudio/ALSA is running and the user has proper permissions"
 		}
 
-		c.logWarnIfEnabled("Failed to list audio devices for verification",
+		c.LogWarnIfEnabled("Failed to list audio devices for verification",
 			logger.String("device_name", deviceName),
 			logger.Error(err),
 			logger.String("os", runtime.GOOS),
@@ -1043,7 +1043,7 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 			diagnostics["suggestion"] = fmt.Sprintf("Consider using one of the available devices: %s", strings.Join(availableDevices, ", "))
 		}
 
-		c.logWarnIfEnabled("Configured audio device not found on system",
+		c.LogWarnIfEnabled("Configured audio device not found on system",
 			logger.String("configured_device", deviceName),
 			logger.String("available_devices", strings.Join(availableDevices, ", ")),
 			logger.String("os", runtime.GOOS),
@@ -1060,7 +1060,7 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 		})
 	}
 
-	c.logInfoIfEnabled("Active audio device verified",
+	c.LogInfoIfEnabled("Active audio device verified",
 		logger.String("device_name", deviceName),
 		logger.String("device_id", activeDevice.ID),
 		logger.Int("sample_rate", activeDevice.SampleRate),
@@ -1085,7 +1085,7 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 	name, err := p.Name()
 	if err != nil {
 		// Log error but continue, maybe process terminated?
-		c.logWarnIfEnabled("Failed to get process name", logger.Any("pid", p.Pid), logger.Error(err))
+		c.LogWarnIfEnabled("Failed to get process name", logger.Any("pid", p.Pid), logger.Error(err))
 		// Return an error to indicate this process couldn't be fully processed
 		return ProcessInfo{}, fmt.Errorf("failed to get process name for pid %d: %w", p.Pid, err)
 	}
@@ -1095,7 +1095,7 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 	switch {
 	case err != nil:
 		status = ValueUnknown
-		c.logWarnIfEnabled("Failed to get process status", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
+		c.LogWarnIfEnabled("Failed to get process status", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
 	case len(statusList) > 0:
 		// Use the first status code returned
 		status = mapProcessStatus(statusList[0])
@@ -1106,7 +1106,7 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 	cpuPercent, err := p.CPUPercent()
 	if err != nil {
 		// Log error but default to 0
-		c.logWarnIfEnabled("Failed to get process CPU percent", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
+		c.LogWarnIfEnabled("Failed to get process CPU percent", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
 		cpuPercent = 0.0
 	}
 
@@ -1114,7 +1114,7 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 	var memRSS uint64
 	if err != nil {
 		// Log error but default to 0
-		c.logWarnIfEnabled("Failed to get process memory info", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
+		c.LogWarnIfEnabled("Failed to get process memory info", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
 		memRSS = 0
 	} else {
 		memRSS = memInfo.RSS // Resident Set Size
@@ -1124,7 +1124,7 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 	var uptimeSeconds int64
 	if err != nil {
 		// Log error but default to 0
-		c.logWarnIfEnabled("Failed to get process create time", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
+		c.LogWarnIfEnabled("Failed to get process create time", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
 		uptimeSeconds = 0
 	} else {
 		// Calculate uptime relative to now
@@ -1171,19 +1171,19 @@ func mapProcessStatus(statusCode string) string {
 // By default, it shows only the main application process and its direct children.
 func (c *Controller) GetProcessInfo(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting process information", logger.String("path", path), logger.String("ip", ip), logger.String("query", ctx.QueryString()))
+	c.LogInfoIfEnabled("Getting process information", logger.String("path", path), logger.String("ip", ip), logger.String("query", ctx.QueryString()))
 
 	showAll := ctx.QueryParam("all") == "true"
 
 	procs, err := process.Processes()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to list processes", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Failed to list processes", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to list processes", http.StatusInternalServerError)
 	}
 
 	processInfos := c.collectProcessInfos(procs, showAll)
 
-	c.logInfoIfEnabled("Process information retrieved successfully", logger.Int("count", len(processInfos)), logger.Bool("filter_applied", !showAll), logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Process information retrieved successfully", logger.Int("count", len(processInfos)), logger.Bool("filter_applied", !showAll), logger.String("path", path), logger.String("ip", ip))
 
 	return ctx.JSON(http.StatusOK, processInfos)
 }
@@ -1200,7 +1200,7 @@ func (c *Controller) collectProcessInfos(procs []*process.Process, showAll bool)
 
 		info, err := c.getSingleProcessInfo(p)
 		if err != nil {
-			c.logWarnIfEnabled("Skipping process due to error retrieving details", logger.Any("pid", p.Pid), logger.Error(err))
+			c.LogWarnIfEnabled("Skipping process due to error retrieving details", logger.Any("pid", p.Pid), logger.Error(err))
 			continue
 		}
 
@@ -1214,7 +1214,7 @@ func (c *Controller) collectProcessInfos(procs []*process.Process, showAll bool)
 func (c *Controller) isRelevantProcess(p *process.Process, currentPID int32) bool {
 	parentPID, err := p.Ppid()
 	if err != nil {
-		c.logWarnIfEnabled("Failed to get parent PID, skipping process", logger.Any("pid", p.Pid), logger.Error(err))
+		c.LogWarnIfEnabled("Failed to get parent PID, skipping process", logger.Any("pid", p.Pid), logger.Error(err))
 		return false
 	}
 	return p.Pid == currentPID || parentPID == currentPID
@@ -1230,7 +1230,7 @@ func (c *Controller) checkThermalZone(zonePath string, targetTypes map[string]bo
 	typeData, err := os.ReadFile(typePath)
 	if err != nil {
 		// Not a critical error for the overall request, just skip this zone.
-		c.logDebugIfEnabled("Failed to read type file for zone", logger.String("zone", zoneName), logger.String("type_path", typePath), logger.Error(err))
+		c.LogDebugIfEnabled("Failed to read type file for zone", logger.String("zone", zoneName), logger.String("type_path", typePath), logger.Error(err))
 		return 0, fmt.Sprintf("Failed to read type for %s", zoneName), false, nil
 	}
 
@@ -1247,7 +1247,7 @@ func (c *Controller) checkThermalZone(zonePath string, targetTypes map[string]bo
 	tempData, err := os.ReadFile(tempFilePath)
 	if err != nil {
 		details = fmt.Sprintf("Error reading temp from %s (type: %s)", zoneName, sensorType)
-		c.logWarnIfEnabled(details, logger.String("temp_path", tempFilePath), logger.Error(err))
+		c.LogWarnIfEnabled(details, logger.String("temp_path", tempFilePath), logger.Error(err))
 		return 0, details, false, nil // Error reading temp, but might find another valid zone.
 	}
 
@@ -1255,7 +1255,7 @@ func (c *Controller) checkThermalZone(zonePath string, targetTypes map[string]bo
 	tempMillCelsius, err := strconv.Atoi(tempStr)
 	if err != nil {
 		details = fmt.Sprintf("Error parsing temp from %s (type: %s, value: '%s')", zoneName, sensorType, tempStr)
-		c.logWarnIfEnabled(details, logger.Error(err))
+		c.LogWarnIfEnabled(details, logger.Error(err))
 		return 0, details, false, nil // Error parsing temp.
 	}
 
@@ -1264,7 +1264,7 @@ func (c *Controller) checkThermalZone(zonePath string, targetTypes map[string]bo
 	// Validate temperature range (0 to 100 °C inclusive)
 	if celsius < 0.0 || celsius > 100.0 {
 		details = fmt.Sprintf("Invalid temp from %s (type: %s, value: %.1f°C, expected 0-100°C)", zoneName, sensorType, celsius)
-		c.logWarnIfEnabled("Temperature reading out of valid range", logger.String("details", details))
+		c.LogWarnIfEnabled("Temperature reading out of valid range", logger.String("details", details))
 		return 0, details, false, nil // Temp out of range.
 	}
 
@@ -1294,7 +1294,7 @@ var cpuThermalTypes = map[string]bool{
 
 func (c *Controller) GetSystemCPUTemperature(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting system CPU temperature", logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Getting system CPU temperature", logger.String("path", path), logger.String("ip", ip))
 
 	response := SystemTemperature{
 		IsAvailable: false,
@@ -1317,7 +1317,7 @@ func (c *Controller) GetSystemCPUTemperature(ctx echo.Context) error {
 	}
 	if len(zones) == 0 {
 		response.Message = "No thermal zones found. This feature is typically available on Linux systems."
-		c.logInfoIfEnabled("No thermal zones found via Glob.", logger.String("pattern", filepath.Join(thermalBasePath, "thermal_zone*")), logger.String("os", runtime.GOOS), logger.String("request_path", path), logger.String("ip", ip))
+		c.LogInfoIfEnabled("No thermal zones found via Glob.", logger.String("pattern", filepath.Join(thermalBasePath, "thermal_zone*")), logger.String("os", runtime.GOOS), logger.String("request_path", path), logger.String("ip", ip))
 		return ctx.JSON(http.StatusOK, response)
 	}
 
@@ -1338,11 +1338,11 @@ func (c *Controller) checkThermalDirectoryAccess(response *SystemTemperature, ip
 
 	if errors.Is(err, os.ErrNotExist) {
 		response.Message = "Thermal zone directory not found. This feature is typically available on Linux systems."
-		c.logDebugIfEnabled("Thermal zone directory not found, CPU temperature feature unavailable.", logger.String("path", thermalBasePath), logger.String("os", runtime.GOOS), logger.String("request_path", path), logger.String("ip", ip))
+		c.LogDebugIfEnabled("Thermal zone directory not found, CPU temperature feature unavailable.", logger.String("path", thermalBasePath), logger.String("os", runtime.GOOS), logger.String("request_path", path), logger.String("ip", ip))
 		return false, nil
 	}
 
-	c.logErrorIfEnabled("Failed to stat thermal base path", logger.String("path", thermalBasePath), logger.Error(err), logger.String("request_path", path), logger.String("ip", ip))
+	c.LogErrorIfEnabled("Failed to stat thermal base path", logger.String("path", thermalBasePath), logger.Error(err), logger.String("request_path", path), logger.String("ip", ip))
 	return false, fmt.Errorf("failed to access thermal information: %w", err)
 }
 
@@ -1350,7 +1350,7 @@ func (c *Controller) checkThermalDirectoryAccess(response *SystemTemperature, ip
 func (c *Controller) getThermalZones(ctx echo.Context, ip, path string) ([]string, error) {
 	zones, err := filepath.Glob(filepath.Join(thermalBasePath, "thermal_zone*"))
 	if err != nil {
-		c.logErrorIfEnabled("Failed to glob for thermal zones", logger.String("base_path", thermalBasePath), logger.Error(err), logger.String("request_path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Failed to glob for thermal zones", logger.String("base_path", thermalBasePath), logger.Error(err), logger.String("request_path", path), logger.String("ip", ip))
 		return nil, c.HandleError(ctx, err, "Error scanning for thermal zones", http.StatusInternalServerError)
 	}
 	return zones, nil
@@ -1363,7 +1363,7 @@ func (c *Controller) findValidThermalZone(zones []string, response *SystemTemper
 	for _, zonePath := range zones {
 		celsius, details, isValid, err := c.checkThermalZone(zonePath, cpuThermalTypes)
 		if err != nil {
-			c.logErrorIfEnabled("Unexpected error checking thermal zone", logger.String("zone", zonePath), logger.Error(err))
+			c.LogErrorIfEnabled("Unexpected error checking thermal zone", logger.String("zone", zonePath), logger.Error(err))
 			continue
 		}
 
@@ -1372,7 +1372,7 @@ func (c *Controller) findValidThermalZone(zones []string, response *SystemTemper
 			response.IsAvailable = true
 			response.SensorDetails = details
 			response.Message = "CPU temperature retrieved successfully."
-			c.logInfoIfEnabled("CPU temperature retrieved successfully", logger.Float64("temperature_celsius", response.Celsius), logger.String("sensor_details", response.SensorDetails), logger.String("request_path", path), logger.String("ip", ip))
+			c.LogInfoIfEnabled("CPU temperature retrieved successfully", logger.Float64("temperature_celsius", response.Celsius), logger.String("sensor_details", response.SensorDetails), logger.String("request_path", path), logger.String("ip", ip))
 			return
 		}
 
@@ -1394,7 +1394,7 @@ func (c *Controller) setTemperatureNotFoundResponse(response *SystemTemperature,
 		response.Message = "No targeted CPU temperature sensor types (e.g., cpu-thermal, x86_pkg_temp) found or readable in available thermal zones."
 	}
 
-	c.logInfoIfEnabled("Could not retrieve a valid CPU temperature after checking all zones.", logger.String("final_message", response.Message), logger.String("sensor_details_attempted", response.SensorDetails), logger.String("request_path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Could not retrieve a valid CPU temperature after checking all zones.", logger.String("final_message", response.Message), logger.String("sensor_details_attempted", response.SensorDetails), logger.String("request_path", path), logger.String("ip", ip))
 }
 
 // Helper functions
@@ -1473,7 +1473,7 @@ func skipFilesystem(fstype string) bool {
 
 // GetEqualizerConfig handles GET /api/v2/system/audio/equalizer/config
 func (c *Controller) GetEqualizerConfig(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting equalizer filter configuration",
+	c.LogInfoIfEnabled("Getting equalizer filter configuration",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -1490,14 +1490,14 @@ func (c *Controller) GetEqualizerConfig(ctx echo.Context) error {
 // for the active store (legacy SQLite/MySQL or v2only.Datastore).
 func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting database statistics",
+	c.LogInfoIfEnabled("Getting database statistics",
 		logger.String("path", path),
 		logger.String("ip", ip),
 	)
 
 	ds := c.DS
 	if ds == nil {
-		c.logErrorIfEnabled("Datastore not available",
+		c.LogErrorIfEnabled("Datastore not available",
 			logger.String("path", path),
 			logger.String("ip", ip),
 		)
@@ -1511,7 +1511,7 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 	if err != nil {
 		// If the database is not connected, log as warning and return partial stats with 200 OK
 		if errors.Is(err, datastore.ErrDBNotConnected) {
-			c.logWarnIfEnabled("Database not connected, returning partial stats",
+			c.LogWarnIfEnabled("Database not connected, returning partial stats",
 				logger.Error(err),
 				logger.String("path", path),
 				logger.String("ip", ip),
@@ -1519,7 +1519,7 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 			isPartialStats = true
 			// Continue to return partial stats below
 		} else {
-			c.logErrorIfEnabled("Failed to get database stats",
+			c.LogErrorIfEnabled("Failed to get database stats",
 				logger.Error(err),
 				logger.String("path", path),
 				logger.String("ip", ip),
@@ -1530,7 +1530,7 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 
 	// Guard against nil stats (defensive - future implementations might return nil)
 	if stats == nil {
-		c.logErrorIfEnabled("GetDatabaseStats returned nil stats",
+		c.LogErrorIfEnabled("GetDatabaseStats returned nil stats",
 			logger.String("path", path),
 			logger.String("ip", ip),
 		)
@@ -1539,14 +1539,14 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 
 	// Log with appropriate message based on whether stats are partial or complete
 	if isPartialStats {
-		c.logInfoIfEnabled("Database statistics retrieved (partial)",
+		c.LogInfoIfEnabled("Database statistics retrieved (partial)",
 			logger.String("type", stats.Type),
 			logger.Bool("connected", stats.Connected),
 			logger.String("path", path),
 			logger.String("ip", ip),
 		)
 	} else {
-		c.logInfoIfEnabled("Database statistics retrieved successfully",
+		c.LogInfoIfEnabled("Database statistics retrieved successfully",
 			logger.String("type", stats.Type),
 			logger.Any("size_bytes", stats.SizeBytes),
 			logger.Any("total_detections", stats.TotalDetections),
@@ -1584,7 +1584,7 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 
 	if !mgr.IsMySQL() {
 		if err := db.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&stats.SizeBytes).Error; err != nil {
-			c.logWarnIfEnabled("Failed to get v2 SQLite database size", logger.Error(err))
+			c.LogWarnIfEnabled("Failed to get v2 SQLite database size", logger.Error(err))
 		}
 	} else {
 		prefix := mgr.TablePrefix()
@@ -1596,7 +1596,7 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 				FROM information_schema.TABLES
 				WHERE table_schema = DATABASE() AND table_name LIKE ?
 			`, escaped+"%").Scan(&stats.SizeBytes).Error; err != nil {
-				c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
+				c.LogWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
 			}
 		} else {
 			if err := db.WithContext(ctx).Raw(`
@@ -1604,14 +1604,14 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 				FROM information_schema.TABLES
 				WHERE table_schema = DATABASE()
 			`).Scan(&stats.SizeBytes).Error; err != nil {
-				c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
+				c.LogWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
 			}
 		}
 	}
 
 	var count int64
 	if err := db.WithContext(ctx).Table(mgr.TablePrefix() + "detections").Count(&count).Error; err != nil {
-		c.logWarnIfEnabled("Failed to count v2 detections", logger.Error(err))
+		c.LogWarnIfEnabled("Failed to count v2 detections", logger.Error(err))
 	} else {
 		stats.TotalDetections = count
 	}
@@ -1622,7 +1622,7 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 // GetV2DatabaseStats handles GET /api/v2/system/database/v2/stats
 func (c *Controller) GetV2DatabaseStats(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
-	c.logInfoIfEnabled("Getting v2 database statistics",
+	c.LogInfoIfEnabled("Getting v2 database statistics",
 		logger.String("path", path), logger.String("ip", ip))
 
 	stats, ok := c.getV2ManagerStats(ctx.Request().Context())
@@ -1651,7 +1651,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	ip, reqPath := ctx.RealIP(), ctx.Request().URL.Path
 	dbType := ctx.QueryParam("type")
 
-	c.logInfoIfEnabled("Database backup requested",
+	c.LogInfoIfEnabled("Database backup requested",
 		logger.String("db_type", dbType),
 		logger.String("path", reqPath), logger.String("ip", ip))
 
@@ -1667,7 +1667,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 
 	if dbType == dbTypeLegacy {
 		// Check if it's SQLite
-		settings := c.currentSettings()
+		settings := c.CurrentSettings()
 		if settings == nil || settings.Output.SQLite.Path == "" {
 			return c.HandleError(ctx, fmt.Errorf("not sqlite"),
 				"Backup download only available for SQLite databases. Use MySQL tools for MySQL backup.",
@@ -1716,7 +1716,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	}
 	dbSize := fileInfo.Size()
 
-	c.logInfoIfEnabled("Database backup: source database info",
+	c.LogInfoIfEnabled("Database backup: source database info",
 		logger.String("db_type", dbType),
 		logger.String("db_path", dbPath),
 		// #nosec G115 -- dbSize from os.FileInfo.Size() is always non-negative
@@ -1738,7 +1738,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 			http.StatusInsufficientStorage) // HTTP 507
 	}
 
-	c.logInfoIfEnabled("Database backup: disk space check passed",
+	c.LogInfoIfEnabled("Database backup: disk space check passed",
 		logger.String("temp_dir", tempDir),
 		logger.String("free_space", formatBytesUint64(usage.Free)),
 		logger.String("required_space", formatBytesUint64(requiredSpace)))
@@ -1769,7 +1769,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		flusher.Flush()
 	}
 
-	c.logInfoIfEnabled("Database backup: headers sent, starting VACUUM INTO",
+	c.LogInfoIfEnabled("Database backup: headers sent, starting VACUUM INTO",
 		logger.String("db_type", dbType),
 		logger.String("temp_path", tempPath))
 
@@ -1783,7 +1783,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	vacuumDuration := time.Since(vacuumStart)
 
 	if vacuumErr != nil {
-		c.logWarnIfEnabled("Database backup: VACUUM INTO failed",
+		c.LogWarnIfEnabled("Database backup: VACUUM INTO failed",
 			logger.String("db_type", dbType),
 			logger.Duration("duration", vacuumDuration),
 			logger.Error(vacuumErr))
@@ -1794,10 +1794,10 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	// Ensure cleanup of temp file after response is sent
 	defer func() {
 		if err := os.Remove(tempPath); err != nil && !os.IsNotExist(err) {
-			c.logWarnIfEnabled("Failed to cleanup backup temp file",
+			c.LogWarnIfEnabled("Failed to cleanup backup temp file",
 				logger.String("path", tempPath), logger.Error(err))
 		} else {
-			c.logInfoIfEnabled("Database backup: temp file cleaned up",
+			c.LogInfoIfEnabled("Database backup: temp file cleaned up",
 				logger.String("path", tempPath))
 		}
 	}()
@@ -1812,7 +1812,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		backupSize = formatBytesUint64(uint64(backupSizeBytes))
 	}
 
-	c.logInfoIfEnabled("Database backup: VACUUM INTO completed, streaming file",
+	c.LogInfoIfEnabled("Database backup: VACUUM INTO completed, streaming file",
 		logger.String("db_type", dbType),
 		logger.Duration("vacuum_duration", vacuumDuration),
 		logger.String("backup_size", backupSize))
@@ -1821,14 +1821,14 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	//#nosec G304 -- tempPath is constructed from trusted sources (os.TempDir + controlled filename)
 	backupFile, err := os.Open(tempPath)
 	if err != nil {
-		c.logWarnIfEnabled("Database backup: failed to open backup file",
+		c.LogWarnIfEnabled("Database backup: failed to open backup file",
 			logger.String("path", tempPath),
 			logger.Error(err))
 		return err
 	}
 	defer func() {
 		if err := backupFile.Close(); err != nil {
-			c.logWarnIfEnabled("Database backup: failed to close backup file", logger.Error(err))
+			c.LogWarnIfEnabled("Database backup: failed to close backup file", logger.Error(err))
 		}
 	}()
 
@@ -1837,7 +1837,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 
 	totalDuration := time.Since(backupStart)
 	if copyErr != nil {
-		c.logWarnIfEnabled("Database backup: file transfer failed",
+		c.LogWarnIfEnabled("Database backup: file transfer failed",
 			logger.String("db_type", dbType),
 			logger.String("filename", filename),
 			logger.Int64("bytes_written", written),
@@ -1846,7 +1846,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		return copyErr
 	}
 
-	c.logInfoIfEnabled("Database backup: completed successfully",
+	c.LogInfoIfEnabled("Database backup: completed successfully",
 		logger.String("db_type", dbType),
 		logger.String("filename", filename),
 		logger.String("backup_size", backupSize),

--- a/internal/api/v2/system_test.go
+++ b/internal/api/v2/system_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/restart"
 )
@@ -31,10 +32,7 @@ func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
 		},
 	}
 
-	controller := &Controller{
-		Echo:  e,
-		Group: e.Group("/api/v2"),
-	}
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(settings)
 
 	return e, controller
@@ -583,10 +581,7 @@ func TestGetActiveAudioDevice(t *testing.T) {
 				},
 			},
 		}
-		controller := &Controller{
-			Echo:  e,
-			Group: e.Group("/api/v2"),
-		}
+		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 		controller.Settings.Store(settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)

--- a/internal/api/v2/telemetry_test.go
+++ b/internal/api/v2/telemetry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
@@ -42,7 +43,7 @@ func newTestContext(t *testing.T, method, path string) (echo.Context, *httptest.
 func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
 
@@ -64,7 +65,7 @@ func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodPost, "/api/v2/settings")
 
@@ -80,7 +81,7 @@ func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
 func TestHandleError_NilError_5xxReported(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/health")
 
@@ -100,7 +101,7 @@ func TestHandleError_NilError_5xxReported(t *testing.T) {
 func TestHandleErrorWithKey_5xxReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodDelete, "/api/v2/detections/123")
 
@@ -133,7 +134,7 @@ func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
 	// Now install the hook (after pre-reporting, so the Build() call above is not counted).
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
 
@@ -149,7 +150,7 @@ func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
 func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections/99999")
 
@@ -165,7 +166,7 @@ func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
 func TestHandleError_502BadGatewayReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(getTestSettings(t))
 	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/system")
 

--- a/internal/api/v2/terminal.go
+++ b/internal/api/v2/terminal.go
@@ -53,13 +53,13 @@ var terminalUpgrader = websocket.Upgrader{
 
 // initTerminalRoutes registers the terminal WebSocket endpoint.
 func (c *Controller) initTerminalRoutes() {
-	c.logInfoIfEnabled("Initializing terminal routes")
+	c.LogInfoIfEnabled("Initializing terminal routes")
 
 	terminalGroup := c.Group.Group("/terminal")
-	protectedGroup := terminalGroup.Group("", c.authMiddleware)
+	protectedGroup := terminalGroup.Group("", c.AuthMiddleware)
 	protectedGroup.GET("/ws", c.HandleTerminalWS)
 
-	c.logInfoIfEnabled("Terminal routes initialized successfully")
+	c.LogInfoIfEnabled("Terminal routes initialized successfully")
 }
 
 // HandleTerminalWS handles WebSocket connections for the browser terminal.
@@ -72,7 +72,7 @@ func (c *Controller) HandleTerminalWS(ctx echo.Context) error {
 
 	conn, err := terminalUpgrader.Upgrade(ctx.Response(), ctx.Request(), nil)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to upgrade terminal WebSocket", logger.Error(err))
+		c.LogErrorIfEnabled("Failed to upgrade terminal WebSocket", logger.Error(err))
 		return err
 	}
 	defer func() { _ = conn.Close() }()
@@ -80,9 +80,9 @@ func (c *Controller) HandleTerminalWS(ctx echo.Context) error {
 	conn.SetReadLimit(terminalMaxMsgSize)
 
 	// startPTY is platform-specific (terminal_unix.go / terminal_windows.go).
-	ph, cleanup, err := startPTY(c.ctx)
+	ph, cleanup, err := startPTY(c.Context())
 	if err != nil {
-		c.logErrorIfEnabled("Failed to start terminal PTY", logger.Error(err))
+		c.LogErrorIfEnabled("Failed to start terminal PTY", logger.Error(err))
 		_ = conn.WriteMessage(websocket.TextMessage, []byte("\r\nFailed to start shell: "+err.Error()+"\r\n"))
 		// The WebSocket connection is already hijacked; return nil to avoid
 		// Echo's error handler writing an HTTP response to a hijacked conn.
@@ -136,7 +136,7 @@ func (c *Controller) HandleTerminalWS(ctx echo.Context) error {
 				if err != nil {
 					return
 				}
-			case <-c.ctx.Done():
+			case <-c.Context().Done():
 				return
 			}
 		}

--- a/internal/api/v2/test_helpers_test.go
+++ b/internal/api/v2/test_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/httpclient"
 )
@@ -35,11 +36,7 @@ const (
 // Note: DisableHTTPKeepAlivesForTesting() is called in TestMain before any tests run
 func getTestController(t *testing.T, e *echo.Echo) *Controller {
 	t.Helper()
-	c := &Controller{
-		Echo:                e,
-		controlChan:         make(chan string, testControlChanBuffer),
-		DisableSaveSettings: true, // Disable saving to disk during tests
-	}
+	c := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
 	c.Settings.Store(getTestSettings(t))
 	return c
 }

--- a/internal/api/v2/test_utils_test.go
+++ b/internal/api/v2/test_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -29,7 +30,7 @@ const (
 // Use this for tests that only need to call handler methods without database or full infrastructure.
 // Includes default settings to prevent nil pointer panics if a handler accesses c.Settings.
 func newMinimalController() *Controller {
-	c := &Controller{}
+	c := &Controller{Core: &apicore.Core{}}
 	c.Settings.Store(newValidTestSettings())
 	return c
 }
@@ -91,10 +92,7 @@ func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterfa
 
 	// Create a controller with the test datastore and default settings
 	// to prevent nil pointer panics if a handler accesses c.Settings.
-	controller := &Controller{
-		Group: e.Group(apiV2Prefix),
-		DS:    mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{Group: e.Group(apiV2Prefix), DS: mockDS}}
 	controller.Settings.Store(newValidTestSettings())
 
 	// Don't initialize routes as it causes nil pointer dereference in tests

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -56,16 +56,16 @@ type TLSGenerateRequest struct {
 
 // initTLSRoutes registers TLS certificate management endpoints.
 func (c *Controller) initTLSRoutes() {
-	c.logInfoIfEnabled("Initializing TLS routes")
+	c.LogInfoIfEnabled("Initializing TLS routes")
 
-	tlsGroup := c.Group.Group("/tls", c.authMiddleware)
+	tlsGroup := c.Group.Group("/tls", c.AuthMiddleware)
 	tlsGroup.GET("/certificate", c.GetTLSCertificate)
 	tlsGroup.POST("/certificate", c.UploadTLSCertificate)
 	tlsGroup.DELETE("/certificate", c.DeleteTLSCertificate)
 	tlsGroup.POST("/certificate/generate", c.GenerateSelfSignedCertificate)
 	tlsGroup.GET("/certificate/download", c.DownloadTLSCertificate)
 
-	c.logInfoIfEnabled("TLS routes initialized successfully")
+	c.LogInfoIfEnabled("TLS routes initialized successfully")
 }
 
 // GetTLSCertificate handles GET /api/v2/tls/certificate.
@@ -84,7 +84,7 @@ func (c *Controller) GetTLSCertificate(ctx echo.Context) error {
 
 	// Include current TLS mode from settings (skip when no snapshot is stored,
 	// e.g. a standalone/test controller; controllerSettings() may then be nil).
-	if settings := c.controllerSettings(); settings != nil {
+	if settings := c.ControllerSettings(); settings != nil {
 		info.Mode = string(settings.Security.TLSMode)
 	}
 

--- a/internal/api/v2/tls.go
+++ b/internal/api/v2/tls.go
@@ -83,7 +83,7 @@ func (c *Controller) GetTLSCertificate(ctx echo.Context) error {
 	}
 
 	// Include current TLS mode from settings (skip when no snapshot is stored,
-	// e.g. a standalone/test controller; controllerSettings() may then be nil).
+	// e.g. a standalone/test controller; ControllerSettings() may then be nil).
 	if settings := c.ControllerSettings(); settings != nil {
 		info.Mode = string(settings.Security.TLSMode)
 	}

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -187,7 +187,7 @@ func NormalizeClipPath(p, clipsPrefix string) string {
 func (c *Controller) requireQueryParam(ctx echo.Context, paramName, operation string) error {
 	value := ctx.QueryParam(paramName)
 	if value == "" {
-		c.logErrorIfEnabled("Missing required parameter",
+		c.LogErrorIfEnabled("Missing required parameter",
 			logger.String("parameter", paramName),
 			logger.String("operation", operation),
 			logger.String("ip", ctx.RealIP()),
@@ -204,7 +204,7 @@ func (c *Controller) requireQueryParam(ctx echo.Context, paramName, operation st
 func (c *Controller) requireQueryArrayParam(ctx echo.Context, paramName, operation string) error {
 	values := ctx.QueryParams()[paramName]
 	if len(values) == 0 {
-		c.logErrorIfEnabled("Missing required parameter",
+		c.LogErrorIfEnabled("Missing required parameter",
 			logger.String("parameter", paramName),
 			logger.String("operation", operation),
 			logger.String("ip", ctx.RealIP()),
@@ -220,7 +220,7 @@ func (c *Controller) requireQueryArrayParam(ctx echo.Context, paramName, operati
 // Returns ErrResponseHandled after sending error response, or nil if valid.
 func (c *Controller) validateBatchSize(ctx echo.Context, count, maxSize int, operation string) error {
 	if count > maxSize {
-		c.logErrorIfEnabled("Batch size exceeded limit",
+		c.LogErrorIfEnabled("Batch size exceeded limit",
 			logger.Int("requested", count),
 			logger.Int("max", maxSize),
 			logger.String("operation", operation),
@@ -240,7 +240,7 @@ func (c *Controller) validateDateFormatWithResponse(ctx echo.Context, dateStr, p
 		return nil // Empty is valid (optional parameter)
 	}
 	if _, err := time.Parse(time.DateOnly, dateStr); err != nil {
-		c.logErrorIfEnabled("Invalid date format",
+		c.LogErrorIfEnabled("Invalid date format",
 			logger.String("parameter", paramName),
 			logger.String("value", dateStr),
 			logger.String("operation", operation),
@@ -261,7 +261,7 @@ func (c *Controller) validateDateFormatStrictWithResponse(ctx echo.Context, date
 		return nil // Empty is valid (optional parameter)
 	}
 	if !dateRegex.MatchString(dateStr) {
-		c.logErrorIfEnabled("Invalid date format",
+		c.LogErrorIfEnabled("Invalid date format",
 			logger.String("parameter", paramName),
 			logger.String("value", dateStr),
 			logger.String("operation", operation),
@@ -283,7 +283,7 @@ func (c *Controller) parseOptionalPositiveInt(ctx echo.Context, paramName string
 	}
 	val, err := strconv.Atoi(str)
 	if err != nil || val <= 0 {
-		c.logWarnIfEnabled("Invalid parameter, using default",
+		c.LogWarnIfEnabled("Invalid parameter, using default",
 			logger.String("parameter", paramName),
 			logger.String("value", str),
 			logger.Int("default", defaultVal),
@@ -304,7 +304,7 @@ func (c *Controller) parseOptionalFloat(ctx echo.Context, paramName string, defa
 	}
 	val, err := strconv.ParseFloat(str, 64)
 	if err != nil {
-		c.logWarnIfEnabled("Invalid parameter, using default",
+		c.LogWarnIfEnabled("Invalid parameter, using default",
 			logger.String("parameter", paramName),
 			logger.String("value", str),
 			logger.Float64("default", defaultVal),
@@ -439,7 +439,7 @@ func (c *Controller) validateDateOrderWithResponse(ctx echo.Context, startDate, 
 	start, _ := time.Parse(time.DateOnly, startDate)
 	end, _ := time.Parse(time.DateOnly, endDate)
 	if start.After(end) {
-		c.logErrorIfEnabled("Invalid date range",
+		c.LogErrorIfEnabled("Invalid date range",
 			logger.String("start_date", startDate),
 			logger.String("end_date", endDate),
 			logger.String("error", "start_date cannot be after end_date"),
@@ -710,29 +710,29 @@ func parseDateRangeFilter(singleDate, startDate, endDate string) *DateRangeResul
 
 // recordSSEError records an SSE error metric if metrics are available
 func (c *Controller) recordSSEError(endpoint, errorType string) {
-	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.RecordSSEError(endpoint, errorType)
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.RecordSSEError(endpoint, errorType)
 	}
 }
 
 // recordSSEMessage records an SSE message sent metric if metrics are available
 func (c *Controller) recordSSEMessage(endpoint, messageType string) {
-	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.RecordSSEMessageSent(endpoint, messageType)
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.RecordSSEMessageSent(endpoint, messageType)
 	}
 }
 
 // recordSSEConnectionStart records an SSE connection start if metrics are available
 func (c *Controller) recordSSEConnectionStart(endpoint string) {
-	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.SSEConnectionStarted(endpoint)
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.SSEConnectionStarted(endpoint)
 	}
 }
 
 // recordSSEConnectionClose records an SSE connection close if metrics are available
 func (c *Controller) recordSSEConnectionClose(endpoint string, duration float64, reason string) {
-	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.SSEConnectionClosed(endpoint, duration, reason)
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.SSEConnectionClosed(endpoint, duration, reason)
 	}
 }
 
@@ -845,67 +845,6 @@ func (c *Controller) log() logger.Logger {
 	return GetLogger()
 }
 
-// logInfoIfEnabled logs info message if apiLogger is enabled
-func (c *Controller) logInfoIfEnabled(msg string, fields ...logger.Field) {
-	if c.apiLogger != nil {
-		c.apiLogger.Info(msg, fields...)
-	}
-}
-
-// logErrorIfEnabled logs error message if apiLogger is enabled
-func (c *Controller) logErrorIfEnabled(msg string, fields ...logger.Field) {
-	if c.apiLogger != nil {
-		c.apiLogger.Error(msg, fields...)
-	}
-}
-
-// logWarnIfEnabled logs warning message if apiLogger is enabled
-func (c *Controller) logWarnIfEnabled(msg string, fields ...logger.Field) {
-	if c.apiLogger != nil {
-		c.apiLogger.Warn(msg, fields...)
-	}
-}
-
-// logDebugIfEnabled logs debug message if apiLogger is enabled
-func (c *Controller) logDebugIfEnabled(msg string, fields ...logger.Field) {
-	if c.apiLogger != nil {
-		c.apiLogger.Debug(msg, fields...)
-	}
-}
-
-// The logSecurity* helpers mirror the api-module helpers above but write to the
-// "security" module logger, so authentication events (form login/logout, OAuth
-// callback) are co-located with the OAuth and provider-init logging where
-// admins look when debugging auth.
-
-// logSecurityInfoIfEnabled logs an info message to the security module if enabled.
-func (c *Controller) logSecurityInfoIfEnabled(msg string, fields ...logger.Field) {
-	if c.securityLogger != nil {
-		c.securityLogger.Info(msg, fields...)
-	}
-}
-
-// logSecurityWarnIfEnabled logs a warning message to the security module if enabled.
-func (c *Controller) logSecurityWarnIfEnabled(msg string, fields ...logger.Field) {
-	if c.securityLogger != nil {
-		c.securityLogger.Warn(msg, fields...)
-	}
-}
-
-// logSecurityErrorIfEnabled logs an error message to the security module if enabled.
-func (c *Controller) logSecurityErrorIfEnabled(msg string, fields ...logger.Field) {
-	if c.securityLogger != nil {
-		c.securityLogger.Error(msg, fields...)
-	}
-}
-
-// logSecurityDebugIfEnabled logs a debug message to the security module if enabled.
-func (c *Controller) logSecurityDebugIfEnabled(msg string, fields ...logger.Field) {
-	if c.securityLogger != nil {
-		c.securityLogger.Debug(msg, fields...)
-	}
-}
-
 // =============================================================================
 // Batch Response Helpers
 // =============================================================================
@@ -915,7 +854,7 @@ func (c *Controller) logSecurityDebugIfEnabled(msg string, fields ...logger.Fiel
 func (c *Controller) handleBatchResponse(ctx echo.Context, result any, successCount, requestedCount int, processingErrors []string, operationName, ip, urlPath string) error {
 	// Log partial failures if any
 	if len(processingErrors) > 0 && successCount > 0 {
-		c.logWarnIfEnabled(operationName+" completed with partial failures",
+		c.LogWarnIfEnabled(operationName+" completed with partial failures",
 			logger.Int("successful", successCount),
 			logger.Int("failed", len(processingErrors)),
 			logger.Any("errors", processingErrors),
@@ -925,7 +864,7 @@ func (c *Controller) handleBatchResponse(ctx echo.Context, result any, successCo
 
 	// Return error if all items failed
 	if successCount == 0 {
-		c.logErrorIfEnabled("All items in "+operationName+" failed",
+		c.LogErrorIfEnabled("All items in "+operationName+" failed",
 			logger.Int("requested", requestedCount),
 			logger.Any("errors", processingErrors),
 			logger.String("ip", ip),
@@ -935,7 +874,7 @@ func (c *Controller) handleBatchResponse(ctx echo.Context, result any, successCo
 	}
 
 	// Log successful completion
-	c.logInfoIfEnabled(operationName+" completed",
+	c.LogInfoIfEnabled(operationName+" completed",
 		logger.Int("requested", requestedCount),
 		logger.Int("successful", successCount),
 		logger.Int("failed", len(processingErrors)),

--- a/internal/api/v2/weather.go
+++ b/internal/api/v2/weather.go
@@ -115,14 +115,14 @@ func (c *Controller) buildDailyWeatherResponse(dailyEvents *datastore.DailyEvent
 func (c *Controller) GetDailyWeather(ctx echo.Context) error {
 	date := ctx.Param("date")
 	if date == "" {
-		c.logErrorIfEnabled("Missing date parameter in daily weather request",
+		c.LogErrorIfEnabled("Missing date parameter in daily weather request",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
 		return c.HandleError(ctx, echo.NewHTTPError(http.StatusBadRequest), "Date parameter is required", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Getting daily weather",
+	c.LogInfoIfEnabled("Getting daily weather",
 		logger.String("date", date),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -131,7 +131,7 @@ func (c *Controller) GetDailyWeather(ctx echo.Context) error {
 	// Get daily weather data from datastore
 	dailyEvents, err := c.DS.GetDailyEvents(date)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get daily weather data",
+		c.LogErrorIfEnabled("Failed to get daily weather data",
 			logger.String("date", date),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -143,7 +143,7 @@ func (c *Controller) GetDailyWeather(ctx echo.Context) error {
 	// Convert to response format using the helper function
 	response := c.buildDailyWeatherResponse(&dailyEvents)
 
-	c.logInfoIfEnabled("Retrieved daily weather data",
+	c.LogInfoIfEnabled("Retrieved daily weather data",
 		logger.String("date", date),
 		logger.String("sunrise", response.Sunrise.Format(time.RFC3339)),
 		logger.String("sunset", response.Sunset.Format(time.RFC3339)),
@@ -160,15 +160,15 @@ func (c *Controller) GetHourlyWeatherForDay(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	date := ctx.Param("date")
 	if date == "" {
-		c.logErrorIfEnabled("Missing date parameter in hourly weather request", logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Missing date parameter in hourly weather request", logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, echo.NewHTTPError(http.StatusBadRequest), "Date parameter is required", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Getting hourly weather for day", logger.String("date", date), logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Getting hourly weather for day", logger.String("date", date), logger.String("path", path), logger.String("ip", ip))
 
 	hourlyWeather, err := c.DS.GetHourlyWeather(date)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get hourly weather data", logger.String("date", date), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Failed to get hourly weather data", logger.String("date", date), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, err, "Failed to get hourly weather data", http.StatusInternalServerError)
 	}
 
@@ -177,7 +177,7 @@ func (c *Controller) GetHourlyWeatherForDay(ctx echo.Context) error {
 	}
 
 	response := c.buildHourlyWeatherResponseList(hourlyWeather)
-	c.logInfoIfEnabled("Retrieved hourly weather data", logger.String("date", date), logger.Int("count", len(response)), logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Retrieved hourly weather data", logger.String("date", date), logger.Int("count", len(response)), logger.String("path", path), logger.String("ip", ip))
 
 	return ctx.JSON(http.StatusOK, struct {
 		Data []HourlyWeatherResponse `json:"data"`
@@ -198,18 +198,18 @@ func (c *Controller) handleEmptyHourlyWeather(ctx echo.Context, date, ip, path s
 	// Check if it's a future date
 	requestedDate, parseErr := time.Parse(time.DateOnly, date)
 	if parseErr != nil {
-		c.logErrorIfEnabled("Invalid date format in hourly weather request", logger.String("date", date), logger.Error(parseErr), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid date format in hourly weather request", logger.String("date", date), logger.Error(parseErr), logger.String("path", path), logger.String("ip", ip))
 		emptyResponse.Message = "No weather data found for the specified date"
 		return ctx.JSON(http.StatusOK, emptyResponse)
 	}
 
 	if requestedDate.After(time.Now()) {
-		c.logWarnIfEnabled("No hourly weather data for future date", logger.String("date", date), logger.String("reason", "future_date"), logger.String("path", path), logger.String("ip", ip))
+		c.LogWarnIfEnabled("No hourly weather data for future date", logger.String("date", date), logger.String("reason", "future_date"), logger.String("path", path), logger.String("ip", ip))
 		emptyResponse.Message = "No weather data available for future date"
 		return ctx.JSON(http.StatusOK, emptyResponse)
 	}
 
-	c.logWarnIfEnabled("No hourly weather data found", logger.String("date", date), logger.String("reason", "missing_data"), logger.String("path", path), logger.String("ip", ip))
+	c.LogWarnIfEnabled("No hourly weather data found", logger.String("date", date), logger.String("reason", "missing_data"), logger.String("path", path), logger.String("ip", ip))
 	emptyResponse.Message = "No weather data found for the specified date"
 	return ctx.JSON(http.StatusOK, emptyResponse)
 }
@@ -281,11 +281,11 @@ func (c *Controller) GetWeatherForDetection(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	id := ctx.Param("id")
 	if id == "" {
-		c.logErrorIfEnabled("Missing detection ID", logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Missing detection ID", logger.String("path", path), logger.String("ip", ip))
 		return c.HandleError(ctx, echo.NewHTTPError(http.StatusBadRequest), "Detection ID is required", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Getting weather for detection", logger.String("detection_id", id), logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Getting weather for detection", logger.String("detection_id", id), logger.String("path", path), logger.String("ip", ip))
 
 	// Get the detection
 	note, err := c.DS.Get(id)
@@ -306,13 +306,13 @@ func (c *Controller) GetWeatherForDetection(ctx echo.Context) error {
 		TimeOfDay: timeOfDay,
 	}
 
-	c.logInfoIfEnabled("Retrieved weather for detection", logger.String("detection_id", id), logger.String("date", date), logger.String("time_of_day", timeOfDay), logger.String("path", path), logger.String("ip", ip))
+	c.LogInfoIfEnabled("Retrieved weather for detection", logger.String("detection_id", id), logger.String("date", date), logger.String("time_of_day", timeOfDay), logger.String("path", path), logger.String("ip", ip))
 	return ctx.JSON(http.StatusOK, response)
 }
 
 // handleDetectionFetchError handles errors when fetching a detection
 func (c *Controller) handleDetectionFetchError(ctx echo.Context, err error, id, ip, path string) error {
-	c.logErrorIfEnabled("Failed to get detection", logger.String("detection_id", id), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+	c.LogErrorIfEnabled("Failed to get detection", logger.String("detection_id", id), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return c.HandleError(ctx, err, "Detection not found", http.StatusNotFound)
 	}
@@ -323,7 +323,7 @@ func (c *Controller) handleDetectionFetchError(ctx echo.Context, err error, id, 
 func (c *Controller) fetchDailyWeatherForDetection(date, id, ip, path string) DailyWeatherResponse {
 	dailyEvents, err := c.DS.GetDailyEvents(date)
 	if err != nil {
-		c.logWarnIfEnabled("Failed to get daily weather data for detection", logger.String("detection_id", id), logger.String("date", date), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogWarnIfEnabled("Failed to get daily weather data for detection", logger.String("detection_id", id), logger.String("date", date), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		dailyEvents = datastore.DailyEvents{Date: date}
 	}
 	return c.buildDailyWeatherResponse(&dailyEvents)
@@ -333,7 +333,7 @@ func (c *Controller) fetchDailyWeatherForDetection(date, id, ip, path string) Da
 func (c *Controller) fetchHourlyWeatherForDetection(date, id, ip, path string) []datastore.HourlyWeather {
 	hourlyWeatherList, err := c.DS.GetHourlyWeather(date)
 	if err != nil {
-		c.logWarnIfEnabled("Failed to get hourly weather data for detection", logger.String("detection_id", id), logger.String("date", date), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
+		c.LogWarnIfEnabled("Failed to get hourly weather data for detection", logger.String("detection_id", id), logger.String("date", date), logger.Error(err), logger.String("path", path), logger.String("ip", ip))
 		return []datastore.HourlyWeather{}
 	}
 	return hourlyWeatherList
@@ -343,7 +343,7 @@ func (c *Controller) fetchHourlyWeatherForDetection(date, id, ip, path string) [
 func (c *Controller) getDetectionTimeOfDay(note *datastore.Note, date, id string) (detectionTime *time.Time, timeOfDay string) {
 	detectionTime, timeOfDay, parseErr := c.determineTimeOfDayForDetection(note, date, id)
 	if parseErr != nil {
-		c.logWarnIfEnabled("Proceeding with default TimeOfDay due to parsing/calculation error", logger.String("detection_id", id), logger.Error(parseErr))
+		c.LogWarnIfEnabled("Proceeding with default TimeOfDay due to parsing/calculation error", logger.String("detection_id", id), logger.Error(parseErr))
 	}
 	return detectionTime, timeOfDay
 }
@@ -372,7 +372,7 @@ func (c *Controller) findHourlyWeatherByHourString(hourlyWeatherList []datastore
 	hourStr := timeStr[:2]
 	requestedHour, convErr := strconv.Atoi(hourStr)
 	if convErr != nil {
-		c.logErrorIfEnabled("Invalid hour derived from detection time during fallback", logger.String("detection_id", id), logger.String("hour", hourStr), logger.String("time", timeStr), logger.Error(convErr), logger.String("path", path), logger.String("ip", ip))
+		c.LogErrorIfEnabled("Invalid hour derived from detection time during fallback", logger.String("detection_id", id), logger.String("hour", hourStr), logger.String("time", timeStr), logger.Error(convErr), logger.String("path", path), logger.String("ip", ip))
 		return HourlyWeatherResponse{}
 	}
 
@@ -392,18 +392,18 @@ func (c *Controller) determineTimeOfDayForDetection(note *datastore.Note, date, 
 	detectionTimeStr := date + " " + note.Time
 	detectionTime, parseErr := time.ParseInLocation("2006-01-02 15:04:05", detectionTimeStr, time.Local)
 	if parseErr != nil {
-		c.logWarnIfEnabled("Failed to parse detection time for TimeOfDay calculation", logger.String("detection_id", detectionID), logger.String("time_str", detectionTimeStr), logger.Error(parseErr))
+		c.LogWarnIfEnabled("Failed to parse detection time for TimeOfDay calculation", logger.String("detection_id", detectionID), logger.String("time_str", detectionTimeStr), logger.Error(parseErr))
 		return nil, timeOfDay, parseErr
 	}
 
 	if c.SunCalc == nil {
-		c.logWarnIfEnabled("SunCalc not initialized for TimeOfDay calculation", logger.String("detection_id", detectionID))
+		c.LogWarnIfEnabled("SunCalc not initialized for TimeOfDay calculation", logger.String("detection_id", detectionID))
 		return &detectionTime, timeOfDay, nil
 	}
 
 	sunTimes, sunErr := c.SunCalc.GetSunEventTimes(detectionTime)
 	if sunErr != nil {
-		c.logWarnIfEnabled("Failed to get sun times for TimeOfDay calculation", logger.String("detection_id", detectionID), logger.String("date", date), logger.Error(sunErr))
+		c.LogWarnIfEnabled("Failed to get sun times for TimeOfDay calculation", logger.String("detection_id", detectionID), logger.String("date", date), logger.Error(sunErr))
 		return &detectionTime, timeOfDay, sunErr
 	}
 
@@ -439,7 +439,7 @@ func (c *Controller) findClosestHourlyWeather(detectionTime time.Time, hourlyWea
 
 	if !found {
 		// This case should ideally not happen if hourlyWeatherList is not empty
-		c.logWarnIfEnabled("No closest hourly weather record found despite having data", logger.Int("count", len(hourlyWeatherList)))
+		c.LogWarnIfEnabled("No closest hourly weather record found despite having data", logger.Int("count", len(hourlyWeatherList)))
 	}
 
 	return closestHourlyData
@@ -471,7 +471,7 @@ func (c *Controller) buildHourlyWeatherResponse(hw *datastore.HourlyWeather) Hou
 // GetLatestWeather handles GET /api/v2/weather/latest
 // Retrieves the latest available weather data
 func (c *Controller) GetLatestWeather(ctx echo.Context) error {
-	c.logInfoIfEnabled("Getting latest weather data",
+	c.LogInfoIfEnabled("Getting latest weather data",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -479,7 +479,7 @@ func (c *Controller) GetLatestWeather(ctx echo.Context) error {
 	// Get the latest hourly weather data
 	latestWeather, err := c.DS.LatestHourlyWeather()
 	if err != nil {
-		c.logErrorIfEnabled("Failed to get latest weather data",
+		c.LogErrorIfEnabled("Failed to get latest weather data",
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -506,7 +506,7 @@ func (c *Controller) GetLatestWeather(ctx echo.Context) error {
 	dailyEvents, err := c.DS.GetDailyEvents(date)
 	if err != nil {
 		// Log the error but continue with partial response
-		c.logWarnIfEnabled("Failed to get daily weather data for latest weather",
+		c.LogWarnIfEnabled("Failed to get daily weather data for latest weather",
 			logger.String("date", date),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -527,7 +527,7 @@ func (c *Controller) GetLatestWeather(ctx echo.Context) error {
 		IconName:     moonData.IconName,
 	}
 
-	c.logInfoIfEnabled("Retrieved latest weather data",
+	c.LogInfoIfEnabled("Retrieved latest weather data",
 		logger.String("date", date),
 		logger.Float64("temperature", latestWeather.Temperature),
 		logger.Bool("has_daily", response.Daily != nil),
@@ -598,7 +598,7 @@ type SunTimesResponse struct {
 func (c *Controller) GetSunTimes(ctx echo.Context) error {
 	date := ctx.Param("date")
 	if date == "" {
-		c.logErrorIfEnabled("Missing date parameter in sun times request",
+		c.LogErrorIfEnabled("Missing date parameter in sun times request",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -608,7 +608,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 	// Validate date format
 	parsedDate, err := time.Parse(time.DateOnly, date)
 	if err != nil {
-		c.logErrorIfEnabled("Invalid date format in sun times request",
+		c.LogErrorIfEnabled("Invalid date format in sun times request",
 			logger.String("date", date),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -617,7 +617,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid date format. Use YYYY-MM-DD", http.StatusBadRequest)
 	}
 
-	c.logInfoIfEnabled("Getting sun times",
+	c.LogInfoIfEnabled("Getting sun times",
 		logger.String("date", date),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -625,7 +625,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 
 	// Check if SunCalc is available
 	if c.SunCalc == nil {
-		c.logErrorIfEnabled("SunCalc not initialized",
+		c.LogErrorIfEnabled("SunCalc not initialized",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
@@ -638,7 +638,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 	// Calculate sun times using SunCalc
 	sunTimes, err := c.SunCalc.GetSunEventTimes(parsedDate)
 	if err != nil {
-		c.logErrorIfEnabled("Failed to calculate sun times",
+		c.LogErrorIfEnabled("Failed to calculate sun times",
 			logger.String("date", date),
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -657,7 +657,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 		Timezone:  c.SunCalc.LocationName(),
 	}
 
-	c.logInfoIfEnabled("Calculated sun times",
+	c.LogInfoIfEnabled("Calculated sun times",
 		logger.String("date", date),
 		logger.String("sunrise", response.Sunrise.Format(time.RFC3339)),
 		logger.String("sunset", response.Sunset.Format(time.RFC3339)),

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 )
@@ -118,10 +119,7 @@ func setupWeatherTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface
 	mockDS := mocks.NewMockInterface(t)
 
 	// Create a controller with the test datastore
-	controller := &Controller{
-		Group: e.Group("/api/v2"),
-		DS:    mockDS,
-	}
+	controller := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2"), DS: mockDS}}
 	controller.Settings.Store(newValidTestSettings())
 
 	// We don't need to initialize routes for unit tests


### PR DESCRIPTION
## What this does

Phase 1 of splitting the monolithic `internal/api/v2` package so no single package gates the `-race` test timeout. This PR extracts a new leaf package `internal/api/v2/apicore` that owns the genuinely-shared substrate of the old `Controller`, and redefines the facade `Controller` to embed `*apicore.Core` by pointer. No handlers move in this phase; they stay in `package api` and reach the promoted core members.

This is a pure refactor with no public-behavior change. The external API surface (`apiv2.Controller`, `apiv2.New`, all `With*` options, and the externally-called methods) is byte-identical, and the full registered route set is unchanged.

## What moved into `apicore`

- `Core` struct: the cross-cutting deps and infra (Echo, Group, DS, Repo, Settings atomic pointer, BirdImageCache, SunCalc, Processor, EBirdClient, TaxonomyDB, SFS, Metrics, V2Manager, ModelManager, AuthMiddleware, APILogger, securityLogger, DetectionCache, DetectionRateCache, MetricsStore, SSEManager, Engine/AudioWatchdog atomic pointers, the lifecycle ctx/cancel/wg, shutdownRequester).
- Shared helpers: `HandleError`/`HandleErrorWithKey`/`handleErrorInternal`/`NewErrorResponse`/`reportErrorToTelemetry`/`GenerateCorrelationID`, `CurrentSettings`/`ControllerSettings`, the `LogInfoIfEnabled` family + `LogSecurity*IfEnabled`, `LogAPIRequest`, `RequireDatastore` (+ `ErrDatastoreUnavailable`), `Debug`, `GetAuthMiddleware`.
- Shared middleware: `TunnelDetectionMiddleware`, `LoggingMiddleware`, `PrivateModeAuth`, and the whole trusted-proxy IP extractor.
- The SSE hub (`SSEManager`, `SSEClient`, the SSE wire structs) and the broadcasters `BroadcastDetection`/`BroadcastSoundLevel`/`BroadcastPending`.
- Exported echo-context-key constants `CtxKeyIsTunneled`/`CtxKeyTunnelProvider`, used wherever the `is_tunneled`/`tunnel_provider` context values are set or read (including a cross-package read in `media.go`).
- Lifecycle accessors `Context()`/`Go()`/`Cancel()`/`Wait()` so handlers and `Shutdown` reach the ctx/wg without exporting raw sync/context fields.

## Key invariants

- **Embed by pointer only.** `Core` holds `atomic.Pointer`/`sync.RWMutex`/`sync.WaitGroup`; it is constructed once in `NewWithOptions` and shared by that single pointer. `go vet` copylocks stays clean.
- **Promotion preserves the external surface.** Because the facade embeds `*apicore.Core`, the exported core methods re-promote onto `*api.Controller`, so callers in `internal/analysis/*` and `internal/api/server.go` keep compiling and behaving identically.
- **Middleware applied once, same order** at the facade: Recover, TunnelDetectionMiddleware, BodyLimit(1M), LoggingMiddleware, PrivateModeAuth, plus the global trusted-proxy IP extractor.
- **Hot-reload preserved**: settings are still read per request via the atomic snapshot accessors (`CurrentSettings`/`ControllerSettings`); no startup-time branching introduced.
- **No import cycle**: `apicore` imports only leaf packages and never a domain package or the facade (verified with `go list -deps`).

## Judgment calls

- **`BroadcastInferenceTopologyChanged` stays on the facade** (not moved to `apicore` with the other three broadcasters). It is the only broadcaster with a `c == nil` guard; promotion of a `*Core` method would dereference the embedded core on a nil `*Controller` before the guard could run, breaking its nil-safe contract. It now reads the promoted `MetricsStore`.
- **The 5 health stores stay on the facade.** An existing exported accessor method `HealthMetricsStore()` would collide with an exported `Core` field of the same name, so the health stores remain unexported facade fields owned by the diagnostics/metrics-history handlers.
- **Name-map plumbing stays in `package api`.** Its white-box tests reference unexported `buildNameMaps`/`nameMaps`, which cannot be reached cross-package, and it provides no phase-1 benefit; it will move with the insights domain in a later phase.
- **`PrivateModeAuth` takes an injected exempt function.** The exempt allow-list (`isPrivateModeExempt`) and its domain route-path constants stay in `package api`, so `apicore` does not pull in domain constants. Behavior is identical (same function value).

## New test gate

Added `routes_enumeration_test.go`: builds a fully-routed controller and pins the complete sorted method+path route set (268 routes), asserts registration determinism, and pins the greedy `GET /api/v2/audio/:id` route on the Echo instance. This gates route regressions for this and all later split phases.

## Verification

- `go build ./...`: pass
- `go vet ./internal/api/v2/... ./internal/analysis/...` (copylocks): clean
- `go test -race ./internal/api/v2/...`: pass (api/v2 211s, apicore green)
- `go test -race ./internal/analysis/...`: pass
- `golangci-lint run ./internal/api/v2/...`: 0 issues
- Route-enumeration gate: identical 268-route set, deterministic across rebuilds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized API error responses with an added correlation ID and clearer debug behavior.
  * Stream/SSE handling is now centralized for more consistent live updates.

* **Bug Fixes**
  * Improved datastore-unavailable behavior (consistent service-unavailable handling) and safer request lifecycle shutdown.
  * More consistent logging and telemetry across alerts, analytics, media, weather, settings, notifications, health, and system endpoints.

* **Refactor**
  * Unified API v2 controller lifecycle/routing/runtime state and aligned middleware usage across endpoints.
  * Refreshed and expanded tests, including deterministic route enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->