### PR TITLE
fix(api/v2): redact HLS tokens and secrets from request and error logs

### DIFF
--- a/internal/api/v2/apicore/errors.go
+++ b/internal/api/v2/apicore/errors.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 // ErrorResponse is the API error response structure.
@@ -99,13 +100,17 @@ func (c *Core) handleErrorInternal(ctx echo.Context, err error, message string, 
 		errorStr = message
 	}
 
-	// Build log fields
+	// Build log fields. The error string is scrubbed because a raw err.Error()
+	// can carry credentials (e.g. an RTSP/HTTP URL with embedded user:pass or an
+	// API token); the route pattern replaces the raw URL path so HLS stream
+	// tokens and note IDs are never persisted. The message field is the
+	// developer-supplied, already-sanitized text and is logged as-is.
 	fields := []logger.Field{
 		logger.String("correlation_id", errorResp.CorrelationID),
 		logger.String("message", message),
-		logger.String("error", errorStr),
+		logger.String("error", privacy.ScrubMessage(errorStr)),
 		logger.Int("code", code),
-		logger.String("path", ctx.Request().URL.Path),
+		logger.String("path", RoutePattern(ctx)),
 		logger.String("method", ctx.Request().Method),
 		logger.String("ip", ip),
 		logger.Bool("tunneled", isTunneled),
@@ -144,7 +149,10 @@ func (c *Core) reportErrorToTelemetry(ctx echo.Context, err error, message strin
 		return
 	}
 
-	path := ctx.Request().URL.Path
+	// Use the matched route pattern (not the raw URL path) for the telemetry
+	// endpoint so HLS stream tokens and note IDs embedded in the path are never
+	// sent to Sentry.
+	path := RoutePattern(ctx)
 	method := ctx.Request().Method
 
 	var builder *errors.ErrorBuilder

--- a/internal/api/v2/apicore/errors.go
+++ b/internal/api/v2/apicore/errors.go
@@ -157,7 +157,15 @@ func (c *Core) reportErrorToTelemetry(ctx echo.Context, err error, message strin
 
 	var builder *errors.ErrorBuilder
 	if err != nil {
-		builder = errors.New(err)
+		// Sanitize the error at the source before it becomes the telemetry
+		// message: privacy.WrapError returns a SanitizedError whose Error() is
+		// ScrubMessage(err.Error()), while Unwrap() preserves the original chain
+		// so errors.Is/As still work. The telemetry pipeline also scrubs the
+		// message downstream when a privacy scrubber is registered, but that
+		// scrubber can be unset (it then falls back to a weaker URL-only scrub),
+		// so wrapping here guarantees credential-bearing error text never reaches
+		// Sentry regardless.
+		builder = errors.New(privacy.WrapError(err))
 	} else {
 		builder = errors.Newf("%s", message)
 	}

--- a/internal/api/v2/apicore/log_redaction_test.go
+++ b/internal/api/v2/apicore/log_redaction_test.go
@@ -1,0 +1,309 @@
+package apicore
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// recordedEntry captures one logger call so tests can assert on the emitted
+// structured fields.
+type recordedEntry struct {
+	level  logger.LogLevel
+	msg    string
+	fields []logger.Field
+}
+
+// recordingLogger is a logger.Logger that records every logged entry in memory
+// so a test can assert on the structured fields that the middleware and error
+// handler emit. It is safe for concurrent use even though the code under test
+// logs synchronously.
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []recordedEntry
+}
+
+func newRecordingLogger() *recordingLogger { return &recordingLogger{} }
+
+func (r *recordingLogger) record(level logger.LogLevel, msg string, fields ...logger.Field) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Copy the fields so a caller reusing its slice cannot mutate the record.
+	captured := make([]logger.Field, len(fields))
+	copy(captured, fields)
+	r.entries = append(r.entries, recordedEntry{level: level, msg: msg, fields: captured})
+}
+
+func (r *recordingLogger) Module(string) logger.Logger { return r }
+func (r *recordingLogger) Trace(msg string, fields ...logger.Field) {
+	r.record(logger.LogLevelTrace, msg, fields...)
+}
+func (r *recordingLogger) Debug(msg string, fields ...logger.Field) {
+	r.record(logger.LogLevelDebug, msg, fields...)
+}
+func (r *recordingLogger) Info(msg string, fields ...logger.Field) {
+	r.record(logger.LogLevelInfo, msg, fields...)
+}
+func (r *recordingLogger) Warn(msg string, fields ...logger.Field) {
+	r.record(logger.LogLevelWarn, msg, fields...)
+}
+func (r *recordingLogger) Error(msg string, fields ...logger.Field) {
+	r.record(logger.LogLevelError, msg, fields...)
+}
+func (r *recordingLogger) With(...logger.Field) logger.Logger        { return r }
+func (r *recordingLogger) WithContext(context.Context) logger.Logger { return r }
+func (r *recordingLogger) Log(level logger.LogLevel, msg string, fields ...logger.Field) {
+	r.record(level, msg, fields...)
+}
+func (r *recordingLogger) Flush() error { return nil }
+
+// requireSingleEntry asserts exactly one entry was logged and returns it.
+func (r *recordingLogger) requireSingleEntry(t *testing.T) recordedEntry {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	require.Len(t, r.entries, 1, "expected exactly one logged entry")
+	return r.entries[0]
+}
+
+// requireStringField returns the string value of the field with key, failing the
+// test if the field is missing or not a string. Field keys are interned, but the
+// interned value compares equal by content to the plain key string.
+func requireStringField(t *testing.T, entry recordedEntry, key string) string {
+	t.Helper()
+	for _, f := range entry.fields {
+		if f.Key == key {
+			value, ok := f.Value.(string)
+			require.Truef(t, ok, "field %q is not a string: %T", key, f.Value)
+			return value
+		}
+	}
+	require.Failf(t, "field not found", "no field with key %q in logged entry", key)
+	return ""
+}
+
+func TestRoutePattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setPath  string
+		wantPath string
+	}{
+		{
+			name:     "matched route returns the pattern",
+			setPath:  "/api/v2/audio/:id",
+			wantPath: "/api/v2/audio/:id",
+		},
+		{
+			name:     "tokenized HLS route returns the pattern not the token",
+			setPath:  "/api/v2/streams/hls/t/:streamToken/playlist.m3u8",
+			wantPath: "/api/v2/streams/hls/t/:streamToken/playlist.m3u8",
+		},
+		{
+			name:     "unmatched route returns the placeholder",
+			setPath:  "",
+			wantPath: unmatchedRoutePattern,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/hls/t/SECRET-TOKEN/playlist.m3u8", http.NoBody)
+			ctx := e.NewContext(req, httptest.NewRecorder())
+			if tt.setPath != "" {
+				ctx.SetPath(tt.setPath)
+			}
+
+			got := RoutePattern(ctx)
+
+			assert.Equal(t, tt.wantPath, got)
+			assert.NotContains(t, got, "SECRET-TOKEN", "the raw path token must never appear in the route pattern")
+		})
+	}
+}
+
+func TestScrubQueryForLog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rawQuery    string
+		wantAbsent  []string
+		wantPresent []string
+		wantEmpty   bool
+	}{
+		{
+			name:      "empty query stays empty",
+			rawQuery:  "",
+			wantEmpty: true,
+		},
+		{
+			name:        "plain token value is redacted",
+			rawQuery:    "token=secretvalue123&foo=bar",
+			wantAbsent:  []string{"secretvalue123"},
+			wantPresent: []string{"[TOKEN]", "foo=bar"},
+		},
+		{
+			name:        "url-encoded token value is redacted after decoding",
+			rawQuery:    "token=ab%2Bcd1234567890",
+			wantAbsent:  []string{"ab%2Bcd1234567890", "ab+cd1234567890", "1234567890"},
+			wantPresent: []string{"[TOKEN]"},
+		},
+		{
+			name:        "api_key value is redacted",
+			rawQuery:    "api_key=SUPERSECRETKEY123",
+			wantAbsent:  []string{"SUPERSECRETKEY123"},
+			wantPresent: []string{"[TOKEN]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := scrubQueryForLog(tt.rawQuery)
+			if tt.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContainsf(t, got, absent, "secret %q must be scrubbed from the logged query", absent)
+			}
+			for _, present := range tt.wantPresent {
+				assert.Contains(t, got, present)
+			}
+		})
+	}
+}
+
+func TestLoggingMiddlewareRedactsPathAndQuery(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hlsToken     = "SUPERSECRETHLSTOKEN"
+		routePattern = "/api/v2/streams/hls/t/:streamToken/playlist.m3u8"
+	)
+
+	rec := newRecordingLogger()
+	core := &Core{APILogger: rec}
+
+	e := echo.New()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v2/streams/hls/t/"+hlsToken+"/playlist.m3u8?token=ab%2Bcd1234567890&page=2",
+		http.NoBody,
+	)
+	ctx := e.NewContext(req, httptest.NewRecorder())
+	// Echo populates ctx.Path() with the matched route pattern after routing.
+	// LoggingMiddleware logs after next(ctx), so the pattern is set by then; the
+	// test simulates that post-routing state with SetPath.
+	ctx.SetPath(routePattern)
+
+	handler := core.LoggingMiddleware()(func(echo.Context) error { return nil })
+	require.NoError(t, handler(ctx))
+
+	entry := rec.requireSingleEntry(t)
+
+	pathValue := requireStringField(t, entry, "path")
+	assert.Equal(t, routePattern, pathValue)
+	assert.NotContains(t, pathValue, hlsToken, "the HLS token must never appear in the logged path")
+
+	queryValue := requireStringField(t, entry, "query")
+	assert.NotContains(t, queryValue, "1234567890", "the query token value must be scrubbed")
+	assert.NotContains(t, queryValue, "ab%2Bcd", "the raw url-encoded token must not be logged")
+	assert.Contains(t, queryValue, "[TOKEN]")
+}
+
+func TestLoggingMiddlewareUnmatchedRouteUsesPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	rec := newRecordingLogger()
+	core := &Core{APILogger: rec}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/does/not/exist", http.NoBody)
+	ctx := e.NewContext(req, httptest.NewRecorder())
+	// No SetPath: ctx.Path() is empty, simulating an unmatched request.
+
+	handler := core.LoggingMiddleware()(func(echo.Context) error { return nil })
+	require.NoError(t, handler(ctx))
+
+	entry := rec.requireSingleEntry(t)
+	assert.Equal(t, unmatchedRoutePattern, requireStringField(t, entry, "path"))
+}
+
+func TestLoggingMiddlewareScrubsHandlerError(t *testing.T) {
+	t.Parallel()
+
+	rec := newRecordingLogger()
+	core := &Core{APILogger: rec}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/audio", http.NoBody)
+	ctx := e.NewContext(req, httptest.NewRecorder())
+	ctx.SetPath("/api/v2/streams/:source")
+
+	// A handler that returns a credential-bearing error directly (without routing
+	// it through HandleError) must not leak the raw error into the request log.
+	handler := core.LoggingMiddleware()(func(echo.Context) error {
+		return errors.NewStd("failed to dial rtsp://user:pass@192.168.1.50:554/stream")
+	})
+	err := handler(ctx)
+	require.Error(t, err, "the middleware must propagate the handler error unchanged")
+
+	entry := rec.requireSingleEntry(t)
+	errValue := requireStringField(t, entry, "error")
+	assert.NotContains(t, errValue, "user:pass", "credentials in the handler error must be scrubbed")
+	assert.NotContains(t, errValue, "192.168.1.50", "the IP in the handler error must be scrubbed")
+}
+
+func TestHandleErrorInternalScrubsErrorAndPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hlsToken     = "SUPERSECRETHLSTOKEN"
+		routePattern = "/api/v2/streams/hls/t/:streamToken/playlist.m3u8"
+		devMessage   = "audio stream unavailable"
+	)
+
+	rec := newRecordingLogger()
+	core := &Core{APILogger: rec}
+
+	e := echo.New()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v2/streams/hls/t/"+hlsToken+"/playlist.m3u8",
+		http.NoBody,
+	)
+	ctx := e.NewContext(req, httptest.NewRecorder())
+	ctx.SetPath(routePattern)
+
+	// Use a credential-bearing underlying error. Status 400 keeps the >=500
+	// telemetry path (reportErrorToTelemetry) out of this unit test.
+	credErr := errors.NewStd("failed to dial rtsp://user:pass@192.168.1.50:554/stream")
+	require.NoError(t, core.handleErrorInternal(ctx, credErr, devMessage, http.StatusBadRequest, "", nil))
+
+	entry := rec.requireSingleEntry(t)
+
+	errValue := requireStringField(t, entry, "error")
+	assert.NotContains(t, errValue, "user:pass", "credentials in the error must be scrubbed")
+	assert.NotContains(t, errValue, "192.168.1.50", "the IP in the error must be scrubbed")
+
+	pathValue := requireStringField(t, entry, "path")
+	assert.Equal(t, routePattern, pathValue)
+	assert.NotContains(t, pathValue, hlsToken, "the HLS token must never appear in the logged path")
+
+	// The developer-supplied message stays as-is (it is already sanitized).
+	assert.Equal(t, devMessage, requireStringField(t, entry, "message"))
+}

