### PR TITLE
fix(frontend): raise sidebar z-index to prevent detection cards overlapping on mobile

### DIFF
--- a/frontend/src/lib/desktop/components/ui/ToastContainer.svelte
+++ b/frontend/src/lib/desktop/components/ui/ToastContainer.svelte
@@ -58,8 +58,13 @@
 
 <!-- Render toast containers for each position that has toasts -->
 {#each Object.entries(toastsByPosition) as [position, positionToasts] (position)}
+  <!-- z-[2000] = Z_INDEX.TOAST: toasts must stay above all overlays, including the mobile sidebar drawer (z-[200]) -->
   <div
-    class="fixed z-50 pointer-events-none {safeGet(positionClasses, position as ToastPosition, '')}"
+    class="fixed z-[2000] pointer-events-none {safeGet(
+      positionClasses,
+      position as ToastPosition,
+      ''
+    )}"
     role="region"
     aria-live="polite"
     aria-label="{position} notifications"

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -751,10 +751,13 @@ Performance Optimizations:
     </div>
   </nav>
 
-  <!-- Fixed-position tooltip for collapsed sidebar (escapes overflow containers) -->
+  <!-- Fixed-position tooltip for collapsed sidebar (escapes overflow containers).
+       z-[210] keeps it above the drawer (z-[200] = Z_INDEX.SIDEBAR_DRAWER): the
+       collapsed state persists in localStorage and can carry over to a mobile
+       viewport, where the drawer is raised to z-[200] and would otherwise hide it. -->
   {#if tooltipVisible && isCollapsed}
     <div
-      class="sidebar-tooltip fixed px-2 py-1 bg-[var(--color-base-300)] text-[var(--color-base-content)] text-sm rounded shadow-lg pointer-events-none whitespace-nowrap z-[100] -translate-y-1/2"
+      class="sidebar-tooltip fixed px-2 py-1 bg-[var(--color-base-300)] text-[var(--color-base-content)] text-sm rounded shadow-lg pointer-events-none whitespace-nowrap z-[210] -translate-y-1/2"
       style:top="{tooltipPosition.top}px"
       style:left="{tooltipPosition.left}px"
     >

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -457,6 +457,7 @@ Performance Optimizations:
 
 <aside
   class={cn(
+    // z-[200] matches Z_INDEX.SIDEBAR_DRAWER; lg:z-10 restores desktop stacking
     'drawer-side z-[200] lg:z-10 transition-all duration-200 ease-in-out overflow-visible',
     isCollapsed ? 'lg:w-16' : 'lg:w-64',
     className

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -450,7 +450,7 @@ Performance Optimizations:
 
 <aside
   class={cn(
-    'drawer-side z-10 transition-all duration-200 ease-in-out overflow-visible',
+    'drawer-side z-[200] transition-all duration-200 ease-in-out overflow-visible',
     isCollapsed ? 'lg:w-16' : 'lg:w-64',
     className
   )}

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -417,8 +417,7 @@ Performance Optimizations:
     // Capture the full current location (path + query) at click time so the
     // post-login redirect returns the user to the exact filtered view (#3306).
     loginRedirectUrl = getCurrentPathWithQuery();
-    // Close the mobile drawer before opening the modal so the modal renders
-    // above the sidebar rather than behind it (modal z-index < drawer z-index).
+    // Close the mobile drawer before opening the modal to ensure a clean transition.
     const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
     if (drawer?.checked) {
       drawer.checked = false;

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -417,6 +417,13 @@ Performance Optimizations:
     // Capture the full current location (path + query) at click time so the
     // post-login redirect returns the user to the exact filtered view (#3306).
     loginRedirectUrl = getCurrentPathWithQuery();
+    // Close the mobile drawer before opening the modal so the modal renders
+    // above the sidebar rather than behind it (modal z-index < drawer z-index).
+    const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
+    if (drawer?.checked) {
+      drawer.checked = false;
+      drawer.dispatchEvent(new Event('change', { bubbles: true }));
+    }
     showLoginModal = true;
   }
 
@@ -450,7 +457,7 @@ Performance Optimizations:
 
 <aside
   class={cn(
-    'drawer-side z-[200] transition-all duration-200 ease-in-out overflow-visible',
+    'drawer-side z-[200] lg:z-10 transition-all duration-200 ease-in-out overflow-visible',
     isCollapsed ? 'lg:w-16' : 'lg:w-64',
     className
   )}

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -383,19 +383,23 @@ Performance Optimizations:
     },
   ]);
 
