### PR TITLE
fix(audiocore): resolve USB stable token from /sys when /proc/asound is masked (Docker)

### DIFF
--- a/internal/audiocore/usb_linux.go
+++ b/internal/audiocore/usb_linux.go
@@ -148,8 +148,11 @@ func usbIdentityFromSysfs(root string, card int) usbIdentity {
 		return usbIdentity{}
 	}
 	vendor := readSysfsAttr(filepath.Join(dir, "idVendor"))
+	if !hex4Re.MatchString(vendor) {
+		return usbIdentity{}
+	}
 	product := readSysfsAttr(filepath.Join(dir, "idProduct"))
-	if !hex4Re.MatchString(vendor) || !hex4Re.MatchString(product) {
+	if !hex4Re.MatchString(product) {
 		return usbIdentity{}
 	}
 	return usbIdentity{

--- a/internal/audiocore/usb_linux.go
+++ b/internal/audiocore/usb_linux.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// maxUSBSysfsWalkDepth bounds the upward sysfs walk in readUSBSerial; the USB
+// maxUSBSysfsWalkDepth bounds the upward sysfs walk in findUSBDeviceNode; the USB
 // device node is normally only 3-4 levels above the card directory, so this is a
 // generous cap that simply guarantees termination.
 const maxUSBSysfsWalkDepth = 12
@@ -22,12 +22,14 @@ const maxUSBSysfsWalkDepth = 12
 //
 // It returns a zero usbIdentity (never an error) on any failure, so device
 // matching falls back to the legacy id/name tiers and capture is never broken by
-// a probing failure. Bus path and USB detection come from /proc/asound/cards and
-// vendor:product from /proc/asound/cardN/usbid (regular files, available even in
-// Docker containers using --device /dev/snd). The serial is a best-effort sysfs
-// read that is often empty. A persisted usb-path:/usb-id: token therefore depends
-// on /proc/asound being readable; when it is not, the token matches nothing and
-// capture reports the device as missing rather than risking a wrong-device match.
+// a probing failure. On a native install the bus path and vendor:product come from
+// /proc/asound (cards + cardN/usbid). In a Docker container /proc/asound is masked
+// with an empty tmpfs even with --device /dev/snd, so usbIdentityForCard falls back
+// to /sys/class/sound (still exposed) for vendor:product:serial. A usb-id: token
+// (vendor:product:serial) therefore resolves in both; a usb-path: token is
+// /proc-only because the sysfs bus-path format differs, so it resolves natively but
+// not in a masked-/proc container, where capture reports the device missing rather
+// than risking a wrong-device match.
 func resolveUSBIdentity(decodedID, root string) usbIdentity {
 	card := parseALSACardNumber(decodedID)
 	if card < 0 {
@@ -46,12 +48,21 @@ func readProcAsoundCards(root string) map[int]procCardEntry {
 	return parseProcAsoundCards(string(data))
 }
 
-// usbIdentityForCard resolves the USB identity of a single ALSA card from an
-// already-parsed cards map. Returns a zero usbIdentity for a non-USB card or an
-// absent entry.
+// usbIdentityForCard resolves the USB identity of a single ALSA card. When the card is present
+// in the parsed /proc/asound/cards map it uses /proc (bus path from the map, vendor:product from
+// /proc/asound/cardN/usbid) plus a best-effort sysfs serial. When the card is ABSENT from that
+// map (Docker masks /proc/asound with an empty tmpfs, so /proc/asound/cards does not exist, or
+// /proc is otherwise unreadable) it falls back to deriving vendor:product:serial from /sys via
+// usbIdentityFromSysfs, so the usb-id token still resolves in a container. Returns a zero
+// usbIdentity for a card the /proc map lists as non-USB.
 func usbIdentityForCard(card int, cards map[int]procCardEntry, root string) usbIdentity {
 	entry, ok := cards[card]
-	if !ok || !entry.isUSB {
+	if !ok {
+		// Card not listed in /proc/asound/cards (masked or unavailable): derive from /sys,
+		// which Docker still exposes. Yields a usb-id (vendor:product:serial) token only.
+		return usbIdentityFromSysfs(root, card)
+	}
+	if !entry.isUSB {
 		return usbIdentity{}
 	}
 	ident := usbIdentity{BusPath: entry.busPath}
@@ -65,43 +76,33 @@ func usbIdentityForCard(card int, cards map[int]procCardEntry, root string) usbI
 	return ident
 }
 
-// readUSBSerial walks up from <root>/sys/class/sound/cardN to the USB device node
-// and returns that device's serial, or "" when the device reports none. The
-// device node is the first ancestor exposing an "idVendor" file; the serial (when
-// present) lives alongside it. The walk stops there so a parent hub or host
-// controller's serial (e.g. "xhci-hcd.0" on a root hub) is never mistaken for the
-// device's, and is bounded to the <root>/sys subtree so a symlink that resolves
-// outside sysfs cannot send it wandering into unrelated system directories.
-// Returns "" on any failure; the USB serial is optional and many audio adapters
-// do not report one.
-func readUSBSerial(root string, card int) string {
+// findUSBDeviceNode walks up from <root>/sys/class/sound/cardN to the USB device node and
+// returns its directory. The device node is the first ancestor exposing an "idVendor" file; the
+// walk stops there so a parent hub or host controller (e.g. "xhci-hcd.0" on a root hub) is never
+// mistaken for the device, and is bounded to the <root>/sys subtree so a symlink that resolves
+// outside sysfs cannot send it wandering into unrelated system directories. Returns ("", false)
+// when the card is absent or is not backed by a USB device.
+func findUSBDeviceNode(root string, card int) (string, bool) {
 	sysRoot := filepath.Join(root, "sys")
-	// Resolve sysRoot the same way as target below; otherwise a symlinked element
-	// in root (a test temp dir, or a path like macOS /var -> /private/var) would
-	// leave the resolved target without the literal sysRoot prefix and the walk
-	// would stop immediately.
+	// Resolve sysRoot the same way as target below; otherwise a symlinked element in root (a
+	// test temp dir, or a path like macOS /var -> /private/var) would leave the resolved target
+	// without the literal sysRoot prefix and the walk would stop immediately.
 	if resolved, symErr := filepath.EvalSymlinks(sysRoot); symErr == nil {
 		sysRoot = resolved
 	}
 	target, err := filepath.EvalSymlinks(filepath.Join(sysRoot, "class", "sound", "card"+strconv.Itoa(card)))
 	if err != nil {
-		return ""
+		return "", false
 	}
 	dir := target
 	for range maxUSBSysfsWalkDepth {
-		// Stay strictly below the sysfs root: the USB device node is always a
-		// descendant of <root>/sys, so stop at sysRoot itself or anything that
-		// symlink resolution placed outside the subtree.
+		// Stay strictly below the sysfs root: the USB device node is always a descendant of
+		// <root>/sys, so stop at sysRoot itself or anything symlink resolution placed outside.
 		if dir == sysRoot || !strings.HasPrefix(dir, sysRoot+string(os.PathSeparator)) {
 			break
 		}
 		if _, statErr := os.Stat(filepath.Join(dir, "idVendor")); statErr == nil {
-			// Reached the USB device node. Its serial is optional.
-			data, readErr := os.ReadFile(filepath.Join(dir, "serial"))
-			if readErr != nil {
-				return ""
-			}
-			return strings.TrimSpace(string(data))
+			return dir, true
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -109,5 +110,51 @@ func readUSBSerial(root string, card int) string {
 		}
 		dir = parent
 	}
-	return ""
+	return "", false
+}
+
+// readSysfsAttr reads a single sysfs attribute file and returns its trimmed contents, or "" on
+// any read error.
+func readSysfsAttr(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// readUSBSerial returns the serial of the USB device backing ALSA card N, or "" when the device
+// reports none (common on inexpensive audio adapters) or cannot be located.
+func readUSBSerial(root string, card int) string {
+	dir, ok := findUSBDeviceNode(root, card)
+	if !ok {
+		return ""
+	}
+	return readSysfsAttr(filepath.Join(dir, "serial"))
+}
+
+// usbIdentityFromSysfs derives a card's USB identity entirely from <root>/sys, the fallback used
+// when /proc/asound is unavailable (Docker masks /proc/asound with an empty tmpfs, so
+// /proc/asound/cards and /proc/asound/cardN/usbid do not exist even with --device /dev/snd,
+// while /sys/class/sound is still exposed). It returns vendor:product:serial; the BusPath is left
+// empty on purpose, because the sysfs bus-path string (e.g. "1-1") differs in format from the
+// /proc bus path (e.g. "usb-xhci-hcd.0-1"), so a sysfs value could not match a /proc-derived
+// usb-path token. The usb-id token (vendor:product:serial) is identical from both sources, so it
+// stays a stable cross-reboot identifier here. Returns a zero usbIdentity for a non-USB card or
+// when the vendor/product ids are missing or malformed.
+func usbIdentityFromSysfs(root string, card int) usbIdentity {
+	dir, ok := findUSBDeviceNode(root, card)
+	if !ok {
+		return usbIdentity{}
+	}
+	vendor := readSysfsAttr(filepath.Join(dir, "idVendor"))
+	product := readSysfsAttr(filepath.Join(dir, "idProduct"))
+	if !hex4Re.MatchString(vendor) || !hex4Re.MatchString(product) {
+		return usbIdentity{}
+	}
+	return usbIdentity{
+		VendorID:  vendor,
+		ProductID: product,
+		Serial:    readSysfsAttr(filepath.Join(dir, "serial")),
+	}
 }

--- a/internal/audiocore/usb_linux_test.go
+++ b/internal/audiocore/usb_linux_test.go
@@ -126,3 +126,84 @@ func TestReadUSBSerial_StopsAtDeviceNode(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dev, "serial"), []byte("DEVICE123\n"), 0o644))
 	assert.Equal(t, "DEVICE123", readUSBSerial(root, 0))
 }
+
+// writeFakeSysfsUSBCard builds a fake <root>/sys tree for a USB-backed ALSA card and writes NO
+// /proc/asound (the Docker scenario, where /proc/asound is masked). The card's
+// /sys/class/sound/cardN symlink resolves to a sound node under a USB device directory carrying
+// idVendor/idProduct and, when non-empty, a serial.
+func writeFakeSysfsUSBCard(t *testing.T, card int, vendor, product, serial string) string {
+	t.Helper()
+	root := t.TempDir()
+	dev := filepath.Join(root, "sys", "devices", "platform", "xhci-hcd.0", "usb1", "1-1")
+	cardDir := filepath.Join(dev, "1-1:1.0", "sound", "card"+strconv.Itoa(card))
+	require.NoError(t, os.MkdirAll(cardDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dev, "idVendor"), []byte(vendor+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dev, "idProduct"), []byte(product+"\n"), 0o644))
+	if serial != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dev, "serial"), []byte(serial+"\n"), 0o644))
+	}
+	classDir := filepath.Join(root, "sys", "class", "sound")
+	require.NoError(t, os.MkdirAll(classDir, 0o755))
+	require.NoError(t, os.Symlink(cardDir, filepath.Join(classDir, "card"+strconv.Itoa(card))))
+	return root
+}
+
+// TestUsbIdentityForCard_SysfsFallbackWhenProcAbsent covers the Docker case: /proc/asound is
+// masked (the parsed cards map is nil), so the identity must come from /sys and yield a usb-id
+// token. Before the fallback this returned a zero identity and the device fell back to the
+// unstable legacy ALSA index.
+func TestUsbIdentityForCard_SysfsFallbackWhenProcAbsent(t *testing.T) {
+	t.Parallel()
+	root := writeFakeSysfsUSBCard(t, 0, "0d8c", "0014", "")
+
+	ident := usbIdentityForCard(0, nil, root)
+	assert.Empty(t, ident.BusPath, "no /proc bus path is synthesized in the Docker fallback")
+	assert.Equal(t, "0d8c", ident.VendorID)
+	assert.Equal(t, "0014", ident.ProductID)
+	assert.Empty(t, ident.Serial)
+	assert.True(t, ident.hasStableID())
+	assert.Equal(t, "usb-id:0d8c:0014:", ident.stableToken())
+}
+
+func TestUsbIdentityForCard_SysfsFallbackWithSerial(t *testing.T) {
+	t.Parallel()
+	root := writeFakeSysfsUSBCard(t, 2, "0b33", "0024", "ZOOMSER9")
+
+	ident := usbIdentityForCard(2, nil, root)
+	assert.Equal(t, "ZOOMSER9", ident.Serial)
+	assert.Equal(t, "usb-id:0b33:0024:ZOOMSER9", ident.stableToken())
+}
+
+// TestResolveUSBIdentity_DockerSysfsFallback is the full masked-/proc path: resolveUSBIdentity
+// reads /proc/asound (absent -> nil map) and falls back to /sys, producing a usable usb-id token
+// where the unfixed code produced a zero identity.
+func TestResolveUSBIdentity_DockerSysfsFallback(t *testing.T) {
+	t.Parallel()
+	root := writeFakeSysfsUSBCard(t, 0, "0d8c", "0014", "")
+
+	ident := resolveUSBIdentity(":0,0", root)
+	require.True(t, ident.hasStableID(), "Docker (no /proc/asound) must still resolve a usb-id token")
+	assert.Equal(t, "usb-id:0d8c:0014:", ident.stableToken())
+}
+
+// TestUsbIdentityFromSysfs_NonUSBYieldsZero: a card whose /sys path has no idVendor ancestor
+// (non-USB, e.g. an HDMI codec) yields a zero identity from both the helper and the fallback.
+func TestUsbIdentityFromSysfs_NonUSBYieldsZero(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	cardDir := filepath.Join(root, "sys", "devices", "platform", "soc", "sound", "card1")
+	require.NoError(t, os.MkdirAll(cardDir, 0o755))
+	classDir := filepath.Join(root, "sys", "class", "sound")
+	require.NoError(t, os.MkdirAll(classDir, 0o755))
+	require.NoError(t, os.Symlink(cardDir, filepath.Join(classDir, "card1")))
+
+	assert.False(t, usbIdentityFromSysfs(root, 1).hasStableID())
+	assert.False(t, usbIdentityForCard(1, nil, root).hasStableID())
+}
+
+// TestUsbIdentityFromSysfs_MalformedIDsYieldZero: a non-hex idVendor/idProduct is rejected.
+func TestUsbIdentityFromSysfs_MalformedIDsYieldZero(t *testing.T) {
+	t.Parallel()
+	root := writeFakeSysfsUSBCard(t, 0, "zzzz", "0014", "")
+	assert.False(t, usbIdentityFromSysfs(root, 0).hasStableID())
+}

