### PR TITLE
refactor(api/v2): extract range domain into its own package

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/api/v2/weather"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
@@ -65,6 +66,12 @@ type Controller struct {
 	// the facade's settings-save machinery (see NewWithOptions) because TLS writes
 	// mutate persisted settings.
 	tlsHandler *tlsapi.Handler
+
+	// rangeHandler serves the /api/v2/range/* endpoints (range-filter status,
+	// species scores/count/list/CSV, test, rebuild). It is named rangeHandler
+	// because "range" is a Go reserved word; the domain package is imported as
+	// rangeapi. Like weather it needs only the shared *apicore.Core.
+	rangeHandler *rangeapi.Handler
 
 	controlChan chan string
 
@@ -293,6 +300,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Construct domain handlers around the shared core. They hold the same
 	// *apicore.Core pointer and register their routes in initRoutes.
 	c.weather = weather.New(c.Core)
+	c.rangeHandler = rangeapi.New(c.Core)
 	// The TLS handler needs the facade's settings-save machinery: the shared
 	// settingsMutex (passed by pointer so TLS certificate writes serialize against
 	// the main settings update handlers) and the bound method values for reading,
@@ -402,7 +410,7 @@ func (c *Controller) initRoutes() {
 		{"control routes", c.initControlRoutes},
 		{"auth routes", c.initAuthRoutes},
 		{"media routes", c.initMediaRoutes},
-		{"range routes", c.initRangeRoutes},
+		{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }},
 		{"heatmap routes", c.initHeatmapRoutes},
 		{"sse routes", c.initSSERoutes},
 		{"diagnostics routes", c.initDiagnosticsRoutes},

--- a/internal/api/v2/apicore/shared_helpers.go
+++ b/internal/api/v2/apicore/shared_helpers.go
@@ -1,0 +1,71 @@
+// shared_helpers.go holds small helpers shared across multiple api/v2 domains.
+// They live on apicore (the shared substrate) so every domain handler and the
+// facade reach them through the embedded *Core without importing each other.
+package apicore
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/tphakala/birdnet-go/internal/classifier"
+)
+
+// BirdNET week-model constants, shared across api/v2 domains. BirdNET uses a
+// custom 48-week year (4 weeks per month). These were originally defined in the
+// range filter code; the range, heatmap, and support handlers all key off the
+// same model, so they live on the shared substrate to stay in sync.
+const (
+	WeeksPerMonth = 4                  // BirdNET model: 4 weeks per month
+	WeeksPerYear  = WeeksPerMonth * 12 // 48 weeks per year in BirdNET's model
+	DaysPerWeek   = 7                  // Days in a calendar week
+)
+
+// GetBirdNETInstance returns the BirdNET orchestrator or an error if unavailable.
+// It snapshots the processor first to avoid a TOCTOU race. Shared by the range,
+// heatmap, and diagnostics handlers.
+func (c *Core) GetBirdNETInstance() (*classifier.Orchestrator, error) {
+	// Snapshot processor to avoid TOCTOU race
+	proc := c.Processor
+	if proc == nil {
+		return nil, fmt.Errorf("BirdNET processor not available")
+	}
+	instance := proc.GetBirdNET()
+	if instance == nil {
+		return nil, fmt.Errorf("BirdNET instance not available")
+	}
+	return instance, nil
+}
+
+// CurrentLocale returns the BirdNET locale from the current settings snapshot.
+// Reading it per call keeps locale changes hot-reloadable. Shared by the range
+// and species handlers.
+func (c *Core) CurrentLocale() string {
+	locale := c.CurrentSettings().BirdNET.Locale
+	return locale
+}
+
+// NormalizeForLookup prepares a string for case- and Unicode-form-insensitive
+// map lookup. BirdNET labels ship in composed (NFC) form, but users typing
+// on macOS or with composing keyboards may submit decomposed (NFD) bytes
+// for diacritics, so normalising both sides to NFC prevents silent misses
+// on species like "Lehtopöllö". Shared by the insights, search, and range
+// (display de-duplication) code so the keys stay consistent across them.
+func NormalizeForLookup(s string) string {
+	return strings.ToLower(norm.NFC.String(s))
+}
+
+// ParseFloat64 parses a string to float64. Shared by the range and heatmap
+// query-parameter parsing.
+func ParseFloat64(s string) (float64, error) {
+	return strconv.ParseFloat(s, 64)
+}
+
+// ParseFloat32 parses a string to float32. Shared by the range and heatmap
+// query-parameter parsing.
+func ParseFloat32(s string) (float32, error) {
+	f, err := strconv.ParseFloat(s, 32)
+	return float32(f), err
+}

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -143,7 +143,7 @@ func (c *Controller) registerHealthChecks() {
 			return status.Supported, status.Active
 		}),
 		checks.NewRangeFilterCheck(func() checks.RangeFilterStatusInfo {
-			orch, err := c.getBirdNETInstance()
+			orch, err := c.GetBirdNETInstance()
 			if err != nil || orch == nil {
 				return checks.RangeFilterStatusInfo{}
 			}

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -23,7 +24,7 @@ const (
 	bnhmMagic      = "BNHM"
 	bnhmVersion    = 1
 	bnhmHeaderSize = 40
-	bnhmWeeks      = weeksPerYear // 48 BirdNET weeks, matches range.go
+	bnhmWeeks      = apicore.WeeksPerYear // 48 BirdNET weeks (shared BirdNET week model)
 )
 
 // Heatmap validation constraints
@@ -240,23 +241,23 @@ func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, er
 		return nil, fmt.Errorf("species parameter is required")
 	}
 
-	south, err := parseFloat64(ctx.QueryParam("south"))
+	south, err := apicore.ParseFloat64(ctx.QueryParam("south"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid south parameter: %w", err)
 	}
-	north, err := parseFloat64(ctx.QueryParam("north"))
+	north, err := apicore.ParseFloat64(ctx.QueryParam("north"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid north parameter: %w", err)
 	}
-	west, err := parseFloat64(ctx.QueryParam("west"))
+	west, err := apicore.ParseFloat64(ctx.QueryParam("west"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid west parameter: %w", err)
 	}
-	east, err := parseFloat64(ctx.QueryParam("east"))
+	east, err := apicore.ParseFloat64(ctx.QueryParam("east"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid east parameter: %w", err)
 	}
-	resolution, err := parseFloat64(ctx.QueryParam("resolution"))
+	resolution, err := apicore.ParseFloat64(ctx.QueryParam("resolution"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid resolution parameter: %w", err)
 	}
@@ -447,7 +448,7 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 	}
 
 	// Try the dedicated heatmap service (optimized path)
-	birdnet, err := c.getBirdNETInstance()
+	birdnet, err := c.GetBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -5,16 +5,15 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
-	"golang.org/x/text/unicode/norm"
 )
 
 // Insights constants
@@ -160,15 +159,6 @@ type nameMaps struct {
 	commonToSci map[string]string
 }
 
-// normalizeForLookup prepares a string for case- and Unicode-form-insensitive
-// map lookup. BirdNET labels ship in composed (NFC) form, but users typing
-// on macOS or with composing keyboards may submit decomposed (NFD) bytes
-// for diacritics, so normalising both sides to NFC prevents silent misses
-// on species like "Lehtopöllö".
-func normalizeForLookup(s string) string {
-	return strings.ToLower(norm.NFC.String(s))
-}
-
 // buildNameMaps parses a BirdNET label list ("ScientificName_CommonName")
 // and builds both lookup maps in a single pass. If two or more labels share
 // the same normalised common name but map to different scientific names,
@@ -190,7 +180,7 @@ func buildNameMaps(labels []string, resolver datastore.SpeciesNameResolver) *nam
 	for _, sn := range datastore.ResolveLabelNames(labels, resolver) {
 		nm.sciToCommon[sn.Scientific] = sn.Common
 
-		key := normalizeForLookup(sn.Common)
+		key := apicore.NormalizeForLookup(sn.Common)
 		if _, seen := ambiguous[key]; seen {
 			continue
 		}

--- a/internal/api/v2/insights_nameresolver_test.go
+++ b/internal/api/v2/insights_nameresolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 )
 
 // fakeResolver is a minimal datastore.SpeciesNameResolver for tests.
@@ -23,7 +24,7 @@ func TestBuildNameMaps_ResolverLocalizes(t *testing.T) {
 	nm := buildNameMaps([]string{"Turdus merula_LabelName"},
 		fakeResolver{m: map[string]string{"Turdus merula": "Mustarastas"}})
 	assert.Equal(t, "Mustarastas", nm.sciToCommon["Turdus merula"])
-	assert.Equal(t, "Turdus merula", nm.commonToSci[normalizeForLookup("Mustarastas")])
+	assert.Equal(t, "Turdus merula", nm.commonToSci[apicore.NormalizeForLookup("Mustarastas")])
 }
 
 func TestBuildNameMaps_NilResolverKeepsLabel(t *testing.T) {
@@ -38,7 +39,7 @@ func TestBuildNameMaps_ScientificOnlyLabelSearchable(t *testing.T) {
 	nm := buildNameMaps([]string{"Myotis myotis"},
 		fakeResolver{m: map[string]string{"Myotis myotis": "Greater Mouse-eared Bat"}})
 	assert.Equal(t, "Greater Mouse-eared Bat", nm.sciToCommon["Myotis myotis"])
-	assert.Equal(t, "Myotis myotis", nm.commonToSci[normalizeForLookup("Greater Mouse-eared Bat")])
+	assert.Equal(t, "Myotis myotis", nm.commonToSci[apicore.NormalizeForLookup("Greater Mouse-eared Bat")])
 
 	// Without a resolver, a scientific-only label has no common name and is skipped.
 	bare := buildNameMaps([]string{"Myotis myotis"}, nil)

--- a/internal/api/v2/range/range.go
+++ b/internal/api/v2/range/range.go
@@ -1,5 +1,13 @@
-// range.go contains API v2 endpoints for range filter operations
-package api
+// Package rangeapi is the api/v2 range-filter domain handler. It owns the
+// /api/v2/range/* endpoints (status, species scores/count/list/CSV, test, and
+// rebuild). The package lives in directory internal/api/v2/range but cannot be
+// named "range" (a Go reserved word), so it is named rangeapi and imported under
+// that alias. The Handler embeds *apicore.Core by pointer so the shared
+// dependencies and helpers (Processor, TaxonomyDB, HandleError, CurrentSettings,
+// the logging helpers, GetBirdNETInstance) promote onto it; the facade
+// constructs one Handler and calls RegisterRoutes to wire the routes in their
+// existing order.
+package rangeapi
 
 import (
 	"bytes"
@@ -14,18 +22,40 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// Range filter constants (file-local)
-const (
-	weeksPerMonth = 4                  // Simplified ML model uses 4 weeks per month
-	weeksPerYear  = weeksPerMonth * 12 // 48 weeks per year in BirdNET's model
-	daysPerWeek   = 7                  // Days in a week for week calculation
-)
+// Handler serves the range-filter domain endpoints. It embeds *apicore.Core BY
+// POINTER so the shared Core members promote onto it without re-wiring; Core
+// carries atomic/lock-bearing fields and must never be copied by value.
+type Handler struct {
+	*apicore.Core
+}
+
+// New builds a range Handler around the shared core.
+func New(core *apicore.Core) *Handler {
+	return &Handler{core}
+}
+
+// RegisterRoutes registers all range-filter related API endpoints on the
+// supplied API v2 group, preserving the exact routes and order the facade used
+// before the range domain was extracted.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+	// Range filter status and scores
+	g.GET("/range/status", c.GetRangeFilterStatus)
+	g.GET("/range/species/scores", c.GetRangeFilterSpeciesScores)
+
+	// Range filter species routes
+	g.GET("/range/species/count", c.GetRangeFilterSpeciesCount)
+	g.GET("/range/species/list", c.GetRangeFilterSpeciesList)
+	g.GET("/range/species/csv", c.GetRangeFilterSpeciesCSV)
+	g.POST("/range/species/test", c.TestRangeFilter)
+	g.POST("/range/rebuild", c.RebuildRangeFilter)
+}
 
 // validateRangeFilterRequest validates the range filter test request parameters.
 // Returns user-facing error messages with capitalized first letter for API responses.
@@ -39,8 +69,8 @@ func validateRangeFilterRequest(req *RangeFilterTestRequest) error {
 	if req.Threshold < 0 || req.Threshold > 1 {
 		return fmt.Errorf("Threshold must be between 0 and 1") //nolint:staticcheck // user-facing API message
 	}
-	if req.Week != 0 && (req.Week < 1 || req.Week > weeksPerYear) {
-		return fmt.Errorf("Week must be between 1 and %d", weeksPerYear) //nolint:staticcheck // user-facing API message
+	if req.Week != 0 && (req.Week < 1 || req.Week > apicore.WeeksPerYear) {
+		return fmt.Errorf("Week must be between 1 and %d", apicore.WeeksPerYear) //nolint:staticcheck // user-facing API message
 	}
 	return nil
 }
@@ -58,36 +88,16 @@ func parseTestDate(dateStr string) (time.Time, error) {
 func calculateWeek(date time.Time) float32 {
 	month := int(date.Month())
 	day := date.Day()
-	weeksFromMonths := (month - 1) * weeksPerMonth
-	weekInMonth := (day-1)/daysPerWeek + 1
+	weeksFromMonths := (month - 1) * apicore.WeeksPerMonth
+	weekInMonth := (day-1)/apicore.DaysPerWeek + 1
 	return float32(weeksFromMonths + weekInMonth)
-}
-
-// getBirdNETInstance returns the BirdNET instance or an error if unavailable.
-func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
-	// Snapshot processor to avoid TOCTOU race
-	proc := c.Processor
-	if proc == nil {
-		return nil, fmt.Errorf("BirdNET processor not available")
-	}
-	instance := proc.GetBirdNET()
-	if instance == nil {
-		return nil, fmt.Errorf("BirdNET instance not available")
-	}
-	return instance, nil
-}
-
-// currentLocale returns the BirdNET locale from the current settings.
-func (c *Controller) currentLocale() string {
-	locale := c.CurrentSettings().BirdNET.Locale
-	return locale
 }
 
 // buildTestSettings creates a settings snapshot with the given test coordinates
 // and threshold for range filter testing. The snapshot is a clone of the
 // current settings with only the test values overridden, so it can be passed
 // directly to GetProbableSpeciesWithSettings without modifying global state.
-func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *conf.Settings {
+func (c *Handler) buildTestSettings(lat, lon float64, threshold float32) *conf.Settings {
 	testSnapshot := conf.CloneSettings(c.CurrentSettings())
 
 	testSnapshot.BirdNET.Latitude = lat
@@ -179,9 +189,9 @@ func dedupeSpeciesForDisplay(species []RangeFilterSpecies) []RangeFilterSpecies 
 	indexByKey := make(map[string]int, len(species))
 	deduped := make([]RangeFilterSpecies, 0, len(species))
 	for _, sp := range species {
-		key := normalizeForLookup(sp.CommonName)
+		key := apicore.NormalizeForLookup(sp.CommonName)
 		if key == "" {
-			key = normalizeForLookup(sp.ScientificName)
+			key = apicore.NormalizeForLookup(sp.ScientificName)
 		}
 		if key == "" {
 			// No name to key on: keep the row rather than collapsing every
@@ -231,7 +241,9 @@ type RangeFilterSpeciesCount struct {
 	Location    Location  `json:"location"`
 }
 
-// RangeFilterSpecies represents a single species in the range filter
+// RangeFilterSpecies represents a single species in the range filter. It stays
+// exported because the species domain (/api/v2/species/all) reuses it as its
+// response element type.
 type RangeFilterSpecies struct {
 	Label          string   `json:"label"`
 	ScientificName string   `json:"scientificName"`
@@ -292,20 +304,6 @@ type RangeFilterTestResponse struct {
 	} `json:"parameters"`
 }
 
-// initRangeRoutes sets up the range filter related routes
-func (c *Controller) initRangeRoutes() {
-	// Range filter status and scores
-	c.Group.GET("/range/status", c.GetRangeFilterStatus)
-	c.Group.GET("/range/species/scores", c.GetRangeFilterSpeciesScores)
-
-	// Range filter species routes
-	c.Group.GET("/range/species/count", c.GetRangeFilterSpeciesCount)
-	c.Group.GET("/range/species/list", c.GetRangeFilterSpeciesList)
-	c.Group.GET("/range/species/csv", c.GetRangeFilterSpeciesCSV)
-	c.Group.POST("/range/species/test", c.TestRangeFilter)
-	c.Group.POST("/range/rebuild", c.RebuildRangeFilter)
-}
-
 // GetRangeFilterStatus returns introspection data about the active range filter
 // @Summary Get range filter status
 // @Description Returns per-classifier geomodel coverage, auto-selection status, and threshold
@@ -314,8 +312,8 @@ func (c *Controller) initRangeRoutes() {
 // @Success 200 {object} classifier.RangeFilterStatusResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/status [get]
-func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
-	birdnetInstance, err := c.getBirdNETInstance()
+func (c *Handler) GetRangeFilterStatus(ctx echo.Context) error {
+	birdnetInstance, err := c.GetBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
@@ -343,8 +341,8 @@ func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
 // @Failure 400 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/scores [get]
-func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
-	birdnetInstance, err := c.getBirdNETInstance()
+func (c *Handler) GetRangeFilterSpeciesScores(ctx echo.Context) error {
+	birdnetInstance, err := c.GetBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
@@ -358,7 +356,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 
 	// Override with query params if provided
 	if latStr := ctx.QueryParam("lat"); latStr != "" {
-		parsed, err := parseFloat64(latStr)
+		parsed, err := apicore.ParseFloat64(latStr)
 		if err != nil {
 			return c.HandleError(ctx, err, "Invalid latitude format", http.StatusBadRequest)
 		}
@@ -369,7 +367,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 	}
 
 	if lonStr := ctx.QueryParam("lon"); lonStr != "" {
-		parsed, err := parseFloat64(lonStr)
+		parsed, err := apicore.ParseFloat64(lonStr)
 		if err != nil {
 			return c.HandleError(ctx, err, "Invalid longitude format", http.StatusBadRequest)
 		}
@@ -388,8 +386,8 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		if err != nil {
 			return c.HandleError(ctx, err, "Invalid week format", http.StatusBadRequest)
 		}
-		if parsed < 1 || parsed > weeksPerYear {
-			return c.HandleError(ctx, nil, fmt.Sprintf("Week must be between 1 and %d", weeksPerYear), http.StatusBadRequest)
+		if parsed < 1 || parsed > apicore.WeeksPerYear {
+			return c.HandleError(ctx, nil, fmt.Sprintf("Week must be between 1 and %d", apicore.WeeksPerYear), http.StatusBadRequest)
 		}
 		week = float32(parsed)
 	}
@@ -430,13 +428,13 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 // @Success 200 {object} RangeFilterSpeciesCount
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/count [get]
-func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
+func (c *Handler) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 	settings := c.CurrentSettings()
 
 	// Count the de-duplicated display list so the count matches what
 	// /range/species/list renders (the same collapse of force-include override
 	// copies and localized taxonomic synonyms).
-	birdnetInstance, _ := c.getBirdNETInstance()
+	birdnetInstance, _ := c.GetBirdNETInstance()
 	speciesList := dedupeSpeciesForDisplay(convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale))
 
 	response := RangeFilterSpeciesCount{
@@ -460,11 +458,11 @@ func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 // @Success 200 {object} RangeFilterSpeciesList
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/list [get]
-func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
+func (c *Handler) GetRangeFilterSpeciesList(ctx echo.Context) error {
 	settings := c.CurrentSettings()
 	includedSpecies := settings.GetIncludedSpecies()
 
-	birdnetInstance, _ := c.getBirdNETInstance()
+	birdnetInstance, _ := c.GetBirdNETInstance()
 	speciesList := dedupeSpeciesForDisplay(convertLabels(includedSpecies, birdnetInstance, settings.BirdNET.Locale))
 
 	// Extract taxonomy groups from species list via taxonomy DB
@@ -480,7 +478,7 @@ func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
 		for _, sp := range speciesList {
 			_, meta, ok := c.TaxonomyDB.LookupGenusByScientificName(sp.ScientificName)
 			if !ok {
-				continue // Species not in taxonomy DB — skip gracefully
+				continue // Species not in taxonomy DB - skip gracefully
 			}
 
 			// Extract genus (first word of scientific name)
@@ -555,7 +553,7 @@ func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
 // @Failure 400 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/test [post]
-func (c *Controller) TestRangeFilter(ctx echo.Context) error {
+func (c *Handler) TestRangeFilter(ctx echo.Context) error {
 	var req RangeFilterTestRequest
 	if err := ctx.Bind(&req); err != nil {
 		return c.HandleError(ctx, err, "Invalid request format", http.StatusBadRequest)
@@ -573,7 +571,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 	}
 
 	// Check if processor and BirdNET are available
-	birdnetInstance, err := c.getBirdNETInstance()
+	birdnetInstance, err := c.GetBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
@@ -594,7 +592,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}
 
-	speciesList := dedupeSpeciesForDisplay(convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale()))
+	speciesList := dedupeSpeciesForDisplay(convertSpeciesScores(speciesScores, birdnetInstance, c.CurrentLocale()))
 
 	response := RangeFilterTestResponse{
 		Species:   speciesList,
@@ -631,7 +629,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 // @Failure 400 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/csv [get]
-func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
+func (c *Handler) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 	// Check for custom parameters in query string
 	customLat := ctx.QueryParam("latitude")
 	customLon := ctx.QueryParam("longitude")
@@ -654,7 +652,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 
 		// Override with custom values if provided
 		if customLat != "" {
-			lat, err := parseFloat64(customLat)
+			lat, err := apicore.ParseFloat64(customLat)
 			if err != nil {
 				return c.HandleError(ctx, err, "Invalid latitude format", http.StatusBadRequest)
 			}
@@ -665,7 +663,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		}
 
 		if customLon != "" {
-			lon, err := parseFloat64(customLon)
+			lon, err := apicore.ParseFloat64(customLon)
 			if err != nil {
 				return c.HandleError(ctx, err, "Invalid longitude format", http.StatusBadRequest)
 			}
@@ -676,7 +674,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		}
 
 		if customThreshold != "" {
-			thr, err := parseFloat32(customThreshold)
+			thr, err := apicore.ParseFloat32(customThreshold)
 			if err != nil {
 				return c.HandleError(ctx, err, "Invalid threshold format", http.StatusBadRequest)
 			}
@@ -701,7 +699,7 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		// hits that branch; this branch is the no-argument fallback.
 		settings := c.CurrentSettings()
 
-		birdnetInstance, _ := c.getBirdNETInstance()
+		birdnetInstance, _ := c.GetBirdNETInstance()
 		speciesList = dedupeSpeciesForDisplay(convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale))
 		location = Location{
 			Latitude:  settings.BirdNET.Latitude,
@@ -740,9 +738,9 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 // species (bats/Perch). This is the path the settings UI's CSV download takes
 // (it always sends parameters), so a user who sees bats in the Active Species
 // preview gets the same bats when exporting those parameters to CSV.
-func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilterSpecies, Location, float32, error) {
+func (c *Handler) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilterSpecies, Location, float32, error) {
 	// Check if BirdNET is available
-	birdnetInstance, err := c.getBirdNETInstance()
+	birdnetInstance, err := c.GetBirdNETInstance()
 	if err != nil {
 		return nil, Location{}, 0, err
 	}
@@ -761,7 +759,7 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 		return nil, Location{}, 0, err
 	}
 
-	speciesList := dedupeSpeciesForDisplay(convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale()))
+	speciesList := dedupeSpeciesForDisplay(convertSpeciesScores(speciesScores, birdnetInstance, c.CurrentLocale()))
 
 	location := Location{
 		Latitude:  req.Latitude,
@@ -786,7 +784,7 @@ func sanitizeCSVField(field string) string {
 }
 
 // generateSpeciesCSV generates CSV content from species list using the standard CSV library
-func (c *Controller) generateSpeciesCSV(species []RangeFilterSpecies, location Location, threshold float32) ([]byte, error) {
+func (c *Handler) generateSpeciesCSV(species []RangeFilterSpecies, location Location, threshold float32) ([]byte, error) {
 	var buf bytes.Buffer
 
 	// Write UTF-8 BOM for Excel compatibility
@@ -844,17 +842,6 @@ func (c *Controller) generateSpeciesCSV(species []RangeFilterSpecies, location L
 	return buf.Bytes(), nil
 }
 
-// parseFloat64 is a helper function to parse string to float64
-func parseFloat64(s string) (float64, error) {
-	return strconv.ParseFloat(s, 64)
-}
-
-// parseFloat32 is a helper function to parse string to float32
-func parseFloat32(s string) (float32, error) {
-	f, err := strconv.ParseFloat(s, 32)
-	return float32(f), err
-}
-
 // RebuildRangeFilter rebuilds the range filter with current settings
 // @Summary Rebuild range filter
 // @Description Rebuilds the range filter using current location and threshold settings
@@ -863,9 +850,9 @@ func parseFloat32(s string) (float32, error) {
 // @Success 200 {object} map[string]interface{}
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/rebuild [post]
-func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
+func (c *Handler) RebuildRangeFilter(ctx echo.Context) error {
 	// Check if BirdNET is available
-	birdnetInstance, err := c.getBirdNETInstance()
+	birdnetInstance, err := c.GetBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/range/range_dedup_test.go
+++ b/internal/api/v2/range/range_dedup_test.go
@@ -2,7 +2,7 @@
 // range-filter species lists (collapsing force-include override copies and
 // localized taxonomic synonyms into a single displayed row).
 
-package api
+package rangeapi
 
 import (
 	"testing"
@@ -81,11 +81,11 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 			// This pins the NFC half of the key; ToLower alone would not collapse them.
 			name: "NFC and NFD decomposed common name collapse",
 			in: []RangeFilterSpecies{
-				{ScientificName: "Strix aluco", CommonName: "Lehtop\u00f6ll\u00f6", Score: new(0.6)},
-				{ScientificName: "Syrnium aluco", CommonName: "Lehtopo\u0308llo\u0308", Score: new(0.4)},
+				{ScientificName: "Strix aluco", CommonName: "Lehtopöllö", Score: new(0.6)},
+				{ScientificName: "Syrnium aluco", CommonName: "Lehtopöllö", Score: new(0.4)},
 			},
 			want: []RangeFilterSpecies{
-				{ScientificName: "Strix aluco", CommonName: "Lehtop\u00f6ll\u00f6", Score: new(0.6)},
+				{ScientificName: "Strix aluco", CommonName: "Lehtopöllö", Score: new(0.6)},
 			},
 		},
 		{

--- a/internal/api/v2/range/range_test.go
+++ b/internal/api/v2/range/range_test.go
@@ -1,6 +1,6 @@
-// range_test.go: Package api provides tests for range filter API v2 endpoints.
+// range_test.go: tests for the API v2 range-filter domain endpoints.
 
-package api
+package rangeapi
 
 import (
 	"bytes"
@@ -15,6 +15,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -47,26 +49,29 @@ func (m *MockProcessor) GetBirdNET() *classifier.Orchestrator {
 	return nil
 }
 
-// setupRangeTestEnvironment creates a test environment specifically for range filter tests
-func setupRangeTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Controller) {
+// setupRangeTestEnvironment creates a test environment with Echo, a mock
+// datastore, and a range Handler built from a *apicore.Core via apitest. The
+// settings carry range-filter test data (coordinates, threshold, included
+// species) injected before the snapshot is published.
+func setupRangeTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Handler) {
 	t.Helper()
 
-	e, mockDS, controller := setupTestEnvironment(t)
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithDatastore(mockDS),
+		apitest.WithSettingsFunc(func(s *conf.Settings) {
+			s.BirdNET.Latitude = 60.1699
+			s.BirdNET.Longitude = 24.9384
+			s.BirdNET.RangeFilter.Threshold = 0.01
+			s.BirdNET.RangeFilter.LastUpdated = time.Now()
+			s.BirdNET.RangeFilter.Species = []string{
+				"Turdus merula_Eurasian Blackbird",
+				"Parus major_Great Tit",
+				"Corvus cornix_Hooded Crow",
+			}
+		}))
 
-	// Set up mock settings with range filter data
-	controller.Settings.Load().BirdNET.Latitude = 60.1699
-	controller.Settings.Load().BirdNET.Longitude = 24.9384
-	controller.Settings.Load().BirdNET.RangeFilter.Threshold = 0.01
-	controller.Settings.Load().BirdNET.RangeFilter.LastUpdated = time.Now()
-
-	// Set the included species list directly for test setup
-	controller.Settings.Load().BirdNET.RangeFilter.Species = []string{
-		"Turdus merula_Eurasian Blackbird",
-		"Parus major_Great Tit",
-		"Corvus cornix_Hooded Crow",
-	}
-
-	return e, mockDS, controller
+	return e, mockDS, New(core)
 }
 
 // TestGetRangeFilterSpeciesCount tests the species count endpoint
@@ -166,7 +171,7 @@ func TestTestRangeFilterWithoutProcessor(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	// Parse error response
-	var response ErrorResponse
+	var response apicore.ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
 	require.NoError(t, err)
 	assert.Contains(t, response.Message, "BirdNET service not available")
@@ -295,7 +300,7 @@ func TestTestRangeFilterValidation(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, rec.Code)
 
 			// Parse error response
-			var response ErrorResponse
+			var response apicore.ErrorResponse
 			err = json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
 			assert.Contains(t, response.Message, tt.expectedError)
@@ -331,7 +336,7 @@ func TestValidWeekBoundaries(t *testing.T) {
 			// Valid week passes validation and reaches processor (500, not 400)
 			assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
-			var response ErrorResponse
+			var response apicore.ErrorResponse
 			err = json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
 			assert.Contains(t, response.Message, "BirdNET service not available")
@@ -361,7 +366,7 @@ func TestRebuildRangeFilterWithoutProcessor(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	// Parse error response
-	var response ErrorResponse
+	var response apicore.ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
 	require.NoError(t, err)
 	assert.Contains(t, response.Message, "BirdNET service not available")

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -433,7 +434,7 @@ func (c *Controller) resolveSpeciesToScientific(input string) (resolved string, 
 		return "", false
 	}
 	lookup := c.loadCommonToScientificMap()
-	if scientific, ok := lookup[normalizeForLookup(trimmed)]; ok {
+	if scientific, ok := lookup[apicore.NormalizeForLookup(trimmed)]; ok {
 		return scientific, true
 	}
 	return trimmed, false

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/ebird"
@@ -107,8 +108,8 @@ func (c *Controller) initSpeciesRoutes() {
 
 // AllSpeciesResponse represents the response for the all species endpoint
 type AllSpeciesResponse struct {
-	Species []RangeFilterSpecies `json:"species"`
-	Count   int                  `json:"count"`
+	Species []rangeapi.RangeFilterSpecies `json:"species"`
+	Count   int                           `json:"count"`
 }
 
 // GetAllSpecies returns all known BirdNET species labels regardless of location or range filter.
@@ -157,11 +158,11 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 // orchestrator's AllLabels union there (not just the primary BirdNET labels), so the
 // picker still includes secondary-model species during that window; the fallback
 // preserves input order and the original label string.
-func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string) []RangeFilterSpecies {
+func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string) []rangeapi.RangeFilterSpecies {
 	if len(sciToCommon) > 0 {
-		speciesList := make([]RangeFilterSpecies, 0, len(sciToCommon))
+		speciesList := make([]rangeapi.RangeFilterSpecies, 0, len(sciToCommon))
 		for sci, common := range sciToCommon {
-			speciesList = append(speciesList, RangeFilterSpecies{
+			speciesList = append(speciesList, rangeapi.RangeFilterSpecies{
 				Label:          sci + "_" + common,
 				ScientificName: sci,
 				CommonName:     common,
@@ -173,7 +174,7 @@ func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string)
 		return speciesList
 	}
 
-	speciesList := make([]RangeFilterSpecies, 0, len(fallbackLabels))
+	speciesList := make([]rangeapi.RangeFilterSpecies, 0, len(fallbackLabels))
 	seen := make(map[string]struct{}, len(fallbackLabels))
 	for _, label := range fallbackLabels {
 		sp := detection.ParseSpeciesString(label)
@@ -185,7 +186,7 @@ func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string)
 			continue
 		}
 		seen[key] = struct{}{}
-		speciesList = append(speciesList, RangeFilterSpecies{
+		speciesList = append(speciesList, rangeapi.RangeFilterSpecies{
 			Label:          label,
 			ScientificName: sp.ScientificName,
 			CommonName:     sp.CommonName,
@@ -276,7 +277,7 @@ func (c *Controller) getSpeciesInfo(ctx context.Context, scientificName string) 
 	// name) as "needs localizing" and resolve through the orchestrator's
 	// OpenFauna-authoritative resolver, passing the configured locale explicitly.
 	if matchedLabel != "" && (commonName == "" || strings.EqualFold(commonName, scientificName)) {
-		if resolved := bn.ResolveName(scientificName, c.currentLocale()); resolved != "" {
+		if resolved := bn.ResolveName(scientificName, c.CurrentLocale()); resolved != "" {
 			commonName = resolved
 		}
 	}

--- a/internal/api/v2/species_test.go
+++ b/internal/api/v2/species_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -448,7 +449,7 @@ func TestGetAllSpecies_LocalizedSecondaryModel(t *testing.T) {
 	var response AllSpeciesResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 
-	byScientific := make(map[string]RangeFilterSpecies, len(response.Species))
+	byScientific := make(map[string]rangeapi.RangeFilterSpecies, len(response.Species))
 	for _, s := range response.Species {
 		byScientific[s.ScientificName] = s
 	}

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -178,8 +179,8 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		IncludeDatabaseInfo:   req.IncludeDatabaseInfo,
 		IncludeDeploymentInfo: true,
 		IncludeAppEvents:      req.IncludeAppEvents,
-		LogDuration:           supportLogDurationWeeks * daysPerWeek * HoursPerDay * time.Hour, // 4 weeks
-		MaxLogSize:            supportMaxLogSizeMB * supportBytesPerMB,                         // 50MB to accommodate more logs
+		LogDuration:           supportLogDurationWeeks * apicore.DaysPerWeek * HoursPerDay * time.Hour, // 4 weeks
+		MaxLogSize:            supportMaxLogSizeMB * supportBytesPerMB,                                 // 50MB to accommodate more logs
 		ScrubSensitive:        true,
 		AnonymizePII:          true,
 	}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -680,7 +680,7 @@ func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float
 // "Eptesicus nilssonii") are deliberately kept as distinct scientific names so
 // both pass the scientific-name inclusion gate (conf.Settings.IsSpeciesIncluded)
 // during audio processing. Those near-duplicates are collapsed for the user only
-// at the display boundary (dedupeSpeciesForDisplay in internal/api/v2/range.go),
+// at the display boundary (dedupeSpeciesForDisplay in internal/api/v2/range/range.go),
 // keyed on the resolved common name, so the functional inclusion set stays intact.
 //
 // The bat model is handled separately from the loop above: it has no geomodel,

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -344,7 +344,7 @@ func resolveOverrideLabels(settings *conf.Settings, geoLabels []string) []string
 // plus this score-1.0 entry) when the two carry different label strings; that is
 // expected. The score-1.0 entry must be kept so the species reads as
 // always-active, and same-taxon near-duplicates are collapsed for the user at
-// the display boundary (dedupeSpeciesForDisplay in internal/api/v2/range.go),
+// the display boundary (dedupeSpeciesForDisplay in internal/api/v2/range/range.go),
 // not here, so the functional inclusion set keeps every scientific name.
 func addUserOverrideSpeciesScores(bn *BirdNET, speciesScores *[]SpeciesScore, settings *conf.Settings, geoLabels []string) {
 	seen := make(map[string]bool, len(*speciesScores))


### PR DESCRIPTION
## What

Phase 4 of the `internal/api/v2` package split: extract the range-filter domain
out of the monolithic `package api` into a new `internal/api/v2/range`
subpackage, so it gets its own `-race` test binary and stops adding to the api/v2
package's per-package test-timeout budget. Follows the merged weather (Core-only)
and tls (export-shared-symbol) extraction precedents.

The directory is `range/` but the package is named `rangeapi` because `range` is
a Go reserved word; it is imported under that alias and the facade field is named
`rangeHandler`.

## Pattern

- `rangeapi.Handler` embeds `*apicore.Core` by pointer (never copied by value).
- `New(core)` constructs the handler; `RegisterRoutes(g *echo.Group)` wires the
  exact 7 routes from the old `initRangeRoutes` in the same order, with no
  per-route middleware (matching the original).
- Handler methods moved verbatim, only the receiver retyped from `*Controller` to
  `*Handler` (receiver name kept `c`); bodies rely on promotion of the embedded
  Core's exported members.
- Range response DTOs, helpers, and tests moved with the package. The response
  structs keep identical `json` tags, so the wire format is byte-identical.

## Facade wiring (order preserved exactly)

- `Controller` gains an unexported `rangeHandler *rangeapi.Handler` field.
- `NewWithOptions` constructs it once via `rangeapi.New(c.Core)`.
- `initRoutes` replaces the range `routeInitializers` entry in place with
  `{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }}` at the
  same index, so registration order (and the route-enumeration golden gate) is
  byte-identical. No `init()`-based self-registration.

## Shared helpers moved to apicore

Range can no longer reach `package api`, so helpers it consumes that are also used
by other (not-yet-extracted) domains moved to `apicore` (the shared substrate),
exported, giving a single source:

- `GetBirdNETInstance` (range, heatmap, diagnostics) keeps the TOCTOU-safe
  processor snapshot.
- `CurrentLocale` (range, species).
- `NormalizeForLookup` (range display de-dup, insights, search); its `norm`/
  `strings` imports were removed from `insights.go`.
- `ParseFloat64`/`ParseFloat32` (range, heatmap).
- The BirdNET week-model constants `WeeksPerMonth`/`WeeksPerYear`/`DaysPerWeek`
  (range, heatmap, support) so they stay in sync from one definition.

## Cross-domain type coupling

`RangeFilterSpecies` stays exported in the range package; `species.go`
(`/api/v2/species/all`) imports `rangeapi` and uses `rangeapi.RangeFilterSpecies`,
matching the tls `TLSCertificateInfo` precedent. The dependency graph
`api -> rangeapi -> apicore` stays acyclic.

## Verification

- `go build ./...` clean (only the unrelated `frontend/embed.go all:dist` placeholder).
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks).
- `go test -race ./internal/api/v2/... ./internal/analysis/...` green, including the
  range domain's own `-race` binary and `TestRouteEnumerationMatchesGolden`
  unchanged.
- `golangci-lint run` clean on `internal/api/v2/...` and `internal/classifier/...`.
- No public-behavior change: range endpoints, auth, and responses identical; JSON
  tags byte-identical; `apiv2.Controller`/`New`/external signatures unchanged.

## Preflight Status

- [x] Single concern: one refactor (extract the range domain)
- [x] Linters clean: `golangci-lint run` zero issues
- [x] Tests pass: `go test -race` green incl. range's own binary and the route gate
- [x] No regression/backward-compat break: identical routes, JSON tags, and external
      signatures; new apicore exports are purely additive
- [x] No secrets or PII


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Range-related endpoints and species listings now share more consistent behavior across the app.
  * Search and lookup results better handle name matching with accents and Unicode variations.

* **Bug Fixes**
  * Improved validation for numeric request parameters in heatmap and range requests.
  * Fixed locale handling in species and range responses for more accurate name resolution.
  * Support and diagnostic information now uses the same shared data sources for more reliable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->