+  // Close the mobile drawer by unchecking the toggle. Dispatch a synthetic
+  // change event so Svelte's bind:checked binding stays in sync.
+  function closeMobileDrawer() {
+    const drawer = document.getElementById('my-drawer');
+    if (drawer instanceof HTMLInputElement && drawer.checked) {
+      drawer.checked = false;
+      drawer.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
   function navigate(url: string) {
     if (url === navigationUrls.dashboard) {
       resetDateToToday();
     }
     // Close flyouts on navigation
     activeFlyout = null;
-    // Close the mobile drawer on navigation by unchecking the toggle.
-    // Dispatch a synthetic event so Svelte's bind:checked stays in sync.
-    const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
-    if (drawer?.checked) {
-      drawer.checked = false;
-      drawer.dispatchEvent(new Event('change', { bubbles: true }));
-    }
+    closeMobileDrawer();
     if (onNavigate) {
       onNavigate(url);
     } else {
@@ -418,11 +422,7 @@ Performance Optimizations:
     // post-login redirect returns the user to the exact filtered view (#3306).
     loginRedirectUrl = getCurrentPathWithQuery();
     // Close the mobile drawer before opening the modal to ensure a clean transition.
-    const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
-    if (drawer?.checked) {
-      drawer.checked = false;
-      drawer.dispatchEvent(new Event('change', { bubbles: true }));
-    }
+    closeMobileDrawer();
     showLoginModal = true;
   }
 

--- a/frontend/src/lib/utils/z-index.ts
+++ b/frontend/src/lib/utils/z-index.ts
@@ -23,6 +23,9 @@ export const Z_INDEX = {
   STICKY_HEADER: 10,
   STICKY_FOOTER: 10,
 
+  // Mobile sidebar drawer (must exceed card z-indices: z-[11], z-50, z-[60])
+  SIDEBAR_DRAWER: 200,
+
   // Overlays and dropdowns
   DROPDOWN: 100,
   AUTOCOMPLETE: 150,

--- a/frontend/src/lib/utils/z-index.ts
+++ b/frontend/src/lib/utils/z-index.ts
@@ -25,6 +25,9 @@ export const Z_INDEX = {
 
   // Mobile sidebar drawer (must exceed card z-indices: z-[11], z-50, z-[60])
   SIDEBAR_DRAWER: 200,
+  // Collapsed-sidebar tooltip (must exceed SIDEBAR_DRAWER so it stays visible
+  // when the persisted collapsed state carries over to a mobile viewport)
+  SIDEBAR_TOOLTIP: 210,
 
   // Overlays and dropdowns
   DROPDOWN: 100,


### PR DESCRIPTION
## Summary

On mobile, when the navigation drawer (sidebar) is open, detection card elements were rendering **visually above the sidebar**, causing bird thumbnails, species names, and status badges to appear overlaid on top of the navigation menu items.

## Root Cause

The sidebar `<aside>` element had `z-10` (z-index: 10), while detection card child elements carry higher z-index values by design:
- Species info bar button: `z-[11]` — must sit above the spectrogram background within the card
- Action menu trigger: `z-50` — must appear above adjacent cards when the dropdown opens
- Detection card (menu open): `z-[60]` — elevates the whole card's stacking context

On mobile, DaisyUI's drawer makes `drawer-side` `position: fixed`. Any detection card element with z-index > 10 therefore painted above the sidebar overlay.

## Changes

- **`frontend/src/lib/desktop/layouts/DesktopSidebar.svelte`**
  - Raise sidebar `<aside>` z-index from `z-10` to `z-[200] lg:z-10` — mobile gets z-200, desktop keeps the existing z-10 (matching the `.lg:drawer-open > .drawer-side` stylesheet rule so the desktop stacking context is unchanged)
  - Close the mobile drawer in `handleLogin()` before opening the `LoginModal`, mirroring the pattern already used in `navigate()` — prevents the modal (z-50) from rendering behind the now-elevated sidebar (z-200) on mobile
  - Add cross-reference comment linking `z-[200]` to `Z_INDEX.SIDEBAR_DRAWER` in `z-index.ts`

- **`frontend/src/lib/utils/z-index.ts`**
  - Add `SIDEBAR_DRAWER: 200` constant to the centralized z-index scale, documenting the value and its rationale

## Testing

- [x] Linting passes (`npm run check:all` — zero warnings/errors)
- [x] Preflight quality gate passed (all 6 reviewers clean)
- [x] Go tests: not applicable — no Go changes
- [x] Frontend unit tests: not applicable — pure CSS stacking fix; no unit-testable behavior change
- [x] Manual testing: visual CSS bug — verify on mobile viewport with drawer open and detection cards visible

## Preflight Status

- ✅ Single concern: one bug fix (mobile sidebar z-index overlap)
- ✅ Preflight passed: all 6 review passes completed; one in-scope fix applied (cross-reference comment); DesktopHeader has no modal triggers, so no incomplete multi-site fix
- ✅ Linters clean: `npm run check:all` passes with zero warnings (ESLint, Prettier, Stylelint, TypeScript, ast-grep)
- ✅ No unrelated changes
- ✅ Scope complete: fully implements the stated fix
- ✅ No regression/backward-compat break: desktop z-index unchanged; `ZIndexValue` type widening is additive and has no consumers
- ✅ No breaking changes (no API, config, DB schema, CLI changes)
- ✅ Maintainer-confirm items: none
- ✅ i18n: no new user-facing strings
- ✅ No secrets or PII

## Related Issues

Fixes mobile UI bug where detection card content (bird thumbnail, species name, verification status) was visible above the open navigation sidebar drawer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhyZg8kMR72rgVwMjTdJzG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login and navigation on smaller screens by reliably closing the mobile sidebar drawer before opening login/login-related UI, preventing layering conflicts.
  * Improved sidebar overlay stacking by raising the sidebar and tooltip z-index values to keep tooltips visible during mobile/collapsed transitions.
  * Adjusted toast notification layering and position styling so toasts consistently render above other high-priority interface elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->