### PR TITLE
refactor(api/v2): add apicore import guard, update docs to the post-split pattern, revisit -race timeout

### DIFF
--- a/internal/api/v2/CLAUDE.md
+++ b/internal/api/v2/CLAUDE.md
@@ -2,79 +2,200 @@
 
 ## Essential Reference
 
-**ALWAYS read `internal/api/v2/README.md` first** - it contains:
+**ALWAYS read `internal/api/v2/README.md` first** - it is the endpoint catalog:
 
-- Complete list of all API endpoints
-- Route registration patterns
-- Authentication requirements
-- Best practices and security guidelines
+- Complete list of all API endpoints, grouped by domain
+- Per-route authentication requirements
+- Request/response shapes and best practices
 
-## Quick Development Rules
+## Architecture (post-split)
 
-### Finding Existing Endpoints
+`internal/api/v2` is a thin composition root (package `api`) plus one subpackage
+per domain. The dependency direction is strictly acyclic:
 
-1. Check `internal/api/v2/README.md` for complete endpoint list
-2. Search by category (auth, analytics, detections, etc.)
-3. Look for similar patterns before creating new endpoints
+```
+internal/api (parent server.go)
+        |  api.New, *api.Controller
+        v
+internal/api/v2            package api  (the facade)
+  Controller{ *apicore.Core; <domain>.Handler fields }
+  New / NewWithOptions / InitializeAPI, ordered initRoutes()
+        |                         |                      |
+        | imports                 | imports              | imports
+        v                         v                      v
+internal/api/v2/analytics   internal/api/v2/weather  ...  internal/api/v2/<domain>
+        |  type Handler struct{ *apicore.Core }; New; RegisterRoutes
+        +------------------+------------------+
+                 | imports          | imports
+                 v                  v
+       internal/api/v2/apicore   internal/api/v2/dto
+       (Core: shared state,        (cross-domain request/
+        helpers, middleware,        response DTOs)
+        SSE hub, broadcasters)
+                 |
+                 v
+   leaf pkgs: conf, datastore, logger, securefs, observability, ...
+```
 
-### Adding New Endpoints
+Rule, stated once: **domains depend on `apicore` and `dto`; the facade depends on
+`apicore` and every domain; `apicore` depends on neither a domain nor the
+facade.** There is no path back up, so no import cycle is possible. This is
+enforced mechanically by `internal/api/v2/apicore/import_guard_test.go` (a
+`go list -deps` check that fails if `apicore` or `apitest` ever imports a domain
+or the facade); it runs inside the normal `go test ./...` unit-test jobs.
 
