### PR TITLE
refactor(api/v2): extract models domain into its own package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ assets/tailwind.css
 log/
 clips/
 models/
+# The bare models/ pattern above ignores the runtime ML-model download dir, but
+# it also matches the api/v2 models domain package; keep that source tracked.
+!internal/api/v2/models/
 plans/
 superpowers/
 docs/plans/

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/models"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/api/v2/species"
 	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
@@ -82,6 +83,12 @@ type Controller struct {
 	// species-image proxy handler (ServeSpeciesImageProxy), both still owned by
 	// package api until their domains are extracted.
 	species *species.Handler
+
+	// models serves the /api/v2/models/* endpoints (listing enabled classifier
+	// models, browsing the gallery catalog, and install/reinstall/uninstall plus
+	// streamed download progress). Like weather it needs only the shared
+	// *apicore.Core (ModelManager, settings, error/log helpers, goroutine plumbing).
+	models *models.Handler
 
 	controlChan chan string
 
@@ -325,6 +332,9 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// thumbnail endpoint forwards to). They are passed as bound method values; c is
 	// fully constructed here, so the method values are stable for its lifetime.
 	c.species = species.New(c.Core, c.loadCommonNameMap, c.ServeSpeciesImageProxy)
+	// The models handler needs only the shared core (ModelManager and the
+	// settings/error/log/goroutine helpers all promote from it).
+	c.models = models.New(c.Core)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -437,7 +447,7 @@ func (c *Controller) initRoutes() {
 		{"species routes", func() { c.species.RegisterRoutes(c.Group) }},
 		{"dynamic threshold routes", c.initDynamicThresholdRoutes},
 		{"alert routes", c.initAlertRoutes},
-		{"model routes", c.initModelRoutes},
+		{"model routes", func() { c.models.RegisterRoutes(c.Group) }},
 		{"insights routes", c.initInsightsRoutes},
 		{"tls routes", func() { c.tlsHandler.RegisterRoutes(c.Group) }},
 		{"import routes", c.initImportRoutes},

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -1,0 +1,30 @@
+package apicore
+
+import (
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Server-Sent Events streaming configuration shared by every SSE endpoint
+// (detection/sound-level streams, notifications, metrics history, import
+// progress, model install progress). Keeping these in apicore gives every
+// domain a single source of truth so the streaming behavior cannot drift.
+const (
+	// SSEHeartbeatInterval is the keep-alive heartbeat interval. It must stay
+	// below the server WriteTimeout so a quiet stream is not torn down.
+	SSEHeartbeatInterval = 15 * time.Second
+
+	// SSEEventLoopSleep is the sleep duration used to throttle an SSE poll loop
+	// when there are no events to send.
+	SSEEventLoopSleep = 10 * time.Millisecond
+)
+
+// SetSSEHeaders sets the required HTTP headers for a Server-Sent Events response.
+func SetSSEHeaders(ctx echo.Context) {
+	ctx.Response().Header().Set("Content-Type", "text/event-stream")
+	ctx.Response().Header().Set("Cache-Control", "no-cache")
+	ctx.Response().Header().Set("Connection", "keep-alive")
+	ctx.Response().Header().Set("Access-Control-Allow-Origin", "*")
+	ctx.Response().Header().Set("Access-Control-Allow-Headers", "Cache-Control")
+}

--- a/internal/api/v2/apicore/sse_stream_test.go
+++ b/internal/api/v2/apicore/sse_stream_test.go
@@ -1,0 +1,34 @@
+package apicore
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SetSSEHeaders(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	SetSSEHeaders(ctx)
+
+	expectedHeaders := map[string]string{
+		"Content-Type":                 "text/event-stream",
+		"Cache-Control":                "no-cache",
+		"Connection":                   "keep-alive",
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Headers": "Cache-Control",
+	}
+
+	for key, expectedValue := range expectedHeaders {
+		actualValue := rec.Header().Get(key)
+		assert.Equal(t, expectedValue, actualValue, "SetSSEHeaders() header %q mismatch", key)
+	}
+}

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -339,7 +339,7 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "import job not found", http.StatusNotFound)
 	}
 
-	setSSEHeaders(ctx)
+	apicore.SetSSEHeaders(ctx)
 
 	// Bound the stream lifetime independently of the import itself.
 	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), maxSSEStreamDuration)
