### PR TITLE
refactor(api/v2): extract notifications domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -170,7 +170,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/spectrogram/:id/status`            | `GetSpectrogramStatus`   | ❌   | Get spectrogram generation status  |
 | POST   | `/audio/:id/clip`                    | `ExtractAudioClipByID`   | ✅   | Extract audio clip from time range |
 
-### Notifications (`notifications.go`)
+### Notifications (`notifications/notifications.go`)
 
 | Method | Route                              | Handler                            | Auth | Description                                                                                                         |
 | ------ | ---------------------------------- | ---------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/dynamicthresholds"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
+	"github.com/tphakala/birdnet-go/internal/api/v2/notifications"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/api/v2/species"
 	"github.com/tphakala/birdnet-go/internal/api/v2/support"
@@ -161,8 +162,20 @@ type Controller struct {
 	// nil in production, where getNotificationService() falls back to the
 	// process-global singleton (notification.GetService()). Tests inject an
 	// isolated per-test instance via WithNotificationService so each test gets its
-	// own config and store without touching the global singleton.
+	// own config and store without touching the global singleton. The facade
+	// keeps this field because debug.go, migration.go and legacy_cleanup.go still
+	// resolve the service through getNotificationService(); the same value is
+	// handed to the notifications domain handler below.
 	notificationService *notification.Service
+
+	// notifications serves the /api/v2/notifications/* endpoints (list, unread
+	// count, SSE notification+toast stream, per-item mutations, the test
+	// new-species trigger, and the NTFY connectivity probe). Beyond the shared
+	// *apicore.Core it receives the facade-injected notificationService and
+	// authService. It is constructed AFTER the functional options are applied so
+	// both services reflect WithNotificationService / WithAuthService (see
+	// NewWithOptions).
+	notifications *notifications.Handler
 
 	// Audio processing fields
 	processingCache     *processingCache
@@ -198,12 +211,6 @@ type Controller struct {
 	// importSourceFactory builds an import Source from a resolved path.
 	// Defaults to a BirdNET-Pi adapter when nil. Overridable in tests.
 	importSourceFactory func(path string) (imports.Source, error)
-
-	// ntfyCheckTimeoutOverride overrides the per-scheme ntfy connectivity probe
-	// timeout used by CheckNtfyServer. Zero in production, where the probe uses
-	// ntfyServerCheckTimeout. Tests set a short timeout so the unreachable-host
-	// path returns quickly instead of waiting the full default for each scheme.
-	ntfyCheckTimeoutOverride time.Duration
 
 	// audioWaitTimeoutOverride overrides the server-side wait for an in-progress
 	// audio encoding used by waitForAudioFile. Zero in production, where the wait
@@ -262,6 +269,20 @@ func WithNotificationService(svc *notification.Service) Option {
 	return func(c *Controller) {
 		c.notificationService = svc
 	}
+}
+
+// getNotificationService returns the notification service this controller uses:
+// the injected instance when set (tests inject via WithNotificationService),
+// otherwise the process-global singleton (notification.GetService()). The
+// notifications domain handler holds its own injected copy; this facade accessor
+// serves the remaining package-api callers (debug.go, migration.go,
+// legacy_cleanup.go) that resolve the service outside that handler. The field is
+// nil in production, so it falls back to the singleton exactly as before.
+func (c *Controller) getNotificationService() *notification.Service {
+	if c.notificationService != nil {
+		return c.notificationService
+	}
+	return notification.GetService()
 }
 
 // WithMetricsStore sets the system metrics history store for the controller.
@@ -435,6 +456,16 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// read at RegisterRoutes time (after this), so it is also populated.
 	c.authHandler = authapi.New(c.Core, c.authService)
 
+	// Construct the notifications domain handler AFTER the functional options are
+	// applied, for the same reason as the auth handler: both WithNotificationService
+	// and WithAuthService set their fields in the loop above. The handler captures
+	// the injected services (notificationService falls back to the global singleton
+	// when nil; authService is nil-guarded). Neither changes after this point, so
+	// capturing the post-option values is behaviorally identical to the monolith's
+	// per-request reads. The facade keeps c.notificationService for the other
+	// handlers that still resolve the service via getNotificationService().
+	c.notifications = notifications.New(c.Core, c.notificationService, c.authService)
+
 	// Log auth configuration status
 	log := GetLogger()
 	if c.AuthMiddleware != nil {
@@ -521,7 +552,7 @@ func (c *Controller) initRoutes() {
 		{"sse routes", c.initSSERoutes},
 		{"diagnostics routes", c.initDiagnosticsRoutes},
 		{"metrics history routes", c.initMetricsHistoryRoutes},
-		{"notification routes", c.initNotificationRoutes},
+		{"notification routes", func() { c.notifications.RegisterRoutes(c.Group) }},
 		{"support routes", func() { c.support.RegisterRoutes(c.Group) }},
 		{"debug routes", c.initDebugRoutes},
 		{"species routes", func() { c.species.RegisterRoutes(c.Group) }},

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -1,9 +1,15 @@
 package apicore
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // Server-Sent Events streaming configuration shared by every SSE endpoint
@@ -18,7 +24,18 @@ const (
 	// SSEEventLoopSleep is the sleep duration used to throttle an SSE poll loop
 	// when there are no events to send.
 	SSEEventLoopSleep = 10 * time.Millisecond
+
+	// SSEWriteDeadline bounds how long a single SSE message write may block on a
+	// slow or disconnected client before it is abandoned.
+	SSEWriteDeadline = 10 * time.Second
 )
+
+// WriteDeadlineSetter is implemented by response writers that support a write
+// deadline (e.g. the underlying TCP connection). SSE writers use it to avoid
+// hanging on stalled clients.
+type WriteDeadlineSetter interface {
+	SetWriteDeadline(time.Time) error
+}
 
 // SetSSEHeaders sets the required HTTP headers for a Server-Sent Events response.
 func SetSSEHeaders(ctx echo.Context) {
@@ -27,4 +44,75 @@ func SetSSEHeaders(ctx echo.Context) {
 	ctx.Response().Header().Set("Connection", "keep-alive")
 	ctx.Response().Header().Set("Access-Control-Allow-Origin", "*")
 	ctx.Response().Header().Set("Access-Control-Allow-Headers", "Cache-Control")
+}
+
+// SafeMarshalJSON marshals data to JSON with panic recovery.
+// This protects against panics from concurrent map access or unmarshalable data.
+func (c *Core) SafeMarshalJSON(event string, data any) (jsonData []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("JSON marshal panic: %v", r)
+			c.LogErrorIfEnabled("SSE marshal panic recovered",
+				logger.String("event", event),
+				logger.Any("panic", r),
+				logger.String("stack", string(debug.Stack())),
+			)
+			_ = errors.Newf("SSE JSON marshal panic: %v", r).
+				Component("api").
+				Category(errors.CategoryBroadcast).
+				Context("operation", "sse_marshal_panic").
+				Priority(errors.PriorityCritical).
+				Build()
+		}
+	}()
+	return json.Marshal(data)
+}
+
+// SendSSEMessage sends a Server-Sent Event message. It applies a write deadline
+// so a stalled client cannot block the writer, and flushes so the client
+// receives the event promptly.
+func (c *Core) SendSSEMessage(ctx echo.Context, event string, data any) error {
+	// Convert data to JSON with panic recovery
+	jsonData, err := c.SafeMarshalJSON(event, data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal SSE data: %w", err)
+	}
+
+	// Format SSE message
+	message := fmt.Sprintf("event: %s\ndata: %s\n\n", event, string(jsonData))
+
+	// Set write deadline to prevent hanging on slow/disconnected clients
+	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
+		deadline := time.Now().Add(SSEWriteDeadline) // Write deadline timeout
+		if err := conn.SetWriteDeadline(deadline); err != nil {
+			// If we can't set deadline, log but continue - not all response writers support this
+			c.LogDebugIfEnabled("Failed to set write deadline for SSE message", logger.Error(err))
+		}
+	}
+
+	// Write to response
+	if _, err := ctx.Response().Write([]byte(message)); err != nil {
+		return fmt.Errorf("failed to write SSE message: %w", err)
+	}
+
+	// Flush the response
+	if flusher, ok := ctx.Response().Writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	return nil
+}
+
+// RecordSSEError records an SSE error metric if metrics are available.
+func (c *Core) RecordSSEError(endpoint, errorType string) {
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.RecordSSEError(endpoint, errorType)
+	}
+}
+
+// RecordSSEMessage records an SSE message-sent metric if metrics are available.
+func (c *Core) RecordSSEMessage(endpoint, messageType string) {
+	if c.Metrics != nil && c.Metrics.HTTP != nil {
+		c.Metrics.HTTP.RecordSSEMessageSent(endpoint, messageType)
+	}
 }

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -662,7 +663,7 @@ func (c *Controller) extractRemoteAddr(ctx echo.Context) string {
 // resetAudioLevelWriteDeadline resets the write deadline for the SSE connection.
 // This prevents the server's WriteTimeout from terminating long-lived SSE connections.
 func (c *Controller) resetAudioLevelWriteDeadline(ctx echo.Context, operation string) {
-	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
+	if conn, ok := ctx.Response().Writer.(apicore.WriteDeadlineSetter); ok {
 		if err := conn.SetWriteDeadline(time.Now().Add(audioLevelWriteDeadline)); err != nil {
 			c.LogDebugIfEnabled("Failed to set write deadline for "+operation, logger.Error(err))
 		}

--- a/internal/api/v2/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio_level_write_deadline_test.go
@@ -27,7 +27,7 @@ type mockWriteDeadlineResponseWriter struct {
 	lastDeadline           time.Time
 }
 
-// SetWriteDeadline implements WriteDeadlineSetter interface
+// SetWriteDeadline implements apicore.WriteDeadlineSetter interface
 func (m *mockWriteDeadlineResponseWriter) SetWriteDeadline(t time.Time) error {
 	m.setWriteDeadlineCalled.Store(true)
 	m.lastDeadline = t

--- a/internal/api/v2/dashboard_public_endpoints_test.go
+++ b/internal/api/v2/dashboard_public_endpoints_test.go
@@ -340,7 +340,7 @@ func TestNotifications_GuestSSEFiltersNonDetectionAndToasts(t *testing.T) {
 	require.Eventually(t, func() bool {
 		select {
 		case ev := <-events:
-			return ev.Event == sseEventConnected
+			return ev.Event == SSEStatusConnected
 		default:
 			return false
 		}

--- a/internal/api/v2/import.go
+++ b/internal/api/v2/import.go
@@ -448,15 +448,15 @@ func (c *Controller) GetImportStatus(ctx echo.Context) error {
 
 // sendImportEvent sends a single SSE event with a monotonic id field.
 func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, data any) error {
-	payload, err := c.safeMarshalJSON(event, data)
+	payload, err := c.SafeMarshalJSON(event, data)
 	if err != nil {
 		return fmt.Errorf("marshal import event: %w", err)
 	}
 	msg := fmt.Sprintf("id: %d\nevent: %s\ndata: %s\n\n", id, event, payload)
-	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
-		if err := conn.SetWriteDeadline(time.Now().Add(sseWriteDeadline)); err != nil {
+	if conn, ok := ctx.Response().Writer.(apicore.WriteDeadlineSetter); ok {
+		if err := conn.SetWriteDeadline(time.Now().Add(apicore.SSEWriteDeadline)); err != nil {
 			// Best-effort: not all response writers support deadlines; log and proceed,
-			// matching sendSSEMessage in sse.go.
+			// matching SendSSEMessage in apicore.
 			c.LogDebugIfEnabled("Failed to set write deadline for import SSE event", logger.Error(err))
 		}
 	}
@@ -471,7 +471,7 @@ func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, 
 
 // sendImportHeartbeat sends a lightweight SSE event to keep the connection alive.
 func (c *Controller) sendImportHeartbeat(ctx echo.Context) error {
-	return c.sendSSEMessage(ctx, importEventHeartbeat, map[string]int64{"ts": time.Now().Unix()})
+	return c.SendSSEMessage(ctx, importEventHeartbeat, map[string]int64{"ts": time.Now().Unix()})
 }
 
 // sendImportTerminal sends the final SSE event based on the import outcome.

--- a/internal/api/v2/metrics_history.go
+++ b/internal/api/v2/metrics_history.go
@@ -113,7 +113,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 	)
 
 	// Send initial connection message
-	if err := c.sendSSEMessage(ctx, "connected", map[string]string{
+	if err := c.SendSSEMessage(ctx, "connected", map[string]string{
 		"clientId": clientID,
 		"message":  "Connected to metrics stream",
 	}); err != nil {
@@ -156,7 +156,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 			}
 
 			if len(data) > 0 {
-				if err := c.sendSSEMessage(ctx, "metrics", data); err != nil {
+				if err := c.SendSSEMessage(ctx, "metrics", data); err != nil {
 					c.LogDebugIfEnabled("Metrics SSE send failed, client likely disconnected",
 						logger.String("client_id", clientID),
 						logger.Error(err),
@@ -166,7 +166,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 			}
 
 		case <-topoCh:
-			if err := c.sendSSEMessage(ctx, eventInferenceTopologyChanged, map[string]any{
+			if err := c.SendSSEMessage(ctx, eventInferenceTopologyChanged, map[string]any{
 				"timestamp": time.Now().Unix(),
 			}); err != nil {
 				c.LogDebugIfEnabled("Metrics SSE topology-changed send failed, client likely disconnected",
@@ -177,7 +177,7 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 			}
 
 		case <-heartbeatTicker.C:
-			if err := c.sendSSEMessage(ctx, "heartbeat", map[string]any{
+			if err := c.SendSSEMessage(ctx, "heartbeat", map[string]any{
 				"timestamp": time.Now().Unix(),
 			}); err != nil {
 				c.LogDebugIfEnabled("Metrics SSE heartbeat failed",

--- a/internal/api/v2/notifications/notifications.go
+++ b/internal/api/v2/notifications/notifications.go
@@ -1,4 +1,23 @@
-package api
+// Package notifications is the api/v2 notifications domain handler. It owns the
+// /api/v2/notifications/* endpoints: the notification list and unread-count, the
+// SSE notification+toast stream, per-item read/acknowledge/delete mutations, the
+// test new-species trigger, and the NTFY connectivity probe.
+//
+// The Handler embeds *apicore.Core by pointer so the shared dependencies and
+// helpers (HandleError/HandleErrorWithKey, the logging helpers, the SSE write
+// primitives SendSSEMessage/RecordSSEMessage/RecordSSEError, Metrics, the
+// settings accessors, and the AuthMiddleware field) promote onto it.
+//
+// Two domain members are injected from the facade because they are supplied via
+// functional options applied AFTER the facade's options loop:
+//   - notificationService: getNotificationService() returns the injected
+//     instance or falls back to the process-global singleton
+//     (notification.GetService()) when nil, exactly as the monolith did. The
+//     facade keeps its own copy of this field for the other handlers (debug,
+//     migration, legacy cleanup) that still resolve the service.
+//   - authService: used by isGuestNotificationRequest to harden the public
+//     notification endpoints so guests only ever see bird-detection events.
+package notifications
 
 import (
 	"context"
@@ -15,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -23,6 +43,44 @@ import (
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"golang.org/x/time/rate"
 )
+
+// Handler serves the api/v2 notifications domain endpoints. It embeds the shared
+// *apicore.Core (by pointer) and additionally holds the facade-injected
+// notification and auth services plus a test-only probe timeout override.
+type Handler struct {
+	*apicore.Core
+
+	// notificationService is the notification service injected from the facade
+	// (set there via the WithNotificationService functional option). It is nil in
+	// production, where getNotificationService() falls back to the process-global
+	// singleton (notification.GetService()). Tests inject an isolated per-test
+	// instance so each test gets its own config and store.
+	notificationService *notification.Service
+
+	// authService is the authentication service injected from the facade (set
+	// there via the WithAuthService functional option). It is used by
+	// isGuestNotificationRequest; a nil service means auth is disabled and every
+	// caller is treated as trusted, exactly as in the monolith.
+	authService auth.Service
+
+	// ntfyCheckTimeoutOverride overrides the per-scheme ntfy connectivity probe
+	// timeout used by CheckNtfyServer. Zero in production, where the probe uses
+	// ntfyServerCheckTimeout. Tests set a short timeout so the unreachable-host
+	// path returns quickly instead of waiting the full default for each scheme.
+	ntfyCheckTimeoutOverride time.Duration
+}
+
+// New constructs the notifications domain handler around the shared core and the
+// facade-injected services. The facade constructs this AFTER applying its
+// functional options so notificationService and authService reflect
+// WithNotificationService / WithAuthService.
+func New(core *apicore.Core, notificationService *notification.Service, authService auth.Service) *Handler {
+	return &Handler{
+		Core:                core,
+		notificationService: notificationService,
+		authService:         authService,
+	}
+}
 
 // SSE Connection configuration
 const (
@@ -108,13 +166,13 @@ type notificationAction struct {
 	successRespMsg string
 }
 
-// getNotificationService returns the notification service this controller uses:
+// getNotificationService returns the notification service this handler uses:
 // the injected instance when set (tests inject via WithNotificationService),
 // otherwise the process-global singleton (notification.GetService()). Routing all
-// handlers through this accessor lets a controller be fully isolated from global
+// handlers through this accessor lets a handler be fully isolated from global
 // state while keeping production behavior unchanged (the field is nil in
 // production, so it falls back to the singleton exactly as before).
-func (c *Controller) getNotificationService() *notification.Service {
+func (c *Handler) getNotificationService() *notification.Service {
 	if c.notificationService != nil {
 		return c.notificationService
 	}
@@ -122,7 +180,7 @@ func (c *Controller) getNotificationService() *notification.Service {
 }
 
 // requireNotificationService is middleware that returns 503 if the notification service is not initialized.
-func (c *Controller) requireNotificationService(next echo.HandlerFunc) echo.HandlerFunc {
+func (c *Handler) requireNotificationService(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		if c.getNotificationService() == nil {
 			return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
@@ -134,7 +192,7 @@ func (c *Controller) requireNotificationService(next echo.HandlerFunc) echo.Hand
 // executeNotificationAction handles the common pattern for notification operations:
 // validate ID, execute operation, handle errors.
 // All callers are behind the requireNotificationService middleware.
-func (c *Controller) executeNotificationAction(ctx echo.Context, action notificationAction) error {
+func (c *Handler) executeNotificationAction(ctx echo.Context, action notificationAction) error {
 	id := ctx.Param("id")
 	if id == "" {
 		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
@@ -156,18 +214,15 @@ func (c *Controller) executeNotificationAction(ctx echo.Context, action notifica
 	})
 }
 
-// initNotificationRoutes registers notification-related routes
-func (c *Controller) initNotificationRoutes() {
-	c.SetupNotificationRoutes()
-}
-
-// SetupNotificationRoutes configures notification-related routes
-func (c *Controller) SetupNotificationRoutes() {
+// RegisterRoutes registers the notifications domain routes on the provided v2
+// API group, preserving the exact route order and per-route middleware the
+// monolithic initNotificationRoutes/SetupNotificationRoutes pair used.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	// Rate limiter configuration for SSE connections. `Rate` is interpreted
 	// as tokens per second by golang.org/x/time/rate, so
 	// `rateLimitRequestsPerWindow / rateLimitWindow` gives us the intended
 	// 10 connections per minute (≈0.1667/sec). A bare `10` here would mean
-	// 10/second — 60× too permissive for an unauthenticated SSE endpoint
+	// 10/second; 60x too permissive for an unauthenticated SSE endpoint
 	// (Sentry flagged this on PR #2775).
 	rateLimiterConfig := middleware.RateLimiterConfig{
 		Skipper: middleware.DefaultSkipper,
@@ -195,18 +250,18 @@ func (c *Controller) SetupNotificationRoutes() {
 	// Route priority: Echo matches static path segments before parameter
 	// routes ("/:id"), so /unread/count and /stream always win over the
 	// /:id routes registered in the auth group below. Register these on
-	// the parent c.Group so they are NOT wrapped by c.AuthMiddleware.
-	// (/check-ntfy-server is intentionally NOT public — see the auth group
+	// the parent group g so they are NOT wrapped by c.AuthMiddleware.
+	// (/check-ntfy-server is intentionally NOT public; see the auth group
 	// registration later in this function, kept authed to prevent SSRF.)
-	c.Group.GET("/notifications", c.GetNotifications, c.requireNotificationService)
-	c.Group.GET("/notifications/unread/count", c.GetUnreadCount, c.requireNotificationService)
-	c.Group.GET("/notifications/stream", c.StreamNotifications,
+	g.GET("/notifications", c.GetNotifications, c.requireNotificationService)
+	g.GET("/notifications/unread/count", c.GetUnreadCount, c.requireNotificationService)
+	g.GET("/notifications/stream", c.StreamNotifications,
 		c.requireNotificationService, middleware.RateLimiterWithConfig(rateLimiterConfig))
 
 	// Auth-protected endpoints: per-item read, mutations, the test-notification
 	// trigger, and the NTFY connectivity probe (kept authed to avoid being
 	// used as an SSRF relay by unauthenticated callers).
-	notificationsGroup := c.Group.Group("/notifications", c.AuthMiddleware)
+	notificationsGroup := g.Group("/notifications", c.AuthMiddleware)
 
 	notifServiceGroup := notificationsGroup.Group("", c.requireNotificationService)
 	notifServiceGroup.PUT("/read-all", c.MarkAllNotificationsRead)
@@ -242,7 +297,7 @@ type NtfyServerCheckResponse struct {
 // CheckNtfyServer probes an NTFY server host for HTTPS and HTTP connectivity.
 // It tries HTTPS first; on failure it falls back to HTTP.
 // GET /api/v2/notifications/check-ntfy-server?host=<hostname[:port]>
-func (c *Controller) CheckNtfyServer(ctx echo.Context) error {
+func (c *Handler) CheckNtfyServer(ctx echo.Context) error {
 	host := ctx.QueryParam("host")
 	if host == "" {
 		return c.HandleErrorWithKey(ctx, nil, "host parameter is required", http.StatusBadRequest, notification.MsgErrNotifHostRequired, nil)
@@ -271,7 +326,7 @@ func isValidNtfyHost(host string) bool {
 		return false
 	}
 
-	// Reject if a scheme is included — we expect a bare host or host:port
+	// Reject if a scheme is included; we expect a bare host or host:port
 	if strings.Contains(host, "://") {
 		return false
 	}
@@ -287,7 +342,7 @@ func isValidNtfyHost(host string) bool {
 		return false
 	}
 
-	// Try parsing as host:port — if it works, validate both parts
+	// Try parsing as host:port; if it works, validate both parts
 	if h, port, err := net.SplitHostPort(host); err == nil {
 		p, err := strconv.Atoi(port)
 		if err != nil || p < 1 || p > 65535 {
@@ -397,7 +452,7 @@ func probeNtfyServer(ctx context.Context, host string, timeout time.Duration) Nt
 }
 
 // StreamNotifications handles the SSE connection for real-time notification streaming
-func (c *Controller) StreamNotifications(ctx echo.Context) error {
+func (c *Handler) StreamNotifications(ctx echo.Context) error {
 	// Track connection start time for metrics
 	connectionStartTime := time.Now()
 
@@ -445,7 +500,7 @@ func (c *Controller) StreamNotifications(ctx echo.Context) error {
 }
 
 // setupNotificationSSEClient initializes the SSE client and establishes connection
-func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*NotificationClient, *notification.Service, error) {
+func (c *Handler) setupNotificationSSEClient(ctx echo.Context) (*NotificationClient, *notification.Service, error) {
 	// Set SSE headers
 	apicore.SetSSEHeaders(ctx)
 
@@ -470,7 +525,7 @@ func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*Notification
 	}
 
 	// Send initial connection message
-	if err := c.sendSSEMessage(ctx, sseEventConnected, map[string]string{
+	if err := c.SendSSEMessage(ctx, sseEventConnected, map[string]string{
 		"clientId": clientID,
 		"message":  "Connected to notification stream",
 	}); err != nil {
@@ -489,7 +544,7 @@ func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*Notification
 }
 
 // setupNotificationDisconnectHandler sets up client disconnect handling with timeout
-func (c *Controller) setupNotificationDisconnectHandler(ctx echo.Context, client *NotificationClient) {
+func (c *Handler) setupNotificationDisconnectHandler(ctx echo.Context, client *NotificationClient) {
 	go func() {
 		// Wait for client disconnect or timeout
 		<-ctx.Request().Context().Done()
@@ -506,7 +561,7 @@ func (c *Controller) setupNotificationDisconnectHandler(ctx echo.Context, client
 }
 
 // runNotificationEventLoop runs the main SSE event loop
-func (c *Controller) runNotificationEventLoop(ctx echo.Context, client *NotificationClient) error {
+func (c *Handler) runNotificationEventLoop(ctx echo.Context, client *NotificationClient) error {
 	// Send heartbeat every 30 seconds
 	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
@@ -554,10 +609,10 @@ func (c *Controller) runNotificationEventLoop(ctx echo.Context, client *Notifica
 			}
 			// Send heartbeat
 			if err := c.sendNotificationHeartbeat(ctx); err != nil {
-				c.recordSSEError(sseEndpoint, "heartbeat_failed")
+				c.RecordSSEError(sseEndpoint, "heartbeat_failed")
 				return err
 			}
-			c.recordSSEMessage(sseEndpoint, "heartbeat")
+			c.RecordSSEMessage(sseEndpoint, "heartbeat")
 
 		case <-client.Done:
 			// Client disconnected
@@ -571,7 +626,7 @@ func (c *Controller) runNotificationEventLoop(ctx echo.Context, client *Notifica
 }
 
 // processNotificationEvent processes a single notification event
-func (c *Controller) processNotificationEvent(ctx echo.Context, clientID string, notif *notification.Notification) error {
+func (c *Handler) processNotificationEvent(ctx echo.Context, clientID string, notif *notification.Notification) error {
 	// Check if this is a toast notification
 	isToast, _ := notif.Metadata[notification.MetadataKeyIsToast].(bool)
 
@@ -583,24 +638,24 @@ func (c *Controller) processNotificationEvent(ctx echo.Context, clientID string,
 }
 
 // sendToastEvent sends a toast event via SSE
-func (c *Controller) sendToastEvent(ctx echo.Context, clientID string, notif *notification.Notification) error {
+func (c *Handler) sendToastEvent(ctx echo.Context, clientID string, notif *notification.Notification) error {
 	// Clone notification to prevent concurrent access issues during JSON marshaling
 	safeNotif := notif.Clone()
 	toastEvent := c.createToastEventData(safeNotif)
 
-	if err := c.sendSSEMessage(ctx, "toast", toastEvent); err != nil {
+	if err := c.SendSSEMessage(ctx, "toast", toastEvent); err != nil {
 		c.logNotificationError("failed to send toast SSE", err, clientID)
-		c.recordSSEError(sseEndpoint, "send_failed")
+		c.RecordSSEError(sseEndpoint, "send_failed")
 		return err
 	}
 
-	c.recordSSEMessage(sseEndpoint, "toast")
+	c.RecordSSEMessage(sseEndpoint, "toast")
 	c.logToastSent(clientID, notif)
 	return nil
 }
 
 // sendNotificationEvent sends a notification event via SSE
-func (c *Controller) sendNotificationEvent(ctx echo.Context, clientID string, notif *notification.Notification) error {
+func (c *Handler) sendNotificationEvent(ctx echo.Context, clientID string, notif *notification.Notification) error {
 	// Clone notification to prevent concurrent access issues during JSON marshaling
 	safeNotif := notif.Clone()
 
@@ -609,19 +664,19 @@ func (c *Controller) sendNotificationEvent(ctx echo.Context, clientID string, no
 		EventType:    "notification",
 	}
 
-	if err := c.sendSSEMessage(ctx, "notification", event); err != nil {
+	if err := c.SendSSEMessage(ctx, "notification", event); err != nil {
 		c.logNotificationError("failed to send notification SSE", err, clientID)
-		c.recordSSEError(sseEndpoint, "send_failed")
+		c.RecordSSEError(sseEndpoint, "send_failed")
 		return err
 	}
 
-	c.recordSSEMessage(sseEndpoint, "notification")
+	c.RecordSSEMessage(sseEndpoint, "notification")
 	c.logNotificationSent(clientID, notif)
 	return nil
 }
 
 // createToastEventData creates toast event data from notification
-func (c *Controller) createToastEventData(notif *notification.Notification) map[string]any {
+func (c *Handler) createToastEventData(notif *notification.Notification) map[string]any {
 	toastType, _ := notif.Metadata["toastType"].(string)
 	duration, _ := notif.Metadata["duration"].(int)
 	action, _ := notif.Metadata["action"].(*notification.ToastAction)
@@ -653,14 +708,14 @@ func (c *Controller) createToastEventData(notif *notification.Notification) map[
 }
 
 // sendNotificationHeartbeat sends a heartbeat message
-func (c *Controller) sendNotificationHeartbeat(ctx echo.Context) error {
-	return c.sendSSEMessage(ctx, "heartbeat", map[string]string{
+func (c *Handler) sendNotificationHeartbeat(ctx echo.Context) error {
+	return c.SendSSEMessage(ctx, "heartbeat", map[string]string{
 		"timestamp": time.Now().Format(time.RFC3339),
 	})
 }
 
 // logNotificationConnection logs SSE client connection/disconnection events
-func (c *Controller) logNotificationConnection(clientID, ip, userAgent string, connected bool) {
+func (c *Handler) logNotificationConnection(clientID, ip, userAgent string, connected bool) {
 	action := "connected"
 	if !connected {
 		action = "disconnected"
@@ -679,14 +734,14 @@ func (c *Controller) logNotificationConnection(clientID, ip, userAgent string, c
 }
 
 // logNotificationError logs SSE errors
-func (c *Controller) logNotificationError(message string, err error, clientID string) {
+func (c *Handler) logNotificationError(message string, err error, clientID string) {
 	c.LogErrorIfEnabled(message,
 		logger.Error(err),
 		logger.String("clientId", clientID))
 }
 
 // logToastSent logs successful toast sending
-func (c *Controller) logToastSent(clientID string, notif *notification.Notification) {
+func (c *Handler) logToastSent(clientID string, notif *notification.Notification) {
 	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug {
 		toastType, _ := notif.Metadata["toastType"].(string)
 		c.LogDebugIfEnabled("toast sent via SSE",
@@ -698,7 +753,7 @@ func (c *Controller) logToastSent(clientID string, notif *notification.Notificat
 }
 
 // logNotificationSent logs successful notification sending
-func (c *Controller) logNotificationSent(clientID string, notif *notification.Notification) {
+func (c *Handler) logNotificationSent(clientID string, notif *notification.Notification) {
 	if s := c.CurrentSettings(); s != nil && s.WebServer.Debug {
 		c.LogDebugIfEnabled("notification sent via SSE",
 			logger.String("clientId", clientID),
@@ -713,7 +768,7 @@ func (c *Controller) logNotificationSent(clientID string, notif *notification.No
 // notifications endpoints to detection-type notifications only so that
 // operational/admin notifications (integration errors, config problems) are
 // not leaked to anonymous clients.
-func (c *Controller) isGuestNotificationRequest(ctx echo.Context) bool {
+func (c *Handler) isGuestNotificationRequest(ctx echo.Context) bool {
 	if c.authService == nil {
 		// No auth service configured → auth is disabled, treat everyone as trusted.
 		return false
@@ -722,7 +777,7 @@ func (c *Controller) isGuestNotificationRequest(ctx echo.Context) bool {
 }
 
 // GetNotifications returns a list of notifications with optional filtering
-func (c *Controller) GetNotifications(ctx echo.Context) error {
+func (c *Handler) GetNotifications(ctx echo.Context) error {
 	service := c.getNotificationService()
 
 	// Build filter options from query parameters
@@ -822,7 +877,7 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 }
 
 // GetNotification returns a single notification by ID
-func (c *Controller) GetNotification(ctx echo.Context) error {
+func (c *Handler) GetNotification(ctx echo.Context) error {
 	id := ctx.Param("id")
 	if id == "" {
 		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
@@ -844,7 +899,7 @@ func (c *Controller) GetNotification(ctx echo.Context) error {
 }
 
 // MarkAllNotificationsRead marks every unread notification as read in one call.
-func (c *Controller) MarkAllNotificationsRead(ctx echo.Context) error {
+func (c *Handler) MarkAllNotificationsRead(ctx echo.Context) error {
 	service := c.getNotificationService()
 
 	count, err := service.MarkAllAsRead()
@@ -860,7 +915,7 @@ func (c *Controller) MarkAllNotificationsRead(ctx echo.Context) error {
 }
 
 // MarkNotificationRead marks a notification as read
-func (c *Controller) MarkNotificationRead(ctx echo.Context) error {
+func (c *Handler) MarkNotificationRead(ctx echo.Context) error {
 	return c.executeNotificationAction(ctx, notificationAction{
 		operation:      func(s *notification.Service, id string) error { return s.MarkAsRead(id) },
 		errorLogMsg:    "failed to mark notification as read",
@@ -870,7 +925,7 @@ func (c *Controller) MarkNotificationRead(ctx echo.Context) error {
 }
 
 // MarkNotificationAcknowledged marks a notification as acknowledged
-func (c *Controller) MarkNotificationAcknowledged(ctx echo.Context) error {
+func (c *Handler) MarkNotificationAcknowledged(ctx echo.Context) error {
 	return c.executeNotificationAction(ctx, notificationAction{
 		operation:      func(s *notification.Service, id string) error { return s.MarkAsAcknowledged(id) },
 		errorLogMsg:    "failed to mark notification as acknowledged",
@@ -880,7 +935,7 @@ func (c *Controller) MarkNotificationAcknowledged(ctx echo.Context) error {
 }
 
 // DeleteNotification deletes a notification
-func (c *Controller) DeleteNotification(ctx echo.Context) error {
+func (c *Handler) DeleteNotification(ctx echo.Context) error {
 	return c.executeNotificationAction(ctx, notificationAction{
 		operation:      func(s *notification.Service, id string) error { return s.Delete(id) },
 		errorLogMsg:    "failed to delete notification",
@@ -892,7 +947,7 @@ func (c *Controller) DeleteNotification(ctx echo.Context) error {
 // GetUnreadCount returns the count of unread notifications. For
 // unauthenticated dashboard requests, only unread detection notifications are
 // counted so the NotificationBell badge matches the filtered guest list.
-func (c *Controller) GetUnreadCount(ctx echo.Context) error {
+func (c *Handler) GetUnreadCount(ctx echo.Context) error {
 	service := c.getNotificationService()
 
 	if c.isGuestNotificationRequest(ctx) {
@@ -925,7 +980,7 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 }
 
 // CreateTestNewSpeciesNotification creates a test new species detection notification
-func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
+func (c *Handler) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 	settings := c.CurrentSettings()
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not initialized", http.StatusServiceUnavailable)

--- a/internal/api/v2/notifications/notifications_helpers_test.go
+++ b/internal/api/v2/notifications/notifications_helpers_test.go
@@ -1,4 +1,4 @@
-package api
+package notifications
 
 import (
 	"net/http"
@@ -9,7 +9,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
@@ -43,21 +42,10 @@ func assertNoNilAction(t *testing.T, result, metadata map[string]any) {
 	}
 }
 
-// mockController creates a controller with minimal setup for testing
-func mockController() *Controller {
-	c := &Controller{Core: &apicore.Core{APILogger: nil}}
-	c.Settings.Store(&conf.Settings{
-		WebServer: conf.WebServerSettings{
-			Debug: true,
-		},
-	})
-	return c
-}
-
 func TestController_createToastEventData(t *testing.T) {
 	t.Parallel()
 
-	c := mockController()
+	c := mockHandler()
 
 	tests := []struct {
 		name     string
@@ -211,7 +199,7 @@ func TestController_processNotificationEvent(t *testing.T) {
 
 	// Since processNotificationEvent calls other methods that require HTTP context,
 	// we'll test the decision logic by checking which path it takes
-	c := mockController()
+	c := mockHandler()
 
 	tests := []struct {
 		name      string
@@ -273,11 +261,11 @@ func TestController_processNotificationEvent(t *testing.T) {
 			rec := httptest.NewRecorder()
 			ctx := e.NewContext(req, rec)
 
-			// We can't easily test the full method without mocking sendSSEMessage,
+			// We can't easily test the full method without mocking SendSSEMessage,
 			// but we can verify that the method doesn't panic and handles the input
 			err := c.processNotificationEvent(ctx, "test-client", tt.notif)
 
-			// The method will likely fail because sendSSEMessage isn't mocked,
+			// The method will likely fail because SendSSEMessage isn't mocked,
 			// but we're mainly testing that it doesn't panic and follows the right path
 			if tt.expectErr {
 				assert.Error(t, err, "processNotificationEvent() expected error but got none")
@@ -293,8 +281,8 @@ func TestController_logNotificationConnection(t *testing.T) {
 	t.Parallel()
 
 	// Test with nil logger (should not panic)
-	c := &Controller{Core: &apicore.Core{APILogger: nil}}
-	c.Settings.Store(mockController().Settings.Load())
+	c := New(&apicore.Core{APILogger: nil}, nil, nil)
+	c.Settings.Store(mockHandler().Settings.Load())
 
 	// These should not panic
 	c.logNotificationConnection("test-client", "192.168.1.1", "test-agent", true)
@@ -308,7 +296,7 @@ func TestController_logNotificationConnection(t *testing.T) {
 func TestController_logNotificationError(t *testing.T) {
 	t.Parallel()
 
-	c := mockController()
+	c := mockHandler()
 
 	// Should not panic with nil logger
 	c.logNotificationError("test error", nil, "test-client")
@@ -318,7 +306,7 @@ func TestController_logNotificationError(t *testing.T) {
 func TestController_logToastSent(t *testing.T) {
 	t.Parallel()
 
-	c := mockController()
+	c := mockHandler()
 
 	notif := &notification.Notification{
 		ID:        "test-id",
@@ -341,7 +329,7 @@ func TestController_logToastSent(t *testing.T) {
 func TestController_logNotificationSent(t *testing.T) {
 	t.Parallel()
 
-	c := mockController()
+	c := mockHandler()
 
 	notif := &notification.Notification{
 		ID:       "test-id",

--- a/internal/api/v2/notifications/notifications_mark_read_test.go
+++ b/internal/api/v2/notifications/notifications_mark_read_test.go
@@ -1,53 +1,25 @@
-package api
+package notifications
 
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
-
-// newNotificationTestController builds a controller wired to an isolated, per-test
-// notification service injected through the controller's DI seam. The service is
-// stopped via t.Cleanup so its cleanupLoop goroutine does not leak (TestMain runs
-// a goleak gate). Because no process-global state is touched, tests using this
-// helper are safe to run with t.Parallel().
-func newNotificationTestController(t *testing.T) (*Controller, *notification.Service) {
-	t.Helper()
-
-	config := &notification.ServiceConfig{
-		Debug:              true,
-		MaxNotifications:   100,
-		CleanupInterval:    30 * time.Minute,
-		RateLimitWindow:    1 * time.Minute,
-		RateLimitMaxEvents: 10,
-	}
-
-	service := notification.NewService(config)
-	t.Cleanup(service.Stop)
-
-	controller := &Controller{Core: &apicore.Core{}, notificationService: service}
-	controller.Settings.Store(&conf.Settings{})
-
-	return controller, service
-}
 
 // runMarkNotificationNotFoundTest exercises a mark-state handler against a
 // missing notification ID and asserts the idempotent 200 response with the
 // handler's confirmation message. Shared by the read and acknowledge NotFound
 // cases, which are identical apart from the path suffix, handler, and message.
-func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage string, handler func(*Controller, echo.Context) error) {
+func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage string, handler func(*Handler, echo.Context) error) {
 	t.Helper()
 
-	controller, _ := newNotificationTestController(t)
+	controller, _ := newNotificationTestHandler(t)
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications/non-existent-id/"+pathSuffix, http.NoBody)
@@ -70,12 +42,12 @@ func runMarkNotificationNotFoundTest(t *testing.T, pathSuffix, expectedMessage s
 func TestMarkNotificationRead_NotFound(t *testing.T) {
 	t.Parallel()
 	runMarkNotificationNotFoundTest(t, "read", "Notification marked as read",
-		(*Controller).MarkNotificationRead)
+		(*Handler).MarkNotificationRead)
 }
 
 func TestMarkNotificationRead_EmptyID(t *testing.T) {
 	t.Parallel()
-	controller, _ := newNotificationTestController(t)
+	controller, _ := newNotificationTestHandler(t)
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPut, "/api/v2/notifications//read", http.NoBody)
@@ -92,7 +64,7 @@ func TestMarkNotificationRead_EmptyID(t *testing.T) {
 
 func TestMarkNotificationRead_Success(t *testing.T) {
 	t.Parallel()
-	controller, service := newNotificationTestController(t)
+	controller, service := newNotificationTestHandler(t)
 
 	// Create a notification first
 	notif := notification.NewNotification(notification.TypeInfo, notification.PriorityMedium, "Test", "Test message")
@@ -115,5 +87,5 @@ func TestMarkNotificationRead_Success(t *testing.T) {
 func TestMarkNotificationAcknowledged_NotFound(t *testing.T) {
 	t.Parallel()
 	runMarkNotificationNotFoundTest(t, "acknowledge", "Notification marked as acknowledged",
-		(*Controller).MarkNotificationAcknowledged)
+		(*Handler).MarkNotificationAcknowledged)
 }

--- a/internal/api/v2/notifications/notifications_new_species_test.go
+++ b/internal/api/v2/notifications/notifications_new_species_test.go
@@ -1,4 +1,4 @@
-package api
+package notifications
 
 import (
 	"encoding/json"
@@ -36,7 +36,7 @@ func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := New(&apicore.Core{}, nil, nil)
 	controller.Settings.Store(&conf.Settings{})
 
 	// Call through middleware to test the guard
@@ -71,7 +71,7 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{Core: &apicore.Core{}, notificationService: service}
+	controller := New(&apicore.Core{}, service, nil)
 	// Build a minimal settings snapshot with only the fields this test needs,
 	// then publish it once (the empty base matches the original test).
 	settings := &conf.Settings{}

--- a/internal/api/v2/notifications/notifications_ntfy_check_test.go
+++ b/internal/api/v2/notifications/notifications_ntfy_check_test.go
@@ -1,5 +1,5 @@
-// Package api provides tests for the NTFY server connectivity check endpoint.
-package api
+// Package notifications provides tests for the NTFY server connectivity check endpoint.
+package notifications
 
 import (
 	"encoding/json"
@@ -24,7 +24,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{Core: &apicore.Core{}}
+	ctrl := New(&apicore.Core{}, nil, nil)
 	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	// ts.Listener.Addr().String() returns "127.0.0.1:PORT"
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
@@ -44,7 +44,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 
 func TestCheckNtfyServer_MissingHost(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Core: &apicore.Core{}}
+	ctrl := New(&apicore.Core{}, nil, nil)
 	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -57,7 +57,7 @@ func TestCheckNtfyServer_MissingHost(t *testing.T) {
 
 func TestCheckNtfyServer_InvalidHost_Unreachable(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Core: &apicore.Core{}}
+	ctrl := New(&apicore.Core{}, nil, nil)
 	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	// Inject a short per-scheme probe timeout so the unreachable-host path returns
 	// quickly. 192.0.2.1 never responds, so the result is deterministically
@@ -89,7 +89,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{Core: &apicore.Core{}}
+	ctrl := New(&apicore.Core{}, nil, nil)
 	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 
 func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Core: &apicore.Core{}}
+	ctrl := New(&apicore.Core{}, nil, nil)
 	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	// Slash injection attempt
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=evil.com%2F%40good.com", http.NoBody)
@@ -120,7 +120,7 @@ func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 
 func TestCheckNtfyServer_CloudMetadataBlocked(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{Core: &apicore.Core{}}
+	ctrl := New(&apicore.Core{}, nil, nil)
 	ctrl.Settings.Store(apitest.NewValidTestSettings())
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=169.254.169.254", http.NoBody)
 	rec := httptest.NewRecorder()

--- a/internal/api/v2/notifications/notifications_routes_test.go
+++ b/internal/api/v2/notifications/notifications_routes_test.go
@@ -1,0 +1,38 @@
+package notifications
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+)
+
+// TestRegisterRoutesRegistration verifies the notifications domain registers
+// exactly the routes (and the same method+path set) the monolithic
+// initNotificationRoutes/SetupNotificationRoutes pair did, in its own -race test
+// binary. The auth-protected mutation/probe group is mounted with the
+// AuthMiddleware promoted from the core; a pass-through is injected so the empty
+// service group and the auth group register the same way production wiring does.
+func TestRegisterRoutesRegistration(t *testing.T) {
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	core.AuthMiddleware = func(next echo.HandlerFunc) echo.HandlerFunc { return next }
+
+	// The handlers are not invoked here, so nil services are sufficient for the
+	// route-enumeration gate.
+	h := New(core, nil, nil)
+	h.RegisterRoutes(core.Group)
+
+	apitest.AssertRoutesRegistered(t, e, []string{
+		"GET /api/v2/notifications",
+		"GET /api/v2/notifications/unread/count",
+		"GET /api/v2/notifications/stream",
+		"PUT /api/v2/notifications/read-all",
+		"GET /api/v2/notifications/:id",
+		"PUT /api/v2/notifications/:id/read",
+		"PUT /api/v2/notifications/:id/acknowledge",
+		"DELETE /api/v2/notifications/:id",
+		"POST /api/v2/notifications/test/new-species",
+		"GET /api/v2/notifications/check-ntfy-server",
+	})
+}

--- a/internal/api/v2/notifications/notifications_test_helpers_test.go
+++ b/internal/api/v2/notifications/notifications_test_helpers_test.go
@@ -1,0 +1,89 @@
+package notifications
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// testFailFastTimeout is a short timeout injected into deliberate-failure probe
+// paths so the unreachable-host test does not wait the full production default
+// for each scheme. It mirrors the package-api constant of the same name.
+const testFailFastTimeout = 200 * time.Millisecond
+
+// mockHandler creates a Handler with minimal setup for testing (debug settings,
+// no injected services). It mirrors the old package-api mockController helper.
+func mockHandler() *Handler {
+	h := New(&apicore.Core{APILogger: nil}, nil, nil)
+	h.Settings.Store(&conf.Settings{
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+	})
+	return h
+}
+
+// newNotificationTestHandler builds a Handler wired to an isolated, per-test
+// notification service injected through New. The service is stopped via
+// t.Cleanup so its cleanupLoop goroutine does not leak. Because no process-global
+// state is touched, tests using this helper are safe to run with t.Parallel().
+func newNotificationTestHandler(t *testing.T) (*Handler, *notification.Service) {
+	t.Helper()
+
+	config := &notification.ServiceConfig{
+		Debug:              true,
+		MaxNotifications:   100,
+		CleanupInterval:    30 * time.Minute,
+		RateLimitWindow:    1 * time.Minute,
+		RateLimitMaxEvents: 10,
+	}
+
+	service := notification.NewService(config)
+	t.Cleanup(service.Stop)
+
+	h := New(&apicore.Core{}, service, nil)
+	h.Settings.Store(&conf.Settings{})
+
+	return h, service
+}
+
+// newToastTestHandler builds a Handler wired to an isolated, per-test
+// notification service for the toast SSE-formatting tests. The service is
+// stopped via tb.Cleanup so its cleanupLoop goroutine does not leak.
+func newToastTestHandler(tb testing.TB) (*Handler, *notification.Service) {
+	tb.Helper()
+	service := notification.NewService(notification.DefaultServiceConfig())
+	tb.Cleanup(service.Stop)
+	h := mockHandler()
+	h.notificationService = service
+	return h, service
+}
+
+// assertEventDataNil checks that a field in eventData is nil.
+func assertEventDataNil(t *testing.T, eventData map[string]any, field, context string) {
+	t.Helper()
+	assert.Nil(t, eventData[field], "Event data %s should be nil for %s", field, context)
+}
+
+// assertEventDataEmpty checks that a string field in eventData is empty.
+func assertEventDataEmpty(t *testing.T, eventData map[string]any, field, context string) {
+	t.Helper()
+	assert.Empty(t, eventData[field], "Event data %s should be empty string for %s", field, context)
+}
+
+// assertEventDataMissing checks that a field is not present in eventData.
+func assertEventDataMissing(t *testing.T, eventData map[string]any, field string) {
+	t.Helper()
+	_, exists := eventData[field]
+	assert.False(t, exists, "Event data should not include %s when not set", field)
+}
+
+// assertEventDataValue checks a specific field value in eventData.
+func assertEventDataValue(t *testing.T, eventData map[string]any, field string, expected any) {
+	t.Helper()
+	assert.Equal(t, expected, eventData[field], "Event data %s mismatch", field)
+}

--- a/internal/api/v2/notifications/ntfy_integration_test.go
+++ b/internal/api/v2/notifications/ntfy_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package api
+package notifications
 
 import (
 	"context"
@@ -56,7 +56,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 	t.Run("handler_integration", func(t *testing.T) {
 		// Test the full CheckNtfyServer handler via Echo context
 		e := echo.New()
-		ctrl := &Controller{Core: &apicore.Core{}}
+		ctrl := New(&apicore.Core{}, nil, nil)
 		ctrl.Settings.Store(apitest.NewValidTestSettings())
 
 		req := httptest.NewRequest(http.MethodGet,

--- a/internal/api/v2/notifications/toast_integration_test.go
+++ b/internal/api/v2/notifications/toast_integration_test.go
@@ -109,7 +109,7 @@ func TestToastIntegrationFlow(t *testing.T) {
 			err := service.SendToastWithDuration(tc.message, tc.toastType, "api", tc.duration)
 			require.NoError(t, err, "SendToastWithDuration() error")
 
-			capturedNotif := awaitNotification(t, notifCh, 100*time.Millisecond)
+			capturedNotif := awaitNotification(t, notifCh, 500*time.Millisecond)
 			toastID := checkToastMarking(t, capturedNotif)
 			sseEventData := h.createToastEventData(capturedNotif)
 

--- a/internal/api/v2/notifications/toast_integration_test.go
+++ b/internal/api/v2/notifications/toast_integration_test.go
@@ -2,7 +2,7 @@
 // - Uses b.Loop() for benchmark iterations
 // LLM GUIDANCE: Always use b.Loop() instead of manual for i := 0; i < b.N; i++
 
-package api
+package notifications
 
 import (
 	"testing"
@@ -59,22 +59,23 @@ func checkSSERequired(t *testing.T, eventData map[string]any) {
 	assert.WithinDuration(t, time.Now(), timestamp, time.Second, "SSE event timestamp should be recent")
 }
 
-// TestToastIntegrationFlow tests the complete flow:
-// SendToast -> notification creation -> SSE event data creation
+// TestToastIntegrationFlow tests the toast SSE-formatting flow: toast creation
+// (via the notification service, the same path Controller.SendToast delegates to)
+// -> broadcast -> SSE event data creation (createToastEventData).
 func TestToastIntegrationFlow(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name              string
 		message           string
-		toastType         string
+		toastType         notification.ToastType
 		duration          int
 		expectedSSEFields map[string]any
 	}{
 		{
 			name:      "success toast complete flow",
 			message:   "Operation completed successfully",
-			toastType: "success",
+			toastType: notification.ToastTypeSuccess,
 			duration:  3000,
 			expectedSSEFields: map[string]any{
 				"message": "Operation completed successfully", "type": "success",
@@ -84,7 +85,7 @@ func TestToastIntegrationFlow(t *testing.T) {
 		{
 			name:      "error toast complete flow",
 			message:   "Operation failed with error",
-			toastType: "error",
+			toastType: notification.ToastTypeError,
 			duration:  5000,
 			expectedSSEFields: map[string]any{
 				"message": "Operation failed with error", "type": "error",
@@ -98,16 +99,19 @@ func TestToastIntegrationFlow(t *testing.T) {
 			t.Parallel()
 			// Each subtest gets its own isolated service so parallel subtests do
 			// not receive each other's broadcasts on a shared subscription.
-			c, service := newToastTestController(t)
+			h, service := newToastTestHandler(t)
 			notifCh, _ := service.Subscribe()
 			defer service.Unsubscribe(notifCh)
 
-			err := c.SendToast(tc.message, tc.toastType, tc.duration)
-			require.NoError(t, err, "SendToast() error")
+			// Produce the toast through the same service path Controller.SendToast
+			// delegates to (SendToastWithDuration), so the wire-format assertions
+			// below exercise a real broadcast notification.
+			err := service.SendToastWithDuration(tc.message, tc.toastType, "api", tc.duration)
+			require.NoError(t, err, "SendToastWithDuration() error")
 
 			capturedNotif := awaitNotification(t, notifCh, 100*time.Millisecond)
 			toastID := checkToastMarking(t, capturedNotif)
-			sseEventData := c.createToastEventData(capturedNotif)
+			sseEventData := h.createToastEventData(capturedNotif)
 
 			checkSSEFields(t, sseEventData, tc.expectedSSEFields)
 			checkSSERequired(t, sseEventData)
@@ -119,7 +123,7 @@ func TestToastIntegrationFlow(t *testing.T) {
 
 // TestToastEventDataEdgeCases tests edge cases in SSE event data creation
 func TestToastEventDataEdgeCases(t *testing.T) {
-	c := mockController()
+	c := mockHandler()
 
 	t.Run("notification without toast metadata", func(t *testing.T) {
 		notif := notification.NewNotification(
@@ -177,7 +181,7 @@ func TestToastToSSEEventConsistency(t *testing.T) {
 	notif := originalToast.ToNotification()
 
 	// Create SSE event data
-	c := mockController()
+	c := mockHandler()
 	eventData := c.createToastEventData(notif)
 
 	// Verify consistency
@@ -193,9 +197,9 @@ func TestToastToSSEEventConsistency(t *testing.T) {
 
 // BenchmarkCompleteToastFlow benchmarks the complete toast flow
 func BenchmarkCompleteToastFlow(b *testing.B) {
-	c, service := newToastTestController(b)
+	h, service := newToastTestHandler(b)
 
-	// Subscribe to notifications (needed for SendToast to work)
+	// Subscribe to notifications (needed for the broadcast to be observed)
 	notifCh, _ := service.Subscribe()
 	defer service.Unsubscribe(notifCh)
 
@@ -204,15 +208,15 @@ func BenchmarkCompleteToastFlow(b *testing.B) {
 
 	// Use b.Loop() for benchmark iteration (Go 1.25)
 	for b.Loop() {
-		// Step 1: Send toast
-		err := c.SendToast("Benchmark message", "info", 3000)
-		require.NoError(b, err, "SendToast error")
+		// Step 1: Send toast (same service path Controller.SendToast delegates to)
+		err := service.SendToastWithDuration("Benchmark message", notification.ToastTypeInfo, "api", 3000)
+		require.NoError(b, err, "SendToastWithDuration error")
 
 		// Step 2: Receive notification
 		select {
 		case notif := <-notifCh:
 			// Step 3: Create SSE event data
-			_ = c.createToastEventData(notif)
+			_ = h.createToastEventData(notif)
 		case <-time.After(10 * time.Millisecond):
 			require.Fail(b, "Timeout waiting for notification")
 		}

--- a/internal/api/v2/sse.go
+++ b/internal/api/v2/sse.go
@@ -3,16 +3,13 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"runtime/debug"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
-	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
 )
@@ -21,7 +18,6 @@ import (
 const (
 	// Connection timeouts
 	maxSSEStreamDuration = 30 * time.Minute // Maximum stream duration to prevent resource leaks
-	sseWriteDeadline     = 10 * time.Second // Write deadline for SSE messages
 
 	// Endpoints
 	detectionStreamEndpoint  = "/api/v2/detections/stream"
@@ -38,11 +34,6 @@ const (
 	sseRateLimitRequests = 10              // SSE rate limit requests per window
 	sseRateLimitWindow   = 1 * time.Minute // SSE rate limit time window
 )
-
-// WriteDeadlineSetter interface for response writers that support write deadlines
-type WriteDeadlineSetter interface {
-	SetWriteDeadline(time.Time) error
-}
 
 // SSEEvent represents a generic SSE event that can contain different data types
 type SSEEvent struct {
@@ -109,7 +100,7 @@ func (c *Controller) sendConnectionMessage(ctx echo.Context, clientID, message, 
 	if streamType != "" {
 		data["type"] = streamType
 	}
-	return c.sendSSEMessage(ctx, SSEStatusConnected, data)
+	return c.SendSSEMessage(ctx, SSEStatusConnected, data)
 }
 
 // logSSEConnection logs SSE client connection/disconnection events
@@ -136,7 +127,7 @@ func (c *Controller) sendSSEHeartbeat(ctx echo.Context, clientID, streamType str
 		data["type"] = streamType
 	}
 
-	if err := c.sendSSEMessage(ctx, "heartbeat", data); err != nil {
+	if err := c.SendSSEMessage(ctx, "heartbeat", data); err != nil {
 		c.LogDebugIfEnabled("SSE heartbeat failed, client likely disconnected",
 			logger.String("client_id", clientID),
 			logger.Error(err),
@@ -242,10 +233,10 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 		select {
 		case <-ticker.C:
 			if err := c.sendSSEHeartbeat(ctx, clientID, ""); err != nil {
-				c.recordSSEError(endpoint, "heartbeat_failed")
+				c.RecordSSEError(endpoint, "heartbeat_failed")
 				return err
 			}
-			c.recordSSEMessage(endpoint, "heartbeat")
+			c.RecordSSEMessage(endpoint, "heartbeat")
 
 		case <-ctx.Request().Context().Done():
 			return nil
@@ -262,16 +253,16 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 				if !ok {
 					return nil
 				}
-				if err := c.sendSSEMessage(ctx, "detection", detection); err != nil {
+				if err := c.SendSSEMessage(ctx, "detection", detection); err != nil {
 					c.LogErrorIfEnabled("Failed to send SSE detection",
 						logger.String("client_id", clientID),
 						logger.String("endpoint", endpoint),
 						logger.Error(err),
 					)
-					c.recordSSEError(endpoint, "send_failed")
+					c.RecordSSEError(endpoint, "send_failed")
 					return err
 				}
-				c.recordSSEMessage(endpoint, "detection")
+				c.RecordSSEMessage(endpoint, "detection")
 				sent = true
 			default:
 			}
@@ -283,16 +274,16 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 					if !ok {
 						return nil
 					}
-					if err := c.sendSSEMessage(ctx, "pending", pending); err != nil {
+					if err := c.SendSSEMessage(ctx, "pending", pending); err != nil {
 						c.LogErrorIfEnabled("Failed to send SSE pending",
 							logger.String("client_id", clientID),
 							logger.String("endpoint", endpoint),
 							logger.Error(err),
 						)
-						c.recordSSEError(endpoint, "send_failed")
+						c.RecordSSEError(endpoint, "send_failed")
 						return err
 					}
-					c.recordSSEMessage(endpoint, "pending")
+					c.RecordSSEMessage(endpoint, "pending")
 					sent = true
 				default:
 				}
@@ -343,10 +334,10 @@ func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, client
 		case <-ticker.C:
 			// Send heartbeat
 			if err := c.sendSSEHeartbeat(ctx, clientID, heartbeatType); err != nil {
-				c.recordSSEError(endpoint, "heartbeat_failed")
+				c.RecordSSEError(endpoint, "heartbeat_failed")
 				return err
 			}
-			c.recordSSEMessage(endpoint, "heartbeat")
+			c.RecordSSEMessage(endpoint, "heartbeat")
 
 		case <-ctx.Request().Context().Done():
 			// Client disconnected
@@ -359,78 +350,23 @@ func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, client
 		default:
 			// Check for data on the channel (non-blocking)
 			if data, hasData := dataReceiver(); hasData {
-				if err := c.sendSSEMessage(ctx, eventType, data); err != nil {
+				if err := c.SendSSEMessage(ctx, eventType, data); err != nil {
 					c.LogErrorIfEnabled("Failed to send SSE message",
 						logger.String("client_id", clientID),
 						logger.String("endpoint", endpoint),
 						logger.String("event_type", eventType),
 						logger.Error(err),
 					)
-					c.recordSSEError(endpoint, "send_failed")
+					c.RecordSSEError(endpoint, "send_failed")
 					return err
 				}
-				c.recordSSEMessage(endpoint, eventType)
+				c.RecordSSEMessage(endpoint, eventType)
 			} else {
 				// Small sleep to prevent busy-waiting when no data
 				time.Sleep(apicore.SSEEventLoopSleep)
 			}
 		}
 	}
-}
-
-// sendSSEMessage sends a Server-Sent Event message
-func (c *Controller) sendSSEMessage(ctx echo.Context, event string, data any) error {
-	// Convert data to JSON with panic recovery
-	jsonData, err := c.safeMarshalJSON(event, data)
-	if err != nil {
-		return fmt.Errorf("failed to marshal SSE data: %w", err)
-	}
-
-	// Format SSE message
-	message := fmt.Sprintf("event: %s\ndata: %s\n\n", event, string(jsonData))
-
-	// Set write deadline to prevent hanging on slow/disconnected clients
-	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
-		deadline := time.Now().Add(sseWriteDeadline) // Write deadline timeout
-		if err := conn.SetWriteDeadline(deadline); err != nil {
-			// If we can't set deadline, log but continue - not all response writers support this
-			c.LogDebugIfEnabled("Failed to set write deadline for SSE message", logger.Error(err))
-		}
-	}
-
-	// Write to response
-	if _, err := ctx.Response().Write([]byte(message)); err != nil {
-		return fmt.Errorf("failed to write SSE message: %w", err)
-	}
-
-	// Flush the response
-	if flusher, ok := ctx.Response().Writer.(http.Flusher); ok {
-		flusher.Flush()
-	}
-
-	return nil
-}
-
-// safeMarshalJSON marshals data to JSON with panic recovery.
-// This protects against panics from concurrent map access or unmarshalable data.
-func (c *Controller) safeMarshalJSON(event string, data any) (jsonData []byte, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("JSON marshal panic: %v", r)
-			c.LogErrorIfEnabled("SSE marshal panic recovered",
-				logger.String("event", event),
-				logger.Any("panic", r),
-				logger.String("stack", string(debug.Stack())),
-			)
-			_ = errors.Newf("SSE JSON marshal panic: %v", r).
-				Component("api").
-				Category(errors.CategoryBroadcast).
-				Context("operation", "sse_marshal_panic").
-				Priority(errors.PriorityCritical).
-				Build()
-		}
-	}()
-	return json.Marshal(data)
 }
 
 // GetSSEStatus returns information about SSE connections

--- a/internal/api/v2/sse_panic_recovery_test.go
+++ b/internal/api/v2/sse_panic_recovery_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
-// TestSendSSEMessagePanicRecovery verifies that sendSSEMessage handles
+// TestSendSSEMessagePanicRecovery verifies that SendSSEMessage handles
 // unmarshalable data gracefully without panicking.
 func TestSendSSEMessagePanicRecovery(t *testing.T) {
 	t.Parallel()
@@ -42,7 +42,7 @@ func TestSendSSEMessagePanicRecovery(t *testing.T) {
 			"normal":  "value",
 		}
 
-		err := c.sendSSEMessage(ctx, "test", badData)
+		err := c.SendSSEMessage(ctx, "test", badData)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "marshal")
 	})
@@ -55,7 +55,7 @@ func TestSendSSEMessagePanicRecovery(t *testing.T) {
 			"normal": "value",
 		}
 
-		err := c.sendSSEMessage(ctx, "test", badData)
+		err := c.SendSSEMessage(ctx, "test", badData)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "marshal")
 	})
@@ -74,7 +74,7 @@ func TestSendSSEMessagePanicRecovery(t *testing.T) {
 		}
 
 		// Should succeed without error
-		err := c.sendSSEMessage(ctx, "notification", validData)
+		err := c.SendSSEMessage(ctx, "notification", validData)
 		require.NoError(t, err)
 
 		// Verify SSE format in response
@@ -89,10 +89,10 @@ func TestSendSSEMessagePanicRecovery(t *testing.T) {
 		ctx = e.NewContext(req, rec)
 
 		// Use a custom type that panics during JSON marshaling
-		// to verify the recover() block in safeMarshalJSON works correctly.
+		// to verify the recover() block in SafeMarshalJSON works correctly.
 		badData := &panicMarshaler{}
 
-		err := c.sendSSEMessage(ctx, "test_panic", badData)
+		err := c.SendSSEMessage(ctx, "test_panic", badData)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "JSON marshal panic")
 		assert.Contains(t, err.Error(), "intentional panic for testing")
@@ -100,7 +100,7 @@ func TestSendSSEMessagePanicRecovery(t *testing.T) {
 }
 
 // panicMarshaler is a helper type that panics during JSON marshaling.
-// Used to test the recover() block in safeMarshalJSON.
+// Used to test the recover() block in SafeMarshalJSON.
 type panicMarshaler struct{}
 
 // MarshalJSON implements json.Marshaler and panics when called.

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -727,7 +727,7 @@ func (c *Controller) processRemovedStreams(ctx echo.Context, clientID string, he
 			EventType:            "stream_removed",
 		}
 
-		if err := c.sendSSEMessage(ctx, "stream_health", event); err != nil {
+		if err := c.SendSSEMessage(ctx, "stream_health", event); err != nil {
 			return err
 		}
 
@@ -755,7 +755,7 @@ func (c *Controller) sendStreamHealthUpdate(ctx echo.Context, rawURL string, hea
 		EventType:            eventType,
 	}
 
-	if err := c.sendSSEMessage(ctx, "stream_health", event); err != nil {
+	if err := c.SendSSEMessage(ctx, "stream_health", event); err != nil {
 		return err
 	}
 
@@ -806,5 +806,5 @@ func (c *Controller) sendStreamStatsUpdate(ctx echo.Context, rawURL string, heal
 		EventType:            "stats_update",
 	}
 
-	return c.sendSSEMessage(ctx, "stream_health", event)
+	return c.SendSSEMessage(ctx, "stream_health", event)
 }

--- a/internal/api/v2/toast_helpers_test.go
+++ b/internal/api/v2/toast_helpers_test.go
@@ -10,8 +10,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+// mockController creates a controller with minimal setup for testing. It lives
+// here (alongside the toast SendToast tests) because the notifications domain
+// handler tests moved to the internal/api/v2/notifications package along with
+// the previous home of this helper.
+func mockController() *Controller {
+	c := &Controller{Core: &apicore.Core{APILogger: nil}}
+	c.Settings.Store(&conf.Settings{
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+	})
+	return c
+}
 
 // assertEventDataNil checks that a field in eventData is nil.
 func assertEventDataNil(t *testing.T, eventData map[string]any, field, context string) {

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -708,20 +708,6 @@ func parseDateRangeFilter(singleDate, startDate, endDate string) *DateRangeResul
 // SSE Metrics Helpers
 // =============================================================================
 
-// recordSSEError records an SSE error metric if metrics are available
-func (c *Controller) recordSSEError(endpoint, errorType string) {
-	if c.Metrics != nil && c.Metrics.HTTP != nil {
-		c.Metrics.HTTP.RecordSSEError(endpoint, errorType)
-	}
-}
-
-// recordSSEMessage records an SSE message sent metric if metrics are available
-func (c *Controller) recordSSEMessage(endpoint, messageType string) {
-	if c.Metrics != nil && c.Metrics.HTTP != nil {
-		c.Metrics.HTTP.RecordSSEMessageSent(endpoint, messageType)
-	}
-}
-
 // recordSSEConnectionStart records an SSE connection start if metrics are available
 func (c *Controller) recordSSEConnectionStart(endpoint string) {
 	if c.Metrics != nil && c.Metrics.HTTP != nil {


### PR DESCRIPTION
## Summary

Phase 5 of the internal/api/v2 split: extract the **notifications** domain out of the monolithic `package api` into a new `internal/api/v2/notifications` subpackage (`package notifications`), following the established pattern (Handler embeds `*apicore.Core` by pointer; the facade `Controller` holds a handler field, constructs it, and calls `RegisterRoutes` in the deterministic `initRoutes` order). No public-behavior change.

## Scope: handlers moved

The `/api/v2/notifications/*` endpoints move into the new package: `GetNotifications`, `GetNotification`, `GetUnreadCount`, `StreamNotifications` (the SSE notification+toast stream), `MarkAllNotificationsRead`, `MarkNotificationRead`, `MarkNotificationAcknowledged`, `DeleteNotification`, `CreateTestNewSpeciesNotification`, and the NTFY connectivity probe `CheckNtfyServer`, plus their domain-local helpers, types, and constants. Each handler method moved verbatim; only the receiver retyped from `*Controller` to `*Handler` (receiver name kept `c`).

## Dual facade-dep injection (notificationService + authService)

Unlike the Core-only leaf domains, the notification handlers reference two facade fields that are set via functional options applied **after** the options loop:

- **notificationService** (`WithNotificationService`): `getNotificationService()` returns the injected instance or falls back to the process-global singleton (`notification.GetService()`) when nil. This field is also resolved by `debug.go`, `migration.go` and `legacy_cleanup.go`, so the facade keeps its own `notificationService` field plus a `getNotificationService()` accessor; the notifications `Handler` gets its own injected copy with the same accessor (the `authService` precedent: the field lives on both the facade and the handler).
- **authService** (`WithAuthService`): used by `isGuestNotificationRequest` to keep the public notification endpoints showing guests bird-detection events only.

Both services are set by options in the loop, so the facade constructs `c.notifications = notifications.New(c.Core, c.notificationService, c.authService)` **after** the loop (right after `c.authHandler`), capturing the injected values. Neither service changes after this point, so capturing the post-option value is behaviorally identical to the monolith's per-request reads. The test-only `ntfyCheckTimeoutOverride` field moved from the `Controller` onto the `Handler` (no other user).

## SSE handling

`apicore` already owns `SetSSEHeaders`, the streaming intervals, and the `SSEManager`; the SSE hub stays in `apicore`. The three SSE write primitives the notifications stream needs were still in `package api` and shared by other still-in-package-api files (`import.go`, `streams_health.go`, `metrics_history.go`, `sse.go`), so they were **promoted to apicore and exported** (the same precedent as the dynamic_thresholds phase promoting `ParsePaginationLimit`):

- `(*Core).SendSSEMessage`, `(*Core).SafeMarshalJSON`, `(*Core).RecordSSEError`, `(*Core).RecordSSEMessage`, plus the `WriteDeadlineSetter` interface and the `SSEWriteDeadline` constant.

Every package-api caller (`sse.go`, `utils.go`, `import.go`, `streams_health.go`, `metrics_history.go`, `audio_level.go`) was repointed to the promoted members; no duplicate definitions remain.

## Facade wiring (order preserved exactly)

- `Controller` gains a `notifications *notifications.Handler` field.
- `c.notifications = notifications.New(c.Core, c.notificationService, c.authService)` is constructed after the options loop.
- The ordered `initRoutes` entry changed in place from `{"notification routes", c.initNotificationRoutes}` to `{"notification routes", func() { c.notifications.RegisterRoutes(c.Group) }}` at the **same index**, so registration order and the route-enumeration golden gate are byte-identical.

notifications owns no background goroutine or singleton (per-request SSE goroutines are tied to the request context; the notification service lifecycle stays with the facade/global), so no `Shutdown` hook is added. `apiv2.Controller` / `New` / `NewWithOptions` and the external signatures are unchanged.

## Tests

Moved into the notifications package and rebuilt against `apitest` plus a new `mockHandler` / `newNotificationTestHandler` / `newToastTestHandler` helper set: `notifications_helpers_test.go`, `notifications_mark_read_test.go`, `notifications_new_species_test.go`, `notifications_ntfy_check_test.go`, plus a new `notifications_routes_test.go` (route-enumeration gate; notifications now has its own `-race` binary). Two cross-domain test files were notifications-domain tests in disguise and moved here too: `ntfy_integration_test.go` (tests only `CheckNtfyServer` / `probeNtfyServer`) and `toast_integration_test.go` (whose toast producer was rewritten from `Controller.SendToast` to `service.SendToastWithDuration`, the exact call `SendToast` delegates to, so the SSE-format assertions still exercise `createToastEventData` on a real broadcast notification). `SendToast` itself stays in `package api` and is still covered by `toast_helpers_test.go`; `mockController` was re-homed there.

## Verification

- `go build ./...` clean.
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (no copylocks).
- `go test -race ./internal/api/v2/...` green (full suite ~175s, including the route-enumeration golden gate); `internal/api/v2/notifications` runs as its own `-race` binary; `internal/analysis` and `apicore` `-race` green.
- `golangci-lint`: 0 issues on `internal/api/v2/...`, the notifications package, and `apicore`.
- No public-behavior change: the 10 notification endpoints (paths, methods, auth, the SSE rate limiter, the SSRF-guarded check-ntfy-server), the guest SSE/list filtering, and the responses are identical; the README endpoint section path reference was updated minimally.

## Preflight Status

Six-pass preflight quality gate run (reuse, correctness, quality, integration wiring, regression/backward-compat; i18n not applicable, no frontend changes). All reviewers reported clean; the only items were two LOW cosmetic stale-comment touch-ups, which are fixed in this PR. No behavioral or backward-compatibility concerns; no external importer references any relocated symbol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now expose a dedicated v2 API experience with public streaming, unread count, and notification item management endpoints.
* **Bug Fixes**
  * SSE delivery is more robust: safer payload marshaling (with panic recovery), per-message write time limits, and consistent SSE messaging/metrics/error recording across live streams, heartbeats, and stream health events.
  * Improved notification stream connectivity handling and guest filtering behavior.
* **Tests**
  * Expanded and updated notification route, SSE, and panic-recovery coverage to match the new wiring and SSE handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->