### PR TITLE
fix(api/v2): anonymize SSE detection-stream source for unauthenticated clients

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -255,7 +255,7 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 
 | Method | Route                 | Handler             | Auth | Description                  |
 | ------ | --------------------- | ------------------- | ---- | ---------------------------- |
-| GET    | `/detections/stream`  | `StreamDetections`  | ❌⚡ | Real-time detection stream   |
+| GET    | `/detections/stream`  | `StreamDetections`  | ❌⚡ | Real-time detection stream. Source display names are anonymized for unauthenticated clients (only the stable source id is exposed, on both the `detection` and `pending` events); authenticated clients receive the full display name |
 | GET    | `/soundlevels/stream` | `StreamSoundLevels` | ❌⚡ | Real-time audio level stream |
 | GET    | `/sse/status`         | `GetSSEStatus`      | ❌   | SSE connection status        |
 

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -414,7 +414,12 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// *apicore.Core pointer and register their routes in initRoutes.
 	c.weather = weather.New(c.Core)
 	c.rangeHandler = rangeapi.New(c.Core)
-	c.sse = sse.New(c.Core)
+	// The SSE handler receives the facade-owned auth check (isClientAuthenticated)
+	// so the public detection stream can anonymize the source DisplayName for
+	// unauthenticated subscribers (matching detections/analytics and the
+	// StreamAudioLevel precedent). The bound method value reads c.authService at
+	// call time, so the post-functional-option authService is observed per request.
+	c.sse = sse.New(c.Core, c.isClientAuthenticated)
 	// The TLS handler needs the facade's settings-save machinery: the shared
 	// settingsMutex (passed by pointer so TLS certificate writes serialize against
 	// the main settings update handlers) and the bound method values for reading,

