### PR TITLE
refactor(api/v2): extract apitest importable test helpers

### DIFF
--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	speciestracker "github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -617,7 +618,7 @@ func TestGetInvalidAnalyticsRequests(t *testing.T) {
 	// Initialize a mock image cache for controller creation - ONCE for all test cases
 	testMetrics, _ := observability.NewMetrics() // Create a dummy metrics instance
 	// Create a stub provider to avoid nil pointer panics
-	stubProvider := &TestImageProvider{
+	stubProvider := &apitest.TestImageProvider{
 		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
 			return imageprovider.BirdImage{}, nil
 		},
@@ -766,7 +767,7 @@ func TestGetDailySpeciesSummary_MultipleDetections(t *testing.T) {
 	// mockDS.On("SaveImageCache", mock.AnythingOfType("*datastore.ImageCache")).Return(nil)
 
 	// Create a mock image provider (can be nil if cache doesn't need real fetching)
-	mockImageProvider := &TestImageProvider{
+	mockImageProvider := &apitest.TestImageProvider{
 		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
 			// Return placeholder or specific mock image data if needed
 			return imageprovider.BirdImage{
@@ -1030,7 +1031,7 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 	// mockDS.On("SaveImageCache", mock.AnythingOfType("*datastore.ImageCache")).Return(nil)
 
 	// Create a mock image provider
-	mockImageProvider := &TestImageProvider{
+	mockImageProvider := &apitest.TestImageProvider{
 		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
 			return imageprovider.BirdImage{
 				ScientificName: scientificName,
@@ -1040,7 +1041,7 @@ func TestGetDailySpeciesSummary_SingleDetection(t *testing.T) {
 	}
 
 	// Create a bird image cache with our mock provider
-	imageCache := imageprovider.InitCache("test", mockImageProvider, NewTestMetrics(t), mockDS)
+	imageCache := imageprovider.InitCache("test", mockImageProvider, apitest.NewTestMetrics(t), mockDS)
 
 	// Create a controller with our mocks
 	controller := &Controller{Core: &apicore.Core{DS: mockDS, BirdImageCache: imageCache}}

--- a/internal/api/v2/api_datastore_guard_test.go
+++ b/internal/api/v2/api_datastore_guard_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 )
 
 // TestGetSpectrogramStatusReturns503WhenDatastoreDisabled pins that a DS-dependent
@@ -94,7 +95,7 @@ func TestInitDebugRoutesReadsSettingsNilSafely(t *testing.T) {
 	withRestoredGlobalSettings(t)
 
 	e := echo.New()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Debug = false // debug mode off -> initDebugRoutes takes the skip path
 
 	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}

--- a/internal/api/v2/api_debug_race_test.go
+++ b/internal/api/v2/api_debug_race_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 )
@@ -26,7 +27,7 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 	})
 
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	stopWriter := make(chan struct{})
 	writerDone := make(chan struct{})
@@ -37,7 +38,7 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 			case <-stopWriter:
 				return
 			default:
-				updated := newValidTestSettings()
+				updated := apitest.NewValidTestSettings()
 				updated.WebServer.Debug = true
 				controller.Settings.Store(updated)
 			}

--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 )
@@ -427,7 +428,7 @@ func TestGetEffectiveSummaryLimit_AfterMigration(t *testing.T) {
 	t.Attr("type", "regression")
 	t.Attr("issue", "2352")
 
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 
 	// Pre-migration baseline: capture effective limit before migration
 	expectedLimit := settings.GetEffectiveSummaryLimit()

--- a/internal/api/v2/api_error_response_race_test.go
+++ b/internal/api/v2/api_error_response_race_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 )
 
 // TestNewErrorResponseConcurrentSettingsPublishIsRaceFree hammers
@@ -27,7 +28,7 @@ func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
 	withRestoredGlobalSettings(t)
 
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	testErr := echo.NewHTTPError(http.StatusInternalServerError, "raw internal detail")
 
@@ -42,7 +43,7 @@ func TestNewErrorResponseConcurrentSettingsPublishIsRaceFree(t *testing.T) {
 	for w := range writers {
 		wg.Go(func() {
 			for i := range itersPerWorker {
-				snap := newValidTestSettings()
+				snap := apitest.NewValidTestSettings()
 				snap.WebServer.Debug = (w+i)%2 == 0
 				// Republish the same way UpdateSettings does: Settings.Store while
 				// holding settingsMutex. The mutex serialises writers; the read side

--- a/internal/api/v2/apitest/apitest.go
+++ b/internal/api/v2/apitest/apitest.go
@@ -1,0 +1,95 @@
+// Package apitest provides reusable, Core-level test scaffolding for the
+// internal/api/v2 packages. It exists so the per-domain test packages created by
+// the api/v2 split can build a *apicore.Core (and the supporting mocks, settings,
+// HTTP scaffolding, and assertions) without each one re-deriving the setup.
+//
+// Importability and the import-cycle rule: this is a regular (non-_test.go)
+// package because a _test.go file cannot be imported by another package's tests.
+// It has no production importers. apitest imports ONLY apicore and leaf or
+// test-support packages (conf, conf/conftest, datastore, datastore/mocks,
+// imageprovider, suncalc, observability, httpclient). It MUST NEVER import the
+// api/v2 facade (package api) or any api/v2 domain package: package api's tests
+// and the future domain tests import apitest, so importing the facade or a domain
+// from here would close an import cycle. Consequently apitest builds and returns
+// only *apicore.Core, never *api.Controller.
+//
+// Isolation contract: helpers here guarantee per-binary isolation so the
+// now-parallel api/v2 test binaries cannot collide. Scratch space comes from
+// t.TempDir() only, there are no fixed TCP ports (use echo.New() + httptest), and
+// the datastore is always a mock (no shared on-disk DB). See NewCore.
+package apitest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// NewValidTestSettings returns a *conf.Settings populated with minimal values
+// that pass conf.ValidateSettings(). Tests that create inline controllers or
+// cores should call this and then override the fields they care about.
+//
+// Debug defaults to false to match production behavior. Tests that specifically
+// need debug mode should set settings.WebServer.Debug = true.
+func NewValidTestSettings() *conf.Settings {
+	return &conf.Settings{
+		BirdNET: conf.BirdNETConfig{
+			Sensitivity: 1.0,
+			Threshold:   0.8,
+			Locale:      "en",
+		},
+		WebServer: conf.WebServerSettings{
+			Debug: false,
+			LiveStream: conf.LiveStreamSettings{
+				BitRate:       128,
+				SegmentLength: 5,
+			},
+		},
+		Security: conf.Security{
+			SessionDuration: 168 * time.Hour,
+		},
+		Realtime: conf.RealtimeSettings{
+			Interval: 15,
+			Dashboard: conf.Dashboard{
+				SummaryLimit: 100,
+			},
+			Weather: conf.WeatherSettings{
+				PollInterval: 30,
+			},
+		},
+	}
+}
+
+// PublishTestSettings publishes settings as the process-global atomic snapshot so
+// handlers reading via apicore.Core.CurrentSettings() observe them, and restores
+// the previous snapshot on cleanup so the publish does not leak into sibling
+// tests.
+//
+// IMPORTANT: tests using this helper must NOT call t.Parallel(). It mutates the
+// process-global settings snapshot, so parallel tests in the same binary would
+// observe each other's settings and flake. Cross-binary isolation is automatic:
+// each api/v2 package compiles to its own test binary (its own OS process), so
+// the global snapshot is never shared across domains.
+//
+// CurrentSettings() prefers the process-global snapshot over a core-cached
+// Settings field, so tests that inject a per-core *conf.Settings must publish it
+// here for request-time reads to observe it (pass nil to exercise a handler's
+// nil-settings fallback path).
+func PublishTestSettings(tb testing.TB, settings *conf.Settings) {
+	tb.Helper()
+	prev := conf.GetSettings()
+	conftest.SetTestSettings(settings)
+	tb.Cleanup(func() { conftest.SetTestSettings(prev) })
+}
+
+// NewTestMetrics creates a new observability.Metrics instance for testing.
+func NewTestMetrics(t *testing.T) *observability.Metrics {
+	t.Helper()
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err, "apitest: creating test metrics")
+	return metrics
+}

--- a/internal/api/v2/apitest/core.go
+++ b/internal/api/v2/apitest/core.go
@@ -1,0 +1,200 @@
+package apitest
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/observability"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// Default coordinates for the test SunCalc (Helsinki, Finland).
+const (
+	testLatitude  = 60.1699
+	testLongitude = 24.9384
+)
+
+// apiV2Prefix is the echo route-group prefix the facade registers domain routes
+// under. NewCore sets core.Group to echo.Group(apiV2Prefix) so domain handler
+// tests register routes the same way the facade does. It mirrors the facade's own
+// apiV2Prefix; apitest cannot import package api to share the literal.
+const apiV2Prefix = "/api/v2"
+
+// coreConfig holds the resolved inputs for NewCore. All fields are optional; any
+// left unset get a test default in NewCore.
+type coreConfig struct {
+	echo              *echo.Echo
+	ds                datastore.Interface
+	dsSet             bool
+	settings          *conf.Settings
+	settingsFuncs     []func(*conf.Settings)
+	birdImageCache    *imageprovider.BirdImageCache
+	sunCalc           *suncalc.SunCalc
+	metrics           *observability.Metrics
+	privateModeExempt func(method, path string) bool
+	publishSettings   bool
+}
+
+// CoreOption configures NewCore.
+type CoreOption func(*coreConfig)
+
+// WithEcho injects an existing Echo instance instead of echo.New().
+func WithEcho(e *echo.Echo) CoreOption { return func(c *coreConfig) { c.echo = e } }
+
+// WithDatastore injects a datastore (typically a mocks.MockInterface a test sets
+// expectations on). Passing nil exercises the datastore-disabled path. When this
+// option is omitted, NewCore creates a fresh mocks.NewMockInterface(t).
+func WithDatastore(ds datastore.Interface) CoreOption {
+	return func(c *coreConfig) { c.ds = ds; c.dsSet = true }
+}
+
+// WithSettings injects a *conf.Settings instead of NewValidTestSettings(). The
+// media export path is still overridden to a per-test t.TempDir() for isolation
+// unless a WithSettingsFunc restores it.
+func WithSettings(s *conf.Settings) CoreOption { return func(c *coreConfig) { c.settings = s } }
+
+// WithSettingsFunc registers a mutator applied to the resolved settings after the
+// t.TempDir() export-path override, so a test can tweak (or deliberately replace)
+// fields. Multiple mutators run in registration order.
+func WithSettingsFunc(fn func(*conf.Settings)) CoreOption {
+	return func(c *coreConfig) { c.settingsFuncs = append(c.settingsFuncs, fn) }
+}
+
+// WithBirdImageCache injects a bird image cache instead of NewMockBirdImageCache.
+func WithBirdImageCache(cache *imageprovider.BirdImageCache) CoreOption {
+	return func(c *coreConfig) { c.birdImageCache = cache }
+}
+
+// WithSunCalc injects a SunCalc instead of the default Helsinki-coordinate one.
+func WithSunCalc(sc *suncalc.SunCalc) CoreOption { return func(c *coreConfig) { c.sunCalc = sc } }
+
+// WithMetrics injects an observability.Metrics instead of NewTestMetrics(t).
+func WithMetrics(m *observability.Metrics) CoreOption { return func(c *coreConfig) { c.metrics = m } }
+
+// WithPrivateModeExempt injects the PrivateMode exempt predicate consulted by the
+// core's PrivateModeAuth middleware. The default exempts nothing (returns false).
+func WithPrivateModeExempt(fn func(method, path string) bool) CoreOption {
+	return func(c *coreConfig) { c.privateModeExempt = fn }
+}
+
+// WithoutSettingsPublish skips publishing the settings to the process-global
+// snapshot. Use it for parallel tests that do not read CurrentSettings() from the
+// global, or that manage the global snapshot themselves.
+func WithoutSettingsPublish() CoreOption { return func(c *coreConfig) { c.publishSettings = false } }
+
+// NewCore builds a fully wired *apicore.Core for tests and registers cleanup. It
+// honors the apitest isolation contract: the media export path is a per-test
+// t.TempDir(), the datastore is a mock (no shared DB file), and the Echo server
+// is in-memory (no fixed TCP port). Future domain tests build their handler from
+// it directly, for example:
+//
+//	h := analytics.New(apitest.NewCore(t))
+//
+// Common overrides go through the CoreOption functions; tests needing mock
+// expectations pass their own mock via WithDatastore and keep the reference (the
+// default mock is reachable as core.DS). The returned core has its v2 route group
+// (core.Group) wired so a domain test can call h.RegisterRoutes(core.Group); the
+// facade's group-level middleware is not applied (see the wiring comment below).
+//
+// By default NewCore publishes its settings to the process-global snapshot so
+// handlers reading CurrentSettings() observe them. That snapshot is process-wide,
+// not per-core: building two publishing cores in one test leaves the second core's
+// settings as the global, so the first core's CurrentSettings() would observe the
+// second's. Build the second with WithoutSettingsPublish, and a test that publishes
+// must not call t.Parallel.
+//
+// The core's DetectionCache (a patrickmn/go-cache) starts a janitor goroutine that
+// cannot be stopped (cleanup only flushes it). A domain test package that adds a
+// goleak gate must ignore "github.com/patrickmn/go-cache.(*janitor).Run", the same
+// way package api's TestMain does.
+func NewCore(t *testing.T, opts ...CoreOption) *apicore.Core {
+	t.Helper()
+
+	cfg := &coreConfig{
+		publishSettings:   true,
+		privateModeExempt: func(_, _ string) bool { return false },
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.privateModeExempt == nil {
+		// A nil predicate would panic in PrivateModeAuth; restore the safe default
+		// (exempt nothing) if an option cleared it.
+		cfg.privateModeExempt = func(_, _ string) bool { return false }
+	}
+
+	if cfg.settings == nil {
+		cfg.settings = NewValidTestSettings()
+	}
+	// Isolation: scratch media export path under t.TempDir() so parallel package
+	// test binaries never share a media directory or contend on a fixed path.
+	cfg.settings.Realtime.Audio.Export.Path = t.TempDir()
+	for _, fn := range cfg.settingsFuncs {
+		fn(cfg.settings)
+	}
+
+	if cfg.echo == nil {
+		cfg.echo = echo.New()
+	}
+	if !cfg.dsSet {
+		cfg.ds = mocks.NewMockInterface(t)
+	}
+	if cfg.birdImageCache == nil {
+		cfg.birdImageCache = NewMockBirdImageCache(t)
+	}
+	if cfg.sunCalc == nil {
+		cfg.sunCalc = suncalc.NewSunCalc(testLatitude, testLongitude)
+	}
+	if cfg.metrics == nil {
+		cfg.metrics = NewTestMetrics(t)
+	}
+
+	core, err := apicore.NewCore(cfg.echo, cfg.ds, cfg.settings, cfg.birdImageCache,
+		cfg.sunCalc, cfg.metrics, cfg.privateModeExempt)
+	require.NoError(t, err, "apitest: building apicore.Core")
+
+	// Register the v2 route group the same way the facade does so domain handler
+	// tests can call h.RegisterRoutes(core.Group). apicore.NewCore deliberately
+	// leaves Group nil (the facade owns it); apitest plays the facade's role here.
+	// The facade's group-level middleware (tunnel detection, body limit, logging,
+	// PrivateMode auth) is NOT applied: those are facade concerns, and a minimal
+	// test core exercises a handler directly. A test that needs them applies them
+	// to core.Group itself.
+	core.Group = cfg.echo.Group(apiV2Prefix)
+
+	if cfg.publishSettings {
+		PublishTestSettings(t, cfg.settings)
+	}
+
+	// Tear down the core's lifecycle and release resources. apitest.NewCore
+	// returns a *apicore.Core, not an *api.Controller, so api.Controller.Shutdown
+	// never runs for domain tests; this cleanup mirrors the Core-level teardown it
+	// performs, in the same order. Closing SFS is mandatory: the media SecureFS
+	// holds an open os.Root directory handle, and on Windows that handle blocks
+	// t.TempDir() removal (t.Cleanup is LIFO, so SFS.Close runs before t.TempDir's
+	// RemoveAll).
+	t.Cleanup(func() {
+		// Close SSE clients before cancelling, matching api.Controller.Shutdown: a
+		// streaming handler can block on its request context, so releasing clients
+		// first avoids a circular wait if a future test drives one via core.Go.
+		if core.SSEManager != nil {
+			core.SSEManager.CloseAllClients()
+		}
+		core.Cancel()
+		core.Wait()
+		if core.SFS != nil {
+			_ = core.SFS.Close()
+		}
+		if core.DetectionCache != nil {
+			core.DetectionCache.Flush()
+		}
+	})
+
+	return core
+}

--- a/internal/api/v2/apitest/core_test.go
+++ b/internal/api/v2/apitest/core_test.go
@@ -1,0 +1,82 @@
+package apitest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+// TestNewCoreWiresDefaults verifies NewCore returns a fully wired core with the
+// isolation defaults: a mock datastore, an in-memory Echo, and a media SecureFS
+// rooted under the per-test t.TempDir().
+func TestNewCoreWiresDefaults(t *testing.T) {
+	tmp := t.TempDir()
+
+	core := NewCore(t, WithSettingsFunc(func(s *conf.Settings) {
+		// Pin the export path so we can assert the SecureFS landed under it.
+		s.Realtime.Audio.Export.Path = tmp
+	}))
+
+	require.NotNil(t, core)
+	assert.NotNil(t, core.Echo, "Echo should be wired")
+	assert.NotNil(t, core.DS, "datastore should default to a mock")
+	assert.IsType(t, &mocks.MockInterface{}, core.DS, "default datastore should be a MockInterface")
+	require.NotNil(t, core.SFS, "media SecureFS should be wired")
+	assert.Equal(t, tmp, core.SFS.BaseDir(), "media SecureFS must be rooted under the test temp dir")
+	assert.NotNil(t, core.SSEManager, "SSE manager should be wired")
+	assert.NotNil(t, core.DetectionCache, "detection cache should be wired")
+	assert.NotNil(t, core.Group, "v2 route group should be wired for domain route registration")
+
+	// CurrentSettings should observe the published snapshot.
+	got := core.CurrentSettings()
+	require.NotNil(t, got)
+	assert.Equal(t, tmp, got.Realtime.Audio.Export.Path)
+}
+
+// TestNewCoreGroupRegistersRoutes verifies the wired core.Group can register a
+// route under the /api/v2 prefix and that AssertRoutesRegistered finds it. This
+// exercises the route-registration path future domain tests rely on.
+func TestNewCoreGroupRegistersRoutes(t *testing.T) {
+	core := NewCore(t)
+	require.NotNil(t, core.Group)
+
+	core.Group.GET("/apitest/ping", func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	AssertRoutesRegistered(t, core.Echo, []string{"GET /api/v2/apitest/ping"})
+}
+
+// TestNewCoreInjectedDatastore verifies WithDatastore wires a caller-provided
+// datastore instead of creating a default mock.
+func TestNewCoreInjectedDatastore(t *testing.T) {
+	mockDS := mocks.NewMockInterface(t)
+	core := NewCore(t, WithDatastore(mockDS))
+	assert.Same(t, mockDS, core.DS, "WithDatastore should inject the provided datastore")
+}
+
+// TestNewCoreIsolatedExportPaths verifies two cores built in the same test get
+// distinct media export directories, the property that keeps parallel binaries
+// from colliding on a shared path.
+func TestNewCoreIsolatedExportPaths(t *testing.T) {
+	a := NewCore(t)
+	b := NewCore(t)
+	require.NotNil(t, a.SFS)
+	require.NotNil(t, b.SFS)
+	assert.NotEqual(t, a.SFS.BaseDir(), b.SFS.BaseDir(), "each core should get its own export dir")
+}
+
+// TestNewTestHTTPClientDisablesKeepAlives is a thin smoke test of the HTTP
+// scaffolding so the helper stays exercised.
+func TestNewTestHTTPClientDisablesKeepAlives(t *testing.T) {
+	client := NewTestHTTPClient(TestResponseHeaderTimeout)
+	require.NotNil(t, client)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.True(t, transport.DisableKeepAlives)
+}

--- a/internal/api/v2/apitest/http.go
+++ b/internal/api/v2/apitest/http.go
@@ -1,0 +1,81 @@
+package apitest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/httpclient"
+)
+
+// TestResponseHeaderTimeout is the HTTP response-header timeout used by
+// NewTestHTTPClient and DisableHTTPKeepAlivesForTesting.
+const TestResponseHeaderTimeout = 30 * time.Second
+
+// newLeakSafeTestTransport clones DefaultTransport (per golang/go#26013, to
+// inherit proxy support and bounded dials) and disables keep-alives, connection
+// pooling, and HTTP/2 so test HTTP clients leave no persistent-connection
+// goroutines behind. The response-header timeout is caller-supplied.
+func newLeakSafeTestTransport(responseHeaderTimeout time.Duration) *http.Transport {
+	transport := httpclient.CloneDefaultTransport()
+	transport.DisableKeepAlives = true // Prevents persistent connection goroutines
+	transport.IdleConnTimeout = 1 * time.Second
+	transport.MaxIdleConns = 0 // Disable connection pooling
+	transport.MaxIdleConnsPerHost = 0
+	transport.ForceAttemptHTTP2 = false // Disable HTTP/2 for simplicity in tests
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	return transport
+}
+
+// NewTestHTTPClient creates an HTTP client optimized for tests to prevent
+// goroutine leaks (see newLeakSafeTestTransport).
+func NewTestHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: newLeakSafeTestTransport(timeout),
+	}
+}
+
+// DisableHTTPKeepAlivesForTesting overrides the default HTTP client transport to
+// prevent goroutine leaks from persistent connections in ALL HTTP clients during
+// testing. Call it once from a package's TestMain before any test creates a client.
+func DisableHTTPKeepAlivesForTesting() {
+	http.DefaultTransport = newLeakSafeTestTransport(TestResponseHeaderTimeout)
+}
+
+// AssertControllerError asserts a handler error response. It handles both cases:
+// when the handler returned an echo.HTTPError directly, and when the handler
+// already sent an HTTP error response to the recorder.
+func AssertControllerError(t *testing.T, err error, rec *httptest.ResponseRecorder, expectedCode int, expectedMessage string) {
+	t.Helper()
+
+	if err == nil {
+		// Handler handled the error and sent an HTTP response.
+		assert.Equal(t, expectedCode, rec.Code, "Expected HTTP status code")
+
+		var response map[string]any
+		jsonErr := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, jsonErr, "Response should be valid JSON")
+
+		// Check that the error response contains the expected message (if specified).
+		if expectedMessage != "" {
+			if message, exists := response["message"]; exists {
+				assert.Contains(t, message, expectedMessage, "Error message should contain expected text")
+			}
+		}
+		return
+	}
+
+	// Handler returned an error directly.
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr, "Error should be an echo.HTTPError")
+	assert.Equal(t, expectedCode, httpErr.Code, "Error should have expected HTTP code")
+	if expectedMessage != "" {
+		assert.Contains(t, httpErr.Message, expectedMessage, "Error message should contain expected text")
+	}
+}

--- a/internal/api/v2/apitest/imageprovider.go
+++ b/internal/api/v2/apitest/imageprovider.go
@@ -1,0 +1,53 @@
+package apitest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// MockImageProvider is a testify/mock implementation of the imageprovider
+// provider interface. Use it when a test needs to verify specific Fetch calls
+// and arguments.
+type MockImageProvider struct {
+	mock.Mock
+}
+
+// Fetch implements the image provider interface.
+func (m *MockImageProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
+	args := m.Called(scientificName)
+	return args.Get(0).(imageprovider.BirdImage), args.Error(1)
+}
+
+// TestImageProvider implements the image provider interface with a function field
+// for simple, customizable behavior without testify/mock expectations. Use it
+// when a test only needs to control Fetch's return value.
+type TestImageProvider struct {
+	FetchFunc func(scientificName string) (imageprovider.BirdImage, error)
+}
+
+// Fetch implements the image provider interface.
+func (m *TestImageProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
+	if m.FetchFunc != nil {
+		return m.FetchFunc(scientificName)
+	}
+	return imageprovider.BirdImage{}, nil
+}
+
+// NewMockBirdImageCache returns an imageprovider.BirdImageCache backed by a
+// MockImageProvider whose Fetch returns an empty placeholder image for any
+// species. It is the shared image-cache builder used by both the facade test
+// setup and apitest.NewCore so the mock-cache construction lives in one place.
+func NewMockBirdImageCache(t *testing.T) *imageprovider.BirdImageCache {
+	t.Helper()
+	provider := new(MockImageProvider)
+	provider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{
+		URL:            "https://example.com/empty.jpg",
+		ScientificName: "Test Species",
+	}, nil)
+	// Only exported fields are settable; wire the provider via SetImageProvider.
+	cache := &imageprovider.BirdImageCache{}
+	cache.SetImageProvider(provider)
+	return cache
+}

--- a/internal/api/v2/apitest/routes.go
+++ b/internal/api/v2/apitest/routes.go
@@ -1,0 +1,33 @@
+package apitest
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertRoutesRegistered verifies that all expected routes are registered on the
+// Echo instance. Each expected entry is a "METHOD PATH" string (for example
+// "GET /api/v2/control/actions"). It asserts every expected route is present;
+// extra registered routes are ignored.
+func AssertRoutesRegistered(t *testing.T, e *echo.Echo, expectedRoutes []string) {
+	t.Helper()
+
+	// Track which expected routes were found.
+	routeFound := make(map[string]bool, len(expectedRoutes))
+	for _, route := range expectedRoutes {
+		routeFound[route] = false
+	}
+
+	for _, r := range e.Routes() {
+		routePath := r.Method + " " + r.Path
+		if _, exists := routeFound[routePath]; exists {
+			routeFound[routePath] = true
+		}
+	}
+
+	for route, found := range routeFound {
+		assert.True(t, found, "Route not registered: %s", route)
+	}
+}

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/branding"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -67,7 +68,7 @@ func setupAppConfigTest(t *testing.T, securityConfig *conf.Security) (*echo.Echo
 		Security: secCfg,
 	}
 
-	mockImageProvider := &MockImageProvider{}
+	mockImageProvider := &apitest.MockImageProvider{}
 	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
 
 	birdImageCache := &imageprovider.BirdImageCache{}
@@ -77,7 +78,7 @@ func setupAppConfigTest(t *testing.T, securityConfig *conf.Security) (*echo.Echo
 	controlChan := make(chan string, testControlChannelBuf)
 	mockMetrics, _ := observability.NewMetrics()
 
-	publishTestSettings(t, settings)
+	apitest.PublishTestSettings(t, settings)
 
 	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, false)
 	require.NoError(t, err, "Failed to create test API controller")
@@ -119,7 +120,7 @@ func setupAppConfigTestWithAuth(t *testing.T, securityConfig *conf.Security) (*e
 		Security: secCfg,
 	}
 
-	mockImageProvider := &MockImageProvider{}
+	mockImageProvider := &apitest.MockImageProvider{}
 	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
 
 	birdImageCache := &imageprovider.BirdImageCache{}
@@ -131,7 +132,7 @@ func setupAppConfigTestWithAuth(t *testing.T, securityConfig *conf.Security) (*e
 
 	// Publish settings to the global snapshot so GetAppConfig (which reads via
 	// currentSettings) observes this controller's settings, not a leaked snapshot.
-	publishTestSettings(t, settings)
+	apitest.PublishTestSettings(t, settings)
 
 	// Create OAuth2Server for auth
 	oauth2Server := securitytest.NewOAuth2ServerForTesting(t, settings)
@@ -593,7 +594,7 @@ func TestGetAppConfig_EmptyVersion(t *testing.T) {
 		},
 	}
 
-	mockImageProvider := &MockImageProvider{}
+	mockImageProvider := &apitest.MockImageProvider{}
 	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
 	birdImageCache := &imageprovider.BirdImageCache{}
 	birdImageCache.SetImageProvider(mockImageProvider)
@@ -653,7 +654,7 @@ func TestGetAppConfig_VersionWithSpecialChars(t *testing.T) {
 				},
 			}
 
