### PR TITLE
fix(audiocore): collapse concurrent device capability probes with singleflight

### DIFF
--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"golang.org/x/sync/singleflight"
 )
 
 // capabilitiesCache stores probed device capabilities keyed by device name.
@@ -21,6 +22,16 @@ import (
 var (
 	capabilitiesCache   = make(map[string]*DeviceCapabilities)
 	capabilitiesCacheMu sync.RWMutex
+
+	// probeGroup collapses concurrent live probes for the same device so only one opens
+	// the ALSA device in malgo.Exclusive mode; the rest wait and read the freshly-cached
+	// result instead of racing into a "device busy" ALSA error.
+	probeGroup singleflight.Group
+
+	// probeLiveFn is the live-probe entry point, indirected through a package var so tests
+	// can substitute a stub. The real implementation calls malgo/CGO and cannot run in a
+	// unit test.
+	probeLiveFn = probeDeviceCapabilitiesLive
 )
 
 // CandidateSampleRates are the rates tested during device probing.
@@ -103,36 +114,60 @@ func GetCachedCapabilities(deviceName string) *DeviceCapabilities {
 	return nil
 }
 
-// ProbeDeviceCapabilities returns cached capabilities if available, otherwise
-// probes the device live. The cache is populated at startup; live probing is
-// the fallback for devices plugged in after startup.
+// ProbeDeviceCapabilities returns cached capabilities if available, otherwise probes the
+// device live. The cache is populated at startup; live probing is the fallback for devices
+// plugged in after startup. Concurrent live probes for the same device are collapsed so the
+// device is opened in exclusive mode by at most one goroutine at a time.
 func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabilities, error) {
-	// Check cache first (covers devices probed at startup). The cache is keyed by
-	// both the decoded ALSA id and the stable USB token, so a direct lookup hits
-	// for a "usb-path:"/"usb-id:" config; the name-substring scan is a legacy
-	// fallback for name-based configs.
-	capabilitiesCacheMu.RLock()
-	if caps, ok := capabilitiesCache[deviceID]; ok {
-		capabilitiesCacheMu.RUnlock()
+	// Fast path: the cache covers devices probed at startup.
+	if caps, ok := lookupCachedCapabilities(deviceID); ok {
 		return cloneCapabilities(caps), nil
 	}
+
+	// Cache miss (device likely plugged in after startup): probe live. Collapse concurrent
+	// probes for the same device through singleflight so only one opens the ALSA device in
+	// malgo.Exclusive mode; the rest wait and read the freshly-cached result instead of both
+	// racing into a "device busy" failure.
+	result, err, _ := probeGroup.Do(deviceID, func() (any, error) {
+		// Re-check the cache: a probe that completed while we waited for the group slot
+		// already populated it, so we skip a redundant second live probe.
+		if caps, ok := lookupCachedCapabilities(deviceID); ok {
+			return caps, nil
+		}
+		caps, probeErr := probeLiveFn(deviceID, log)
+		if probeErr == nil && caps != nil {
+			capabilitiesCacheMu.Lock()
+			capabilitiesCache[caps.DeviceID] = caps
+			capabilitiesCacheMu.Unlock()
+		}
+		return caps, probeErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	// The shared result is one *DeviceCapabilities handed to every waiter; clone it so no
+	// caller can mutate another's copy (matching the cache-hit return above).
+	caps, _ := result.(*DeviceCapabilities)
+	return cloneCapabilities(caps), nil
+}
+
+// lookupCachedCapabilities returns the cached capabilities for deviceID and true on a hit, or
+// (nil, false) on a miss. The cache is keyed by both the decoded ALSA id and the stable USB
+// token, so a direct lookup hits for a "usb-path:"/"usb-id:" config; the name-substring scan
+// is a legacy fallback for name-based configs. The returned pointer is the cached value (the
+// caller clones before handing it out); cached entries are never mutated in place.
+func lookupCachedCapabilities(deviceID string) (*DeviceCapabilities, bool) {
+	capabilitiesCacheMu.RLock()
+	defer capabilitiesCacheMu.RUnlock()
+	if caps, ok := capabilitiesCache[deviceID]; ok {
+		return caps, true
+	}
 	for _, caps := range capabilitiesCache {
-		if caps.DeviceName == deviceID ||
-			strings.Contains(caps.DeviceName, deviceID) {
-			capabilitiesCacheMu.RUnlock()
-			return cloneCapabilities(caps), nil
+		if caps.DeviceName == deviceID || strings.Contains(caps.DeviceName, deviceID) {
+			return caps, true
 		}
 	}
-	capabilitiesCacheMu.RUnlock()
-
-	// Cache miss: probe live (device may have been plugged in after startup).
-	caps, err := probeDeviceCapabilitiesLive(deviceID, log)
-	if err == nil && caps != nil {
-		capabilitiesCacheMu.Lock()
-		capabilitiesCache[caps.DeviceID] = caps
-		capabilitiesCacheMu.Unlock()
-	}
-	return caps, err
+	return nil, false
 }
 
 // probeDeviceCapabilitiesLive queries supported sample rates for a device.

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -119,6 +119,13 @@ func GetCachedCapabilities(deviceName string) *DeviceCapabilities {
 // plugged in after startup. Concurrent live probes for the same device are collapsed so the
 // device is opened in exclusive mode by at most one goroutine at a time.
 func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabilities, error) {
+	// An empty deviceID would match any cached device via the name-substring scan in
+	// lookupCachedCapabilities (strings.Contains(name, "") is always true), so reject it as
+	// not-found rather than returning an arbitrary device.
+	if deviceID == "" {
+		return nil, fmt.Errorf("probe device: %w", ErrDeviceNotFound)
+	}
+
 	// Fast path: the cache covers devices probed at startup.
 	if caps, ok := lookupCachedCapabilities(deviceID); ok {
 		return cloneCapabilities(caps), nil
@@ -163,7 +170,7 @@ func lookupCachedCapabilities(deviceID string) (*DeviceCapabilities, bool) {
 		return caps, true
 	}
 	for _, caps := range capabilitiesCache {
-		if caps.DeviceName == deviceID || strings.Contains(caps.DeviceName, deviceID) {
+		if caps != nil && (caps.DeviceName == deviceID || strings.Contains(caps.DeviceName, deviceID)) {
 			return caps, true
 		}
 	}

--- a/internal/audiocore/capabilities_test.go
+++ b/internal/audiocore/capabilities_test.go
@@ -158,8 +158,14 @@ func TestProbeDeviceCapabilities_SingleFlightCollapsesConcurrentProbes(t *testin
 			require.NotNilf(t, results[i], "caller %d", i)
 			assert.Equalf(t, []int{wantRate}, results[i].SampleRates, "caller %d sample rates", i)
 		}
-		// Every caller must get its own clone, never a shared pointer into the cache.
-		assert.NotSame(t, results[0], results[1], "callers must receive independent clones")
+		// Every caller must get its own clone, never a shared pointer into the cache; check
+		// all pairs so a shared pointer among any callers is caught.
+		for i := range concurrentCallers {
+			for j := i + 1; j < concurrentCallers; j++ {
+				assert.NotSamef(t, results[i], results[j],
+					"callers %d and %d must receive independent clones", i, j)
+			}
+		}
 	})
 
 	// The probe populated the cache, so a follow-up call is served from it without a new
@@ -169,4 +175,28 @@ func TestProbeDeviceCapabilities_SingleFlightCollapsesConcurrentProbes(t *testin
 	require.NotNil(t, got)
 	assert.Equal(t, int32(1), liveCalls.Load(),
 		"a cached follow-up must not trigger another live probe")
+}
+
+// TestProbeDeviceCapabilities_EmptyDeviceIDRejected verifies an empty deviceID is rejected as
+// not-found rather than matching an arbitrary cached device via the name-substring scan
+// (strings.Contains(name, "") is always true). Mutates the package cache, so it is not parallel.
+func TestProbeDeviceCapabilities_EmptyDeviceIDRejected(t *testing.T) {
+	log := logger.Global().Module("audiocore_test")
+
+	// Seed a device so a "" substring scan would otherwise return it.
+	capabilitiesCacheMu.Lock()
+	savedCache := capabilitiesCache
+	capabilitiesCache = map[string]*DeviceCapabilities{
+		"hw:0,0": {DeviceID: "hw:0,0", DeviceName: "Some Mic", SampleRates: []int{48000}, Verified: true},
+	}
+	capabilitiesCacheMu.Unlock()
+	t.Cleanup(func() {
+		capabilitiesCacheMu.Lock()
+		capabilitiesCache = savedCache
+		capabilitiesCacheMu.Unlock()
+	})
+
+	caps, err := ProbeDeviceCapabilities("", log)
+	require.ErrorIs(t, err, ErrDeviceNotFound)
+	assert.Nil(t, caps, "empty deviceID must not return the cached device")
 }

--- a/internal/audiocore/capabilities_test.go
+++ b/internal/audiocore/capabilities_test.go
@@ -4,11 +4,16 @@ package audiocore
 
 import (
 	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/gen2brain/malgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 func TestExtractSampleRates_ExplicitFormats(t *testing.T) {
@@ -91,4 +96,77 @@ func TestCandidateSampleRates_Sorted(t *testing.T) {
 		assert.GreaterOrEqual(t, CandidateSampleRates[0], MinCaptureSampleRate)
 		assert.LessOrEqual(t, CandidateSampleRates[len(CandidateSampleRates)-1], MaxCaptureSampleRate)
 	}
+}
+
+// TestProbeDeviceCapabilities_SingleFlightCollapsesConcurrentProbes verifies that several
+// concurrent cache-miss probes for the same device collapse into a single live probe (so the
+// device is opened in exclusive mode only once and the rest do not hit a "device busy" error),
+// and that each caller receives an independent clone of the result. It mutates package globals
+// (the cache and the live-probe seam), so it must not run in parallel.
+func TestProbeDeviceCapabilities_SingleFlightCollapsesConcurrentProbes(t *testing.T) {
+	log := logger.Global().Module("audiocore_test")
+
+	const deviceID = "test-device-uncached"
+	const wantRate = 48000
+
+	// Start from an empty cache so deviceID is a guaranteed miss; restore on cleanup.
+	capabilitiesCacheMu.Lock()
+	savedCache := capabilitiesCache
+	capabilitiesCache = make(map[string]*DeviceCapabilities)
+	capabilitiesCacheMu.Unlock()
+	t.Cleanup(func() {
+		capabilitiesCacheMu.Lock()
+		capabilitiesCache = savedCache
+		capabilitiesCacheMu.Unlock()
+		probeGroup.Forget(deviceID)
+	})
+
+	// Stub the live probe with a call counter; it blocks briefly so concurrent callers pile
+	// up behind the single in-flight probe (virtual time under synctest makes this exact).
+	var liveCalls atomic.Int32
+	savedFn := probeLiveFn
+	probeLiveFn = func(id string, _ logger.Logger) (*DeviceCapabilities, error) {
+		liveCalls.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		return &DeviceCapabilities{
+			DeviceID:    id,
+			DeviceName:  "Stub Mic",
+			SampleRates: []int{wantRate},
+			Verified:    true,
+		}, nil
+	}
+	t.Cleanup(func() { probeLiveFn = savedFn })
+
+	synctest.Test(t, func(t *testing.T) {
+		const concurrentCallers = 8
+		results := make([]*DeviceCapabilities, concurrentCallers)
+		errs := make([]error, concurrentCallers)
+
+		var wg sync.WaitGroup
+		for i := range concurrentCallers {
+			wg.Go(func() {
+				results[i], errs[i] = ProbeDeviceCapabilities(deviceID, log)
+			})
+		}
+		wg.Wait()
+
+		assert.Equal(t, int32(1), liveCalls.Load(),
+			"concurrent probes for the same device must collapse to a single live probe")
+
+		for i := range concurrentCallers {
+			require.NoErrorf(t, errs[i], "caller %d", i)
+			require.NotNilf(t, results[i], "caller %d", i)
+			assert.Equalf(t, []int{wantRate}, results[i].SampleRates, "caller %d sample rates", i)
+		}
+		// Every caller must get its own clone, never a shared pointer into the cache.
+		assert.NotSame(t, results[0], results[1], "callers must receive independent clones")
+	})
+
+	// The probe populated the cache, so a follow-up call is served from it without a new
+	// live probe.
+	got, err := ProbeDeviceCapabilities(deviceID, log)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(1), liveCalls.Load(),
+		"a cached follow-up must not trigger another live probe")
 }


### PR DESCRIPTION
## What

Collapse concurrent device-capability probes for the same device with `singleflight`, so the ALSA device is opened in exclusive mode by at most one goroutine at a time.

## Why

`ProbeDeviceCapabilities` probes live on a cache miss and stores the result. Two concurrent requests for the same uncached device (e.g. the settings UI polling a device hot-plugged after startup) both miss the cache and both call `probeDeviceCapabilitiesLive`, which opens the ALSA device in `malgo.Exclusive` mode. The second probe loses the race and fails with a "device busy" ALSA error, producing log noise and an unverified-rates fallback in the UI.

## How

- Guard live probing with `golang.org/x/sync/singleflight` keyed by `deviceID`: concurrent requests collapse to one probe and the rest read the freshly-cached result.
- The cache lookup is factored into `lookupCachedCapabilities` (used by both the fast path and the singleflight closure). The closure re-checks the cache after acquiring the group slot to skip a redundant probe.
- The shared `*DeviceCapabilities` result is cloned per caller (matching the cache-hit path), so no waiter mutates another's copy. This is also a small safety improvement over the previous code, which returned the same pointer it stored in the cache.
- The live-probe call is indirected through a `probeLiveFn` package var so a unit test can substitute a stub (`probeDeviceCapabilitiesLive` itself calls malgo/CGO and cannot run in a unit test).

## Tests

Added a `testing/synctest` race test that fires 8 concurrent probes for an uncached device and asserts exactly one live probe runs, each caller receives an independent clone, and a cached follow-up does not re-probe. It fails without the singleflight guard (8 live probes). Full `internal/audiocore` suite passes under `-race`; `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device capability lookups so concurrent requests for the same device share a single live probe, reducing duplicate work and improving consistency.
  * Added safer result handling to ensure each caller receives its own copy of the capability data.
  * Expanded test coverage for concurrent probing and cache reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->