### PR TITLE
refactor(api/v2): extract species domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -233,7 +233,7 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 | ------ | -------------------- | ------------------ | ---- | -------------------------------------------------------- |
 | GET    | `/filesystem/browse` | `BrowseFileSystem` | ✅   | Browse files and directories with secure path validation |
 
-### Species (`species.go`)
+### Species (`species/species.go`)
 
 | Method | Route                      | Handler               | Auth | Description                                                       |
 | ------ | -------------------------- | --------------------- | ---- | ----------------------------------------------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
+	"github.com/tphakala/birdnet-go/internal/api/v2/species"
 	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/api/v2/weather"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
@@ -72,6 +73,15 @@ type Controller struct {
 	// because "range" is a Go reserved word; the domain package is imported as
 	// rangeapi. Like weather it needs only the shared *apicore.Core.
 	rangeHandler *rangeapi.Handler
+
+	// species serves the /api/v2/species/* and /api/v2/taxonomy/* endpoints
+	// (species info, rarity, the all-species picker, the dictionary, thumbnails,
+	// and genus/family/tree lookups). Besides the shared *apicore.Core it receives
+	// two facade-owned function dependencies: a read accessor over the shared
+	// scientific-to-common name map (loadCommonNameMap) and the media domain's
+	// species-image proxy handler (ServeSpeciesImageProxy), both still owned by
+	// package api until their domains are extracted.
+	species *species.Handler
 
 	controlChan chan string
 
@@ -309,6 +319,12 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// stable for the controller's lifetime.
 	c.tlsHandler = tlsapi.New(c.Core, &c.settingsMutex,
 		c.getSettingsOrFallback, c.publishAndSaveSettings, c.handleSettingsChanges)
+	// The species handler delegates to two facade-owned dependencies that have not
+	// been extracted into their own domains yet: loadCommonNameMap (the shared
+	// name-map read accessor) and ServeSpeciesImageProxy (the media image proxy the
+	// thumbnail endpoint forwards to). They are passed as bound method values; c is
+	// fully constructed here, so the method values are stable for its lifetime.
+	c.species = species.New(c.Core, c.loadCommonNameMap, c.ServeSpeciesImageProxy)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -418,7 +434,7 @@ func (c *Controller) initRoutes() {
 		{"notification routes", c.initNotificationRoutes},
 		{"support routes", c.initSupportRoutes},
 		{"debug routes", c.initDebugRoutes},
-		{"species routes", c.initSpeciesRoutes},
+		{"species routes", func() { c.species.RegisterRoutes(c.Group) }},
 		{"dynamic threshold routes", c.initDynamicThresholdRoutes},
 		{"alert routes", c.initAlertRoutes},
 		{"model routes", c.initModelRoutes},

--- a/internal/api/v2/apicore/errors.go
+++ b/internal/api/v2/apicore/errors.go
@@ -174,6 +174,17 @@ func (c *Core) HandleErrorWithKey(ctx echo.Context, err error, message string, c
 	return c.handleErrorInternal(ctx, err, message, code, errorKey, errorParams)
 }
 
+// HandleErrorWithNotFound handles errors that may be not-found errors.
+// If the error is an EnhancedError with CategoryNotFound, returns a 404.
+// Otherwise returns a 500 internal server error.
+func (c *Core) HandleErrorWithNotFound(ctx echo.Context, err error, notFoundMsg, fallbackMsg string) error {
+	var enhancedErr *errors.EnhancedError
+	if errors.As(err, &enhancedErr) && enhancedErr.Category == errors.CategoryNotFound {
+		return c.HandleError(ctx, err, notFoundMsg, http.StatusNotFound)
+	}
+	return c.HandleError(ctx, err, fallbackMsg, http.StatusInternalServerError)
+}
+
 // RequireDatastore writes a 503 Service Unavailable response and returns the non-nil
 // errDatastoreUnavailable when the controller has no datastore, so handlers can guard with:
 //

--- a/internal/api/v2/dto/range.go
+++ b/internal/api/v2/dto/range.go
@@ -1,0 +1,13 @@
+package dto
+
+// RangeFilterSpecies represents a single species in the range filter. It lives in
+// the shared dto package because it is the response element type for two domains:
+// the range filter endpoints (/api/v2/range/species/*) and the species picker
+// (/api/v2/species/all). Keeping it here avoids a domain-to-domain import between
+// those packages. The json tags are the wire contract and must not change.
+type RangeFilterSpecies struct {
+	Label          string   `json:"label"`
+	ScientificName string   `json:"scientificName"`
+	CommonName     string   `json:"commonName"`
+	Score          *float64 `json:"score,omitempty"` // Nullable - only present when individual scores are available
+}

--- a/internal/api/v2/dynamic_thresholds.go
+++ b/internal/api/v2/dynamic_thresholds.go
@@ -304,7 +304,7 @@ func (c *Controller) GetDynamicThreshold(ctx echo.Context) error {
 	model := ctx.QueryParam("model")
 	dt, err := c.DS.GetDynamicThreshold(species, model)
 	if err != nil {
-		return c.handleErrorWithNotFound(ctx, err, "Threshold not found", "Failed to get threshold")
+		return c.HandleErrorWithNotFound(ctx, err, "Threshold not found", "Failed to get threshold")
 	}
 
 	response := DynamicThresholdResponse{

--- a/internal/api/v2/dynamic_thresholds_test.go
+++ b/internal/api/v2/dynamic_thresholds_test.go
@@ -165,7 +165,7 @@ func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
 }
 
 // TestGetDynamicThreshold_NotFoundStatus pins both sides of the handler's not-found
-// classification boundary that #1068 turned on. handleErrorWithNotFound maps
+// classification boundary that #1068 turned on. HandleErrorWithNotFound maps
 // a CategoryNotFound EnhancedError to 404 but an unclassified error (a bare sentinel)
 // to 500. The v2only datastore used to return the bare ErrDynamicThresholdNotFound
 // sentinel, so a missing threshold fell through to 500 while the legacy backend

--- a/internal/api/v2/range/range.go
+++ b/internal/api/v2/range/range.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/dto"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/detection"
@@ -122,12 +123,12 @@ func resolveLocalizedName(resolver *classifier.Orchestrator, locale string, sp d
 // convertSpeciesScores converts classifier.SpeciesScore entries to the API
 // response format with probability score pointers. When resolver and locale
 // are provided, common names are resolved to the user's locale.
-func convertSpeciesScores(scores []classifier.SpeciesScore, resolver *classifier.Orchestrator, locale string) []RangeFilterSpecies {
-	species := make([]RangeFilterSpecies, 0, len(scores))
+func convertSpeciesScores(scores []classifier.SpeciesScore, resolver *classifier.Orchestrator, locale string) []dto.RangeFilterSpecies {
+	species := make([]dto.RangeFilterSpecies, 0, len(scores))
 	for _, s := range scores {
 		sp := detection.ParseSpeciesString(s.Label)
 		score := s.Score
-		species = append(species, RangeFilterSpecies{
+		species = append(species, dto.RangeFilterSpecies{
 			Label:          s.Label,
 			ScientificName: sp.ScientificName,
 			CommonName:     resolveLocalizedName(resolver, locale, sp),
@@ -140,11 +141,11 @@ func convertSpeciesScores(scores []classifier.SpeciesScore, resolver *classifier
 // convertLabels converts string labels to the API response format without scores.
 // When resolver and locale are provided, common names are resolved to the
 // user's locale.
-func convertLabels(labels []string, resolver *classifier.Orchestrator, locale string) []RangeFilterSpecies {
-	species := make([]RangeFilterSpecies, 0, len(labels))
+func convertLabels(labels []string, resolver *classifier.Orchestrator, locale string) []dto.RangeFilterSpecies {
+	species := make([]dto.RangeFilterSpecies, 0, len(labels))
 	for _, label := range labels {
 		sp := detection.ParseSpeciesString(label)
-		species = append(species, RangeFilterSpecies{
+		species = append(species, dto.RangeFilterSpecies{
 			Label:          label,
 			ScientificName: sp.ScientificName,
 			CommonName:     resolveLocalizedName(resolver, locale, sp),
@@ -182,12 +183,12 @@ func convertLabels(labels []string, resolver *classifier.Orchestrator, locale st
 // always-active 1.0 sentinel survives over its lower range-filter probability.
 // The first occurrence's position is preserved (the input arrives sorted by
 // score descending), keeping the output order stable and deterministic.
-func dedupeSpeciesForDisplay(species []RangeFilterSpecies) []RangeFilterSpecies {
+func dedupeSpeciesForDisplay(species []dto.RangeFilterSpecies) []dto.RangeFilterSpecies {
 	if len(species) < 2 {
 		return species
 	}
 	indexByKey := make(map[string]int, len(species))
-	deduped := make([]RangeFilterSpecies, 0, len(species))
+	deduped := make([]dto.RangeFilterSpecies, 0, len(species))
 	for _, sp := range species {
 		key := apicore.NormalizeForLookup(sp.CommonName)
 		if key == "" {
@@ -217,7 +218,7 @@ func dedupeSpeciesForDisplay(species []RangeFilterSpecies) []RangeFilterSpecies 
 // speciesScoreHigher reports whether a has a strictly higher score than b. A nil
 // score (label-only display rows) sorts below any real score, so a scored entry
 // always wins over an unscored one.
-func speciesScoreHigher(a, b RangeFilterSpecies) bool {
+func speciesScoreHigher(a, b dto.RangeFilterSpecies) bool {
 	if a.Score == nil {
 		return false
 	}
@@ -241,16 +242,6 @@ type RangeFilterSpeciesCount struct {
 	Location    Location  `json:"location"`
 }
 
-// RangeFilterSpecies represents a single species in the range filter. It stays
-// exported because the species domain (/api/v2/species/all) reuses it as its
-// response element type.
-type RangeFilterSpecies struct {
-	Label          string   `json:"label"`
-	ScientificName string   `json:"scientificName"`
-	CommonName     string   `json:"commonName"`
-	Score          *float64 `json:"score,omitempty"` // Nullable - only present when individual scores are available
-}
-
 // TaxonomyFamily represents a bird family with scientific and common names
 type TaxonomyFamily struct {
 	Name       string `json:"name"`       // Scientific name, e.g. "Strigidae"
@@ -259,23 +250,23 @@ type TaxonomyFamily struct {
 
 // RangeFilterSpeciesList represents the full list response for range filter species
 type RangeFilterSpeciesList struct {
-	Species     []RangeFilterSpecies `json:"species"`
-	Count       int                  `json:"count"`
-	LastUpdated time.Time            `json:"lastUpdated"`
-	Threshold   float32              `json:"threshold"`
-	Location    Location             `json:"location"`
-	Genera      []string             `json:"genera"`
-	Families    []TaxonomyFamily     `json:"families"`
-	Orders      []string             `json:"orders"`
+	Species     []dto.RangeFilterSpecies `json:"species"`
+	Count       int                      `json:"count"`
+	LastUpdated time.Time                `json:"lastUpdated"`
+	Threshold   float32                  `json:"threshold"`
+	Location    Location                 `json:"location"`
+	Genera      []string                 `json:"genera"`
+	Families    []TaxonomyFamily         `json:"families"`
+	Orders      []string                 `json:"orders"`
 }
 
 // RangeFilterScoresResponse represents all species with their raw geomodel scores
 type RangeFilterScoresResponse struct {
-	Species   []RangeFilterSpecies `json:"species"`
-	Count     int                  `json:"count"`
-	Location  Location             `json:"location"`
-	Week      int                  `json:"week"`
-	Threshold float32              `json:"threshold"`
+	Species   []dto.RangeFilterSpecies `json:"species"`
+	Count     int                      `json:"count"`
+	Location  Location                 `json:"location"`
+	Week      int                      `json:"week"`
+	Threshold float32                  `json:"threshold"`
 }
 
 // RangeFilterTestRequest represents the request for testing range filter
@@ -289,12 +280,12 @@ type RangeFilterTestRequest struct {
 
 // RangeFilterTestResponse represents the response for range filter testing
 type RangeFilterTestResponse struct {
-	Species    []RangeFilterSpecies `json:"species"`
-	Count      int                  `json:"count"`
-	Threshold  float32              `json:"threshold"`
-	Location   Location             `json:"location"`
-	TestDate   time.Time            `json:"testDate"`
-	Week       int                  `json:"week"`
+	Species    []dto.RangeFilterSpecies `json:"species"`
+	Count      int                      `json:"count"`
+	Threshold  float32                  `json:"threshold"`
+	Location   Location                 `json:"location"`
+	TestDate   time.Time                `json:"testDate"`
+	Week       int                      `json:"week"`
 	Parameters struct {
 		InputLatitude  float64 `json:"inputLatitude"`
 		InputLongitude float64 `json:"inputLongitude"`
@@ -635,7 +626,7 @@ func (c *Handler) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 	customLon := ctx.QueryParam("longitude")
 	customThreshold := ctx.QueryParam("threshold")
 
-	var speciesList []RangeFilterSpecies
+	var speciesList []dto.RangeFilterSpecies
 	var location Location
 	var threshold float32
 
@@ -738,7 +729,7 @@ func (c *Handler) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 // species (bats/Perch). This is the path the settings UI's CSV download takes
 // (it always sends parameters), so a user who sees bats in the Active Species
 // preview gets the same bats when exporting those parameters to CSV.
-func (c *Handler) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilterSpecies, Location, float32, error) {
+func (c *Handler) getTestSpeciesList(req RangeFilterTestRequest) ([]dto.RangeFilterSpecies, Location, float32, error) {
 	// Check if BirdNET is available
 	birdnetInstance, err := c.GetBirdNETInstance()
 	if err != nil {
@@ -784,7 +775,7 @@ func sanitizeCSVField(field string) string {
 }
 
 // generateSpeciesCSV generates CSV content from species list using the standard CSV library
-func (c *Handler) generateSpeciesCSV(species []RangeFilterSpecies, location Location, threshold float32) ([]byte, error) {
+func (c *Handler) generateSpeciesCSV(species []dto.RangeFilterSpecies, location Location, threshold float32) ([]byte, error) {
 	var buf bytes.Buffer
 
 	// Write UTF-8 BOM for Excel compatibility

--- a/internal/api/v2/range/range_dedup_test.go
+++ b/internal/api/v2/range/range_dedup_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/dto"
 )
 
 func TestDedupeSpeciesForDisplay(t *testing.T) {
@@ -16,8 +17,8 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 
 	tests := []struct {
 		name string
-		in   []RangeFilterSpecies
-		want []RangeFilterSpecies
+		in   []dto.RangeFilterSpecies
+		want []dto.RangeFilterSpecies
 	}{
 		{
 			name: "nil input",
@@ -26,19 +27,19 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 		},
 		{
 			name: "single entry unchanged",
-			in:   []RangeFilterSpecies{{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)}},
-			want: []RangeFilterSpecies{{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)}},
+			in:   []dto.RangeFilterSpecies{{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)}},
+			want: []dto.RangeFilterSpecies{{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)}},
 		},
 		{
 			// R1: a geomodel-scored species and its force-include override copy
 			// carry different label strings but the same resolved common name.
 			// They collapse to one row at the always-active 1.0 score.
 			name: "override copy collapses, 1.0 wins",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
 				{Label: "Corvus cornix_Hooded Crow", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
 			},
 		},
@@ -46,32 +47,32 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 			// R4: two taxonomic synonyms that localize to the same common name
 			// collapse to a single displayed row (max score wins).
 			name: "synonyms with same common name collapse",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{Label: "Eptesicus nilssonii", ScientificName: "Eptesicus nilssonii", CommonName: "pohjanlepakko", Score: new(1.0)},
 				{Label: "Cnephaeus nilssonii_Northern Bat", ScientificName: "Cnephaeus nilssonii", CommonName: "pohjanlepakko", Score: new(0.01)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{Label: "Eptesicus nilssonii", ScientificName: "Eptesicus nilssonii", CommonName: "pohjanlepakko", Score: new(1.0)},
 			},
 		},
 		{
 			name: "distinct species are kept",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
 				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.73)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
 				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.73)},
 			},
 		},
 		{
 			name: "case insensitive common name collapse",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{ScientificName: "Eptesicus nilssonii", CommonName: "Pohjanlepakko", Score: new(0.5)},
 				{ScientificName: "Cnephaeus nilssonii", CommonName: "pohjanlepakko", Score: new(0.5)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{ScientificName: "Eptesicus nilssonii", CommonName: "Pohjanlepakko", Score: new(0.5)},
 			},
 		},
@@ -80,11 +81,11 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 			// normalizeForLookup recomposes via norm.NFC, so both key identically.
 			// This pins the NFC half of the key; ToLower alone would not collapse them.
 			name: "NFC and NFD decomposed common name collapse",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{ScientificName: "Strix aluco", CommonName: "Lehtopöllö", Score: new(0.6)},
 				{ScientificName: "Syrnium aluco", CommonName: "Lehtopöllö", Score: new(0.4)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{ScientificName: "Strix aluco", CommonName: "Lehtopöllö", Score: new(0.6)},
 			},
 		},
@@ -92,12 +93,12 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 			// Without a common name, fall back to the scientific name so unrelated
 			// unresolved rows are not all merged into one bucket.
 			name: "empty common name falls back to scientific name",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{Label: "Foobarus_x", ScientificName: "Foobarus x"},
 				{Label: "Foobarus x", ScientificName: "Foobarus x"},
 				{Label: "Bazquxus y", ScientificName: "Bazquxus y"},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{Label: "Foobarus_x", ScientificName: "Foobarus x"},
 				{Label: "Bazquxus y", ScientificName: "Bazquxus y"},
 			},
@@ -106,11 +107,11 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 			// Rows with neither common nor scientific name have no identity to key
 			// on and must not collapse into a single bucket.
 			name: "identity-less rows are all kept",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{Label: "a"},
 				{Label: "b"},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{Label: "a"},
 				{Label: "b"},
 			},
@@ -119,22 +120,22 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 			// Defensive: even when the higher score is not first, the survivor
 			// surfaces the higher score while keeping the first position.
 			name: "higher score wins regardless of order",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{Label: "Corvus cornix_Hooded Crow", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(0.71)},
 				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{Label: "Corvus cornix_varis", ScientificName: "Corvus cornix", CommonName: "varis", Score: new(1.0)},
 			},
 		},
 		{
 			// A scored entry beats an unscored (label-only) entry for the same species.
 			name: "scored entry wins over unscored",
-			in: []RangeFilterSpecies{
+			in: []dto.RangeFilterSpecies{
 				{ScientificName: "Parus major", CommonName: "talitiainen"},
 				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.42)},
 			},
-			want: []RangeFilterSpecies{
+			want: []dto.RangeFilterSpecies{
 				{ScientificName: "Parus major", CommonName: "talitiainen", Score: new(0.42)},
 			},
 		},
@@ -162,11 +163,11 @@ func TestDedupeSpeciesForDisplay(t *testing.T) {
 
 func TestSpeciesScoreHigher(t *testing.T) {
 	t.Parallel()
-	assert.True(t, speciesScoreHigher(RangeFilterSpecies{Score: new(1.0)}, RangeFilterSpecies{Score: new(0.5)}))
-	assert.False(t, speciesScoreHigher(RangeFilterSpecies{Score: new(0.5)}, RangeFilterSpecies{Score: new(1.0)}))
-	assert.False(t, speciesScoreHigher(RangeFilterSpecies{Score: new(0.5)}, RangeFilterSpecies{Score: new(0.5)}))
+	assert.True(t, speciesScoreHigher(dto.RangeFilterSpecies{Score: new(1.0)}, dto.RangeFilterSpecies{Score: new(0.5)}))
+	assert.False(t, speciesScoreHigher(dto.RangeFilterSpecies{Score: new(0.5)}, dto.RangeFilterSpecies{Score: new(1.0)}))
+	assert.False(t, speciesScoreHigher(dto.RangeFilterSpecies{Score: new(0.5)}, dto.RangeFilterSpecies{Score: new(0.5)}))
 	// nil score sorts below any real score.
-	assert.False(t, speciesScoreHigher(RangeFilterSpecies{}, RangeFilterSpecies{Score: new(0.0)}))
-	assert.True(t, speciesScoreHigher(RangeFilterSpecies{Score: new(0.0)}, RangeFilterSpecies{}))
-	assert.False(t, speciesScoreHigher(RangeFilterSpecies{}, RangeFilterSpecies{}))
+	assert.False(t, speciesScoreHigher(dto.RangeFilterSpecies{}, dto.RangeFilterSpecies{Score: new(0.0)}))
+	assert.True(t, speciesScoreHigher(dto.RangeFilterSpecies{Score: new(0.0)}, dto.RangeFilterSpecies{}))
+	assert.False(t, speciesScoreHigher(dto.RangeFilterSpecies{}, dto.RangeFilterSpecies{}))
 }

--- a/internal/api/v2/species/dictionary.go
+++ b/internal/api/v2/species/dictionary.go
@@ -1,5 +1,4 @@
-// internal/api/v2/species_dictionary.go
-package api
+package species
 
 import (
 	"fmt"
@@ -45,7 +44,7 @@ const (
 // immutable caching; requests without it receive a short-lived cache header.
 //
 // Public endpoint, no authentication required.
-func (c *Controller) ServeSpeciesDictionary(ctx echo.Context) error {
+func (c *Handler) ServeSpeciesDictionary(ctx echo.Context) error {
 	locale := ctx.Param("locale")
 
 	// Validate locale against the embedded allowlist before touching anything

--- a/internal/api/v2/species/dictionary_test.go
+++ b/internal/api/v2/species/dictionary_test.go
@@ -1,5 +1,5 @@
-// species_dictionary_test.go: Package api tests for the species dictionary endpoint.
-package api
+// dictionary_test.go: tests for the species dictionary endpoint.
+package species
 
 import (
 	"compress/gzip"
@@ -16,15 +16,16 @@ import (
 	"github.com/tphakala/birdnet-go/internal/speciesdict"
 )
 
-// newDictController creates an Echo + Controller and registers the species routes
-// through the production initSpeciesRoutes path, so these tests exercise the real
-// route registration (public mount, no auth middleware) rather than a hand-mounted
-// route. No auth middleware is injected, matching the public endpoint's contract.
-func newDictController(t *testing.T) (*echo.Echo, *Controller) {
+// newDictController creates an Echo + species Handler and registers the species
+// routes through the production RegisterRoutes path, so these tests exercise the
+// real route registration (public mount, no auth middleware) rather than a
+// hand-mounted route. No auth middleware is injected, matching the public
+// endpoint's contract.
+func newDictController(t *testing.T) (*echo.Echo, *Handler) {
 	t.Helper()
 	e := echo.New()
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
-	controller.initSpeciesRoutes()
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+	controller.RegisterRoutes(controller.Group)
 	return e, controller
 }
 
@@ -108,7 +109,7 @@ func TestSpeciesDictionary_UnknownLocale(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 
 	// Assert the standardized error payload contract, not just the status code.
-	var body ErrorResponse
+	var body apicore.ErrorResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, http.StatusNotFound, body.Code)
 	assert.NotEmpty(t, body.Error)

--- a/internal/api/v2/species/species.go
+++ b/internal/api/v2/species/species.go
@@ -1,5 +1,23 @@
-// internal/api/v2/species.go
-package api
+// Package species is the api/v2 species domain handler. It owns the
+// /api/v2/species/* and /api/v2/taxonomy/* endpoints (species info, rarity, the
+// all-species picker list, the species dictionary, thumbnails, and genus/family/
+// tree taxonomy lookups). The Handler embeds *apicore.Core by pointer so the
+// shared dependencies and helpers (Processor, TaxonomyDB, EBirdClient,
+// BirdImageCache, CurrentLocale, HandleError, the logging helpers) promote onto
+// it; the facade constructs one Handler and calls RegisterRoutes to wire the
+// routes in their existing order.
+//
+// Two dependencies the species handlers need are owned by other parts of the
+// monolith that have not been extracted yet, so the facade injects them as
+// function values (the tls-domain facade-dependency-injection precedent):
+//   - commonNameMap: a read accessor over the shared scientific-to-common name
+//     map. The name-map plumbing (UpdateCommonNameMap/SetNameResolver) stays in
+//     the facade package because control_monitor drives it and several domains
+//     share it; species only needs read access.
+//   - serveImageProxy: the media domain's bird-image proxy handler, which the
+//     species thumbnail endpoint delegates to. When media is extracted this can
+//     point at the media handler instead.
+package species
 
 import (
 	"context"
@@ -9,13 +27,63 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/dto"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// hoursPerDay is the number of hours in a day, used to truncate a timestamp to
+// the start of the local day. Defined locally so the species package does not
+// depend on a package-api constant; a physical constant with no need to stay in
+// sync with anything else.
+const hoursPerDay = 24
+
+// Handler serves the species domain endpoints. It embeds *apicore.Core BY
+// POINTER so the shared Core members promote onto it without re-wiring; Core
+// carries atomic/lock-bearing fields and must never be copied by value.
+type Handler struct {
+	*apicore.Core
+
+	// commonNameMap returns the current scientific-to-common lookup map, owned by
+	// the facade's name-map plumbing and injected so species stays read-only over
+	// it. Always returns a non-nil map.
+	commonNameMap func() map[string]string
+
+	// serveImageProxy is the media domain's species-image proxy handler. The
+	// thumbnail endpoint resolves a species code to a scientific name and then
+	// delegates to it.
+	serveImageProxy echo.HandlerFunc
+}
+
+// New builds a species Handler around the shared core and the two facade-owned
+// dependencies the species handlers delegate to (the common-name map accessor
+// and the media image-proxy handler).
+func New(core *apicore.Core, commonNameMap func() map[string]string, serveImageProxy echo.HandlerFunc) *Handler {
+	return &Handler{Core: core, commonNameMap: commonNameMap, serveImageProxy: serveImageProxy}
+}
+
+// RegisterRoutes registers all species-related API endpoints on the supplied API
+// v2 group, preserving the exact routes and order the facade used before the
+// species domain was extracted.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+	// Public endpoints for species information
+	g.GET("/species", c.GetSpeciesInfo)
+	g.GET("/species/all", c.GetAllSpecies)
+	g.GET("/species/taxonomy", c.GetSpeciesTaxonomy)
+	g.GET("/species/dictionary/:locale", c.ServeSpeciesDictionary)
+
+	// RESTful thumbnail endpoint - uses species code from path
+	g.GET("/species/:code/thumbnail", c.GetSpeciesThumbnail)
+
+	// New taxonomy endpoints using local database
+	g.GET("/taxonomy/genus/:genus", c.GetGenusSpecies)
+	g.GET("/taxonomy/family/:family", c.GetFamilySpecies)
+	g.GET("/taxonomy/tree/:scientific_name", c.GetSpeciesTree)
+}
 
 // RarityStatus represents the rarity classification of a species
 type RarityStatus string
@@ -65,7 +133,7 @@ type taxonomyLookupResult struct {
 
 // lookupTaxonomyTree attempts to find taxonomy for a species, trying local DB first then eBird.
 // Returns nil result (not error) if taxonomy is unavailable from both sources.
-func (c *Controller) lookupTaxonomyTree(ctx context.Context, scientificName string) *taxonomyLookupResult {
+func (c *Handler) lookupTaxonomyTree(ctx context.Context, scientificName string) *taxonomyLookupResult {
 	// Try local taxonomy database first (fast, no network)
 	if c.TaxonomyDB != nil {
 		tree, err := c.TaxonomyDB.BuildFamilyTree(scientificName)
@@ -89,27 +157,10 @@ func (c *Controller) lookupTaxonomyTree(ctx context.Context, scientificName stri
 	return nil
 }
 
-// initSpeciesRoutes registers all species-related API endpoints
-func (c *Controller) initSpeciesRoutes() {
-	// Public endpoints for species information
-	c.Group.GET("/species", c.GetSpeciesInfo)
-	c.Group.GET("/species/all", c.GetAllSpecies)
-	c.Group.GET("/species/taxonomy", c.GetSpeciesTaxonomy)
-	c.Group.GET("/species/dictionary/:locale", c.ServeSpeciesDictionary)
-
-	// RESTful thumbnail endpoint - uses species code from path
-	c.Group.GET("/species/:code/thumbnail", c.GetSpeciesThumbnail)
-
-	// New taxonomy endpoints using local database
-	c.Group.GET("/taxonomy/genus/:genus", c.GetGenusSpecies)
-	c.Group.GET("/taxonomy/family/:family", c.GetFamilySpecies)
-	c.Group.GET("/taxonomy/tree/:scientific_name", c.GetSpeciesTree)
-}
-
 // AllSpeciesResponse represents the response for the all species endpoint
 type AllSpeciesResponse struct {
-	Species []rangeapi.RangeFilterSpecies `json:"species"`
-	Count   int                           `json:"count"`
+	Species []dto.RangeFilterSpecies `json:"species"`
+	Count   int                      `json:"count"`
 }
 
 // GetAllSpecies returns all known BirdNET species labels regardless of location or range filter.
@@ -122,7 +173,7 @@ type AllSpeciesResponse struct {
 // @Success 200 {object} AllSpeciesResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/species/all [get]
-func (c *Controller) GetAllSpecies(ctx echo.Context) error {
+func (c *Handler) GetAllSpecies(ctx echo.Context) error {
 	ip := ctx.RealIP()
 	path := ctx.Request().URL.Path
 	c.LogDebugIfEnabled("Retrieving all BirdNET species labels",
@@ -130,7 +181,7 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 		logger.String("path", path),
 	)
 
-	speciesList := buildAllSpeciesList(c.loadCommonNameMap(), c.allModelLabels())
+	speciesList := buildAllSpeciesList(c.commonNameMap(), c.allModelLabels())
 
 	c.LogInfoIfEnabled("All species labels retrieved successfully",
 		logger.Int("count", len(speciesList)),
@@ -158,11 +209,11 @@ func (c *Controller) GetAllSpecies(ctx echo.Context) error {
 // orchestrator's AllLabels union there (not just the primary BirdNET labels), so the
 // picker still includes secondary-model species during that window; the fallback
 // preserves input order and the original label string.
-func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string) []rangeapi.RangeFilterSpecies {
+func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string) []dto.RangeFilterSpecies {
 	if len(sciToCommon) > 0 {
-		speciesList := make([]rangeapi.RangeFilterSpecies, 0, len(sciToCommon))
+		speciesList := make([]dto.RangeFilterSpecies, 0, len(sciToCommon))
 		for sci, common := range sciToCommon {
-			speciesList = append(speciesList, rangeapi.RangeFilterSpecies{
+			speciesList = append(speciesList, dto.RangeFilterSpecies{
 				Label:          sci + "_" + common,
 				ScientificName: sci,
 				CommonName:     common,
@@ -174,7 +225,7 @@ func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string)
 		return speciesList
 	}
 
-	speciesList := make([]rangeapi.RangeFilterSpecies, 0, len(fallbackLabels))
+	speciesList := make([]dto.RangeFilterSpecies, 0, len(fallbackLabels))
 	seen := make(map[string]struct{}, len(fallbackLabels))
 	for _, label := range fallbackLabels {
 		sp := detection.ParseSpeciesString(label)
@@ -186,7 +237,7 @@ func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string)
 			continue
 		}
 		seen[key] = struct{}{}
-		speciesList = append(speciesList, rangeapi.RangeFilterSpecies{
+		speciesList = append(speciesList, dto.RangeFilterSpecies{
 			Label:          label,
 			ScientificName: sp.ScientificName,
 			CommonName:     sp.CommonName,
@@ -199,7 +250,7 @@ func buildAllSpeciesList(sciToCommon map[string]string, fallbackLabels []string)
 // secondary models such as the bat and Perch classifiers) from the orchestrator,
 // falling back to the primary BirdNET labels from settings when the orchestrator is
 // not yet available (e.g. early startup before the audio pipeline builds it).
-func (c *Controller) allModelLabels() []string {
+func (c *Handler) allModelLabels() []string {
 	if proc := c.Processor; proc != nil {
 		if bn := proc.GetBirdNET(); bn != nil {
 			if labels := bn.AllLabels(); len(labels) > 0 {
@@ -214,7 +265,7 @@ func (c *Controller) allModelLabels() []string {
 }
 
 // GetSpeciesInfo retrieves extended information about a bird species
-func (c *Controller) GetSpeciesInfo(ctx echo.Context) error {
+func (c *Handler) GetSpeciesInfo(ctx echo.Context) error {
 	// Get scientific name from query parameter
 	scientificName := ctx.QueryParam("scientific_name")
 	if scientificName == "" {
@@ -237,14 +288,14 @@ func (c *Controller) GetSpeciesInfo(ctx echo.Context) error {
 	// Get species info
 	speciesInfo, err := c.getSpeciesInfo(ctx.Request().Context(), scientificName)
 	if err != nil {
-		return c.handleErrorWithNotFound(ctx, err, "Species not found", "Failed to get species information")
+		return c.HandleErrorWithNotFound(ctx, err, "Species not found", "Failed to get species information")
 	}
 
 	return ctx.JSON(http.StatusOK, speciesInfo)
 }
 
 // getSpeciesInfo retrieves species information including rarity status
-func (c *Controller) getSpeciesInfo(ctx context.Context, scientificName string) (*SpeciesInfo, error) {
+func (c *Handler) getSpeciesInfo(ctx context.Context, scientificName string) (*SpeciesInfo, error) {
 	// Snapshot to avoid TOCTOU race on c.Processor
 	proc := c.Processor
 	if proc == nil || proc.Bn == nil {
@@ -331,9 +382,9 @@ func speciesHasGeomodelCoverage(bn *classifier.Orchestrator, scientificName stri
 	return false
 }
 
-func (c *Controller) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel string) (*SpeciesRarityInfo, error) {
+func (c *Handler) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLabel string) (*SpeciesRarityInfo, error) {
 	// Get current date
-	today := time.Now().Truncate(HoursPerDay * time.Hour)
+	today := time.Now().Truncate(hoursPerDay * time.Hour)
 	settings := bn.CurrentSettings()
 
 	// Rarity is the geomodel occurrence probability, so use the geomodel-backed
@@ -444,7 +495,7 @@ type SubspeciesInfo struct {
 }
 
 // GetSpeciesTaxonomy retrieves detailed taxonomy information for a species
-func (c *Controller) GetSpeciesTaxonomy(ctx echo.Context) error {
+func (c *Handler) GetSpeciesTaxonomy(ctx echo.Context) error {
 	// Get parameters from query
 	scientificName := ctx.QueryParam("scientific_name")
 	if scientificName == "" {
@@ -472,7 +523,7 @@ func (c *Controller) GetSpeciesTaxonomy(ctx echo.Context) error {
 	// Get taxonomy info
 	taxonomyInfo, err := c.getDetailedTaxonomy(ctx.Request().Context(), scientificName, locale, includeSubspecies, includeHierarchy)
 	if err != nil {
-		return c.handleErrorWithNotFound(ctx, err, "Species not found", "Failed to get taxonomy information")
+		return c.HandleErrorWithNotFound(ctx, err, "Species not found", "Failed to get taxonomy information")
 	}
 
 	return ctx.JSON(http.StatusOK, taxonomyInfo)
@@ -480,7 +531,7 @@ func (c *Controller) GetSpeciesTaxonomy(ctx echo.Context) error {
 
 // getDetailedTaxonomy retrieves detailed taxonomy information
 // Tries local database first, falls back to eBird API if needed
-func (c *Controller) getDetailedTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) (*TaxonomyInfo, error) {
+func (c *Handler) getDetailedTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) (*TaxonomyInfo, error) {
 	// Try local taxonomy database first
 	if info := c.tryLocalTaxonomy(ctx, scientificName, locale, includeSubspecies, includeHierarchy); info != nil {
 		return info, nil
@@ -502,7 +553,7 @@ func (c *Controller) getDetailedTaxonomy(ctx context.Context, scientificName, lo
 
 // tryLocalTaxonomy attempts to retrieve taxonomy from the local database.
 // Returns nil if local DB is unavailable or lookup fails.
-func (c *Controller) tryLocalTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) *TaxonomyInfo {
+func (c *Handler) tryLocalTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies, includeHierarchy bool) *TaxonomyInfo {
 	if c.TaxonomyDB == nil {
 		return nil
 	}
@@ -548,7 +599,7 @@ func convertToTaxonomyHierarchy(tree *ebird.TaxonomyTree) *TaxonomyHierarchy {
 }
 
 // enhanceWithEBirdData adds subspecies and locale data from eBird API to local taxonomy info.
-func (c *Controller) enhanceWithEBirdData(ctx context.Context, info *TaxonomyInfo, scientificName, locale string, includeSubspecies bool) {
+func (c *Handler) enhanceWithEBirdData(ctx context.Context, info *TaxonomyInfo, scientificName, locale string, includeSubspecies bool) {
 	if c.EBirdClient == nil || (!includeSubspecies && locale == "") {
 		return
 	}
@@ -572,7 +623,7 @@ func (c *Controller) enhanceWithEBirdData(ctx context.Context, info *TaxonomyInf
 }
 
 // getEBirdTaxonomy retrieves taxonomy information from eBird API
-func (c *Controller) getEBirdTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies bool) (*TaxonomyInfo, error) {
+func (c *Handler) getEBirdTaxonomy(ctx context.Context, scientificName, locale string, includeSubspecies bool) (*TaxonomyInfo, error) {
 	// Get full taxonomy data with locale if specified
 	taxonomyData, err := c.EBirdClient.GetTaxonomy(ctx, locale)
 	if err != nil {
@@ -638,7 +689,7 @@ func (c *Controller) getEBirdTaxonomy(ctx context.Context, scientificName, local
 }
 
 // findDetailedSubspecies finds all subspecies with detailed information
-func (c *Controller) findDetailedSubspecies(taxonomy []ebird.TaxonomyEntry, speciesCode string) []SubspeciesInfo {
+func (c *Handler) findDetailedSubspecies(taxonomy []ebird.TaxonomyEntry, speciesCode string) []SubspeciesInfo {
 	var subspecies []SubspeciesInfo
 
 	for i := range taxonomy {
@@ -668,7 +719,7 @@ func (c *Controller) findDetailedSubspecies(taxonomy []ebird.TaxonomyEntry, spec
 
 // GetSpeciesThumbnail retrieves a bird thumbnail image by species code
 // GET /api/v2/species/:code/thumbnail
-func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
+func (c *Handler) GetSpeciesThumbnail(ctx echo.Context) error {
 	speciesCode := ctx.Param("code")
 	if speciesCode == "" {
 		return c.HandleError(ctx, errors.Newf("species code parameter is required").
@@ -728,5 +779,5 @@ func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
 	// Delegate to the image proxy handler
 	ctx.SetParamNames("scientific_name")
 	ctx.SetParamValues(scientificName)
-	return c.ServeSpeciesImageProxy(ctx)
+	return c.serveImageProxy(ctx)
 }

--- a/internal/api/v2/species/species_all_test.go
+++ b/internal/api/v2/species/species_all_test.go
@@ -1,7 +1,7 @@
 // species_all_test.go: tests for buildAllSpeciesList, the /api/v2/species/all
 // include/exclude picker payload builder.
 
-package api
+package species
 
 import (
 	"testing"

--- a/internal/api/v2/species/species_test.go
+++ b/internal/api/v2/species/species_test.go
@@ -1,6 +1,7 @@
-// species_test.go: Package api provides tests for species-related functions and endpoints.
+// species_test.go: tests for species-related functions and endpoints in the
+// api/v2 species domain package.
 
-package api
+package species
 
 import (
 	"encoding/json"
@@ -12,9 +13,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
-	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/api/v2/dto"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
+
+// newSpeciesHandler builds a minimal species Handler with valid default settings
+// for validation tests. The injected facade dependencies (commonNameMap,
+// serveImageProxy) are left nil because the validation paths exercised here never
+// reach them.
+func newSpeciesHandler() *Handler {
+	h := &Handler{Core: &apicore.Core{}}
+	h.Settings.Store(apitest.NewValidTestSettings())
+	return h
+}
 
 // TestCalculateRarityStatus tests the calculateRarityStatus helper function.
 func TestCalculateRarityStatus(t *testing.T) {
@@ -169,46 +181,46 @@ func TestSpeciesAPIValidation(t *testing.T) {
 		url            string
 		paramNames     []string
 		paramValues    []string
-		handler        func(*Controller) func(echo.Context) error
+		handler        func(*Handler) func(echo.Context) error
 		expectedStatus int
 		expectedBody   string
 	}{
 		// Missing parameter tests
 		{"GetSpeciesInfo missing param", "/api/v2/species", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesInfo },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesInfo },
 			http.StatusBadRequest, "Missing required parameter"},
 		{"GetSpeciesTaxonomy missing param", "/api/v2/species/taxonomy", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesTaxonomy },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesTaxonomy },
 			http.StatusBadRequest, "Missing required parameter"},
 		{"GetSpeciesThumbnail missing code", "/api/v2/species//thumbnail", []string{"code"}, []string{""},
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesThumbnail },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesThumbnail },
 			http.StatusBadRequest, "Missing species code"},
 
 		// Invalid format tests - GetSpeciesInfo
 		{"GetSpeciesInfo too short", "/api/v2/species?scientific_name=Ab", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesInfo },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesInfo },
 			http.StatusBadRequest, "Invalid scientific name format"},
 		{"GetSpeciesInfo no space", "/api/v2/species?scientific_name=Turdusmigratorius", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesInfo },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesInfo },
 			http.StatusBadRequest, "Invalid scientific name format"},
 		{"GetSpeciesInfo single word", "/api/v2/species?scientific_name=Turdus", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesInfo },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesInfo },
 			http.StatusBadRequest, "Invalid scientific name format"},
 
 		// Invalid format tests - GetSpeciesTaxonomy
 		{"GetSpeciesTaxonomy too short", "/api/v2/species/taxonomy?scientific_name=Ab", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesTaxonomy },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesTaxonomy },
 			http.StatusBadRequest, "Invalid scientific name format"},
 		{"GetSpeciesTaxonomy no space", "/api/v2/species/taxonomy?scientific_name=Turdusmigratorius", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesTaxonomy },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesTaxonomy },
 			http.StatusBadRequest, "Invalid scientific name format"},
 		{"GetSpeciesTaxonomy single word", "/api/v2/species/taxonomy?scientific_name=Turdus", nil, nil,
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesTaxonomy },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesTaxonomy },
 			http.StatusBadRequest, "Invalid scientific name format"},
 
 		// Error handling - nil processor
 		{"GetSpeciesThumbnail nil processor", "/api/v2/species/amro/thumbnail", []string{"code"}, []string{"amro"},
-			func(c *Controller) func(echo.Context) error { return c.GetSpeciesThumbnail },
+			func(c *Handler) func(echo.Context) error { return c.GetSpeciesThumbnail },
 			http.StatusServiceUnavailable, "BirdNET service unavailable"},
 	}
 
@@ -225,7 +237,7 @@ func TestSpeciesAPIValidation(t *testing.T) {
 				ctx.SetParamValues(tt.paramValues...)
 			}
 
-			c := newMinimalController()
+			c := newSpeciesHandler()
 			err := tt.handler(c)(ctx)
 
 			require.NoError(t, err, tt.name)
@@ -416,40 +428,44 @@ func TestTaxonomyInfoJSONSerialization(t *testing.T) {
 }
 
 // TestGetAllSpecies_LocalizedSecondaryModel verifies that GetAllSpecies serves
-// secondary-model species (a scientific-only bat label resolved via the batch
-// localizer) with their localized common name, sourced from the controller's
-// cached resolver-built maps rather than the raw primary BirdNET.Labels.
+// secondary-model species (a scientific-only bat label) with their localized
+// common name, sourced from the injected scientific-to-common name map rather
+// than the raw primary BirdNET.Labels.
+//
+// In production the name map is seeded by control_monitor (UpdateCommonNameMap
+// with the orchestrator's AllLabels union, localized through the batch resolver);
+// that construction lives in the facade's name-map plumbing, not the species
+// domain. Here the already-localized map is injected directly so the test
+// isolates the species handler's own behavior: building the list from the cached
+// map, carrying the localized common name, and sorting by scientific name.
 func TestGetAllSpecies_LocalizedSecondaryModel(t *testing.T) {
 	t.Parallel()
 	t.Attr("component", "species")
 	t.Attr("feature", "localized-name-resolution")
 
 	e := echo.New()
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
-	controller.Settings.Store(&conf.Settings{})
-
-	// Wire a batch-capable resolver so the scientific-only bat label gets a
-	// Finnish localized name, then populate the cached maps the way production
-	// does (control_monitor -> UpdateCommonNameMap with the AllLabels union).
-	controller.SetNameResolver(&analyticsBatchFakeResolver{batch: map[string]string{
-		"Barbastella barbastellus": "mopsilepakko",
-	}})
-	controller.UpdateCommonNameMap([]string{
-		"Parus major_Great Tit",
-		"Barbastella barbastellus",
-	})
+	handler := &Handler{
+		Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")},
+		commonNameMap: func() map[string]string {
+			return map[string]string{
+				"Barbastella barbastellus": "mopsilepakko", // localized bat name (secondary model)
+				"Parus major":              "Great Tit",
+			}
+		},
+	}
+	handler.Settings.Store(&conf.Settings{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/species/all", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	require.NoError(t, controller.GetAllSpecies(ctx))
+	require.NoError(t, handler.GetAllSpecies(ctx))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var response AllSpeciesResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 
-	byScientific := make(map[string]rangeapi.RangeFilterSpecies, len(response.Species))
+	byScientific := make(map[string]dto.RangeFilterSpecies, len(response.Species))
 	for _, s := range response.Species {
 		byScientific[s.ScientificName] = s
 	}
@@ -470,7 +486,8 @@ func TestGetAllSpecies_LocalizedSecondaryModel(t *testing.T) {
 	assert.Equal(t, len(response.Species), response.Count)
 }
 
-// TestGetAllSpecies tests the GetAllSpecies endpoint returns all BirdNET labels.
+// TestGetAllSpecies tests the GetAllSpecies endpoint returns all BirdNET labels
+// via the fallback path (empty cached name map; labels read from settings).
 func TestGetAllSpecies(t *testing.T) {
 	t.Parallel()
 	t.Attr("component", "species")
@@ -511,14 +528,20 @@ func TestGetAllSpecies(t *testing.T) {
 			settings := &conf.Settings{}
 			settings.BirdNET.Labels = tt.labels
 
-			controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
-			controller.Settings.Store(settings)
+			// Empty injected name map forces the fallback path that parses
+			// allModelLabels() (which reads settings.BirdNET.Labels here, since
+			// Processor is nil).
+			handler := &Handler{
+				Core:          &apicore.Core{Echo: e, Group: e.Group("/api/v2")},
+				commonNameMap: func() map[string]string { return nil },
+			}
+			handler.Settings.Store(settings)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/species/all", http.NoBody)
 			rec := httptest.NewRecorder()
 			ctx := e.NewContext(req, rec)
 
-			err := controller.GetAllSpecies(ctx)
+			err := handler.GetAllSpecies(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, rec.Code)
 

--- a/internal/api/v2/species/taxonomy.go
+++ b/internal/api/v2/species/taxonomy.go
@@ -1,5 +1,4 @@
-// internal/api/v2/species_taxonomy.go
-package api
+package species
 
 import (
 	"net/http"
@@ -56,7 +55,7 @@ func titleFirst(s string) string {
 
 // GetGenusSpecies retrieves all species in a given genus
 // GET /api/v2/taxonomy/genus/:genus
-func (c *Controller) GetGenusSpecies(ctx echo.Context) error {
+func (c *Handler) GetGenusSpecies(ctx echo.Context) error {
 	genus := ctx.Param("genus")
 	if genus == "" {
 		return c.HandleError(ctx, errors.Newf("genus parameter is required").
@@ -107,7 +106,7 @@ func (c *Controller) GetGenusSpecies(ctx echo.Context) error {
 
 // GetFamilySpecies retrieves all species in a given family
 // GET /api/v2/taxonomy/family/:family
-func (c *Controller) GetFamilySpecies(ctx echo.Context) error {
+func (c *Handler) GetFamilySpecies(ctx echo.Context) error {
 	family := ctx.Param("family")
 	if family == "" {
 		return c.HandleError(ctx, errors.Newf("family parameter is required").
@@ -164,7 +163,7 @@ func (c *Controller) GetFamilySpecies(ctx echo.Context) error {
 
 // GetSpeciesTree retrieves the complete taxonomic tree for a species
 // GET /api/v2/taxonomy/tree/:scientific_name
-func (c *Controller) GetSpeciesTree(ctx echo.Context) error {
+func (c *Handler) GetSpeciesTree(ctx echo.Context) error {
 	scientificName := ctx.Param("scientific_name")
 	if scientificName == "" {
 		return c.HandleError(ctx, errors.Newf("scientific_name parameter is required").

--- a/internal/api/v2/species/taxonomy_test.go
+++ b/internal/api/v2/species/taxonomy_test.go
@@ -1,6 +1,6 @@
-// species_taxonomy_test.go: Package api provides tests for taxonomy API endpoints.
+// taxonomy_test.go: tests for taxonomy API endpoints.
 
-package api
+package species
 
 import (
 	"encoding/json"
@@ -26,7 +26,7 @@ func TestGetGenusSpecies(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	// Create a minimal controller with taxonomy DB
-	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
@@ -124,7 +124,7 @@ func TestGetFamilySpecies(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
@@ -203,7 +203,7 @@ func TestGetSpeciesTree(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
@@ -306,7 +306,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	taxonomyDB, err := classifier.LoadTaxonomyDatabase()
 	require.NoError(t, err, "Failed to load taxonomy database")
 
-	c := &Controller{Core: &apicore.Core{TaxonomyDB: taxonomyDB, EBirdClient: nil}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: taxonomyDB, EBirdClient: nil}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	tests := []struct {
@@ -359,7 +359,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
-	c := &Controller{Core: &apicore.Core{TaxonomyDB: nil, EBirdClient: nil}}
+	c := &Handler{Core: &apicore.Core{TaxonomyDB: nil, EBirdClient: nil}}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	// This should fail gracefully

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/datastore"
-	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -882,15 +881,4 @@ func (c *Controller) handleBatchResponse(ctx echo.Context, result any, successCo
 		logger.String("path", urlPath))
 
 	return ctx.JSON(http.StatusOK, result)
-}
-
-// handleErrorWithNotFound handles errors that may be not-found errors.
-// If the error is an EnhancedError with CategoryNotFound, returns a 404.
-// Otherwise returns a 500 internal server error.
-func (c *Controller) handleErrorWithNotFound(ctx echo.Context, err error, notFoundMsg, fallbackMsg string) error {
-	var enhancedErr *errors.EnhancedError
-	if errors.As(err, &enhancedErr) && enhancedErr.Category == errors.CategoryNotFound {
-		return c.HandleError(ctx, err, notFoundMsg, http.StatusNotFound)
-	}
-	return c.HandleError(ctx, err, fallbackMsg, http.StatusInternalServerError)
 }


### PR DESCRIPTION
Phase 4 of the internal/api/v2 split: move the species domain (species info, rarity, the all-species picker, the species dictionary, thumbnails, and the genus/family/tree taxonomy lookups) out of the monolithic `package api` into a new `internal/api/v2/species` subpackage. Follows the merged `weather` (Core-only), `tls` (facade-dependency injection), and `range` (shared helpers to apicore + dto) precedents.

## Pattern
- `species.Handler` embeds `*apicore.Core` by pointer (never copied by value).
- `New(core, commonNameMap, serveImageProxy)` constructs the handler; `RegisterRoutes(g *echo.Group)` wires the exact 8 routes from the old `initSpeciesRoutes` in the same order, all public with no per-route middleware.
- Handler methods moved verbatim, only the receiver retyped `*Controller` -> `*Handler` (receiver name kept `c`); bodies rely on promotion of the embedded Core.
- Species response DTOs, rarity constants, helpers, and tests moved with the package. Response structs keep identical json tags, so the wire format of every species/taxonomy endpoint is unchanged.

## Facade-dependency injection (the tls precedent)
Two dependencies the species handlers delegate to are still owned by `package api` because their domains are not extracted yet, so the facade injects them as bound method values:
- `commonNameMap func() map[string]string` = `c.loadCommonNameMap`, the read accessor over the shared scientific-to-common name map. The name-map plumbing (`UpdateCommonNameMap`/`SetNameResolver`, driven by control_monitor and shared by detections/insights/search) stays in the facade; species only needs read access.
- `serveImageProxy echo.HandlerFunc` = `c.ServeSpeciesImageProxy`, the media image proxy the thumbnail endpoint forwards to. When media is extracted this can point at the media handler instead.

## RangeFilterSpecies resolution: moved to dto
`RangeFilterSpecies`, previously owned by the range package and imported by `species.go`, is a flat dep-free struct now shared by two domains. Per the design's "structs shared by 2+ domains move to dto" rule, it moved to `internal/api/v2/dto` (`dto/range.go`) with identical json tags; both range and species now import `dto.RangeFilterSpecies`. This removes the domain-to-domain dependency that would otherwise exist (species importing rangeapi), while keeping the `/species/all` and `/range/species/*` wire formats unchanged. The dep-free fallback (species importing rangeapi) was available but dto is cleaner since the type pulls in no range-specific deps.

## Shared error helper to the substrate
`handleErrorWithNotFound` (used by species and dynamic_thresholds) moved to apicore as the exported `HandleErrorWithNotFound`, byte-identical mapping (CategoryNotFound -> 404, else 500). The `dynamic_thresholds.go` call site was repointed and `utils.go` dropped its now-unused errors import. `HoursPerDay` (24) is defined locally as an unexported `hoursPerDay` in the species package rather than moved to apicore, to avoid adding apicore imports and edits to unrelated files; the package-api `HoursPerDay` is preserved for its remaining users.

## Facade wiring (order preserved exactly)
- `Controller` gains an unexported `species *species.Handler` field.
- `NewWithOptions` constructs it once via `species.New(c.Core, c.loadCommonNameMap, c.ServeSpeciesImageProxy)`.
- `initRoutes` replaces the species `routeInitializers` entry in place at the same index, so the route-enumeration golden gate stays byte-identical.

## Verification
- `gofmt` clean; `go build ./...` clean (ignoring the frontend embed `all:dist`).
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks).
- `go test -race ./internal/api/v2/...` green, including the species domain's own `-race` binary and `TestRouteEnumerationMatchesGolden` unchanged; `./internal/analysis/...` green (with a frontend dist stub for the embed).
- `golangci-lint run` clean on `internal/api/v2/...`.
- No public-behavior change: species/taxonomy endpoints, auth, status codes, and response JSON (including `/species/all` wire format) are identical; `apiv2.Controller`/`New`/external method signatures unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Species-related API responses now use a shared response shape, including labels, names, and optional scores for better consistency.
  * Species and taxonomy endpoints continue to be served through the public API with updated routing support.

* **Bug Fixes**
  * Improved “not found” handling so missing resources return a clearer 404 response instead of a generic server error.
  * Updated range-filter species deduplication and sorting to handle name normalization and missing scores more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->