--- a/internal/audiocore/usb_linux_test.go
+++ b/internal/audiocore/usb_linux_test.go
@@ -201,9 +201,24 @@ func TestUsbIdentityFromSysfs_NonUSBYieldsZero(t *testing.T) {
 	assert.False(t, usbIdentityForCard(1, nil, root).hasStableID())
 }
 
-// TestUsbIdentityFromSysfs_MalformedIDsYieldZero: a non-hex idVendor/idProduct is rejected.
+// TestUsbIdentityFromSysfs_MalformedIDsYieldZero: a non-hex idVendor or idProduct is rejected.
+// Both are exercised separately so the vendor || product short-circuit cannot hide a broken
+// product check.
 func TestUsbIdentityFromSysfs_MalformedIDsYieldZero(t *testing.T) {
 	t.Parallel()
-	root := writeFakeSysfsUSBCard(t, 0, "zzzz", "0014", "")
-	assert.False(t, usbIdentityFromSysfs(root, 0).hasStableID())
+	tests := []struct {
+		name    string
+		vendor  string
+		product string
+	}{
+		{name: "malformed vendor", vendor: "zzzz", product: "0014"},
+		{name: "malformed product", vendor: "0d8c", product: "zzzz"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := writeFakeSysfsUSBCard(t, 0, tc.vendor, tc.product, "")
+			assert.False(t, usbIdentityFromSysfs(root, 0).hasStableID())
+		})
+	}
 }


