### PR TITLE
refactor(api/v2): extract alerts domain into its own package

### DIFF
--- a/internal/api/v2/alerts/alerts.go
+++ b/internal/api/v2/alerts/alerts.go
@@ -1,4 +1,15 @@
-package api
+// Package alerts is the api/v2 alerts domain handler. It owns the
+// /api/v2/alerts/* endpoints (alert-rule CRUD, import/export, history, and the
+// schema/test-fire helpers). The Handler embeds *apicore.Core by pointer so the
+// shared dependencies and helpers (HandleError, HandleErrorWithKey, the logging
+// helpers, the V2Manager and auth middleware) promote onto it.
+//
+// Unlike the Core-only leaf domains, alerts owns two domain-specific
+// dependencies: the alert-rule repository and the alerting engine. Both are
+// referenced only by this domain (plus the facade Shutdown), so the Handler owns
+// them outright: they are constructed lazily in RegisterRoutes (mirroring the
+// old initAlertRoutes) and torn down in Shutdown, which the facade calls.
+package alerts
 
 import (
 	"encoding/json"
@@ -10,6 +21,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/alerting"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
@@ -20,17 +32,42 @@ import (
 
 const maxHistoryLimit = 200
 
-// initAlertRoutes registers alert rule API endpoints and starts the alerting engine.
+// queryValueTrue is the canonical "true" query-parameter value used when parsing
+// optional boolean filters (enabled, built_in). Kept local to the alerts domain
+// to avoid rippling the shared constant in package api into unrelated domains.
+const queryValueTrue = "true"
+
+// Handler serves the alerts domain endpoints. It embeds *apicore.Core BY POINTER
+// so the shared Core members promote onto it without re-wiring; Core carries
+// atomic/lock-bearing fields and must never be copied by value. alertRuleRepo and
+// alertEngine are owned by this handler: they are nil until RegisterRoutes
+// constructs them (only when the enhanced v2 database schema is active), and the
+// facade calls Shutdown to stop them on teardown.
+type Handler struct {
+	*apicore.Core
+
+	alertRuleRepo repository.AlertRuleRepository
+	alertEngine   *alerting.Engine
+}
+
+// New builds an alerts Handler around the shared core. The alert-rule repository
+// and alerting engine are constructed lazily in RegisterRoutes.
+func New(core *apicore.Core) *Handler {
+	return &Handler{Core: core}
+}
+
+// RegisterRoutes registers alert rule API endpoints and starts the alerting engine.
 // Routes are registered when V2Manager is available (handlers check v2 mode
 // per-request), but the alerting engine is only started when the v2 schema is
-// active — preventing background operations (rule seeding, history cleanup)
-// against missing tables.
-func (c *Controller) initAlertRoutes() {
+// active - preventing background operations (rule seeding, history cleanup)
+// against missing tables. The routes, per-route middleware, and order match the
+// facade's old initAlertRoutes exactly.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	if c.V2Manager == nil {
 		return
 	}
 
-	alerts := c.Group.Group("/alerts")
+	alerts := g.Group("/alerts")
 
 	// Public read endpoints
 	alerts.GET("/schema", c.GetAlertSchema)
@@ -54,23 +91,37 @@ func (c *Controller) initAlertRoutes() {
 	// On legacy databases the alert tables do not exist, so starting the
 	// engine would fail during rule seeding and history cleanup.
 	if !datastoreV2.IsEnhancedDatabase() {
-		GetLogger().Info("alerting engine skipped: v2 database schema not active")
+		apicore.GetLogger().Info("alerting engine skipped: v2 database schema not active")
 		return
 	}
 
 	// Initialize repository lazily from V2Manager
 	c.alertRuleRepo = repository.NewAlertRuleRepository(c.V2Manager.DB(), nil)
 
-	// Initialize the alerting engine — seeds default rules and starts event processing
+	// Initialize the alerting engine - seeds default rules and starts event processing
 	alertTelemetry := alerting.NewAlertingTelemetry()
 	eventBus := alerting.NewAlertEventBus(alertTelemetry)
-	engine, err := alerting.Initialize(c.alertRuleRepo, eventBus, GetLogger(), alertTelemetry)
+	engine, err := alerting.Initialize(c.alertRuleRepo, eventBus, apicore.GetLogger(), alertTelemetry)
 	if err != nil {
-		GetLogger().Error("failed to initialize alerting engine", logger.Error(err))
+		apicore.GetLogger().Error("failed to initialize alerting engine", logger.Error(err))
 		eventBus.Stop() // Stop the bus goroutine since Initialize didn't set it as global
-		// Continue without engine — CRUD routes still work, but events won't fire
+		// Continue without engine - CRUD routes still work, but events won't fire
 	} else {
 		c.alertEngine = engine
+	}
+}
+
+// Shutdown stops the alerting engine's background goroutines and its global event
+// bus. The facade Controller.Shutdown calls this in the same order the monolith
+// used (after closing SSE clients, before cancelling the controller context). It
+// is safe to call when the engine was never initialized: alertEngine is nil and
+// GetGlobalBus returns nil when Initialize failed or was skipped.
+func (c *Handler) Shutdown() {
+	if c.alertEngine != nil {
+		c.alertEngine.Stop()
+	}
+	if bus := alerting.GetGlobalBus(); bus != nil {
+		bus.Stop()
 	}
 }
 
@@ -104,7 +155,7 @@ func validateEscalationSteps(steps []float64) error {
 // bindAndValidateAlertRule binds and validates the alert rule from the request body.
 // On validation failure, it writes the error response and returns nil with the written error.
 // Callers should check: if rule == nil { return err }
-func (c *Controller) bindAndValidateAlertRule(ctx echo.Context) (*entities.AlertRule, error) {
+func (c *Handler) bindAndValidateAlertRule(ctx echo.Context) (*entities.AlertRule, error) {
 	var rule entities.AlertRule
 	if err := ctx.Bind(&rule); err != nil {
 		return nil, c.HandleErrorWithKey(ctx, err, "Invalid request body", http.StatusBadRequest, notification.MsgErrAlertInvalidBody, nil)
@@ -122,13 +173,13 @@ func (c *Controller) bindAndValidateAlertRule(ctx echo.Context) (*entities.Alert
 }
 
 // requireV2 checks that the enhanced database is available and returns an error response if not.
-func (c *Controller) requireV2(ctx echo.Context) error {
+func (c *Handler) requireV2(ctx echo.Context) error {
 	return c.HandleErrorWithKey(ctx, nil,
 		"Alert rules require the enhanced (v2) database", http.StatusConflict, notification.MsgErrAlertV2Required, nil)
 }
 
 // GetAlertSchema returns the alerting schema for the UI.
-func (c *Controller) GetAlertSchema(ctx echo.Context) error {
+func (c *Handler) GetAlertSchema(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -136,7 +187,7 @@ func (c *Controller) GetAlertSchema(ctx echo.Context) error {
 }
 
 // ListAlertRules returns all alert rules, optionally filtered.
-func (c *Controller) ListAlertRules(ctx echo.Context) error {
+func (c *Handler) ListAlertRules(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -145,11 +196,11 @@ func (c *Controller) ListAlertRules(ctx echo.Context) error {
 		ObjectType: ctx.QueryParam("object_type"),
 	}
 	if enabledParam := ctx.QueryParam("enabled"); enabledParam != "" {
-		v := enabledParam == QueryValueTrue
+		v := enabledParam == queryValueTrue
 		filter.Enabled = &v
 	}
 	if builtInParam := ctx.QueryParam("built_in"); builtInParam != "" {
-		v := builtInParam == QueryValueTrue
+		v := builtInParam == queryValueTrue
 		filter.BuiltIn = &v
 	}
 
@@ -166,7 +217,7 @@ func (c *Controller) ListAlertRules(ctx echo.Context) error {
 }
 
 // GetAlertRule returns a single alert rule by ID.
-func (c *Controller) GetAlertRule(ctx echo.Context) error {
+func (c *Handler) GetAlertRule(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -189,7 +240,7 @@ func (c *Controller) GetAlertRule(ctx echo.Context) error {
 }
 
 // CreateAlertRule creates a new alert rule.
-func (c *Controller) CreateAlertRule(ctx echo.Context) error {
+func (c *Handler) CreateAlertRule(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -225,7 +276,7 @@ func (c *Controller) CreateAlertRule(ctx echo.Context) error {
 }
 
 // UpdateAlertRule replaces an existing alert rule.
-func (c *Controller) UpdateAlertRule(ctx echo.Context) error {
+func (c *Handler) UpdateAlertRule(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -263,7 +314,7 @@ func (c *Controller) UpdateAlertRule(ctx echo.Context) error {
 }
 
 // ToggleAlertRule enables or disables an alert rule.
-func (c *Controller) ToggleAlertRule(ctx echo.Context) error {
+func (c *Handler) ToggleAlertRule(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -294,7 +345,7 @@ func (c *Controller) ToggleAlertRule(ctx echo.Context) error {
 }
 
 // DeleteAlertRule deletes an alert rule.
-func (c *Controller) DeleteAlertRule(ctx echo.Context) error {
+func (c *Handler) DeleteAlertRule(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -318,7 +369,7 @@ func (c *Controller) DeleteAlertRule(ctx echo.Context) error {
 }
 
 // TestAlertRule simulates firing a rule for testing purposes.
-func (c *Controller) TestAlertRule(ctx echo.Context) error {
+func (c *Handler) TestAlertRule(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -345,7 +396,7 @@ func (c *Controller) TestAlertRule(ctx echo.Context) error {
 }
 
 // ResetDefaultAlertRules deletes all built-in rules and re-seeds them.
-func (c *Controller) ResetDefaultAlertRules(ctx echo.Context) error {
+func (c *Handler) ResetDefaultAlertRules(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -373,7 +424,7 @@ func (c *Controller) ResetDefaultAlertRules(ctx echo.Context) error {
 }
 
 // ListAlertHistory returns paginated alert firing history.
-func (c *Controller) ListAlertHistory(ctx echo.Context) error {
+func (c *Handler) ListAlertHistory(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -420,7 +471,7 @@ func (c *Controller) ListAlertHistory(ctx echo.Context) error {
 }
 
 // ClearAlertHistory deletes all alert history records.
-func (c *Controller) ClearAlertHistory(ctx echo.Context) error {
+func (c *Handler) ClearAlertHistory(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -435,7 +486,7 @@ func (c *Controller) ClearAlertHistory(ctx echo.Context) error {
 }
 
 // ExportAlertRules exports all rules as JSON.
-func (c *Controller) ExportAlertRules(ctx echo.Context) error {
+func (c *Handler) ExportAlertRules(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -454,7 +505,7 @@ func (c *Controller) ExportAlertRules(ctx echo.Context) error {
 }
 
 // ImportAlertRules imports rules from JSON.
-func (c *Controller) ImportAlertRules(ctx echo.Context) error {
+func (c *Handler) ImportAlertRules(ctx echo.Context) error {
 	if !datastoreV2.IsEnhancedDatabase() {
 		return c.requireV2(ctx)
 	}
@@ -505,7 +556,7 @@ func (c *Controller) ImportAlertRules(ctx echo.Context) error {
 }
 
 // refreshAlertEngine refreshes the engine's rule cache if the engine is set.
-func (c *Controller) refreshAlertEngine(ctx echo.Context) {
+func (c *Handler) refreshAlertEngine(ctx echo.Context) {
 	if c.alertEngine != nil {
 		if err := c.alertEngine.RefreshRules(ctx.Request().Context()); err != nil {
 			c.LogErrorIfEnabled("failed to refresh alert engine rules", logger.Error(err))

--- a/internal/api/v2/alerts/alerts_test.go
+++ b/internal/api/v2/alerts/alerts_test.go
@@ -1,4 +1,4 @@
-package api
+package alerts
 
 import (
 	"math"

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -14,9 +14,9 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/mem"
-	"github.com/tphakala/birdnet-go/internal/alerting"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/alerts"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
@@ -104,6 +104,15 @@ type Controller struct {
 	// middleware, and the error/log helpers all promote from it).
 	filesystem *filesystem.Handler
 
+	// alerts serves the /api/v2/alerts/* endpoints (alert-rule CRUD,
+	// import/export, history, schema, and test-fire). Beyond the shared
+	// *apicore.Core it OWNS its two domain dependencies (the alert-rule
+	// repository and the alerting engine), which it constructs lazily in
+	// RegisterRoutes when the enhanced v2 database schema is active. The facade
+	// calls c.alerts.Shutdown() during teardown to stop the engine and its
+	// global event bus.
+	alerts *alerts.Handler
+
 	controlChan chan string
 
 	// DisableSaveSettings prevents persisting settings changes to disk.
@@ -184,10 +193,6 @@ type Controller struct {
 
 	// Application metadata repository (initialized lazily in initAppRoutes)
 	appMetadataRepo repository.AppMetadataRepository
-
-	// Alerting fields (initialized lazily in initAlertRoutes)
-	alertRuleRepo repository.AlertRuleRepository
-	alertEngine   *alerting.Engine
 
 	// Insights fields (initialized lazily in initInsightsRoutes)
 	insightsRepo repository.InsightsRepository
@@ -355,6 +360,11 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// The filesystem handler needs only the shared core (the media SecureFS
 	// sandbox, the auth middleware, and the error/log helpers all promote from it).
 	c.filesystem = filesystem.New(c.Core)
+	// The alerts handler owns its two domain dependencies (alert-rule repository
+	// and alerting engine), constructed lazily in RegisterRoutes; it needs only
+	// the shared core here (V2Manager, auth middleware, and the error/log helpers
+	// all promote from it).
+	c.alerts = alerts.New(c.Core)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -466,7 +476,7 @@ func (c *Controller) initRoutes() {
 		{"debug routes", c.initDebugRoutes},
 		{"species routes", func() { c.species.RegisterRoutes(c.Group) }},
 		{"dynamic threshold routes", c.initDynamicThresholdRoutes},
-		{"alert routes", c.initAlertRoutes},
+		{"alert routes", func() { c.alerts.RegisterRoutes(c.Group) }},
 		{"model routes", func() { c.models.RegisterRoutes(c.Group) }},
 		{"insights routes", c.initInsightsRoutes},
 		{"tls routes", func() { c.tlsHandler.RegisterRoutes(c.Group) }},
@@ -603,12 +613,11 @@ func (c *Controller) Shutdown() {
 		c.SSEManager.CloseAllClients()
 	}
 
-	// Stop alerting engine background goroutines and event bus
-	if c.alertEngine != nil {
-		c.alertEngine.Stop()
-	}
-	if bus := alerting.GetGlobalBus(); bus != nil {
-		bus.Stop()
+	// Stop the alerting engine background goroutines and its global event bus.
+	// The alerts handler owns the engine; Shutdown is a no-op when the engine was
+	// never initialized (legacy database or V2Manager absent).
+	if c.alerts != nil {
+		c.alerts.Shutdown()
 	}
 
 	// Cancel context to stop all goroutines, then wait for them to finish.

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -14,7 +14,17 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+// requireV2 checks that the enhanced database is available and returns an error
+// response if not. Shared by the insights handlers in this file. The alerts
+// domain (now its own package) keeps its own copy of this guard; consolidating
+// the two is deferred so this extraction stays behavior-preserving.
+func (c *Controller) requireV2(ctx echo.Context) error {
+	return c.HandleErrorWithKey(ctx, nil,
+		"Alert rules require the enhanced (v2) database", http.StatusConflict, notification.MsgErrAlertV2Required, nil)
+}
 
 // Insights constants
 const (


### PR DESCRIPTION
## Summary

Phase 4 of the `internal/api/v2` package split: moves the alert-rule / alert-history domain out of the monolithic `package api` into a new `internal/api/v2/alerts` subpackage, following the established Phase 4 pattern (Handler embeds `*apicore.Core` by pointer; the facade `Controller` holds a handler field, constructs it, and calls `RegisterRoutes` in the deterministic `initRoutes` order).

This gives the alerts domain its own `-race` test binary so it no longer shares the single per-package timeout ceiling with the rest of api/v2.

## Pattern

- `alerts.Handler` embeds `*apicore.Core` by pointer (never copied by value) so the shared deps and helpers (`HandleError`, `HandleErrorWithKey`, the logging helpers, `V2Manager`, `AuthMiddleware`) promote onto it.
- `New(core)` constructs the handler; `RegisterRoutes(g *echo.Group)` wires the exact routes from the old `initAlertRoutes` in the same order with the same per-route middleware (public `GET` schema/rules/rules/:id/history, then a protected subgroup under `AuthMiddleware` for export/create/update/toggle/delete/test/reset-defaults/import/history-delete), preserving the `V2Manager`-nil and `IsEnhancedDatabase` guards.
- Handler methods moved verbatim, only the receiver retyped from `*Controller` to `*Handler` (receiver name kept `c`). The two package-local substitutions are `GetLogger()` -> `apicore.GetLogger()` (byte-identical; both return `logger.Global().Module("api")`) and the shared `QueryValueTrue` -> a local `queryValueTrue` const, kept in the alerts package to avoid rippling the shared constant into the not-yet-extracted detections/audio_hls domains.
- alerts-only symbols (`validateEscalationSteps`, `parseUintParam`, `bindAndValidateAlertRule`, `refreshAlertEngine`, `maxHistoryLimit`) moved into the package, unexported.

## Domain-owned dependencies (how alerts differs from the Core-only leaf domains)

The alert-rule repository and the alerting engine are referenced only by this domain and the facade `Shutdown`, so the Handler OWNS them as fields rather than receiving them injected. `RegisterRoutes` constructs them lazily (only when the enhanced v2 database schema is active), exactly as the old `initAlertRoutes` did.

## Lifecycle preservation

The facade `Shutdown` used to call `alertEngine.Stop()` then `alerting.GetGlobalBus().Stop()`; both moved into `alerts.Handler.Shutdown()`, which the facade now calls in the same position (after `SSEManager.CloseAllClients`, before `Cancel`/`Wait`). The teardown is a no-op when the engine was never initialized (legacy database or `V2Manager` absent), and the global-bus stop is safe because `alerting.Initialize` only sets the global bus after all its error returns, so a failed init leaves `GetGlobalBus()` nil. The facade dropped its now-unused `alerting` import and the `alertRuleRepo`/`alertEngine` fields.

`requireV2` was shared by alerts and insights (insights stays in `package api`). To keep `apicore` free of a `notification` dependency, the guard is kept as two local copies: the package-api copy relocated to `insights.go` (its only remaining in-package consumer), and the alerts package keeps its own. Both return the identical response, so behavior is unchanged.

## Facade wiring (order preserved exactly)

- `Controller` gains an unexported `alerts *alerts.Handler` field.
- `NewWithOptions` constructs `c.alerts = alerts.New(c.Core)` alongside the other domain handlers.
- `initRoutes` replaces the alert `routeInitializers` entry in place with `{"alert routes", func() { c.alerts.RegisterRoutes(c.Group) }}` at the same index, so registration order (and the route-enumeration golden gate) is byte-identical.

## Verification

- `go build ./...` clean (only the unrelated `frontend/embed.go all:dist` artifact from the unbuilt frontend).
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (no copylocks).
- `go test -race ./internal/api/v2/...` green; alerts has its own `-race` binary.
- `go test -race ./internal/analysis/...` green.
- Route-enumeration golden gate identical (V2Manager nil in the test, so no alert routes register, before and after).
- `golangci-lint`: 0 issues. `apiv2.Controller`/`New`/`NewWithOptions` and external signatures unchanged.

No public-behavior change: alerts endpoints, auth, responses, and the alert-engine lifecycle are identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts are now handled through a dedicated v2 alerting flow, with routes and lifecycle management integrated into the app.
  * Alert data and history actions continue to be available, with rule changes automatically reflected immediately.

* **Bug Fixes**
  * Alert background processing now starts only when the required v2 database schema is available, helping avoid partial or unstable behavior.
  * If alert initialization fails, core alert management pages still remain usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->