### PR TITLE
refactor(api/v2): extract control domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -102,7 +102,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/analytics/confidence/distribution`  | `GetConfidenceDistribution` | ❌  | Confidence distribution per species: per-species normalized histogram of detection confidence scores (Review & Accuracy tab). `start_date` required; `end_date` optional (defaults to `start_date` + 30 days); `species` optional (single species filter; default is the top-N species by volume); `bins` optional (default 20, clamped to 5-50); `limit` optional (default 5, max 8) |
 | GET    | `/analytics/sources`                  | `GetAnalyticsSources`      | ❌   | Audio sources that have detections in range, powering the analytics hub's source/mic filter: each source's opaque id (string), display label, and in-range detection count (false positives excluded), most active first. `start_date`/`end_date` optional (omit both for all history). v2only (the legacy schema does not persist a detection's source; legacy returns an empty list). Source names are anonymized for unauthenticated clients; the opaque id is safe to expose. Returns `{sources[]}` (never null) |
 
-### Control Operations (`control.go`)
+### Control Operations (`control/control.go`)
 
 | Method | Route                         | Handler               | Auth | Description                            |
 | ------ | ----------------------------- | --------------------- | ---- | -------------------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/alerts"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/control"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
@@ -113,6 +114,15 @@ type Controller struct {
 	// global event bus.
 	alerts *alerts.Handler
 
+	// control serves the /api/v2/control/* endpoints (restart analysis, reload
+	// model, rebuild range filter, restart server/container, restart a single
+	// audio source, and list actions). Beyond the shared *apicore.Core it OWNS
+	// sourceRestarter (set via the SetSourceRestarter facade delegator) and
+	// receives the shared controlChan as a send-only injection (the facade keeps
+	// the bidirectional field because the settings domain also sends on it and
+	// internal/analysis owns and closes it).
+	control *control.Handler
+
 	controlChan chan string
 
 	// DisableSaveSettings prevents persisting settings changes to disk.
@@ -153,10 +163,6 @@ type Controller struct {
 	// This is primarily used in testing to ensure proper setup before assertions.
 	// Only created when routes are initialized (production mode or specific tests).
 	goroutinesStarted chan struct{} // signals when all background goroutines have started (nil if routes not initialized)
-
-	// sourceRestarter restarts a single audio source by ID. Set during
-	// pipeline Start() and called by the restart-source control endpoint.
-	sourceRestarter atomic.Pointer[SourceRestarterFunc]
 
 	// externalMediaEnv and externalMediaProbe are injectable dependencies for
 	// the GET /api/v2/system/external-media endpoint. Both default to the real
@@ -212,9 +218,6 @@ type Controller struct {
 	healthMetricsStore *observability.HealthMetricsStore
 	healthEvents       *observability.HealthEventBuffer
 }
-
-// SourceRestarterFunc restarts a single audio source identified by sourceID.
-type SourceRestarterFunc func(sourceID string) error
 
 // Option is a functional option for configuring the Controller.
 type Option func(*Controller)
@@ -365,6 +368,13 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// the shared core here (V2Manager, auth middleware, and the error/log helpers
 	// all promote from it).
 	c.alerts = alerts.New(c.Core)
+	// The control handler owns its sourceRestarter and receives the shared
+	// control-signal channel as a send-only injection. c.controlChan is already
+	// set in the Controller literal above; passing it here narrows it to a
+	// send-only view so the handler can never read or close a channel that
+	// internal/analysis owns. The remaining deps (Engine, ShutdownRequester, and
+	// the error/log helpers) all promote from the shared core.
+	c.control = control.New(c.Core, c.controlChan)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
@@ -434,6 +444,14 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	return c, nil // Return controller and nil error
 }
 
+// SetSourceRestarter injects the function used by the restart-source control
+// endpoint. It delegates to the control domain handler, which owns the
+// sourceRestarter slot. The audio pipeline calls this on *Controller during
+// Start(), so the method stays on the facade as a one-line delegator.
+func (c *Controller) SetSourceRestarter(fn control.SourceRestarterFunc) {
+	c.control.SetSourceRestarter(fn)
+}
+
 // initRoutes registers all API endpoints
 func (c *Controller) initRoutes() {
 	// Health check endpoint - publicly accessible
@@ -463,7 +481,7 @@ func (c *Controller) initRoutes() {
 		{"audio level routes", c.initAudioLevelRoutes},
 		{"hls streaming routes", c.initHLSRoutes},
 		{"integration routes", c.initIntegrationsRoutes},
-		{"control routes", c.initControlRoutes},
+		{"control routes", func() { c.control.RegisterRoutes(c.Group) }},
 		{"auth routes", c.initAuthRoutes},
 		{"media routes", c.initMediaRoutes},
 		{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }},

--- a/internal/api/v2/control/control.go
+++ b/internal/api/v2/control/control.go
@@ -1,13 +1,29 @@
-// internal/api/v2/control.go
-package api
+// Package control is the api/v2 control domain handler. It owns the
+// /api/v2/control/* endpoints (restart analysis, reload model, rebuild range
+// filter, restart server/container, restart a single audio source, and list
+// available actions). The Handler embeds *apicore.Core by pointer so the shared
+// dependencies and helpers (HandleError, the logging helpers, Debug, Context,
+// GetShutdownRequester, and the audio Engine) promote onto it.
+//
+// Two domain members differ from the Core-only leaf domains:
+//   - controlChan is the control-signal channel. It is SHARED: the settings
+//     domain also sends on it and internal/analysis creates and closes it, so
+//     the facade keeps the field and injects the same channel here as a
+//     send-only view. The control handler never reads or closes it.
+//   - sourceRestarter is referenced only by this domain (SetSourceRestarter and
+//     the restart-source endpoint), so the Handler owns it outright. The facade
+//     exposes a one-line SetSourceRestarter delegator for the external pipeline.
+package control
 
 import (
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/restart"
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
@@ -45,12 +61,45 @@ const (
 	SignalRebuildFilter   = "rebuild_range_filter"
 )
 
-// initControlRoutes registers all control-related API endpoints
-func (c *Controller) initControlRoutes() {
+// SourceRestarterFunc restarts a single audio source identified by sourceID.
+type SourceRestarterFunc func(sourceID string) error
+
+// Handler serves the control domain endpoints. It embeds *apicore.Core BY
+// POINTER so the shared Core members promote onto it without re-wiring; Core
+// carries atomic/lock-bearing fields and must never be copied by value.
+//
+// controlChan is injected from the facade as a send-only view of the shared
+// control-signal channel: the control handler only sends on it, while the
+// settings domain (also a sender) and internal/analysis (the owner that creates
+// and closes it) keep their bidirectional references. sourceRestarter is owned
+// by this handler; it is set via SetSourceRestarter (called from the audio
+// pipeline through the facade delegator) and read by the restart-source endpoint.
+type Handler struct {
+	*apicore.Core
+
+	controlChan     chan<- string
+	sourceRestarter atomic.Pointer[SourceRestarterFunc]
+}
+
+// New builds a control Handler around the shared core and the shared
+// control-signal channel. controlChan MUST be the same channel the settings
+// domain sends on and internal/analysis owns; it is held as a send-only view so
+// the control handler can never read or close it.
+func New(core *apicore.Core, controlChan chan<- string) *Handler {
+	return &Handler{
+		Core:        core,
+		controlChan: controlChan,
+	}
+}
+
+// RegisterRoutes registers all control-related API endpoints on the supplied API
+// v2 group, preserving the exact routes, per-route middleware, and order the
+// facade used before the control domain was extracted.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	c.LogInfoIfEnabled("Initializing control routes")
 
 	// Create control API group with auth middleware
-	controlGroup := c.Group.Group("/control", c.AuthMiddleware)
+	controlGroup := g.Group("/control", c.AuthMiddleware)
 
 	// Control routes
 	controlGroup.POST("/restart", c.RestartAnalysis)
@@ -66,7 +115,7 @@ func (c *Controller) initControlRoutes() {
 
 // GetAvailableActions handles GET /api/v2/control/actions
 // Returns a list of available control actions
-func (c *Controller) GetAvailableActions(ctx echo.Context) error {
+func (c *Handler) GetAvailableActions(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Getting available control actions",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -120,7 +169,7 @@ func (c *Controller) GetAvailableActions(ctx echo.Context) error {
 //   - successMessage: Message to return in the response when successful
 //
 // Returns an error if the control channel is nil or if the request times out
-func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMessage, successMessage string) error {
+func (c *Handler) handleControlSignal(ctx echo.Context, signal, action, logMessage, successMessage string) error {
 	c.LogInfoIfEnabled(logMessage,
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -178,21 +227,21 @@ func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMe
 
 // RestartAnalysis handles POST /api/v2/control/restart
 // Restarts the audio analysis process
-func (c *Controller) RestartAnalysis(ctx echo.Context) error {
+func (c *Handler) RestartAnalysis(ctx echo.Context) error {
 	return c.handleControlSignal(ctx, SignalRestartAnalysis, ActionRestartAnalysis,
 		"Received request to restart analysis", "Analysis restart signal sent")
 }
 
 // ReloadModel handles POST /api/v2/control/reload
 // Reloads the BirdNET model
-func (c *Controller) ReloadModel(ctx echo.Context) error {
+func (c *Handler) ReloadModel(ctx echo.Context) error {
 	return c.handleControlSignal(ctx, SignalReloadModel, ActionReloadModel,
 		"Received request to reload model", "Model reload signal sent")
 }
 
 // RebuildFilter handles POST /api/v2/control/rebuild-filter
 // Rebuilds the species filter based on current location
-func (c *Controller) RebuildFilter(ctx echo.Context) error {
+func (c *Handler) RebuildFilter(ctx echo.Context) error {
 	return c.handleControlSignal(ctx, SignalRebuildFilter, ActionRebuildFilter,
 		"Received request to rebuild species filter", "Filter rebuild signal sent")
 }
@@ -200,7 +249,7 @@ func (c *Controller) RebuildFilter(ctx echo.Context) error {
 // handleRestartRequest is the shared logic for restart endpoints.
 // It checks the shutdown requester, applies the CAS flag via setFlag,
 // and schedules an async shutdown after the HTTP response is sent.
-func (c *Controller) handleRestartRequest(ctx echo.Context, action string, setFlag func() bool, successMessage string) error {
+func (c *Handler) handleRestartRequest(ctx echo.Context, action string, setFlag func() bool, successMessage string) error {
 	sr := c.GetShutdownRequester()
 	if sr == nil {
 		err := fmt.Errorf("shutdown requester not initialized")
@@ -245,7 +294,7 @@ func (c *Controller) handleRestartRequest(ctx echo.Context, action string, setFl
 
 // RestartServer handles POST /api/v2/control/restart-server
 // Triggers a graceful binary restart.
-func (c *Controller) RestartServer(ctx echo.Context) error {
+func (c *Handler) RestartServer(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Received request to restart server",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -256,7 +305,7 @@ func (c *Controller) RestartServer(ctx echo.Context) error {
 
 // RestartContainer handles POST /api/v2/control/restart-container
 // Triggers a container restart by exiting the process.
-func (c *Controller) RestartContainer(ctx echo.Context) error {
+func (c *Handler) RestartContainer(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Received request to restart container",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -274,7 +323,7 @@ func (c *Controller) RestartContainer(ctx echo.Context) error {
 }
 
 // SetSourceRestarter injects the function used by the restart-source endpoint.
-func (c *Controller) SetSourceRestarter(fn SourceRestarterFunc) {
+func (c *Handler) SetSourceRestarter(fn SourceRestarterFunc) {
 	if fn == nil {
 		c.sourceRestarter.Store(nil)
 		return
@@ -284,7 +333,7 @@ func (c *Controller) SetSourceRestarter(fn SourceRestarterFunc) {
 
 // RestartAudioSource handles POST /api/v2/control/restart-source/:id
 // Restarts a single audio source without affecting the rest of the pipeline.
-func (c *Controller) RestartAudioSource(ctx echo.Context) error {
+func (c *Handler) RestartAudioSource(ctx echo.Context) error {
 	sourceID := ctx.Param("id")
 	if sourceID == "" {
 		return c.HandleError(ctx, nil, "Source ID is required", http.StatusBadRequest)

--- a/internal/api/v2/control/control_restart_source_test.go
+++ b/internal/api/v2/control/control_restart_source_test.go
@@ -1,4 +1,4 @@
-package api
+package control
 
 import (
 	"encoding/json"
@@ -18,7 +18,7 @@ import (
 func TestRestartAudioSource_NoEngine(t *testing.T) {
 	t.Parallel()
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newControlHandler(t, e)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/test-src", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -33,7 +33,7 @@ func TestRestartAudioSource_NoEngine(t *testing.T) {
 func TestRestartAudioSource_SourceNotFound(t *testing.T) {
 	t.Parallel()
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newControlHandler(t, e)
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
@@ -52,7 +52,7 @@ func TestRestartAudioSource_SourceNotFound(t *testing.T) {
 func TestRestartAudioSource_NoPipeline(t *testing.T) {
 	t.Parallel()
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newControlHandler(t, e)
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
@@ -79,7 +79,7 @@ func TestRestartAudioSource_NoPipeline(t *testing.T) {
 func TestRestartAudioSource_Success(t *testing.T) {
 	t.Parallel()
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newControlHandler(t, e)
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
@@ -121,7 +121,7 @@ func TestRestartAudioSource_Success(t *testing.T) {
 func TestRestartAudioSource_RestartError(t *testing.T) {
 	t.Parallel()
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newControlHandler(t, e)
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
@@ -153,7 +153,7 @@ func TestRestartAudioSource_RestartError(t *testing.T) {
 func TestRestartAudioSource_EmptyID(t *testing.T) {
 	t.Parallel()
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newControlHandler(t, e)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/control/control_test.go
+++ b/internal/api/v2/control/control_test.go
@@ -1,11 +1,11 @@
-// control_test.go: Package api provides tests for API v2 control endpoints.
+// control_test.go: tests for the API v2 control domain endpoints.
 //
 // Go 1.25 improvements:
 // - Uses sync.WaitGroup.Go() for cleaner goroutine management
 // - Uses T.Attr() for test metadata
 // LLM GUIDANCE: Always use WaitGroup.Go() instead of manual Add/Done patterns
 
-package api
+package control
 
 import (
 	"context"
@@ -27,8 +27,33 @@ import (
 	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
-// runControlEndpointTest runs a control endpoint test with the given parameters
-func runControlEndpointTest(t *testing.T, e *echo.Echo, controller *Controller, method, path string, handler func(echo.Context) error, expectedMessage, expectedAction, expectedSignal string) {
+// testControlChannelBuf is the control channel buffer size for concurrent test
+// scenarios (e.g. TestConcurrentControlRequests sends 5). Size 10 is sufficient.
+const testControlChannelBuf = 10
+
+// newControlTestHandler builds a control Handler around an apicore.Core (via
+// apitest) and a buffered control channel. It returns the Echo instance, the
+// handler, and the bidirectional channel so tests can read the signals the
+// handler sends (the handler holds only the send-only view).
+func newControlTestHandler(t *testing.T) (*echo.Echo, *Handler, chan string) {
+	t.Helper()
+	e := echo.New()
+	ch := make(chan string, testControlChannelBuf)
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	return e, New(core, ch), ch
+}
+
+// newControlHandler builds a control Handler on the supplied Echo instance with a
+// buffered control channel the caller does not need to observe.
+func newControlHandler(t *testing.T, e *echo.Echo) *Handler {
+	t.Helper()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	return New(core, make(chan string, testControlChannelBuf))
+}
+
+// runControlEndpointTest runs a control endpoint test with the given parameters.
+// signals are read from the supplied bidirectional channel.
+func runControlEndpointTest(t *testing.T, e *echo.Echo, controlChan chan string, method, path string, handler func(echo.Context) error, expectedMessage, expectedAction, expectedSignal string) {
 	t.Helper()
 
 	// Create a request
@@ -59,7 +84,7 @@ func runControlEndpointTest(t *testing.T, e *echo.Echo, controller *Controller, 
 
 		// Verify signal was sent to control channel
 		select {
-		case signal := <-controller.controlChan:
+		case signal := <-controlChan:
 			assert.Equal(t, expectedSignal, signal)
 		case <-time.After(100 * time.Millisecond):
 			assert.Fail(t, "Control signal was not sent")
@@ -69,7 +94,7 @@ func runControlEndpointTest(t *testing.T, e *echo.Echo, controller *Controller, 
 
 // runConcurrentControlRequestsTest runs multiple concurrent control requests test
 // Uses Go 1.25's WaitGroup.Go() for automatic goroutine management
-func runConcurrentControlRequestsTest(t *testing.T, e *echo.Echo, controller *Controller, handler func(echo.Context) error, path, expectedSignal string) {
+func runConcurrentControlRequestsTest(t *testing.T, e *echo.Echo, controlChan chan string, handler func(echo.Context) error, path, expectedSignal string) {
 	t.Helper()
 	t.Attr("component", "control")
 	t.Attr("type", "concurrent")
@@ -106,11 +131,11 @@ func runConcurrentControlRequestsTest(t *testing.T, e *echo.Echo, controller *Co
 	wg.Wait()
 
 	// Verify that all signals were sent to the channel
-	assert.Len(t, controller.controlChan, numRequests, "All signals should be received")
+	assert.Len(t, controlChan, numRequests, "All signals should be received")
 
 	// Drain the channel
 	for range numRequests {
-		signal := <-controller.controlChan
+		signal := <-controlChan
 		assert.Equal(t, expectedSignal, signal, "Each signal should be the expected signal")
 	}
 }
@@ -122,16 +147,16 @@ func runControlActionsWithBlockedChannelTest(t *testing.T, handler func(echo.Con
 	t.Attr("type", "blocked-channel")
 
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	// Save original channel and create a non-buffered channel that will block
-	originalChan := controller.controlChan
+	originalChan := h.controlChan
 	controlChan := make(chan string)
-	controller.controlChan = controlChan
+	h.controlChan = controlChan
 
 	// Restore original channel after test
 	defer func() {
-		controller.controlChan = originalChan
+		h.controlChan = originalChan
 	}()
 
 	// Start a goroutine that will eventually unblock the channel, but after the test timeout
@@ -168,7 +193,7 @@ func runControlActionsWithBlockedChannelTest(t *testing.T, handler func(echo.Con
 	select {
 	case <-done:
 		// Handler completed successfully without blocking indefinitely
-		// Note: With buffered channel in setupTestEnvironment, the send won't block
+		// Note: With buffered channel in the test handler, the send won't block
 		// so we expect success (200) instead of timeout (408)
 		assert.Equal(t, http.StatusOK, rec.Code,
 			"Should return success with buffered channel")
@@ -180,7 +205,7 @@ func runControlActionsWithBlockedChannelTest(t *testing.T, handler func(echo.Con
 // TestGetAvailableActions tests the GetAvailableActions endpoint
 func TestGetAvailableActions(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	// Create a request to the control actions endpoint
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/control/actions", http.NoBody)
@@ -189,7 +214,7 @@ func TestGetAvailableActions(t *testing.T) {
 	c.SetPath("/api/v2/control/actions")
 
 	// Test
-	require.NoError(t, controller.GetAvailableActions(c))
+	require.NoError(t, h.GetAvailableActions(c))
 	{
 		// Check status code
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -249,37 +274,37 @@ func TestGetAvailableActions(t *testing.T) {
 // TestRestartAnalysis tests the RestartAnalysis endpoint
 func TestRestartAnalysis(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, ch := newControlTestHandler(t)
 
-	runControlEndpointTest(t, e, controller, http.MethodPost, "/api/v2/control/restart", controller.RestartAnalysis,
+	runControlEndpointTest(t, e, ch, http.MethodPost, "/api/v2/control/restart", h.RestartAnalysis,
 		"Analysis restart signal sent", ActionRestartAnalysis, SignalRestartAnalysis)
 }
 
 // TestReloadModel tests the ReloadModel endpoint
 func TestReloadModel(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, ch := newControlTestHandler(t)
 
-	runControlEndpointTest(t, e, controller, http.MethodPost, "/api/v2/control/reload", controller.ReloadModel,
+	runControlEndpointTest(t, e, ch, http.MethodPost, "/api/v2/control/reload", h.ReloadModel,
 		"Model reload signal sent", ActionReloadModel, SignalReloadModel)
 }
 
 // TestRebuildFilter tests the RebuildFilter endpoint
 func TestRebuildFilter(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, ch := newControlTestHandler(t)
 
-	runControlEndpointTest(t, e, controller, http.MethodPost, "/api/v2/control/rebuild-filter", controller.RebuildFilter,
+	runControlEndpointTest(t, e, ch, http.MethodPost, "/api/v2/control/rebuild-filter", h.RebuildFilter,
 		"Filter rebuild signal sent", ActionRebuildFilter, SignalRebuildFilter)
 }
 
 // TestControlActionsWithNilChannel tests the control endpoints with a nil control channel
 func TestControlActionsWithNilChannel(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	// Explicitly set the control channel to nil
-	controller.controlChan = nil
+	h.controlChan = nil
 
 	// Define test cases
 	testCases := []struct {
@@ -290,17 +315,17 @@ func TestControlActionsWithNilChannel(t *testing.T) {
 		{
 			name:     "RestartAnalysis with nil channel",
 			endpoint: "/api/v2/control/restart",
-			handler:  controller.RestartAnalysis,
+			handler:  h.RestartAnalysis,
 		},
 		{
 			name:     "ReloadModel with nil channel",
 			endpoint: "/api/v2/control/reload",
-			handler:  controller.ReloadModel,
+			handler:  h.ReloadModel,
 		},
 		{
 			name:     "RebuildFilter with nil channel",
 			endpoint: "/api/v2/control/rebuild-filter",
-			handler:  controller.RebuildFilter,
+			handler:  h.RebuildFilter,
 		},
 	}
 
@@ -325,7 +350,7 @@ func TestControlActionsWithNilChannel(t *testing.T) {
 			err = json.Unmarshal(rec.Body.Bytes(), &errorResp)
 			require.NoError(t, err)
 
-			// Check error response content — in non-debug mode, error field uses
+			// Check error response content - in non-debug mode, error field uses
 			// sanitized message instead of raw err.Error()
 			assert.Contains(t, fmt.Sprint(errorResp["error"]), "System control interface not available")
 			assert.Contains(t, errorResp["message"], "System control interface not available")
@@ -334,13 +359,13 @@ func TestControlActionsWithNilChannel(t *testing.T) {
 	}
 }
 
-// TestInitControlRoutesRegistration tests the registration of control-related API endpoints
-func TestInitControlRoutesRegistration(t *testing.T) {
-	// Use setupTestEnvironment to get a properly configured Echo and controller
-	e, _, controller := setupTestEnvironment(t)
+// TestRegisterRoutesRegistration tests the registration of control-related API endpoints
+func TestRegisterRoutesRegistration(t *testing.T) {
+	// Build a handler whose apicore.Core exposes the /api/v2 group
+	e, h, _ := newControlTestHandler(t)
 
-	// Re-initialize the routes to ensure a clean state
-	controller.initControlRoutes()
+	// Register the control routes on the shared group
+	h.RegisterRoutes(h.Group)
 
 	// Verify expected control routes are registered
 	apitest.AssertRoutesRegistered(t, e, []string{
@@ -426,11 +451,11 @@ func TestControlActionsConstants(t *testing.T) {
 // TestControlEndpointsWithUserAuth tests the control endpoints with proper auth
 func TestControlEndpointsWithUserAuth(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	// Set up the control channel
 	controlChan := make(chan string, 3) // Buffer for multiple signals
-	controller.controlChan = controlChan
+	h.controlChan = controlChan
 
 	// Test endpoints directly
 	handlers := []struct {
@@ -438,20 +463,20 @@ func TestControlEndpointsWithUserAuth(t *testing.T) {
 		handler func(echo.Context) error
 		signal  string
 	}{
-		{"Restart Analysis", controller.RestartAnalysis, SignalRestartAnalysis},
-		{"Reload Model", controller.ReloadModel, SignalReloadModel},
-		{"Rebuild Filter", controller.RebuildFilter, SignalRebuildFilter},
+		{"Restart Analysis", h.RestartAnalysis, SignalRestartAnalysis},
+		{"Reload Model", h.ReloadModel, SignalReloadModel},
+		{"Rebuild Filter", h.RebuildFilter, SignalRebuildFilter},
 	}
 
-	for _, h := range handlers {
-		t.Run(h.name, func(t *testing.T) {
+	for _, hc := range handlers {
+		t.Run(hc.name, func(t *testing.T) {
 			// Create request and context
 			req := httptest.NewRequest(http.MethodPost, "/api/v2/control/test", http.NoBody)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
 			// Call handler directly (bypass middleware)
-			err := h.handler(c)
+			err := hc.handler(c)
 			require.NoError(t, err)
 
 			// Verify response
@@ -470,7 +495,7 @@ func TestControlEndpointsWithUserAuth(t *testing.T) {
 			// Verify signal
 			select {
 			case signal := <-controlChan:
-				assert.Equal(t, h.signal, signal)
+				assert.Equal(t, hc.signal, signal)
 			case <-time.After(100 * time.Millisecond):
 				assert.Fail(t, "Control signal was not sent")
 			}
@@ -482,28 +507,28 @@ func TestControlEndpointsWithUserAuth(t *testing.T) {
 // to ensure they don't hang indefinitely
 func TestControlActionsWithBlockedChannel(t *testing.T) {
 	// Setup
-	_, _, controller := setupTestEnvironment(t)
+	_, h, _ := newControlTestHandler(t)
 
-	runControlActionsWithBlockedChannelTest(t, controller.RestartAnalysis)
+	runControlActionsWithBlockedChannelTest(t, h.RestartAnalysis)
 }
 
 // TestConcurrentControlRequests tests that multiple concurrent control requests
 // are handled properly
 func TestConcurrentControlRequests(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, ch := newControlTestHandler(t)
 
-	runConcurrentControlRequestsTest(t, e, controller, controller.RestartAnalysis, "/api/v2/control/restart", SignalRestartAnalysis)
+	runConcurrentControlRequestsTest(t, e, ch, h.RestartAnalysis, "/api/v2/control/restart", SignalRestartAnalysis)
 }
 
 // TestControlEndpointsAuthScenarios tests various authentication scenarios for control endpoints
 func TestControlEndpointsAuthScenarios(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	// Set up the control channel
 	controlChan := make(chan string, 5)
-	controller.controlChan = controlChan
+	h.controlChan = controlChan
 
 	// Configure auth middleware with a validator that checks for a specific token
 	authConfig := middleware.KeyAuthConfig{
@@ -519,7 +544,7 @@ func TestControlEndpointsAuthScenarios(t *testing.T) {
 	authGroup.Use(middleware.KeyAuthWithConfig(authConfig))
 
 	// Register the control handler on the auth group
-	authGroup.POST("/restart", controller.RestartAnalysis)
+	authGroup.POST("/restart", h.RestartAnalysis)
 
 	// Define test cases for different auth scenarios
 	testCases := []struct {
@@ -565,11 +590,11 @@ func TestControlEndpointsAuthScenarios(t *testing.T) {
 // TestInvalidPayloads tests the control endpoints with invalid request payloads
 func TestInvalidPayloads(t *testing.T) {
 	// Setup
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	// Set up the control channel
 	controlChan := make(chan string, 1)
-	controller.controlChan = controlChan
+	h.controlChan = controlChan
 
 	// Create a request with invalid JSON payload
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart",
@@ -579,7 +604,7 @@ func TestInvalidPayloads(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	// Call the handler
-	err := controller.RestartAnalysis(c)
+	err := h.RestartAnalysis(c)
 
 	// The handler should still work with invalid payloads since it doesn't expect any
 	require.NoError(t, err, "Handler should not return an error with invalid payload")
@@ -607,17 +632,17 @@ func (m *mockShutdownRequester) RequestShutdown() {
 // TestRestartServer tests the RestartServer endpoint with a valid shutdown requester.
 func TestRestartServer(t *testing.T) {
 	t.Cleanup(restart.Reset)
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	mock := &mockShutdownRequester{}
-	controller.SetShutdownRequester(mock)
+	h.SetShutdownRequester(mock)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-server", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.SetPath("/api/v2/control/restart-server")
 
-	require.NoError(t, controller.RestartServer(c))
+	require.NoError(t, h.RestartServer(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var result ControlResult
@@ -629,34 +654,34 @@ func TestRestartServer(t *testing.T) {
 // TestRestartServerAlreadyInProgress tests that a second restart request returns 409 Conflict.
 func TestRestartServerAlreadyInProgress(t *testing.T) {
 	t.Cleanup(restart.Reset)
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 	mock := &mockShutdownRequester{}
-	controller.SetShutdownRequester(mock)
+	h.SetShutdownRequester(mock)
 
 	// First call succeeds
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-server", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	require.NoError(t, controller.RestartServer(c))
+	require.NoError(t, h.RestartServer(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Second call returns 409
 	req2 := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-server", http.NoBody)
 	rec2 := httptest.NewRecorder()
 	c2 := e.NewContext(req2, rec2)
-	require.NoError(t, controller.RestartServer(c2))
+	require.NoError(t, h.RestartServer(c2))
 	assert.Equal(t, http.StatusConflict, rec2.Code)
 }
 
 // TestRestartServerNoShutdownRequester tests that RestartServer returns 500 when no shutdown requester is set.
 func TestRestartServerNoShutdownRequester(t *testing.T) {
 	t.Cleanup(restart.Reset)
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-server", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	require.NoError(t, controller.RestartServer(c))
+	require.NoError(t, h.RestartServer(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -670,14 +695,14 @@ func TestRestartContainerNotInContainer(t *testing.T) {
 		t.Skipf("Skipping: detected container environment %q", envType)
 	}
 
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 	mock := &mockShutdownRequester{}
-	controller.SetShutdownRequester(mock)
+	h.SetShutdownRequester(mock)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-container", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	require.NoError(t, controller.RestartContainer(c))
+	require.NoError(t, h.RestartContainer(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
@@ -691,14 +716,14 @@ func TestRestartContainerInContainer(t *testing.T) {
 		t.Skipf("Skipping: detected non-container environment %q", envType)
 	}
 
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 	mock := &mockShutdownRequester{}
-	controller.SetShutdownRequester(mock)
+	h.SetShutdownRequester(mock)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-container", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	require.NoError(t, controller.RestartContainer(c))
+	require.NoError(t, h.RestartContainer(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var result ControlResult
@@ -717,12 +742,12 @@ func TestRestartContainerNoShutdownRequester(t *testing.T) {
 		t.Skipf("Skipping: detected non-container environment %q", envType)
 	}
 
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-container", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	require.NoError(t, controller.RestartContainer(c))
+	require.NoError(t, h.RestartContainer(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -735,21 +760,21 @@ func TestRestartContainerAlreadyInProgress(t *testing.T) {
 		t.Skipf("Skipping: detected non-container environment %q", envType)
 	}
 
-	e, _, controller := setupTestEnvironment(t)
+	e, h, _ := newControlTestHandler(t)
 	mock := &mockShutdownRequester{}
-	controller.SetShutdownRequester(mock)
+	h.SetShutdownRequester(mock)
 
 	// First call succeeds
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-container", http.NoBody)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	require.NoError(t, controller.RestartContainer(c))
+	require.NoError(t, h.RestartContainer(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Second call returns 409
 	req2 := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-container", http.NoBody)
 	rec2 := httptest.NewRecorder()
 	c2 := e.NewContext(req2, rec2)
-	require.NoError(t, controller.RestartContainer(c2))
+	require.NoError(t, h.RestartContainer(c2))
 	assert.Equal(t, http.StatusConflict, rec2.Code)
 }


### PR DESCRIPTION
## Summary

Phase 4 of the internal/api/v2 package split: move the **control** domain (restart analysis, reload model, rebuild range filter, restart server/container, restart a single audio source, and list available actions) out of the monolithic `package api` into a new `internal/api/v2/control` subpackage. Follows the established Phase 4 pattern proven by weather/tls/alerts: a domain `Handler` embeds `*apicore.Core` by pointer, the facade `Controller` holds a handler field, constructs it, and calls `RegisterRoutes` in the deterministic `initRoutes` order.

Goal: zero public-behavior change. The `/api/v2/control/*` endpoints, their auth, request/response JSON, status codes, and the control-signal flow are byte-identical; `apiv2.Controller`/`New`/`NewWithOptions` external signatures are unchanged.

## What moved

- `control.Handler` embeds `*apicore.Core` by pointer (never copied by value); the shared deps/helpers (`HandleError`, the logging helpers, `Debug`, `Context`, `GetShutdownRequester`, the audio `Engine`, `AuthMiddleware`) promote onto it.
- `New(core, controlChan)` builds the handler; `RegisterRoutes(g *echo.Group)` wires the exact 7 routes from the old `initControlRoutes` in the same order with the same per-route middleware (`g.Group("/control", c.AuthMiddleware)`).
- Handler methods moved verbatim, only the receiver retyped `*Controller` -> `*Handler` (receiver name kept `c`). No `GetLogger`/settings substitution was needed (control uses neither).
- Control-owned symbols moved into the package: `ControlAction`/`ControlResult` (exported, used by no other domain), the `Action*`/`Signal*` constants, the `SourceRestarterFunc` type, and all handlers/helpers.

## Dependency wiring

This is where control differs from the Core-only leaf domains:

- **`controlChan` is SHARED.** The settings domain also sends on it and `internal/analysis` creates and closes it, so the facade keeps the bidirectional `controlChan` field and injects the same channel into the control `Handler` as a **send-only view** (`chan<- string`). The handler can never read or close a channel it does not own; the type system enforces this. The shutdown-race guard (the `select` on `c.Context().Done()` that prevents a send-on-closed-channel panic) is preserved verbatim.
- **`sourceRestarter`** (`atomic.Pointer[SourceRestarterFunc]`) is referenced only by the control domain, so the `Handler` owns it. `SetSourceRestarter` and `RestartAudioSource` moved with it.

## External surface preserved

- `(*apiv2.Controller).SetSourceRestarter` stays on the facade as a one-line delegator to `c.control.SetSourceRestarter` (the `RestartHLSStreams`-delegator precedent). Its sole external caller (`internal/analysis/audio_pipeline_service.go`) passes a method value, so retyping the parameter to `control.SourceRestarterFunc` compiles unchanged. The old exported `api.SourceRestarterFunc` named type was referenced nowhere else and is removed.
- `internal/analysis/control_monitor.go` is unaffected: its `commonNameController` interface (`SetNameResolver`, `UpdateCommonNameMap`) and the other facade methods it calls are unrelated to control.
- `apiv2.Controller`/`New`/`NewWithOptions` signatures unchanged.

## Facade wiring (order preserved exactly)

- `Controller` gains an unexported `control *control.Handler` field.
- `NewWithOptions` constructs `c.control = control.New(c.Core, c.controlChan)` alongside the other domain handlers (`c.controlChan` is set in the `Controller` literal above, before this call).
- `initRoutes` replaces the control `routeInitializers` entry in place with `{"control routes", func() { c.control.RegisterRoutes(c.Group) }}` at the same index, so registration order (and the route-enumeration golden gate) stays byte-identical.

control owns no background goroutine or singleton (the restart goroutine is fire-and-forget), so no `Shutdown` hook is added; the facade `Shutdown` is untouched.

Tests moved into the control package, rebuilt against `apitest.NewCore`. The handler holds the send-only channel view, so the test helpers keep a separate bidirectional channel to read back the signals the handler sends. The control package now has its own `-race` test binary.

## Preflight Status

- [x] Single concern: one refactor (control domain extraction)
- [x] Linters clean: `golangci-lint run -v ./internal/api/v2/... ./internal/api/v2/control/` -> 0 issues
- [x] Tests pass: `go test -race ./internal/api/v2/... ./internal/api/v2/control/ ./internal/analysis/...` green
- [x] No regression/backward-compat break: endpoints, auth, JSON shapes, status codes, signal constants verified byte-for-byte; no config/DB/CLI surface touched
- [x] No public-behavior change: route-enumeration golden gate identical; `apiv2.Controller`/`New`/`NewWithOptions` signatures unchanged
- [x] Secondary-model cross-validation: plan reviewed by Gemini 3.1 Pro before coding; four parallel read-only review passes (reuse/quality, correctness/safety, integration/wiring, regression/backcompat) all clean

## Verification

- `go build ./internal/api/v2/... ./internal/analysis/...` clean
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (no copylocks)
- `go test -race ./internal/api/v2/... ./internal/api/v2/control/ ./internal/analysis/...` green; control has its own `-race` binary
- Route-enumeration golden gate identical (same 7 control routes + group stubs, same order)
- `golangci-lint`: 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of control actions, including restart and reload operations.
  * Fixed routing so control endpoints are registered consistently.
  * Updated source-restart handling to work more safely at runtime.

* **Documentation**
  * Corrected a documentation link to point to the current control source location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->