### PR TITLE
fix(install): make reconfigure config writers indent-agnostic for app-serialized configs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -162,38 +162,38 @@ sed_escape_pattern() {
     printf '%s' "$1" | tr -d '\n\r' | sed -e 's/[][\\.^$*|]/\\&/g'
 }
 
-# Safely set a scalar VALUE for KEY inside the top-level YAML block BLOCK of the config
-# file (default $CONFIG_FILE). The substitution is scoped with a sed address range to the
-# block, so it never touches an identically named key in another block (for example
-# webserver.port vs mysql.port vs the rtsp port). BLOCK and KEY MUST be literal YAML
-# identifiers from the caller (never user input); VALUE is the only untrusted part and is
-# escaped via sed_escape_replacement, with '|' as the sed delimiter to match that escaping.
-# Any inline comment on the edited line is dropped. Re-run-safe: matches the current value
-# regardless of what it is. No-op if BLOCK or KEY is absent.
-#
-# set_yaml_value (below) is the path-aware superset of this helper, handling keys nested deeper
-# than a top-level block's direct child. This sed variant is kept separate on purpose: the
-# TLS/port callers rely on its silent-success-on-missing-key contract, so do not merge the two.
+# Safely set a scalar VALUE for KEY (a direct child of the top-level YAML block BLOCK) in the
+# config file (default $CONFIG_FILE). A top-level block plus its direct child is just a
+# two-element path, so this delegates to set_yaml_value, which descends structurally and learns
+# each level's indentation from the file. That makes it work on both the 2-space template and
+# the app's 4-space serialized config; the previous fixed 2-space sed anchor silently no-opped
+# on a live (app-written) config. The structural descent keeps the original block-scoping
+# guarantee (it never touches an identically named key in another block, e.g. webserver.port vs
+# mysql.port). BLOCK and KEY MUST be literal YAML identifiers from the caller (never user
+# input); VALUE is the only untrusted part and is written literally by set_yaml_value (through
+# the environment), so no sed/regex metacharacter escaping is needed. Any inline comment on the
+# edited line is dropped. Re-run-safe. The set_yaml_value not-found return is intentionally
+# swallowed to preserve this helper's silent-success-on-missing-key contract that the TLS/port
+# callers rely on; a missing file still returns non-zero.
 set_config_value() {
     local block="$1"
     local key="$2"
     local value="$3"
     local file="${4:-$CONFIG_FILE}"
     [ -f "$file" ] || return 1
-    local escaped
-    escaped=$(sed_escape_replacement "$value")
-    # Anchor to exactly two leading spaces (the indentation of a direct child of a top-level
-    # block) so a same-named key in a deeper nested block is never overwritten.
-    sed -i -E "/^${block}:/,/^[A-Za-z0-9_]/ s|^([[:space:]]{2}${key}:[[:space:]]*).*|\\1${escaped}|" -- "$file"
+    set_yaml_value "${block}.${key}" "$value" "$file"
+    return 0
 }
 
 # Re-run-safe set of a scalar value at an arbitrary YAML key PATH (dotted, e.g.
 # "security.basicauth.enabled" or "realtime.audio.export.type") in the config file (default
-# $CONFIG_FILE). Generalizes set_config_value to keys nested deeper than a top-level block's
-# direct child: it walks the single known descent path, matching each element at exactly two
-# spaces of indentation per level and popping scope on dedent, so a same-named key in a
-# SIBLING block (e.g. security.allowsubnetbypass.enabled vs security.basicauth.enabled, both
-# at indent 4) is never touched and field order within a block is irrelevant. Only the leaf
+# $CONFIG_FILE). Walks the single known descent path, learning each level's indentation from
+# the file rather than assuming a fixed width, so it works on both the 2-space template and the
+# app's 4-space serialized config. A child must be more indented than its parent and at the
+# indent the parent's first child established, so a same-named key in a SIBLING block (e.g.
+# security.allowsubnetbypass.enabled vs security.basicauth.enabled) or one nested deeper under a
+# non-matching sibling is never touched, and field order within a block is irrelevant. Only the
+# leaf
 # scalar is rewritten; any inline comment on that line is dropped. PATH elements MUST be
 # literal YAML identifiers from the caller (never user input); VALUE is the only untrusted
 # part and is passed to awk through the environment (not -v), so awk performs no backslash
