### PR TITLE
fix(api/v2): guard /search against nil datastore and honor =N confidence operator

### DIFF
--- a/internal/api/v2/apicore/query_filters.go
+++ b/internal/api/v2/apicore/query_filters.go
@@ -31,7 +31,8 @@ type ConfidenceFilterResult struct {
 }
 
 // ParseConfidenceFilter parses a confidence filter parameter with operator support.
-// Supports operators: >=, <=, >, <, = (default)
+// Supports operators: >=, <=, >, <, =. Equality may be written either as an
+// explicit "=50" or as a bare "50" (both parse to operator "=", value 50).
 // Returns nil if the parameter is empty.
 func ParseConfidenceFilter(param string) *ConfidenceFilterResult {
 	if param == "" {
@@ -54,7 +55,13 @@ func ParseConfidenceFilter(param string) *ConfidenceFilterResult {
 	case strings.HasPrefix(param, "<"):
 		operator = "<"
 		value = param[1:]
+	case strings.HasPrefix(param, "="):
+		// Explicit equality, e.g. "=50". A lone "=" yields value "", which
+		// strconv.ParseFloat rejects below, so the filter correctly returns nil.
+		operator = "="
+		value = param[1:]
 	default:
+		// Bare number, e.g. "50", treated as equality.
 		operator = "="
 		value = param
 	}

--- a/internal/api/v2/apicore/query_filters_test.go
+++ b/internal/api/v2/apicore/query_filters_test.go
@@ -1,0 +1,125 @@
+package apicore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// confidenceValueDelta is the tolerance used when comparing parsed confidence
+// fractions, since values like 0.1 have no exact binary float representation.
+const confidenceValueDelta = 1e-9
+
+// TestParseConfidenceFilter pins the operator/value parsing of the confidence
+// filter, including the previously-broken explicit "=N" form. Before the fix a
+// bare "50" parsed as equality but the documented "=50" fell through to the
+// default case with value "=50", which strconv.ParseFloat rejected, silently
+// dropping the whole filter. Both forms must now parse to operator "=".
+func TestParseConfidenceFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		param        string
+		wantNil      bool
+		wantOperator string
+		wantValue    float64 // fraction, i.e. param/100
+	}{
+		{
+			name:         "explicit equals operator",
+			param:        "=50",
+			wantOperator: "=",
+			wantValue:    0.5,
+		},
+		{
+			name:         "bare number defaults to equals",
+			param:        "50",
+			wantOperator: "=",
+			wantValue:    0.5,
+		},
+		{
+			name:         "greater than or equal",
+			param:        ">=80",
+			wantOperator: ">=",
+			wantValue:    0.8,
+		},
+		{
+			name:         "less than or equal",
+			param:        "<=20",
+			wantOperator: "<=",
+			wantValue:    0.2,
+		},
+		{
+			name:         "greater than",
+			param:        ">10",
+			wantOperator: ">",
+			wantValue:    0.1,
+		},
+		{
+			name:         "less than",
+			param:        "<90",
+			wantOperator: "<",
+			wantValue:    0.9,
+		},
+		{
+			name:         "explicit equals zero boundary",
+			param:        "=0",
+			wantOperator: "=",
+			wantValue:    0.0,
+		},
+		{
+			name:         "explicit equals hundred boundary",
+			param:        "=100",
+			wantOperator: "=",
+			wantValue:    1.0,
+		},
+		{
+			name:    "empty string returns nil",
+			param:   "",
+			wantNil: true,
+		},
+		{
+			name:    "explicit equals with non-numeric value returns nil",
+			param:   "=abc",
+			wantNil: true,
+		},
+		{
+			name:    "lone equals returns nil",
+			param:   "=",
+			wantNil: true,
+		},
+		{
+			name:    "explicit equals out of range high returns nil",
+			param:   "=150",
+			wantNil: true,
+		},
+		{
+			name:    "explicit equals negative returns nil",
+			param:   "=-5",
+			wantNil: true,
+		},
+		{
+			name:    "explicit equals NaN returns nil",
+			param:   "=NaN",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseConfidenceFilter(tt.param)
+
+			if tt.wantNil {
+				assert.Nil(t, got, "expected nil result for param %q", tt.param)
+				return
+			}
+
+			require.NotNil(t, got, "expected non-nil result for param %q", tt.param)
+			assert.Equal(t, tt.wantOperator, got.Operator, "operator mismatch for param %q", tt.param)
+			assert.InDelta(t, tt.wantValue, got.Value, confidenceValueDelta, "value mismatch for param %q", tt.param)
+		})
+	}
+}

--- a/internal/api/v2/detections/handler.go
+++ b/internal/api/v2/detections/handler.go
@@ -105,6 +105,15 @@ func New(
 // Search is registered as its own ordered initializer (preceding the detection
 // routes), mirroring the facade's previous initSearchRoutes entry.
 func (c *Handler) RegisterSearchRoutes(g *echo.Group) {
+	// HandleSearch dereferences c.DS (SearchDetections). Honor the constructor's
+	// "datastore disabled" mode (NewWithOptions permits a nil datastore) by not
+	// registering the search route when there is no datastore, instead of
+	// registering a handler that would panic. This mirrors RegisterDetectionRoutes.
+	if c.DS == nil {
+		c.LogWarnIfEnabled("Skipping search routes: datastore is not available")
+		return
+	}
+
 	c.LogInfoIfEnabled("Initializing search routes")
 
 	// Search endpoints - publicly accessible

--- a/internal/api/v2/detections/routes_guard_test.go
+++ b/internal/api/v2/detections/routes_guard_test.go
@@ -27,3 +27,26 @@ func TestRegisterDetectionRoutesSkippedWhenDatastoreDisabled(t *testing.T) {
 			"detection routes must not register when the datastore is disabled: %s %s", r.Method, r.Path)
 	}
 }
