### PR TITLE
refactor(api/v2): extract sse endpoint handlers into their own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -244,7 +244,7 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 | GET    | `/species/:code/thumbnail`          | `GetSpeciesThumbnail`     | ❌   | Get bird thumbnail image by species code (redirects to image URL) |
 | GET    | `/species/dictionary/:locale`       | `ServeSpeciesDictionary`  | ❌   | Precompressed per-locale species name dictionary (gzip JSON)      |
 
-### Server-Sent Events (`sse.go`)
+### Server-Sent Events (`sse/sse.go`)
 
 | Method | Route                 | Handler             | Auth | Description                  |
 | ------ | --------------------- | ------------------- | ---- | ---------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/notifications"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
 	"github.com/tphakala/birdnet-go/internal/api/v2/species"
+	"github.com/tphakala/birdnet-go/internal/api/v2/sse"
 	"github.com/tphakala/birdnet-go/internal/api/v2/support"
 	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/api/v2/weather"
@@ -195,6 +196,13 @@ type Controller struct {
 	// both services reflect WithNotificationService / WithAuthService (see
 	// NewWithOptions).
 	notifications *notifications.Handler
+
+	// sse serves the SSE stream endpoints (/api/v2/detections/stream,
+	// /api/v2/soundlevels/stream, /api/v2/sse/status). It needs only the shared
+	// *apicore.Core: the SSE hub (SSEManager), the write primitives and the stream
+	// scaffolding (SendSSEHeartbeat/LogSSEConnection/SendConnectionMessage) all
+	// promote from the embedded core. The hub itself stays in apicore.
+	sse *sse.Handler
 
 	// Audio processing fields
 	processingCache     *processingCache
@@ -398,6 +406,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// *apicore.Core pointer and register their routes in initRoutes.
 	c.weather = weather.New(c.Core)
 	c.rangeHandler = rangeapi.New(c.Core)
+	c.sse = sse.New(c.Core)
 	// The TLS handler needs the facade's settings-save machinery: the shared
 	// settingsMutex (passed by pointer so TLS certificate writes serialize against
 	// the main settings update handlers) and the bound method values for reading,
@@ -588,7 +597,7 @@ func (c *Controller) initRoutes() {
 		{"media routes", c.initMediaRoutes},
 		{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }},
 		{"heatmap routes", c.initHeatmapRoutes},
-		{"sse routes", c.initSSERoutes},
+		{"sse routes", func() { c.sse.RegisterRoutes(c.Group) }},
 		{"diagnostics routes", c.initDiagnosticsRoutes},
 		{"metrics history routes", c.initMetricsHistoryRoutes},
 		{"notification routes", func() { c.notifications.RegisterRoutes(c.Group) }},

--- a/internal/api/v2/apicore/sse_stream.go
+++ b/internal/api/v2/apicore/sse_stream.go
@@ -28,6 +28,21 @@ const (
 	// SSEWriteDeadline bounds how long a single SSE message write may block on a
 	// slow or disconnected client before it is abandoned.
 	SSEWriteDeadline = 10 * time.Second
+
+	// MaxSSEStreamDuration is the maximum lifetime of a single SSE stream
+	// connection before it is closed to prevent resource leaks. It is shared by
+	// every SSE endpoint (detection/sound-level streams, stream health, import
+	// progress) so the timeout cannot drift between domains.
+	MaxSSEStreamDuration = 30 * time.Minute
+)
+
+// SSE connection status strings used in connection/heartbeat log lines and the
+// initial connection event. Shared by every SSE endpoint.
+const (
+	// SSEStatusConnected marks an established SSE client connection.
+	SSEStatusConnected = "connected"
+	// SSEStatusDisconnected marks a torn-down SSE client connection.
+	SSEStatusDisconnected = "disconnected"
 )
 
 // WriteDeadlineSetter is implemented by response writers that support a write
@@ -115,4 +130,53 @@ func (c *Core) RecordSSEMessage(endpoint, messageType string) {
 	if c.Metrics != nil && c.Metrics.HTTP != nil {
 		c.Metrics.HTTP.RecordSSEMessageSent(endpoint, messageType)
 	}
+}
+
+// SendConnectionMessage sends the initial connection message to an SSE client.
+// Shared by every SSE endpoint (detection/sound-level streams, stream health).
+func (c *Core) SendConnectionMessage(ctx echo.Context, clientID, message, streamType string) error {
+	data := map[string]string{
+		"clientId": clientID,
+		"message":  message,
+	}
+	if streamType != "" {
+		data["type"] = streamType
+	}
+	return c.SendSSEMessage(ctx, SSEStatusConnected, data)
+}
+
+// LogSSEConnection logs SSE client connection/disconnection events. Shared by
+// every SSE endpoint.
+func (c *Core) LogSSEConnection(clientID, ip, userAgent, streamType string, connected bool) {
+	action := SSEStatusConnected
+	if !connected {
+		action = SSEStatusDisconnected
+	}
+
+	c.LogInfoIfEnabled(fmt.Sprintf("SSE %s client %s", streamType, action),
+		logger.String("client_id", clientID),
+		logger.String("ip", ip),
+		logger.String("user_agent", userAgent),
+	)
+}
+
+// SendSSEHeartbeat sends a heartbeat message to keep an SSE connection alive.
+// Shared by every SSE endpoint.
+func (c *Core) SendSSEHeartbeat(ctx echo.Context, clientID, streamType string) error {
+	data := map[string]any{
+		"timestamp": time.Now().Unix(),
+		"clients":   c.SSEManager.GetClientCount(),
+	}
+	if streamType != "" {
+		data["type"] = streamType
+	}
+
+	if err := c.SendSSEMessage(ctx, "heartbeat", data); err != nil {
+		c.LogDebugIfEnabled("SSE heartbeat failed, client likely disconnected",
+			logger.String("client_id", clientID),
+			logger.Error(err),
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/api/v2/apicore_bridge.go
+++ b/internal/api/v2/apicore_bridge.go
@@ -24,10 +24,17 @@ type (
 	ShutdownRequester = apicore.ShutdownRequester
 )
 
-// Stream-type identifiers re-declared from apicore so the SSE stream handlers in
-// package api keep using the short, unexported names.
+// SSE stream scaffolding re-declared from apicore so the remaining SSE producers
+// still in package api (streams_health.go, import.go) and the dashboard public
+// endpoint test keep referring to them by their short names. The canonical
+// definitions and the SendSSEHeartbeat/LogSSEConnection/SendConnectionMessage
+// helpers live in apicore and are promoted onto *Controller via the embedded
+// *apicore.Core.
 const (
-	streamTypeDetections  = apicore.StreamTypeDetections
-	streamTypeSoundLevels = apicore.StreamTypeSoundLevels
-	streamTypeAll         = apicore.StreamTypeAll
+	// maxSSEStreamDuration is the maximum lifetime of a single SSE stream.
+	maxSSEStreamDuration = apicore.MaxSSEStreamDuration
+	// SSEStatusConnected marks an established SSE client connection.
+	SSEStatusConnected = apicore.SSEStatusConnected
+	// SSEStatusDisconnected marks a torn-down SSE client connection.
+	SSEStatusDisconnected = apicore.SSEStatusDisconnected
 )

--- a/internal/api/v2/constants.go
+++ b/internal/api/v2/constants.go
@@ -58,11 +58,8 @@ const (
 	SettingsSectionSpecies   = "species"
 )
 
-// SSE connection status constants
-const (
-	SSEStatusConnected    = "connected"
-	SSEStatusDisconnected = "disconnected"
-)
+// SSE connection status constants are defined in apicore and re-exported via
+// apicore_bridge.go (SSEStatusConnected / SSEStatusDisconnected).
 
 // Toast notification type constants
 const (

--- a/internal/api/v2/sse/main_test.go
+++ b/internal/api/v2/sse/main_test.go
@@ -1,0 +1,54 @@
+package sse
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+	"go.uber.org/goleak"
+)
+
+// testCleanupGracePeriod gives per-request SSE event-loop goroutines a brief
+// window to exit after their client disconnects before the package-wide leak
+// gate runs, so one test's still-terminating goroutine is not attributed to a
+// leak. It mirrors the package-api harness this domain was extracted from.
+const testCleanupGracePeriod = 100 * time.Millisecond
+
+// TestMain disables HTTP keep-alives before any test runs (so the SSE
+// connection-lifecycle tests get immediate client teardown) and then runs a
+// package-wide goroutine-leak gate after all tests complete. The SSE stream
+// endpoints spawn a long-lived event-loop goroutine per HTTP request; the gate
+// verifies those loops exit when the client disconnects, guarding against the
+// memory-leak regressions the connection-cleanup tests were written for. The
+// ignore list mirrors package api's TestMain.
+func TestMain(m *testing.M) {
+	apitest.DisableHTTPKeepAlivesForTesting()
+
+	testResult := m.Run()
+
+	// Give a small grace period for goroutines to clean up after all tests, so
+	// the gate does not observe a goroutine that is still terminating.
+	time.Sleep(testCleanupGracePeriod)
+
+	if testResult == 0 {
+		opts := []goleak.Option{
+			// Test-framework goroutines (not leaks).
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("testing.(*T).Parallel"),
+			// Process-lifetime third-party workers that cannot be stopped: the
+			// go-cache janitor (started by the core's DetectionCache) and the
+			// lumberjack log-rotation worker.
+			goleak.IgnoreTopFunction("github.com/patrickmn/go-cache.(*janitor).Run"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		}
+
+		if err := goleak.Find(opts...); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: Goroutine leak detected after all tests:\n%v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	os.Exit(testResult)
+}

--- a/internal/api/v2/sse/sse.go
+++ b/internal/api/v2/sse/sse.go
@@ -1,9 +1,13 @@
-// internal/api/v2/sse.go
-package api
+// Package sse implements the Server-Sent Events ENDPOINT handlers for the v2
+// API (the real-time detection and sound-level streams plus the SSE status
+// endpoint). The SSE hub itself (SSEManager, broadcasters, SSEClient, the wire
+// structs and the low-level write primitives) lives in apicore and is shared by
+// every SSE producer; this package only owns the stream endpoints and their
+// per-request event loops.
+package sse
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -16,9 +20,6 @@ import (
 
 // SSE connection configuration
 const (
-	// Connection timeouts
-	maxSSEStreamDuration = 30 * time.Minute // Maximum stream duration to prevent resource leaks
-
 	// Endpoints
 	detectionStreamEndpoint  = "/api/v2/detections/stream"
 	soundLevelStreamEndpoint = "/api/v2/soundlevels/stream"
@@ -35,20 +36,23 @@ const (
 	sseRateLimitWindow   = 1 * time.Minute // SSE rate limit time window
 )
 
-// SSEEvent represents a generic SSE event that can contain different data types
-type SSEEvent struct {
-	Type      string    `json:"type"`
-	Data      any       `json:"data"`
-	Timestamp time.Time `json:"timestamp"`
+// Handler serves the SSE stream endpoints. It embeds *apicore.Core by pointer so
+// the shared SSE hub (SSEManager), write primitives (SendSSEMessage,
+// RecordSSE*), stream scaffolding (SendSSEHeartbeat, LogSSEConnection,
+// SendConnectionMessage) and logging helpers promote directly onto it.
+type Handler struct {
+	*apicore.Core
 }
 
-// initSSERoutes registers SSE-related API endpoints
-func (c *Controller) initSSERoutes() {
-	// Initialize SSE manager if not already done
-	if c.SSEManager == nil {
-		c.SSEManager = apicore.NewSSEManager()
-	}
+// New constructs the SSE endpoint handler from the shared core.
+func New(core *apicore.Core) *Handler {
+	return &Handler{Core: core}
+}
 
+// RegisterRoutes registers the SSE-related API endpoints on the given group,
+// preserving the exact routes, order and per-route middleware (the SSE rate
+// limiter on the two stream endpoints) from the original initSSERoutes.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	// Create rate limiter for SSE connections (10 requests per minute per IP)
 	rateLimiterConfig := middleware.RateLimiterConfig{
 		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
@@ -71,18 +75,18 @@ func (c *Controller) initSSERoutes() {
 	}
 
 	// SSE endpoint for detection stream with rate limiting
-	c.Group.GET("/detections/stream", c.StreamDetections, middleware.RateLimiterWithConfig(rateLimiterConfig))
+	g.GET("/detections/stream", c.StreamDetections, middleware.RateLimiterWithConfig(rateLimiterConfig))
 
 	// SSE endpoint for sound level stream with rate limiting
-	c.Group.GET("/soundlevels/stream", c.StreamSoundLevels, middleware.RateLimiterWithConfig(rateLimiterConfig))
+	g.GET("/soundlevels/stream", c.StreamSoundLevels, middleware.RateLimiterWithConfig(rateLimiterConfig))
 
 	// SSE status endpoint - shows connected client count
-	c.Group.GET("/sse/status", c.GetSSEStatus)
+	g.GET("/sse/status", c.GetSSEStatus)
 }
 
 // createSSEClient creates a new SSE client with common settings
-func createSSEClient(clientID string, ctx echo.Context, streamType string) *SSEClient {
-	return &SSEClient{
+func createSSEClient(clientID string, ctx echo.Context, streamType string) *apicore.SSEClient {
+	return &apicore.SSEClient{
 		ID:         clientID,
 		Request:    ctx.Request(),
 		Response:   ctx.Response(),
@@ -91,63 +95,17 @@ func createSSEClient(clientID string, ctx echo.Context, streamType string) *SSEC
 	}
 }
 
-// sendConnectionMessage sends the initial connection message to the client
-func (c *Controller) sendConnectionMessage(ctx echo.Context, clientID, message, streamType string) error {
-	data := map[string]string{
-		"clientId": clientID,
-		"message":  message,
-	}
-	if streamType != "" {
-		data["type"] = streamType
-	}
-	return c.SendSSEMessage(ctx, SSEStatusConnected, data)
-}
-
-// logSSEConnection logs SSE client connection/disconnection events
-func (c *Controller) logSSEConnection(clientID, ip, userAgent, streamType string, connected bool) {
-	action := SSEStatusConnected
-	if !connected {
-		action = SSEStatusDisconnected
-	}
-
-	c.LogInfoIfEnabled(fmt.Sprintf("SSE %s client %s", streamType, action),
-		logger.String("client_id", clientID),
-		logger.String("ip", ip),
-		logger.String("user_agent", userAgent),
-	)
-}
-
-// sendSSEHeartbeat sends a heartbeat message to keep the connection alive
-func (c *Controller) sendSSEHeartbeat(ctx echo.Context, clientID, streamType string) error {
-	data := map[string]any{
-		"timestamp": time.Now().Unix(),
-		"clients":   c.SSEManager.GetClientCount(),
-	}
-	if streamType != "" {
-		data["type"] = streamType
-	}
-
-	if err := c.SendSSEMessage(ctx, "heartbeat", data); err != nil {
-		c.LogDebugIfEnabled("SSE heartbeat failed, client likely disconnected",
-			logger.String("client_id", clientID),
-			logger.Error(err),
-		)
-		return err
-	}
-	return nil
-}
-
 // handleSSEStream handles the common SSE stream setup and teardown with timeout protection
-func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logPrefix string, setupFunc func(*SSEClient), eventLoop func(echo.Context, *SSEClient, string) error) error {
+func (c *Handler) handleSSEStream(ctx echo.Context, streamType, message, logPrefix string, setupFunc func(*apicore.SSEClient), eventLoop func(echo.Context, *apicore.SSEClient, string) error) error {
 	// Track connection start time for metrics
 	connectionStartTime := time.Now()
 
 	// Track metrics if available
 	endpoint := ""
 	switch streamType {
-	case streamTypeDetections:
+	case apicore.StreamTypeDetections:
 		endpoint = detectionStreamEndpoint
-	case streamTypeSoundLevels:
+	case apicore.StreamTypeSoundLevels:
 		endpoint = soundLevelStreamEndpoint
 	}
 
@@ -166,7 +124,7 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 	}
 
 	// Create a context with timeout for maximum connection duration
-	timeoutCtx, cancel := context.WithTimeout(ctx.Request().Context(), maxSSEStreamDuration)
+	timeoutCtx, cancel := context.WithTimeout(ctx.Request().Context(), apicore.MaxSSEStreamDuration)
 	defer cancel()
 
 	// Override the request context with timeout context
@@ -193,18 +151,18 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 	}
 
 	// Send initial connection message
-	if err := c.sendConnectionMessage(ctx, clientID, message, streamType); err != nil {
+	if err := c.SendConnectionMessage(ctx, clientID, message, streamType); err != nil {
 		c.SSEManager.RemoveClient(clientID)
 		return err
 	}
 
 	// Log the connection
-	c.logSSEConnection(clientID, ctx.RealIP(), ctx.Request().UserAgent(), logPrefix, true)
+	c.LogSSEConnection(clientID, ctx.RealIP(), ctx.Request().UserAgent(), logPrefix, true)
 
 	// Handle the SSE connection
 	defer func() {
 		c.SSEManager.RemoveClient(clientID)
-		c.logSSEConnection(clientID, ctx.RealIP(), "", logPrefix, false)
+		c.LogSSEConnection(clientID, ctx.RealIP(), "", logPrefix, false)
 	}()
 
 	// Run the event loop
@@ -212,27 +170,27 @@ func (c *Controller) handleSSEStream(ctx echo.Context, streamType, message, logP
 }
 
 // StreamDetections handles the SSE connection for real-time detection streaming
-func (c *Controller) StreamDetections(ctx echo.Context) error {
-	return c.handleSSEStream(ctx, streamTypeDetections, "Connected to detection stream", "detection",
-		func(client *SSEClient) {
-			client.Channel = make(chan SSEDetectionData, sseDetectionBufferSize) // Buffer for high detection periods
-			client.PendingChan = make(chan any, ssePendingBufferSize)            // Buffer for pending detection snapshots
+func (c *Handler) StreamDetections(ctx echo.Context) error {
+	return c.handleSSEStream(ctx, apicore.StreamTypeDetections, "Connected to detection stream", "detection",
+		func(client *apicore.SSEClient) {
+			client.Channel = make(chan apicore.SSEDetectionData, sseDetectionBufferSize) // Buffer for high detection periods
+			client.PendingChan = make(chan any, ssePendingBufferSize)                    // Buffer for pending detection snapshots
 		},
-		func(ctx echo.Context, client *SSEClient, clientID string) error {
+		func(ctx echo.Context, client *apicore.SSEClient, clientID string) error {
 			return c.runSSEEventLoopMulti(ctx, client, clientID, detectionStreamEndpoint)
 		})
 }
 
 // runSSEEventLoopMulti handles the SSE event loop for detection streams,
 // which receive both detection events and pending detection snapshots.
-func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, clientID, endpoint string) error {
+func (c *Handler) runSSEEventLoopMulti(ctx echo.Context, client *apicore.SSEClient, clientID, endpoint string) error {
 	ticker := time.NewTicker(apicore.SSEHeartbeatInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			if err := c.sendSSEHeartbeat(ctx, clientID, ""); err != nil {
+			if err := c.SendSSEHeartbeat(ctx, clientID, ""); err != nil {
 				c.RecordSSEError(endpoint, "heartbeat_failed")
 				return err
 			}
@@ -297,13 +255,13 @@ func (c *Controller) runSSEEventLoopMulti(ctx echo.Context, client *SSEClient, c
 }
 
 // StreamSoundLevels handles the SSE connection for real-time sound level streaming
-func (c *Controller) StreamSoundLevels(ctx echo.Context) error {
-	return c.handleSSEStream(ctx, streamTypeSoundLevels, "Connected to sound level stream", "sound level",
-		func(client *SSEClient) {
-			client.Channel = make(chan SSEDetectionData, sseMinimalBufferSize)            // Minimal buffer, not used for sound levels
-			client.SoundLevelChan = make(chan SSESoundLevelData, sseSoundLevelBufferSize) // Buffer for sound level data
+func (c *Handler) StreamSoundLevels(ctx echo.Context) error {
+	return c.handleSSEStream(ctx, apicore.StreamTypeSoundLevels, "Connected to sound level stream", "sound level",
+		func(client *apicore.SSEClient) {
+			client.Channel = make(chan apicore.SSEDetectionData, sseMinimalBufferSize)            // Minimal buffer, not used for sound levels
+			client.SoundLevelChan = make(chan apicore.SSESoundLevelData, sseSoundLevelBufferSize) // Buffer for sound level data
 		},
-		func(ctx echo.Context, client *SSEClient, clientID string) error {
+		func(ctx echo.Context, client *apicore.SSEClient, clientID string) error {
 			return c.runSSEEventLoop(ctx, client, clientID, soundLevelStreamEndpoint,
 				func() (any, bool) {
 					select {
@@ -317,13 +275,13 @@ func (c *Controller) StreamSoundLevels(ctx echo.Context) error {
 					}
 				},
 				"soundlevel",
-				streamTypeSoundLevels,
+				apicore.StreamTypeSoundLevels,
 			)
 		})
 }
 
 // runSSEEventLoop handles the common SSE event loop pattern for all stream types
-func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, clientID string, endpoint string,
+func (c *Handler) runSSEEventLoop(ctx echo.Context, client *apicore.SSEClient, clientID string, endpoint string,
 	dataReceiver func() (any, bool), eventType string, heartbeatType string) error {
 
 	ticker := time.NewTicker(apicore.SSEHeartbeatInterval)
@@ -333,7 +291,7 @@ func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, client
 		select {
 		case <-ticker.C:
 			// Send heartbeat
-			if err := c.sendSSEHeartbeat(ctx, clientID, heartbeatType); err != nil {
+			if err := c.SendSSEHeartbeat(ctx, clientID, heartbeatType); err != nil {
 				c.RecordSSEError(endpoint, "heartbeat_failed")
 				return err
 			}
@@ -370,7 +328,7 @@ func (c *Controller) runSSEEventLoop(ctx echo.Context, client *SSEClient, client
 }
 
 // GetSSEStatus returns information about SSE connections
-func (c *Controller) GetSSEStatus(ctx echo.Context) error {
+func (c *Handler) GetSSEStatus(ctx echo.Context) error {
 	if c.SSEManager == nil {
 		return ctx.JSON(http.StatusOK, map[string]any{
 			"connected_clients": 0,

--- a/internal/api/v2/sse/sse_connection_test.go
+++ b/internal/api/v2/sse/sse_connection_test.go
@@ -13,7 +13,7 @@
 // 4. For benchmark loops, use b.Loop() instead of manual for i := 0; i < b.N; i++
 // 5. Avoid testing/synctest.Test() if code creates background goroutines with time.Sleep
 
-package api
+package sse
 
 import (
 	"bufio"
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
@@ -95,7 +96,8 @@ func attemptSSEConnection(t *testing.T, serverURL, endpoint string, connID int, 
 
 // Common test configurations for different SSE endpoints
 var sseTestConfigs = []SSETestConfig{
-	// Note: /notifications/stream endpoint requires authentication and is tested separately
+	// Note: /notifications/stream endpoint requires authentication and lives in
+	// the notifications domain; it is tested there separately.
 	{
 		endpoint:          "/detections/stream",
 		maxConnections:    3,
@@ -131,11 +133,7 @@ func TestSSEConnectionCleanup(t *testing.T) {
 func testSSEEndpointCleanup(t *testing.T, config SSETestConfig) {
 	t.Helper()
 	// Create test server
-	server, controller := setupSSETestServer(t)
-	t.Cleanup(func() {
-		controller.Shutdown()
-		server.Close()
-	})
+	server, _ := setupSSETestServer(t)
 
 	t.Run("single_connection_manual_disconnect", func(t *testing.T) {
 		testSingleConnectionManualDisconnect(t, server, config)
@@ -322,9 +320,7 @@ func TestSSEUnbufferedChannelFix(t *testing.T) {
 	t.Attr("issue", "unbuffered-channel-fix")
 
 	// Test the detections endpoint to verify the critical unbuffered channel fix
-	server, controller := setupSSETestServer(t)
-	defer server.Close()
-	defer controller.Shutdown()
+	server, _ := setupSSETestServer(t)
 
 	client := apitest.NewTestHTTPClient(3 * time.Second)
 
@@ -360,9 +356,7 @@ func TestSSERateLimiting(t *testing.T) {
 	t.Attr("component", "sse")
 	t.Attr("feature", "rate-limiting")
 
-	server, controller := setupSSETestServer(t)
-	defer server.Close()
-	defer controller.Shutdown()
+	server, _ := setupSSETestServer(t)
 
 	client := apitest.NewTestHTTPClient(2 * time.Second)
 
@@ -403,63 +397,38 @@ func TestSSERateLimiting(t *testing.T) {
 	// Cleanup is immediate with DisableKeepAlives=true
 }
 
-// setupSSETestServer creates a test server with SSE endpoints configured
-func setupSSETestServer(t *testing.T) (*httptest.Server, *Controller) {
+// setupSSETestServer creates a test server with the SSE endpoints registered.
+// It builds an apicore.Core via apitest (mock datastore, per-test t.TempDir
+// media path, in-memory Echo), wires only this domain's handler, and serves it
+// over httptest. The core's lifecycle (SSE client teardown, context cancel, SFS
+// close) is torn down by apitest.NewCore's own t.Cleanup; this helper adds a
+// cleanup that closes lingering clients and the httptest server first (LIFO) so
+// a blocked streaming handler is released before the server is closed. Settings
+// are not published to the process-global snapshot (the SSE endpoints never read
+// it) so the parallel endpoint subtests do not contend on the global.
+func setupSSETestServer(t *testing.T) (*httptest.Server, *apicore.Core) {
 	t.Helper()
-	// Create Echo instance
 	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithoutSettingsPublish())
 
-	// Create mock datastore
-	mockDS := mocks.NewMockInterface(t)
-	mockDS.EXPECT().PruneAppEvents(mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
+	h := New(core)
+	h.RegisterRoutes(core.Group)
 
-	// Create settings with required paths
-	settings := &conf.Settings{
-		WebServer: conf.WebServerSettings{
-			Debug: true,
-		},
-		Realtime: conf.RealtimeSettings{
-			Audio: conf.AudioSettings{
-				Export: conf.ExportSettings{
-					Path: t.TempDir(),
-				},
-			},
-		},
-	}
-
-	// Create control channel
-	controlChan := make(chan string, 10)
-
-	// Create mock metrics
-	mockMetrics, err := observability.NewMetrics()
-	require.NoError(t, err, "Failed to initialize metrics")
-
-	// Create controller WITH route initialization
-	controller, err := NewWithOptions(e, mockDS, settings, nil, nil, controlChan, mockMetrics, true)
-	require.NoError(t, err)
-
-	// Wait for goroutines to start
-	if controller.goroutinesStarted != nil {
-		select {
-		case <-controller.goroutinesStarted:
-			// Controller is ready
-		case <-time.After(2 * time.Second):
-			require.Fail(t, "Controller failed to start within timeout")
-		}
-	}
-
-	// Create test server
 	server := httptest.NewServer(e)
+	t.Cleanup(func() {
+		if core.SSEManager != nil {
+			core.SSEManager.CloseAllClients()
+		}
+		server.Close()
+	})
 
-	return server, controller
+	return server, core
 }
 
 // Benchmark for SSE connection performance
 // Uses Go 1.25's b.Loop() for iteration
 func BenchmarkSSEConnectionSetup(b *testing.B) {
-	server, controller := setupSSETestServerForBench(b)
-	defer server.Close()
-	defer controller.Shutdown()
+	server, _ := setupSSETestServerForBench(b)
 
 	client := apitest.NewTestHTTPClient(5 * time.Second)
 	defer client.CloseIdleConnections()
@@ -469,7 +438,7 @@ func BenchmarkSSEConnectionSetup(b *testing.B) {
 
 	// Use b.Loop() for benchmark iteration (Go 1.25)
 	for b.Loop() {
-		req, err := http.NewRequest("GET", server.URL+"/api/v2/notifications/stream", http.NoBody)
+		req, err := http.NewRequest("GET", server.URL+"/api/v2/detections/stream", http.NoBody)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -493,8 +462,11 @@ func BenchmarkSSEConnectionSetup(b *testing.B) {
 	}
 }
 
-// setupSSETestServerForBench creates a test server for benchmarking
-func setupSSETestServerForBench(b *testing.B) (*httptest.Server, *Controller) {
+// setupSSETestServerForBench creates a test server for benchmarking. apitest.NewCore
+// requires a *testing.T, so the benchmark composes the core directly via
+// apicore.NewCore (the datastore mock accepts a testing.TB) and tears it down in
+// b.Cleanup, mirroring apitest's Core-level teardown order.
+func setupSSETestServerForBench(b *testing.B) (*httptest.Server, *apicore.Core) {
 	b.Helper()
 	e := echo.New()
 	mockDS := mocks.NewMockInterface(b)
@@ -507,22 +479,39 @@ func setupSSETestServerForBench(b *testing.B) (*httptest.Server, *Controller) {
 			},
 		},
 	}
-	controlChan := make(chan string, 10)
-	mockMetrics, _ := observability.NewMetrics()
-
-	controller, err := NewWithOptions(e, mockDS, settings, nil, nil, controlChan, mockMetrics, true)
+	mockMetrics, err := observability.NewMetrics()
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	if controller.goroutinesStarted != nil {
-		select {
-		case <-controller.goroutinesStarted:
-			// Controller is ready
-		case <-time.After(2 * time.Second):
-			b.Fatal("Controller failed to start within timeout")
-		}
+	core, err := apicore.NewCore(e, mockDS, settings, nil, nil, mockMetrics,
+		func(_, _ string) bool { return false })
+	if err != nil {
+		b.Fatal(err)
 	}
+	// apicore.NewCore leaves Group nil (the facade owns it); play the facade's
+	// role so the handler registers under /api/v2.
+	core.Group = e.Group("/api/v2")
 
-	return httptest.NewServer(e), controller
+	h := New(core)
+	h.RegisterRoutes(core.Group)
+
+	server := httptest.NewServer(e)
+	b.Cleanup(func() {
+		// Close lingering SSE clients first so a blocked streaming handler is
+		// released, then close the server: server.Close must run so its accept
+		// goroutine is not left alive for the package goleak gate when the
+		// benchmark is exercised with -bench.
+		if core.SSEManager != nil {
+			core.SSEManager.CloseAllClients()
+		}
+		server.Close()
+		core.Cancel()
+		core.Wait()
+		if core.SFS != nil {
+			_ = core.SFS.Close()
+		}
+	})
+
+	return server, core
 }

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -478,7 +478,7 @@ func convertErrorContextToResponse(errCtx *ffmpeg.ErrorContext) *ErrorContextRes
 
 // handleStreamHealthHeartbeat sends a heartbeat and returns true if client disconnected.
 func (c *Controller) handleStreamHealthHeartbeat(ctx echo.Context, clientID string) error {
-	if err := c.sendSSEHeartbeat(ctx, clientID, "stream_health"); err != nil {
+	if err := c.SendSSEHeartbeat(ctx, clientID, "stream_health"); err != nil {
 		c.LogDebugIfEnabled("Stream health SSE heartbeat failed, client likely disconnected",
 			logger.String("client_id", clientID),
 			logger.Error(err))
@@ -552,10 +552,10 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 	apicore.SetSSEHeaders(ctx)
 	clientID := apicore.GenerateCorrelationID()
 
-	c.logSSEConnection(clientID, ctx.RealIP(), ctx.Request().UserAgent(), "stream-health", true)
-	defer c.logSSEConnection(clientID, ctx.RealIP(), "", "stream-health", false)
+	c.LogSSEConnection(clientID, ctx.RealIP(), ctx.Request().UserAgent(), "stream-health", true)
+	defer c.LogSSEConnection(clientID, ctx.RealIP(), "", "stream-health", false)
 
-	if err := c.sendConnectionMessage(ctx, clientID, "Connected to stream health updates", "stream_health"); err != nil {
+	if err := c.SendConnectionMessage(ctx, clientID, "Connected to stream health updates", "stream_health"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What this does

Extracts the Server-Sent Events ENDPOINT handlers out of the monolithic facade package `api` (`internal/api/v2`) into a new `internal/api/v2/sse` package, following the established domain-extraction pattern: `Handler` embeds `*apicore.Core` by pointer and exposes `RegisterRoutes(g *echo.Group)`. This is the `sse` slice of the ongoing api/v2 split.

### Endpoints that moved into `internal/api/v2/sse`

| Method | Route | Handler |
| --- | --- | --- |
| GET | `/api/v2/detections/stream` | `StreamDetections` (rate-limited) |
| GET | `/api/v2/soundlevels/stream` | `StreamSoundLevels` (rate-limited) |
| GET | `/api/v2/sse/status` | `GetSSEStatus` |

Also moved: their per-request scaffolding (`handleSSEStream`, `runSSEEventLoop`, `runSSEEventLoopMulti`, `createSSEClient`), the endpoint-specific constants (stream paths, channel buffer sizes, SSE rate-limit config), the connection-lifecycle tests (rebuilt against `apitest.NewCore` + the new `Handler`), and a `goleak` `TestMain` so the package runs as its own isolated `-race` binary.

### What STAYS in `apicore` (the SSE hub is shared infrastructure, not a domain)

`SSEManager`, the broadcasters, `SSEClient`, the SSE wire structs, and the low-level write primitives (`SendSSEMessage`, `RecordSSE*`, `SetSSEHeaders`) already live in `apicore` and remain there.

This change additionally PROMOTES into `apicore` the SSE stream scaffolding that is shared by SSE producers still in package `api` (`streams_health.go`) and a later phase (`import.go`): the `SendSSEHeartbeat`, `LogSSEConnection` and `SendConnectionMessage` helpers (now methods on `*apicore.Core`), the `MaxSSEStreamDuration` constant, and the `SSEStatusConnected`/`SSEStatusDisconnected` constants. Package `api` keeps the short names via `apicore_bridge.go` aliases, so `streams_health.go` and `import.go` keep compiling. This mirrors the precedent set when the notifications phase promoted the SSE write primitives.

### Facade wiring

New `sse *sse.Handler` field on `Controller`, constructed as `c.sse = sse.New(c.Core)`. The `routeInitializers` "sse routes" entry now calls `c.sse.RegisterRoutes(c.Group)` at the SAME ordinal index, preserving route order and the per-route SSE rate limiters verbatim. The dead/unused `SSEEvent` type and the now-unused stream-type bridge aliases were dropped as cleanup.

## No public-behavior change

The SSE wire contract (event names `connected`/`heartbeat`/`detection`/`pending`/`soundlevel`, payload shapes, status codes, the 10 req/min rate limiting with 429 bodies, the 30 minute stream timeout) and the external `apiv2.Controller` / `apiv2.New` surface are unchanged. The route-enumeration golden test is identical.

The benchmark that previously hit `/notifications/stream` (a different domain, mislabeled) was retargeted to `/detections/stream`, which this package actually owns.

## Verification

- `go build ./...` clean; `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks)
- `go test -race` green for `./internal/api/v2/` (facade, 122s), `./internal/api/v2/sse/` (own binary, 8.1s), `./internal/api/v2/apicore/`, and `./internal/analysis/`
- Route-enumeration golden test (`TestRouteEnumerationMatchesGolden`) and greedy-audio-route test pass unchanged
- `golangci-lint run` reports 0 issues
- SSE benchmark runs cleanly with the package `goleak` gate active

## Preflight Status

- [x] Single concern: one refactor (extract the sse endpoint domain)
- [x] Preflight passed: 3 review passes (correctness/safety, quality/integration, regression). One real finding fixed (benchmark leaked its `httptest.Server`); one dead-code cleanup applied. No regressions found.
- [x] Linters clean: `golangci-lint run` zero issues
- [x] Tests pass: `go test -race` green across the affected packages
- [x] No unrelated changes
- [x] No regression/backward-compat break: SSE wire contract and external API surface unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Server-Sent Events streaming for detections and sound levels, including clearer connection status updates and periodic heartbeats.
  * Added a dedicated SSE status endpoint response that better reflects whether streams are active.

* **Bug Fixes**
  * Stream connections now have more consistent startup, logging, and cleanup behavior.
  * SSE streams now use a fixed maximum lifetime to help prevent stuck connections.

* **Tests**
  * Expanded SSE test coverage and leak checks to improve reliability during streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->