--- a/internal/api/v2/apicore/log_redaction_test.go
+++ b/internal/api/v2/apicore/log_redaction_test.go
@@ -162,6 +162,16 @@ func TestScrubQueryForLog(t *testing.T) {
 			wantPresent: []string{"[TOKEN]"},
 		},
 		{
+			// A literal '+' in a base64 token must stay part of the token value:
+			// decoding with url.QueryUnescape would turn it into a space and split
+			// the value, leaking the tail past the scrubber. url.PathUnescape
+			// preserves the '+', so the whole value is redacted.
+			name:        "literal plus in token value is redacted not split on a space",
+			rawQuery:    "token=ab+cd1234567890",
+			wantAbsent:  []string{"ab+cd1234567890", "ab cd1234567890", "1234567890"},
+			wantPresent: []string{"[TOKEN]"},
+		},
+		{
 			name:        "api_key value is redacted",
 			rawQuery:    "api_key=SUPERSECRETKEY123",
 			wantAbsent:  []string{"SUPERSECRETKEY123"},

--- a/internal/api/v2/apicore/logging.go
+++ b/internal/api/v2/apicore/logging.go
@@ -59,9 +59,11 @@ func (c *Core) LogAPIRequest(ctx echo.Context, level logger.LogLevel, msg string
 		return // Do nothing if logger isn't initialized
 	}
 
-	// Extract common context info
+	// Extract common context info. Log the matched route pattern rather than the
+	// raw URL path so secrets embedded in path segments (HLS stream tokens, note
+	// IDs) are never persisted; see RoutePattern.
 	ip := ctx.RealIP()
-	path := ctx.Request().URL.Path
+	path := RoutePattern(ctx)
 
 	// Create base fields with preallocated capacity
 	baseFields := make([]logger.Field, 0, 2+len(fields))

--- a/internal/api/v2/apicore/middleware.go
+++ b/internal/api/v2/apicore/middleware.go
@@ -37,16 +37,20 @@ func RoutePattern(ctx echo.Context) string {
 }
 
 // scrubQueryForLog redacts credential-bearing values from a raw URL query string
-// before it is logged. It URL-decodes the query first because privacy's token
+// before it is logged. It percent-decodes the query first because privacy's token
 // scrubber pattern does not span percent-escapes, so an encoded token value (for
 // example token=ab%2Bcd1234) would otherwise slip through unredacted; on a decode
-// error it falls back to scrubbing the raw string. privacy.ScrubMessage also
+// error it falls back to scrubbing the raw string. url.PathUnescape is used rather
+// than url.QueryUnescape because the latter turns a literal '+' into a space, which
+// would split a base64 token value (token=ab+cd...) and leak its tail past the
+// scrubber; PathUnescape still decodes %2B to '+' but preserves a literal '+', so
+// the whole token value stays a single matchable run. privacy.ScrubMessage also
 // redacts URLs, emails, UUIDs, IPs, coordinates, and file paths.
 func scrubQueryForLog(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
 	}
-	decoded, err := url.QueryUnescape(rawQuery)
+	decoded, err := url.PathUnescape(rawQuery)
 	if err != nil {
 		decoded = rawQuery
 	}

--- a/internal/api/v2/apicore/middleware.go
+++ b/internal/api/v2/apicore/middleware.go
@@ -2,16 +2,56 @@ package apicore
 
 import (
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/labstack/echo/v4"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 // tunnelProviderUnknown is the tunnel provider label for unknown providers.
 const tunnelProviderUnknown = "unknown"
+
+// unmatchedRoutePattern is the placeholder logged for the request route when echo
+// has not matched the request to a registered route. echo populates ctx.Path()
+// (the matched route pattern) only after routing, so an unmatched request (a 404,
+// or any log emitted before routing completes) has an empty Path.
+const unmatchedRoutePattern = "<unmatched>"
+
+// RoutePattern returns the matched echo route pattern for ctx (for example
+// "/api/v2/audio/:id") instead of the raw request URL path. Logging the pattern
+// rather than req.URL.Path keeps secrets that live in path segments out of logs
+// and telemetry: an HLS stream token in
+// /api/v2/streams/hls/t/:streamToken/playlist.m3u8 and a note :id collapse to
+// their route placeholders, so neither value is ever persisted. echo sets
+// ctx.Path() only after routing, so an unmatched request yields
+// unmatchedRoutePattern.
+func RoutePattern(ctx echo.Context) string {
+	if pattern := ctx.Path(); pattern != "" {
+		return pattern
+	}
+	return unmatchedRoutePattern
+}
+
+// scrubQueryForLog redacts credential-bearing values from a raw URL query string
+// before it is logged. It URL-decodes the query first because privacy's token
+// scrubber pattern does not span percent-escapes, so an encoded token value (for
+// example token=ab%2Bcd1234) would otherwise slip through unredacted; on a decode
+// error it falls back to scrubbing the raw string. privacy.ScrubMessage also
+// redacts URLs, emails, UUIDs, IPs, coordinates, and file paths.
+func scrubQueryForLog(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	decoded, err := url.QueryUnescape(rawQuery)
+	if err != nil {
+		decoded = rawQuery
+	}
+	return privacy.ScrubMessage(decoded)
+}
 
 // Echo context keys set by TunnelDetectionMiddleware and read by
 // LoggingMiddleware, handleErrorInternal, and domain handlers (e.g. media). They
@@ -100,8 +140,8 @@ func (c *Core) LoggingMiddleware() echo.MiddlewareFunc {
 			// Log the request with structured data
 			fields := []logger.Field{
 				logger.String("method", req.Method),
-				logger.String("path", req.URL.Path),
-				logger.String("query", req.URL.RawQuery),
+				logger.String("path", RoutePattern(ctx)),
+				logger.String("query", scrubQueryForLog(req.URL.RawQuery)),
 				logger.Int("status", status),
 				logger.String("ip", ctx.RealIP()), // Uses custom extractor
 				logger.Bool("tunneled", isTunneled),
@@ -110,7 +150,12 @@ func (c *Core) LoggingMiddleware() echo.MiddlewareFunc {
 				logger.Int64("latency_ms", time.Since(start).Milliseconds()),
 			}
 			if err != nil {
-				fields = append(fields, logger.Error(err))
+				// Scrub the handler error the same way handleErrorInternal does: a
+				// handler that returns an error directly (instead of routing it
+				// through HandleError) would otherwise persist raw err.Error() text,
+				// which can carry credentials (e.g. an RTSP/HTTP URL with embedded
+				// user:pass or a token).
+				fields = append(fields, logger.String("error", privacy.ScrubMessage(err.Error())))
 			}
 
 			c.APILogger.Info("API Request", fields...)

--- a/internal/api/v2/telemetry_test.go
+++ b/internal/api/v2/telemetry_test.go
@@ -67,6 +67,28 @@ func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 	assert.Equal(t, http.MethodGet, ee.Context["method"])
 }
 
+// TestHandleError_5xxTelemetryErrorIsScrubbed verifies the error that reaches the
+// telemetry pipeline has its message sanitized at the source (privacy.WrapError),
+// so credential-bearing error text never reaches Sentry even when the global
+// telemetry privacy scrubber is unset.
+// Note: Not parallel; modifies global error-hook state.
+func TestHandleError_5xxTelemetryErrorIsScrubbed(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Core: &apicore.Core{}}
+	c.Settings.Store(getTestSettings(t))
+	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/streams")
+
+	credErr := fmt.Errorf("failed to dial rtsp://user:pass@192.168.1.50:554/stream")
+	err := c.HandleError(ctx, credErr, "Internal server error", http.StatusInternalServerError)
+	require.NoError(t, err)
+
+	require.Len(t, *captured, 1, "expected one telemetry event for the 5xx error")
+	telemetryMsg := (*captured)[0].Error()
+	assert.NotContains(t, telemetryMsg, "user:pass", "credentials must be scrubbed from the telemetry error")
+	assert.NotContains(t, telemetryMsg, "192.168.1.50", "the IP must be scrubbed from the telemetry error")
+}
+
 // TestHandleError_4xxNotReportedToTelemetry verifies that a 4xx HandleError call
 // produces no telemetry events (4xx errors are client mistakes, not server bugs).
 // Note: Not parallel; modifies global error-hook state.

--- a/internal/api/v2/telemetry_test.go
+++ b/internal/api/v2/telemetry_test.go
@@ -28,18 +28,26 @@ func captureHook(t *testing.T) *[]*errors.EnhancedError {
 	return &captured
 }
 
-// newTestContext creates an echo.Context for use in telemetry tests.
+// newTestContext creates an echo.Context for use in telemetry tests. It also sets
+// the matched route pattern (via SetPath) to the request path, simulating echo's
+// post-routing state: the telemetry endpoint context is now recorded from
+// apicore.RoutePattern(ctx) (the matched route pattern) rather than the raw URL
+// path, so the token-bearing path of a request like an HLS stream is never sent to
+// Sentry. The static test paths used here have no path parameters, so the pattern
+// equals the path.
 func newTestContext(t *testing.T, method, path string) (echo.Context, *httptest.ResponseRecorder) {
 	t.Helper()
 	e := echo.New()
 	req := httptest.NewRequest(method, path, http.NoBody)
 	rec := httptest.NewRecorder()
-	return e.NewContext(req, rec), rec
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath(path)
+	return ctx, rec
 }
 
 // TestHandleError_5xxReportedToTelemetry verifies that a 5xx HandleError call
 // publishes exactly one EnhancedError to the telemetry hook.
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
@@ -61,7 +69,7 @@ func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
 
 // TestHandleError_4xxNotReportedToTelemetry verifies that a 4xx HandleError call
 // produces no telemetry events (4xx errors are client mistakes, not server bugs).
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
@@ -77,7 +85,7 @@ func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
 
 // TestHandleError_NilError_5xxReported verifies that a nil underlying error with a
 // 5xx code still produces a telemetry event, using the message as the error text.
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleError_NilError_5xxReported(t *testing.T) {
 	captured := captureHook(t)
 
@@ -97,7 +105,7 @@ func TestHandleError_NilError_5xxReported(t *testing.T) {
 
 // TestHandleErrorWithKey_5xxReportedToTelemetry verifies the i18n variant also
 // reports 5xx errors to telemetry.
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleErrorWithKey_5xxReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
@@ -122,7 +130,7 @@ func TestHandleErrorWithKey_5xxReportedToTelemetry(t *testing.T) {
 // TestHandleError_AlreadyReportedSkipsDuplicate verifies that an error already
 // reported by a lower layer (IsReported() == true) is not sent to Sentry again
 // from the API layer.
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
 	// Build and pre-report an EnhancedError to simulate a lower-layer report.
 	preReported := errors.Newf("db deadlock").
@@ -146,7 +154,7 @@ func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
 
 // TestHandleError_404NotReportedToTelemetry verifies that 404 Not Found errors
 // are not reported (they are expected conditions for unknown resources).
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 
@@ -162,7 +170,7 @@ func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
 
 // TestHandleError_502BadGatewayReportedToTelemetry verifies that non-500 5xx codes
 // (e.g., 502 Bad Gateway) are also reported as server errors.
-// Note: Not parallel — modifies global error-hook state.
+// Note: Not parallel; modifies global error-hook state.
 func TestHandleError_502BadGatewayReportedToTelemetry(t *testing.T) {
 	captured := captureHook(t)
 


### PR DESCRIPTION
## Summary

Security/privacy hardening of the api/v2 request and error logging. Several shared `apicore` log sites recorded the raw request URL path, the raw query string, and raw `err.Error()` text, all of which can carry secrets. Most importantly, HLS stream tokens are embedded directly in URL paths (`/api/v2/streams/hls/t/<token>/playlist.m3u8`), so every request logged by the shared middleware persisted a live token to the logs.

This change makes the shared `apicore` log sites record the matched echo route pattern instead of the raw URL path, and scrubs the query string and the logged error text through the existing `internal/privacy` sanitizer, so HLS tokens and other secrets are no longer written to logs or telemetry.

This is a follow-up surfaced during the recent `apicore` extraction review.

## What changed

- New `apicore.RoutePattern(ctx)` helper returns the matched echo route pattern (e.g. `/api/v2/audio/:id`), or `"<unmatched>"` when echo has not matched a route. The pattern never contains a token or id value.
- `LoggingMiddleware` now logs `RoutePattern(ctx)` for `path`, a scrubbed query for `query`, and scrubs the handler error when a handler returns one directly.
- `handleErrorInternal` now logs `privacy.ScrubMessage(errorStr)` for the `error` field and `RoutePattern(ctx)` for `path`.
- `reportErrorToTelemetry` now sends `RoutePattern(ctx)` as the Sentry `endpoint` context.
- `LogAPIRequest` (shared helper) now logs `RoutePattern(ctx)`.
- Query scrubbing URL-decodes the raw query first, then runs `privacy.ScrubMessage`, because the token scrubber pattern does not span percent-escapes (an encoded `token=ab%2Bcd...` would otherwise leak).

This is a log-content change only. No HTTP status codes, response bodies, routes, config keys, or DB schema change. The JSON error response still gates raw `err.Error()` exposure on debug mode (unchanged).

## Decisions

- Query field: scrub with `privacy.ScrubMessage` (after URL-decoding) rather than dropping it, to preserve debuggability while redacting token-like values.
- Error log field: scrub with `privacy.ScrubMessage` rather than gating on debug mode; this is the least-surprising minimal fix that removes secrets while keeping the error visible for debugging.

## Tests

- `internal/api/v2/apicore/log_redaction_test.go` (new): `TestRoutePattern`, `TestScrubQueryForLog`, `TestLoggingMiddlewareRedactsPathAndQuery` (asserts a tokenized HLS path logs the route pattern with the token absent, and a URL-encoded query token is scrubbed), `TestLoggingMiddlewareScrubsHandlerError`, `TestLoggingMiddlewareUnmatchedRouteUsesPlaceholder`, `TestHandleErrorInternalScrubsErrorAndPath`.
- `telemetry_test.go` helper updated so the telemetry `endpoint` assertion reflects the new route-pattern behavior.

The `apicore` acyclic import guard stays green (`internal/privacy` is a leaf utility, not an api/v2 package, so it is not subject to the guard). The route enumeration golden test stays green and unchanged.

## Preflight Status

- [x] Single concern: log redaction in `apicore`
- [x] Preflight passed: reuse, correctness, quality, integration, and regression review passes run; the one Medium finding (a second unscrubbed error path in `LoggingMiddleware`) was fixed and covered by a test
- [x] Linters clean: `golangci-lint run` on the changed packages reports 0 issues
- [x] Tests pass: `go test -race ./internal/api/v2/...` and `./internal/analysis/...`
- [x] No regression/backward-compat break: no API/status/response/config/DB/CLI changes; only log/telemetry content changes
- [x] No secrets or PII in the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request logging to record matched route patterns and scrub sensitive query parameters, reducing leakage of token-bearing path/query data.
  * Updated error logging/telemetry to sanitize credential-bearing error text before it’s recorded.
  * Ensured consistent logging behavior for unmatched routes by using a safe placeholder instead of raw request paths.

* **Tests**
  * Added new coverage to validate route-pattern/path/query redaction and error/telemetry scrubbing behavior, including 5xx telemetry sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->