@@ -359,7 +359,7 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 		}
 	}
 
-	hb := time.NewTicker(sseHeartbeatInterval)
+	hb := time.NewTicker(apicore.SSEHeartbeatInterval)
 	defer hb.Stop()
 
 	// Capture shutdown channel defensively; c.Context() may be nil in isolated unit tests.

--- a/internal/api/v2/metrics_history.go
+++ b/internal/api/v2/metrics_history.go
@@ -104,7 +104,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 	defer topoCancel()
 
 	// Set SSE headers
-	setSSEHeaders(ctx)
+	apicore.SetSSEHeaders(ctx)
 
 	clientID := apicore.GenerateCorrelationID()
 	c.LogInfoIfEnabled("Metrics SSE client connected",

--- a/internal/api/v2/models/models.go
+++ b/internal/api/v2/models/models.go
@@ -1,4 +1,12 @@
-package api
+// Package models is the api/v2 models domain handler. It owns the
+// /api/v2/models/* endpoints: listing the enabled classifier models, browsing
+// the model gallery catalog, and installing, reinstalling, uninstalling, and
+// streaming download progress for gallery models. The Handler embeds
+// *apicore.Core by pointer so the shared dependencies and helpers (ModelManager,
+// CurrentSettings, HandleError, the Go/Context goroutine plumbing, and the
+// logging helpers) promote onto it; the facade constructs one Handler and calls
+// RegisterRoutes to wire the routes in their existing order.
+package models
 
 import (
 	"encoding/json"
@@ -9,11 +17,39 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// Handler serves the models domain endpoints. It embeds *apicore.Core BY
+// POINTER so the shared Core members promote onto it without re-wiring; Core
+// carries atomic/lock-bearing fields and must never be copied by value.
+type Handler struct {
+	*apicore.Core
+}
+
+// New builds a models Handler around the shared core. The models handlers need
+// only the shared *apicore.Core (ModelManager, settings, error/log helpers and
+// the goroutine plumbing), so there are no facade-owned dependencies to inject.
+func New(core *apicore.Core) *Handler {
+	return &Handler{Core: core}
+}
+
+// RegisterRoutes registers all model-related API endpoints on the supplied API
+// v2 group, preserving the exact routes and order the facade used before the
+// models domain was extracted.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+	g.GET("/models", c.ListModels)
+	g.GET("/models/catalog", c.GetModelCatalog)
+	g.GET("/models/installed", c.GetInstalledModels)
+	g.POST("/models/install/:id", c.InstallModel, c.AuthMiddleware)
+	g.POST("/models/reinstall/:id", c.ReinstallModel, c.AuthMiddleware)
+	g.DELETE("/models/installed/:id", c.UninstallModel, c.AuthMiddleware)
+	g.GET("/models/install/:id/progress", c.StreamInstallProgress)
+}
 
 // ModelListItem represents a model in the API response.
 type ModelListItem struct {
@@ -44,19 +80,8 @@ type CatalogEntryResponse struct {
 	HasGeomodel        bool   `json:"hasGeomodel"`
 }
 
-// initModelRoutes registers model-related API routes.
-func (c *Controller) initModelRoutes() {
-	c.Group.GET("/models", c.ListModels)
-	c.Group.GET("/models/catalog", c.GetModelCatalog)
-	c.Group.GET("/models/installed", c.GetInstalledModels)
-	c.Group.POST("/models/install/:id", c.InstallModel, c.AuthMiddleware)
-	c.Group.POST("/models/reinstall/:id", c.ReinstallModel, c.AuthMiddleware)
-	c.Group.DELETE("/models/installed/:id", c.UninstallModel, c.AuthMiddleware)
-	c.Group.GET("/models/install/:id/progress", c.StreamInstallProgress)
-}
-
 // ListModels returns classifier models that are enabled in the configuration.
-func (c *Controller) ListModels(ctx echo.Context) error {
+func (c *Handler) ListModels(ctx echo.Context) error {
 	// Read from the live settings (atomic pointer) so that models added
 	// at runtime (via gallery install) are immediately visible.
 	settings := conf.GetSettings()
@@ -106,7 +131,7 @@ func (c *Controller) ListModels(ctx echo.Context) error {
 
 // GetModelCatalog returns the embedded model catalog enriched with install
 // status and compatibility information.
-func (c *Controller) GetModelCatalog(ctx echo.Context) error {
+func (c *Handler) GetModelCatalog(ctx echo.Context) error {
 	visible := classifier.VisibleCatalog()
 	catalog := make([]CatalogEntryResponse, 0, len(visible))
 
@@ -162,7 +187,7 @@ func (c *Controller) GetModelCatalog(ctx echo.Context) error {
 }
 
 // GetInstalledModels returns all models that have been downloaded and installed.
-func (c *Controller) GetInstalledModels(ctx echo.Context) error {
+func (c *Handler) GetInstalledModels(ctx echo.Context) error {
 	if c.ModelManager == nil {
 		return ctx.JSON(http.StatusOK, []classifier.InstalledModel{})
 	}
@@ -172,7 +197,7 @@ func (c *Controller) GetInstalledModels(ctx echo.Context) error {
 
 // InstallModel starts an asynchronous model download and installation.
 // It returns 202 Accepted immediately while the download runs in the background.
-func (c *Controller) InstallModel(ctx echo.Context) error {
+func (c *Handler) InstallModel(ctx echo.Context) error {
 	catalogID := ctx.Param("id")
 	if catalogID == "" {
 		return c.HandleError(ctx, nil, "catalog ID is required", http.StatusBadRequest)
@@ -229,7 +254,7 @@ func (c *Controller) InstallModel(ctx echo.Context) error {
 // ReinstallModel re-downloads missing or corrupt files for an installed model.
 // Files that pass SHA256 validation are skipped. It returns 202 Accepted
 // immediately while the re-download runs in the background.
-func (c *Controller) ReinstallModel(ctx echo.Context) error {
+func (c *Handler) ReinstallModel(ctx echo.Context) error {
 	catalogID := ctx.Param("id")
 	if catalogID == "" {
 		return c.HandleError(ctx, nil, "catalog ID is required", http.StatusBadRequest)
@@ -288,7 +313,7 @@ func (c *Controller) ReinstallModel(ctx echo.Context) error {
 }
 
 // UninstallModel removes a downloaded model from disk.
-func (c *Controller) UninstallModel(ctx echo.Context) error {
+func (c *Handler) UninstallModel(ctx echo.Context) error {
 	catalogID := ctx.Param("id")
 	if catalogID == "" {
 		return c.HandleError(ctx, nil, "catalog ID is required", http.StatusBadRequest)
@@ -310,7 +335,7 @@ func (c *Controller) UninstallModel(ctx echo.Context) error {
 
 // StreamInstallProgress streams model download progress as Server-Sent Events.
 // The stream closes automatically when the download completes or fails.
-func (c *Controller) StreamInstallProgress(ctx echo.Context) error {
+func (c *Handler) StreamInstallProgress(ctx echo.Context) error {
 	catalogID := ctx.Param("id")
 	if catalogID == "" {
 		return c.HandleError(ctx, nil, "catalog ID is required", http.StatusBadRequest)
@@ -321,7 +346,7 @@ func (c *Controller) StreamInstallProgress(ctx echo.Context) error {
 	}
 
 	// Set SSE headers.
-	setSSEHeaders(ctx)
+	apicore.SetSSEHeaders(ctx)
 
 	// Flush helper for the response writer.
 	flusher, ok := ctx.Response().Writer.(http.Flusher)
@@ -329,7 +354,7 @@ func (c *Controller) StreamInstallProgress(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "streaming not supported", http.StatusInternalServerError)
 	}
 
-	ticker := time.NewTicker(sseHeartbeatInterval)
+	ticker := time.NewTicker(apicore.SSEHeartbeatInterval)
 	defer ticker.Stop()
 
 	reqCtx := ctx.Request().Context()
@@ -386,7 +411,7 @@ func (c *Controller) StreamInstallProgress(ctx echo.Context) error {
 
 				// No download and not installed: nothing to report yet.
 				// Wait briefly before re-checking.
-				time.Sleep(sseEventLoopSleep)
+				time.Sleep(apicore.SSEEventLoopSleep)
 				continue
 			}
 
@@ -405,7 +430,7 @@ func (c *Controller) StreamInstallProgress(ctx echo.Context) error {
 			}
 
 			// Small sleep to avoid busy-waiting.
-			time.Sleep(sseEventLoopSleep)
+			time.Sleep(apicore.SSEEventLoopSleep)
 		}
 	}
 }

--- a/internal/api/v2/models/models_test.go
+++ b/internal/api/v2/models/models_test.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+)
+
+// TestModelsRouteRegistration verifies the models handler registers exactly the
+// model endpoints, with the same methods and paths the monolithic facade used
+// before the domain was extracted.
+func TestModelsRouteRegistration(t *testing.T) {
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	h := New(core)
+
+	h.RegisterRoutes(core.Group)
+
+	expectedRoutes := []string{
+		"GET /api/v2/models",
+		"GET /api/v2/models/catalog",
+		"GET /api/v2/models/installed",
+		"POST /api/v2/models/install/:id",
+		"POST /api/v2/models/reinstall/:id",
+		"DELETE /api/v2/models/installed/:id",
+		"GET /api/v2/models/install/:id/progress",
+	}
+	apitest.AssertRoutesRegistered(t, e, expectedRoutes)
+}

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
@@ -446,7 +447,7 @@ func (c *Controller) StreamNotifications(ctx echo.Context) error {
 // setupNotificationSSEClient initializes the SSE client and establishes connection
 func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*NotificationClient, *notification.Service, error) {
 	// Set SSE headers
-	setSSEHeaders(ctx)
+	apicore.SetSSEHeaders(ctx)
 
 	// Generate client ID
 	clientID := uuid.New().String()

--- a/internal/api/v2/notifications_helpers_test.go
+++ b/internal/api/v2/notifications_helpers_test.go
@@ -289,30 +289,6 @@ func TestController_processNotificationEvent(t *testing.T) {
 	}
 }
 
-func Test_setSSEHeaders(t *testing.T) {
-	t.Parallel()
-
-	e := echo.New()
-	req := httptest.NewRequest("GET", "/test", http.NoBody)
-	rec := httptest.NewRecorder()
-	ctx := e.NewContext(req, rec)
-
-	setSSEHeaders(ctx)
-
-	expectedHeaders := map[string]string{
-		"Content-Type":                 "text/event-stream",
-		"Cache-Control":                "no-cache",
-		"Connection":                   "keep-alive",
-		"Access-Control-Allow-Origin":  "*",
-		"Access-Control-Allow-Headers": "Cache-Control",
-	}
-
-	for key, expectedValue := range expectedHeaders {
-		actualValue := rec.Header().Get(key)
-		assert.Equal(t, expectedValue, actualValue, "setSSEHeaders() header %q mismatch", key)
-	}
-}
-
 func TestController_logNotificationConnection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/v2/sse.go
+++ b/internal/api/v2/sse.go
@@ -20,10 +20,8 @@ import (
 // SSE connection configuration
 const (
 	// Connection timeouts
-	maxSSEStreamDuration = 30 * time.Minute      // Maximum stream duration to prevent resource leaks
-	sseHeartbeatInterval = 15 * time.Second      // Heartbeat interval for keep-alive (must be < server WriteTimeout)
-	sseEventLoopSleep    = 10 * time.Millisecond // Sleep duration when no events
-	sseWriteDeadline     = 10 * time.Second      // Write deadline for SSE messages
+	maxSSEStreamDuration = 30 * time.Minute // Maximum stream duration to prevent resource leaks
+	sseWriteDeadline     = 10 * time.Second // Write deadline for SSE messages
 
 	// Endpoints
 	detectionStreamEndpoint  = "/api/v2/detections/stream"
@@ -89,15 +87,6 @@ func (c *Controller) initSSERoutes() {
 
 	// SSE status endpoint - shows connected client count
 	c.Group.GET("/sse/status", c.GetSSEStatus)
-}
-
-// setSSEHeaders sets the required headers for Server-Sent Events
-func setSSEHeaders(ctx echo.Context) {
-	ctx.Response().Header().Set("Content-Type", "text/event-stream")
-	ctx.Response().Header().Set("Cache-Control", "no-cache")
-	ctx.Response().Header().Set("Connection", "keep-alive")
-	ctx.Response().Header().Set("Access-Control-Allow-Origin", "*")
-	ctx.Response().Header().Set("Access-Control-Allow-Headers", "Cache-Control")
 }
 
 // createSSEClient creates a new SSE client with common settings
@@ -194,7 +183,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 	ctx.SetRequest(originalReq.WithContext(timeoutCtx))
 
 	// Set SSE headers
-	setSSEHeaders(ctx)
+	apicore.SetSSEHeaders(ctx)
 
 	// Generate client ID and create client
 	clientID := apicore.GenerateCorrelationID()
@@ -246,7 +235,7 @@ func (c *Controller) StreamDetections(ctx echo.Context) error {
 // runSSEEventLoopMulti handles the SSE event loop for detection streams,
 // which receive both detection events and pending detection snapshots.
 func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, clientID, endpoint string) error {
-	ticker := time.NewTicker(sseHeartbeatInterval)
+	ticker := time.NewTicker(apicore.SSEHeartbeatInterval)
 	defer ticker.Stop()
 
 	for {
@@ -310,7 +299,7 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 			}
 
 			if !sent {
-				time.Sleep(sseEventLoopSleep)
+				time.Sleep(apicore.SSEEventLoopSleep)
 			}
 		}
 	}
@@ -346,7 +335,7 @@ func (c *Controller) StreamSoundLevels(ctx echo.Context) error {
 func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, clientID string, endpoint string,
 	dataReceiver func() (any, bool), eventType string, heartbeatType string) error {
 
-	ticker := time.NewTicker(sseHeartbeatInterval)
+	ticker := time.NewTicker(apicore.SSEHeartbeatInterval)
 	defer ticker.Stop()
 
 	for {
@@ -383,7 +372,7 @@ func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, client
 				c.recordSSEMessage(endpoint, eventType)
 			} else {
 				// Small sleep to prevent busy-waiting when no data
-				time.Sleep(sseEventLoopSleep)
+				time.Sleep(apicore.SSEEventLoopSleep)
 			}
 		}
 	}

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -549,7 +549,7 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 	// Override the request context with timeout context
 	ctx.SetRequest(ctx.Request().WithContext(timeoutCtx))
 
-	setSSEHeaders(ctx)
+	apicore.SetSSEHeaders(ctx)
 	clientID := apicore.GenerateCorrelationID()
 
 	c.logSSEConnection(clientID, ctx.RealIP(), ctx.Request().UserAgent(), "stream-health", true)
@@ -564,7 +564,7 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 
 	ticker := time.NewTicker(streamHealthPollInterval)
 	defer ticker.Stop()
-	heartbeatTicker := time.NewTicker(sseHeartbeatInterval)
+	heartbeatTicker := time.NewTicker(apicore.SSEHeartbeatInterval)
 	defer heartbeatTicker.Stop()
 	statsTicker := time.NewTicker(streamStatsUpdateInterval)
 	defer statsTicker.Stop()


### PR DESCRIPTION
## Summary

Phase 4 of the `internal/api/v2` split: move the `models` domain (the model gallery endpoints) out of the monolithic package `api` into a new `internal/api/v2/models` subpackage, following the weather/tls/range/species precedents.

The `models` domain owns the `/api/v2/models/*` endpoints: listing the enabled classifier models, browsing the gallery catalog, install / reinstall / uninstall, and streaming download progress over SSE.

## Pattern

- `models.Handler` embeds `*apicore.Core` by pointer (never copied by value).
- `New(core)` constructs the handler with Core-only dependencies (the weather pattern); the handlers need only shared Core members (`ModelManager`, `CurrentSettings`, `HandleError`, the `Go`/`Context` goroutine plumbing, and the logging helpers), so there are no facade-owned dependencies to inject.
- `RegisterRoutes(g *echo.Group)` wires the exact 7 routes from the old `initModelRoutes` in the same order, with the same per-route middleware (`c.AuthMiddleware` on the install/reinstall/uninstall routes).
- Handler methods moved verbatim; only the receiver retyped from `*Controller` to `*Handler` (receiver name kept `c`). The two response DTOs (`ModelListItem`, `CatalogEntryResponse`) and the unexported `writeSSEEvent` helper moved with the package. The JSON wire format of every models endpoint is unchanged.

## Shared SSE helpers moved to apicore

The models SSE progress endpoint depends on three SSE-streaming primitives that were still defined in the facade `sse.go` (package `api`) and are shared by several not-yet-extracted SSE endpoints (detection/sound-level streams, notifications, metrics history, import progress). To avoid a domain-to-facade import cycle, and following the range precedent of moving a helper shared by 2+ domains to `apicore` as the single exported source, they now live in `internal/api/v2/apicore/sse_stream.go`:

- `func SetSSEHeaders(ctx echo.Context)` (the SSE protocol response headers)
- `const SSEHeartbeatInterval = 15 * time.Second`
- `const SSEEventLoopSleep = 10 * time.Millisecond`

All former consumers (`sse.go`, `streams_health.go`, `notifications.go`, `metrics_history.go`, `import.go`, and the new `models` package) now reference the apicore versions. The header-helper unit test moved to apicore alongside it. This keeps the SSE protocol headers and timing single-sourced so they cannot drift across endpoints.

## Facade wiring (order preserved exactly)

- `Controller` gains an unexported `models *models.Handler` field.
- `NewWithOptions` constructs it once via `models.New(c.Core)`.
- `initRoutes` replaces the `model routes` `routeInitializers` entry in place with `{"model routes", func() { c.models.RegisterRoutes(c.Group) }}` at the same index, so the route-enumeration golden gate stays byte-identical.
- The old facade `models.go` and its `initModelRoutes` are deleted. `system_models.go` (the separate `/system/models` system-domain endpoint) is untouched.

## .gitignore

A bare `models/` ignore pattern (for the runtime ML-model download directory) also matched the new package directory; added `!internal/api/v2/models/` so the source package is tracked while the runtime ignore stays intact.

## Verification

- `go build ./...` clean.
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks).
- `go test -race ./internal/api/v2/... ./internal/analysis/...` green; the `models` package builds its own `-race` test binary, and the route-enumeration golden gate passes unchanged.
- `golangci-lint run ./internal/api/v2/... ./internal/api/v2/models/`: 0 issues.

No public-behavior change: the models endpoints, auth, and responses are identical, and `apiv2.Controller` / `New` / external signatures are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new model management area in the v2 API, including listing, installing, reinstalling, uninstalling, and progress updates.
  * Introduced shared Server-Sent Events handling for streaming updates.

* **Bug Fixes**
  * Improved streaming responses by standardizing SSE headers and heartbeat timing across notifications, health updates, metrics, import progress, and model install progress.
  * Prevented the model source directory from being accidentally ignored while keeping runtime download folders excluded.

* **Tests**
  * Added coverage for SSE header setup and model route registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->