--- a/internal/api/v2/apicore/sse.go
+++ b/internal/api/v2/apicore/sse.go
@@ -171,6 +171,15 @@ type SSEClient struct {
 	Done           chan struct{} // Signal-only buffered channel to prevent blocking
 	StreamType     string        // StreamTypeDetections, StreamTypeSoundLevels, or StreamTypeAll
 
+	// Authenticated records the client's authentication state, captured ONCE at
+	// connect time (mirroring StreamAudioLevel, which checks isClientAuthenticated
+	// per connection). The detection stream reads this to decide whether to expose
+	// the raw audio source DisplayName: unauthenticated subscribers receive only
+	// the stable Source.ID, since DisplayName can embed internal host details for
+	// stream sources without a user-configured name. Set before the read loop runs
+	// and never mutated afterwards, so concurrent broadcasts read it race-free.
+	Authenticated bool
+
 	// Health tracking for auto-disconnect of slow/blocked clients
 	// Uses atomic operations for thread-safe access during concurrent broadcasts
 	consecutiveDrops atomic.Int32 // Count of consecutive failed message sends

--- a/internal/api/v2/sse/sse.go
+++ b/internal/api/v2/sse/sse.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability/metrics"
@@ -40,13 +41,28 @@ const (
 // the shared SSE hub (SSEManager), write primitives (SendSSEMessage,
 // RecordSSE*), stream scaffolding (SendSSEHeartbeat, LogSSEConnection,
 // SendConnectionMessage) and logging helpers promote directly onto it.
+//
+// isClientAuthenticated is injected from the facade (the auth-service check that
+// lives on facade-owned state, matching the detections/analytics domains). The
+// detection stream evaluates it ONCE at connect time so unauthenticated
+// subscribers receive a sanitized payload that omits the raw audio source
+// DisplayName (which can embed internal host details), exposing only the stable
+// Source.ID.
 type Handler struct {
 	*apicore.Core
+
+	isClientAuthenticated func(ctx echo.Context) bool
 }
 
-// New constructs the SSE endpoint handler from the shared core.
-func New(core *apicore.Core) *Handler {
-	return &Handler{Core: core}
+// New constructs the SSE endpoint handler from the shared core and the
+// facade-injected auth check. isClientAuthenticated is read once per connection
+// (at connect time) to decide whether the detection stream exposes the raw source
+// DisplayName to that subscriber.
+func New(core *apicore.Core, isClientAuthenticated func(ctx echo.Context) bool) *Handler {
+	return &Handler{
+		Core:                  core,
+		isClientAuthenticated: isClientAuthenticated,
+	}
 }
 
 // RegisterRoutes registers the SSE-related API endpoints on the given group,
@@ -175,10 +191,111 @@ func (c *Handler) StreamDetections(ctx echo.Context) error {
 		func(client *apicore.SSEClient) {
 			client.Channel = make(chan apicore.SSEDetectionData, sseDetectionBufferSize) // Buffer for high detection periods
 			client.PendingChan = make(chan any, ssePendingBufferSize)                    // Buffer for pending detection snapshots
+			// Capture the authentication state ONCE at connect time (mirroring
+			// StreamAudioLevel). setupFunc runs synchronously before the client is
+			// registered and before the event loop starts, so this snapshot is
+			// race-free and is read by the per-client send path to decide whether to
+			// expose the raw source DisplayName.
+			client.Authenticated = c.clientAuthenticated(ctx)
 		},
 		func(ctx echo.Context, client *apicore.SSEClient, clientID string) error {
 			return c.runSSEEventLoopMulti(ctx, client, clientID, detectionStreamEndpoint)
 		})
+}
+
+// clientAuthenticated reports whether the current request is authenticated,
+// delegating to the facade-injected auth check. The facade always injects a
+// non-nil bound method (api.go), so the nil branch is defense-in-depth for this
+// privacy-sensitive public stream: a missing check fails closed (the client is
+// treated as unauthenticated and the source is anonymized) instead of panicking.
+// The injected facade method itself returns false when no auth service is
+// configured. The detections/analytics/audio siblings call their injected check
+// directly without this extra guard; keeping it here is deliberate.
+func (c *Handler) clientAuthenticated(ctx echo.Context) bool {
+	if c.isClientAuthenticated == nil {
+		return false
+	}
+	return c.isClientAuthenticated(ctx)
+}
+
+// sanitizeDetectionForUnauthenticated returns a COPY of a detection event with the
+// audio source DisplayName stripped, exposing only the stable Source.ID to
+// unauthenticated subscribers. The source DisplayName can embed internal host
+// details (for stream sources without a user-configured name), so it must never
+// reach unauthenticated clients.
+//
+// Deliberate divergence from the detections REST/search endpoints: those strip the
+// entire Source (id included) for unauthenticated clients, whereas this stream
+// keeps Source.ID. The stream follows the StreamAudioLevel precedent (which exposes
+// the raw source id and only anonymizes the display name) and the issue's explicit
+// guidance ("only expose the stable Source.ID"). The id is an opaque, stable
+// identifier the live UI needs to distinguish/correlate sources, and DisplayName is
+// the only field that can carry sensitive host details.
+//
+// The returned event rebuilds Source as a FRESH pointer. The broadcast struct is
+// fanned out to every client as a shared *apicore.SSESourceInfo (BroadcastDetection
+// does `client.Channel <- *detection`, which copies the struct VALUE per client but
+// shares the Source pointer), so mutating Source in place would race across clients
+// under -race and corrupt authenticated clients' payloads. The function copies the
+// dereferenced value first and rebinds Source only on that local copy, so the
+// caller's struct and shared pointer are left untouched. The input is taken by
+// pointer to avoid copying the (large) value twice.
+func sanitizeDetectionForUnauthenticated(event *apicore.SSEDetectionData) apicore.SSEDetectionData {
+	out := *event
+	if out.Source != nil {
+		out.Source = &apicore.SSESourceInfo{ID: out.Source.ID}
+	}
+	return out
+}
+
+// detectionPayloadForClient returns the detection payload to serialize for a single
+// subscriber. Authenticated subscribers receive the event unchanged (full
+// DisplayName, via the shared pointer, which is never mutated); unauthenticated
+// subscribers receive a sanitized copy exposing only the stable Source.ID.
+func detectionPayloadForClient(event *apicore.SSEDetectionData, authenticated bool) apicore.SSEDetectionData {
+	if authenticated {
+		return *event
+	}
+	return sanitizeDetectionForUnauthenticated(event)
+}
+
+// sanitizePendingForUnauthenticated returns a sanitized COPY of a pending detection
+// snapshot for unauthenticated subscribers: each item's Source (the audio source
+// display name) is stripped, leaving only the stable SourceID.
+//
+// PendingChan is typed `any`; the only payload the broadcaster sends today is
+// []processor.SSEPendingDetection (verified at the BroadcastPending call site). An
+// unexpected concrete type fails CLOSED, returning an empty pending list rather
+// than forwarding an unknown (potentially display-name-bearing) payload to an
+// unauthenticated client. This matches clientAuthenticated's fail-closed posture.
+//
+// The pending snapshot is broadcast as a single shared slice to every detection
+// client (BroadcastPending sends the same []processor.SSEPendingDetection to all
+// PendingChan channels), so all clients alias the same backing array. A fresh slice
+// of copied, sanitized elements is allocated; the shared array is never mutated,
+// which would race across clients and corrupt authenticated clients' payloads.
+func sanitizePendingForUnauthenticated(pending any) any {
+	items, ok := pending.([]processor.SSEPendingDetection)
+	if !ok {
+		return []processor.SSEPendingDetection{}
+	}
+	sanitized := make([]processor.SSEPendingDetection, len(items))
+	for i := range items {
+		item := items[i] // copy the struct value (does not touch the shared array)
+		item.Source = "" // strip the display name; SourceID is retained for filtering
+		sanitized[i] = item
+	}
+	return sanitized
+}
+
+// pendingPayloadForClient returns the pending snapshot to serialize for a single
+// subscriber: authenticated subscribers receive it unchanged; unauthenticated
+// subscribers receive a sanitized copy with the per-item display name removed.
+func pendingPayloadForClient(pending any, authenticated bool) any {
+	if authenticated {
+		return pending
+	}
+	return sanitizePendingForUnauthenticated(pending)
 }
 
 // runSSEEventLoopMulti handles the SSE event loop for detection streams,
@@ -211,7 +328,12 @@ func (c *Handler) runSSEEventLoopMulti(ctx echo.Context, client *apicore.SSEClie
 				if !ok {
 					return nil
 				}
-				if err := c.SendSSEMessage(ctx, "detection", detection); err != nil {
+				// Per-client send path: unauthenticated subscribers receive a copy
+				// with the source DisplayName stripped (only Source.ID exposed). The
+				// shared broadcast struct is never mutated; see
+				// sanitizeDetectionForUnauthenticated.
+				payload := detectionPayloadForClient(&detection, client.Authenticated)
+				if err := c.SendSSEMessage(ctx, "detection", payload); err != nil {
 					c.LogErrorIfEnabled("Failed to send SSE detection",
 						logger.String("client_id", clientID),
 						logger.String("endpoint", endpoint),
@@ -232,6 +354,10 @@ func (c *Handler) runSSEEventLoopMulti(ctx echo.Context, client *apicore.SSEClie
 					if !ok {
 						return nil
 					}
+					// Same per-client anonymization as the detection path: the
+					// pending snapshot also carries the source display name, so
+					// unauthenticated subscribers receive a sanitized copy.
+					pending = pendingPayloadForClient(pending, client.Authenticated)
 					if err := c.SendSSEMessage(ctx, "pending", pending); err != nil {
 						c.LogErrorIfEnabled("Failed to send SSE pending",
 							logger.String("client_id", clientID),

--- a/internal/api/v2/sse/sse_connection_test.go
+++ b/internal/api/v2/sse/sse_connection_test.go
@@ -411,7 +411,7 @@ func setupSSETestServer(t *testing.T) (*httptest.Server, *apicore.Core) {
 	e := echo.New()
 	core := apitest.NewCore(t, apitest.WithEcho(e), apitest.WithoutSettingsPublish())
 
-	h := New(core)
+	h := New(core, func(echo.Context) bool { return false })
 	h.RegisterRoutes(core.Group)
 
 	server := httptest.NewServer(e)
@@ -493,7 +493,7 @@ func setupSSETestServerForBench(b *testing.B) (*httptest.Server, *apicore.Core) 
 	// role so the handler registers under /api/v2.
 	core.Group = e.Group("/api/v2")
 
-	h := New(core)
+	h := New(core, func(echo.Context) bool { return false })
 	h.RegisterRoutes(core.Group)
 
 	server := httptest.NewServer(e)

--- a/internal/api/v2/sse/sse_sanitize_test.go
+++ b/internal/api/v2/sse/sse_sanitize_test.go
@@ -1,0 +1,197 @@
+// sse_sanitize_test.go verifies the per-client source anonymization applied to
+// the public detection stream: unauthenticated subscribers must receive only the
+// stable Source.ID, never the raw DisplayName, while authenticated subscribers
+// keep the full payload. The tests also lock in the shared-pointer / shared-slice
+// safety invariant: sanitization must never mutate the broadcast struct that is
+// fanned out to every connected client.
+package sse
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apicore"
+	"github.com/tphakala/birdnet-go/internal/api/v2/apitest"
+)
+
+// sensitiveDisplayName is an internal-looking source label of the kind that must
+// never leak to unauthenticated clients (it embeds host and credential details).
+const sensitiveDisplayName = "rtsp://user:pass@host/cam"
+
+func TestSanitizeDetectionForUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("strips display name and rebuilds source without mutating input", func(t *testing.T) {
+		t.Parallel()
+
+		input := apicore.SSEDetectionData{
+			ID:         42,
+			CommonName: "Eurasian Wren",
+			Source:     &apicore.SSESourceInfo{ID: "rtsp-1", DisplayName: sensitiveDisplayName},
+		}
+
+		out := sanitizeDetectionForUnauthenticated(&input)
+
+		// The sanitized payload exposes only the stable ID.
+		require.NotNil(t, out.Source)
+		assert.Equal(t, "rtsp-1", out.Source.ID)
+		assert.Empty(t, out.Source.DisplayName, "DisplayName must not reach unauthenticated clients")
+
+		// The shared input struct/pointer must be untouched (no in-place mutation),
+		// otherwise the broadcast struct shared across all clients would be corrupted
+		// and a data race would occur under -race.
+		assert.Equal(t, sensitiveDisplayName, input.Source.DisplayName, "original DisplayName must be unchanged")
+		assert.NotSame(t, input.Source, out.Source, "Source must be a fresh pointer, not the shared one")
+
+		// Non-source fields carry through unchanged.
+		assert.Equal(t, uint(42), out.ID)
+		assert.Equal(t, "Eurasian Wren", out.CommonName)
+	})
+
+	t.Run("nil source is returned unchanged without panic", func(t *testing.T) {
+		t.Parallel()
+
+		input := apicore.SSEDetectionData{ID: 7, Source: nil}
+		out := sanitizeDetectionForUnauthenticated(&input)
+		assert.Nil(t, out.Source)
+		assert.Equal(t, uint(7), out.ID)
+	})
+}
+
+func TestDetectionPayloadForClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("authenticated keeps full display name via shared pointer", func(t *testing.T) {
+		t.Parallel()
+
+		src := &apicore.SSESourceInfo{ID: "rtsp-1", DisplayName: sensitiveDisplayName}
+		event := apicore.SSEDetectionData{ID: 1, Source: src}
+
+		out := detectionPayloadForClient(&event, true)
+
+		require.NotNil(t, out.Source)
+		assert.Equal(t, sensitiveDisplayName, out.Source.DisplayName, "authenticated clients keep DisplayName")
+		assert.Same(t, src, out.Source, "authenticated path must not copy the source")
+	})
+
+	t.Run("unauthenticated receives sanitized copy", func(t *testing.T) {
+		t.Parallel()
+
+		src := &apicore.SSESourceInfo{ID: "rtsp-1", DisplayName: sensitiveDisplayName}
+		event := apicore.SSEDetectionData{ID: 1, Source: src}
+
+		out := detectionPayloadForClient(&event, false)
+
+		require.NotNil(t, out.Source)
+		assert.Equal(t, "rtsp-1", out.Source.ID)
+		assert.Empty(t, out.Source.DisplayName)
+		assert.Equal(t, sensitiveDisplayName, src.DisplayName, "shared source must be unchanged")
+		assert.NotSame(t, src, out.Source)
+	})
+}
+
+func TestSanitizePendingForUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("strips per-item display name without mutating shared slice", func(t *testing.T) {
+		t.Parallel()
+
+		input := []processor.SSEPendingDetection{
+			{Species: "Eurasian Wren", Source: sensitiveDisplayName, SourceID: "rtsp-1"},
+			{Species: "European Robin", Source: "Backyard mic", SourceID: "card-0"},
+		}
+
+		result := sanitizePendingForUnauthenticated(input)
+		out, ok := result.([]processor.SSEPendingDetection)
+		require.True(t, ok, "result must be a pending detection slice")
+		require.Len(t, out, 2)
+
+		// Display names stripped, SourceID retained for client-side filtering.
+		assert.Empty(t, out[0].Source)
+		assert.Equal(t, "rtsp-1", out[0].SourceID)
+		assert.Empty(t, out[1].Source)
+		assert.Equal(t, "card-0", out[1].SourceID)
+
+		// The shared backing array fanned out to every client must be untouched.
+		assert.Equal(t, sensitiveDisplayName, input[0].Source, "shared slice must be unchanged")
+		assert.Equal(t, "Backyard mic", input[1].Source, "shared slice must be unchanged")
+		assert.NotSame(t, &input[0], &out[0], "must allocate a fresh backing array")
+	})
+
+	t.Run("unexpected payload type fails closed to empty list", func(t *testing.T) {
+		t.Parallel()
+
+		// An unknown concrete type must not be forwarded to an unauthenticated
+		// client (it could carry a display name); it fails closed to an empty list.
+		result := sanitizePendingForUnauthenticated("not-a-pending-slice")
+		out, ok := result.([]processor.SSEPendingDetection)
+		require.True(t, ok, "fail-closed result must be a (empty) pending detection slice")
+		assert.Empty(t, out)
+	})
+}
+
+func TestPendingPayloadForClient(t *testing.T) {
+	t.Parallel()
+
+	input := []processor.SSEPendingDetection{
+		{Species: "Eurasian Wren", Source: sensitiveDisplayName, SourceID: "rtsp-1"},
+	}
+
+	t.Run("authenticated returns payload unchanged", func(t *testing.T) {
+		t.Parallel()
+		out := pendingPayloadForClient(input, true)
+		assert.Equal(t, sensitiveDisplayName, input[0].Source)
+		// Authenticated path must not copy: the same slice value is returned.
+		got, ok := out.([]processor.SSEPendingDetection)
+		require.True(t, ok)
+		assert.Same(t, &input[0], &got[0])
+	})
+
+	t.Run("unauthenticated returns sanitized copy", func(t *testing.T) {
+		t.Parallel()
+		out := pendingPayloadForClient(input, false)
+		got, ok := out.([]processor.SSEPendingDetection)
+		require.True(t, ok)
+		require.Len(t, got, 1)
+		assert.Empty(t, got[0].Source)
+		assert.Equal(t, "rtsp-1", got[0].SourceID)
+		assert.Equal(t, sensitiveDisplayName, input[0].Source, "shared slice must be unchanged")
+	})
+}
+
+// TestNewWiresAuthCheck verifies the facade-injected auth check is stored by New
+// and consulted by clientAuthenticated, and that a nil check fails closed
+// (treated as unauthenticated so the stream anonymizes by default).
+func TestNewWiresAuthCheck(t *testing.T) {
+	t.Parallel()
+
+	newCtx := func() echo.Context {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/stream", http.NoBody)
+		return e.NewContext(req, httptest.NewRecorder())
+	}
+
+	t.Run("authenticated stub", func(t *testing.T) {
+		t.Parallel()
+		h := New(apitest.NewCore(t, apitest.WithoutSettingsPublish()), func(echo.Context) bool { return true })
+		assert.True(t, h.clientAuthenticated(newCtx()))
+	})
+
+	t.Run("unauthenticated stub", func(t *testing.T) {
+		t.Parallel()
+		h := New(apitest.NewCore(t, apitest.WithoutSettingsPublish()), func(echo.Context) bool { return false })
+		assert.False(t, h.clientAuthenticated(newCtx()))
+	})
+
+	t.Run("nil check fails closed", func(t *testing.T) {
+		t.Parallel()
+		h := New(apitest.NewCore(t, apitest.WithoutSettingsPublish()), nil)
+		assert.False(t, h.clientAuthenticated(newCtx()))
+	})
+}


### PR DESCRIPTION
## Summary

The public SSE detection stream (`GET /api/v2/detections/stream`) broadcast the raw user-defined audio source display name to unauthenticated subscribers. The source display name can embed internal host details for stream sources that have no user-configured name (for example an RTSP URL with host/credentials), so it should not be exposed to clients that have not authenticated.

This is a privacy fix, a follow-up surfaced during the api/v2 apicore extraction review.

## Fix

Unauthenticated detection-stream subscribers now receive only the stable source id; the display name is stripped. Authenticated subscribers are unchanged and still receive the full display name.

This matches the `StreamAudioLevel` behavior, which checks authentication once at connect time and anonymizes per connection. The api/v2 guidelines already state that public endpoints exposing source metadata must anonymize display names for unauthenticated clients.

Both event paths on the detection stream are covered:
- `detection` events: the source `displayName` is omitted, only the stable `id` remains.
- `pending` snapshot events: the per-item source display name is stripped, the stable `sourceID` is retained.

## Shared-pointer / shared-slice safety

The broadcaster builds one payload and fans the same struct value (sharing the `*SSESourceInfo` pointer) and the same pending slice out to every connected client. To avoid corrupting authenticated clients or racing under `-race`, sanitization never mutates the shared broadcast data: it builds a fresh `SSESourceInfo` for the detection path and a fresh slice of copied elements for the pending path. Authenticated clients receive the shared data unchanged (read-only marshal).

## Implementation

- `apicore.SSEClient` gains an `Authenticated bool`, captured once at connect time.
- The sse domain handler receives the facade-injected `isClientAuthenticated` (the same injection pattern as the detections and analytics domains).
- Small pure helpers do the per-client sanitization; the pending path fails closed on an unexpected payload type.

## Tests

New unit tests in `internal/api/v2/sse/sse_sanitize_test.go`:
- detection sanitization strips the display name, keeps the id, and does not mutate the shared source pointer (asserts the input is unchanged and the output uses a fresh pointer).
- authenticated passthrough preserves the display name via the shared pointer.
- pending sanitization strips per-item display names, keeps `sourceID`, and allocates a fresh backing array (no shared-slice mutation); unexpected types fail closed.
- the injected auth check is wired and consulted; a nil check fails closed.

## Behavior change

For existing users this changes only the unauthenticated experience: unauthenticated SSE subscribers (and any unauthenticated script consuming `/api/v2/detections/stream`) no longer receive the source display name, only the stable id. Authenticated subscribers' payloads are byte-for-byte unchanged.

## Follow-up

A sibling public endpoint, the soundlevels stream (`GET /api/v2/soundlevels/stream`), has the same class of display-name exposure to unauthenticated clients and will get the same treatment in a separate change; it is intentionally out of scope here (different domain and payload).

## Preflight Status

- Single concern: one privacy fix for the SSE detection stream.
- `go build ./...` passes.
- `go test -race ./internal/api/v2/... ./internal/analysis/...` passes.
- `golangci-lint run` on the changed packages is clean.
- Route enumeration golden test stays green (payload-only change, no route change; golden unchanged).
- No config, DB, or CLI schema changes; authenticated payloads unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detection stream updates now adapt to authentication status in real time.
  * Unauthenticated clients see anonymized source details, while authenticated clients continue to see full source display names.

* **Bug Fixes**
  * Improved privacy for live detection and pending-detection updates by removing sensitive source names from unauthenticated SSE responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->