-1. **Find the right file**: Group by functionality (detections.go, analytics.go, etc.)
-2. **Follow registration pattern**:
+### What lives where
+
+- **`apicore`** (`internal/api/v2/apicore`): the shared `Core` struct (deps,
+  settings accessors, error/log helpers, telemetry reporting, `RequireDatastore`),
+  the shared group middleware (`TunnelDetectionMiddleware`, `LoggingMiddleware`,
+  `PrivateModeAuth`, the trusted-proxy IP extractor, `GetAuthMiddleware`), the SSE
+  hub (`SSEManager`, `SSEClient`) and the broadcasters (`BroadcastDetection`,
+  `BroadcastSoundLevel`, `BroadcastPending`). Everything a domain handler touches
+  is **exported** on `Core` (cross-package field/method promotion does not bypass
+  Go's export rules).
+- **`<domain>`** (e.g. `internal/api/v2/weather`): `type Handler struct{ *apicore.Core }`,
+  `New(core *apicore.Core) *Handler`, and `RegisterRoutes(g *echo.Group)`. The
+  handler embeds `*apicore.Core` **by pointer** so the shared members promote onto
+  it. Domain-only types and helpers stay unexported in the domain package.
+- **`dto`** (`internal/api/v2/dto`): request/response structs shared by 2+ domains
+  (e.g. `SourceInfo`, `WeatherInfo`, `RangeFilterSpecies`). Domain-only structs
+  stay in their domain package.
+- **`apitest`** (`internal/api/v2/apitest`): importable test scaffolding built
+  around `*apicore.Core`. Domain tests build their own handler:
+  `h := weather.New(apitest.NewCore(t))`. `apitest` imports only `apicore`/`dto`.
+- **`api` (facade, directory root)**: `Controller` embeds `*apicore.Core` and holds
+  one field per domain Handler. `New`/`NewWithOptions`/`InitializeAPI` build the
+  single `Core`, construct each domain Handler around it, and `initRoutes` calls
+  every `RegisterRoutes` in a deterministic ordered list. `settings.go` (and its
+  large test suite) intentionally still lives here, as does the facade-owned
+  name-map plumbing (`name_maps.go`) and the cross-domain `/system` wiring
+  (`system_routes.go`).
+
+> **Embed `*apicore.Core` by pointer only, never by value.** `Core` holds
+> `atomic.Pointer`, `sync.RWMutex` and `sync.WaitGroup` fields; copying it by value
+> desyncs the atomics and trips `go vet` copylocks. A single `Core` is built once
+> in `NewWithOptions` and shared by pointer to every handler and the facade.
+
+> **Broadcaster-payload rule.** Because the SSE broadcasters live in `apicore` and
+> are called from domains, their parameter/return types must stay in leaf packages,
+> `dto`, or `apicore` itself - **never a domain type** - or `apicore` would have to
+> import a domain and close a cycle. Use a leaf type, `any` + serialize, or push the
+> payload struct to `dto`.
+
+## Adding endpoints
+
+### Recipe A - new endpoint in an EXISTING domain (no facade change)
+
+1. Add the handler method on that domain's `*Handler` in
+   `internal/api/v2/<domain>/`, receiver named `c`:
 
    ```go
-   // Public endpoint
-   c.Group.GET("/path", c.HandlerName)
-
-   // Protected endpoint
-   c.Group.POST("/path", c.HandlerName, c.getEffectiveAuthMiddleware())
+   func (c *Handler) GetThing(ctx echo.Context) error {
+       if c.DS == nil {
+           return c.HandleError(ctx, nil, "datastore unavailable", http.StatusServiceUnavailable)
+       }
+       // ... use c.CurrentSettings(), c.HandleError(...), dto.Thing, etc.
+       return ctx.JSON(http.StatusOK, resp)
+   }
    ```
 
-3. **Update README.md** with new endpoint documentation
-4. **Use error handling**: `return c.HandleError(ctx, err, "message", statusCode)`
+2. Add the route line to that domain's `RegisterRoutes(g *echo.Group)`:
 
-### Authentication Patterns
+   ```go
+   g.GET("/things", c.GetThing)                       // public
+   g.POST("/things", c.CreateThing, c.AuthMiddleware) // protected
+   ```
 
-- Public endpoints: No middleware
-- Protected endpoints: `c.getEffectiveAuthMiddleware()`
-- Rate-limited streams: `middleware.RateLimiterWithConfig(config)`
+3. Update `README.md` with the new endpoint. No facade edit is needed.
 
-### Route Namespace Guide
+### Recipe B - new domain
 
-The API uses distinct namespaces. Adding endpoints to the wrong namespace causes route collisions.
+1. Create `internal/api/v2/<domain>/<domain>.go` with
+   `type Handler struct{ *apicore.Core }`, `New(core *apicore.Core) *Handler`, and
+   `RegisterRoutes(g *echo.Group)`.
+2. In the facade (`api.go`): add one `*<domain>.Handler` field to `Controller`, one
+   `c.<domain> = <domain>.New(c.Core)` line in `NewWithOptions`, and one ordered
+   entry `{"<domain> routes", func() { c.<domain>.RegisterRoutes(c.Group) }}` in
+   `initRoutes`. Registration is explicit (not `init()`-based) so order stays
+   deterministic; preserve the existing ordering.
+3. New domains are subpackages of `api/v2`, so the "all new endpoints stay under
+   api/v2" rule holds.
+
+A single `RegisterRoutes` is the norm, but a larger domain may expose several named
+registrars (e.g. `detections` has `RegisterSearchRoutes` + `RegisterDetectionRoutes`;
+`analytics` has `RegisterAnalyticsRoutes` + `RegisterHeatmapRoutes` +
+`RegisterInsightsRoutes` + `RegisterDatabaseOverviewRoutes`; `audio` and `system`
+similarly). Each is wired as its own ordered `initRoutes` entry, which keeps the
+original per-route registration order across the split.
+
+### Recipe C - new shared dependency or middleware
+
+- Shared dependency: add an exported field (+ functional option) on `apicore.Core`
+  and thread it through `NewCore`; domains read it via promotion.
+- Shared middleware: add it on `apicore` and apply it at the facade group level in
+  `NewWithOptions` (preserving order), or as a shared per-route middleware
+  constructor that domains call.
+
+## Authentication patterns
+
+- Public endpoints: no middleware.
+- Protected endpoints/groups: apply the promoted `c.AuthMiddleware` field directly,
+  e.g. `g.Group("/control", c.AuthMiddleware)` or
+  `g.POST("/path", c.Handler, c.AuthMiddleware)`. (`c.GetAuthMiddleware()` returns
+  the same value for callers that prefer an accessor.) The middleware is injected
+  from the parent server via the `WithAuthMiddleware` functional option.
+- Rate-limited streams: `middleware.RateLimiterWithConfig(config)`.
+- PrivateMode: all endpoints are gated by `apicore.PrivateModeAuth` group
+  middleware; the bootstrap/login/live-audio carve-outs are listed in the facade's
+  `isPrivateModeExempt` allow-list (keyed on method + path, fail-closed).
+
+## Route namespace guide
+
+The API uses distinct namespaces. Adding endpoints to the wrong namespace causes
+route collisions.
 
 | Namespace | Purpose | Registration | Example |
 |---|---|---|---|
-| `/audio/:id` | Detection audio clips by numeric note ID | `c.Echo.GET(...)` | `ServeAudioByID` |
-| `/system/audio/*` | Audio device/source management (protected) | `protectedGroup.Group("/audio")` | `GetAudioDevices`, `ListAudioSources` |
-| `/streams/*` | Live streaming, SSE, source listing (public) | `c.Group.GET("/streams/...")` | `StreamAudioLevel`, `ListStreamSources` |
-| `/media/*` | Static media files (images, spectrograms) | `c.Group.GET("/media/...")` | `ServeSpectrogram` |
+| `/audio/:id` | Detection audio clips by numeric note ID | `c.Echo.GET(...)` (media domain) | `ServeAudioByID` |
+| `/system/audio/*` | Audio device/source management (protected) | `protectedGroup.Group("/audio")` (audio domain) | `GetAudioDevices`, `ListAudioSources` |
+| `/streams/*` | Live streaming, SSE, source listing (public) | `g.GET("/streams/...")` (audio/sse domains) | `StreamAudioLevel`, `ListStreamSources` |
+| `/media/*` | Static media files (images, spectrograms) | `g.GET("/media/...")` (media domain) | `ServeSpectrogram` |
 
-**WARNING:** `GET /api/v2/audio/:id` is registered directly on `c.Echo` (not `c.Group`) and catches ALL paths under `/api/v2/audio/*`. Any non-numeric path like `/api/v2/audio/sources` returns 400. Never add new endpoints under `/api/v2/audio/` unless they use a numeric `:id` parameter.
+**WARNING:** `GET /api/v2/audio/:id` is registered directly on `c.Echo` (not the
+`/api/v2` group) and catches ALL paths under `/api/v2/audio/*`. Any non-numeric
+path like `/api/v2/audio/sources` returns 400. Never add new endpoints under
+`/api/v2/audio/` unless they use a numeric `:id` parameter.
 
-**Public endpoints that expose source metadata** must anonymize display names for unauthenticated clients using `c.getAnonymizedSourceName()`, matching the behavior of `StreamAudioLevel`.
+**Public endpoints that expose source metadata** must anonymize display names for
+unauthenticated clients (the audio domain does this with its local
+`getAnonymizedSourceName`, matching `StreamAudioLevel`).
 
-### Critical Rules
+## Critical rules
 
-- **Never duplicate existing endpoints** - check README.md first
-- **Always validate input** - prevent injection attacks
-- **Use structured logging** - `c.logAPIRequest(ctx, level, msg, args...)`
-- **Follow error format** - Use `c.HandleError()` consistently
-- **Document in README.md** - Update endpoint table immediately
+- **Never duplicate existing endpoints** - check `README.md` first.
+- **Always validate input** - prevent injection attacks; use SecureFS (`c.SFS`) for
+  file operations and parameterized queries only.
+- **Use structured logging** - `c.LogAPIRequest(ctx, level, msg, args...)` and the
+  `c.LogInfoIfEnabled`/`LogWarnIfEnabled`/`LogErrorIfEnabled`/`LogDebugIfEnabled`
+  family.
+- **Follow the error format** - `return c.HandleError(ctx, err, "message", statusCode)`
+  (or `c.HandleErrorWithKey(...)` for an i18n key). The `ErrorResponse` shape and
+  correlation-id behavior live in `apicore`.
+- **Hot-reload** - read settings per request via `c.CurrentSettings()` /
+  `c.ControllerSettings()` (the atomic snapshot on `Core`); never branch on settings
+  captured at startup.
+- **Document in README.md** - update the endpoint table immediately.
 
-### Code Quality
+## Future api/v3
 
-- Input validation is mandatory
-- Use SecureFS for file operations
-- Parameterized database queries only
-- Follow existing naming conventions
-- Include authentication where needed
+A future `internal/api/v3` lives as a sibling facade with its own `Core` (do not
+re-monolith). It can reuse these patterns but should not couple to `apicore` so the
+two versions evolve independently.
 
-## CSRF Protection (Legacy Info)
+## CSRF Protection (legacy info)
 
-CSRF middleware validates tokens from:
-
-1. `X-CSRF-Token` header (primary)
-2. `_csrf` form field (fallback)
-
+CSRF middleware validates tokens from the `X-CSRF-Token` header (primary) or the
+`_csrf` form field (fallback); it is wired globally in the parent `server.go`. The
+token is issued by the `/app/config` endpoint via `middleware.EnsureCSRFToken()`.
 Public read-only endpoints skip CSRF validation.

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -6,21 +6,25 @@ The API v2 provides comprehensive access to BirdNET-Go's bird detection and moni
 
 ## Endpoint Registration Pattern
 
-### Standard Registration
+> Architecture and the "add a new endpoint / add a new domain" recipes live in
+> `internal/api/v2/CLAUDE.md`. The summary below is the registration mechanics.
 
-All endpoints follow this registration pattern in their respective `init*Routes()` functions:
+### Per-domain registration
+
+`internal/api/v2` is a thin facade (package `api`) plus one subpackage per domain.
+Each domain package exposes `type Handler struct{ *apicore.Core }`, a
+`New(core *apicore.Core)` constructor, and a `RegisterRoutes(g *echo.Group)` method
+that wires its own routes on the `/api/v2` group:
 
 ```go
-func (c *Controller) initExampleRoutes() {
+// internal/api/v2/example/example.go
+func (c *Handler) RegisterRoutes(g *echo.Group) {
     // Public endpoints (no authentication required)
-    c.Group.GET("/path", c.HandlerFunction)
-    c.Group.POST("/path", c.HandlerFunction)
+    g.GET("/path", c.HandlerFunction)
+    g.POST("/path", c.HandlerFunction)
 
-    // Protected endpoints (authentication required)
-    c.Group.POST("/protected-path", c.HandlerFunction, c.getEffectiveAuthMiddleware())
-
-    // Alternative auth pattern (deprecated, use above)
-    c.Group.POST("/legacy-auth", c.HandlerFunction, c.AuthMiddleware)
+    // Protected endpoints: apply the promoted c.AuthMiddleware field
+    g.POST("/protected-path", c.HandlerFunction, c.AuthMiddleware)
 
     // Rate-limited endpoints (typically for streams)
     rateLimiterConfig := middleware.RateLimiterConfig{
@@ -29,25 +33,28 @@ func (c *Controller) initExampleRoutes() {
             middleware.RateLimiterMemoryStoreConfig{Rate: rate.Limit(1), Burst: 5},
         ),
     }
-    c.Group.GET("/stream", c.StreamHandler, middleware.RateLimiterWithConfig(rateLimiterConfig))
+    g.GET("/stream", c.StreamHandler, middleware.RateLimiterWithConfig(rateLimiterConfig))
 }
 ```
 
 ### Authentication Middleware
 
-Use `c.getEffectiveAuthMiddleware()` for new protected endpoints. This automatically selects the appropriate authentication method.
+Apply the promoted `c.AuthMiddleware` field (injected from the parent server via
+the `WithAuthMiddleware` option) to protected routes and groups.
+`c.GetAuthMiddleware()` returns the same value for callers that prefer an accessor.
 
 ### Route Initialization
 
-All route initialization functions are called from `api.go:initRoutes()`:
+The facade constructs each domain Handler in `NewWithOptions` and calls every
+`RegisterRoutes` from `api.go:initRoutes()` in a deterministic ordered list:
 
 ```go
 routeInitializers := []struct {
     name string
     fn   func()
 }{
-    {"example routes", c.initExampleRoutes},
-    // Add new route groups here
+    {"example routes", func() { c.example.RegisterRoutes(c.Group) }},
+    // Add a new domain's RegisterRoutes here, preserving the existing order
 }
 ```
 
@@ -185,7 +192,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | POST   | `/notifications/test/new-species`  | `CreateTestNewSpeciesNotification` | ✅   | Create test new-species notification                                                                                |
 | GET    | `/notifications/check-ntfy-server` | `CheckNtfyServer`                  | ✅   | Probe NTFY host for HTTPS/HTTP connectivity (authenticated to prevent SSRF relay). Query: `host=<hostname[:port]>`. |
 
-### Range Filter (`range.go`)
+### Range Filter (`range/range.go`)
 
 | Method | Route                   | Handler                       | Auth | Description                                                 |
 | ------ | ----------------------- | ----------------------------- | ---- | ----------------------------------------------------------- |
@@ -460,7 +467,7 @@ Registered under the system route group. All endpoints require authentication.
 | GET    | `/weather/latest`             | `GetLatestWeather`        | ❌   | Latest weather data                 |
 | GET    | `/weather/sun/:date`          | `GetSunTimes`             | ❌   | Sun times (sunrise/sunset) for date |
 
-### Alert Rules (`alerts.go`)
+### Alert Rules (`alerts/alerts.go`)
 
 Requires enhanced (v2) database. Returns 409 Conflict if not available.
 
@@ -502,7 +509,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 
 - All insights endpoints accept optional `model_id` query parameter to filter by BirdNET model
 
-### Models (`models.go`)
+### Models (`models/models.go`)
 
 | Method | Route                          | Handler                 | Auth | Description                                           |
 | ------ | ------------------------------ | ----------------------- | ---- | ----------------------------------------------------- |
@@ -514,7 +521,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 | DELETE | `/models/installed/:id`        | `UninstallModel`        | ✅   | Remove an installed model from disk                   |
 | GET    | `/models/install/:id/progress` | `StreamInstallProgress` | ❌   | SSE stream for install/reinstall progress             |
 
-**GET /api/v2/models** — Returns all classifier models registered in the model registry. Each entry includes a config alias (used in audio source configuration) and a human-readable display name.
+**GET /api/v2/models** - Returns all classifier models registered in the model registry. Each entry includes a config alias (used in audio source configuration) and a human-readable display name.
 
 **Response:**
 
@@ -535,9 +542,9 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 | POST   | `/tls/certificate/generate` | `GenerateSelfSignedCertificate` | ✅   | Generate self-signed certificate           |
 | GET    | `/tls/certificate/download` | `DownloadTLSCertificate`        | ✅   | Download installed certificate as PEM file |
 
-**GET /api/v2/tls/certificate** — Returns `{"installed": false}` when no certificate is installed, or full certificate metadata (subject, issuer, SANs, expiry, fingerprint) when one is present.
+**GET /api/v2/tls/certificate** - Returns `{"installed": false}` when no certificate is installed, or full certificate metadata (subject, issuer, SANs, expiry, fingerprint) when one is present.
 
-**POST /api/v2/tls/certificate** — Upload a PEM-encoded certificate and private key. The pair is validated before saving. Sets TLS mode to `manual`.
+**POST /api/v2/tls/certificate** - Upload a PEM-encoded certificate and private key. The pair is validated before saving. Sets TLS mode to `manual`.
 
 ```json
 {
@@ -547,7 +554,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 }
 ```
 
-**POST /api/v2/tls/certificate/generate** — Generate a self-signed certificate. Validity accepts duration strings like `30d`, `1y`, `8760h` (default: `365d`, min: `1d`, max: `10y`). SANs are auto-collected from configured host, base URL, and local network interfaces.
+**POST /api/v2/tls/certificate/generate** - Generate a self-signed certificate. Validity accepts duration strings like `30d`, `1y`, `8760h` (default: `365d`, min: `1d`, max: `10y`). SANs are auto-collected from configured host, base URL, and local network interfaces.
 
 ```json
 {
@@ -564,7 +571,7 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 | GET    | `/system/diagnostics/report/:id` | `GetDiagnosticsReport`   | ✅   | Retrieve completed report      |
 | GET    | `/system/diagnostics/errors`     | `GetRecentErrors`        | ✅   | Recent error log entries       |
 
-### Import (`import.go`)
+### Import (`imports/import.go`)
 
 | Method | Route                          | Handler              | Auth | Description                              |
 | ------ | ------------------------------ | -------------------- | ---- | ---------------------------------------- |
@@ -585,52 +592,43 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 
 - ✅ = Authentication required
 - ✅ publicLiveAudio = Authentication required unless `PublicAccess.LiveAudio` is enabled (dynamic per-request check)
-- 🔑 token = Token-based access — the crypto-random `stream_token` returned by `/start` acts as the credential
+- 🔑 token = Token-based access - the crypto-random `stream_token` returned by `/start` acts as the credential
 - ❌ = No authentication required
 - ⚡ = Rate limited
 - 🔒 = Admin only (subset of authenticated)
 
 ## Adding New Endpoints
 
-### 1. Create Handler Function
+See `internal/api/v2/CLAUDE.md` for the full architecture and the "add a new
+domain" recipe. To add an endpoint to an EXISTING domain:
+
+### 1. Create the Handler method (on the domain's `*Handler`)
 
 ```go
+// internal/api/v2/<domain>/<domain>.go
 // HandlerName handles the endpoint description
-func (c *Controller) HandlerName(ctx echo.Context) error {
+func (c *Handler) HandlerName(ctx echo.Context) error {
     // Validate input
-    // Process request
-    // Return response
+    // Process request, using c.HandleError / c.CurrentSettings / dto.* etc.
     return ctx.JSON(http.StatusOK, response)
 }
 ```
 
-### 2. Register Route
-
-Add to appropriate `init*Routes()` function:
+### 2. Register the route in that domain's `RegisterRoutes`
 
 ```go
-func (c *Controller) initExampleRoutes() {
-    // Choose appropriate pattern based on authentication needs
-    c.Group.GET("/path", c.HandlerName)                                    // Public
-    c.Group.POST("/path", c.HandlerName, c.getEffectiveAuthMiddleware())   // Protected
+func (c *Handler) RegisterRoutes(g *echo.Group) {
+    // Choose the pattern based on authentication needs
+    g.GET("/path", c.HandlerName)                       // Public
+    g.POST("/path", c.HandlerName, c.AuthMiddleware)    // Protected
 }
 ```
 
-### 3. Add to Route Initializers
+No facade change is needed for a new endpoint in an existing domain. A brand-new
+domain additionally needs a `Controller` field, a `New(...)` call, and one ordered
+`RegisterRoutes` entry in `api.go:initRoutes()` (see CLAUDE.md Recipe B).
 
-Update `api.go:initRoutes()` if creating a new route category:
-
-```go
-routeInitializers := []struct {
-    name string
-    fn   func()
-}{
-    // ... existing routes ...
-    {"new category routes", c.initNewCategoryRoutes},
-}
-```
-
-### 4. Update Documentation
+### 3. Update Documentation
 
 - Add endpoint to this README.md
 - Add usage examples if complex
@@ -719,8 +717,8 @@ The `/notifications/stream` endpoint provides both notifications and toast messa
 
 **Event Types:**
 
-- `notification` - System notifications (errors, warnings, info — delivered to authenticated subscribers)
-- `toast` - Temporary UI messages (success, info, warning, error — authenticated only)
+- `notification` - System notifications (errors, warnings, info - delivered to authenticated subscribers)
+- `toast` - Temporary UI messages (success, info, warning, error - authenticated only)
 - `connected` - Connection established
 - `heartbeat` - Keep-alive signal
 
@@ -746,7 +744,7 @@ The `/notifications/stream` endpoint provides both notifications and toast messa
 
 ## Stream Health Monitoring API
 
-The Stream Health API provides comprehensive real-time monitoring of RTSP stream status, leveraging the FFmpeg error detection system from PR #1380. These endpoints are **settings-page only** — they are consumed by the `StreamManager` component in the audio settings page and all require authentication, so the example `curl` calls below must be accompanied by the usual session cookie or bearer token. They are not called from the public dashboard.
+The Stream Health API provides comprehensive real-time monitoring of RTSP stream status, leveraging the FFmpeg error detection system from PR #1380. These endpoints are **settings-page only** - they are consumed by the `StreamManager` component in the audio settings page and all require authentication, so the example `curl` calls below must be accompanied by the usual session cookie or bearer token. They are not called from the public dashboard.
 
 ### Key Features
 
@@ -999,7 +997,7 @@ Updates are sent only when changes are detected, reducing bandwidth compared to 
 
 ### Integration Tips
 
-1. **Choose the Right Endpoint** (all require authentication — settings page only):
+1. **Choose the Right Endpoint** (all require authentication - settings page only):
    - Use SSE (`/streams/health/stream`) for real-time settings-page monitoring
    - Use REST polling (`/streams/status`) for periodic background checks on the settings page
    - Use REST (`/streams/health/:url`) for on-demand detailed diagnostics

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -662,7 +662,7 @@ c.log.Info("operation completed",
 
 ### Authentication
 
-- Use `c.getEffectiveAuthMiddleware()` for protected endpoints
+- Apply the promoted `c.AuthMiddleware` field to protected endpoints
 - Consider IP bypass rules for local access
 - Use proper HTTP status codes (401 vs 403)
 

--- a/internal/api/v2/apicore/import_guard_test.go
+++ b/internal/api/v2/apicore/import_guard_test.go
@@ -1,0 +1,113 @@
+package apicore
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// This guard locks in the acyclic dependency direction the api/v2 split is built
+// on (epic design 2.2/2.7): domains depend on apicore and dto; the facade
+// (package api at internal/api/v2) depends on apicore and every domain; apicore
+// depends on NEITHER a domain NOR the facade, and apitest depends only on
+// apicore and dto. Because go test compiles a separate binary per package, the
+// only thing stopping apicore from growing a domain import over time is a
+// mechanical check: if apicore ever imported a domain (or a broadcaster grew a
+// domain-typed payload), the import graph would close a cycle and this test
+// fails, pointing at the offending package by name.
+//
+// The check shells out to `go list -deps`, which reports the transitive
+// NON-TEST import set of a package. Non-test scope is exactly right: the rule is
+// about the production build graph (a test file importing a domain cannot form a
+// production cycle). No build tags are passed: build tags select files, so a
+// tag-gated file could in principle add an import the default build never sees,
+// but apicore and apitest currently have no build-constrained files, so the
+// default build covers their entire import graph (narrow the check to a tag set
+// if that ever changes). The test runs inside the normal `go test ./...`
+// unit-test jobs on every platform, so it gates CI without a dedicated workflow
+// step.
+
+const (
+	// apiV2Prefix is the import path of the api/v2 facade package (package api).
+	apiV2Prefix = "github.com/tphakala/birdnet-go/internal/api/v2"
+	// apicorePkg, apitestPkg and dtoPkg are the api/v2 leaf/substrate packages a
+	// substrate package is allowed to import.
+	apicorePkg = apiV2Prefix + "/apicore"
+	apitestPkg = apiV2Prefix + "/apitest"
+	dtoPkg     = apiV2Prefix + "/dto"
+)
+
+// listDeps returns the transitive non-test import paths of pkg via `go list
+// -deps`. It skips (rather than fails) the test when the Go toolchain is not on
+// PATH so the suite stays runnable in a stripped-down environment; a present-but-
+// failing toolchain is a real problem and fails the test with the stderr output.
+func listDeps(t *testing.T, pkg string) []string {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not available, skipping import guard: %v", err)
+	}
+	// Output() captures stdout only (the dep list); on failure stderr is carried on
+	// the *exec.ExitError, so diagnostics never leak into the parsed import set.
+	out, err := exec.Command("go", "list", "-deps", pkg).Output() //nolint:gosec // fixed args, no user input
+	if err != nil {
+		var exitErr *exec.ExitError
+		var stderr []byte
+		if errors.As(err, &exitErr) {
+			stderr = exitErr.Stderr
+		}
+		require.NoErrorf(t, err, "go list -deps %s failed: %s", pkg, stderr)
+	}
+	return strings.Fields(string(out))
+}
+
+// isAPIV2Package reports whether dep is the api/v2 facade or one of its
+// subpackages. The facade is matched by exact equality and subpackages by the
+// "/"-separated prefix, so a sibling like internal/api/v2foo can never match.
+func isAPIV2Package(dep string) bool {
+	return dep == apiV2Prefix || strings.HasPrefix(dep, apiV2Prefix+"/")
+}
+
+// assertNoForbiddenAPIV2Imports fails when pkg transitively imports any api/v2
+// package outside allowed. allowed must list every api/v2 package the substrate
+// package is permitted to depend on (itself plus the leaf packages); any other
+// api/v2 dependency is a domain handler or the facade and closes a cycle.
+func assertNoForbiddenAPIV2Imports(t *testing.T, pkg string, allowed map[string]bool) {
+	t.Helper()
+	for _, dep := range listDeps(t, pkg) {
+		if !isAPIV2Package(dep) || allowed[dep] {
+			continue
+		}
+		assert.Failf(t, "forbidden api/v2 import",
+			"%s must not import %s: it would create a dependency cycle (the api/v2 split requires apicore/apitest to depend only on leaf packages, never on a domain or the facade)",
+			pkg, dep)
+	}
+}
+
+// TestApicoreDoesNotImportDomainsOrFacade asserts the substrate package apicore
+// imports no api/v2 domain and not the facade. apicore may import only itself and
+// the dto leaf package.
+func TestApicoreDoesNotImportDomainsOrFacade(t *testing.T) {
+	t.Parallel()
+	assertNoForbiddenAPIV2Imports(t, apicorePkg, map[string]bool{
+		apicorePkg: true,
+		dtoPkg:     true,
+	})
+}
+
+// TestApitestDoesNotImportDomainsOrFacade asserts the importable test-helper
+// package apitest imports no api/v2 domain and not the facade. apitest may import
+// only itself, apicore and the dto leaf package, so a domain test depending on
+// apitest cannot pull in another domain (a domain -> apitest -> domain cycle).
+func TestApitestDoesNotImportDomainsOrFacade(t *testing.T) {
+	t.Parallel()
+	assertNoForbiddenAPIV2Imports(t, apitestPkg, map[string]bool{
+		apicorePkg: true,
+		apitestPkg: true,
+		dtoPkg:     true,
+	})
+}

--- a/internal/api/v2/apicore/import_guard_test.go
+++ b/internal/api/v2/apicore/import_guard_test.go
@@ -1,15 +1,23 @@
 package apicore
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
+
+// goListTimeout bounds the nested `go list` invocation so the guard fails fast
+// instead of hanging indefinitely if the toolchain stalls (e.g. a wedged module
+// fetch). The dependency resolution of an already-built package is sub-second, so
+// 60s is generous headroom.
+const goListTimeout = 60 * time.Second
 
 // This guard locks in the acyclic dependency direction the api/v2 split is built
 // on (epic design 2.2/2.7): domains depend on apicore and dto; the facade
@@ -51,10 +59,16 @@ func listDeps(t *testing.T, pkg string) []string {
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skipf("go toolchain not available, skipping import guard: %v", err)
 	}
+	ctx, cancel := context.WithTimeout(t.Context(), goListTimeout)
+	defer cancel()
 	// Output() captures stdout only (the dep list); on failure stderr is carried on
 	// the *exec.ExitError, so diagnostics never leak into the parsed import set.
-	out, err := exec.Command("go", "list", "-deps", pkg).Output() //nolint:gosec // fixed args, no user input
+	out, err := exec.CommandContext(ctx, "go", "list", "-deps", pkg).Output() //nolint:gosec // fixed args, no user input
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			require.Failf(t, "go list timed out",
+				"go list -deps %s did not finish within %s", pkg, goListTimeout)
+		}
 		var exitErr *exec.ExitError
 		var stderr []byte
 		if errors.As(err, &exitErr) {

--- a/internal/api/v2/apicore_bridge.go
+++ b/internal/api/v2/apicore_bridge.go
@@ -24,12 +24,12 @@ type (
 	ShutdownRequester = apicore.ShutdownRequester
 )
 
-// SSE stream scaffolding re-declared from apicore so the remaining SSE producers
-// still in package api (streams_health.go, import.go) and the dashboard public
-// endpoint test keep referring to them by their short names. The canonical
-// definitions and the SendSSEHeartbeat/LogSSEConnection/SendConnectionMessage
-// helpers live in apicore and are promoted onto *Controller via the embedded
-// *apicore.Core.
+// SSE stream scaffolding re-declared from apicore so the SSE contract and
+// dashboard-public-endpoint tests still resident in package api keep referring to
+// them by their short names (the SSE producers themselves now live in the sse,
+// audio, notifications and imports domains). The canonical definitions and the
+// SendSSEHeartbeat/LogSSEConnection/SendConnectionMessage helpers live in apicore
+// and are promoted onto *Controller via the embedded *apicore.Core.
 const (
 	// maxSSEStreamDuration is the maximum lifetime of a single SSE stream.
 	maxSSEStreamDuration = apicore.MaxSSEStreamDuration

--- a/internal/api/v2/detections/detections_test.go
+++ b/internal/api/v2/detections/detections_test.go
@@ -2501,7 +2501,8 @@ func TestTrueConcurrentPlatformSpecific(t *testing.T) {
 
 // TestApplySpeciesTrackingMetadata_NoveltyFlags verifies that the isNewSpecies,
 // isNewThisYear, and isNewThisSeason flags are true only when the detection date
-// matches the species' first-seen date for each period. Regression test for Forgejo #98.
+// matches the species' first-seen date for each period. Regression test for the
+// species-tracking novelty-flag bug.
 func TestApplySpeciesTrackingMetadata_NoveltyFlags(t *testing.T) {
 	t.Parallel()
 	t.Attr("component", "detections")

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -8,24 +8,6 @@ import (
 )
 
 // =============================================================================
-// SSE Metrics Helpers
-// =============================================================================
-
-// recordSSEConnectionStart records an SSE connection start if metrics are available
-func (c *Controller) recordSSEConnectionStart(endpoint string) {
-	if c.Metrics != nil && c.Metrics.HTTP != nil {
-		c.Metrics.HTTP.SSEConnectionStarted(endpoint)
-	}
-}
-
-// recordSSEConnectionClose records an SSE connection close if metrics are available
-func (c *Controller) recordSSEConnectionClose(endpoint string, duration float64, reason string) {
-	if c.Metrics != nil && c.Metrics.HTTP != nil {
-		c.Metrics.HTTP.SSEConnectionClosed(endpoint, duration, reason)
-	}
-}
-
-// =============================================================================
 // Settings Validation Helpers
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Final cleanup phase of the `internal/api/v2` split. The package is now a thin facade (package `api`) embedding `*apicore.Core`, with ~20 domain subpackages each owning their own `-race` test binary. This phase locks in the architecture with a mechanical import guard, brings the docs up to date with the post-split pattern, removes dead facade glue, and revisits the per-package `-race` timeout with measured data.

## What changed

### 1. apicore import guard (new test)

`internal/api/v2/apicore/import_guard_test.go` asserts the acyclic dependency direction the split depends on: `apicore` and `apitest` must never transitively import an api/v2 domain package or the facade. The test shells out to `go list -deps` (non-test transitive deps) and fails, naming the offender, if `apicore` ever grows a domain import (for example, a broadcaster taking a domain-typed payload) or `apitest` pulls in a domain. It runs inside the normal `go test ./...` unit-test jobs on every platform, so it gates CI without a dedicated workflow step. It skips gracefully when the Go toolchain is not on PATH, and fails loudly (not silently) on a real `go list` error.

### 2. Docs updated to the post-split pattern

- `internal/api/v2/CLAUDE.md`: replaced the old `init<Domain>Routes` / `routeInitializers` guidance with the current architecture: domains are `internal/api/v2/<domain>` packages with `type Handler struct{ *apicore.Core }`, `New(core)`, and `RegisterRoutes(g *echo.Group)`; the facade embeds `*apicore.Core`, constructs each domain Handler, and calls `RegisterRoutes` in the ordered `initRoutes`; shared state/helpers/middleware/SSE-hub live (exported) in `apicore`; cross-domain DTOs live in `dto`. Added the "add an endpoint to an existing domain" vs "add a new domain" recipes, the embed-`*apicore.Core`-by-pointer-only and broadcaster-payload rules, and kept the greedy `GET /api/v2/audio/:id` caveat. Auth guidance now points at the real promoted `c.AuthMiddleware` field (the docs previously referenced the long-renamed `getEffectiveAuthMiddleware()`).
- `internal/api/v2/README.md`: updated the registration-pattern and "Adding New Endpoints" sections to per-domain `RegisterRoutes`, and fixed four stale section-header file paths to the extracted locations (`range/range.go`, `alerts/alerts.go`, `models/models.go`, `imports/import.go`). `settings.go` correctly stays in the facade root (settings was intentionally not extracted). Minimal targeted edits, no repo-wide reflow.

### 3. Dead glue removed + comment fixes

- Removed two unused facade helpers `recordSSEConnectionStart` / `recordSSEConnectionClose` (zero references repo-wide; SSE metrics now flow through the domains' `apicore` plumbing).
- Refreshed a stale comment in `apicore_bridge.go` that named SSE producers (`streams_health.go`, `import.go`) which moved to domain packages.
- Scrubbed a private-tracker reference from a `detections` test comment.

### dto consolidation (deliberately conservative)

The one genuinely cross-domain DTO, `dto.RangeFilterSpecies`, is already consolidated in `dto` (50 references from the `range` and `species` domains). The `detections` package keeps its own `DetectionResponse`/`SourceInfo`/`WeatherInfo`/`PaginatedResponse` (domain-local, not referenced by any other domain). I deliberately left `dto/detection.go`'s parallel `DetectionResponse`/`PaginatedResponse`/`SourceInfo`/`WeatherInfo`/`Comment`/`ModelInfo` types in place: they predate this epic and are unused repo-wide, so removing them is out of scope for a split-cleanup and risks deleting intended scaffolding. Flagged as a possible separate follow-up.

## Per-package `-race` timeout: measured, left at 900s

Measured `go test -race -tags noembed,skipfrontend -count=1` per package (local, fast Linux). Largest binaries:

| package | isolated (s) | parallel, GOMAXPROCS=3 (s) |
| --- | --- | --- |
| `internal/api/v2` (facade + settings) | 53.0 | 66.2 |
| `media` | 45.9 | 47.0 |
| `app` | 23.7 | 24.6 |
| `integrations` | 23.5 | 30.7 |
| `detections` | 22.4 | 26.7 |
| next tier (control/tls/analytics/weather/system/auth) | 11-15 | 10-16 |
| remaining 13 packages | 1-9 | 1-9 |

The split did its job: the monolithic ~2073-test single binary is gone and the load is spread across 24 binaries. But `settings.go` (~5.5k test LOC) was intentionally not extracted, so the facade is still the largest binary (53s isolated, 66s under 3-core contention), with `media` a close second at ~46s.

Decision: **leave the macOS/Windows 900s `-timeout` unchanged.** The 900s ceiling lives on the slow native `-race` runners, which are roughly 3-5x slower per operation than this Linux box and run the entire repo `go test ./...` in parallel (much heavier contention than an api/v2-only run). Projecting the facade's 66s (3-core contention here) by a 3-5x native slowdown lands around 200-330s before adding full-repo parallel contention, which does not leave the comfortable headroom a reduction toward 600s would need. I cannot measure on the actual native runners, and a wrong reduction reintroduces exactly the flaky timeouts that PR #3636 fixed, so the conservative call is to hold at 900s.

Recommended follow-ups before revisiting the timeout: extract `settings.go` into a `settings` domain (drops the facade into the ~24s tier) and trim `media`'s real-wait tests. Once both land, the largest binary would be ~24s isolated and a reduction toward 600s could be verified with margin.

## Verification

- `go build -tags noembed,skipfrontend ./...`: clean
- `go vet -tags noembed,skipfrontend ./internal/api/v2/... ./internal/analysis/...`: clean
- `go test -race -tags noembed,skipfrontend ./internal/api/v2/...`: all 24 packages green, including the new import guard
- `golangci-lint run --build-tags noembed,skipfrontend ./internal/api/v2/...`: 0 issues

No public-behavior change: `apiv2.Controller` / `New` / `NewWithOptions` / `InitializeAPI` and the external method surface are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded API v2 development and routing guidance for adding endpoints and domains, including shared middleware and authentication handling.
  * Added automated checks to help prevent unintended dependency cycles in the API v2 split.
* **Documentation**
  * Rewrote the API v2 development guidelines and refreshed the API v2 README with consistent endpoint descriptions and updated CSRF/authentication notes.
* **Tests**
  * Added an import-acyclicity guard test enforcing allowed dependency boundaries for `apicore` and `apitest`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->