### PR TITLE
refactor(api/v2): extract audio and streaming domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -252,7 +252,7 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 | GET    | `/soundlevels/stream` | `StreamSoundLevels` | ❌⚡ | Real-time audio level stream |
 | GET    | `/sse/status`         | `GetSSEStatus`      | ❌   | SSE connection status        |
 
-### Audio Level SSE (`audio_level.go`) and Stream Sources (`audio_sources.go`)
+### Audio Level SSE (`audio/audio_level.go`) and Stream Sources (`audio/audio_sources.go`)
 
 | Method | Route                  | Handler             | Auth | Description                              |
 | ------ | ---------------------- | ------------------- | ---- | ---------------------------------------- |
@@ -300,7 +300,7 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 
 Returns an empty `sources` array when no sources are configured. The `type` field is one of: `rtsp`, `http`, `hls`, `rtmp`, `udp`, `audio_card`, `file`. The `state` field is one of: `inactive`, `starting`, `running`, `error`, `stopped`. The `/streams/sources` endpoint returns only stream types (excludes `audio_card` and `file`).
 
-### HLS Streaming (`audio_hls.go`)
+### HLS Streaming (`audio/audio_hls.go`)
 
 | Method | Route                                       | Handler            | Auth               | Description                   |
 | ------ | ------------------------------------------- | ------------------ | ------------------ | ----------------------------- |
@@ -377,7 +377,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 - `SegmentLength`: HLS segment duration in seconds (default: 2, range: 1-30)
 - `FfmpegLogLevel`: FFmpeg log level (default: "warning")
 
-### Stream Health Monitoring (`streams_health.go`)
+### Stream Health Monitoring (`audio/streams_health.go`)
 
 | Method | Route                    | Handler                   | Auth | Description                                                                          |
 | ------ | ------------------------ | ------------------------- | ---- | ------------------------------------------------------------------------------------ |
@@ -387,7 +387,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 | GET    | `/streams/health/stream` | `StreamHealthUpdates`     | ✅⚡ | Real-time stream health updates via SSE (settings page, not dashboard)               |
 | POST   | `/streams/test`          | `TestStream`              | ✅   | Test a stream URL to verify connectivity and discover audio properties (sample rate, codec, bat compatibility) |
 
-### Quiet Hours Status (`quiet_hours.go`)
+### Quiet Hours Status (`audio/quiet_hours.go`)
 
 | Method | Route                         | Handler               | Auth | Description                                                                                                             |
 | ------ | ----------------------------- | --------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------- |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/alerts"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	audioapi "github.com/tphakala/birdnet-go/internal/api/v2/audio"
 	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
 	"github.com/tphakala/birdnet-go/internal/api/v2/control"
 	"github.com/tphakala/birdnet-go/internal/api/v2/detections"
