### PR TITLE
refactor(api/v2): extract media domain into its own package

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -156,7 +156,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | POST   | `/integrations/weather/test`                 | `TestWeatherConnection`         | ✅   | Test weather provider connection               |
 | POST   | `/integrations/ebird/test`                   | `TestEBirdConnection`           | ✅   | Test eBird API connectivity and authentication |
 
-### Media (`media.go`)
+### Media (`media/media.go`)
 
 | Method | Route                                | Handler                  | Auth | Description                        |
 | ------ | ------------------------------------ | ------------------------ | ---- | ---------------------------------- |

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -85,9 +85,9 @@ func (c *Controller) handleAnalyticsQueryError(ctx echo.Context, err error, opLa
 	case errors.Is(err, context.Canceled):
 		// Client disconnected (navigated away / closed the tab). An expected lifecycle
 		// event, not a server error: log at info and return the non-standard
-		// client-closed status, matching the convention in media.go.
+		// client-closed status, matching the convention in the media handler.
 		c.LogInfoIfEnabled(opLabel+" query canceled by client", fields...)
-		return c.HandleError(ctx, err, "Request canceled by client", StatusClientClosedRequest)
+		return c.HandleError(ctx, err, "Request canceled by client", apicore.StatusClientClosedRequest)
 	case errors.Is(err, context.DeadlineExceeded):
 		c.LogErrorIfEnabled(opLabel+" query timeout", fields...)
 		return c.HandleError(ctx, err, msgQueryTimeout, http.StatusRequestTimeout)

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -200,7 +200,7 @@ func TestAnalyticsEndpointContextErrors(t *testing.T) {
 		wantMsg    string
 	}{
 		{"deadline exceeded", context.DeadlineExceeded, http.StatusRequestTimeout, "Query timeout"},
-		{"client canceled", context.Canceled, StatusClientClosedRequest, "Request canceled by client"},
+		{"client canceled", context.Canceled, apicore.StatusClientClosedRequest, "Request canceled by client"},
 	}
 
 	endpoints := []struct {

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/dynamicthresholds"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
 	"github.com/tphakala/birdnet-go/internal/api/v2/integrations"
+	mediaapi "github.com/tphakala/birdnet-go/internal/api/v2/media"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
 	"github.com/tphakala/birdnet-go/internal/api/v2/notifications"
 	rangeapi "github.com/tphakala/birdnet-go/internal/api/v2/range"
@@ -47,9 +47,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
-	"github.com/tphakala/birdnet-go/internal/spectrogram"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
-	"github.com/tphakala/birdnet-go/internal/sysinfo"
 )
 
 // apiV2Prefix is the base path prefix for all v2 API routes (the Echo group
@@ -177,8 +175,18 @@ type Controller struct {
 	isGlobalOwner       bool         // true when this controller owns the global settings singleton
 	settingsMutex       sync.RWMutex // Serializes the read-modify-write in settings update handlers; reads are lock-free via the atomic Settings pointer
 
-	startTime            *time.Time
-	spectrogramGenerator *spectrogram.Generator // Shared spectrogram generator (initialized after SFS)
+	startTime *time.Time
+
+	// media serves the media domain: media-file serving (audio clips and
+	// spectrogram images from the SecureFS sandbox), on-demand spectrogram
+	// generation, the ID-based audio/spectrogram endpoints (including the greedy
+	// GET /api/v2/audio/:id route on c.Echo), clip extraction and audio
+	// processing, the cached bird-image proxy (ServeSpeciesImageProxy, injected
+	// into the species handler), and the external-media mount-status endpoint.
+	// Beyond the shared *apicore.Core it owns the audio-processing cache and
+	// concurrency limiter and the spectrogram generator. It is constructed BEFORE
+	// the species handler because species injects c.media.ServeSpeciesImageProxy.
+	media *mediaapi.Handler
 
 	// authService is the authentication service injected from server (via the
 	// WithAuthService functional option). The facade keeps it as the injection
@@ -217,10 +225,6 @@ type Controller struct {
 	// promote from the embedded core. The hub itself stays in apicore.
 	sse *sse.Handler
 
-	// Audio processing fields
-	processingCache     *processingCache
-	processingSemaphore chan struct{}
-
 	// Legacy cleanup state tracker
 	cleanupStatus *CleanupStatus
 
@@ -229,12 +233,6 @@ type Controller struct {
 	// This is primarily used in testing to ensure proper setup before assertions.
 	// Only created when routes are initialized (production mode or specific tests).
 	goroutinesStarted chan struct{} // signals when all background goroutines have started (nil if routes not initialized)
-
-	// externalMediaEnv and externalMediaProbe are injectable dependencies for
-	// the GET /api/v2/system/external-media endpoint. Both default to the real
-	// sysinfo implementations at request time when nil.
-	externalMediaEnv   sysinfo.EnvGetter
-	externalMediaProbe sysinfo.MountProber
 
 	// importMgr manages the one-at-a-time import lifecycle.
 	importMgr *importManager
@@ -246,12 +244,6 @@ type Controller struct {
 	// importSourceFactory builds an import Source from a resolved path.
 	// Defaults to a BirdNET-Pi adapter when nil. Overridable in tests.
 	importSourceFactory func(path string) (imports.Source, error)
-
-	// audioWaitTimeoutOverride overrides the server-side wait for an in-progress
-	// audio encoding used by waitForAudioFile. Zero in production, where the wait
-	// uses audioWaitTimeout. Tests set a short timeout to exercise the
-	// 503-after-timeout path without waiting the full default.
-	audioWaitTimeoutOverride time.Duration
 
 	// Audio level channel for SSE streaming
 	// TODO: Consider moving to a dedicated audio manager
@@ -451,12 +443,18 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	c.detections = detections.New(c.Core, &c.settingsMutex,
 		c.getSettingsOrFallback, c.publishAndSaveSettings, c.handleSettingsChanges,
 		c.isClientAuthenticated, c.loadCommonNameMap, c.loadCommonToScientificMap)
-	// The species handler delegates to two facade-owned dependencies that have not
-	// been extracted into their own domains yet: loadCommonNameMap (the shared
-	// name-map read accessor) and ServeSpeciesImageProxy (the media image proxy the
-	// thumbnail endpoint forwards to). They are passed as bound method values; c is
-	// fully constructed here, so the method values are stable for its lifetime.
-	c.species = species.New(c.Core, c.loadCommonNameMap, c.ServeSpeciesImageProxy)
+	// The media handler owns the audio-processing cache, the spectrogram
+	// generator, and the cache-cleanup goroutine (all built from the shared
+	// SecureFS in mediaapi.New). It is constructed BEFORE the species handler
+	// because species injects c.media.ServeSpeciesImageProxy (a method value on
+	// the media handler) for its thumbnail endpoint.
+	c.media = mediaapi.New(c.Core)
+	// The species handler delegates to two dependencies: loadCommonNameMap (the
+	// shared name-map read accessor, still facade-owned until insights is
+	// extracted) and the media domain's species-image proxy handler
+	// (c.media.ServeSpeciesImageProxy). They are passed as bound method values; c
+	// is fully constructed here, so the method values are stable for its lifetime.
+	c.species = species.New(c.Core, c.loadCommonNameMap, c.media.ServeSpeciesImageProxy)
 	// The models handler needs only the shared core (ModelManager and the
 	// settings/error/log/goroutine helpers all promote from it).
 	c.models = models.New(c.Core)
@@ -481,28 +479,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// internal/analysis owns. The remaining deps (Engine, ShutdownRequester, and
 	// the error/log helpers) all promote from the shared core.
 	c.control = control.New(c.Core, c.controlChan)
-
-	// Initialize audio processing cache and concurrency limiter
-	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")
-	c.processingCache = newProcessingCache(cacheDir, processingCacheMaxFiles)
-	c.processingSemaphore = make(chan struct{}, 2)
-
-	// Start cache cleanup goroutine (tracked by the core wait group)
-	c.Go(func() {
-		ticker := time.NewTicker(processingCacheTickerInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-c.Context().Done():
-				return
-			case <-ticker.C:
-				c.processingCache.cleanExpired()
-			}
-		}
-	})
-
-	// Spectrogram generator (needs the media SecureFS)
-	c.spectrogramGenerator = spectrogram.NewGenerator(settings, c.SFS, getSpectrogramLogger())
 
 	// Apply functional options (auth middleware and service injected from server)
 	for _, opt := range opts {
@@ -628,7 +604,7 @@ func (c *Controller) initRoutes() {
 		{"integration routes", func() { c.integrations.RegisterRoutes(c.Group) }},
 		{"control routes", func() { c.control.RegisterRoutes(c.Group) }},
 		{"auth routes", func() { c.authHandler.RegisterRoutes(c.Group) }},
-		{"media routes", c.initMediaRoutes},
+		{"media routes", func() { c.media.RegisterRoutes(c.Group) }},
 		{"range routes", func() { c.rangeHandler.RegisterRoutes(c.Group) }},
 		{"heatmap routes", c.initHeatmapRoutes},
 		{"sse routes", func() { c.sse.RegisterRoutes(c.Group) }},

--- a/internal/api/v2/api_datastore_guard_test.go
+++ b/internal/api/v2/api_datastore_guard_test.go
@@ -1,16 +1,13 @@
-// api_datastore_guard_test.go: coverage for the nil-datastore route contract.
+// api_datastore_guard_test.go: coverage for nil-safe route initialization on a
+// standalone/test controller.
 //
-// NewWithOptions permits a nil datastore ("datastore disabled" mode) but the route
-// layer used to register the detection and media route groups unconditionally and
-// their handlers dereferenced c.DS with no guard, so hitting one with a nil datastore
-// panicked despite the constructor advertising the mode. The fix honors the mode:
-// initRoutes skips registering the DS-dependent route groups when c.DS == nil, and the
-// affected handlers return 503 instead of panicking (defense in depth).
+// initDebugRoutes reads the debug flag via the nil-safe controllerSettings()
+// snapshot (matching requireDebugMode) instead of dereferencing a possibly-nil
+// c.Settings on a standalone/test controller. The media domain's equivalent
+// nil-datastore route contract is covered in internal/api/v2/media.
 package api
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -20,62 +17,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
 )
 
-// TestGetSpectrogramStatusReturns503WhenDatastoreDisabled pins that a DS-dependent
-// handler returns 503 Service Unavailable instead of panicking when the controller was
-// constructed without a datastore.
-func TestGetSpectrogramStatusReturns503WhenDatastoreDisabled(t *testing.T) {
-	// Build a fully-formed controller (metrics, logger, telemetry) then disable its
-	// datastore, so the test exercises the nil-DS guard rather than tripping over an
-	// otherwise-unrelated nil dependency in the 5xx error path.
-	e, _, controller := setupTestEnvironment(t)
-	controller.DS = nil // datastore disabled
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/spectrogram/123/status", http.NoBody)
-	rec := httptest.NewRecorder()
-	ctx := e.NewContext(req, rec)
-	ctx.SetParamNames("id")
-	ctx.SetParamValues("123")
-
-	var err error
-	require.NotPanics(t, func() { err = controller.GetSpectrogramStatus(ctx) })
-	require.ErrorIs(t, err, apicore.ErrDatastoreUnavailable,
-		"DS-dependent handler must short-circuit with the datastore-unavailable sentinel, not panic")
-	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
-		"DS-dependent handler must return 503 when the datastore is disabled, not panic")
-}
-
-// TestInitMediaRoutesSkippedWhenDatastoreDisabled pins that the ID-based (datastore
-// dependent) media routes are not registered when the controller has no datastore, while
-// the datastore-independent media routes (filename serve, species images) still register.
-func TestInitMediaRoutesSkippedWhenDatastoreDisabled(t *testing.T) {
-	e := echo.New()
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: nil}}
-
-	controller.initMediaRoutes()
-
-	var hasFilenameSpectrogram, hasSpeciesImage bool
-	for _, r := range e.Routes() {
-		// Every datastore-dependent media handler is registered under an :id parameter.
-		assert.NotContains(t, r.Path, ":id",
-			"ID-based media routes must not register when the datastore is disabled: %s %s", r.Method, r.Path)
-		// The query-ID audio endpoint is also datastore-dependent.
-		assert.NotEqual(t, "/api/v2/media/audio", r.Path,
-			"the datastore-dependent query-ID audio route must not register: %s %s", r.Method, r.Path)
-		switch r.Path {
-		case "/api/v2/media/spectrogram/:filename":
-			hasFilenameSpectrogram = true
-		case "/api/v2/media/species-image":
-			hasSpeciesImage = true
-		}
-	}
-	assert.True(t, hasFilenameSpectrogram,
-		"datastore-independent filename spectrogram route must still register when the datastore is disabled")
-	assert.True(t, hasSpeciesImage,
-		"datastore-independent species-image route must still register when the datastore is disabled")
-}
-
-// TestInitDetectionRoutesSkippedWhenDatastoreDisabled pins that the detection route group
-// is not registered when the controller has no datastore.
 // TestInitDebugRoutesReadsSettingsNilSafely pins that initDebugRoutes reads the debug
 // flag via the nil-safe controllerSettings() snapshot (matching requireDebugMode) instead
 // of dereferencing a possibly-nil c.Settings on a standalone/test controller.

--- a/internal/api/v2/apicore/shared_helpers.go
+++ b/internal/api/v2/apicore/shared_helpers.go
@@ -37,6 +37,13 @@ const (
 	SpectrogramSizeXl = 2050 // height=1025, DFT=2048
 )
 
+// StatusClientClosedRequest is Nginx's non-standard HTTP status code for a
+// client that closed the connection before the server responded. It is shared
+// across api/v2 domains: the media handler returns it when a client cancels an
+// audio/spectrogram request, and the analytics handler returns it when a client
+// cancels an analytics query, so the value lives on the shared substrate.
+const StatusClientClosedRequest = 499
+
 // GetBirdNETInstance returns the BirdNET orchestrator or an error if unavailable.
 // It snapshots the processor first to avoid a TOCTOU race. Shared by the range,
 // heatmap, and diagnostics handlers.

--- a/internal/api/v2/constants.go
+++ b/internal/api/v2/constants.go
@@ -21,18 +21,6 @@ const (
 	SpectrogramCacheDuration = 30 * 24 * time.Hour
 )
 
-// Cache duration in seconds for HTTP headers
-const (
-	// ImageCacheSeconds is the cache duration for species images in seconds
-	ImageCacheSeconds = 2592000 // 30 days
-
-	// NotFoundCacheSeconds is the cache duration for 404 responses in seconds
-	NotFoundCacheSeconds = 86400 // 24 hours
-
-	// SpectrogramCacheSeconds is the cache duration for spectrograms in seconds
-	SpectrogramCacheSeconds = 2592000 // 30 days
-)
-
 // Log level constants
 const (
 	LogLevelError   = "error"

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -190,7 +190,7 @@ func TestInsightsEndpointContextErrors(t *testing.T) {
 		wantMsg    string
 	}{
 		{"deadline exceeded", context.DeadlineExceeded, http.StatusRequestTimeout, "Query timeout"},
-		{"client canceled", context.Canceled, StatusClientClosedRequest, "Request canceled by client"},
+		{"client canceled", context.Canceled, apicore.StatusClientClosedRequest, "Request canceled by client"},
 	}
 
 	endpoints := []struct {

--- a/internal/api/v2/media/clip_test.go
+++ b/internal/api/v2/media/clip_test.go
@@ -1,4 +1,4 @@
-package api
+package media
 
 import (
 	"net/http"

--- a/internal/api/v2/media/datastore_guard_test.go
+++ b/internal/api/v2/media/datastore_guard_test.go
@@ -1,0 +1,79 @@
+// datastore_guard_test.go: coverage for the nil-datastore route contract of the
+// media domain.
+//
+// NewWithOptions permits a nil datastore ("datastore disabled" mode) but the route
+// layer used to register the media route group unconditionally and its handlers
+// dereferenced c.DS with no guard, so hitting one with a nil datastore panicked
+// despite the constructor advertising the mode. The fix honors the mode:
+// RegisterRoutes skips registering the DS-dependent media routes when c.DS == nil,
+// and the affected handlers return 503 instead of panicking (defense in depth).
+package media
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+)
+
+// TestGetSpectrogramStatusReturns503WhenDatastoreDisabled pins that a DS-dependent
+// handler returns 503 Service Unavailable instead of panicking when the handler's
+// datastore is disabled.
+func TestGetSpectrogramStatusReturns503WhenDatastoreDisabled(t *testing.T) {
+	// Build a fully-formed handler (metrics, logger, telemetry) then disable its
+	// datastore, so the test exercises the nil-DS guard rather than tripping over an
+	// otherwise-unrelated nil dependency in the 5xx error path.
+	e := echo.New()
+	h := New(apitest.NewCore(t, apitest.WithEcho(e)))
+	h.DS = nil // datastore disabled
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/spectrogram/123/status", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("123")
+
+	var err error
+	require.NotPanics(t, func() { err = h.GetSpectrogramStatus(ctx) })
+	require.ErrorIs(t, err, apicore.ErrDatastoreUnavailable,
+		"DS-dependent handler must short-circuit with the datastore-unavailable sentinel, not panic")
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"DS-dependent handler must return 503 when the datastore is disabled, not panic")
+}
+
+// TestRegisterRoutesSkipsIDRoutesWhenDatastoreDisabled pins that the ID-based
+// (datastore dependent) media routes are not registered when the handler has no
+// datastore, while the datastore-independent media routes (filename serve, species
+// images) still register.
+func TestRegisterRoutesSkipsIDRoutesWhenDatastoreDisabled(t *testing.T) {
+	e := echo.New()
+	h := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: nil}}
+
+	h.RegisterRoutes(h.Group)
+
+	var hasFilenameSpectrogram, hasSpeciesImage bool
+	for _, r := range e.Routes() {
+		// Every datastore-dependent media handler is registered under an :id parameter.
+		assert.NotContains(t, r.Path, ":id",
+			"ID-based media routes must not register when the datastore is disabled: %s %s", r.Method, r.Path)
+		// The query-ID audio endpoint is also datastore-dependent.
+		assert.NotEqual(t, "/api/v2/media/audio", r.Path,
+			"the datastore-dependent query-ID audio route must not register: %s %s", r.Method, r.Path)
+		switch r.Path {
+		case "/api/v2/media/spectrogram/:filename":
+			hasFilenameSpectrogram = true
+		case "/api/v2/media/species-image":
+			hasSpeciesImage = true
+		}
+	}
+	assert.True(t, hasFilenameSpectrogram,
+		"datastore-independent filename spectrogram route must still register when the datastore is disabled")
+	assert.True(t, hasSpeciesImage,
+		"datastore-independent species-image route must still register when the datastore is disabled")
+}

--- a/internal/api/v2/media/external_media.go
+++ b/internal/api/v2/media/external_media.go
@@ -1,4 +1,4 @@
-package api
+package media
 
 import (
 	"net/http"
@@ -45,7 +45,7 @@ type ExternalMediaResponse struct {
 // It reports whether the external-media bind-mount is reachable from the
 // running application, and when it is not, provides deployment-specific setup
 // instructions for the detected container runtime.
-func (c *Controller) GetExternalMedia(ctx echo.Context) error {
+func (c *Handler) GetExternalMedia(ctx echo.Context) error {
 	c.LogAPIRequest(ctx, logger.LogLevelInfo, "Getting external media status")
 
 	envGetter := c.externalMediaEnv

--- a/internal/api/v2/media/external_media_test.go
+++ b/internal/api/v2/media/external_media_test.go
@@ -1,4 +1,4 @@
-package api
+package media
 
 import (
 	"encoding/json"
@@ -21,16 +21,16 @@ func newExternalMediaController(
 	t *testing.T,
 	envGetter sysinfo.EnvGetter,
 	prober sysinfo.MountProber,
-) (*echo.Echo, *Controller) {
+) (*echo.Echo, *Handler) {
 	t.Helper()
 	e := echo.New()
-	c := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}, externalMediaEnv: envGetter, externalMediaProbe: prober}
+	c := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}, externalMediaEnv: envGetter, externalMediaProbe: prober}
 	return e, c
 }
 
 // callExternalMediaEndpoint fires the GET /api/v2/system/external-media handler
 // and returns the parsed response.
-func callExternalMediaEndpoint(t *testing.T, ctrl *Controller) (resp ExternalMediaResponse, statusCode int) {
+func callExternalMediaEndpoint(t *testing.T, ctrl *Handler) (resp ExternalMediaResponse, statusCode int) {
 	t.Helper()
 	e := ctrl.Echo
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/system/external-media", http.NoBody)

--- a/internal/api/v2/media/handler.go
+++ b/internal/api/v2/media/handler.go
@@ -1,0 +1,102 @@
+// Package media is the api/v2 media domain handler. It owns the media-serving
+// endpoints (audio clips and spectrogram images served from the SecureFS
+// sandbox), the on-demand spectrogram generation pipeline, the ID-based audio
+// and spectrogram endpoints (including the greedy GET /api/v2/audio/:id route
+// registered directly on the Echo instance), audio clip extraction and
+// processing, the cached bird-image proxy (ServeSpeciesImageProxy, which the
+// species domain injects for its thumbnail endpoint), and the external-media
+// mount-status endpoint.
+//
+// The Handler embeds *apicore.Core by pointer so the shared dependencies and
+// helpers (the media SecureFS sandbox, BirdImageCache, Settings accessors,
+// AuthMiddleware, the HandleError/logging helpers, and the Context/Cancel/Wait
+// lifecycle) are available without re-plumbing. Beyond the core it owns the
+// audio-processing cache and concurrency limiter, the spectrogram generator,
+// and the injectable external-media probe seams.
+package media
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/spectrogram"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
+)
+
+const (
+	// processingCacheDirName is the SecureFS-relative directory under the media
+	// export root that holds temporary processed-audio cache files.
+	processingCacheDirName = ".processing-cache"
+
+	// processingSemaphoreSize bounds the number of concurrent audio-processing
+	// (normalize/denoise/gain) operations to limit CPU/memory pressure.
+	processingSemaphoreSize = 2
+)
+
+// Handler serves the api/v2 media domain endpoints. It embeds the shared
+// *apicore.Core (by pointer) and additionally owns the audio-processing cache
+// and concurrency limiter, the spectrogram generator, and the injectable
+// external-media probe seams.
+type Handler struct {
+	*apicore.Core
+
+	// processingCache caches processed (normalize/denoise/gain) audio previews
+	// under the media export root; processingSemaphore bounds concurrent
+	// processing work. Both are owned by this handler and built in New.
+	processingCache     *processingCache
+	processingSemaphore chan struct{}
+
+	// spectrogramGenerator renders spectrogram images from audio clips via the
+	// media SecureFS sandbox. Built in New from the shared SecureFS.
+	spectrogramGenerator *spectrogram.Generator
+
+	// externalMediaEnv and externalMediaProbe are injectable dependencies for the
+	// GET /api/v2/system/external-media endpoint. Both default to the real
+	// sysinfo implementations at request time when nil; tests override them.
+	externalMediaEnv   sysinfo.EnvGetter
+	externalMediaProbe sysinfo.MountProber
+
+	// audioWaitTimeoutOverride overrides the server-side wait for an in-progress
+	// audio encoding used by waitForAudioFile. Zero in production, where the wait
+	// uses audioWaitTimeout. Tests set a short timeout to exercise the
+	// 503-after-timeout path without waiting the full default.
+	audioWaitTimeoutOverride time.Duration
+}
+
+// New constructs the media domain handler around the shared core. It builds the
+// audio-processing cache and concurrency limiter and the spectrogram generator
+// from the shared SecureFS, and starts the cache-cleanup goroutine on the core's
+// wait group; the facade's Shutdown (Cancel + Wait) tears it down, so no
+// separate shutdown hook is needed (the audio-domain precedent). The
+// external-media probe seams default to nil (real sysinfo at request time).
+func New(core *apicore.Core) *Handler {
+	h := &Handler{Core: core}
+
+	// Initialize the audio processing cache and concurrency limiter under the
+	// media SecureFS export root.
+	cacheDir := filepath.Join(core.SFS.BaseDir(), processingCacheDirName)
+	h.processingCache = newProcessingCache(cacheDir, processingCacheMaxFiles)
+	h.processingSemaphore = make(chan struct{}, processingSemaphoreSize)
+
+	// Start the cache cleanup goroutine (tracked by the core wait group, stopped
+	// when the core context is cancelled by the facade's Shutdown).
+	core.Go(func() {
+		ticker := time.NewTicker(processingCacheTickerInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-core.Context().Done():
+				return
+			case <-ticker.C:
+				h.processingCache.cleanExpired()
+			}
+		}
+	})
+
+	// Spectrogram generator (needs the media SecureFS). The construction-time
+	// settings snapshot from the shared core matches the monolith's behavior.
+	h.spectrogramGenerator = spectrogram.NewGenerator(core.Settings.Load(), core.SFS, getSpectrogramLogger())
+
+	return h
+}

--- a/internal/api/v2/media/media.go
+++ b/internal/api/v2/media/media.go
@@ -1,5 +1,5 @@
-// internal/api/v2/media.go
-package api
+// internal/api/v2/media/media.go
+package media
 
 import (
 	"context"
@@ -30,9 +30,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// Non-standard HTTP status codes
+// Non-standard HTTP status codes. Aliased from apicore so this media handler and
+// the analytics handler (still in package api) share one source for the
+// client-closed status.
 const (
-	StatusClientClosedRequest = 499 // Nginx's non-standard status for client closed connection
+	StatusClientClosedRequest = apicore.StatusClientClosedRequest // Nginx's non-standard status for client closed connection
 )
 
 // Spectrogram size constants - FFT-friendly dimensions. Aliased from apicore so
@@ -54,6 +56,18 @@ const (
 	MimeTypeMP3  = "audio/mpeg"
 	MimeTypeM4A  = "audio/mp4"
 	MimeTypeOGG  = "audio/ogg"
+)
+
+// Cache duration in seconds for HTTP Cache-Control headers on media responses.
+const (
+	// ImageCacheSeconds is the cache duration for species images in seconds
+	ImageCacheSeconds = 2592000 // 30 days
+
+	// NotFoundCacheSeconds is the cache duration for 404 responses in seconds
+	NotFoundCacheSeconds = 86400 // 24 hours
+
+	// SpectrogramCacheSeconds is the cache duration for spectrograms in seconds
+	SpectrogramCacheSeconds = 2592000 // 30 days
 )
 
 // isClipNotFoundErr reports whether err indicates the audio clip or its parent
@@ -172,23 +186,32 @@ type ProcessAudioRequest struct {
 	GainDB    float64 `json:"gain_db"`
 }
 
-// Initialize media routes
-func (c *Controller) initMediaRoutes() {
+// RegisterRoutes registers the media domain routes. It is called by the facade
+// in the deterministic initRoutes order, at the same slot the former
+// initMediaRoutes occupied, so the registered route set stays byte-identical.
+//
+// The /media/* routes register on the passed v2 group g (== c.Group). The
+// ID-based routes register directly on c.Echo (the embedded core's Echo
+// instance), preserving the greedy GET /api/v2/audio/:id route documented in
+// internal/api/v2/CLAUDE.md: it is registered on the Echo instance (not the
+// group) and catches all /api/v2/audio/* paths. Registering it here, at the
+// media slot, keeps it on c.Echo at the exact same point in initialization.
+func (c *Handler) RegisterRoutes(g *echo.Group) {
 	c.LogInfoIfEnabled("Initializing media routes")
 
 	// Datastore-independent media routes serve from SecureFS / BirdImageCache and do
 	// not touch c.DS, so they register regardless of datastore availability.
 	// Original filename-based routes (keep for backward compatibility if needed, but ensure they use SFS)
-	c.Group.GET("/media/audio/:filename", c.ServeAudioClip)
-	c.Group.GET("/media/spectrogram/:filename", c.ServeSpectrogram)
+	g.GET("/media/audio/:filename", c.ServeAudioClip)
+	g.GET("/media/spectrogram/:filename", c.ServeSpectrogram)
 
 	// Bird image endpoints
-	c.Group.GET("/media/species-image", c.GetSpeciesImage)
-	c.Group.GET("/media/species-image/info", c.GetSpeciesImageInfo)
+	g.GET("/media/species-image", c.GetSpeciesImage)
+	g.GET("/media/species-image/info", c.GetSpeciesImageInfo)
 
 	// Proxied bird image endpoints (serve cached files, solve CORS)
-	c.Group.GET("/media/image/:scientific_name", c.ServeSpeciesImageProxy)
-	c.Group.GET("/media/bird-image/:scientific_name", c.ServeSpeciesImageProxy) // backward-compat alias
+	g.GET("/media/image/:scientific_name", c.ServeSpeciesImageProxy)
+	g.GET("/media/bird-image/:scientific_name", c.ServeSpeciesImageProxy) // backward-compat alias
 
 	// The remaining ID-based media handlers dereference c.DS (clip/model lookups).
 	// Honor the constructor's "datastore disabled" mode (NewWithOptions permits a nil
@@ -200,7 +223,8 @@ func (c *Controller) initMediaRoutes() {
 		return
 	}
 
-	// ID-based routes using SFS
+	// ID-based routes using SFS. Registered on c.Echo (not the group); the
+	// GET /api/v2/audio/:id route is greedy and catches all /api/v2/audio/* paths.
 	c.Echo.GET("/api/v2/audio/:id", c.ServeAudioByID)
 	c.Echo.GET("/api/v2/spectrogram/:id", c.ServeSpectrogramByID)
 	c.Echo.GET("/api/v2/spectrogram/:id/status", c.GetSpectrogramStatus)
@@ -216,7 +240,7 @@ func (c *Controller) initMediaRoutes() {
 	c.Echo.POST("/api/v2/spectrogram/:id/process", c.ProcessedSpectrogramByID, c.AuthMiddleware)
 
 	// Convenient combined endpoint (redirects to ID-based internally)
-	c.Group.GET("/media/audio", c.ServeAudioByQueryID)
+	g.GET("/media/audio", c.ServeAudioByQueryID)
 
 	c.LogInfoIfEnabled("Media routes initialized successfully")
 }
@@ -224,7 +248,7 @@ func (c *Controller) initMediaRoutes() {
 // translateSecureFSError handles SecureFS errors consistently across handler methods.
 // It checks if the error is already an HTTPError from SecureFS and returns it directly,
 // or maps specific error types to appropriate HTTP status codes.
-func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg string) error {
+func (c *Handler) translateSecureFSError(ctx echo.Context, err error, userMsg string) error {
 	var httpErr *echo.HTTPError
 	if errors.As(err, &httpErr) {
 		// If it's already an HTTPError from SecureFS, just pass it through
@@ -361,7 +385,7 @@ func parseRawParameter(rawParam string) bool {
 // so a temp written by an older build mid-upgrade is handled. Returning the
 // concrete path lets a waiting caller poll that fixed name with StatRel instead
 // of re-scanning the directory on every tick.
-func (c *Controller) findEncodingTempPath(relClipPath string) (string, bool) {
+func (c *Handler) findEncodingTempPath(relClipPath string) (string, bool) {
 	dir := filepath.Dir(relClipPath)
 	entries, err := c.SFS.ReadDirRel(dir)
 	if err != nil {
@@ -418,14 +442,14 @@ func isExportTempFor(name, base string) bool {
 // exists for relClipPath. Callers that then wait for the clip should use
 // findEncodingTempPath directly so they can poll the temp's fixed name with
 // StatRel rather than re-scanning the directory each tick.
-func (c *Controller) isAudioBeingEncoded(relClipPath string) bool {
+func (c *Handler) isAudioBeingEncoded(relClipPath string) bool {
 	_, ok := c.findEncodingTempPath(relClipPath)
 	return ok
 }
 
 // handleAudioNotReady returns a 503 Service Unavailable response with a
 // Retry-After header, indicating that the audio file is still being encoded.
-func (c *Controller) handleAudioNotReady(ctx echo.Context) error {
+func (c *Handler) handleAudioNotReady(ctx echo.Context) error {
 	ctx.Response().Header().Set("Retry-After", audioRetryAfterSeconds)
 	return c.HandleError(ctx, ffmpeg.ErrAudioFileNotReady,
 		"Audio file is still being processed, please retry",
@@ -437,7 +461,7 @@ func (c *Controller) handleAudioNotReady(ctx echo.Context) error {
 // timeout, false if encoding is still ongoing or the temp file disappeared.
 // This reduces 503 responses by waiting server-side instead of requiring
 // the client to retry.
-func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath, tempPath string) bool {
+func (c *Handler) waitForAudioFile(ctx echo.Context, relClipPath, tempPath string) bool {
 	// Resolve the wait timeout. Production leaves the override at zero and uses the
 	// default constant; tests inject a short timeout to exercise the
 	// 503-after-timeout path without waiting the full default.
@@ -470,7 +494,7 @@ func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath, tempPath st
 		// Wait for the next event.
 		select {
 		case <-waitCtx.Done():
-			// Timeout or client disconnect — final check in case file appeared
+			// Timeout or client disconnect - final check in case file appeared
 			// between the last tick and the deadline.
 			_, err := c.SFS.StatRel(relClipPath)
 			return err == nil
@@ -485,7 +509,7 @@ func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath, tempPath st
 // detection DB record is committed but FFmpeg hasn't created the temp file
 // yet, or has already atomically renamed it to the final path.
 // Returns true if the file appeared within the grace period.
-func (c *Controller) waitForAudioFileGrace(ctx echo.Context, relClipPath string) bool {
+func (c *Handler) waitForAudioFileGrace(ctx echo.Context, relClipPath string) bool {
 	// Check immediately to avoid waiting one full poll interval when the file
 	// appears right after the initial 404.
 	if _, err := c.SFS.StatRel(relClipPath); err == nil {
@@ -517,13 +541,13 @@ func (c *Controller) waitForAudioFileGrace(ctx echo.Context, relClipPath string)
 // then falls back to a brief grace period for the race window where FFmpeg hasn't
 // created the temp file yet or already renamed it. Returns nil if the file was
 // successfully served, or the original/translated error otherwise.
-func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, logFields ...logger.Field) error {
+func (c *Handler) handleAudio404WithWait(ctx echo.Context, relClipPath string, originalErr error, logFields ...logger.Field) error {
 	if tempPath, encoding := c.findEncodingTempPath(relClipPath); encoding {
 		// Wait server-side for the file to appear instead of immediately
 		// returning 503, reducing unnecessary client round-trips. Pass the
 		// concrete temp path so the wait loop polls it directly.
 		if c.waitForAudioFile(ctx, relClipPath, tempPath) {
-			// File appeared — serve it now
+			// File appeared - serve it now
 			if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
 				return c.translateSecureFSError(ctx, retryErr, "Failed to serve audio clip after encoding completed")
 			}
@@ -534,12 +558,12 @@ func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string
 		if c.isAudioBeingEncoded(relClipPath) {
 			return c.handleAudioNotReady(ctx)
 		}
-		// Temp file disappeared and final file is still missing —
+		// Temp file disappeared and final file is still missing -
 		// encoding failed, fall back to normal error translation.
 		return c.translateSecureFSError(ctx, originalErr, "Failed to serve audio clip due to an unexpected error")
 	}
 
-	// No temp file visible — brief grace wait for the race window where
+	// No temp file visible - brief grace wait for the race window where
 	// FFmpeg hasn't created the temp file yet or already renamed it.
 	if c.waitForAudioFileGrace(ctx, relClipPath) {
 		if retryErr := c.SFS.ServeRelativeFile(ctx, relClipPath); retryErr != nil {
@@ -553,7 +577,7 @@ func (c *Controller) handleAudio404WithWait(ctx echo.Context, relClipPath string
 }
 
 // ServeAudioClip serves an audio clip file by filename using SecureFS
-func (c *Controller) ServeAudioClip(ctx echo.Context) error {
+func (c *Handler) ServeAudioClip(ctx echo.Context) error {
 	filename := ctx.Param("filename")
 	if filename == "" {
 		c.LogErrorIfEnabled("Missing filename parameter for ServeAudioClip",
@@ -612,7 +636,7 @@ func (c *Controller) ServeAudioClip(ctx echo.Context) error {
 }
 
 // ServeAudioByID serves an audio clip file based on note ID using SecureFS
-func (c *Controller) ServeAudioByID(ctx echo.Context) error {
+func (c *Handler) ServeAudioByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
 	if err := c.RequireDatastore(ctx); err != nil {
@@ -709,7 +733,7 @@ func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 //
 // POST /api/v2/audio/:id/clip
 // Body: {"start": 1.5, "end": 4.2, "format": "mp3"}
-func (c *Controller) ExtractAudioClipByID(ctx echo.Context) error {
+func (c *Handler) ExtractAudioClipByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
 	if err := c.RequireDatastore(ctx); err != nil {
@@ -863,7 +887,7 @@ func clipFileExtension(format string) string {
 //
 // POST /api/v2/audio/:id/process
 // Body: {"normalize": true, "denoise": "medium", "gain_db": 6.0}
-func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
+func (c *Handler) ProcessAudioByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
 	if err := c.RequireDatastore(ctx); err != nil {
@@ -983,7 +1007,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 // POST /api/v2/spectrogram/:id/process
 // Body: {"normalize": true, "denoise": "medium", "gain_db": 0}
 // Query: same as GET /api/v2/spectrogram/:id (size, raw)
-func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
+func (c *Handler) ProcessedSpectrogramByID(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereference below anyway.
 	if err := c.RequireDatastore(ctx); err != nil {
@@ -1103,13 +1127,13 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to read spectrogram", http.StatusInternalServerError)
 	}
 
-	// No cache — processed spectrograms are ephemeral previews
+	// No cache - processed spectrograms are ephemeral previews
 	ctx.Response().Header().Set("Cache-Control", "no-store")
 	return ctx.Blob(http.StatusOK, "image/png", pngData)
 }
 
 // spectrogramHTTPError handles common spectrogram generation errors and converts them to appropriate HTTP responses
-func (c *Controller) spectrogramHTTPError(ctx echo.Context, err error) error {
+func (c *Handler) spectrogramHTTPError(ctx echo.Context, err error) error {
 	switch {
 	case errors.Is(err, ffmpeg.ErrAudioFileNotReady) || errors.Is(err, ffmpeg.ErrAudioFileIncomplete):
 		// Audio file is not ready yet - client should retry
@@ -1166,7 +1190,7 @@ type spectrogramParameters struct {
 // Style and dynamic range are read from settings (not query params) because they are
 // global settings that affect the visual appearance of all spectrograms. Including them
 // in the filename prevents serving stale cached spectrograms when these settings change.
-func (c *Controller) parseSpectrogramParameters(ctx echo.Context) spectrogramParameters {
+func (c *Handler) parseSpectrogramParameters(ctx echo.Context) spectrogramParameters {
 	spec := c.CurrentSettings().Realtime.Dashboard.Spectrogram
 	params := spectrogramParameters{
 		width:        SpectrogramSizeLg, // Default width (lg) - single render size for all contexts
@@ -1197,7 +1221,7 @@ func (c *Controller) parseSpectrogramParameters(ctx echo.Context) spectrogramPar
 
 // validateNoteIDAndGetClipPath validates the note ID parameter and retrieves the clip path.
 // Returns the noteID and clipPath, or an error if validation fails.
-func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, clipPath string, err error) {
+func (c *Handler) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, clipPath string, err error) {
 	// Defense in depth: initMediaRoutes already skips registering the ID-based media
 	// handlers when the datastore is disabled, but guard the c.DS dereference below
 	// anyway.
@@ -1256,7 +1280,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 
 // handleUserRequestedMode handles spectrogram serving in user-requested mode.
 // Returns true if the request was handled (either success or error response sent).
-func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters, freqSuffix string) (bool, error) {
+func (c *Handler) handleUserRequestedMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters, freqSuffix string) (bool, error) {
 	// Normalize and validate the audio path
 	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalizedPath := apicore.NormalizeClipPath(clipPath, clipsPrefix)
@@ -1299,7 +1323,7 @@ func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath 
 
 // returnSpectrogramNotGeneratedError returns a standardized 404 response for user-requested mode
 // when a spectrogram hasn't been generated yet.
-func (c *Controller) returnSpectrogramNotGeneratedError(ctx echo.Context) (bool, error) {
+func (c *Handler) returnSpectrogramNotGeneratedError(ctx echo.Context) (bool, error) {
 	// Return JSON response with mode information using standard v2 error envelope.
 	// Flow: <img> element's onerror handler triggers -> frontend makes fetch() call to same URL
 	// -> this JSON response is parsed by frontend -> mode field triggers UI to show "Generate" button
@@ -1330,7 +1354,7 @@ func (c *Controller) returnSpectrogramNotGeneratedError(ctx echo.Context) (bool,
 }
 
 // handleAutoPreRenderMode handles spectrogram generation and serving in auto/prerender modes.
-func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters, freqSuffix string, extraOpts ...spectrogram.GenerateOption) error {
+func (c *Handler) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath string, params spectrogramParameters, freqSuffix string, extraOpts ...spectrogram.GenerateOption) error {
 	// Auto or prerender mode - generate on-demand if needed
 	generationStart := time.Now()
 	spectrogramPath, err := c.generateSpectrogram(ctx.Request().Context(), clipPath, params.width, params.raw, params.style, params.dynamicRange, freqSuffix, extraOpts...)
@@ -1365,7 +1389,7 @@ func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath 
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()))
 
-	// Set cache headers before serving — spectrograms are deterministic (same clip + params = same image)
+	// Set cache headers before serving - spectrograms are deterministic (same clip + params = same image)
 	// and never change once generated. This allows browsers to serve from disk cache on reload,
 	// avoiding HTTP/1.1 connection exhaustion when loading many detection cards simultaneously.
 	ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", SpectrogramCacheSeconds))
@@ -1448,7 +1472,7 @@ func (c *Controller) handleAutoPreRenderMode(ctx echo.Context, noteID, clipPath 
 //
 // The raw parameter defaults to true to maintain compatibility with existing cached
 // spectrograms from the old HTMX API which generated raw spectrograms by default.
-func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
+func (c *Handler) ServeSpectrogramByID(ctx echo.Context) error {
 	// Validate note ID and get clip path
 	noteID, clipPath, err := c.validateNoteIDAndGetClipPath(ctx)
 	if err != nil {
@@ -1493,7 +1517,7 @@ func (c *Controller) ServeSpectrogramByID(ctx echo.Context) error {
 }
 
 // ServeAudioByQueryID serves an audio clip using query parameter for ID
-func (c *Controller) ServeAudioByQueryID(ctx echo.Context) error {
+func (c *Handler) ServeAudioByQueryID(ctx echo.Context) error {
 	noteID := ctx.QueryParam("id")
 	if noteID == "" {
 		return c.HandleError(ctx, fmt.Errorf("missing ID"), "Note ID is required as query parameter", http.StatusBadRequest)
@@ -1519,7 +1543,7 @@ func (c *Controller) ServeAudioByQueryID(ctx echo.Context) error {
 //
 // The raw parameter defaults to true to maintain compatibility with existing cached
 // spectrograms from the old HTMX API which generated raw spectrograms by default.
-func (c *Controller) ServeSpectrogram(ctx echo.Context) error {
+func (c *Handler) ServeSpectrogram(ctx echo.Context) error {
 	filename := ctx.Param("filename")
 
 	// Parse size parameter
@@ -1593,7 +1617,7 @@ func (c *Controller) ServeSpectrogram(ctx echo.Context) error {
 //   - "generated": Successfully generated (in queue cache)
 //   - "failed": Generation failed
 //   - "exists": Already exists on disk
-func (c *Controller) GetSpectrogramStatus(ctx echo.Context) error {
+func (c *Handler) GetSpectrogramStatus(ctx echo.Context) error {
 	// Defense in depth: initMediaRoutes already skips registering this handler when the
 	// datastore is disabled, but guard the c.DS dereferences below anyway.
 	if err := c.RequireDatastore(ctx); err != nil {
@@ -1723,7 +1747,7 @@ func (c *Controller) GetSpectrogramStatus(ctx echo.Context) error {
 //   - 404 Not Found: Audio file not found
 //   - 408 Request Timeout: Generation timed out
 //   - 500 Internal Server Error: Generation failed
-func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
+func (c *Handler) GenerateSpectrogramByID(ctx echo.Context) error {
 	// Validate note ID and get clip path using shared helper
 	noteID, clipPath, err := c.validateNoteIDAndGetClipPath(ctx)
 	if err != nil {
@@ -1881,8 +1905,8 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 }
 
 // maxConcurrentSpectrograms limits concurrent spectrogram generations to the number of CPU cores.
-// This adapts automatically to the deployment hardware — 4 on Raspberry Pi 4/5, fewer on Pi Zero/3,
-// more on multi-core desktops — preventing CPU contention while utilizing available resources.
+// This adapts automatically to the deployment hardware - 4 on Raspberry Pi 4/5, fewer on Pi Zero/3,
+// more on multi-core desktops - preventing CPU contention while utilizing available resources.
 var maxConcurrentSpectrograms = runtime.NumCPU()
 
 // semaphoreAcquireTimeout is the maximum time to wait for a semaphore slot before timing out
@@ -1977,7 +2001,7 @@ func getSpectrogramLogger() logger.Logger {
 // resolveDetectionFrequencyProfile resolves a detection's spectrogram frequency
 // profile from its model type, defaulting to the bird profile when the model
 // type cannot be looked up.
-func (c *Controller) resolveDetectionFrequencyProfile(noteID string) spectrogram.FrequencyProfile {
+func (c *Handler) resolveDetectionFrequencyProfile(noteID string) spectrogram.FrequencyProfile {
 	modelType, err := c.DS.GetNoteModelType(noteID)
 	if err != nil {
 		c.LogWarnIfEnabled("GetNoteModelType failed, defaulting to bird profile",
@@ -1991,7 +2015,7 @@ func (c *Controller) resolveDetectionFrequencyProfile(noteID string) spectrogram
 // detection so by-ID spectrogram paths and queue keys do not collide with the
 // default bird-profile render. Returns "" (bird) when the model type cannot be
 // resolved.
-func (c *Controller) spectrogramProfileSuffix(noteID string) string {
+func (c *Handler) spectrogramProfileSuffix(noteID string) string {
 	return spectrogram.ProfileSuffix(c.resolveDetectionFrequencyProfile(noteID))
 }
 
@@ -2108,7 +2132,7 @@ type durationCacheEntry struct {
 
 // validateSpectrogramInputs validates that the audio file is complete and ready for spectrogram generation.
 // It returns the validation result and any error encountered during validation.
-func (c *Controller) validateSpectrogramInputs(ctx context.Context, absAudioPath, audioPath, queueKey string) (*ffmpeg.ValidationResult, error) {
+func (c *Handler) validateSpectrogramInputs(ctx context.Context, absAudioPath, audioPath, queueKey string) (*ffmpeg.ValidationResult, error) {
 	// Check cache first
 	fileInfo, err := os.Stat(absAudioPath)
 	if err != nil {
@@ -2329,7 +2353,7 @@ func getCachedAudioDuration(ctx context.Context, audioPath string) float64 {
 }
 
 // normalizeAndValidatePath handles path normalization and validation
-func (c *Controller) normalizeAndValidatePath(audioPath string) (string, error) {
+func (c *Handler) normalizeAndValidatePath(audioPath string) (string, error) {
 	// Pass nil since spectrogram context has its own logging via getSpectrogramLogger()
 	return c.normalizeAndValidatePathWithLogger(audioPath, nil)
 }
@@ -2342,7 +2366,7 @@ func (c *Controller) normalizeAndValidatePath(audioPath string) (string, error) 
 // 4. Validating with SecureFS
 //
 // This reduces duplication across the codebase where this pattern is used.
-func (c *Controller) normalizeAndValidatePathWithLogger(audioPath string, log logger.Logger) (string, error) {
+func (c *Handler) normalizeAndValidatePathWithLogger(audioPath string, log logger.Logger) (string, error) {
 	clipsPrefix := c.CurrentSettings().Realtime.Audio.Export.Path
 	normalizedPath := apicore.NormalizeClipPath(audioPath, clipsPrefix)
 
@@ -2374,7 +2398,7 @@ func (c *Controller) normalizeAndValidatePathWithLogger(audioPath string, log lo
 }
 
 // checkSpectrogramExists performs fast path check for existing spectrogram
-func (c *Controller) checkSpectrogramExists(relSpectrogramPath, queueKey string, start time.Time) (bool, error) {
+func (c *Handler) checkSpectrogramExists(relSpectrogramPath, queueKey string, start time.Time) (bool, error) {
 	getSpectrogramLogger().Debug("Fast path check: checking if spectrogram exists",
 		logger.String("queue_key", queueKey),
 		logger.String("relative_spectrogram_path", relSpectrogramPath))
@@ -2430,7 +2454,7 @@ func (c *Controller) checkSpectrogramExists(relSpectrogramPath, queueKey string,
 }
 
 // updateQueueStatus updates the spectrogram generation queue status (thread-safe)
-func (c *Controller) updateQueueStatus(queueKey, status string, queuePos int, message string) {
+func (c *Handler) updateQueueStatus(queueKey, status string, queuePos int, message string) {
 	// Using sync.Map for lock-free lookups + struct mutex for safe updates
 	if statusValue, exists := spectrogramQueue.Load(queueKey); exists {
 		if queueStatus, ok := statusValue.(*SpectrogramQueueStatus); ok {
@@ -2444,7 +2468,7 @@ func (c *Controller) updateQueueStatus(queueKey, status string, queuePos int, me
 }
 
 // checkAudioFileExists verifies the audio file exists
-func (c *Controller) checkAudioFileExists(relAudioPath string) error {
+func (c *Handler) checkAudioFileExists(relAudioPath string) error {
 	getSpectrogramLogger().Debug("Checking if audio file exists",
 		logger.String("relative_audio_path", relAudioPath))
 
@@ -2474,8 +2498,8 @@ func (c *Controller) checkAudioFileExists(relAudioPath string) error {
 // It uses the same timeout and poll interval as the audio serving wait logic
 // (audioWaitTimeout / audioWaitPollInterval).
 // Returns nil if the file appeared, or the original not-found error otherwise.
-func (c *Controller) waitForAudioFileCtx(ctx context.Context, relAudioPath string) error {
-	// Immediate check — avoid waiting if file already exists.
+func (c *Handler) waitForAudioFileCtx(ctx context.Context, relAudioPath string) error {
+	// Immediate check - avoid waiting if file already exists.
 	if _, err := c.SFS.StatRel(relAudioPath); err == nil {
 		return nil
 	}
@@ -2489,7 +2513,7 @@ func (c *Controller) waitForAudioFileCtx(ctx context.Context, relAudioPath strin
 	for {
 		select {
 		case <-waitCtx.Done():
-			// Final check before giving up — the file may have appeared
+			// Final check before giving up - the file may have appeared
 			// between the last tick and the deadline.
 			if _, err := c.SFS.StatRel(relAudioPath); err == nil {
 				return nil
@@ -2510,7 +2534,7 @@ func (c *Controller) waitForAudioFileCtx(ctx context.Context, relAudioPath strin
 
 // initializeQueueStatus initializes the queue tracking for a spectrogram request
 // Optimized to minimize lock hold time - calculation done outside lock, only write is locked
-func (c *Controller) initializeQueueStatus(queueKey string) {
+func (c *Handler) initializeQueueStatus(queueKey string) {
 	// Step 1: Calculate queue position OUTSIDE the lock to minimize contention
 	currentSlotsInUse := len(spectrogramSemaphore)
 
@@ -2548,7 +2572,7 @@ func (c *Controller) initializeQueueStatus(queueKey string) {
 
 // cleanupQueueStatus removes the queue entry for a spectrogram request
 // Failed statuses are retained briefly (30s) so polling clients can see the error
-func (c *Controller) cleanupQueueStatus(queueKey string) {
+func (c *Handler) cleanupQueueStatus(queueKey string) {
 	// Check if this is a failed status that should be retained temporarily
 	if statusValue, ok := spectrogramQueue.Load(queueKey); ok {
 		if status, ok := statusValue.(*SpectrogramQueueStatus); ok {
@@ -2582,7 +2606,7 @@ func deleteFailedStatusIfUnchanged(queueKey string, original any) {
 
 // acquireSemaphoreSlot acquires a semaphore slot for spectrogram generation
 // With timeout handling to prevent indefinite blocking
-func (c *Controller) acquireSemaphoreSlot(ctx context.Context, queueKey string) error {
+func (c *Handler) acquireSemaphoreSlot(ctx context.Context, queueKey string) error {
 	slotsInUseBeforeAcquire := len(spectrogramSemaphore)
 	availableSlots := maxConcurrentSpectrograms - slotsInUseBeforeAcquire
 
@@ -2632,8 +2656,8 @@ func (c *Controller) acquireSemaphoreSlot(ctx context.Context, queueKey string) 
 }
 
 // performSpectrogramGeneration executes the actual spectrogram generation logic
-func (c *Controller) performSpectrogramGeneration(ctx context.Context, relSpectrogramPath, absAudioPath, absSpectrogramPath, queueKey string, width int, raw bool, validatedDuration float64, extraOpts ...spectrogram.GenerateOption) (any, error) {
-	// Fast path inside the group – now race-free
+func (c *Handler) performSpectrogramGeneration(ctx context.Context, relSpectrogramPath, absAudioPath, absSpectrogramPath, queueKey string, width int, raw bool, validatedDuration float64, extraOpts ...spectrogram.GenerateOption) (any, error) {
+	// Fast path inside the group - now race-free
 	getSpectrogramLogger().Debug("Inside singleflight group, double-checking if spectrogram exists",
 		logger.String("queue_key", queueKey))
 
@@ -2706,7 +2730,7 @@ func (c *Controller) performSpectrogramGeneration(ctx context.Context, relSpectr
 
 // verifySpectrogramFile checks that a spectrogram file exists with retries for filesystem sync delays.
 // It tries direct filesystem and SecureFS checks with exponential backoff.
-func (c *Controller) verifySpectrogramFile(absPath, relPath string) error {
+func (c *Handler) verifySpectrogramFile(absPath, relPath string) error {
 	var statErr error
 	for i := range spectrogramVerifyRetries {
 		// Try direct filesystem check first (more reliable for newly created files)
@@ -2765,7 +2789,7 @@ func (c *Controller) verifySpectrogramFile(absPath, relPath string) error {
 }
 
 // generateWithFallback attempts to generate a spectrogram with SoX, falling back to FFmpeg on failure
-func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, absSpectrogramPath, queueKey string, width int, raw bool, validatedDuration float64, extraOpts ...spectrogram.GenerateOption) error {
+func (c *Handler) generateWithFallback(ctx context.Context, absAudioPath, absSpectrogramPath, queueKey string, width int, raw bool, validatedDuration float64, extraOpts ...spectrogram.GenerateOption) error {
 	generationStart := time.Now()
 
 	getSpectrogramLogger().Debug("Starting spectrogram generation via shared generator",
@@ -2822,7 +2846,7 @@ func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, abs
 // the relative path at a request boundary (e.g. GenerateSpectrogramByID) must
 // call generateSpectrogramFromRel directly and thread that path in, so the queue
 // key cannot drift if Export.Path changes mid-flight.
-func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, width int, raw bool, style, dynamicRange, freqSuffix string, extraOpts ...spectrogram.GenerateOption) (string, error) {
+func (c *Handler) generateSpectrogram(ctx context.Context, audioPath string, width int, raw bool, style, dynamicRange, freqSuffix string, extraOpts ...spectrogram.GenerateOption) (string, error) {
 	// Step 1: Normalize and validate path
 	relAudioPath, err := c.normalizeAndValidatePath(audioPath)
 	if err != nil {
@@ -2846,7 +2870,7 @@ func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, 
 // buildSpectrogramKey, which is also used as the singleflight coalescing key so that
 // concurrent requests for the same on-disk file still share one generation pass.
 // audioPath is retained only for log and error context.
-func (c *Controller) generateSpectrogramFromRel(ctx context.Context, relAudioPath, audioPath, queueKey string, width int, raw bool, style, dynamicRange, freqSuffix string, extraOpts ...spectrogram.GenerateOption) (string, error) {
+func (c *Handler) generateSpectrogramFromRel(ctx context.Context, relAudioPath, audioPath, queueKey string, width int, raw bool, style, dynamicRange, freqSuffix string, extraOpts ...spectrogram.GenerateOption) (string, error) {
 	start := time.Now()
 	getSpectrogramLogger().Debug("Spectrogram generation requested",
 		logger.String("audio_path", audioPath),
@@ -3036,7 +3060,7 @@ func (c *Controller) generateSpectrogramFromRel(ctx context.Context, relAudioPat
 // c.spectrogramGenerator.GenerateFromFile().
 
 // GetSpeciesImage serves an image for a bird species by scientific name
-func (c *Controller) GetSpeciesImage(ctx echo.Context) error {
+func (c *Handler) GetSpeciesImage(ctx echo.Context) error {
 	scientificName := ctx.QueryParam("name")
 	if scientificName == "" {
 		return c.HandleError(ctx, fmt.Errorf("missing scientific name"), "Scientific name is required", http.StatusBadRequest)
@@ -3055,7 +3079,7 @@ func (c *Controller) GetSpeciesImage(ctx echo.Context) error {
 }
 
 // GetSpeciesImageInfo returns attribution metadata for a species image as JSON
-func (c *Controller) GetSpeciesImageInfo(ctx echo.Context) error {
+func (c *Handler) GetSpeciesImageInfo(ctx echo.Context) error {
 	scientificName := ctx.QueryParam("name")
 	if scientificName == "" {
 		return c.HandleError(ctx, fmt.Errorf("missing scientific name"), "Scientific name is required", http.StatusBadRequest)
@@ -3097,7 +3121,7 @@ func (c *Controller) GetSpeciesImageInfo(ctx echo.Context) error {
 // Falls back to 302 redirect to external URL if local fetch fails.
 // Route: GET /media/image/:scientific_name
 // Route: GET /media/bird-image/:scientific_name (alias)
-func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
+func (c *Handler) ServeSpeciesImageProxy(ctx echo.Context) error {
 	scientificName, err := url.PathUnescape(ctx.Param("scientific_name"))
 	if err != nil {
 		return c.HandleError(ctx, fmt.Errorf("invalid scientific name encoding"), "Invalid species name", http.StatusBadRequest)
@@ -3159,7 +3183,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 		return c.serveImageFile(ctx, cachedPath, contentType)
 	}
 
-	// File not cached or stale — download it
+	// File not cached or stale - download it
 	newPath, newCT, dlErr := fileCache.DownloadAndStore(ctx.Request().Context(), provider, scientificName, birdImage.URL)
 	if dlErr != nil {
 		// Graceful degradation: serve stale file if available, otherwise redirect
@@ -3186,7 +3210,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 
 // serveImageFile serves a cached image file with appropriate cache headers.
 // http.ServeContent handles Last-Modified, If-Modified-Since, and If-None-Match natively.
-func (c *Controller) serveImageFile(ctx echo.Context, filePath, contentType string) error {
+func (c *Handler) serveImageFile(ctx echo.Context, filePath, contentType string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to open cached image", http.StatusInternalServerError)
@@ -3212,4 +3236,5 @@ func (c *Controller) serveImageFile(ctx echo.Context, filePath, contentType stri
 	return nil
 }
 
-// HandleError method should exist on Controller, typically defined in controller.go or api.go
+// HandleError, CurrentSettings, and the logging helpers are promoted from the
+// embedded *apicore.Core; see internal/api/v2/apicore.

--- a/internal/api/v2/media/media_ffmpeg_optimization_test.go
+++ b/internal/api/v2/media/media_ffmpeg_optimization_test.go
@@ -1,4 +1,4 @@
-package api
+package media
 
 import (
 	"context"

--- a/internal/api/v2/media/media_spectrogram_queuekey_test.go
+++ b/internal/api/v2/media/media_spectrogram_queuekey_test.go
@@ -9,7 +9,7 @@
 // progress. The fix keys the in-memory queue on an immutable identifier (note ID
 // plus visual params) that does not depend on Export.Path, so enqueue, the worker,
 // and the status poll always agree.
-package api
+package media
 
 import (
 	"context"
@@ -60,7 +60,7 @@ func TestGetSpectrogramStatusFindsInFlightJobAfterExportPathChange(t *testing.T)
 
 	controllerCore := &apicore.Core{SFS: sfs, DS: mockDS}
 	controllerCore.SetTestContext(t.Context(), nil)
-	controller := &Controller{Core: controllerCore}
+	controller := &Handler{Core: controllerCore}
 	controller.Settings.Store(settings)
 	conftest.SetTestSettings(settings)
 
@@ -118,7 +118,7 @@ func TestGenerateSpectrogramFromRelRetainsFailedStatusForPolling(t *testing.T) {
 	settings := apitest.NewValidTestSettings()
 	controllerCore := &apicore.Core{SFS: sfs}
 	controllerCore.SetTestContext(ctx, nil)
-	controller := &Controller{Core: controllerCore}
+	controller := &Handler{Core: controllerCore}
 	controller.Settings.Store(settings)
 	conftest.SetTestSettings(settings)
 

--- a/internal/api/v2/media/media_spectrogram_toctou_test.go
+++ b/internal/api/v2/media/media_spectrogram_toctou_test.go
@@ -9,7 +9,7 @@
 // the worker run under a different key, orphaning the handler's queued entry and
 // making GET /spectrogram/:id/status miss the in-flight job. The fix threads the
 // handler-validated relative path into generateSpectrogramFromRel.
-package api
+package media
 
 import (
 	"os"
@@ -45,7 +45,7 @@ func TestGenerateSpectrogramFromRelIgnoresLiveExportPath(t *testing.T) {
 
 	controllerCore := &apicore.Core{SFS: sfs}
 	controllerCore.SetTestContext(ctx, nil)
-	controller := &Controller{Core: controllerCore}
+	controller := &Handler{Core: controllerCore}
 	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	const (

--- a/internal/api/v2/media/media_test.go
+++ b/internal/api/v2/media/media_test.go
@@ -1,6 +1,6 @@
 // media_test.go: Package api provides tests for API v2 media endpoints.
 
-package api
+package media
 
 import (
 	"errors"
@@ -23,7 +23,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
-	"github.com/tphakala/birdnet-go/internal/securefs"
 	"gorm.io/gorm"
 )
 
@@ -154,7 +153,7 @@ func TestInitMediaRoutesRegistration(t *testing.T) {
 	e, controller, _ := setupMediaTestEnvironment(t)
 
 	// Re-initialize the routes to ensure a clean state
-	controller.initMediaRoutes()
+	controller.RegisterRoutes(controller.Group)
 
 	// Get all routes from the Echo instance
 	routes := e.Routes()
@@ -407,43 +406,27 @@ func TestServeSpectrogram(t *testing.T) {
 	}
 }
 
-// Setup function to create a test environment with SecureFS
-func setupMediaTestEnvironment(t *testing.T) (*echo.Echo, *Controller, string) {
+// setupMediaTestEnvironment builds a media Handler wired to a test core (with an
+// isolated SecureFS export root) and registers the media routes. It returns the
+// echo instance, the handler, and the SecureFS root directory tests write their
+// fixture files into. A passthrough auth middleware is injected so the
+// authenticated ID-based routes (clip extraction / audio processing) register and
+// can be exercised without a real auth service.
+func setupMediaTestEnvironment(t *testing.T) (*echo.Echo, *Handler, string) {
 	t.Helper()
 
-	// Create a temporary directory for test files (auto-cleaned by testing framework)
-	tempDir := t.TempDir()
+	e := echo.New()
+	core := apitest.NewCore(t, apitest.WithEcho(e))
+	// Passthrough auth so the authenticated clip/process routes register and run
+	// without a real auth service.
+	core.AuthMiddleware = passthroughMiddleware()
 
-	// Use the standard test setup which now initializes SFS
-	// We need the controller instance to reconfigure its SFS
-	e, _, controller := setupTestEnvironment(t)
+	h := New(core)
+	h.RegisterRoutes(core.Group)
 
-	// --- Crucially: Re-initialize SFS in the controller to use the *media test* tempDir ---
-	// Close the SFS created by setupTestEnvironment (if any)
-	if controller.SFS != nil {
-		require.NoError(t, controller.SFS.Close(), "Failed to close SFS")
-	}
-	// Create and assign the new SFS rooted in our tempDir
-	newSFS, err := securefs.New(tempDir)
-	require.NoError(t, err, "Failed to create SecureFS for media test environment")
-	controller.SFS = newSFS
-	t.Cleanup(func() {
-		assert.NoError(t, controller.SFS.Close(), "Failed to close SFS")
-	}) // Ensure this one is closed too
-
-	// Assign the tempDir to settings just in case any *other* part relies on it
-	// (though SecureFS should make this less necessary)
-	controller.Settings.Load().Realtime.Audio.Export.Path = tempDir
-
-	// Inject passthrough auth middleware so authenticated routes (e.g. clip extraction)
-	// can be registered and tested without a real auth service
-	WithAuthMiddleware(passthroughMiddleware())(controller)
-
-	// Initialize media routes on the controller instance that has the correct SFS
-	controller.initMediaRoutes()
-
-	// Return the Echo instance, the *correctly configured* controller, and the tempDir path
-	return e, controller, tempDir
+	// The media SecureFS is rooted at the per-test export path apitest.NewCore
+	// provisions (a t.TempDir()); tests create their fixture files under it.
+	return e, h, core.SFS.BaseDir()
 }
 
 // TestMediaEndpointsIntegration tests the media endpoints in an integrated way
@@ -1011,7 +994,7 @@ func TestServeAudioByID_AudioFormats(t *testing.T) {
 				}
 			})
 
-			// Setup mock to return this filename — use numeric IDs since the handler
+			// Setup mock to return this filename - use numeric IDs since the handler
 			// validates that :id is a valid number
 			audioID := fmt.Sprintf("%d", i+1)
 			mockDS.On("GetNoteClipPath", audioID).Return(format.filename, nil).Once()
@@ -1255,8 +1238,9 @@ func TestSpeciesImageNotFound_Returns404(t *testing.T) {
 	t.Attr("type", "regression")
 	t.Attr("issue", "2201")
 
-	// Setup test environment — the default mock provider returns images for any species
-	e, _, controller := setupTestEnvironment(t)
+	// Setup test environment - the default mock provider returns images for any species
+	e := echo.New()
+	controller := New(apitest.NewCore(t, apitest.WithEcho(e)))
 
 	// Replace the mock provider with one that returns ErrImageNotFound for unknown species
 	notFoundProvider := &apitest.TestImageProvider{
@@ -1401,7 +1385,7 @@ func TestServeAudioClipWaitsForEncoding(t *testing.T) {
 		}
 	})
 
-	// Make the request — should wait for the file and serve it
+	// Make the request - should wait for the file and serve it
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/audio/"+audioFilename, http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -1509,7 +1493,7 @@ func TestServeAudioClipGraceWaitServesFile(t *testing.T) {
 	audioFilename := "grace-wait-test.wav"
 	audioFilePath := filepath.Join(tempDir, audioFilename)
 
-	// No temp file — only the final file appears after a short delay.
+	// No temp file - only the final file appears after a short delay.
 	// This simulates the race window where FFmpeg hasn't started yet.
 	// Delay is derived from audioGracePeriod to stay aligned with production timing.
 	var wg sync.WaitGroup
@@ -1530,7 +1514,7 @@ func TestServeAudioClipGraceWaitServesFile(t *testing.T) {
 
 	handlerErr := controller.ServeAudioClip(ctx)
 
-	// Should succeed — grace wait should pick up the file
+	// Should succeed - grace wait should pick up the file
 	if handlerErr != nil {
 		if httpErr, ok := errors.AsType[*echo.HTTPError](handlerErr); ok {
 			assert.NotEqual(t, http.StatusNotFound, httpErr.Code,

--- a/internal/api/v2/media/process_cache.go
+++ b/internal/api/v2/media/process_cache.go
@@ -1,4 +1,4 @@
-package api
+package media
 
 import (
 	"fmt"
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -61,7 +62,7 @@ func (c *processingCache) get(key string) []byte {
 	}
 	if time.Since(info.ModTime()) > processingCacheTTL {
 		if err := os.Remove(path); err != nil {
-			GetLogger().Debug("Processing cache: failed to remove expired entry on read",
+			apicore.GetLogger().Debug("Processing cache: failed to remove expired entry on read",
 				logger.String("path", path),
 				logger.Error(err))
 		}
@@ -112,7 +113,7 @@ func (c *processingCache) put(key string, data []byte) error {
 func (c *processingCache) evictIfNeeded() {
 	entries, err := os.ReadDir(c.dir)
 	if err != nil {
-		GetLogger().Debug("Processing cache: failed to read directory for eviction",
+		apicore.GetLogger().Debug("Processing cache: failed to read directory for eviction",
 			logger.String("dir", c.dir),
 			logger.Error(err))
 		return
@@ -132,7 +133,7 @@ func (c *processingCache) evictIfNeeded() {
 		}
 		info, err := e.Info()
 		if err != nil {
-			GetLogger().Debug("Processing cache: failed to stat entry during eviction",
+			apicore.GetLogger().Debug("Processing cache: failed to stat entry during eviction",
 				logger.String("name", e.Name()),
 				logger.Error(err))
 			continue
@@ -154,7 +155,7 @@ func (c *processingCache) evictIfNeeded() {
 	}
 	for i := range min(toRemove, len(files)) {
 		if err := os.Remove(files[i].path); err != nil {
-			GetLogger().Debug("Processing cache: failed to remove file during eviction",
+			apicore.GetLogger().Debug("Processing cache: failed to remove file during eviction",
 				logger.String("path", files[i].path),
 				logger.Error(err))
 		}
@@ -167,7 +168,7 @@ func (c *processingCache) cleanExpired() {
 	defer c.mu.Unlock()
 	entries, err := os.ReadDir(c.dir)
 	if err != nil {
-		GetLogger().Debug("Processing cache: failed to read directory for cleanup",
+		apicore.GetLogger().Debug("Processing cache: failed to read directory for cleanup",
 			logger.String("dir", c.dir),
 			logger.Error(err))
 		return
@@ -178,14 +179,14 @@ func (c *processingCache) cleanExpired() {
 		}
 		info, err := e.Info()
 		if err != nil {
-			GetLogger().Debug("Processing cache: failed to stat entry during cleanup",
+			apicore.GetLogger().Debug("Processing cache: failed to stat entry during cleanup",
 				logger.String("name", e.Name()),
 				logger.Error(err))
 			continue
 		}
 		if time.Since(info.ModTime()) > processingCacheTTL {
 			if err := os.Remove(filepath.Join(c.dir, e.Name())); err != nil {
-				GetLogger().Debug("Processing cache: failed to remove expired file",
+				apicore.GetLogger().Debug("Processing cache: failed to remove expired file",
 					logger.String("name", e.Name()),
 					logger.Error(err))
 			}

--- a/internal/api/v2/media/process_cache_test.go
+++ b/internal/api/v2/media/process_cache_test.go
@@ -1,4 +1,4 @@
-package api
+package media
 
 import (
 	"math"

--- a/internal/api/v2/media/testhelpers_test.go
+++ b/internal/api/v2/media/testhelpers_test.go
@@ -32,6 +32,6 @@ func passthroughMiddleware() echo.MiddlewareFunc {
 // into sibling tests.
 func withRestoredGlobalSettings(t *testing.T) {
 	t.Helper()
-	orig := conf.GetSettings()
+	orig := conf.CloneSettings(conf.GetSettings())
 	t.Cleanup(func() { conftest.SetTestSettings(orig) })
 }

--- a/internal/api/v2/media/testhelpers_test.go
+++ b/internal/api/v2/media/testhelpers_test.go
@@ -1,0 +1,37 @@
+package media
+
+import (
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/conf/conftest"
+)
+
+// testFailFastTimeout is a short timeout injected into deliberate-failure waits
+// (an audio file that never appears) so those tests reach the expected timeout
+// state quickly instead of waiting the full production defaults. It is well above
+// any local/CI scheduling latency while staying far below the production timeouts.
+const testFailFastTimeout = 200 * time.Millisecond
+
+// passthroughMiddleware returns a no-op auth middleware used so the
+// authentication-protected media routes (clip extraction, audio processing) can
+// be registered and exercised in tests without a real auth service.
+func passthroughMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			return next(c)
+		}
+	}
+}
+
+// withRestoredGlobalSettings snapshots the process-global settings and restores
+// them on cleanup, so a test that publishes a divergent snapshot does not leak it
+// into sibling tests.
+func withRestoredGlobalSettings(t *testing.T) {
+	t.Helper()
+	orig := conf.GetSettings()
+	t.Cleanup(func() { conftest.SetTestSettings(orig) })
+}

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -39,7 +39,7 @@ func (c *Controller) initSystemRoutes() {
 	protectedGroup := systemGroup.Group("", authMiddleware)
 
 	// External media status (media domain).
-	protectedGroup.GET("/external-media", c.GetExternalMedia)
+	protectedGroup.GET("/external-media", c.media.GetExternalMedia)
 
 	// Database overview (analytics domain).
 	c.initDatabaseOverviewRoutes()


### PR DESCRIPTION
Phase 6 of the internal/api/v2 package split: move the media domain out of the monolithic package api into a new `internal/api/v2/media` subpackage, following the established pattern (Handler embeds `*apicore.Core` by pointer; the facade Controller holds a `media *media.Handler` field, constructs it, and calls its RegisterRoutes in the deterministic initRoutes order).

## Moved (receiver retyped `*Controller` -> `*Handler` only; bodies verbatim)
- `media.go` (~3.2k LOC): media-file serving (audio clips and spectrogram images from the SecureFS sandbox), the on-demand spectrogram generation pipeline, the ID-based audio/spectrogram endpoints, clip extraction, audio processing, and the cached bird-image proxy (`ServeSpeciesImageProxy`).
- `external_media.go`: the `GET /system/external-media` mount-status endpoint.
- `process_cache.go`: the processed-audio cache, now owned by the media Handler.
- The matching tests move alongside, rebuilt against the apitest helper (`apitest.NewCore` + `media.New`).

## The greedy `/api/v2/audio/:id` route
`RegisterRoutes` registers the `/media/*` routes on the passed v2 group and the 7 ID-based routes (including the greedy `GET /api/v2/audio/:id`) directly on `c.Echo` (the embedded core's Echo), behind the same nil-datastore guard and in the same order as the old `initMediaRoutes`. The facade calls `c.media.RegisterRoutes(c.Group)` at the same initRoutes slot (between auth and range), so the greedy route stays on `c.Echo` at the same point in initialization. The route-enumeration golden gate (incl. `TestGreedyAudioRouteRegisteredOnEcho`) is byte-identical.

## ServeSpeciesImageProxy re-wire
`ServeSpeciesImageProxy` is a media handler that the species domain injects for its thumbnail endpoint. The facade now constructs `c.media` before `c.species` and passes `c.media.ServeSpeciesImageProxy` (a method value on the media handler) instead of the removed facade method. `species.New`'s signature is unchanged.

## process_cache / spectrogram generator lifecycle
`media.New` builds the processing cache, the concurrency limiter, and the spectrogram generator from the shared SecureFS, and starts the cache-cleanup goroutine on the shared Core wait group (`core.Go`) bound to `core.Context()`. The facade Shutdown's existing `Cancel()`/`Wait()` tears it down, so no new shutdown hook is needed and no goroutine leaks. The six media-only facade fields (processingCache, processingSemaphore, spectrogramGenerator, externalMediaEnv, externalMediaProbe, audioWaitTimeoutOverride) move onto the Handler.

## SecureFS preservation
The SecureFS path-traversal helpers (translateSecureFSError, normalizeAndValidatePath, isValidFilename, checkAudioFileExists, findEncodingTempPath, isExportTempFor) move verbatim with only the receiver retyped. `NormalizeClipPath` already lives in apicore; media references it unchanged. `c.SFS` is the shared Core SecureFS; the facade Shutdown still closes it.

## Shared constant
`StatusClientClosedRequest` (499), used by both media and analytics, was promoted to apicore; analytics and the media handler reference `apicore.StatusClientClosedRequest`.

## External surface
`apiv2.Controller` / `New` / `NewWithOptions` and the methods `internal/analysis` calls are unchanged. The only cross-domain wiring change is `system_routes.go` re-pointing `/external-media` to `c.media.GetExternalMedia`.

## Verification
- `go vet ./internal/api/v2/...` clean; `go vet -tags skipfrontend ./internal/analysis/...` clean (no copylocks).
- `go test -race ./internal/api/v2/...` green (21 packages; media has its own -race binary). `internal/analysis` green (one pre-existing GC-timing-flaky memory test in analysis/species is unrelated and passes on retry).
- Route-enumeration golden gate, the greedy `/audio/:id` pin, and all `/media/*` per-route middleware pass byte-identical.
- golangci-lint: 0 issues on `internal/api/v2/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved organization of media endpoints, with consistent handling for audio, spectrograms, species images, and external media lookup.

* **Bug Fixes**
  * Standardized canceled-request responses (e.g., client disconnect) to return the correct non-standard HTTP status across analytics and insights.
  * Prevented crashes when media datastore is unavailable, returning appropriate errors instead.
  * Ensured debug routes are not registered when debugging is disabled.

* **Documentation**
  * Updated media API documentation to match the current media source reference.

* **Tests**
  * Expanded coverage for route registration, datastore-disabled behavior, and cancellation status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->