+
+// TestRegisterSearchRoutesSkippedWhenDatastoreDisabled pins the datastore-disabled
+// guard for the search domain: when DS is nil (the "datastore disabled" mode the
+// facade constructor permits), RegisterSearchRoutes registers no /search route
+// instead of wiring HandleSearch, which dereferences a nil datastore via
+// SearchDetections and would panic on the first request. This mirrors
+// TestRegisterDetectionRoutesSkippedWhenDatastoreDisabled.
+func TestRegisterSearchRoutesSkippedWhenDatastoreDisabled(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	h := &Handler{Core: &apicore.Core{Echo: e, Group: e.Group("/api/v2"), DS: nil}}
+
+	// Must not panic and must not register any /search route.
+	assert.NotPanics(t, func() {
+		h.RegisterSearchRoutes(h.Group)
+	}, "RegisterSearchRoutes must not panic when the datastore is disabled")
+
+	for _, r := range e.Routes() {
+		assert.NotContains(t, r.Path, "/search",
+			"search routes must not register when the datastore is disabled: %s %s", r.Method, r.Path)
+	}
+}


### PR DESCRIPTION
## Summary

Two behavior-changing fixes in the api/v2 detections domain, both surfaced as follow-ups during the detections domain extraction review.

### 1. `/search` now guards against a nil datastore

`RegisterSearchRoutes` registered `POST /api/v2/search` unconditionally, but `HandleSearch` dereferences `c.DS` via `SearchDetections`. `NewWithOptions` permits a nil datastore (datastore-disabled mode), so the first `/search` request nil-panicked, while the sibling `/detections` routes were correctly skipped by their own guard.

`RegisterSearchRoutes` now skips registration with a `LogWarnIfEnabled` message when `c.DS == nil`, matching the existing `RegisterDetectionRoutes` guard. In normal mode (datastore present) `/search` registers exactly as before, so the route enumeration is unchanged.

Behavior change: in datastore-disabled mode, `/search` now returns 404 (route not registered) instead of panicking on the first request. There was never a working `/search` in that mode, so nothing that previously worked stops working.

### 2. Confidence filter now honors the documented `=N` operator

`ParseConfidenceFilter` documented support for the `=` operator, but only a bare number (`50`) worked. The explicit `=50` form fell through to the `default` case with value `"=50"`, which `strconv.ParseFloat` rejected, so the whole confidence filter was silently dropped (results came back unfiltered).

A new `case strings.HasPrefix(param, "=")` strips the prefix and parses the remainder, so `=50` now parses to operator `=`, value `0.5`. Bare-number behavior is unchanged, and a lone `=` still yields `nil` (the empty value is rejected by `ParseFloat`).

Behavior change: a client that previously sent `=50` and got no filtering will now get equality filtering at `0.5`. Operator `=` was already handled downstream (it is what the bare-number path has always produced), so no new/untested code path is introduced. The in-tree Svelte frontend never sends an operator-prefixed `confidence` param, so no shipped client relies on the old buggy behavior.

## Tests

- `TestParseConfidenceFilter` (apicore): table-driven coverage of `=N`, bare `N`, `>=`, `<=`, `>`, `<`, empty, invalid (`=abc`), out-of-range (`=150`), negative (`=-5`), lone `=`, and NaN inputs, asserting both operator and fractional value.
- `TestRegisterSearchRoutesSkippedWhenDatastoreDisabled` (detections): asserts no `/search` route registers and no panic when the datastore is nil, mirroring the existing `TestRegisterDetectionRoutesSkippedWhenDatastoreDisabled`.

## Verification

- `go build ./...` passes
- `go test -race ./internal/api/v2/... ./internal/analysis/... -count=1` passes
- `TestRouteEnumerationMatchesGolden` and `TestRouteEnumerationIsDeterministic` pass unchanged (the golden test runs with a mock datastore, so `/search` still registers and the golden route set is identical)
- `golangci-lint run` on the changed packages: 0 issues

## Preflight Status

Ran the preflight quality gate (reuse, correctness/safety, quality/patterns, integration/wiring, regression/backward-compat) plus a secondary-model cross-validation on the regression pass. No Critical/High/Medium findings. Both deltas are intentional Low-severity fixes to previously-broken paths; no config, DB schema, CLI, or API-contract changes, and no migration needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confidence filters now accept both `=50` and `50` as valid equality input, and invalid or empty values are safely ignored.
  * Search routes are no longer registered when search data is unavailable, preventing startup errors.

* **Tests**
  * Added coverage for confidence filter parsing across valid, invalid, and edge-case inputs.
  * Added coverage to confirm search routes stay disabled when the datastore is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->