@@ -221,17 +221,32 @@ set_yaml_value() {
             key = $0
             sub(/^[[:space:]]*/, "", key)
             sub(/:.*/, "", key)
-            # Pop ancestors we have dedented out of: a key line at or shallower than the
-            # deepest matched ancestor header indent means that block has ended.
-            while (depth > 0 && ind <= 2 * (depth - 1)) depth--
-            if (depth < n && ind == 2 * depth && key == p[depth + 1]) {
-                if (depth + 1 == n) {
-                    # Leaf reached: rewrite the scalar, preserving the original indentation.
-                    print substr($0, 1, ind) key ": " val
-                    replaced = 1
-                    next
+            # Pop ancestors we have dedented out of: a key at or shallower than a matched
+            # ancestor indent means that block has ended. Per-level indentation is learned from
+            # the file (ancInd[] holds each matched ancestor indent for this pop; childInd[]
+            # below holds the child indent used for matching) rather than assumed to be two
+            # spaces, so the setter works on both the 2-space template and the 4-space config
+            # the app serializes. Assuming two spaces silently no-opped every nested set on a
+            # live (app-written) config.
+            while (depth > 0 && ind <= ancInd[depth]) depth--
+            # The next path component must be a direct child of the deepest matched ancestor:
+            # deeper than it (column 0 at the root) and at the child indent the first child
+            # established (childInd[]). Keys deeper than that are grandchildren under a
+            # non-matching sibling and must not match, which is the safety the old
+            # exact-indent check gave for free.
+            if (depth < n && (depth == 0 ? ind == 0 : ind > ancInd[depth])) {
+                if (childInd[depth] == "") childInd[depth] = ind
+                if (ind == childInd[depth] && key == p[depth + 1]) {
+                    if (depth + 1 == n) {
+                        # Leaf reached: rewrite the scalar, preserving the original indentation.
+                        print substr($0, 1, ind) key ": " val
+                        replaced = 1
+                        next
+                    }
+                    depth++
+                    ancInd[depth] = ind
+                    childInd[depth] = ""
                 }
-                depth++
             }
         }
         { print }
@@ -266,10 +281,12 @@ set_first_audio_source() {
     # multi-source config (e.g. extra sources added via the web UI) is not clobbered. The
     # item boundary is the list dash (`- `), and the name/device fields are matched with an
     # optional leading dash so the edit works regardless of which field comes first.
-    # device/name are passed as literal awk variables, so sed/regex metacharacters in a
-    # device name need no escaping here. Write to a temp file then copy back over the
-    # original so its ownership and permissions are preserved.
-    if awk -v device="$device" -v name="$name" '
+    # device/name are passed through the environment and read with ENVIRON (like
+    # set_yaml_value) rather than awk -v, so awk never interprets backslash escapes in a
+    # device name and no sed/regex metacharacters need escaping here. Write to a temp file
+    # then copy back over the original so its ownership and permissions are preserved.
+    if BIRDNET_SRC_DEVICE="$device" BIRDNET_SRC_NAME="$name" awk '
+        BEGIN { device = ENVIRON["BIRDNET_SRC_DEVICE"]; name = ENVIRON["BIRDNET_SRC_NAME"] }
         /^    sources:/ { in_sources=1; print; next }
         in_sources && /^    [A-Za-z]/ { in_sources=0 }
         in_sources && /^[[:space:]]*-[[:space:]]/ { item++ }
@@ -767,9 +784,12 @@ backup_config_with_version() {
         # Update version history with backup info
         if [ -n "$image_hash" ]; then
             # Update only the most recent entry matching this image_hash with empty backup
-            local temp_file
-            temp_file=$(mktemp /tmp/version_history_XXXXXX.tmp)
             if [ -f "$VERSION_HISTORY_FILE" ]; then
+                # Allocate the temp file only when there is a history file to rewrite, so a
+                # fresh install (no history yet) does not leak an empty /tmp file until the
+                # EXIT trap reaps it.
+                local temp_file
+                temp_file=$(mktemp /tmp/version_history_XXXXXX.tmp)
                 # Store lines and find last matching row index, then update only that row
                 awk -F'|' -v OFS='|' -v ih="$image_hash" -v bf="$backup_filename" '
                   { lines[NR]=$0 }

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -182,6 +182,56 @@ assert_nonzero "missing leaf returns non-zero" "$rc"
 set_yaml_value "webserver.port" '"9000"' "$cfg"
 assert_eq "webserver.port set" '"9000"' "$(yaml_after "$cfg" '^webserver:' 2 port)"
 
+# The app (Go yaml.v3) re-serializes config.yaml with 4-space indentation, not the
+# template's 2-space. set_yaml_value must locate nested paths regardless of indent width,
+# or reconfigure silently no-ops on a live install (audio format / web auth / locale).
+# The soundlevel.export node is synthetic (the real config has no audio.soundlevel.export);
+# it exists only to place a same-named key one level deeper than the real audio.export.type
+# so the grandchild-false-match guard is exercised.
+app_config() { # -> path to a 4-space app-style fixture
+    local p="${WORK}/app.$RANDOM.$RANDOM.yaml"
+    cat > "$p" <<'YAML'
+realtime:
+    audio:
+        soundlevel:
+            export:
+                type: bad
+        export:
+            enabled: true
+            type: wav
+birdnet:
+    locale: en
+    threshold: "0.8"
+security:
+    basicauth:
+        enabled: false
+        password: ""
+    allowsubnetbypass:
+        enabled: false
+YAML
+    printf '%s' "$p"
+}
+
+it "set_yaml_value (4-space app config)"
+
+acfg="$(app_config)"
+set_yaml_value "realtime.audio.export.type" "flac" "$acfg"
+assert_eq "4-space export.type set to flac" "flac" "$(yaml_after "$acfg" '^[[:space:]]{8}export:' 12 type)"
+assert_eq "4-space export.enabled untouched" "true" "$(yaml_after "$acfg" '^[[:space:]]{8}export:' 12 enabled)"
+# A same-named key nested deeper under a non-matching sibling must not be rewritten.
+assert_eq "4-space grandchild soundlevel.export.type untouched" "bad" "$(yaml_after "$acfg" '^[[:space:]]{12}export:' 16 type)"
+
+set_yaml_value "birdnet.locale" "fi" "$acfg"
+assert_eq "4-space birdnet.locale set to fi" "fi" "$(yaml_after "$acfg" '^birdnet:' 4 locale)"
+
+set_yaml_value "security.basicauth.enabled" "true" "$acfg"
+assert_eq "4-space basicauth.enabled set to true" "true" "$(yaml_after "$acfg" '^[[:space:]]{4}basicauth:' 8 enabled)"
+assert_eq "4-space allowsubnetbypass.enabled untouched" "false" "$(yaml_after "$acfg" '^[[:space:]]{4}allowsubnetbypass:' 8 enabled)"
+
+# Re-run on the 4-space config changes an already-set value (not a no-op).
+set_yaml_value "realtime.audio.export.type" "opus" "$acfg"
+assert_eq "4-space export.type re-changed flac->opus" "opus" "$(yaml_after "$acfg" '^[[:space:]]{8}export:' 12 type)"
+
 # ===========================================================================
 # set_config_value
 # ===========================================================================
@@ -199,6 +249,17 @@ assert_eq "security.host re-changed" "other.example.com" "$(yaml_after "$cfg" '^
 set_config_value security enabled "true"
 assert_eq "set_config_value does not reach grandchild basicauth.enabled" "false" "$(yaml_after "$cfg" '^[[:space:]]{2}basicauth:' 4 enabled)"
 
+# 4-space (app-serialized) config: a direct child of a top-level block sits at indent 4, not 2.
+# The old fixed 2-space sed anchor silently no-opped here (breaking TLS / web-port reconfigure
+# on a live config); delegating to the indent-agnostic set_yaml_value fixes it. Fails on old code.
+acfg2="$(app_config)"
+CONFIG_FILE="$acfg2"
+set_config_value birdnet locale "fi"
+assert_eq "4-space set_config_value reaches indent-4 child" "fi" "$(yaml_after "$acfg2" '^birdnet:' 4 locale)"
+# A non-existent direct scalar child must no-op without reaching the indent-8 grandchild.
+set_config_value security enabled "true"
+assert_eq "4-space set_config_value does not reach grandchild" "false" "$(yaml_after "$acfg2" '^[[:space:]]{4}basicauth:' 8 enabled)"
+
 # ===========================================================================
 # set_first_audio_source
 # ===========================================================================
@@ -212,6 +273,13 @@ dev="$(awk '/^[[:space:]]{4}sources:/{f=1} f&&/^[[:space:]]+(-[[:space:]]+)?devi
 nm="$(awk '/^[[:space:]]{4}sources:/{f=1} f&&/^[[:space:]]+-[[:space:]]+name:/{sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/,"");print;exit}' "$cfg")"
 assert_eq "device set" '"hw:1,0"' "$dev"
 assert_eq "name set" '"USB Mic"' "$nm"
+
+# ENVIRON (not awk -v) preserves a backslash in the device verbatim. With the old `awk -v`,
+# `\t` in the value was processed into a literal tab; ENVIRON keeps it as two characters.
+cfg="$(fresh_config)"
+set_first_audio_source 'hw:Foo\tBar' "USB Mic" "$cfg"
+dev="$(awk '/^[[:space:]]{4}sources:/{f=1} f&&/^[[:space:]]+(-[[:space:]]+)?device:/{sub(/^[[:space:]]*(-[[:space:]]+)?device:[[:space:]]*/,"");print;exit}' "$cfg")"
+assert_eq "backslash in device preserved verbatim (ENVIRON, not awk -v)" '"hw:Foo\tBar"' "$dev"
 
 # Reverse field order (device before name) must also work.
 cat > "$cfg" <<'EOF'


### PR DESCRIPTION
## What

Makes the installer's reconfigure config writers indent-agnostic so the reconfigure menu's config-level options actually take effect on a real install.

## Why

The reconfigure menu (added recently) writes `config.yaml` through `set_yaml_value` (audio export format, web auth, locale) and `set_config_value` (web port, TLS, metrics). Both assumed a **fixed YAML indent**: `set_yaml_value` hardcoded 2 spaces per nesting level (`ind == 2 * depth`), and `set_config_value` anchored its sed to exactly 2 leading spaces. BirdNET-Go's app re-serializes `config.yaml` with **4-space** indentation (Go yaml.v3 default), so on any install where the app has written the config (the normal state), both **silently no-opped while the menu reported success**.

This was caught during end-to-end host validation on a real arm64 host: reconfigure reported "Selected audio format: flac" but `config.yaml` stayed `type: wav`. A direct awk replication confirmed it (2-space rc=0/changed, 4-space rc=1/unchanged). The 2-space test fixtures and the bundled config template never exercised the 4-space app config, so CI stayed green.

## How

- **`set_yaml_value`** now learns the actual indentation of each matched ancestor and the direct-child indent established by the first child at each level, locating nested paths under any consistent indent width while still rejecting a same-named key nested deeper under a non-matching sibling (the safety the old exact-indent check provided). Verified across gawk, mawk, and busybox awk.
- **`set_config_value`** now delegates to `set_yaml_value` (a top-level block plus its direct child is a two-element path), inheriting the indent-agnostic descent and the literal value write, while preserving its silent-success-on-missing-key contract that the TLS/port callers rely on.

Two small related cleanups in the same file:
- **`set_first_audio_source`**: pass device/name via the environment and read them with `ENVIRON` instead of `awk -v`, so awk never interprets backslash escapes in a device name.
- **`backup_config_with_version`**: allocate the version-history temp file only when a history file exists, so a fresh install no longer leaks an empty `/tmp` file until the EXIT trap reaps it.

## Tests

`scripts/install_test.sh` gains 4-space (app-serialized) fixtures and assertions for `set_yaml_value` and `set_config_value` (nested set, grandchild-false-match rejection, sibling isolation, re-run change), plus a backslash test for the `ENVIRON` change. These **fail on the old helpers and pass on the fixed ones**: 55 pass / 6 fail on old code, **61 pass / 0 fail** on the fix. No new shellcheck notices.

Reviewed by three parallel review agents plus an independent Gemini pass before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config editing so nested YAML values are updated correctly even when indentation differs between config formats.
  * Fixed rerun behavior so existing values can be updated reliably instead of being skipped.
  * Prevented deeper, similarly named keys from being overwritten by mistake.
  * Preserved literal backslash sequences when updating audio source settings.

* **Chores**
  * Reduced unnecessary temporary file creation during fresh installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->