-			mockImageProvider := &MockImageProvider{}
+			mockImageProvider := &apitest.MockImageProvider{}
 			mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
 			birdImageCache := &imageprovider.BirdImageCache{}
 			birdImageCache.SetImageProvider(mockImageProvider)
@@ -1028,7 +1029,7 @@ func FuzzGetAppConfig_Headers(f *testing.F) {
 
 		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
-		publishTestSettings(t, settings)
+		apitest.PublishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		if accept != "" {
@@ -1150,7 +1151,7 @@ func FuzzGetAppConfig_CSRFToken(f *testing.F) {
 
 		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
-		publishTestSettings(t, settings)
+		apitest.PublishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1213,7 +1214,7 @@ func FuzzGetAppConfig_Version(f *testing.F) {
 
 		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
-		publishTestSettings(t, settings)
+		apitest.PublishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1364,7 +1365,7 @@ func FuzzGetAppConfig_SecurityConfig(f *testing.F) {
 
 		controller := &Controller{Core: &apicore.Core{DS: mockDS}, authService: nil}
 		controller.Settings.Store(settings)
-		publishTestSettings(t, settings)
+		apitest.PublishTestSettings(t, settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/app/config", http.NoBody)
 		rec := httptest.NewRecorder()

--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"gorm.io/driver/sqlite"
@@ -249,7 +250,7 @@ func TestDismissWizard_Success(t *testing.T) {
 	e := echo.New()
 	c := &Controller{Core: &apicore.Core{}, appMetadataRepo: mockRepo}
 	c.Settings.Store(&conf.Settings{Version: "v0.9.0"})
-	publishTestSettings(t, c.Settings.Load())
+	apitest.PublishTestSettings(t, c.Settings.Load())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/app/wizard/dismiss", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -527,7 +528,7 @@ func TestResolveClientID(t *testing.T) {
 
 	t.Run("prefers session ID when provided", func(t *testing.T) {
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr
@@ -541,7 +542,7 @@ func TestResolveClientID(t *testing.T) {
 
 	t.Run("falls back to generateClientID when no session", func(t *testing.T) {
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr
@@ -556,7 +557,7 @@ func TestResolveClientID(t *testing.T) {
 
 	t.Run("different sessions from same IP get different IDs", func(t *testing.T) {
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 
 		req1 := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -574,7 +575,7 @@ func TestResolveClientID(t *testing.T) {
 
 	t.Run("rejects invalid session ID format", func(t *testing.T) {
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr

--- a/internal/api/v2/audio_level_test.go
+++ b/internal/api/v2/audio_level_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -69,7 +70,7 @@ func TestAudioLevelSSEDataFormat(t *testing.T) {
 func TestIsSourceInactive(t *testing.T) {
 	// Create a minimal controller for testing
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	t.Run("new source is active", func(t *testing.T) {
 		lastUpdate := make(map[string]time.Time)
@@ -124,7 +125,7 @@ func TestIsSourceInactive(t *testing.T) {
 // TestCheckSourceActivity tests the source activity checking for multiple sources
 func TestCheckSourceActivity(t *testing.T) {
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	t.Run("no inactive sources", func(t *testing.T) {
 		now := time.Now()
@@ -180,7 +181,7 @@ func TestCheckSourceActivity(t *testing.T) {
 // TestGetAnonymizedSourceNameFallback tests the fallback source name anonymization
 func TestGetAnonymizedSourceNameFallback(t *testing.T) {
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	t.Run("audio card source", func(t *testing.T) {
 		name := controller.getAnonymizedSourceNameFallback("audio_card_default")

--- a/internal/api/v2/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio_level_write_deadline_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -69,7 +70,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 
 		// Create minimal controller
 		controller := &Controller{Core: &apicore.Core{}}
-		controller.Settings.Store(newValidTestSettings())
+		controller.Settings.Store(apitest.NewValidTestSettings())
 
 		// Create test audio level data
 		levels := map[string]audiocore.AudioLevelData{
@@ -110,7 +111,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		controller := &Controller{Core: &apicore.Core{}}
-		controller.Settings.Store(newValidTestSettings())
+		controller.Settings.Store(apitest.NewValidTestSettings())
 		levels := map[string]audiocore.AudioLevelData{
 			"test_source": {Level: 50, Name: "Test Source", Source: "test_source"},
 		}
@@ -143,7 +144,7 @@ func TestSendAudioLevelHeartbeatSetsWriteDeadline(t *testing.T) {
 
 		// Create minimal controller
 		controller := &Controller{Core: &apicore.Core{}}
-		controller.Settings.Store(newValidTestSettings())
+		controller.Settings.Store(apitest.NewValidTestSettings())
 
 		// Call sendAudioLevelHeartbeat
 		err := controller.sendAudioLevelHeartbeat(ctx)

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -63,7 +64,7 @@ func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Controller, *conf.Sett
 	}
 
 	// Create mock ImageProvider
-	mockImageProvider := &MockImageProvider{}
+	mockImageProvider := &apitest.MockImageProvider{}
 	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
 
 	// Create bird image cache with mock provider
@@ -313,7 +314,7 @@ func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 		},
 	}
 
-	mockImageProvider := &MockImageProvider{}
+	mockImageProvider := &apitest.MockImageProvider{}
 	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
 	birdImageCache := &imageprovider.BirdImageCache{}
 	birdImageCache.SetImageProvider(mockImageProvider)

--- a/internal/api/v2/control_restart_source_test.go
+++ b/internal/api/v2/control_restart_source_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
 )
@@ -26,7 +27,7 @@ func TestRestartAudioSource_NoEngine(t *testing.T) {
 	ctx.SetParamValues("test-src")
 
 	err := c.RestartAudioSource(ctx)
-	assertControllerError(t, err, rec, http.StatusInternalServerError, "Audio engine not available")
+	apitest.AssertControllerError(t, err, rec, http.StatusInternalServerError, "Audio engine not available")
 }
 
 func TestRestartAudioSource_SourceNotFound(t *testing.T) {
@@ -45,7 +46,7 @@ func TestRestartAudioSource_SourceNotFound(t *testing.T) {
 	ctx.SetParamValues("nonexistent")
 
 	err := c.RestartAudioSource(ctx)
-	assertControllerError(t, err, rec, http.StatusNotFound, "Audio source not found")
+	apitest.AssertControllerError(t, err, rec, http.StatusNotFound, "Audio source not found")
 }
 
 func TestRestartAudioSource_NoPipeline(t *testing.T) {
@@ -72,7 +73,7 @@ func TestRestartAudioSource_NoPipeline(t *testing.T) {
 	ctx.SetParamValues("test-src")
 
 	err = c.RestartAudioSource(ctx)
-	assertControllerError(t, err, rec, http.StatusServiceUnavailable, "Audio pipeline not started")
+	apitest.AssertControllerError(t, err, rec, http.StatusServiceUnavailable, "Audio pipeline not started")
 }
 
 func TestRestartAudioSource_Success(t *testing.T) {
@@ -146,7 +147,7 @@ func TestRestartAudioSource_RestartError(t *testing.T) {
 	ctx.SetParamValues("test-src")
 
 	err = c.RestartAudioSource(ctx)
-	assertControllerError(t, err, rec, http.StatusInternalServerError, "Failed to restart audio source")
+	apitest.AssertControllerError(t, err, rec, http.StatusInternalServerError, "Failed to restart audio source")
 }
 
 func TestRestartAudioSource_EmptyID(t *testing.T) {
@@ -161,5 +162,5 @@ func TestRestartAudioSource_EmptyID(t *testing.T) {
 	ctx.SetParamValues("")
 
 	err := c.RestartAudioSource(ctx)
-	assertControllerError(t, err, rec, http.StatusBadRequest, "Source ID is required")
+	apitest.AssertControllerError(t, err, rec, http.StatusBadRequest, "Source ID is required")
 }

--- a/internal/api/v2/control_test.go
+++ b/internal/api/v2/control_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/restart"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
@@ -342,7 +343,7 @@ func TestInitControlRoutesRegistration(t *testing.T) {
 	controller.initControlRoutes()
 
 	// Verify expected control routes are registered
-	assertRoutesRegistered(t, e, []string{
+	apitest.AssertRoutesRegistered(t, e, []string{
 		"GET /api/v2/control/actions",
 		"POST /api/v2/control/restart",
 		"POST /api/v2/control/reload",

--- a/internal/api/v2/detections_batch_test.go
+++ b/internal/api/v2/detections_batch_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -384,7 +385,7 @@ func TestBatchRoutes(t *testing.T) {
 	e, _, controller := setupTestEnvironment(t)
 	controller.initDetectionRoutes()
 
-	assertRoutesRegistered(t, e, []string{
+	apitest.AssertRoutesRegistered(t, e, []string{
 		"POST /api/v2/detections/batch/delete",
 		"POST /api/v2/detections/batch/review",
 		"POST /api/v2/detections/batch/lock",

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
@@ -2358,7 +2359,7 @@ func TestTrueConcurrentReviewAccess(t *testing.T) {
 			barrier.Wait()
 
 			// Create a fresh request for each goroutine
-			client := createTestHTTPClient(5 * time.Second)
+			client := apitest.NewTestHTTPClient(5 * time.Second)
 			defer client.CloseIdleConnections() // Ensure cleanup
 			req, _ := http.NewRequest(
 				http.MethodPost,
@@ -2470,7 +2471,7 @@ func TestTrueConcurrentPlatformSpecific(t *testing.T) {
 				barrier.Wait()
 
 				// Create request with timeout appropriate for platform
-				client := createTestHTTPClient(5 * time.Second)
+				client := apitest.NewTestHTTPClient(5 * time.Second)
 				defer client.CloseIdleConnections() // Ensure cleanup
 
 				// Add small stagger time to simulate more realistic conditions
@@ -2597,7 +2598,7 @@ func TestNoteToDetectionResponse_SourceInfo(t *testing.T) {
 	t.Attr("feature", "source-info")
 
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
 		name        string

--- a/internal/api/v2/events_test.go
+++ b/internal/api/v2/events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/logger/reader"
 )
 
@@ -43,7 +44,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("empty entries returns empty response", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		result := c.aggregateDetectionEvents(nil, baseTime)
 
@@ -59,7 +60,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("single approve creates one bucket and one species", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{
@@ -98,7 +99,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("multiple operations same bucket same species accumulate", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Sparrow", map[string]any{"confidence": 0.7, "match_count": float64(1)}),
@@ -128,7 +129,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("multiple species same bucket grouped correctly", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.9, "match_count": float64(2)}),
@@ -145,7 +146,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("multiple buckets separated by hour and sorted newest first", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
 		hour14 := time.Date(2024, 6, 15, 14, 45, 0, 0, time.UTC)
@@ -166,7 +167,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("pre-filters counted in bucket but not in species", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "dog_bark_filter", "", nil),
@@ -192,7 +193,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("pending count from create_pending_detection hourly array", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(time.Date(2024, 6, 15, 8, 0, 0, 0, time.UTC), "create_pending_detection", "", nil),
@@ -210,7 +211,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("species sorting approved first then by total descending", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			// Crow: 3 discards (no approvals)
@@ -238,7 +239,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("top discarded species top 3", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			// 5 discards for Alpha
@@ -272,7 +273,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("audio clip matching attached to correct species", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.9, "match_count": float64(1)}),
@@ -305,7 +306,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("peak confidence tracks highest value", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.7, "match_count": float64(1)}),
@@ -323,7 +324,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("max match count tracks highest value", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.8, "match_count": float64(2)}),
@@ -341,7 +342,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("empty species name entries are skipped", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "", map[string]any{"confidence": 0.9, "match_count": float64(1)}),
@@ -362,7 +363,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("approved per hour metric calculated correctly", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
 		hour14 := time.Date(2024, 6, 15, 14, 45, 0, 0, time.UTC)
@@ -383,7 +384,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("timestamps are recorded for approve and discard", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		approveTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
 		discardTime := time.Date(2024, 6, 15, 10, 35, 0, 0, time.UTC)
@@ -405,7 +406,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 	t.Run("species summary sorted by total descending", func(t *testing.T) {
 		t.Parallel()
 		c := &Controller{Core: &apicore.Core{}}
-		c.Settings.Store(newValidTestSettings())
+		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
 			// Robin: 3 total

--- a/internal/api/v2/filesystem_test.go
+++ b/internal/api/v2/filesystem_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/securefs"
 )
 
@@ -81,7 +82,7 @@ func TestBrowseFileSystem_BasicDirectory(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	// Make request to browse the temp directory
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + tempDir)
@@ -130,7 +131,7 @@ func TestBrowseFileSystem_EmptyPath(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	// Browse with no path parameter
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse")
@@ -167,7 +168,7 @@ func TestBrowseFileSystem_SubDirectory(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	// Browse the nested directory
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + subDir)
@@ -197,7 +198,7 @@ func TestBrowseFileSystem_PathTraversal(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	// Test various path traversal attempts
 	traversalPaths := []struct {
@@ -237,7 +238,7 @@ func TestBrowseFileSystem_NonExistentPath(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	nonExistent := filepath.Join(tempDir, "does-not-exist")
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + nonExistent)
@@ -263,7 +264,7 @@ func TestBrowseFileSystem_FileNotDirectory(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	// Try to browse the file as if it were a directory
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + testFile)
@@ -289,7 +290,7 @@ func TestBrowseFileSystem_EmptyDirectory(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + emptyDir)
 	require.NoError(t, err)
@@ -323,7 +324,7 @@ func TestBrowseFileSystem_ParentPath(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	tests := []struct {
 		name               string
@@ -428,7 +429,7 @@ func TestBrowseFileSystem_MixedFileTypes(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + tempDir)
 	require.NoError(t, err)
@@ -474,7 +475,7 @@ func TestBrowseFileSystem_LargeDirectory(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + tempDir)
 	require.NoError(t, err)
@@ -513,7 +514,7 @@ func TestBrowseFileSystem_SpecialCharactersInPath(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + tempDir)
 	require.NoError(t, err)
@@ -658,7 +659,7 @@ func TestBrowseFileSystem_SymlinkHandling(t *testing.T) {
 	server := httptest.NewServer(e)
 	defer server.Close()
 
-	client := createTestHTTPClient(testResponseHeaderTimeout)
+	client := apitest.NewTestHTTPClient(apitest.TestResponseHeaderTimeout)
 
 	resp, err := client.Get(server.URL + "/api/v2/filesystem/browse?path=" + tempDir)
 	require.NoError(t, err)

--- a/internal/api/v2/import_test.go
+++ b/internal/api/v2/import_test.go
@@ -27,6 +27,7 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imports"
 )
@@ -122,7 +123,7 @@ func newImportController(t *testing.T) (*echo.Echo, *Controller) {
 	cCore := &apicore.Core{Group: e.Group(apiV2Prefix), AuthMiddleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next }}
 	cCore.SetTestContext(ctx, cancel)
 	c := &Controller{Core: cCore, importMgr: newImportManager()}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 	t.Cleanup(func() {
 		cancel()
 		c.Wait()
@@ -253,7 +254,7 @@ func TestImportManager_GetByID(t *testing.T) {
 func TestStartBirdNETPiImport_NoRepo_Returns503(t *testing.T) {
 	e := echo.New()
 	c := &Controller{Core: &apicore.Core{Group: e.Group(apiV2Prefix)}, importMgr: newImportManager()}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	body := testDBOnlyBody
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/import/birdnet-pi", bytes.NewBufferString(body))
@@ -317,7 +318,7 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 
 	// db-audio mode now requires a configured export path; provide one so the
 	// handler accepts the request instead of returning 400.
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Audio.Export.Path = t.TempDir()
 	c.Settings.Store(settings)
 
@@ -361,8 +362,8 @@ func TestStartBirdNETPiImport_ModeDBAudio_NoExportPath_Returns400(t *testing.T) 
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
 
-	// Settings with an empty export path (newValidTestSettings leaves it unset).
-	c.Settings.Store(newValidTestSettings())
+	// Settings with an empty export path (apitest.NewValidTestSettings leaves it unset).
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	det := imports.SourceDetection{
 		Date: "2024-01-01", Time: "10:00:00",
@@ -481,7 +482,7 @@ func TestStartBirdNETPiImport_ModeDBAudio_CopiesClip(t *testing.T) {
 	// Configure a real export directory so the engine receives a non-empty
 	// ClipExportPath and the audio path is exercised.
 	exportDir := t.TempDir()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Audio.Export.Path = exportDir
 	c.Settings.Store(settings)
 
@@ -1040,7 +1041,7 @@ func TestImportRoutes_Registered(t *testing.T) {
 		"POST " + apiV2Prefix + "/import/jobs/:jobId/cancel",
 		"GET " + apiV2Prefix + "/import/status",
 	}
-	assertRoutesRegistered(t, e, expected)
+	apitest.AssertRoutesRegistered(t, e, expected)
 }
 
 // TestImportRoutes_FailClosedWhenNoAuth verifies the import group fails closed:

--- a/internal/api/v2/inference_status_test.go
+++ b/internal/api/v2/inference_status_test.go
@@ -210,7 +210,7 @@ func TestApplyRuntimeBackend(t *testing.T) {
 // the shared setupTestEnvironment harness (minimalController + Echo) to exercise
 // the handler over httptest without starting any background goroutines.
 func TestGetInferenceStatus_HTTP200(t *testing.T) {
-	// NOT parallel: publishTestSettings in setupTestEnvironment mutates global state.
+	// NOT parallel: apitest.PublishTestSettings in setupTestEnvironment mutates global state.
 	e, _, controller := setupTestEnvironment(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/inference", http.NoBody)
@@ -270,7 +270,7 @@ func TestBroadcastInferenceTopologyChanged_NilSafe(t *testing.T) {
 // audio block with the expected metric key for queue depth and a non-negative
 // queue capacity matching RouteInboxCapacity.
 func TestGetInferenceStatus_AudioBlock(t *testing.T) {
-	// NOT parallel: publishTestSettings in setupTestEnvironment mutates global state.
+	// NOT parallel: apitest.PublishTestSettings in setupTestEnvironment mutates global state.
 	e, _, controller := setupTestEnvironment(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/inference", http.NoBody)

--- a/internal/api/v2/integrations_test.go
+++ b/internal/api/v2/integrations_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -127,7 +128,7 @@ func TestInitIntegrationsRoutesRegistration(t *testing.T) {
 	controller.initIntegrationsRoutes()
 
 	// Verify expected integration routes are registered
-	assertRoutesRegistered(t, e, []string{
+	apitest.AssertRoutesRegistered(t, e, []string{
 		"GET /api/v2/integrations/mqtt/status",
 		"POST /api/v2/integrations/mqtt/test",
 		"GET /api/v2/integrations/birdweather/status",
@@ -811,7 +812,7 @@ func publishWeatherTestSettings(t *testing.T, mutate func(*conf.Settings)) (*ech
 	e, _, controller := setupTestEnvironment(t)
 	settings := controller.Settings.Load()
 	mutate(settings)
-	publishTestSettings(t, settings)
+	apitest.PublishTestSettings(t, settings)
 	return e, controller
 }
 

--- a/internal/api/v2/legacy_cleanup_test.go
+++ b/internal/api/v2/legacy_cleanup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -33,7 +34,7 @@ func createLegacyTestController(tb testing.TB, e *echo.Echo, settings *conf.Sett
 	tb.Helper()
 	// Handlers read the live snapshot via currentSettings(); publish the test's
 	// settings so the read resolves to them (restored on cleanup).
-	publishTestSettings(tb, settings)
+	apitest.PublishTestSettings(tb, settings)
 	c := &Controller{Core: &apicore.Core{Echo: e}, cleanupStatus: NewCleanupStatus()}
 	c.Settings.Store(settings)
 	return c

--- a/internal/api/v2/media_spectrogram_queuekey_test.go
+++ b/internal/api/v2/media_spectrogram_queuekey_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -49,7 +50,7 @@ func TestGetSpectrogramStatusFindsInFlightJobAfterExportPathChange(t *testing.T)
 		raw    = true
 	)
 
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Audio.Export.Path = filepath.Join(tmp, "original")
 
 	// A non-nil datastore satisfies requireDatastore; no Get expectation is set because
@@ -114,7 +115,7 @@ func TestGenerateSpectrogramFromRelRetainsFailedStatusForPolling(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	controllerCore := &apicore.Core{SFS: sfs}
 	controllerCore.SetTestContext(ctx, nil)
 	controller := &Controller{Core: controllerCore}

--- a/internal/api/v2/media_spectrogram_toctou_test.go
+++ b/internal/api/v2/media_spectrogram_toctou_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/conf/conftest"
 	"github.com/tphakala/birdnet-go/internal/securefs"
@@ -45,7 +46,7 @@ func TestGenerateSpectrogramFromRelIgnoresLiveExportPath(t *testing.T) {
 	controllerCore := &apicore.Core{SFS: sfs}
 	controllerCore.SetTestContext(ctx, nil)
 	controller := &Controller{Core: controllerCore}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	const (
 		width = SpectrogramSizeLg

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/middleware"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -1258,7 +1259,7 @@ func TestSpeciesImageNotFound_Returns404(t *testing.T) {
 	e, _, controller := setupTestEnvironment(t)
 
 	// Replace the mock provider with one that returns ErrImageNotFound for unknown species
-	notFoundProvider := &TestImageProvider{
+	notFoundProvider := &apitest.TestImageProvider{
 		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
 			return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
 		},

--- a/internal/api/v2/migration_test.go
+++ b/internal/api/v2/migration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -119,7 +120,7 @@ func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *data
 
 	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
 	controller.Settings.Store(getTestSettings(t))
-	publishTestSettings(t, controller.Settings.Load())
+	apitest.PublishTestSettings(t, controller.Settings.Load())
 
 	return e, controller, sm
 }

--- a/internal/api/v2/mqtt_tls_test.go
+++ b/internal/api/v2/mqtt_tls_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -390,5 +391,5 @@ func TestMQTTTLSRouteRegistration(t *testing.T) {
 		"POST /api/v2/integrations/mqtt/tls/certificate",
 		"DELETE /api/v2/integrations/mqtt/tls/certificate",
 	}
-	assertRoutesRegistered(t, e, expectedRoutes)
+	apitest.AssertRoutesRegistered(t, e, expectedRoutes)
 }

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
@@ -50,7 +51,7 @@ func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
 
 func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	// No t.Parallel(): this test publishes to the process-global settings
-	// singleton via publishTestSettings (CreateTestNewSpeciesNotification reads
+	// singleton via apitest.PublishTestSettings (CreateTestNewSpeciesNotification reads
 	// the live snapshot through currentSettings(), which consults
 	// conf.GetSettings() first). The notification service is fully isolated
 	// per test via dependency injection.
@@ -83,7 +84,7 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	controller.Settings.Store(settings)
 	// CreateTestNewSpeciesNotification reads the live snapshot via currentSettings();
 	// publish the controller's settings so the read resolves to them.
-	publishTestSettings(t, settings)
+	apitest.PublishTestSettings(t, settings)
 
 	err := controller.CreateTestNewSpeciesNotification(c)
 	require.NoError(t, err)

--- a/internal/api/v2/notifications_ntfy_check_test.go
+++ b/internal/api/v2/notifications_ntfy_check_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 )
 
 func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
@@ -24,7 +25,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 
 	e := echo.New()
 	ctrl := &Controller{Core: &apicore.Core{}}
-	ctrl.Settings.Store(newValidTestSettings())
+	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	// ts.Listener.Addr().String() returns "127.0.0.1:PORT"
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
@@ -44,7 +45,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 func TestCheckNtfyServer_MissingHost(t *testing.T) {
 	e := echo.New()
 	ctrl := &Controller{Core: &apicore.Core{}}
-	ctrl.Settings.Store(newValidTestSettings())
+	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -57,7 +58,7 @@ func TestCheckNtfyServer_MissingHost(t *testing.T) {
 func TestCheckNtfyServer_InvalidHost_Unreachable(t *testing.T) {
 	e := echo.New()
 	ctrl := &Controller{Core: &apicore.Core{}}
-	ctrl.Settings.Store(newValidTestSettings())
+	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	// Inject a short per-scheme probe timeout so the unreachable-host path returns
 	// quickly. 192.0.2.1 never responds, so the result is deterministically
 	// "unreachable" regardless of the timeout; the override only bounds the wait
@@ -89,7 +90,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 
 	e := echo.New()
 	ctrl := &Controller{Core: &apicore.Core{}}
-	ctrl.Settings.Store(newValidTestSettings())
+	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -106,7 +107,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 	e := echo.New()
 	ctrl := &Controller{Core: &apicore.Core{}}
-	ctrl.Settings.Store(newValidTestSettings())
+	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	// Slash injection attempt
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=evil.com%2F%40good.com", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -120,7 +121,7 @@ func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 func TestCheckNtfyServer_CloudMetadataBlocked(t *testing.T) {
 	e := echo.New()
 	ctrl := &Controller{Core: &apicore.Core{}}
-	ctrl.Settings.Store(newValidTestSettings())
+	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=169.254.169.254", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)

--- a/internal/api/v2/ntfy_integration_test.go
+++ b/internal/api/v2/ntfy_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/testutil/containers"
 )
 
@@ -56,7 +57,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 		// Test the full CheckNtfyServer handler via Echo context
 		e := echo.New()
 		ctrl := &Controller{Core: &apicore.Core{}}
-		ctrl.Settings.Store(newValidTestSettings())
+		ctrl.Settings.Store(apitest.NewValidTestSettings())
 
 		req := httptest.NewRequest(http.MethodGet,
 			"/api/v2/notifications/check-ntfy-server?host="+host, http.NoBody)

--- a/internal/api/v2/prerequisites_test.go
+++ b/internal/api/v2/prerequisites_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 
@@ -304,7 +305,7 @@ func TestCheckMemoryAvailable(t *testing.T) {
 	t.Attr("feature", "prerequisites")
 
 	controller := &Controller{Core: &apicore.Core{}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	check := controller.checkMemoryAvailable()
 
@@ -469,7 +470,7 @@ func TestGetDatabaseDirectoryResolved_NilSettings(t *testing.T) {
 	controller := &Controller{Core: &apicore.Core{}}
 	// Publish a nil global so currentSettings() falls back to the controller's
 	// nil c.Settings and exercises the "settings not available" path.
-	publishTestSettings(t, nil)
+	apitest.PublishTestSettings(t, nil)
 
 	_, err := controller.getDatabaseDirectoryResolved()
 
@@ -579,7 +580,7 @@ func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *
 
 	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
 	controller.Settings.Store(getTestSettings(t))
-	publishTestSettings(t, controller.Settings.Load())
+	apitest.PublishTestSettings(t, controller.Settings.Load())
 
 	return e, controller, sm
 }

--- a/internal/api/v2/routes_enumeration_test.go
+++ b/internal/api/v2/routes_enumeration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -303,9 +304,9 @@ func buildFullyRoutedController(t *testing.T) *echo.Echo {
 	// Permissive expectations for DS methods that background goroutines started
 	// by initRoutes (e.g. the app-event pruning worker) may call before Shutdown.
 	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Audio.Export.Path = t.TempDir()
-	publishTestSettings(t, settings)
+	apitest.PublishTestSettings(t, settings)
 	birdImageCache := &imageprovider.BirdImageCache{}
 	sunCalc := suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
 	controlChan := make(chan string, testControlChannelBuf)
@@ -330,7 +331,7 @@ func sortedRouteSet(e *echo.Echo) []string {
 // TestRouteEnumerationMatchesGolden pins the full method+path route set so the
 // API v2 package-split phases cannot silently add, drop, or reorder a route.
 func TestRouteEnumerationMatchesGolden(t *testing.T) {
-	// NOT parallel: publishTestSettings mutates the process-global snapshot.
+	// NOT parallel: apitest.PublishTestSettings mutates the process-global snapshot.
 	e := buildFullyRoutedController(t)
 	got := sortedRouteSet(e)
 
@@ -341,7 +342,7 @@ func TestRouteEnumerationMatchesGolden(t *testing.T) {
 // TestRouteEnumerationIsDeterministic builds the controller twice and asserts the
 // route set is identical, guarding against registration-order nondeterminism.
 func TestRouteEnumerationIsDeterministic(t *testing.T) {
-	// NOT parallel: publishTestSettings mutates the process-global snapshot.
+	// NOT parallel: apitest.PublishTestSettings mutates the process-global snapshot.
 	first := sortedRouteSet(buildFullyRoutedController(t))
 	second := sortedRouteSet(buildFullyRoutedController(t))
 	assert.Equal(t, first, second)
@@ -351,7 +352,7 @@ func TestRouteEnumerationIsDeterministic(t *testing.T) {
 // registered directly on the Echo instance (not the group), preserving the
 // documented greedy-route behavior that catches all /api/v2/audio/* paths.
 func TestGreedyAudioRouteRegisteredOnEcho(t *testing.T) {
-	// NOT parallel: publishTestSettings mutates the process-global snapshot.
+	// NOT parallel: apitest.PublishTestSettings mutates the process-global snapshot.
 	e := buildFullyRoutedController(t)
 	found := false
 	for _, r := range e.Routes() {

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -281,7 +282,7 @@ func TestHandleSearch_LocalizedCommonName_SecondaryModelSpecies(t *testing.T) {
 	mockDS := mocks.NewMockInterface(t)
 
 	controller := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2"), DS: mockDS}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	// Wire a batch-capable resolver so the scientific-only bat label
 	// "Barbastella barbastellus" (no underscore-separated common name in the

--- a/internal/api/v2/settings_extreme_test.go
+++ b/internal/api/v2/settings_extreme_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 )
 
 // executeLargeDataSettingsPatch creates and executes a PATCH request with large data.
@@ -217,7 +218,7 @@ func TestExtremeValues(t *testing.T) {
 
 			if tt.expectedError {
 				// Use helper function to assert error response (expects BadRequest for extreme values)
-				assertControllerError(t, err, rec, http.StatusBadRequest, "")
+				apitest.AssertControllerError(t, err, rec, http.StatusBadRequest, "")
 				t.Logf("Extreme value properly rejected: %s", tt.description)
 			} else {
 				if err != nil {

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -107,7 +108,7 @@ func newSettingsAuthTestEnvWithNotifier(t *testing.T) (*echo.Echo, *notification
 		},
 	}
 
-	mockImageProvider := &MockImageProvider{}
+	mockImageProvider := &apitest.MockImageProvider{}
 	mockImageProvider.On("Fetch", mock.Anything).
 		Return(imageprovider.BirdImage{}, nil).Maybe()
 

--- a/internal/api/v2/settings_restart_test.go
+++ b/internal/api/v2/settings_restart_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/restart"
 )
@@ -78,7 +79,7 @@ func TestRestartDetectors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			base := newValidTestSettings()
+			base := apitest.NewValidTestSettings()
 			updated := conf.CloneSettings(base)
 			tt.mutate(updated)
 
@@ -99,7 +100,7 @@ func TestHandleSettingsChangesMarksRestart(t *testing.T) {
 	t.Cleanup(restart.Reset)
 
 	c := createTestController(t)
-	base := newValidTestSettings()
+	base := apitest.NewValidTestSettings()
 	updated := conf.CloneSettings(base)
 	updated.WebServer.Port = "9999"
 
@@ -116,7 +117,7 @@ func TestHandleSettingsChangesNoRestartForHotReloadField(t *testing.T) {
 	t.Cleanup(restart.Reset)
 
 	c := createTestController(t)
-	base := newValidTestSettings()
+	base := apitest.NewValidTestSettings()
 	updated := conf.CloneSettings(base)
 	updated.WebServer.Debug = !base.WebServer.Debug
 

--- a/internal/api/v2/settings_species_test.go
+++ b/internal/api/v2/settings_species_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -150,7 +151,7 @@ func TestSpeciesSettingsUpdate(t *testing.T) {
 
 	// Setup
 	e := echo.New()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Interval = 15
 	settings.Realtime.Species = conf.SpeciesSettings{
 		Include: []string{"Robin"},
@@ -225,7 +226,7 @@ func TestPartialSpeciesConfigUpdate(t *testing.T) {
 
 	// Setup with existing configs (use lowercase keys since they're set directly)
 	e := echo.New()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Species = conf.SpeciesSettings{
 		Config: map[string]conf.SpeciesConfig{
 			"bird a": {
@@ -293,7 +294,7 @@ func TestSpeciesSettingsPatchGetSync(t *testing.T) {
 	// Setup controller with its own settings (simulating real usage)
 	// Use lowercase keys since they're set directly
 	e := echo.New()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Interval = 15
 	settings.Realtime.Species = conf.SpeciesSettings{
 		Include: []string{},
@@ -420,7 +421,7 @@ func TestSpeciesSettingsRejectInvalid(t *testing.T) {
 func newAPIContext(t *testing.T, e *echo.Echo, method, path string, body any) (echo.Context, *httptest.ResponseRecorder, *Controller) {
 	t.Helper()
 
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Main.Name = "TestNode"
 	settings.Realtime.Species = conf.SpeciesSettings{
 		Include: []string{},
@@ -493,7 +494,7 @@ func TestSpeciesConfigNormalizationOnAPIUpdate(t *testing.T) {
 	t.Parallel()
 
 	e := echo.New()
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Species = conf.SpeciesSettings{
 		Include: []string{},
 		Exclude: []string{},
@@ -555,7 +556,7 @@ func TestSpeciesConfigNormalizationOnAPIUpdate(t *testing.T) {
 func createTestController(t *testing.T) *Controller {
 	t.Helper()
 
-	settings := newValidTestSettings()
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Species = conf.SpeciesSettings{
 		Include: []string{},
 		Exclude: []string{},

--- a/internal/api/v2/settings_test_setup_test.go
+++ b/internal/api/v2/settings_test_setup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"go.uber.org/goleak"
 )
@@ -39,7 +40,7 @@ const (
 func TestMain(m *testing.M) {
 	// Disable HTTP keep-alives for all tests to prevent goroutine leaks from
 	// persistent connections. Must run before any test creates an HTTP client.
-	DisableHTTPKeepAlivesForTesting()
+	apitest.DisableHTTPKeepAlivesForTesting()
 
 	// Run tests
 	testResult := m.Run()

--- a/internal/api/v2/settings_update_test.go
+++ b/internal/api/v2/settings_update_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -547,7 +548,7 @@ func TestValidationErrors(t *testing.T) {
 			err = controller.UpdateSectionSettings(ctx)
 
 			// Use helper function to assert error response
-			assertControllerError(t, err, rec, tt.expectedCode, tt.expectedError)
+			apitest.AssertControllerError(t, err, rec, tt.expectedCode, tt.expectedError)
 		})
 	}
 }

--- a/internal/api/v2/species_taxonomy_test.go
+++ b/internal/api/v2/species_taxonomy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 )
 
@@ -26,7 +27,7 @@ func TestGetGenusSpecies(t *testing.T) {
 
 	// Create a minimal controller with taxonomy DB
 	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -124,7 +125,7 @@ func TestGetFamilySpecies(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -203,7 +204,7 @@ func TestGetSpeciesTree(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -306,7 +307,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB, EBirdClient: nil}}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
 		name           string
@@ -359,7 +360,7 @@ func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
 	c := &Controller{Core: &apicore.Core{TaxonomyDB: nil, EBirdClient: nil}}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 
 	// This should fail gracefully
 	_, err := c.getDetailedTaxonomy(t.Context(), "Turdus migratorius", "", false, true)

--- a/internal/api/v2/sse_connection_test.go
+++ b/internal/api/v2/sse_connection_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -56,7 +57,7 @@ const maxSSEReadLines = 3
 // Returns true if connection was established and events were read.
 func attemptSSEConnection(t *testing.T, serverURL, endpoint string, connID int, timeout time.Duration) bool {
 	t.Helper()
-	client := createTestHTTPClient(timeout)
+	client := apitest.NewTestHTTPClient(timeout)
 	defer client.CloseIdleConnections()
 
 	req, err := http.NewRequest("GET", serverURL+"/api/v2"+endpoint, http.NoBody)
@@ -158,7 +159,7 @@ func testSSEEndpointCleanup(t *testing.T, config SSETestConfig) {
 func testSingleConnectionManualDisconnect(t *testing.T, server *httptest.Server, config SSETestConfig) {
 	t.Helper()
 	// Create HTTP client optimized for tests
-	client := createTestHTTPClient(config.testTimeout)
+	client := apitest.NewTestHTTPClient(config.testTimeout)
 
 	// Make SSE request
 	req, err := http.NewRequest("GET", server.URL+"/api/v2"+config.endpoint, http.NoBody)
@@ -211,7 +212,7 @@ func testSingleConnectionContextCancellation(t *testing.T, server *httptest.Serv
 	ctx, cancel := context.WithCancel(t.Context())
 
 	// Create HTTP client optimized for tests
-	client := createTestHTTPClient(config.testTimeout)
+	client := apitest.NewTestHTTPClient(config.testTimeout)
 
 	// Make SSE request with context
 	req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/api/v2"+config.endpoint, http.NoBody)
@@ -288,7 +289,7 @@ func testConnectionTimeout(t *testing.T, server *httptest.Server, config SSETest
 	// This test would require modifying the timeout constants for testing
 	// For now, we'll test the behavior with a short-lived connection
 
-	client := createTestHTTPClient(config.connectionTimeout)
+	client := apitest.NewTestHTTPClient(config.connectionTimeout)
 
 	req, err := http.NewRequest("GET", server.URL+"/api/v2"+config.endpoint, http.NoBody)
 	require.NoError(t, err)
@@ -325,7 +326,7 @@ func TestSSEUnbufferedChannelFix(t *testing.T) {
 	defer server.Close()
 	defer controller.Shutdown()
 
-	client := createTestHTTPClient(3 * time.Second)
+	client := apitest.NewTestHTTPClient(3 * time.Second)
 
 	// Create multiple rapid connections and disconnections to stress test
 	// the Done channel handling
@@ -363,7 +364,7 @@ func TestSSERateLimiting(t *testing.T) {
 	defer server.Close()
 	defer controller.Shutdown()
 
-	client := createTestHTTPClient(2 * time.Second)
+	client := apitest.NewTestHTTPClient(2 * time.Second)
 
 	var successCount, rateLimitedCount int
 
@@ -460,7 +461,7 @@ func BenchmarkSSEConnectionSetup(b *testing.B) {
 	defer server.Close()
 	defer controller.Shutdown()
 
-	client := createTestHTTPClient(5 * time.Second)
+	client := apitest.NewTestHTTPClient(5 * time.Second)
 	defer client.CloseIdleConnections()
 
 	b.ReportAllocs()

--- a/internal/api/v2/test_helpers_test.go
+++ b/internal/api/v2/test_helpers_test.go
@@ -1,19 +1,13 @@
 package api
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/httpclient"
 )
 
 // Test MQTT topic constant
@@ -21,9 +15,8 @@ const testMQTTTopic = "birdnet/detections"
 
 // Test controller constants
 const (
-	testControlChanBuffer     = 10               // Buffer size for control channel in tests
-	testNewYorkLongitude      = -74.0060         // New York City longitude for test data
-	testResponseHeaderTimeout = 30 * time.Second // HTTP response header timeout for tests
+	testControlChanBuffer = 10       // Buffer size for control channel in tests
+	testNewYorkLongitude  = -74.0060 // New York City longitude for test data
 	// testFailFastTimeout is a short timeout injected into deliberate-failure
 	// waits (unreachable ntfy host, audio file that never appears) so those
 	// tests reach the expected timeout state quickly instead of waiting the full
@@ -33,7 +26,7 @@ const (
 )
 
 // getTestController creates a test controller with disabled saving
-// Note: DisableHTTPKeepAlivesForTesting() is called in TestMain before any tests run
+// Note: apitest.DisableHTTPKeepAlivesForTesting() is called in TestMain before any tests run
 func getTestController(t *testing.T, e *echo.Echo) *Controller {
 	t.Helper()
 	c := &Controller{Core: &apicore.Core{Echo: e}, controlChan: make(chan string, testControlChanBuffer), DisableSaveSettings: true}
@@ -109,66 +102,4 @@ func getTestSettings(t *testing.T) *conf.Settings {
 	settings.Realtime.MQTT.RetrySettings.BackoffMultiplier = 2.0
 
 	return settings
-}
-
-// assertControllerError is a helper function that asserts controller error responses
-// It handles both cases: when the controller returns an HTTP error or sends an HTTP response
-func assertControllerError(t *testing.T, err error, rec *httptest.ResponseRecorder, expectedCode int, expectedMessage string) {
-	t.Helper()
-
-	if err == nil {
-		// Controller handled the error and sent an HTTP response
-		assert.Equal(t, expectedCode, rec.Code, "Expected HTTP status code")
-
-		var response map[string]any
-		jsonErr := json.Unmarshal(rec.Body.Bytes(), &response)
-		require.NoError(t, jsonErr, "Response should be valid JSON")
-
-		// Check that the error response contains the expected message (if specified)
-		if expectedMessage != "" {
-			if message, exists := response["message"]; exists {
-				assert.Contains(t, message, expectedMessage, "Error message should contain expected text")
-			}
-		}
-	} else {
-		// Controller returned an error directly
-		var httpErr *echo.HTTPError
-		require.ErrorAs(t, err, &httpErr, "Error should be an echo.HTTPError")
-		assert.Equal(t, expectedCode, httpErr.Code, "Error should have expected HTTP code")
-		if expectedMessage != "" {
-			assert.Contains(t, httpErr.Message, expectedMessage, "Error message should contain expected text")
-		}
-	}
-}
-
-// createTestHTTPClient creates an HTTP client optimized for tests to prevent goroutine leaks.
-// Clones DefaultTransport (per golang/go#26013) to inherit proxy support and bounded dials,
-// then disables keep-alives, pooling, and HTTP/2.
-func createTestHTTPClient(timeout time.Duration) *http.Client {
-	transport := httpclient.CloneDefaultTransport()
-	transport.DisableKeepAlives = true // Prevents persistent connection goroutines
-	transport.IdleConnTimeout = 1 * time.Second
-	transport.MaxIdleConns = 0 // Disable connection pooling
-	transport.MaxIdleConnsPerHost = 0
-	transport.ForceAttemptHTTP2 = false // Disable HTTP/2 for simplicity in tests
-	transport.ResponseHeaderTimeout = timeout
-	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
-	}
-}
-
-// DisableHTTPKeepAlivesForTesting configures the default HTTP client transport
-// to prevent goroutine leaks from persistent connections during testing.
-// Clones DefaultTransport to preserve proxy and dial timeout defaults.
-func DisableHTTPKeepAlivesForTesting() {
-	// Override the default transport to prevent goroutine leaks in ALL HTTP clients
-	transport := httpclient.CloneDefaultTransport()
-	transport.DisableKeepAlives = true
-	transport.IdleConnTimeout = 1 * time.Second
-	transport.MaxIdleConns = 0
-	transport.MaxIdleConnsPerHost = 0
-	transport.ForceAttemptHTTP2 = false
-	transport.ResponseHeaderTimeout = testResponseHeaderTimeout
-	http.DefaultTransport = transport
 }

--- a/internal/api/v2/test_utils_test.go
+++ b/internal/api/v2/test_utils_test.go
@@ -1,21 +1,24 @@
-// Shared test utilities for API v2 tests.
+// Shared test utilities for API v2 facade (package api) tests.
+//
+// Core-level scaffolding (settings builders, mock image providers, metrics, HTTP
+// helpers, route assertions, and the *apicore.Core builder) lives in the
+// importable internal/api/v2/apitest package. The helpers here are the thin
+// facade glue that builds a *Controller, which apitest cannot do (it must not
+// import this package).
 
 package api
 
 import (
 	"testing"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
-	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
-	"github.com/tphakala/birdnet-go/internal/imageprovider"
-	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
@@ -31,53 +34,8 @@ const (
 // Includes default settings to prevent nil pointer panics if a handler accesses c.Settings.
 func newMinimalController() *Controller {
 	c := &Controller{Core: &apicore.Core{}}
-	c.Settings.Store(newValidTestSettings())
+	c.Settings.Store(apitest.NewValidTestSettings())
 	return c
-}
-
-// publishTestSettings publishes settings as the global atomic snapshot so that
-// handlers reading via c.currentSettings() observe them, and restores the
-// previous snapshot on cleanup so the publish does not leak into sibling tests.
-//
-// IMPORTANT: tests using this helper must NOT call t.Parallel(). It mutates the
-// process-global settings snapshot, so parallel tests would observe each
-// other's settings and flake.
-//
-// Routing handler reads through currentSettings() makes every
-// handler read the lock-free global snapshot rather than the controller-cached
-// c.Settings field. Tests that inject a per-controller *conf.Settings must
-// therefore publish it here (pass nil to exercise a handler's nil-settings
-// fallback path).
-func publishTestSettings(tb testing.TB, settings *conf.Settings) {
-	tb.Helper()
-	prev := conf.GetSettings()
-	conftest.SetTestSettings(settings)
-	tb.Cleanup(func() { conftest.SetTestSettings(prev) })
-}
-
-// TestImageProvider implements the imageprovider.Provider interface for testing
-// with a function field for easier test setup.
-// Use this when you need a simple mock with customizable behavior via FetchFunc.
-type TestImageProvider struct {
-	FetchFunc func(scientificName string) (imageprovider.BirdImage, error)
-}
-
-// Fetch implements the ImageProvider Fetch method
-func (m *TestImageProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
-	if m.FetchFunc != nil {
-		return m.FetchFunc(scientificName)
-	}
-	return imageprovider.BirdImage{}, nil
-}
-
-// NewTestMetrics creates a new metrics instance for testing
-func NewTestMetrics(t *testing.T) *observability.Metrics {
-	t.Helper()
-	metrics, err := observability.NewMetrics()
-	if err != nil {
-		t.Fatalf("Failed to create test metrics: %v", err)
-	}
-	return metrics
 }
 
 // setupAnalyticsTestEnvironment creates a test environment with Echo, mocks.MockInterface, and Controller
@@ -93,7 +51,7 @@ func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterfa
 	// Create a controller with the test datastore and default settings
 	// to prevent nil pointer panics if a handler accesses c.Settings.
 	controller := &Controller{Core: &apicore.Core{Group: e.Group(apiV2Prefix), DS: mockDS}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	// Don't initialize routes as it causes nil pointer dereference in tests
 	// controller.initRoutes()
@@ -101,33 +59,21 @@ func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterfa
 	return e, mockDS, controller
 }
 
-// MockImageProvider is a mock implementation of imageprovider.ImageProvider interface
-// that uses testify/mock for expectations and verification.
-// Use this when you need to verify specific method calls and arguments.
-type MockImageProvider struct {
-	mock.Mock
-}
-
-// Fetch implements the ImageProvider interface
-func (m *MockImageProvider) Fetch(scientificName string) (imageprovider.BirdImage, error) {
-	args := m.Called(scientificName)
-	return args.Get(0).(imageprovider.BirdImage), args.Error(1)
-}
-
-// Setup function to create a test environment
+// setupTestEnvironment creates a complete facade test environment.
 //
-// This function creates a complete test environment for API tests with the following components:
-// 1. Echo instance - A new Echo web framework instance for handling HTTP requests
-// 2. mocks.MockInterface - A generated mock implementation of the datastore interface for test data
-// 3. Settings - Default configuration settings for testing
-// 4. Logger - A test logger that outputs to stdout
-// 5. MockImageProvider - A mock image provider for bird images
-// 6. BirdImageCache - An initialized image cache with the mock provider
-// 7. SunCalc - A mock sun calculator for time-based calculations
-// 8. Control channel - A channel for control messages between components
+// It builds a real *Controller via the production NewWithOptions constructor
+// (initializeRoutes=false to avoid starting background route goroutines), wiring:
+//  1. Echo instance - a new web framework instance for handling HTTP requests
+//  2. mocks.MockInterface - a generated mock datastore for test data
+//  3. Settings - shared valid defaults with a per-test temp export path
+//  4. A mock BirdImageCache whose Fetch returns an empty placeholder image
+//  5. SunCalc - a sun calculator seeded with Helsinki coordinates
+//  6. Control channel - buffered to avoid blocking in tests
 //
-// The function returns the Echo instance, mocks.MockInterface, and Controller for use in tests.
-// Note: Callers are responsible for closing any resources (like channels) when tests complete.
+// The Core-level building blocks (settings, mock cache, metrics, settings publish)
+// come from the apitest package so they are not duplicated here. It returns the
+// Echo instance, mock datastore, and Controller. Cleanup (Shutdown + channel
+// close) is registered via t.Cleanup.
 func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Controller) {
 	t.Helper()
 
@@ -137,48 +83,33 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 	// Create mock datastore
 	mockDS := mocks.NewMockInterface(t)
 
-	// Create settings from shared valid defaults, with test-specific overrides
-	settings := newValidTestSettings()
+	// Settings from shared valid defaults, with a per-test temp export path for
+	// isolation (the media SecureFS is rooted here).
+	settings := apitest.NewValidTestSettings()
 	settings.Realtime.Audio.Export.Path = t.TempDir()
 
-	// Create a mock ImageProvider for testing
-	mockImageProvider := new(MockImageProvider)
+	// Mock image cache (default Fetch returns an empty placeholder image).
+	birdImageCache := apitest.NewMockBirdImageCache(t)
 
-	// Set default behavior to return an empty bird image for any species
-	emptyBirdImage := imageprovider.BirdImage{
-		URL:            "https://example.com/empty.jpg",
-		ScientificName: "Test Species",
-	}
-	mockImageProvider.On("Fetch", mock.Anything).Return(emptyBirdImage, nil)
-
-	// Create a properly initialized BirdImageCache with the mock provider
-	birdImageCache := &imageprovider.BirdImageCache{
-		// We can only set exported fields, so we'll use SetImageProvider method instead
-	}
-	birdImageCache.SetImageProvider(mockImageProvider)
-
-	// Create sun calculator with test coordinates (Helsinki, Finland)
+	// Sun calculator with test coordinates (Helsinki, Finland)
 	sunCalc := suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
 
-	// Create control channel with buffer to prevent blocking in tests
-	// Size 10 is sufficient for concurrent test scenarios (e.g., TestConcurrentControlRequests uses 5)
+	// Buffered control channel to prevent blocking in tests. Size 10 is sufficient
+	// for concurrent test scenarios (e.g., TestConcurrentControlRequests uses 5).
 	controlChan := make(chan string, testControlChannelBuf)
 
-	// Create mock metrics for testing
-	mockMetrics, _ := observability.NewMetrics()
+	// Mock metrics for testing
+	mockMetrics := apitest.NewTestMetrics(t)
 
-	// Sync controller settings with the global conf.settingsInstance so that
-	// functions like conf.SaveSettings() (called by toggleSpeciesInIgnoredList)
-	// operate on the same instance the controller uses, and so handlers reading
-	// via currentSettings() observe this controller's settings. Restored on
-	// cleanup so it does not leak into sibling tests.
-	publishTestSettings(t, settings)
+	// Publish settings to the process-global snapshot so functions like
+	// conf.SaveSettings() (called by toggleSpeciesInIgnoredList) and handlers
+	// reading via currentSettings() operate on this controller's settings.
+	// Restored on cleanup so it does not leak into sibling tests.
+	apitest.PublishTestSettings(t, settings)
 
 	// Create API controller without initializing routes to avoid starting background goroutines
 	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, false)
-	if err != nil {
-		t.Fatalf("Failed to create test API controller: %v", err)
-	}
+	require.NoError(t, err, "Failed to create test API controller")
 	// Handler tests assert on in-memory settings and the HTTP response, not on
 	// disk persistence. Disable disk saves so settings-mutating handlers (e.g.
 	// IgnoreSpecies -> toggleSpeciesInIgnoredList -> conf.SaveSettings) do not
@@ -199,67 +130,6 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 	})
 
 	return e, mockDS, controller
-}
-
-// newValidTestSettings returns a *conf.Settings populated with minimal values
-// that pass conf.ValidateSettings(). Tests that create inline Controller structs
-// should call this and then override the fields they care about.
-//
-// Debug defaults to false to match production behavior. Tests that specifically
-// need debug mode should set controller.Settings.WebServer.Debug = true.
-func newValidTestSettings() *conf.Settings {
-	return &conf.Settings{
-		BirdNET: conf.BirdNETConfig{
-			Sensitivity: 1.0,
-			Threshold:   0.8,
-			Locale:      "en",
-		},
-		WebServer: conf.WebServerSettings{
-			Debug: false,
-			LiveStream: conf.LiveStreamSettings{
-				BitRate:       128,
-				SegmentLength: 5,
-			},
-		},
-		Security: conf.Security{
-			SessionDuration: 168 * time.Hour,
-		},
-		Realtime: conf.RealtimeSettings{
-			Interval: 15,
-			Dashboard: conf.Dashboard{
-				SummaryLimit: 100,
-			},
-			Weather: conf.WeatherSettings{
-				PollInterval: 30,
-			},
-		},
-	}
-}
-
-// assertRoutesRegistered verifies that all expected routes are registered in the Echo instance.
-// It creates a map from expected route strings (e.g., "GET /api/v2/control/actions"),
-// checks each registered route against this map, and asserts that all expected routes were found.
-func assertRoutesRegistered(t *testing.T, e *echo.Echo, expectedRoutes []string) {
-	t.Helper()
-
-	// Create a map to track which routes were found
-	routeFound := make(map[string]bool, len(expectedRoutes))
-	for _, route := range expectedRoutes {
-		routeFound[route] = false
-	}
-
-	// Check each registered route
-	for _, r := range e.Routes() {
-		routePath := r.Method + " " + r.Path
-		if _, exists := routeFound[routePath]; exists {
-			routeFound[routePath] = true
-		}
-	}
-
-	// Verify all expected routes were found
-	for route, found := range routeFound {
-		assert.True(t, found, "Route not registered: %s", route)
-	}
 }
 
 // SpeciesDailySummaryExpected contains expected values for species daily summary assertions.

--- a/internal/api/v2/tls_test.go
+++ b/internal/api/v2/tls_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	tlspkg "github.com/tphakala/birdnet-go/internal/tls"
 )
@@ -298,5 +299,5 @@ func TestTLSRouteRegistration(t *testing.T) {
 		"POST /api/v2/tls/certificate/generate",
 		"GET /api/v2/tls/certificate/download",
 	}
-	assertRoutesRegistered(t, e, expectedRoutes)
+	apitest.AssertRoutesRegistered(t, e, expectedRoutes)
 }

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 )
@@ -120,7 +121,7 @@ func setupWeatherTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface
 
 	// Create a controller with the test datastore
 	controller := &Controller{Core: &apicore.Core{Group: e.Group("/api/v2"), DS: mockDS}}
-	controller.Settings.Store(newValidTestSettings())
+	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	// We don't need to initialize routes for unit tests
 	// But we could initialize the weather routes specifically if needed


### PR DESCRIPTION
## What and why

Phase 2 of the `internal/api/v2` package split. The goal of the split is to stop the single monolithic `api/v2` test binary from gating the per-package `-race` timeout; later phases move handlers into per-domain subpackages. Before any domain test can leave package `api`, the shared test setup has to become importable, because a `_test.go` file cannot be imported by another package's tests.

This PR creates an importable `internal/api/v2/apitest` package (`package apitest`, regular `.go` files, no production importers) holding the reusable, Core-level test scaffolding so future per-domain test packages can do `analytics.New(apitest.NewCore(t))` without re-deriving setup.

Phase 1 already extracted `internal/api/v2/apicore` (`apicore.Core`); the facade `api.Controller` embeds `*apicore.Core`. This phase builds on that.

## The import-cycle constraint

`apitest` imports only `apicore` plus leaf/test-support packages (`conf`, `conf/conftest`, `datastore`, `datastore/mocks`, `imageprovider`, `suncalc`, `observability`, `httpclient`, `echo`, `testify`). It never imports the facade (`package api`) or any future domain package: the facade tests and the future domain tests import `apitest`, so importing the facade or a domain from here would form a cycle. Consequently `apitest` builds and returns only `*apicore.Core`, never `*api.Controller`.

Verified: `go list -deps ./internal/api/v2/apitest/` shows its only `api/v2` dependency is `apicore`.

## What moved to apitest (Core-level, no facade dependency)

- `NewValidTestSettings`, `PublishTestSettings` (minimal valid settings builder + global-snapshot publish/restore)
- `MockImageProvider`, `TestImageProvider`, `NewMockBirdImageCache`
- `NewTestMetrics`
- `AssertRoutesRegistered`, `AssertControllerError`
- `NewTestHTTPClient`, `DisableHTTPKeepAlivesForTesting`, `TestResponseHeaderTimeout`
- `NewCore(t, opts...) *apicore.Core`: the new test-core builder. Functional options: `WithEcho`, `WithDatastore`, `WithSettings`, `WithSettingsFunc`, `WithBirdImageCache`, `WithSunCalc`, `WithMetrics`, `WithPrivateModeExempt`, `WithoutSettingsPublish`.

`NewCore` wires `core.Group` to `echo.Group("/api/v2")` so a domain test can register routes the way the facade does (`h.RegisterRoutes(core.Group)`); the facade's group-level middleware is intentionally left to the caller. Its `t.Cleanup` mirrors the Core-level teardown of `api.Controller.Shutdown` in the same order: close SSE clients, cancel + wait on the lifecycle context, close the media SecureFS, then flush the detection cache.

## The facade-glue split (no duplicated setup)

`apitest` cannot construct an `*api.Controller`, so the thin facade-construction glue stays in package `api` and sources its inputs from `apitest`:

- `setupTestEnvironment` still calls the real production `NewWithOptions` (so the facade is exercised faithfully, including its middleware/processing-cache/spectrogram-generator wiring), but now builds its settings, mock image cache, metrics, and settings-publish via the `apitest` helpers.
- `setupAnalyticsTestEnvironment`, `newMinimalController`, `getTestController`, `getTestSettings`, `assertSpeciesDailySummary`, `setupValidReviewMock`, and `TestMain` stay in package `api`.

The shared building blocks (settings, mock cache, metrics, publish, isolation) now live once in `apitest`; the two Core-construction paths (`NewWithOptions` for facade tests, `apitest.NewCore` for future domain tests) both delegate to `apicore.NewCore`. No setup logic is duplicated, and no moved helper remains defined in package `api`.

The ~40 package-`api` test files that referenced the moved helpers were mechanically repointed to the `apitest.`-qualified names.

## Isolation contract

So the soon-to-be-parallel package test binaries cannot collide, `apitest.NewCore` uses a per-test `t.TempDir()` media export path, a mock datastore (no shared DB file), and an in-memory `echo.New()` server (no fixed TCP port). Closing the media SecureFS in cleanup is required so the open `os.Root` handle does not block Windows `t.TempDir()` removal.

## apicore.SetTestContext

Left in place. A handful of narrow unit tests build minimal bare `*apicore.Core` values to drive specific context-cancel paths of unexported handlers; routing them through the fully wired `NewCore` would change what they exercise and add overhead. It remains a documented test-only seam, complementary to `NewCore`.

## No production behavior change

This PR only moves and reshapes test scaffolding. No production `.go` file is modified (the diff is entirely `*_test.go` files plus the new `apitest/` package).

## Local verification

- `go build ./internal/api/v2/...`: ok
- `go vet ./internal/api/v2/ ./internal/api/v2/apitest/`: clean
- `go test -race ./internal/api/v2/...`: ok (package `api` ~208s, including the goroutine-leak gate and the route-enumeration regression gate)
- Route-enumeration gate (`TestRouteEnumerationMatchesGolden`, `TestRouteEnumerationIsDeterministic`, `TestGreedyAudioRouteRegisteredOnEcho`): pass
- `go test -race ./internal/analysis/...`: subpackages pass; the top-level `internal/analysis` package only fails to link on the unbuilt-frontend `embed.go all:dist` artifact, and passes once a `frontend/dist` stub exists (verified locally), so it is unaffected by this change
- `golangci-lint run ./internal/api/v2/apitest/ ./internal/api/v2/`: 0 issues

## Preflight Status

Ran the preflight gate (reuse, correctness/safety, quality/patterns, integration/wiring). No Critical/High findings. Addressed in-scope items: wired `core.Group` (so the shipped `AssertRoutesRegistered` and the future `RegisterRoutes(core.Group)` pattern work), aligned the cleanup ordering with the facade (close SSE clients before cancel/wait), reset `privateModeExempt` to the safe default if an option clears it, de-duplicated the HTTP-transport tuning into one helper, and documented the two-publishing-cores process-global-settings caveat and the go-cache janitor goleak note for future domain test packages. i18n and regression/backward-compat passes are N/A (no frontend/messages and no production/config/API/DB/CLI surface in the diff).

- [x] Single concern: extract apitest test scaffolding
- [x] Tests pass: `go test -race ./internal/api/v2/...`
- [x] Linters clean: `golangci-lint run` reports 0 issues for the touched packages
- [x] No unrelated changes: diff is only `*_test.go` files and the new `apitest/` package
- [x] No regression/backward-compat break: test-only change, no production behavior change
- [x] No secrets or PII


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API v2 test coverage and reliability, reducing the chance of regressions in routes, settings, media, audio, notifications, and integrations.
  * Standardized test setup so API behavior is validated more consistently across scenarios.
* **Tests**
  * Added reusable test helpers for route checks, HTTP clients, settings setup, metrics, and image handling.
  * Updated existing tests to use the shared helpers and cleaner setup patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->