### PR TITLE
refactor(api/v2): extract filesystem domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -227,7 +227,7 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 - `startEvent` / `endEvent` (`"sunrise"` | `"sunset"`): Solar mode events
 - `startOffset` / `endOffset` (int, -180 to 180): Minutes offset from solar event
 
-### Filesystem (`filesystem.go`)
+### Filesystem (`filesystem/filesystem.go`)
 
 | Method | Route                | Handler            | Auth | Description                                              |
 | ------ | -------------------- | ------------------ | ---- | -------------------------------------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/api/v2/species"
@@ -96,6 +97,12 @@ type Controller struct {
 	// it needs only the shared *apicore.Core (settings, datastore, V2 manager,
 	// error/log helpers, goroutine plumbing).
 	support *support.Handler
+
+	// filesystem serves the /api/v2/filesystem/* endpoints (the secure
+	// file-browser endpoint backing the frontend directory picker). Like weather
+	// it needs only the shared *apicore.Core (the media SecureFS sandbox, the auth
+	// middleware, and the error/log helpers all promote from it).
+	filesystem *filesystem.Handler
 
 	controlChan chan string
 
@@ -345,6 +352,9 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// The support handler needs only the shared core (settings, datastore, V2
 	// manager, and the error/log/goroutine helpers all promote from it).
 	c.support = support.New(c.Core)
+	// The filesystem handler needs only the shared core (the media SecureFS
+	// sandbox, the auth middleware, and the error/log helpers all promote from it).
+	c.filesystem = filesystem.New(c.Core)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -435,7 +445,7 @@ func (c *Controller) initRoutes() {
 		{"system routes", c.initSystemRoutes},
 		{"terminal routes", c.initTerminalRoutes},
 		{"settings routes", c.initSettingsRoutes},
-		{"filesystem routes", c.initFileSystemRoutes},
+		{"filesystem routes", func() { c.filesystem.RegisterRoutes(c.Group) }},
 		{"stream health routes", c.initStreamHealthRoutes},
 		{"stream test routes", c.initStreamTestRoutes},
 		{"audio health routes", c.initAudioHealthRoutes},

--- a/internal/api/v2/filesystem/filesystem.go
+++ b/internal/api/v2/filesystem/filesystem.go
@@ -1,5 +1,11 @@
-// internal/api/v2/filesystem.go
-package api
+// Package filesystem is the api/v2 filesystem domain handler. It owns the
+// /api/v2/filesystem/* endpoints: the secure file-browser endpoint backing the
+// frontend directory picker. The Handler embeds *apicore.Core by pointer so the
+// shared dependencies and helpers (the media SecureFS sandbox, the auth
+// middleware, and the error/log helpers) promote onto it; the facade constructs
+// one Handler and calls RegisterRoutes to wire the routes in their existing
+// order.
+package filesystem
 
 import (
 	"fmt"
@@ -10,8 +16,40 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// Handler serves the filesystem domain endpoints. It embeds *apicore.Core BY
+// POINTER so the shared Core members (notably the SecureFS sandbox SFS, the
+// AuthMiddleware, and the error/log helpers) promote onto it without re-wiring;
+// Core carries atomic/lock-bearing fields and must never be copied by value.
+type Handler struct {
+	*apicore.Core
+}
+
+// New builds a filesystem Handler around the shared core. The filesystem
+// handlers need only the shared *apicore.Core (the media SecureFS instance, the
+// auth middleware, and the error/log helpers), so there are no facade-owned
+// dependencies to inject.
+func New(core *apicore.Core) *Handler {
+	return &Handler{Core: core}
+}
+
+// RegisterRoutes registers all filesystem-related API endpoints on the supplied
+// API v2 group, preserving the exact route, order, and per-route middleware the
+// facade used before the filesystem domain was extracted.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+	c.LogInfoIfEnabled("Initializing filesystem routes")
+
+	// Create filesystem API group with authentication
+	fsGroup := g.Group("/filesystem", c.AuthMiddleware)
+
+	// GET /api/v2/filesystem/browse - Browse files and directories
+	fsGroup.GET("/browse", c.BrowseFileSystem)
+
+	c.LogInfoIfEnabled("Filesystem routes initialized")
+}
 
 // FileSystemItem represents a file or directory for the frontend file browser
 type FileSystemItem struct {
@@ -34,19 +72,6 @@ type BrowseResponse struct {
 	ParentPath  string           `json:"parentPath,omitempty"`
 }
 
-// initFileSystemRoutes registers all filesystem-related API endpoints
-func (c *Controller) initFileSystemRoutes() {
-	c.LogInfoIfEnabled("Initializing filesystem routes")
-
-	// Create filesystem API group with authentication
-	fsGroup := c.Group.Group("/filesystem", c.AuthMiddleware)
-
-	// GET /api/v2/filesystem/browse - Browse files and directories
-	fsGroup.GET("/browse", c.BrowseFileSystem)
-
-	c.LogInfoIfEnabled("Filesystem routes initialized")
-}
-
 // browsePathResult holds validated path information for browsing.
 type browsePathResult struct {
 	browsePath string
@@ -55,7 +80,7 @@ type browsePathResult struct {
 
 // validateBrowsePath validates and normalizes the browse path, checking security constraints.
 // Returns the validated path info or an error with appropriate HTTP status code.
-func (c *Controller) validateBrowsePath(reqPath string) (browsePathResult, error) {
+func (c *Handler) validateBrowsePath(reqPath string) (browsePathResult, error) {
 	// Default to base directory if no path specified
 	browsePath := reqPath
 	if browsePath == "" {
@@ -95,7 +120,7 @@ func (c *Controller) validateBrowsePath(reqPath string) (browsePathResult, error
 }
 
 // BrowseFileSystem lists files and directories in the specified path
-func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
+func (c *Handler) BrowseFileSystem(ctx echo.Context) error {
 	var req BrowseRequest
 	if err := ctx.Bind(&req); err != nil {
 		c.LogErrorIfEnabled("Failed to bind browse request",
@@ -180,7 +205,7 @@ func (c *Controller) BrowseFileSystem(ctx echo.Context) error {
 }
 
 // validateSymlinkTarget validates that a symlink target is within allowed boundaries
-func (c *Controller) validateSymlinkTarget(symlinkPath string) error {
+func (c *Handler) validateSymlinkTarget(symlinkPath string) error {
 	// Use SecureFS to safely read the symlink target within the sandbox
 	target, err := c.SFS.Readlink(symlinkPath)
 	if err != nil {
@@ -207,7 +232,7 @@ func (c *Controller) validateSymlinkTarget(symlinkPath string) error {
 }
 
 // convertDirEntryToItem converts a fs.DirEntry to FileSystemItem with enhanced error context
-func (c *Controller) convertDirEntryToItem(basePath string, entry fs.DirEntry) (FileSystemItem, error) {
+func (c *Handler) convertDirEntryToItem(basePath string, entry fs.DirEntry) (FileSystemItem, error) {
 	fullPath := filepath.Join(basePath, entry.Name())
 
 	info, err := entry.Info()

--- a/internal/api/v2/filesystem/filesystem_test.go
+++ b/internal/api/v2/filesystem/filesystem_test.go
@@ -1,6 +1,6 @@
-// filesystem_test.go: Package api provides tests for filesystem browsing functionality.
+// filesystem_test.go: tests for the filesystem domain browse endpoint.
 
-package api
+package filesystem
 
 import (
 	"encoding/json"
@@ -15,11 +15,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
-	"github.com/tphakala/birdnet-go/internal/securefs"
 )
 
+// osWindows is the runtime.GOOS value for Windows. Used to gate the symlink
+// tests, where creating a symlink requires SeCreateSymbolicLinkPrivilege.
+const osWindows = "windows"
+
 // passthroughMiddleware returns a middleware that does nothing (allows all requests).
-// Used for testing endpoints that require authentication middleware.
+// Used for testing endpoints that require authentication middleware: the
+// /filesystem group is created with c.AuthMiddleware, so a non-nil passthrough is
+// needed for behavioral tests that route HTTP requests through it.
 func passthroughMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -29,37 +34,47 @@ func passthroughMiddleware() echo.MiddlewareFunc {
 }
 
 // setupFilesystemTestEnvironment creates a test environment specifically for filesystem tests.
-// It sets up a controller with SecureFS rooted in a temporary directory.
-func setupFilesystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller, string) {
+// apitest.NewCore already provisions an isolated SecureFS rooted in its own
+// per-test t.TempDir() (and registers cleanup that closes it before the TempDir
+// is removed), so this reuses that base directory as the browse root instead of
+// re-rooting SFS, which would invert the cleanup order and break Windows TempDir
+// removal. A passthrough auth middleware is injected so requests route through
+// the /filesystem group middleware.
+func setupFilesystemTestEnvironment(t *testing.T) (*echo.Echo, *Handler, string) {
 	t.Helper()
 
-	// Get base test environment
-	e, _, controller := setupTestEnvironment(t)
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
 
-	// Create temp directory for filesystem tests
-	tempDir := t.TempDir()
+	// Set passthrough auth middleware for testing so the /filesystem group
+	// middleware (c.AuthMiddleware) is non-nil and lets requests through.
+	core.AuthMiddleware = passthroughMiddleware()
 
-	// Close existing SFS if any
-	if controller.SFS != nil {
-		require.NoError(t, controller.SFS.Close(), "Failed to close existing SFS")
+	// Use the SecureFS base directory apitest already rooted at a per-test
+	// t.TempDir() as the browse root.
+	tempDir := core.SFS.BaseDir()
+
+	h := New(core)
+	h.RegisterRoutes(core.Group)
+
+	return e, h, tempDir
+}
+
+// TestFilesystemRouteRegistration verifies the filesystem handler registers exactly
+// the browse endpoint, with the same method and path the monolithic facade used
+// before the domain was extracted.
+func TestFilesystemRouteRegistration(t *testing.T) {
+	e := echo.New()
+
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	h := New(core)
+
+	h.RegisterRoutes(core.Group)
+
+	expectedRoutes := []string{
+		"GET /api/v2/filesystem/browse",
 	}
-
-	// Create new SecureFS rooted in temp directory
-	sfs, err := securefs.New(tempDir)
-	require.NoError(t, err, "Failed to create SecureFS for filesystem test")
-	controller.SFS = sfs
-
-	// Set passthrough auth middleware for testing
-	WithAuthMiddleware(passthroughMiddleware())(controller)
-
-	t.Cleanup(func() {
-		assert.NoError(t, controller.SFS.Close(), "Failed to close SFS")
-	})
-
-	// Initialize filesystem routes
-	controller.initFileSystemRoutes()
-
-	return e, controller, tempDir
+	apitest.AssertRoutesRegistered(t, e, expectedRoutes)
 }
 
 // TestBrowseFileSystem_BasicDirectory tests browsing a directory with files and subdirectories.
@@ -372,7 +387,7 @@ func TestConvertDirEntryToItem(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "dir-entry-conversion")
 
-	_, controller, tempDir := setupFilesystemTestEnvironment(t)
+	_, handler, tempDir := setupFilesystemTestEnvironment(t)
 
 	// Create test files
 	testFile := filepath.Join(tempDir, "testfile.txt")
@@ -387,7 +402,7 @@ func TestConvertDirEntryToItem(t *testing.T) {
 	require.Len(t, entries, 2)
 
 	for _, entry := range entries {
-		item, err := controller.convertDirEntryToItem(tempDir, entry)
+		item, err := handler.convertDirEntryToItem(tempDir, entry)
 		require.NoError(t, err)
 
 		assert.Equal(t, entry.Name(), item.Name)
@@ -545,7 +560,7 @@ func TestValidateSymlinkTarget(t *testing.T) {
 	t.Attr("type", "security")
 	t.Attr("feature", "symlink-validation")
 
-	_, controller, tempDir := setupFilesystemTestEnvironment(t)
+	_, handler, tempDir := setupFilesystemTestEnvironment(t)
 
 	// Create a subdirectory and file for symlink targets
 	targetDir := filepath.Join(tempDir, "target")
@@ -567,7 +582,7 @@ func TestValidateSymlinkTarget(t *testing.T) {
 			// maps only ERROR_ACCESS_DENIED/EACCES/EPERM to os.ErrPermission, so
 			// it would NOT match ERROR_PRIVILEGE_NOT_HELD and the skip would never
 			// fire. On Unix a symlink failure is a genuine error and must fail.
-			if runtime.GOOS == OSWindows {
+			if runtime.GOOS == osWindows {
 				t.Skipf("skipping: cannot create symlink (needs privilege/Developer Mode on Windows): %v", err)
 			}
 			require.NoError(t, err)
@@ -606,7 +621,7 @@ func TestValidateSymlinkTarget(t *testing.T) {
 				// use a Windows-absolute target there to exercise the escaping-
 				// symlink rejection on every OS.
 				outside := "/etc"
-				if runtime.GOOS == OSWindows {
+				if runtime.GOOS == osWindows {
 					outside = `C:\Windows`
 				}
 				return symlinkOrSkip(t, outside, filepath.Join(tempDir, "escape_link"))
@@ -628,7 +643,7 @@ func TestValidateSymlinkTarget(t *testing.T) {
 			// Note: Not parallel because setup creates files in shared directory
 			symlinkPath := tc.setup(t)
 
-			err := controller.validateSymlinkTarget(symlinkPath)
+			err := handler.validateSymlinkTarget(symlinkPath)
 			if tc.expectError {
 				assert.Error(t, err, "Expected error for symlink %q", symlinkPath)
 			} else {

--- a/internal/api/v2/test_helpers_test.go
+++ b/internal/api/v2/test_helpers_test.go
@@ -25,6 +25,16 @@ const (
 	testFailFastTimeout = 200 * time.Millisecond
 )
 
+// passthroughMiddleware returns a middleware that does nothing (allows all requests).
+// Used for testing endpoints that require authentication middleware.
+func passthroughMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			return next(c)
+		}
+	}
+}
+
 // getTestController creates a test controller with disabled saving
 // Note: apitest.DisableHTTPKeepAlivesForTesting() is called in TestMain before any tests run
 func getTestController(t *testing.T, e *echo.Echo) *Controller {


### PR DESCRIPTION
## Summary

Phase 4 of the internal/api/v2 split: move the filesystem domain (the secure file-browser endpoint) out of the monolithic package `api` into a new `internal/api/v2/filesystem` subpackage, following the weather/tls/range/species/models/support precedents.

The filesystem domain owns the `/api/v2/filesystem/*` surface: a single authenticated endpoint, `GET /api/v2/filesystem/browse`, that lists files and directories inside the media SecureFS sandbox for the frontend directory picker.

## Pattern

- `filesystem.Handler` embeds `*apicore.Core` by pointer (never copied by value; Core carries locks/atomics).
- `New(core)` constructs the handler with Core-only dependencies (the weather pattern). The handlers need only shared Core members (the media SecureFS instance `SFS`, `AuthMiddleware`, `HandleError`, and the `Log*IfEnabled` helpers), so there are no facade-owned dependencies to inject.
- `RegisterRoutes` wires the exact route from the old `initFileSystemRoutes` in the same order under the same `/filesystem` AuthMiddleware group.
- Handler methods moved verbatim; only the receiver was retyped from `*Controller` to `*Handler` (receiver name kept `c`). The path-traversal and symlink-target validation (`validateBrowsePath`, `validateSymlinkTarget`, `convertDirEntryToItem`) is preserved character-for-character. The domain-owned types (`FileSystemItem`, `BrowseRequest`, `BrowseResponse`, the unexported `browsePathResult`) moved with the package; they are referenced by no other domain, so they stay exported in the package rather than moving to `dto`.

## Facade wiring

- Added a `filesystem *filesystem.Handler` field to the `api` Controller.
- Construct `c.filesystem = filesystem.New(c.Core)` alongside the other domain handlers.
- Replaced the `filesystem routes` entry in the ordered `routeInitializers` slice with `c.filesystem.RegisterRoutes(c.Group)` at the same index, preserving registration order.

## Test relocation

- The filesystem tests moved into the package and were rebuilt against `apitest`. The setup now reuses the isolated SecureFS that `apitest.NewCore` already roots at a per-test `t.TempDir()` (via `core.SFS.BaseDir()`) instead of re-rooting SFS, which keeps the cleanup order correct on Windows.
- Added a `TestFilesystemRouteRegistration` route-registration test so the new package has its own `-race` binary and route assertion (mirrors the support precedent).
- `passthroughMiddleware` was relocated from the old `filesystem_test.go` into `test_helpers_test.go` (package `api`) because `media_test.go` also consumes it; the new package defines its own local copy.

## Verification

- `go build ./...` clean.
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks: Core embedded by pointer).
- `go test -race ./internal/api/v2/... ./internal/analysis/...` green, including the new `internal/api/v2/filesystem` package as its own `-race` binary.
- `TestRouteEnumerationMatchesGolden` passes: the route enumeration (method + path + per-route middleware + order) is identical; no golden update needed.
- `golangci-lint run` clean on `./internal/api/v2/` and `./internal/api/v2/filesystem/`.
- No public-behavior change: `apiv2.Controller`, `New`, and external signatures are unchanged; the `GET /api/v2/filesystem/browse` contract (method, path, auth, JSON shape) is identical.

## Preflight Status

- [x] Single concern: extract the filesystem domain only.
- [x] Linters clean: golangci-lint on the affected packages, zero issues.
- [x] Tests pass: go test -race on api/v2 (all subpackages) and analysis.
- [x] No regression/backward-compat break: route contract and golden enumeration unchanged; no config/DB/CLI surface touched.
- [x] No secrets or PII.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filesystem browsing is now wired into the v2 API and available through the existing authenticated filesystem endpoint.
  * Route registration for filesystem browsing has been standardized, keeping the same access and behavior for users.

* **Documentation**
  * Updated the filesystem API v2 docs to reflect the current implementation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->