### PR TITLE
fix(ui): portal ActionMenu to body so it can't be clipped

### DIFF
--- a/frontend/src/lib/desktop/components/ui/ActionMenu.svelte
+++ b/frontend/src/lib/desktop/components/ui/ActionMenu.svelte
@@ -31,6 +31,7 @@
     CircleX,
   } from '@lucide/svelte';
   import { dropdown } from '$lib/utils/transitions';
+  import { portal } from '$lib/utils/portal';
   import { computeAnchorPosition, applyAnchorPosition } from '$lib/utils/anchorPosition';
   import { auth } from '$lib/stores/auth';
   import { t } from '$lib/i18n';
@@ -225,6 +226,7 @@
         variant === 'overlay' ? 'hover:bg-white/10' : 'hover:bg-[var(--color-base-300)]'}
       <ul
         bind:this={menuElement}
+        use:portal
         in:dropdown
         out:dropdown={{ duration: 100 }}
         class={cn(


### PR DESCRIPTION
## Summary

On mobile/narrow viewports, when only one detection is shown, the ActionMenu
(three-dot menu on detection cards) was clipped — the lower items (lock,
download, delete) were cut off and unreachable. The menu uses `position:fixed`
but its `<ul>` remained inside the detections-list DOM subtree, whose ancestor
establishes a containing block for fixed positioning. With a single detection
the ancestor is only one card tall, so any menu items beyond its height are
invisible.

## Changes

- Import the existing `portal` action from `$lib/utils/portal` in `ActionMenu.svelte`
- Add `use:portal` to the menu `<ul>` so it renders directly under `document.body`,
  escaping any ancestor overflow or containing-block constraints — the same pattern
  already used by `SelectDropdown` and `SpeciesInput`

No new utilities were created; no positioning math, z-index, or event-handling
logic was changed. The outro transition continues to play correctly (verified in
Chromium via Playwright).

## Testing

- [x] Frontend tests pass (`task frontend-test`) — 32/32 ActionMenu tests pass
- [x] Linting passes (`npm run check:all` — 0 errors, 0 warnings)
- [x] Manual testing completed — verified outro animation plays and no ghost nodes
  accumulate after repeated open/close cycles
- [x] Preflight quality gate passed

## Related Issues

Fixes detection action menu clipping on single-detection mobile view (reported via screenshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop action menu so open dropdowns render in the correct place on screen, helping avoid layout and clipping issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

