### PR TITLE
refactor(api/v2): extract dynamic_thresholds domain into its own package

### DIFF
--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -1628,7 +1628,7 @@ func serveTopNHourlyChart[T any](
 		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
-	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultLimit, maxLimit)
+	limit := apicore.ParsePaginationLimit(ctx.QueryParam("limit"), defaultLimit, maxLimit)
 
 	c.LogInfoIfEnabled("Retrieving "+operation,
 		logger.String("start_date", startDate),
@@ -1805,7 +1805,7 @@ func (c *Controller) GetConfidenceDistribution(ctx echo.Context) error {
 	}
 
 	bins := clampConfidenceBins(ctx.QueryParam("bins"))
-	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesRidgelineLimit, maxSpeciesRidgelineLimit)
+	limit := apicore.ParsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesRidgelineLimit, maxSpeciesRidgelineLimit)
 
 	c.LogInfoIfEnabled("Retrieving confidence distribution",
 		logger.String("start_date", startDate),
@@ -2208,7 +2208,7 @@ func (c *Controller) GetSpeciesPhenology(ctx echo.Context) error {
 		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
-	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesPhenologyLimit, maxSpeciesPhenologyLimit)
+	limit := apicore.ParsePaginationLimit(ctx.QueryParam("limit"), defaultSpeciesPhenologyLimit, maxSpeciesPhenologyLimit)
 
 	c.LogInfoIfEnabled("Retrieving species phenology",
 		logger.String("start_date", startDate),

--- a/internal/api/v2/analytics_species_phenology_test.go
+++ b/internal/api/v2/analytics_species_phenology_test.go
@@ -110,7 +110,7 @@ func TestGetSpeciesPhenology_LimitClamping(t *testing.T) {
 	t.Run("over-max limit falls back to the default", func(t *testing.T) {
 		t.Parallel()
 		e, mockDS, controller := setupAnalyticsTestEnvironment(t)
-		// 999 exceeds the max (20), so parsePaginationLimit returns the default (12).
+		// 999 exceeds the max (20), so apicore.ParsePaginationLimit returns the default (12).
 		mockDS.On("GetSpeciesPhenology", mock.Anything, "2026-03-01", "2026-03-02", 12).
 			Return(sampleSpeciesPhenology(), nil)
 

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/control"
+	"github.com/tphakala/birdnet-go/internal/api/v2/dynamicthresholds"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
@@ -105,6 +106,14 @@ type Controller struct {
 	// it needs only the shared *apicore.Core (the media SecureFS sandbox, the auth
 	// middleware, and the error/log helpers all promote from it).
 	filesystem *filesystem.Handler
+
+	// dynamicThresholds serves the /api/v2/dynamic-thresholds* endpoints (BG-59:
+	// reading the merged runtime threshold data from the database and processor
+	// memory, aggregate stats, per-species lookups and event history, plus the
+	// protected single and bulk reset controls). Like weather it needs only the
+	// shared *apicore.Core (DS, Processor, AuthMiddleware, settings, and the
+	// error/log helpers all promote from it).
+	dynamicThresholds *dynamicthresholds.Handler
 
 	// alerts serves the /api/v2/alerts/* endpoints (alert-rule CRUD,
 	// import/export, history, schema, and test-fire). Beyond the shared
@@ -372,6 +381,9 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// The filesystem handler needs only the shared core (the media SecureFS
 	// sandbox, the auth middleware, and the error/log helpers all promote from it).
 	c.filesystem = filesystem.New(c.Core)
+	// The dynamic-thresholds handler needs only the shared core (DS, Processor,
+	// the auth middleware, settings, and the error/log helpers all promote from it).
+	c.dynamicThresholds = dynamicthresholds.New(c.Core)
 	// The alerts handler owns its two domain dependencies (alert-rule repository
 	// and alerting engine), constructed lazily in RegisterRoutes; it needs only
 	// the shared core here (V2Manager, auth middleware, and the error/log helpers
@@ -513,7 +525,7 @@ func (c *Controller) initRoutes() {
 		{"support routes", func() { c.support.RegisterRoutes(c.Group) }},
 		{"debug routes", c.initDebugRoutes},
 		{"species routes", func() { c.species.RegisterRoutes(c.Group) }},
-		{"dynamic threshold routes", c.initDynamicThresholdRoutes},
+		{"dynamic threshold routes", func() { c.dynamicThresholds.RegisterRoutes(c.Group) }},
 		{"alert routes", func() { c.alerts.RegisterRoutes(c.Group) }},
 		{"model routes", func() { c.models.RegisterRoutes(c.Group) }},
 		{"insights routes", c.initInsightsRoutes},

--- a/internal/api/v2/apicore/shared_helpers.go
+++ b/internal/api/v2/apicore/shared_helpers.go
@@ -70,3 +70,14 @@ func ParseFloat32(s string) (float32, error) {
 	f, err := strconv.ParseFloat(s, 32)
 	return float32(f), err
 }
+
+// ParsePaginationLimit parses and validates a pagination "limit" query value.
+// It returns defaultVal when the value is missing, non-numeric, non-positive, or
+// exceeds maxVal. Shared by the analytics and dynamic-thresholds query parsing.
+func ParsePaginationLimit(value string, defaultVal, maxVal int) int {
+	limit, _ := strconv.Atoi(value)
+	if limit <= 0 || limit > maxVal {
+		return defaultVal
+	}
+	return limit
+}

--- a/internal/api/v2/dynamicthresholds/dynamicthresholds.go
+++ b/internal/api/v2/dynamicthresholds/dynamicthresholds.go
@@ -1,6 +1,13 @@
-// internal/api/v2/dynamic_thresholds.go
-// BG-59: Dynamic threshold runtime data and reset controls
-package api
+// Package dynamicthresholds is the api/v2 dynamic-thresholds domain handler. It
+// owns the /api/v2/dynamic-thresholds* endpoints (BG-59: reading the merged
+// runtime threshold data from the database and processor memory, aggregate
+// stats, per-species lookups and event history, plus the protected single and
+// bulk reset controls). The Handler embeds *apicore.Core by pointer so the
+// shared dependencies and helpers (DS, Processor, AuthMiddleware, HandleError,
+// HandleErrorWithNotFound, CurrentSettings, Debug, and the v2 route group)
+// promote onto it. The domain needs only the shared core; it injects no
+// facade-owned dependencies.
+package dynamicthresholds
 
 import (
 	"net/http"
@@ -11,6 +18,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
@@ -21,6 +29,34 @@ const (
 	defaultEventLimit     = 10
 	maxEventLimit         = 100
 )
+
+// Handler serves the api/v2 dynamic-thresholds endpoints. It embeds the shared
+// *apicore.Core by pointer (never copied by value) so the shared state and
+// helpers promote onto the handler methods.
+type Handler struct {
+	*apicore.Core
+}
+
+// New builds a dynamic-thresholds Handler around the shared core. The domain has
+// no facade-owned dependencies; everything it needs promotes from the core.
+func New(core *apicore.Core) *Handler {
+	return &Handler{Core: core}
+}
+
+// RegisterRoutes wires the dynamic-threshold endpoints onto the v2 group,
+// preserving the exact routes, order, and per-route middleware of the former
+// initDynamicThresholdRoutes.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+	// Public endpoints for reading threshold data
+	g.GET("/dynamic-thresholds", c.GetDynamicThresholds)
+	g.GET("/dynamic-thresholds/stats", c.GetDynamicThresholdStats)
+	g.GET("/dynamic-thresholds/:species", c.GetDynamicThreshold)
+	g.GET("/dynamic-thresholds/:species/events", c.GetThresholdEvents)
+
+	// Protected endpoints for modifying thresholds (require authentication)
+	g.DELETE("/dynamic-thresholds/:species", c.ResetDynamicThreshold, c.AuthMiddleware)
+	g.DELETE("/dynamic-thresholds", c.ResetAllDynamicThresholds, c.AuthMiddleware)
+}
 
 // DynamicThresholdResponse represents a single dynamic threshold for API responses
 type DynamicThresholdResponse struct {
@@ -70,7 +106,7 @@ type LevelStatItem struct {
 
 // parseSpeciesParam extracts and validates the species parameter from the request.
 // Returns the species name and nil on success, or empty string and error on failure.
-func (c *Controller) parseSpeciesParam(ctx echo.Context) (string, error) {
+func (c *Handler) parseSpeciesParam(ctx echo.Context) (string, error) {
 	species, err := url.PathUnescape(ctx.Param("species"))
 	if err != nil {
 		return "", c.HandleError(ctx, errors.Newf("invalid species parameter").
@@ -90,7 +126,7 @@ func (c *Controller) parseSpeciesParam(ctx echo.Context) (string, error) {
 // requireProcessor snapshots c.Processor and returns it if non-nil.
 // Callers must use the returned pointer for all subsequent accesses
 // to avoid a TOCTOU race between the nil check and usage.
-func (c *Controller) requireProcessor(ctx echo.Context) (*processor.Processor, error) {
+func (c *Handler) requireProcessor(ctx echo.Context) (*processor.Processor, error) {
 	proc := c.Processor
 	if proc == nil {
 		err := errors.Newf("processor not available").
@@ -118,25 +154,12 @@ func applyMemoryOverlay(response *DynamicThresholdResponse, level, highConfCount
 	}
 }
 
-// initDynamicThresholdRoutes registers all dynamic threshold API endpoints
-func (c *Controller) initDynamicThresholdRoutes() {
-	// Public endpoints for reading threshold data
-	c.Group.GET("/dynamic-thresholds", c.GetDynamicThresholds)
-	c.Group.GET("/dynamic-thresholds/stats", c.GetDynamicThresholdStats)
-	c.Group.GET("/dynamic-thresholds/:species", c.GetDynamicThreshold)
-	c.Group.GET("/dynamic-thresholds/:species/events", c.GetThresholdEvents)
-
-	// Protected endpoints for modifying thresholds (require authentication)
-	c.Group.DELETE("/dynamic-thresholds/:species", c.ResetDynamicThreshold, c.AuthMiddleware)
-	c.Group.DELETE("/dynamic-thresholds", c.ResetAllDynamicThresholds, c.AuthMiddleware)
-}
-
 // GetDynamicThresholds returns all dynamic thresholds with optional pagination
 // GET /api/v2/dynamic-thresholds?limit=50&offset=0
-func (c *Controller) GetDynamicThresholds(ctx echo.Context) error {
+func (c *Handler) GetDynamicThresholds(ctx echo.Context) error {
 	// Parse pagination parameters
-	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultThresholdLimit, maxThresholdLimit)
-	offset := c.parsePaginationOffset(ctx.QueryParam("offset"))
+	limit := apicore.ParsePaginationLimit(ctx.QueryParam("limit"), defaultThresholdLimit, maxThresholdLimit)
+	offset := parsePaginationOffset(ctx.QueryParam("offset"))
 
 	// Get merged threshold data from memory and database
 	thresholdMap := c.getMergedThresholdData()
@@ -159,17 +182,12 @@ func (c *Controller) GetDynamicThresholds(ctx echo.Context) error {
 	})
 }
 
-// parsePaginationLimit parses and validates the limit parameter
-func (c *Controller) parsePaginationLimit(value string, defaultVal, maxVal int) int {
-	limit, _ := strconv.Atoi(value)
-	if limit <= 0 || limit > maxVal {
-		return defaultVal
-	}
-	return limit
-}
-
-// parsePaginationOffset parses and validates the offset parameter
-func (c *Controller) parsePaginationOffset(value string) int {
+// parsePaginationOffset parses and validates the offset parameter. The offset is
+// dynamic-thresholds-specific (no other domain paginates by offset), so it stays
+// local; the shared limit parser lives in apicore as ParsePaginationLimit. It is a
+// package-level function (no receiver state needed), matching the apicore parser
+// convention.
+func parsePaginationOffset(value string) int {
 	offset, _ := strconv.Atoi(value)
 	if offset < 0 {
 		return 0
@@ -178,7 +196,7 @@ func (c *Controller) parsePaginationOffset(value string) int {
 }
 
 // getMergedThresholdData merges database and in-memory threshold data
-func (c *Controller) getMergedThresholdData() map[string]*DynamicThresholdResponse {
+func (c *Handler) getMergedThresholdData() map[string]*DynamicThresholdResponse {
 	thresholdMap := make(map[string]*DynamicThresholdResponse)
 
 	// Add database thresholds first
@@ -193,7 +211,7 @@ func (c *Controller) getMergedThresholdData() map[string]*DynamicThresholdRespon
 // addDatabaseThresholds adds thresholds from the database to the map.
 // Map keys are normalized to lowercase to ensure case-insensitive merging
 // with in-memory data (which uses lowercase species names).
-func (c *Controller) addDatabaseThresholds(thresholdMap map[string]*DynamicThresholdResponse) {
+func (c *Handler) addDatabaseThresholds(thresholdMap map[string]*DynamicThresholdResponse) {
 	dbThresholds, err := c.DS.GetAllDynamicThresholds()
 	if err != nil {
 		c.Debug("Failed to get dynamic thresholds from database: %v", err)
@@ -224,7 +242,7 @@ func (c *Controller) addDatabaseThresholds(thresholdMap map[string]*DynamicThres
 
 // addMemoryThresholds adds/updates thresholds from processor memory.
 // If processor is unavailable, this function returns early without modification.
-func (c *Controller) addMemoryThresholds(thresholdMap map[string]*DynamicThresholdResponse) {
+func (c *Handler) addMemoryThresholds(thresholdMap map[string]*DynamicThresholdResponse) {
 	proc := c.Processor
 	if proc == nil {
 		return
@@ -255,7 +273,7 @@ func (c *Controller) addMemoryThresholds(thresholdMap map[string]*DynamicThresho
 }
 
 // paginateThresholds applies offset and limit to the threshold slice
-func (c *Controller) paginateThresholds(result []DynamicThresholdResponse, offset, limit int) []DynamicThresholdResponse {
+func (c *Handler) paginateThresholds(result []DynamicThresholdResponse, offset, limit int) []DynamicThresholdResponse {
 	total := len(result)
 	if offset >= total {
 		return []DynamicThresholdResponse{}
@@ -266,7 +284,7 @@ func (c *Controller) paginateThresholds(result []DynamicThresholdResponse, offse
 
 // GetDynamicThresholdStats returns aggregate statistics about dynamic thresholds
 // GET /api/v2/dynamic-thresholds/stats
-func (c *Controller) GetDynamicThresholdStats(ctx echo.Context) error {
+func (c *Handler) GetDynamicThresholdStats(ctx echo.Context) error {
 	totalCount, activeCount, atMinimumCount, levelDist, err := c.DS.GetDynamicThresholdStats()
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to get threshold statistics", http.StatusInternalServerError)
@@ -294,7 +312,7 @@ func (c *Controller) GetDynamicThresholdStats(ctx echo.Context) error {
 
 // GetDynamicThreshold returns a single dynamic threshold by species name
 // GET /api/v2/dynamic-thresholds/:species
-func (c *Controller) GetDynamicThreshold(ctx echo.Context) error {
+func (c *Handler) GetDynamicThreshold(ctx echo.Context) error {
 	species, err := c.parseSpeciesParam(ctx)
 	if err != nil {
 		return err
@@ -339,14 +357,14 @@ func (c *Controller) GetDynamicThreshold(ctx echo.Context) error {
 
 // GetThresholdEvents returns event history for a specific species
 // GET /api/v2/dynamic-thresholds/:species/events?limit=10
-func (c *Controller) GetThresholdEvents(ctx echo.Context) error {
+func (c *Handler) GetThresholdEvents(ctx echo.Context) error {
 	species, err := c.parseSpeciesParam(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Parse limit parameter
-	limit := c.parsePaginationLimit(ctx.QueryParam("limit"), defaultEventLimit, maxEventLimit)
+	limit := apicore.ParsePaginationLimit(ctx.QueryParam("limit"), defaultEventLimit, maxEventLimit)
 
 	events, err := c.DS.GetThresholdEvents(species, limit)
 	if err != nil {
@@ -379,7 +397,7 @@ func (c *Controller) GetThresholdEvents(ctx echo.Context) error {
 
 // ResetDynamicThreshold resets a single species threshold
 // DELETE /api/v2/dynamic-thresholds/:species
-func (c *Controller) ResetDynamicThreshold(ctx echo.Context) error {
+func (c *Handler) ResetDynamicThreshold(ctx echo.Context) error {
 	proc, err := c.requireProcessor(ctx)
 	if err != nil {
 		return err
@@ -404,7 +422,7 @@ func (c *Controller) ResetDynamicThreshold(ctx echo.Context) error {
 
 // ResetAllDynamicThresholds resets all dynamic thresholds
 // DELETE /api/v2/dynamic-thresholds?confirm=true
-func (c *Controller) ResetAllDynamicThresholds(ctx echo.Context) error {
+func (c *Handler) ResetAllDynamicThresholds(ctx echo.Context) error {
 	proc, err := c.requireProcessor(ctx)
 	if err != nil {
 		return err

--- a/internal/api/v2/dynamicthresholds/dynamicthresholds_test.go
+++ b/internal/api/v2/dynamicthresholds/dynamicthresholds_test.go
@@ -1,4 +1,4 @@
-package api
+package dynamicthresholds
 
 import (
 	"net/http"
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -55,10 +56,13 @@ func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	controller := &Controller{Core: &apicore.Core{DS: mockDS, Processor: proc}}
-	controller.Settings.Store(proc.Settings)
+	// The merge tests construct the Core directly (rather than via apitest.NewCore)
+	// because they need to inject a *processor.Processor, which apitest.NewCore does
+	// not expose; the NotFound tests below use apitest.NewCore (Processor stays nil).
+	handler := &Handler{Core: &apicore.Core{DS: mockDS, Processor: proc}}
+	handler.Settings.Store(proc.Settings)
 
-	result := controller.getMergedThresholdData()
+	result := handler.getMergedThresholdData()
 
 	// Bug: before fix this returns 2 entries (one Title Case, one lowercase)
 	// After fix: should return exactly 1 entry with memory overlay applied
@@ -104,10 +108,10 @@ func TestGetMergedThresholdData_MemoryOnlySpecies(t *testing.T) {
 		},
 	}
 
-	controller := &Controller{Core: &apicore.Core{DS: mockDS, Processor: proc}}
-	controller.Settings.Store(proc.Settings)
+	handler := &Handler{Core: &apicore.Core{DS: mockDS, Processor: proc}}
+	handler.Settings.Store(proc.Settings)
 
-	result := controller.getMergedThresholdData()
+	result := handler.getMergedThresholdData()
 
 	require.Len(t, result, 1, "memory-only species should appear")
 	var entry *DynamicThresholdResponse
@@ -148,10 +152,10 @@ func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
 		DynamicThresholds: map[string]*processor.DynamicThreshold{},
 	}
 
-	controller := &Controller{Core: &apicore.Core{DS: mockDS, Processor: proc}}
-	controller.Settings.Store(proc.Settings)
+	handler := &Handler{Core: &apicore.Core{DS: mockDS, Processor: proc}}
+	handler.Settings.Store(proc.Settings)
 
-	result := controller.getMergedThresholdData()
+	result := handler.getMergedThresholdData()
 
 	require.Len(t, result, 1, "database-only species should appear")
 	var entry *DynamicThresholdResponse
@@ -176,7 +180,7 @@ func TestGetDynamicThreshold_NotFoundStatus(t *testing.T) {
 	const species = "Nonexistent species"
 
 	t.Run("CategoryNotFoundMapsTo404", func(t *testing.T) {
-		e, mockDS, controller := setupTestEnvironment(t)
+		e, mockDS, handler := newThresholdsTestHandler(t)
 		// What the fixed v2only datastore (and the legacy backend) returns.
 		notFound := errors.New(errors.NewStd("dynamic threshold not found")).
 			Component("datastore").
@@ -184,36 +188,48 @@ func TestGetDynamicThreshold_NotFoundStatus(t *testing.T) {
 			Build()
 		mockDS.EXPECT().GetDynamicThreshold(species, "").Return(nil, notFound)
 
-		rec := serveGetDynamicThreshold(t, e, controller, species)
+		rec := serveGetDynamicThreshold(t, e, handler, species)
 		assert.Equal(t, http.StatusNotFound, rec.Code,
 			"a CategoryNotFound threshold miss must map to 404, not 500")
 	})
 
 	t.Run("BareSentinelMapsTo500", func(t *testing.T) {
-		e, mockDS, controller := setupTestEnvironment(t)
+		e, mockDS, handler := newThresholdsTestHandler(t)
 		// The pre-fix v2only behavior: a bare, unclassified sentinel. The handler
 		// cannot tell it is a benign not-found, so it falls through to 500. This is
 		// the #1068 bug, pinned so a future unwrapped return is caught at the handler.
 		mockDS.EXPECT().GetDynamicThreshold(species, "").
 			Return(nil, errors.NewStd("dynamic threshold not found"))
 
-		rec := serveGetDynamicThreshold(t, e, controller, species)
+		rec := serveGetDynamicThreshold(t, e, handler, species)
 		assert.Equal(t, http.StatusInternalServerError, rec.Code,
 			"an unclassified (bare sentinel) threshold miss falls through to 500")
 	})
 }
 
+// newThresholdsTestHandler builds a dynamic-thresholds Handler around an
+// apicore.Core (via apitest) with a mock datastore the caller can set
+// expectations on. apitest.NewCore leaves Processor nil, so GetDynamicThreshold's
+// processor-overlay branch is skipped and only DS.GetDynamicThreshold is exercised.
+func newThresholdsTestHandler(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Handler) {
+	t.Helper()
+	e := echo.New()
+	mockDS := mocks.NewMockInterface(t)
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithDatastore(mockDS))
+	return e, mockDS, New(core)
+}
+
 // serveGetDynamicThreshold issues GET /api/v2/dynamic-thresholds/:species against the
-// controller with the given species path param and returns the response recorder. The
+// handler with the given species path param and returns the response recorder. The
 // handler writes the response via HandleError and returns nil (ctx.JSON success), so
 // the observable contract is the recorded status code.
-func serveGetDynamicThreshold(t *testing.T, e *echo.Echo, controller *Controller, species string) *httptest.ResponseRecorder {
+func serveGetDynamicThreshold(t *testing.T, e *echo.Echo, handler *Handler, species string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/dynamic-thresholds/test", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 	ctx.SetParamNames("species")
 	ctx.SetParamValues(species)
-	require.NoError(t, controller.GetDynamicThreshold(ctx))
+	require.NoError(t, handler.GetDynamicThreshold(ctx))
 	return rec
 }


### PR DESCRIPTION
## Summary

Phase 5 of the internal/api/v2 package split: move the dynamic-thresholds domain (BG-59: reading merged runtime threshold data from the database and processor memory, aggregate stats, per-species lookups and event history, plus the protected single and bulk reset controls) out of the monolithic package api into a new internal/api/v2/dynamicthresholds subpackage, following the weather/tls/range/species/control precedents.

## Pattern

- dynamicthresholds.Handler embeds *apicore.Core by pointer (never copied by value).
- New(core) constructs the handler; RegisterRoutes(g *echo.Group) wires the exact 6 routes from the old initDynamicThresholdRoutes in the same order: 4 public GET reads and 2 DELETE resets gated by AuthMiddleware.
- Handler methods moved verbatim, only the receiver retyped from *Controller to *Handler (receiver name kept c); bodies rely on promotion of the embedded Core.
- The four response DTOs (DynamicThresholdResponse, ThresholdEventResponse, ThresholdStatsResponse, LevelStatItem), the pagination constants, the local helpers, and the tests moved with the package. The response structs keep identical json tags, so the wire format of every dynamic-thresholds endpoint is unchanged.

## Core-only domain

Every dependency the handlers touch already promotes from apicore.Core (DS, Processor, AuthMiddleware, HandleError, HandleErrorWithNotFound, CurrentSettings, Debug, the v2 group, and the Settings atomic snapshot), so the domain injects no facade-owned dependency. New takes only the shared core.

## Cross-domain coupling resolved via apicore

parsePaginationLimit was defined in dynamic_thresholds.go but also called by the analytics domain (3 call sites in analytics.go). Since it is shared by 2+ domains it moved to apicore as the free function ParsePaginationLimit, next to the existing ParseFloat64/ParseFloat32 helpers, with identical validation semantics (returns the default when the value is missing, non-numeric, non-positive, or exceeds the max). analytics.go and the dynamicthresholds handlers now both call apicore.ParsePaginationLimit. parsePaginationOffset is dynamic-thresholds-only, so it stays a package-local function in the new package.

## Facade wiring (order preserved exactly)

- Controller gains an unexported dynamicThresholds *dynamicthresholds.Handler field.
- NewWithOptions constructs it once via dynamicthresholds.New(c.Core).
- initRoutes replaces the dynamic-threshold routeInitializers entry in place with {"dynamic threshold routes", func() { c.dynamicThresholds.RegisterRoutes(c.Group) }} at the same index, so the route-enumeration golden gate stays byte-identical.

## Verification

- go build ./... clean (only the unrelated frontend all:dist embed needs a frontend build; verified locally with -tags skipfrontend).
- go vet ./internal/api/v2/... ./internal/analysis/... clean (Core embedded by pointer only, no copylocks).
- go test -race ./internal/api/v2/ green (169s); dynamicthresholds runs as its own isolated -race binary (green); apicore green; internal/analysis/processor and internal/analysis/species green under -race in isolation.
- Route-enumeration golden gate (TestRouteEnumerationMatchesGolden, TestRouteEnumerationIsDeterministic, TestGreedyAudioRouteRegisteredOnEcho) passes unchanged: same method+path+per-route-middleware set and order.
- golangci-lint run clean (0 issues) on the new and changed packages.

No public-behavior change: apiv2.Controller, New, and all external signatures are unchanged; every endpoint keeps its path, method, auth, and JSON shape.

## Preflight Status

- [x] Single concern: one refactor (extract dynamic_thresholds domain)
- [x] Linters clean: golangci-lint 0 issues on changed packages
- [x] Tests pass: go test -race green for the affected packages; domain has its own -race binary
- [x] No unrelated changes
- [x] No regression/backward-compat break: response json tags, routes, auth, and pagination semantics all identical
- [x] No secrets or PII


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic threshold routes now use a dedicated handler setup, with the same endpoints and responses available as before.
  * Analytics endpoints now apply consistent pagination limit handling across several charts and lists.

* **Bug Fixes**
  * Improved pagination limit validation so invalid, missing, or out-of-range `limit` values fall back to safe defaults.
  * Updated dynamic threshold behavior to better handle not-found errors, returning the appropriate status code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->