### PR TITLE
refactor(api/v2): extract support domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -408,7 +408,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 - `soundCardSuppressed`: true if the sound card is currently in quiet hours
 - `suppressedStreams`: map of stream URLs to their suppression state (only suppressed streams included)
 
-### Support (`support.go`)
+### Support (`support/support.go`)
 
 | Method | Route                   | Handler               | Auth | Description                      |
 | ------ | ----------------------- | --------------------- | ---- | -------------------------------- |

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -633,7 +634,7 @@ func getThumbnailWithFallback(thumbnailURLs map[string]string, scientificName st
 
 // buildSpeciesSummaryFromData creates a SpeciesDailySummary from aggregated data
 func buildSpeciesSummaryFromData(data *aggregatedBirdInfo, thumbnailURL string) SpeciesDailySummary {
-	hourlyCountsSlice := make([]int, HoursPerDay)
+	hourlyCountsSlice := make([]int, apicore.HoursPerDay)
 	copy(hourlyCountsSlice, data.HourlyCounts[:])
 
 	return SpeciesDailySummary{
@@ -898,12 +899,12 @@ func (c *Controller) GetHourlyAnalytics(ctx echo.Context) error {
 	}
 
 	// Create a 24-hour array filled with zeros
-	hourlyCountsArray := make([]int, HoursPerDay)
+	hourlyCountsArray := make([]int, apicore.HoursPerDay)
 
 	// Fill in the actual counts
 	for i := range hourlyData {
 		data := hourlyData[i]
-		if data.Hour >= 0 && data.Hour < HoursPerDay {
+		if data.Hour >= 0 && data.Hour < apicore.HoursPerDay {
 			hourlyCountsArray[data.Hour] = data.Count
 		}
 	}

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/api/v2/species"
+	"github.com/tphakala/birdnet-go/internal/api/v2/support"
 	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/api/v2/weather"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
@@ -89,6 +90,12 @@ type Controller struct {
 	// streamed download progress). Like weather it needs only the shared
 	// *apicore.Core (ModelManager, settings, error/log helpers, goroutine plumbing).
 	models *models.Handler
+
+	// support serves the /api/v2/support/* endpoints (generating a diagnostic
+	// support dump, downloading it, and reporting telemetry status). Like weather
+	// it needs only the shared *apicore.Core (settings, datastore, V2 manager,
+	// error/log helpers, goroutine plumbing).
+	support *support.Handler
 
 	controlChan chan string
 
@@ -335,6 +342,9 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// The models handler needs only the shared core (ModelManager and the
 	// settings/error/log/goroutine helpers all promote from it).
 	c.models = models.New(c.Core)
+	// The support handler needs only the shared core (settings, datastore, V2
+	// manager, and the error/log/goroutine helpers all promote from it).
+	c.support = support.New(c.Core)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -442,7 +452,7 @@ func (c *Controller) initRoutes() {
 		{"diagnostics routes", c.initDiagnosticsRoutes},
 		{"metrics history routes", c.initMetricsHistoryRoutes},
 		{"notification routes", c.initNotificationRoutes},
-		{"support routes", c.initSupportRoutes},
+		{"support routes", func() { c.support.RegisterRoutes(c.Group) }},
 		{"debug routes", c.initDebugRoutes},
 		{"species routes", func() { c.species.RegisterRoutes(c.Group) }},
 		{"dynamic threshold routes", c.initDynamicThresholdRoutes},

--- a/internal/api/v2/apicore/shared_helpers.go
+++ b/internal/api/v2/apicore/shared_helpers.go
@@ -21,6 +21,7 @@ const (
 	WeeksPerMonth = 4                  // BirdNET model: 4 weeks per month
 	WeeksPerYear  = WeeksPerMonth * 12 // 48 weeks per year in BirdNET's model
 	DaysPerWeek   = 7                  // Days in a calendar week
+	HoursPerDay   = 24                 // Hours in a day
 )
 
 // GetBirdNETInstance returns the BirdNET orchestrator or an error if unavailable.

--- a/internal/api/v2/constants.go
+++ b/internal/api/v2/constants.go
@@ -106,9 +106,6 @@ const (
 	// PercentageMultiplier is used for converting fractions to percentages
 	PercentageMultiplier = 100.0
 
-	// HoursPerDay is the number of hours in a day
-	HoursPerDay = 24
-
 	// SecondsPerMinute is the number of seconds in a minute
 	SecondsPerMinute = 60
 
@@ -135,9 +132,6 @@ const (
 
 	// FilePermExecutable is the permission for executable files (0o755)
 	FilePermExecutable = 0o755
-
-	// FilePermOwnerOnly is the permission for owner-only read/write (0o600)
-	FilePermOwnerOnly = 0o600
 )
 
 // Buffer and channel size constants

--- a/internal/api/v2/support/support.go
+++ b/internal/api/v2/support/support.go
@@ -1,4 +1,13 @@
-package api
+// Package support is the api/v2 support domain handler. It owns the
+// /api/v2/support/* endpoints: generating a diagnostic support dump (optionally
+// uploaded to Sentry), downloading a previously generated dump, and reporting
+// the current support/telemetry configuration status. The Handler embeds
+// *apicore.Core by pointer so the shared dependencies and helpers (settings,
+// datastore, the V2 manager, error/log helpers, and the Go/Context goroutine
+// plumbing) promote onto it; the facade constructs one Handler and calls
+// RegisterRoutes to wire the routes (and start the background cleanup and
+// app-event-pruning goroutines) in their existing order.
+package support
 
 import (
 	"context"
@@ -15,9 +24,50 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
-	"github.com/tphakala/birdnet-go/internal/support"
+	supportpkg "github.com/tphakala/birdnet-go/internal/support"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
+
+// Handler serves the support domain endpoints. It embeds *apicore.Core BY
+// POINTER so the shared Core members promote onto it without re-wiring; Core
+// carries atomic/lock-bearing fields and must never be copied by value.
+type Handler struct {
+	*apicore.Core
+}
+
+// New builds a support Handler around the shared core. The support handlers
+// need only the shared *apicore.Core (settings, datastore, V2 manager, the
+// error/log helpers and the goroutine plumbing), so there are no facade-owned
+// dependencies to inject.
+func New(core *apicore.Core) *Handler {
+	return &Handler{Core: core}
+}
+
+// RegisterRoutes registers the support-related API endpoints on the supplied API
+// v2 group, preserving the exact routes, order, and per-route middleware the
+// facade used before the support domain was extracted. It also starts the
+// background goroutines that clean up old temporary support dumps and prune old
+// application events, matching the previous initSupportRoutes behavior.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+	// Create protected group for support endpoints (consistent with other route files)
+	supportGroup := g.Group("/support", c.AuthMiddleware)
+	supportGroup.POST("/generate", c.GenerateSupportDump)
+	supportGroup.GET("/download/:id", c.DownloadSupportDump)
+	supportGroup.GET("/status", c.GetSupportStatus)
+
+	// Start cleanup goroutine for old support dumps with proper context
+	// Go 1.25: Using WaitGroup.Go() for automatic Add/Done management
+	if c.Context() != nil {
+		c.Go(func() {
+			c.startSupportDumpCleanup(c.Context())
+		})
+
+		c.Go(func() {
+			c.startAppEventPruning(c.Context())
+		})
+
+	}
+}
 
 // Support constants (file-local)
 const (
@@ -26,6 +76,12 @@ const (
 	supportBytesPerMB       = 1024 * 1024 // Bytes per megabyte
 	supportDumpTimeout      = 120 * time.Second
 )
+
+// filePermOwnerOnly is the permission for owner-only read/write (0o600). The
+// support dump is written to a temporary file before download; restrict it to
+// the owning user so diagnostics (which may contain sensitive data) are not
+// world-readable.
+const filePermOwnerOnly = 0o600
 
 // valueContext wraps a cancellation-bearing context while delegating
 // Value lookups to a separate context. This lets the support dump
@@ -75,7 +131,7 @@ func sanitizeGitHubIssueNumber(issueNum string) string {
 }
 
 // GenerateSupportDump handles the generation and optional upload of support dumps
-func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
+func (c *Handler) GenerateSupportDump(ctx echo.Context) error {
 	c.LogDebugIfEnabled("Support dump generation started")
 
 	// Use the server lifecycle context for cancellation so the dump
@@ -143,7 +199,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	}
 
 	// Create collector with proper paths
-	collector := support.NewCollector(
+	collector := supportpkg.NewCollector(
 		configPath[0], // Use first config path
 		".",           // Data directory (current directory)
 		settings.SystemID,
@@ -156,7 +212,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		if c.V2Manager.IsMySQL() {
 			dialect = datastore.DialectMySQL
 		}
-		dbCollector := support.NewGormDatabaseInfoCollector(
+		dbCollector := supportpkg.NewGormDatabaseInfoCollector(
 			c.V2Manager.DB(),
 			dialect,
 			c.V2Manager.Path(),
@@ -168,19 +224,19 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 
 	// Wire app events provider
 	if req.IncludeAppEvents && c.DS != nil {
-		collector.SetAppEventsProvider(support.NewDatastoreAppEventsProvider(c.DS, nil))
+		collector.SetAppEventsProvider(supportpkg.NewDatastoreAppEventsProvider(c.DS, nil))
 	}
 
 	// Set collection options
-	opts := support.CollectorOptions{
+	opts := supportpkg.CollectorOptions{
 		IncludeLogs:           req.IncludeLogs,
 		IncludeConfig:         req.IncludeConfig,
 		IncludeSystemInfo:     req.IncludeSystemInfo,
 		IncludeDatabaseInfo:   req.IncludeDatabaseInfo,
 		IncludeDeploymentInfo: true,
 		IncludeAppEvents:      req.IncludeAppEvents,
-		LogDuration:           supportLogDurationWeeks * apicore.DaysPerWeek * HoursPerDay * time.Hour, // 4 weeks
-		MaxLogSize:            supportMaxLogSizeMB * supportBytesPerMB,                                 // 50MB to accommodate more logs
+		LogDuration:           supportLogDurationWeeks * apicore.DaysPerWeek * apicore.HoursPerDay * time.Hour, // 4 weeks
+		MaxLogSize:            supportMaxLogSizeMB * supportBytesPerMB,                                         // 50MB to accommodate more logs
 		ScrubSensitive:        true,
 		AnonymizePII:          true,
 	}
@@ -265,7 +321,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 	if !req.UploadToSentry {
 		// Store temporarily for download
 		tempFile := filepath.Join(os.TempDir(), fmt.Sprintf("birdnet-go-support-%s.zip", dump.ID))
-		if err := os.WriteFile(tempFile, archiveData, FilePermOwnerOnly); err != nil {
+		if err := os.WriteFile(tempFile, archiveData, filePermOwnerOnly); err != nil {
 			c.LogErrorIfEnabled("Failed to store temporary file",
 				logger.Error(err),
 				logger.String("path", tempFile),
@@ -286,7 +342,7 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 }
 
 // DownloadSupportDump handles downloading a generated support dump
-func (c *Controller) DownloadSupportDump(ctx echo.Context) error {
+func (c *Handler) DownloadSupportDump(ctx echo.Context) error {
 	dumpID := ctx.Param("id")
 	if dumpID == "" {
 		return c.HandleError(ctx, nil, "Missing dump ID", http.StatusBadRequest)
@@ -320,7 +376,7 @@ func (c *Controller) DownloadSupportDump(ctx echo.Context) error {
 }
 
 // GetSupportStatus returns the current support/telemetry configuration status
-func (c *Controller) GetSupportStatus(ctx echo.Context) error {
+func (c *Handler) GetSupportStatus(ctx echo.Context) error {
 	// Read the live global snapshot (race-free, hot-reloading) via
 	// CurrentSettings() so out-of-band republishes are seen and the read never
 	// races the Settings.Store in UpdateSettings.
@@ -338,30 +394,8 @@ func (c *Controller) GetSupportStatus(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, status)
 }
 
-// initSupportRoutes registers support-related routes
-func (c *Controller) initSupportRoutes() {
-	// Create protected group for support endpoints (consistent with other route files)
-	supportGroup := c.Group.Group("/support", c.AuthMiddleware)
-	supportGroup.POST("/generate", c.GenerateSupportDump)
-	supportGroup.GET("/download/:id", c.DownloadSupportDump)
-	supportGroup.GET("/status", c.GetSupportStatus)
-
-	// Start cleanup goroutine for old support dumps with proper context
-	// Go 1.25: Using WaitGroup.Go() for automatic Add/Done management
-	if c.Context() != nil {
-		c.Go(func() {
-			c.startSupportDumpCleanup(c.Context())
-		})
-
-		c.Go(func() {
-			c.startAppEventPruning(c.Context())
-		})
-
-	}
-}
-
 // startSupportDumpCleanup runs a periodic cleanup of old temporary support dump files
-func (c *Controller) startSupportDumpCleanup(ctx context.Context) {
+func (c *Handler) startSupportDumpCleanup(ctx context.Context) {
 	// Ensure we have a valid context
 	if ctx == nil {
 		c.LogErrorIfEnabled("Cannot start support dump cleanup with nil context")
@@ -388,7 +422,7 @@ func (c *Controller) startSupportDumpCleanup(ctx context.Context) {
 }
 
 // cleanupOldSupportDumps removes temporary support dump files older than 1 hour
-func (c *Controller) cleanupOldSupportDumps() {
+func (c *Handler) cleanupOldSupportDumps() {
 	tempDir := os.TempDir()
 	pattern := filepath.Join(tempDir, "birdnet-go-support-*.zip")
 
@@ -415,7 +449,7 @@ func (c *Controller) cleanupOldSupportDumps() {
 
 // tryRemoveOldFile attempts to remove a file if it's older than cutoff.
 // Returns true if the file was successfully removed.
-func (c *Controller) tryRemoveOldFile(file string, cutoff time.Time) bool {
+func (c *Handler) tryRemoveOldFile(file string, cutoff time.Time) bool {
 	info, err := os.Stat(file)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -440,7 +474,7 @@ func (c *Controller) tryRemoveOldFile(file string, cutoff time.Time) bool {
 const appEventRetentionDays = 90
 
 // startAppEventPruning runs periodic pruning of old application events.
-func (c *Controller) startAppEventPruning(ctx context.Context) {
+func (c *Handler) startAppEventPruning(ctx context.Context) {
 	if ctx == nil || c.DS == nil {
 		return
 	}
@@ -468,7 +502,7 @@ func (c *Controller) startAppEventPruning(ctx context.Context) {
 }
 
 // pruneAppEvents removes application events older than the retention period.
-func (c *Controller) pruneAppEvents(ctx context.Context) {
+func (c *Handler) pruneAppEvents(ctx context.Context) {
 	if c.DS == nil {
 		return
 	}

--- a/internal/api/v2/support/support_test.go
+++ b/internal/api/v2/support/support_test.go
@@ -1,0 +1,46 @@
+package support
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/mock"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+// TestSupportRouteRegistration verifies the support handler registers exactly the
+// support endpoints, with the same methods and paths the monolithic facade used
+// before the domain was extracted.
+//
+// RegisterRoutes also starts two background goroutines (guarded by a non-nil
+// lifecycle context): the app-event-pruning goroutine, which prunes once at
+// startup via DS.PruneAppEvents before blocking on the context, and the
+// support-dump cleanup goroutine, which runs cleanupOldSupportDumps() once at
+// startup (a glob of os.TempDir() that removes only birdnet-go-support-*.zip
+// files older than an hour, identical to production) before blocking on the
+// context. apitest.NewCore wires a non-nil lifecycle context and cancels +
+// waits for it on cleanup, so both goroutines start and stop cleanly here; the
+// PruneAppEvents expectation below is marked Maybe because it may or may not run
+// before that cancellation.
+func TestSupportRouteRegistration(t *testing.T) {
+	e := echo.New()
+
+	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().
+		PruneAppEvents(mock.Anything, mock.Anything).
+		Return(int64(0), nil).
+		Maybe()
+
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithDatastore(mockDS))
+	h := New(core)
+
+	h.RegisterRoutes(core.Group)
+
+	expectedRoutes := []string{
+		"POST /api/v2/support/generate",
+		"GET /api/v2/support/download/:id",
+		"GET /api/v2/support/status",
+	}
+	apitest.AssertRoutesRegistered(t, e, expectedRoutes)
+}

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -341,8 +342,8 @@ func deduplicateSpeciesList(speciesParams []string) []string {
 
 // initEmptyHourlyDistribution creates an array of 24 HourlyDistribution entries initialized to zero.
 func initEmptyHourlyDistribution() []HourlyDistribution {
-	data := make([]HourlyDistribution, HoursPerDay)
-	for hour := range HoursPerDay {
+	data := make([]HourlyDistribution, apicore.HoursPerDay)
+	for hour := range apicore.HoursPerDay {
 		data[hour] = HourlyDistribution{Hour: hour, Count: 0}
 	}
 	return data
@@ -373,7 +374,7 @@ func fillHourlyFromItems(dest []HourlyDistribution, items []hourlyDataItem) int 
 	totalCount := 0
 	for _, item := range items {
 		hour := item.GetHour()
-		if hour >= 0 && hour < HoursPerDay {
+		if hour >= 0 && hour < apicore.HoursPerDay {
 			dest[hour].Count = item.GetCount()
 			totalCount += item.GetCount()
 		}


### PR DESCRIPTION
## What

Phase 4 of the `internal/api/v2` package split: move the **support** domain (the support-dump endpoints) out of the monolithic package `api` into a new `internal/api/v2/support` subpackage, following the weather / tls / range / species / models precedents (#3700, #3701, #3702, #3703).

The support domain owns the `/api/v2/support/*` endpoints:

| Method | Route | Handler | Auth |
| ------ | ----- | ------- | ---- |
| POST | `/support/generate` | `GenerateSupportDump` | yes |
| GET | `/support/download/:id` | `DownloadSupportDump` | yes |
| GET | `/support/status` | `GetSupportStatus` | yes |

## How

- `support.Handler` embeds `*apicore.Core` by pointer (never copied by value).
- `New(core)` constructs the handler with Core-only dependencies (the weather pattern): the handlers need only shared Core members (`CurrentSettings`, `DS`, `V2Manager`, `HandleError`, the `Go`/`Context` goroutine plumbing, `AuthMiddleware`, and the logging helpers), so there are no facade-owned dependencies to inject.
- `RegisterRoutes` wires the exact 3 routes from the old `initSupportRoutes` in the same order under the same `/support` `AuthMiddleware` group, and starts the same two background goroutines (temporary support-dump cleanup and app-event pruning) guarded by the same non-nil lifecycle-context check.
- Handler methods moved verbatim; only the receiver retyped from `*Controller` to `*Handler` (receiver name kept `c`). The request/response DTOs (`GenerateSupportDumpRequest`, `GenerateSupportDumpResponse`), the `valueContext` write-deadline helper, `sanitizeGitHubIssueNumber`, and the file-local support constants moved with the package. The JSON wire format of every support endpoint is unchanged.
- The `internal/support` collector package is imported as `supportpkg` to avoid a confusing self-named import inside `package support`.

### Shared constants relocated

- `HoursPerDay` moved to `apicore/shared_helpers.go` as the single exported source (the range precedent: a value shared by 2+ domains lives on the shared substrate). It is consumed by support plus the still-facade `analytics.go` and `utils.go`, which now reference `apicore.HoursPerDay`.
- `FilePermOwnerOnly` was used only by support, so it moved into the support package as the unexported `filePermOwnerOnly`. Both constants were removed from the facade `constants.go`.

### Facade wiring (order preserved exactly)

- `Controller` gains an unexported `support *support.Handler` field.
- `NewWithOptions` constructs it once via `support.New(c.Core)`.
- `initRoutes` replaces the `support routes` `routeInitializers` entry in place with the `support.RegisterRoutes` call at the same index, so the route-enumeration golden gate stays byte-identical.
- The old facade `support.go` and its `initSupportRoutes` are deleted.

A route-registration test was added so the support package builds its own `-race` binary (support had no tests before). The test injects a mock datastore with a `PruneAppEvents().Maybe()` expectation because `RegisterRoutes` starts the app-event-pruning goroutine; `apitest` cleanup cancels and waits for the lifecycle goroutines, keeping the test leak- and race-clean.

## Verification

- `go build ./...` clean (only the unrelated `frontend/embed.go all:dist` placeholder, present on `main`).
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean.
- `go test -race ./internal/api/v2/ ./internal/api/v2/support/ ./internal/api/v2/apicore/ ./internal/analysis/...` green. The support package builds its own `-race` binary and the route-enumeration golden gate passes unchanged.
- `golangci-lint run` on `./internal/api/v2/... ./internal/api/v2/support/`: 0 issues.

No public-behavior change: the support endpoints, auth, and responses are identical, and `apiv2.Controller` / `New` / external signatures are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support options are now organized under a dedicated support area, with the same three endpoints available for generating, downloading, and checking support status.

* **Bug Fixes**
  * Hour-based analytics and distributions now consistently use a shared 24-hour limit, reducing edge-case issues with hourly counts.
  * Downloaded support files now use stricter file permissions.

* **Documentation**
  * Corrected a support documentation link to point to the right source location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->