@@ -155,6 +156,17 @@ type Controller struct {
 	// internal/analysis owns and closes it).
 	control *control.Handler
 
+	// audio serves the audio/streaming domain: the live audio-level SSE stream and
+	// stream-source listing, the HLS streaming endpoints (incl. the bespoke
+	// stream-token playlist/segment serving and the publicLiveAudio dynamic auth
+	// gate), the stream health/test endpoints, quiet-hours status, the audio
+	// liveness health endpoint, and the /system/audio device/source endpoints.
+	// Beyond the shared *apicore.Core it owns the HLS manager and audio-level
+	// broadcaster singletons; the facade exposes RestartHLSStreams/SetAudioWatchdog/
+	// SetAudioLevelChan delegators for the internal/analysis and parent-server
+	// callers.
+	audio *audioapi.Handler
+
 	controlChan chan string
 
 	// DisableSaveSettings prevents persisting settings changes to disk.
@@ -208,11 +220,6 @@ type Controller struct {
 	// Audio processing fields
 	processingCache     *processingCache
 	processingSemaphore chan struct{}
-
-	// probeStreamInfo probes a live stream's audio characteristics for the
-	// stream-test endpoint. Nil in production, where TestStream falls back to
-	// ffmpeg.ProbeStreamInfo; tests set it to stub probing without ffprobe.
-	probeStreamInfo probeStreamInfoFunc
 
 	// Legacy cleanup state tracker
 	cleanupStatus *CleanupStatus
@@ -523,6 +530,16 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// handlers that still resolve the service via getNotificationService().
 	c.notifications = notifications.New(c.Core, c.notificationService, c.authService)
 
+	// Construct the audio/streaming domain handler AFTER the functional options are
+	// applied so it captures the post-option authService (used by the public
+	// audio-level stream and quiet-hours status to anonymize source names / stream
+	// URLs for unauthenticated callers; nil-guarded). authService never changes
+	// after this point, so capturing it is behaviorally identical to the monolith's
+	// per-request reads. The audio Engine/AudioWatchdog atomic pointers and the
+	// Settings/AuthMiddleware helpers promote from c.Core; the live audio-level
+	// channel is wired later via SetAudioLevelChan.
+	c.audio = audioapi.New(c.Core, c.authService)
+
 	// Log auth configuration status
 	log := GetLogger()
 	if c.AuthMiddleware != nil {
@@ -557,7 +574,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// c.startTime is set (the diagnostics uptime check captures the pointer). It
 	// owns the diagnostics health infrastructure; its routes are registered in
 	// initRoutes below.
-	c.system = system.New(c.Core, c.startTime, c.healthErrorBuf, LatestAudioLevels)
+	c.system = system.New(c.Core, c.startTime, c.healthErrorBuf, audioapi.LatestAudioLevels)
 
 	// Initialize routes if requested (skip in tests to avoid starting background goroutines)
 	if initializeRoutes {
@@ -598,15 +615,16 @@ func (c *Controller) initRoutes() {
 		{"analytics routes", c.initAnalyticsRoutes},
 		{"weather routes", func() { c.weather.RegisterRoutes(c.Group) }},
 		{"system routes", c.initSystemRoutes},
+		{"audio device routes", func() { c.audio.RegisterAudioDeviceRoutes(c.Group) }},
 		{"terminal routes", func() { c.system.RegisterTerminalRoutes(c.Group) }},
 		{"settings routes", c.initSettingsRoutes},
 		{"filesystem routes", func() { c.filesystem.RegisterRoutes(c.Group) }},
-		{"stream health routes", c.initStreamHealthRoutes},
-		{"stream test routes", c.initStreamTestRoutes},
-		{"audio health routes", c.initAudioHealthRoutes},
-		{"quiet hours routes", c.initQuietHoursRoutes},
-		{"audio level routes", c.initAudioLevelRoutes},
-		{"hls streaming routes", c.initHLSRoutes},
+		{"stream health routes", func() { c.audio.RegisterStreamHealthRoutes(c.Group) }},
+		{"stream test routes", func() { c.audio.RegisterStreamTestRoutes(c.Group) }},
+		{"audio health routes", func() { c.audio.RegisterAudioHealthRoutes(c.Group) }},
+		{"quiet hours routes", func() { c.audio.RegisterQuietHoursRoutes(c.Group) }},
+		{"audio level routes", func() { c.audio.RegisterAudioLevelRoutes(c.Group) }},
+		{"hls streaming routes", func() { c.audio.RegisterHLSRoutes(c.Group) }},
 		{"integration routes", func() { c.integrations.RegisterRoutes(c.Group) }},
 		{"control routes", func() { c.control.RegisterRoutes(c.Group) }},
 		{"auth routes", func() { c.authHandler.RegisterRoutes(c.Group) }},

--- a/internal/api/v2/audio/audio_devices.go
+++ b/internal/api/v2/audio/audio_devices.go
@@ -1,5 +1,5 @@
-// internal/api/v2/audio_devices.go
-package api
+// internal/api/v2/audio/audio_devices.go
+package audio
 
 import (
 	goerrors "errors"
@@ -18,9 +18,24 @@ import (
 // This file holds the /api/v2/system/audio/* device-management handlers
 // (GetAudioDevices, GetDeviceCapabilities, GetActiveAudioDevice,
 // GetEqualizerConfig). They physically lived in system.go but belong to the
-// audio/streaming domain; they stay in package api until that domain is
-// extracted in its own phase. They are registered by the trimmed initSystemRoutes
-// in system_routes.go.
+// audio/streaming domain; they moved here with the audio domain extraction and
+// are registered by RegisterAudioDeviceRoutes.
+
+// RegisterAudioDeviceRoutes registers the /api/v2/system/audio/* device-management
+// endpoints. It recreates the /system group and its auth-protected subgroup; the
+// system domain handler and the facade's /system/external-media registration each
+// create their own /system group too, and Echo deduplicates the resulting group
+// not-found stubs by method+path, so the registered route set is unchanged.
+func (c *Handler) RegisterAudioDeviceRoutes(g *echo.Group) {
+	systemGroup := g.Group("/system")
+	protectedGroup := systemGroup.Group("", c.AuthMiddleware)
+	audioGroup := protectedGroup.Group("/audio")
+	audioGroup.GET("/devices", c.GetAudioDevices)
+	audioGroup.GET("/devices/capabilities", c.GetDeviceCapabilities)
+	audioGroup.GET("/active", c.GetActiveAudioDevice)
+	audioGroup.GET("/equalizer/config", c.GetEqualizerConfig)
+	audioGroup.GET("/sources", c.ListAudioSources)
+}
 
 // Audio device constants
 const (
@@ -56,7 +71,7 @@ type ActiveAudioDevice struct {
 }
 
 // GetAudioDevices handles GET /api/v2/system/audio/devices
-func (c *Controller) GetAudioDevices(ctx echo.Context) error {
+func (c *Handler) GetAudioDevices(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Getting audio devices",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -115,7 +130,7 @@ func (c *Controller) GetAudioDevices(ctx echo.Context) error {
 
 // GetDeviceCapabilities handles GET /api/v2/system/audio/devices/capabilities
 // Probes a specific audio device to discover supported sample rates.
-func (c *Controller) GetDeviceCapabilities(ctx echo.Context) error {
+func (c *Handler) GetDeviceCapabilities(ctx echo.Context) error {
 	deviceID := ctx.QueryParam("deviceId")
 	if deviceID == "" {
 		return c.HandleError(ctx, nil, "deviceId query parameter is required", http.StatusBadRequest)
@@ -150,7 +165,7 @@ func (c *Controller) GetDeviceCapabilities(ctx echo.Context) error {
 }
 
 // GetActiveAudioDevice handles GET /api/v2/system/audio/active
-func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
+func (c *Handler) GetActiveAudioDevice(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Getting active audio device",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -205,11 +220,11 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 
 		// OS-specific additional checks
 		switch runtime.GOOS {
-		case OSWindows:
+		case osWindows:
 			diagnostics["note"] = "On Windows, check that audio drivers are properly installed and the device is not disabled in Sound settings"
-		case OSDarwin:
+		case osDarwin:
 			diagnostics["note"] = "On macOS, check System Preferences > Sound and ensure the device has proper permissions"
-		case OSLinux:
+		case osLinux:
 			diagnostics["note"] = "On Linux, check if PulseAudio/ALSA is running and the user has proper permissions"
 		}
 
@@ -299,7 +314,7 @@ func (c *Controller) GetActiveAudioDevice(ctx echo.Context) error {
 }
 
 // GetEqualizerConfig handles GET /api/v2/system/audio/equalizer/config
-func (c *Controller) GetEqualizerConfig(ctx echo.Context) error {
+func (c *Handler) GetEqualizerConfig(ctx echo.Context) error {
 	c.LogInfoIfEnabled("Getting equalizer filter configuration",
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),

--- a/internal/api/v2/audio/audio_devices_test.go
+++ b/internal/api/v2/audio/audio_devices_test.go
@@ -1,6 +1,6 @@
 // audio_devices_test.go: tests for the /system/audio/* device handlers that
 // stay in package api until the audio/streaming domain is extracted.
-package api
+package audio
 
 import (
 	"encoding/json"
@@ -16,7 +16,7 @@ import (
 )
 
 // setupSystemTestEnvironment creates a test environment for system API tests
-func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
+func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Handler) {
 	t.Helper()
 
 	e := echo.New()
@@ -29,7 +29,7 @@ func setupSystemTestEnvironment(t *testing.T) (*echo.Echo, *Controller) {
 		},
 	}
 
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(settings)
 
 	return e, controller
@@ -100,7 +100,7 @@ func TestGetActiveAudioDevice(t *testing.T) {
 				},
 			},
 		}
-		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+		controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 		controller.Settings.Store(settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/active", http.NoBody)

--- a/internal/api/v2/audio/audio_health.go
+++ b/internal/api/v2/audio/audio_health.go
@@ -1,4 +1,4 @@
-package api
+package audio
 
 import (
 	"net/http"
@@ -12,18 +12,18 @@ type AudioHealthResponse struct {
 	Sources []audiocore.SourceHealthSnapshot `json:"sources"`
 }
 
-// initAudioHealthRoutes registers the audio liveness health endpoints.
-func (c *Controller) initAudioHealthRoutes() {
-	c.Group.GET("/health/audio", c.GetAudioHealth, c.AuthMiddleware)
+// RegisterAudioHealthRoutes registers the audio liveness health endpoints.
+func (c *Handler) RegisterAudioHealthRoutes(g *echo.Group) {
+	g.GET("/health/audio", c.GetAudioHealth, c.AuthMiddleware)
 }
 
 // SetAudioWatchdog injects the liveness watchdog for the health endpoint.
-func (c *Controller) SetAudioWatchdog(w *audiocore.LivenessWatchdog) {
+func (c *Handler) SetAudioWatchdog(w *audiocore.LivenessWatchdog) {
 	c.AudioWatchdog.Store(w)
 }
 
 // GetAudioHealth returns the current liveness state for all monitored audio sources.
-func (c *Controller) GetAudioHealth(ctx echo.Context) error {
+func (c *Handler) GetAudioHealth(ctx echo.Context) error {
 	w := c.AudioWatchdog.Load()
 	if w == nil {
 		return ctx.JSON(http.StatusOK, AudioHealthResponse{

--- a/internal/api/v2/audio/audio_health_test.go
+++ b/internal/api/v2/audio/audio_health_test.go
@@ -1,4 +1,4 @@
-package api
+package audio
 
 import (
 	"encoding/json"
@@ -9,12 +9,21 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
+// newAudioHealthTestHandler builds a minimal audio Handler around an isolated
+// apitest core for the health endpoint tests (GetAudioHealth reads only the
+// AudioWatchdog atomic pointer on the shared core).
+func newAudioHealthTestHandler(t *testing.T, e *echo.Echo) *Handler {
+	t.Helper()
+	return &Handler{Core: apitest.NewCore(t, apitest.WithEcho(e))}
+}
+
 func TestGetAudioHealth_NoWatchdog(t *testing.T) {
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newAudioHealthTestHandler(t, e)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/health/audio", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -31,7 +40,7 @@ func TestGetAudioHealth_NoWatchdog(t *testing.T) {
 
 func TestGetAudioHealth_WithWatchdog(t *testing.T) {
 	e := echo.New()
-	c := getTestController(t, e)
+	c := newAudioHealthTestHandler(t, e)
 
 	router := audiocore.NewAudioRouter(audiocore.GetLogger(), nil)
 	defer router.Close()

--- a/internal/api/v2/audio/audio_hls.go
+++ b/internal/api/v2/audio/audio_hls.go
@@ -1,5 +1,5 @@
-// internal/api/v2/audio_hls.go
-package api
+// internal/api/v2/audio/audio_hls.go
+package audio
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
@@ -144,7 +144,7 @@ type HLSHeartbeatRequest struct {
 }
 
 // hlsManager manages HLS streaming state
-// TODO: Consider moving to Controller struct for better encapsulation
+// TODO: Consider moving to Handler struct for better encapsulation
 type hlsManager struct {
 	// Active streams indexed by sourceID
 	streams   map[string]*HLSStreamInfo
@@ -182,7 +182,7 @@ type hlsManager struct {
 }
 
 // Global HLS manager instance
-// TODO: Consider moving to Controller struct for better encapsulation
+// TODO: Consider moving to Handler struct for better encapsulation
 var hlsMgr = &hlsManager{
 	streams:        make(map[string]*HLSStreamInfo),
 	clients:        make(map[string]map[string]bool),
@@ -195,51 +195,52 @@ var hlsMgr = &hlsManager{
 }
 
 // HLS route path fragments, registered relative to the v2 API group in
-// initHLSRoutes. They are reused by isPrivateModeExempt so the PrivateMode
-// exempt allow-list cannot drift from the registered routes.
+// RegisterHLSRoutes. They are exported so the facade's isPrivateModeExempt
+// allow-list (which still lives in package api) cannot drift from the routes
+// registered here.
 const (
-	hlsGroupPath      = "/streams/hls"
-	hlsTokenGroupPath = "/t"
-	hlsStartPath      = "/:sourceID/start"
-	hlsStopPath       = "/:sourceID/stop"
-	hlsHeartbeatPath  = "/heartbeat"
-	hlsStatusPath     = "/status"
-	hlsPlaylistPath   = "/:streamToken/playlist.m3u8"
-	hlsContentPath    = "/:streamToken/*"
+	HLSGroupPath      = "/streams/hls"
+	HLSTokenGroupPath = "/t"
+	HLSStartPath      = "/:sourceID/start"
+	HLSStopPath       = "/:sourceID/stop"
+	HLSHeartbeatPath  = "/heartbeat"
+	HLSStatusPath     = "/status"
+	HLSPlaylistPath   = "/:streamToken/playlist.m3u8"
+	HLSContentPath    = "/:streamToken/*"
 )
 
 // hlsPlaylistURL builds the client-facing playlist URL for a stream token from
 // the same route constants used to register the playlist route (see
-// initHLSRoutes), so the emitted URL cannot drift from the actual route on a
+// RegisterHLSRoutes), so the emitted URL cannot drift from the actual route on a
 // prefix or fragment rename.
 func hlsPlaylistURL(token string) string {
-	tokenPath := strings.Replace(hlsPlaylistPath, ":streamToken", token, 1)
-	return apiV2Prefix + hlsGroupPath + hlsTokenGroupPath + tokenPath
+	tokenPath := strings.Replace(HLSPlaylistPath, ":streamToken", token, 1)
+	return apiV2Prefix + HLSGroupPath + HLSTokenGroupPath + tokenPath
 }
 
-// initHLSRoutes registers HLS streaming endpoints
-func (c *Controller) initHLSRoutes() {
+// RegisterHLSRoutes registers HLS streaming endpoints
+func (c *Handler) RegisterHLSRoutes(g *echo.Group) {
 	// Get authentication middleware
 	authMiddleware := c.AuthMiddleware
 
 	// HLS base group (no auth by default)
-	hlsGroup := c.Group.Group(hlsGroupPath)
+	hlsGroup := g.Group(HLSGroupPath)
 
 	// Stream control endpoints
 	// Start uses dynamic middleware that checks PublicAccess.LiveAudio per-request,
 	// so changes take effect immediately without server restart.
 	// Stop always requires authentication to prevent abuse.
-	hlsGroup.POST(hlsStartPath, c.StartHLSStream, c.publicLiveAudioAuth)
-	hlsGroup.POST(hlsStopPath, c.StopHLSStream, authMiddleware)
+	hlsGroup.POST(HLSStartPath, c.StartHLSStream, c.publicLiveAudioAuth)
+	hlsGroup.POST(HLSStopPath, c.StopHLSStream, authMiddleware)
 
 	// Auth-gated endpoints
-	hlsGroup.POST(hlsHeartbeatPath, c.HLSHeartbeat, c.publicLiveAudioAuth)
-	hlsGroup.GET(hlsStatusPath, c.GetHLSStatus, c.publicLiveAudioAuth)
+	hlsGroup.POST(HLSHeartbeatPath, c.HLSHeartbeat, c.publicLiveAudioAuth)
+	hlsGroup.GET(HLSStatusPath, c.GetHLSStatus, c.publicLiveAudioAuth)
 
 	// Token-based content serving
-	hlsTokenGroup := hlsGroup.Group(hlsTokenGroupPath)
-	hlsTokenGroup.GET(hlsPlaylistPath, c.ServeHLSPlaylist)
-	hlsTokenGroup.GET(hlsContentPath, c.ServeHLSContent)
+	hlsTokenGroup := hlsGroup.Group(HLSTokenGroupPath)
+	hlsTokenGroup.GET(HLSPlaylistPath, c.ServeHLSPlaylist)
+	hlsTokenGroup.GET(HLSContentPath, c.ServeHLSContent)
 
 	// Start the HLS activity sync goroutine (only once across all controller instances)
 	hlsMgr.activitySyncOnce.Do(func() {
@@ -253,7 +254,7 @@ func (c *Controller) initHLSRoutes() {
 // on each request. When enabled, the request proceeds without authentication.
 // When disabled, the standard auth middleware is applied. This allows the setting
 // to take effect immediately without a server restart.
-func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc {
+func (c *Handler) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		isPublic := c.CurrentSettings().Security.PublicAccess.LiveAudio
 		if isPublic {
@@ -261,54 +262,6 @@ func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc
 		}
 		return c.AuthMiddleware(next)(ctx)
 	}
-}
-
-// isPrivateModeExempt returns true for v2 API (method, route pattern)
-// pairs that must remain reachable without authentication even when
-// PrivateMode is on. Two categories are exempt:
-//
-//  1. Bootstrap and auth flow paths so the frontend can fetch /app/config
-//     and complete a login (including OAuth callback) from an unauthenticated
-//     state.
-//  2. Live audio (HLS) paths that already have their own publicLiveAudioAuth
-//     middleware. Letting them through privateModeAuth preserves the
-//     PublicAccess.LiveAudio carve-out: when LiveAudio is enabled the route
-//     stays public, when it is disabled the per-route middleware applies
-//     authMiddleware as before.
-//
-// The allow-list is keyed on method + path so any future handler added
-// at one of these paths under a different verb is fail-closed by default.
-func isPrivateModeExempt(method, path string) bool {
-	// Compose the exempt paths from the same constants used at the route
-	// registration sites (see initHLSRoutes, the auth domain's RegisterRoutes and
-	// the app config route in initAppRoutes) so the allow-list cannot silently
-	// drift from the actual routes. The auth route fragments are sourced from the
-	// authapi package, which both registers the routes and owns the constants.
-	// TestPrivateModeExemptPathsAreRegisteredRoutes asserts this correspondence.
-	const (
-		authBase     = apiV2Prefix + authapi.AuthGroupPath
-		hlsBase      = apiV2Prefix + hlsGroupPath
-		hlsTokenBase = hlsBase + hlsTokenGroupPath
-	)
-	switch {
-	case method == http.MethodGet && path == apiV2Prefix+AppConfigEndpoint:
-		return true
-	case method == http.MethodPost && path == authBase+authapi.AuthLoginPath:
-		return true
-	case method == http.MethodGet && path == authBase+authapi.AuthCallbackPath:
-		return true
-	case method == http.MethodPost && path == hlsBase+hlsStartPath:
-		return true
-	case method == http.MethodPost && path == hlsBase+hlsHeartbeatPath:
-		return true
-	case method == http.MethodGet && path == hlsBase+hlsStatusPath:
-		return true
-	case method == http.MethodGet && path == hlsTokenBase+hlsPlaylistPath:
-		return true
-	case method == http.MethodGet && path == hlsTokenBase+hlsContentPath:
-		return true
-	}
-	return false
 }
 
 // generateStreamToken creates a crypto-random 32-character hex token for stream URL access.
@@ -367,7 +320,7 @@ func removeStreamToken(sourceID string) {
 
 // StartHLSStream initiates an HLS stream for a specific audio source
 // POST /api/v2/streams/hls/:sourceID/start
-func (c *Controller) StartHLSStream(ctx echo.Context) error {
+func (c *Handler) StartHLSStream(ctx echo.Context) error {
 	sourceID, err := c.validateAndDecodeSourceID(ctx)
 	if err != nil {
 		return err
@@ -376,13 +329,13 @@ func (c *Controller) StartHLSStream(ctx echo.Context) error {
 	// Bind optional request body for session_id
 	var req HLSSessionRequest
 	if err := ctx.Bind(&req); err != nil {
-		GetLogger().Debug("Failed to bind start request body", logger.Error(err))
+		apicore.GetLogger().Debug("Failed to bind start request body", logger.Error(err))
 	}
 
 	clientID := c.resolveClientID(ctx, req.SessionID)
 
 	// Check for force restart query param
-	forceRestart := ctx.QueryParam("force") == QueryValueTrue
+	forceRestart := ctx.QueryParam("force") == queryValueTrue
 
 	// Only allow force restart for authenticated users to prevent DoS
 	// (force kills the FFmpeg process and spawns a new one)
@@ -439,7 +392,7 @@ func (c *Controller) StartHLSStream(ctx echo.Context) error {
 }
 
 // buildHLSStreamResponse constructs the HLS stream status response
-func (c *Controller) buildHLSStreamResponse(ctx echo.Context, sourceID string, stream *HLSStreamInfo, playlistReady ...bool) error {
+func (c *Handler) buildHLSStreamResponse(ctx echo.Context, sourceID string, stream *HLSStreamInfo, playlistReady ...bool) error {
 	// Get client count
 	clientCount := getStreamClientCount(sourceID)
 
@@ -488,7 +441,7 @@ func (c *Controller) buildHLSStreamResponse(ctx echo.Context, sourceID string, s
 }
 
 // checkHLSPlaylistReady checks if the playlist file exists and is valid
-func (c *Controller) checkHLSPlaylistReady(stream *HLSStreamInfo) bool {
+func (c *Handler) checkHLSPlaylistReady(stream *HLSStreamInfo) bool {
 	if stream == nil || stream.PlaylistPath == "" {
 		return false
 	}
@@ -504,7 +457,7 @@ func (c *Controller) checkHLSPlaylistReady(stream *HLSStreamInfo) bool {
 	}
 	defer func() {
 		if err := secFS.Close(); err != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
 		}
 	}()
 
@@ -522,7 +475,7 @@ func (c *Controller) checkHLSPlaylistReady(stream *HLSStreamInfo) bool {
 
 // StopHLSStream stops an HLS stream for a specific client
 // POST /api/v2/streams/hls/:sourceID/stop
-func (c *Controller) StopHLSStream(ctx echo.Context) error {
+func (c *Handler) StopHLSStream(ctx echo.Context) error {
 	sourceID, err := c.validateAndDecodeSourceID(ctx)
 	if err != nil {
 		return err
@@ -531,7 +484,7 @@ func (c *Controller) StopHLSStream(ctx echo.Context) error {
 	// Bind optional request body for session_id
 	var req HLSSessionRequest
 	if err := ctx.Bind(&req); err != nil {
-		GetLogger().Debug("Failed to bind stop request body", logger.Error(err))
+		apicore.GetLogger().Debug("Failed to bind stop request body", logger.Error(err))
 	}
 
 	clientID := c.resolveClientID(ctx, req.SessionID)
@@ -555,7 +508,7 @@ func (c *Controller) StopHLSStream(ctx echo.Context) error {
 
 // HLSHeartbeat processes client heartbeat to keep streams alive
 // POST /api/v2/streams/hls/heartbeat
-func (c *Controller) HLSHeartbeat(ctx echo.Context) error {
+func (c *Handler) HLSHeartbeat(ctx echo.Context) error {
 	var heartbeat HLSHeartbeatRequest
 	if err := ctx.Bind(&heartbeat); err != nil {
 		return c.HandleError(ctx, err, "Invalid heartbeat format", http.StatusBadRequest)
@@ -571,7 +524,7 @@ func (c *Controller) HLSHeartbeat(ctx echo.Context) error {
 	clientID := c.resolveClientID(ctx, heartbeat.SessionID)
 
 	// Handle disconnection announcements
-	if ctx.QueryParam("disconnect") == QueryValueTrue || ctx.QueryParam("status") == "disconnect" {
+	if ctx.QueryParam("disconnect") == queryValueTrue || ctx.QueryParam("status") == "disconnect" {
 		return c.handleHLSDisconnect(ctx, sourceID, clientID)
 	}
 
@@ -592,7 +545,7 @@ func (c *Controller) HLSHeartbeat(ctx echo.Context) error {
 
 // GetHLSStatus returns the status of all active HLS streams
 // GET /api/v2/streams/hls/status
-func (c *Controller) GetHLSStatus(ctx echo.Context) error {
+func (c *Handler) GetHLSStatus(ctx echo.Context) error {
 	hlsMgr.streamsMu.RLock()
 	// Copy stream references under lock to minimize lock duration
 	streamsCopy := make(map[string]*HLSStreamInfo, len(hlsMgr.streams))
@@ -633,7 +586,7 @@ func (c *Controller) GetHLSStatus(ctx echo.Context) error {
 
 // ServeHLSPlaylist serves the HLS playlist file
 // GET /api/v2/streams/hls/t/:streamToken/playlist.m3u8
-func (c *Controller) ServeHLSPlaylist(ctx echo.Context) error {
+func (c *Handler) ServeHLSPlaylist(ctx echo.Context) error {
 	streamToken := ctx.Param("streamToken")
 	sourceID := resolveStreamToken(streamToken)
 	if sourceID == "" {
@@ -646,7 +599,7 @@ func (c *Controller) ServeHLSPlaylist(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Stream not found", http.StatusNotFound)
 	}
 
-	// Update stream-level activity (no client registration — lifecycle managed by start/stop/heartbeat)
+	// Update stream-level activity (no client registration - lifecycle managed by start/stop/heartbeat)
 	c.updateStreamActivity(sourceID)
 
 	// Get HLS base directory
@@ -662,7 +615,7 @@ func (c *Controller) ServeHLSPlaylist(ctx echo.Context) error {
 	}
 	defer func() {
 		if err := secFS.Close(); err != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
 		}
 	}()
 
@@ -708,7 +661,7 @@ func (c *Controller) ServeHLSPlaylist(ctx echo.Context) error {
 
 	serveDuration := time.Since(serveStart)
 	if serveDuration > hlsServeSlowThreshold {
-		GetLogger().Warn("Slow playlist serve (disk read + PDT correction + network write)",
+		apicore.GetLogger().Warn("Slow playlist serve (disk read + PDT correction + network write)",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.String("serve_duration", serveDuration.String()))
 	}
@@ -719,7 +672,7 @@ func (c *Controller) ServeHLSPlaylist(ctx echo.Context) error {
 // correctPlaylistPDT adjusts PROGRAM_DATE_TIME tags in the playlist to compensate
 // for FFmpeg's process startup delay. On the first successful parse, it computes
 // the offset between FFmpeg's clock and wall time, then applies it to all PDT tags.
-func (c *Controller) correctPlaylistPDT(stream *HLSStreamInfo, playlist string) string {
+func (c *Handler) correctPlaylistPDT(stream *HLSStreamInfo, playlist string) string {
 	// If we don't know when first audio data arrived, return unmodified
 	if stream.firstDataTime.Load() == 0 {
 		return playlist
@@ -742,7 +695,7 @@ func (c *Controller) correctPlaylistPDT(stream *HLSStreamInfo, playlist string) 
 		// Only the first goroutine to succeed sets the offset
 		if stream.pdtOffsetComputed.CompareAndSwap(false, true) {
 			stream.pdtOffset.Store(int64(offset))
-			GetLogger().Info("HLS PDT correction computed",
+			apicore.GetLogger().Info("HLS PDT correction computed",
 				logger.String("source_id", privacy.SanitizeRTSPUrl(stream.SourceID)),
 				logger.String("hls_head", hlsNow.UTC().Format(time.RFC3339Nano)),
 				logger.String("wall_clock", wallNow.UTC().Format(time.RFC3339Nano)),
@@ -809,7 +762,7 @@ func parsePlaylistSegments(playlist string) []hlsSegment {
 				curPDT = parsePDT(val)
 			}
 		case line != "" && !strings.HasPrefix(line, "#"):
-			// Segment URI — flush
+			// Segment URI - flush
 			if hasDur && !curPDT.IsZero() {
 				segments = append(segments, hlsSegment{pdt: curPDT, duration: curDur})
 			}
@@ -857,7 +810,7 @@ func rewritePDTTags(playlist string, offset time.Duration) string {
 
 // ServeHLSContent serves HLS segment files
 // GET /api/v2/streams/hls/t/:streamToken/*
-func (c *Controller) ServeHLSContent(ctx echo.Context) error {
+func (c *Handler) ServeHLSContent(ctx echo.Context) error {
 	streamToken := ctx.Param("streamToken")
 	sourceID := resolveStreamToken(streamToken)
 	if sourceID == "" {
@@ -878,7 +831,7 @@ func (c *Controller) ServeHLSContent(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Stream not found", http.StatusNotFound)
 	}
 
-	// Update stream-level activity (no client registration — lifecycle managed by start/stop/heartbeat)
+	// Update stream-level activity (no client registration - lifecycle managed by start/stop/heartbeat)
 	c.updateStreamActivity(sourceID)
 
 	// Log client connection (rate-limited)
@@ -897,7 +850,7 @@ func (c *Controller) ServeHLSContent(ctx echo.Context) error {
 	}
 	defer func() {
 		if err := secFS.Close(); err != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
 		}
 	}()
 
@@ -951,7 +904,7 @@ func (c *Controller) ServeHLSContent(ctx echo.Context) error {
 	serveErr := secFS.ServeFile(ctx, segmentPath)
 	serveDuration := time.Since(serveStart)
 	if serveDuration > hlsServeSlowThreshold {
-		GetLogger().Warn("Slow segment serve (disk read + network write)",
+		apicore.GetLogger().Warn("Slow segment serve (disk read + network write)",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.String("serve_duration", serveDuration.String()),
 			logger.String("segment", safeRequestPath))
@@ -962,7 +915,7 @@ func (c *Controller) ServeHLSContent(ctx echo.Context) error {
 // Helper methods
 
 // validateAndDecodeSourceID extracts and validates the sourceID parameter
-func (c *Controller) validateAndDecodeSourceID(ctx echo.Context) (string, error) {
+func (c *Handler) validateAndDecodeSourceID(ctx echo.Context) (string, error) {
 	sourceIDParam := ctx.Param("sourceID")
 
 	decodedSourceID, err := url.PathUnescape(sourceIDParam)
@@ -979,7 +932,7 @@ func (c *Controller) validateAndDecodeSourceID(ctx echo.Context) (string, error)
 
 // generateClientID creates a standardized client identifier
 // Uses RemoteAddr (not RealIP) for consistency with audio_level.go to prevent IP spoofing
-func (c *Controller) generateClientID(ctx echo.Context) string {
+func (c *Handler) generateClientID(ctx echo.Context) string {
 	clientIP := c.extractRemoteAddr(ctx)
 	userAgent := ctx.Request().Header.Get("User-Agent")
 
@@ -999,7 +952,7 @@ func (c *Controller) generateClientID(ctx echo.Context) string {
 // resolveClientID returns a client identifier, preferring session-based ID when available.
 // Session ID is validated as a UUID and prefixed with IP to prevent spoofing.
 // Invalid or missing session IDs fall back to IP+UA-based identification.
-func (c *Controller) resolveClientID(ctx echo.Context, sessionID string) string {
+func (c *Handler) resolveClientID(ctx echo.Context, sessionID string) string {
 	if sessionID != "" {
 		if _, err := uuid.Parse(sessionID); err == nil {
 			return c.extractRemoteAddr(ctx) + "-" + sessionID
@@ -1017,12 +970,12 @@ func generateFilesystemSafeName(input string) string {
 
 // setHLSHeaders sets common HLS response headers
 // Note: CORS is handled by middleware at the v2 group level
-func (c *Controller) setHLSHeaders(ctx echo.Context) {
+func (c *Handler) setHLSHeaders(ctx echo.Context) {
 	// HLS-specific headers only; CORS is handled by middleware
 }
 
 // getEffectiveSegmentLength returns the configured segment length with defaults and limits applied
-func (c *Controller) getEffectiveSegmentLength() int {
+func (c *Handler) getEffectiveSegmentLength() int {
 	segmentLength := c.CurrentSettings().WebServer.LiveStream.SegmentLength
 	switch {
 	case segmentLength < hlsMinSegmentLen:
@@ -1035,7 +988,7 @@ func (c *Controller) getEffectiveSegmentLength() int {
 }
 
 // setHLSContentType sets appropriate content type based on file extension
-func (c *Controller) setHLSContentType(ctx echo.Context, path string) {
+func (c *Handler) setHLSContentType(ctx echo.Context, path string) {
 	switch filepath.Ext(path) {
 	case ".ts":
 		ctx.Response().Header().Set("Content-Type", "video/mp2t")
@@ -1060,7 +1013,7 @@ var lastFreshnessCheck sync.Map // sourceID → time.Time
 // it logs a warning indicating FFmpeg may be blocked (e.g., SD card I/O stall).
 // The threshold is derived from the configured segment length to avoid false positives.
 // Rate-limited to avoid adding I/O load on every playlist poll.
-func (c *Controller) checkSegmentFreshness(outputDir, sourceID string) {
+func (c *Handler) checkSegmentFreshness(outputDir, sourceID string) {
 	now := time.Now()
 	if v, ok := lastFreshnessCheck.Load(sourceID); ok {
 		if now.Sub(v.(time.Time)) < hlsFreshnessCheckInterval {
@@ -1071,7 +1024,7 @@ func (c *Controller) checkSegmentFreshness(outputDir, sourceID string) {
 
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
-		return // Don't log errors for diagnostics — the caller handles missing dirs
+		return // Don't log errors for diagnostics - the caller handles missing dirs
 	}
 
 	var newestMod time.Time
@@ -1101,7 +1054,7 @@ func (c *Controller) checkSegmentFreshness(outputDir, sourceID string) {
 	age := time.Since(newestMod)
 	freshnessThreshold := time.Duration(c.getEffectiveSegmentLength()*hlsSegmentFreshnessMultiplier) * time.Second
 	if age > freshnessThreshold {
-		GetLogger().Warn("Stale HLS segments detected (FFmpeg may be blocked on I/O)",
+		apicore.GetLogger().Warn("Stale HLS segments detected (FFmpeg may be blocked on I/O)",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.String("newest_segment", newestName),
 			logger.String("segment_age", age.Truncate(time.Millisecond).String()))
@@ -1113,7 +1066,7 @@ func (c *Controller) checkSegmentFreshness(outputDir, sourceID string) {
 // getOrCreateHLSStream gets existing stream or creates a new one.
 // Uses singleflight to serialize creation per sourceID, preventing concurrent
 // goroutines from racing on directory creation and FFmpeg spawning.
-func (c *Controller) getOrCreateHLSStream(sourceID string) (*HLSStreamInfo, error) {
+func (c *Handler) getOrCreateHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	// Fast-path: existing stream (no singleflight overhead)
 	if stream := c.getHLSStream(sourceID); stream != nil {
 		return stream, nil
@@ -1135,7 +1088,7 @@ func (c *Controller) getOrCreateHLSStream(sourceID string) (*HLSStreamInfo, erro
 
 // forceCreateHLSStream cleans up any existing stream and creates a new one,
 // atomically under the singleflight gate to prevent cleanup/creation races.
-func (c *Controller) forceCreateHLSStream(sourceID string) (*HLSStreamInfo, error) {
+func (c *Handler) forceCreateHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	result, err, _ := hlsMgr.streamCreate.Do(sourceID, func() (any, error) {
 		// Phase 1: Synchronous cleanup under singleflight serialization.
 		// This prevents a concurrent request from creating a new stream
@@ -1157,8 +1110,8 @@ func (c *Controller) forceCreateHLSStream(sourceID string) (*HLSStreamInfo, erro
 }
 
 // createHLSStream creates a new HLS stream (called under singleflight serialization).
-func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
-	GetLogger().Info("Creating new HLS stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+func (c *Handler) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
+	apicore.GetLogger().Info("Creating new HLS stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 
 	// Generate filesystem-safe name
 	filesystemSafeID := generateFilesystemSafeName(sourceID)
@@ -1183,7 +1136,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	}
 	defer func() {
 		if err := secFS.Close(); err != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
 		}
 	}()
 
@@ -1205,7 +1158,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	fifoPath, pipeName, err := c.setupHLSFifo(secFS, hlsBaseDir, outputDir)
 	if err != nil {
 		if removeErr := secFS.RemoveAll(outputDir); removeErr != nil {
-			GetLogger().Error("Failed to remove output directory", logger.Error(removeErr))
+			apicore.GetLogger().Error("Failed to remove output directory", logger.Error(removeErr))
 		}
 		streamCancel()
 		return nil, err
@@ -1215,7 +1168,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	// On Windows, setupWindowsAudioFeed writes audio data to FFmpeg's stdin,
 	// so FFmpeg must read from "pipe:0" (stdin) rather than the named pipe.
 	readerPath := fifoPath
-	if runtime.GOOS == OSWindows {
+	if runtime.GOOS == osWindows {
 		readerPath = "pipe:0"
 	}
 
@@ -1227,7 +1180,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	}
 
 	// Setup Windows-specific stdin pipe handling
-	if runtime.GOOS == OSWindows {
+	if runtime.GOOS == osWindows {
 		if err := c.setupWindowsAudioFeed(streamCtx, sourceID, cmd); err != nil {
 			streamCancel()
 			return nil, err
@@ -1240,7 +1193,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	// its PROGRAM_DATE_TIME epoch aligns closely with the already-buffered audio,
 	// minimizing the PDT-to-wall-clock offset.
 	var feedResources *audioFeedResources
-	if runtime.GOOS != OSWindows {
+	if runtime.GOOS != osWindows {
 		var prepErr error
 		feedResources, prepErr = c.prepareAudioFeed(sourceID, pipeName)
 		if prepErr != nil {
@@ -1285,18 +1238,18 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 	// goroutine starts writing buffered audio to FFmpeg immediately.
 	// If the feed goroutine exits abnormally (not due to context cancellation),
 	// cancel the stream context to trigger cleanup via the context goroutine below.
-	if runtime.GOOS != OSWindows {
+	if runtime.GOOS != osWindows {
 		go func() {
 			c.runAudioFeedLoop(stream.ctx, sourceID, stream, feedResources)
 			if stream.ctx.Err() == nil {
-				GetLogger().Warn("Audio feed exited unexpectedly, cancelling stream",
+				apicore.GetLogger().Warn("Audio feed exited unexpectedly, cancelling stream",
 					logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 				stream.cancel()
 			}
 		}()
 	}
 
-	// Start context cleanup goroutine — pass stream pointer to verify identity
+	// Start context cleanup goroutine - pass stream pointer to verify identity
 	// before cleanup, preventing a force-restarted stream from being killed
 	// by the old stream's context cancellation goroutine.
 	go func(s *HLSStreamInfo) {
@@ -1317,7 +1270,7 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 }
 
 // prepareHLSDirectory creates and validates the output directory
-func (c *Controller) prepareHLSDirectory(secFS *securefs.SecureFS, hlsBaseDir, filesystemSafeID string) (outputDir, playlistPath string, err error) {
+func (c *Handler) prepareHLSDirectory(secFS *securefs.SecureFS, hlsBaseDir, filesystemSafeID string) (outputDir, playlistPath string, err error) {
 	outputDir = filepath.Join(hlsBaseDir, fmt.Sprintf("stream_%s", filesystemSafeID))
 
 	// Verify output directory is within HLS base
@@ -1337,7 +1290,7 @@ func (c *Controller) prepareHLSDirectory(secFS *securefs.SecureFS, hlsBaseDir, f
 	}
 
 	// Create directory
-	if err := secFS.MkdirAll(outputDir, FilePermExecutable); err != nil {
+	if err := secFS.MkdirAll(outputDir, filePermExecutable); err != nil {
 		return "", "", fmt.Errorf("failed to create HLS directory: %w", err)
 	}
 
@@ -1353,7 +1306,7 @@ func (c *Controller) prepareHLSDirectory(secFS *securefs.SecureFS, hlsBaseDir, f
 }
 
 // setupHLSFifo creates the FIFO pipe for audio streaming
-func (c *Controller) setupHLSFifo(secFS *securefs.SecureFS, hlsBaseDir, outputDir string) (fifoPath, pipeName string, err error) {
+func (c *Handler) setupHLSFifo(secFS *securefs.SecureFS, hlsBaseDir, outputDir string) (fifoPath, pipeName string, err error) {
 	fifoPath = filepath.Join(outputDir, "audio.pcm")
 
 	isWithin, pathErr := securefs.IsPathWithinBase(hlsBaseDir, fifoPath)
@@ -1370,7 +1323,7 @@ func (c *Controller) setupHLSFifo(secFS *securefs.SecureFS, hlsBaseDir, outputDi
 }
 
 // setupHLSFFmpeg creates the FFmpeg command
-func (c *Controller) setupHLSFFmpeg(ctx context.Context, ffmpegPath, inputSource, outputDir, playlistPath string) (*exec.Cmd, error) {
+func (c *Handler) setupHLSFFmpeg(ctx context.Context, ffmpegPath, inputSource, outputDir, playlistPath string) (*exec.Cmd, error) {
 	args := c.buildFFmpegArgs(inputSource, outputDir, playlistPath)
 	//nolint:gosec // G204: ffmpegPath is from admin config (Settings.Realtime.Audio.FfmpegPath), not user input
 	cmd := exec.CommandContext(ctx, ffmpegPath, args...)
@@ -1378,7 +1331,7 @@ func (c *Controller) setupHLSFFmpeg(ctx context.Context, ffmpegPath, inputSource
 	// Graceful shutdown: send SIGINT first (lets FFmpeg flush output buffers),
 	// escalate to SIGKILL after WaitDelay if it hasn't exited.
 	// Windows doesn't support SIGINT; exec.CommandContext defaults to TerminateProcess.
-	if runtime.GOOS != OSWindows {
+	if runtime.GOOS != osWindows {
 		cmd.Cancel = func() error {
 			if cmd.Process == nil {
 				return nil
@@ -1392,7 +1345,7 @@ func (c *Controller) setupHLSFFmpeg(ctx context.Context, ffmpegPath, inputSource
 }
 
 // buildFFmpegArgs constructs FFmpeg command line arguments
-func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string) []string {
+func (c *Handler) buildFFmpegArgs(inputSource, outputDir, playlistPath string) []string {
 	settings := c.CurrentSettings().WebServer.LiveStream
 
 	// Apply defaults and limits
@@ -1425,7 +1378,7 @@ func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string
 		}
 	}
 
-	logLevel := LogLevelWarning
+	logLevel := logLevelWarning
 	if settings.FfmpegLogLevel != "" {
 		logLevel = settings.FfmpegLogLevel
 	}
@@ -1448,7 +1401,7 @@ func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string
 	// but FFmpeg fails to create it when reading from a non-seekable source.
 	// Use MPEG-TS segments on Windows which are self-contained and don't need
 	// a separate initialization segment.
-	if runtime.GOOS == OSWindows {
+	if runtime.GOOS == osWindows {
 		args = append(args,
 			"-hls_flags", "delete_segments+program_date_time+independent_segments",
 			"-hls_segment_type", "mpegts",
@@ -1472,7 +1425,7 @@ func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string
 
 	// Segment filename extension matches the segment type
 	segExt := "m4s"
-	if runtime.GOOS == OSWindows {
+	if runtime.GOOS == osWindows {
 		segExt = "ts"
 	}
 	args = append(args,
@@ -1484,7 +1437,7 @@ func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string
 }
 
 // setupWindowsAudioFeed sets up audio feeding via stdin for Windows
-func (c *Controller) setupWindowsAudioFeed(ctx context.Context, sourceID string, cmd *exec.Cmd) error {
+func (c *Handler) setupWindowsAudioFeed(ctx context.Context, sourceID string, cmd *exec.Cmd) error {
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("failed to create stdin pipe: %w", err)
@@ -1493,14 +1446,14 @@ func (c *Controller) setupWindowsAudioFeed(ctx context.Context, sourceID string,
 	go func() {
 		defer func() {
 			if err := stdin.Close(); err != nil {
-				GetLogger().Error("Failed to close stdin", logger.Error(err))
+				apicore.GetLogger().Error("Failed to close stdin", logger.Error(err))
 			}
 		}()
-		GetLogger().Debug("Starting audio feed via stdin", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+		apicore.GetLogger().Debug("Starting audio feed via stdin", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 
 		audioChan, cleanup, err := c.setupAudioCallback(sourceID)
 		if err != nil {
-			GetLogger().Error("Error setting up audio callback", logger.Error(err))
+			apicore.GetLogger().Error("Error setting up audio callback", logger.Error(err))
 			return
 		}
 		defer cleanup()
@@ -1508,11 +1461,11 @@ func (c *Controller) setupWindowsAudioFeed(ctx context.Context, sourceID string,
 		for {
 			select {
 			case <-ctx.Done():
-				GetLogger().Debug("Audio feed terminated due to context cancellation", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+				apicore.GetLogger().Debug("Audio feed terminated due to context cancellation", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 				return
 			case data, ok := <-audioChan:
 				if !ok {
-					GetLogger().Debug("Audio channel closed", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+					apicore.GetLogger().Debug("Audio channel closed", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 					return
 				}
 
@@ -1520,7 +1473,7 @@ func (c *Controller) setupWindowsAudioFeed(ctx context.Context, sourceID string,
 				for written < len(data) {
 					n, err := stdin.Write(data[written:])
 					if err != nil {
-						GetLogger().Error("Error writing to FFmpeg stdin", logger.Error(err))
+						apicore.GetLogger().Error("Error writing to FFmpeg stdin", logger.Error(err))
 						return
 					}
 					written += n
@@ -1535,7 +1488,7 @@ func (c *Controller) setupWindowsAudioFeed(ctx context.Context, sourceID string,
 // setupFFmpegLogging configures FFmpeg output logging and starts the FFmpeg process.
 // Returns the log file which must be closed by the caller after the process exits.
 // The caller is responsible for calling cmd.Wait() and then closing the returned file.
-func (c *Controller) setupFFmpegLogging(secFS *securefs.SecureFS, cmd *exec.Cmd, hlsBaseDir, outputDir string) (*os.File, error) {
+func (c *Handler) setupFFmpegLogging(secFS *securefs.SecureFS, cmd *exec.Cmd, hlsBaseDir, outputDir string) (*os.File, error) {
 	logFilePath := filepath.Join(outputDir, "ffmpeg.log")
 
 	isWithin, err := securefs.IsPathWithinBase(hlsBaseDir, logFilePath)
@@ -1543,7 +1496,7 @@ func (c *Controller) setupFFmpegLogging(secFS *securefs.SecureFS, cmd *exec.Cmd,
 		return nil, fmt.Errorf("security error: log file path outside HLS base")
 	}
 
-	logFile, err := secFS.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, FilePermReadWrite)
+	logFile, err := secFS.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, filePermReadWrite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ffmpeg log file: %w", err)
 	}
@@ -1553,12 +1506,12 @@ func (c *Controller) setupFFmpegLogging(secFS *securefs.SecureFS, cmd *exec.Cmd,
 
 	if err := cmd.Start(); err != nil {
 		if closeErr := logFile.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close log file", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close log file", logger.Error(closeErr))
 		}
 		return nil, fmt.Errorf("failed to start FFmpeg: %w", err)
 	}
 
-	GetLogger().Debug("FFmpeg process started", logger.String("output_dir", outputDir))
+	apicore.GetLogger().Debug("FFmpeg process started", logger.String("output_dir", outputDir))
 	return logFile, nil
 }
 
@@ -1615,7 +1568,7 @@ func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocriti
 			dropped = true
 		default:
 		}
-		// Non-blocking send — drop if still full
+		// Non-blocking send - drop if still full
 		select {
 		case h.ch <- buf:
 		default:
@@ -1627,10 +1580,10 @@ func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocriti
 			now := time.Now()
 			if now.Sub(h.lastDropLog) >= hlsDropLogInterval {
 				sanitizedID := privacy.SanitizeRTSPUrl(h.sourceID)
-				GetLogger().Warn("HLS audio data dropped: channel full",
+				apicore.GetLogger().Warn("HLS audio data dropped: channel full",
 					logger.String("source_id", sanitizedID),
 					logger.Int64("drops_since_last_log", h.dropCount),
-					logger.Int("channel_cap", DefaultReadBufferSize))
+					logger.Int("channel_cap", defaultReadBufferSize))
 				h.dropCount = 0
 				h.lastDropLog = now
 			}
@@ -1647,8 +1600,8 @@ func (h *hlsConsumer) Close() error {
 }
 
 // setupAudioCallback sets up the audio callback channel using the AudioRouter.
-func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte, cleanup func(), err error) {
-	audioChan = make(chan []byte, DefaultReadBufferSize)
+func (c *Handler) setupAudioCallback(sourceID string) (audioChan chan []byte, cleanup func(), err error) {
+	audioChan = make(chan []byte, defaultReadBufferSize)
 
 	consumerID := fmt.Sprintf("hls_%s_%s", privacy.SanitizeStreamUrl(sourceID), uuid.New().String()[:8])
 	// Use the configured live stream sample rate, falling back to the default HLS sample rate.
@@ -1692,7 +1645,7 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	if src != nil && src.SampleRate > 0 {
 		sourceSampleRate = src.SampleRate
 	} else {
-		GetLogger().Warn("Audio source sample rate unavailable, falling back to HLS target rate", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.Int("fallback_rate", sampleRate))
+		apicore.GetLogger().Warn("Audio source sample rate unavailable, falling back to HLS target rate", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.Int("fallback_rate", sampleRate))
 	}
 
 	// Add route on the AudioRouter
@@ -1700,11 +1653,11 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 		return nil, nil, fmt.Errorf("failed to add HLS route: %w", routeErr)
 	}
 
-	GetLogger().Debug("Registered HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
+	apicore.GetLogger().Debug("Registered HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
 
 	cleanup = func() {
 		eng.Router().RemoveRoute(sourceID, consumerID)
-		GetLogger().Debug("Removed HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
+		apicore.GetLogger().Debug("Removed HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
 	}
 
 	return audioChan, cleanup, nil
@@ -1749,9 +1702,9 @@ type audioFeedResources struct {
 // It must be called BEFORE FFmpeg starts so that audio data begins buffering
 // in the channel immediately. The returned resources are consumed by
 // runAudioFeedLoop, which should be started as a goroutine after cmd.Start().
-func (c *Controller) prepareAudioFeed(sourceID, pipePath string) (*audioFeedResources, error) {
+func (c *Handler) prepareAudioFeed(sourceID, pipePath string) (*audioFeedResources, error) {
 	sanitizedID := privacy.SanitizeRTSPUrl(sourceID)
-	GetLogger().Debug("Preparing audio feed", logger.String("source_id", sanitizedID), logger.String("pipe_path", pipePath))
+	apicore.GetLogger().Debug("Preparing audio feed", logger.String("source_id", sanitizedID), logger.String("pipe_path", pipePath))
 
 	hlsBaseDir, err := conf.GetHLSDirectory()
 	if err != nil {
@@ -1768,7 +1721,7 @@ func (c *Controller) prepareAudioFeed(sourceID, pipePath string) (*audioFeedReso
 	audioChan, callbackCleanup, err := c.setupAudioCallback(sourceID)
 	if err != nil {
 		if closeErr := secFS.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
 		}
 		return nil, fmt.Errorf("error setting up audio callback: %w", err)
 	}
@@ -1782,7 +1735,7 @@ func (c *Controller) prepareAudioFeed(sourceID, pipePath string) (*audioFeedReso
 	if err != nil {
 		callbackCleanup()
 		if closeErr := secFS.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
 		}
 		return nil, fmt.Errorf("error opening pipe: %w", err)
 	}
@@ -1794,15 +1747,15 @@ func (c *Controller) prepareAudioFeed(sourceID, pipePath string) (*audioFeedReso
 		cleanup: func() {
 			callbackCleanup()
 			if closeErr := fifo.Close(); closeErr != nil {
-				GetLogger().Error("Failed to close FIFO", logger.Error(closeErr))
+				apicore.GetLogger().Error("Failed to close FIFO", logger.Error(closeErr))
 			}
 			if closeErr := secFS.Close(); closeErr != nil {
-				GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
+				apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
 			}
 		},
 	}
 
-	GetLogger().Debug("Audio feed prepared, callback registered and FIFO open",
+	apicore.GetLogger().Debug("Audio feed prepared, callback registered and FIFO open",
 		logger.String("source_id", sanitizedID))
 	return res, nil
 }
@@ -1810,11 +1763,11 @@ func (c *Controller) prepareAudioFeed(sourceID, pipePath string) (*audioFeedReso
 // runAudioFeedLoop reads audio data from the pre-registered callback channel
 // and writes it to the FIFO pipe. It takes ownership of the audioFeedResources
 // and releases them on exit. Must be called as a goroutine after FFmpeg starts.
-func (c *Controller) runAudioFeedLoop(ctx context.Context, sourceID string, stream *HLSStreamInfo, res *audioFeedResources) {
+func (c *Handler) runAudioFeedLoop(ctx context.Context, sourceID string, stream *HLSStreamInfo, res *audioFeedResources) {
 	defer res.cleanup()
 
 	sanitizedID := privacy.SanitizeRTSPUrl(sourceID)
-	GetLogger().Debug("Audio feed loop starting", logger.String("source_id", sanitizedID))
+	apicore.GetLogger().Debug("Audio feed loop starting", logger.String("source_id", sanitizedID))
 
 	dataWritten := false
 	var totalWrites int64
@@ -1824,7 +1777,7 @@ func (c *Controller) runAudioFeedLoop(ctx context.Context, sourceID string, stre
 
 	// Always log exit stats regardless of how the feed stops
 	defer func() {
-		GetLogger().Debug("Audio feed stats on exit",
+		apicore.GetLogger().Debug("Audio feed stats on exit",
 			logger.String("source_id", sanitizedID),
 			logger.Int64("total_fifo_writes", totalWrites),
 			logger.Int64("slow_fifo_writes", slowWrites),
@@ -1834,21 +1787,21 @@ func (c *Controller) runAudioFeedLoop(ctx context.Context, sourceID string, stre
 	for {
 		select {
 		case <-ctx.Done():
-			GetLogger().Debug("Audio feed stopped due to context cancellation",
+			apicore.GetLogger().Debug("Audio feed stopped due to context cancellation",
 				logger.String("source_id", sanitizedID))
 			return
 		case data, ok := <-res.audioChan:
 			if !ok {
-				GetLogger().Debug("Audio channel closed", logger.String("source_id", sanitizedID))
+				apicore.GetLogger().Debug("Audio channel closed", logger.String("source_id", sanitizedID))
 				return
 			}
 
 			writeStart := time.Now()
 			if err := writeToFIFO(ctx, res.fifo, data); err != nil {
 				if ctx.Err() != nil {
-					GetLogger().Debug("Audio feed stopped due to context cancellation", logger.String("source_id", sanitizedID))
+					apicore.GetLogger().Debug("Audio feed stopped due to context cancellation", logger.String("source_id", sanitizedID))
 				} else {
-					GetLogger().Error("Error writing to FIFO", logger.Error(err),
+					apicore.GetLogger().Error("Error writing to FIFO", logger.Error(err),
 						logger.String("write_duration", time.Since(writeStart).String()))
 				}
 				return
@@ -1867,7 +1820,7 @@ func (c *Controller) runAudioFeedLoop(ctx context.Context, sourceID string, stre
 				now := time.Now()
 				if now.Sub(lastSlowWriteLog) >= hlsDropLogInterval {
 					lastSlowWriteLog = now
-					GetLogger().Warn("Slow FIFO write detected (possible I/O stall)",
+					apicore.GetLogger().Warn("Slow FIFO write detected (possible I/O stall)",
 						logger.String("source_id", sanitizedID),
 						logger.String("write_duration", writeDuration.String()),
 						logger.Int("data_bytes", len(data)),
@@ -1878,7 +1831,7 @@ func (c *Controller) runAudioFeedLoop(ctx context.Context, sourceID string, stre
 
 			if !dataWritten {
 				stream.firstDataTime.Store(writeStart.UnixNano())
-				GetLogger().Debug("First audio data written", logger.String("source_id", sanitizedID),
+				apicore.GetLogger().Debug("First audio data written", logger.String("source_id", sanitizedID),
 					logger.String("first_data_time", writeStart.UTC().Format(time.RFC3339Nano)))
 				dataWritten = true
 			}
@@ -1889,7 +1842,7 @@ func (c *Controller) runAudioFeedLoop(ctx context.Context, sourceID string, stre
 // Activity and client management
 
 // updateHLSActivity records activity for a stream
-func (c *Controller) updateHLSActivity(sourceID, clientID, activityType string, gracePeriod ...time.Duration) {
+func (c *Handler) updateHLSActivity(sourceID, clientID, activityType string, gracePeriod ...time.Duration) {
 	// Track client
 	if clientID != "" {
 		hlsMgr.clientsMu.Lock()
@@ -1920,21 +1873,21 @@ func (c *Controller) updateHLSActivity(sourceID, clientID, activityType string, 
 // updateStreamActivity updates stream-level activity without registering a client.
 // Used by playlist/segment handlers where session context is not available,
 // preventing ghost client entries from non-session-aware traffic.
-func (c *Controller) updateStreamActivity(sourceID string) {
+func (c *Handler) updateStreamActivity(sourceID string) {
 	hlsMgr.activityMu.Lock()
 	hlsMgr.activity[sourceID] = time.Now()
 	hlsMgr.activityMu.Unlock()
 }
 
 // getHLSStream returns the stream info if it exists
-func (c *Controller) getHLSStream(sourceID string) *HLSStreamInfo {
+func (c *Handler) getHLSStream(sourceID string) *HLSStreamInfo {
 	hlsMgr.streamsMu.RLock()
 	defer hlsMgr.streamsMu.RUnlock()
 	return hlsMgr.streams[sourceID]
 }
 
 // hlsStreamExists checks if a stream exists
-func (c *Controller) hlsStreamExists(sourceID string) bool {
+func (c *Handler) hlsStreamExists(sourceID string) bool {
 	hlsMgr.streamsMu.RLock()
 	defer hlsMgr.streamsMu.RUnlock()
 	_, exists := hlsMgr.streams[sourceID]
@@ -1942,7 +1895,7 @@ func (c *Controller) hlsStreamExists(sourceID string) bool {
 }
 
 // removeHLSClient removes a client from tracking, returns true if last client
-func (c *Controller) removeHLSClient(sourceID, clientID string) bool {
+func (c *Handler) removeHLSClient(sourceID, clientID string) bool {
 	hlsMgr.clientsMu.Lock()
 	defer hlsMgr.clientsMu.Unlock()
 
@@ -1957,7 +1910,7 @@ func (c *Controller) removeHLSClient(sourceID, clientID string) bool {
 }
 
 // handleHLSDisconnect handles client disconnect announcements
-func (c *Controller) handleHLSDisconnect(ctx echo.Context, sourceID, clientID string) error {
+func (c *Handler) handleHLSDisconnect(ctx echo.Context, sourceID, clientID string) error {
 	// Check for premature disconnect
 	hlsMgr.activityMu.Lock()
 	if lastTime, exists := hlsMgr.clientActivity[sourceID+":"+clientID]; exists {
@@ -1982,7 +1935,7 @@ func (c *Controller) handleHLSDisconnect(ctx echo.Context, sourceID, clientID st
 // Cleanup methods
 
 // cleanupExistingHLSStream cleans up an existing stream before restart
-func (c *Controller) cleanupExistingHLSStream(sourceID string) {
+func (c *Handler) cleanupExistingHLSStream(sourceID string) {
 	hlsMgr.streamsMu.Lock()
 	stream, exists := hlsMgr.streams[sourceID]
 	if !exists {
@@ -1990,7 +1943,7 @@ func (c *Controller) cleanupExistingHLSStream(sourceID string) {
 		return
 	}
 
-	GetLogger().Debug("Cleaning up existing stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+	apicore.GetLogger().Debug("Cleaning up existing stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 
 	if stream.cancel != nil {
 		stream.cancel()
@@ -2011,14 +1964,14 @@ func (c *Controller) cleanupExistingHLSStream(sourceID string) {
 	// so that cmd.Cancel/cmd.WaitDelay escalation to SIGKILL works correctly.
 	if cmd != nil {
 		if err := cmd.Wait(); err != nil {
-			GetLogger().Debug("FFmpeg process exited during cleanup", logger.Error(err))
+			apicore.GetLogger().Debug("FFmpeg process exited during cleanup", logger.Error(err))
 		}
 	}
 
 	// Close log file after process exits (must be done after Wait())
 	if logFile != nil {
 		if closeErr := logFile.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close log file", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close log file", logger.Error(closeErr))
 		}
 	}
 
@@ -2029,12 +1982,12 @@ func (c *Controller) cleanupExistingHLSStream(sourceID string) {
 			if secFS, err := securefs.New(hlsBaseDir); err == nil {
 				defer func() {
 					if closeErr := secFS.Close(); closeErr != nil {
-						GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
+						apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
 					}
 				}()
 				if secFS.ExistsNoErr(outputDir) {
 					if removeErr := secFS.RemoveAll(outputDir); removeErr != nil {
-						GetLogger().Error("Failed to remove output directory", logger.Error(removeErr))
+						apicore.GetLogger().Error("Failed to remove output directory", logger.Error(removeErr))
 					}
 				}
 			}
@@ -2043,7 +1996,7 @@ func (c *Controller) cleanupExistingHLSStream(sourceID string) {
 }
 
 // RestartHLSStreams stops all active HLS streams so they restart with fresh settings.
-func (c *Controller) RestartHLSStreams() {
+func (c *Handler) RestartHLSStreams() {
 	hlsMgr.streamsMu.Lock()
 	sourceIDs := slices.Collect(maps.Keys(hlsMgr.streams))
 	hlsMgr.streamsMu.Unlock()
@@ -2054,7 +2007,7 @@ func (c *Controller) RestartHLSStreams() {
 }
 
 // stopHLSStream stops a stream with a specific reason
-func (c *Controller) stopHLSStream(sourceID, reason string) {
+func (c *Handler) stopHLSStream(sourceID, reason string) {
 	hlsMgr.streamsMu.Lock()
 	stream, exists := hlsMgr.streams[sourceID]
 	if !exists {
@@ -2062,7 +2015,7 @@ func (c *Controller) stopHLSStream(sourceID, reason string) {
 		return
 	}
 
-	GetLogger().Info("Stopping HLS stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("reason", reason))
+	apicore.GetLogger().Info("Stopping HLS stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("reason", reason))
 	delete(hlsMgr.streams, sourceID)
 	removeStreamToken(sourceID)
 	hlsMgr.streamsMu.Unlock()
@@ -2071,8 +2024,8 @@ func (c *Controller) stopHLSStream(sourceID, reason string) {
 }
 
 // performHLSCleanup performs the actual cleanup of stream resources
-func (c *Controller) performHLSCleanup(sourceID string, stream *HLSStreamInfo, reason string) {
-	GetLogger().Debug("Performing HLS cleanup", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("reason", reason))
+func (c *Handler) performHLSCleanup(sourceID string, stream *HLSStreamInfo, reason string) {
+	apicore.GetLogger().Debug("Performing HLS cleanup", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("reason", reason))
 
 	// Cancel context
 	if stream.cancel != nil {
@@ -2088,13 +2041,13 @@ func (c *Controller) performHLSCleanup(sourceID string, stream *HLSStreamInfo, r
 	// Clean up tracking data
 	c.cleanupStreamTracking(sourceID)
 
-	GetLogger().Debug("HLS stream cleanup completed", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+	apicore.GetLogger().Debug("HLS stream cleanup completed", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 }
 
 // cleanupFFmpegProcess terminates the FFmpeg process and closes the log file.
 // Waits synchronously for the process to exit so that callers can safely
 // remove the output directory afterward (cmd.WaitDelay caps the wait at 5s).
-func (c *Controller) cleanupFFmpegProcess(sourceID string, stream *HLSStreamInfo) {
+func (c *Handler) cleanupFFmpegProcess(sourceID string, stream *HLSStreamInfo) {
 	if stream.FFmpegCmd != nil && stream.FFmpegCmd.Process != nil {
 		c.waitForFFmpegProcess(sourceID, stream.FFmpegCmd, stream.logFile)
 		return
@@ -2106,12 +2059,12 @@ func (c *Controller) cleanupFFmpegProcess(sourceID string, stream *HLSStreamInfo
 // waitForFFmpegProcess waits for FFmpeg to exit and cleans up resources.
 // Uses cmd.Wait() (not cmd.Process.Wait()) so that cmd.Cancel/cmd.WaitDelay
 // escalation to SIGKILL works correctly.
-func (c *Controller) waitForFFmpegProcess(sourceID string, cmd *exec.Cmd, logFile *os.File) {
+func (c *Handler) waitForFFmpegProcess(sourceID string, cmd *exec.Cmd, logFile *os.File) {
 	if err := cmd.Wait(); err != nil {
-		GetLogger().Debug("FFmpeg process exited", logger.Error(err))
+		apicore.GetLogger().Debug("FFmpeg process exited", logger.Error(err))
 	}
 	closeLogFile(logFile)
-	GetLogger().Debug("FFmpeg process terminated", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+	apicore.GetLogger().Debug("FFmpeg process terminated", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 }
 
 // closeLogFile safely closes a log file if it's not nil.
@@ -2120,17 +2073,17 @@ func closeLogFile(f *os.File) {
 		return
 	}
 	if err := f.Close(); err != nil {
-		GetLogger().Error("Failed to close log file", logger.Error(err))
+		apicore.GetLogger().Error("Failed to close log file", logger.Error(err))
 	}
 }
 
 // cleanupStreamTracking removes all tracking data for a stream.
-func (c *Controller) cleanupStreamTracking(sourceID string) {
+func (c *Handler) cleanupStreamTracking(sourceID string) {
 	cleanupStreamTrackingData(sourceID)
 }
 
 // cleanupStreamTrackingData removes all tracking data for a stream from the global manager.
-// Package-level function so it can be called from both Controller methods and standalone functions.
+// Package-level function so it can be called from both Handler methods and standalone functions.
 func cleanupStreamTrackingData(sourceID string) {
 	// Clean up client tracking
 	hlsMgr.clientsMu.Lock()
@@ -2151,7 +2104,7 @@ func cleanupStreamTrackingData(sourceID string) {
 }
 
 // waitForHLSPlaylist waits for the playlist file to be ready
-func (c *Controller) waitForHLSPlaylist(ctx echo.Context, sourceID string, stream *HLSStreamInfo) bool {
+func (c *Handler) waitForHLSPlaylist(ctx echo.Context, sourceID string, stream *HLSStreamInfo) bool {
 	hlsBaseDir, err := conf.GetHLSDirectory()
 	if err != nil {
 		return false
@@ -2163,7 +2116,7 @@ func (c *Controller) waitForHLSPlaylist(ctx echo.Context, sourceID string, strea
 	}
 	defer func() {
 		if err := secFS.Close(); err != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(err))
 		}
 	}()
 
@@ -2206,7 +2159,7 @@ func (c *Controller) waitForHLSPlaylist(ctx echo.Context, sourceID string, strea
 }
 
 // logHLSClientConnection logs client connections with rate limiting
-func (c *Controller) logHLSClientConnection(sourceID, clientIP, requestPath string) {
+func (c *Handler) logHLSClientConnection(sourceID, clientIP, requestPath string) {
 	logKey := sourceID + "-" + clientIP
 
 	hlsMgr.clientLogTimeMu.Lock()
@@ -2224,7 +2177,7 @@ func (c *Controller) logHLSClientConnection(sourceID, clientIP, requestPath stri
 		if strings.HasPrefix(requestPath, "segment00") {
 			streamStartMsg = " (streaming started)"
 		}
-		GetLogger().Info("HLS stream request",
+		apicore.GetLogger().Info("HLS stream request",
 			logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 			logger.String("client_ip", clientIP),
 			logger.String("status", streamStartMsg))
@@ -2232,7 +2185,7 @@ func (c *Controller) logHLSClientConnection(sourceID, clientIP, requestPath stri
 }
 
 // CleanupAllHLSStreams removes all HLS streams (called on shutdown)
-func (c *Controller) CleanupAllHLSStreams() error {
+func (c *Handler) CleanupAllHLSStreams() error {
 	// Clone and clear streams atomically using Go 1.21+ maps package
 	hlsMgr.streamsMu.Lock()
 	streamsToClean := maps.Clone(hlsMgr.streams)
@@ -2255,7 +2208,7 @@ func (c *Controller) CleanupAllHLSStreams() error {
 		return err
 	}
 
-	if runtime.GOOS == OSWindows {
+	if runtime.GOOS == osWindows {
 		securefs.CleanupNamedPipes()
 	}
 
@@ -2263,7 +2216,7 @@ func (c *Controller) CleanupAllHLSStreams() error {
 }
 
 // cleanupHLSDirectories removes all stream directories from the HLS base directory.
-func (c *Controller) cleanupHLSDirectories() error {
+func (c *Handler) cleanupHLSDirectories() error {
 	hlsBaseDir, err := conf.GetHLSDirectory()
 	if err != nil {
 		return fmt.Errorf("failed to get HLS directory: %w", err)
@@ -2275,7 +2228,7 @@ func (c *Controller) cleanupHLSDirectories() error {
 	}
 	defer func() {
 		if closeErr := secFS.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
 		}
 	}()
 
@@ -2287,9 +2240,9 @@ func (c *Controller) cleanupHLSDirectories() error {
 	for _, entry := range entries {
 		if entry.IsDir() && strings.HasPrefix(entry.Name(), "stream_") {
 			streamDir := filepath.Join(hlsBaseDir, entry.Name())
-			GetLogger().Debug("Removing HLS stream directory", logger.String("stream_dir", streamDir))
+			apicore.GetLogger().Debug("Removing HLS stream directory", logger.String("stream_dir", streamDir))
 			if removeErr := secFS.RemoveAll(streamDir); removeErr != nil {
-				GetLogger().Error("Failed to remove stream directory", logger.Error(removeErr))
+				apicore.GetLogger().Error("Failed to remove stream directory", logger.Error(removeErr))
 			}
 		}
 	}
@@ -2305,7 +2258,7 @@ func runHLSActivitySync(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			GetLogger().Info("HLS activity sync stopped")
+			apicore.GetLogger().Info("HLS activity sync stopped")
 			return
 		case <-ticker.C:
 			syncHLSActivity()
@@ -2378,7 +2331,7 @@ func shouldCleanupStream(sourceID string) bool {
 	}
 
 	clientCount := getStreamClientCount(sourceID)
-	GetLogger().Info("Stream inactive, marking for cleanup",
+	apicore.GetLogger().Info("Stream inactive, marking for cleanup",
 		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
 		logger.Duration("inactive_duration", inactiveDuration),
 		logger.Duration("timeout", hlsStreamInactivityTimeout),
@@ -2436,14 +2389,14 @@ func cleanupStream(s *HLSStreamInfo, sourceID string) {
 	// escalation to SIGKILL works correctly.
 	if s.FFmpegCmd != nil {
 		if err := s.FFmpegCmd.Wait(); err != nil {
-			GetLogger().Debug("FFmpeg process exited during cleanup", logger.Error(err))
+			apicore.GetLogger().Debug("FFmpeg process exited during cleanup", logger.Error(err))
 		}
 	}
 
 	// Close log file after process exits (must be done after Wait())
 	if s.logFile != nil {
 		if closeErr := s.logFile.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close log file", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close log file", logger.Error(closeErr))
 		}
 	}
 
@@ -2452,7 +2405,7 @@ func cleanupStream(s *HLSStreamInfo, sourceID string) {
 	// Clean up tracking data (clients, activity) so stale entries don't persist
 	cleanupStreamTrackingData(sourceID)
 
-	GetLogger().Debug("Cleaned up inactive stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
+	apicore.GetLogger().Debug("Cleaned up inactive stream", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)))
 }
 
 // cleanupStreamDirectory removes the stream's output directory
@@ -2463,22 +2416,22 @@ func cleanupStreamDirectory(outputDir string) {
 
 	hlsBaseDir, err := conf.GetHLSDirectory()
 	if err != nil {
-		GetLogger().Error("Failed to get HLS directory", logger.Error(err))
+		apicore.GetLogger().Error("Failed to get HLS directory", logger.Error(err))
 		return
 	}
 
 	secFS, err := securefs.New(hlsBaseDir)
 	if err != nil {
-		GetLogger().Error("Failed to create secure filesystem", logger.Error(err))
+		apicore.GetLogger().Error("Failed to create secure filesystem", logger.Error(err))
 		return
 	}
 	defer func() {
 		if closeErr := secFS.Close(); closeErr != nil {
-			GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
+			apicore.GetLogger().Error("Failed to close secure filesystem", logger.Error(closeErr))
 		}
 	}()
 
 	if removeErr := secFS.RemoveAll(outputDir); removeErr != nil {
-		GetLogger().Error("Failed to remove output directory", logger.Error(removeErr))
+		apicore.GetLogger().Error("Failed to remove output directory", logger.Error(removeErr))
 	}
 }

--- a/internal/api/v2/audio/audio_hls_test.go
+++ b/internal/api/v2/audio/audio_hls_test.go
@@ -1,6 +1,6 @@
-// internal/api/v2/audio_hls_test.go
+// internal/api/v2/audio/audio_hls_test.go
 // Tests for HLS streaming endpoint functionality
-package api
+package audio
 
 import (
 	"encoding/hex"
@@ -18,7 +18,6 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
-	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
@@ -528,7 +527,7 @@ func TestResolveClientID(t *testing.T) {
 	const testRemoteAddr = "192.168.1.100:12345"
 
 	t.Run("prefers session ID when provided", func(t *testing.T) {
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -542,7 +541,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("falls back to generateClientID when no session", func(t *testing.T) {
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -557,7 +556,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("different sessions from same IP get different IDs", func(t *testing.T) {
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 
@@ -566,7 +565,7 @@ func TestResolveClientID(t *testing.T) {
 		ctx1 := e.NewContext(req1, httptest.NewRecorder())
 
 		req2 := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
-		req2.RemoteAddr = testRemoteAddr // Same IP, same port — session ID differentiates
+		req2.RemoteAddr = testRemoteAddr // Same IP, same port - session ID differentiates
 		ctx2 := e.NewContext(req2, httptest.NewRecorder())
 
 		id1 := c.resolveClientID(ctx1, "550e8400-e29b-41d4-a716-446655440000")
@@ -575,7 +574,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("rejects invalid session ID format", func(t *testing.T) {
-		c := &Controller{Core: &apicore.Core{}}
+		c := &Handler{Core: &apicore.Core{}}
 		c.Settings.Store(apitest.NewValidTestSettings())
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -632,138 +631,5 @@ func TestHLSConsumer_WriteDoesNotRetainFrameData(t *testing.T) {
 			"hlsConsumer must copy frame.Data, not retain the caller's slice")
 	case <-time.After(time.Second):
 		t.Fatal("no frame delivered to channel")
-	}
-}
-
-// TestIsPrivateModeExempt verifies the (method, route) allow-list that
-// privateModeAuth uses when Security.PrivateMode is enabled. Bootstrap/auth
-// paths must stay reachable for unauthenticated clients so the frontend can
-// fetch the /app/config endpoint and complete a login; HLS live audio routes
-// must stay exempt so the per-route publicLiveAudioAuth middleware can honour
-// PublicAccess.LiveAudio. Exemptions are method-specific so unrelated
-// handlers added on the same paths later fail closed by default.
-func TestIsPrivateModeExempt(t *testing.T) {
-	t.Parallel()
-
-	// Exempt paths are composed from the same route constants the controllers
-	// register with, so this allow-list cannot drift from production routing.
-	exempt := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodGet, apiV2Prefix + AppConfigEndpoint},
-		{http.MethodPost, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLoginPath},
-		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthCallbackPath},
-		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsStartPath},
-		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsHeartbeatPath},
-		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsStatusPath},
-		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsTokenGroupPath + hlsPlaylistPath},
-		{http.MethodGet, apiV2Prefix + hlsGroupPath + hlsTokenGroupPath + hlsContentPath},
-	}
-	for _, tt := range exempt {
-		t.Run("exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
-			t.Parallel()
-			assert.True(t, isPrivateModeExempt(tt.method, tt.path),
-				"expected %s %q to be exempt", tt.method, tt.path)
-		})
-	}
-
-	notExempt := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodGet, ""},
-		{http.MethodGet, "/api/v2/detections"},
-		{http.MethodGet, "/api/v2/notifications"},
-		{http.MethodGet, "/api/v2/settings/dashboard"},
-		{http.MethodPost, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLogoutPath},
-		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthStatusPath},
-		{http.MethodPost, apiV2Prefix + hlsGroupPath + hlsStopPath}, // mutation, always auth-gated
-		{http.MethodPost, apiV2Prefix + WizardDismissEndpoint},      // gated under PrivateMode by design
-		{http.MethodGet, "/api/v2/streams/audio-level"},
-		{http.MethodGet, "/api/v2/streams/sources"},
-		{http.MethodGet, "/health"},
-		// Method mismatches must NOT match the allow-list.
-		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLoginPath}, // login is POST-only
-		{http.MethodPost, apiV2Prefix + AppConfigEndpoint},                            // config is GET-only
-		{http.MethodDelete, apiV2Prefix + AppConfigEndpoint},
-	}
-	for _, tt := range notExempt {
-		t.Run("not_exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
-			t.Parallel()
-			assert.False(t, isPrivateModeExempt(tt.method, tt.path),
-				"expected %s %q to NOT be exempt", tt.method, tt.path)
-		})
-	}
-}
-
-// TestPrivateModeExemptPathsAreRegisteredRoutes mounts the routes that the
-// PrivateMode exempt allow-list cares about (using the same path constants the
-// controllers register them with) and asserts that isPrivateModeExempt's
-// verdict matches the intended policy for every registered route. This closes
-// the drift risk from Forgejo follow-up #890: if a route constant is renamed
-// the registered path and the exempt composition move together, and if
-// isPrivateModeExempt's composition is edited incorrectly the verdict no longer
-// matches a real route and this test fails.
-func TestPrivateModeExemptPathsAreRegisteredRoutes(t *testing.T) {
-	t.Parallel()
-
-	noop := func(echo.Context) error { return nil }
-
-	e := echo.New()
-	g := e.Group(apiV2Prefix)
-
-	// App config (public bootstrap endpoint, registered in initAppRoutes).
-	g.GET(AppConfigEndpoint, noop)
-	g.POST(WizardDismissEndpoint, noop) // registered but NOT exempt under PrivateMode
-
-	// Auth flow (mirrors the auth domain's RegisterRoutes).
-	authGroup := g.Group(authapi.AuthGroupPath)
-	authGroup.POST(authapi.AuthLoginPath, noop)
-	authGroup.GET(authapi.AuthCallbackPath, noop)
-	authGroup.POST(authapi.AuthLogoutPath, noop)
-	authGroup.GET(authapi.AuthStatusPath, noop)
-
-	// HLS streaming (mirrors initHLSRoutes).
-	hlsGroup := g.Group(hlsGroupPath)
-	hlsGroup.POST(hlsStartPath, noop)
-	hlsGroup.POST(hlsStopPath, noop)
-	hlsGroup.POST(hlsHeartbeatPath, noop)
-	hlsGroup.GET(hlsStatusPath, noop)
-	hlsTokenGroup := hlsGroup.Group(hlsTokenGroupPath)
-	hlsTokenGroup.GET(hlsPlaylistPath, noop)
-	hlsTokenGroup.GET(hlsContentPath, noop)
-
-	key := func(method, path string) string { return method + " " + path }
-
-	// Expected exempt set, with paths composed from the same constants the
-	// production code and isPrivateModeExempt use.
-	wantExempt := map[string]bool{
-		key(http.MethodGet, apiV2Prefix+AppConfigEndpoint):                              true,
-		key(http.MethodPost, apiV2Prefix+authapi.AuthGroupPath+authapi.AuthLoginPath):   true,
-		key(http.MethodGet, apiV2Prefix+authapi.AuthGroupPath+authapi.AuthCallbackPath): true,
-		key(http.MethodPost, apiV2Prefix+hlsGroupPath+hlsStartPath):                     true,
-		key(http.MethodPost, apiV2Prefix+hlsGroupPath+hlsHeartbeatPath):                 true,
-		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsStatusPath):                     true,
-		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsTokenGroupPath+hlsPlaylistPath): true,
-		key(http.MethodGet, apiV2Prefix+hlsGroupPath+hlsTokenGroupPath+hlsContentPath):  true,
-	}
-
-	registered := make(map[string]bool)
-	for _, r := range e.Routes() {
-		// Echo can register auxiliary entries; only assert on the verbs we use.
-		if r.Method != http.MethodGet && r.Method != http.MethodPost {
-			continue
-		}
-		k := key(r.Method, r.Path)
-		registered[k] = true
-		assert.Equalf(t, wantExempt[k], isPrivateModeExempt(r.Method, r.Path),
-			"isPrivateModeExempt verdict mismatch for registered route %s", k)
-	}
-
-	// Every expected-exempt entry must correspond to an actually registered
-	// route (catches an exempt path that no real route serves).
-	for k := range wantExempt {
-		assert.Truef(t, registered[k], "exempt route %q is not a registered route", k)
 	}
 }

--- a/internal/api/v2/audio/audio_level.go
+++ b/internal/api/v2/audio/audio_level.go
@@ -1,5 +1,5 @@
-// internal/api/v2/audio_level.go
-package api
+// internal/api/v2/audio/audio_level.go
+package audio
 
 import (
 	"context"
@@ -80,7 +80,7 @@ type audioLevelManager struct {
 const maxStreamAnonymMapSize = 100
 
 // Global audio level manager instance
-// TODO: Consider moving to Controller struct for better encapsulation
+// TODO: Consider moving to Handler struct for better encapsulation
 var audioLevelMgr = &audioLevelManager{
 	streamAnonymMap: make(map[string]string),
 	subscribers:     make(map[chan audiocore.AudioLevelData]struct{}),
@@ -97,7 +97,7 @@ var audioLevelMgr = &audioLevelManager{
 // requests may result in data races.
 //
 // This connects the audio capture system to the SSE endpoint.
-func (c *Controller) SetAudioLevelChan(ch chan audiocore.AudioLevelData) {
+func (c *Handler) SetAudioLevelChan(ch chan audiocore.AudioLevelData) {
 	c.audioLevelChan = ch
 	c.LogInfoIfEnabled("Audio level channel connected to API v2 controller")
 
@@ -216,20 +216,20 @@ func cacheStreamAnonymName(sourceID, displayName string) {
 	audioLevelMgr.streamAnonymMap[sourceID] = displayName
 }
 
-// initAudioLevelRoutes registers audio level SSE endpoints
-func (c *Controller) initAudioLevelRoutes() {
+// RegisterAudioLevelRoutes registers audio level SSE endpoints
+func (c *Handler) RegisterAudioLevelRoutes(g *echo.Group) {
 	// Audio level SSE endpoint - public, no rate limiting
 	// The per-IP connection limit (audioLevelMaxConnectionsPerIP) still applies
 	// Authentication is checked within the handler to control data anonymization
-	c.Group.GET("/streams/audio-level", c.StreamAudioLevel)
+	g.GET("/streams/audio-level", c.StreamAudioLevel)
 
 	// Stream sources listing - public, returns active stream sources
-	c.Group.GET("/streams/sources", c.ListStreamSources)
+	g.GET("/streams/sources", c.ListStreamSources)
 }
 
 // StreamAudioLevel handles SSE connections for real-time audio level streaming
 // This provides simple audio level data (0-100 with clipping detection) for UI indicators
-func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
+func (c *Handler) StreamAudioLevel(ctx echo.Context) error {
 	// Early nil check for audio level channel
 	if c.audioLevelChan == nil {
 		c.LogAPIRequest(ctx, logger.LogLevelWarn, "Audio level stream unavailable - channel not configured")
@@ -350,7 +350,7 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	for {
 		select {
 		case <-c.Context().Done():
-			// Controller shutting down
+			// handler shutting down
 			c.LogAPIRequest(ctx, logger.LogLevelInfo, "Audio level SSE connection closed",
 				logger.String("reason", "shutdown"))
 			return nil
@@ -401,15 +401,6 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 	}
 }
 
-// isClientAuthenticated checks if the current request is authenticated
-// by delegating to the auth service's centralized IsAuthenticated method.
-func (c *Controller) isClientAuthenticated(ctx echo.Context) bool {
-	if c.authService == nil {
-		return false
-	}
-	return c.authService.IsAuthenticated(ctx)
-}
-
 // createAudioLevelEntry creates an AudioLevelData entry for a source with appropriate display name.
 func createAudioLevelEntry(sourceID, displayName string) audiocore.AudioLevelData {
 	return audiocore.AudioLevelData{
@@ -420,7 +411,7 @@ func createAudioLevelEntry(sourceID, displayName string) audiocore.AudioLevelDat
 }
 
 // initializeAudioLevels creates the initial levels map with configured sources
-func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audiocore.AudioLevelData {
+func (c *Handler) initializeAudioLevels(isAuthenticated bool) map[string]audiocore.AudioLevelData {
 	levels := make(map[string]audiocore.AudioLevelData)
 	eng := c.Engine.Load()
 	if eng == nil {
@@ -447,7 +438,7 @@ func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audi
 }
 
 // getAudioCardSources retrieves all configured audio card sources from the registry.
-func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*audiocore.AudioSource {
+func (c *Handler) getAudioCardSources(registry *audiocore.SourceRegistry) []*audiocore.AudioSource {
 	var sources []*audiocore.AudioSource
 	settings := c.CurrentSettings()
 	if settings == nil {
@@ -466,7 +457,7 @@ func (c *Controller) getAudioCardSources(registry *audiocore.SourceRegistry) []*
 }
 
 // addStreamSourcesToLevels adds all configured stream sources to the levels map.
-func (c *Controller) addStreamSourcesToLevels(registry *audiocore.SourceRegistry, levels map[string]audiocore.AudioLevelData, isAuthenticated bool) {
+func (c *Handler) addStreamSourcesToLevels(registry *audiocore.SourceRegistry, levels map[string]audiocore.AudioLevelData, isAuthenticated bool) {
 	settings := c.CurrentSettings()
 	if settings == nil {
 		return
@@ -486,7 +477,7 @@ func (c *Controller) addStreamSourcesToLevels(registry *audiocore.SourceRegistry
 }
 
 // updateAudioLevel processes incoming audio data and updates the levels map
-func (c *Controller) updateAudioLevel(
+func (c *Handler) updateAudioLevel(
 	audioData audiocore.AudioLevelData,
 	levels map[string]audiocore.AudioLevelData,
 	lastUpdateTime, lastNonZeroTime map[string]time.Time,
@@ -529,7 +520,7 @@ func (c *Controller) updateAudioLevel(
 }
 
 // getAnonymizedSourceName returns an anonymized name for a source
-func (c *Controller) getAnonymizedSourceName(source *audiocore.AudioSource) string {
+func (c *Handler) getAnonymizedSourceName(source *audiocore.AudioSource) string {
 	switch source.Type {
 	case audiocore.SourceTypeAudioCard:
 		return audioSourceDefaultName
@@ -556,7 +547,7 @@ func (c *Controller) getAnonymizedSourceName(source *audiocore.AudioSource) stri
 }
 
 // getAnonymizedSourceNameFallback returns anonymized name when registry is unavailable
-func (c *Controller) getAnonymizedSourceNameFallback(sourceID string) string {
+func (c *Handler) getAnonymizedSourceNameFallback(sourceID string) string {
 	// Check for audio card source
 	if strings.HasPrefix(sourceID, "audio_card_") {
 		return audioSourceDefaultName
@@ -590,7 +581,7 @@ func (c *Controller) getAnonymizedSourceNameFallback(sourceID string) string {
 }
 
 // isSourceInactive checks if a source should be considered inactive
-func (c *Controller) isSourceInactive(
+func (c *Handler) isSourceInactive(
 	source string,
 	now time.Time,
 	lastUpdateTime, lastNonZeroTime map[string]time.Time,
@@ -611,7 +602,7 @@ func (c *Controller) isSourceInactive(
 // pruneRemovedSources removes sources from the levels map that are no longer
 // present in the registry (e.g. a stream was disabled and torn down mid-session).
 // Returns true if any sources were pruned so the caller can send an update.
-func (c *Controller) pruneRemovedSources(
+func (c *Handler) pruneRemovedSources(
 	registry *audiocore.SourceRegistry,
 	levels map[string]audiocore.AudioLevelData,
 	lastUpdateTime, lastNonZeroTime map[string]time.Time,
@@ -629,7 +620,7 @@ func (c *Controller) pruneRemovedSources(
 }
 
 // checkSourceActivity checks all sources for inactivity
-func (c *Controller) checkSourceActivity(
+func (c *Handler) checkSourceActivity(
 	levels map[string]audiocore.AudioLevelData,
 	lastUpdateTime, lastNonZeroTime map[string]time.Time,
 ) bool {
@@ -650,7 +641,7 @@ func (c *Controller) checkSourceActivity(
 // extractRemoteAddr extracts the IP address from RemoteAddr, stripping port if present.
 // This is used for rate limiting and duplicate connection detection where we want
 // the actual connection address rather than proxy-provided headers which can be spoofed.
-func (c *Controller) extractRemoteAddr(ctx echo.Context) string {
+func (c *Handler) extractRemoteAddr(ctx echo.Context) string {
 	remoteAddr := ctx.Request().RemoteAddr
 	// RemoteAddr is typically "IP:port", extract just the IP
 	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
@@ -662,7 +653,7 @@ func (c *Controller) extractRemoteAddr(ctx echo.Context) string {
 
 // resetAudioLevelWriteDeadline resets the write deadline for the SSE connection.
 // This prevents the server's WriteTimeout from terminating long-lived SSE connections.
-func (c *Controller) resetAudioLevelWriteDeadline(ctx echo.Context, operation string) {
+func (c *Handler) resetAudioLevelWriteDeadline(ctx echo.Context, operation string) {
 	if conn, ok := ctx.Response().Writer.(apicore.WriteDeadlineSetter); ok {
 		if err := conn.SetWriteDeadline(time.Now().Add(audioLevelWriteDeadline)); err != nil {
 			c.LogDebugIfEnabled("Failed to set write deadline for "+operation, logger.Error(err))
@@ -671,7 +662,7 @@ func (c *Controller) resetAudioLevelWriteDeadline(ctx echo.Context, operation st
 }
 
 // sendAudioLevelUpdate sends the current levels to the client
-func (c *Controller) sendAudioLevelUpdate(ctx echo.Context, levels map[string]audiocore.AudioLevelData) error {
+func (c *Handler) sendAudioLevelUpdate(ctx echo.Context, levels map[string]audiocore.AudioLevelData) error {
 	message := AudioLevelSSEData{
 		Type:   "audio-level",
 		Levels: levels,
@@ -695,7 +686,7 @@ func (c *Controller) sendAudioLevelUpdate(ctx echo.Context, levels map[string]au
 
 // sendAudioLevelHeartbeat sends a heartbeat comment to keep the SSE connection alive.
 // It resets the write deadline before writing to prevent server WriteTimeout.
-func (c *Controller) sendAudioLevelHeartbeat(ctx echo.Context) error {
+func (c *Handler) sendAudioLevelHeartbeat(ctx echo.Context) error {
 	// Reset write deadline to prevent server WriteTimeout from closing connection.
 	c.resetAudioLevelWriteDeadline(ctx, "heartbeat")
 

--- a/internal/api/v2/audio/audio_level_test.go
+++ b/internal/api/v2/audio/audio_level_test.go
@@ -1,6 +1,6 @@
-// internal/api/v2/audio_level_test.go
+// internal/api/v2/audio/audio_level_test.go
 // Tests for audio level SSE endpoint functionality
-package api
+package audio
 
 import (
 	"fmt"
@@ -69,7 +69,7 @@ func TestAudioLevelSSEDataFormat(t *testing.T) {
 // TestIsSourceInactive tests the source inactivity detection logic
 func TestIsSourceInactive(t *testing.T) {
 	// Create a minimal controller for testing
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := &Handler{Core: &apicore.Core{}}
 	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	t.Run("new source is active", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestIsSourceInactive(t *testing.T) {
 
 // TestCheckSourceActivity tests the source activity checking for multiple sources
 func TestCheckSourceActivity(t *testing.T) {
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := &Handler{Core: &apicore.Core{}}
 	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	t.Run("no inactive sources", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestCheckSourceActivity(t *testing.T) {
 
 // TestGetAnonymizedSourceNameFallback tests the fallback source name anonymization
 func TestGetAnonymizedSourceNameFallback(t *testing.T) {
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := &Handler{Core: &apicore.Core{}}
 	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	t.Run("audio card source", func(t *testing.T) {

--- a/internal/api/v2/audio/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio/audio_level_write_deadline_test.go
@@ -1,7 +1,7 @@
-// internal/api/v2/audio_level_write_deadline_test.go
+// internal/api/v2/audio/audio_level_write_deadline_test.go
 // Tests for SSE write deadline handling to prevent WriteTimeout disconnections
 // This test suite verifies the fix for GitHub issue #1673
-package api
+package audio
 
 import (
 	"net/http"
@@ -69,7 +69,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{Core: &apicore.Core{}}
+		controller := &Handler{Core: &apicore.Core{}}
 		controller.Settings.Store(apitest.NewValidTestSettings())
 
 		// Create test audio level data
@@ -110,7 +110,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		ctx.Response().Writer = mockWriter
 
-		controller := &Controller{Core: &apicore.Core{}}
+		controller := &Handler{Core: &apicore.Core{}}
 		controller.Settings.Store(apitest.NewValidTestSettings())
 		levels := map[string]audiocore.AudioLevelData{
 			"test_source": {Level: 50, Name: "Test Source", Source: "test_source"},
@@ -143,7 +143,7 @@ func TestSendAudioLevelHeartbeatSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{Core: &apicore.Core{}}
+		controller := &Handler{Core: &apicore.Core{}}
 		controller.Settings.Store(apitest.NewValidTestSettings())
 
 		// Call sendAudioLevelHeartbeat

--- a/internal/api/v2/audio/audio_sources.go
+++ b/internal/api/v2/audio/audio_sources.go
@@ -1,5 +1,5 @@
 // audio_sources.go - Handlers for audio source listing endpoints.
-package api
+package audio
 
 import (
 	"net/http"
@@ -50,7 +50,7 @@ func isStreamSourceType(t audiocore.SourceType) bool {
 // When filter is nil, all sources are included. When anonymize is true,
 // source names are replaced with anonymized values for unauthenticated
 // clients, matching the behavior of the audio-level SSE stream.
-func (c *Controller) listSources(ctx echo.Context, label string, filter func(audiocore.SourceType) bool, anonymize bool) error {
+func (c *Handler) listSources(ctx echo.Context, label string, filter func(audiocore.SourceType) bool, anonymize bool) error {
 	c.LogInfoIfEnabled("Listing "+label,
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -93,13 +93,13 @@ func (c *Controller) listSources(ctx echo.Context, label string, filter func(aud
 
 // ListAudioSources handles GET /api/v2/system/audio/sources.
 // Returns all active audio sources from the engine registry (sound cards + streams).
-func (c *Controller) ListAudioSources(ctx echo.Context) error {
+func (c *Handler) ListAudioSources(ctx echo.Context) error {
 	return c.listSources(ctx, "audio sources", nil, false)
 }
 
 // ListStreamSources handles GET /api/v2/streams/sources.
 // Returns only stream-type audio sources (RTSP, HTTP, HLS, RTMP, UDP).
 // Source names are anonymized for unauthenticated clients.
-func (c *Controller) ListStreamSources(ctx echo.Context) error {
+func (c *Handler) ListStreamSources(ctx echo.Context) error {
 	return c.listSources(ctx, "stream sources", isStreamSourceType, true)
 }

--- a/internal/api/v2/audio/audio_sources_test.go
+++ b/internal/api/v2/audio/audio_sources_test.go
@@ -1,5 +1,5 @@
 // audio_sources_test.go - Tests for audio source listing endpoints.
-package api
+package audio
 
 import (
 	"encoding/json"
@@ -16,11 +16,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
-// setupAudioSourcesTestEnv creates a Controller with an AudioEngine whose
+// setupAudioSourcesTestEnv creates a Handler with an AudioEngine whose
 // registry contains the given sources. Sources are registered directly in the
 // registry to avoid requiring real audio hardware or network streams.
 // The engine is stopped automatically when the test completes.
-func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (*echo.Echo, *Controller) {
+func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (*echo.Echo, *Handler) {
 	t.Helper()
 
 	ctx := t.Context()
@@ -38,7 +38,7 @@ func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (
 	}
 
 	e := echo.New()
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(&conf.Settings{})
 	controller.Engine.Store(eng)
 	return e, controller
@@ -52,7 +52,7 @@ func TestListAudioSources(t *testing.T) {
 
 	t.Run("No engine returns empty list", func(t *testing.T) {
 		e := echo.New()
-		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+		controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 		controller.Settings.Store(&conf.Settings{})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/sources", http.NoBody)
@@ -119,7 +119,7 @@ func TestListStreamSources(t *testing.T) {
 
 	t.Run("No engine returns empty list", func(t *testing.T) {
 		e := echo.New()
-		controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+		controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 		controller.Settings.Store(&conf.Settings{})
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/sources", http.NoBody)

--- a/internal/api/v2/audio/handler.go
+++ b/internal/api/v2/audio/handler.go
@@ -1,0 +1,113 @@
+// Package audio is the api/v2 audio/streaming domain handler. It owns the live
+// audio-level SSE stream, the HLS streaming endpoints (including the bespoke
+// stream-token playlist/segment serving and the publicLiveAudio dynamic auth
+// gate), the stream health and stream-test endpoints, the quiet-hours status
+// endpoint, the audio liveness health endpoint, and the /system/audio device and
+// source listing endpoints.
+//
+// The Handler embeds *apicore.Core by pointer so the shared dependencies and
+// helpers (Settings accessors, AuthMiddleware, the HandleError/logging helpers,
+// the Context/Cancel/Wait lifecycle, the audio Engine and AudioWatchdog atomic
+// pointers, and the promoted SSE helpers) are available without re-plumbing.
+//
+// Two members are injected from the facade because they live on facade-owned
+// state that is not part of the shared core:
+//   - authService: the auth service (nil-guarded), read per request so the public
+//     audio-level stream and quiet-hours status can anonymize source display
+//     names / stream URLs for unauthenticated callers. The facade keeps its own
+//     copy because the detections domain also depends on the same check.
+//   - audioLevelChan: the live audio-level channel, injected after construction
+//     via SetAudioLevelChan (the parent server owns and feeds it).
+//
+// probeStreamInfo is an injectable stream-probe seam used by the stream-test
+// endpoint; it defaults to ffmpeg.ProbeStreamInfo lazily and is overridden in
+// tests.
+package audio
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// Local copies of constants that live in the facade package (constants.go, and
+// apiV2Prefix in api.go). They are duplicated here (the system-domain precedent)
+// rather than rippled into apicore, because they are read only by this domain
+// after the split.
+const (
+	// apiV2Prefix is the v2 API path prefix used when building the client-facing
+	// HLS playlist URL. It mirrors the facade's apiV2Prefix and the auth domain's
+	// local copy.
+	apiV2Prefix = "/api/v2"
+
+	// osWindows/osDarwin/osLinux are runtime.GOOS identifiers used by the audio
+	// device diagnostics and the HLS Windows-audio-feed path.
+	osWindows = "windows"
+	osDarwin  = "darwin"
+	osLinux   = "linux"
+
+	// secondsPerMinute converts the stream-health SSE rate limit (requests per
+	// minute) into echo's per-second rate.Limit.
+	secondsPerMinute = 60
+
+	// queryValueTrue is the canonical "true" query-parameter value parsed by the
+	// HLS handlers.
+	queryValueTrue = "true"
+
+	// logLevelWarning is the ffmpeg log-level used when verbose HLS logging is off.
+	logLevelWarning = "warning"
+
+	// filePermReadWrite (0o644) and filePermExecutable (0o755) are the file/dir
+	// permissions used for the HLS FFmpeg output directory and log files.
+	filePermReadWrite  = 0o644
+	filePermExecutable = 0o755
+
+	// defaultReadBufferSize is the default channel/buffer capacity for the HLS
+	// audio feed.
+	defaultReadBufferSize = 1024
+)
+
+// Handler serves the api/v2 audio/streaming domain endpoints. It embeds the
+// shared *apicore.Core (by pointer) and additionally holds the facade-injected
+// auth service, the injectable stream-probe seam, and the live audio-level channel
+// (set after construction via SetAudioLevelChan).
+type Handler struct {
+	*apicore.Core
+
+	// authService is the facade-injected authentication service (nil-guarded). It
+	// is read per request so the public audio-level stream and quiet-hours status
+	// can strip source metadata / stream URLs for unauthenticated callers.
+	authService auth.Service
+
+	// probeStreamInfo probes a live stream's audio characteristics for the
+	// stream-test endpoint. nil by default (TestStream falls back to
+	// ffmpeg.ProbeStreamInfo); overridden in tests to stub probing.
+	probeStreamInfo probeStreamInfoFunc
+
+	// audioLevelChan is the live audio-level channel injected by the parent server
+	// via SetAudioLevelChan after construction.
+	audioLevelChan chan audiocore.AudioLevelData
+}
+
+// New constructs the audio/streaming domain handler around the shared core and
+// the facade-injected auth service. The audio-level channel is wired later via
+// SetAudioLevelChan.
+func New(core *apicore.Core, authService auth.Service) *Handler {
+	return &Handler{
+		Core:        core,
+		authService: authService,
+	}
+}
+
+// isClientAuthenticated reports whether the current request is authenticated by
+// delegating to the auth service's centralized IsAuthenticated method. It returns
+// false when no auth service is configured (matching the facade's behavior for the
+// audio-level stream).
+func (c *Handler) isClientAuthenticated(ctx echo.Context) bool {
+	if c.authService == nil {
+		return false
+	}
+	return c.authService.IsAuthenticated(ctx)
+}

--- a/internal/api/v2/audio/quiet_hours.go
+++ b/internal/api/v2/audio/quiet_hours.go
@@ -1,5 +1,5 @@
-// internal/api/v2/quiet_hours.go
-package api
+// internal/api/v2/audio/quiet_hours.go
+package audio
 
 import (
 	"fmt"
@@ -22,14 +22,14 @@ type QuietHoursStatusResponse struct {
 	SuppressedStreams map[string]bool `json:"suppressedStreams"`
 }
 
-// initQuietHoursRoutes registers quiet hours API routes.
-func (c *Controller) initQuietHoursRoutes() {
+// RegisterQuietHoursRoutes registers quiet hours API routes.
+func (c *Handler) RegisterQuietHoursRoutes(g *echo.Group) {
 	// Public read-only endpoint: the dashboard's "Currently Hearing" card
 	// polls this to show whether any source is in a quiet-hours window.
 	// Stream URLs are sanitized via privacy.SanitizeStreamUrl before the
 	// response is serialized, so raw RTSP credentials are never leaked.
 	// Mirrors the PR #2763 pattern for other dashboard read-only endpoints.
-	c.Group.GET("/streams/quiet-hours/status", c.GetQuietHoursStatus)
+	g.GET("/streams/quiet-hours/status", c.GetQuietHoursStatus)
 }
 
 // GetQuietHoursStatus returns the current quiet hours suppression state for
@@ -39,7 +39,7 @@ func (c *Controller) initQuietHoursRoutes() {
 // preserved true/false values still let the dashboard "Currently Hearing"
 // indicator count active suppressions. Authenticated requests (e.g. the
 // StreamManager settings form) continue to receive the sanitized URL map.
-func (c *Controller) GetQuietHoursStatus(ctx echo.Context) error {
+func (c *Handler) GetQuietHoursStatus(ctx echo.Context) error {
 	// Read the live global snapshot (race-free, hot-reloading) via
 	// CurrentSettings() so out-of-band republishes are seen and the read never
 	// races the Settings.Store in UpdateSettings.

--- a/internal/api/v2/audio/quiet_hours_test.go
+++ b/internal/api/v2/audio/quiet_hours_test.go
@@ -1,4 +1,4 @@
-// quiet_hours_test.go: Unit tests for buildSuppressedStreamsPayload — the
+// quiet_hours_test.go: Unit tests for buildSuppressedStreamsPayload - the
 // helper that powers the /api/v2/streams/quiet-hours/status response.
 //
 // The guest-facing path replaces raw URLs with opaque "stream-N"
@@ -12,7 +12,7 @@
 //   - that the authenticated path passes URLs through privacy.SanitizeStreamUrl
 //     without leaking credentials.
 
-package api
+package audio
 
 import (
 	"maps"
@@ -98,7 +98,7 @@ func TestBuildSuppressedStreamsPayload_GuestStableWithinResponse(t *testing.T) {
 
 // TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort documents
 // the current behavior: adding a URL that sorts before existing ones shifts
-// every existing placeholder index by one. Today this is benign — the
+// every existing placeholder index by one. Today this is benign - the
 // "Currently Hearing" dashboard card only counts true values and does not
 // key UI state on placeholder names. If a future consumer needs hash-stable
 // placeholders, this test will fail and force a deliberate refactor.
@@ -143,7 +143,7 @@ func TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort(t *testing.
 }
 
 // TestBuildSuppressedStreamsPayload_AuthenticatedSanitizesURLs asserts the
-// non-guest path passes URLs through privacy.SanitizeStreamUrl — credentials
+// non-guest path passes URLs through privacy.SanitizeStreamUrl - credentials
 // are stripped but host/port remain visible to the settings UI.
 func TestBuildSuppressedStreamsPayload_AuthenticatedSanitizesURLs(t *testing.T) {
 	t.Parallel()

--- a/internal/api/v2/audio/streams_health.go
+++ b/internal/api/v2/audio/streams_health.go
@@ -1,5 +1,5 @@
-// internal/api/v2/streams_health.go
-package api
+// internal/api/v2/audio/streams_health.go
+package audio
 
 import (
 	"context"
@@ -108,7 +108,7 @@ type StreamSummaryResponse struct {
 	TimeSinceData *float64 `json:"time_since_data_seconds,omitempty"` // Seconds since last data
 }
 
-// initStreamHealthRoutes registers all stream health monitoring endpoints.
+// RegisterStreamHealthRoutes registers all stream health monitoring endpoints.
 // These endpoints are consumed exclusively by the StreamManager component on
 // the (auth-protected) settings page; the dashboard does NOT use them. They
 // therefore remain auth-protected to avoid leaking stream topology, target
@@ -116,21 +116,21 @@ type StreamSummaryResponse struct {
 // Output is still sanitized defensively (sanitizeFFmpegError / sanitizeStreamUrls)
 // so that if a handler is ever carved out in the future, raw RTSP credentials
 // cannot leak.
-func (c *Controller) initStreamHealthRoutes() {
+func (c *Handler) RegisterStreamHealthRoutes(g *echo.Group) {
 	authMiddleware := c.AuthMiddleware
 
-	// REST endpoints — authenticated
-	c.Group.GET("/streams/health", c.GetAllStreamsHealth, authMiddleware)
-	c.Group.GET("/streams/health/:url", c.GetStreamHealth, authMiddleware)
-	c.Group.GET("/streams/status", c.GetStreamsStatusSummary, authMiddleware)
+	// REST endpoints - authenticated
+	g.GET("/streams/health", c.GetAllStreamsHealth, authMiddleware)
+	g.GET("/streams/health/:url", c.GetStreamHealth, authMiddleware)
+	g.GET("/streams/status", c.GetStreamsStatusSummary, authMiddleware)
 
-	// SSE endpoint for real-time stream health updates — authenticated and
+	// SSE endpoint for real-time stream health updates - authenticated and
 	// rate-limited to 5 connections per minute with burst of 5 to tolerate
 	// page-refresh reconnects.
 	rateLimiterConfig := middleware.RateLimiterConfig{
 		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
 			middleware.RateLimiterMemoryStoreConfig{
-				Rate:      rate.Limit(float64(streamHealthRateLimitRequests) / float64(SecondsPerMinute)), // 5 per 60 seconds
+				Rate:      rate.Limit(float64(streamHealthRateLimitRequests) / float64(secondsPerMinute)), // 5 per 60 seconds
 				Burst:     streamHealthRateLimitRequests,                                                  // Allow 5 immediate connections
 				ExpiresIn: streamHealthRateLimitWindow,
 			},
@@ -148,7 +148,7 @@ func (c *Controller) initStreamHealthRoutes() {
 		},
 	}
 
-	c.Group.GET("/streams/health/stream", c.StreamHealthUpdates,
+	g.GET("/streams/health/stream", c.StreamHealthUpdates,
 		authMiddleware,
 		middleware.RateLimiterWithConfig(rateLimiterConfig))
 }
@@ -157,7 +157,7 @@ func (c *Controller) initStreamHealthRoutes() {
 // registry. Returns an empty string if the source is not found. The raw URL
 // is needed for matching against config entries; callers that expose the URL
 // to API clients MUST sanitize it first (privacy.SanitizeStreamUrl).
-func (c *Controller) resolveSourceURL(registry *audiocore.SourceRegistry, sourceID string) string {
+func (c *Handler) resolveSourceURL(registry *audiocore.SourceRegistry, sourceID string) string {
 	if registry == nil {
 		return ""
 	}
@@ -178,7 +178,7 @@ type streamInfo struct {
 // Returns empty values if stream is not found in config.
 // Reads the controller's lock-free settings snapshot, so a hot-reload that
 // republishes settings is visible on the next call.
-func (c *Controller) getStreamInfo(rawURL string) streamInfo {
+func (c *Handler) getStreamInfo(rawURL string) streamInfo {
 	settings := c.ControllerSettings()
 	if settings == nil {
 		return streamInfo{}
@@ -202,7 +202,7 @@ func (c *Controller) getStreamInfo(rawURL string) streamInfo {
 // @Success 200 {array} StreamHealthResponse "Array of stream health information"
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health [get]
-func (c *Controller) GetAllStreamsHealth(ctx echo.Context) error {
+func (c *Handler) GetAllStreamsHealth(ctx echo.Context) error {
 	eng := c.Engine.Load()
 	if eng == nil {
 		// No engine - we cannot report real stream health. Signal the
@@ -247,8 +247,8 @@ func (c *Controller) GetAllStreamsHealth(ctx echo.Context) error {
 // @Failure 404 {object} ErrorResponse "Stream not found"
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health/{url} [get]
-func (c *Controller) GetStreamHealth(ctx echo.Context) error {
-	// Get URL parameter (URL-encoded) — may be a sourceID or a stream URL
+func (c *Handler) GetStreamHealth(ctx echo.Context) error {
+	// Get URL parameter (URL-encoded) - may be a sourceID or a stream URL
 	encodedURL := ctx.Param("url")
 	if encodedURL == "" {
 		return c.HandleError(ctx, nil, "URL parameter is required", http.StatusBadRequest)
@@ -316,7 +316,7 @@ func (c *Controller) GetStreamHealth(ctx echo.Context) error {
 // @Success 200 {object} StreamsStatusSummaryResponse "Streams status summary"
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/status [get]
-func (c *Controller) GetStreamsStatusSummary(ctx echo.Context) error {
+func (c *Handler) GetStreamsStatusSummary(ctx echo.Context) error {
 	eng := c.Engine.Load()
 	if eng == nil {
 		// Zero counts would be technically accurate but misleading: clients
@@ -477,7 +477,7 @@ func convertErrorContextToResponse(errCtx *ffmpeg.ErrorContext) *ErrorContextRes
 }
 
 // handleStreamHealthHeartbeat sends a heartbeat and returns true if client disconnected.
-func (c *Controller) handleStreamHealthHeartbeat(ctx echo.Context, clientID string) error {
+func (c *Handler) handleStreamHealthHeartbeat(ctx echo.Context, clientID string) error {
 	if err := c.SendSSEHeartbeat(ctx, clientID, "stream_health"); err != nil {
 		c.LogDebugIfEnabled("Stream health SSE heartbeat failed, client likely disconnected",
 			logger.String("client_id", clientID),
@@ -488,7 +488,7 @@ func (c *Controller) handleStreamHealthHeartbeat(ctx echo.Context, clientID stri
 }
 
 // handleStreamHealthPoll polls for stream health changes and processes updates.
-func (c *Controller) handleStreamHealthPoll(ctx echo.Context, clientID string, previousState map[string]streamHealthSnapshot) error {
+func (c *Handler) handleStreamHealthPoll(ctx echo.Context, clientID string, previousState map[string]streamHealthSnapshot) error {
 	eng := c.Engine.Load()
 	if eng == nil {
 		return nil
@@ -505,7 +505,7 @@ func (c *Controller) handleStreamHealthPoll(ctx echo.Context, clientID string, p
 // handleStreamStatsUpdate sends periodic stats updates for all active streams.
 // This enables real-time bandwidth and bytes display in the UI regardless of state changes.
 // Note: This sends a lightweight payload without history arrays to reduce bandwidth.
-func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) error {
+func (c *Handler) handleStreamStatsUpdate(ctx echo.Context, clientID string) error {
 	eng := c.Engine.Load()
 	if eng == nil {
 		return nil
@@ -536,14 +536,14 @@ func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) 
 // @Failure 429 {object} ErrorResponse "Too many requests"
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health/stream [get]
-func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
+func (c *Handler) StreamHealthUpdates(ctx echo.Context) error {
 	eng := c.Engine.Load()
 	if eng == nil {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 
 	// Create a context with timeout for maximum connection duration
-	timeoutCtx, cancel := context.WithTimeout(ctx.Request().Context(), maxSSEStreamDuration)
+	timeoutCtx, cancel := context.WithTimeout(ctx.Request().Context(), apicore.MaxSSEStreamDuration)
 	defer cancel()
 
 	// Override the request context with timeout context
@@ -572,7 +572,7 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 	for {
 		select {
 		case <-c.Context().Done():
-			// Controller shutting down
+			// handler shutting down
 			c.LogInfoIfEnabled("stream health SSE client disconnected due to shutdown",
 				logger.String("client_id", clientID),
 			)
@@ -663,7 +663,7 @@ func determineEventType(prev, current *streamHealthSnapshot) string {
 }
 
 // processStreamHealthUpdates processes health updates for all active streams.
-func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, registry *audiocore.SourceRegistry, previousState map[string]streamHealthSnapshot) error {
+func (c *Handler) processStreamHealthUpdates(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, registry *audiocore.SourceRegistry, previousState map[string]streamHealthSnapshot) error {
 
 	for sourceID, health := range healthData {
 		// Resolve the connection URL for SSE events (sourceID is an internal key, not a URL)
@@ -704,7 +704,7 @@ func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID strin
 }
 
 // processRemovedStreams checks for and processes streams that have been removed
-func (c *Controller) processRemovedStreams(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, previousState map[string]streamHealthSnapshot) error {
+func (c *Handler) processRemovedStreams(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, previousState map[string]streamHealthSnapshot) error {
 	for prevSourceID, prevSnapshot := range previousState {
 		if _, exists := healthData[prevSourceID]; exists {
 			continue
@@ -742,7 +742,7 @@ func (c *Controller) processRemovedStreams(ctx echo.Context, clientID string, he
 }
 
 // sendStreamHealthUpdate sends a stream health update via SSE.
-func (c *Controller) sendStreamHealthUpdate(ctx echo.Context, rawURL string, health *ffmpeg.StreamHealth, eventType string) error {
+func (c *Handler) sendStreamHealthUpdate(ctx echo.Context, rawURL string, health *ffmpeg.StreamHealth, eventType string) error {
 	response := convertStreamHealthToResponse(rawURL, health)
 
 	// Add stream name and type from config
@@ -771,7 +771,7 @@ func (c *Controller) sendStreamHealthUpdate(ctx echo.Context, rawURL string, hea
 // sendStreamStatsUpdate sends a lightweight stats-only update via SSE.
 // This excludes history arrays (ErrorHistory, StateHistory) to reduce bandwidth
 // for frequent periodic updates.
-func (c *Controller) sendStreamStatsUpdate(ctx echo.Context, rawURL string, health *ffmpeg.StreamHealth) error {
+func (c *Handler) sendStreamStatsUpdate(ctx echo.Context, rawURL string, health *ffmpeg.StreamHealth) error {
 	// Build lightweight response with only essential stats fields
 	var timeSinceData *float64
 	if !health.LastDataReceived.IsZero() {

--- a/internal/api/v2/audio/streams_health_test.go
+++ b/internal/api/v2/audio/streams_health_test.go
@@ -1,5 +1,5 @@
-// internal/api/v2/streams_health_test.go
-package api
+// internal/api/v2/audio/streams_health_test.go
+package audio
 
 import (
 	"errors"

--- a/internal/api/v2/audio/streams_test_handler.go
+++ b/internal/api/v2/audio/streams_test_handler.go
@@ -1,4 +1,4 @@
-package api
+package audio
 
 import (
 	"context"
@@ -57,20 +57,20 @@ var blockedHosts = map[string]bool{
 }
 
 // probeStreamInfoFunc probes a live stream for its audio characteristics.
-// Controller.probeStreamInfo defaults to ffmpeg.ProbeStreamInfo (used when the
+// Handler.probeStreamInfo defaults to ffmpeg.ProbeStreamInfo (used when the
 // field is nil) and is overridden in tests to stub probing without ffprobe.
 type probeStreamInfoFunc func(ctx context.Context, url string) (*ffmpeg.StreamInfo, error)
 
-// initStreamTestRoutes registers stream testing endpoints.
-func (c *Controller) initStreamTestRoutes() {
-	c.Group.POST("/streams/test", c.TestStream, c.AuthMiddleware)
-	c.Group.POST("/streams/analyze-channels", c.AnalyzeChannels, c.AuthMiddleware)
+// RegisterStreamTestRoutes registers stream testing endpoints.
+func (c *Handler) RegisterStreamTestRoutes(g *echo.Group) {
+	g.POST("/streams/test", c.TestStream, c.AuthMiddleware)
+	g.POST("/streams/analyze-channels", c.AnalyzeChannels, c.AuthMiddleware)
 }
 
 // TestStream tests a stream URL to discover its audio properties.
 // Used by the frontend to verify connectivity and check model compatibility
 // before saving a stream configuration.
-func (c *Controller) TestStream(ctx echo.Context) error {
+func (c *Handler) TestStream(ctx echo.Context) error {
 	var req testStreamRequest
 	if err := ctx.Bind(&req); err != nil {
 		return c.HandleErrorWithKey(ctx, err, "invalid request body",
@@ -132,7 +132,7 @@ func (c *Controller) TestStream(ctx echo.Context) error {
 
 // AnalyzeChannels captures a short stereo sample and returns per-channel
 // energy levels with a recommendation for which channel to use.
-func (c *Controller) AnalyzeChannels(ctx echo.Context) error {
+func (c *Handler) AnalyzeChannels(ctx echo.Context) error {
 	var req analyzeChannelsRequest
 	if err := ctx.Bind(&req); err != nil {
 		return c.HandleErrorWithKey(ctx, err, "invalid request body",

--- a/internal/api/v2/audio/streams_test_handler_test.go
+++ b/internal/api/v2/audio/streams_test_handler_test.go
@@ -1,4 +1,4 @@
-package api
+package audio
 
 import (
 	"context"
@@ -90,13 +90,13 @@ func TestTestStreamHandler_ValidationErrors(t *testing.T) {
 			rec := httptest.NewRecorder()
 			ctx := e.NewContext(req, rec)
 
-			ctrl := &Controller{Core: &apicore.Core{}}
+			ctrl := &Handler{Core: &apicore.Core{}}
 			ctrl.Settings.Store(&conf.Settings{})
 			err := ctrl.TestStream(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.status, rec.Code)
 
-			var resp ErrorResponse
+			var resp apicore.ErrorResponse
 			require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 			assert.Equal(t, tt.errorKey, resp.ErrorKey)
 		})
@@ -114,7 +114,7 @@ func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	ctrl := &Controller{Core: &apicore.Core{}, probeStreamInfo: func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
+	ctrl := &Handler{Core: &apicore.Core{}, probeStreamInfo: func(_ context.Context, _ string) (*ffmpeg.StreamInfo, error) {
 		return nil, ffmpeg.ErrNoAudioStreamsFound
 	}}
 	ctrl.Settings.Store(&conf.Settings{})
@@ -123,7 +123,7 @@ func TestTestStreamHandler_NoAudioStreamError(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 
-	var resp ErrorResponse
+	var resp apicore.ErrorResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, "errors.streams.test.noAudioTrack", resp.ErrorKey)
 	assert.Equal(t, "stream has no audio track", resp.Message)

--- a/internal/api/v2/audio_facade.go
+++ b/internal/api/v2/audio_facade.go
@@ -1,0 +1,90 @@
+// internal/api/v2/audio_facade.go
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	audioapi "github.com/tphakala/birdnet-go/internal/api/v2/audio"
+	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// isClientAuthenticated checks if the current request is authenticated by
+// delegating to the auth service's centralized IsAuthenticated method. It stays
+// on the facade because the detections domain depends on it as an injected bound
+// method value (the audio domain holds its own authService copy and reimplements
+// the same check locally).
+func (c *Controller) isClientAuthenticated(ctx echo.Context) bool {
+	if c.authService == nil {
+		return false
+	}
+	return c.authService.IsAuthenticated(ctx)
+}
+
+// isPrivateModeExempt returns true for v2 API (method, route pattern) pairs that
+// must remain reachable without authentication even when PrivateMode is on. Two
+// categories are exempt:
+//
+//  1. Bootstrap and auth flow paths so the frontend can fetch /app/config and
+//     complete a login (including OAuth callback) from an unauthenticated state.
+//  2. Live audio (HLS) paths that already have their own publicLiveAudioAuth
+//     middleware. Letting them through privateModeAuth preserves the
+//     PublicAccess.LiveAudio carve-out: when LiveAudio is enabled the route stays
+//     public, when it is disabled the per-route middleware applies authMiddleware
+//     as before.
+//
+// The allow-list is keyed on method + path so any future handler added at one of
+// these paths under a different verb is fail-closed by default. It is injected
+// into apicore.NewCore so the apicore privateModeAuth middleware reads it without
+// importing a domain. The HLS path fragments come from the audio domain package
+// (their registration site) so the allow-list cannot drift from the routes.
+func isPrivateModeExempt(method, path string) bool {
+	const (
+		authBase     = apiV2Prefix + authapi.AuthGroupPath
+		hlsBase      = apiV2Prefix + audioapi.HLSGroupPath
+		hlsTokenBase = hlsBase + audioapi.HLSTokenGroupPath
+	)
+	switch {
+	case method == http.MethodGet && path == apiV2Prefix+AppConfigEndpoint:
+		return true
+	case method == http.MethodPost && path == authBase+authapi.AuthLoginPath:
+		return true
+	case method == http.MethodGet && path == authBase+authapi.AuthCallbackPath:
+		return true
+	case method == http.MethodPost && path == hlsBase+audioapi.HLSStartPath:
+		return true
+	case method == http.MethodPost && path == hlsBase+audioapi.HLSHeartbeatPath:
+		return true
+	case method == http.MethodGet && path == hlsBase+audioapi.HLSStatusPath:
+		return true
+	case method == http.MethodGet && path == hlsTokenBase+audioapi.HLSPlaylistPath:
+		return true
+	case method == http.MethodGet && path == hlsTokenBase+audioapi.HLSContentPath:
+		return true
+	}
+	return false
+}
+
+// RestartHLSStreams stops all active HLS streams so they restart with fresh
+// settings. It delegates to the audio domain handler, which owns the HLS manager.
+// The audio pipeline calls this on *Controller (internal/analysis), so the method
+// stays on the facade as a one-line delegator.
+func (c *Controller) RestartHLSStreams() {
+	c.audio.RestartHLSStreams()
+}
+
+// SetAudioWatchdog injects the liveness watchdog read by the audio health
+// endpoint. It delegates to the audio domain handler. internal/analysis calls
+// this on *Controller during pipeline Start(), so it stays on the facade.
+func (c *Controller) SetAudioWatchdog(w *audiocore.LivenessWatchdog) {
+	c.audio.SetAudioWatchdog(w)
+}
+
+// SetAudioLevelChan wires the live audio-level channel into the audio domain
+// handler and starts the broadcaster goroutine. The parent server (internal/api)
+// owns the channel and calls this on *Controller, so it stays on the facade.
+func (c *Controller) SetAudioLevelChan(ch chan audiocore.AudioLevelData) {
+	c.audio.SetAudioLevelChan(ch)
+}

--- a/internal/api/v2/audio_facade_test.go
+++ b/internal/api/v2/audio_facade_test.go
@@ -1,0 +1,150 @@
+// internal/api/v2/audio_facade_test.go
+// Tests for the facade-side audio wiring: the PrivateMode exempt allow-list
+// (isPrivateModeExempt) which composes app-config, auth, and HLS route constants
+// and is injected into apicore.NewCore. These stay in package api because they
+// exercise the facade function and reference facade-owned constants; the HLS path
+// fragments come from the extracted audio domain package.
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	audioapi "github.com/tphakala/birdnet-go/internal/api/v2/audio"
+	authapi "github.com/tphakala/birdnet-go/internal/api/v2/auth"
+)
+
+// TestIsPrivateModeExempt verifies the (method, route) allow-list that
+// privateModeAuth uses when Security.PrivateMode is enabled. Bootstrap/auth
+// paths must stay reachable for unauthenticated clients so the frontend can
+// fetch the /app/config endpoint and complete a login; HLS live audio routes
+// must stay exempt so the per-route publicLiveAudioAuth middleware can honour
+// PublicAccess.LiveAudio. Exemptions are method-specific so unrelated
+// handlers added on the same paths later fail closed by default.
+func TestIsPrivateModeExempt(t *testing.T) {
+	t.Parallel()
+
+	// Exempt paths are composed from the same route constants the controllers
+	// register with, so this allow-list cannot drift from production routing.
+	exempt := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, apiV2Prefix + AppConfigEndpoint},
+		{http.MethodPost, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLoginPath},
+		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthCallbackPath},
+		{http.MethodPost, apiV2Prefix + audioapi.HLSGroupPath + audioapi.HLSStartPath},
+		{http.MethodPost, apiV2Prefix + audioapi.HLSGroupPath + audioapi.HLSHeartbeatPath},
+		{http.MethodGet, apiV2Prefix + audioapi.HLSGroupPath + audioapi.HLSStatusPath},
+		{http.MethodGet, apiV2Prefix + audioapi.HLSGroupPath + audioapi.HLSTokenGroupPath + audioapi.HLSPlaylistPath},
+		{http.MethodGet, apiV2Prefix + audioapi.HLSGroupPath + audioapi.HLSTokenGroupPath + audioapi.HLSContentPath},
+	}
+	for _, tt := range exempt {
+		t.Run("exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, isPrivateModeExempt(tt.method, tt.path),
+				"expected %s %q to be exempt", tt.method, tt.path)
+		})
+	}
+
+	notExempt := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, ""},
+		{http.MethodGet, "/api/v2/detections"},
+		{http.MethodGet, "/api/v2/notifications"},
+		{http.MethodGet, "/api/v2/settings/dashboard"},
+		{http.MethodPost, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLogoutPath},
+		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthStatusPath},
+		{http.MethodPost, apiV2Prefix + audioapi.HLSGroupPath + audioapi.HLSStopPath}, // mutation, always auth-gated
+		{http.MethodPost, apiV2Prefix + WizardDismissEndpoint},                        // gated under PrivateMode by design
+		{http.MethodGet, "/api/v2/streams/audio-level"},
+		{http.MethodGet, "/api/v2/streams/sources"},
+		{http.MethodGet, "/health"},
+		// Method mismatches must NOT match the allow-list.
+		{http.MethodGet, apiV2Prefix + authapi.AuthGroupPath + authapi.AuthLoginPath}, // login is POST-only
+		{http.MethodPost, apiV2Prefix + AppConfigEndpoint},                            // config is GET-only
+		{http.MethodDelete, apiV2Prefix + AppConfigEndpoint},
+	}
+	for _, tt := range notExempt {
+		t.Run("not_exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, isPrivateModeExempt(tt.method, tt.path),
+				"expected %s %q to NOT be exempt", tt.method, tt.path)
+		})
+	}
+}
+
+// TestPrivateModeExemptPathsAreRegisteredRoutes mounts the routes that the
+// PrivateMode exempt allow-list cares about (using the same path constants the
+// controllers register them with) and asserts that isPrivateModeExempt's
+// verdict matches the intended policy for every registered route. If a route
+// constant is renamed the registered path and the exempt composition move
+// together, and if isPrivateModeExempt's composition is edited incorrectly the
+// verdict no longer matches a real route and this test fails.
+func TestPrivateModeExemptPathsAreRegisteredRoutes(t *testing.T) {
+	t.Parallel()
+
+	noop := func(echo.Context) error { return nil }
+
+	e := echo.New()
+	g := e.Group(apiV2Prefix)
+
+	// App config (public bootstrap endpoint, registered in initAppRoutes).
+	g.GET(AppConfigEndpoint, noop)
+	g.POST(WizardDismissEndpoint, noop) // registered but NOT exempt under PrivateMode
+
+	// Auth flow (mirrors the auth domain's RegisterRoutes).
+	authGroup := g.Group(authapi.AuthGroupPath)
+	authGroup.POST(authapi.AuthLoginPath, noop)
+	authGroup.GET(authapi.AuthCallbackPath, noop)
+	authGroup.POST(authapi.AuthLogoutPath, noop)
+	authGroup.GET(authapi.AuthStatusPath, noop)
+
+	// HLS streaming (mirrors the audio domain's RegisterHLSRoutes).
+	hlsGroup := g.Group(audioapi.HLSGroupPath)
+	hlsGroup.POST(audioapi.HLSStartPath, noop)
+	hlsGroup.POST(audioapi.HLSStopPath, noop)
+	hlsGroup.POST(audioapi.HLSHeartbeatPath, noop)
+	hlsGroup.GET(audioapi.HLSStatusPath, noop)
+	hlsTokenGroup := hlsGroup.Group(audioapi.HLSTokenGroupPath)
+	hlsTokenGroup.GET(audioapi.HLSPlaylistPath, noop)
+	hlsTokenGroup.GET(audioapi.HLSContentPath, noop)
+
+	key := func(method, path string) string { return method + " " + path }
+
+	// Expected exempt set, with paths composed from the same constants the
+	// production code and isPrivateModeExempt use.
+	wantExempt := map[string]bool{
+		key(http.MethodGet, apiV2Prefix+AppConfigEndpoint):                                                         true,
+		key(http.MethodPost, apiV2Prefix+authapi.AuthGroupPath+authapi.AuthLoginPath):                              true,
+		key(http.MethodGet, apiV2Prefix+authapi.AuthGroupPath+authapi.AuthCallbackPath):                            true,
+		key(http.MethodPost, apiV2Prefix+audioapi.HLSGroupPath+audioapi.HLSStartPath):                              true,
+		key(http.MethodPost, apiV2Prefix+audioapi.HLSGroupPath+audioapi.HLSHeartbeatPath):                          true,
+		key(http.MethodGet, apiV2Prefix+audioapi.HLSGroupPath+audioapi.HLSStatusPath):                              true,
+		key(http.MethodGet, apiV2Prefix+audioapi.HLSGroupPath+audioapi.HLSTokenGroupPath+audioapi.HLSPlaylistPath): true,
+		key(http.MethodGet, apiV2Prefix+audioapi.HLSGroupPath+audioapi.HLSTokenGroupPath+audioapi.HLSContentPath):  true,
+	}
+
+	registered := make(map[string]bool)
+	for _, r := range e.Routes() {
+		// Echo can register auxiliary entries; only assert on the verbs we use.
+		if r.Method != http.MethodGet && r.Method != http.MethodPost {
+			continue
+		}
+		k := key(r.Method, r.Path)
+		registered[k] = true
+		assert.Equalf(t, wantExempt[k], isPrivateModeExempt(r.Method, r.Path),
+			"isPrivateModeExempt verdict mismatch for registered route %s", k)
+	}
+
+	// Every expected-exempt entry must correspond to an actually registered
+	// route (catches an exempt path that no real route serves).
+	for k := range wantExempt {
+		assert.Truef(t, registered[k], "exempt route %q is not a registered route", k)
+	}
+}

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -19,10 +19,12 @@ const MetricsHistoryMaxPoints = system.MetricsHistoryMaxPoints
 // share the /system namespace but belong to domains not yet extracted into their
 // own packages; they stay here until their own phase:
 //   - GET /system/external-media -> media domain (external_media.go)
-//   - the /system/audio/* device routes -> audio/streaming domain (audio_devices.go,
-//     audio_sources.go)
 //   - /system/database/overview -> analytics domain (database_overview.go)
 //   - /system/database/{migration,backup,legacy} -> import domain
+//
+// The /system/audio/* device routes have moved to the audio/streaming domain and
+// are registered by c.audio.RegisterAudioDeviceRoutes (its own ordered initRoutes
+// entry), which recreates its own /system group.
 //
 // Recreating the /system group and its auth-protected subgroup here (in addition
 // to the one RegisterSystemRoutes creates) is safe: Echo deduplicates the group
@@ -38,14 +40,6 @@ func (c *Controller) initSystemRoutes() {
 
 	// External media status (media domain).
 	protectedGroup.GET("/external-media", c.GetExternalMedia)
-
-	// Audio device routes (audio/streaming domain).
-	audioGroup := protectedGroup.Group("/audio")
-	audioGroup.GET("/devices", c.GetAudioDevices)
-	audioGroup.GET("/devices/capabilities", c.GetDeviceCapabilities)
-	audioGroup.GET("/active", c.GetActiveAudioDevice)
-	audioGroup.GET("/equalizer/config", c.GetEqualizerConfig)
-	audioGroup.GET("/sources", c.ListAudioSources)
 
 	// Database overview (analytics domain).
 	c.initDatabaseOverviewRoutes()


### PR DESCRIPTION
Phase 6 of the internal/api/v2 package split: move the audio/streaming domain out of the monolithic package `api` into a new `internal/api/v2/audio` subpackage, following the established pattern (Handler embeds `*apicore.Core` by pointer; the facade `Controller` holds an `audio *audio.Handler` field, constructs it, and calls its `RegisterRoutes` in the deterministic `initRoutes` order).

## What moved (receiver retyped `*Controller` -> `*Handler`, bodies verbatim)
- `audio_level.go`: live audio-level SSE stream (`/streams/audio-level`) + `/streams/sources`, the `audioLevelMgr` broadcaster singleton, `LatestAudioLevels`.
- `audio_sources.go`: `ListStreamSources` and `ListAudioSources` + source DTOs.
- `audio_hls.go`: the full HLS subsystem (`/streams/hls/*`), the bespoke stream-token playlist/segment serving, the `publicLiveAudioAuth` dynamic per-request gate, the `hlsMgr` singleton + activity-sync goroutine, `RestartHLSStreams`.
- `audio_health.go`: `/health/audio` + `SetAudioWatchdog`.
- `streams_health.go`: `/streams/health*`, `/streams/status` (auth + SSE rate limiter).
- `streams_test_handler.go`: `/streams/test`, `/streams/analyze-channels`.
- `quiet_hours.go`: `/streams/quiet-hours/status`.
- `audio_devices.go`: `/system/audio/{devices,devices/capabilities,active,equalizer/config,sources}`, lifted out of `initSystemRoutes` into `RegisterAudioDeviceRoutes` (recreates its own `/system` + auth-protected `/audio` group; Echo dedups the group not-found stubs by method+path so the route set is unchanged).

Each old `init*Routes` became a `Register*Routes(g *echo.Group)` method swapped into the same ordered `initRoutes` slots; a new `"audio device routes"` entry registers the `/system/audio` block.

## Dependency wiring
- Handler embeds `*apicore.Core`; the audio `Engine` and `AudioWatchdog` atomic pointers, Settings accessors, `AuthMiddleware`, error/logging helpers, the `Context/Cancel/Wait` lifecycle, and the promoted SSE helpers all come from it.
- `authService` (`auth.Service`) is injected; the Handler is constructed AFTER the functional-options loop (like the auth/notifications handlers) so it captures the post-option `authService` used to anonymize source names / stream URLs for unauthenticated callers.
- `audioLevelChan` is owned by the Handler, wired later via `SetAudioLevelChan`.
- `probeStreamInfo` (the stream-test probe seam) moved to the Handler with its lazy `ffmpeg.ProbeStreamInfo` default.

## External surface preserved (one-line facade delegators on `*apiv2.Controller`)
- `RestartHLSStreams()` (`internal/analysis/control_monitor.go`)
- `SetAudioWatchdog(...)` (`internal/analysis/audio_pipeline_service.go`)
- `SetAudioLevelChan(...)` (`internal/api/server.go`)
- `system.New` now takes `audioapi.LatestAudioLevels` (the function moved to the audio package, same signature).
- The greedy `GET /api/v2/audio/:id` (and `/clip`, `/process`) stay in `media.go` on `c.Echo`, untouched (media domain, a later phase).
- `apiv2.Controller`/`New`/`NewWithOptions` signatures unchanged.

## Security / hot-reload preservation
- `publicLiveAudioAuth` still reads `c.CurrentSettings().Security.PublicAccess.LiveAudio` per request (hot-reload), falling back to `AuthMiddleware`; moved verbatim.
- The HLS stream-token check (`resolveStreamToken` / `ServeHLSPlaylist` / `ServeHLSContent`) moved verbatim.
- `isPrivateModeExempt` stays in the facade (it is injected into `apicore.NewCore` and composes app-config/auth/HLS paths). The HLS path fragments are now exported from the audio package (`HLSGroupPath` etc., same string values) so the allow-list still cannot drift from the registered routes. Its two tests stay in package `api`.
- Per-route auth and the stream-health SSE rate limiter moved verbatim.

## Lifecycle
The broadcaster and HLS activity-sync goroutines derive from `c.Context()` (shared Core context) and are stopped by the facade `Shutdown`'s existing `c.Cancel()`; the Handler shares the same Core, so no new Shutdown hook is needed and no goroutines leak (goleak/leakcheck green).

## Verification
- `go build ./...` clean; `go vet ./internal/api/v2/... ./internal/analysis/...` clean (no copylocks).
- `go test -race ./internal/api/v2/... ./internal/api/v2/audio/ ./internal/analysis/...` green; audio has its own `-race` binary (~7s).
- Route-enumeration golden gate (sorted method+path set), the greedy `/audio/:id` pin, and the `isPrivateModeExempt` tests all pass.
- golangci-lint: 0 issues on `internal/api/v2/` and `internal/api/v2/audio/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added and expanded audio/streaming API coverage for device info, audio health, quiet-hours status, stream health, HLS playback, and audio level updates.
  * Improved stream testing and channel analysis support for audio playback workflows.

* **Bug Fixes**
  * Corrected route handling so audio-related endpoints are registered and served from the proper location.
  * Updated private-mode access behavior to keep approved audio and login-related routes available when needed.

* **Documentation**
  * Fixed audio API documentation links to point to the correct source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->