### PR TITLE
refactor(api/v2): extract tls domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -524,7 +524,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 ]
 ```
 
-### TLS Certificate Management (`tls.go`)
+### TLS Certificate Management (`tls/tls.go`)
 
 | Method | Route                       | Handler                         | Auth | Description                                |
 | ------ | --------------------------- | ------------------------------- | ---- | ------------------------------------------ |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/api/v2/weather"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
@@ -57,6 +58,13 @@ type Controller struct {
 	// *apicore.Core; the facade constructs them once and calls their
 	// RegisterRoutes in the deterministic order initRoutes defines.
 	weather *weather.Handler
+
+	// tlsHandler serves the /api/v2/tls/* certificate endpoints. It is named
+	// tlsHandler (not tls) and the domain package is imported as tlsapi to avoid
+	// colliding with the crypto/tls standard package. Unlike weather it also holds
+	// the facade's settings-save machinery (see NewWithOptions) because TLS writes
+	// mutate persisted settings.
+	tlsHandler *tlsapi.Handler
 
 	controlChan chan string
 
@@ -285,6 +293,14 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Construct domain handlers around the shared core. They hold the same
 	// *apicore.Core pointer and register their routes in initRoutes.
 	c.weather = weather.New(c.Core)
+	// The TLS handler needs the facade's settings-save machinery: the shared
+	// settingsMutex (passed by pointer so TLS certificate writes serialize against
+	// the main settings update handlers) and the bound method values for reading,
+	// publishing/persisting, and post-processing settings changes. c is fully
+	// constructed here, so the &c.settingsMutex address and the method values are
+	// stable for the controller's lifetime.
+	c.tlsHandler = tlsapi.New(c.Core, &c.settingsMutex,
+		c.getSettingsOrFallback, c.publishAndSaveSettings, c.handleSettingsChanges)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -399,7 +415,7 @@ func (c *Controller) initRoutes() {
 		{"alert routes", c.initAlertRoutes},
 		{"model routes", c.initModelRoutes},
 		{"insights routes", c.initInsightsRoutes},
-		{"tls routes", c.initTLSRoutes},
+		{"tls routes", func() { c.tlsHandler.RegisterRoutes(c.Group) }},
 		{"import routes", c.initImportRoutes},
 	}
 

--- a/internal/api/v2/mqtt_tls.go
+++ b/internal/api/v2/mqtt_tls.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -14,9 +15,9 @@ const mqttTLSServiceName = "mqtt"
 
 // MQTTTLSCertificateInfo represents the installation status of MQTT TLS certificates.
 type MQTTTLSCertificateInfo struct {
-	CA     *TLSCertificateInfo `json:"ca"`
-	Client *TLSCertificateInfo `json:"client"`
-	HasKey bool                `json:"hasKey"`
+	CA     *tlsapi.TLSCertificateInfo `json:"ca"`
+	Client *tlsapi.TLSCertificateInfo `json:"client"`
+	HasKey bool                       `json:"hasKey"`
 }
 
 // MQTTTLSCertificateUpload represents the request body for uploading MQTT TLS certificates.
@@ -68,21 +69,21 @@ func (c *Controller) getMQTTCertPath(certType conf.TLSCertificateType) string {
 // GetMQTTTLSCertificate handles GET /api/v2/integrations/mqtt/tls/certificate.
 func (c *Controller) GetMQTTTLSCertificate(ctx echo.Context) error {
 	result := &MQTTTLSCertificateInfo{
-		CA:     &TLSCertificateInfo{Installed: false},
-		Client: &TLSCertificateInfo{Installed: false},
+		CA:     &tlsapi.TLSCertificateInfo{Installed: false},
+		Client: &tlsapi.TLSCertificateInfo{Installed: false},
 		HasKey: false,
 	}
 
 	// Check CA certificate
 	if caPath := c.getMQTTCertPath(conf.TLSCertTypeCA); caPath != "" {
-		if info, err := ParseCertificateInfo(caPath); err == nil {
+		if info, err := tlsapi.ParseCertificateInfo(caPath); err == nil {
 			result.CA = info
 		}
 	}
 
 	// Check client certificate
 	if clientPath := c.getMQTTCertPath(conf.TLSCertTypeClient); clientPath != "" {
-		if info, err := ParseCertificateInfo(clientPath); err == nil {
+		if info, err := tlsapi.ParseCertificateInfo(clientPath); err == nil {
 			result.Client = info
 		}
 	}

--- a/internal/api/v2/mqtt_tls_helpers_test.go
+++ b/internal/api/v2/mqtt_tls_helpers_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	tlspkg "github.com/tphakala/birdnet-go/internal/tls"
+)
+
+// generateTestCertKeyPair creates a valid self-signed cert+key pair for testing.
+// Shared by the MQTT TLS handler tests (mqtt_tls_test.go). The standalone TLS
+// domain has its own copy in internal/api/v2/tls; this one stays here for the
+// integrations (MQTT) handlers that still live in package api.
+func generateTestCertKeyPair(t *testing.T) (certPEM, keyPEM string) {
+	t.Helper()
+	cert, key, err := tlspkg.GenerateSelfSigned(tlspkg.SelfSignedOptions{
+		Validity: 24 * time.Hour,
+		SANs:     []string{"localhost", "127.0.0.1"},
+	})
+	require.NoError(t, err, "failed to generate test certificate")
+	return cert, key
+}
+
+// setupTLSTestEnvironment creates a test environment with a TLS manager pointing
+// at a temporary directory, used by the MQTT TLS handler tests. It builds the
+// full *Controller (the MQTT TLS handlers are facade methods) and overrides the
+// global TLS manager for the duration of the test.
+func setupTLSTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *conf.TLSManager) {
+	t.Helper()
+
+	e, _, controller := setupTestEnvironment(t)
+
+	// Create a TLS manager using a temp directory
+	tlsDir := t.TempDir()
+	tlsMgr := conf.NewTLSManager(tlsDir)
+
+	// Override the global TLS manager for the duration of this test
+	origManager := conf.GetTLSManager()
+	conf.SetTLSManagerForTest(tlsMgr)
+	t.Cleanup(func() {
+		conf.SetTLSManagerForTest(origManager)
+	})
+
+	// Disable settings persistence in tests
+	controller.DisableSaveSettings = true
+
+	return e, controller, tlsMgr
+}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2162,7 +2162,6 @@ const (
 	reasonWebserverRestart = "restart.reasons.webserver"
 	reasonDatabaseRestart  = "restart.reasons.database"
 	reasonLoggingRestart   = "restart.reasons.logging"
-	reasonTLSCertRestart   = "restart.reasons.tlsCertificate"
 )
 
 // settingsChangeChecks defines all settings change detectors in order of execution.

--- a/internal/api/v2/tls/tls.go
+++ b/internal/api/v2/tls/tls.go
@@ -1,5 +1,13 @@
-// Package api provides TLS certificate management endpoints.
-package api
+// Package tls is the api/v2 TLS domain handler. It owns the /api/v2/tls/*
+// certificate-management endpoints (get/upload/delete/generate/download). The
+// Handler embeds *apicore.Core by pointer so the shared dependencies and helpers
+// (HandleError, ControllerSettings, AuthMiddleware, the logging helpers) promote
+// onto it. Unlike the weather domain, TLS certificate writes mutate persisted
+// settings, so the Handler also holds the facade's settings-save machinery
+// (the shared settings mutex and the publish/save/change helpers) injected as
+// function fields; the facade constructs one Handler and calls RegisterRoutes to
+// wire the routes in their existing order.
+package tls
 
 import (
 	"crypto/sha256"
@@ -11,9 +19,11 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/restart"
@@ -28,7 +38,15 @@ const (
 	tlsServiceName      = "webserver"   // Service name for TLS certificate storage
 )
 
+// reasonTLSCertRestart is the restart-reason i18n key recorded via
+// restart.MarkRestartRequired when a TLS certificate change requires the web
+// server to restart before the new certificate takes effect. The frontend
+// RestartBanner resolves it via t(). Named constant to avoid a magic string.
+const reasonTLSCertRestart = "restart.reasons.tlsCertificate"
+
 // TLSCertificateInfo represents TLS certificate details returned by the API.
+// It is exported because the integrations (MQTT TLS) domain reuses
+// ParseCertificateInfo and embeds this type in its own response struct.
 type TLSCertificateInfo struct {
 	Installed       bool     `json:"installed"`
 	Mode            string   `json:"mode,omitempty"`
@@ -42,23 +60,63 @@ type TLSCertificateInfo struct {
 	Fingerprint     string   `json:"fingerprint,omitempty"`
 }
 
-// TLSCertificateUpload represents the request body for uploading a TLS certificate.
-type TLSCertificateUpload struct {
+// certificateUpload represents the request body for uploading a TLS certificate.
+type certificateUpload struct {
 	Certificate   string `json:"certificate"`
 	PrivateKey    string `json:"privateKey"`
 	CACertificate string `json:"caCertificate,omitempty"`
 }
 
-// TLSGenerateRequest represents the request body for generating a self-signed certificate.
-type TLSGenerateRequest struct {
+// generateRequest represents the request body for generating a self-signed certificate.
+type generateRequest struct {
 	Validity string `json:"validity,omitempty"`
 }
 
-// initTLSRoutes registers TLS certificate management endpoints.
-func (c *Controller) initTLSRoutes() {
+// Handler serves the TLS domain endpoints. It embeds *apicore.Core BY POINTER so
+// the shared Core members promote onto it without re-wiring; Core carries
+// atomic/lock-bearing fields and must never be copied by value. The four
+// settings-save members are injected from the facade (the settings domain still
+// owns them): the shared *sync.RWMutex serializes TLS certificate writes against
+// the main settings update handlers, and the function fields are bound method
+// values of the facade Controller, named identically to the originals so the
+// moved handler bodies stay verbatim.
+type Handler struct {
+	*apicore.Core
+
+	settingsMutex          *sync.RWMutex
+	getSettingsOrFallback  func() *conf.Settings
+	publishAndSaveSettings func(current, updated *conf.Settings) error
+	handleSettingsChanges  func(oldSettings, currentSettings *conf.Settings) error
+}
+
+// New builds a TLS Handler around the shared core and the facade's settings-save
+// machinery. settingsMutex MUST be the same *sync.RWMutex the settings update
+// handlers lock, so TLS certificate writes serialize against them; the function
+// arguments are the facade's getSettingsOrFallback/publishAndSaveSettings/
+// handleSettingsChanges method values.
+func New(
+	core *apicore.Core,
+	settingsMutex *sync.RWMutex,
+	getSettingsOrFallback func() *conf.Settings,
+	publishAndSaveSettings func(current, updated *conf.Settings) error,
+	handleSettingsChanges func(oldSettings, currentSettings *conf.Settings) error,
+) *Handler {
+	return &Handler{
+		Core:                   core,
+		settingsMutex:          settingsMutex,
+		getSettingsOrFallback:  getSettingsOrFallback,
+		publishAndSaveSettings: publishAndSaveSettings,
+		handleSettingsChanges:  handleSettingsChanges,
+	}
+}
+
+// RegisterRoutes registers all TLS certificate management endpoints on the
+// supplied API v2 group, preserving the exact routes, per-route middleware, and
+// order the facade used before the TLS domain was extracted.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	c.LogInfoIfEnabled("Initializing TLS routes")
 
-	tlsGroup := c.Group.Group("/tls", c.AuthMiddleware)
+	tlsGroup := g.Group("/tls", c.AuthMiddleware)
 	tlsGroup.GET("/certificate", c.GetTLSCertificate)
 	tlsGroup.POST("/certificate", c.UploadTLSCertificate)
 	tlsGroup.DELETE("/certificate", c.DeleteTLSCertificate)
@@ -70,7 +128,7 @@ func (c *Controller) initTLSRoutes() {
 
 // GetTLSCertificate handles GET /api/v2/tls/certificate.
 // Returns certificate information if installed, or {installed: false} otherwise.
-func (c *Controller) GetTLSCertificate(ctx echo.Context) error {
+func (c *Handler) GetTLSCertificate(ctx echo.Context) error {
 	tlsMgr := conf.GetTLSManager()
 	if !tlsMgr.CertificateExists(tlsServiceName, conf.TLSCertTypeServerCert) {
 		return ctx.JSON(http.StatusOK, &TLSCertificateInfo{Installed: false})
@@ -94,8 +152,8 @@ func (c *Controller) GetTLSCertificate(ctx echo.Context) error {
 // UploadTLSCertificate handles POST /api/v2/tls/certificate.
 // Accepts a PEM-encoded certificate and private key pair, validates them,
 // and stores them for use by the web server.
-func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
-	var req TLSCertificateUpload
+func (c *Handler) UploadTLSCertificate(ctx echo.Context) error {
+	var req certificateUpload
 	if err := ctx.Bind(&req); err != nil {
 		return c.HandleError(ctx, err, "Invalid request body", http.StatusBadRequest)
 	}
@@ -149,7 +207,7 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 			http.StatusInternalServerError)
 	}
 	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
-		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
+		apicore.GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
 			logger.Error(handleErr))
 	}
 	tlsMgr.CleanupBackups(tlsServiceName)
@@ -174,7 +232,7 @@ func (c *Controller) UploadTLSCertificate(ctx echo.Context) error {
 
 // DeleteTLSCertificate handles DELETE /api/v2/tls/certificate.
 // Removes all TLS certificates for the web server and resets TLS mode to none.
-func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
+func (c *Handler) DeleteTLSCertificate(ctx echo.Context) error {
 	tlsMgr := conf.GetTLSManager()
 
 	// Serialise the entire backup-remove-save sequence so concurrent
@@ -200,7 +258,7 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 			http.StatusInternalServerError)
 	}
 	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
-		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
+		apicore.GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
 			logger.Error(handleErr))
 	}
 	tlsMgr.CleanupBackups(tlsServiceName)
@@ -213,8 +271,8 @@ func (c *Controller) DeleteTLSCertificate(ctx echo.Context) error {
 
 // GenerateSelfSignedCertificate handles POST /api/v2/tls/certificate/generate.
 // Generates a self-signed TLS certificate with SANs collected from the system.
-func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
-	var req TLSGenerateRequest
+func (c *Handler) GenerateSelfSignedCertificate(ctx echo.Context) error {
+	var req generateRequest
 	if err := ctx.Bind(&req); err != nil {
 		return c.HandleError(ctx, err, "Invalid request body", http.StatusBadRequest)
 	}
@@ -282,7 +340,7 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 			http.StatusInternalServerError)
 	}
 	if handleErr := c.handleSettingsChanges(current, updated); handleErr != nil {
-		GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
+		apicore.GetLogger().Warn("Failed to trigger settings side-effects after TLS certificate change",
 			logger.Error(handleErr))
 	}
 	tlsMgr.CleanupBackups(tlsServiceName)
@@ -307,7 +365,7 @@ func (c *Controller) GenerateSelfSignedCertificate(ctx echo.Context) error {
 // Serves the installed server certificate as a downloadable PEM file.
 // Users can install this in their OS trust store to avoid browser warnings
 // when using self-signed certificates.
-func (c *Controller) DownloadTLSCertificate(ctx echo.Context) error {
+func (c *Handler) DownloadTLSCertificate(ctx echo.Context) error {
 	tlsMgr := conf.GetTLSManager()
 	if !tlsMgr.CertificateExists(tlsServiceName, conf.TLSCertTypeServerCert) {
 		return c.HandleError(ctx, nil, "No certificate installed", http.StatusNotFound)

--- a/internal/api/v2/tls/tls_test.go
+++ b/internal/api/v2/tls/tls_test.go
@@ -1,16 +1,20 @@
-package api
+// tls_test.go: tests for the API v2 TLS domain endpoints.
+
+package tls
 
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	tlspkg "github.com/tphakala/birdnet-go/internal/tls"
@@ -27,12 +31,31 @@ func generateTestCertKeyPair(t *testing.T) (certPEM, keyPEM string) {
 	return cert, key
 }
 
-// setupTLSTestEnvironment creates a test environment with a TLS manager
-// pointing at a temporary directory.
-func setupTLSTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *conf.TLSManager) {
+// newTestHandler builds a TLS Handler around a *apicore.Core via apitest, with
+// in-memory test doubles for the facade's settings-save machinery. The doubles
+// mirror the production behavior the original tests asserted: getSettingsOrFallback
+// reads the core's atomic snapshot, publishAndSaveSettings stores the updated
+// snapshot back (no disk write, matching the original DisableSaveSettings=true),
+// and handleSettingsChanges is a no-op. They share the supplied mutex so the
+// handler serialises just as the facade does.
+func newTestHandler(t *testing.T, core *apicore.Core, mu *sync.RWMutex) *Handler {
+	t.Helper()
+	return New(core, mu,
+		func() *conf.Settings { return core.Settings.Load() },
+		func(_, updated *conf.Settings) error { core.Settings.Store(updated); return nil },
+		func(_, _ *conf.Settings) error { return nil },
+	)
+}
+
+// setupTLSTestEnvironment creates a test environment with Echo, an apicore.Core
+// built via apitest, a TLS Handler, and a TLS manager pointing at a temporary
+// directory. The returned Handler reads through the same core whose Settings the
+// test doubles mutate, so assertions on the TLS mode observe the writes.
+func setupTLSTestEnvironment(t *testing.T) (*echo.Echo, *Handler, *conf.TLSManager) {
 	t.Helper()
 
-	e, _, controller := setupTestEnvironment(t)
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
 
 	// Create a TLS manager using a temp directory
 	tlsDir := t.TempDir()
@@ -45,10 +68,8 @@ func setupTLSTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *conf.TLSMa
 		conf.SetTLSManagerForTest(origManager)
 	})
 
-	// Disable settings persistence in tests
-	controller.DisableSaveSettings = true
-
-	return e, controller, tlsMgr
+	var mu sync.RWMutex
+	return e, newTestHandler(t, core, &mu), tlsMgr
 }
 
 func TestTLSGetCertificate_NoCert(t *testing.T) {
@@ -106,7 +127,7 @@ func TestTLSUploadCertificate_ValidPEM(t *testing.T) {
 
 	certPEM, keyPEM := generateTestCertKeyPair(t)
 
-	body, err := json.Marshal(TLSCertificateUpload{
+	body, err := json.Marshal(certificateUpload{
 		Certificate: certPEM,
 		PrivateKey:  keyPEM,
 	})
@@ -134,7 +155,7 @@ func TestTLSUploadCertificate_ValidPEM(t *testing.T) {
 func TestTLSUploadCertificate_InvalidPEM(t *testing.T) {
 	e, controller, _ := setupTLSTestEnvironment(t)
 
-	body, err := json.Marshal(TLSCertificateUpload{
+	body, err := json.Marshal(certificateUpload{
 		Certificate: "not-a-valid-pem",
 		PrivateKey:  "also-not-valid",
 	})
@@ -158,7 +179,7 @@ func TestTLSUploadCertificate_MismatchedKeyPair(t *testing.T) {
 	_, keyPEM2 := generateTestCertKeyPair(t)
 
 	// Upload cert from pair 1 with key from pair 2
-	body, err := json.Marshal(TLSCertificateUpload{
+	body, err := json.Marshal(certificateUpload{
 		Certificate: certPEM1,
 		PrivateKey:  keyPEM2,
 	})
@@ -207,7 +228,7 @@ func TestTLSDeleteCertificate(t *testing.T) {
 func TestTLSGenerateSelfSignedCertificate(t *testing.T) {
 	e, controller, _ := setupTLSTestEnvironment(t)
 
-	body, err := json.Marshal(TLSGenerateRequest{
+	body, err := json.Marshal(generateRequest{
 		Validity: "30d",
 	})
 	require.NoError(t, err)
@@ -288,9 +309,12 @@ func TestTLSDownloadCertificate_NoCert(t *testing.T) {
 }
 
 func TestTLSRouteRegistration(t *testing.T) {
-	e, _, controller := setupTestEnvironment(t)
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	var mu sync.RWMutex
+	h := newTestHandler(t, core, &mu)
 
-	controller.initTLSRoutes()
+	h.RegisterRoutes(core.Group)
 
 	expectedRoutes := []string{
 		"GET /api/v2/tls/certificate",


### PR DESCRIPTION
## Summary

Phase 4 of the internal/api/v2 package split: move the TLS certificate-management domain out of the monolithic `package api` into a new `internal/api/v2/tls` subpackage so it gets its own `-race` test binary and stops gating the package's test timeout. This follows the weather extraction pattern from #3698 (Phase 3).

## Pattern (same as weather)

- `tls.Handler` embeds `*apicore.Core` by pointer (never copied by value).
- `New(...)` constructs the handler; `RegisterRoutes(g *echo.Group)` wires the exact routes from the old `initTLSRoutes` in the same order with the same per-route middleware (`g.Group("/tls", c.AuthMiddleware)`).
- Handler methods moved verbatim; only the receiver type was retyped from `*Controller` to `*Handler` (receiver name kept `c`). Bodies rely on promotion of the embedded Core's exported members. The one package-local change is `GetLogger()` -> `apicore.GetLogger()`, which is byte-identical (both return `logger.Global().Module("api")`).
- TLS-local request types unexported (`certificateUpload`, `generateRequest`); the validity/service constants and `reasonTLSCertRestart` moved into the package. JSON struct tags are unchanged, so the wire format is identical.

## Facade-only dependency wiring (where tls differs from weather)

TLS certificate writes mutate persisted settings, so the handler needs the facade's settings-save machinery. That machinery belongs to the settings domain (not yet extracted) and is not on `apicore.Core`. The Handler takes these as extra constructor args and holds them as fields named identically to the originals, so the moved bodies stay verbatim:

- `settingsMutex *sync.RWMutex`, passed as `&c.settingsMutex` so TLS writes serialize against the main settings PATCH/PUT handlers (the same lock instance).
- `getSettingsOrFallback` / `publishAndSaveSettings` / `handleSettingsChanges`, passed as the facade's bound method values.

The facade constructs it once in `NewWithOptions` after the `Controller` literal (so `&c.settingsMutex` and the method values are stable), then registers it at the same ordered position the old `initTLSRoutes` entry occupied. No `init()`-based self-registration.

## Naming

The domain package is imported as `tlsapi` and the facade field is named `tlsHandler` to avoid colliding with the stdlib `crypto/tls` package and the field name.

## Cross-domain coupling

`mqtt_tls.go` (integrations domain, still in `package api`) reuses `ParseCertificateInfo` and the `TLSCertificateInfo` type. Both are exported from the tls package (the `weather.ClosestHourlyWeather` precedent); `mqtt_tls.go` imports the package as `tlsapi` and calls `tlsapi.ParseCertificateInfo` / `*tlsapi.TLSCertificateInfo`. Dependency direction stays acyclic (`api -> tls -> apicore`).

## Tests

Tests moved into the tls package, rebuilt against `apitest.NewCore` with in-memory test doubles for the four injected settings-save deps (the `publishAndSaveSettings` double stores the updated snapshot into `core.Settings`, matching `DisableSaveSettings=true`; `handleSettingsChanges` is a no-op). The MQTT TLS handler tests stay in `package api`; the small shared helpers they used (`setupTLSTestEnvironment` returning `*Controller`, `generateTestCertKeyPair`) moved into `mqtt_tls_helpers_test.go`.

## Preflight Status

- Single concern: one refactor (extract the tls domain).
- `go build ./...` clean.
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks).
- `go test -race ./internal/api/v2/...` green, including the tls domain's own `-race` binary and `TestRouteEnumerationMatchesGolden` passing unchanged (route set byte-identical).
- `golangci-lint run` clean on `internal/api/v2/...` (0 issues).
- No regression/backward-compat break: no config key, JSON response field, endpoint path, HTTP method, status code, or default value changed. `apiv2.Controller` / `apiv2.New` / `apiv2.NewWithOptions` signatures unchanged.
- Reviewed by three parallel quality-gate passes (correctness/safety, integration/regression, quality/reuse) plus a Gemini design review; no blockers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate management routing and handling, keeping certificate actions available and consistent.
  * Corrected restart-related behavior tied to TLS certificate changes.

* **Documentation**
  * Fixed the TLS certificate management README reference path.

* **Refactor**
  * Reworked TLS API handling to use a dedicated structure for cleaner routing and settings updates.

* **Tests**
  * Updated and expanded TLS and MQTT TLS test coverage for the new routing and request handling flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->