### PR TITLE
refactor(api/v2): extract system domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -417,7 +417,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 | GET    | `/support/download/:id` | `DownloadSupportDump` | ✅   | Download support dump            |
 | GET    | `/support/status`       | `GetSupportStatus`    | ✅   | Support system status            |
 
-### System Information (`system.go`)
+### System Information (`system/system.go`)
 
 | Method | Route                            | Handler                   | Auth | Description                          |
 | ------ | -------------------------------- | ------------------------- | ---- | ------------------------------------ |
@@ -435,7 +435,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 | GET    | `/system/models`                 | `GetActiveModels`         | ✅   | Active model metadata                |
 | GET    | `/system/inference`              | `GetInferenceStatus`      | ✅   | Read-only snapshot of the inference subsystem: hardware, backends, loaded models with stats/RAM/source attachment, audio pipeline metrics, per-model error rate, load failures, last detection, and metric key names for time-series lookups. |
 
-### Events (`events.go`, `events_aggregation.go`)
+### Events (`system/events.go`, `system/events_aggregation.go`)
 
 Registered under the system route group. All endpoints require authentication.
 
@@ -555,7 +555,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 }
 ```
 
-### Diagnostics (`diagnostics.go`)
+### Diagnostics (`system/diagnostics.go`)
 
 | Method | Route                            | Handler                  | Auth | Description                    |
 | ------ | -------------------------------- | ------------------------ | ---- | ------------------------------ |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/species"
 	"github.com/tphakala/birdnet-go/internal/api/v2/sse"
 	"github.com/tphakala/birdnet-go/internal/api/v2/support"
+	"github.com/tphakala/birdnet-go/internal/api/v2/system"
 	tlsapi "github.com/tphakala/birdnet-go/internal/api/v2/tls"
 	"github.com/tphakala/birdnet-go/internal/api/v2/weather"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
@@ -259,16 +260,23 @@ type Controller struct {
 	// classifier orchestrator. Overrides label-derived names in the cached maps.
 	nameResolver atomic.Pointer[datastore.SpeciesNameResolver]
 
-	// Health check infrastructure for the diagnostics endpoints (initialized lazily
-	// in initDiagnosticsRoutes; healthErrors may be injected via WithHealthErrorBuffer).
-	// These stay on the facade: the diagnostics and metrics-history handlers own
-	// them, and HealthMetricsStore()/HealthEventBuffer() expose them to the analysis
-	// pipeline as exported accessor methods (which would collide with exported fields).
-	healthRegistry     *health.Registry
-	healthReports      *health.ReportStore
-	healthErrors       *health.ErrorRingBuffer
-	healthMetricsStore *observability.HealthMetricsStore
-	healthEvents       *observability.HealthEventBuffer
+	// healthErrorBuf is the optional shared ErrorRingBuffer seed injected via
+	// WithHealthErrorBuffer. It is handed to the system domain handler at
+	// construction; the system handler owns the live diagnostics health
+	// infrastructure (registry, report store, error buffer, metrics store, event
+	// buffer) and exposes the metrics store / event buffer to the analysis pipeline
+	// through the HealthMetricsStore()/HealthEventBuffer() facade delegators.
+	healthErrorBuf *health.ErrorRingBuffer
+
+	// system serves the /api/v2/system/* information endpoints plus the events,
+	// diagnostics, metrics-history and terminal endpoints. Beyond the shared
+	// *apicore.Core it owns the diagnostics health infrastructure and receives the
+	// controller start time and the optional health-error-buffer seed by injection.
+	// The facade keeps the genuine-system route registration plus the cross-domain
+	// /system routes (audio devices, external-media, database overview/migration/
+	// backup/legacy) in initSystemRoutes (system_routes.go) until those domains are
+	// extracted.
+	system *system.Handler
 }
 
 // Option is a functional option for configuring the Controller.
@@ -347,11 +355,12 @@ func WithModelManager(mm *classifier.ModelManager) Option {
 }
 
 // WithHealthErrorBuffer injects a shared ErrorRingBuffer created at startup.
-// When set, initDiagnosticsRoutes uses this buffer instead of creating its own,
-// enabling the logger to feed errors into the same buffer the health checks read.
+// When set, the system handler's diagnostics initializer uses this buffer instead
+// of creating its own, enabling the logger to feed errors into the same buffer the
+// health checks read.
 func WithHealthErrorBuffer(buf *health.ErrorRingBuffer) Option {
 	return func(c *Controller) {
-		c.healthErrors = buf
+		c.healthErrorBuf = buf
 	}
 }
 
@@ -543,6 +552,13 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	now := time.Now()
 	c.startTime = &now
 
+	// Construct the system domain handler AFTER the functional options are applied
+	// (so the WithHealthErrorBuffer seed in c.healthErrorBuf is observed) and after
+	// c.startTime is set (the diagnostics uptime check captures the pointer). It
+	// owns the diagnostics health infrastructure; its routes are registered in
+	// initRoutes below.
+	c.system = system.New(c.Core, c.startTime, c.healthErrorBuf, LatestAudioLevels)
+
 	// Initialize routes if requested (skip in tests to avoid starting background goroutines)
 	if initializeRoutes {
 		// Initialize synchronization channel for testing
@@ -582,7 +598,7 @@ func (c *Controller) initRoutes() {
 		{"analytics routes", c.initAnalyticsRoutes},
 		{"weather routes", func() { c.weather.RegisterRoutes(c.Group) }},
 		{"system routes", c.initSystemRoutes},
-		{"terminal routes", c.initTerminalRoutes},
+		{"terminal routes", func() { c.system.RegisterTerminalRoutes(c.Group) }},
 		{"settings routes", c.initSettingsRoutes},
 		{"filesystem routes", func() { c.filesystem.RegisterRoutes(c.Group) }},
 		{"stream health routes", c.initStreamHealthRoutes},
@@ -598,8 +614,8 @@ func (c *Controller) initRoutes() {
 		{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }},
 		{"heatmap routes", c.initHeatmapRoutes},
 		{"sse routes", func() { c.sse.RegisterRoutes(c.Group) }},
-		{"diagnostics routes", c.initDiagnosticsRoutes},
-		{"metrics history routes", c.initMetricsHistoryRoutes},
+		{"diagnostics routes", func() { c.system.RegisterDiagnosticsRoutes(c.Group) }},
+		{"metrics history routes", func() { c.system.RegisterMetricsHistoryRoutes(c.Group) }},
 		{"notification routes", func() { c.notifications.RegisterRoutes(c.Group) }},
 		{"support routes", func() { c.support.RegisterRoutes(c.Group) }},
 		{"debug routes", c.initDebugRoutes},
@@ -693,7 +709,7 @@ func (c *Controller) HealthCheck(ctx echo.Context) error {
 	systemMetrics := make(map[string]any)
 
 	// CPU usage from cached background sampler
-	cpuPercent := GetCachedCPUUsage()
+	cpuPercent := apicore.GetCachedCPUUsage()
 	if len(cpuPercent) > 0 {
 		systemMetrics["cpu_usage"] = cpuPercent[0]
 	} else {

--- a/internal/api/v2/apicore/cpu_cache.go
+++ b/internal/api/v2/apicore/cpu_cache.go
@@ -1,0 +1,70 @@
+package apicore
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+)
+
+// cpuCacheUpdateInterval is the interval between CPU cache samples.
+const cpuCacheUpdateInterval = 2 * time.Second // Interval for CPU cache updates
+
+// CPUCache holds the cached CPU usage data.
+type CPUCache struct {
+	mu          sync.RWMutex
+	cpuPercent  []float64
+	lastUpdated time.Time
+}
+
+// Global CPU cache instance. It is shared substrate: the background sampler is
+// started by the system domain's route initializer, and the cached value is read
+// by the system handlers, the diagnostics CPU-load check, the metrics-history
+// collector and the facade /health endpoint. It lives in apicore so all of those
+// consumers (across the facade and the system package) share one source without
+// an import cycle.
+var cpuCache = &CPUCache{
+	cpuPercent:  []float64{0}, // Initialize with 0 value
+	lastUpdated: time.Now(),
+}
+
+// UpdateCPUCache updates the cached CPU usage data until the context is cancelled.
+func UpdateCPUCache(ctx context.Context) {
+	ticker := time.NewTicker(cpuCacheUpdateInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			// Get CPU usage (this will block for 1 second)
+			percent, err := cpu.Percent(time.Second, false)
+			if err == nil && len(percent) > 0 {
+				cpuCache.mu.Lock()
+				cpuCache.cpuPercent = percent
+				cpuCache.lastUpdated = time.Now()
+				cpuCache.mu.Unlock()
+			}
+
+			// Wait for next tick or context cancellation
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
+// GetCachedCPUUsage returns the cached CPU usage.
+func GetCachedCPUUsage() []float64 {
+	cpuCache.mu.RLock()
+	defer cpuCache.mu.RUnlock()
+
+	// Return a copy to avoid race conditions
+	result := make([]float64, len(cpuCache.cpuPercent))
+	copy(result, cpuCache.cpuPercent)
+	return result
+}

--- a/internal/api/v2/apicore/cpu_cache_test.go
+++ b/internal/api/v2/apicore/cpu_cache_test.go
@@ -1,0 +1,27 @@
+package apicore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCachedCPUUsage tests the GetCachedCPUUsage function
+func TestGetCachedCPUUsage(t *testing.T) {
+	t.Attr("component", "system")
+	t.Attr("type", "unit")
+	t.Attr("feature", "cpu-cache")
+
+	// The cache is initialized with [0], so we should get at least that
+	result := GetCachedCPUUsage()
+	require.NotNil(t, result, "CPU cache should not be nil")
+	require.Len(t, result, 1, "CPU cache should have at least 1 value")
+
+	// Verify it returns a copy (modifying result shouldn't affect cache)
+	originalValue := result[0]
+	result[0] = 999.0
+
+	newResult := GetCachedCPUUsage()
+	assert.InDelta(t, originalValue, newResult[0], 0.001, "Cache should return a copy, not the original slice")
+}

--- a/internal/api/v2/apicore/format.go
+++ b/internal/api/v2/apicore/format.go
@@ -1,0 +1,19 @@
+package apicore
+
+import "fmt"
+
+// FormatBytesUint64 formats bytes into human-readable format (for uint64 values).
+// It is shared substrate: the system domain's database-stats/backup handlers and
+// the package-api async backup handlers both render byte counts with it.
+func FormatBytesUint64(bytes uint64) string {
+	const unit uint64 = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := unit, 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/api/v2/apicore/system_shared.go
+++ b/internal/api/v2/apicore/system_shared.go
@@ -1,0 +1,17 @@
+package apicore
+
+import "time"
+
+// MetricsCollectorInterval is the time between metric-collection ticks. It is
+// shared substrate: the system domain's metrics-history collector samples on this
+// cadence, and the analytics database-overview sparkline math derives its
+// per-bucket sample count from it to stay consistent with the collector.
+const MetricsCollectorInterval = 5 * time.Second
+
+// Database backend type discriminators used by the v2 database stats and the
+// backup/migration prerequisite logic. They live in apicore so the system domain
+// (v2 stats) and the package-api backup handlers share one source.
+const (
+	DBTypeLegacy = "legacy"
+	DBTypeV2     = "v2"
+)

--- a/internal/api/v2/audio_devices.go
+++ b/internal/api/v2/audio_devices.go
@@ -1,0 +1,313 @@
+// internal/api/v2/audio_devices.go
+package api
+
+import (
+	goerrors "errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// This file holds the /api/v2/system/audio/* device-management handlers
+// (GetAudioDevices, GetDeviceCapabilities, GetActiveAudioDevice,
+// GetEqualizerConfig). They physically lived in system.go but belong to the
+// audio/streaming domain; they stay in package api until that domain is
+// extracted in its own phase. They are registered by the trimmed initSystemRoutes
+// in system_routes.go.
+
+// Audio device constants
+const (
+	defaultAudioSampleRate = 48000 // Standard BirdNET audio sample rate
+	defaultAudioBitDepth   = 16    // Standard audio bit depth
+)
+
+// AudioDeviceInfo wraps the audiocore.DeviceInfo struct for API responses
+type AudioDeviceInfo struct {
+	Index int    `json:"index"`
+	Name  string `json:"name"`
+	ID    string `json:"id"`
+	// StableID is the reboot-stable identifier to persist for this device
+	// ("usb-path:..." / "usb-id:..."), empty when no stable USB identity exists.
+	// Clients should save this in preference to ID so the selection survives
+	// reboots (GH #3651).
+	StableID string `json:"stableId,omitempty"`
+	// BusPath is the USB bus path for display (e.g. "usb-0000:00:14.0-3"),
+	// empty for non-USB devices and non-Linux platforms.
+	BusPath string `json:"busPath,omitempty"`
+	// VendorID and ProductID are the 4-hex-digit USB ids, empty when unavailable.
+	VendorID  string `json:"vendorId,omitempty"`
+	ProductID string `json:"productId,omitempty"`
+}
+
+// ActiveAudioDevice represents the currently active audio device
+type ActiveAudioDevice struct {
+	Name       string `json:"name"`
+	ID         string `json:"id"`
+	SampleRate int    `json:"sample_rate"`
+	BitDepth   int    `json:"bit_depth"`
+	Channels   int    `json:"channels"`
+}
+
+// GetAudioDevices handles GET /api/v2/system/audio/devices
+func (c *Controller) GetAudioDevices(ctx echo.Context) error {
+	c.LogInfoIfEnabled("Getting audio devices",
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	// Get audio devices
+	devices, err := audiocore.ListCaptureDevices()
+	if err != nil {
+		c.LogErrorIfEnabled("Failed to list audio devices",
+			logger.Error(err),
+			logger.String("path", ctx.Request().URL.Path),
+			logger.String("ip", ctx.RealIP()),
+		)
+		return c.HandleError(ctx, err, "Failed to list audio devices", http.StatusInternalServerError)
+	}
+
+	// Check if no devices were found
+	if len(devices) == 0 {
+		c.Debug("No audio devices found on the system")
+		c.LogWarnIfEnabled("No audio devices found on the system",
+			logger.String("path", ctx.Request().URL.Path),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("os", runtime.GOOS),
+		)
+		return ctx.JSON(http.StatusOK, []AudioDeviceInfo{}) // Return empty array instead of null
+	}
+
+	// Convert to API response format
+	apiDevices := make([]AudioDeviceInfo, len(devices))
+	for i, device := range devices {
+		apiDevices[i] = AudioDeviceInfo{
+			Index:     device.Index,
+			Name:      device.Name,
+			ID:        device.ID,
+			StableID:  device.StableID,
+			BusPath:   device.BusPath,
+			VendorID:  device.VendorID,
+			ProductID: device.ProductID,
+		}
+	}
+
+	deviceNames := make([]string, len(devices))
+	for i, device := range devices {
+		deviceNames[i] = device.Name
+	}
+
+	c.LogInfoIfEnabled("Audio devices retrieved successfully",
+		logger.Int("device_count", len(apiDevices)),
+		logger.String("devices", strings.Join(deviceNames, ", ")),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	return ctx.JSON(http.StatusOK, apiDevices)
+}
+
+// GetDeviceCapabilities handles GET /api/v2/system/audio/devices/capabilities
+// Probes a specific audio device to discover supported sample rates.
+func (c *Controller) GetDeviceCapabilities(ctx echo.Context) error {
+	deviceID := ctx.QueryParam("deviceId")
+	if deviceID == "" {
+		return c.HandleError(ctx, nil, "deviceId query parameter is required", http.StatusBadRequest)
+	}
+
+	c.LogInfoIfEnabled("Probing device capabilities",
+		logger.String("device_id", deviceID),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	caps, err := audiocore.ProbeDeviceCapabilities(deviceID, c.APILogger)
+	if err != nil {
+		if goerrors.Is(err, audiocore.ErrDeviceNotFound) {
+			return c.HandleError(ctx, err, "Device not found", http.StatusNotFound)
+		}
+		c.LogErrorIfEnabled("Failed to probe device capabilities",
+			logger.Error(err),
+			logger.String("device_id", deviceID),
+		)
+		return c.HandleError(ctx, err, "Failed to probe device capabilities", http.StatusInternalServerError)
+	}
+
+	c.LogInfoIfEnabled("Device capabilities retrieved",
+		logger.String("device_id", caps.DeviceID),
+		logger.String("device_name", caps.DeviceName),
+		logger.Int("rate_count", len(caps.SampleRates)),
+		logger.Bool("verified", caps.Verified),
+	)
+
+	return ctx.JSON(http.StatusOK, caps)
+}
+
+// GetActiveAudioDevice handles GET /api/v2/system/audio/active
+func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
+	c.LogInfoIfEnabled("Getting active audio device",
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	// Get active audio device from settings (first configured source)
+	var deviceName string
+	settings := c.CurrentSettings()
+	if settings != nil && len(settings.Realtime.Audio.Sources) > 0 {
+		deviceName = settings.Realtime.Audio.Sources[0].Device
+	}
+
+	// Check if no device is configured
+	if deviceName == "" {
+		c.LogInfoIfEnabled("No audio device currently active",
+			logger.String("path", ctx.Request().URL.Path),
+			logger.String("ip", ctx.RealIP()),
+		)
+		return ctx.JSON(http.StatusOK, map[string]any{
+			"device":   nil,
+			"active":   false,
+			"verified": false,
+			"message":  "No audio device currently active",
+		})
+	}
+
+	// Create response with default values
+	activeDevice := ActiveAudioDevice{
+		Name:       deviceName,
+		SampleRate: defaultAudioSampleRate, // Standard BirdNET sample rate
+		BitDepth:   defaultAudioBitDepth,   // Assuming 16-bit as per the capture.go implementation
+		Channels:   1,                      // Assuming mono as per the capture.go implementation
+	}
+
+	// Diagnostic information map
+	diagnostics := map[string]any{
+		"os":                runtime.GOOS,
+		"check_time":        time.Now().Format(time.RFC3339),
+		"error_details":     nil,
+		"device_found":      false,
+		"available_devices": []string{},
+	}
+
+	// Try to get additional device info and validate the device exists
+	devices, err := audiocore.ListCaptureDevices()
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to list audio devices: %v", err)
+		c.Debug("%s", errorMsg)
+
+		// Add more detailed diagnostics
+		diagnostics["error_details"] = errorMsg
+
+		// OS-specific additional checks
+		switch runtime.GOOS {
+		case OSWindows:
+			diagnostics["note"] = "On Windows, check that audio drivers are properly installed and the device is not disabled in Sound settings"
+		case OSDarwin:
+			diagnostics["note"] = "On macOS, check System Preferences > Sound and ensure the device has proper permissions"
+		case OSLinux:
+			diagnostics["note"] = "On Linux, check if PulseAudio/ALSA is running and the user has proper permissions"
+		}
+
+		c.LogWarnIfEnabled("Failed to list audio devices for verification",
+			logger.String("device_name", deviceName),
+			logger.Error(err),
+			logger.String("os", runtime.GOOS),
+			logger.String("path", ctx.Request().URL.Path),
+			logger.String("ip", ctx.RealIP()),
+		)
+
+		// Still return the configured device, but note that we couldn't verify it exists
+		return ctx.JSON(http.StatusOK, map[string]any{
+			"device":      activeDevice,
+			"active":      true,
+			"verified":    false,
+			"message":     "Device configured but could not verify if it exists",
+			"diagnostics": diagnostics,
+		})
+	}
+
+	// Populate available devices for diagnostics
+	availableDevices := make([]string, len(devices))
+	for i, device := range devices {
+		availableDevices[i] = device.Name
+	}
+	diagnostics["available_devices"] = availableDevices
+
+	// Check if the configured device exists in the system
+	deviceFound := false
+	for _, device := range devices {
+		if device.ID != deviceName && device.Name != deviceName {
+			continue
+		}
+
+		activeDevice.Name = device.Name
+		activeDevice.ID = device.ID
+		deviceFound = true
+		diagnostics["device_found"] = true
+
+		break
+	}
+
+	if !deviceFound {
+		// Device is configured but not found on the system
+		errorMsg := "Configured audio device not found on the system"
+		diagnostics["suggested_action"] = "Check if the device is properly connected and recognized by the system"
+
+		if len(devices) > 0 {
+			diagnostics["suggestion"] = fmt.Sprintf("Consider using one of the available devices: %s", strings.Join(availableDevices, ", "))
+		}
+
+		c.LogWarnIfEnabled("Configured audio device not found on system",
+			logger.String("configured_device", deviceName),
+			logger.String("available_devices", strings.Join(availableDevices, ", ")),
+			logger.String("os", runtime.GOOS),
+			logger.String("path", ctx.Request().URL.Path),
+			logger.String("ip", ctx.RealIP()),
+		)
+
+		return ctx.JSON(http.StatusOK, map[string]any{
+			"device":      activeDevice,
+			"active":      true,
+			"verified":    false,
+			"message":     errorMsg,
+			"diagnostics": diagnostics,
+		})
+	}
+
+	c.LogInfoIfEnabled("Active audio device verified",
+		logger.String("device_name", deviceName),
+		logger.String("device_id", activeDevice.ID),
+		logger.Int("sample_rate", activeDevice.SampleRate),
+		logger.Int("bit_depth", activeDevice.BitDepth),
+		logger.Int("channels", activeDevice.Channels),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	// Device is configured and verified to exist
+	return ctx.JSON(http.StatusOK, map[string]any{
+		"device":      activeDevice,
+		"active":      true,
+		"verified":    true,
+		"diagnostics": diagnostics,
+	})
+}
+
+// GetEqualizerConfig handles GET /api/v2/system/audio/equalizer/config
+func (c *Controller) GetEqualizerConfig(ctx echo.Context) error {
+	c.LogInfoIfEnabled("Getting equalizer filter configuration",
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	// Set cache headers for static configuration data
+	ctx.Response().Header().Set("Cache-Control", "public, max-age=3600")
+
+	// Return the equalizer filter configuration
+	return ctx.JSON(http.StatusOK, conf.EqFilterConfig)
+}

--- a/internal/api/v2/audio_devices_test.go
+++ b/internal/api/v2/audio_devices_test.go
@@ -1,0 +1,127 @@
+// audio_devices_test.go: tests for the /system/audio/* device handlers that
+// stay in package api until the audio/streaming domain is extracted.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// setupSystemTestEnvironment creates a test environment for system API tests
+func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
+	t.Helper()
+
+	e := echo.New()
+
+	settings := &conf.Settings{
+		Realtime: conf.RealtimeSettings{
+			Audio: conf.AudioSettings{
+				Source: "test-device",
+			},
+		},
+	}
+
+	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+	controller.Settings.Store(settings)
+
+	return e, controller
+}
+
+// TestGetEqualizerConfig tests the GetEqualizerConfig endpoint
+func TestGetEqualizerConfig(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "integration")
+	t.Attr("feature", "equalizer-config")
+
+	e, controller := setupSystemTestEnvironment(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/equalizer/config", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/v2/system/audio/equalizer/config")
+
+	err := controller.GetEqualizerConfig(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify cache headers are set
+	assert.Contains(t, rec.Header().Get("Cache-Control"), "public", "Should have public cache header")
+
+	// Response should be valid JSON
+	var response any
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err, "Response should be valid JSON")
+}
+
+// TestGetActiveAudioDevice tests the GetActiveAudioDevice endpoint
+func TestGetActiveAudioDevice(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "integration")
+	t.Attr("feature", "audio-device")
+
+	t.Run("With configured device", func(t *testing.T) {
+		e, controller := setupSystemTestEnvironment(t)
+		// Settings already have a device configured
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/api/v2/system/audio/active")
+
+		err := controller.GetActiveAudioDevice(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response map[string]any
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// Should have device info
+		assert.Contains(t, response, "device", "Response should contain device")
+		assert.Contains(t, response, "active", "Response should contain active flag")
+	})
+
+	t.Run("No device configured", func(t *testing.T) {
+		e := echo.New()
+		settings := &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Source: "", // No device configured
+				},
+			},
+		}
+		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+		controller.Settings.Store(settings)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/api/v2/system/audio/active")
+
+		err := controller.GetActiveAudioDevice(c)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response map[string]any
+		err = json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// Should indicate no device active
+		active, ok := response["active"].(bool)
+		require.True(t, ok, "response should have 'active' field as bool")
+		assert.False(t, active, "Should not be active when no device configured")
+		msg, ok := response["message"].(string)
+		require.True(t, ok, "response should have 'message' field as string")
+		assert.Contains(t, msg, "No audio device", "Should have appropriate message")
+	})
+}

--- a/internal/api/v2/backup.go
+++ b/internal/api/v2/backup.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -392,7 +393,7 @@ func (c *Controller) initBackupRoutes() {
 // StartBackupJob handles POST /api/v2/system/database/backup/jobs
 func (c *Controller) StartBackupJob(ctx echo.Context) error {
 	dbType := ctx.QueryParam("type")
-	if dbType != dbTypeLegacy && dbType != dbTypeV2 {
+	if dbType != apicore.DBTypeLegacy && dbType != apicore.DBTypeV2 {
 		return c.HandleErrorWithKey(ctx, nil,
 			"Type must be 'legacy' or 'v2'", http.StatusBadRequest,
 			notification.MsgErrBackupInvalidType, nil)
@@ -433,8 +434,8 @@ func (c *Controller) StartBackupJob(ctx echo.Context) error {
 	// #nosec G115 -- dbSize from os.FileInfo.Size() is always non-negative
 	requiredSpace := uint64(dbSize) + backupDiskBuffer
 	if usage.Free < requiredSpace {
-		neededStr := formatBytesUint64(requiredSpace)
-		availableStr := formatBytesUint64(usage.Free)
+		neededStr := apicore.FormatBytesUint64(requiredSpace)
+		availableStr := apicore.FormatBytesUint64(usage.Free)
 		return c.HandleErrorWithKey(ctx, nil,
 			fmt.Sprintf("Not enough disk space. Need %s, have %s", neededStr, availableStr),
 			http.StatusInsufficientStorage,
@@ -636,7 +637,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 
 // getBackupDBInfo returns the database path and GORM DB for the given type.
 func (c *Controller) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
-	if dbType == dbTypeLegacy {
+	if dbType == apicore.DBTypeLegacy {
 		settings := c.CurrentSettings()
 		if settings == nil || settings.Output.SQLite.Path == "" {
 			return "", nil, fmt.Errorf("backup only available for SQLite databases")

--- a/internal/api/v2/constants.go
+++ b/internal/api/v2/constants.go
@@ -95,12 +95,6 @@ const (
 
 	// SecondsPerMinute is the number of seconds in a minute
 	SecondsPerMinute = 60
-
-	// SecondsPerHour is the number of seconds in an hour
-	SecondsPerHour = 3600
-
-	// MillisecondsPerSecond converts seconds to milliseconds
-	MillisecondsPerSecond = 1000
 )
 
 // Timeout and duration constants

--- a/internal/api/v2/database_overview.go
+++ b/internal/api/v2/database_overview.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -31,8 +32,8 @@ const (
 )
 
 // metricsCollectorIntervalSec is the collector interval in seconds, derived from
-// metricsCollectorInterval to guarantee consistency.
-var metricsCollectorIntervalSec = metricsCollectorInterval.Seconds()
+// apicore.MetricsCollectorInterval to guarantee consistency.
+var metricsCollectorIntervalSec = apicore.MetricsCollectorInterval.Seconds()
 
 // samplesPerHour is how many ring buffer entries cover one hour at the collector interval.
 var samplesPerHour = int(3600 / metricsCollectorIntervalSec)

--- a/internal/api/v2/inference_broadcast_test.go
+++ b/internal/api/v2/inference_broadcast_test.go
@@ -1,0 +1,44 @@
+// internal/api/v2/inference_broadcast_test.go
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// TestBroadcastInferenceTopologyChanged_ReachesConsumer verifies that the
+// controller broadcast reaches a topology subscriber on the wired metrics store.
+func TestBroadcastInferenceTopologyChanged_ReachesConsumer(t *testing.T) {
+	t.Parallel()
+
+	store := observability.NewMemoryStore(10)
+	controller := &Controller{Core: &apicore.Core{MetricsStore: store}}
+
+	topoCh, cancel := store.SubscribeTopology()
+	t.Cleanup(cancel)
+
+	controller.BroadcastInferenceTopologyChanged()
+
+	select {
+	case <-topoCh:
+		// Expected: broadcast reached the subscriber.
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for topology broadcast to reach the subscriber")
+	}
+}
+
+// TestBroadcastInferenceTopologyChanged_NilSafe verifies the broadcast is a
+// no-op (no panic) when the controller or its metrics store is nil.
+func TestBroadcastInferenceTopologyChanged_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var nilController *Controller
+	assert.NotPanics(t, nilController.BroadcastInferenceTopologyChanged)
+
+	noStore := &Controller{Core: &apicore.Core{}}
+	assert.NotPanics(t, noStore.BroadcastInferenceTopologyChanged)
+}

--- a/internal/api/v2/system/constants.go
+++ b/internal/api/v2/system/constants.go
@@ -1,0 +1,55 @@
+package system
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// Operating system name constants (compared against runtime.GOOS).
+const (
+	osLinux   = "linux"
+	osWindows = "windows"
+	osDarwin  = "darwin"
+)
+
+// valueUnknown is the generic fallback value for unavailable system fields.
+const valueUnknown = "unknown"
+
+// Time conversion constants.
+const (
+	secondsPerMinute      = 60   // Seconds in a minute
+	secondsPerHour        = 3600 // Seconds in an hour
+	millisecondsPerSecond = 1000 // Milliseconds in a second
+)
+
+// errResponseHandled signals that an HTTP error response has already been sent to
+// the client, so the caller should return it without sending another. It mirrors
+// the package-api sentinel of the same purpose; the value never escapes this
+// package (callers only check it for non-nil).
+var errResponseHandled = errors.NewStd("response already handled")
+
+// validateDateFormatWithResponse validates a date string is in YYYY-MM-DD format.
+// It returns errResponseHandled after sending an error response, or nil if valid
+// (an empty string is treated as a valid optional parameter).
+func (c *Handler) validateDateFormatWithResponse(ctx echo.Context, dateStr, paramName, operation string) error {
+	if dateStr == "" {
+		return nil // Empty is valid (optional parameter)
+	}
+	if _, err := time.Parse(time.DateOnly, dateStr); err != nil {
+		c.LogErrorIfEnabled("Invalid date format",
+			logger.String("parameter", paramName),
+			logger.String("value", dateStr),
+			logger.String("operation", operation),
+			logger.Error(err),
+			logger.String("ip", ctx.RealIP()),
+			logger.String("path", ctx.Request().URL.Path),
+		)
+		_ = c.HandleError(ctx, nil, "Invalid date format. Use YYYY-MM-DD", http.StatusBadRequest)
+		return errResponseHandled
+	}
+	return nil
+}

--- a/internal/api/v2/system/diagnostics.go
+++ b/internal/api/v2/system/diagnostics.go
@@ -1,5 +1,5 @@
-// internal/api/v2/diagnostics.go
-package api
+// internal/api/v2/system/diagnostics.go
+package system
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/shirou/gopsutil/v3/host"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
@@ -38,9 +39,10 @@ type diagnosticsStatusResponse struct {
 	LastRun    *time.Time                        `json:"last_run"`
 }
 
-// initDiagnosticsRoutes initializes health check infrastructure and registers
-// the diagnostics API endpoints.
-func (c *Controller) initDiagnosticsRoutes() {
+// RegisterDiagnosticsRoutes initializes health check infrastructure and registers
+// the diagnostics API endpoints, preserving the exact routes and auth middleware
+// from the original initDiagnosticsRoutes.
+func (c *Handler) RegisterDiagnosticsRoutes(g *echo.Group) {
 	c.healthReports = health.NewReportStore(10)
 	if c.healthErrors == nil {
 		c.healthErrors = health.NewErrorRingBuffer(health.DefaultErrorBufferSize)
@@ -51,7 +53,7 @@ func (c *Controller) initDiagnosticsRoutes() {
 
 	c.registerHealthChecks()
 
-	diagnosticsGroup := c.Group.Group("/system/diagnostics", c.AuthMiddleware)
+	diagnosticsGroup := g.Group("/system/diagnostics", c.AuthMiddleware)
 	diagnosticsGroup.GET("/status", c.GetDiagnosticsStatus)
 	diagnosticsGroup.POST("/run", c.RunDiagnostics)
 	diagnosticsGroup.GET("/report/:id", c.GetDiagnosticsReport)
@@ -62,19 +64,19 @@ func (c *Controller) initDiagnosticsRoutes() {
 // the diagnostics subsystem has not been initialized. It lets other subsystems
 // (e.g. the analysis pipeline) record health counters into the same store the
 // health checks read, avoiding an import cycle on internal/api/v2.
-func (c *Controller) HealthMetricsStore() *observability.HealthMetricsStore {
+func (c *Handler) HealthMetricsStore() *observability.HealthMetricsStore {
 	return c.healthMetricsStore
 }
 
 // HealthEventBuffer returns the diagnostics health event buffer, or nil if the
 // diagnostics subsystem has not been initialized. Paired with HealthMetricsStore
 // so recorded counters can also surface as recent events on the System Health page.
-func (c *Controller) HealthEventBuffer() *observability.HealthEventBuffer {
+func (c *Handler) HealthEventBuffer() *observability.HealthEventBuffer {
 	return c.healthEvents
 }
 
 // registerHealthChecks registers all health checks with dependency injection closures.
-func (c *Controller) registerHealthChecks() {
+func (c *Handler) registerHealthChecks() {
 	snapshotProvider := func() []audiocore.SourceHealthSnapshot {
 		w := c.AudioWatchdog.Load()
 		if w == nil {
@@ -89,7 +91,7 @@ func (c *Controller) registerHealthChecks() {
 		// System checks
 		checks.NewDiskSpaceCheck(c.getDataPaths()),
 		checks.NewMemoryCheck(),
-		checks.NewCPULoadCheck(GetCachedCPUUsage),
+		checks.NewCPULoadCheck(apicore.GetCachedCPUUsage),
 		checks.NewTemperatureCheck(func() (float64, error) {
 			temps, err := host.SensorsTemperatures()
 			// gopsutil returns partial results with warnings when some sensors
@@ -289,7 +291,7 @@ func (c *Controller) registerHealthChecks() {
 
 // buildModelLoadInfoProvider returns a closure that queries the orchestrator for
 // all loaded models and converts them to the health check's ModelLoadInfo format.
-func (c *Controller) buildModelLoadInfoProvider() func() []checks.ModelLoadInfo {
+func (c *Handler) buildModelLoadInfoProvider() func() []checks.ModelLoadInfo {
 	return func() []checks.ModelLoadInfo {
 		p := c.Processor
 		if p == nil {
@@ -321,7 +323,7 @@ func (c *Controller) buildModelLoadInfoProvider() func() []checks.ModelLoadInfo 
 // inference counters and model specs to produce per-model latency stats.
 // Each model's analysis window is derived from its own BufferInterval
 // (ClipLength / 2), not from a global setting.
-func (c *Controller) buildPerModelInferenceProvider() func() []checks.ModelInferenceInfo {
+func (c *Handler) buildPerModelInferenceProvider() func() []checks.ModelInferenceInfo {
 	return func() []checks.ModelInferenceInfo {
 		p := c.Processor
 		if p == nil {
@@ -371,7 +373,7 @@ func mapInferenceSnapshots(snapshots map[string]inferencestats.PeekSnapshot, inf
 			name = mi.DisplayName()
 			windowMS = float64(mi.Spec.BufferInterval().Milliseconds())
 		} else {
-			GetLogger().Warn("inference counter has no matching model info; surfacing raw id",
+			apicore.GetLogger().Warn("inference counter has no matching model info; surfacing raw id",
 				logger.String("model_id", modelID))
 		}
 		result = append(result, checks.ModelInferenceInfo{
@@ -391,7 +393,7 @@ var errNoTempSensors = errors.NewStd("no temperature sensors found")
 // buildStreamHealthProvider returns a closure that bridges the FFmpegManager's
 // stream health data to the checks.StreamHealthInfo format. The closure
 // atomically loads c.Engine at call time because it is set after Controller init.
-func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
+func (c *Handler) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 	return func() []checks.StreamHealthInfo {
 		eng := c.Engine.Load()
 		if eng == nil {
@@ -432,7 +434,7 @@ func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInf
 
 // buildAudioRouterSnapshotProvider returns a closure that reads cumulative
 // audio counter values from the audio router for the health metrics collector.
-func (c *Controller) buildAudioRouterSnapshotProvider() func() []observability.AudioRouterSnapshot {
+func (c *Handler) buildAudioRouterSnapshotProvider() func() []observability.AudioRouterSnapshot {
 	return func() []observability.AudioRouterSnapshot {
 		eng := c.Engine.Load()
 		if eng == nil {
@@ -473,7 +475,7 @@ func (c *Controller) buildAudioRouterSnapshotProvider() func() []observability.A
 
 // buildStreamHealthSnapshotProvider returns a closure that reads cumulative
 // stream restart counts for the health metrics collector.
-func (c *Controller) buildStreamHealthSnapshotProvider() func() []observability.StreamHealthSnapshot {
+func (c *Handler) buildStreamHealthSnapshotProvider() func() []observability.StreamHealthSnapshot {
 	return func() []observability.StreamHealthSnapshot {
 		eng := c.Engine.Load()
 		if eng == nil {
@@ -500,9 +502,12 @@ func (c *Controller) buildStreamHealthSnapshotProvider() func() []observability.
 
 // buildAudioLevelProvider returns a closure that reads the latest audio level
 // per source from the global audio level manager, filtered to active sources.
-func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
+func (c *Handler) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 	return func() []checks.AudioLevelInfo {
-		levels := LatestAudioLevels()
+		if c.audioLevelProvider == nil {
+			return nil
+		}
+		levels := c.audioLevelProvider()
 		if len(levels) == 0 {
 			return nil
 		}
@@ -545,7 +550,7 @@ func (c *Controller) buildAudioLevelProvider() func() []checks.AudioLevelInfo {
 
 // buildCaptureBufferHealthProvider returns a closure that reads capture buffer
 // utilization from the buffer manager.
-func (c *Controller) buildCaptureBufferHealthProvider() func() []checks.CaptureBufferInfo {
+func (c *Handler) buildCaptureBufferHealthProvider() func() []checks.CaptureBufferInfo {
 	return func() []checks.CaptureBufferInfo {
 		eng := c.Engine.Load()
 		if eng == nil {
@@ -572,7 +577,7 @@ func (c *Controller) buildCaptureBufferHealthProvider() func() []checks.CaptureB
 }
 
 // getDataPaths returns filesystem paths that should be monitored for disk space.
-func (c *Controller) getDataPaths() []string {
+func (c *Handler) getDataPaths() []string {
 	settings := c.CurrentSettings()
 	seen := make(map[string]struct{})
 	var paths []string
@@ -596,7 +601,7 @@ func (c *Controller) getDataPaths() []string {
 }
 
 // GetDiagnosticsStatus returns a quick health summary from the latest stored report.
-func (c *Controller) GetDiagnosticsStatus(ctx echo.Context) error {
+func (c *Handler) GetDiagnosticsStatus(ctx echo.Context) error {
 	latest := c.healthReports.Latest()
 	if latest == nil {
 		return ctx.JSON(http.StatusOK, diagnosticsStatusResponse{
@@ -637,7 +642,7 @@ func parseWindow(s string) (time.Duration, error) {
 }
 
 // RunDiagnostics executes all registered health checks and stores the report.
-func (c *Controller) RunDiagnostics(ctx echo.Context) error {
+func (c *Handler) RunDiagnostics(ctx echo.Context) error {
 	window, err := parseWindow(ctx.QueryParam("window"))
 	if err != nil {
 		return c.HandleError(ctx, err, err.Error(), http.StatusBadRequest)
@@ -654,7 +659,7 @@ func (c *Controller) RunDiagnostics(ctx echo.Context) error {
 }
 
 // GetDiagnosticsReport retrieves a stored diagnostics report by ID.
-func (c *Controller) GetDiagnosticsReport(ctx echo.Context) error {
+func (c *Handler) GetDiagnosticsReport(ctx echo.Context) error {
 	id := ctx.Param("id")
 	report, ok := c.healthReports.Get(id)
 	if !ok {
@@ -664,7 +669,7 @@ func (c *Controller) GetDiagnosticsReport(ctx echo.Context) error {
 }
 
 // GetRecentErrors returns recent error log entries from the error ring buffer.
-func (c *Controller) GetRecentErrors(ctx echo.Context) error {
+func (c *Handler) GetRecentErrors(ctx echo.Context) error {
 	const defaultLimit = 50
 	const maxLimit = 200
 

--- a/internal/api/v2/system/diagnostics_test.go
+++ b/internal/api/v2/system/diagnostics_test.go
@@ -1,5 +1,5 @@
-// internal/api/v2/diagnostics_test.go
-package api
+// internal/api/v2/system/diagnostics_test.go
+package system
 
 import (
 	"testing"

--- a/internal/api/v2/system/diagnostics_window_test.go
+++ b/internal/api/v2/system/diagnostics_window_test.go
@@ -1,4 +1,4 @@
-package api
+package system
 
 import (
 	"encoding/json"
@@ -10,16 +10,18 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/health/checks"
 	"github.com/tphakala/birdnet-go/internal/observability"
 )
 
-// setupDiagnosticsTest creates a test Controller wired for diagnostics
+// setupDiagnosticsTest creates a test system Handler wired for diagnostics
 // tests with the given health metrics store and optional event buffer.
-func setupDiagnosticsTest(t *testing.T, store *observability.HealthMetricsStore, eventBuf *observability.HealthEventBuffer) (*echo.Echo, *Controller) {
+func setupDiagnosticsTest(t *testing.T, store *observability.HealthMetricsStore, eventBuf *observability.HealthEventBuffer) (*echo.Echo, *Handler) {
 	t.Helper()
-	e, _, controller := setupTestEnvironment(t)
+	e := echo.New()
+	controller := &Handler{Core: apitest.NewCore(t, apitest.WithEcho(e))}
 	controller.healthMetricsStore = store
 	if eventBuf != nil {
 		controller.healthEvents = eventBuf

--- a/internal/api/v2/system/events.go
+++ b/internal/api/v2/system/events.go
@@ -1,5 +1,5 @@
-// internal/api/v2/events.go
-package api
+// internal/api/v2/system/events.go
+package system
 
 import (
 	"encoding/binary"
@@ -155,7 +155,7 @@ type SystemMetrics struct {
 
 // registerEventsRoutes registers the /events sub-routes on the given parent group.
 // Called from initSystemRoutes so events are under /system/events/* with auth middleware.
-func (c *Controller) registerEventsRoutes(parent *echo.Group) {
+func (c *Handler) registerEventsRoutes(parent *echo.Group) {
 	eventsGroup := parent.Group("/events")
 	eventsGroup.GET("/detections", c.GetDetectionEvents)
 	eventsGroup.GET("/operational", c.GetOperationalEvents)
@@ -165,7 +165,7 @@ func (c *Controller) registerEventsRoutes(parent *echo.Group) {
 
 // GetDetectionEvents returns detection lifecycle events aggregated into hourly buckets
 // for the requested date (defaults to today).
-func (c *Controller) GetDetectionEvents(ctx echo.Context) error {
+func (c *Handler) GetDetectionEvents(ctx echo.Context) error {
 	date := ctx.QueryParam("date")
 	if date == "" {
 		date = time.Now().Format(time.DateOnly)
@@ -213,7 +213,7 @@ func (c *Controller) GetDetectionEvents(ctx echo.Context) error {
 
 // GetOperationalEvents returns operational log events for the requested date and minimum level.
 // Defaults to today and INFO level.
-func (c *Controller) GetOperationalEvents(ctx echo.Context) error {
+func (c *Handler) GetOperationalEvents(ctx echo.Context) error {
 	date := ctx.QueryParam("date")
 	if date == "" {
 		date = time.Now().Format(time.DateOnly)
@@ -265,7 +265,7 @@ func (c *Controller) GetOperationalEvents(ctx echo.Context) error {
 		}
 	}
 
-	// Sort all entries by timestamp (descending — newest first)
+	// Sort all entries by timestamp (descending - newest first)
 	slices.SortFunc(allEntries, func(a, b reader.LogEntry) int {
 		return b.Time.Compare(a.Time) // reverse order
 	})

--- a/internal/api/v2/system/events_aggregation.go
+++ b/internal/api/v2/system/events_aggregation.go
@@ -1,5 +1,5 @@
-// internal/api/v2/events_aggregation.go
-package api
+// internal/api/v2/system/events_aggregation.go
+package system
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ const topDiscardedCount = 3
 // bucketKeyFormat is the time format used for hourly bucket keys (e.g., "2006-01-02T15").
 const bucketKeyFormat = "2006-01-02T15"
 
-// bucketLabelFormat is the human-readable label for buckets (e.g., "15:00–16:00").
+// bucketLabelFormat is the human-readable label for buckets (e.g., "15:00-16:00").
 const bucketLabelFormat = "15:00"
 
 // speciesIndex tracks species entries within a bucket for O(1) lookup during construction.
@@ -26,7 +26,7 @@ type speciesIndex struct {
 // aggregateDetectionEvents processes raw log entries into hourly bucketed detection data.
 // Events are assigned to buckets based on their resolution timestamp (approve/discard/flush),
 // not the pending creation time. The returned buckets are sorted newest-first.
-func (c *Controller) aggregateDetectionEvents(entries []reader.LogEntry, _ time.Time) DetectionEventsResponse {
+func (c *Handler) aggregateDetectionEvents(entries []reader.LogEntry, _ time.Time) DetectionEventsResponse {
 	bucketMap := make(map[string]*DetectionBucket)
 	speciesIdxMap := make(map[string]*speciesIndex) // bucket key → species index
 	var hourlyPending [24]int

--- a/internal/api/v2/system/events_test.go
+++ b/internal/api/v2/system/events_test.go
@@ -1,6 +1,6 @@
-// events_test.go: Package api provides tests for API v2 events endpoints.
+// events_test.go: system-domain events endpoint tests (extracted from package api).
 
-package api
+package system
 
 import (
 	"testing"
@@ -43,7 +43,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty entries returns empty response", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		result := c.aggregateDetectionEvents(nil, baseTime)
@@ -59,7 +59,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("single approve creates one bucket and one species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -98,7 +98,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple operations same bucket same species accumulate", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -128,7 +128,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple species same bucket grouped correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -145,7 +145,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple buckets separated by hour and sorted newest first", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
@@ -166,7 +166,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pre-filters counted in bucket but not in species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -192,7 +192,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pending count from create_pending_detection hourly array", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -210,7 +210,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species sorting approved first then by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -238,7 +238,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("top discarded species top 3", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -272,7 +272,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("audio clip matching attached to correct species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -305,7 +305,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("peak confidence tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -323,7 +323,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("max match count tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -341,7 +341,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty species name entries are skipped", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{
@@ -362,7 +362,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("approved per hour metric calculated correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
@@ -383,7 +383,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("timestamps are recorded for approve and discard", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		approveTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
@@ -405,7 +405,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species summary sorted by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 
 		entries := []reader.LogEntry{

--- a/internal/api/v2/system/handler.go
+++ b/internal/api/v2/system/handler.go
@@ -1,0 +1,120 @@
+// Package system implements the v2 API system-information domain: the
+// /api/v2/system/* information endpoints (host info, resources, disks, job
+// queue, processes, CPU temperature, database stats/backup, network interfaces,
+// restart status, active models, inference status), the detection/operational
+// events endpoints, the diagnostics/health endpoints, the metrics-history
+// endpoints, and the browser terminal websocket.
+//
+// The handler embeds *apicore.Core by pointer so the shared deps (DS, Settings,
+// Processor, Metrics, MetricsStore, Engine, error/log helpers, goroutine
+// plumbing) promote directly onto it. Beyond the core it owns the diagnostics
+// health infrastructure (registry/report-store/error-buffer/metrics-store/event-
+// buffer) and receives two facade-owned values by injection: the controller
+// start time (for the uptime health check) and the optional shared health error
+// ring buffer (WithHealthErrorBuffer).
+package system
+
+import (
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// Handler serves the system-domain endpoints around the shared core.
+type Handler struct {
+	*apicore.Core
+
+	// startTime is the controller construction time, injected from the facade. It
+	// backs the diagnostics uptime health check (NewUptimeCheck). It is distinct
+	// from the package-level processStartTime var (process start) used by
+	// GetSystemInfo's app-start/app-uptime fields.
+	startTime *time.Time
+
+	// audioLevelProvider returns the latest per-source audio levels for the
+	// diagnostics audio-level health check. It is injected from the facade
+	// (LatestAudioLevels) because the audio-level manager belongs to the
+	// audio/streaming domain, which has not been extracted yet.
+	audioLevelProvider func() []audiocore.AudioLevelData
+
+	// Health check infrastructure for the diagnostics endpoints. healthErrors may
+	// be seeded from the facade (WithHealthErrorBuffer) so the logger and the
+	// health checks share one ring buffer; the rest are created in
+	// RegisterDiagnosticsRoutes. HealthMetricsStore()/HealthEventBuffer() expose
+	// the metrics store and event buffer to the analysis pipeline through facade
+	// delegators.
+	healthRegistry     *health.Registry
+	healthReports      *health.ReportStore
+	healthErrors       *health.ErrorRingBuffer
+	healthMetricsStore *observability.HealthMetricsStore
+	healthEvents       *observability.HealthEventBuffer
+}
+
+// New constructs the system handler from the shared core, the facade controller
+// start time (for the diagnostics uptime check), an optional health error ring
+// buffer seed (WithHealthErrorBuffer; nil when not injected, in which case
+// RegisterDiagnosticsRoutes allocates its own) and the audio-level provider used
+// by the diagnostics audio-level health check.
+func New(core *apicore.Core, startTime *time.Time, healthErrorBuf *health.ErrorRingBuffer, audioLevelProvider func() []audiocore.AudioLevelData) *Handler {
+	return &Handler{
+		Core:               core,
+		startTime:          startTime,
+		healthErrors:       healthErrorBuf,
+		audioLevelProvider: audioLevelProvider,
+	}
+}
+
+// RegisterSystemRoutes registers the /api/v2/system/* information endpoints and
+// the /system/events/* endpoints, and starts the background CPU usage sampler.
+// It preserves the exact routes and per-route auth middleware from the original
+// initSystemRoutes (minus the cross-domain audio/external-media/database routes,
+// which the facade registers in its trimmed initSystemRoutes).
+func (c *Handler) RegisterSystemRoutes(g *echo.Group) {
+	c.LogInfoIfEnabled("Initializing system routes")
+
+	// Start CPU usage monitoring in background with the controller's context for
+	// controlled shutdown (Go 1.25 WaitGroup.Go()).
+	c.Go(func() {
+		apicore.UpdateCPUCache(c.Context())
+	})
+	c.LogInfoIfEnabled("Started CPU usage monitoring")
+
+	systemGroup := g.Group("/system")
+	authMiddleware := c.AuthMiddleware
+	protectedGroup := systemGroup.Group("", authMiddleware)
+
+	protectedGroup.GET("/info", c.GetSystemInfo)
+	protectedGroup.GET("/resources", c.GetResourceInfo)
+	protectedGroup.GET("/disks", c.GetDiskInfo)
+	protectedGroup.GET("/jobs", c.GetJobQueueStats)
+	protectedGroup.GET("/processes", c.GetProcessInfo)
+	protectedGroup.GET("/temperature/cpu", c.GetSystemCPUTemperature)
+	protectedGroup.GET("/database/stats", c.GetDatabaseStats)
+	protectedGroup.GET("/database/v2/stats", c.GetV2DatabaseStats)
+	protectedGroup.POST("/database/backup", c.DownloadDatabaseBackup)
+	protectedGroup.GET("/network-interfaces", c.GetNetworkInterfaces)
+	protectedGroup.GET("/restart-status", c.GetRestartStatus)
+	protectedGroup.GET("/models", c.GetActiveModels)
+	protectedGroup.GET("/inference", c.GetInferenceStatus)
+
+	// Events routes (detection lifecycle + operational logs).
+	c.registerEventsRoutes(protectedGroup)
+
+	c.LogInfoIfEnabled("System routes initialized successfully")
+}
+
+// RegisterTerminalRoutes registers the browser terminal websocket endpoint,
+// preserving the exact route and auth middleware from the original
+// initTerminalRoutes.
+func (c *Handler) RegisterTerminalRoutes(g *echo.Group) {
+	c.LogInfoIfEnabled("Initializing terminal routes")
+
+	terminalGroup := g.Group("/terminal")
+	protectedGroup := terminalGroup.Group("", c.AuthMiddleware)
+	protectedGroup.GET("/ws", c.HandleTerminalWS)
+
+	c.LogInfoIfEnabled("Terminal routes initialized successfully")
+}

--- a/internal/api/v2/system/inference_status.go
+++ b/internal/api/v2/system/inference_status.go
@@ -1,5 +1,5 @@
-// internal/api/v2/inference_status.go
-package api
+// internal/api/v2/system/inference_status.go
+package system
 
 import (
 	"cmp"
@@ -318,7 +318,7 @@ func applyRuntimeBackend(status *InferenceModelStatus, backend, precision string
 // models with per-model stats and memory, source attachment, and audio pipeline
 // metrics. The snapshot is assembled from live sources on every request so it
 // reflects hot-reload changes without any caching.
-func (c *Controller) GetInferenceStatus(ctx echo.Context) error {
+func (c *Handler) GetInferenceStatus(ctx echo.Context) error {
 	settings := c.CurrentSettings()
 
 	resp := InferenceStatusResponse{
@@ -529,18 +529,4 @@ func buildSourceAttachments(settings *conf.Settings, models []classifier.ModelIn
 		attach(st.Name, st.Type, st.Models)
 	}
 	return out
-}
-
-// BroadcastInferenceTopologyChanged signals all metrics-stream SSE clients that
-// the inference topology (models or source attachment) changed so they re-fetch
-// the /api/v2/system/inference snapshot. Safe to call when the controller, its
-// core, or its metrics store is nil. It stays on the facade (rather than moving
-// to apicore with the other broadcasters) to preserve its nil-*Controller-safe
-// contract: promotion of a *Core method would dereference the embedded core on a
-// nil *Controller before the guard could run.
-func (c *Controller) BroadcastInferenceTopologyChanged() {
-	if c == nil || c.Core == nil || c.MetricsStore == nil {
-		return
-	}
-	c.MetricsStore.BroadcastTopologyChanged()
 }

--- a/internal/api/v2/system/inference_status_test.go
+++ b/internal/api/v2/system/inference_status_test.go
@@ -1,5 +1,5 @@
-// internal/api/v2/inference_status_test.go
-package api
+// internal/api/v2/system/inference_status_test.go
+package system
 
 import (
 	"encoding/json"
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
@@ -207,11 +208,12 @@ func TestApplyRuntimeBackend(t *testing.T) {
 
 // TestGetInferenceStatus_HTTP200 verifies that GetInferenceStatus returns HTTP
 // 200 and a valid InferenceStatusResponse with TFLite marked available. It uses
-// the shared setupTestEnvironment harness (minimalController + Echo) to exercise
-// the handler over httptest without starting any background goroutines.
+// an apitest.NewCore-backed Handler over httptest to exercise the handler
+// without starting any background goroutines.
 func TestGetInferenceStatus_HTTP200(t *testing.T) {
-	// NOT parallel: apitest.PublishTestSettings in setupTestEnvironment mutates global state.
-	e, _, controller := setupTestEnvironment(t)
+	// NOT parallel: apitest.NewCore publishes settings to the process-global snapshot.
+	e := echo.New()
+	controller := &Handler{Core: apitest.NewCore(t, apitest.WithEcho(e))}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/inference", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -230,48 +232,13 @@ func TestGetInferenceStatus_HTTP200(t *testing.T) {
 // the SSE event name stays the single source of truth shared with the frontend.
 const eventInferenceTopologyChangedName = "system.inference_topology_changed"
 
-// TestBroadcastInferenceTopologyChanged_ReachesConsumer verifies that the
-// controller broadcast reaches a topology subscriber on the wired metrics store.
-func TestBroadcastInferenceTopologyChanged_ReachesConsumer(t *testing.T) {
-	t.Parallel()
-
-	// Constant matches the shared event-name contract.
-	assert.Equal(t, eventInferenceTopologyChangedName, eventInferenceTopologyChanged)
-
-	store := observability.NewMemoryStore(10)
-	controller := &Controller{Core: &apicore.Core{MetricsStore: store}}
-
-	topoCh, cancel := store.SubscribeTopology()
-	t.Cleanup(cancel)
-
-	controller.BroadcastInferenceTopologyChanged()
-
-	select {
-	case <-topoCh:
-		// Expected: broadcast reached the subscriber.
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for topology broadcast to reach the subscriber")
-	}
-}
-
-// TestBroadcastInferenceTopologyChanged_NilSafe verifies the broadcast is a
-// no-op (no panic) when the controller or its metrics store is nil.
-func TestBroadcastInferenceTopologyChanged_NilSafe(t *testing.T) {
-	t.Parallel()
-
-	var nilController *Controller
-	assert.NotPanics(t, nilController.BroadcastInferenceTopologyChanged)
-
-	noStore := &Controller{Core: &apicore.Core{}}
-	assert.NotPanics(t, noStore.BroadcastInferenceTopologyChanged)
-}
-
 // TestGetInferenceStatus_AudioBlock verifies that GetInferenceStatus returns an
 // audio block with the expected metric key for queue depth and a non-negative
 // queue capacity matching RouteInboxCapacity.
 func TestGetInferenceStatus_AudioBlock(t *testing.T) {
-	// NOT parallel: apitest.PublishTestSettings in setupTestEnvironment mutates global state.
-	e, _, controller := setupTestEnvironment(t)
+	// NOT parallel: apitest.NewCore publishes settings to the process-global snapshot.
+	e := echo.New()
+	controller := &Handler{Core: apitest.NewCore(t, apitest.WithEcho(e))}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/inference", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -443,4 +410,11 @@ func TestSortInferenceModelsByName(t *testing.T) {
 	got := []string{models[0].ID, models[1].ID, models[2].ID}
 	// "alpha" and "Alpha" tie case-insensitively; tie broken by ID (a before c).
 	require.Equal(t, []string{"a", "c", "b"}, got)
+}
+
+// TestEventInferenceTopologyChangedNameContract pins the SSE event name constant
+// shared with the frontend so the metrics-stream contract stays stable.
+func TestEventInferenceTopologyChangedNameContract(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, eventInferenceTopologyChangedName, eventInferenceTopologyChanged)
 }

--- a/internal/api/v2/system/main_test.go
+++ b/internal/api/v2/system/main_test.go
@@ -1,0 +1,45 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+)
+
+// testCleanupGracePeriod gives any background goroutines started by the system
+// domain (the CPU sampler, the metrics collector, terminal PTY readers) a brief
+// window to exit after their owning context is cancelled before the package-wide
+// leak gate runs.
+const testCleanupGracePeriod = 100 * time.Millisecond
+
+// TestMain runs a package-wide goroutine-leak gate after all tests complete so
+// the system domain gets its own isolated -race test binary, matching the
+// package-api harness this domain was extracted from. The ignore list mirrors
+// package api's TestMain: test-framework goroutines plus the process-lifetime
+// third-party workers (the go-cache janitor started by the core's DetectionCache
+// and the lumberjack log-rotation worker) that cannot be stopped.
+func TestMain(m *testing.M) {
+	testResult := m.Run()
+
+	// Give a small grace period for goroutines to clean up after all tests.
+	time.Sleep(testCleanupGracePeriod)
+
+	if testResult == 0 {
+		opts := []goleak.Option{
+			goleak.IgnoreTopFunction("testing.(*T).Run"),
+			goleak.IgnoreTopFunction("testing.(*T).Parallel"),
+			goleak.IgnoreTopFunction("github.com/patrickmn/go-cache.(*janitor).Run"),
+			goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
+		}
+
+		if err := goleak.Find(opts...); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: Goroutine leak detected after all tests:\n%v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	os.Exit(testResult)
+}

--- a/internal/api/v2/system/metrics_history.go
+++ b/internal/api/v2/system/metrics_history.go
@@ -1,5 +1,5 @@
-// internal/api/v2/metrics_history.go
-package api
+// internal/api/v2/system/metrics_history.go
+package system
 
 import (
 	"fmt"
@@ -33,7 +33,7 @@ type MetricsHistoryResponse struct {
 // GetMetricsHistory returns historical metric data for sparkline rendering.
 //
 //	GET /api/v2/system/metrics/history?metrics=cpu.total,memory.used_percent&points=60
-func (c *Controller) GetMetricsHistory(ctx echo.Context) error {
+func (c *Handler) GetMetricsHistory(ctx echo.Context) error {
 	if c.MetricsStore == nil {
 		return c.HandleError(ctx, nil, "Metrics history not available", http.StatusServiceUnavailable)
 	}
@@ -76,7 +76,7 @@ func (c *Controller) GetMetricsHistory(ctx echo.Context) error {
 // StreamMetrics provides an SSE stream of live metric updates.
 //
 //	GET /api/v2/system/metrics/stream?metrics=cpu.total,memory.used_percent
-func (c *Controller) StreamMetrics(ctx echo.Context) error {
+func (c *Handler) StreamMetrics(ctx echo.Context) error {
 	if c.MetricsStore == nil {
 		return c.HandleError(ctx, nil, "Metrics stream not available", http.StatusServiceUnavailable)
 	}
@@ -190,8 +190,10 @@ func (c *Controller) StreamMetrics(ctx echo.Context) error {
 	}
 }
 
-// initMetricsHistoryRoutes registers the metrics history endpoints.
-func (c *Controller) initMetricsHistoryRoutes() {
+// RegisterMetricsHistoryRoutes registers the metrics history endpoints,
+// preserving the exact routes, rate limiter and auth middleware from the
+// original initMetricsHistoryRoutes.
+func (c *Handler) RegisterMetricsHistoryRoutes(g *echo.Group) {
 	if c.MetricsStore == nil {
 		c.LogWarnIfEnabled("Metrics store not configured, skipping metrics history routes")
 		return
@@ -199,7 +201,7 @@ func (c *Controller) initMetricsHistoryRoutes() {
 
 	c.LogInfoIfEnabled("Initializing metrics history routes")
 
-	systemGroup := c.Group.Group("/system")
+	systemGroup := g.Group("/system")
 	authMiddleware := c.AuthMiddleware
 
 	// Rate limiter for metrics SSE connections (10 requests per minute per IP)
@@ -231,7 +233,7 @@ func (c *Controller) initMetricsHistoryRoutes() {
 	c.Go(func() {
 		collector := observability.NewCollector(
 			c.MetricsStore,
-			metricsCollectorInterval,
+			apicore.MetricsCollectorInterval,
 			c.getCPUUsageFunc(),
 		)
 
@@ -271,16 +273,13 @@ func (c *Controller) initMetricsHistoryRoutes() {
 		collector.Start(c.Context())
 	})
 
-	c.LogInfoIfEnabled(fmt.Sprintf("Metrics history routes initialized (collector interval: %s)", metricsCollectorInterval))
+	c.LogInfoIfEnabled(fmt.Sprintf("Metrics history routes initialized (collector interval: %s)", apicore.MetricsCollectorInterval))
 }
 
-// metricsCollectorInterval is the time between metric collection ticks.
-const metricsCollectorInterval = 5 * time.Second
-
 // getCPUUsageFunc returns a function that reads from the existing CPUCache.
-func (c *Controller) getCPUUsageFunc() observability.CPUUsageFunc {
+func (c *Handler) getCPUUsageFunc() observability.CPUUsageFunc {
 	return func() float64 {
-		values := GetCachedCPUUsage()
+		values := apicore.GetCachedCPUUsage()
 		if len(values) > 0 {
 			return values[0]
 		}

--- a/internal/api/v2/system/system.go
+++ b/internal/api/v2/system/system.go
@@ -1,12 +1,11 @@
-// internal/api/v2/system.go
-package api
+// internal/api/v2/system/system.go
+package system
 
 import (
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	goerrors "errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,17 +16,14 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/shirou/gopsutil/v3/process"
-	"github.com/tphakala/birdnet-go/internal/audiocore"
-	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -40,12 +36,9 @@ import (
 
 // System info constants (file-local)
 const (
-	cpuCacheUpdateInterval = 2 * time.Second // Interval for CPU cache updates
-	bytesPerKB             = 1024            // Bytes per kilobyte
-	maxPercentage          = 100             // Maximum percentage value
-	defaultAudioSampleRate = 48000           // Standard BirdNET audio sample rate
-	defaultAudioBitDepth   = 16              // Standard audio bit depth
-	minRequiredElements    = 2               // Minimum required elements for various checks
+	bytesPerKB          = 1024 // Bytes per kilobyte
+	maxPercentage       = 100  // Maximum percentage value
+	minRequiredElements = 2    // Minimum required elements for various checks
 )
 
 // SystemInfo represents basic system information
@@ -111,33 +104,6 @@ type DiskInfo struct {
 	IsReadOnly      bool    `json:"is_read_only"`                   // Whether the filesystem is mounted as read-only
 }
 
-// AudioDeviceInfo wraps the audiocore.DeviceInfo struct for API responses
-type AudioDeviceInfo struct {
-	Index int    `json:"index"`
-	Name  string `json:"name"`
-	ID    string `json:"id"`
-	// StableID is the reboot-stable identifier to persist for this device
-	// ("usb-path:..." / "usb-id:..."), empty when no stable USB identity exists.
-	// Clients should save this in preference to ID so the selection survives
-	// reboots (GH #3651).
-	StableID string `json:"stableId,omitempty"`
-	// BusPath is the USB bus path for display (e.g. "usb-0000:00:14.0-3"),
-	// empty for non-USB devices and non-Linux platforms.
-	BusPath string `json:"busPath,omitempty"`
-	// VendorID and ProductID are the 4-hex-digit USB ids, empty when unavailable.
-	VendorID  string `json:"vendorId,omitempty"`
-	ProductID string `json:"productId,omitempty"`
-}
-
-// ActiveAudioDevice represents the currently active audio device
-type ActiveAudioDevice struct {
-	Name       string `json:"name"`
-	ID         string `json:"id"`
-	SampleRate int    `json:"sample_rate"`
-	BitDepth   int    `json:"bit_depth"`
-	Channels   int    `json:"channels"`
-}
-
 // ProcessInfo represents information about a running process
 type ProcessInfo struct {
 	PID    int32   `json:"pid"`
@@ -165,61 +131,8 @@ type RestartStatus struct {
 }
 
 // Use monotonic clock for start time
-var startTime = time.Now()
+var processStartTime = time.Now()
 var startMonotonicTime = time.Now() // This inherently includes monotonic clock reading
-
-// CPUCache holds the cached CPU usage data
-type CPUCache struct {
-	mu          sync.RWMutex
-	cpuPercent  []float64
-	lastUpdated time.Time
-}
-
-// Global CPU cache instance
-var cpuCache = &CPUCache{
-	cpuPercent:  []float64{0}, // Initialize with 0 value
-	lastUpdated: time.Now(),
-}
-
-// UpdateCPUCache updates the cached CPU usage data
-func UpdateCPUCache(ctx context.Context) {
-	ticker := time.NewTicker(cpuCacheUpdateInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			// Get CPU usage (this will block for 1 second)
-			percent, err := cpu.Percent(time.Second, false)
-			if err == nil && len(percent) > 0 {
-				cpuCache.mu.Lock()
-				cpuCache.cpuPercent = percent
-				cpuCache.lastUpdated = time.Now()
-				cpuCache.mu.Unlock()
-			}
-
-			// Wait for next tick or context cancellation
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-			}
-		}
-	}
-}
-
-// GetCachedCPUUsage returns the cached CPU usage
-func GetCachedCPUUsage() []float64 {
-	cpuCache.mu.RLock()
-	defer cpuCache.mu.RUnlock()
-
-	// Return a copy to avoid race conditions
-	result := make([]float64, len(cpuCache.cpuPercent))
-	copy(result, cpuCache.cpuPercent)
-	return result
-}
 
 // JobQueueStats represents the job queue statistics
 type JobQueueStats struct {
@@ -229,7 +142,7 @@ type JobQueueStats struct {
 }
 
 // GetJobQueueStats returns statistics about the job queue
-func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
+func (c *Handler) GetJobQueueStats(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Getting job queue statistics",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -295,7 +208,7 @@ type NetworkInterface struct {
 
 // GetNetworkInterfaces returns the IPv4 network interfaces available for binding.
 // GET /api/v2/system/network-interfaces
-func (c *Controller) GetNetworkInterfaces(ctx echo.Context) error {
+func (c *Handler) GetNetworkInterfaces(ctx echo.Context) error {
 	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting network interfaces")
 
 	interfaces := []NetworkInterface{
@@ -307,7 +220,7 @@ func (c *Controller) GetNetworkInterfaces(ctx echo.Context) error {
 
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		// Log but don't fail — return at least the wildcard and loopback
+		// Log but don't fail - return at least the wildcard and loopback
 		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Failed to enumerate network interfaces", logger.Error(err))
 		interfaces = append(interfaces, NetworkInterface{
 			Address: "127.0.0.1", Name: "lo", Label: "Loopback", Status: "up",
@@ -369,7 +282,7 @@ func (c *Controller) GetNetworkInterfaces(ctx echo.Context) error {
 }
 
 // GetRestartStatus handles GET /api/v2/system/restart-status
-func (c *Controller) GetRestartStatus(ctx echo.Context) error {
+func (c *Handler) GetRestartStatus(ctx echo.Context) error {
 	canRestart := c.GetShutdownRequester() != nil
 	status := RestartStatus{
 		BinaryRestartAvailable:    canRestart,
@@ -381,71 +294,8 @@ func (c *Controller) GetRestartStatus(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, status)
 }
 
-// Initialize system routes
-func (c *Controller) initSystemRoutes() {
-	c.LogInfoIfEnabled("Initializing system routes")
-
-	// Start CPU usage monitoring in background with controller's context for controlled shutdown
-	// Go 1.25: Using WaitGroup.Go() for cleaner goroutine management
-	c.Go(func() {
-		UpdateCPUCache(c.Context())
-	})
-
-	c.LogInfoIfEnabled("Started CPU usage monitoring")
-
-	// Create system API group
-	systemGroup := c.Group.Group("/system")
-
-	// Get the appropriate auth middleware
-	authMiddleware := c.AuthMiddleware
-
-	// Create auth-protected group using the appropriate middleware
-	protectedGroup := systemGroup.Group("", authMiddleware)
-
-	// Add system routes (all protected)
-	protectedGroup.GET("/info", c.GetSystemInfo)
-	protectedGroup.GET("/resources", c.GetResourceInfo)
-	protectedGroup.GET("/disks", c.GetDiskInfo)
-	protectedGroup.GET("/jobs", c.GetJobQueueStats)
-	protectedGroup.GET("/processes", c.GetProcessInfo)
-	protectedGroup.GET("/temperature/cpu", c.GetSystemCPUTemperature)
-	protectedGroup.GET("/database/stats", c.GetDatabaseStats)
-	protectedGroup.GET("/database/v2/stats", c.GetV2DatabaseStats)
-	protectedGroup.POST("/database/backup", c.DownloadDatabaseBackup)
-	protectedGroup.GET("/network-interfaces", c.GetNetworkInterfaces)
-	protectedGroup.GET("/restart-status", c.GetRestartStatus)
-	protectedGroup.GET("/models", c.GetActiveModels)
-	protectedGroup.GET("/inference", c.GetInferenceStatus)
-	protectedGroup.GET("/external-media", c.GetExternalMedia)
-
-	// Audio device routes (all protected)
-	audioGroup := protectedGroup.Group("/audio")
-	audioGroup.GET("/devices", c.GetAudioDevices)
-	audioGroup.GET("/devices/capabilities", c.GetDeviceCapabilities)
-	audioGroup.GET("/active", c.GetActiveAudioDevice)
-	audioGroup.GET("/equalizer/config", c.GetEqualizerConfig)
-	audioGroup.GET("/sources", c.ListAudioSources)
-
-	// Events routes (detection lifecycle + operational logs)
-	c.registerEventsRoutes(protectedGroup)
-
-	// Initialize database overview route
-	c.initDatabaseOverviewRoutes()
-
-	// Initialize migration routes
-	c.initMigrationRoutes()
-
-	// Initialize async backup routes
-	c.initBackupRoutes()
-
-	// Initialize legacy cleanup routes
-	c.initLegacyCleanupRoutes()
-
-	c.LogInfoIfEnabled("System routes initialized successfully")
-}
-
 // GetSystemInfo handles GET /api/v2/system/info
-func (c *Controller) GetSystemInfo(ctx echo.Context) error {
+func (c *Handler) GetSystemInfo(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting system information", logger.String("path", path), logger.String("ip", ip))
 
@@ -466,7 +316,7 @@ func (c *Controller) GetSystemInfo(ctx echo.Context) error {
 		KernelVersion:  hostInfo.KernelVersion,
 		UpTime:         hostInfo.Uptime,
 		BootTime:       time.Unix(int64(hostInfo.BootTime), 0), // #nosec G115 -- BootTime from system APIs, safe conversion for timestamp
-		AppStart:       startTime,
+		AppStart:       processStartTime,
 		AppUptime:      int64(time.Since(startMonotonicTime).Seconds()),
 		NumCPU:         runtime.NumCPU(),
 		SystemModel:    systemModel,
@@ -483,18 +333,18 @@ func (c *Controller) GetSystemInfo(ctx echo.Context) error {
 }
 
 // getHostnameWithFallback gets hostname or returns "unknown" on error
-func (c *Controller) getHostnameWithFallback(ip, path string) string {
+func (c *Handler) getHostnameWithFallback(ip, path string) string {
 	hostname, err := os.Hostname()
 	if err != nil {
 		c.LogWarnIfEnabled("Failed to get hostname, using 'unknown'", logger.Error(err), logger.String("path", path), logger.String("ip", ip))
-		return ValueUnknown
+		return valueUnknown
 	}
 	return hostname
 }
 
 // getSystemModelWithLogging gets system model on Linux with logging
-func (c *Controller) getSystemModelWithLogging(ip, path string) string {
-	if runtime.GOOS != OSLinux {
+func (c *Handler) getSystemModelWithLogging(ip, path string) string {
+	if runtime.GOOS != osLinux {
 		return ""
 	}
 	systemModel := getSystemModelFromProc()
@@ -515,8 +365,8 @@ func getTimeZoneString() string {
 
 	// Fallback if Olson name is "Local" or empty
 	name, offset := time.Now().Zone()
-	offsetHours := offset / SecondsPerHour
-	offsetMinutes := (offset % SecondsPerHour) / SecondsPerMinute
+	offsetHours := offset / secondsPerHour
+	offsetMinutes := (offset % secondsPerHour) / secondsPerMinute
 	if offsetMinutes < 0 {
 		offsetMinutes = -offsetMinutes
 	}
@@ -533,14 +383,14 @@ func getOSDisplayString(platform string) string {
 	platformName := tcaser.String(platform)
 
 	switch runtime.GOOS {
-	case OSLinux:
+	case osLinux:
 		if platformName != "" {
 			return fmt.Sprintf("%s Linux", platformName)
 		}
 		return "Linux"
-	case OSWindows:
+	case osWindows:
 		return "Microsoft Windows"
-	case OSDarwin:
+	case osDarwin:
 		return "Apple macOS"
 	default:
 		if platformName != "" {
@@ -555,7 +405,7 @@ func getOSDisplayString(platform string) string {
 func getSystemModelFromProc() string {
 	data, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
-		GetLogger().Warn("Could not read /proc/cpuinfo", logger.Error(err))
+		apicore.GetLogger().Warn("Could not read /proc/cpuinfo", logger.Error(err))
 		return ""
 	}
 
@@ -577,7 +427,7 @@ func getSystemModelFromProc() string {
 }
 
 // GetResourceInfo handles GET /api/v2/system/resources
-func (c *Controller) GetResourceInfo(ctx echo.Context) error {
+func (c *Handler) GetResourceInfo(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Getting system resource information",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -606,7 +456,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 	}
 
 	// Get CPU usage from cache instead of blocking
-	cpuPercent := GetCachedCPUUsage()
+	cpuPercent := apicore.GetCachedCPUUsage()
 
 	// Get process information (current process)
 	proc, err := process.NewProcess(int32(os.Getpid())) // #nosec G115 -- PID conversion safe, PIDs are within int32 range
@@ -684,7 +534,7 @@ func (c *Controller) GetResourceInfo(ctx echo.Context) error {
 }
 
 // GetDiskInfo handles GET /api/v2/system/disks
-func (c *Controller) GetDiskInfo(ctx echo.Context) error {
+func (c *Handler) GetDiskInfo(ctx echo.Context) error {
 	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting disk information")
 
 	partitions, err := disk.Partitions(false)
@@ -716,17 +566,17 @@ func (c *Controller) GetDiskInfo(ctx echo.Context) error {
 }
 
 // getUptimeMs returns system uptime in milliseconds
-func (c *Controller) getUptimeMs() uint64 {
+func (c *Handler) getUptimeMs() uint64 {
 	hostInfo, err := host.Info()
 	if err != nil {
 		c.Debug("Failed to get host information for uptime: %v", err)
 		return 0
 	}
-	return hostInfo.Uptime * MillisecondsPerSecond
+	return hostInfo.Uptime * millisecondsPerSecond
 }
 
 // buildDiskInfo creates a DiskInfo struct from partition data
-func (c *Controller) buildDiskInfo(partition disk.PartitionStat, ioCounters map[string]disk.IOCountersStat, uptimeMs uint64) DiskInfo {
+func (c *Handler) buildDiskInfo(partition disk.PartitionStat, ioCounters map[string]disk.IOCountersStat, uptimeMs uint64) DiskInfo {
 	diskInfo := DiskInfo{
 		Device:     partition.Device,
 		Mountpoint: partition.Mountpoint,
@@ -742,7 +592,7 @@ func (c *Controller) buildDiskInfo(partition disk.PartitionStat, ioCounters map[
 }
 
 // populateDiskUsage adds usage statistics to disk info
-func (c *Controller) populateDiskUsage(info *DiskInfo, mountpoint string) {
+func (c *Handler) populateDiskUsage(info *DiskInfo, mountpoint string) {
 	usage, err := disk.Usage(mountpoint)
 	if err != nil {
 		c.Debug("Failed to get usage for %s: %v", mountpoint, err)
@@ -763,7 +613,7 @@ func (c *Controller) populateDiskUsage(info *DiskInfo, mountpoint string) {
 }
 
 // populateIOMetrics adds IO metrics to disk info
-func (c *Controller) populateIOMetrics(info *DiskInfo, device string, ioCounters map[string]disk.IOCountersStat, uptimeMs uint64) {
+func (c *Handler) populateIOMetrics(info *DiskInfo, device string, ioCounters map[string]disk.IOCountersStat, uptimeMs uint64) {
 	deviceName := getDeviceBaseName(device)
 	counter, exists := ioCounters[deviceName]
 	if !exists {
@@ -781,7 +631,7 @@ func (c *Controller) populateIOMetrics(info *DiskInfo, device string, ioCounters
 }
 
 // calculateIOBusyPerc calculates IO busy percentage
-func (c *Controller) calculateIOBusyPerc(counter *disk.IOCountersStat, uptimeMs uint64) float64 {
+func (c *Handler) calculateIOBusyPerc(counter *disk.IOCountersStat, uptimeMs uint64) float64 {
 	if uptimeMs == 0 {
 		return 0
 	}
@@ -836,252 +686,9 @@ func isReadOnlyMount(opts []string) bool {
 	return slices.Contains(opts, "ro")
 }
 
-// GetAudioDevices handles GET /api/v2/system/audio/devices
-func (c *Controller) GetAudioDevices(ctx echo.Context) error {
-	c.LogInfoIfEnabled("Getting audio devices",
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	// Get audio devices
-	devices, err := audiocore.ListCaptureDevices()
-	if err != nil {
-		c.LogErrorIfEnabled("Failed to list audio devices",
-			logger.Error(err),
-			logger.String("path", ctx.Request().URL.Path),
-			logger.String("ip", ctx.RealIP()),
-		)
-		return c.HandleError(ctx, err, "Failed to list audio devices", http.StatusInternalServerError)
-	}
-
-	// Check if no devices were found
-	if len(devices) == 0 {
-		c.Debug("No audio devices found on the system")
-		c.LogWarnIfEnabled("No audio devices found on the system",
-			logger.String("path", ctx.Request().URL.Path),
-			logger.String("ip", ctx.RealIP()),
-			logger.String("os", runtime.GOOS),
-		)
-		return ctx.JSON(http.StatusOK, []AudioDeviceInfo{}) // Return empty array instead of null
-	}
-
-	// Convert to API response format
-	apiDevices := make([]AudioDeviceInfo, len(devices))
-	for i, device := range devices {
-		apiDevices[i] = AudioDeviceInfo{
-			Index:     device.Index,
-			Name:      device.Name,
-			ID:        device.ID,
-			StableID:  device.StableID,
-			BusPath:   device.BusPath,
-			VendorID:  device.VendorID,
-			ProductID: device.ProductID,
-		}
-	}
-
-	deviceNames := make([]string, len(devices))
-	for i, device := range devices {
-		deviceNames[i] = device.Name
-	}
-
-	c.LogInfoIfEnabled("Audio devices retrieved successfully",
-		logger.Int("device_count", len(apiDevices)),
-		logger.String("devices", strings.Join(deviceNames, ", ")),
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	return ctx.JSON(http.StatusOK, apiDevices)
-}
-
-// GetDeviceCapabilities handles GET /api/v2/system/audio/devices/capabilities
-// Probes a specific audio device to discover supported sample rates.
-func (c *Controller) GetDeviceCapabilities(ctx echo.Context) error {
-	deviceID := ctx.QueryParam("deviceId")
-	if deviceID == "" {
-		return c.HandleError(ctx, nil, "deviceId query parameter is required", http.StatusBadRequest)
-	}
-
-	c.LogInfoIfEnabled("Probing device capabilities",
-		logger.String("device_id", deviceID),
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	caps, err := audiocore.ProbeDeviceCapabilities(deviceID, c.APILogger)
-	if err != nil {
-		if goerrors.Is(err, audiocore.ErrDeviceNotFound) {
-			return c.HandleError(ctx, err, "Device not found", http.StatusNotFound)
-		}
-		c.LogErrorIfEnabled("Failed to probe device capabilities",
-			logger.Error(err),
-			logger.String("device_id", deviceID),
-		)
-		return c.HandleError(ctx, err, "Failed to probe device capabilities", http.StatusInternalServerError)
-	}
-
-	c.LogInfoIfEnabled("Device capabilities retrieved",
-		logger.String("device_id", caps.DeviceID),
-		logger.String("device_name", caps.DeviceName),
-		logger.Int("rate_count", len(caps.SampleRates)),
-		logger.Bool("verified", caps.Verified),
-	)
-
-	return ctx.JSON(http.StatusOK, caps)
-}
-
-// GetActiveAudioDevice handles GET /api/v2/system/audio/active
-func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
-	c.LogInfoIfEnabled("Getting active audio device",
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	// Get active audio device from settings (first configured source)
-	var deviceName string
-	settings := c.CurrentSettings()
-	if settings != nil && len(settings.Realtime.Audio.Sources) > 0 {
-		deviceName = settings.Realtime.Audio.Sources[0].Device
-	}
-
-	// Check if no device is configured
-	if deviceName == "" {
-		c.LogInfoIfEnabled("No audio device currently active",
-			logger.String("path", ctx.Request().URL.Path),
-			logger.String("ip", ctx.RealIP()),
-		)
-		return ctx.JSON(http.StatusOK, map[string]any{
-			"device":   nil,
-			"active":   false,
-			"verified": false,
-			"message":  "No audio device currently active",
-		})
-	}
-
-	// Create response with default values
-	activeDevice := ActiveAudioDevice{
-		Name:       deviceName,
-		SampleRate: defaultAudioSampleRate, // Standard BirdNET sample rate
-		BitDepth:   defaultAudioBitDepth,   // Assuming 16-bit as per the capture.go implementation
-		Channels:   1,                      // Assuming mono as per the capture.go implementation
-	}
-
-	// Diagnostic information map
-	diagnostics := map[string]any{
-		"os":                runtime.GOOS,
-		"check_time":        time.Now().Format(time.RFC3339),
-		"error_details":     nil,
-		"device_found":      false,
-		"available_devices": []string{},
-	}
-
-	// Try to get additional device info and validate the device exists
-	devices, err := audiocore.ListCaptureDevices()
-	if err != nil {
-		errorMsg := fmt.Sprintf("Failed to list audio devices: %v", err)
-		c.Debug("%s", errorMsg)
-
-		// Add more detailed diagnostics
-		diagnostics["error_details"] = errorMsg
-
-		// OS-specific additional checks
-		switch runtime.GOOS {
-		case OSWindows:
-			diagnostics["note"] = "On Windows, check that audio drivers are properly installed and the device is not disabled in Sound settings"
-		case OSDarwin:
-			diagnostics["note"] = "On macOS, check System Preferences > Sound and ensure the device has proper permissions"
-		case OSLinux:
-			diagnostics["note"] = "On Linux, check if PulseAudio/ALSA is running and the user has proper permissions"
-		}
-
-		c.LogWarnIfEnabled("Failed to list audio devices for verification",
-			logger.String("device_name", deviceName),
-			logger.Error(err),
-			logger.String("os", runtime.GOOS),
-			logger.String("path", ctx.Request().URL.Path),
-			logger.String("ip", ctx.RealIP()),
-		)
-
-		// Still return the configured device, but note that we couldn't verify it exists
-		return ctx.JSON(http.StatusOK, map[string]any{
-			"device":      activeDevice,
-			"active":      true,
-			"verified":    false,
-			"message":     "Device configured but could not verify if it exists",
-			"diagnostics": diagnostics,
-		})
-	}
-
-	// Populate available devices for diagnostics
-	availableDevices := make([]string, len(devices))
-	for i, device := range devices {
-		availableDevices[i] = device.Name
-	}
-	diagnostics["available_devices"] = availableDevices
-
-	// Check if the configured device exists in the system
-	deviceFound := false
-	for _, device := range devices {
-		if device.ID != deviceName && device.Name != deviceName {
-			continue
-		}
-
-		activeDevice.Name = device.Name
-		activeDevice.ID = device.ID
-		deviceFound = true
-		diagnostics["device_found"] = true
-
-		break
-	}
-
-	if !deviceFound {
-		// Device is configured but not found on the system
-		errorMsg := "Configured audio device not found on the system"
-		diagnostics["suggested_action"] = "Check if the device is properly connected and recognized by the system"
-
-		if len(devices) > 0 {
-			diagnostics["suggestion"] = fmt.Sprintf("Consider using one of the available devices: %s", strings.Join(availableDevices, ", "))
-		}
-
-		c.LogWarnIfEnabled("Configured audio device not found on system",
-			logger.String("configured_device", deviceName),
-			logger.String("available_devices", strings.Join(availableDevices, ", ")),
-			logger.String("os", runtime.GOOS),
-			logger.String("path", ctx.Request().URL.Path),
-			logger.String("ip", ctx.RealIP()),
-		)
-
-		return ctx.JSON(http.StatusOK, map[string]any{
-			"device":      activeDevice,
-			"active":      true,
-			"verified":    false,
-			"message":     errorMsg,
-			"diagnostics": diagnostics,
-		})
-	}
-
-	c.LogInfoIfEnabled("Active audio device verified",
-		logger.String("device_name", deviceName),
-		logger.String("device_id", activeDevice.ID),
-		logger.Int("sample_rate", activeDevice.SampleRate),
-		logger.Int("bit_depth", activeDevice.BitDepth),
-		logger.Int("channels", activeDevice.Channels),
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	// Device is configured and verified to exist
-	return ctx.JSON(http.StatusOK, map[string]any{
-		"device":      activeDevice,
-		"active":      true,
-		"verified":    true,
-		"diagnostics": diagnostics,
-	})
-}
-
 // getSingleProcessInfo retrieves detailed information for a single process.
 // It handles errors gracefully and returns a ProcessInfo struct.
-func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, error) {
+func (c *Handler) getSingleProcessInfo(p *process.Process) (ProcessInfo, error) {
 	name, err := p.Name()
 	if err != nil {
 		// Log error but continue, maybe process terminated?
@@ -1094,13 +701,13 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 	var status string
 	switch {
 	case err != nil:
-		status = ValueUnknown
+		status = valueUnknown
 		c.LogWarnIfEnabled("Failed to get process status", logger.Any("pid", p.Pid), logger.String("name", name), logger.Error(err))
 	case len(statusList) > 0:
 		// Use the first status code returned
 		status = mapProcessStatus(statusList[0])
 	default:
-		status = ValueUnknown
+		status = valueUnknown
 	}
 
 	cpuPercent, err := p.CPUPercent()
@@ -1128,7 +735,7 @@ func (c *Controller) getSingleProcessInfo(p *process.Process) (ProcessInfo, erro
 		uptimeSeconds = 0
 	} else {
 		// Calculate uptime relative to now
-		uptimeSeconds = max(time.Now().Unix()-(createTimeMillis/MillisecondsPerSecond),
+		uptimeSeconds = max(time.Now().Unix()-(createTimeMillis/millisecondsPerSecond),
 			// Sanity check for clock skew
 			0)
 	}
@@ -1169,7 +776,7 @@ func mapProcessStatus(statusCode string) string {
 // GetProcessInfo returns a list of running processes and their basic information
 // It accepts an optional query parameter `?all=true` to show all processes.
 // By default, it shows only the main application process and its direct children.
-func (c *Controller) GetProcessInfo(ctx echo.Context) error {
+func (c *Handler) GetProcessInfo(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting process information", logger.String("path", path), logger.String("ip", ip), logger.String("query", ctx.QueryString()))
 
@@ -1189,7 +796,7 @@ func (c *Controller) GetProcessInfo(ctx echo.Context) error {
 }
 
 // collectProcessInfos filters and collects process information
-func (c *Controller) collectProcessInfos(procs []*process.Process, showAll bool) []ProcessInfo {
+func (c *Handler) collectProcessInfos(procs []*process.Process, showAll bool) []ProcessInfo {
 	currentPID := int32(os.Getpid()) // #nosec G115 -- PID conversion safe, PIDs are within int32 range
 	processInfos := make([]ProcessInfo, 0, len(procs))
 
@@ -1211,7 +818,7 @@ func (c *Controller) collectProcessInfos(procs []*process.Process, showAll bool)
 }
 
 // isRelevantProcess checks if process is main process or direct child
-func (c *Controller) isRelevantProcess(p *process.Process, currentPID int32) bool {
+func (c *Handler) isRelevantProcess(p *process.Process, currentPID int32) bool {
 	parentPID, err := p.Ppid()
 	if err != nil {
 		c.LogWarnIfEnabled("Failed to get parent PID, skipping process", logger.Any("pid", p.Pid), logger.Error(err))
@@ -1222,7 +829,7 @@ func (c *Controller) isRelevantProcess(p *process.Process, currentPID int32) boo
 
 // checkThermalZone attempts to read and validate the temperature from a specific thermal zone.
 // It returns the Celsius temperature, details about the sensor/error, whether it was valid, and any critical error.
-func (c *Controller) checkThermalZone(zonePath string, targetTypes map[string]bool) (celsius float64, details string, isValid bool, err error) {
+func (c *Handler) checkThermalZone(zonePath string, targetTypes map[string]bool) (celsius float64, details string, isValid bool, err error) {
 	zoneName := filepath.Base(zonePath)
 	typePath := filepath.Join(zonePath, "type")
 
@@ -1259,7 +866,7 @@ func (c *Controller) checkThermalZone(zonePath string, targetTypes map[string]bo
 		return 0, details, false, nil // Error parsing temp.
 	}
 
-	celsius = float64(tempMillCelsius) / float64(MillisecondsPerSecond)
+	celsius = float64(tempMillCelsius) / float64(millisecondsPerSecond)
 
 	// Validate temperature range (0 to 100 °C inclusive)
 	if celsius < 0.0 || celsius > 100.0 {
@@ -1292,7 +899,7 @@ var cpuThermalTypes = map[string]bool{
 	"thermal-fan-est": true, // Seen on some systems
 }
 
-func (c *Controller) GetSystemCPUTemperature(ctx echo.Context) error {
+func (c *Handler) GetSystemCPUTemperature(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting system CPU temperature", logger.String("path", path), logger.String("ip", ip))
 
@@ -1330,7 +937,7 @@ func (c *Controller) GetSystemCPUTemperature(ctx echo.Context) error {
 // checkThermalDirectoryAccess checks if thermal directory exists and is accessible.
 // Returns (true, nil) if the directory exists, (false, nil) if not found (with response
 // fields set), or (false, error) for other filesystem failures.
-func (c *Controller) checkThermalDirectoryAccess(response *SystemTemperature, ip, path string) (bool, error) {
+func (c *Handler) checkThermalDirectoryAccess(response *SystemTemperature, ip, path string) (bool, error) {
 	_, err := os.Stat(thermalBasePath)
 	if err == nil {
 		return true, nil
@@ -1347,7 +954,7 @@ func (c *Controller) checkThermalDirectoryAccess(response *SystemTemperature, ip
 }
 
 // getThermalZones retrieves available thermal zone paths
-func (c *Controller) getThermalZones(ctx echo.Context, ip, path string) ([]string, error) {
+func (c *Handler) getThermalZones(ctx echo.Context, ip, path string) ([]string, error) {
 	zones, err := filepath.Glob(filepath.Join(thermalBasePath, "thermal_zone*"))
 	if err != nil {
 		c.LogErrorIfEnabled("Failed to glob for thermal zones", logger.String("base_path", thermalBasePath), logger.Error(err), logger.String("request_path", path), logger.String("ip", ip))
@@ -1357,7 +964,7 @@ func (c *Controller) getThermalZones(ctx echo.Context, ip, path string) ([]strin
 }
 
 // findValidThermalZone searches for a valid CPU thermal zone and updates response
-func (c *Controller) findValidThermalZone(zones []string, response *SystemTemperature, ip, path string) {
+func (c *Handler) findValidThermalZone(zones []string, response *SystemTemperature, ip, path string) {
 	var lastAttemptDetails string
 
 	for _, zonePath := range zones {
@@ -1386,7 +993,7 @@ func (c *Controller) findValidThermalZone(zones []string, response *SystemTemper
 }
 
 // setTemperatureNotFoundResponse sets appropriate message when no valid sensor found
-func (c *Controller) setTemperatureNotFoundResponse(response *SystemTemperature, lastAttemptDetails, ip, path string) {
+func (c *Handler) setTemperatureNotFoundResponse(response *SystemTemperature, lastAttemptDetails, ip, path string) {
 	response.SensorDetails = lastAttemptDetails
 	if lastAttemptDetails != "" {
 		response.Message = fmt.Sprintf("A targeted CPU sensor was found but could not be read successfully or value was invalid. Last attempt details: %s", lastAttemptDetails)
@@ -1471,24 +1078,10 @@ func skipFilesystem(fstype string) bool {
 	return false
 }
 
-// GetEqualizerConfig handles GET /api/v2/system/audio/equalizer/config
-func (c *Controller) GetEqualizerConfig(ctx echo.Context) error {
-	c.LogInfoIfEnabled("Getting equalizer filter configuration",
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	// Set cache headers for static configuration data
-	ctx.Response().Header().Set("Cache-Control", "public, max-age=3600")
-
-	// Return the equalizer filter configuration
-	return ctx.JSON(http.StatusOK, conf.EqFilterConfig)
-}
-
 // GetDatabaseStats handles GET /api/v2/system/database/stats
 // Delegates to c.DS.GetDatabaseStats which returns the correct stats
 // for the active store (legacy SQLite/MySQL or v2only.Datastore).
-func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
+func (c *Handler) GetDatabaseStats(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting database statistics",
 		logger.String("path", path),
@@ -1560,7 +1153,7 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 }
 
 // getV2ManagerStats retrieves v2 database statistics directly from V2Manager.
-func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.DatabaseStats, bool) {
+func (c *Handler) getV2ManagerStats(ctx context.Context) (*datastore.DatabaseStats, bool) {
 	mgr := c.V2Manager
 	if mgr == nil || !mgr.Exists() {
 		return nil, false
@@ -1620,7 +1213,7 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 }
 
 // GetV2DatabaseStats handles GET /api/v2/system/database/v2/stats
-func (c *Controller) GetV2DatabaseStats(ctx echo.Context) error {
+func (c *Handler) GetV2DatabaseStats(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting v2 database statistics",
 		logger.String("path", path), logger.String("ip", ip))
@@ -1638,15 +1231,12 @@ func (c *Controller) GetV2DatabaseStats(ctx echo.Context) error {
 const (
 	// backupDiskSpaceBuffer is the additional disk space required beyond the database size for backup.
 	backupDiskSpaceBuffer = 100 * 1024 * 1024 // 100 MB
-	// Database type constants for backup API
-	dbTypeLegacy = "legacy"
-	dbTypeV2     = "v2"
 )
 
 // DownloadDatabaseBackup handles POST /api/v2/system/database/backup
 // Creates a safe backup using SQLite's VACUUM INTO command.
 // Uses chunked transfer encoding to keep connection alive during long VACUUM operations.
-func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
+func (c *Handler) DownloadDatabaseBackup(ctx echo.Context) error {
 	backupStart := time.Now()
 	ip, reqPath := ctx.RealIP(), ctx.Request().URL.Path
 	dbType := ctx.QueryParam("type")
@@ -1656,7 +1246,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		logger.String("path", reqPath), logger.String("ip", ip))
 
 	// Validate dbType parameter
-	if dbType != dbTypeLegacy && dbType != dbTypeV2 {
+	if dbType != apicore.DBTypeLegacy && dbType != apicore.DBTypeV2 {
 		return c.HandleError(ctx, fmt.Errorf("invalid type"),
 			"Type must be 'legacy' or 'v2'", http.StatusBadRequest)
 	}
@@ -1665,7 +1255,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	var dbPath string
 	var gormDB *gorm.DB
 
-	if dbType == dbTypeLegacy {
+	if dbType == apicore.DBTypeLegacy {
 		// Check if it's SQLite
 		settings := c.CurrentSettings()
 		if settings == nil || settings.Output.SQLite.Path == "" {
@@ -1720,7 +1310,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		logger.String("db_type", dbType),
 		logger.String("db_path", dbPath),
 		// #nosec G115 -- dbSize from os.FileInfo.Size() is always non-negative
-		logger.String("db_size", formatBytesUint64(uint64(dbSize))))
+		logger.String("db_size", apicore.FormatBytesUint64(uint64(dbSize))))
 
 	// Check disk space on temp directory where VACUUM INTO will write
 	tempDir := os.TempDir()
@@ -1734,14 +1324,14 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	if usage.Free < requiredSpace {
 		return c.HandleError(ctx, fmt.Errorf("insufficient space"),
 			fmt.Sprintf("Not enough disk space for backup. Need %s free, have %s available.",
-				formatBytesUint64(requiredSpace), formatBytesUint64(usage.Free)),
+				apicore.FormatBytesUint64(requiredSpace), apicore.FormatBytesUint64(usage.Free)),
 			http.StatusInsufficientStorage) // HTTP 507
 	}
 
 	c.LogInfoIfEnabled("Database backup: disk space check passed",
 		logger.String("temp_dir", tempDir),
-		logger.String("free_space", formatBytesUint64(usage.Free)),
-		logger.String("required_space", formatBytesUint64(requiredSpace)))
+		logger.String("free_space", apicore.FormatBytesUint64(usage.Free)),
+		logger.String("required_space", apicore.FormatBytesUint64(requiredSpace)))
 
 	// Create temp file path for VACUUM INTO with random suffix to prevent
 	// predictable filenames (symlink attacks on shared /tmp).
@@ -1809,7 +1399,7 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 	if statErr == nil {
 		backupSizeBytes = backupInfo.Size()
 		// #nosec G115 -- backupSizeBytes from os.FileInfo.Size() is always non-negative
-		backupSize = formatBytesUint64(uint64(backupSizeBytes))
+		backupSize = apicore.FormatBytesUint64(uint64(backupSizeBytes))
 	}
 
 	c.LogInfoIfEnabled("Database backup: VACUUM INTO completed, streaming file",
@@ -1856,18 +1446,4 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		logger.String("ip", ip))
 
 	return nil
-}
-
-// formatBytesUint64 formats bytes into human-readable format (for uint64 values).
-func formatBytesUint64(bytes uint64) string {
-	const unit uint64 = 1024
-	if bytes < unit {
-		return fmt.Sprintf("%d B", bytes)
-	}
-	div, exp := unit, 0
-	for n := bytes / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }

--- a/internal/api/v2/system/system_models.go
+++ b/internal/api/v2/system/system_models.go
@@ -1,4 +1,4 @@
-package api
+package system
 
 import (
 	"net/http"
@@ -18,7 +18,7 @@ type ActiveModelResponse struct {
 
 // GetActiveModels returns metadata for all currently loaded models.
 // GET /api/v2/system/models
-func (c *Controller) GetActiveModels(ctx echo.Context) error {
+func (c *Handler) GetActiveModels(ctx echo.Context) error {
 	if c.ModelManager == nil {
 		return ctx.JSON(http.StatusOK, []ActiveModelResponse{})
 	}

--- a/internal/api/v2/system/system_test.go
+++ b/internal/api/v2/system/system_test.go
@@ -1,6 +1,5 @@
-// system_test.go: Package api provides tests for API v2 system endpoints.
-
-package api
+// system_test.go: system-domain endpoint tests (extracted from package api).
+package system
 
 import (
 	"encoding/json"
@@ -19,7 +18,7 @@ import (
 )
 
 // setupSystemTestEnvironment creates a test environment for system API tests
-func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
+func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Handler) {
 	t.Helper()
 
 	e := echo.New()
@@ -32,7 +31,7 @@ func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
 		},
 	}
 
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(settings)
 
 	return e, controller
@@ -335,25 +334,6 @@ func TestMapProcessStatus(t *testing.T) {
 	}
 }
 
-// TestGetCachedCPUUsage tests the GetCachedCPUUsage function
-func TestGetCachedCPUUsage(t *testing.T) {
-	t.Attr("component", "system")
-	t.Attr("type", "unit")
-	t.Attr("feature", "cpu-cache")
-
-	// The cache is initialized with [0], so we should get at least that
-	result := GetCachedCPUUsage()
-	require.NotNil(t, result, "CPU cache should not be nil")
-	require.Len(t, result, 1, "CPU cache should have at least 1 value")
-
-	// Verify it returns a copy (modifying result shouldn't affect cache)
-	originalValue := result[0]
-	result[0] = 999.0
-
-	newResult := GetCachedCPUUsage()
-	assert.InDelta(t, originalValue, newResult[0], 0.001, "Cache should return a copy, not the original slice")
-}
-
 // TestGetSystemInfo tests the GetSystemInfo endpoint
 func TestGetSystemInfo(t *testing.T) {
 	t.Parallel()
@@ -513,97 +493,6 @@ func TestGetProcessInfo(t *testing.T) {
 
 		// With all=true, should have more processes
 		assert.Greater(t, len(response), 1, "Should have multiple processes with all=true")
-	})
-}
-
-// TestGetEqualizerConfig tests the GetEqualizerConfig endpoint
-func TestGetEqualizerConfig(t *testing.T) {
-	t.Parallel()
-	t.Attr("component", "system")
-	t.Attr("type", "integration")
-	t.Attr("feature", "equalizer-config")
-
-	e, controller := setupSystemTestEnvironment(t)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/equalizer/config", http.NoBody)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPath("/api/v2/system/audio/equalizer/config")
-
-	err := controller.GetEqualizerConfig(c)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	// Verify cache headers are set
-	assert.Contains(t, rec.Header().Get("Cache-Control"), "public", "Should have public cache header")
-
-	// Response should be valid JSON
-	var response any
-	err = json.Unmarshal(rec.Body.Bytes(), &response)
-	require.NoError(t, err, "Response should be valid JSON")
-}
-
-// TestGetActiveAudioDevice tests the GetActiveAudioDevice endpoint
-func TestGetActiveAudioDevice(t *testing.T) {
-	t.Parallel()
-	t.Attr("component", "system")
-	t.Attr("type", "integration")
-	t.Attr("feature", "audio-device")
-
-	t.Run("With configured device", func(t *testing.T) {
-		e, controller := setupSystemTestEnvironment(t)
-		// Settings already have a device configured
-
-		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetPath("/api/v2/system/audio/active")
-
-		err := controller.GetActiveAudioDevice(c)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, rec.Code)
-
-		var response map[string]any
-		err = json.Unmarshal(rec.Body.Bytes(), &response)
-		require.NoError(t, err)
-
-		// Should have device info
-		assert.Contains(t, response, "device", "Response should contain device")
-		assert.Contains(t, response, "active", "Response should contain active flag")
-	})
-
-	t.Run("No device configured", func(t *testing.T) {
-		e := echo.New()
-		settings := &conf.Settings{
-			Realtime: conf.RealtimeSettings{
-				Audio: conf.AudioSettings{
-					Source: "", // No device configured
-				},
-			},
-		}
-		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
-		controller.Settings.Store(settings)
-
-		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		c.SetPath("/api/v2/system/audio/active")
-
-		err := controller.GetActiveAudioDevice(c)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, rec.Code)
-
-		var response map[string]any
-		err = json.Unmarshal(rec.Body.Bytes(), &response)
-		require.NoError(t, err)
-
-		// Should indicate no device active
-		active, ok := response["active"].(bool)
-		require.True(t, ok, "response should have 'active' field as bool")
-		assert.False(t, active, "Should not be active when no device configured")
-		msg, ok := response["message"].(string)
-		require.True(t, ok, "response should have 'message' field as string")
-		assert.Contains(t, msg, "No audio device", "Should have appropriate message")
 	})
 }
 

--- a/internal/api/v2/system/terminal.go
+++ b/internal/api/v2/system/terminal.go
@@ -1,5 +1,5 @@
-// terminal.go — platform-agnostic terminal WebSocket handler.
-package api
+// terminal.go - platform-agnostic terminal WebSocket handler.
+package system
 
 import (
 	"encoding/json"
@@ -19,7 +19,7 @@ import (
 const (
 	terminalWriteWait  = 10 * time.Second
 	terminalPongWait   = 60 * time.Second
-	terminalPingPeriod = (terminalPongWait * 9) / 10 // 54s — must be < pongWait
+	terminalPingPeriod = (terminalPongWait * 9) / 10 // 54s - must be < pongWait
 	terminalMaxMsgSize = 32 * 1024                   // 32KB max message
 )
 
@@ -37,7 +37,7 @@ var terminalUpgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		// Validate Origin against Host to prevent Cross-Site WebSocket Hijacking (CSWSH).
 		// Browsers set Origin on WebSocket upgrade; non-browser clients (curl, wscat) may
-		// omit it — we allow those through to support local tooling and API testing.
+		// omit it - we allow those through to support local tooling and API testing.
 		origin := r.Header.Get("Origin")
 		if origin == "" {
 			return true // non-browser client; auth middleware still enforces authentication
@@ -51,20 +51,9 @@ var terminalUpgrader = websocket.Upgrader{
 	},
 }
 
-// initTerminalRoutes registers the terminal WebSocket endpoint.
-func (c *Controller) initTerminalRoutes() {
-	c.LogInfoIfEnabled("Initializing terminal routes")
-
-	terminalGroup := c.Group.Group("/terminal")
-	protectedGroup := terminalGroup.Group("", c.AuthMiddleware)
-	protectedGroup.GET("/ws", c.HandleTerminalWS)
-
-	c.LogInfoIfEnabled("Terminal routes initialized successfully")
-}
-
 // HandleTerminalWS handles WebSocket connections for the browser terminal.
 // The terminal is only available when EnableTerminal is set in config.
-func (c *Controller) HandleTerminalWS(ctx echo.Context) error {
+func (c *Handler) HandleTerminalWS(ctx echo.Context) error {
 	settings := conf.Setting()
 	if settings == nil || !settings.WebServer.EnableTerminal {
 		return c.HandleErrorWithKey(ctx, nil, "Terminal is disabled. Enable it in settings.", http.StatusForbidden, notification.MsgErrTerminalDisabled, nil)
@@ -90,7 +79,7 @@ func (c *Controller) HandleTerminalWS(ctx echo.Context) error {
 	}
 	defer cleanup()
 
-	// writeMu serializes all WebSocket writes — gorilla/websocket requires
+	// writeMu serializes all WebSocket writes - gorilla/websocket requires
 	// at most one concurrent writer; we have both a PTY goroutine and a ping
 	// goroutine that write, so they must share this mutex.
 	var writeMu sync.Mutex

--- a/internal/api/v2/system/terminal_test.go
+++ b/internal/api/v2/system/terminal_test.go
@@ -1,4 +1,4 @@
-package api
+package system
 
 import (
 	"testing"

--- a/internal/api/v2/system/terminal_unix.go
+++ b/internal/api/v2/system/terminal_unix.go
@@ -1,7 +1,7 @@
 //go:build !windows
 
-// terminal_unix.go — Unix PTY implementation for the browser terminal.
-package api
+// terminal_unix.go - Unix PTY implementation for the browser terminal.
+package system
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 )
 
 // unixPTY wraps a Unix PTY file descriptor to satisfy ptyHandle.
-// Close is guarded by sync.Once for parity with windowsPTY —
+// Close is guarded by sync.Once for parity with windowsPTY -
 // double-closing a Unix fd can close a recycled fd belonging to
 // another goroutine.
 type unixPTY struct {

--- a/internal/api/v2/system/terminal_unix_test.go
+++ b/internal/api/v2/system/terminal_unix_test.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package api
+package system
 
 import (
 	"testing"

--- a/internal/api/v2/system/terminal_windows.go
+++ b/internal/api/v2/system/terminal_windows.go
@@ -1,7 +1,7 @@
 //go:build windows
 
-// terminal_windows.go — Windows ConPTY implementation for the browser terminal.
-package api
+// terminal_windows.go - Windows ConPTY implementation for the browser terminal.
+package system
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 
 // windowsPTY wraps a Windows ConPTY to satisfy ptyHandle.
 // Close is guarded by sync.Once because ConPty.Close() calls
-// windows.CloseHandle on raw handles — double-closing a Windows
+// windows.CloseHandle on raw handles - double-closing a Windows
 // handle is undefined behavior (it can close a recycled handle
 // belonging to another subsystem).
 type windowsPTY struct {

--- a/internal/api/v2/system/terminal_windows_test.go
+++ b/internal/api/v2/system/terminal_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package api
+package system
 
 import (
 	"testing"

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -1,0 +1,94 @@
+// internal/api/v2/system_routes.go
+package api
+
+import (
+	"github.com/tphakala/birdnet-go/internal/api/v2/system"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// MetricsHistoryMaxPoints re-exports the system domain's metrics-history ring
+// capacity so the parent server wiring (internal/api/server.go) keeps reading it
+// as apiv2.MetricsHistoryMaxPoints after the system domain extraction.
+const MetricsHistoryMaxPoints = system.MetricsHistoryMaxPoints
+
+// initSystemRoutes registers the /api/v2/system/* routes. The genuine
+// system-domain endpoints (info, resources, disks, jobs, processes, temperature,
+// database stats/backup, network interfaces, restart status, active models,
+// inference status, and the events sub-routes) live in the system package and
+// are registered by c.system.RegisterSystemRoutes. The remaining routes below
+// share the /system namespace but belong to domains not yet extracted into their
+// own packages; they stay here until their own phase:
+//   - GET /system/external-media -> media domain (external_media.go)
+//   - the /system/audio/* device routes -> audio/streaming domain (audio_devices.go,
+//     audio_sources.go)
+//   - /system/database/overview -> analytics domain (database_overview.go)
+//   - /system/database/{migration,backup,legacy} -> import domain
+//
+// Recreating the /system group and its auth-protected subgroup here (in addition
+// to the one RegisterSystemRoutes creates) is safe: Echo deduplicates the group
+// not-found stubs by method+path, and the metrics-history initializer already
+// creates a second /system group today.
+func (c *Controller) initSystemRoutes() {
+	// System-domain routes + CPU sampler live in the system package.
+	c.system.RegisterSystemRoutes(c.Group)
+
+	systemGroup := c.Group.Group("/system")
+	authMiddleware := c.AuthMiddleware
+	protectedGroup := systemGroup.Group("", authMiddleware)
+
+	// External media status (media domain).
+	protectedGroup.GET("/external-media", c.GetExternalMedia)
+
+	// Audio device routes (audio/streaming domain).
+	audioGroup := protectedGroup.Group("/audio")
+	audioGroup.GET("/devices", c.GetAudioDevices)
+	audioGroup.GET("/devices/capabilities", c.GetDeviceCapabilities)
+	audioGroup.GET("/active", c.GetActiveAudioDevice)
+	audioGroup.GET("/equalizer/config", c.GetEqualizerConfig)
+	audioGroup.GET("/sources", c.ListAudioSources)
+
+	// Database overview (analytics domain).
+	c.initDatabaseOverviewRoutes()
+
+	// Migration, async backup and legacy cleanup routes (import domain).
+	c.initMigrationRoutes()
+	c.initBackupRoutes()
+	c.initLegacyCleanupRoutes()
+}
+
+// BroadcastInferenceTopologyChanged signals all metrics-stream SSE clients that
+// the inference topology (models or source attachment) changed so they re-fetch
+// the /api/v2/system/inference snapshot. Safe to call when the controller, its
+// core, or its metrics store is nil. It stays on the facade (rather than moving
+// to apicore with the other broadcasters, or into the system domain package) to
+// preserve its nil-*Controller-safe contract: promotion of a *Core method would
+// dereference the embedded core on a nil *Controller before the guard could run.
+// It is part of the external surface: internal/analysis calls it through
+// *apiv2.Controller.
+func (c *Controller) BroadcastInferenceTopologyChanged() {
+	if c == nil || c.Core == nil || c.MetricsStore == nil {
+		return
+	}
+	c.MetricsStore.BroadcastTopologyChanged()
+}
+
+// HealthMetricsStore returns the diagnostics health metrics store owned by the
+// system domain handler, or nil if it has not been initialized. It is part of the
+// external surface: internal/analysis feeds health samples into the same store the
+// health checks read by calling it through *apiv2.Controller.
+func (c *Controller) HealthMetricsStore() *observability.HealthMetricsStore {
+	if c == nil || c.system == nil {
+		return nil
+	}
+	return c.system.HealthMetricsStore()
+}
+
+// HealthEventBuffer returns the diagnostics health event buffer owned by the
+// system domain handler, or nil if it has not been initialized. Part of the
+// external surface used by internal/analysis through *apiv2.Controller.
+func (c *Controller) HealthEventBuffer() *observability.HealthEventBuffer {
+	if c == nil || c.system == nil {
+		return nil
+	}
+	return c.system.HealthEventBuffer()
+}


### PR DESCRIPTION
Move the system-information domain handlers out of the monolithic facade
package `api` into a new `internal/api/v2/system` package, following the
established domain-extraction pattern (Handler embeds `*apicore.Core` by pointer
and exposes `Register*Routes`). This is the `system` slice of the api/v2 split.

## What moved into internal/api/v2/system (package `system`)

- System info endpoints (`system.go`): `/system/info`, `/resources`, `/disks`,
  `/jobs`, `/processes`, `/temperature/cpu`, `/database/stats`,
  `/database/v2/stats`, `POST /database/backup`, `/network-interfaces`,
  `/restart-status`, plus `/system/models` (system_models.go) and
  `/system/inference` (inference_status.go).
- Events (`events.go`, `events_aggregation.go`): `/system/events/detections`,
  `/system/events/operational`.
- Diagnostics (`diagnostics.go`): the health-check infrastructure and
  `/system/diagnostics/*` endpoints, with the `HealthMetricsStore()` /
  `HealthEventBuffer()` accessors.
- Metrics history (`metrics_history.go`): `/system/metrics/history` and the
  `/system/metrics/stream` SSE endpoint (rate limiter preserved verbatim).
- Browser terminal (`terminal.go`, `terminal_unix.go`, `terminal_windows.go`):
  `/terminal/ws`.

Handlers are receiver-retyped `*Controller` -> `*Handler` with bodies verbatim.
The four route initializers are kept as separate ordered `Register*Routes`
entries (system, terminal, diagnostics, metrics-history) at the same ordinal
positions in the facade `routeInitializers` slice, so route order is preserved.

## Inference / broadcaster handling

`BroadcastInferenceTopologyChanged` deliberately stays on the facade
(`*Controller`, system_routes.go) with its nil-receiver guard, because promoting
it to a `*Core` method would dereference the embedded core on a nil `*Controller`
before the guard could run; it is called externally by `internal/analysis`. Only
the `GetInferenceStatus` endpoint and its snapshot helpers moved to the system
package.

## Health infrastructure

The five diagnostics health fields (registry, report store, error buffer, metrics
store, event buffer) moved onto `system.Handler`, which owns them. The facade
keeps thin nil-guarded delegators `HealthMetricsStore()` / `HealthEventBuffer()`
so the analysis pipeline keeps reading them through `*apiv2.Controller`.
`WithHealthErrorBuffer` now seeds `c.healthErrorBuf`, which is injected into
`system.New`.

## Lifecycle

The CPU-usage sampler and the metrics-history collector run via the shared core's
`Go()` (tracked by the core WaitGroup and bound to the core context), so the
existing facade `Shutdown()` tears them down exactly as before; no teardown was
dropped.

## Shared substrate promoted to apicore

- `cpu_cache.go`: `CPUCache`, `UpdateCPUCache`, `GetCachedCPUUsage` (consumed by
  the facade `/health` endpoint and the moved system handlers).
- `format.go`: `FormatBytesUint64` (shared by the system db handlers and the
  package-api async backup handlers).
- `system_shared.go`: `MetricsCollectorInterval` (shared with the analytics
  database-overview sparkline math) and `DBTypeLegacy` / `DBTypeV2`.

## Stays in package api

- The `/system/audio/*` device handlers (`audio_devices.go`) and the
  external-media endpoint belong to the audio/streaming and media domains and are
  registered by a trimmed `initSystemRoutes` (system_routes.go) until those
  domains are extracted. `process_cache.go` stays as well: its `processingCache`
  is consumed only by `media.go` (clip processing) and the cleanup lifecycle, not
  by any system handler, so it will extract with the media domain.
- `apiv2.MetricsHistoryMaxPoints` is re-exported as an alias to keep
  `internal/api/server.go` compiling. Two now-orphaned constants
  (`SecondsPerHour`, `MillisecondsPerSecond`, only used by the moved code) were
  dropped from the facade `constants.go`.

## No public-behavior change

`apiv2.Controller` / `New` / `NewWithOptions` signatures, the route set, all JSON
contracts, per-route middleware, and the external methods
(`BroadcastInferenceTopologyChanged`, `HealthMetricsStore`, `HealthEventBuffer`,
`MetricsHistoryMaxPoints`, `RestartHLSStreams`) are unchanged. The
route-enumeration golden test is byte-identical.

## Preflight Status

- Single concern: one refactor (extract the system domain).
- `go build ./...` clean; `go vet ./internal/api/v2/... ./internal/analysis/...`
  clean (copylocks).
- `go test -race` green for `./internal/api/v2/`, `./internal/api/v2/system/`,
  `./internal/api/v2/apicore/`, and `./internal/analysis/...`. The system domain
  has its own `-race` binary with a goleak `TestMain`.
- Route-enumeration golden test identical (sorted method+path set).
- `golangci-lint run` reports 0 issues.
- No regression / backward-compat break: no config/DB/API contract change, no
  changed default; external Go surface preserved.
- No new user-facing strings; no secrets/PII.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system audio device endpoints, including device listing, capability checks, active device status, and equalizer config access.
  * Added broader system and metrics pages, plus live metrics streaming and terminal access under the system area.
  * Added cached CPU usage and improved backup size display for clearer system reporting.

* **Bug Fixes**
  * Improved handling when no audio device is configured or a device can’t be verified.
  * Made system health and diagnostics responses more reliable and consistent.

* **Documentation**
  * Updated endpoint documentation headings to match current source locations.

* **Tests**
  * Added coverage for audio, metrics, diagnostics, terminal, and topology update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->