### PR TITLE
refactor(api/v2): extract auth domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -74,11 +74,12 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Authentication (`auth/auth.go`)
 
-| Method | Route          | Handler         | Auth | Description                 |
-| ------ | -------------- | --------------- | ---- | --------------------------- |
-| POST   | `/auth/login`  | `Login`         | ❌   | User authentication         |
-| POST   | `/auth/logout` | `Logout`        | ✅   | End user session            |
-| GET    | `/auth/status` | `GetAuthStatus` | ✅   | Check authentication status |
+| Method | Route            | Handler         | Auth | Description                 |
+| ------ | ---------------- | --------------- | ---- | --------------------------- |
+| POST   | `/auth/login`    | `Login`         | ❌   | User authentication         |
+| GET    | `/auth/callback` | `OAuthCallback` | ❌   | Complete OAuth login flow   |
+| POST   | `/auth/logout`   | `Logout`        | ✅   | End user session            |
+| GET    | `/auth/status`   | `GetAuthStatus` | ✅   | Check authentication status |
 
 ### Analytics (`analytics.go`)
 

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -72,7 +72,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 }
 ```
 
-### Authentication (`auth.go`)
+### Authentication (`auth/auth.go`)
 
 | Method | Route          | Handler         | Auth | Description                 |
 | ------ | -------------- | --------------- | ---- | --------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/alerts"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/control"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
@@ -136,8 +137,16 @@ type Controller struct {
 	startTime            *time.Time
 	spectrogramGenerator *spectrogram.Generator // Shared spectrogram generator (initialized after SFS)
 
-	// authService is the authentication service injected from server.
+	// authService is the authentication service injected from server (via the
+	// WithAuthService functional option). The facade keeps it as the injection
+	// source and hands the same value to the auth domain handler.
 	authService auth.Service
+
+	// authHandler serves the /api/v2/auth/* endpoints (login, OAuth callback,
+	// logout, auth status). Beyond the shared *apicore.Core it receives the
+	// facade-injected authService. It is constructed AFTER the functional options
+	// are applied so authService reflects WithAuthService (see NewWithOptions).
+	authHandler *authapi.Handler
 
 	// notificationService is the notification service this controller uses. It is
 	// nil in production, where getNotificationService() falls back to the
@@ -403,6 +412,17 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		opt(c)
 	}
 
+	// Construct the auth domain handler AFTER the functional options are applied:
+	// WithAuthService sets c.authService in the loop above (unlike the other
+	// domain deps, which are set in the Controller literal before construction).
+	// The handler captures the injected authService (nil if WithAuthService was
+	// not passed; the handlers nil-guard it). authService is read fresh per
+	// request in the monolith but never changes after this point, so capturing
+	// the post-option value is behaviorally identical. The shared AuthMiddleware
+	// it uses for the protected logout/status group promotes from c.Core and is
+	// read at RegisterRoutes time (after this), so it is also populated.
+	c.authHandler = authapi.New(c.Core, c.authService)
+
 	// Log auth configuration status
 	log := GetLogger()
 	if c.AuthMiddleware != nil {
@@ -482,7 +502,7 @@ func (c *Controller) initRoutes() {
 		{"hls streaming routes", c.initHLSRoutes},
 		{"integration routes", c.initIntegrationsRoutes},
 		{"control routes", func() { c.control.RegisterRoutes(c.Group) }},
-		{"auth routes", c.initAuthRoutes},
+		{"auth routes", func() { c.authHandler.RegisterRoutes(c.Group) }},
 		{"media routes", c.initMediaRoutes},
 		{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }},
 		{"heatmap routes", c.initHeatmapRoutes},

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
@@ -279,21 +280,22 @@ func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc
 // at one of these paths under a different verb is fail-closed by default.
 func isPrivateModeExempt(method, path string) bool {
 	// Compose the exempt paths from the same constants used at the route
-	// registration sites (see initHLSRoutes, initAuthRoutes and the app config
-	// route in initAppRoutes) so the allow-list cannot silently drift from the
-	// actual routes. TestPrivateModeExemptPathsAreRegisteredRoutes asserts this
-	// correspondence.
+	// registration sites (see initHLSRoutes, the auth domain's RegisterRoutes and
+	// the app config route in initAppRoutes) so the allow-list cannot silently
+	// drift from the actual routes. The auth route fragments are sourced from the
+	// authapi package, which both registers the routes and owns the constants.
+	// TestPrivateModeExemptPathsAreRegisteredRoutes asserts this correspondence.
 	const (
-		authBase     = apiV2Prefix + authGroupPath
+		authBase     = apiV2Prefix + authapi.AuthGroupPath
 		hlsBase      = apiV2Prefix + hlsGroupPath
 		hlsTokenBase = hlsBase + hlsTokenGroupPath
 	)
 	switch {
 	case method == http.MethodGet && path == apiV2Prefix+AppConfigEndpoint:
 		return true
-	case method == http.MethodPost && path == authBase+authLoginPath:
+	case method == http.MethodPost && path == authBase+authapi.AuthLoginPath:
 		return true
-	case method == http.MethodGet && path == authBase+authCallbackPath:
+	case method == http.MethodGet && path == authBase+authapi.AuthCallbackPath:
 		return true
 	case method == http.MethodPost && path == hlsBase+hlsStartPath:
 		return true

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -651,8 +652,8 @@ func TestIsPrivateModeExempt(t *testing.T) {
 		path   string
 	}{
 		{http.MethodGet, apiV2Prefix + AppConfigEndpoint},
-		{http.MethodPost, apiV2Prefix + authGroupPath + authLoginPath},
-		{http.MethodGet, apiV2Prefix + authGroupPath + authCallbackPath},
+		{http.MethodPost, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLoginPath},
+		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthCallbackPath},
 		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsStartPath},
 		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsHeartbeatPath},
 		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsStatusPath},
@@ -675,16 +676,16 @@ func TestIsPrivateModeExempt(t *testing.T) {
 		{http.MethodGet, "/api/v2/detections"},
 		{http.MethodGet, "/api/v2/notifications"},
 		{http.MethodGet, "/api/v2/settings/dashboard"},
-		{http.MethodPost, apiV2Prefix + authGroupPath + authLogoutPath},
-		{http.MethodGet, apiV2Prefix + authGroupPath + authStatusPath},
+		{http.MethodPost, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLogoutPath},
+		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthStatusPath},
 		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsStopPath}, // mutation, always auth-gated
 		{http.MethodPost, apiV2Prefix + WizardDismissEndpoint},      // gated under PrivateMode by design
 		{http.MethodGet, "/api/v2/streams/audio-level"},
 		{http.MethodGet, "/api/v2/streams/sources"},
 		{http.MethodGet, "/health"},
 		// Method mismatches must NOT match the allow-list.
-		{http.MethodGet, apiV2Prefix + authGroupPath + authLoginPath}, // login is POST-only
-		{http.MethodPost, apiV2Prefix + AppConfigEndpoint},            // config is GET-only
+		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLoginPath}, // login is POST-only
+		{http.MethodPost, apiV2Prefix + AppConfigEndpoint},                            // config is GET-only
 		{http.MethodDelete, apiV2Prefix + AppConfigEndpoint},
 	}
 	for _, tt := range notExempt {
@@ -716,12 +717,12 @@ func TestPrivateModeExemptPathsAreRegisteredRoutes(t *testing.T) {
 	g.GET(AppConfigEndpoint, noop)
 	g.POST(WizardDismissEndpoint, noop) // registered but NOT exempt under PrivateMode
 
-	// Auth flow (mirrors initAuthRoutes).
-	authGroup := g.Group(authGroupPath)
-	authGroup.POST(authLoginPath, noop)
-	authGroup.GET(authCallbackPath, noop)
-	authGroup.POST(authLogoutPath, noop)
-	authGroup.GET(authStatusPath, noop)
+	// Auth flow (mirrors the auth domain's RegisterRoutes).
+	authGroup := g.Group(authapi.AuthGroupPath)
+	authGroup.POST(authapi.AuthLoginPath, noop)
+	authGroup.GET(authapi.AuthCallbackPath, noop)
+	authGroup.POST(authapi.AuthLogoutPath, noop)
+	authGroup.GET(authapi.AuthStatusPath, noop)
 
 	// HLS streaming (mirrors initHLSRoutes).
 	hlsGroup := g.Group(hlsGroupPath)
@@ -739,8 +740,8 @@ func TestPrivateModeExemptPathsAreRegisteredRoutes(t *testing.T) {
 	// production code and isPrivateModeExempt use.
 	wantExempt := map[string]bool{
 		key(http.MethodGet, apiV2Prefix+AppConfigEndpoint):                              true,
-		key(http.MethodPost, apiV2Prefix+authGroupPath+authLoginPath):                   true,
-		key(http.MethodGet, apiV2Prefix+authGroupPath+authCallbackPath):                 true,
+		key(http.MethodPost, apiV2Prefix+authapi.AuthGroupPath+authapi.AuthLoginPath):   true,
+		key(http.MethodGet, apiV2Prefix+authapi.AuthGroupPath+authapi.AuthCallbackPath): true,
 		key(http.MethodPost, apiV2Prefix+hlsGroupPath+hlsStartPath):                     true,
 		key(http.MethodPost, apiV2Prefix+hlsGroupPath+hlsHeartbeatPath):                 true,
 		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsStatusPath):                     true,

--- a/internal/api/v2/auth/auth.go
+++ b/internal/api/v2/auth/auth.go
@@ -1,5 +1,22 @@
-// internal/api/v2/auth.go
-package api
+// Package authapi is the api/v2 auth domain handler. It owns the
+// /api/v2/auth/* endpoints (login, OAuth callback, logout, and auth status).
+// The Handler embeds *apicore.Core by pointer so the shared dependencies and
+// helpers (HandleError, HandleErrorWithKey, the logging/security-logging
+// helpers, and the AuthMiddleware field) promote onto it.
+//
+// One domain member differs from the Core-only leaf domains:
+//   - authService is the authentication/OAuth service. It is injected from the
+//     facade because it is supplied via the WithAuthService functional option
+//     (applied after the other handlers are constructed). The facade keeps the
+//     authService field as the injection source and hands the same value to the
+//     auth Handler. The handler nil-guards authService exactly as the monolith
+//     did, so an unconfigured auth service degrades identically.
+//
+// The auth MIDDLEWARE (GetAuthMiddleware, PrivateModeAuth, the trusted-proxy IP
+// extractor, the AuthMiddleware field) lives in apicore and is NOT part of this
+// package; this package only registers the auth domain endpoints and reuses the
+// AuthMiddleware via promotion from the embedded Core.
+package authapi
 
 import (
 	"context"
@@ -16,10 +33,18 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/security"
 )
+
+// apiV2Prefix is the base path prefix for all v2 API routes (the Echo group the
+// facade mounts the domain handlers under). It is used to compose the
+// client-facing OAuth callback URL so the redirect matches the actual mounted
+// route. It mirrors the facade's own apiV2Prefix; this package cannot import
+// package api to share the literal.
+const apiV2Prefix = "/api/v2"
 
 // Auth constants (file-local)
 const (
@@ -62,20 +87,46 @@ type AuthStatus struct {
 }
 
 // Auth route path fragments, registered relative to the v2 API group in
-// initAuthRoutes. They are reused by isPrivateModeExempt so the PrivateMode
-// exempt allow-list cannot drift from the registered routes.
+// RegisterRoutes. They are exported so the facade's PrivateMode exempt
+// allow-list (isPrivateModeExempt in audio_hls.go) composes the exempt auth
+// paths from the same constants the routes register with, so the allow-list
+// cannot drift from the registered routes.
 const (
-	authGroupPath    = "/auth"
-	authLoginPath    = "/login"
-	authCallbackPath = "/callback"
-	authLogoutPath   = "/logout"
-	authStatusPath   = "/status"
+	AuthGroupPath    = "/auth"
+	AuthLoginPath    = "/login"
+	AuthCallbackPath = "/callback"
+	AuthLogoutPath   = "/logout"
+	AuthStatusPath   = "/status"
 )
 
-// initAuthRoutes registers all authentication-related API endpoints
-func (c *Controller) initAuthRoutes() {
+// Handler serves the api/v2 auth domain endpoints. It embeds the shared
+// *apicore.Core (by pointer) and additionally holds the authService injected
+// from the facade.
+type Handler struct {
+	*apicore.Core
+
+	// authService is the authentication service injected from the facade (set
+	// there via the WithAuthService functional option). The handlers nil-guard
+	// it; an unconfigured service degrades exactly as in the monolith.
+	authService auth.Service
+}
+
+// New constructs the auth domain handler around the shared core and the
+// facade-injected auth service. The facade constructs this AFTER applying its
+// functional options so authService reflects WithAuthService.
+func New(core *apicore.Core, authService auth.Service) *Handler {
+	return &Handler{
+		Core:        core,
+		authService: authService,
+	}
+}
+
+// RegisterRoutes registers all authentication-related API endpoints on the
+// supplied v2 API group, preserving the exact routes, order, and per-route
+// middleware from the original initAuthRoutes.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	// Create auth API group
-	authGroup := c.Group.Group(authGroupPath)
+	authGroup := g.Group(AuthGroupPath)
 
 	// Create rate limiter for login endpoint to prevent brute force attacks
 	// Allow 5 login attempts per 15 minutes per IP address
@@ -113,20 +164,20 @@ func (c *Controller) initAuthRoutes() {
 	})
 
 	// Routes that don't require authentication (but are rate limited)
-	authGroup.POST(authLoginPath, c.Login, loginRateLimiter)
+	authGroup.POST(AuthLoginPath, c.Login, loginRateLimiter)
 
 	// OAuth callback endpoint - public, completes the OAuth flow
 	// This is the V2 replacement for /api/v1/oauth2/callback
-	authGroup.GET(authCallbackPath, c.OAuthCallback)
+	authGroup.GET(AuthCallbackPath, c.OAuthCallback)
 
 	// Routes that require authentication
 	protectedGroup := authGroup.Group("", c.AuthMiddleware)
-	protectedGroup.POST(authLogoutPath, c.Logout)
-	protectedGroup.GET(authStatusPath, c.GetAuthStatus)
+	protectedGroup.POST(AuthLogoutPath, c.Logout)
+	protectedGroup.GET(AuthStatusPath, c.GetAuthStatus)
 }
 
 // Login handles POST /api/v2/auth/login
-func (c *Controller) Login(ctx echo.Context) error {
+func (c *Handler) Login(ctx echo.Context) error {
 	// Parse login request
 	var req AuthRequest
 	if err := ctx.Bind(&req); err != nil {
@@ -262,9 +313,9 @@ func (c *Controller) Login(ctx echo.Context) error {
 		finalRedirect = ensurePathWithinBase(finalRedirect, requestBase+"/")
 	}
 	// Compose the callback path from the same constants used to register the
-	// route (see initAuthRoutes) so the client-facing redirect URL cannot drift
+	// route (see RegisterRoutes) so the client-facing redirect URL cannot drift
 	// from the actual route on a prefix or fragment rename.
-	callbackPath := apiV2Prefix + authGroupPath + authCallbackPath
+	callbackPath := apiV2Prefix + AuthGroupPath + AuthCallbackPath
 	redirectURL := fmt.Sprintf("%s%s?code=%s&redirect=%s", requestBase, callbackPath, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
 
 	c.LogSecurityInfoIfEnabled("Returning successful login response with redirect",
@@ -284,7 +335,7 @@ func (c *Controller) Login(ctx echo.Context) error {
 }
 
 // Logout handles POST /api/v2/auth/logout
-func (c *Controller) Logout(ctx echo.Context) error {
+func (c *Handler) Logout(ctx echo.Context) error {
 	// Use the stored auth service instance
 	authService := c.authService
 	if authService == nil {
@@ -329,7 +380,7 @@ func (c *Controller) Logout(ctx echo.Context) error {
 }
 
 // GetAuthStatus handles GET /api/v2/auth/status
-func (c *Controller) GetAuthStatus(ctx echo.Context) error {
+func (c *Handler) GetAuthStatus(ctx echo.Context) error {
 	// Read authentication status details set by the AuthMiddleware in the context.
 	// Use the auth.CtxKey* constants to ensure consistency with the middleware.
 	isAuthenticated := boolFromCtx(ctx, auth.CtxKeyIsAuthenticated, false)
@@ -404,9 +455,9 @@ func stringFromCtx(ctx echo.Context, key, defaultValue string) string {
 // 1. Explicit basePath from request
 // 2. Referer header analysis
 // 3. Default fallback
-func (c *Controller) extractBasePath(ctx echo.Context, req AuthRequest) string {
+func (c *Handler) extractBasePath(ctx echo.Context, req AuthRequest) string {
 	// 1. If explicitly provided and valid, use it
-	if req.BasePath != "" && isValidBasePath(req.BasePath) {
+	if req.BasePath != "" && IsValidBasePath(req.BasePath) {
 		c.LogDebugIfEnabled("Using explicit base path from request",
 			logger.String("basePath", req.BasePath),
 			logger.String("ip", ctx.RealIP()),
@@ -437,8 +488,10 @@ func (c *Controller) extractBasePath(ctx echo.Context, req AuthRequest) string {
 	return defaultBasePath
 }
 
-// isValidBasePath validates that a base path is safe to use
-func isValidBasePath(basePath string) bool {
+// IsValidBasePath validates that a base path is safe to use. It is exported so
+// the api/v2 security fuzz/invariant tests in package api can exercise it across
+// the package boundary after the auth domain split.
+func IsValidBasePath(basePath string) bool {
 	// Must start with /
 	if !strings.HasPrefix(basePath, "/") {
 		return false
@@ -504,7 +557,7 @@ func extractBasePathFromReferer(referer string) string {
 	for _, basePath := range commonBasePaths {
 		if strings.HasPrefix(path, basePath) {
 			// Validate before returning
-			if isValidBasePath(basePath) {
+			if IsValidBasePath(basePath) {
 				return basePath
 			}
 		}
@@ -534,7 +587,7 @@ func ensurePathWithinBase(redirectPath, basePath string) string {
 // OAuthCallback handles GET /api/v2/auth/callback
 // Completes the OAuth flow by exchanging auth code for access token and establishing session.
 // This endpoint is the V2 equivalent of /api/v1/oauth2/callback.
-func (c *Controller) OAuthCallback(ctx echo.Context) error {
+func (c *Handler) OAuthCallback(ctx echo.Context) error {
 	code := ctx.QueryParam("code")
 	redirect := ctx.QueryParam("redirect")
 
@@ -596,7 +649,7 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	}
 
 	// 5. Validate redirect path (prevent open redirects)
-	safeRedirect := validateAndSanitizeRedirect(redirect)
+	safeRedirect := ValidateAndSanitizeRedirect(redirect)
 
 	c.LogSecurityInfoIfEnabled("Redirecting user to final destination",
 		logger.String("destination", safeRedirect),
@@ -607,8 +660,10 @@ func (c *Controller) OAuthCallback(ctx echo.Context) error {
 	return ctx.Redirect(http.StatusFound, safeRedirect)
 }
 
-// containsCRLFCharacters checks if a string contains CR/LF injection characters.
-func containsCRLFCharacters(s string) bool {
+// ContainsCRLFCharacters checks if a string contains CR/LF injection characters.
+// It is exported so the api/v2 security fuzz/invariant tests in package api can
+// exercise it across the package boundary after the auth domain split.
+func ContainsCRLFCharacters(s string) bool {
 	lower := strings.ToLower(s)
 	return strings.ContainsAny(s, "\r\n") ||
 		strings.Contains(lower, "%0d") ||
@@ -633,9 +688,11 @@ func isValidRelativePath(parsedURL *url.URL) bool {
 	return true
 }
 
-// validateAndSanitizeRedirect validates and sanitizes a redirect path to prevent open redirects.
-// Returns "/" if the path is invalid, otherwise returns the sanitized path.
-func validateAndSanitizeRedirect(redirect string) string {
+// ValidateAndSanitizeRedirect validates and sanitizes a redirect path to prevent open redirects.
+// Returns "/" if the path is invalid, otherwise returns the sanitized path. It is
+// exported so the api/v2 security fuzz/invariant tests in package api can
+// exercise it across the package boundary after the auth domain split.
+func ValidateAndSanitizeRedirect(redirect string) string {
 	if redirect == "" {
 		return "/"
 	}

--- a/internal/api/v2/auth/auth_compatibility_test.go
+++ b/internal/api/v2/auth/auth_compatibility_test.go
@@ -2,7 +2,7 @@
 // This file exposes issues where the old UI (/login) works but the new UI (/api/v2/auth/login) fails.
 // See GitHub Issue #1234: "Cannot login when using /ui endpoint"
 
-package api
+package authapi
 
 import (
 	"crypto/sha256"

--- a/internal/api/v2/auth/auth_fuzz_test.go
+++ b/internal/api/v2/auth/auth_fuzz_test.go
@@ -1,0 +1,446 @@
+// Package authapi fuzz/security tests for the auth domain input validators.
+// These moved here verbatim from package api's fuzz_test.go when the auth domain
+// was split into its own package; they validate the auth input handling against
+// malformed and malicious inputs to keep the API hardened.
+package authapi
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// Fuzz Tests for Auth Input Validation
+// =============================================================================
+
+// FuzzIsValidBasePath tests base path validation with random inputs.
+// Goals:
+// - No panics on any input
+// - Consistent behavior (same input = same output)
+// - Rejects dangerous patterns (traversal, XSS, CRLF)
+func FuzzIsValidBasePath(f *testing.F) {
+	seedInputs := []string{
+		// Valid base paths
+		"/",
+		"/ui/",
+		"/app/",
+		"/admin/",
+		"/dashboard/",
+		"/some-path/",
+		"/path_with_underscore/",
+		"/Path123/",
+		// Invalid - missing leading slash
+		"ui/",
+		"",
+		"app",
+		// Invalid - missing trailing slash
+		"/ui",
+		"/app",
+		// Path traversal attempts
+		"/../",
+		"/ui/../",
+		"/..%2f/",
+		"/ui/../../",
+		"/../../../etc/passwd/",
+		// Protocol-relative URLs
+		"//evil.com/",
+		"///evil.com/",
+		// XSS attempts
+		"/ui/<script>/",
+		"/ui/javascript:/",
+		"/ui/data:/",
+		"/<img%20onerror=alert(1)>/",
+		// CRLF injection
+		"/ui/\r\n/",
+		"/ui/\n/",
+		"/ui/\r/",
+		"/ui/%0d%0a/",
+		// Null bytes
+		"/ui/\x00/",
+		"/ui/%00/",
+		// Backslashes
+		"/ui\\/",
+		"\\ui/",
+		// Very long paths
+		"/" + strings.Repeat("a", 200) + "/",
+		// Unicode
+		"/настройки/",
+		"/日本語/",
+		// Special characters
+		"/path with spaces/",
+		"/path%20encoded/",
+		"/path+plus/",
+	}
+
+	for _, input := range seedInputs {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Should never panic
+		result := IsValidBasePath(input)
+
+		// Invariants that must hold for valid paths
+		if result {
+			// Must start with /
+			assert.True(t, strings.HasPrefix(input, "/"), "Valid base path must start with /")
+
+			// Must end with /
+			assert.True(t, strings.HasSuffix(input, "/"), "Valid base path must end with /")
+
+			// Must not exceed max length
+			assert.LessOrEqual(t, len(input), maxBasePathLength, "Valid base path must not exceed max length")
+
+			// Must not contain dangerous patterns
+			lower := strings.ToLower(input)
+			assert.NotContains(t, input, "..", "Valid base path must not contain ..")
+			assert.NotContains(t, input, "//", "Valid base path must not contain //")
+			assert.NotContains(t, input, "\\", "Valid base path must not contain \\")
+			assert.NotContains(t, input, "<", "Valid base path must not contain <")
+			assert.NotContains(t, input, ">", "Valid base path must not contain >")
+			assert.NotContains(t, lower, "javascript:", "Valid base path must not contain javascript:")
+			assert.NotContains(t, lower, "data:", "Valid base path must not contain data:")
+			assert.NotContains(t, input, "\n", "Valid base path must not contain newline")
+			assert.NotContains(t, input, "\r", "Valid base path must not contain carriage return")
+			assert.NotContains(t, input, "\x00", "Valid base path must not contain null byte")
+		}
+
+		// Consistency check
+		result2 := IsValidBasePath(input)
+		assert.Equal(t, result, result2, "Inconsistent results for: %q", input)
+	})
+}
+
+// FuzzValidateAndSanitizeRedirect tests redirect path sanitization.
+// Goals:
+// - No panics
+// - Always returns safe relative path
+// - Rejects open redirect attempts
+func FuzzValidateAndSanitizeRedirect(f *testing.F) {
+	seedInputs := []string{
+		// Valid redirects
+		"/",
+		"/dashboard",
+		"/admin/settings",
+		"/path?query=value",
+		"/path?a=1&b=2",
+		// Empty
+		"",
+		// Protocol-relative URLs (should be rejected)
+		"//evil.com",
+		"//evil.com/path",
+		"///evil.com",
+		// Absolute URLs (should be rejected)
+		"http://evil.com",
+		"https://evil.com/path",
+		"javascript:alert(1)",
+		"data:text/html,<script>alert(1)</script>",
+		// Backslash attacks
+		"/\\evil.com",
+		"\\\\evil.com",
+		"/path\\..\\..\\etc",
+		// CRLF injection
+		"/path\r\n",
+		"/path%0d%0a",
+		"/path\r\nSet-Cookie:evil=true",
+		"/path%0d%0aLocation:http://evil.com",
+		// Path traversal
+		"/../etc/passwd",
+		"/path/../../../etc/passwd",
+		// Encoded attacks
+		"/%2f%2fevil.com",
+		"/%5c%5cevil.com",
+		// Unicode attacks
+		"/\u202epath",
+		"/path\uFEFF",
+		// Very long paths
+		"/" + strings.Repeat("a", 10000),
+		// Null bytes
+		"/path\x00",
+		"/path%00",
+	}
+
+	for _, input := range seedInputs {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Should never panic
+		result := ValidateAndSanitizeRedirect(input)
+
+		// Result must always be a safe relative path
+		assert.True(t, strings.HasPrefix(result, "/"), "Result must start with /")
+
+		// Result must not be protocol-relative
+		if len(result) > 1 {
+			assert.NotEqual(t, '/', result[1], "Result must not be protocol-relative (//...)")
+			assert.NotEqual(t, '\\', result[1], "Result must not start with /\\")
+		}
+
+		// Result must not contain raw CRLF
+		assert.False(t, strings.ContainsAny(result, "\r\n"), "Result must not contain CRLF")
+
+		// Result must be a valid relative URL
+		parsed, err := url.Parse(result)
+		if err == nil {
+			assert.Empty(t, parsed.Scheme, "Result must not have a scheme")
+			assert.Empty(t, parsed.Host, "Result must not have a host")
+		}
+
+		// Consistency check
+		result2 := ValidateAndSanitizeRedirect(input)
+		assert.Equal(t, result, result2, "Inconsistent results for: %q", input)
+	})
+}
+
+// FuzzContainsCRLFCharacters tests CRLF detection in auth module.
+func FuzzContainsCRLFCharacters(f *testing.F) {
+	seedInputs := []string{
+		// No CRLF
+		"",
+		"hello world",
+		"/path/to/resource",
+		"normal%20encoding",
+		// Raw CRLF
+		"hello\rworld",
+		"hello\nworld",
+		"hello\r\nworld",
+		// Encoded CRLF
+		"hello%0dworld",
+		"hello%0aworld",
+		"hello%0d%0aworld",
+		"%0D%0A",
+		// Mixed case encoding
+		"%0D%0a",
+		"%0d%0A",
+		// Partial patterns
+		"test%0test",
+		"test%2test",
+		"0d0a",
+	}
+
+	for _, input := range seedInputs {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Should never panic
+		result := ContainsCRLFCharacters(input)
+
+		// If input contains raw CRLF, result must be true
+		if strings.ContainsAny(input, "\r\n") {
+			assert.True(t, result, "Must detect raw CRLF in: %q", input)
+		}
+
+		// If input contains encoded CRLF (case insensitive), result must be true
+		lower := strings.ToLower(input)
+		if strings.Contains(lower, "%0d") || strings.Contains(lower, "%0a") {
+			assert.True(t, result, "Must detect encoded CRLF in: %q", input)
+		}
+
+		// Consistency check
+		result2 := ContainsCRLFCharacters(input)
+		assert.Equal(t, result, result2, "Inconsistent results")
+	})
+}
+
+// FuzzIsValidRelativePath tests relative path validation.
+func FuzzIsValidRelativePath(f *testing.F) {
+	seedInputs := []string{
+		// Valid relative paths
+		"/",
+		"/dashboard",
+		"/admin/settings",
+		"/path/to/resource",
+		// Invalid - has scheme
+		"http://example.com",
+		"https://example.com/path",
+		"javascript:alert(1)",
+		"data:text/html",
+		// Invalid - has host
+		"//evil.com",
+		"//evil.com/path",
+		// Invalid - protocol-relative patterns
+		"/\\evil.com",
+		// Invalid - doesn't start with /
+		"path",
+		"",
+		"dashboard",
+	}
+
+	for _, input := range seedInputs {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		parsed, err := url.Parse(input)
+		if err != nil {
+			// Invalid URL, can't test
+			return
+		}
+
+		// Should never panic
+		result := isValidRelativePath(parsed)
+
+		// If result is true, verify invariants
+		if result {
+			assert.Empty(t, parsed.Scheme, "Valid relative path must not have scheme")
+			assert.Empty(t, parsed.Host, "Valid relative path must not have host")
+			assert.True(t, strings.HasPrefix(parsed.Path, "/"), "Valid relative path must start with /")
+			if len(parsed.Path) > 1 {
+				assert.NotEqual(t, '/', parsed.Path[1], "Valid relative path must not start with //")
+				assert.NotEqual(t, '\\', parsed.Path[1], "Valid relative path must not start with /\\")
+			}
+		}
+
+		// Consistency check
+		result2 := isValidRelativePath(parsed)
+		assert.Equal(t, result, result2, "Inconsistent results")
+	})
+}
+
+// FuzzExtractBasePathFromReferer tests referer parsing for base path extraction.
+func FuzzExtractBasePathFromReferer(f *testing.F) {
+	seedInputs := []string{
+		// Valid referers
+		"http://localhost/ui/login",
+		"https://example.com/app/dashboard",
+		"http://localhost:8080/admin/settings",
+		// Invalid URLs
+		"not-a-url",
+		"",
+		"   ",
+		// Malicious referers
+		"http://evil.com/ui/attack",
+		"javascript:alert(1)",
+		"data:text/html,<script>alert(1)</script>",
+		// Path traversal
+		"http://localhost/../../../etc/passwd",
+		"http://localhost/ui/../../../etc/passwd",
+		// CRLF injection
+		"http://localhost/ui/%0d%0aSet-Cookie:evil=true",
+		// Unicode
+		"http://localhost/\u202e/",
+		// Very long
+		"http://localhost/" + strings.Repeat("a", 10000),
+	}
+
+	for _, input := range seedInputs {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Should never panic
+		result := extractBasePathFromReferer(input)
+
+		// Result is either empty or a valid base path
+		if result != "" {
+			// Must be a valid base path if non-empty
+			assert.True(t, IsValidBasePath(result), "Extracted base path must be valid: %q", result)
+		}
+
+		// Consistency check
+		result2 := extractBasePathFromReferer(input)
+		assert.Equal(t, result, result2, "Inconsistent results")
+	})
+}
+
+// FuzzEnsurePathWithinBase tests path containment validation.
+func FuzzEnsurePathWithinBase(f *testing.F) {
+	type testCase struct {
+		redirect string
+		basePath string
+	}
+
+	seeds := []testCase{
+		{"/dashboard", "/ui/"},
+		{"/ui/settings", "/ui/"},
+		{"/", "/app/"},
+		{"//evil.com", "/ui/"},
+		{"/\\evil.com", "/ui/"},
+		{"/../etc/passwd", "/ui/"},
+		{"", "/ui/"},
+	}
+
+	for _, s := range seeds {
+		f.Add(s.redirect, s.basePath)
+	}
+
+	f.Fuzz(func(t *testing.T, redirect, basePath string) {
+		// Should never panic
+		result := ensurePathWithinBase(redirect, basePath)
+
+		// Result should start with something
+		assert.NotEmpty(t, result, "Result should not be empty")
+
+		// If redirect was protocol-relative, result should be safe
+		if strings.HasPrefix(redirect, "//") || strings.HasPrefix(redirect, "/\\") {
+			// Should return base path for protocol-relative redirects
+			assert.True(t, strings.HasPrefix(result, basePath) || result == basePath,
+				"Protocol-relative redirect should use base path")
+		}
+
+		// Consistency check
+		result2 := ensurePathWithinBase(redirect, basePath)
+		assert.Equal(t, result, result2, "Inconsistent results")
+	})
+}
+
+// TestAdvancedRedirectAttacks tests sophisticated open redirect attempts.
+func TestAdvancedRedirectAttacks(t *testing.T) {
+	t.Parallel()
+
+	attacks := []struct {
+		name           string
+		redirect       string
+		expectedPrefix string
+		shouldBeRoot   bool
+	}{
+		// Protocol-relative variations
+		{"Double slash", "//evil.com", "/", true},
+		{"Triple slash", "///evil.com", "/", true},
+		{"Backslash protocol-relative", "/\\evil.com", "/", true},
+		{"Mixed slashes", "/\\/evil.com", "/", true},
+
+		// Scheme attacks
+		{"JavaScript scheme", "javascript:alert(1)", "/", true},
+		{"Data scheme", "data:text/html,<script>alert(1)</script>", "/", true},
+		{"VBScript scheme", "vbscript:msgbox(1)", "/", true},
+		{"File scheme", "file:///etc/passwd", "/", true},
+
+		// Domain confusion
+		{"Domain with @", "//@evil.com", "/", true},
+
+		// Whitespace attacks
+		{"Tab before scheme", "\thttp://evil.com", "/", true},
+		{"Newline before scheme", "\nhttp://evil.com", "/", true},
+
+		// Valid redirects
+		{"Simple path", "/dashboard", "/dashboard", false},
+		{"Path with query", "/path?param=value", "/path?param=value", false},
+		{"Root path", "/", "/", true},
+	}
+
+	for _, tc := range attacks {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := ValidateAndSanitizeRedirect(tc.redirect)
+
+			if tc.shouldBeRoot {
+				assert.Equal(t, "/", result, "Should be root for: %q", tc.redirect)
+			} else {
+				assert.True(t, strings.HasPrefix(result, tc.expectedPrefix),
+					"Result %q should start with %q for input %q", result, tc.expectedPrefix, tc.redirect)
+			}
+
+			// All results must be safe relative paths
+			assert.True(t, strings.HasPrefix(result, "/"), "Must start with /")
+			if len(result) > 1 {
+				assert.NotEqual(t, '/', result[1], "Must not be protocol-relative")
+			}
+		})
+	}
+}

--- a/internal/api/v2/auth/auth_integration_test.go
+++ b/internal/api/v2/auth/auth_integration_test.go
@@ -1,6 +1,9 @@
 // auth_integration_test.go: Integration tests for V2 authentication flow.
-// Tests the complete login flow using /api/v2/auth endpoints.
-package api
+// Tests the complete login flow using the /api/v2/auth handlers. After the
+// auth domain split these build the auth Handler directly from an apitest core
+// plus a real auth service (SecurityAdapter), rather than the full facade
+// Controller, and invoke the handlers directly.
+package authapi
 
 import (
 	"encoding/json"
@@ -15,29 +18,23 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/markbates/goth/gothic"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
-	"github.com/tphakala/birdnet-go/internal/imageprovider"
-	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/security"
 	"github.com/tphakala/birdnet-go/internal/security/securitytest"
-	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
-// setupAuthIntegrationTest creates a test environment with real OAuth2Server for integration tests.
-func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Controller, *conf.Settings) {
+// setupAuthIntegrationTest creates a test environment with a real OAuth2Server
+// for integration tests. It builds the auth Handler around an apitest core and
+// a SecurityAdapter auth service, mirroring the facade wiring
+// (authapi.New(core, authService)) without constructing the full Controller.
+func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Handler, *conf.Settings) {
 	t.Helper()
 
 	// Create Echo instance
 	e := echo.New()
-
-	// Create mock datastore
-	mockDS := mocks.NewMockInterface(t)
-	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	// Create settings with BasicAuth enabled
 	settings := &conf.Settings{
@@ -63,45 +60,19 @@ func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Controller, *conf.Sett
 		},
 	}
 
-	// Create mock ImageProvider
-	mockImageProvider := &apitest.MockImageProvider{}
-	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
-
-	// Create bird image cache with mock provider
-	birdImageCache := &imageprovider.BirdImageCache{}
-	birdImageCache.SetImageProvider(mockImageProvider)
-
-	// Create sun calculator
-	sunCalc := suncalc.NewSunCalc(60.1699, 24.9384)
-
-	// Create control channel
-	controlChan := make(chan string, 10)
-
-	// Create mock metrics
-	mockMetrics, _ := observability.NewMetrics()
-
-	// Create OAuth2Server with test settings
+	// Create OAuth2Server with test settings, then the auth service the handler uses.
 	oauth2Server := createTestOAuth2Server(t, settings)
-
-	// Create auth service and middleware for testing
 	authService := auth.NewSecurityAdapter(oauth2Server)
-	authMw := auth.NewMiddleware(authService)
 
 	// Initialize gothic session store for testing (required for session operations)
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
-	// Create API controller with OAuth2Server via functional options
-	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, true,
-		WithAuthMiddleware(authMw.Authenticate), WithAuthService(authService))
-	require.NoError(t, err, "Failed to create test API controller")
+	// Build the shared core (the auth handlers reach the logging helpers through
+	// it) and construct the auth Handler exactly as the facade does.
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithSettings(settings))
+	h := New(core, authService)
 
-	// Register cleanup
-	t.Cleanup(func() {
-		controller.Shutdown()
-		close(controlChan)
-	})
-
-	return e, controller, settings
+	return e, h, settings
 }
 
 // createTestOAuth2Server creates an OAuth2Server with the provided settings for testing.
@@ -112,7 +83,7 @@ func createTestOAuth2Server(tb testing.TB, settings *conf.Settings) *security.OA
 
 // TestV2AuthFlow_CompleteLogin tests the complete V2 login flow end-to-end.
 func TestV2AuthFlow_CompleteLogin(t *testing.T) {
-	e, controller, settings := setupAuthIntegrationTest(t)
+	e, h, settings := setupAuthIntegrationTest(t)
 
 	t.Run("complete login flow with V2 callback", func(t *testing.T) {
 		// Step 1: POST /api/v2/auth/login with valid credentials
@@ -128,7 +99,7 @@ func TestV2AuthFlow_CompleteLogin(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		// Execute login handler
-		err := controller.Login(c)
+		err := h.Login(c)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -155,7 +126,7 @@ func TestV2AuthFlow_CompleteLogin(t *testing.T) {
 		callbackCtx := e.NewContext(callbackReq, callbackRec)
 
 		// Execute callback handler
-		err = controller.OAuthCallback(callbackCtx)
+		err = h.OAuthCallback(callbackCtx)
 		require.NoError(t, err)
 
 		// Should redirect (302) to final destination
@@ -181,7 +152,7 @@ func TestV2AuthFlow_CompleteLogin(t *testing.T) {
 // back to the base path. Regression guard for the query-aware redirect fix:
 // path-traversal heuristics must only apply to the path, not to the query.
 func TestV2AuthFlow_FilterQueryRedirectSurvives(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	const filteredRedirect = "/detections?queryType=species&q=a..b//c"
 	const wantFinalRedirect = "/ui/detections?queryType=species&q=a..b//c"
@@ -198,7 +169,7 @@ func TestV2AuthFlow_FilterQueryRedirectSurvives(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	require.NoError(t, controller.Login(c))
+	require.NoError(t, h.Login(c))
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var loginResp AuthResponse
@@ -215,7 +186,7 @@ func TestV2AuthFlow_FilterQueryRedirectSurvives(t *testing.T) {
 	// Following the callback must 302 to the filtered view with the query intact.
 	callbackReq := httptest.NewRequest(http.MethodGet, loginResp.RedirectURL, http.NoBody)
 	callbackRec := httptest.NewRecorder()
-	require.NoError(t, controller.OAuthCallback(e.NewContext(callbackReq, callbackRec)))
+	require.NoError(t, h.OAuthCallback(e.NewContext(callbackReq, callbackRec)))
 
 	assert.Equal(t, http.StatusFound, callbackRec.Code)
 	assert.Equal(t, wantFinalRedirect, callbackRec.Header().Get("Location"),
@@ -228,7 +199,7 @@ func TestV2AuthFlow_FilterQueryRedirectSurvives(t *testing.T) {
 // rather than dropped to the default base path. Regression guard for the
 // proxy-aware base-path handling.
 func TestV2AuthFlow_ProxyPrefixedBasePathRedirect(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	// HA Ingress tokens are base64url (alphanumeric, '-', '_'), accepted by the
 	// backend basePath regex.
@@ -246,7 +217,7 @@ func TestV2AuthFlow_ProxyPrefixedBasePathRedirect(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
-	require.NoError(t, controller.Login(e.NewContext(req, rec)))
+	require.NoError(t, h.Login(e.NewContext(req, rec)))
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var loginResp AuthResponse
@@ -261,7 +232,7 @@ func TestV2AuthFlow_ProxyPrefixedBasePathRedirect(t *testing.T) {
 
 // TestV2AuthFlow_InvalidCredentials tests login with wrong password.
 func TestV2AuthFlow_InvalidCredentials(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	t.Run("login fails with wrong password", func(t *testing.T) {
 		loginPayload := `{
@@ -274,7 +245,7 @@ func TestV2AuthFlow_InvalidCredentials(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		err := controller.Login(c)
+		err := h.Login(c)
 		require.NoError(t, err) // Handler should not return error, but set appropriate response
 
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -292,8 +263,6 @@ func TestV2AuthFlow_InvalidCredentials(t *testing.T) {
 func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 	// Create custom test environment with empty ClientID
 	e := echo.New()
-	mockDS := mocks.NewMockInterface(t)
-	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
 
 	settings := &conf.Settings{
 		WebServer: conf.WebServerSettings{Debug: true},
@@ -314,27 +283,12 @@ func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 		},
 	}
 
-	mockImageProvider := &apitest.MockImageProvider{}
-	mockImageProvider.On("Fetch", mock.Anything).Return(imageprovider.BirdImage{}, nil).Maybe()
-	birdImageCache := &imageprovider.BirdImageCache{}
-	birdImageCache.SetImageProvider(mockImageProvider)
-	sunCalc := suncalc.NewSunCalc(60.1699, 24.9384)
-	controlChan := make(chan string, 10)
-	mockMetrics, _ := observability.NewMetrics()
 	oauth2Server := createTestOAuth2Server(t, settings)
-
-	// Create auth service and middleware for testing
 	authService := auth.NewSecurityAdapter(oauth2Server)
-	authMw := auth.NewMiddleware(authService)
+	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
-	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, true,
-		WithAuthMiddleware(authMw.Authenticate), WithAuthService(authService))
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		controller.Shutdown()
-		close(controlChan)
-	})
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithSettings(settings))
+	h := New(core, authService)
 
 	t.Run("empty ClientID allows any username (V1 compatible)", func(t *testing.T) {
 		// Any username should work when ClientID is empty
@@ -348,7 +302,7 @@ func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		err := controller.Login(c)
+		err := h.Login(c)
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -365,7 +319,7 @@ func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 
 // TestV2AuthFlow_CallbackErrors tests callback error scenarios.
 func TestV2AuthFlow_CallbackErrors(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	testCases := []struct {
 		name           string
@@ -393,7 +347,7 @@ func TestV2AuthFlow_CallbackErrors(t *testing.T) {
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
-			err := controller.OAuthCallback(c)
+			err := h.OAuthCallback(c)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedStatus, rec.Code)
@@ -483,7 +437,7 @@ func TestV2AuthFlow_OpenRedirectPrevention(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := validateAndSanitizeRedirect(tc.maliciousURL)
+			result := ValidateAndSanitizeRedirect(tc.maliciousURL)
 			assert.Equal(t, tc.expectedResult, result,
 				"Redirect sanitization failed for: %s", tc.maliciousURL)
 		})
@@ -492,7 +446,7 @@ func TestV2AuthFlow_OpenRedirectPrevention(t *testing.T) {
 
 // TestV2AuthFlow_MissingCredentials tests login with missing username or password.
 func TestV2AuthFlow_MissingCredentials(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	testCases := []struct {
 		name    string
@@ -519,7 +473,7 @@ func TestV2AuthFlow_MissingCredentials(t *testing.T) {
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
-			err := controller.Login(c)
+			err := h.Login(c)
 			require.NoError(t, err)
 
 			assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -536,7 +490,7 @@ func TestV2AuthFlow_MissingCredentials(t *testing.T) {
 
 // TestV2AuthFlow_WrongUsername tests login with wrong username when ClientID is set.
 func TestV2AuthFlow_WrongUsername(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	t.Run("login fails with wrong username when ClientID is set", func(t *testing.T) {
 		loginPayload := `{
@@ -549,7 +503,7 @@ func TestV2AuthFlow_WrongUsername(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		err := controller.Login(c)
+		err := h.Login(c)
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -565,7 +519,7 @@ func TestV2AuthFlow_WrongUsername(t *testing.T) {
 
 // TestV2AuthFlow_RedirectURLInResponse tests that the login response contains V2 callback URL.
 func TestV2AuthFlow_RedirectURLInResponse(t *testing.T) {
-	e, controller, _ := setupAuthIntegrationTest(t)
+	e, h, _ := setupAuthIntegrationTest(t)
 
 	t.Run("login response contains V2 callback URL", func(t *testing.T) {
 		loginPayload := `{
@@ -578,7 +532,7 @@ func TestV2AuthFlow_RedirectURLInResponse(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
-		err := controller.Login(c)
+		err := h.Login(c)
 		require.NoError(t, err)
 
 		var resp AuthResponse

--- a/internal/api/v2/auth/auth_routes_test.go
+++ b/internal/api/v2/auth/auth_routes_test.go
@@ -1,0 +1,31 @@
+package authapi
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+)
+
+// TestRegisterRoutesRegistration verifies the auth domain registers exactly the
+// routes (and the same method+path set) the monolithic initAuthRoutes did, in
+// its own -race test binary. The protected logout/status group is mounted with
+// the AuthMiddleware promoted from the core; a pass-through is injected so the
+// empty-prefix protected group registers the same way production wiring does.
+func TestRegisterRoutesRegistration(t *testing.T) {
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	core.AuthMiddleware = func(next echo.HandlerFunc) echo.HandlerFunc { return next }
+
+	// authService is not needed to register routes (the handlers are not invoked
+	// here), so a nil service is sufficient for the route-enumeration gate.
+	h := New(core, nil)
+	h.RegisterRoutes(core.Group)
+
+	apitest.AssertRoutesRegistered(t, e, []string{
+		"POST /api/v2/auth/login",
+		"GET /api/v2/auth/callback",
+		"POST /api/v2/auth/logout",
+		"GET /api/v2/auth/status",
+	})
+}

--- a/internal/api/v2/fuzz_test.go
+++ b/internal/api/v2/fuzz_test.go
@@ -6,392 +6,16 @@ package api
 import (
 	"fmt"
 	"math"
-	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"unicode/utf8"
 
+	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
+
 	"github.com/stretchr/testify/assert"
 )
-
-// =============================================================================
-// Fuzz Tests for Auth Input Validation
-// =============================================================================
-
-// FuzzIsValidBasePath tests base path validation with random inputs.
-// Goals:
-// - No panics on any input
-// - Consistent behavior (same input = same output)
-// - Rejects dangerous patterns (traversal, XSS, CRLF)
-func FuzzIsValidBasePath(f *testing.F) {
-	seedInputs := []string{
-		// Valid base paths
-		"/",
-		"/ui/",
-		"/app/",
-		"/admin/",
-		"/dashboard/",
-		"/some-path/",
-		"/path_with_underscore/",
-		"/Path123/",
-		// Invalid - missing leading slash
-		"ui/",
-		"",
-		"app",
-		// Invalid - missing trailing slash
-		"/ui",
-		"/app",
-		// Path traversal attempts
-		"/../",
-		"/ui/../",
-		"/..%2f/",
-		"/ui/../../",
-		"/../../../etc/passwd/",
-		// Protocol-relative URLs
-		"//evil.com/",
-		"///evil.com/",
-		// XSS attempts
-		"/ui/<script>/",
-		"/ui/javascript:/",
-		"/ui/data:/",
-		"/<img%20onerror=alert(1)>/",
-		// CRLF injection
-		"/ui/\r\n/",
-		"/ui/\n/",
-		"/ui/\r/",
-		"/ui/%0d%0a/",
-		// Null bytes
-		"/ui/\x00/",
-		"/ui/%00/",
-		// Backslashes
-		"/ui\\/",
-		"\\ui/",
-		// Very long paths
-		"/" + strings.Repeat("a", 200) + "/",
-		// Unicode
-		"/настройки/",
-		"/日本語/",
-		// Special characters
-		"/path with spaces/",
-		"/path%20encoded/",
-		"/path+plus/",
-	}
-
-	for _, input := range seedInputs {
-		f.Add(input)
-	}
-
-	f.Fuzz(func(t *testing.T, input string) {
-		// Should never panic
-		result := isValidBasePath(input)
-
-		// Invariants that must hold for valid paths
-		if result {
-			// Must start with /
-			assert.True(t, strings.HasPrefix(input, "/"), "Valid base path must start with /")
-
-			// Must end with /
-			assert.True(t, strings.HasSuffix(input, "/"), "Valid base path must end with /")
-
-			// Must not exceed max length
-			assert.LessOrEqual(t, len(input), maxBasePathLength, "Valid base path must not exceed max length")
-
-			// Must not contain dangerous patterns
-			lower := strings.ToLower(input)
-			assert.NotContains(t, input, "..", "Valid base path must not contain ..")
-			assert.NotContains(t, input, "//", "Valid base path must not contain //")
-			assert.NotContains(t, input, "\\", "Valid base path must not contain \\")
-			assert.NotContains(t, input, "<", "Valid base path must not contain <")
-			assert.NotContains(t, input, ">", "Valid base path must not contain >")
-			assert.NotContains(t, lower, "javascript:", "Valid base path must not contain javascript:")
-			assert.NotContains(t, lower, "data:", "Valid base path must not contain data:")
-			assert.NotContains(t, input, "\n", "Valid base path must not contain newline")
-			assert.NotContains(t, input, "\r", "Valid base path must not contain carriage return")
-			assert.NotContains(t, input, "\x00", "Valid base path must not contain null byte")
-		}
-
-		// Consistency check
-		result2 := isValidBasePath(input)
-		assert.Equal(t, result, result2, "Inconsistent results for: %q", input)
-	})
-}
-
-// FuzzValidateAndSanitizeRedirect tests redirect path sanitization.
-// Goals:
-// - No panics
-// - Always returns safe relative path
-// - Rejects open redirect attempts
-func FuzzValidateAndSanitizeRedirect(f *testing.F) {
-	seedInputs := []string{
-		// Valid redirects
-		"/",
-		"/dashboard",
-		"/admin/settings",
-		"/path?query=value",
-		"/path?a=1&b=2",
-		// Empty
-		"",
-		// Protocol-relative URLs (should be rejected)
-		"//evil.com",
-		"//evil.com/path",
-		"///evil.com",
-		// Absolute URLs (should be rejected)
-		"http://evil.com",
-		"https://evil.com/path",
-		"javascript:alert(1)",
-		"data:text/html,<script>alert(1)</script>",
-		// Backslash attacks
-		"/\\evil.com",
-		"\\\\evil.com",
-		"/path\\..\\..\\etc",
-		// CRLF injection
-		"/path\r\n",
-		"/path%0d%0a",
-		"/path\r\nSet-Cookie:evil=true",
-		"/path%0d%0aLocation:http://evil.com",
-		// Path traversal
-		"/../etc/passwd",
-		"/path/../../../etc/passwd",
-		// Encoded attacks
-		"/%2f%2fevil.com",
-		"/%5c%5cevil.com",
-		// Unicode attacks
-		"/\u202epath",
-		"/path\uFEFF",
-		// Very long paths
-		"/" + strings.Repeat("a", 10000),
-		// Null bytes
-		"/path\x00",
-		"/path%00",
-	}
-
-	for _, input := range seedInputs {
-		f.Add(input)
-	}
-
-	f.Fuzz(func(t *testing.T, input string) {
-		// Should never panic
-		result := validateAndSanitizeRedirect(input)
-
-		// Result must always be a safe relative path
-		assert.True(t, strings.HasPrefix(result, "/"), "Result must start with /")
-
-		// Result must not be protocol-relative
-		if len(result) > 1 {
-			assert.NotEqual(t, '/', result[1], "Result must not be protocol-relative (//...)")
-			assert.NotEqual(t, '\\', result[1], "Result must not start with /\\")
-		}
-
-		// Result must not contain raw CRLF
-		assert.False(t, strings.ContainsAny(result, "\r\n"), "Result must not contain CRLF")
-
-		// Result must be a valid relative URL
-		parsed, err := url.Parse(result)
-		if err == nil {
-			assert.Empty(t, parsed.Scheme, "Result must not have a scheme")
-			assert.Empty(t, parsed.Host, "Result must not have a host")
-		}
-
-		// Consistency check
-		result2 := validateAndSanitizeRedirect(input)
-		assert.Equal(t, result, result2, "Inconsistent results for: %q", input)
-	})
-}
-
-// FuzzContainsCRLFCharacters tests CRLF detection in auth module.
-func FuzzContainsCRLFCharacters(f *testing.F) {
-	seedInputs := []string{
-		// No CRLF
-		"",
-		"hello world",
-		"/path/to/resource",
-		"normal%20encoding",
-		// Raw CRLF
-		"hello\rworld",
-		"hello\nworld",
-		"hello\r\nworld",
-		// Encoded CRLF
-		"hello%0dworld",
-		"hello%0aworld",
-		"hello%0d%0aworld",
-		"%0D%0A",
-		// Mixed case encoding
-		"%0D%0a",
-		"%0d%0A",
-		// Partial patterns
-		"test%0test",
-		"test%2test",
-		"0d0a",
-	}
-
-	for _, input := range seedInputs {
-		f.Add(input)
-	}
-
-	f.Fuzz(func(t *testing.T, input string) {
-		// Should never panic
-		result := containsCRLFCharacters(input)
-
-		// If input contains raw CRLF, result must be true
-		if strings.ContainsAny(input, "\r\n") {
-			assert.True(t, result, "Must detect raw CRLF in: %q", input)
-		}
-
-		// If input contains encoded CRLF (case insensitive), result must be true
-		lower := strings.ToLower(input)
-		if strings.Contains(lower, "%0d") || strings.Contains(lower, "%0a") {
-			assert.True(t, result, "Must detect encoded CRLF in: %q", input)
-		}
-
-		// Consistency check
-		result2 := containsCRLFCharacters(input)
-		assert.Equal(t, result, result2, "Inconsistent results")
-	})
-}
-
-// FuzzIsValidRelativePath tests relative path validation.
-func FuzzIsValidRelativePath(f *testing.F) {
-	seedInputs := []string{
-		// Valid relative paths
-		"/",
-		"/dashboard",
-		"/admin/settings",
-		"/path/to/resource",
-		// Invalid - has scheme
-		"http://example.com",
-		"https://example.com/path",
-		"javascript:alert(1)",
-		"data:text/html",
-		// Invalid - has host
-		"//evil.com",
-		"//evil.com/path",
-		// Invalid - protocol-relative patterns
-		"/\\evil.com",
-		// Invalid - doesn't start with /
-		"path",
-		"",
-		"dashboard",
-	}
-
-	for _, input := range seedInputs {
-		f.Add(input)
-	}
-
-	f.Fuzz(func(t *testing.T, input string) {
-		parsed, err := url.Parse(input)
-		if err != nil {
-			// Invalid URL, can't test
-			return
-		}
-
-		// Should never panic
-		result := isValidRelativePath(parsed)
-
-		// If result is true, verify invariants
-		if result {
-			assert.Empty(t, parsed.Scheme, "Valid relative path must not have scheme")
-			assert.Empty(t, parsed.Host, "Valid relative path must not have host")
-			assert.True(t, strings.HasPrefix(parsed.Path, "/"), "Valid relative path must start with /")
-			if len(parsed.Path) > 1 {
-				assert.NotEqual(t, '/', parsed.Path[1], "Valid relative path must not start with //")
-				assert.NotEqual(t, '\\', parsed.Path[1], "Valid relative path must not start with /\\")
-			}
-		}
-
-		// Consistency check
-		result2 := isValidRelativePath(parsed)
-		assert.Equal(t, result, result2, "Inconsistent results")
-	})
-}
-
-// FuzzExtractBasePathFromReferer tests referer parsing for base path extraction.
-func FuzzExtractBasePathFromReferer(f *testing.F) {
-	seedInputs := []string{
-		// Valid referers
-		"http://localhost/ui/login",
-		"https://example.com/app/dashboard",
-		"http://localhost:8080/admin/settings",
-		// Invalid URLs
-		"not-a-url",
-		"",
-		"   ",
-		// Malicious referers
-		"http://evil.com/ui/attack",
-		"javascript:alert(1)",
-		"data:text/html,<script>alert(1)</script>",
-		// Path traversal
-		"http://localhost/../../../etc/passwd",
-		"http://localhost/ui/../../../etc/passwd",
-		// CRLF injection
-		"http://localhost/ui/%0d%0aSet-Cookie:evil=true",
-		// Unicode
-		"http://localhost/\u202e/",
-		// Very long
-		"http://localhost/" + strings.Repeat("a", 10000),
-	}
-
-	for _, input := range seedInputs {
-		f.Add(input)
-	}
-
-	f.Fuzz(func(t *testing.T, input string) {
-		// Should never panic
-		result := extractBasePathFromReferer(input)
-
-		// Result is either empty or a valid base path
-		if result != "" {
-			// Must be a valid base path if non-empty
-			assert.True(t, isValidBasePath(result), "Extracted base path must be valid: %q", result)
-		}
-
-		// Consistency check
-		result2 := extractBasePathFromReferer(input)
-		assert.Equal(t, result, result2, "Inconsistent results")
-	})
-}
-
-// FuzzEnsurePathWithinBase tests path containment validation.
-func FuzzEnsurePathWithinBase(f *testing.F) {
-	type testCase struct {
-		redirect string
-		basePath string
-	}
-
-	seeds := []testCase{
-		{"/dashboard", "/ui/"},
-		{"/ui/settings", "/ui/"},
-		{"/", "/app/"},
-		{"//evil.com", "/ui/"},
-		{"/\\evil.com", "/ui/"},
-		{"/../etc/passwd", "/ui/"},
-		{"", "/ui/"},
-	}
-
-	for _, s := range seeds {
-		f.Add(s.redirect, s.basePath)
-	}
-
-	f.Fuzz(func(t *testing.T, redirect, basePath string) {
-		// Should never panic
-		result := ensurePathWithinBase(redirect, basePath)
-
-		// Result should start with something
-		assert.NotEmpty(t, result, "Result should not be empty")
-
-		// If redirect was protocol-relative, result should be safe
-		if strings.HasPrefix(redirect, "//") || strings.HasPrefix(redirect, "/\\") {
-			// Should return base path for protocol-relative redirects
-			assert.True(t, strings.HasPrefix(result, basePath) || result == basePath,
-				"Protocol-relative redirect should use base path")
-		}
-
-		// Consistency check
-		result2 := ensurePathWithinBase(redirect, basePath)
-		assert.Equal(t, result, result2, "Inconsistent results")
-	})
-}
 
 // =============================================================================
 // Fuzz Tests for Path Normalization
@@ -723,7 +347,7 @@ func TestSecurityInvariantsWithMalformedInput(t *testing.T) {
 		t.Run(fmt.Sprintf("isValidBasePath/%d", idx), func(t *testing.T) {
 			t.Parallel()
 			// Should not panic
-			result := isValidBasePath(input)
+			result := authapi.IsValidBasePath(input)
 			// Most malformed inputs should be rejected
 			// Use filepath.IsLocal for comprehensive path validation
 			if strings.Contains(input, "\x00") || !filepath.IsLocal(strings.TrimPrefix(input, "/")) {
@@ -735,7 +359,7 @@ func TestSecurityInvariantsWithMalformedInput(t *testing.T) {
 		t.Run(fmt.Sprintf("validateAndSanitizeRedirect/%d", idx), func(t *testing.T) {
 			t.Parallel()
 			// Should not panic and should return safe default
-			result := validateAndSanitizeRedirect(input)
+			result := authapi.ValidateAndSanitizeRedirect(input)
 			assert.True(t, strings.HasPrefix(result, "/"), "Should return path starting with /")
 		})
 
@@ -743,7 +367,7 @@ func TestSecurityInvariantsWithMalformedInput(t *testing.T) {
 		t.Run(fmt.Sprintf("containsCRLFCharacters/%d", idx), func(t *testing.T) {
 			t.Parallel()
 			// Should not panic
-			_ = containsCRLFCharacters(input)
+			_ = authapi.ContainsCRLFCharacters(input)
 		})
 
 		// Test parseConfidenceFilter
@@ -789,66 +413,10 @@ func TestInvalidUTF8Handling(t *testing.T) {
 			assert.False(t, utf8.ValidString(input), "Test input should be invalid UTF-8")
 
 			// Functions should handle without panic
-			_ = isValidBasePath(input)
-			_ = validateAndSanitizeRedirect(input)
-			_ = containsCRLFCharacters(input)
+			_ = authapi.IsValidBasePath(input)
+			_ = authapi.ValidateAndSanitizeRedirect(input)
+			_ = authapi.ContainsCRLFCharacters(input)
 			_, _ = NormalizeClipPathStrict(input, "clips/")
-		})
-	}
-}
-
-// TestAdvancedRedirectAttacks tests sophisticated open redirect attempts.
-func TestAdvancedRedirectAttacks(t *testing.T) {
-	t.Parallel()
-
-	attacks := []struct {
-		name           string
-		redirect       string
-		expectedPrefix string
-		shouldBeRoot   bool
-	}{
-		// Protocol-relative variations
-		{"Double slash", "//evil.com", "/", true},
-		{"Triple slash", "///evil.com", "/", true},
-		{"Backslash protocol-relative", "/\\evil.com", "/", true},
-		{"Mixed slashes", "/\\/evil.com", "/", true},
-
-		// Scheme attacks
-		{"JavaScript scheme", "javascript:alert(1)", "/", true},
-		{"Data scheme", "data:text/html,<script>alert(1)</script>", "/", true},
-		{"VBScript scheme", "vbscript:msgbox(1)", "/", true},
-		{"File scheme", "file:///etc/passwd", "/", true},
-
-		// Domain confusion
-		{"Domain with @", "//@evil.com", "/", true},
-
-		// Whitespace attacks
-		{"Tab before scheme", "\thttp://evil.com", "/", true},
-		{"Newline before scheme", "\nhttp://evil.com", "/", true},
-
-		// Valid redirects
-		{"Simple path", "/dashboard", "/dashboard", false},
-		{"Path with query", "/path?param=value", "/path?param=value", false},
-		{"Root path", "/", "/", true},
-	}
-
-	for _, tc := range attacks {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			result := validateAndSanitizeRedirect(tc.redirect)
-
-			if tc.shouldBeRoot {
-				assert.Equal(t, "/", result, "Should be root for: %q", tc.redirect)
-			} else {
-				assert.True(t, strings.HasPrefix(result, tc.expectedPrefix),
-					"Result %q should start with %q for input %q", result, tc.expectedPrefix, tc.redirect)
-			}
-
-			// All results must be safe relative paths
-			assert.True(t, strings.HasPrefix(result, "/"), "Must start with /")
-			if len(result) > 1 {
-				assert.NotEqual(t, '/', result[1], "Must not be protocol-relative")
-			}
 		})
 	}
 }


### PR DESCRIPTION
Phase 4 of the internal/api/v2 split: move the auth domain handlers (login,
OAuth callback, logout, auth status) out of the monolithic package api into a
new internal/api/v2/auth subpackage (package authapi), following the established
Phase 4 pattern (Handler embeds *apicore.Core by pointer; the facade Controller
holds a handler field, constructs it, and calls RegisterRoutes in the
deterministic initRoutes order). This is the FINAL leaf domain of Phase 4.

## Scope: handlers moved, middleware stays

Only the auth DOMAIN HANDLERS registered by the old initAuthRoutes move here:
Login (POST /auth/login), OAuthCallback (GET /auth/callback), Logout
(POST /auth/logout), GetAuthStatus (GET /auth/status), plus their domain-local
helpers/types/constants. The auth MIDDLEWARE (GetAuthMiddleware, PrivateModeAuth,
the trusted-proxy IP extractor, the AuthMiddleware field) already moved to
apicore.Core in Phase 1 and stays there; the handlers reuse AuthMiddleware via
promotion from the embedded Core.

## Pattern

- authapi.Handler embeds *apicore.Core by pointer so the shared helpers
  (HandleError, HandleErrorWithKey, the LogSecurity*IfEnabled / LogDebugIfEnabled
  family, and the AuthMiddleware field) promote onto it.
- New(core, authService) constructs the handler; RegisterRoutes(g *echo.Group)
  wires the exact 4 routes from the old initAuthRoutes in the same order with the
  same per-route middleware: the login rate limiter on POST /login (5 attempts /
  15 min per IP, byte-identical config) and AuthMiddleware on the protected
  logout/status group (authGroup.Group("", c.AuthMiddleware)).
- Handler methods moved verbatim, only the receiver retyped from *Controller to
  *Handler (receiver name kept c). Bodies read c.authService (the Handler's own
  field) exactly as before.

## Dependency wiring (the auth-specific part)

authService (auth.Service) is INJECTED from the facade. Unlike the other domain
deps, which are set in the Controller literal before construction, authService is
supplied via the WithAuthService functional option, which is applied in the
`for _, opt := range opts { opt(c) }` loop AFTER the other handlers are built. So
the facade constructs c.authHandler = authapi.New(c.Core, c.authService) AFTER
that options loop, guaranteeing the handler captures the injected service (or nil
if WithAuthService was not passed; the handlers nil-guard authService exactly as
the monolith did). authService never changes after the options loop, so capturing
the post-option value is behaviorally identical to the monolith's per-request
`c.authService` read. The facade keeps the authService field and the
WithAuthService option as the injection source.

## Cross-domain coupling

- The 5 auth route-path constants (AuthGroupPath..AuthStatusPath) are exported in
  authapi and consumed by the facade's isPrivateModeExempt PrivateMode allow-list
  (audio_hls.go) and its tests, so the exempt list composes its auth paths from
  the same constants the routes register with and cannot drift (the same approach
  as RangeFilterSpecies in rangeapi and ParseCertificateInfo in tls). The const
  expression `const authBase = apiV2Prefix + authapi.AuthGroupPath` stays a valid
  compile-time constant.
- fuzz_test.go (package api) is a mixed security file: some test functions call
  both auth validators and non-auth validators (NormalizeClipPathStrict,
  parseConfidenceFilter) in the same loop, so they cannot all move. The 6
  dedicated pure-auth Fuzz functions + TestAdvancedRedirectAttacks moved verbatim
  to authapi/auth_fuzz_test.go (auth now owns its security fuzzing in its own
  -race binary). Three validators (IsValidBasePath, ValidateAndSanitizeRedirect,
  ContainsCRLFCharacters) are exported so the remaining facade mixed tests
  exercise them across the package boundary; their bodies are unchanged (only the
  identifier case differs), so coverage is preserved with zero loss.

## Facade wiring (order preserved exactly)

- Controller gains an unexported authHandler *authapi.Handler field.
- c.authHandler = authapi.New(c.Core, c.authService) is constructed after the
  options loop.
- initRoutes replaces the auth routeInitializers entry in place with
  {"auth routes", func() { c.authHandler.RegisterRoutes(c.Group) }} at the same
  index, so registration order (and the route-enumeration golden gate) is
  byte-identical.

auth owns no background goroutine or singleton, so no Shutdown hook is added; the
facade Shutdown is untouched. apiv2.Controller/New/NewWithOptions signatures are
unchanged.

## Tests

Moved into the auth package, rebuilt against apitest:
- auth_compatibility_test.go (self-contained V1/V2 auth-logic simulation).
- auth_integration_test.go: setup rewritten to build the Handler via
  apitest.NewCore(...) + New(core, authService) with a real SecurityAdapter,
  invoking the handlers directly (same assertions: full login+callback flow,
  filtered-query redirect survival, proxy-prefixed base path, invalid/missing/
  wrong credentials, empty-ClientID V1 compatibility, callback errors, open-
  redirect prevention, Service-interface conformance).
- auth_fuzz_test.go (the moved fuzz funcs + advanced redirect attacks).
- auth_routes_test.go (route-enumeration gate for the 4 auth routes; auth now has
  its own -race binary).

## Verification

- go build ./... clean.
- go vet ./internal/api/v2/... ./internal/analysis/... clean (no copylocks).
- go test -race ./internal/api/v2/... green (incl. the route-enumeration golden
  gate and the PrivateMode-exempt tests); internal/api/v2/auth has its own -race
  binary; internal/analysis -race green (its only failure was the unrelated
  frontend dist embed, which is environmental).
- golangci-lint: 0 issues on internal/api/v2/... and internal/api/v2/auth/.
- No public-behavior change: auth endpoints, auth/CSRF/session/rate-limit/redirect
  handling, and responses are identical; README endpoint catalog accurate.

## Security preservation

Every auth check is preserved verbatim: the login rate limiter config and its
error/deny handlers, the AuthMiddleware on the protected logout/status routes,
the timing-attack randomDelay on the missing-credential and auth-failure paths,
the query-aware open-redirect validation (path/query split, security.IsValidRedirect,
EscapedPath emission), the session-fixation EstablishSession, and fetching the
provider logout URL before Logout() destroys the session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth endpoints are now registered via a dedicated v2 authentication handler, with standardized route paths for login, callback, logout, and status.
* **Bug Fixes**
  * Private-mode “exempt” routing now consistently matches the authentication endpoints.
  * OAuth callback redirect URLs and redirect validation are more reliably constructed and sanitized.
* **Documentation**
  * Updated v2 authentication API documentation to include the auth callback endpoint and refreshed references.
* **Tests**
  * Refreshed auth integration tests and added route registration checks plus security-focused fuzz coverage for redirect/base-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->