### PR TITLE
refactor(api/v2): extract import and migration domain; move migration-worker funcs and update analysis call sites

### DIFF
--- a/internal/analysis/database_migration.go
+++ b/internal/analysis/database_migration.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	apiv2 "github.com/tphakala/birdnet-go/internal/api/v2"
+	importsapi "github.com/tphakala/birdnet-go/internal/api/v2/imports"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -167,8 +167,8 @@ func setupMigrationWorker(cfg *migrationSetupConfig) error {
 	}
 
 	// Inject dependencies into the API layer
-	apiv2.SetMigrationDependencies(stateManager, worker)
-	apiv2.SetMigrationTelemetry(migrationTelemetry)
+	importsapi.SetMigrationDependencies(stateManager, worker)
+	importsapi.SetMigrationTelemetry(migrationTelemetry)
 
 	// Check for state recovery - resume migration if it was in progress
 	state, err := stateManager.GetState()
@@ -195,7 +195,7 @@ func setupMigrationWorker(cfg *migrationSetupConfig) error {
 			// Create cancellable context for the worker - this allows graceful shutdown
 			// to stop the worker by cancelling this context
 			workerCtx, workerCancel := context.WithCancel(context.Background())
-			apiv2.SetMigrationWorkerCancel(workerCancel)
+			importsapi.SetMigrationWorkerCancel(workerCancel)
 			if startErr := worker.Start(workerCtx); startErr != nil {
 				workerCancel() // Clean up on failure
 				migrationLogger.Warn("failed to resume migration worker",

--- a/internal/analysis/database_service.go
+++ b/internal/analysis/database_service.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	apiv2 "github.com/tphakala/birdnet-go/internal/api/v2"
+	importsapi "github.com/tphakala/birdnet-go/internal/api/v2/imports"
 	"github.com/tphakala/birdnet-go/internal/app"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -200,7 +200,7 @@ func (d *DatabaseService) Start(_ context.Context) error {
 			// Set global enhanced database flag
 			datastoreV2.SetEnhancedDatabaseMode()
 			// Notify the API layer that we're in v2-only mode
-			apiv2.SetV2OnlyMode()
+			importsapi.SetV2OnlyMode()
 			// Set the v2 database manager
 			d.v2Manager = v2OnlyDatastore.Manager()
 		}
@@ -228,7 +228,7 @@ func (d *DatabaseService) Start(_ context.Context) error {
 			// Set global enhanced database flag
 			datastoreV2.SetEnhancedDatabaseMode()
 			// Notify the API layer that we're in v2-only mode
-			apiv2.SetV2OnlyMode()
+			importsapi.SetV2OnlyMode()
 			// Set the v2 database manager
 			d.v2Manager = v2OnlyDatastore.Manager()
 		}
@@ -305,7 +305,7 @@ func (d *DatabaseService) Stop(_ context.Context) error {
 	log := GetLogger()
 
 	// Stop the migration worker before closing databases.
-	apiv2.StopMigrationWorker()
+	importsapi.StopMigrationWorker()
 
 	// Close v2 database (only in migration mode, not v2-only).
 	if !d.v2OnlyMode {

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/v2/detections"
 	"github.com/tphakala/birdnet-go/internal/api/v2/dynamicthresholds"
 	"github.com/tphakala/birdnet-go/internal/api/v2/filesystem"
+	importsapi "github.com/tphakala/birdnet-go/internal/api/v2/imports"
 	"github.com/tphakala/birdnet-go/internal/api/v2/integrations"
 	mediaapi "github.com/tphakala/birdnet-go/internal/api/v2/media"
 	"github.com/tphakala/birdnet-go/internal/api/v2/models"
@@ -44,7 +45,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
-	"github.com/tphakala/birdnet-go/internal/imports"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -226,25 +226,23 @@ type Controller struct {
 	// promote from the embedded core. The hub itself stays in apicore.
 	sse *sse.Handler
 
-	// Legacy cleanup state tracker
-	cleanupStatus *CleanupStatus
+	// imports serves the import/migration domain: the BirdNET-Pi import endpoints,
+	// the legacy->v2 migration endpoints and the background migration-worker control
+	// surface, the migration prerequisite checks, the async SQLite backup-job
+	// endpoints, and the legacy-database cleanup endpoints. Beyond the shared
+	// *apicore.Core it owns the import lifecycle manager, the import source-path
+	// root/factory, the legacy-cleanup tracker, and the facade-injected notification
+	// service. The facade calls c.imports.Shutdown() during teardown to stop the
+	// backup job manager's cleanup goroutine. The migration-worker package-level
+	// funcs (importsapi.SetMigration*/StopMigrationWorker) are driven by
+	// internal/analysis.
+	imports *importsapi.Handler
 
 	// Test synchronization fields (only populated when initializeRoutes is true)
 	// goroutinesStarted signals when all background goroutines have successfully started.
 	// This is primarily used in testing to ensure proper setup before assertions.
 	// Only created when routes are initialized (production mode or specific tests).
 	goroutinesStarted chan struct{} // signals when all background goroutines have started (nil if routes not initialized)
-
-	// importMgr manages the one-at-a-time import lifecycle.
-	importMgr *importManager
-
-	// importSourceRoot is the directory under which import source paths must resolve.
-	// Defaults to sysinfo.DefaultExternalMountPath when empty.
-	importSourceRoot string
-
-	// importSourceFactory builds an import Source from a resolved path.
-	// Defaults to a BirdNET-Pi adapter when nil. Overridable in tests.
-	importSourceFactory func(path string) (imports.Source, error)
 
 	// Audio level channel for SSE streaming
 	// TODO: Consider moving to a dedicated audio manager
@@ -417,7 +415,6 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		Core:          core,
 		controlChan:   controlChan,
 		isGlobalOwner: settings == conf.GetSettings(),
-		importMgr:     newImportManager(),
 	}
 
 	// Construct domain handlers around the shared core. They hold the same
@@ -522,6 +519,14 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// per-request reads. The facade keeps c.notificationService for the other
 	// handlers that still resolve the service via getNotificationService().
 	c.notifications = notifications.New(c.Core, c.notificationService, c.authService)
+
+	// Construct the import/migration domain handler AFTER the functional options
+	// are applied so it captures the post-option notificationService (the migration
+	// and legacy-cleanup completion notifications resolve the service through it,
+	// falling back to the process-global singleton when nil), mirroring the
+	// notifications handler above. Its import lifecycle manager is created in New;
+	// the legacy-cleanup tracker is created lazily in RegisterLegacyCleanupRoutes.
+	c.imports = importsapi.New(c.Core, c.notificationService)
 
 	// Construct the audio/streaming domain handler AFTER the functional options are
 	// applied so it captures the post-option authService (used by the public
@@ -636,7 +641,7 @@ func (c *Controller) initRoutes() {
 		{"model routes", func() { c.models.RegisterRoutes(c.Group) }},
 		{"insights routes", c.initInsightsRoutes},
 		{"tls routes", func() { c.tlsHandler.RegisterRoutes(c.Group) }},
-		{"import routes", c.initImportRoutes},
+		{"import routes", func() { c.imports.RegisterImportRoutes(c.Group) }},
 	}
 
 	for _, initializer := range routeInitializers {
@@ -794,9 +799,11 @@ func (c *Controller) Shutdown() {
 		}
 	}
 
-	// Shutdown the backup job manager to stop its cleanup goroutine
-	if backupJobManager != nil {
-		backupJobManager.Shutdown()
+	// Shut down the import/migration domain (stops the backup job manager's cleanup
+	// goroutine). The migration worker is stopped separately by internal/analysis as
+	// part of the datastore lifecycle.
+	if c.imports != nil {
+		c.imports.Shutdown()
 	}
 
 	// Flush all log writers (the main writer plus every module writer, including

--- a/internal/api/v2/imports/backup.go
+++ b/internal/api/v2/imports/backup.go
@@ -1,6 +1,6 @@
-// internal/api/v2/backup.go
+// internal/api/v2/imports/backup.go
 // Async database backup with progress tracking.
-package api
+package importsapi
 
 import (
 	"context"
@@ -349,13 +349,13 @@ func (job *BackupJob) setDownloadURL(url string) {
 	job.DownloadURL = url
 }
 
-// Controller methods for backup endpoints
+// Handler methods for backup endpoints
 
 // backupJobManager is the singleton job manager (initialized in initBackupRoutes).
 var backupJobManager *BackupJobManager
 
-// initBackupRoutes initializes backup-related routes.
-func (c *Controller) initBackupRoutes() {
+// RegisterBackupRoutes registers the async backup-job routes on the supplied v2 group.
+func (c *Handler) RegisterBackupRoutes(g *echo.Group) {
 	// Initialize job manager if not already done
 	if backupJobManager == nil {
 		backupJobManager = NewBackupJobManager()
@@ -374,7 +374,7 @@ func (c *Controller) initBackupRoutes() {
 	}
 
 	// Create backup API group under system/database
-	backupGroup := c.Group.Group("/system/database/backup/jobs")
+	backupGroup := g.Group("/system/database/backup/jobs")
 
 	// Get the appropriate auth middleware
 	authMiddleware := c.AuthMiddleware
@@ -391,7 +391,7 @@ func (c *Controller) initBackupRoutes() {
 }
 
 // StartBackupJob handles POST /api/v2/system/database/backup/jobs
-func (c *Controller) StartBackupJob(ctx echo.Context) error {
+func (c *Handler) StartBackupJob(ctx echo.Context) error {
 	dbType := ctx.QueryParam("type")
 	if dbType != apicore.DBTypeLegacy && dbType != apicore.DBTypeV2 {
 		return c.HandleErrorWithKey(ctx, nil,
@@ -475,7 +475,7 @@ func (c *Controller) StartBackupJob(ctx echo.Context) error {
 }
 
 // ListBackupJobs handles GET /api/v2/system/database/backup/jobs
-func (c *Controller) ListBackupJobs(ctx echo.Context) error {
+func (c *Handler) ListBackupJobs(ctx echo.Context) error {
 	dbType := ctx.QueryParam("type")
 
 	var jobs []*BackupJob
@@ -501,7 +501,7 @@ func (c *Controller) ListBackupJobs(ctx echo.Context) error {
 }
 
 // GetBackupJobStatus handles GET /api/v2/system/database/backup/jobs/:id
-func (c *Controller) GetBackupJobStatus(ctx echo.Context) error {
+func (c *Handler) GetBackupJobStatus(ctx echo.Context) error {
 	jobID := ctx.Param("id")
 
 	job, exists := backupJobManager.GetJob(jobID)
@@ -525,7 +525,7 @@ func (c *Controller) GetBackupJobStatus(ctx echo.Context) error {
 }
 
 // DownloadBackupFile handles GET /api/v2/system/database/backup/jobs/:id/download
-func (c *Controller) DownloadBackupFile(ctx echo.Context) error {
+func (c *Handler) DownloadBackupFile(ctx echo.Context) error {
 	jobID := ctx.Param("id")
 
 	job, exists := backupJobManager.GetJob(jobID)
@@ -563,7 +563,7 @@ func (c *Controller) DownloadBackupFile(ctx echo.Context) error {
 }
 
 // CancelBackupJob handles DELETE /api/v2/system/database/backup/jobs/:id
-func (c *Controller) CancelBackupJob(ctx echo.Context) error {
+func (c *Handler) CancelBackupJob(ctx echo.Context) error {
 	jobID := ctx.Param("id")
 
 	if !backupJobManager.DeleteJob(jobID) {
@@ -581,7 +581,7 @@ func (c *Controller) CancelBackupJob(ctx echo.Context) error {
 }
 
 // runBackupJob executes the VACUUM INTO operation in a goroutine.
-func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
+func (c *Handler) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 	job.setStatus(BackupStatusInProgress, "")
 
 	vacuumSQL := fmt.Sprintf("VACUUM INTO '%s'", job.tempPath)
@@ -636,7 +636,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 }
 
 // getBackupDBInfo returns the database path and GORM DB for the given type.
-func (c *Controller) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
+func (c *Handler) getBackupDBInfo(dbType string) (string, *gorm.DB, error) {
 	if dbType == apicore.DBTypeLegacy {
 		settings := c.CurrentSettings()
 		if settings == nil || settings.Output.SQLite.Path == "" {

--- a/internal/api/v2/imports/handler.go
+++ b/internal/api/v2/imports/handler.go
@@ -1,0 +1,107 @@
+// Package importsapi implements the v2 API import/migration domain: the
+// BirdNET-Pi import endpoints (/api/v2/import/*), the legacy->v2 database
+// migration endpoints and the background migration-worker control surface
+// (/api/v2/system/database/migration/*), the migration prerequisite checks, the
+// async SQLite backup-job endpoints (/api/v2/system/database/backup/jobs/*), and
+// the legacy-database cleanup endpoints (/api/v2/system/database/legacy/*).
+//
+// The package is named importsapi (not the bare imports) to avoid colliding with
+// the internal/imports package it depends on, mirroring the rangeapi/authapi
+// precedent for domains whose natural name shadows an existing import.
+//
+// The Handler embeds *apicore.Core by pointer so the shared dependencies and
+// helpers (Settings accessors, DS/Repo/V2Manager, AuthMiddleware, the
+// HandleError/logging helpers, the Context/Go/Cancel/Wait lifecycle, and the SSE
+// write primitives) are available without re-plumbing. Beyond the core it owns:
+//   - importMgr: the one-at-a-time import lifecycle manager.
+//   - importSourceRoot/importSourceFactory: the import source-path root and the
+//     injectable Source factory (both default lazily; overridden in tests).
+//   - cleanupStatus: the legacy-cleanup state tracker, initialized lazily in
+//     RegisterLegacyCleanupRoutes (the migration status handler reads it
+//     nil-guarded).
+//   - notificationService: the facade-injected notification service (nil-guarded,
+//     falling back to the process-global singleton), used by the migration and
+//     legacy-cleanup completion notifications.
+//
+// The migration-worker control functions (SetMigrationDependencies,
+// SetMigrationWorkerCancel, SetV2OnlyMode, StopMigrationWorker,
+// SetMigrationTelemetry) are package-level functions over package-level state
+// (migration.go); internal/analysis drives the worker lifecycle through them.
+package importsapi
+
+import (
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/imports"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// apiV2Prefix is the v2 API path prefix. It mirrors the facade's apiV2Prefix; the
+// import domain keeps a local copy (the audio/auth/system precedent) rather than
+// importing it from package api.
+const apiV2Prefix = "/api/v2"
+
+// Handler serves the api/v2 import/migration domain endpoints. It embeds the
+// shared *apicore.Core (by pointer) and additionally owns the import lifecycle
+// manager, the import source-path root and factory, the legacy-cleanup state
+// tracker, and the facade-injected notification service.
+type Handler struct {
+	*apicore.Core
+
+	// importMgr manages the one-at-a-time import lifecycle.
+	importMgr *importManager
+
+	// importSourceRoot is the directory under which import source paths must
+	// resolve. Defaults to sysinfo.DefaultExternalMountPath when empty.
+	importSourceRoot string
+
+	// importSourceFactory builds an import Source from a resolved path. Defaults to
+	// a BirdNET-Pi adapter when nil. Overridable in tests.
+	importSourceFactory func(path string) (imports.Source, error)
+
+	// cleanupStatus tracks the state of legacy database cleanup. It is initialized
+	// lazily in RegisterLegacyCleanupRoutes; the migration status handler reads it
+	// nil-guarded.
+	cleanupStatus *CleanupStatus
+
+	// notificationService is the notification service injected from the facade. It
+	// is nil in production, where getNotificationService() falls back to the
+	// process-global singleton (notification.GetService()). Tests inject an
+	// isolated per-test instance so each test gets its own config and store without
+	// touching the global singleton.
+	notificationService *notification.Service
+}
+
+// New constructs the import/migration domain handler around the shared core and
+// the facade-injected notification service. The import lifecycle manager is
+// created here; the import source-path root/factory default lazily and the legacy
+// cleanup tracker is created in RegisterLegacyCleanupRoutes.
+func New(core *apicore.Core, notificationService *notification.Service) *Handler {
+	return &Handler{
+		Core:                core,
+		notificationService: notificationService,
+		importMgr:           newImportManager(),
+	}
+}
+
+// getNotificationService returns the notification service this handler uses: the
+// injected instance when set (tests inject it), otherwise the process-global
+// singleton (notification.GetService()). It mirrors the facade accessor of the
+// same name (which still serves the remaining package-api callers); the field is
+// nil in production, so it falls back to the singleton exactly as before.
+func (c *Handler) getNotificationService() *notification.Service {
+	if c.notificationService != nil {
+		return c.notificationService
+	}
+	return notification.GetService()
+}
+
+// Shutdown stops the background singletons this domain owns. It stops the backup
+// job manager's cleanup goroutine (a no-op when no backup routes were registered,
+// so the singleton is nil). The migration worker is stopped separately by
+// internal/analysis via StopMigrationWorker() as part of the datastore lifecycle,
+// so it is deliberately not torn down here.
+func (c *Handler) Shutdown() {
+	if backupJobManager != nil {
+		backupJobManager.Shutdown()
+	}
+}

--- a/internal/api/v2/imports/import.go
+++ b/internal/api/v2/imports/import.go
@@ -1,5 +1,5 @@
-// Package api provides the HTTP API for BirdNET-Go.
-package api
+// internal/api/v2/imports/import.go
+package importsapi
 
 import (
 	"context"
@@ -176,7 +176,8 @@ func isContained(root, target string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-// initImportRoutes registers all import-related API routes.
+// RegisterImportRoutes registers all import-related API routes on the supplied
+// v2 group.
 //
 // These endpoints start, cancel, and inspect a database import, so the group
 // must fail closed. c.AuthMiddleware is non-nil in every real deployment: the
@@ -185,7 +186,7 @@ func isContained(root, target string) bool {
 // in unit tests or a misconfiguration; in that case install a middleware that
 // denies access with 401 rather than registering the routes unprotected (Echo's
 // applyMiddleware would also panic on a literal nil entry).
-func (c *Controller) initImportRoutes() {
+func (c *Handler) RegisterImportRoutes(g *echo.Group) {
 	authMiddleware := c.AuthMiddleware
 	if authMiddleware == nil {
 		authMiddleware = func(echo.HandlerFunc) echo.HandlerFunc {
@@ -194,16 +195,16 @@ func (c *Controller) initImportRoutes() {
 			}
 		}
 	}
-	g := c.Group.Group("/import", authMiddleware)
-	g.POST("/birdnet-pi", c.StartBirdNETPiImport)
-	g.GET("/jobs/:jobId/progress", c.StreamImportProgress)
-	g.POST("/jobs/:jobId/cancel", c.CancelImport)
-	g.GET("/status", c.GetImportStatus)
+	importGroup := g.Group("/import", authMiddleware)
+	importGroup.POST("/birdnet-pi", c.StartBirdNETPiImport)
+	importGroup.GET("/jobs/:jobId/progress", c.StreamImportProgress)
+	importGroup.POST("/jobs/:jobId/cancel", c.CancelImport)
+	importGroup.GET("/status", c.GetImportStatus)
 }
 
 // StartBirdNETPiImport validates a BirdNET-Pi SQLite source and starts a DB-only import.
 // Returns 202 Accepted with a job_id on success.
-func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
+func (c *Handler) StartBirdNETPiImport(ctx echo.Context) error {
 	// Verify datastore is available.
 	if err := c.RequireDatastore(ctx); err != nil {
 		return err
@@ -332,7 +333,7 @@ func (c *Controller) StartBirdNETPiImport(ctx echo.Context) error {
 
 // StreamImportProgress streams import progress as Server-Sent Events.
 // Closing the SSE connection does NOT cancel the import; use the cancel endpoint.
-func (c *Controller) StreamImportProgress(ctx echo.Context) error {
+func (c *Handler) StreamImportProgress(ctx echo.Context) error {
 	id := ctx.Param("jobId")
 	job := c.importMgr.get(id)
 	if job == nil {
@@ -342,7 +343,7 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 	apicore.SetSSEHeaders(ctx)
 
 	// Bound the stream lifetime independently of the import itself.
-	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), maxSSEStreamDuration)
+	reqCtx, cancel := context.WithTimeout(ctx.Request().Context(), apicore.MaxSSEStreamDuration)
 	defer cancel()
 
 	// Send initial snapshot before entering the event loop. If the job already
@@ -401,7 +402,7 @@ func (c *Controller) StreamImportProgress(ctx echo.Context) error {
 
 // CancelImport requests cancellation of a running import job.
 // Returns 200 with status "cancelling" (or "done" if already finished).
-func (c *Controller) CancelImport(ctx echo.Context) error {
+func (c *Handler) CancelImport(ctx echo.Context) error {
 	id := ctx.Param("jobId")
 	job := c.importMgr.get(id)
 	if job == nil {
@@ -416,7 +417,7 @@ func (c *Controller) CancelImport(ctx echo.Context) error {
 }
 
 // GetImportStatus returns the current import state for polling UIs.
-func (c *Controller) GetImportStatus(ctx echo.Context) error {
+func (c *Handler) GetImportStatus(ctx echo.Context) error {
 	job := c.importMgr.active()
 	if job == nil {
 		return ctx.JSON(http.StatusOK, importStatusResponse{
@@ -447,7 +448,7 @@ func (c *Controller) GetImportStatus(ctx echo.Context) error {
 }
 
 // sendImportEvent sends a single SSE event with a monotonic id field.
-func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, data any) error {
+func (c *Handler) sendImportEvent(ctx echo.Context, id uint64, event string, data any) error {
 	payload, err := c.SafeMarshalJSON(event, data)
 	if err != nil {
 		return fmt.Errorf("marshal import event: %w", err)
@@ -470,12 +471,12 @@ func (c *Controller) sendImportEvent(ctx echo.Context, id uint64, event string, 
 }
 
 // sendImportHeartbeat sends a lightweight SSE event to keep the connection alive.
-func (c *Controller) sendImportHeartbeat(ctx echo.Context) error {
+func (c *Handler) sendImportHeartbeat(ctx echo.Context) error {
 	return c.SendSSEMessage(ctx, importEventHeartbeat, map[string]int64{"ts": time.Now().Unix()})
 }
 
 // sendImportTerminal sends the final SSE event based on the import outcome.
-func (c *Controller) sendImportTerminal(ctx echo.Context, seq uint64, stats imports.ImportStats, runErr error) error {
+func (c *Handler) sendImportTerminal(ctx echo.Context, seq uint64, stats imports.ImportStats, runErr error) error {
 	switch {
 	case runErr == nil:
 		return c.sendImportEvent(ctx, seq, importEventComplete, toImportProgress(stats))

--- a/internal/api/v2/imports/import_manager.go
+++ b/internal/api/v2/imports/import_manager.go
@@ -1,5 +1,5 @@
-// Package api provides the HTTP API for BirdNET-Go.
-package api
+// internal/api/v2/imports/import_manager.go
+package importsapi
 
 import (
 	"context"

--- a/internal/api/v2/imports/import_test.go
+++ b/internal/api/v2/imports/import_test.go
@@ -1,5 +1,5 @@
-// Package api provides tests for the import API endpoints.
-package api
+// internal/api/v2/imports/import_test.go: tests for the import API endpoints.
+package importsapi
 
 import (
 	"bufio"
@@ -115,14 +115,14 @@ func (f *fakeSource) Iterate(ctx context.Context, _ int, fn func([]imports.Sourc
 
 func (f *fakeSource) Close() error { return nil }
 
-// newImportController creates a lightweight Controller for import tests.
-func newImportController(t *testing.T) (*echo.Echo, *Controller) {
+// newImportHandler creates a lightweight Handler for import tests.
+func newImportHandler(t *testing.T) (*echo.Echo, *Handler) {
 	t.Helper()
 	e := echo.New()
 	ctx, cancel := context.WithCancel(t.Context())
 	cCore := &apicore.Core{Group: e.Group(apiV2Prefix), AuthMiddleware: func(next echo.HandlerFunc) echo.HandlerFunc { return next }}
 	cCore.SetTestContext(ctx, cancel)
-	c := &Controller{Core: cCore, importMgr: newImportManager()}
+	c := &Handler{Core: cCore, importMgr: newImportManager()}
 	c.Settings.Store(apitest.NewValidTestSettings())
 	t.Cleanup(func() {
 		cancel()
@@ -253,7 +253,7 @@ func TestImportManager_GetByID(t *testing.T) {
 // TestStartBirdNETPiImport_NoRepo_Returns503 verifies 503 when no datastore.
 func TestStartBirdNETPiImport_NoRepo_Returns503(t *testing.T) {
 	e := echo.New()
-	c := &Controller{Core: &apicore.Core{Group: e.Group(apiV2Prefix)}, importMgr: newImportManager()}
+	c := &Handler{Core: &apicore.Core{Group: e.Group(apiV2Prefix)}, importMgr: newImportManager()}
 	c.Settings.Store(apitest.NewValidTestSettings())
 
 	body := testDBOnlyBody
@@ -271,7 +271,7 @@ func TestStartBirdNETPiImport_NoRepo_Returns503(t *testing.T) {
 
 // TestStartBirdNETPiImport_BadJSON_Returns400 verifies 400 on malformed JSON.
 func TestStartBirdNETPiImport_BadJSON_Returns400(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
@@ -298,7 +298,7 @@ func TestStartBirdNETPiImport_ModeDBAudio_Returns202(t *testing.T) {
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	mockRepo := mocks.NewMockDetectionRepository(t)
@@ -357,7 +357,7 @@ func TestStartBirdNETPiImport_ModeDBAudio_NoExportPath_Returns400(t *testing.T) 
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
@@ -459,8 +459,8 @@ func TestStartBirdNETPiImport_ModeDBAudio_CopiesClip(t *testing.T) {
 	)
 	clipContent := []byte("fake source audio content")
 
-	e, c := newImportController(t)
-	c.initImportRoutes()
+	e, c := newImportHandler(t)
+	c.RegisterImportRoutes(c.Group)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	mockRepo := mocks.NewMockDetectionRepository(t)
@@ -535,7 +535,7 @@ func TestStartBirdNETPiImport_ModeDBAudio_CopiesClip(t *testing.T) {
 
 // TestStartBirdNETPiImport_UnknownMode_Returns400 verifies unknown modes are rejected.
 func TestStartBirdNETPiImport_UnknownMode_Returns400(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
@@ -555,7 +555,7 @@ func TestStartBirdNETPiImport_UnknownMode_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_TraversalPath_Returns400 verifies path traversal is blocked.
 func TestStartBirdNETPiImport_TraversalPath_Returns400(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
@@ -624,7 +624,7 @@ func TestResolveImportSourcePath_SymlinkEscape(t *testing.T) {
 
 // TestStartBirdNETPiImport_MissingFile_Returns400 verifies missing file returns 400.
 func TestStartBirdNETPiImport_MissingFile_Returns400(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
@@ -644,7 +644,7 @@ func TestStartBirdNETPiImport_MissingFile_Returns400(t *testing.T) {
 
 // TestStartBirdNETPiImport_FakeValidationFailure_Returns400 verifies validation errors return 400.
 func TestStartBirdNETPiImport_FakeValidationFailure_Returns400(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	c.Repo = mocks.NewMockDetectionRepository(t)
@@ -679,7 +679,7 @@ func TestStartBirdNETPiImport_GoodFakeSource_Returns202(t *testing.T) {
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	mockRepo := mocks.NewMockDetectionRepository(t)
@@ -727,7 +727,7 @@ func TestStartBirdNETPiImport_ConflictWhileRunning_Returns409(t *testing.T) {
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	mockRepo := mocks.NewMockDetectionRepository(t)
@@ -779,7 +779,7 @@ func TestStartBirdNETPiImport_ConflictWhileRunning_Returns409(t *testing.T) {
 
 // TestStreamImportProgress_JobNotFound_Returns404 verifies 404 for unknown job.
 func TestStreamImportProgress_JobNotFound_Returns404(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/import/jobs/notexist/progress", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -793,7 +793,7 @@ func TestStreamImportProgress_JobNotFound_Returns404(t *testing.T) {
 
 // TestStreamImportProgress_DoneJob_EmitsCompleteEvent verifies complete event is emitted.
 func TestStreamImportProgress_DoneJob_EmitsCompleteEvent(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 
 	jobCtx, jobCancel := context.WithCancel(t.Context())
 	jobCancel()
@@ -832,7 +832,7 @@ func TestStreamImportProgress_DoneJob_EmitsCompleteEvent(t *testing.T) {
 // This test covers the connect-after-done path (terminal-only event), complementing
 // TestStreamImportProgress_LiveStreaming which covers the live multi-event path.
 func TestStreamImportProgress_EventIDsMonotonic(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 
 	_, jobCancel := context.WithCancel(t.Context())
 	defer jobCancel()
@@ -884,7 +884,7 @@ func TestStreamImportProgress_EventIDsMonotonic(t *testing.T) {
 
 // TestCancelImport_JobNotFound_Returns404 verifies 404 for unknown job.
 func TestCancelImport_JobNotFound_Returns404(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -906,7 +906,7 @@ func TestCancelImport_RunningJob_Returns200Cancelling(t *testing.T) {
 		goleak.IgnoreTopFunction("runtime.gopark"),
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	mockRepo := mocks.NewMockDetectionRepository(t)
@@ -962,7 +962,7 @@ func TestCancelImport_RunningJob_Returns200Cancelling(t *testing.T) {
 
 // TestGetImportStatus_NoJob_ReturnsIdle verifies idle status when no job exists.
 func TestGetImportStatus_NoJob_ReturnsIdle(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -979,7 +979,7 @@ func TestGetImportStatus_NoJob_ReturnsIdle(t *testing.T) {
 
 // TestGetImportStatus_RunningJob verifies running status with progress.
 func TestGetImportStatus_RunningJob(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 
 	_, jobCancel := context.WithCancel(t.Context())
 	defer jobCancel()
@@ -1007,7 +1007,7 @@ func TestGetImportStatus_RunningJob(t *testing.T) {
 
 // TestGetImportStatus_DoneJob verifies done status after completion.
 func TestGetImportStatus_DoneJob(t *testing.T) {
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 
 	_, jobCancel := context.WithCancel(t.Context())
 	jobCancel()
@@ -1032,8 +1032,8 @@ func TestGetImportStatus_DoneJob(t *testing.T) {
 
 // TestImportRoutes_Registered verifies all import routes are registered.
 func TestImportRoutes_Registered(t *testing.T) {
-	e, c := newImportController(t)
-	c.initImportRoutes()
+	e, c := newImportHandler(t)
+	c.RegisterImportRoutes(c.Group)
 
 	expected := []string{
 		"POST " + apiV2Prefix + "/import/birdnet-pi",
@@ -1048,9 +1048,9 @@ func TestImportRoutes_Registered(t *testing.T) {
 // with no auth middleware configured it denies access with 401 rather than
 // registering the state-changing endpoints unprotected.
 func TestImportRoutes_FailClosedWhenNoAuth(t *testing.T) {
-	e, c := newImportController(t)
+	e, c := newImportHandler(t)
 	c.AuthMiddleware = nil // exercise the fail-closed path: no auth middleware configured
-	c.initImportRoutes()
+	c.RegisterImportRoutes(c.Group)
 
 	req := httptest.NewRequest(http.MethodGet, apiV2Prefix+"/import/status", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -1074,7 +1074,7 @@ func TestStartBirdNETPiImport_RealSQLiteSource_EndToEnd(t *testing.T) {
 
 	dir, _ := makeTempDB(t, rowCount)
 
-	_, c := newImportController(t)
+	_, c := newImportHandler(t)
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
 	mockRepo := mocks.NewMockDetectionRepository(t)
@@ -1171,8 +1171,8 @@ func TestStreamImportProgress_LiveStreaming(t *testing.T) {
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 
-	e, c := newImportController(t)
-	c.initImportRoutes()
+	e, c := newImportHandler(t)
+	c.RegisterImportRoutes(c.Group)
 
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
@@ -1307,8 +1307,8 @@ func TestStreamImportProgress_CancelEmitsCancelledEvent(t *testing.T) {
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 
-	e, c := newImportController(t)
-	c.initImportRoutes()
+	e, c := newImportHandler(t)
+	c.RegisterImportRoutes(c.Group)
 
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS
@@ -1422,8 +1422,8 @@ func TestStartBirdNETPiImport_PanicInEngine_RecoverAndPreserveStats(t *testing.T
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 
-	e, c := newImportController(t)
-	c.initImportRoutes()
+	e, c := newImportHandler(t)
+	c.RegisterImportRoutes(c.Group)
 
 	mockDS := mocks.NewMockInterface(t)
 	c.DS = mockDS

--- a/internal/api/v2/imports/imports_test_helpers_test.go
+++ b/internal/api/v2/imports/imports_test_helpers_test.go
@@ -1,0 +1,139 @@
+// imports_test_helpers_test.go: shared scaffolding for the import/migration
+// domain tests.
+//
+// getTestSettings was copied from the package-api test_helpers_test.go when the
+// import domain moved out of package api; the migration and prerequisites tests
+// store it into the core's atomic Settings pointer so the prerequisite checks see
+// a valid SQLite path under a per-test t.TempDir().
+package importsapi
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gorm_logger "gorm.io/gorm/logger"
+)
+
+const (
+	testMQTTTopic        = "birdnet/detections"
+	testNewYorkLongitude = -74.0060 // New York City longitude for test data
+)
+
+// getTestSettings returns a *conf.Settings populated with valid defaults for the
+// import/migration domain tests, including a test-isolated SQLite path under
+// t.TempDir() for the migration prerequisite checks.
+func getTestSettings(t *testing.T) *conf.Settings {
+	t.Helper()
+	settings := &conf.Settings{}
+
+	// Initialize with valid defaults
+	settings.Realtime.Interval = 15                // Must be positive after hardening
+	settings.Realtime.Dashboard.SummaryLimit = 100 // Valid range: 10-1000
+	settings.Realtime.Dashboard.Thumbnails.Summary = true
+	settings.Realtime.Dashboard.Thumbnails.Recent = true
+	settings.Realtime.Dashboard.Thumbnails.ImageProvider = "avicommons"
+	settings.Realtime.Dashboard.Locale = "en"
+
+	// Weather settings
+	settings.Realtime.Weather.Provider = "yrno"
+	settings.Realtime.Weather.PollInterval = 60
+
+	// MQTT settings
+	settings.Realtime.MQTT.Enabled = false
+	settings.Realtime.MQTT.Broker = "tcp://localhost:1883"
+	settings.Realtime.MQTT.Topic = testMQTTTopic
+
+	// BirdNET settings
+	settings.BirdNET.Latitude = 40.7128
+	settings.BirdNET.Longitude = testNewYorkLongitude
+	settings.BirdNET.Sensitivity = 1.0
+	settings.BirdNET.Threshold = 0.8
+	settings.BirdNET.Locale = "en"
+	settings.BirdNET.RangeFilter.Model = "latest"
+	settings.BirdNET.RangeFilter.Threshold = 0.03
+
+	// Audio settings
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{{
+		Name:   "Test Sound Card",
+		Device: "default",
+	}}
+	settings.Realtime.Audio.Export.Enabled = true
+	settings.Realtime.Audio.Export.Type = "wav"
+	settings.Realtime.Audio.Export.Path = "clips"
+	settings.Realtime.Audio.Export.Bitrate = "192k"
+	settings.Realtime.Audio.Export.Length = 15
+
+	// Species settings
+	settings.Realtime.Species.Include = []string{"American Robin"}
+	settings.Realtime.Species.Config = make(map[string]conf.SpeciesConfig)
+
+	// WebServer settings
+	settings.WebServer.Port = "8080"
+	settings.WebServer.Enabled = true
+	settings.WebServer.LiveStream.BitRate = 128
+	settings.WebServer.LiveStream.SegmentLength = 5
+
+	// Security settings - session duration must be positive
+	settings.Security.SessionDuration = 168 * time.Hour // 7 days
+
+	// Output settings - SQLite path for prerequisite checks
+	// Use t.TempDir() for test-isolated, auto-cleaned directory
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = filepath.Join(t.TempDir(), "birdnet-test.db")
+
+	// Initialize other maps to prevent nil pointer issues
+	settings.Realtime.MQTT.RetrySettings.MaxRetries = 3
+	settings.Realtime.MQTT.RetrySettings.InitialDelay = 10
+	settings.Realtime.MQTT.RetrySettings.MaxDelay = 300
+	settings.Realtime.MQTT.RetrySettings.BackoffMultiplier = 2.0
+
+	return settings
+}
+
+// fakeV2Manager implements the subset of datastoreV2.Manager used by the
+// migration prerequisite checks (DB() and TablePrefix()). It is copied from the
+// package-api app_wizard_test.go fake so the prerequisites tests stay
+// self-contained after the import-domain move.
+type fakeV2Manager struct {
+	db          *gorm.DB
+	tablePrefix string
+}
+
+func (f *fakeV2Manager) Initialize() error    { return nil }
+func (f *fakeV2Manager) DB() *gorm.DB         { return f.db }
+func (f *fakeV2Manager) Path() string         { return ":memory:" }
+func (f *fakeV2Manager) Close() error         { return nil }
+func (f *fakeV2Manager) CheckpointWAL() error { return nil }
+func (f *fakeV2Manager) Delete() error        { return nil }
+func (f *fakeV2Manager) Exists() bool         { return true }
+func (f *fakeV2Manager) IsMySQL() bool        { return false }
+func (f *fakeV2Manager) TablePrefix() string  { return f.tablePrefix }
+
+// newFakeV2ManagerWithTable creates a fakeV2Manager backed by an in-memory SQLite
+// database with a single arbitrary table (e.g. "v2_detections") holding count rows,
+// and reports the given prefix from TablePrefix(). Used to verify that table names are
+// derived from the manager's prefix rather than guessed from the dialect.
+func newFakeV2ManagerWithTable(t *testing.T, tableName, prefix string, count int) *fakeV2Manager {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gorm_logger.Default.LogMode(gorm_logger.Silent),
+	})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	require.NoError(t, db.Exec("CREATE TABLE IF NOT EXISTS "+tableName+" (id INTEGER PRIMARY KEY)").Error)
+	for i := range count {
+		require.NoError(t, db.Exec("INSERT INTO "+tableName+" (id) VALUES (?)", i+1).Error)
+	}
+
+	return &fakeV2Manager{db: db, tablePrefix: prefix}
+}

--- a/internal/api/v2/imports/leakcheck_test.go
+++ b/internal/api/v2/imports/leakcheck_test.go
@@ -1,0 +1,47 @@
+// leakcheck_test.go: shared goroutine-leak helper for the import/migration
+// domain tests. Copied from the package-api helper of the same name when the
+// import domain moved out of package api (the import SSE-stream tests rely on it).
+
+package importsapi
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// verifyNoLeaks registers a goroutine-leak check that runs when the test ends.
+//
+// It snapshots the goroutines alive at the moment it is called (via
+// goleak.IgnoreCurrent) and ignores them, so a leftover goroutine from a
+// previously-run test, most often a net/http.(*Transport).dialConn still
+// connecting after another test opened an outbound HTTP connection, is not
+// wrongly attributed to this test. goleak inspects every goroutine in the
+// process, not just the ones this test spawned, so without the snapshot these
+// checks flake under `go test -race -shuffle=on` depending on which test ran
+// first.
+//
+// Because the snapshot is taken when verifyNoLeaks is called, callers must call
+// it directly (NOT with defer) at the START of the test, before constructing
+// the component under test or doing any work that starts goroutines. Calling it
+// with defer would take the snapshot at the end of the test and silently mask
+// every leak it is meant to catch. The VerifyNone itself is scheduled via
+// t.Cleanup, so no defer is needed at the callsite. Goroutines spawned after
+// the snapshot are not in it, so a real leak (a goroutine started during the
+// test and never stopped) still fails the check.
+//
+// extra options are appended after the snapshot, for per-test ignores such as
+// goleak.IgnoreTopFunction for known process-lifetime workers.
+//
+// These tests run sequentially; do not add t.Parallel() to a test that calls
+// verifyNoLeaks, as a process-wide leak check cannot coexist with goroutines
+// from other tests running concurrently.
+func verifyNoLeaks(t *testing.T, extra ...goleak.Option) {
+	t.Helper()
+	opts := make([]goleak.Option, 0, len(extra)+1)
+	opts = append(opts, goleak.IgnoreCurrent())
+	opts = append(opts, extra...)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, opts...)
+	})
+}

--- a/internal/api/v2/imports/legacy_cleanup.go
+++ b/internal/api/v2/imports/legacy_cleanup.go
@@ -1,5 +1,5 @@
-// internal/api/v2/legacy_cleanup.go
-package api
+// internal/api/v2/imports/legacy_cleanup.go
+package importsapi
 
 import (
 	"context"
@@ -68,7 +68,7 @@ var legacyTables = []string{
 }
 
 // tableExistsMySQL checks if a table exists in the MySQL database.
-func (c *Controller) tableExistsMySQL(db *gorm.DB, tableName string) (bool, error) {
+func (c *Handler) tableExistsMySQL(db *gorm.DB, tableName string) (bool, error) {
 	var count int64
 	err := db.Raw(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
@@ -137,15 +137,15 @@ func (cs *CleanupStatus) TryStart() bool {
 	return true
 }
 
-// initLegacyCleanupRoutes registers the legacy cleanup API routes.
-func (c *Controller) initLegacyCleanupRoutes() {
+// RegisterLegacyCleanupRoutes registers the legacy cleanup API routes on the supplied v2 group.
+func (c *Handler) RegisterLegacyCleanupRoutes(g *echo.Group) {
 	c.LogInfoIfEnabled("Initializing legacy cleanup routes")
 
 	// Initialize cleanup status tracker
 	c.cleanupStatus = NewCleanupStatus()
 
 	// Create legacy API group under system/database
-	legacyGroup := c.Group.Group("/system/database/legacy")
+	legacyGroup := g.Group("/system/database/legacy")
 
 	// Get the appropriate auth middleware
 	authMiddleware := c.AuthMiddleware
@@ -162,7 +162,7 @@ func (c *Controller) initLegacyCleanupRoutes() {
 
 // GetLegacyStatus handles GET /api/v2/system/database/legacy/status
 // Returns information about the legacy database for the cleanup UI.
-func (c *Controller) GetLegacyStatus(ctx echo.Context) error {
+func (c *Handler) GetLegacyStatus(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting legacy database status", logger.String("path", path), logger.String("ip", ip))
 
@@ -179,7 +179,7 @@ func (c *Controller) GetLegacyStatus(ctx echo.Context) error {
 }
 
 // getLegacyStatusSQLite handles legacy status for SQLite deployments.
-func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacyStatusResponse) error {
+func (c *Handler) getLegacyStatusSQLite(ctx echo.Context, response *LegacyStatusResponse) error {
 	legacyPath := c.CurrentSettings().Output.SQLite.Path
 	response.Location = legacyPath
 
@@ -248,7 +248,7 @@ func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacySta
 }
 
 // getLegacyStatusMySQL handles legacy status for MySQL deployments.
-func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStatusResponse) error {
+func (c *Handler) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStatusResponse) error {
 	response.Location = c.CurrentSettings().Output.MySQL.Database
 
 	// Check if we're in v2-only mode (required for cleanup)
@@ -350,7 +350,7 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 
 // StartLegacyCleanup handles POST /api/v2/system/database/legacy/cleanup
 // Initiates asynchronous legacy database cleanup.
-func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
+func (c *Handler) StartLegacyCleanup(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Starting legacy database cleanup", logger.String("path", path), logger.String("ip", ip))
 
@@ -419,7 +419,7 @@ func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 }
 
 // cleanupSQLiteLegacy deletes the legacy SQLite database files.
-func (c *Controller) cleanupSQLiteLegacy(ctx context.Context) error {
+func (c *Handler) cleanupSQLiteLegacy(ctx context.Context) error {
 	// Check for cancellation before starting
 	select {
 	case <-ctx.Done():
@@ -462,7 +462,7 @@ func (c *Controller) cleanupSQLiteLegacy(ctx context.Context) error {
 }
 
 // cleanupMySQLLegacy drops legacy tables from MySQL.
-func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
+func (c *Handler) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 	c.LogInfoIfEnabled("Starting MySQL legacy tables cleanup",
 		logger.Int("total_tables", len(legacyTables)))
 
@@ -525,7 +525,7 @@ func (c *Controller) cleanupMySQLLegacy(ctx context.Context) ([]string, error) {
 }
 
 // getSQLiteLegacySize returns the total size of SQLite legacy files.
-func (c *Controller) getSQLiteLegacySize() int64 {
+func (c *Handler) getSQLiteLegacySize() int64 {
 	legacyPath := c.CurrentSettings().Output.SQLite.Path
 	var totalSize int64
 
@@ -545,7 +545,7 @@ func (c *Controller) getSQLiteLegacySize() int64 {
 // getMySQLLegacySize returns the total size of MySQL legacy tables. ctx (the
 // request context) bounds the information_schema queries so they abort if the
 // caller disconnects instead of running unbounded on the request thread.
-func (c *Controller) getMySQLLegacySize(ctx context.Context) int64 {
+func (c *Handler) getMySQLLegacySize(ctx context.Context) int64 {
 	dbProvider, ok := c.Repo.(gormDBProvider)
 	if !ok {
 		return 0
@@ -589,7 +589,7 @@ func (c *Controller) getMySQLLegacySize(ctx context.Context) int64 {
 }
 
 // sendCleanupNotification sends a notification about cleanup status.
-func (c *Controller) sendCleanupNotification(success bool, spaceReclaimed int64, errMsg string) {
+func (c *Handler) sendCleanupNotification(success bool, spaceReclaimed int64, errMsg string) {
 	notifService := c.getNotificationService()
 	if notifService == nil {
 		return

--- a/internal/api/v2/imports/legacy_cleanup_test.go
+++ b/internal/api/v2/imports/legacy_cleanup_test.go
@@ -1,5 +1,5 @@
-// internal/api/v2/legacy_cleanup_test.go
-package api
+// internal/api/v2/imports/legacy_cleanup_test.go
+package importsapi
 
 import (
 	"database/sql"
@@ -29,13 +29,13 @@ func createTestSettings(legacyPath string) *conf.Settings {
 	return settings
 }
 
-// createLegacyTestController creates a controller with initialized cleanupStatus for testing.
-func createLegacyTestController(tb testing.TB, e *echo.Echo, settings *conf.Settings) *Controller {
+// createLegacyTestHandler creates a controller with initialized cleanupStatus for testing.
+func createLegacyTestHandler(tb testing.TB, e *echo.Echo, settings *conf.Settings) *Handler {
 	tb.Helper()
 	// Handlers read the live snapshot via currentSettings(); publish the test's
 	// settings so the read resolves to them (restored on cleanup).
 	apitest.PublishTestSettings(tb, settings)
-	c := &Controller{Core: &apicore.Core{Echo: e}, cleanupStatus: NewCleanupStatus()}
+	c := &Handler{Core: &apicore.Core{Echo: e}, cleanupStatus: NewCleanupStatus()}
 	c.Settings.Store(settings)
 	return c
 }
@@ -51,7 +51,7 @@ func TestGetLegacyStatus_V2OnlyMode_NoLegacy(t *testing.T) {
 
 	// Create settings with non-existent legacy path
 	settings := createTestSettings(filepath.Join(tmpDir, "nonexistent.db"))
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	// Set v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -89,7 +89,7 @@ func TestGetLegacyStatus_V2OnlyMode_WithLegacy(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	// Set v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -127,7 +127,7 @@ func TestGetLegacyStatus_NotV2OnlyMode(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	// NOT in v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -164,7 +164,7 @@ func TestStartLegacyCleanup_NotV2OnlyMode(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	// NOT in v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -207,7 +207,7 @@ func TestStartLegacyCleanup_SQLite_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	// Set v2-only mode
 	prevV2OnlyMode := isV2OnlyMode
@@ -288,7 +288,7 @@ func TestStartLegacyCleanup_SQLite_V2DatabaseSafetyCheck(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	prevV2OnlyMode := isV2OnlyMode
 	isV2OnlyMode = true
@@ -331,7 +331,7 @@ func TestStartLegacyCleanup_AlreadyInProgress(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := createTestSettings(legacyPath)
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 
 	prevV2OnlyMode := isV2OnlyMode
 	isV2OnlyMode = true
@@ -372,7 +372,7 @@ func TestGetLegacyStatus_MySQL_NoDBProvider(t *testing.T) {
 
 	e := echo.New()
 	settings := createMySQLTestSettings()
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 	// Repo is nil, so gormDBProvider cast will fail
 
 	prevV2OnlyMode := isV2OnlyMode
@@ -403,7 +403,7 @@ func TestStartLegacyCleanup_MySQL_NoDBProvider(t *testing.T) {
 
 	e := echo.New()
 	settings := createMySQLTestSettings()
-	controller := createLegacyTestController(t, e, settings)
+	controller := createLegacyTestHandler(t, e, settings)
 	// Repo is nil, so gormDBProvider cast will fail
 
 	prevV2OnlyMode := isV2OnlyMode

--- a/internal/api/v2/imports/migration.go
+++ b/internal/api/v2/imports/migration.go
@@ -1,5 +1,5 @@
-// internal/api/v2/migration.go
-package api
+// internal/api/v2/imports/migration.go
+package importsapi
 
 import (
 	"context"
@@ -162,7 +162,7 @@ func getIsV2OnlyMode() bool {
 }
 
 // requireMigrationStateManager is middleware that returns 503 if the migration state manager is not available.
-func (c *Controller) requireMigrationStateManager(next echo.HandlerFunc) echo.HandlerFunc {
+func (c *Handler) requireMigrationStateManager(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		if getStateManager() == nil {
 			return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
@@ -172,12 +172,12 @@ func (c *Controller) requireMigrationStateManager(next echo.HandlerFunc) echo.Ha
 	}
 }
 
-// initMigrationRoutes registers the migration API routes.
-func (c *Controller) initMigrationRoutes() {
+// RegisterMigrationRoutes registers the migration API routes on the supplied v2 group.
+func (c *Handler) RegisterMigrationRoutes(g *echo.Group) {
 	c.LogInfoIfEnabled("Initializing migration routes")
 
 	// Create migration API group under system/database
-	migrationGroup := c.Group.Group("/system/database/migration")
+	migrationGroup := g.Group("/system/database/migration")
 
 	// Get the appropriate auth middleware
 	authMiddleware := c.AuthMiddleware
@@ -202,7 +202,7 @@ func (c *Controller) initMigrationRoutes() {
 }
 
 // GetMigrationStatus handles GET /api/v2/system/database/migration/status
-func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
+func (c *Handler) GetMigrationStatus(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Getting migration status", logger.String("path", path), logger.String("ip", ip))
 
@@ -370,7 +370,7 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 }
 
 // StartMigration handles POST /api/v2/system/database/migration/start
-func (c *Controller) StartMigration(ctx echo.Context) error {
+func (c *Handler) StartMigration(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Starting migration", logger.String("path", path), logger.String("ip", ip))
 
@@ -477,7 +477,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 }
 
 // PauseMigration handles POST /api/v2/system/database/migration/pause
-func (c *Controller) PauseMigration(ctx echo.Context) error {
+func (c *Handler) PauseMigration(ctx echo.Context) error {
 	// Snapshot state under lock for thread-safety
 	sm := getStateManager()
 	worker := getMigrationWorker()
@@ -500,7 +500,7 @@ func (c *Controller) PauseMigration(ctx echo.Context) error {
 }
 
 // ResumeMigration handles POST /api/v2/system/database/migration/resume
-func (c *Controller) ResumeMigration(ctx echo.Context) error {
+func (c *Handler) ResumeMigration(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Resuming migration", logger.String("path", path), logger.String("ip", ip))
 
@@ -555,7 +555,7 @@ func (c *Controller) ResumeMigration(ctx echo.Context) error {
 }
 
 // RetryValidation handles POST /api/v2/system/database/migration/retry-validation
-func (c *Controller) RetryValidation(ctx echo.Context) error {
+func (c *Handler) RetryValidation(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Retrying migration validation", logger.String("path", path), logger.String("ip", ip))
 
@@ -601,7 +601,7 @@ func (c *Controller) RetryValidation(ctx echo.Context) error {
 }
 
 // CancelMigration handles POST /api/v2/system/database/migration/cancel
-func (c *Controller) CancelMigration(ctx echo.Context) error {
+func (c *Handler) CancelMigration(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Cancelling migration", logger.String("path", path), logger.String("ip", ip))
 
@@ -669,7 +669,7 @@ func (c *Controller) CancelMigration(ctx echo.Context) error {
 
 // RollbackMigration handles POST /api/v2/system/database/migration/rollback
 // Rolls back a completed migration to use the legacy database.
-func (c *Controller) RollbackMigration(ctx echo.Context) error {
+func (c *Handler) RollbackMigration(ctx echo.Context) error {
 	// Snapshot state under lock for thread-safety
 	sm := getStateManager()
 	worker := getMigrationWorker()
@@ -688,7 +688,7 @@ func (c *Controller) RollbackMigration(ctx echo.Context) error {
 
 // runPreflightChecks verifies the system is ready for migration.
 // This runs the same critical checks as GetPrerequisites and fails if any are not passed.
-func (c *Controller) runPreflightChecks() error {
+func (c *Handler) runPreflightChecks() error {
 	// Run all critical prerequisite checks
 	checks := c.runCriticalPrerequisiteChecks()
 
@@ -704,7 +704,7 @@ func (c *Controller) runPreflightChecks() error {
 
 // runCriticalPrerequisiteChecks runs all critical checks that must pass before migration.
 // This is used by both GetPrerequisites and runPreflightChecks to ensure consistency.
-func (c *Controller) runCriticalPrerequisiteChecks() []PrerequisiteCheck {
+func (c *Handler) runCriticalPrerequisiteChecks() []PrerequisiteCheck {
 	checks := make([]PrerequisiteCheck, 0, 6)
 
 	// Common critical checks
@@ -751,7 +751,7 @@ type migrationActionParams struct {
 
 // executeMigrationAction handles common migration action logic.
 // All callers are behind the requireMigrationStateManager middleware.
-func (c *Controller) executeMigrationAction(ctx echo.Context, params *migrationActionParams) error {
+func (c *Handler) executeMigrationAction(ctx echo.Context, params *migrationActionParams) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled(params.logStart, logger.String("path", path), logger.String("ip", ip))
 

--- a/internal/api/v2/imports/migration_test.go
+++ b/internal/api/v2/imports/migration_test.go
@@ -1,5 +1,5 @@
-// migration_test.go: Package api provides tests for migration API endpoints.
-package api
+// migration_test.go: tests for the migration API endpoints.
+package importsapi
 
 import (
 	"encoding/json"
@@ -64,7 +64,7 @@ func setupMigrationTestDB(t *testing.T) *gorm.DB {
 
 // setupMigrationTestEnvironment creates a test environment for migration API tests.
 // Note: Tests using this function must NOT be run in parallel due to global state.
-func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *datastoreV2.StateManager) {
+func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Handler, *datastoreV2.StateManager) {
 	t.Helper()
 
 	// Lock to prevent parallel tests from interfering
@@ -118,7 +118,7 @@ func setupMigrationTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *data
 		db:            db,
 	}
 
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
 	controller.Settings.Store(getTestSettings(t))
 	apitest.PublishTestSettings(t, controller.Settings.Load())
 
@@ -570,7 +570,7 @@ func TestGetMigrationStatus_NoStateManager(t *testing.T) {
 	t.Attr("feature", "error-handling")
 
 	e := echo.New()
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2")}}
 	controller.Settings.Store(getTestSettings(t))
 
 	// Save and clear the global state manager

--- a/internal/api/v2/imports/prerequisites.go
+++ b/internal/api/v2/imports/prerequisites.go
@@ -1,5 +1,5 @@
-// internal/api/v2/prerequisites.go
-package api
+// internal/api/v2/imports/prerequisites.go
+package importsapi
 
 import (
 	"context"
@@ -82,7 +82,7 @@ const MinMySQLWaitTimeout = 600
 
 // GetPrerequisites handles GET /api/v2/system/database/migration/prerequisites
 // Returns the status of all prerequisite checks before migration can start.
-func (c *Controller) GetPrerequisites(ctx echo.Context) error {
+func (c *Handler) GetPrerequisites(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.LogInfoIfEnabled("Checking migration prerequisites", logger.String("path", path), logger.String("ip", ip))
 
@@ -138,7 +138,7 @@ func (c *Controller) GetPrerequisites(ctx echo.Context) error {
 }
 
 // isUsingMySQL returns true if the application is configured to use MySQL.
-func (c *Controller) isUsingMySQL() bool {
+func (c *Handler) isUsingMySQL() bool {
 	settings := c.CurrentSettings()
 	if settings == nil {
 		return false
@@ -147,7 +147,7 @@ func (c *Controller) isUsingMySQL() bool {
 }
 
 // checkStateIdle verifies the migration is in IDLE state.
-func (c *Controller) checkStateIdle() PrerequisiteCheck {
+func (c *Handler) checkStateIdle() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "state_idle",
 		Name:        "Migration State",
@@ -186,7 +186,7 @@ func (c *Controller) checkStateIdle() PrerequisiteCheck {
 
 // checkDiskSpace verifies there is sufficient free disk space for migration.
 // Required space is the greater of: 1GB minimum or 50% of existing database size.
-func (c *Controller) checkDiskSpace() PrerequisiteCheck {
+func (c *Handler) checkDiskSpace() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "disk_space",
 		Name:        "Disk Space",
@@ -253,7 +253,7 @@ func (c *Controller) checkDiskSpace() PrerequisiteCheck {
 // getDatabaseDirectoryResolved returns the database directory with symlinks resolved.
 // Returns an error if the directory cannot be determined or verified.
 // For MySQL, returns empty string with nil error (disk space check not applicable to remote DB).
-func (c *Controller) getDatabaseDirectoryResolved() (string, error) {
+func (c *Handler) getDatabaseDirectoryResolved() (string, error) {
 	settings := c.CurrentSettings()
 	if settings == nil {
 		return "", fmt.Errorf("settings not available")
@@ -295,7 +295,7 @@ func (c *Controller) getDatabaseDirectoryResolved() (string, error) {
 }
 
 // checkLegacyAccessible verifies the legacy database is accessible for reading.
-func (c *Controller) checkLegacyAccessible() PrerequisiteCheck {
+func (c *Handler) checkLegacyAccessible() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "legacy_accessible",
 		Name:        "Legacy Database",
@@ -330,7 +330,7 @@ func (c *Controller) checkLegacyAccessible() PrerequisiteCheck {
 
 // checkSQLiteIntegrity runs PRAGMA quick_check on the SQLite database.
 // Scans all result rows since quick_check can return multiple errors.
-func (c *Controller) checkSQLiteIntegrity() PrerequisiteCheck {
+func (c *Handler) checkSQLiteIntegrity() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "sqlite_integrity",
 		Name:        "Database Integrity",
@@ -373,7 +373,7 @@ func (c *Controller) checkSQLiteIntegrity() PrerequisiteCheck {
 }
 
 // checkWritePermission verifies write access to the database directory.
-func (c *Controller) checkWritePermission() PrerequisiteCheck {
+func (c *Handler) checkWritePermission() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "write_permission",
 		Name:        "Write Permission",
@@ -411,7 +411,7 @@ func (c *Controller) checkWritePermission() PrerequisiteCheck {
 }
 
 // checkMySQLTableHealth runs CHECK TABLE on legacy MySQL tables.
-func (c *Controller) checkMySQLTableHealth() PrerequisiteCheck {
+func (c *Handler) checkMySQLTableHealth() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "mysql_table_health",
 		Name:        "MySQL Table Health",
@@ -462,7 +462,7 @@ func (c *Controller) checkMySQLTableHealth() PrerequisiteCheck {
 
 // checkMySQLPermissions verifies CREATE, INSERT, UPDATE, DELETE, DROP permissions.
 // Uses a unique table name with timestamp to prevent concurrent request collisions.
-func (c *Controller) checkMySQLPermissions() PrerequisiteCheck {
+func (c *Handler) checkMySQLPermissions() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "mysql_permissions",
 		Name:        "MySQL Permissions",
@@ -527,7 +527,7 @@ func (c *Controller) checkMySQLPermissions() PrerequisiteCheck {
 }
 
 // checkMySQLConfiguration checks MySQL configuration for potential issues.
-func (c *Controller) checkMySQLConfiguration() []PrerequisiteCheck {
+func (c *Handler) checkMySQLConfiguration() []PrerequisiteCheck {
 	checks := make([]PrerequisiteCheck, 0, 2)
 
 	db := c.getLegacyGormDB()
@@ -577,7 +577,7 @@ func (c *Controller) checkMySQLConfiguration() []PrerequisiteCheck {
 }
 
 // checkRecordCount verifies we can count legacy records.
-func (c *Controller) checkRecordCount() PrerequisiteCheck {
+func (c *Handler) checkRecordCount() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "record_count",
 		Name:        "Record Count",
@@ -615,7 +615,7 @@ func (c *Controller) checkRecordCount() PrerequisiteCheck {
 }
 
 // checkExistingV2Data warns if migration target tables already have data.
-func (c *Controller) checkExistingV2Data() PrerequisiteCheck {
+func (c *Handler) checkExistingV2Data() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "existing_v2_data",
 		Name:        "Existing Migration Data",
@@ -661,7 +661,7 @@ func (c *Controller) checkExistingV2Data() PrerequisiteCheck {
 }
 
 // checkMemoryAvailable checks if there's enough free memory for migration.
-func (c *Controller) checkMemoryAvailable() PrerequisiteCheck {
+func (c *Handler) checkMemoryAvailable() PrerequisiteCheck {
 	check := PrerequisiteCheck{
 		ID:          "memory_available",
 		Name:        "Available Memory",
@@ -690,7 +690,7 @@ func (c *Controller) checkMemoryAvailable() PrerequisiteCheck {
 
 // getLegacyGormDB returns the GORM database instance from the legacy datastore.
 // Returns nil if the datastore doesn't implement gormDBProvider.
-func (c *Controller) getLegacyGormDB() *gorm.DB {
+func (c *Handler) getLegacyGormDB() *gorm.DB {
 	if c.DS == nil {
 		return nil
 	}

--- a/internal/api/v2/imports/prerequisites_test.go
+++ b/internal/api/v2/imports/prerequisites_test.go
@@ -1,5 +1,5 @@
-// prerequisites_test.go: Package api provides tests for prerequisites API endpoint.
-package api
+// prerequisites_test.go: tests for the prerequisites API endpoint.
+package importsapi
 
 import (
 	"encoding/json"
@@ -154,7 +154,7 @@ func TestCheckLegacyAccessible_NilDS(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{DS: nil}}
+	controller := &Handler{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkLegacyAccessible()
 
@@ -186,7 +186,7 @@ func TestCheckRecordCount_NilRepo(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{Repo: nil}}
+	controller := &Handler{Core: &apicore.Core{Repo: nil}}
 
 	check := controller.checkRecordCount()
 
@@ -217,7 +217,7 @@ func TestCheckSQLiteIntegrity_NilDB(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{DS: nil}}
+	controller := &Handler{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkSQLiteIntegrity()
 
@@ -240,7 +240,7 @@ func TestCheckSQLiteIntegrity_V2OnlyMode(t *testing.T) {
 	isV2OnlyMode = true
 	t.Cleanup(func() { isV2OnlyMode = prevV2Only })
 
-	controller := &Controller{Core: &apicore.Core{DS: nil}}
+	controller := &Handler{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkSQLiteIntegrity()
 
@@ -264,7 +264,7 @@ func TestCheckLegacyAccessible_V2OnlyMode(t *testing.T) {
 	isV2OnlyMode = true
 	t.Cleanup(func() { isV2OnlyMode = prevV2Only })
 
-	controller := &Controller{Core: &apicore.Core{DS: nil}}
+	controller := &Handler{Core: &apicore.Core{DS: nil}}
 
 	check := controller.checkLegacyAccessible()
 
@@ -288,7 +288,7 @@ func TestCheckRecordCount_V2OnlyMode(t *testing.T) {
 	isV2OnlyMode = true
 	t.Cleanup(func() { isV2OnlyMode = prevV2Only })
 
-	controller := &Controller{Core: &apicore.Core{Repo: nil}}
+	controller := &Handler{Core: &apicore.Core{Repo: nil}}
 
 	check := controller.checkRecordCount()
 
@@ -304,7 +304,7 @@ func TestCheckMemoryAvailable(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := &Handler{Core: &apicore.Core{}}
 	controller.Settings.Store(apitest.NewValidTestSettings())
 
 	check := controller.checkMemoryAvailable()
@@ -321,7 +321,7 @@ func TestCheckExistingV2Data_NilManager(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{V2Manager: nil}}
+	controller := &Handler{Core: &apicore.Core{V2Manager: nil}}
 
 	check := controller.checkExistingV2Data()
 
@@ -375,7 +375,7 @@ func TestCheckExistingV2Data_UsesManagerTablePrefix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			controller := &Controller{Core: &apicore.Core{V2Manager: newFakeV2ManagerWithTable(t, tt.tableName, tt.prefix, tt.count)}}
+			controller := &Handler{Core: &apicore.Core{V2Manager: newFakeV2ManagerWithTable(t, tt.tableName, tt.prefix, tt.count)}}
 
 			check := controller.checkExistingV2Data()
 
@@ -440,7 +440,7 @@ func TestIsUsingMySQL_NilSettings(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := &Handler{Core: &apicore.Core{}}
 
 	result := controller.isUsingMySQL()
 
@@ -467,7 +467,7 @@ func TestGetDatabaseDirectoryResolved_NilSettings(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{}}
+	controller := &Handler{Core: &apicore.Core{}}
 	// Publish a nil global so currentSettings() falls back to the controller's
 	// nil c.Settings and exercises the "settings not available" path.
 	apitest.PublishTestSettings(t, nil)
@@ -497,7 +497,7 @@ func TestGetLegacyGormDB_NilDS(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{Core: &apicore.Core{DS: nil}}
+	controller := &Handler{Core: &apicore.Core{DS: nil}}
 
 	db := controller.getLegacyGormDB()
 
@@ -524,7 +524,7 @@ func TestRunCriticalPrerequisiteChecks(t *testing.T) {
 
 // setupPrerequisitesTestEnvironment creates a test environment for prerequisites API tests.
 // Note: Tests using this function must NOT be run in parallel due to global state.
-func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *datastoreV2.StateManager) {
+func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Handler, *datastoreV2.StateManager) {
 	t.Helper()
 
 	// Lock to prevent parallel tests from interfering
@@ -578,7 +578,7 @@ func setupPrerequisitesTestEnvironment(t *testing.T) (*echo.Echo, *Controller, *
 		db:            db,
 	}
 
-	controller := &Controller{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
+	controller := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: testDS, Repo: mockRepo}}
 	controller.Settings.Store(getTestSettings(t))
 	apitest.PublishTestSettings(t, controller.Settings.Load())
 

--- a/internal/api/v2/system_routes.go
+++ b/internal/api/v2/system_routes.go
@@ -45,9 +45,9 @@ func (c *Controller) initSystemRoutes() {
 	c.analytics.RegisterDatabaseOverviewRoutes(c.Group)
 
 	// Migration, async backup and legacy cleanup routes (import domain).
-	c.initMigrationRoutes()
-	c.initBackupRoutes()
-	c.initLegacyCleanupRoutes()
+	c.imports.RegisterMigrationRoutes(c.Group)
+	c.imports.RegisterBackupRoutes(c.Group)
+	c.imports.RegisterLegacyCleanupRoutes(c.Group)
 }
 
 // BroadcastInferenceTopologyChanged signals all metrics-stream SSE clients that


### PR DESCRIPTION
## What

Extracts the import/migration/backup/legacy-cleanup/prerequisites domain out of the monolithic `internal/api/v2` (package `api`) into a new subpackage `internal/api/v2/imports` (package `importsapi`), continuing the api/v2 domain split. This is the one phase that deliberately changes the external surface: the package-level migration-worker control functions move into the new package and the `internal/analysis` call sites are updated to the new import path (no dead facade forwarders).

## Moved into `internal/api/v2/imports` (package `importsapi`)

- Source: `import.go`, `import_manager.go`, `migration.go`, `legacy_cleanup.go`, `backup.go`, `prerequisites.go`. Handler methods receiver-retyped `*Controller` -> `*Handler`, bodies verbatim. `prerequisites.go` moves with the domain because `GetPrerequisites` is a migration route and `runCriticalPrerequisiteChecks` / `legacy_cleanup.go` use its check helpers.
- Tests: `import_test.go`, `migration_test.go`, `legacy_cleanup_test.go`, `prerequisites_test.go`, rebuilt against the new `Handler` (`&Controller{...}` -> `&Handler{...}`, `c.initImportRoutes()` -> `c.RegisterImportRoutes(c.Group)`).
- New `handler.go`: `Handler` embedding `*apicore.Core` (by pointer), `New(core, notificationService)`, `Shutdown()`, a domain-local `getNotificationService()` (falls back to the global singleton), and the four `Register*Routes(g *echo.Group)` methods (renamed from the old `init*Routes`).
- New test support: `leakcheck_test.go` (`verifyNoLeaks`) and `imports_test_helpers_test.go` (`getTestSettings`, `fakeV2Manager`, `newFakeV2ManagerWithTable`), copied from the package-api test files that stay (a `_test.go` file cannot be imported across packages).

## Deliberate external-surface change (migration worker)

The package-level migration-worker state (`migrationMu`, `stateManager`, `migrationWorker`, `migrationWorkerCancel`, `isV2OnlyMode`, `migrationTelemetry`) and the funcs (`SetMigrationDependencies`, `SetMigrationWorkerCancel`, `SetV2OnlyMode`, `StopMigrationWorker`, `SetMigrationTelemetry`) moved verbatim into the new package. The `internal/analysis` call sites now import `importsapi` instead of `apiv2`:

- `internal/analysis/database_migration.go`: `importsapi.SetMigrationDependencies`, `importsapi.SetMigrationTelemetry`, `importsapi.SetMigrationWorkerCancel`
- `internal/analysis/database_service.go`: `importsapi.SetV2OnlyMode` (x2), `importsapi.StopMigrationWorker`

Both files used `apiv2` only for these funcs, so the import was repointed outright with no dangling references. Single-worker semantics, locking, and start/stop/cancel behavior are unchanged (state and funcs moved together as a unit). The migration worker is still stopped by `internal/analysis` as part of the datastore lifecycle, not by the facade.

## Facade wiring

- `Controller` gains `imports *importsapi.Handler` and loses `cleanupStatus` / `importMgr` / `importSourceRoot` / `importSourceFactory`.
- Constructed once after the functional-options loop (so the injected `notificationService` is observed), mirroring the notifications handler.
- The `routeInitializers` "import routes" entry and the `system_routes.go` migration/backup/legacy registrations repoint to the new `Register*Routes` methods at the same indices and in the same order.
- `Shutdown()` calls `c.imports.Shutdown()` (which stops the backup job manager's cleanup goroutine) at the same point in the teardown order.

## Naming

The package is `importsapi` (directory `imports`) rather than the bare `imports`, which would collide with the existing `internal/imports` dependency it uses; this follows the `range` -> `rangeapi` / `auth` -> `authapi` precedent.

## Verification

- `go build ./...` clean.
- `go vet ./internal/api/v2/... ./internal/analysis/...` clean (copylocks).
- `go test -race ./internal/api/v2/... ./internal/api/v2/imports/ ./internal/analysis/...` all green. The `imports` package has its own `-race` test binary; the analysis migration-worker tests pass against the new `importsapi.X` call sites.
- Route-enumeration golden gate (`routes_enumeration_test.go`, stays in package `api`) passes unchanged: identical method + path + per-route-middleware set and registration order.
- `golangci-lint run` reports 0 issues on all affected packages.

No public-behavior change except the deliberate migration-worker import-path move. `apiv2.Controller` / `apiv2.New` / `apiv2.NewWithOptions` and all other external methods are unchanged.

## Preflight Status

- [x] Single concern: the import/migration domain extraction only
- [x] Preflight passed: reuse, correctness/safety, quality/patterns, integration/wiring, and regression/backward-compatibility reviews all clean (i18n N/A: no frontend changes)
- [x] Linters clean: `golangci-lint run` 0 issues on the affected packages
- [x] Tests pass: `go test -race` green for api/v2 (incl. the new `imports` binary) and analysis
- [x] No unrelated changes: 17 files, all part of the move + wiring
- [x] No regression/backward-compat break: no config-key, REST API, DB schema, or CLI changes; the only removed exported symbols are the 5 migration funcs, whose only callers (internal/analysis) were updated in this same PR
- [x] No secrets or PII in the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import, migration, backup, and legacy-cleanup flows now run through a dedicated backend handler for more consistent system behavior.
  * Import progress streaming now has a clearer time limit, helping long-running requests end predictably.

* **Bug Fixes**
  * Improved startup and shutdown handling for database migration and backup tasks.
  * Fixed route wiring for system database actions, helping import and migration pages/endpoints respond more reliably.
  * Strengthened test coverage around import, migration, and cleanup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->