### PR DESCRIPTION
## What

Make stable USB device matching work in the default Docker deployment by deriving the device identity from `/sys` when `/proc/asound` is masked.

## Why

Stable USB device matching (the fix for the most-reported audio bug, where a local USB sound card was lost after a reboot because the ALSA card index is reassigned in enumeration order) reads the bus path and vendor:product from `/proc/asound`. **Docker masks `/proc/asound` with an empty tmpfs by default**, even with `--device /dev/snd`, so inside the container `/proc/asound/cards` does not exist. `usbIdentityForCard` returned a zero identity, the device's `StableID` came back empty, and the config fell back to the legacy unstable `:0,0` ALSA index. The fix therefore did **not** work in the default `install.sh` (Docker) deployment, which is exactly the population most affected.

Found during end-to-end host validation on a real arm64 host (Docker, C-Media USB card): `GET /api/v2/system/audio/devices` returned the card with no `stableId`.

## How

- `usbIdentityForCard` falls back to `/sys/class/sound/cardN` (which the container still exposes) when the card is absent from the parsed `/proc/asound/cards` map, deriving vendor:product:serial via a new `usbIdentityFromSysfs`. That yields a `usb-id` token, which is format-identical from `/proc/asound/cardN/usbid` and the `/sys` USB device node, so it stays a stable cross-reboot identifier in a container.
- The bus path is deliberately **not** synthesized from `/sys`: its sysfs string (`1-1`) differs in format from the `/proc` bus path (`usb-xhci-hcd.0-1`), so a `usb-path` token remains `/proc`-only (native installs) rather than producing a token a `/proc`-based resolve could not match.
- The sysfs walk is factored into a shared `findUSBDeviceNode` helper used by both `readUSBSerial` and `usbIdentityFromSysfs` (no behavior change to `readUSBSerial`).

## Tests

Added sysfs-only unit tests (no `/proc/asound`) covering the Docker fallback, serial handling, non-USB cards, and malformed ids; they fail on the old code. Full `internal/audiocore` suite passes under `-race`; `golangci-lint` clean.

Validated on hardware (rpi5, arm64, Docker, C-Media card): the devices API now returns `stableId: usb-id:0d8c:0014:` where it was previously empty, and the token persists across a full host reboot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB device identification when process-based audio info is missing (for example, in containerized environments) by falling back to sysfs.
  * USB audio devices now retain a consistent USB identity even when process-derived card data isn’t available.
  * Non-USB devices still return an empty identity, and malformed USB attributes are ignored safely.
* **Tests**
  * Added new test coverage for sysfs fallback behavior, optional serial handling, non-USB sysfs layouts, and malformed vendor/product values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->